### PR TITLE
Support SSH workspaces for AI Vault session resume and restrict runtime hosts

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -35,7 +35,6 @@ import {
   type AiVaultSession,
   type AiVaultSort
 } from '../../../../shared/ai-vault-types'
-import { getLocalExecutionHostLabel } from '../../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
 import { AiVaultPanelHeader } from './AiVaultPanelHeader'
 import { AiVaultSessionVirtualList } from './AiVaultSessionVirtualList'
@@ -61,9 +60,9 @@ export default function AiVaultPanel(): React.JSX.Element {
   const userChangedScopeRef = useRef(false)
   const preferredScopeRef = useRef<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
 
-  const isNonLocalWorktree = useAppStore(
+  const isRuntimeWorktree = useAppStore(
     (state) =>
-      getAiVaultResumeWorkspaceTargetStatus(state, activeWorktree?.id ?? null) === 'non-local'
+      getAiVaultResumeWorkspaceTargetStatus(state, activeWorktree?.id ?? null) === 'runtime'
   )
   const activeWorktreePath = activeWorktree?.path ?? null
   // Why: AI Vault ownership is cwd-based, so we must consider live worktrees across all repos.
@@ -278,12 +277,11 @@ export default function AiVaultPanel(): React.JSX.Element {
         onRefresh={() => void refresh({ force: true })}
       />
 
-      {isNonLocalWorktree ? (
+      {isRuntimeWorktree ? (
         <div className="border-b border-sidebar-border px-3 py-2 text-[11px] leading-4 text-muted-foreground">
           {translate(
-            'auto.components.right.sidebar.AiVaultPanel.remoteBrowseLocalHistory',
-            'Non-local workspaces can browse local history. Resume actions run from {{value0}} workspaces.',
-            { value0: getLocalExecutionHostLabel() }
+            'auto.components.right.sidebar.AiVaultPanel.runtimeBrowseLocalHistory',
+            'Runtime-hosted workspaces can browse local history. Resume actions are available in local and SSH workspaces.'
           )}
         </div>
       ) : null}

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import {
   useActiveRepo,
   useActiveWorktree,
+  useActiveWorktreeId,
   useAllWorktrees,
   useProjectHostSetupProjection,
   useRepos
@@ -41,11 +43,20 @@ import { AiVaultSessionVirtualList } from './AiVaultSessionVirtualList'
 import { useAiVaultSessionRefresh } from './ai-vault-session-refresh'
 
 export default function AiVaultPanel(): React.JSX.Element {
+  const activeWorktreeId = useActiveWorktreeId()
   const activeWorktree = useActiveWorktree()
   const activeRepo = useActiveRepo()
   const repos = useRepos()
   const allWorktrees = useAllWorktrees()
   const projectHostSetupProjection = useProjectHostSetupProjection()
+  const resumeTargetState = useAppStore(
+    useShallow((state) => ({
+      folderWorkspaces: state.folderWorkspaces,
+      projectGroups: state.projectGroups,
+      repos: state.repos,
+      worktreesByRepo: state.worktreesByRepo
+    }))
+  )
   const settings = useAppStore((s) => s.settings)
   const agentCmdOverrides = settings?.agentCmdOverrides
   const { getOriginalPaneTarget, jumpToOriginalPane, jumpToWorktree } =
@@ -60,9 +71,11 @@ export default function AiVaultPanel(): React.JSX.Element {
   const userChangedScopeRef = useRef(false)
   const preferredScopeRef = useRef<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
 
-  const isRuntimeWorktree = useAppStore(
-    (state) =>
-      getAiVaultResumeWorkspaceTargetStatus(state, activeWorktree?.id ?? null) === 'runtime'
+  const isRuntimeWorktree = useMemo(
+    () =>
+      getAiVaultResumeWorkspaceTargetStatus(resumeTargetState, activeWorktreeId ?? null) ===
+      'runtime',
+    [activeWorktreeId, resumeTargetState]
   )
   const activeWorktreePath = activeWorktree?.path ?? null
   // Why: AI Vault ownership is cwd-based, so we must consider live worktrees across all repos.
@@ -109,12 +122,12 @@ export default function AiVaultPanel(): React.JSX.Element {
   const sessionWorktreeById = useAiVaultSessionWorktreeMap({
     sessions,
     worktrees: allWorktrees,
-    activeWorktreeId: activeWorktree?.id ?? null
+    activeWorktreeId: activeWorktreeId ?? activeWorktree?.id ?? null
   })
   const { buildResumeStartup, copyResumeCommand, handleResume } = useAiVaultSessionLaunchActions({
     activeWorktree: activeWorktree ?? null,
-    allWorktrees,
-    repos,
+    activeWorktreeId: activeWorktreeId ?? activeWorktree?.id ?? null,
+    targetState: resumeTargetState,
     agentCmdOverrides
   })
   const hasAllAgentsSelected = agents.length === AI_VAULT_AGENTS.length
@@ -198,22 +211,38 @@ export default function AiVaultPanel(): React.JSX.Element {
     (session: AiVaultSession) =>
       resolveAiVaultSessionResumeState({
         worktreeInfo: sessionWorktreeById.get(session.id) ?? null,
-        activeWorktreeId: activeWorktree?.id ?? null,
+        activeWorktreeId: activeWorktreeId ?? activeWorktree?.id ?? null,
         worktrees: allWorktrees,
-        repos
+        repos,
+        targetState: resumeTargetState
       }),
-    [activeWorktree?.id, allWorktrees, repos, sessionWorktreeById]
+    [
+      activeWorktree?.id,
+      activeWorktreeId,
+      allWorktrees,
+      repos,
+      resumeTargetState,
+      sessionWorktreeById
+    ]
   )
 
   const getSessionResumeActions = useCallback(
     (session: AiVaultSession) =>
       resolveAiVaultSessionResumeActions({
         worktreeInfo: sessionWorktreeById.get(session.id) ?? null,
-        activeWorktreeId: activeWorktree?.id ?? null,
+        activeWorktreeId: activeWorktreeId ?? activeWorktree?.id ?? null,
         worktrees: allWorktrees,
-        repos
+        repos,
+        targetState: resumeTargetState
       }),
-    [activeWorktree?.id, allWorktrees, repos, sessionWorktreeById]
+    [
+      activeWorktree?.id,
+      activeWorktreeId,
+      allWorktrees,
+      repos,
+      resumeTargetState,
+      sessionWorktreeById
+    ]
   )
 
   const setAgentEnabled = useCallback((agent: AiVaultAgent, enabled: boolean) => {

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -8,7 +8,10 @@ import {
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useAppStore } from '@/store'
-import { isNonLocalAiVaultResumeRepo } from '@/lib/ai-vault-resume-target'
+import {
+  getAiVaultResumeWorktreeTargetStatus,
+  isSupportedAiVaultResumeTargetStatus
+} from '@/lib/ai-vault-resume-target'
 import type { AiVaultAgent, AiVaultSession } from '../../../../shared/ai-vault-types'
 import type { Repo, Worktree } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
@@ -80,13 +83,22 @@ export function useAiVaultSessionLaunchActions({
         return
       }
 
-      const worktreeRepo = repos.find((repo) => repo.id === worktree.repoId)
-      if (isNonLocalAiVaultResumeRepo(worktreeRepo)) {
+      const targetStatus = getAiVaultResumeWorktreeTargetStatus({
+        worktreeId: worktree.id,
+        worktrees: allWorktrees,
+        repos
+      })
+      if (!isSupportedAiVaultResumeTargetStatus(targetStatus)) {
         toast.error(
-          translate(
-            'auto.components.right.sidebar.AiVaultPanel.localWorkspacesOnly',
-            'Resume from history is only available in local workspaces.'
-          )
+          targetStatus === 'runtime'
+            ? translate(
+                'auto.components.right.sidebar.AiVaultPanel.runtimeWorkspacesUnsupported',
+                'Resume from history is not available in runtime-hosted workspaces.'
+              )
+            : translate(
+                'auto.components.right.sidebar.AiVaultPanel.openSupportedWorkspace',
+                'Open a local or SSH workspace before resuming a session.'
+              )
         )
         return
       }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -6,26 +6,34 @@ import {
   type AiVaultResumeStartup
 } from '@/lib/ai-vault-resume-command'
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
-import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import {
+  activateAndRevealFolderWorkspace,
+  activateAndRevealWorktree
+} from '@/lib/worktree-activation'
 import { useAppStore } from '@/store'
 import {
-  getAiVaultResumeWorktreeTargetStatus,
+  getAiVaultResumeWorkspaceTargetStatus,
   isSupportedAiVaultResumeTargetStatus
 } from '@/lib/ai-vault-resume-target'
 import type { AiVaultAgent, AiVaultSession } from '../../../../shared/ai-vault-types'
-import type { Repo, Worktree } from '../../../../shared/types'
+import type { Worktree } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 import { agentLabel } from './ai-vault-session-filters'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import {
+  isKnownAiVaultResumeWorkspaceTarget,
+  type AiVaultSessionResumeTargetState
+} from './ai-vault-session-resume'
 
 export function useAiVaultSessionLaunchActions({
   activeWorktree,
-  allWorktrees,
-  repos,
+  activeWorktreeId,
+  targetState,
   agentCmdOverrides
 }: {
   activeWorktree: Worktree | null
-  allWorktrees: readonly Worktree[]
-  repos: readonly Repo[]
+  activeWorktreeId: string | null
+  targetState: AiVaultSessionResumeTargetState
   agentCmdOverrides?: Partial<Record<AiVaultAgent, string | null>>
 }): {
   buildResumeStartup: (session: AiVaultSession, worktreeId?: string | null) => AiVaultResumeStartup
@@ -36,22 +44,22 @@ export function useAiVaultSessionLaunchActions({
     (session: AiVaultSession, worktreeId?: string | null): string =>
       buildAiVaultResumeCommandForWorktree({
         state: useAppStore.getState(),
-        worktreeId: worktreeId ?? activeWorktree?.id ?? null,
+        worktreeId: worktreeId ?? activeWorktreeId ?? activeWorktree?.id ?? null,
         session,
         commandOverride: agentCmdOverrides?.[session.agent]
       }),
-    [activeWorktree?.id, agentCmdOverrides]
+    [activeWorktree?.id, activeWorktreeId, agentCmdOverrides]
   )
 
   const buildResumeStartup = useCallback(
     (session: AiVaultSession, worktreeId?: string | null) =>
       buildAiVaultResumeStartupForWorktree({
         state: useAppStore.getState(),
-        worktreeId: worktreeId ?? activeWorktree?.id ?? null,
+        worktreeId: worktreeId ?? activeWorktreeId ?? activeWorktree?.id ?? null,
         session,
         commandOverride: agentCmdOverrides?.[session.agent]
       }),
-    [activeWorktree?.id, agentCmdOverrides]
+    [activeWorktree?.id, activeWorktreeId, agentCmdOverrides]
   )
 
   const copyResumeCommand = useCallback(
@@ -69,11 +77,12 @@ export function useAiVaultSessionLaunchActions({
 
   const handleResume = useCallback(
     (session: AiVaultSession, targetWorktreeId?: string): void => {
-      const worktree =
-        (targetWorktreeId
-          ? allWorktrees.find((candidate) => candidate.id === targetWorktreeId)
-          : null) ?? activeWorktree
-      if (!worktree) {
+      const targetId = resolveAiVaultSessionLaunchTarget({
+        activeWorktreeId: activeWorktreeId ?? activeWorktree?.id ?? null,
+        targetWorktreeId,
+        targetState
+      })
+      if (targetId.status === 'missing') {
         toast.error(
           translate(
             'auto.components.right.sidebar.AiVaultPanel.openWorkspaceBeforeResuming',
@@ -83,14 +92,9 @@ export function useAiVaultSessionLaunchActions({
         return
       }
 
-      const targetStatus = getAiVaultResumeWorktreeTargetStatus({
-        worktreeId: worktree.id,
-        worktrees: allWorktrees,
-        repos
-      })
-      if (!isSupportedAiVaultResumeTargetStatus(targetStatus)) {
+      if (targetId.status === 'unsupported') {
         toast.error(
-          targetStatus === 'runtime'
+          targetId.targetStatus === 'runtime'
             ? translate(
                 'auto.components.right.sidebar.AiVaultPanel.runtimeWorkspacesUnsupported',
                 'Resume from history is not available in runtime-hosted workspaces.'
@@ -105,11 +109,11 @@ export function useAiVaultSessionLaunchActions({
 
       launchAiVaultSessionInNewTab({
         agent: session.agent,
-        worktreeId: worktree.id,
-        ...buildResumeStartup(session, worktree.id)
+        worktreeId: targetId.worktreeId,
+        ...buildResumeStartup(session, targetId.worktreeId)
       })
-      if (useAppStore.getState().activeWorktreeId !== worktree.id) {
-        activateAndRevealWorktree(worktree.id)
+      if (useAppStore.getState().activeWorktreeId !== targetId.worktreeId) {
+        activateAiVaultResumeWorkspace(targetId.worktreeId)
       }
       toast.success(
         translate(
@@ -119,8 +123,46 @@ export function useAiVaultSessionLaunchActions({
         )
       )
     },
-    [activeWorktree, allWorktrees, buildResumeStartup, repos]
+    [activeWorktree?.id, activeWorktreeId, buildResumeStartup, targetState]
   )
 
   return { buildResumeStartup, copyResumeCommand, handleResume }
+}
+
+export type AiVaultSessionLaunchTarget =
+  | { status: 'missing' }
+  | {
+      status: 'unsupported'
+      targetStatus: ReturnType<typeof getAiVaultResumeWorkspaceTargetStatus>
+    }
+  | { status: 'ready'; worktreeId: string }
+
+export function resolveAiVaultSessionLaunchTarget(args: {
+  activeWorktreeId: string | null
+  targetWorktreeId?: string
+  targetState: AiVaultSessionResumeTargetState
+}): AiVaultSessionLaunchTarget {
+  const targetWorktreeId = args.targetWorktreeId ?? args.activeWorktreeId
+  if (
+    !targetWorktreeId ||
+    !isKnownAiVaultResumeWorkspaceTarget(args.targetState, targetWorktreeId)
+  ) {
+    return { status: 'missing' }
+  }
+
+  const targetStatus = getAiVaultResumeWorkspaceTargetStatus(args.targetState, targetWorktreeId)
+  if (!isSupportedAiVaultResumeTargetStatus(targetStatus)) {
+    return { status: 'unsupported', targetStatus }
+  }
+
+  return { status: 'ready', worktreeId: targetWorktreeId }
+}
+
+function activateAiVaultResumeWorkspace(workspaceId: string): void {
+  const workspaceScope = parseWorkspaceKey(workspaceId)
+  if (workspaceScope?.type === 'folder') {
+    activateAndRevealFolderWorkspace(workspaceScope.folderWorkspaceId)
+    return
+  }
+  activateAndRevealWorktree(workspaceId)
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
@@ -86,7 +86,7 @@ describe('resolveAiVaultSessionResumeState', () => {
     })
   })
 
-  it('blocks remote targets and missing worktrees', () => {
+  it('blocks missing worktrees even when the repo is SSH-owned', () => {
     expect(
       resolveAiVaultSessionResumeState({
         worktreeInfo: makeWorktreeInfo('active'),
@@ -98,6 +98,36 @@ describe('resolveAiVaultSessionResumeState', () => {
       blocked: true,
       worktreeId: null,
       usesSessionWorktree: false
+    })
+  })
+
+  it('allows SSH-owned session worktrees', () => {
+    expect(
+      resolveAiVaultSessionResumeState({
+        worktreeInfo: makeWorktreeInfo('active'),
+        activeWorktreeId: null,
+        worktrees: [makeWorktree()],
+        repos: [makeRepo({ connectionId: 'ssh-1' })]
+      })
+    ).toEqual({
+      blocked: false,
+      worktreeId: 'repo-1::/repo/orca',
+      usesSessionWorktree: true
+    })
+  })
+
+  it('allows SSH-stamped worktrees even when the repo owner is runtime', () => {
+    expect(
+      resolveAiVaultSessionResumeState({
+        worktreeInfo: makeWorktreeInfo('active'),
+        activeWorktreeId: null,
+        worktrees: [makeWorktree({ hostId: 'ssh:ssh-1' })],
+        repos: [makeRepo({ connectionId: null, executionHostId: 'runtime:env-1' })]
+      })
+    ).toEqual({
+      blocked: false,
+      worktreeId: 'repo-1::/repo/orca',
+      usesSessionWorktree: true
     })
   })
 
@@ -121,7 +151,22 @@ describe('resolveAiVaultSessionResumeState', () => {
     })
   })
 
-  it('uses a local session worktree when the active workspace is remote', () => {
+  it('blocks runtime-stamped worktrees even when the repo owner is local', () => {
+    expect(
+      resolveAiVaultSessionResumeState({
+        worktreeInfo: makeWorktreeInfo('active'),
+        activeWorktreeId: null,
+        worktrees: [makeWorktree({ hostId: 'runtime:env-1' })],
+        repos: [makeRepo({ connectionId: null, executionHostId: 'local' })]
+      })
+    ).toEqual({
+      blocked: true,
+      worktreeId: null,
+      usesSessionWorktree: false
+    })
+  })
+
+  it('prefers the session worktree when the active workspace is SSH-owned', () => {
     expect(
       resolveAiVaultSessionResumeState({
         worktreeInfo: makeWorktreeInfo('active'),
@@ -192,7 +237,7 @@ describe('resolveAiVaultSessionResumeActions', () => {
     })
   })
 
-  it('disables only the remote active-workspace action when the session worktree is local', () => {
+  it('enables an SSH active-workspace action when the session worktree is local', () => {
     expect(
       resolveAiVaultSessionResumeActions({
         worktreeInfo: makeWorktreeInfo('active'),
@@ -209,7 +254,7 @@ describe('resolveAiVaultSessionResumeActions', () => {
       })
     ).toEqual({
       worktree: { worktreeId: 'repo-1::/repo/orca', disabled: false },
-      newTab: { worktreeId: 'repo-2::/remote/orca', disabled: true }
+      newTab: { worktreeId: 'repo-2::/remote/orca', disabled: false }
     })
   })
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { Repo, Worktree } from '../../../../shared/types'
 import type { AiVaultSessionWorktreeInfo } from './ai-vault-session-worktree'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import { resolveAiVaultSessionLaunchTarget } from './ai-vault-session-launch-actions'
 import {
   aiVaultSessionResumeLabel,
+  type AiVaultSessionResumeTargetState,
   resolveAiVaultSessionResumeActions,
   resolveAiVaultSessionResumeState
 } from './ai-vault-session-resume'
@@ -39,6 +42,57 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
     addedAt: 1,
     ...overrides
   }
+}
+
+function makeTargetState(
+  overrides: Partial<AiVaultSessionResumeTargetState> = {}
+): AiVaultSessionResumeTargetState {
+  return {
+    folderWorkspaces: [],
+    projectGroups: [],
+    repos: [],
+    worktreesByRepo: {},
+    ...overrides
+  } as AiVaultSessionResumeTargetState
+}
+
+function makeFolderTargetState(
+  projectGroup: Partial<AiVaultSessionResumeTargetState['projectGroups'][number]>
+): AiVaultSessionResumeTargetState {
+  return makeTargetState({
+    folderWorkspaces: [
+      {
+        id: 'folder-1',
+        projectGroupId: 'group-1',
+        name: 'Platform',
+        folderPath: '/repo/platform',
+        linkedTask: null,
+        comment: '',
+        isArchived: false,
+        isUnread: false,
+        isPinned: false,
+        sortOrder: 0,
+        lastActivityAt: 1,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ],
+    projectGroups: [
+      {
+        id: 'group-1',
+        name: 'Platform',
+        parentPath: null,
+        parentGroupId: null,
+        createdFrom: 'manual',
+        tabOrder: 0,
+        isCollapsed: false,
+        color: null,
+        createdAt: 1,
+        updatedAt: 1,
+        ...projectGroup
+      }
+    ]
+  })
 }
 
 function makeWorktreeInfo(
@@ -217,6 +271,38 @@ describe('resolveAiVaultSessionResumeState', () => {
       usesSessionWorktree: false
     })
   })
+
+  it('falls back to an active SSH folder workspace', () => {
+    expect(
+      resolveAiVaultSessionResumeState({
+        worktreeInfo: makeWorktreeInfo('archived'),
+        activeWorktreeId: folderWorkspaceKey('folder-1'),
+        worktrees: [],
+        repos: [],
+        targetState: makeFolderTargetState({ id: 'group-1', connectionId: 'ssh-1' })
+      })
+    ).toEqual({
+      blocked: false,
+      worktreeId: folderWorkspaceKey('folder-1'),
+      usesSessionWorktree: false
+    })
+  })
+
+  it('blocks an active runtime folder workspace', () => {
+    expect(
+      resolveAiVaultSessionResumeState({
+        worktreeInfo: makeWorktreeInfo('archived'),
+        activeWorktreeId: folderWorkspaceKey('folder-1'),
+        worktrees: [],
+        repos: [],
+        targetState: makeFolderTargetState({ id: 'group-1', executionHostId: 'runtime:env-1' })
+      })
+    ).toEqual({
+      blocked: true,
+      worktreeId: null,
+      usesSessionWorktree: false
+    })
+  })
 })
 
 describe('resolveAiVaultSessionResumeActions', () => {
@@ -298,6 +384,62 @@ describe('resolveAiVaultSessionResumeActions', () => {
     ).toEqual({
       worktree: { worktreeId: 'repo-1::/repo/orca', disabled: false },
       newTab: { worktreeId: null, disabled: true }
+    })
+  })
+
+  it('enables the active folder workspace action when it is local or SSH-owned', () => {
+    expect(
+      resolveAiVaultSessionResumeActions({
+        worktreeInfo: makeWorktreeInfo('archived'),
+        activeWorktreeId: folderWorkspaceKey('folder-1'),
+        worktrees: [],
+        repos: [],
+        targetState: makeFolderTargetState({ id: 'group-1', connectionId: 'ssh-1' })
+      })
+    ).toEqual({
+      worktree: { worktreeId: null, disabled: true },
+      newTab: { worktreeId: folderWorkspaceKey('folder-1'), disabled: false }
+    })
+  })
+
+  it('disables the active folder workspace action when it is runtime-owned', () => {
+    expect(
+      resolveAiVaultSessionResumeActions({
+        worktreeInfo: makeWorktreeInfo('archived'),
+        activeWorktreeId: folderWorkspaceKey('folder-1'),
+        worktrees: [],
+        repos: [],
+        targetState: makeFolderTargetState({ id: 'group-1', executionHostId: 'runtime:env-1' })
+      })
+    ).toEqual({
+      worktree: { worktreeId: null, disabled: true },
+      newTab: { worktreeId: folderWorkspaceKey('folder-1'), disabled: true }
+    })
+  })
+})
+
+describe('resolveAiVaultSessionLaunchTarget', () => {
+  it('allows direct resume into an active SSH folder workspace', () => {
+    expect(
+      resolveAiVaultSessionLaunchTarget({
+        activeWorktreeId: folderWorkspaceKey('folder-1'),
+        targetState: makeFolderTargetState({ id: 'group-1', connectionId: 'ssh-1' })
+      })
+    ).toEqual({
+      status: 'ready',
+      worktreeId: folderWorkspaceKey('folder-1')
+    })
+  })
+
+  it('blocks direct resume into a runtime folder workspace', () => {
+    expect(
+      resolveAiVaultSessionLaunchTarget({
+        activeWorktreeId: folderWorkspaceKey('folder-1'),
+        targetState: makeFolderTargetState({ id: 'group-1', executionHostId: 'runtime:env-1' })
+      })
+    ).toEqual({
+      status: 'unsupported',
+      targetStatus: 'runtime'
     })
   })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
@@ -1,5 +1,8 @@
 import type { Repo, Worktree } from '../../../../shared/types'
-import { isLocalAiVaultResumeRepo } from '@/lib/ai-vault-resume-target'
+import {
+  getAiVaultResumeWorktreeTargetStatus,
+  isSupportedAiVaultResumeTargetStatus
+} from '@/lib/ai-vault-resume-target'
 import { translate } from '@/i18n/i18n'
 import {
   canJumpToAiVaultSessionWorktree,
@@ -45,8 +48,12 @@ export function resolveAiVaultSessionResumeState(args: {
     if (!worktree) {
       continue
     }
-    const repo = args.repos.find((candidate) => candidate.id === worktree.repoId)
-    if (!isLocalAiVaultResumeRepo(repo)) {
+    const targetStatus = getAiVaultResumeWorktreeTargetStatus({
+      worktreeId,
+      worktrees: args.worktrees,
+      repos: args.repos
+    })
+    if (!isSupportedAiVaultResumeTargetStatus(targetStatus)) {
       continue
     }
     return {
@@ -74,12 +81,12 @@ export function resolveAiVaultSessionResumeActions(args: {
       ? args.worktreeInfo.worktreeId
       : null
 
-  const sessionTargetId = resolveLocalResumeWorktreeId({
+  const sessionTargetId = resolveSupportedResumeWorktreeId({
     worktreeId: sessionWorktreeId,
     worktrees: args.worktrees,
     repos: args.repos
   })
-  const activeTargetId = resolveLocalResumeWorktreeId({
+  const activeTargetId = resolveSupportedResumeWorktreeId({
     worktreeId:
       args.activeWorktreeId && args.activeWorktreeId !== sessionWorktreeId
         ? args.activeWorktreeId
@@ -103,7 +110,7 @@ export function resolveAiVaultSessionResumeActions(args: {
   }
 }
 
-function resolveLocalResumeWorktreeId(args: {
+function resolveSupportedResumeWorktreeId(args: {
   worktreeId: string | null
   worktrees: readonly Worktree[]
   repos: readonly Repo[]
@@ -117,8 +124,12 @@ function resolveLocalResumeWorktreeId(args: {
     return null
   }
 
-  const repo = args.repos.find((candidate) => candidate.id === worktree.repoId)
-  if (!isLocalAiVaultResumeRepo(repo)) {
+  const targetStatus = getAiVaultResumeWorktreeTargetStatus({
+    worktreeId: args.worktreeId,
+    worktrees: args.worktrees,
+    repos: args.repos
+  })
+  if (!isSupportedAiVaultResumeTargetStatus(targetStatus)) {
     return null
   }
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
@@ -1,13 +1,20 @@
 import type { Repo, Worktree } from '../../../../shared/types'
 import {
-  getAiVaultResumeWorktreeTargetStatus,
+  getAiVaultResumeWorkspaceTargetStatus,
   isSupportedAiVaultResumeTargetStatus
 } from '@/lib/ai-vault-resume-target'
+import type { AppState } from '@/store/types'
 import { translate } from '@/i18n/i18n'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
   canJumpToAiVaultSessionWorktree,
   type AiVaultSessionWorktreeInfo
 } from './ai-vault-session-worktree'
+
+export type AiVaultSessionResumeTargetState = Pick<
+  AppState,
+  'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'
+>
 
 export type AiVaultSessionResumeState = {
   blocked: boolean
@@ -30,6 +37,7 @@ export function resolveAiVaultSessionResumeState(args: {
   activeWorktreeId: string | null
   worktrees: readonly Worktree[]
   repos: readonly Repo[]
+  targetState?: AiVaultSessionResumeTargetState
 }): AiVaultSessionResumeState {
   const sessionWorktreeId =
     canJumpToAiVaultSessionWorktree(args.worktreeInfo) && args.worktreeInfo?.worktreeId
@@ -42,18 +50,14 @@ export function resolveAiVaultSessionResumeState(args: {
       ? args.activeWorktreeId
       : null
   ].filter((value): value is string => Boolean(value))
+  const targetState = resolveAiVaultResumeTargetState(args)
 
   for (const worktreeId of candidateWorktreeIds) {
-    const worktree = args.worktrees.find((candidate) => candidate.id === worktreeId)
-    if (!worktree) {
-      continue
-    }
-    const targetStatus = getAiVaultResumeWorktreeTargetStatus({
+    const targetId = resolveSupportedResumeWorktreeId({
       worktreeId,
-      worktrees: args.worktrees,
-      repos: args.repos
+      targetState
     })
-    if (!isSupportedAiVaultResumeTargetStatus(targetStatus)) {
+    if (!targetId) {
       continue
     }
     return {
@@ -75,24 +79,24 @@ export function resolveAiVaultSessionResumeActions(args: {
   activeWorktreeId: string | null
   worktrees: readonly Worktree[]
   repos: readonly Repo[]
+  targetState?: AiVaultSessionResumeTargetState
 }): AiVaultSessionResumeActions {
   const sessionWorktreeId =
     canJumpToAiVaultSessionWorktree(args.worktreeInfo) && args.worktreeInfo?.worktreeId
       ? args.worktreeInfo.worktreeId
       : null
+  const targetState = resolveAiVaultResumeTargetState(args)
 
   const sessionTargetId = resolveSupportedResumeWorktreeId({
     worktreeId: sessionWorktreeId,
-    worktrees: args.worktrees,
-    repos: args.repos
+    targetState
   })
   const activeTargetId = resolveSupportedResumeWorktreeId({
     worktreeId:
       args.activeWorktreeId && args.activeWorktreeId !== sessionWorktreeId
         ? args.activeWorktreeId
         : null,
-    worktrees: args.worktrees,
-    repos: args.repos
+    targetState
   })
 
   return {
@@ -110,30 +114,65 @@ export function resolveAiVaultSessionResumeActions(args: {
   }
 }
 
+export function isKnownAiVaultResumeWorkspaceTarget(
+  state: AiVaultSessionResumeTargetState,
+  workspaceId: string | null
+): boolean {
+  if (!workspaceId) {
+    return false
+  }
+
+  const workspaceKey = parseWorkspaceKey(workspaceId)
+  if (workspaceKey?.type === 'folder') {
+    return state.folderWorkspaces.some(
+      (workspace) => workspace.id === workspaceKey.folderWorkspaceId
+    )
+  }
+
+  const worktreeId = workspaceKey?.type === 'worktree' ? workspaceKey.worktreeId : workspaceId
+  return Object.values(state.worktreesByRepo).some((worktrees) =>
+    worktrees.some((worktree) => worktree.id === worktreeId)
+  )
+}
+
 function resolveSupportedResumeWorktreeId(args: {
   worktreeId: string | null
-  worktrees: readonly Worktree[]
-  repos: readonly Repo[]
+  targetState: AiVaultSessionResumeTargetState
 }): string | null {
   if (!args.worktreeId) {
     return null
   }
 
-  const worktree = args.worktrees.find((candidate) => candidate.id === args.worktreeId)
-  if (!worktree) {
+  if (!isKnownAiVaultResumeWorkspaceTarget(args.targetState, args.worktreeId)) {
     return null
   }
 
-  const targetStatus = getAiVaultResumeWorktreeTargetStatus({
-    worktreeId: args.worktreeId,
-    worktrees: args.worktrees,
-    repos: args.repos
-  })
+  const targetStatus = getAiVaultResumeWorkspaceTargetStatus(args.targetState, args.worktreeId)
   if (!isSupportedAiVaultResumeTargetStatus(targetStatus)) {
     return null
   }
 
   return args.worktreeId
+}
+
+function resolveAiVaultResumeTargetState(args: {
+  worktrees: readonly Worktree[]
+  repos: readonly Repo[]
+  targetState?: AiVaultSessionResumeTargetState
+}): AiVaultSessionResumeTargetState {
+  if (args.targetState) {
+    return args.targetState
+  }
+  const worktreesByRepo: AiVaultSessionResumeTargetState['worktreesByRepo'] = {}
+  for (const worktree of args.worktrees) {
+    worktreesByRepo[worktree.repoId] = [...(worktreesByRepo[worktree.repoId] ?? []), worktree]
+  }
+  return {
+    folderWorkspaces: [],
+    projectGroups: [],
+    repos: [...args.repos],
+    worktreesByRepo
+  }
 }
 
 export function aiVaultSessionResumeLabel(

--- a/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
@@ -167,11 +167,11 @@ export default function AiVaultSessionDropLayer({
       }
 
       const targetStatus = getAiVaultResumeWorkspaceTargetStatus(useAppStore.getState(), worktreeId)
-      if (targetStatus === 'non-local') {
+      if (targetStatus === 'runtime') {
         toast.error(
           translate(
-            'auto.components.tab.group.AiVaultSessionDropLayer.localWorkspacesOnly',
-            'Resume from history is only available in local workspaces.'
+            'auto.components.tab.group.AiVaultSessionDropLayer.runtimeWorkspacesUnsupported',
+            'Resume from history is not available in runtime-hosted workspaces.'
           )
         )
         return true
@@ -179,8 +179,8 @@ export default function AiVaultSessionDropLayer({
       if (targetStatus === 'unknown') {
         toast.error(
           translate(
-            'auto.components.tab.group.AiVaultSessionDropLayer.openLocalWorkspace',
-            'Open a local workspace before resuming a session.'
+            'auto.components.tab.group.AiVaultSessionDropLayer.openSupportedWorkspace',
+            'Open a local or SSH workspace before resuming a session.'
           )
         )
         return true

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2496,7 +2496,9 @@
             "couldNotReadPayload": "Could not read the session drag payload.",
             "localWorkspacesOnly": "Resume from history is only available in local workspaces.",
             "openLocalWorkspace": "Open a local workspace before resuming a session.",
-            "sessionQueued": "Session queued"
+            "sessionQueued": "Session queued",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "TabGroupDropOverlay": {
             "paneColumnLabel": "New split"
@@ -9207,7 +9209,10 @@
             "sessionId": "Session ID",
             "logPath": "Log path",
             "originalPaneUnavailable": "Original pane is no longer available.",
-            "worktreeUnavailable": "Worktree is no longer available."
+            "worktreeUnavailable": "Worktree is no longer available.",
+            "runtimeBrowseLocalHistory": "Runtime-hosted workspaces can browse local history. Resume actions are available in local and SSH workspaces.",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "AiVaultPanelControls": {
             "scanningSessions": "Scanning sessions",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2496,7 +2496,9 @@
             "couldNotReadPayload": "No se pudo leer la carga arrastrada de la sesión.",
             "localWorkspacesOnly": "Reanudar desde el historial solo está disponible en espacios de trabajo locales.",
             "openLocalWorkspace": "Abre un espacio de trabajo local antes de reanudar una sesión.",
-            "sessionQueued": "Sesión en cola"
+            "sessionQueued": "Sesión en cola",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "TabGroupDropOverlay": {
             "paneColumnLabel": "Nueva división"
@@ -9207,7 +9209,10 @@
             "agents": "Agentes",
             "sessionsShownCompact": "{{value0}} mostradas",
             "originalPaneUnavailable": "Original pane is no longer available.",
-            "worktreeUnavailable": "Worktree is no longer available."
+            "worktreeUnavailable": "Worktree is no longer available.",
+            "runtimeBrowseLocalHistory": "Runtime-hosted workspaces can browse local history. Resume actions are available in local and SSH workspaces.",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "AiVaultPanelControls": {
             "scanningSessions": "Scanning sessions",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2496,7 +2496,9 @@
             "couldNotReadPayload": "セッションのドラッグデータを読み取れませんでした。",
             "localWorkspacesOnly": "履歴からの再開はローカルワークスペースでのみ利用できます。",
             "openLocalWorkspace": "セッションを再開する前にローカルワークスペースを開いてください。",
-            "sessionQueued": "セッションをキューに追加しました"
+            "sessionQueued": "セッションをキューに追加しました",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "TabGroupDropOverlay": {
             "paneColumnLabel": "新しい分割"
@@ -9207,7 +9209,10 @@
             "agents": "エージェント",
             "sessionsShownCompact": "{{value0}} 件表示",
             "originalPaneUnavailable": "元のペインは利用できなくなりました。",
-            "worktreeUnavailable": "ワークツリーは利用できなくなりました。"
+            "worktreeUnavailable": "ワークツリーは利用できなくなりました。",
+            "runtimeBrowseLocalHistory": "Runtime-hosted workspaces can browse local history. Resume actions are available in local and SSH workspaces.",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "AiVaultPanelControls": {
             "scanningSessions": "Scanning sessions",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2496,7 +2496,9 @@
             "couldNotReadPayload": "세션 드래그 데이터를 읽을 수 없습니다.",
             "localWorkspacesOnly": "기록에서 재개하기는 로컬 워크스페이스에서만 사용할 수 있습니다.",
             "openLocalWorkspace": "세션을 재개하기 전에 로컬 워크스페이스를 여세요.",
-            "sessionQueued": "세션이 대기열에 추가됨"
+            "sessionQueued": "세션이 대기열에 추가됨",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "TabGroupDropOverlay": {
             "paneColumnLabel": "새 분할"
@@ -9207,7 +9209,10 @@
             "agents": "에이전트",
             "sessionsShownCompact": "{{value0}} 표시됨",
             "originalPaneUnavailable": "원래 창은 더 이상 사용할 수 없습니다.",
-            "worktreeUnavailable": "워크트리는 더 이상 사용할 수 없습니다."
+            "worktreeUnavailable": "워크트리는 더 이상 사용할 수 없습니다.",
+            "runtimeBrowseLocalHistory": "Runtime-hosted workspaces can browse local history. Resume actions are available in local and SSH workspaces.",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "AiVaultPanelControls": {
             "scanningSessions": "세션 스캔 중",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2496,7 +2496,9 @@
             "couldNotReadPayload": "无法读取会话拖拽数据。",
             "localWorkspacesOnly": "从历史恢复仅支持本地工作区。",
             "openLocalWorkspace": "恢复会话前请先打开一个本地工作区。",
-            "sessionQueued": "会话已排队"
+            "sessionQueued": "会话已排队",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "TabGroupDropOverlay": {
             "paneColumnLabel": "新建拆分"
@@ -9207,7 +9209,10 @@
             "agents": "智能体",
             "sessionsShownCompact": "已显示 {{value0}} 个",
             "originalPaneUnavailable": "Original pane is no longer available.",
-            "worktreeUnavailable": "Worktree is no longer available."
+            "worktreeUnavailable": "Worktree is no longer available.",
+            "runtimeBrowseLocalHistory": "Runtime-hosted workspaces can browse local history. Resume actions are available in local and SSH workspaces.",
+            "runtimeWorkspacesUnsupported": "Resume from history is not available in runtime-hosted workspaces.",
+            "openSupportedWorkspace": "Open a local or SSH workspace before resuming a session."
           },
           "AiVaultPanelControls": {
             "scanningSessions": "正在扫描会话",

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -12,16 +12,27 @@ vi.mock('@/lib/new-workspace', () => ({
 
 type RuntimePreference = { kind: 'windows-host' } | { kind: 'wsl'; distro: string }
 
+type AiVaultResumeCommandState = Pick<
+  AppState,
+  | 'activeRepoId'
+  | 'activeWorktreeId'
+  | 'folderWorkspaces'
+  | 'projectGroups'
+  | 'projects'
+  | 'repos'
+  | 'settings'
+  | 'worktreesByRepo'
+>
+
 function makeState(args: {
   worktreePath: string
   localWindowsRuntimePreference?: RuntimePreference
-}): Pick<
-  AppState,
-  'activeRepoId' | 'activeWorktreeId' | 'projects' | 'repos' | 'settings' | 'worktreesByRepo'
-> {
+}): AiVaultResumeCommandState {
   return {
     activeRepoId: 'repo-1',
     activeWorktreeId: 'repo-1::worktree-1',
+    folderWorkspaces: [],
+    projectGroups: [],
     repos: [{ id: 'repo-1', path: 'C:\\Users\\alice\\repo' }],
     projects: [
       {
@@ -46,10 +57,7 @@ function makeState(args: {
         }
       ]
     }
-  } as unknown as Pick<
-    AppState,
-    'activeRepoId' | 'activeWorktreeId' | 'projects' | 'repos' | 'settings' | 'worktreesByRepo'
-  >
+  } as unknown as AiVaultResumeCommandState
 }
 
 describe('ai vault resume command runtime', () => {
@@ -109,6 +117,25 @@ describe('ai vault resume command runtime', () => {
       worktreePath: 'C:\\Users\\alice\\repo',
       localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
     })
+
+    expect(getAiVaultResumePlatform(state, 'repo-1::worktree-1')).toBe('linux')
+    expect(
+      buildAiVaultResumeCommandForWorktree({
+        state,
+        worktreeId: 'repo-1::worktree-1',
+        session: {
+          agent: 'claude',
+          sessionId: 'session one',
+          cwd: '/home/alice/repo',
+          codexHome: null
+        }
+      })
+    ).toBe("cd '/home/alice/repo' && claude '--resume' 'session one'")
+  })
+
+  it('uses POSIX command wrapping for SSH-owned worktrees on Windows clients', () => {
+    const state = makeState({ worktreePath: '/home/alice/repo' })
+    state.repos = [{ id: 'repo-1', path: '/home/alice/repo', connectionId: 'ssh-1' }] as never
 
     expect(getAiVaultResumePlatform(state, 'repo-1::worktree-1')).toBe('linux')
     expect(

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -152,6 +152,63 @@ describe('ai vault resume command runtime', () => {
     ).toBe("cd '/home/alice/repo' && claude '--resume' 'session one'")
   })
 
+  it('uses POSIX command wrapping for folder workspaces with their own SSH target', () => {
+    const state = makeState({ worktreePath: 'C:\\Users\\alice\\repo' })
+    state.activeWorktreeId = 'folder:folder-1'
+    state.folderWorkspaces = [
+      {
+        id: 'folder-1',
+        projectGroupId: 'group-1',
+        name: 'Platform',
+        folderPath: '/home/alice/platform',
+        connectionId: 'folder-ssh'
+      }
+    ] as never
+    state.projectGroups = [{ id: 'group-1', connectionId: null, executionHostId: null }] as never
+
+    expect(getAiVaultResumePlatform(state, 'folder:folder-1')).toBe('linux')
+    expect(
+      buildAiVaultResumeCommandForWorktree({
+        state,
+        worktreeId: 'folder:folder-1',
+        session: {
+          agent: 'claude',
+          sessionId: 'session one',
+          cwd: '/home/alice/platform',
+          codexHome: null
+        }
+      })
+    ).toBe("cd '/home/alice/platform' && claude '--resume' 'session one'")
+  })
+
+  it('uses POSIX command wrapping for WSL UNC folder workspaces on Windows clients', () => {
+    const state = makeState({ worktreePath: 'C:\\Users\\alice\\repo' })
+    state.activeWorktreeId = 'folder:folder-1'
+    state.folderWorkspaces = [
+      {
+        id: 'folder-1',
+        projectGroupId: 'group-1',
+        name: 'Platform',
+        folderPath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\platform'
+      }
+    ] as never
+    state.projectGroups = [{ id: 'group-1', connectionId: null, executionHostId: 'local' }] as never
+
+    expect(getAiVaultResumePlatform(state, 'folder:folder-1')).toBe('linux')
+    expect(
+      buildAiVaultResumeCommandForWorktree({
+        state,
+        worktreeId: 'folder:folder-1',
+        session: {
+          agent: 'claude',
+          sessionId: 'session one',
+          cwd: '/home/alice/platform',
+          codexHome: null
+        }
+      })
+    ).toBe("cd '/home/alice/platform' && claude '--resume' 'session one'")
+  })
+
   it('keeps WSL UNC worktrees on POSIX command wrapping without an explicit override', () => {
     const state = makeState({
       worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -16,6 +16,8 @@ import type { AppState } from '@/store/types'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { parseExecutionHostId } from '../../../shared/execution-host'
 
 type AiVaultResumeCommandSession = Pick<AiVaultSession, 'agent' | 'sessionId' | 'cwd' | 'codexHome'>
 
@@ -28,7 +30,14 @@ export type AiVaultResumeStartup = {
 export function buildAiVaultResumeCommandForWorktree(args: {
   state: Pick<
     AppState,
-    'activeRepoId' | 'activeWorktreeId' | 'projects' | 'repos' | 'settings' | 'worktreesByRepo'
+    | 'activeRepoId'
+    | 'activeWorktreeId'
+    | 'folderWorkspaces'
+    | 'projectGroups'
+    | 'projects'
+    | 'repos'
+    | 'settings'
+    | 'worktreesByRepo'
   >
   worktreeId?: string | null
   session: AiVaultResumeCommandSession
@@ -40,7 +49,14 @@ export function buildAiVaultResumeCommandForWorktree(args: {
 export function buildAiVaultResumeStartupForWorktree(args: {
   state: Pick<
     AppState,
-    'activeRepoId' | 'activeWorktreeId' | 'projects' | 'repos' | 'settings' | 'worktreesByRepo'
+    | 'activeRepoId'
+    | 'activeWorktreeId'
+    | 'folderWorkspaces'
+    | 'projectGroups'
+    | 'projects'
+    | 'repos'
+    | 'settings'
+    | 'worktreesByRepo'
   >
   worktreeId?: string | null
   session: AiVaultResumeCommandSession
@@ -107,10 +123,23 @@ function getAiVaultResumeCodexHome(
 export function getAiVaultResumePlatform(
   state: Pick<
     AppState,
-    'activeRepoId' | 'activeWorktreeId' | 'projects' | 'repos' | 'settings' | 'worktreesByRepo'
+    | 'activeRepoId'
+    | 'activeWorktreeId'
+    | 'folderWorkspaces'
+    | 'projectGroups'
+    | 'projects'
+    | 'repos'
+    | 'settings'
+    | 'worktreesByRepo'
   >,
   worktreeId?: string | null
 ): NodeJS.Platform {
+  const targetWorktreeId = worktreeId ?? state.activeWorktreeId
+  const executionHost = parseExecutionHostId(getExecutionHostIdForWorktree(state, targetWorktreeId))
+  if (executionHost?.kind === 'ssh' || executionHost?.kind === 'runtime') {
+    return 'linux'
+  }
+
   const projectRuntime = getLocalProjectExecutionRuntimeContext(state, worktreeId, CLIENT_PLATFORM)
   if (projectRuntime?.status === 'repair-required') {
     return projectRuntime.repair.preferredRuntime.kind === 'wsl' ? 'linux' : CLIENT_PLATFORM
@@ -119,7 +148,6 @@ export function getAiVaultResumePlatform(
     return 'linux'
   }
 
-  const targetWorktreeId = worktreeId ?? state.activeWorktreeId
   const worktree = targetWorktreeId
     ? Object.values(state.worktreesByRepo ?? {})
         .flat()

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -18,6 +18,7 @@ import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { parseExecutionHostId } from '../../../shared/execution-host'
+import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 
 type AiVaultResumeCommandSession = Pick<AiVaultSession, 'agent' | 'sessionId' | 'cwd' | 'codexHome'>
 
@@ -148,10 +149,29 @@ export function getAiVaultResumePlatform(
     return 'linux'
   }
 
-  const worktree = targetWorktreeId
-    ? Object.values(state.worktreesByRepo ?? {})
-        .flat()
-        .find((candidate) => candidate.id === targetWorktreeId)
-    : null
-  return worktree?.path && parseWslUncPath(worktree.path) ? 'linux' : CLIENT_PLATFORM
+  const workspacePath = getAiVaultResumeWorkspacePath(state, targetWorktreeId)
+  return workspacePath && parseWslUncPath(workspacePath) ? 'linux' : CLIENT_PLATFORM
+}
+
+function getAiVaultResumeWorkspacePath(
+  state: Pick<AppState, 'folderWorkspaces' | 'worktreesByRepo'>,
+  worktreeId: string | null | undefined
+): string | null {
+  if (!worktreeId) {
+    return null
+  }
+  const workspaceScope = parseWorkspaceKey(worktreeId)
+  if (workspaceScope?.type === 'folder') {
+    return (
+      state.folderWorkspaces.find((workspace) => workspace.id === workspaceScope.folderWorkspaceId)
+        ?.folderPath ?? null
+    )
+  }
+  const targetWorktreeId =
+    workspaceScope?.type === 'worktree' ? workspaceScope.worktreeId : worktreeId
+  return (
+    Object.values(state.worktreesByRepo ?? {})
+      .flat()
+      .find((candidate) => candidate.id === targetWorktreeId)?.path ?? null
+  )
 }

--- a/src/renderer/src/lib/ai-vault-resume-target.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-target.test.ts
@@ -4,8 +4,8 @@ import {
   getAiVaultResumeRepoTargetStatus,
   getAiVaultResumeWorktreeTargetStatus,
   getAiVaultResumeWorkspaceTargetStatus,
-  isLocalAiVaultResumeRepo,
-  isNonLocalAiVaultResumeRepo
+  isSupportedAiVaultResumeRepo,
+  isUnsupportedAiVaultResumeRepo
 } from './ai-vault-resume-target'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 
@@ -32,21 +32,26 @@ describe('ai vault resume target ownership', () => {
       'local'
     )
     expect(getAiVaultResumeRepoTargetStatus({ connectionId: 'ssh-1', executionHostId: null })).toBe(
-      'non-local'
+      'ssh'
     )
     expect(
       getAiVaultResumeRepoTargetStatus({
         connectionId: null,
         executionHostId: 'runtime:env-1'
       })
-    ).toBe('non-local')
+    ).toBe('runtime')
     expect(getAiVaultResumeRepoTargetStatus(null)).toBe('unknown')
   })
 
   it('exposes boolean predicates for resume gates', () => {
-    expect(isLocalAiVaultResumeRepo({ connectionId: null, executionHostId: 'local' })).toBe(true)
+    expect(isSupportedAiVaultResumeRepo({ connectionId: null, executionHostId: 'local' })).toBe(
+      true
+    )
+    expect(isSupportedAiVaultResumeRepo({ connectionId: 'ssh-1', executionHostId: null })).toBe(
+      true
+    )
     expect(
-      isNonLocalAiVaultResumeRepo({ connectionId: null, executionHostId: 'runtime:env-1' })
+      isUnsupportedAiVaultResumeRepo({ connectionId: null, executionHostId: 'runtime:env-1' })
     ).toBe(true)
   })
 
@@ -57,7 +62,17 @@ describe('ai vault resume target ownership', () => {
         worktrees: [{ id: 'repo-1::/repo/orca', repoId: 'repo-1' }],
         repos: [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-1' }]
       })
-    ).toBe('non-local')
+    ).toBe('runtime')
+  })
+
+  it('prefers explicit worktree host ownership over repo ownership', () => {
+    expect(
+      getAiVaultResumeWorktreeTargetStatus({
+        worktreeId: 'repo-1::/repo/orca',
+        worktrees: [{ id: 'repo-1::/repo/orca', repoId: 'repo-1', hostId: 'ssh:ssh-1' }],
+        repos: [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-1' }]
+      })
+    ).toBe('ssh')
   })
 
   it('uses the composite worktree repo id when worktree discovery is incomplete', () => {
@@ -68,7 +83,7 @@ describe('ai vault resume target ownership', () => {
         }),
         'repo-1::/repo/orca'
       )
-    ).toBe('non-local')
+    ).toBe('runtime')
   })
 
   it('resolves explicit workspace keys through the target worktree owner', () => {
@@ -82,7 +97,85 @@ describe('ai vault resume target ownership', () => {
         }),
         'worktree:repo-1::/repo/orca'
       )
-    ).toBe('non-local')
+    ).toBe('runtime')
+  })
+
+  it('resolves explicit workspace keys through the target worktree host', () => {
+    expect(
+      getAiVaultResumeWorkspaceTargetStatus(
+        makeState({
+          worktreesByRepo: {
+            'repo-1': [{ id: 'repo-1::/repo/orca', repoId: 'repo-1', hostId: 'runtime:env-1' }]
+          },
+          repos: [{ id: 'repo-1', connectionId: 'ssh-1', executionHostId: 'ssh:ssh-1' }]
+        }),
+        'worktree:repo-1::/repo/orca'
+      )
+    ).toBe('runtime')
+  })
+
+  it('supports folder workspaces owned by SSH project groups', () => {
+    expect(
+      getAiVaultResumeWorkspaceTargetStatus(
+        makeState({
+          folderWorkspaces: [
+            {
+              id: 'folder-1',
+              projectGroupId: 'group-1',
+              name: 'Platform',
+              folderPath: '/repo/platform'
+            }
+          ],
+          projectGroups: [{ id: 'group-1', connectionId: 'ssh-1' }]
+        }),
+        folderWorkspaceKey('folder-1')
+      )
+    ).toBe('ssh')
+  })
+
+  it('prefers runtime project-group ownership over stale SSH folder connection ids', () => {
+    expect(
+      getAiVaultResumeWorkspaceTargetStatus(
+        makeState({
+          folderWorkspaces: [
+            {
+              id: 'folder-1',
+              projectGroupId: 'group-1',
+              name: 'Platform',
+              folderPath: '/repo/platform',
+              connectionId: 'ssh-1'
+            }
+          ],
+          projectGroups: [
+            { id: 'group-1', connectionId: 'ssh-1', executionHostId: 'runtime:env-1' }
+          ]
+        }),
+        folderWorkspaceKey('folder-1')
+      )
+    ).toBe('runtime')
+  })
+
+  it('treats mixed local and SSH folder workspace targets as unknown', () => {
+    expect(
+      getAiVaultResumeWorkspaceTargetStatus(
+        makeState({
+          folderWorkspaces: [
+            {
+              id: 'folder-1',
+              projectGroupId: 'group-1',
+              name: 'Platform',
+              folderPath: '/repo/platform'
+            }
+          ],
+          projectGroups: [{ id: 'group-1' }],
+          repos: [
+            { id: 'repo-local', path: '/repo/platform/web', connectionId: null },
+            { id: 'repo-ssh', path: '/repo/platform/api', connectionId: 'ssh-1' }
+          ]
+        }),
+        folderWorkspaceKey('folder-1')
+      )
+    ).toBe('unknown')
   })
 
   it('blocks folder workspaces owned by runtime project groups', () => {
@@ -101,7 +194,7 @@ describe('ai vault resume target ownership', () => {
         }),
         folderWorkspaceKey('folder-1')
       )
-    ).toBe('non-local')
+    ).toBe('runtime')
   })
 
   it('blocks mixed local and runtime folder workspace targets', () => {
@@ -129,6 +222,6 @@ describe('ai vault resume target ownership', () => {
         }),
         folderWorkspaceKey('folder-1')
       )
-    ).toBe('non-local')
+    ).toBe('runtime')
   })
 })

--- a/src/renderer/src/lib/ai-vault-resume-target.ts
+++ b/src/renderer/src/lib/ai-vault-resume-target.ts
@@ -1,7 +1,9 @@
 import {
   getRepoExecutionHostId,
-  LOCAL_EXECUTION_HOST_ID,
-  normalizeExecutionHostId
+  normalizeExecutionHostId,
+  parseExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
 } from '../../../shared/execution-host'
 import type { Repo } from '../../../shared/types'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
@@ -9,7 +11,7 @@ import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import type { AppState } from '@/store/types'
 import { getFolderWorkspaceCandidateRepos } from './folder-workspace-connection'
 
-export type AiVaultResumeTargetStatus = 'local' | 'non-local' | 'unknown'
+export type AiVaultResumeTargetStatus = 'local' | 'ssh' | 'runtime' | 'unknown'
 
 type AiVaultResumeRepoOwner = Pick<Repo, 'connectionId' | 'executionHostId'>
 
@@ -19,26 +21,30 @@ export function getAiVaultResumeRepoTargetStatus(
   if (!repo) {
     return 'unknown'
   }
-  // Why: runtime-owned repos intentionally keep connectionId null, so resume
-  // availability must follow the execution owner instead of SSH state alone.
-  return repo.connectionId || getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID
-    ? 'non-local'
-    : 'local'
+  // Why: SSH and WSL targets use the normal PTY startup path. Runtime-owned
+  // repos intentionally keep connectionId null, so check the execution host.
+  return getAiVaultResumeExecutionHostTargetStatus(getRepoExecutionHostId(repo))
 }
 
-export function isLocalAiVaultResumeRepo(repo: AiVaultResumeRepoOwner | null | undefined): boolean {
-  return getAiVaultResumeRepoTargetStatus(repo) === 'local'
-}
-
-export function isNonLocalAiVaultResumeRepo(
+export function isSupportedAiVaultResumeRepo(
   repo: AiVaultResumeRepoOwner | null | undefined
 ): boolean {
-  return getAiVaultResumeRepoTargetStatus(repo) === 'non-local'
+  return isSupportedAiVaultResumeTargetStatus(getAiVaultResumeRepoTargetStatus(repo))
+}
+
+export function isSupportedAiVaultResumeTargetStatus(status: AiVaultResumeTargetStatus): boolean {
+  return status === 'local' || status === 'ssh'
+}
+
+export function isUnsupportedAiVaultResumeRepo(
+  repo: AiVaultResumeRepoOwner | null | undefined
+): boolean {
+  return getAiVaultResumeRepoTargetStatus(repo) === 'runtime'
 }
 
 export function getAiVaultResumeWorktreeTargetStatus(args: {
   worktreeId: string | null
-  worktrees: readonly { id: string; repoId: string }[]
+  worktrees: readonly { id: string; repoId: string; hostId?: ExecutionHostId }[]
   repos: readonly AiVaultResumeRepoOwnerWithId[]
 }): AiVaultResumeTargetStatus {
   if (!args.worktreeId) {
@@ -47,6 +53,10 @@ export function getAiVaultResumeWorktreeTargetStatus(args: {
   const worktree = args.worktrees.find((candidate) => candidate.id === args.worktreeId)
   if (!worktree) {
     return 'unknown'
+  }
+  const worktreeHost = getAiVaultResumeExecutionHostTargetStatus(worktree.hostId)
+  if (worktreeHost !== 'unknown') {
+    return worktreeHost
   }
   return getAiVaultResumeRepoTargetStatus(
     args.repos.find((candidate) => candidate.id === worktree.repoId)
@@ -70,6 +80,10 @@ export function getAiVaultResumeWorkspaceTargetStatus(
   const worktree = Object.values(state.worktreesByRepo ?? {})
     .flat()
     .find((candidate) => candidate.id === worktreeId)
+  const worktreeHost = getAiVaultResumeExecutionHostTargetStatus(worktree?.hostId)
+  if (worktreeHost !== 'unknown') {
+    return worktreeHost
+  }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
   return getAiVaultResumeRepoTargetStatus(state.repos.find((repo) => repo.id === repoId))
 }
@@ -87,28 +101,42 @@ function getAiVaultResumeFolderTargetStatus(
 
   const group = state.projectGroups.find((entry) => entry.id === workspace.projectGroupId)
   const groupHostId = normalizeExecutionHostId(group?.executionHostId)
-  if (
-    workspace.connectionId ||
-    group?.connectionId ||
-    (groupHostId && groupHostId !== LOCAL_EXECUTION_HOST_ID)
-  ) {
-    return 'non-local'
+  if (groupHostId) {
+    return getAiVaultResumeExecutionHostTargetStatus(groupHostId)
+  }
+  const explicitConnectionId = (workspace.connectionId ?? group?.connectionId ?? '').trim()
+  if (explicitConnectionId) {
+    return getAiVaultResumeExecutionHostTargetStatus(toSshExecutionHostId(explicitConnectionId))
   }
 
-  return mergeAiVaultResumeTargetStatuses(
-    getFolderWorkspaceCandidateRepos(state, folderWorkspaceId).map(getAiVaultResumeRepoTargetStatus)
+  return mergeAiVaultResumeExecutionHostTargetStatuses(
+    getFolderWorkspaceCandidateRepos(state, folderWorkspaceId).map(getRepoExecutionHostId)
   )
 }
 
-function mergeAiVaultResumeTargetStatuses(
-  statuses: readonly AiVaultResumeTargetStatus[]
+function getAiVaultResumeExecutionHostTargetStatus(
+  hostId: ExecutionHostId | null | undefined
 ): AiVaultResumeTargetStatus {
-  if (statuses.length === 0) {
+  const parsed = parseExecutionHostId(hostId)
+  if (!parsed) {
+    return 'unknown'
+  }
+  if (parsed.kind === 'local') {
     return 'local'
   }
-  const uniqueStatuses = new Set(statuses)
-  if (uniqueStatuses.size === 1) {
-    return statuses[0] ?? 'unknown'
+  return parsed.kind
+}
+
+function mergeAiVaultResumeExecutionHostTargetStatuses(
+  hostIds: readonly ExecutionHostId[]
+): AiVaultResumeTargetStatus {
+  if (hostIds.length === 0) {
+    return 'local'
   }
-  return uniqueStatuses.has('unknown') ? 'unknown' : 'non-local'
+  const statuses = hostIds.map(getAiVaultResumeExecutionHostTargetStatus)
+  const uniqueStatuses = new Set(statuses)
+  if (uniqueStatuses.has('runtime')) {
+    return 'runtime'
+  }
+  return new Set(hostIds).size === 1 ? (statuses[0] ?? 'unknown') : 'unknown'
 }

--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -60,6 +60,41 @@ describe('getSettingsForWorktreeRuntimeOwner', () => {
     })
     expect(getExecutionHostIdForWorktree(state, 'folder:local-folder')).toBe('local')
   })
+
+  it('keeps folder workspaces with their own SSH target off the focused runtime', () => {
+    const folderConnectionState: WorktreeRuntimeOwnerState = {
+      ...state,
+      projectGroups: [{ id: 'folder-group', connectionId: null, executionHostId: null }],
+      folderWorkspaces: [
+        { id: 'folder-ssh', projectGroupId: 'folder-group', connectionId: 'folder-remote' }
+      ]
+    }
+
+    expect(getSettingsForWorktreeRuntimeOwner(folderConnectionState, 'folder:folder-ssh')).toEqual({
+      activeRuntimeEnvironmentId: null
+    })
+    expect(getExecutionHostIdForWorktree(folderConnectionState, 'folder:folder-ssh')).toBe(
+      'ssh:folder-remote'
+    )
+  })
+
+  it('prefers project group runtime ownership over stale folder SSH targets', () => {
+    const staleFolderConnectionState: WorktreeRuntimeOwnerState = {
+      ...state,
+      folderWorkspaces: [
+        { id: 'runtime-folder', projectGroupId: 'runtime-group', connectionId: 'old-ssh' }
+      ]
+    }
+
+    expect(
+      getSettingsForWorktreeRuntimeOwner(staleFolderConnectionState, 'folder:runtime-folder')
+    ).toEqual({
+      activeRuntimeEnvironmentId: 'folder-env'
+    })
+    expect(getExecutionHostIdForWorktree(staleFolderConnectionState, 'folder:runtime-folder')).toBe(
+      'runtime:folder-env'
+    )
+  })
 })
 
 describe('getExplicitRuntimeEnvironmentIdForWorktree', () => {

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -1,4 +1,8 @@
-import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  parseExecutionHostId,
+  toSshExecutionHostId
+} from '../../../shared/execution-host'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import type {
   FolderWorkspace,
@@ -14,7 +18,7 @@ export type WorktreeRuntimeOwnerState = {
   repos?: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
   settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
   worktreesByRepo?: Record<string, readonly Pick<Worktree, 'id' | 'repoId' | 'hostId'>[]>
-  folderWorkspaces?: readonly Pick<FolderWorkspace, 'id' | 'projectGroupId'>[]
+  folderWorkspaces?: readonly Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'>[]
   projectGroups?: readonly Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>[]
 }
 
@@ -35,25 +39,36 @@ function findFolderProjectGroup(
   state: WorktreeRuntimeOwnerState,
   folderWorkspaceId: string
 ): Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'> | null {
-  const folderWorkspace = state.folderWorkspaces?.find(
-    (workspace) => workspace.id === folderWorkspaceId
-  )
+  const folderWorkspace = findFolderWorkspace(state, folderWorkspaceId)
   if (!folderWorkspace) {
     return null
   }
   return state.projectGroups?.find((group) => group.id === folderWorkspace.projectGroupId) ?? null
 }
 
+function findFolderWorkspace(
+  state: WorktreeRuntimeOwnerState,
+  folderWorkspaceId: string
+): Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'> | null {
+  return state.folderWorkspaces?.find((workspace) => workspace.id === folderWorkspaceId) ?? null
+}
+
 function getRuntimeEnvironmentIdForFolderWorkspace(
   state: WorktreeRuntimeOwnerState,
   folderWorkspaceId: string
 ): string | null {
+  const folderWorkspace = findFolderWorkspace(state, folderWorkspaceId)
   const projectGroup = findFolderProjectGroup(state, folderWorkspaceId)
   const parsed = parseExecutionHostId(projectGroup?.executionHostId)
   if (parsed?.kind === 'runtime') {
     return parsed.environmentId
   }
-  if (parsed?.kind === 'local' || parsed?.kind === 'ssh' || projectGroup?.connectionId) {
+  if (
+    parsed?.kind === 'local' ||
+    parsed?.kind === 'ssh' ||
+    folderWorkspace?.connectionId?.trim() ||
+    projectGroup?.connectionId?.trim()
+  ) {
     return null
   }
   return state.settings?.activeRuntimeEnvironmentId?.trim() || null
@@ -94,13 +109,15 @@ function getExecutionHostIdForFolderWorkspace(
   state: WorktreeRuntimeOwnerState,
   folderWorkspaceId: string
 ): ExecutionHostId {
+  const folderWorkspace = findFolderWorkspace(state, folderWorkspaceId)
   const projectGroup = findFolderProjectGroup(state, folderWorkspaceId)
   const parsed = parseExecutionHostId(projectGroup?.executionHostId)
   if (parsed) {
     return parsed.id
   }
-  if (projectGroup?.connectionId) {
-    return `ssh:${encodeURIComponent(projectGroup.connectionId)}`
+  const connectionId = folderWorkspace?.connectionId?.trim() || projectGroup?.connectionId?.trim()
+  if (connectionId) {
+    return toSshExecutionHostId(connectionId)
   }
   const environmentId = state.settings?.activeRuntimeEnvironmentId?.trim()
   return environmentId ? `runtime:${encodeURIComponent(environmentId)}` : 'local'


### PR DESCRIPTION
## Summary

This PR enables AI Vault session resume for supported SSH and local workspaces while keeping runtime-hosted or unknown targets blocked. It expands resume target classification from local/non-local to local/ssh/runtime/unknown so UI affordances can allow SSH safely and show runtime-specific copy.

It also fixes Windows-client resume command generation for remote targets: SSH-owned worktrees, folder workspaces with their own SSH connection, and WSL UNC folder/worktree paths now queue POSIX commands instead of Windows `cmd` wrappers.

Closes #6270.

## Details

- Allows drag/drop, row actions, menu actions, and direct click-to-resume for local and SSH targets.
- Blocks runtime-hosted and unknown targets consistently.
- Resolves active `folder:<id>` workspaces through workspace-aware target state instead of `useAllWorktrees`.
- Preserves project-group runtime ownership precedence over stale folder SSH connection IDs.
- Uses folder `connectionId` and `folderPath` when choosing resume command platform.

## Screenshots

- No visual change

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-runtime-owner.test.ts src/renderer/src/lib/ai-vault-resume-target.test.ts src/renderer/src/lib/ai-vault-resume-command.test.ts src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts`
- [x] `pnpm run typecheck:web`
- [x] changed-file `pnpm exec oxlint ...`
- [x] `pnpm run verify:localization-catalog && pnpm run verify:localization-coverage && git diff --check`

## Review

- Reviewed via Orca orchestration by another `gpt-5.5` worker at xhigh effort.
- First pass found folder workspace and folder command-platform gaps; both were fixed.
- Final pass reported no P0/P1/P2 findings.

Residual risk: live end-to-end terminal spawn behavior on real SSH/WSL folder workspaces still depends on environment availability, but the target resolution and command construction paths now have focused regression coverage.