### PR TITLE
Add mouse side-button tab navigation

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -1059,6 +1059,57 @@ describe('createMainWindow', () => {
     expect(webContents.send).not.toHaveBeenCalledWith('ui:switchRecentTab')
   })
 
+  it('forwards browser app-command side buttons to all-tab switching', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const backPreventDefault = vi.fn()
+    const forwardPreventDefault = vi.fn()
+    windowHandlers['app-command'](
+      { preventDefault: backPreventDefault } as never,
+      'browser-backward'
+    )
+    windowHandlers['app-command'](
+      { preventDefault: forwardPreventDefault } as never,
+      'browser-forward'
+    )
+
+    expect(backPreventDefault).toHaveBeenCalledTimes(1)
+    expect(forwardPreventDefault).toHaveBeenCalledTimes(1)
+    expect(webContents.send).toHaveBeenNthCalledWith(1, 'ui:switchTabAcrossAllTypes', -1)
+    expect(webContents.send).toHaveBeenNthCalledWith(2, 'ui:switchTabAcrossAllTypes', 1)
+  })
+
   it('only intercepts the dictation chord when enabled toggle mode can handle it', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -314,6 +314,8 @@ export function createMainWindow(
   // Why: native paste fallback is privileged IPC; only the top-level renderer may request it.
   setTrustedUIRendererWebContentsId(rendererWebContentsId)
 
+  // Why: Electron reports some mouse side-button presses as app-command events,
+  // so bridge them through the same tab-switch channel as renderer mouse input.
   mainWindow.on('app-command', (event, command) => {
     const direction = resolveAppCommandTabSwitchDirection(command)
     if (direction === null) {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -165,7 +165,20 @@ function isMacAppPasteInput(input: Electron.Input): boolean {
   )
 }
 
-// Why: titlebar content center sits ~18 CSS px from top (×zoom); traffic lights are ~12px tall, so top edge = center − 6.
+function resolveAppCommandTabSwitchDirection(command: string): -1 | 1 | null {
+  if (command === 'browser-backward') {
+    return -1
+  }
+  if (command === 'browser-forward') {
+    return 1
+  }
+  return null
+}
+
+// Why: the titlebar is 36px (border-box, 1px border-bottom).  The visual
+// center of the CSS-centered content sits at ~18 CSS px from the top.
+// At zoom factor z that becomes 18·z window px.  Traffic lights are
+// ~12px tall, so we position their top edge at (center − 6).
 const TITLEBAR_CSS_CENTER = 18
 const TRAFFIC_LIGHT_RADIUS = 6
 const TRAFFIC_LIGHT_X = 16
@@ -300,6 +313,15 @@ export function createMainWindow(
   const rendererWebContentsId = mainWindow.webContents.id
   // Why: native paste fallback is privileged IPC; only the top-level renderer may request it.
   setTrustedUIRendererWebContentsId(rendererWebContentsId)
+
+  mainWindow.on('app-command', (event, command) => {
+    const direction = resolveAppCommandTabSwitchDirection(command)
+    if (direction === null) {
+      return
+    }
+    event.preventDefault()
+    mainWindow.webContents.send('ui:switchTabAcrossAllTypes', direction)
+  })
 
   if (process.platform === 'darwin') {
     // Why: throttle the main window while hidden (guests self-unthrottle); toggle only while visible or Chromium blanks the surface (electron#42378).

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -100,6 +100,7 @@ import {
 } from './hooks/usePrimarySelectionPaste'
 import { useAppMenuPaste } from './hooks/useAppMenuPaste'
 import { useLargeTextControlPaste } from './hooks/useLargeTextControlPaste'
+import { useMouseTabNavigation } from './hooks/useMouseTabNavigation'
 import {
   canSkipRuntimeMobileSessionSyncKeyBuild,
   getRuntimeMobileSessionSyncKey,
@@ -669,6 +670,7 @@ function App(): React.JSX.Element {
   usePrimarySelectionPaste(primarySelectionMiddleClickPaste)
   useAppMenuPaste()
   useLargeTextControlPaste()
+  useMouseTabNavigation()
   const petEnabled = useAppStore((s) => s.settings?.experimentalPet === true)
   const petVisible = useAppStore((s) => s.petVisible)
   const renderPetOverlay = shouldRenderPetOverlay({

--- a/src/renderer/src/hooks/useMouseTabNavigation.test.tsx
+++ b/src/renderer/src/hooks/useMouseTabNavigation.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { handleSwitchTabAcrossAllTypes } from './ipc-tab-switch'
+import { useMouseTabNavigation } from './useMouseTabNavigation'
+
+vi.mock('./ipc-tab-switch', () => ({
+  handleSwitchTabAcrossAllTypes: vi.fn()
+}))
+
+const handleSwitchTabAcrossAllTypesMock = vi.mocked(handleSwitchTabAcrossAllTypes)
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function Probe(): null {
+  useMouseTabNavigation()
+  return null
+}
+
+async function renderProbe(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<Probe />)
+  })
+}
+
+function dispatchMouseDown(button: number, overrides: MouseEventInit = {}): MouseEvent {
+  const event = new MouseEvent('mousedown', {
+    bubbles: true,
+    cancelable: true,
+    button,
+    ...overrides
+  })
+  window.dispatchEvent(event)
+  return event
+}
+
+function dispatchAuxClick(button: number): MouseEvent {
+  const event = new MouseEvent('auxclick', {
+    bubbles: true,
+    cancelable: true,
+    button
+  })
+  window.dispatchEvent(event)
+  return event
+}
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root?.unmount()
+    })
+  }
+  root = null
+  container?.remove()
+  container = null
+  vi.clearAllMocks()
+})
+
+describe('useMouseTabNavigation', () => {
+  it('maps Mouse4 and Mouse5 mousedown gestures to previous and next tab navigation', async () => {
+    await renderProbe()
+
+    const backEvent = dispatchMouseDown(3)
+    const forwardEvent = dispatchMouseDown(4)
+
+    expect(backEvent.defaultPrevented).toBe(true)
+    expect(forwardEvent.defaultPrevented).toBe(true)
+    expect(handleSwitchTabAcrossAllTypesMock).toHaveBeenNthCalledWith(1, -1)
+    expect(handleSwitchTabAcrossAllTypesMock).toHaveBeenNthCalledWith(2, 1)
+  })
+
+  it('consumes side-button auxclick without switching tabs a second time', async () => {
+    await renderProbe()
+
+    const event = dispatchAuxClick(3)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(handleSwitchTabAcrossAllTypesMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores modified side-button gestures and regular mouse buttons', async () => {
+    await renderProbe()
+
+    const modified = dispatchMouseDown(3, { shiftKey: true })
+    const primary = dispatchMouseDown(0)
+
+    expect(modified.defaultPrevented).toBe(false)
+    expect(primary.defaultPrevented).toBe(false)
+    expect(handleSwitchTabAcrossAllTypesMock).not.toHaveBeenCalled()
+  })
+
+  it('removes listeners on unmount', async () => {
+    await renderProbe()
+    await act(async () => {
+      root?.unmount()
+    })
+    root = null
+
+    const event = dispatchMouseDown(3)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(handleSwitchTabAcrossAllTypesMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useMouseTabNavigation.ts
+++ b/src/renderer/src/hooks/useMouseTabNavigation.ts
@@ -34,6 +34,8 @@ export function useMouseTabNavigation(): void {
       }
     }
 
+    // Why: browsers treat side buttons as history navigation; capture and
+    // consume each mouse phase before webviews or terminal handlers see it.
     window.addEventListener('mousedown', onMouseDown, { capture: true })
     window.addEventListener('mouseup', consumeSideButtonDefault, { capture: true })
     window.addEventListener('auxclick', consumeSideButtonDefault, { capture: true })

--- a/src/renderer/src/hooks/useMouseTabNavigation.ts
+++ b/src/renderer/src/hooks/useMouseTabNavigation.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react'
+import { handleSwitchTabAcrossAllTypes } from './ipc-tab-switch'
+
+const MOUSE_BACK_BUTTON = 3
+const MOUSE_FORWARD_BUTTON = 4
+
+function resolveMouseSideButtonDirection(event: MouseEvent): -1 | 1 | null {
+  if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+    return null
+  }
+  if (event.button === MOUSE_BACK_BUTTON) {
+    return -1
+  }
+  if (event.button === MOUSE_FORWARD_BUTTON) {
+    return 1
+  }
+  return null
+}
+
+export function useMouseTabNavigation(): void {
+  useEffect(() => {
+    const onMouseDown = (event: MouseEvent): void => {
+      const direction = resolveMouseSideButtonDirection(event)
+      if (direction === null) {
+        return
+      }
+      event.preventDefault()
+      handleSwitchTabAcrossAllTypes(direction)
+    }
+
+    const consumeSideButtonDefault = (event: MouseEvent): void => {
+      if (resolveMouseSideButtonDirection(event) !== null) {
+        event.preventDefault()
+      }
+    }
+
+    window.addEventListener('mousedown', onMouseDown, { capture: true })
+    window.addEventListener('mouseup', consumeSideButtonDefault, { capture: true })
+    window.addEventListener('auxclick', consumeSideButtonDefault, { capture: true })
+    return () => {
+      window.removeEventListener('mousedown', onMouseDown, { capture: true })
+      window.removeEventListener('mouseup', consumeSideButtonDefault, { capture: true })
+      window.removeEventListener('auxclick', consumeSideButtonDefault, { capture: true })
+    }
+  }, [])
+}


### PR DESCRIPTION
## Summary

- Adds Mouse4/Mouse5 support for previous/next visible tab navigation in Orca chrome.
- Handles Electron `browser-backward` / `browser-forward` app commands from the main window so side-button navigation also works when Electron emits app-command events.
- Adds focused coverage for both the main-window app-command path and the renderer mouse-event hook.

Closes #6658.

## Screenshots

No visual change.

## Testing

- `./node_modules/.bin/vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts src/main/browser/browser-guest-ui.test.ts src/renderer/src/hooks/useMouseTabNavigation.test.tsx`
- `./node_modules/.bin/oxlint src/main/window/createMainWindow.ts src/main/window/createMainWindow.test.ts src/main/browser/browser-guest-ui.ts src/main/browser/browser-guest-ui.test.ts src/main/browser/browser-manager.ts src/renderer/src/App.tsx src/renderer/src/hooks/useMouseTabNavigation.ts src/renderer/src/hooks/useMouseTabNavigation.test.tsx`
- `./node_modules/.bin/tsgo --noEmit -p config/tsconfig.node.json`
- `./node_modules/.bin/tsgo --noEmit -p config/tsconfig.tc.web.json`
- `./node_modules/.bin/tsgo --noEmit -p config/tsconfig.tc.cli.json`
- `git diff --check`

## AI Review Report

- Cross-platform check: renderer `MouseEvent.button` handling covers normal app chrome without OS-specific code; Electron app-command handling covers `browser-backward` / `browser-forward` events emitted for mouse back/forward buttons on supported desktop platforms.
- Regression check: the implementation reuses the existing `ui:switchTabAcrossAllTypes` / `handleSwitchTabAcrossAllTypes` tab navigation path instead of introducing a separate tab-history model.
- Scope check: no UI layout, persistence, browser page navigation, or keybinding behavior changes were introduced.

## Security Audit

- No new IPC channels or privileged renderer APIs were added.
- The main process forwards only recognized `browser-backward` / `browser-forward` app commands to an existing renderer navigation channel.
- The renderer hook prevents default browser side-button behavior only for unmodified Mouse4/Mouse5 gestures.

## ELI5

Mouse side buttons (back/forward) switch to the previous or next visible tab. Works both from renderer mouse events and Electron’s app-command path.
