### PR TITLE
Fix Windows history session resume launch quoting

### DIFF
--- a/src/renderer/src/lib/launch-ai-vault-session.test.ts
+++ b/src/renderer/src/lib/launch-ai-vault-session.test.ts
@@ -65,6 +65,7 @@ describe('launchAiVaultSessionInNewTab', () => {
     expect(mockCreateTab).toHaveBeenCalledWith('wt-1', 'group-1')
     expect(mockQueueTabStartupCommand).toHaveBeenCalledWith('tab-1', {
       command: 'claude --resume session-1',
+      delivery: 'terminal-paste',
       telemetry: {
         agent_kind: 'claude',
         launch_source: 'sidebar',
@@ -91,6 +92,7 @@ describe('launchAiVaultSessionInNewTab', () => {
 
     expect(mockQueueTabStartupCommand).toHaveBeenCalledWith('tab-1', {
       command: "claude '--dangerously-skip-permissions' '--effort' 'max' '--resume' 'session-1'",
+      delivery: 'terminal-paste',
       env: { ANTHROPIC_BASE_URL: 'https://claude.example.test' },
       launchConfig: {
         agentCommand: "claude '--dangerously-skip-permissions' '--effort' 'max'",
@@ -104,6 +106,30 @@ describe('launchAiVaultSessionInNewTab', () => {
         request_kind: 'resume'
       }
     })
+  })
+
+  it('pastes Windows shell-wrapped history resume commands instead of passing them to spawn', () => {
+    const command =
+      'cmd /d /s /c "cd /d ""D:\\tydic\\code\\log-diagnosis"" && claude ""--dangerously-skip-permissions"" ""--resume"" ""session-1"""'
+
+    launchAiVaultSessionInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      command,
+      launchConfig: {
+        agentCommand: 'claude "--dangerously-skip-permissions"',
+        agentArgs: '--dangerously-skip-permissions',
+        agentEnv: {}
+      }
+    })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({
+        command,
+        delivery: 'terminal-paste'
+      })
+    )
   })
 
   it('creates a split group before launching when a split direction is provided', () => {

--- a/src/renderer/src/lib/launch-ai-vault-session.ts
+++ b/src/renderer/src/lib/launch-ai-vault-session.ts
@@ -25,6 +25,8 @@ export function launchAiVaultSessionInNewTab(args: {
   const tab = store.createTab(args.worktreeId, targetGroupId)
   store.queueTabStartupCommand(tab.id, {
     command: args.command,
+    // Resume commands must be pasted so Windows shell wraps are not re-quoted as spawn commands.
+    delivery: 'terminal-paste',
     ...(args.env ? { env: args.env } : {}),
     ...(args.launchConfig ? { launchConfig: args.launchConfig, launchAgent: args.agent } : {}),
     telemetry: {


### PR DESCRIPTION
Fixes #6270.

## Summary
- launch AI Vault history resume commands through terminal paste so shell-wrapped Windows commands are not re-quoted as spawn commands
- add a regression test for the Windows `cmd /d /s /c` restore command shape
- document why the terminal paste delivery is required at the queue site

## Screenshots
Not applicable; this is terminal launch behavior with no UI surface change.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/launch-ai-vault-session.test.ts src/renderer/src/lib/ai-vault-resume-command.test.ts src/renderer/src/lib/ai-vault-session-drag.test.ts` (17 passed)
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "terminal-paste startup commands"` (2 passed, 226 skipped)
- `pnpm exec oxfmt --check src/renderer/src/lib/launch-ai-vault-session.ts src/renderer/src/lib/launch-ai-vault-session.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/launch-ai-vault-session.ts src/renderer/src/lib/launch-ai-vault-session.test.ts src/renderer/src/lib/ai-vault-resume-command.test.ts src/renderer/src/lib/ai-vault-session-drag.test.ts`
- `pnpm run tc:web`
- `git diff --check`

## AI Review Report
Reviewed the focused launch path, Windows shell-wrap regression coverage, and related terminal-paste startup behavior. The change remains limited to resume command delivery and its regression tests.

## Security Audit
No new permissions, external network calls, shell inputs, or storage paths are introduced. Existing resume command content is delivered through the terminal paste path instead of being reinterpreted as a spawned command.

## Notes
The branch head is signed and verified. The typecheck command reports the existing Node engine warning because this environment is Node v26 while the project asks for Node 24.
