### PR TITLE
Show each mobile session terminal tab only once

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -13716,6 +13716,177 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('collapses duplicate mobile terminal entries when renderer and headless leaf ids diverge for the same pty', async () => {
+    const rendererLeafId = HEADLESS_SECOND_LEAF_ID
+    const ptyId = 'serve-persisted-pty'
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Persisted Mobile Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: ptyId })
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    electronMocks.BrowserWindow.fromId.mockReturnValue({
+      isDestroyed: () => false,
+      webContents: { send: vi.fn() }
+    })
+    runtime.attachWindow(1)
+    const rendererSnapshot = {
+      worktree: TEST_WORKTREE_ID,
+      publicationEpoch: 'renderer-graph',
+      snapshotVersion: 1,
+      activeGroupId: 'group-1',
+      activeTabId: `host-tab::${rendererLeafId}`,
+      activeTabType: 'terminal' as const,
+      tabGroups: [
+        {
+          id: 'group-1',
+          activeTabId: 'host-tab',
+          tabOrder: ['host-tab']
+        }
+      ],
+      tabs: [
+        {
+          type: 'terminal' as const,
+          id: `host-tab::${rendererLeafId}`,
+          parentTabId: 'host-tab',
+          leafId: rendererLeafId,
+          ptyId,
+          title: 'Persisted Mobile Terminal',
+          isActive: true
+        }
+      ]
+    }
+
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [], mobileSessionTabs: [rendererSnapshot] })
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [], mobileSessionTabs: [rendererSnapshot] })
+
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const terminalTabs = listed.tabs.filter((tab) => tab.type === 'terminal')
+
+    expect(listed.tabs).toHaveLength(1)
+    expect(terminalTabs).toHaveLength(1)
+    expect(terminalTabs[0]).toMatchObject({
+      type: 'terminal',
+      id: `host-tab::${rendererLeafId}`,
+      parentTabId: 'host-tab',
+      leafId: rendererLeafId,
+      ptyId
+    })
+  })
+
+  it('keeps distinct split mobile terminal ptys under the same parent tab', async () => {
+    const rendererLeftLeafId = '33333333-3333-4333-8333-333333333333'
+    const rendererRightLeafId = '44444444-4444-4444-8444-444444444444'
+    const leftPtyId = 'serve-left'
+    const rightPtyId = 'serve-right'
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: leftPtyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Persisted Split Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({
+            [HEADLESS_LEAF_ID]: leftPtyId,
+            [HEADLESS_SECOND_LEAF_ID]: rightPtyId
+          })
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    electronMocks.BrowserWindow.fromId.mockReturnValue({
+      isDestroyed: () => false,
+      webContents: { send: vi.fn() }
+    })
+    runtime.attachWindow(1)
+    const rendererSnapshot = {
+      worktree: TEST_WORKTREE_ID,
+      publicationEpoch: 'renderer-split-graph',
+      snapshotVersion: 1,
+      activeGroupId: 'group-1',
+      activeTabId: `host-tab::${rendererLeftLeafId}`,
+      activeTabType: 'terminal' as const,
+      tabGroups: [
+        {
+          id: 'group-1',
+          activeTabId: 'host-tab',
+          tabOrder: ['host-tab']
+        }
+      ],
+      tabs: [
+        {
+          type: 'terminal' as const,
+          id: `host-tab::${rendererLeftLeafId}`,
+          parentTabId: 'host-tab',
+          leafId: rendererLeftLeafId,
+          ptyId: leftPtyId,
+          title: 'Left',
+          isActive: true
+        },
+        {
+          type: 'terminal' as const,
+          id: `host-tab::${rendererRightLeafId}`,
+          parentTabId: 'host-tab',
+          leafId: rendererRightLeafId,
+          ptyId: rightPtyId,
+          title: 'Right',
+          isActive: false
+        }
+      ]
+    }
+
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [], mobileSessionTabs: [rendererSnapshot] })
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [], mobileSessionTabs: [rendererSnapshot] })
+
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const terminalTabs = listed.tabs.filter((tab) => tab.type === 'terminal')
+
+    expect(listed.tabs).toHaveLength(2)
+    expect(terminalTabs).toHaveLength(2)
+    expect(terminalTabs.map((tab) => tab.ptyId).sort()).toEqual([leftPtyId, rightPtyId])
+    expect(terminalTabs.map((tab) => tab.leafId).sort()).toEqual(
+      [rendererLeftLeafId, rendererRightLeafId].sort()
+    )
+  })
+
   it('hydrates legacy persisted terminal tabs without layout entries', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3075,7 +3075,13 @@ export class OrcaRuntimeService {
     if (tab.type === 'terminal') {
       // Why: split terminal leaves share one parent tab; merge dedup must stay
       // leaf-scoped or preserved siblings collapse into a single surface.
-      return [tab.id, `${tab.parentTabId}::${tab.leafId}`]
+      const keys = [tab.id, `${tab.parentTabId}::${tab.leafId}`]
+      if (typeof tab.ptyId === 'string' && tab.ptyId.length > 0) {
+        // Why: renderer and headless sources can derive different leafIds for the same
+        // terminal; real PTYs collapse those duplicates without merging pending splits.
+        keys.push(`${tab.parentTabId}::pty:${tab.ptyId}`)
+      }
+      return keys
     }
     if (tab.type === 'browser') {
       return [tab.id, tab.browserWorkspaceId]


### PR DESCRIPTION
## What changes

On mobile, the worktree/session screen tab strip rendered **duplicate copies of the same terminal** — e.g. "Claude Code" appeared twice — and the header tab count was inflated to match. This change makes the strip show **exactly one entry per terminal surface**, so the count and the strip agree.

**What does not change:** genuine terminal splits (multiple panes in one tab, each backed by its own PTY) still show one entry per pane, and a terminal that has not yet been materialized (no PTY yet) is unaffected. This is a server-side de-duplication fix; the renderer/mobile UI code is unchanged.

## Design approach

The runtime builds the mobile session tab snapshot from **two sources** and merges them: the renderer graph (`buildMobileSessionTabSnapshots`) and the headless workspace-session hydrate (`hydrateHeadlessMobileSessionTabsFromWorkspaceSession`). Each terminal surface is de-duplicated by an identity keyed on `parentTabId + leafId` (`getMobileSessionSnapshotTabIdentityKeys`), used by both the merge dedup (`mergeMobileSessionSnapshotTabs`) and the preserve filter (`collectPreservedHeadlessMobileSessionTabs`).

The two sources can derive **different leafIds for the same terminal** (a live/persisted UUID leaf from the renderer vs. a `ptyIdsByLeafId`/synthetic leaf from the headless path). When they diverge, the leaf-only identity failed to collapse the two entries, so both survived the merge → the terminal rendered twice and the count was inflated. Both entries always reference the **same underlying PTY**.

The fix adds a pty-scoped identity key, `${parentTabId}::pty:${ptyId}`, guarded on a real (non-empty) PTY id, alongside the existing leaf-based keys. Within one parent tab a PTY backs exactly one surface, so two entries sharing `(parentTabId, ptyId)` are the same terminal and collapse — even when their leafId was derived differently. The change is purely additive (the leaf key is preserved) and mirrors the existing `browserWorkspaceId` secondary-key pattern already in the same function.

The kept entry is the live renderer entry (merge order puts renderer tabs first), which is the one activation resolves against.

## Design-review outcome

Ran an automated design-review loop (parallel reviewers, 2 rounds) before implementation: **clean, no P0/P1**. Reviewers confirmed the minimal additive approach over the heavier alternatives (forcing both sources to derive identical leafIds, or a canonical pty→surface-id registry) — the leaf-derivation is load-bearing for activation/pane-keys/serve-owned reattach and is risky to change, so the dedup is the correct low-risk seam. The reviewed doc clarified the corrupt-state invariant (two leaves under one parent sharing one PTY is invalid state and is intentionally collapsed) and hardened the test plan.

## Implementation & deviations

One additive block in `getMobileSessionSnapshotTabIdentityKeys` (`src/main/runtime/orca-runtime.ts`) plus two regression tests in `orca-runtime.test.ts`. No deviations from the reviewed design. A future follow-up to unify the dual-source leaf-keyed identity into one canonical owner is explicitly deferred and out of scope here.

## Completeness verification

A read-only verification pass confirmed **COMPLETE**: the fix is additive and guarded; it lands in the single identity function feeding both the merge dedup and the preserve filter (no bypassing code path); no other leafId-only terminal de-dup path exists; and all edge cases (splits, pending terminals, synthetic-leaf legacy fallback, cross-tab PTY reuse scoped out by `parentTabId`, browser/markdown/file untouched) are handled by the code.

## Headline behavior status

**Implemented.** The duplicate-collapsing logic runs in production runtime code on the live `session.tabs` RPC path the mobile strip consumes. The regression tests provably fail when the fix is reverted and pass with it, exercising the real serve-owned merge seam — this is not fixture-only or scaffolding behavior. The two residual non-collapse cases (a stale/expired PTY that differs from the renderer's, and the brief pre-PTY pending window) are pre-existing and explicitly out of scope — no regression.

## Performance

Perf audit: **perf-neutral, no action**. The change is `O(1)` per terminal tab — one extra string concat, one array push, and one Set membership op, only when a PTY is present. De-dup stays linear in (#tabs × #keys) with #keys for terminals going from 2 to at most 3 (a small constant factor, not a complexity change). It runs on the graph-sync publication path (which can fire on background agent-title ticks), but adds no allocation in a nested loop and net **reduces** emitted tabs by collapsing duplicates. No cache, render-churn, polling, subprocess, startup, or leak impact.

## Code-review loop

Ran the two-at-a-time `review-code` loop: **2 rounds, both reviewers clean in each round, zero actionable findings, no fixes needed.** Reviewers independently verified key-space disjointness (validated UUID / sha256-hex leafIds can never start with the literal `pty:`, so the leaf key and pty key occupy disjoint spaces), parent-scoping against cross-tab PTY reuse, and that the regression tests are genuine mutation-killers.

## Validation (`brennan-test-changes`)

Verdict: **land**.

- Static/focused: `typecheck:node` ✅, `oxlint` on both changed files ✅, `git diff --check` ✅, `vitest run src/main/runtime/orca-runtime.test.ts` → **494/494** ✅.
- Launched Electron from this worktree (identity verified: branch `brennanb2025/fix-mobile-duplicate-tabs`, this worktree root); clean boot, no console errors related to mobile session tabs / graph sync.
- **Headline behavior proven end-to-end at the runtime-RPC level** — the exact deduper the mobile strip consumes. Seeded the bug condition (headless snapshot leaf A + renderer snapshot same PTY, leaf B) and called `session.tabs.list` → collapses to **1** tab with header count 1, surviving leaf is the renderer's. Negative control: a real distinct-PTY split correctly stays at **2** (no over-merge). A live 2-terminal worktree ("Terminal 1" + "Claude Code") returns exactly 2 tabs with header count 2.

**Accepted gap:** the mobile-emulator UI *pixel* rendering of the (confirmed-correct) RPC payload was not visually driven — advancing the iOS simulator past its dev-client confirmation required a tap mechanism that would have targeted a different running Orca instance, so it was not exercised to avoid disrupting concurrent work. The data layer that produced the bug is server-side only and is proven fixed; the unverified piece is purely on-device rendering of already-correct data.

## Static checks & tests run

`pnpm run typecheck:node`, `pnpm exec oxlint <changed files>`, `git diff --check`, `pnpm vitest run src/main/runtime/orca-runtime.test.ts` (494/494). Confirmed both new regression tests fail without the fix and pass with it.

## SSH / cross-platform

No platform-specific code; pure in-memory data-identity logic in the runtime. Serve-owned (local serve) and `ssh:<conn>@@<relay>` PTYs flow through the same snapshot merge, and the PTY-scoped key is transport-agnostic — the serve-owned reattach test path is in the regression set, so SSH-paired clients benefit identically.

## Risks / assumptions

Low risk: single additive identity key, no migration, no flag; revert is a one-line removal. Assumes a PTY backs exactly one surface within a parent tab (enforced by `ptyIdsByLeafId` being a leaf→pty map); two leaves under one parent sharing a PTY is invalid state and is intentionally collapsed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
