### PR TITLE
Keep custom and prefilled workspace names as user-authored

### DIFF
--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   canResolveFolderSmartGitHubSubmit,
+  getInitialAutoManagedWorkspaceName,
+  isExplicitWorkspaceNameInput,
   resolveInitialWorkspaceRunSeed
 } from './useComposerState'
 
@@ -17,6 +19,47 @@ function sourceBetween(source: string, startPattern: string, endPattern: string)
 }
 
 describe('useComposerState host-context boundaries', () => {
+  it('treats typed workspace names as user-authored, not auto-managed', () => {
+    expect(isExplicitWorkspaceNameInput({ name: 'keep-my-name', lastAutoName: '' })).toBe(true)
+    expect(
+      isExplicitWorkspaceNameInput({
+        name: 'keep-my-name',
+        lastAutoName: 'keep-my-name'
+      })
+    ).toBe(false)
+    expect(isExplicitWorkspaceNameInput({ name: '#1234', lastAutoName: '' })).toBe(false)
+    expect(
+      isExplicitWorkspaceNameInput({
+        name: 'https://github.com/stablyai/orca/pull/1234',
+        lastAutoName: ''
+      })
+    ).toBe(false)
+  })
+
+  it('does not auto-own arbitrary prefilled names', () => {
+    expect(
+      getInitialAutoManagedWorkspaceName({
+        initialName: 'keep-my-name',
+        initialLinkedWorkItem: null
+      })
+    ).toBe('')
+  })
+
+  it('auto-owns linked-item generated prefilled names', () => {
+    expect(
+      getInitialAutoManagedWorkspaceName({
+        initialName: 'fix-workspace-name',
+        initialLinkedWorkItem: {
+          type: 'issue',
+          provider: 'github',
+          number: 1234,
+          title: 'Fix workspace name',
+          url: 'https://github.com/stablyai/orca/issues/1234'
+        }
+      })
+    ).toBe('fix-workspace-name')
+  })
+
   it('resolves GitHub PR bases against the selected run repo, not the source item repo', () => {
     const section = sourceBetween(
       HOOK_SOURCE,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -416,6 +416,42 @@ export function resolveInitialWorkspaceRunSeed({
   }
 }
 
+export function isExplicitWorkspaceNameInput({
+  name,
+  lastAutoName
+}: {
+  name: string
+  lastAutoName: string
+}): boolean {
+  // Why: a user-authored name must win over linked-item and first-message AI naming.
+  return Boolean(name.trim()) && name !== lastAutoName && !isWorkItemLookupText(name)
+}
+
+function getLinkedWorkItemSeedName(item: LinkedWorkItemSummary | null | undefined): string {
+  if (!item) {
+    return ''
+  }
+  return getLinkedWorkItemWorkspaceName(item)?.seedName ?? getLinkedWorkItemSuggestedName(item)
+}
+
+export function getInitialAutoManagedWorkspaceName({
+  draftName,
+  draftLinkedWorkItem,
+  initialName,
+  initialLinkedWorkItem
+}: {
+  draftName?: string | null
+  draftLinkedWorkItem?: LinkedWorkItemSummary | null
+  initialName: string
+  initialLinkedWorkItem?: LinkedWorkItemSummary | null
+}): string {
+  // Why: command-palette prefilled names are user input unless they exactly
+  // match the linked item seed Orca generated for a source selection.
+  const candidateName = draftName ?? initialName
+  const seedName = getLinkedWorkItemSeedName(draftLinkedWorkItem ?? initialLinkedWorkItem)
+  return candidateName && seedName && candidateName === seedName ? candidateName : ''
+}
+
 // Why: both the full-page TaskPage composer and the Cmd+J modal can be
 // mounted simultaneously. Without instance scoping, a single native file
 // drop fires every subscriber and duplicates attachments/prompt edits across
@@ -972,7 +1008,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const [linkDirectLoading, setLinkDirectLoading] = useState(false)
 
   const lastAutoNameRef = useRef<string>(
-    persistDraft ? (newWorkspaceDraft?.name ?? initialName) : initialName
+    getInitialAutoManagedWorkspaceName({
+      draftName: persistDraft ? newWorkspaceDraft?.name : null,
+      draftLinkedWorkItem: persistDraft ? newWorkspaceDraft?.linkedWorkItem : null,
+      initialName,
+      initialLinkedWorkItem
+    })
   )
   const nameRef = useRef<string>(name)
   nameRef.current = name
@@ -3067,8 +3108,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       const submitTitleName = submitLinkedWorkItem
         ? getLinkedWorkItemWorkspaceName(submitLinkedWorkItem)
         : null
-      const nameIsAutoManaged =
-        !name.trim() || name === lastAutoNameRef.current || isWorkItemLookupText(name)
+      const nameIsAutoManaged = !isExplicitWorkspaceNameInput({
+        name,
+        lastAutoName: lastAutoNameRef.current
+      })
       const workspaceName =
         smartGitHubResolution.kind === 'none'
           ? nameIsAutoManaged && submitTitleName
@@ -3472,8 +3515,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         const submitTitleName = submitLinkedWorkItem
           ? getLinkedWorkItemWorkspaceName(submitLinkedWorkItem)
           : null
-        const nameIsAutoManaged =
-          !name.trim() || name === lastAutoNameRef.current || isWorkItemLookupText(name)
+        const nameIsAutoManaged = !isExplicitWorkspaceNameInput({
+          name,
+          lastAutoName: lastAutoNameRef.current
+        })
         const workspaceName =
           smartGitHubResolution.kind === 'none'
             ? nameIsAutoManaged && submitTitleName


### PR DESCRIPTION
## Summary

Ensure that user-customized and prefilled workspace names are treated as user-authored rather than auto-managed, preventing them from being overwritten during submission or resolution.

- Introduces `isExplicitWorkspaceNameInput` to determine if a workspace name was explicitly entered by the user.
- Introduces `getInitialAutoManagedWorkspaceName` to identify whether prefilled workspace names match auto-generated seed names.
- Updates `useComposerState` to leverage these helpers to manage the `lastAutoNameRef` and check if workspace names are auto-managed.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added unit tests in `src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts` covering:
- Treating typed workspace names as user-authored, not auto-managed.
- Ensuring arbitrary prefilled names are not auto-owned.
- Ensuring linked-item generated prefilled names are auto-owned.

## AI Review Report

Reviewed state management and helper functions for workspace naming logic. Checked logic for boundary conditions around linked work items and empty/whitespace names. Cross-platform path or shell logic was not touched as this runs entirely in the React/renderer context.

## Security Audit

Basic audit completed. The changes strictly handle React hook state and local string manipulation. No command execution, IPC communication, custom HTML rendering, or external input handling occurs.

## Notes

No platform-specific risks identified; behavior is consistent across macOS, Linux, and Windows.