### PR TITLE
perf(editor): skip markdown preview TOC parse while the panel is closed

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.toc-visibility-gate.test.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.toc-visibility-gate.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+//
+// Regression guard for the follow-up to #6695: MarkdownPreview must route its
+// Table-of-Contents build through the visibility gate, so the full-document
+// remark parse only runs while the panel is open (closed by default). This
+// renders the real MarkdownPreview and asserts the parse is skipped when closed
+// and a real outline reaches the panel when open. The gate's own semantics are
+// unit-tested in markdown-toc-visibility-gate.test.ts; this proves the wiring.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MarkdownTocItem } from './markdown-table-of-contents'
+import type * as MarkdownTableOfContentsModule from './markdown-table-of-contents'
+
+const buildMarkdownTableOfContentsSpy = vi.hoisted(() => vi.fn())
+
+const storeState = {
+  openFile: vi.fn(),
+  activateMarkdownLink: vi.fn(),
+  openMarkdownPreview: vi.fn(),
+  setMarkdownViewMode: vi.fn(),
+  markdownFrontmatterVisible: {},
+  setPendingEditorReveal: vi.fn(),
+  addDiffComment: vi.fn(),
+  deleteDiffComment: vi.fn(),
+  updateDiffComment: vi.fn(),
+  clearDeliveredDiffComments: vi.fn(),
+  keybindings: {},
+  worktreesByRepo: {},
+  openFiles: [],
+  activeFileIdByWorktree: {},
+  settings: { openLinksInApp: true },
+  editorFontZoomLevel: 0
+}
+
+vi.mock('@/store', () => {
+  const useAppStore = Object.assign(
+    (selector: (s: typeof storeState) => unknown) => selector(storeState),
+    { getState: () => storeState }
+  )
+  return { useAppStore }
+})
+vi.mock('@/store/slices/worktree-helpers', () => ({ findWorktreeById: () => null }))
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  settingsForRuntimeOwner: (settings: unknown) => settings
+}))
+vi.mock('@/runtime/runtime-file-client', () => ({
+  statRuntimePath: vi.fn(async () => ({ isDirectory: false }))
+}))
+vi.mock('@/lib/connection-context', () => ({ getConnectionId: () => null }))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+vi.mock('./useLocalImageSrc', () => ({ useLocalImageSrc: (src?: string) => src }))
+vi.mock('./MermaidBlock', () => ({ default: () => null }))
+vi.mock('./CodeBlockCopyButton', () => ({
+  default: ({ children }: { children: React.ReactNode }) => children
+}))
+vi.mock('../diff-comments/DiffCommentCard', () => ({ DiffCommentCard: () => null }))
+vi.mock('./NotesSendMenu', () => ({ NotesSendMenu: () => null }))
+// Render the items the gate produced so the test can read the outline from the DOM.
+vi.mock('./MarkdownTableOfContentsPanel', () => ({
+  MarkdownTableOfContentsPanel: ({ items }: { items: MarkdownTocItem[] }) => (
+    <nav aria-label="toc-spy">{items.map((item) => item.title).join('|')}</nav>
+  )
+}))
+// Spy on the expensive parse without changing its behavior, so the test can
+// assert it is never invoked while the panel is closed.
+vi.mock('./markdown-table-of-contents', async (importOriginal) => {
+  const actual = await importOriginal<typeof MarkdownTableOfContentsModule>()
+  buildMarkdownTableOfContentsSpy.mockImplementation(actual.buildMarkdownTableOfContents)
+  return { ...actual, buildMarkdownTableOfContents: buildMarkdownTableOfContentsSpy }
+})
+
+import MarkdownPreview from './MarkdownPreview'
+
+const DOC = '# Intro\n\n## Setup\n\n## Usage'
+
+describe('MarkdownPreview TOC visibility gate', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      configurable: true
+    })
+    ;(window as unknown as { api: unknown }).api = {
+      shell: { openUrl: vi.fn(), openFileUri: vi.fn(), pathExists: vi.fn(async () => true) },
+      ui: { writeClipboardText: vi.fn(async () => true) }
+    }
+    buildMarkdownTableOfContentsSpy.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  function render(showTableOfContents: boolean): void {
+    act(() => {
+      root.render(
+        <MarkdownPreview
+          content={DOC}
+          filePath="/repo/docs/README.md"
+          sourceWorktreeId="wt-1"
+          scrollCacheKey="test-key"
+          showTableOfContents={showTableOfContents}
+        />
+      )
+    })
+  }
+
+  it('skips the full-document parse and renders no panel while the panel is closed', () => {
+    render(false)
+    expect(buildMarkdownTableOfContentsSpy).not.toHaveBeenCalled()
+    expect(container.querySelector('nav[aria-label="toc-spy"]')).toBeNull()
+  })
+
+  it('builds and shows the outline when the panel is open', () => {
+    render(true)
+    expect(buildMarkdownTableOfContentsSpy).toHaveBeenCalledWith(DOC)
+    expect(container.querySelector('nav[aria-label="toc-spy"]')?.textContent).toBe('Intro')
+  })
+})

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -76,7 +76,7 @@ import { prewarmMarkdownPreviewLocalImages } from './markdown-preview-local-imag
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { statRuntimePath } from '@/runtime/runtime-file-client'
 import { useMountedRef } from '@/hooks/useMountedRef'
