### PR TITLE
Fix packaged CLI module type detection

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -1,4 +1,4 @@
-const { chmodSync, existsSync, readdirSync } = require('node:fs')
+const { chmodSync, existsSync, readdirSync, writeFileSync } = require('node:fs')
 const { execFileSync } = require('node:child_process')
 const { join, resolve } = require('node:path')
 const electronBuilderNativeRebuild = require('./scripts/electron-builder-native-rebuild.cjs')
@@ -126,6 +126,7 @@ module.exports = {
     }
     prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName)
     verifyPackagedMainRuntimeDeps(resourcesDir)
+    writePackagedCliCommonjsPackage(resourcesDir)
     chmodUnixCliLaunchers(resourcesDir, context.electronPlatformName)
     chmodMacServeSimHelpers(resourcesDir, context.electronPlatformName)
     for (const filename of readdirSync(resourcesDir)) {
@@ -326,6 +327,20 @@ module.exports = {
     repo: 'orca',
     releaseType: 'release'
   }
+}
+
+function writePackagedCliCommonjsPackage(resourcesDir) {
+  const cliDir = join(resourcesDir, 'app.asar.unpacked', 'out', 'cli')
+  if (!existsSync(cliDir)) {
+    return
+  }
+  // Why: Node resolves the CLI's module type from ancestor package.json files;
+  // a local boundary keeps user directories from making the CJS CLI run as ESM.
+  writeFileSync(
+    join(cliDir, 'package.json'),
+    `${JSON.stringify({ name: 'orca-cli', type: 'commonjs', private: true }, null, 2)}\n`,
+    'utf8'
+  )
 }
 
 function chmodUnixCliLaunchers(resourcesDir, electronPlatformName) {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -104,6 +104,35 @@ describe('electron-builder config', () => {
   it('uses Orca native rebuild hook instead of electron-builder default rebuild', () => {
     expect(electronBuilderConfig.beforeBuild).toBe(electronBuilderNativeRebuild)
     expect(electronBuilderConfig.npmRebuild).toBe(true)
+  })
+
+  it('writes a CommonJS package boundary beside the unpacked CLI entry', async () => {
+    const appOutDir = await mkdtemp(join(tmpdir(), 'orca-cli-commonjs-boundary-'))
+    try {
+      const cliDir = join(appOutDir, 'resources', 'app.asar.unpacked', 'out', 'cli')
+      await mkdir(cliDir, { recursive: true })
+      await writeFile(
+        join(cliDir, 'index.js'),
+        'Object.defineProperty(exports, "__esModule", { value: true })\n',
+        'utf8'
+      )
+
+      await electronBuilderConfig.afterPack({
+        appOutDir,
+        electronPlatformName: 'win32',
+        packager: { appInfo: { productFilename: 'Orca' } }
+      })
+
+      await expect(
+        readFile(join(cliDir, 'package.json'), 'utf8').then(JSON.parse)
+      ).resolves.toEqual({
+        name: 'orca-cli',
+        type: 'commonjs',
+        private: true
+      })
+    } finally {
+      await rm(appOutDir, { recursive: true, force: true })
+    }
   })
 
   it('verifies packaged main runtime deps from Windows-style asar entries', async () => {


### PR DESCRIPTION
## Summary

- Writes a local `package.json` beside the unpacked CLI during `afterPack` so Electron-run-as-Node treats the packaged CLI as CommonJS.
- Adds a regression test that exercises the Windows resources layout and verifies the package boundary is emitted.

Fixes #6620.

## Screenshots

No visual change.

## Testing

- `./node_modules/.bin/vitest run --config config/vitest.config.ts config/scripts/electron-builder-config.test.mjs src/main/cli/packaged-cli-assets.test.ts`
- `./node_modules/.bin/oxlint config/electron-builder.config.cjs config/scripts/electron-builder-config.test.mjs`
- `git diff --check HEAD`

## AI Review Report

- Cross-platform check: the fix targets packaged Windows CLI startup while using `path.join` so the after-pack resource path remains platform-safe.
- Regression check: the test creates the packaged `resources/app.asar.unpacked/out/cli` layout and asserts the generated CommonJS package boundary.
- Scope check: no runtime CLI behavior changes were introduced beyond the packaged module-type boundary.

## Security Audit

- No new IPC, network, credential, or user-input handling was added.
- The generated package metadata is static and private to the packaged CLI directory.
- The change reduces accidental influence from unrelated ancestor `package.json` files during CLI startup.

## Notes

- This avoids renaming the compiled CLI entrypoint and keeps the existing Windows launcher path unchanged.