### PR TITLE
Fix linked PR context from terminal cwd

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: the checks panel co-locates PR header, checks, comments,
 merge actions, and conflict state in one component to keep the data flow straightforward. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import {
   LoaderCircle,
   RefreshCw,
@@ -21,7 +22,7 @@ import {
   prCommentsCacheSuffix
 } from '@/store/slices/github'
 import { getGitHubPRCacheKey, getGitHubRepoCacheKey } from '@/store/slices/github-cache-key'
-import { useActiveWorktree, useRepoById } from '@/store/selectors'
+import { useActiveWorktree, useAllWorktrees, useRepoById } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import { openHttpLink } from '@/lib/http-link-routing'
 import { Button } from '@/components/ui/button'
@@ -78,6 +79,11 @@ import type {
 } from '../../../../shared/hosted-review'
 import { resolveHostedReviewCreationProvider } from '../../../../shared/hosted-review-creation-providers'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
+import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import {
+  resolveChecksPanelTerminalPtyId,
+  resolveChecksPanelWorktreeFromTerminalCwd
+} from './checks-panel-terminal-worktree'
 import { getHostedReviewCacheKey, refreshHostedReviewCard } from '@/store/slices/hosted-review'
 import { toast } from 'sonner'
 import { useConfirmationDialog } from '@/components/confirmation-dialog'
@@ -170,6 +176,7 @@ import {
 
 const RUNTIME_SSH_STATUS_REFRESH_MS = 3000
 const GIT_STATUS_FAILURE_RETRY_MS = 3000
+const TERMINAL_CWD_WORKTREE_REFRESH_MS = 2000
 
 type HostedReviewCreationSnapshot = {
   requestKey: string
@@ -366,8 +373,66 @@ async function resolveGitLabMRDiscussionForChecks(args: {
 }
 
 export default function ChecksPanel(): React.JSX.Element {
-  const activeWorktree = useActiveWorktree()
-  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const defaultActiveWorktree = useActiveWorktree()
+  const defaultActiveWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const allWorktrees = useAllWorktrees()
+  const activeTerminalPtyId = useAppStore(
+    useShallow((s) =>
+      resolveChecksPanelTerminalPtyId({
+        activeTabId: s.activeTabId,
+        ptyIdsByTabId: s.ptyIdsByTabId,
+        terminalLayoutsByTabId: s.terminalLayoutsByTabId
+      })
+    )
+  )
+  const [terminalCwdSnapshot, setTerminalCwdSnapshot] = useState<{
+    ptyId: string
+    cwd: string
+  } | null>(null)
+
+  // Why: the sidebar stays mounted when closed (for performance). Gate
+  // polling on visibility so we don't fetch checks/comments in the background
+  // when the panel isn't visible to the user.
+  const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
+  const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
+  const isPanelVisible = rightSidebarOpen && rightSidebarTab === 'checks'
+
+  useEffect(() => {
+    if (!isPanelVisible || !activeTerminalPtyId || isRemoteRuntimePtyId(activeTerminalPtyId)) {
+      setTerminalCwdSnapshot(null)
+      return
+    }
+
+    let disposed = false
+    const refreshTerminalCwd = async (): Promise<void> => {
+      try {
+        const cwd = (await window.api.pty.getCwd(activeTerminalPtyId)).trim()
+        if (!disposed) {
+          setTerminalCwdSnapshot(cwd ? { ptyId: activeTerminalPtyId, cwd } : null)
+        }
+      } catch {
+        if (!disposed) {
+          setTerminalCwdSnapshot(null)
+        }
+      }
+    }
+
+    void refreshTerminalCwd()
+    const interval = window.setInterval(refreshTerminalCwd, TERMINAL_CWD_WORKTREE_REFRESH_MS)
+    return () => {
+      disposed = true
+      window.clearInterval(interval)
+    }
+  }, [activeTerminalPtyId, isPanelVisible])
+
+  const terminalCwd =
+    terminalCwdSnapshot?.ptyId === activeTerminalPtyId ? terminalCwdSnapshot.cwd : null
+  const terminalCwdWorktree = useMemo(
+    () => resolveChecksPanelWorktreeFromTerminalCwd(terminalCwd, allWorktrees),
+    [allWorktrees, terminalCwd]
+  )
+  const activeWorktree = terminalCwdWorktree ?? defaultActiveWorktree
+  const activeWorktreeId = activeWorktree?.id ?? defaultActiveWorktreeId
   const repo = useRepoById(activeWorktree?.repoId ?? null)
   const activeConnectionId = activeWorktreeId
     ? (getConnectionId(activeWorktreeId) ?? repo?.connectionId ?? null)
@@ -401,13 +466,6 @@ export default function ChecksPanel(): React.JSX.Element {
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const updateWorktreeGitIdentity = useAppStore((s) => s.updateWorktreeGitIdentity)
   const openModal = useAppStore((s) => s.openModal)
-
-  // Why: the sidebar stays mounted when closed (for performance). Gate
-  // polling on visibility so we don't fetch checks/comments in the background
-  // when the panel isn't visible to the user.
-  const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
-  const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
-  const isPanelVisible = rightSidebarOpen && rightSidebarTab === 'checks'
 
   const fetchPRChecks = useAppStore((s) => s.fetchPRChecks)
   const fetchPRCheckDetails = useAppStore((s) => s.fetchPRCheckDetails)

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -387,7 +387,7 @@ export default function ChecksPanel(): React.JSX.Element {
   )
   const [terminalCwdSnapshot, setTerminalCwdSnapshot] = useState<{
     ptyId: string
-    cwd: string
+    cwd: string | null
   } | null>(null)
 
   // Why: the sidebar stays mounted when closed (for performance). Gate
@@ -396,9 +396,11 @@ export default function ChecksPanel(): React.JSX.Element {
   const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const isPanelVisible = rightSidebarOpen && rightSidebarTab === 'checks'
+  const shouldPollTerminalCwd =
+    isPanelVisible && activeTerminalPtyId !== null && !isRemoteRuntimePtyId(activeTerminalPtyId)
 
   useEffect(() => {
-    if (!isPanelVisible || !activeTerminalPtyId || isRemoteRuntimePtyId(activeTerminalPtyId)) {
+    if (!shouldPollTerminalCwd || activeTerminalPtyId === null) {
       setTerminalCwdSnapshot(null)
       return
     }
@@ -408,11 +410,11 @@ export default function ChecksPanel(): React.JSX.Element {
       try {
         const cwd = (await window.api.pty.getCwd(activeTerminalPtyId)).trim()
         if (!disposed) {
-          setTerminalCwdSnapshot(cwd ? { ptyId: activeTerminalPtyId, cwd } : null)
+          setTerminalCwdSnapshot({ ptyId: activeTerminalPtyId, cwd: cwd || null })
         }
       } catch {
         if (!disposed) {
-          setTerminalCwdSnapshot(null)
+          setTerminalCwdSnapshot({ ptyId: activeTerminalPtyId, cwd: null })
         }
       }
     }
@@ -423,16 +425,20 @@ export default function ChecksPanel(): React.JSX.Element {
       disposed = true
       window.clearInterval(interval)
     }
-  }, [activeTerminalPtyId, isPanelVisible])
+  }, [activeTerminalPtyId, shouldPollTerminalCwd])
 
+  const terminalCwdPending =
+    shouldPollTerminalCwd && terminalCwdSnapshot?.ptyId !== activeTerminalPtyId
   const terminalCwd =
     terminalCwdSnapshot?.ptyId === activeTerminalPtyId ? terminalCwdSnapshot.cwd : null
   const terminalCwdWorktree = useMemo(
     () => resolveChecksPanelWorktreeFromTerminalCwd(terminalCwd, allWorktrees),
     [allWorktrees, terminalCwd]
   )
-  const activeWorktree = terminalCwdWorktree ?? defaultActiveWorktree
-  const activeWorktreeId = activeWorktree?.id ?? defaultActiveWorktreeId
+  const activeWorktree = terminalCwdPending ? null : (terminalCwdWorktree ?? defaultActiveWorktree)
+  const activeWorktreeId = terminalCwdPending
+    ? null
+    : (activeWorktree?.id ?? defaultActiveWorktreeId)
   const repo = useRepoById(activeWorktree?.repoId ?? null)
   const activeConnectionId = activeWorktreeId
     ? (getConnectionId(activeWorktreeId) ?? repo?.connectionId ?? null)

--- a/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts
@@ -57,6 +57,25 @@ describe('resolveChecksPanelTerminalPtyId', () => {
     ).toBe('pty-live')
   })
 
+  it('falls back to the last live tab PTY when the layout has no live PTY', () => {
+    expect(
+      resolveChecksPanelTerminalPtyId({
+        activeTabId: 'tab-1',
+        ptyIdsByTabId: { 'tab-1': ['pty-left', 'pty-right'] },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: null,
+            activeLeafId: 'leaf-stale',
+            expandedLeafId: null,
+            ptyIdsByLeafId: {
+              'leaf-stale': 'pty-stale'
+            }
+          }
+        }
+      })
+    ).toBe('pty-right')
+  })
+
   it('returns null when the active tab has no live PTY', () => {
     expect(
       resolveChecksPanelTerminalPtyId({

--- a/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import {
+  resolveChecksPanelTerminalPtyId,
+  resolveChecksPanelWorktreeFromTerminalCwd
+} from './checks-panel-terminal-worktree'
+
+function worktree(overrides: Partial<Worktree>): Worktree {
+  return {
+    id: overrides.id ?? `repo-1::${overrides.path ?? '/repo'}`,
+    repoId: overrides.repoId ?? 'repo-1',
+    path: overrides.path ?? '/repo',
+    displayName: overrides.displayName ?? 'Repo',
+    priorWorktreeIds: overrides.priorWorktreeIds,
+    isArchived: overrides.isArchived ?? false
+  } as Worktree
+}
+
+describe('resolveChecksPanelTerminalPtyId', () => {
+  it('uses the active split-pane leaf when it has a live PTY', () => {
+    expect(
+      resolveChecksPanelTerminalPtyId({
+        activeTabId: 'tab-1',
+        ptyIdsByTabId: { 'tab-1': ['pty-left', 'pty-right'] },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: null,
+            activeLeafId: 'leaf-right',
+            expandedLeafId: null,
+            ptyIdsByLeafId: {
+              'leaf-left': 'pty-left',
+              'leaf-right': 'pty-right'
+            }
+          }
+        }
+      })
+    ).toBe('pty-right')
+  })
+
+  it('falls back to a live layout PTY before using the last live tab PTY', () => {
+    expect(
+      resolveChecksPanelTerminalPtyId({
+        activeTabId: 'tab-1',
+        ptyIdsByTabId: { 'tab-1': ['pty-live', 'pty-other'] },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: null,
+            activeLeafId: 'leaf-stale',
+            expandedLeafId: null,
+            ptyIdsByLeafId: {
+              'leaf-stale': 'pty-stale',
+              'leaf-live': 'pty-live'
+            }
+          }
+        }
+      })
+    ).toBe('pty-live')
+  })
+
+  it('returns null when the active tab has no live PTY', () => {
+    expect(
+      resolveChecksPanelTerminalPtyId({
+        activeTabId: 'tab-1',
+        ptyIdsByTabId: { 'tab-1': [] },
+        terminalLayoutsByTabId: {}
+      })
+    ).toBeNull()
+  })
+})
+
+describe('resolveChecksPanelWorktreeFromTerminalCwd', () => {
+  it('matches the deepest worktree that contains the terminal cwd', () => {
+    const parent = worktree({ id: 'repo-1::/repo', path: '/repo', displayName: 'Parent' })
+    const child = worktree({
+      id: 'repo-1::/repo/packages/app',
+      path: '/repo/packages/app',
+      displayName: 'Child'
+    })
+
+    expect(
+      resolveChecksPanelWorktreeFromTerminalCwd('/repo/packages/app/src', [parent, child])
+    ).toBe(child)
+  })
+
+  it('matches prior worktree paths after a path-derived id changes', () => {
+    const renamed = worktree({
+      id: 'repo-1::/new/path',
+      path: '/new/path',
+      priorWorktreeIds: ['repo-1::/old/path']
+    })
+
+    expect(resolveChecksPanelWorktreeFromTerminalCwd('/old/path/src', [renamed])).toBe(renamed)
+  })
+
+  it('matches Linux cwd under a WSL UNC worktree path', () => {
+    const wsl = worktree({
+      id: 'repo-1:://wsl.localhost/Ubuntu/home/me/project',
+      path: '//wsl.localhost/Ubuntu/home/me/project'
+    })
+
+    expect(resolveChecksPanelWorktreeFromTerminalCwd('/home/me/project/src', [wsl])).toBe(wsl)
+  })
+
+  it('does not match relative or empty cwd values', () => {
+    const target = worktree({ path: '/repo' })
+
+    expect(resolveChecksPanelWorktreeFromTerminalCwd('repo/src', [target])).toBeNull()
+    expect(resolveChecksPanelWorktreeFromTerminalCwd('', [target])).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts
@@ -38,6 +38,7 @@ export function resolveChecksPanelTerminalPtyId(context: TerminalPtyContext): st
   const firstLiveLayoutPtyId = Object.values(layout?.ptyIdsByLeafId ?? {}).find((ptyId) =>
     livePtyIds.includes(ptyId)
   )
+  // Last tab PTY is the newest terminal when the split-pane layout is stale or unavailable.
   return firstLiveLayoutPtyId ?? livePtyIds.at(-1) ?? null
 }
 
@@ -85,6 +86,7 @@ function isTerminalCwdInsideWorktree(worktreePath: string, terminalCwd: string):
     return true
   }
 
+  // Windows hosts store WSL worktrees as UNC paths, while the terminal reports Linux paths.
   const wslPath = parseWslUncPath(worktreePath)
   return wslPath ? isPathInsideOrEqual(wslPath.linuxPath, terminalCwd) : false
 }
@@ -99,5 +101,6 @@ function compareWorktreeCandidates(left: WorktreeCandidate, right: WorktreeCandi
   if (left.source === right.source) {
     return 0
   }
+  // Prefer the current path when a renamed worktree still has a matching prior path.
   return left.source === 'current-path' ? -1 : 1
 }

--- a/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts
@@ -1,0 +1,103 @@
+import { parseWslUncPath } from '../../../../shared/wsl-paths'
+import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree-id'
+import {
+  isPathInsideOrEqual,
+  isRuntimePathAbsolute,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
+import type { TerminalLayoutSnapshot, Worktree } from '../../../../shared/types'
+
+type TerminalPtyContext = {
+  activeTabId: string | null
+  ptyIdsByTabId: Record<string, readonly string[] | undefined>
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
+}
+
+type WorktreeCandidate = {
+  worktree: Worktree
+  path: string
+  source: 'current-path' | 'prior-path'
+}
+
+export function resolveChecksPanelTerminalPtyId(context: TerminalPtyContext): string | null {
+  if (!context.activeTabId) {
+    return null
+  }
+
+  const livePtyIds = context.ptyIdsByTabId[context.activeTabId] ?? []
+  if (livePtyIds.length === 0) {
+    return null
+  }
+
+  const layout = context.terminalLayoutsByTabId[context.activeTabId]
+  const activeLeafPtyId = layout?.activeLeafId ? layout.ptyIdsByLeafId?.[layout.activeLeafId] : null
+  if (activeLeafPtyId && livePtyIds.includes(activeLeafPtyId)) {
+    return activeLeafPtyId
+  }
+
+  const firstLiveLayoutPtyId = Object.values(layout?.ptyIdsByLeafId ?? {}).find((ptyId) =>
+    livePtyIds.includes(ptyId)
+  )
+  return firstLiveLayoutPtyId ?? livePtyIds.at(-1) ?? null
+}
+
+export function resolveChecksPanelWorktreeFromTerminalCwd(
+  cwd: string | null,
+  worktrees: readonly Worktree[]
+): Worktree | null {
+  const terminalCwd = cwd?.trim()
+  if (!terminalCwd || !isRuntimePathAbsolute(terminalCwd)) {
+    return null
+  }
+
+  const best = buildWorktreeCandidates(worktrees)
+    .filter((candidate) => isTerminalCwdInsideWorktree(candidate.path, terminalCwd))
+    .sort(compareWorktreeCandidates)[0]
+
+  return best?.worktree ?? null
+}
+
+function buildWorktreeCandidates(worktrees: readonly Worktree[]): WorktreeCandidate[] {
+  const candidates: WorktreeCandidate[] = []
+  for (const worktree of worktrees) {
+    if (hasUsablePath(worktree.path)) {
+      candidates.push({ worktree, path: worktree.path, source: 'current-path' })
+    }
+
+    for (const priorWorktreeId of worktree.priorWorktreeIds ?? []) {
+      const parsed = splitWorktreeIdForFilesystem(priorWorktreeId)
+      if (!parsed || parsed.repoId !== worktree.repoId || !hasUsablePath(parsed.worktreePath)) {
+        continue
+      }
+      candidates.push({ worktree, path: parsed.worktreePath, source: 'prior-path' })
+    }
+  }
+  return candidates
+}
+
+function hasUsablePath(pathValue: string): boolean {
+  const trimmed = pathValue.trim()
+  return Boolean(trimmed && isRuntimePathAbsolute(trimmed))
+}
+
+function isTerminalCwdInsideWorktree(worktreePath: string, terminalCwd: string): boolean {
+  if (isPathInsideOrEqual(worktreePath, terminalCwd)) {
+    return true
+  }
+
+  const wslPath = parseWslUncPath(worktreePath)
+  return wslPath ? isPathInsideOrEqual(wslPath.linuxPath, terminalCwd) : false
+}
+
+function compareWorktreeCandidates(left: WorktreeCandidate, right: WorktreeCandidate): number {
+  const lengthDifference =
+    normalizeRuntimePathForComparison(right.path).length -
+    normalizeRuntimePathForComparison(left.path).length
+  if (lengthDifference !== 0) {
+    return lengthDifference
+  }
+  if (left.source === right.source) {
+    return 0
+  }
+  return left.source === 'current-path' ? -1 : 1
+}

--- a/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts
@@ -19,6 +19,7 @@ type WorktreeCandidate = {
   source: 'current-path' | 'prior-path'
 }
 
+/** Resolve the active terminal PTY that should provide Checks panel cwd context. */
 export function resolveChecksPanelTerminalPtyId(context: TerminalPtyContext): string | null {
   if (!context.activeTabId) {
     return null
@@ -42,6 +43,7 @@ export function resolveChecksPanelTerminalPtyId(context: TerminalPtyContext): st
   return firstLiveLayoutPtyId ?? livePtyIds.at(-1) ?? null
 }
 
+/** Resolve the worktree whose current or prior path contains the terminal cwd. */
 export function resolveChecksPanelWorktreeFromTerminalCwd(
   cwd: string | null,
   worktrees: readonly Worktree[]


### PR DESCRIPTION
## Summary

- Update the Checks panel to use the active terminal CWD when it maps to a known worktree, so linked PR/review state follows the workspace the terminal is actually operating in.
- Resolve the active split-pane PTY before reading CWD, with the existing active-worktree behavior preserved as the fallback.
- Add regression coverage for split-pane PTY selection, deepest worktree matching, prior worktree paths, and WSL UNC path matching.

Fixes #6431

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation run:

- `pnpm run typecheck:web`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/right-sidebar/ChecksPanel.tsx src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts`
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/ChecksPanel.tsx src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts`
- `git diff --check HEAD~1 HEAD`

## Review Report

Reviewed the renderer-side context switch for stale state risk, split-pane active PTY selection, cleanup of the CWD polling interval, and fallback behavior when CWD cannot be resolved. Cross-platform path handling was checked for POSIX, Windows-style separators through the shared path helpers, WSL UNC worktree paths, SSH/remote fallback behavior, and Electron IPC boundaries touched by this PR.

## Security Audit

The change does not add command execution, credentials, new dependencies, or network access. It reads the active local PTY CWD through the existing preload API only while the Checks panel is visible, skips remote runtime PTYs, ignores empty or relative CWD values, and only switches context when the CWD maps to an existing known worktree.

## Notes

Full `pnpm typecheck`, full `pnpm test`, and `pnpm build` were not run. This change is renderer-scoped; `pnpm run typecheck:web`, focused vitest coverage, full lint, formatter check, and diff whitespace check passed.
