### PR TITLE
Harden failed check details links

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/nwparker/orca/workspaces/orca/bug-basher/node_modules

--- a/src/main/github/client-pr-check-details.test.ts
+++ b/src/main/github/client-pr-check-details.test.ts
@@ -166,10 +166,10 @@ describe('getPRCheckDetails', () => {
               id: 8801,
               name: 'verify',
               status: 'completed',
-              conclusion: 'failure',
+              conclusion: 'startup_failure',
               completed_at: '2026-05-18T19:02:00Z',
               html_url: actionUrl,
-              steps: [{ name: 'Run tests', status: 'completed', conclusion: 'failure' }]
+              steps: [{ name: 'Run tests', status: 'completed', conclusion: 'startup_failure' }]
             },
             {
               id: 8802,
@@ -190,7 +190,7 @@ describe('getPRCheckDetails', () => {
     expect(details?.jobs[0]).toMatchObject({
       id: 8801,
       name: 'verify',
-      conclusion: 'failure'
+      conclusion: 'startup_failure'
     })
     expect(details?.jobs[0].logTail).toContain('line 209')
     expect(details?.jobs[0].logTail).not.toContain('line 0')

--- a/src/main/github/client-pr-checks.test.ts
+++ b/src/main/github/client-pr-checks.test.ts
@@ -151,6 +151,41 @@ describe('getPRChecks', () => {
     ])
   })
 
+  it('maps remaining completed GitHub conclusions to failure', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        check_runs: [
+          {
+            name: 'needs-approval',
+            status: 'completed',
+            conclusion: 'action_required',
+            html_url: 'https://github.com/acme/widgets/actions/runs/1',
+            details_url: null
+          },
+          {
+            name: 'old-run',
+            status: 'completed',
+            conclusion: 'stale',
+            html_url: 'https://github.com/acme/widgets/actions/runs/2',
+            details_url: null
+          },
+          {
+            name: 'boot',
+            status: 'completed',
+            conclusion: 'startup_failure',
+            html_url: 'https://github.com/acme/widgets/actions/runs/3',
+            details_url: null
+          }
+        ]
+      })
+    })
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expect(checks.map((check) => check.conclusion)).toEqual(['failure', 'failure', 'failure'])
+  })
+
   it('treats gh pr checks "no checks reported" as an empty check list', async () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -3110,7 +3110,15 @@ function mapWorkflowJobs(raw: unknown, checkName?: string): PRCheckRunDetails['j
 }
 
 function isCheckJobFailureState(state: string | null | undefined): boolean {
-  return state === 'failure' || state === 'failed' || state === 'cancelled' || state === 'timed_out'
+  return (
+    state === 'failure' ||
+    state === 'failed' ||
+    state === 'action_required' ||
+    state === 'cancelled' ||
+    state === 'stale' ||
+    state === 'startup_failure' ||
+    state === 'timed_out'
+  )
 }
 
 function sliceCheckLogTail(logText: string): string {

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -22,7 +22,9 @@ const conclusionMap: Record<string, PRCheckDetail['conclusion']> = {
   timed_out: 'timed_out',
   skipped: 'skipped',
   neutral: 'neutral',
-  action_required: 'failure'
+  action_required: 'failure',
+  stale: 'failure',
+  startup_failure: 'failure'
 }
 
 export function mapCheckRunRESTConclusion(
@@ -57,6 +59,9 @@ export function mapCheckConclusion(state: string): PRCheckDetail['conclusion'] {
     return 'success'
   }
   if (s === 'FAILURE' || s === 'FAIL') {
+    return 'failure'
+  }
+  if (s === 'ACTION_REQUIRED' || s === 'STALE' || s === 'STARTUP_FAILURE') {
     return 'failure'
   }
   if (s === 'CANCELLED') {

--- a/src/renderer/src/components/editor/CheckRunDetailsPanel.tsx
+++ b/src/renderer/src/components/editor/CheckRunDetailsPanel.tsx
@@ -26,7 +26,12 @@ function formatCheckTimestamp(value: string | null | undefined): string | null {
   })
 }
 
-function getCheckStatusLabel(check: PRCheckDetail): string {
+type CheckStatusLike = {
+  status: PRCheckDetail['status'] | string | null | undefined
+  conclusion: PRCheckDetail['conclusion'] | string | null | undefined
+}
+
+function getCheckStatusLabel(check: CheckStatusLike): string {
   const conclusion = check.conclusion ?? 'pending'
   switch (conclusion) {
     case 'success':
@@ -43,11 +48,23 @@ function getCheckStatusLabel(check: PRCheckDetail): string {
       return translate('auto.components.editor.CheckRunDetailsPanel.5a1c8e3d67', 'Neutral')
     case 'pending':
       return translate('auto.components.editor.CheckRunDetailsPanel.3d9f2b8e14', 'Pending')
+    default:
+      return isFailureState(conclusion)
+        ? translate('auto.components.editor.CheckRunDetailsPanel.4c8e1b2d73', 'Failed')
+        : translate('auto.components.editor.CheckRunDetailsPanel.3d9f2b8e14', 'Pending')
   }
 }
 
 function isFailureState(state: string | null | undefined): boolean {
-  return state === 'failure' || state === 'cancelled' || state === 'timed_out'
+  return (
+    state === 'failure' ||
+    state === 'failed' ||
+    state === 'action_required' ||
+    state === 'cancelled' ||
+    state === 'stale' ||
+    state === 'startup_failure' ||
+    state === 'timed_out'
+  )
 }
 
 export function CheckRunDetailsPanel({
@@ -88,10 +105,10 @@ export function CheckRunDetailsPanel({
   })
   const startedAt = formatCheckTimestamp(details?.startedAt)
   const completedAt = formatCheckTimestamp(details?.completedAt)
-  const detailsStatusCheck: PRCheckDetail = {
+  const detailsStatusCheck: CheckStatusLike = {
     ...check,
-    status: (details?.status as PRCheckDetail['status'] | undefined) ?? check.status,
-    conclusion: (details?.conclusion as PRCheckDetail['conclusion'] | undefined) ?? check.conclusion
+    status: details?.status ?? check.status,
+    conclusion: details?.conclusion ?? check.conclusion
   }
   const failedJobs =
     details?.jobs.filter((job) => {

--- a/src/renderer/src/components/editor/CheckRunJobs.tsx
+++ b/src/renderer/src/components/editor/CheckRunJobs.tsx
@@ -39,17 +39,18 @@ function StepRow({ step }: { step: PRCheckStep }): React.JSX.Element {
 
 function JobCard({ job, index }: { job: PRCheckJob; index: number }): React.JSX.Element {
   const breakdown = summarizeJobSteps(job)
-  const jobState = job.conclusion ?? job.status
-  const jobFailed =
-    jobState === 'failure' ||
-    jobState === 'failed' ||
-    jobState === 'cancelled' ||
-    jobState === 'timed_out'
+  const jobFailed = resolveStepOutcome(job) === 'failure'
   // Failures matter most, so surface them and collapse the passing/skipped noise
   // behind a one-line summary. With no failures there is nothing to prioritize,
   // so expand by default rather than hiding the job's only content.
   const collapsible = [...breakdown.succeeded, ...breakdown.skipped, ...breakdown.pending]
+  const failedStepKey = breakdown.failed
+    .map((step) => `${step.name}:${step.status ?? ''}:${step.conclusion ?? ''}`)
+    .join('\0')
   const [showRest, setShowRest] = React.useState(breakdown.failed.length === 0)
+  React.useEffect(() => {
+    setShowRest(breakdown.failed.length === 0)
+  }, [breakdown.failed.length, failedStepKey])
 
   const summaryParts: string[] = []
   if (breakdown.succeeded.length > 0) {

--- a/src/renderer/src/components/editor/check-annotation-open.ts
+++ b/src/renderer/src/components/editor/check-annotation-open.ts
@@ -1,30 +1,13 @@
 import { detectLanguage } from '@/lib/language-detect'
-import { joinPath } from '@/lib/path'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useAppStore } from '@/store'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
-import type { PRCheckAnnotation } from '../../../../shared/types'
+import {
+  getOpenableAnnotationLine,
+  resolveAnnotationPathInsideWorktree
+} from './check-annotation-path'
 
-/**
- * A CI annotation only links to the editor when its path names a real repo file
- * at a line — not a workflow-level reference like `.github` (no extension), which
- * has no on-disk location to reveal. Requiring a file extension keeps the
- * affordance honest: links that wouldn't open never render.
- */
-export function getOpenableAnnotationLine(
-  annotation: PRCheckAnnotation
-): { path: string; line: number } | null {
-  const path = annotation.path?.trim()
-  if (!path || !annotation.startLine) {
-    return null
-  }
-  const basename = path.split(/[\\/]/).pop() ?? ''
-  const hasExtension = basename.lastIndexOf('.') > 0
-  if (!hasExtension) {
-    return null
-  }
-  return { path, line: annotation.startLine }
-}
+export { getOpenableAnnotationLine }
 
 export function openAnnotationLocation(params: {
   worktreeId: string
@@ -39,7 +22,11 @@ export function openAnnotationLocation(params: {
   if (!worktree) {
     return
   }
-  const absolutePath = joinPath(worktree.path, path)
+  const resolvedPath = resolveAnnotationPathInsideWorktree(worktree.path, path)
+  if (!resolvedPath) {
+    return
+  }
+  const { absolutePath, relativePath } = resolvedPath
 
   // Why: reuse the shared activation path so an annotation jump lands in the
   // same history stack as sidebar, palette, and terminal-link navigation.
@@ -48,9 +35,9 @@ export function openAnnotationLocation(params: {
   store.openFile(
     {
       filePath: absolutePath,
-      relativePath: path,
+      relativePath,
       worktreeId,
-      language: detectLanguage(path),
+      language: detectLanguage(relativePath),
       mode: 'edit'
     },
     { forceContentReload: true }

--- a/src/renderer/src/components/editor/check-annotation-path.test.ts
+++ b/src/renderer/src/components/editor/check-annotation-path.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getOpenableAnnotationLine,
+  resolveAnnotationPathInsideWorktree
+} from './check-annotation-path'
+import type { PRCheckAnnotation } from '../../../../shared/types'
+
+function annotation(path: string | null, startLine = 1): PRCheckAnnotation {
+  return {
+    path,
+    startLine,
+    endLine: startLine,
+    annotationLevel: null,
+    title: null,
+    message: '',
+    rawDetails: null
+  }
+}
+
+describe('getOpenableAnnotationLine', () => {
+  it('allows extensionless repo files and dotfiles', () => {
+    expect(getOpenableAnnotationLine(annotation('Dockerfile'))).toEqual({
+      path: 'Dockerfile',
+      line: 1
+    })
+    expect(getOpenableAnnotationLine(annotation('LICENSE'))).toEqual({ path: 'LICENSE', line: 1 })
+    expect(getOpenableAnnotationLine(annotation('.eslintrc'))).toEqual({
+      path: '.eslintrc',
+      line: 1
+    })
+  })
+
+  it('rejects workflow pseudo-paths without blocking workflow files', () => {
+    expect(getOpenableAnnotationLine(annotation('.github'))).toBeNull()
+    expect(getOpenableAnnotationLine(annotation('.github/workflows/ci.yml'))).toEqual({
+      path: '.github/workflows/ci.yml',
+      line: 1
+    })
+  })
+})
+
+describe('resolveAnnotationPathInsideWorktree', () => {
+  it('normalizes safe relative paths inside the worktree', () => {
+    expect(resolveAnnotationPathInsideWorktree('/repo', 'src/../Dockerfile')).toEqual({
+      absolutePath: '/repo/Dockerfile',
+      relativePath: 'Dockerfile'
+    })
+    expect(resolveAnnotationPathInsideWorktree('/repo', ' LICENSE ')).toEqual({
+      absolutePath: '/repo/LICENSE',
+      relativePath: 'LICENSE'
+    })
+  })
+
+  it('rejects paths that escape or start outside the worktree', () => {
+    expect(resolveAnnotationPathInsideWorktree('/repo', '.github')).toBeNull()
+    expect(resolveAnnotationPathInsideWorktree('/repo', '../../tmp/secret.txt')).toBeNull()
+    expect(resolveAnnotationPathInsideWorktree('/repo', '/tmp/secret.txt')).toBeNull()
+    expect(resolveAnnotationPathInsideWorktree('C:\\Repo', 'D:\\secret.txt')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/check-annotation-path.ts
+++ b/src/renderer/src/components/editor/check-annotation-path.ts
@@ -1,0 +1,60 @@
+import type { PRCheckAnnotation } from '../../../../shared/types'
+import { relativePathInsideRoot, resolveRuntimePath } from '../../../../shared/cross-platform-path'
+
+const WORKFLOW_PSEUDO_ANNOTATION_PATH = '.github'
+
+function isRootedAnnotationPath(path: string): boolean {
+  return path.startsWith('/') || path.startsWith('\\') || /^[A-Za-z]:/.test(path)
+}
+
+function normalizeAnnotationRelativePath(path: string): string | null {
+  const trimmedPath = path.trim()
+  if (!trimmedPath || trimmedPath.includes('\0') || isRootedAnnotationPath(trimmedPath)) {
+    return null
+  }
+
+  const segments: string[] = []
+  for (const segment of trimmedPath.replace(/[\\/]+/g, '/').split('/')) {
+    if (!segment || segment === '.') {
+      continue
+    }
+    if (segment === '..') {
+      if (segments.length === 0) {
+        return null
+      }
+      segments.pop()
+      continue
+    }
+    segments.push(segment)
+  }
+
+  return segments.length > 0 ? segments.join('/') : null
+}
+
+export function getOpenableAnnotationLine(
+  annotation: PRCheckAnnotation
+): { path: string; line: number } | null {
+  const path = normalizeAnnotationRelativePath(annotation.path?.trim() ?? '')
+  const line = annotation.startLine
+  if (!path || path === WORKFLOW_PSEUDO_ANNOTATION_PATH || !line || line < 1) {
+    return null
+  }
+  return { path, line }
+}
+
+export function resolveAnnotationPathInsideWorktree(
+  worktreePath: string,
+  path: string
+): { absolutePath: string; relativePath: string } | null {
+  const relativePath = normalizeAnnotationRelativePath(path)
+  if (!relativePath || relativePath === WORKFLOW_PSEUDO_ANNOTATION_PATH) {
+    return null
+  }
+
+  const absolutePath = resolveRuntimePath(worktreePath, relativePath)
+  if (relativePathInsideRoot(worktreePath, absolutePath) !== relativePath) {
+    return null
+  }
+
+  return { absolutePath, relativePath }
+}

--- a/src/renderer/src/components/editor/check-job-step-status.test.ts
+++ b/src/renderer/src/components/editor/check-job-step-status.test.ts
@@ -7,7 +7,15 @@ describe('resolveStepOutcome', () => {
   })
 
   it('maps failure-like states to failure', () => {
-    for (const conclusion of ['failure', 'failed', 'cancelled', 'timed_out']) {
+    for (const conclusion of [
+      'failure',
+      'failed',
+      'action_required',
+      'cancelled',
+      'stale',
+      'startup_failure',
+      'timed_out'
+    ]) {
       expect(resolveStepOutcome({ status: null, conclusion })).toBe('failure')
     }
   })

--- a/src/renderer/src/components/editor/check-job-step-status.ts
+++ b/src/renderer/src/components/editor/check-job-step-status.ts
@@ -8,7 +8,10 @@ export function resolveStepOutcome(step: Pick<PRCheckStep, 'status' | 'conclusio
       return 'success'
     case 'failure':
     case 'failed':
+    case 'action_required':
     case 'cancelled':
+    case 'stale':
+    case 'startup_failure':
     case 'timed_out':
       return 'failure'
     case 'skipped':


### PR DESCRIPTION
## Summary
- allow extensionless CI annotation paths like Dockerfile/LICENSE while still suppressing the .github pseudo-path
- validate annotation paths stay inside the worktree before opening them
- classify remaining GitHub completed conclusions as failures and reset job expansion when failed steps change

## Test plan
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/check-annotation-path.test.ts src/renderer/src/components/editor/check-job-step-status.test.ts src/main/github/client-pr-checks.test.ts src/main/github/client-pr-check-details.test.ts
- pnpm typecheck
- pnpm exec oxlint src/renderer/src/components/editor/check-annotation-path.ts src/renderer/src/components/editor/check-annotation-path.test.ts src/renderer/src/components/editor/check-annotation-open.ts src/renderer/src/components/editor/check-job-step-status.ts src/renderer/src/components/editor/check-job-step-status.test.ts src/renderer/src/components/editor/CheckRunJobs.tsx src/renderer/src/components/editor/CheckRunDetailsPanel.tsx src/main/github/client.ts src/main/github/mappers.ts src/main/github/client-pr-checks.test.ts src/main/github/client-pr-check-details.test.ts