### PR TITLE
fix: restore right-click "Mark Unread" in compact worktree cards

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1907,7 +1907,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
       ) : (
         <WorktreeContextMenu
           worktree={worktree}
-          newCardStyle={newCardStyle}
           selectedWorktrees={selectedWorktrees}
           onContextMenuSelect={handleContextMenuSelect}
         >

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -7,7 +7,6 @@ import {
   shouldRemoveProjectFromContextMenu,
   shouldSuppressContextMenuFollowUpClick,
   shouldContinueDeleteSiblingPositionRestore,
-  shouldShowReadToggleContextMenuItem,
   getWorktreeParentPickerAnchor,
   getWorktreeParentPickerLabel,
   isWorktreeParentPickerDisabled
@@ -96,16 +95,6 @@ describe('shouldSuppressContextMenuFollowUpClick', () => {
 
   it('does not suppress clicks that predate the context menu timestamp', () => {
     expect(shouldSuppressContextMenuFollowUpClick(1_000, 999)).toBe(false)
-  })
-})
-
-describe('shouldShowReadToggleContextMenuItem', () => {
-  it('keeps the read toggle in legacy card menus', () => {
-    expect(shouldShowReadToggleContextMenuItem({ newCardStyle: false })).toBe(true)
-  })
-
-  it('hides the read toggle in experimental card menus', () => {
-    expect(shouldShowReadToggleContextMenuItem({ newCardStyle: true })).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -58,7 +58,6 @@ type Props = {
   worktree: Worktree
   children: React.ReactNode
   contentClassName?: string
-  newCardStyle?: boolean
   selectedWorktrees?: readonly Worktree[]
   onContextMenuSelect?: (event: React.MouseEvent<HTMLElement>) => readonly Worktree[]
   onOpenChange?: (open: boolean) => void
@@ -123,10 +122,6 @@ function isWorktreeParentPickerDisabled(args: {
   eligibleParentCount: number
 }): boolean {
   return args.isDeleting || args.eligibleParentCount === 0
-}
-
-function shouldShowReadToggleContextMenuItem(args: { newCardStyle: boolean }): boolean {
-  return !args.newCardStyle
 }
 
 function getWorktreeParentPickerAnchor(
@@ -249,7 +244,6 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   worktree,
   children,
   contentClassName,
-  newCardStyle = false,
   selectedWorktrees,
   onContextMenuSelect,
   onOpenChange
@@ -351,7 +345,6 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     (item) =>
       worktreeLineageById[item.id] || workspaceLineageByChildKey[worktreeWorkspaceKey(item.id)]
   )
-  const showReadToggle = shouldShowReadToggleContextMenuItem({ newCardStyle })
   const eligibleParentCount = useMemo(
     () =>
       getEligibleWorktreeParents({
@@ -713,24 +706,19 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                   ? translate('auto.components.sidebar.WorktreeContextMenu.697d0f6e1b', 'Unpin')
                   : translate('auto.components.sidebar.WorktreeContextMenu.3baa7d6507', 'Pin')}
               </DropdownMenuItem>
-              {showReadToggle && (
-                <DropdownMenuItem onSelect={handleToggleRead} disabled={isDeleting}>
-                  {worktree.isUnread ? (
-                    <BellOff className="size-3.5" />
-                  ) : (
-                    <Bell className="size-3.5" />
-                  )}
-                  {worktree.isUnread
-                    ? translate(
-                        'auto.components.sidebar.WorktreeContextMenu.8dacff1fe0',
-                        'Mark Read'
-                      )
-                    : translate(
-                        'auto.components.sidebar.WorktreeContextMenu.f50603c6b2',
-                        'Mark Unread'
-                      )}
-                </DropdownMenuItem>
-              )}
+              <DropdownMenuItem onSelect={handleToggleRead} disabled={isDeleting}>
+                {worktree.isUnread ? (
+                  <BellOff className="size-3.5" />
+                ) : (
+                  <Bell className="size-3.5" />
+                )}
+                {worktree.isUnread
+                  ? translate('auto.components.sidebar.WorktreeContextMenu.8dacff1fe0', 'Mark Read')
+                  : translate(
+                      'auto.components.sidebar.WorktreeContextMenu.f50603c6b2',
+                      'Mark Unread'
+                    )}
+              </DropdownMenuItem>
               {repo ? (
                 <>
                   <DropdownMenuSeparator />
@@ -922,7 +910,6 @@ export {
   getWorktreeParentPickerLabel,
   isWorktreeParentPickerDisabled,
   shouldRemoveProjectFromContextMenu,
-  shouldShowReadToggleContextMenuItem,
   shouldUseNativeContextMenu,
   shouldSuppressContextMenuFollowUpClick,
   shouldIgnoreNestedWorktreeContextMenuScope


### PR DESCRIPTION
## Problem

In the new compact worktree card layout (`experimentalNewWorktreeCardStyle`), the right-click **Mark Unread / Mark Read** action disappeared from the worktree card context menu.

The regression came from #5889, which added a `newCardStyle` gate:

```ts
function shouldShowReadToggleContextMenuItem(args: { newCardStyle: boolean }): boolean {
  return !args.newCardStyle
}
```

The intent was that the compact layout's left status lane would own unread *emphasis*. But that lane only *displays* unread state — its bell was simultaneously made display-only (`unreadActionEnabled = showUnreadAction && !newCardStyle` in `WorktreeCardStatusSlot.tsx`). The net effect: in the compact layout there was **no way at all** to toggle unread.

## Fix

Drop the `newCardStyle` gate so the right-click "Mark Unread / Mark Read" item is always present in the worktree card context menu, regardless of layout. This restores the legacy behavior for compact cards without touching the status-lane display.

- Remove `shouldShowReadToggleContextMenuItem` and the `newCardStyle` prop from `WorktreeContextMenu` (it existed solely for this gate).
- Stop passing `newCardStyle` into the menu from `WorktreeCard`.
- Update tests accordingly.

## Verification

- `WorktreeContextMenu`, `WorktreeCard.quick-actions`, `WorktreeCard.compact-hover` tests pass (69 tests).
- Typecheck (`tc.web`) + oxlint + react-doctor + oxfmt clean.
- Ran the dev build with the new card style enabled, right-clicked a compact card → "Mark Unread" is present, and clicking it set `isUnread: true` on the worktree (verified through the real UI surface). Screenshot attached in a PR comment.

Made with [Orca](https://github.com/stablyai/orca) 🐋
