### PR TITLE
fix: center Monaco find widget expand/collapse toggle chevron

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1814,10 +1814,15 @@
   transition: none !important;
 }
 
-/* Specifically for the expand/collapse button icon which is often a nested 'i' or '::before' */
-.monaco-editor .find-widget .button.expand {
-  width: 16px !important;
-  height: 16px !important;
+/* Why: the expand/collapse toggle (the chevron on the far left) is positioned
+   absolutely and relies on Monaco's default height:100% to vertically center
+   its icon over the find row. The generic .button override above forces a fixed
+   20px height, which pins the chevron to the top. Restore Monaco's full-height
+   18px toggle so the chevron centers like the stock find widget. */
+.monaco-editor .find-widget .button.toggle {
+  width: 18px !important;
+  height: 100% !important;
+  top: 0 !important;
 }
 
 .monaco-editor .find-widget .button > .codicon,


### PR DESCRIPTION
## Summary

The expand/collapse toggle (the chevron `>` on the far left of the editor's
Find widget, Ctrl/Cmd+F) was not vertically centered — it rode high against the
top of the find row instead of sitting centered like the stock Monaco / VS Code
find widget.

Root cause was in Orca's find-widget overrides in
`src/renderer/src/assets/main.css`:

- The generic `.monaco-editor .find-widget .button` rule forced
  `height: 20px !important`, which overrode Monaco's default `height: 100%` on
  the toggle button. Because the toggle is `position: absolute; top: 0`, a fixed
  20px height pinned the chevron to the top of the ~33px row.
- The rule meant to handle this (`.button.expand`) targeted a class that does
  not exist — Monaco renders the toggle as `button codicon toggle left`, so the
  override was dead code and never applied.

The fix replaces the dead `.button.expand` rule with a `.button.toggle` rule
that restores Monaco's defaults (`width: 18px`, `height: 100%`, `top: 0`). The
chevron is then centered by the `align-items/justify-content: center` already
applied by the generic button rule — matching the stock find widget.

## Screenshots

**Before:** chevron sits high / not vertically centered.
<img width="623" height="78" alt="image" src="https://github.com/user-attachments/assets/44a590f6-7265-4587-a364-aee142833509" />
<img width="114" height="76" alt="image" src="https://github.com/user-attachments/assets/3349acfb-162d-4d47-9db7-12590829b8de" />



**After:** chevron centered to match the default Monaco find widget.
<img width="621" height="78" alt="image" src="https://github.com/user-attachments/assets/7c711d59-25dc-4d3e-8ca6-3cf1d95355d9" />
<img width="624" height="101" alt="image" src="https://github.com/user-attachments/assets/a5d90534-ddfe-4514-85fd-1f89b2581be2" />


## Testing

> CSS-only visual fix; behavior is unchanged. Verified against the bundled
> Monaco source (`node_modules/monaco-editor/.../findWidget.{css,js}`) to confirm
> the toggle's real class (`.button.toggle`) and its default `height: 100%`
> centering. <!-- TODO: confirm which checks you ran -->

## AI Review Report

Reviewed with an AI coding agent. Scope is a single CSS rule in
`src/renderer/src/assets/main.css`.

- **Cross-platform (macOS/Linux/Windows):** No platform-specific code, shortcuts,
  labels, paths, or shell behavior touched. Monaco renders the find widget
  identically across platforms; the rule only adjusts CSS sizing/positioning.
- **SSH/remote/local:** Pure renderer styling, no process/file/network/credential
  assumptions; behaves identically regardless of where the workspace lives.
- **Agent/integration/git-provider:** Not applicable — no agent, integration, or
  provider logic involved.
- **Performance:** Negligible — one additional static CSS rule; no new selectors
  in hot paths or runtime work.
- **UI quality:** Restores parity with the stock Monaco/VS Code find widget;
  centering holds in both find-only and find+replace modes. Should be checked in
  both light and dark themes.
- **Result:** No issues flagged; `git diff` confirms the change is limited to the
  single intended hunk.

## Security Audit

No security-relevant surface touched. No input handling, command execution, path
handling, auth, secrets, dependency changes, or IPC involved — the change is a
single presentational CSS rule. No follow-up needed.