### PR TITLE
fix(terminal): keep post-spawn reconcile alive through locks

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2156,6 +2156,55 @@ describe('connectPanePty', () => {
     expect(pane.container.dataset.ptyId).toBeUndefined()
   })
 
+  it('continues post-spawn size reconcile after a transient mobile presence lock', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    const runNextFrame = (): void => {
+      const callback = frameCallbacks.shift()
+      if (!callback) {
+        throw new Error('expected a queued animation frame')
+      }
+      callback(0)
+    }
+
+    const { connectPanePty } = await import('./pty-connection')
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+
+    const ptyId = 'pty-post-spawn-transient-lock'
+    setDriverForPty(ptyId, { kind: 'mobile', clientId: 'phone-1' })
+    try {
+      const transport = createMockTransport(ptyId)
+      transportFactoryQueue.push(transport)
+      mockStoreState = {
+        ...mockStoreState,
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+        ptyIdsByTabId: { 'tab-1': [] }
+      }
+      const pane = createPane(1)
+      pane.terminal.cols = 80
+      pane.terminal.rows = 24
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      runNextFrame()
+      await flushAsyncTicks()
+
+      pane.terminal.cols = 120
+      pane.terminal.rows = 40
+      runNextFrame()
+      expect(transport.resize).not.toHaveBeenCalled()
+
+      setDriverForPty(ptyId, { kind: 'idle' })
+      runNextFrame()
+
+      expect(transport.resize).toHaveBeenCalledWith(120, 40)
+    } finally {
+      setDriverForPty(ptyId, { kind: 'idle' })
+    }
+  })
+
   it('does not reuse a sibling split pane pending spawn after remount', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2201,26 +2201,26 @@ export function connectPanePty(
     // ResizeObserver stability loop. Each resize is gated on an actual change,
     // so a TUI sees at most a couple of SIGWINCH during startup, not a loop.
     const MAX_RECONCILE_FRAMES = 12
+    let frame = 0
     let lastSentCols = spawnCols
     let lastSentRows = spawnRows
-    let frame = 0
     const tick = (): void => {
       if (disposed || transport.getPtyId() !== ptyId) {
         return
       }
-      // Mobile legitimately parks the PTY at phone dims; never fight that.
-      if (getFitOverrideForPty(ptyId) || isPtyLocked(ptyId)) {
-        return
-      }
-      safeFit(pane)
-      const cols = pane.terminal.cols
-      const rows = pane.terminal.rows
-      if (cols > 0 && rows > 0 && (cols !== lastSentCols || rows !== lastSentRows)) {
-        // Initial spawn-time sync is authoritative, so it bypasses the
-        // visibility gate that onResize honors (but not the mobile guards above).
-        transport.resize(cols, rows)
-        lastSentCols = cols
-        lastSentRows = rows
+      // Mobile legitimately parks the PTY at phone dims; a transient guard
+      // should only skip this frame, not cancel the reconcile window.
+      if (!getFitOverrideForPty(ptyId) && !isPtyLocked(ptyId)) {
+        safeFit(pane)
+        const cols = pane.terminal.cols
+        const rows = pane.terminal.rows
+        if (cols > 0 && rows > 0 && (cols !== lastSentCols || rows !== lastSentRows)) {
+          // Initial spawn-time sync is authoritative, so it bypasses the
+          // visibility gate that onResize honors (but not the mobile guards above).
+          transport.resize(cols, rows)
+          lastSentCols = cols
+          lastSentRows = rows
+        }
       }
       frame += 1
       if (frame < MAX_RECONCILE_FRAMES) {


### PR DESCRIPTION
## Summary
- keep post-spawn PTY size reconcile polling alive when a transient mobile presence lock or PTY lock skips a frame
- add a regression test that clears a mobile presence lock before the reconcile window ends

Follow-up to #6649.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts