### PR TITLE
Keep the mobile worktree unread bell cleared after opening a worktree

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11945,6 +11945,147 @@ describe('OrcaRuntimeService', () => {
     ])
   })
 
+  it('clears unread metadata on mobile worktree activation without focusing desktop clients', async () => {
+    const metaById: Record<string, WorktreeMeta> = {
+      [TEST_WORKTREE_ID]: makeWorktreeMeta({ isUnread: true })
+    }
+    const setWorktreeMeta = vi.fn((worktreeId: string, meta: Partial<WorktreeMeta>) => {
+      metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+      return metaById[worktreeId]
+    })
+    const activateWorktree = vi.fn()
+    const worktreesChanged = vi.fn()
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta
+    } as never)
+    runtime.setNotifier({
+      worktreesChanged,
+      reposChanged: vi.fn(),
+      activateWorktree,
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn(),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+
+    runtime.attachWindow(TEST_WINDOW_ID)
+    runtime.markGraphReady(TEST_WINDOW_ID)
+
+    await runtime.activateManagedWorktree(`id:${TEST_WORKTREE_ID}`, { notifyClients: false })
+
+    expect(setWorktreeMeta).toHaveBeenCalledWith(TEST_WORKTREE_ID, { isUnread: false })
+    expect(metaById[TEST_WORKTREE_ID]?.isUnread).toBe(false)
+    expect(worktreesChanged).toHaveBeenCalledWith(TEST_REPO_ID)
+    expect(activateWorktree).not.toHaveBeenCalled()
+  })
+
+  it('does not rewrite unread metadata when a mobile activation finds the worktree already read', async () => {
+    // Why: seed instanceId so worktree resolution does not emit its own
+    // metadata-stamp write, isolating the assertion to the unread clear.
+    const metaById: Record<string, WorktreeMeta> = {
+      [TEST_WORKTREE_ID]: makeWorktreeMeta({ isUnread: false, instanceId: 'wt-instance' })
+    }
+    const setWorktreeMeta = vi.fn((worktreeId: string, meta: Partial<WorktreeMeta>) => {
+      metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+      return metaById[worktreeId]
+    })
+    const worktreesChanged = vi.fn()
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta
+    } as never)
+    runtime.setNotifier({
+      worktreesChanged,
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn(),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+
+    runtime.attachWindow(TEST_WINDOW_ID)
+    runtime.markGraphReady(TEST_WINDOW_ID)
+
+    await runtime.activateManagedWorktree(`id:${TEST_WORKTREE_ID}`, { notifyClients: false })
+
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
+    expect(worktreesChanged).not.toHaveBeenCalled()
+
+    metaById[TEST_WORKTREE_ID] = makeWorktreeMeta({ isUnread: true, instanceId: 'wt-instance' })
+    setWorktreeMeta.mockClear()
+    worktreesChanged.mockClear()
+
+    await runtime.activateManagedWorktree(`id:${TEST_WORKTREE_ID}`, { notifyClients: false })
+    await runtime.activateManagedWorktree(`id:${TEST_WORKTREE_ID}`, { notifyClients: false })
+
+    expect(setWorktreeMeta).toHaveBeenCalledTimes(1)
+    expect(setWorktreeMeta).toHaveBeenCalledWith(TEST_WORKTREE_ID, { isUnread: false })
+    expect(worktreesChanged).toHaveBeenCalledTimes(1)
+    expect(worktreesChanged).toHaveBeenCalledWith(TEST_REPO_ID)
+  })
+
+  it('returns unread:false from worktree.ps after a mobile activation clears the flag', async () => {
+    const metaById: Record<string, WorktreeMeta> = {
+      [TEST_WORKTREE_ID]: makeWorktreeMeta({ isUnread: true })
+    }
+    const setWorktreeMeta = vi.fn((worktreeId: string, meta: Partial<WorktreeMeta>) => {
+      metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+      return metaById[worktreeId]
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta
+    } as never)
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn(),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+
+    runtime.attachWindow(TEST_WINDOW_ID)
+    runtime.markGraphReady(TEST_WINDOW_ID)
+
+    const beforeActivation = await runtime.getWorktreePs()
+    expect(
+      beforeActivation.worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+        ?.unread
+    ).toBe(true)
+
+    await runtime.activateManagedWorktree(`id:${TEST_WORKTREE_ID}`, { notifyClients: false })
+
+    const afterActivation = await runtime.getWorktreePs()
+    expect(
+      afterActivation.worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)?.unread
+    ).toBe(false)
+  })
+
   it('materializes pending mobile session terminals without focusing desktop clients', async () => {
     const persistedPtyId = `${TEST_WORKTREE_ID}@@mobile-only-pty`
     const spawn = vi.fn().mockResolvedValue({ id: persistedPtyId })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -11647,6 +11647,13 @@ export class OrcaRuntimeService {
       throw new Error('repo_not_found')
     }
 
+    if (opts.notifyClients === false && this.store?.getWorktreeMeta(worktree.id)?.isUnread) {
+      // Why: mobile/web session activation intentionally bypasses renderer
+      // selection, so the runtime must acknowledge the unread state itself.
+      this.store.setWorktreeMeta(worktree.id, { isUnread: false })
+      this.notifyWorktreesChanged(repo.id)
+    }
+
     if (opts.notifyClients !== false) {
       // Why: inactive worktree terminal panes are renderer-owned and may not have
       // live PTYs until the desktop activates the worktree and mounts them.


### PR DESCRIPTION
## What changes

When you open a worktree on mobile (or web), its unread bell now clears and **stays** cleared. Previously the bell came back on the next mobile list refresh even after you had viewed the worktree.

**What does not change:** this does not alter how a worktree becomes unread (terminal BEL / agent completion still mark it), does not restyle the bell, and does not make a mobile activation pull desktop or other paired clients into the phone's worktree. Desktop behavior is unchanged — desktop already cleared unread on activation; this brings the mobile/web session-only path to the same parity.

## Root cause

Mobile opens a worktree through `worktree.activate({ notifyClients: false })` so a phone does not force other clients to navigate. That session-only path hydrated mobile tabs but never cleared the persisted `isUnread` metadata, so `worktree.ps` (the mobile sidebar's poll source) kept returning `unread: true` and the bell reappeared.

## Design approach

Acknowledge the coarse worktree unread flag at the host/runtime seam. In `OrcaRuntimeService.activateManagedWorktree(...)`, when activation is session-only (`notifyClients === false`) and the worktree is currently unread, clear `isUnread` via `setWorktreeMeta(...)` and fire `notifyWorktreesChanged(repo.id)`. The write is guarded on the current value so already-read worktrees do not churn persistence or list subscribers, and it is idempotent across repeated activations. Placing it on the runtime boundary covers SSH/remote clients automatically, since they route worktree activation through the same host runtime.

## Design review

Ran a design-review loop (Claude + Codex reviewers, 2 rounds) on a scratch design doc until both returned clean. Outcome: the runtime seam was confirmed the right layer over three alternatives (renderer caller, shared helper, `ps`-read seam); the agent-prompt-autonomy boundary is N/A (the change adds no agent-facing text — it flips a persisted boolean and emits a list-refresh). Folder workspaces (`folder:` ids) use a different unread field and are explicitly out of scope.

## Implementation and deviations

Production change is one guarded block in `activateManagedWorktree`. No deviations from the reviewed design. The clear runs before the mobile hydration branch and after `assertGraphReady()` + worktree/repo resolution, so not-ready/invalid paths never acknowledge unread.

## Completeness verification

A read-only pass confirmed every design step, every non-goal, and all required tests are present, with no overreach.

## Headline behavior status

**Implemented.** The production code on the real mobile/web activation path (`worktree.activate({ notifyClients: false })` → `activateManagedWorktree`) clears `isUnread` and the `activate → ps` round-trip proves the mobile poll source returns `unread: false` and keeps returning it. Not behind a setting, fixture, or fallback.

## Performance

Touched hot path: `activateManagedWorktree({ notifyClients: false })`, called once per mobile worktree open / session-screen load (not on scroll/poll). Audit result:
- No `worktree.ps` refetch storm — the change adds no polling; mobile keeps its existing poll.
- No repeated persistence writes when already read — the `isUnread` guard means already-read opens write nothing (covered by the no-op/double-activation test).
- No sidebar re-ranking on activation — the smart-sort comparator scores on `lastActivityAt`/attention/`sortOrder`/`displayName`, never `isUnread`, and this change writes only `{ isUnread: false }` (never `lastActivityAt`). The `sortEpoch` recompute is order-stable, matching the documented "clearing isUnread must not participate in ordering" design. This is the same path desktop's own clear already uses.

No measurement/test added beyond the deterministic guard tests, because the existing smart-sort tests already lock the order-stability invariant and the guard test locks the no-write path.

## Code-review loop

One round, two independent reviewers in parallel — both returned **CLEAN** with zero actionable findings (correctness, ordering, SSH/cross-platform, tests, security/telemetry, reuse all clean). Both independently confirmed the only production `notifyClients:false` callers are genuine mobile/web view events and that the tests fail if the guard is removed or inverted.

## Validation (brennan-test-changes)

Launched a fresh Electron from this branch, verified identity, and drove the runtime through the same RPC surface mobile/web clients use, against a disposable demo-project worktree (no real Orca project/issue/PR touched):
- Forced `isUnread: true` → `worktree.ps` showed `unread: true`.
- `worktree.activate({ notifyClients: false })` → three consecutive `worktree.ps` polls returned `unread: false` (clears and stays cleared — the exact regression).
- No-op re-activation of an already-read worktree: still `unread: false`, no error.
- 0 console errors. Clean cleanup (test worktree removed, only the started Electron stopped).

Verdict: **land**.

## Static checks and focused tests

- `pnpm typecheck:node` — clean
- `pnpm exec oxlint` on both touched files — clean
- `git diff --check` — clean
- `pnpm test src/main/runtime/orca-runtime.test.ts` — 495 passed (3 new unread tests: positive clear, no-op/double-activation guard, `activate → ps` round-trip)
- `pnpm test src/main/runtime/rpc/methods/worktree.test.ts` — 20 passed

## Accepted gaps / residual risk

- Physical/emulated mobile-device rendering of the bell clearing was not exercised end-to-end, but the full server-side contract (`worktree.ps` flips to `unread: false` and stays) — which the mobile sidebar reads — is proven. Low risk.
- Folder workspaces (`folder:` ids) are out of scope; they use a different unread field and the change is inert (harmless) for them.

Made with [Orca](https://github.com/stablyai/orca) 🐋