-import { buildMarkdownTableOfContents } from './markdown-table-of-contents'
+import { selectMarkdownTableOfContents } from './markdown-toc-visibility-gate'
 import { MarkdownTableOfContentsPanel } from './MarkdownTableOfContentsPanel'
 import { isMarkdownComment } from '@/lib/diff-comment-compat'
 import { DiffCommentCard } from '../diff-comments/DiffCommentCard'
@@ -554,9 +554,14 @@ export default function MarkdownPreview({
   }, [renderedContent, filePath, imageRuntimeContext])
 
   const frontMatter = useMemo(() => extractFrontMatter(renderedContent), [renderedContent])
+  // Why: building the table of contents runs a full-document remark parse on
+  // every content change, and the preview's content churns on streamed/external
+  // file writes. The result is only used while the panel is open (closed by
+  // default), so gate the parse on visibility; showTableOfContents in the deps
+  // rebuilds the outline the moment it opens.
   const tableOfContentsItems = useMemo(
-    () => buildMarkdownTableOfContents(renderedContent),
-    [renderedContent]
+    () => selectMarkdownTableOfContents(showTableOfContents, renderedContent),
+    [renderedContent, showTableOfContents]
   )
   const markdownDocumentIndex = useMemo(
     () => createMarkdownDocumentIndex(markdownDocuments),


### PR DESCRIPTION
## What

Follow-up to #6695. That PR gated the **rich-markdown editor's** Table-of-Contents parse on whether the TOC panel is open. The **read-only markdown preview pane** (`MarkdownPreview.tsx`) had the exact same un-gated parse — this gates it too, through the same seam.

## ELI5

The markdown *preview* (the rendered, read-only view) also rebuilds the whole "table of contents" outline by re-parsing the entire document every time the content changes — **even when the TOC panel is closed and nobody can see it**. Unlike the editor, the preview's content doesn't just change while *you* type: it also changes every time the file is written underneath it (e.g. while an AI agent streams edits into the file). So on a large doc being streamed, the app was re-parsing the whole document many times a second to build an outline it then throws away. This PR only does that work when the panel is open (the default is closed).

## The waste

`MarkdownPreview.tsx` ran `buildMarkdownTableOfContents(renderedContent)` — a full `unified().use(remarkParse).use(remarkGfm).use(remarkFrontmatter).parse()` over the whole document, plus a recursive heading walk — in a `useMemo` keyed only on `renderedContent`. The result (`tableOfContentsItems`) is consumed in exactly one place: the `showTableOfContents ? <MarkdownTableOfContentsPanel … /> : null` branch. The panel defaults to closed (`showTableOfContents = false`), so in the common case the parse result was discarded.

This is the same bug class as #6695, but on a hotter path: the preview's `renderedContent` changes on external/streamed file writes, not only on user keystrokes, so the wasted parses can fire faster than the editor's 300 ms-debounced typing path.

The only other TOC consumer in the preview, `navigateToTableOfContentsItem`, depends solely on `scrollToAnchor` and **never reads** `tableOfContentsItems`, so gating the parse cannot break navigation.

## Measurement / benchmark

`config/scripts/markdown-toc-parse-benchmark.mjs` (added in #6695) mirrors the real remark workload and is caller-agnostic — it measures the per-content-change parse cost that this gate eliminates while the panel is closed:

| doc size | headings | per-change median | burst total over ~1 min |
|---|---|---|---|
| 44 KiB | 50 | ~14 ms | ~2.9 s |
| 175 KiB | 200 | ~66 ms | ~13.4 s |
| 351 KiB | 400 | ~136 ms | ~27.4 s |

With the fix, every row costs **~0 ms while the panel is closed** — the parse is skipped and a stable shared empty array is returned. Because the preview re-renders on each streamed write, the real-world saving on a doc being actively edited by an agent is larger than the typing-only figure above.

## The fix

Route the preview's memo through the existing `selectMarkdownTableOfContents(showTableOfContents, renderedContent)` seam from #6695, with `showTableOfContents` added to the deps. While closed it returns the shared stable `EMPTY_MARKDOWN_TOC` (no parse, constant reference → no spurious downstream renders). The moment the panel opens, `showTableOfContents` in the deps rebuilds the outline. No new plumbing: `showTableOfContents` and `onCloseTableOfContents` are already props.

## Degraded UX

**None while the panel is closed.** When you open the TOC, the parse runs once on open (same render pass that mounts the panel) and then per content change exactly as today.

## Tradeoffs / what was deliberately *not* done

I also investigated a more aggressive optimization for the **panel-open** path that #6695 (and this PR) leave untouched: when the panel *is* open, the full remark parse still re-runs on every content change even when no heading changed. The idea was a cheap "heading signature" memo — scan the doc for heading lines and only re-parse when that signature changes.

An adversarial correctness review (against the real `remark-parse@11` + `remark-gfm@4` + `remark-frontmatter@5` pipeline and the stateful slugger) found a naive line-scan signature is **unsound**: there are many edits where the signature is byte-identical but the real TOC changes, producing an invisible **stale-TOC navigation bug** (dead scroll anchors / scrolling to the wrong duplicate heading). Concrete examples:

- Opening/closing a code fence (``` / `~~~`) or HTML block above a heading flips whether following `#` lines are headings.
- Setext headings: the title text lives on the *paragraph line above* the `===`/`---` underline; a blank line above demotes the heading; `---` is a setext underline vs. a thematic break depending on adjacency.
- Leading YAML/TOML frontmatter (`---`/`+++`) edits can surface interior lines as headings.
- The stateful slugger assigns `-1`/`-2` suffixes by document order, so adding/removing/reordering one duplicate-titled heading silently drifts the IDs of later byte-identical headings.

A signature would only be safe as a conservative *bail-out-to-full-parse* superset (re-parse on any fence/HTML/frontmatter/setext ambiguity) behind an exhaustive adversarial test corpus. That's a meaningfully riskier change with a much smaller payoff than this gate, so it's intentionally deferred to a separate PR rather than conflated with this low-risk fix. The gate here captures the high-value, zero-risk win (the panel is closed by default).

Out of scope but noted for later: `markdown-preview-local-images.ts` runs its *own* full remark parse on `renderedContent` (for image prewarming) on the same streaming hot path — a separate, non-TOC perf topic.

## Tests

`MarkdownPreview.toc-visibility-gate.test.tsx`: renders the real `MarkdownPreview` and proves the full-document parse is **not** called (and no panel renders) while closed, and that a real outline builds and reaches the panel when open. The gate seam's own semantics remain covered by `markdown-toc-visibility-gate.test.ts`. Full editor suite green (664 tests).

Made with [Orca](https://github.com/stablyai/orca) 🐋
