### PR TITLE
Add text replace functionality to rich markdown editor and keyboard shortcut for text replace in bindings

### DIFF
--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -370,25 +370,81 @@
   right: 12px;
   z-index: 20;
   display: flex;
-  align-items: center;
-  gap: 0;
+  align-items: stretch;
+  gap: 2px;
   width: fit-content;
-  max-width: min(calc(100% - 24px), 460px);
-  padding: 0 2px 0 4px;
+  max-width: min(calc(100% - 24px), 520px);
+  padding: 4px 4px 4px 2px;
   border: 1px solid var(--border);
   border-radius: 4px;
   background: var(--background);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
 }
 
+/* Why: the expand toggle spans both rows on the left like the source editor's
+   find widget, so it stays vertically centered across the find/replace stack. */
+.rich-markdown-search-toggle {
+  width: 16px;
+  min-width: 16px;
+  height: auto;
+  align-self: stretch;
+  padding: 0;
+  border-radius: 2px;
+  color: var(--muted-foreground);
+}
+
+.rich-markdown-search-toggle:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--foreground);
+}
+
+.rich-markdown-search-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.rich-markdown-search-row {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  min-width: 0;
+}
+
 .rich-markdown-search-field {
   display: flex;
   align-items: center;
+  gap: 1px;
   min-width: 0;
-  width: 220px;
+  width: 240px;
+  padding-right: 2px;
   border: 1px solid var(--ring);
   background: var(--background);
   flex: 0 1 auto;
+}
+
+.rich-markdown-search-option {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  color: var(--muted-foreground);
+  flex: 0 0 auto;
+}
+
+.rich-markdown-search-option:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+}
+
+.rich-markdown-search-option[data-active='true'] {
+  border-color: color-mix(in srgb, var(--foreground) 20%, transparent);
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  color: var(--foreground);
 }
 
 .rich-markdown-search-status {
@@ -412,6 +468,8 @@
 .rich-markdown-search-input {
   font-size: 13px;
   line-height: 1;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .rich-markdown-search-button {

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -310,17 +310,7 @@ export default function RichMarkdownEditor({
     })
   }, [handleLocalImagePick, toggleLinkFromToolbar])
 
-  const {
-    activeMatchIndex,
-    closeSearch,
-    isSearchOpen,
-    matchCount,
-    moveToMatch,
-    openSearch,
-    searchInputRef,
-    searchQuery,
-    setSearchQuery
-  } = useRichMarkdownSearch({
+  const { openSearch, searchState, searchActions } = useRichMarkdownSearch({
     editor,
     rootRef,
     scrollContainerRef
@@ -381,18 +371,8 @@ export default function RichMarkdownEditor({
       markdownSourceLineOffset={markdownSourceLineOffset}
       tableOfContentsItems={tableOfContentsItems}
       showTableOfContents={showTableOfContents}
-      searchState={{
-        activeMatchIndex,
-        isSearchOpen,
-        matchCount,
-        searchQuery,
-        searchInputRef
-      }}
-      searchActions={{
-        closeSearch,
-        moveToMatch,
-        setSearchQuery
-      }}
+      searchState={searchState}
+      searchActions={searchActions}
       linkBubbleActions={{
         handleLinkSave,
         handleLinkRemove,

--- a/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
@@ -70,15 +70,25 @@ type RichMarkdownEditorSurfaceProps = {
   showTableOfContents: boolean
   searchState: {
     activeMatchIndex: number
+    isReplaceMode: boolean
     isSearchOpen: boolean
+    matchCase: boolean
     matchCount: number
+    replaceQuery: string
     searchQuery: string
     searchInputRef: React.RefObject<HTMLInputElement | null>
+    wholeWord: boolean
   }
   searchActions: {
     closeSearch: () => void
     moveToMatch: (direction: 1 | -1) => void
+    replaceAllMatches: () => void
+    replaceCurrentMatch: () => void
+    setReplaceQuery: (query: string) => void
     setSearchQuery: (query: string) => void
+    toggleMatchCase: () => void
+    toggleReplaceMode: () => void
+    toggleWholeWord: () => void
   }
   linkBubbleActions: {
     handleLinkSave: (href: string) => void
@@ -219,12 +229,22 @@ export function RichMarkdownEditorSurface({
           <RichMarkdownSearchBar
             activeMatchIndex={searchState.activeMatchIndex}
             isOpen={searchState.isSearchOpen}
+            isReplaceMode={searchState.isReplaceMode}
+            matchCase={searchState.matchCase}
             matchCount={searchState.matchCount}
+            query={searchState.searchQuery}
+            replaceQuery={searchState.replaceQuery}
+            searchInputRef={searchState.searchInputRef}
+            wholeWord={searchState.wholeWord}
             onClose={searchActions.closeSearch}
             onMoveToMatch={searchActions.moveToMatch}
             onQueryChange={searchActions.setSearchQuery}
-            query={searchState.searchQuery}
-            searchInputRef={searchState.searchInputRef}
+            onReplaceAll={searchActions.replaceAllMatches}
+            onReplaceCurrent={searchActions.replaceCurrentMatch}
+            onReplaceQueryChange={searchActions.setReplaceQuery}
+            onToggleMatchCase={searchActions.toggleMatchCase}
+            onToggleReplaceMode={searchActions.toggleReplaceMode}
+            onToggleWholeWord={searchActions.toggleWholeWord}
           />
         </div>
         {linkBubble ? (

--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
@@ -72,8 +72,8 @@ export function RichMarkdownSearchBar({
 
   const noMatches = matchCount === 0
   const toggleReplaceLabel = isReplaceMode
-    ? translate('auto.components.editor.RichMarkdownSearchBar.hideReplace', 'Hide replace')
-    : translate('auto.components.editor.RichMarkdownSearchBar.showReplace', 'Toggle replace')
+    ? translate('auto.components.editor.RichMarkdownSearchBar.e8c147435f', 'Hide replace')
+    : translate('auto.components.editor.RichMarkdownSearchBar.9cdc38be33', 'Toggle replace')
   const toggleReplaceTitle = replaceShortcut
     ? `${toggleReplaceLabel} (${replaceShortcut})`
     : toggleReplaceLabel
@@ -88,7 +88,7 @@ export function RichMarkdownSearchBar({
         onClick={onToggleReplaceMode}
         title={toggleReplaceTitle}
         aria-label={translate(
-          'auto.components.editor.RichMarkdownSearchBar.toggleReplace',
+          'auto.components.editor.RichMarkdownSearchBar.9cdc38be33',
           'Toggle replace'
         )}
         aria-expanded={isReplaceMode}
@@ -138,11 +138,11 @@ export function RichMarkdownSearchBar({
               data-active={matchCase ? 'true' : undefined}
               aria-pressed={matchCase}
               title={translate(
-                'auto.components.editor.RichMarkdownSearchBar.matchCase',
+                'auto.components.editor.RichMarkdownSearchBar.482b637099',
                 'Match case'
               )}
               aria-label={translate(
-                'auto.components.editor.RichMarkdownSearchBar.matchCase',
+                'auto.components.editor.RichMarkdownSearchBar.482b637099',
                 'Match case'
               )}
               className="rich-markdown-search-option"
@@ -158,11 +158,11 @@ export function RichMarkdownSearchBar({
               data-active={wholeWord ? 'true' : undefined}
               aria-pressed={wholeWord}
               title={translate(
-                'auto.components.editor.RichMarkdownSearchBar.wholeWord',
+                'auto.components.editor.RichMarkdownSearchBar.68d090241d',
                 'Match whole word'
               )}
               aria-label={translate(
-                'auto.components.editor.RichMarkdownSearchBar.wholeWord',
+                'auto.components.editor.RichMarkdownSearchBar.68d090241d',
                 'Match whole word'
               )}
               className="rich-markdown-search-option"
@@ -251,12 +251,12 @@ export function RichMarkdownSearchBar({
                   }
                 }}
                 placeholder={translate(
-                  'auto.components.editor.RichMarkdownSearchBar.replacePlaceholder',
+                  'auto.components.editor.RichMarkdownSearchBar.fd97c7e585',
                   'Replace'
                 )}
                 className="rich-markdown-search-input h-7 !border-0 bg-transparent px-2 shadow-none focus-visible:!border-0 focus-visible:ring-0"
                 aria-label={translate(
-                  'auto.components.editor.RichMarkdownSearchBar.replaceAria',
+                  'auto.components.editor.RichMarkdownSearchBar.44682b4159',
                   'Replace in rich markdown editor'
                 )}
               />
@@ -269,11 +269,11 @@ export function RichMarkdownSearchBar({
               onClick={onReplaceCurrent}
               disabled={noMatches}
               title={translate(
-                'auto.components.editor.RichMarkdownSearchBar.replaceOne',
+                'auto.components.editor.RichMarkdownSearchBar.fd97c7e585',
                 'Replace'
               )}
               aria-label={translate(
-                'auto.components.editor.RichMarkdownSearchBar.replaceOne',
+                'auto.components.editor.RichMarkdownSearchBar.fd97c7e585',
                 'Replace'
               )}
               className="rich-markdown-search-button"
@@ -288,11 +288,11 @@ export function RichMarkdownSearchBar({
               onClick={onReplaceAll}
               disabled={noMatches}
               title={translate(
-                'auto.components.editor.RichMarkdownSearchBar.replaceAll',
+                'auto.components.editor.RichMarkdownSearchBar.c2884f5e95',
                 'Replace all'
               )}
               aria-label={translate(
-                'auto.components.editor.RichMarkdownSearchBar.replaceAll',
+                'auto.components.editor.RichMarkdownSearchBar.c2884f5e95',
                 'Replace all'
               )}
               className="rich-markdown-search-button"

--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
@@ -1,5 +1,14 @@
 import React from 'react'
-import { ChevronDown, ChevronUp, X } from 'lucide-react'
+import {
+  CaseSensitive,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Replace,
+  ReplaceAll,
+  WholeWord,
+  X
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { translate } from '@/i18n/i18n'
@@ -7,23 +16,43 @@ import { translate } from '@/i18n/i18n'
 type RichMarkdownSearchBarProps = {
   activeMatchIndex: number
   isOpen: boolean
+  isReplaceMode: boolean
+  matchCase: boolean
   matchCount: number
+  query: string
+  replaceQuery: string
+  searchInputRef: React.RefObject<HTMLInputElement | null>
+  wholeWord: boolean
   onClose: () => void
   onMoveToMatch: (direction: 1 | -1) => void
   onQueryChange: (query: string) => void
-  query: string
-  searchInputRef: React.RefObject<HTMLInputElement | null>
+  onReplaceAll: () => void
+  onReplaceCurrent: () => void
+  onReplaceQueryChange: (query: string) => void
+  onToggleMatchCase: () => void
+  onToggleReplaceMode: () => void
+  onToggleWholeWord: () => void
 }
 
 export function RichMarkdownSearchBar({
   activeMatchIndex,
   isOpen,
+  isReplaceMode,
+  matchCase,
   matchCount,
+  query,
+  replaceQuery,
+  searchInputRef,
+  wholeWord,
   onClose,
   onMoveToMatch,
   onQueryChange,
-  query,
-  searchInputRef
+  onReplaceAll,
+  onReplaceCurrent,
+  onReplaceQueryChange,
+  onToggleMatchCase,
+  onToggleReplaceMode,
+  onToggleWholeWord
 }: RichMarkdownSearchBarProps): React.JSX.Element | null {
   if (!isOpen) {
     return null
@@ -36,96 +65,239 @@ export function RichMarkdownSearchBar({
     event.preventDefault()
   }
 
+  const noMatches = matchCount === 0
+
   return (
     <div className="rich-markdown-search" onKeyDown={(event) => event.stopPropagation()}>
-      <div className="rich-markdown-search-field">
-        <Input
-          ref={searchInputRef}
-          value={query}
-          onChange={(event) => onQueryChange(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' && event.shiftKey) {
-              event.preventDefault()
-              onMoveToMatch(-1)
-              return
-            }
-            if (event.key === 'Enter') {
-              event.preventDefault()
-              onMoveToMatch(1)
-              return
-            }
-            if (event.key === 'Escape') {
-              event.preventDefault()
-              onClose()
-            }
-          }}
-          placeholder={translate(
-            'auto.components.editor.RichMarkdownSearchBar.98b89276f3',
-            'Find in rich editor'
-          )}
-          className="rich-markdown-search-input h-7 !border-0 bg-transparent px-2 shadow-none focus-visible:!border-0 focus-visible:ring-0"
-          aria-label={translate(
-            'auto.components.editor.RichMarkdownSearchBar.158c645829',
-            'Find in rich markdown editor'
-          )}
-        />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        onMouseDown={keepSearchFocus}
+        onClick={onToggleReplaceMode}
+        title={
+          isReplaceMode
+            ? translate('auto.components.editor.RichMarkdownSearchBar.hideReplace', 'Hide replace')
+            : translate(
+                'auto.components.editor.RichMarkdownSearchBar.showReplace',
+                'Toggle replace'
+              )
+        }
+        aria-label={translate(
+          'auto.components.editor.RichMarkdownSearchBar.toggleReplace',
+          'Toggle replace'
+        )}
+        aria-expanded={isReplaceMode}
+        className="rich-markdown-search-toggle"
+      >
+        {isReplaceMode ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+      </Button>
+      <div className="rich-markdown-search-rows">
+        <div className="rich-markdown-search-row">
+          <div className="rich-markdown-search-field">
+            <Input
+              ref={searchInputRef}
+              value={query}
+              onChange={(event) => onQueryChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && event.shiftKey) {
+                  event.preventDefault()
+                  onMoveToMatch(-1)
+                  return
+                }
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  onMoveToMatch(1)
+                  return
+                }
+                if (event.key === 'Escape') {
+                  event.preventDefault()
+                  onClose()
+                }
+              }}
+              placeholder={translate(
+                'auto.components.editor.RichMarkdownSearchBar.98b89276f3',
+                'Find in rich editor'
+              )}
+              className="rich-markdown-search-input h-7 !border-0 bg-transparent px-2 shadow-none focus-visible:!border-0 focus-visible:ring-0"
+              aria-label={translate(
+                'auto.components.editor.RichMarkdownSearchBar.158c645829',
+                'Find in rich markdown editor'
+              )}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onMouseDown={keepSearchFocus}
+              onClick={onToggleMatchCase}
+              data-active={matchCase ? 'true' : undefined}
+              aria-pressed={matchCase}
+              title={translate(
+                'auto.components.editor.RichMarkdownSearchBar.matchCase',
+                'Match case'
+              )}
+              aria-label={translate(
+                'auto.components.editor.RichMarkdownSearchBar.matchCase',
+                'Match case'
+              )}
+              className="rich-markdown-search-option"
+            >
+              <CaseSensitive size={14} />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onMouseDown={keepSearchFocus}
+              onClick={onToggleWholeWord}
+              data-active={wholeWord ? 'true' : undefined}
+              aria-pressed={wholeWord}
+              title={translate(
+                'auto.components.editor.RichMarkdownSearchBar.wholeWord',
+                'Match whole word'
+              )}
+              aria-label={translate(
+                'auto.components.editor.RichMarkdownSearchBar.wholeWord',
+                'Match whole word'
+              )}
+              className="rich-markdown-search-option"
+            >
+              <WholeWord size={14} />
+            </Button>
+          </div>
+          <div className="rich-markdown-search-status">
+            {query && noMatches
+              ? translate('auto.components.editor.RichMarkdownSearchBar.a86958d508', 'No results')
+              : `${noMatches ? 0 : activeMatchIndex + 1}/${matchCount}`}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onMouseDown={keepSearchFocus}
+            onClick={() => onMoveToMatch(-1)}
+            disabled={noMatches}
+            title={translate(
+              'auto.components.editor.RichMarkdownSearchBar.32ae8d7d57',
+              'Previous match'
+            )}
+            aria-label={translate(
+              'auto.components.editor.RichMarkdownSearchBar.32ae8d7d57',
+              'Previous match'
+            )}
+            className="rich-markdown-search-button"
+          >
+            <ChevronUp size={14} />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onMouseDown={keepSearchFocus}
+            onClick={() => onMoveToMatch(1)}
+            disabled={noMatches}
+            title={translate(
+              'auto.components.editor.RichMarkdownSearchBar.f7bcecbe26',
+              'Next match'
+            )}
+            aria-label={translate(
+              'auto.components.editor.RichMarkdownSearchBar.f7bcecbe26',
+              'Next match'
+            )}
+            className="rich-markdown-search-button"
+          >
+            <ChevronDown size={14} />
+          </Button>
+          <div className="rich-markdown-search-divider" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onMouseDown={keepSearchFocus}
+            onClick={onClose}
+            title={translate(
+              'auto.components.editor.RichMarkdownSearchBar.de68b75bde',
+              'Close search'
+            )}
+            aria-label={translate(
+              'auto.components.editor.RichMarkdownSearchBar.de68b75bde',
+              'Close search'
+            )}
+            className="rich-markdown-search-button"
+          >
+            <X size={14} />
+          </Button>
+        </div>
+        {isReplaceMode ? (
+          <div className="rich-markdown-search-row">
+            <div className="rich-markdown-search-field">
+              <Input
+                value={replaceQuery}
+                onChange={(event) => onReplaceQueryChange(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    onReplaceCurrent()
+                    return
+                  }
+                  if (event.key === 'Escape') {
+                    event.preventDefault()
+                    onClose()
+                  }
+                }}
+                placeholder={translate(
+                  'auto.components.editor.RichMarkdownSearchBar.replacePlaceholder',
+                  'Replace'
+                )}
+                className="rich-markdown-search-input h-7 !border-0 bg-transparent px-2 shadow-none focus-visible:!border-0 focus-visible:ring-0"
+                aria-label={translate(
+                  'auto.components.editor.RichMarkdownSearchBar.replaceAria',
+                  'Replace in rich markdown editor'
+                )}
+              />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onMouseDown={keepSearchFocus}
+              onClick={onReplaceCurrent}
+              disabled={noMatches}
+              title={translate(
+                'auto.components.editor.RichMarkdownSearchBar.replaceOne',
+                'Replace'
+              )}
+              aria-label={translate(
+                'auto.components.editor.RichMarkdownSearchBar.replaceOne',
+                'Replace'
+              )}
+              className="rich-markdown-search-button"
+            >
+              <Replace size={14} />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onMouseDown={keepSearchFocus}
+              onClick={onReplaceAll}
+              disabled={noMatches}
+              title={translate(
+                'auto.components.editor.RichMarkdownSearchBar.replaceAll',
+                'Replace all'
+              )}
+              aria-label={translate(
+                'auto.components.editor.RichMarkdownSearchBar.replaceAll',
+                'Replace all'
+              )}
+              className="rich-markdown-search-button"
+            >
+              <ReplaceAll size={14} />
+            </Button>
+          </div>
+        ) : null}
       </div>
-      <div className="rich-markdown-search-status">
-        {query && matchCount === 0
-          ? translate('auto.components.editor.RichMarkdownSearchBar.a86958d508', 'No results')
-          : `${matchCount === 0 ? 0 : activeMatchIndex + 1}/${matchCount}`}
-      </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-xs"
-        onMouseDown={keepSearchFocus}
-        onClick={() => onMoveToMatch(-1)}
-        disabled={matchCount === 0}
-        title={translate(
-          'auto.components.editor.RichMarkdownSearchBar.32ae8d7d57',
-          'Previous match'
-        )}
-        aria-label={translate(
-          'auto.components.editor.RichMarkdownSearchBar.32ae8d7d57',
-          'Previous match'
-        )}
-        className="rich-markdown-search-button"
-      >
-        <ChevronUp size={14} />
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-xs"
-        onMouseDown={keepSearchFocus}
-        onClick={() => onMoveToMatch(1)}
-        disabled={matchCount === 0}
-        title={translate('auto.components.editor.RichMarkdownSearchBar.f7bcecbe26', 'Next match')}
-        aria-label={translate(
-          'auto.components.editor.RichMarkdownSearchBar.f7bcecbe26',
-          'Next match'
-        )}
-        className="rich-markdown-search-button"
-      >
-        <ChevronDown size={14} />
-      </Button>
-      <div className="rich-markdown-search-divider" />
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-xs"
-        onMouseDown={keepSearchFocus}
-        onClick={onClose}
-        title={translate('auto.components.editor.RichMarkdownSearchBar.de68b75bde', 'Close search')}
-        aria-label={translate(
-          'auto.components.editor.RichMarkdownSearchBar.de68b75bde',
-          'Close search'
-        )}
-        className="rich-markdown-search-button"
-      >
-        <X size={14} />
-      </Button>
     </div>
   )
 }

--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { translate } from '@/i18n/i18n'
+import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 
 type RichMarkdownSearchBarProps = {
   activeMatchIndex: number
@@ -54,6 +55,10 @@ export function RichMarkdownSearchBar({
   onToggleReplaceMode,
   onToggleWholeWord
 }: RichMarkdownSearchBarProps): React.JSX.Element | null {
+  // Why: surface the same replace shortcut the source editor uses so the toggle
+  // is discoverable; reads the user's effective binding, formatted per platform.
+  const replaceShortcut = useOptionalShortcutLabel('editor.replace')
+
   if (!isOpen) {
     return null
   }
@@ -66,6 +71,12 @@ export function RichMarkdownSearchBar({
   }
 
   const noMatches = matchCount === 0
+  const toggleReplaceLabel = isReplaceMode
+    ? translate('auto.components.editor.RichMarkdownSearchBar.hideReplace', 'Hide replace')
+    : translate('auto.components.editor.RichMarkdownSearchBar.showReplace', 'Toggle replace')
+  const toggleReplaceTitle = replaceShortcut
+    ? `${toggleReplaceLabel} (${replaceShortcut})`
+    : toggleReplaceLabel
 
   return (
     <div className="rich-markdown-search" onKeyDown={(event) => event.stopPropagation()}>
@@ -75,14 +86,7 @@ export function RichMarkdownSearchBar({
         size="icon-xs"
         onMouseDown={keepSearchFocus}
         onClick={onToggleReplaceMode}
-        title={
-          isReplaceMode
-            ? translate('auto.components.editor.RichMarkdownSearchBar.hideReplace', 'Hide replace')
-            : translate(
-                'auto.components.editor.RichMarkdownSearchBar.showReplace',
-                'Toggle replace'
-              )
-        }
+        title={toggleReplaceTitle}
         aria-label={translate(
           'auto.components.editor.RichMarkdownSearchBar.toggleReplace',
           'Toggle replace'

--- a/src/renderer/src/components/editor/markdown-preview-search.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.test.ts
@@ -89,6 +89,32 @@ describe('findTextMatchRanges', () => {
     expect(findTextMatchRanges('Alpha beta', '')).toEqual([])
   })
 
+  it('matches only same-case occurrences when matchCase is set', () => {
+    expect(findTextMatchRanges('Alpha beta ALPHA alpha', 'alpha', { matchCase: true })).toEqual([
+      { start: 17, end: 22 }
+    ])
+  })
+
+  it('restricts matches to whole words when wholeWord is set', () => {
+    expect(findTextMatchRanges('cat category scatter cat', 'cat', { wholeWord: true })).toEqual([
+      { start: 0, end: 3 },
+      { start: 21, end: 24 }
+    ])
+  })
+
+  it('treats underscore and digits as word characters for whole-word matching', () => {
+    expect(findTextMatchRanges('id id_2 (id)', 'id', { wholeWord: true })).toEqual([
+      { start: 0, end: 2 },
+      { start: 9, end: 11 }
+    ])
+  })
+
+  it('combines matchCase and wholeWord constraints', () => {
+    expect(
+      findTextMatchRanges('Cat cat catalog', 'cat', { matchCase: true, wholeWord: true })
+    ).toEqual([{ start: 4, end: 7 }])
+  })
+
   it('rejects oversized pasted queries before indexing preview text', () => {
     const oversizedQuery = 'secret-preview-search'.repeat(MARKDOWN_PREVIEW_SEARCH_QUERY_MAX_BYTES)
     const throwingText = {

--- a/src/renderer/src/components/editor/markdown-preview-search.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.test.ts
@@ -3,6 +3,7 @@ import {
   MARKDOWN_PREVIEW_SEARCH_QUERY_MAX_BYTES,
   findTextMatchRanges,
   isMarkdownPreviewFindShortcut,
+  isMarkdownPreviewReplaceShortcut,
   isMarkdownPreviewSearchQueryTooLarge
 } from './markdown-preview-search'
 
@@ -66,6 +67,66 @@ describe('isMarkdownPreviewFindShortcut', () => {
   })
 })
 
+describe('isMarkdownPreviewReplaceShortcut', () => {
+  it('uses Cmd+Option+F on macOS', () => {
+    expect(
+      isMarkdownPreviewReplaceShortcut(
+        {
+          key: 'f',
+          code: 'KeyF',
+          metaKey: true,
+          ctrlKey: false,
+          altKey: true,
+          shiftKey: false
+        },
+        'darwin'
+      )
+    ).toBe(true)
+    expect(
+      isMarkdownPreviewReplaceShortcut(
+        {
+          key: 'h',
+          code: 'KeyH',
+          metaKey: false,
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false
+        },
+        'darwin'
+      )
+    ).toBe(false)
+  })
+
+  it('uses Ctrl+H on non-macOS platforms', () => {
+    expect(
+      isMarkdownPreviewReplaceShortcut(
+        {
+          key: 'h',
+          code: 'KeyH',
+          metaKey: false,
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false
+        },
+        'linux'
+      )
+    ).toBe(true)
+    expect(
+      isMarkdownPreviewReplaceShortcut(
+        {
+          key: 'f',
+          code: 'KeyF',
+          metaKey: true,
+          ctrlKey: false,
+          altKey: true,
+          shiftKey: false
+        },
+        'linux'
+      )
+    ).toBe(false)
+  })
+})
+
 describe('findTextMatchRanges', () => {
   it('finds case-insensitive literal matches', () => {
     expect(findTextMatchRanges('Alpha beta ALPHA', 'alpha')).toEqual([
@@ -107,6 +168,12 @@ describe('findTextMatchRanges', () => {
       { start: 0, end: 2 },
       { start: 9, end: 11 }
     ])
+  })
+
+  it('checks whole-word boundaries around astral letters by code point', () => {
+    const text = '𐐀cat cat𐐀 cat'
+
+    expect(findTextMatchRanges(text, 'cat', { wholeWord: true })).toEqual([{ start: 12, end: 15 }])
   })
 
   it('combines matchCase and wholeWord constraints', () => {

--- a/src/renderer/src/components/editor/markdown-preview-search.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.ts
@@ -109,9 +109,33 @@ function isWordCharacter(char: string | undefined): boolean {
   return char !== undefined && WORD_CHARACTER.test(char)
 }
 
+function codePointBefore(text: string, index: number): string | undefined {
+  if (index <= 0) {
+    return undefined
+  }
+
+  const previousCodeUnit = text.charCodeAt(index - 1)
+  if (
+    previousCodeUnit >= 0xdc00 &&
+    previousCodeUnit <= 0xdfff &&
+    index > 1 &&
+    text.charCodeAt(index - 2) >= 0xd800 &&
+    text.charCodeAt(index - 2) <= 0xdbff
+  ) {
+    return text.slice(index - 2, index)
+  }
+
+  return text[index - 1]
+}
+
+function codePointAt(text: string, index: number): string | undefined {
+  const codePoint = text.codePointAt(index)
+  return codePoint === undefined ? undefined : String.fromCodePoint(codePoint)
+}
+
 function isWholeWordMatch(text: string, start: number, end: number): boolean {
-  const before = start > 0 ? text[start - 1] : undefined
-  const after = end < text.length ? text[end] : undefined
+  const before = codePointBefore(text, start)
+  const after = codePointAt(text, end)
   return !isWordCharacter(before) && !isWordCharacter(after)
 }
 

--- a/src/renderer/src/components/editor/markdown-preview-search.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.ts
@@ -18,7 +18,16 @@ export function isMarkdownPreviewFindShortcut(
   return keybindingMatchesAction('editor.find', event, platform, keybindings)
 }
 
-export function findTextMatchRanges(text: string, query: string): { start: number; end: number }[] {
+export type TextMatchOptions = {
+  matchCase?: boolean
+  wholeWord?: boolean
+}
+
+export function findTextMatchRanges(
+  text: string,
+  query: string,
+  options: TextMatchOptions = {}
+): { start: number; end: number }[] {
   if (!query) {
     return []
   }
@@ -26,6 +35,39 @@ export function findTextMatchRanges(text: string, query: string): { start: numbe
     return []
   }
 
+  const ranges = options.matchCase
+    ? findCaseSensitiveMatchRanges(text, query)
+    : findCaseInsensitiveMatchRanges(text, query)
+
+  if (!options.wholeWord) {
+    return ranges
+  }
+  return ranges.filter((range) => isWholeWordMatch(text, range.start, range.end))
+}
+
+function findCaseSensitiveMatchRanges(
+  text: string,
+  query: string
+): { start: number; end: number }[] {
+  const matches: { start: number; end: number }[] = []
+  let searchStart = 0
+
+  while (searchStart <= text.length - query.length) {
+    const matchStart = text.indexOf(query, searchStart)
+    if (matchStart === -1) {
+      break
+    }
+    matches.push({ start: matchStart, end: matchStart + query.length })
+    searchStart = matchStart + query.length
+  }
+
+  return matches
+}
+
+function findCaseInsensitiveMatchRanges(
+  text: string,
+  query: string
+): { start: number; end: number }[] {
   const normalizedText = buildLocaleLowercaseIndex(text)
   const normalizedQuery = query.toLocaleLowerCase()
   const matches: { start: number; end: number }[] = []
@@ -48,6 +90,21 @@ export function findTextMatchRanges(text: string, query: string): { start: numbe
   }
 
   return matches
+}
+
+// Why: whole-word matching treats Unicode letters, digits, and underscore as
+// word characters so a match only counts when both edges sit on a word boundary,
+// mirroring the editor's "whole word" find toggle.
+const WORD_CHARACTER = /[\p{L}\p{N}_]/u
+
+function isWordCharacter(char: string | undefined): boolean {
+  return char !== undefined && WORD_CHARACTER.test(char)
+}
+
+function isWholeWordMatch(text: string, start: number, end: number): boolean {
+  const before = start > 0 ? text[start - 1] : undefined
+  const after = end < text.length ? text[end] : undefined
+  return !isWordCharacter(before) && !isWordCharacter(after)
 }
 
 function buildLocaleLowercaseIndex(text: string): {

--- a/src/renderer/src/components/editor/markdown-preview-search.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.ts
@@ -18,6 +18,14 @@ export function isMarkdownPreviewFindShortcut(
   return keybindingMatchesAction('editor.find', event, platform, keybindings)
 }
 
+export function isMarkdownPreviewReplaceShortcut(
+  event: Pick<KeyboardEvent, 'key' | 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+  platform: NodeJS.Platform,
+  keybindings?: KeybindingOverrides
+): boolean {
+  return keybindingMatchesAction('editor.replace', event, platform, keybindings)
+}
+
 export type TextMatchOptions = {
   matchCase?: boolean
   wholeWord?: boolean

--- a/src/renderer/src/components/editor/rich-markdown-search.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-search.test.ts
@@ -19,6 +19,15 @@ describe('findRichMarkdownSearchMatches', () => {
     ])
   })
 
+  it('forwards match-case and whole-word options to the range finder', () => {
+    expect(
+      findRichMarkdownSearchMatches(docFromText('Beta beta betas', 10), 'beta', {
+        matchCase: true,
+        wholeWord: true
+      })
+    ).toEqual([{ from: 15, to: 19 }])
+  })
+
   it('does not walk the document for oversized pasted search text', () => {
     const doc = {
       descendants() {

--- a/src/renderer/src/components/editor/rich-markdown-search.ts
+++ b/src/renderer/src/components/editor/rich-markdown-search.ts
@@ -3,7 +3,8 @@ import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
 import {
   findTextMatchRanges,
-  isMarkdownPreviewSearchQueryTooLarge
+  isMarkdownPreviewSearchQueryTooLarge,
+  type TextMatchOptions
 } from './markdown-preview-search'
 
 export type RichMarkdownSearchMatch = {
@@ -29,7 +30,8 @@ export const richMarkdownSearchPluginKey = new PluginKey<RichMarkdownSearchState
 
 export function findRichMarkdownSearchMatches(
   doc: ProseMirrorNode,
-  query: string
+  query: string,
+  options?: TextMatchOptions
 ): RichMarkdownSearchMatch[] {
   if (!query) {
     return []
@@ -49,7 +51,7 @@ export function findRichMarkdownSearchMatches(
       return
     }
 
-    const ranges = findTextMatchRanges(text, query)
+    const ranges = findTextMatchRanges(text, query, options)
     for (const range of ranges) {
       matches.push({
         from: pos + range.start,

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -67,6 +67,23 @@ export function useRichMarkdownSearch({
 
   const matchCount = matches.length
 
+  const getLiveMatches = useCallback(() => {
+    if (
+      !editor ||
+      !isSearchOpen ||
+      !searchQuery ||
+      isMarkdownPreviewSearchQueryTooLarge(searchQuery)
+    ) {
+      return []
+    }
+    // Why: replace mutates document ranges immediately, so it must use the
+    // current input value instead of the debounced highlight match set.
+    return findRichMarkdownSearchMatches(editor.state.doc, searchQuery, {
+      matchCase,
+      wholeWord
+    })
+  }, [editor, isSearchOpen, matchCase, searchQuery, wholeWord])
+
   // Clamp the user-controlled index to the valid range on every render.
   // No state update needed — this is a pure derivation.
   const activeMatchIndex =
@@ -136,27 +153,34 @@ export function useRichMarkdownSearch({
   )
 
   const replaceCurrentMatch = useCallback(() => {
-    if (matchCount === 0) {
+    const liveMatches = getLiveMatches()
+    if (liveMatches.length === 0) {
       return
     }
-    const match = matches[activeMatchIndex]
+    const liveActiveMatchIndex =
+      activeMatchIndex >= 0 && activeMatchIndex < liveMatches.length ? activeMatchIndex : 0
+    const match = liveMatches[liveActiveMatchIndex]
     if (!match) {
       return
     }
     // Why: removing the active match shifts the next match into the same index,
     // so leaving rawActiveMatchIndex untouched advances to it after recompute.
     replaceRange(match.from, match.to)
-  }, [activeMatchIndex, matchCount, matches, replaceRange])
+  }, [activeMatchIndex, getLiveMatches, replaceRange])
 
   const replaceAllMatches = useCallback(() => {
-    if (!editor || matches.length === 0) {
+    if (!editor) {
+      return
+    }
+    const liveMatches = getLiveMatches()
+    if (liveMatches.length === 0) {
       return
     }
     const tr = editor.state.tr
     // Why: process matches last-to-first so each edit can't invalidate the
     // positions of matches we haven't replaced yet, keeping it a single undo.
-    for (let index = matches.length - 1; index >= 0; index -= 1) {
-      const match = matches[index]
+    for (let index = liveMatches.length - 1; index >= 0; index -= 1) {
+      const match = liveMatches[index]
       if (replaceQuery) {
         tr.insertText(replaceQuery, match.from, match.to)
       } else {
@@ -164,7 +188,7 @@ export function useRichMarkdownSearch({
       }
     }
     editor.view.dispatch(tr)
-  }, [editor, matches, replaceQuery])
+  }, [editor, getLiveMatches, replaceQuery])
 
   const moveToMatch = useCallback(
     (direction: 1 | -1) => {

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -26,7 +26,13 @@ export function useRichMarkdownSearch({
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const keybindings = useAppStore((state) => state.keybindings)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [isReplaceMode, setIsReplaceMode] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  const [replaceQuery, setReplaceQuery] = useState('')
+  // Why: match-case / whole-word persist across find sessions (matching the
+  // source editor's find widget), so they live outside the close-reset path.
+  const [matchCase, setMatchCase] = useState(false)
+  const [wholeWord, setWholeWord] = useState(false)
   const [rawActiveMatchIndex, setRawActiveMatchIndex] = useState(-1)
   const [searchRevision, setSearchRevision] = useState(0)
   // Why: debouncing the query that drives match computation prevents the
@@ -50,10 +56,13 @@ export function useRichMarkdownSearch({
     if (!editor || !isSearchOpen || !searchRequestQuery) {
       return []
     }
-    return findRichMarkdownSearchMatches(editor.state.doc, searchRequestQuery)
+    return findRichMarkdownSearchMatches(editor.state.doc, searchRequestQuery, {
+      matchCase,
+      wholeWord
+    })
     // searchRevision is bumped on ProseMirror doc edits to trigger recomputation
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, isSearchOpen, searchRequestQuery, searchRevision])
+  }, [editor, isSearchOpen, searchRequestQuery, searchRevision, matchCase, wholeWord])
 
   const matchCount = matches.length
 
@@ -80,10 +89,65 @@ export function useRichMarkdownSearch({
 
   const closeSearch = useCallback(() => {
     setIsSearchOpen(false)
+    setIsReplaceMode(false)
     setSearchQuery('')
+    setReplaceQuery('')
     setDebouncedQuery('')
     setRawActiveMatchIndex(-1)
   }, [])
+
+  const toggleMatchCase = useCallback(() => setMatchCase((value) => !value), [])
+  const toggleWholeWord = useCallback(() => setWholeWord((value) => !value), [])
+  const toggleReplaceMode = useCallback(() => setIsReplaceMode((value) => !value), [])
+
+  const replaceRange = useCallback(
+    (from: number, to: number) => {
+      if (!editor) {
+        return
+      }
+      const tr = editor.state.tr
+      // Why: empty replacement must delete the range — ProseMirror text nodes
+      // can't hold an empty string, so insertText('') would be a no-op.
+      if (replaceQuery) {
+        tr.insertText(replaceQuery, from, to)
+      } else {
+        tr.delete(from, to)
+      }
+      editor.view.dispatch(tr)
+    },
+    [editor, replaceQuery]
+  )
+
+  const replaceCurrentMatch = useCallback(() => {
+    if (matchCount === 0) {
+      return
+    }
+    const match = matches[activeMatchIndex]
+    if (!match) {
+      return
+    }
+    // Why: removing the active match shifts the next match into the same index,
+    // so leaving rawActiveMatchIndex untouched advances to it after recompute.
+    replaceRange(match.from, match.to)
+  }, [activeMatchIndex, matchCount, matches, replaceRange])
+
+  const replaceAllMatches = useCallback(() => {
+    if (!editor || matches.length === 0) {
+      return
+    }
+    const tr = editor.state.tr
+    // Why: process matches last-to-first so each edit can't invalidate the
+    // positions of matches we haven't replaced yet, keeping it a single undo.
+    for (let index = matches.length - 1; index >= 0; index -= 1) {
+      const match = matches[index]
+      if (replaceQuery) {
+        tr.insertText(replaceQuery, match.from, match.to)
+      } else {
+        tr.delete(match.from, match.to)
+      }
+    }
+    editor.view.dispatch(tr)
+  }, [editor, matches, replaceQuery])
 
   const moveToMatch = useCallback(
     (direction: 1 | -1) => {
@@ -221,14 +285,28 @@ export function useRichMarkdownSearch({
   }, [closeSearch, isSearchOpen, keybindings, openSearch, rootRef])
 
   return {
-    activeMatchIndex,
-    closeSearch,
-    isSearchOpen,
-    matchCount,
-    moveToMatch,
     openSearch,
-    searchInputRef,
-    searchQuery,
-    setSearchQuery
+    searchState: {
+      activeMatchIndex,
+      isReplaceMode,
+      isSearchOpen,
+      matchCase,
+      matchCount,
+      replaceQuery,
+      searchQuery,
+      searchInputRef,
+      wholeWord
+    },
+    searchActions: {
+      closeSearch,
+      moveToMatch,
+      replaceAllMatches,
+      replaceCurrentMatch,
+      setReplaceQuery,
+      setSearchQuery,
+      toggleMatchCase,
+      toggleReplaceMode,
+      toggleWholeWord
+    }
   }
 }

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -6,6 +6,7 @@ import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { useAppStore } from '@/store'
 import {
   isMarkdownPreviewFindShortcut,
+  isMarkdownPreviewReplaceShortcut,
   isMarkdownPreviewSearchQueryTooLarge
 } from './markdown-preview-search'
 import {
@@ -80,6 +81,16 @@ export function useRichMarkdownSearch({
   const openSearch = useCallback(() => {
     if (isSearchOpen) {
       // Why: same-value setState is a no-op so the focus effect won't re-fire.
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    } else {
+      setIsSearchOpen(true)
+    }
+  }, [isSearchOpen])
+
+  const openReplace = useCallback(() => {
+    setIsReplaceMode(true)
+    if (isSearchOpen) {
       searchInputRef.current?.focus()
       searchInputRef.current?.select()
     } else {
@@ -270,6 +281,16 @@ export function useRichMarkdownSearch({
       }
 
       if (
+        isMarkdownPreviewReplaceShortcut(event, getShortcutPlatform(), keybindings) &&
+        targetInsideEditor
+      ) {
+        event.preventDefault()
+        event.stopPropagation()
+        openReplace()
+        return
+      }
+
+      if (
         event.key === 'Escape' &&
         isSearchOpen &&
         (targetInsideEditor || target === searchInputRef.current)
@@ -282,7 +303,7 @@ export function useRichMarkdownSearch({
 
     window.addEventListener('keydown', handleKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [closeSearch, isSearchOpen, keybindings, openSearch, rootRef])
+  }, [closeSearch, isSearchOpen, keybindings, openReplace, openSearch, rootRef])
 
   return {
     openSearch,

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -105,7 +105,13 @@ export function useRichMarkdownSearch({
     setReplaceQuery('')
     setDebouncedQuery('')
     setRawActiveMatchIndex(-1)
-  }, [])
+    // Why: closing the bar unmounts the focused search input, dropping focus to
+    // <body> — outside the editor root — so the find/replace shortcut's
+    // targetInsideEditor guard would ignore the next keypress until the user
+    // re-clicks the editor. Returning focus to the editor keeps reopening via
+    // keyboard working and restores the caret to the document.
+    editor?.commands.focus()
+  }, [editor])
 
   const toggleMatchCase = useCallback(() => setMatchCase((value) => !value), [])
   const toggleWholeWord = useCallback(() => setWholeWord((value) => !value), [])

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10960,7 +10960,16 @@
           "32ae8d7d57": "Previous match",
           "158c645829": "Find in rich markdown editor",
           "98b89276f3": "Find in rich editor",
-          "a86958d508": "No results"
+          "a86958d508": "No results",
+          "hideReplace": "Hide replace",
+          "showReplace": "Toggle replace",
+          "toggleReplace": "Toggle replace",
+          "matchCase": "Match case",
+          "wholeWord": "Match whole word",
+          "replacePlaceholder": "Replace",
+          "replaceAria": "Replace in rich markdown editor",
+          "replaceOne": "Replace",
+          "replaceAll": "Replace all"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "No blocks found",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10961,15 +10961,13 @@
           "158c645829": "Find in rich markdown editor",
           "98b89276f3": "Find in rich editor",
           "a86958d508": "No results",
-          "hideReplace": "Hide replace",
-          "showReplace": "Toggle replace",
-          "toggleReplace": "Toggle replace",
-          "matchCase": "Match case",
-          "wholeWord": "Match whole word",
-          "replacePlaceholder": "Replace",
-          "replaceAria": "Replace in rich markdown editor",
-          "replaceOne": "Replace",
-          "replaceAll": "Replace all"
+          "e8c147435f": "Hide replace",
+          "9cdc38be33": "Toggle replace",
+          "482b637099": "Match case",
+          "68d090241d": "Match whole word",
+          "fd97c7e585": "Replace",
+          "44682b4159": "Replace in rich markdown editor",
+          "c2884f5e95": "Replace all"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "No blocks found",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10960,7 +10960,16 @@
           "32ae8d7d57": "Partido anterior",
           "158c645829": "Buscar en el editor de markdowns enriquecido",
           "98b89276f3": "Buscar en editor enriquecido",
-          "a86958d508": "Sin resultados"
+          "a86958d508": "Sin resultados",
+          "hideReplace": "Hide replace",
+          "showReplace": "Toggle replace",
+          "toggleReplace": "Toggle replace",
+          "matchCase": "Match case",
+          "wholeWord": "Match whole word",
+          "replacePlaceholder": "Replace",
+          "replaceAria": "Replace in rich markdown editor",
+          "replaceOne": "Replace",
+          "replaceAll": "Replace all"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "No se encontraron bloques",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10961,15 +10961,13 @@
           "158c645829": "Buscar en el editor de markdowns enriquecido",
           "98b89276f3": "Buscar en editor enriquecido",
           "a86958d508": "Sin resultados",
-          "hideReplace": "Hide replace",
-          "showReplace": "Toggle replace",
-          "toggleReplace": "Toggle replace",
-          "matchCase": "Match case",
-          "wholeWord": "Match whole word",
-          "replacePlaceholder": "Replace",
-          "replaceAria": "Replace in rich markdown editor",
-          "replaceOne": "Replace",
-          "replaceAll": "Replace all"
+          "e8c147435f": "Ocultar reemplazo",
+          "9cdc38be33": "Mostrar reemplazo",
+          "482b637099": "Distingue mayúsculas y minúsculas",
+          "68d090241d": "Coincidir con toda la palabra",
+          "fd97c7e585": "Reemplazar",
+          "44682b4159": "Reemplazar en el editor de markdown enriquecido",
+          "c2884f5e95": "Reemplazar todo"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "No se encontraron bloques",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10960,7 +10960,16 @@
           "32ae8d7d57": "前の一致",
           "158c645829": "リッチ markdown エディタで検索",
           "98b89276f3": "リッチエディターで検索",
-          "a86958d508": "結果はありません"
+          "a86958d508": "結果はありません",
+          "hideReplace": "Hide replace",
+          "showReplace": "Toggle replace",
+          "toggleReplace": "Toggle replace",
+          "matchCase": "Match case",
+          "wholeWord": "Match whole word",
+          "replacePlaceholder": "Replace",
+          "replaceAria": "Replace in rich markdown editor",
+          "replaceOne": "Replace",
+          "replaceAll": "Replace all"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "ブロックが見つかりませんでした",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10961,15 +10961,13 @@
           "158c645829": "リッチ markdown エディタで検索",
           "98b89276f3": "リッチエディターで検索",
           "a86958d508": "結果はありません",
-          "hideReplace": "Hide replace",
-          "showReplace": "Toggle replace",
-          "toggleReplace": "Toggle replace",
-          "matchCase": "Match case",
-          "wholeWord": "Match whole word",
-          "replacePlaceholder": "Replace",
-          "replaceAria": "Replace in rich markdown editor",
-          "replaceOne": "Replace",
-          "replaceAll": "Replace all"
+          "e8c147435f": "置換を非表示",
+          "9cdc38be33": "置換を表示",
+          "482b637099": "大文字と小文字を区別",
+          "68d090241d": "単語全体に一致",
+          "fd97c7e585": "置換",
+          "44682b4159": "リッチ markdown エディタで置換",
+          "c2884f5e95": "すべて置換"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "ブロックが見つかりませんでした",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10960,7 +10960,16 @@
           "32ae8d7d57": "이전 일치 항목",
           "158c645829": "리치 markdown 편집기에서 찾기",
           "98b89276f3": "리치 에디터에서 찾기",
-          "a86958d508": "결과 없음"
+          "a86958d508": "결과 없음",
+          "hideReplace": "Hide replace",
+          "showReplace": "Toggle replace",
+          "toggleReplace": "Toggle replace",
+          "matchCase": "Match case",
+          "wholeWord": "Match whole word",
+          "replacePlaceholder": "Replace",
+          "replaceAria": "Replace in rich markdown editor",
+          "replaceOne": "Replace",
+          "replaceAll": "Replace all"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "블록을 찾을 수 없습니다.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10961,15 +10961,13 @@
           "158c645829": "리치 markdown 편집기에서 찾기",
           "98b89276f3": "리치 에디터에서 찾기",
           "a86958d508": "결과 없음",
-          "hideReplace": "Hide replace",
-          "showReplace": "Toggle replace",
-          "toggleReplace": "Toggle replace",
-          "matchCase": "Match case",
-          "wholeWord": "Match whole word",
-          "replacePlaceholder": "Replace",
-          "replaceAria": "Replace in rich markdown editor",
-          "replaceOne": "Replace",
-          "replaceAll": "Replace all"
+          "e8c147435f": "바꾸기 숨기기",
+          "9cdc38be33": "바꾸기 표시",
+          "482b637099": "대소문자 구분",
+          "68d090241d": "전체 단어 일치",
+          "fd97c7e585": "바꾸기",
+          "44682b4159": "리치 markdown 편집기에서 바꾸기",
+          "c2884f5e95": "모두 바꾸기"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "블록을 찾을 수 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10961,15 +10961,13 @@
           "158c645829": "在 Markdown 编辑器中查找",
           "98b89276f3": "在编辑器中查找",
           "a86958d508": "没有结果",
-          "hideReplace": "Hide replace",
-          "showReplace": "Toggle replace",
-          "toggleReplace": "Toggle replace",
-          "matchCase": "Match case",
-          "wholeWord": "Match whole word",
-          "replacePlaceholder": "Replace",
-          "replaceAria": "Replace in rich markdown editor",
-          "replaceOne": "Replace",
-          "replaceAll": "Replace all"
+          "e8c147435f": "隐藏替换",
+          "9cdc38be33": "显示替换",
+          "482b637099": "区分大小写",
+          "68d090241d": "匹配整个单词",
+          "fd97c7e585": "替换",
+          "44682b4159": "在 Markdown 编辑器中替换",
+          "c2884f5e95": "全部替换"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "没有找到块",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10960,7 +10960,16 @@
           "32ae8d7d57": "上一个结果",
           "158c645829": "在 Markdown 编辑器中查找",
           "98b89276f3": "在编辑器中查找",
-          "a86958d508": "没有结果"
+          "a86958d508": "没有结果",
+          "hideReplace": "Hide replace",
+          "showReplace": "Toggle replace",
+          "toggleReplace": "Toggle replace",
+          "matchCase": "Match case",
+          "wholeWord": "Match whole word",
+          "replacePlaceholder": "Replace",
+          "replaceAria": "Replace in rich markdown editor",
+          "replaceOne": "Replace",
+          "replaceAll": "Replace all"
         },
         "RichMarkdownSlashMenu": {
           "82c6816ff8": "没有找到块",

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -179,6 +179,14 @@ describe('keybindings', () => {
     expect(formatKeybindingList(['Mod+Shift+O'], 'darwin')).toBe('⌘⇧O')
   })
 
+  it('defines platform-native replace-in-editor shortcuts', () => {
+    expect(getEffectiveKeybindingsForAction('editor.replace', 'darwin')).toEqual(['Mod+Alt+F'])
+    expect(getEffectiveKeybindingsForAction('editor.replace', 'linux')).toEqual(['Mod+H'])
+    expect(getEffectiveKeybindingsForAction('editor.replace', 'win32')).toEqual(['Mod+H'])
+    expect(formatKeybindingList(['Mod+Alt+F'], 'darwin')).toBe('⌘⌥F')
+    expect(formatKeybindingList(['Mod+H'], 'linux')).toBe('Ctrl+H')
+  })
+
   it('uses overrides as the complete effective binding list for an action', () => {
     const overrides = {
       'worktree.quickOpen': ['Ctrl+Alt+O', 'not-a-shortcut']

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -85,6 +85,7 @@ export type KeybindingActionId =
   | 'browser.focusAddressBar'
   | 'browser.grabElement'
   | 'editor.find'
+  | 'editor.replace'
   | 'editor.save'
   | 'editor.markdownPreview'
   | 'editor.copyContext'
@@ -772,6 +773,20 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'editor',
     searchKeywords: ['shortcut', 'editor', 'find', 'search'],
     defaultBindings: platformBindings(['Mod+F'])
+  },
+  {
+    id: 'editor.replace',
+    title: 'Replace in editor',
+    group: 'Editors',
+    scope: 'editor',
+    searchKeywords: ['shortcut', 'editor', 'replace', 'find', 'search'],
+    // Why: match the source editor's native replace shortcut — Cmd+Alt+F on
+    // macOS, Ctrl+H on Linux/Windows.
+    defaultBindings: {
+      darwin: ['Mod+Alt+F'],
+      linux: ['Mod+H'],
+      win32: ['Mod+H']
+    }
   },
   {
     id: 'editor.save',


### PR DESCRIPTION
## Summary

The rich markdown editor's find bar was find-only, forcing users into the source editor for any replace. Add Replace / Replace All plus Match Case and Whole Word toggles in a VSCode-style two-row find widget (regex intentionally omitted). Search/replace operates on the rendered ProseMirror text, consistent with the existing find behavior.

- **Replace** and **Replace All**
- **Match case** (`Aa`) and **Match whole word** (`ab`) toggles
- **Keyboard shortcut to open replace**, matching the source editor: `⌘⌥F` on
  macOS, `Ctrl+H` on Linux/Windows (rebindable in Settings -> Shortcuts)
- **Bug fix:** the find shortcut stopped working after closing the bar (via `X`
  or `Esc`) until the editor was re-clicked. Now focus returns to the editor on
  close, so the shortcut keeps working


## Screenshots

<img width="385" height="86" alt="image" src="https://github.com/user-attachments/assets/29a442c7-8105-46a2-b2b5-f1f42cc8d309" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` -22,046 passed | 28 skipped
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added unit tests for the match engine: `matchCase`, `wholeWord`, the
combination of both, and Unicode/underscore word boundaries, plus option
pass-through in the rich-editor match finder, and verified the new
`editor.replace` keybinding has no conflicts. The close-focus fix and UI wiring
are not separately unit-tested: this module's tests are pure-function only, and
there is no existing harness that mounts the hook with a live Tiptap editor and
real DOM focus (which is what verifying focus restoration would require).
Verified manually in-app.

## AI Review Report

Reviewed the diff for correctness, cross-platform safety, and performance:

- **Correctness:** `Replace All` processes matches in reverse so earlier
  positions aren't invalidated; `Replace` leaves the active index in place so
  the next match shifts into it after recompute. Empty replacement uses
  `tr.delete` because ProseMirror text nodes can't hold an empty string. Toggle
  buttons `preventDefault` on mousedown so focus stays in the search input and
  match navigation keeps working. Decorations recompute via the existing
  debounced revision path after each edit. The close-focus fix routes every
  close path (`X`, Escape in either input, window-level Escape) through one
  `closeSearch` that restores editor focus.
- **Cross-platform (macOS / Linux / Windows):** No hardcoded `metaKey` — the new
  `editor.replace` binding resolves `Mod` → Cmd/Ctrl per platform (`⌘⌥F` /
  `Ctrl+H`), and the registry's exact-modifier matcher was verified not to
  collide with `editor.find`. Shortcut is handled via a window-capture listener
  so `Ctrl+H` can't fall through to a ProseMirror delete. Shortcut label in the
  tooltip is platform-formatted. No file paths, shell, or Electron-specific code
  touched; CSS uses existing design tokens.
- **SSH / remote:** Search/replace and focus handling run entirely on the
  in-memory ProseMirror document in the renderer — no assumption of local
  execution, so behavior is identical over SSH/remote worktrees.
- **Performance:** Match computation stays debounced (150ms) and size-capped;
  `Replace All` is a single dispatch/undo step. No hot-path regressions.

## Security Audit

- **Input handling:** Search and replace strings are user text bounded by the
  existing 2KB query cap. Regex was intentionally not added, so no user input is
  compiled into a regex — **no ReDoS surface**. The whole-word check uses a fixed
  `/[\p{L}\p{N}_]/u` class tested against single characters.
- **Injection:** Replacement text is inserted via `tr.insertText` / `tr.delete`
  as plain text — no HTML/markdown is interpreted, so no markup injection.
- **Other:** No command execution, path handling, IPC, auth, secrets, or new
  dependencies. The new `editor.replace` action is a renderer-scoped keybinding.
  Localization keys were synced into `en/es/ja/ko/zh` via the repo's catalog
  script.