### PR TITLE
perf(renderer): drop per-tick matchMedia alloc + purge hibernation epoch map

### DIFF
--- a/config/scripts/hibernation-output-epoch-leak-benchmark.mjs
+++ b/config/scripts/hibernation-output-epoch-leak-benchmark.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Benchmark: renderer-heap growth of the agent-hibernation output-epoch map
+// across terminal open/close cycles.
+//
+// recordAgentHibernationPaneOutput() adds one entry per pane (keyed by
+// `tabId:leafId`, leafId a fresh UUID each open) on every PTY output chunk.
+// Before the fix nothing purged those entries on permanent pane/worktree close,
+// so the module-level Map grew for the renderer's whole lifetime. This script
+// simulates N open→emit→close cycles and reports retained Map size with the
+// purge disabled vs enabled.
+import { performance } from 'node:perf_hooks'
+import v8 from 'node:v8'
+
+const CYCLES = Number.parseInt(process.env.ORCA_EPOCH_BENCH_CYCLES ?? '20000', 10)
+const PANES_PER_TAB = Number.parseInt(process.env.ORCA_EPOCH_BENCH_PANES ?? '2', 10)
+
+for (const [name, value] of [
+  ['ORCA_EPOCH_BENCH_CYCLES', CYCLES],
+  ['ORCA_EPOCH_BENCH_PANES', PANES_PER_TAB]
+]) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, received ${value}`)
+  }
+}
+
+// Mirror of the module under test (agent-hibernation-output-activity.ts): a
+// module-level Map of paneKey -> epoch, plus the tab-scoped purge the fix adds.
+function makeActivity() {
+  const outputEpochByPaneKey = new Map()
+  return {
+    map: outputEpochByPaneKey,
+    record(paneKey) {
+      outputEpochByPaneKey.set(paneKey, (outputEpochByPaneKey.get(paneKey) ?? 0) + 1)
+    },
+    forgetTab(tabId) {
+      const prefix = `${tabId}:`
+      for (const paneKey of outputEpochByPaneKey.keys()) {
+        if (paneKey.startsWith(prefix)) {
+          outputEpochByPaneKey.delete(paneKey)
+        }
+      }
+    }
+  }
+}
+
+// A v4 UUID-shaped string; varied by index so each pane open mints a fresh key
+// exactly like the real leafId allocation.
+function leafId(index) {
+  const hex = index.toString(16).padStart(12, '0').slice(-12)
+  return `00000000-0000-4000-8000-${hex}`
+}
+
+function runCycles({ purge }) {
+  const activity = makeActivity()
+  let peak = 0
+  for (let cycle = 0; cycle < CYCLES; cycle += 1) {
+    const tabId = `tab-${cycle}`
+    for (let pane = 0; pane < PANES_PER_TAB; pane += 1) {
+      const paneKey = `${tabId}:${leafId(cycle * PANES_PER_TAB + pane)}`
+      // Simulate a burst of PTY output chunks for this pane.
+      for (let chunk = 0; chunk < 8; chunk += 1) {
+        activity.record(paneKey)
+      }
+    }
+    peak = Math.max(peak, activity.map.size)
+    if (purge) {
+      activity.forgetTab(tabId)
+    }
+  }
+  return { retained: activity.map.size, peak }
+}
+
+function approxRetainedBytes(entries) {
+  // Rough lower bound: a paneKey string (~48 UTF-16 chars ≈ 96 B + header) plus a
+  // small-int value and Map node overhead. ~110 B/entry is conservative for V8.
+  return entries * 110
+}
+
+console.log('Hibernation output-epoch map leak benchmark')
+console.log(`cycles=${CYCLES} panes/tab=${PANES_PER_TAB} (open → emit 8 chunks/pane → close)\n`)
+
+const t0 = performance.now()
+const before = runCycles({ purge: false })
+const afterMs = performance.now()
+const after = runCycles({ purge: true })
+const doneMs = performance.now()
+
+const fmtBytes = (n) =>
+  n >= 1024 * 1024 ? `${(n / 1024 / 1024).toFixed(2)} MiB` : `${(n / 1024).toFixed(1)} KiB`
+
+console.log('  variant         │ retained entries │ approx retained heap │ wall time')
+console.log('  ────────────────┼──────────────────┼──────────────────────┼──────────')
+console.log(
+  `  before (leak)   │ ${String(before.retained).padStart(16)} │ ${fmtBytes(approxRetainedBytes(before.retained)).padStart(20)} │ ${(afterMs - t0).toFixed(0)} ms`
+)
+console.log(
+  `  after  (purge)  │ ${String(after.retained).padStart(16)} │ ${fmtBytes(approxRetainedBytes(after.retained)).padStart(20)} │ ${(doneMs - afterMs).toFixed(0)} ms`
+)
+console.log(
+  `\nWithout the purge, retained entries grow unbounded with open/close cycles` +
+    ` (peak ${before.peak} ≈ ${fmtBytes(approxRetainedBytes(before.retained))}).` +
+    `\nWith the purge, the map returns to ~0 after each tab closes — bounded by` +
+    ` the live pane count, not session lifetime.`
+)
+
+// Belt-and-suspenders: confirm v8 can serialize a representative entry so the
+// per-entry estimate is grounded, not invented.
+const sampleBytes = v8.serialize([`tab-0:${leafId(0)}`, 8]).byteLength
+console.log(`\n(v8-serialized size of one [paneKey, epoch] entry: ${sampleBytes} bytes)`)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -50,7 +50,10 @@ import { ActivityTitlebarControls } from './components/activity/ActivityTitlebar
 import Sidebar from './components/Sidebar'
 import { shutdownBufferCaptures } from './components/terminal-pane/shutdown-buffer-captures'
 import { dispatchWindowCloseRequest } from './components/window-close-request-coordinator'
-import { useSystemPrefersDark } from './components/terminal-pane/use-system-prefers-dark'
+import {
+  getSystemPrefersDarkSnapshot,
+  useSystemPrefersDark
+} from './components/terminal-pane/use-system-prefers-dark'
 import RightSidebar from './components/right-sidebar'
 import { StarNagCard } from './components/StarNagCard'
 import { StarNagAgentValueMomentObserver } from './components/star-nag/StarNagAgentValueMomentObserver'
@@ -119,7 +122,6 @@ import {
 } from './lib/startup-ui-hydration'
 import { shouldRenderPetOverlay } from './components/pet/pet-overlay-visibility'
 import { applyDocumentTheme } from './lib/document-theme'
-import { getSystemPrefersDark } from './lib/terminal-theme'
 import { isEditableTarget } from './lib/editable-target'
 import { getSelectedTextForFileSearch } from './lib/file-search-selection'
 import { useShortcutLabel } from './hooks/useShortcutLabel'
@@ -1113,7 +1115,12 @@ function App(): React.JSX.Element {
   useEffect(() => {
     let previousKey = getRuntimeMobileSessionSyncKey(useAppStore.getState())
     return useAppStore.subscribe((state, previousState) => {
-      const systemPrefersDark = getSystemPrefersDark()
+      // Why: this subscriber fires on every store mutation (PTY/agent-status
+      // ticks). Read the cached prefers-dark snapshot — kept fresh by the shared
+      // listener that useSystemPrefersDark() below already mounts — instead of
+      // allocating a throwaway MediaQueryList via matchMedia on every tick,
+      // before the skip-gate even runs.
+      const systemPrefersDark = getSystemPrefersDarkSnapshot()
       // Why: skip the key build entirely when every input field is unchanged
       // by reference. Mirrors every field used by
       // getRuntimeMobileSessionSyncKey so this gate covers every "could the

--- a/src/renderer/src/lib/agent-hibernation-output-activity.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-output-activity.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  forgetAgentHibernationPaneOutput,
+  forgetAgentHibernationTabOutput,
+  getAgentHibernationPaneOutputEpoch,
+  recordAgentHibernationPaneOutput,
+  resetAgentHibernationOutputActivityForTests
+} from './agent-hibernation-output-activity'
+
+const UUID_A = '11111111-1111-4111-8111-111111111111'
+const UUID_B = '22222222-2222-4222-8222-222222222222'
+
+afterEach(() => {
+  resetAgentHibernationOutputActivityForTests()
+})
+
+describe('agent hibernation output activity', () => {
+  it('forgets a single pane epoch so a reopened pane starts fresh at 0', () => {
+    const paneKey = `tab-1:${UUID_A}`
+    recordAgentHibernationPaneOutput(paneKey)
+    recordAgentHibernationPaneOutput(paneKey)
+    expect(getAgentHibernationPaneOutputEpoch(paneKey)).toBe(2)
+
+    forgetAgentHibernationPaneOutput(paneKey)
+
+    // Why: a forgotten entry must read back as never-seen (epoch 0) — identical
+    // to a brand-new pane — so dropping it on close cannot change behavior.
+    expect(getAgentHibernationPaneOutputEpoch(paneKey)).toBe(0)
+  })
+
+  it('forgets every pane under a closed tab without touching other tabs', () => {
+    const closingTabPaneA = `tab-1:${UUID_A}`
+    const closingTabPaneB = `tab-1:${UUID_B}`
+    const survivingTabPane = `tab-2:${UUID_A}`
+    recordAgentHibernationPaneOutput(closingTabPaneA)
+    recordAgentHibernationPaneOutput(closingTabPaneB)
+    recordAgentHibernationPaneOutput(survivingTabPane)
+
+    forgetAgentHibernationTabOutput('tab-1')
+
+    expect(getAgentHibernationPaneOutputEpoch(closingTabPaneA)).toBe(0)
+    expect(getAgentHibernationPaneOutputEpoch(closingTabPaneB)).toBe(0)
+    expect(getAgentHibernationPaneOutputEpoch(survivingTabPane)).toBe(1)
+  })
+
+  it('does not match tab ids by mere prefix overlap', () => {
+    // Why: forgetting "tab-1" must not also evict "tab-10"; the separator guards
+    // against a substring false positive.
+    const tab1Pane = `tab-1:${UUID_A}`
+    const tab10Pane = `tab-10:${UUID_A}`
+    recordAgentHibernationPaneOutput(tab1Pane)
+    recordAgentHibernationPaneOutput(tab10Pane)
+
+    forgetAgentHibernationTabOutput('tab-1')
+
+    expect(getAgentHibernationPaneOutputEpoch(tab1Pane)).toBe(0)
+    expect(getAgentHibernationPaneOutputEpoch(tab10Pane)).toBe(1)
+  })
+})

--- a/src/renderer/src/lib/agent-hibernation-output-activity.ts
+++ b/src/renderer/src/lib/agent-hibernation-output-activity.ts
@@ -11,6 +11,26 @@ export function getAgentHibernationPaneOutputEpoch(paneKey: string): number {
   return outputEpochByPaneKey.get(paneKey) ?? 0
 }
 
+// Why: this module-level map gains an entry per pane that ever emits PTY output
+// and is keyed by `tabId:leafId` (leafId is a fresh UUID each open), so without
+// an explicit purge on permanent pane removal it grows for the renderer's whole
+// lifetime. A reopened pane starts at epoch 0 — identical to never-seen — so
+// dropping a closed pane's entry is safe.
+export function forgetAgentHibernationPaneOutput(paneKey: string): void {
+  outputEpochByPaneKey.delete(paneKey)
+}
+
+// Why: tab and worktree teardown remove every pane under a `tabId:` prefix at
+// once; mirror that bulk shape so callers don't re-implement the key scan.
+export function forgetAgentHibernationTabOutput(tabId: string): void {
+  const prefix = `${tabId}:`
+  for (const paneKey of outputEpochByPaneKey.keys()) {
+    if (paneKey.startsWith(prefix)) {
+      outputEpochByPaneKey.delete(paneKey)
+    }
+  }
+}
+
 export function getAgentHibernationOutputSignature(paneKeys: readonly string[]): string {
   return paneKeys
     .slice()

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -30,6 +30,7 @@ import { resolveLocalWindowsTerminalShellOverrideForTab } from '../../../../shar
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import type { AgentStartedTelemetry } from '../../lib/worktree-activation'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
+import { forgetAgentHibernationTabOutput } from '@/lib/agent-hibernation-output-activity'
 import { clearTransientTerminalState, emptyLayoutSnapshot } from './terminal-helpers'
 import { isClaudeAgent, detectAgentStatusFromTitle } from '@/lib/agent-status'
 import { buildOrphanTerminalCleanupPatch, getOrphanTerminalIds } from './terminal-orphan-helpers'
@@ -1112,6 +1113,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     // so retention suppressors are planted: a live→gone transition inside the
     // same frame as the tab close cannot re-snapshot a row we just dropped.
     get().dropAgentStatusByTabPrefix(tabId)
+    // Why: closing a tab permanently retires every pane under it (a reopen mints
+    // a fresh leafId at epoch 0), so drop the panes' hibernation output epochs to
+    // keep that module-level map from growing for the renderer's whole lifetime.
+    forgetAgentHibernationTabOutput(tabId)
     for (const tabs of Object.values(get().unifiedTabsByWorktree)) {
       const workspaceItem = tabs.find(
         (entry) => entry.contentType === 'terminal' && entry.entityId === tabId

--- a/src/renderer/src/store/slices/worktree-removal-maps-leak.test.ts
+++ b/src/renderer/src/store/slices/worktree-removal-maps-leak.test.ts
@@ -22,6 +22,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type * as AgentStatusModule from '@/lib/agent-status'
 import type { BrowserPage, BrowserWorkspace } from '../../../../shared/types'
+import {
+  getAgentHibernationPaneOutputEpoch,
+  recordAgentHibernationPaneOutput,
+  resetAgentHibernationOutputActivityForTests
+} from '@/lib/agent-hibernation-output-activity'
 
 vi.mock('sonner', () => ({
   toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
@@ -51,7 +56,13 @@ const mockApi = {
 // @ts-expect-error -- minimal window.api stub for the store under test
 globalThis.window = { api: mockApi }
 
-import { createTestStore, seedStore, makeWorktree, makeOpenFile } from './store-test-helpers'
+import {
+  createTestStore,
+  seedStore,
+  makeWorktree,
+  makeOpenFile,
+  makeTab
+} from './store-test-helpers'
 
 const WT1 = 'repo1::/path/wt1'
 const WT2 = 'repo1::/path/wt2'
@@ -91,6 +102,7 @@ describe('worktree removal evicts the per-worktree + per-page maps it previously
   beforeEach(() => {
     vi.clearAllMocks()
     mockApi.worktrees.remove.mockResolvedValue(undefined)
+    resetAgentHibernationOutputActivityForTests()
   })
 
   function seedWorktreeKeyedMaps(store: ReturnType<typeof createTestStore>): void {
@@ -144,6 +156,36 @@ describe('worktree removal evicts the per-worktree + per-page maps it previously
     expect(s.remoteStatusesByWorktree[WT2]).toBeDefined()
     expect(s.recentlyClosedEditorTabsByWorktree[WT2]).toBeDefined()
     expect(s.defaultTerminalTabsAppliedByWorktreeId[WT2]).toBe(true)
+  })
+
+  it('worktree removal drops the hibernation output-epoch map for the removed worktree only', () => {
+    const store = createTestStore()
+    const LEAF = '11111111-1111-4111-8111-111111111111'
+    const TAB1 = 'tab-wt1'
+    const TAB2 = 'tab-wt2'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: WT1, repoId: 'repo1', path: '/path/wt1' }),
+          makeWorktree({ id: WT2, repoId: 'repo1', path: '/path/wt2' })
+        ]
+      },
+      tabsByWorktree: {
+        [WT1]: [makeTab({ id: TAB1, worktreeId: WT1 })],
+        [WT2]: [makeTab({ id: TAB2, worktreeId: WT2 })]
+      }
+    })
+    const removedPaneKey = `${TAB1}:${LEAF}`
+    const survivingPaneKey = `${TAB2}:${LEAF}`
+    recordAgentHibernationPaneOutput(removedPaneKey)
+    recordAgentHibernationPaneOutput(survivingPaneKey)
+
+    store.getState().purgeWorktreeTerminalState([WT1])
+
+    // Removed worktree's pane reads back as never-seen (epoch 0).
+    expect(getAgentHibernationPaneOutputEpoch(removedPaneKey)).toBe(0)
+    // Surviving worktree's pane keeps its epoch (guard over-eviction).
+    expect(getAgentHibernationPaneOutputEpoch(survivingPaneKey)).toBe(1)
   })
 
   it('bulk purgeWorktreeTerminalState drops page/workspace-keyed browser maps for the removed worktree only', () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -38,6 +38,7 @@ import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from './github-cache-k
 import { moveFocusToRendererBeforeFocusedWebviewHidden } from './browser-webview-cleanup'
 import { toast } from 'sonner'
 import { requestVirtualizedScrollAnchorRecord } from '@/hooks/requestVirtualizedScrollAnchorRecord'
+import { forgetAgentHibernationTabOutput } from '@/lib/agent-hibernation-output-activity'
 import { branchName } from '@/lib/git-utils'
 import { markInputQuietSchedulerInput, scheduleAfterInputQuiet } from '@/lib/input-quiet-scheduler'
 import { clearSessionCommitDraftForWorktree } from '@/lib/source-control-commit-draft-session'
@@ -1716,6 +1717,10 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
   for (const id of worktreeIdSet) {
     for (const tab of s.tabsByWorktree[id] ?? []) {
       doomedTabIds.add(tab.id)
+      // Why: a removed worktree's panes are gone for good, so drop their
+      // hibernation output epochs from that module-level map (mirrors the
+      // hosted-review prune above). A future pane mints a fresh leafId at epoch 0.
+      forgetAgentHibernationTabOutput(tab.id)
     }
     for (const workspace of s.browserTabsByWorktree[id] ?? []) {
       doomedBrowserWorkspaceIds.add(workspace.id)


### PR DESCRIPTION
## What

Two small, behavior-preserving renderer-side hygiene fixes found during a perf/memory audit.

## Fix 1 — drop a per-tick `matchMedia` allocation in the App store subscriber

**ELI5:** On every internal state change (dozens/sec while an agent streams output), the app re-asked the browser "is the OS in dark mode?" by allocating a throwaway object — even though a cached, always-fresh answer already exists right next to it.

`App.tsx`'s runtime-mobile-session-sync subscriber fires on every store mutation (PTY/agent-status ticks) and called `getSystemPrefersDark()` → `window.matchMedia(...)` at the **top of the subscriber, before** the reference-equality skip-gate. Swapped for `getSystemPrefersDarkSnapshot()`, which reads a cached boolean kept fresh by the shared media listener `App` already mounts via `useSystemPrefersDark()`. Same boolean, zero per-tick allocation.

*Degraded UX: none.* Identical value; the dedicated theme-change effect still triggers a republish on OS theme change.

## Fix 2 — purge the hibernation output-epoch map on permanent pane/worktree close

**ELI5:** Every terminal pane that ever prints output left a tiny permanent entry in a bookkeeping map that was never removed on close, so it grew for the renderer's whole lifetime.

`recordAgentHibernationPaneOutput()` adds one entry per pane (keyed `tabId:leafId`, a fresh UUID each open) on every PTY output chunk, but nothing purged the module-level `Map` on permanent close. Added `forgetAgentHibernationTabOutput()`, wired into the **two permanent-removal seams only**: `closeTab` (terminals.ts) and `buildWorktreePurgeState` (worktrees.ts, mirroring the existing `pruneHostedReviewLinkMutationGenerations` there).

Sleep/hibernate paths are deliberately **not** touched — `leafId` is stable across sleep/wake — and a reopened pane mints a fresh `leafId` at epoch 0, identical to never-seen, so the purge cannot change hibernation behavior.

### Benchmark

`config/scripts/hibernation-output-epoch-leak-benchmark.mjs`:

| variant | retained entries | approx heap |
|---|---|---|
| before (leak) | 40,000 | ~4.2 MiB |
| after (purge) | 0 | 0 |

(20k open/emit/close cycles.) The map is now bounded by live pane count, not session lifetime.

*Severity: low* — slow growth, never read for closed panes, so no lag. *Degraded UX: none.*

## Tests

- `agent-hibernation-output-activity.test.ts`: new purge functions, incl. a `tab-1` vs `tab-10` prefix false-positive guard.
- `worktree-removal-maps-leak.test.ts`: extended to assert the epoch map is evicted for the removed worktree only.
- All 1473 store-slice tests pass (incl. existing worktree-removal leak suites).

## Verification

Independent adversarial review: **SAFE** — confirmed the two prefers-dark functions are value-identical (incl. the no-matchMedia → `true` default), the snapshot is fresh at the call site, and the epoch purge fires only on permanent removal (sleep/wake retains `leafId`, so the signature is unaffected), with correct `${tabId}:` prefix matching.

Made with [Orca](https://github.com/stablyai/orca) 🐋
