### PR TITLE
Harden system SSH port forwarding

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -68,7 +68,9 @@ const {
     removeForward: vi.fn(),
     listForwards: vi.fn().mockReturnValue([]),
     removeAllForwards: vi.fn(),
-    dispose: vi.fn()
+    dispose: vi.fn(),
+    setCallbacks: vi.fn(),
+    callbacksRef: { current: null as unknown }
   },
   mockPortScannerCallbacks: new Map<string, unknown>(),
   mockNextConnectionManagers: [] as unknown[],
@@ -179,7 +181,12 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 vi.mock('../ssh/ssh-port-forward', () => ({
   SshPortForwardManager: class MockPortForwardManager {
     constructor() {
-      return mockNextPortForwardManagers.shift() ?? mockPortForwardManager
+      const manager = (mockNextPortForwardManagers.shift() ??
+        mockPortForwardManager) as typeof mockPortForwardManager
+      manager.setCallbacks.mockImplementation((callbacks: unknown) => {
+        manager.callbacksRef.current = callbacks
+      })
+      return manager
     }
   }
 }))
@@ -240,7 +247,9 @@ describe('SSH IPC handlers', () => {
     removeForward: vi.fn(),
     listForwards: vi.fn().mockReturnValue([]),
     removeAllForwards: vi.fn(),
-    dispose: vi.fn()
+    dispose: vi.fn(),
+    setCallbacks: vi.fn(),
+    callbacksRef: { current: null as unknown }
   })
 
   beforeEach(async () => {
@@ -260,6 +269,7 @@ describe('SSH IPC handlers', () => {
     mockSshStore.updateTarget.mockReset()
     mockSshStore.removeTarget.mockReset()
     mockSshStore.importFromSshConfig.mockReset().mockReturnValue([])
+    mockWindow.webContents.send.mockReset()
     mockStore.getSshRemotePtyLeases.mockReset().mockReturnValue([])
     mockStore.markSshRemotePtyLease.mockReset()
     mockStore.markSshRemotePtyLeases.mockReset()
@@ -294,6 +304,8 @@ describe('SSH IPC handlers', () => {
     mockPortForwardManager.listForwards.mockReset().mockReturnValue([])
     mockPortForwardManager.removeAllForwards.mockReset()
     mockPortForwardManager.dispose.mockReset()
+    mockPortForwardManager.setCallbacks.mockReset()
+    mockPortForwardManager.callbacksRef.current = null
     powerMonitorOnMock.mockReset()
     powerMonitorOffMock.mockReset()
     vi.mocked(getSshPtyProvider).mockReset()
@@ -747,6 +759,54 @@ describe('SSH IPC handlers', () => {
     )
     expect(replacementConnectionManager.getConnection).not.toHaveBeenCalled()
     expect(replacementPortForwardManager.listForwards).not.toHaveBeenCalled()
+  })
+
+  it('persists desired forwards and broadcasts when an active forward closes unexpectedly', () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy',
+      portForwards: [
+        {
+          localPort: 4100,
+          remoteHost: '127.0.0.1',
+          remotePort: 3000,
+          label: 'app'
+        }
+      ]
+    }
+    const forward = {
+      id: 'pf-1',
+      connectionId: 'ssh-1',
+      localPort: 4100,
+      remoteHost: '127.0.0.1',
+      remotePort: 3000,
+      label: 'app'
+    }
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockPortForwardManager.listForwards.mockReturnValue([])
+
+    const callbacks = mockPortForwardManager.callbacksRef.current as {
+      onForwardClosed: (entry: typeof forward, reason: { kind: 'unexpected-exit' }) => void
+    }
+    callbacks.onForwardClosed(forward, { kind: 'unexpected-exit' })
+
+    expect(mockSshStore.updateTarget).toHaveBeenCalledWith('ssh-1', {
+      portForwards: [
+        {
+          localPort: 4100,
+          remoteHost: '127.0.0.1',
+          remotePort: 3000,
+          label: 'app'
+        }
+      ]
+    })
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith('ssh:port-forwards-changed', {
+      targetId: 'ssh-1',
+      forwards: []
+    })
   })
 
   it('disconnects the original session and releases original forwards after re-registration', async () => {

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -66,6 +66,7 @@ const {
     addForward: vi.fn(),
     updateForward: vi.fn(),
     removeForward: vi.fn(),
+    removeForwardAndWait: vi.fn(),
     listForwards: vi.fn().mockReturnValue([]),
     removeAllForwards: vi.fn(),
     dispose: vi.fn(),
@@ -301,6 +302,7 @@ describe('SSH IPC handlers', () => {
     mockPortForwardManager.addForward.mockReset()
     mockPortForwardManager.updateForward.mockReset()
     mockPortForwardManager.removeForward.mockReset()
+    mockPortForwardManager.removeForwardAndWait.mockReset()
     mockPortForwardManager.listForwards.mockReset().mockReturnValue([])
     mockPortForwardManager.removeAllForwards.mockReset()
     mockPortForwardManager.dispose.mockReset()
@@ -688,7 +690,7 @@ describe('SSH IPC handlers', () => {
       .mockResolvedValueOnce(forward)
       .mockResolvedValueOnce(newForward)
     mockPortForwardManager.updateForward.mockResolvedValue(updatedForward)
-    mockPortForwardManager.removeForward.mockReturnValue(updatedForward)
+    mockPortForwardManager.removeForwardAndWait.mockResolvedValue(updatedForward)
     mockPortForwardManager.listForwards.mockReturnValue([forward])
 
     await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -586,6 +586,19 @@ export function registerSshHandlers(
     connectionManager = new SshConnectionManager(callbacks)
   }
   portForwardManager ??= new SshPortForwardManager()
+  portForwardManager.setCallbacks({
+    onForwardClosed: (entry, reason) => {
+      if (reason.kind === 'unexpected-exit') {
+        console.warn(
+          `[ssh] Port forward ${entry.localPort} → ${entry.remoteHost}:${entry.remotePort} closed unexpectedly${
+            reason.detail ? `: ${reason.detail}` : ''
+          }`
+        )
+      }
+      persistPortForwardsWithUnrestored(entry.connectionId)
+      broadcastPortForwards(getCurrentMainWindow, entry.connectionId)
+    }
+  })
   refreshActiveRelaySessions()
   registerPowerMonitorReconnect()
   registerSshBrowseHandler(() => connectionManager)

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -1107,8 +1107,8 @@ export function registerSshHandlers(
     }
   )
 
-  ipcMain.handle('ssh:removePortForward', (_event, args: { id: string }) => {
-    const removed = portForwardManager!.removeForward(args.id)
+  ipcMain.handle('ssh:removePortForward', async (_event, args: { id: string }) => {
+    const removed = await portForwardManager!.removeForwardAndWait(args.id)
     if (removed) {
       persistPortForwards(removed.connectionId)
       broadcastPortForwards(getCurrentMainWindow, removed.connectionId)

--- a/src/main/ssh/ssh-port-forward-provider.ts
+++ b/src/main/ssh/ssh-port-forward-provider.ts
@@ -1,0 +1,28 @@
+import type { PortForwardEntry } from '../../shared/ssh-types'
+import type { SshConnection } from './ssh-connection'
+
+export type PortForwardCloseReason =
+  | { kind: 'removed' }
+  | { kind: 'unexpected-exit'; detail?: string }
+
+export type PortForwardStartOptions = {
+  id: string
+  connectionId: string
+  localHost: '127.0.0.1'
+  localPort: number
+  remoteHost: string
+  remotePort: number
+  label?: string
+  onUnexpectedClose?: (entry: PortForwardEntry, reason: PortForwardCloseReason) => void
+}
+
+export type StartedPortForward = {
+  entry: PortForwardEntry
+  close: () => Promise<void>
+  dispose: () => void
+}
+
+export type SshPortForwardProvider = {
+  canHandle(conn: SshConnection): boolean
+  start(conn: SshConnection, options: PortForwardStartOptions): Promise<StartedPortForward>
+}

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'events'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { SshPortForwardManager } from './ssh-port-forward'
+
+const { spawnSystemSshPortForwardMock } = vi.hoisted(() => ({
+  spawnSystemSshPortForwardMock: vi.fn()
+}))
+
+vi.mock('./ssh-system-fallback', () => ({
+  spawnSystemSshPortForward: spawnSystemSshPortForwardMock
+}))
 
 function createMockConn(forwardOutErr?: Error) {
   const mockChannel = {
@@ -18,9 +27,34 @@ function createMockConn(forwardOutErr?: Error) {
   }
   return {
     getClient: vi.fn().mockReturnValue(mockClient),
+    usesSystemSshTransport: vi.fn().mockReturnValue(false),
     mockClient,
     mockChannel
   }
+}
+
+function createSystemSshConn() {
+  return {
+    getClient: vi.fn().mockReturnValue(null),
+    usesSystemSshTransport: vi.fn().mockReturnValue(true),
+    getTarget: vi.fn().mockReturnValue({
+      id: 'target-1',
+      label: 'container',
+      host: 'container',
+      port: 22,
+      username: 'vscode'
+    })
+  }
+}
+
+function createFakeSystemSshProcess() {
+  const process = new EventEmitter() as EventEmitter & {
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  process.stderr = new EventEmitter()
+  process.kill = vi.fn()
+  return process
 }
 
 // Mock the net module to avoid real TCP listeners
@@ -48,6 +82,11 @@ describe('SshPortForwardManager', () => {
 
   beforeEach(() => {
     manager = new SshPortForwardManager()
+    spawnSystemSshPortForwardMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('adds a port forward and returns entry', async () => {
@@ -64,10 +103,67 @@ describe('SshPortForwardManager', () => {
   })
 
   it('throws when SSH client is not connected', async () => {
-    const conn = { getClient: vi.fn().mockReturnValue(null) }
+    const conn = {
+      getClient: vi.fn().mockReturnValue(null),
+      usesSystemSshTransport: vi.fn().mockReturnValue(false)
+    }
     await expect(
       manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)
     ).rejects.toThrow('SSH connection is not established')
+  })
+
+  it('adds a system SSH port forward when no ssh2 client is available', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    await vi.advanceTimersByTimeAsync(250)
+    const entry = await pending
+
+    expect(spawnSystemSshPortForwardMock).toHaveBeenCalledWith(
+      conn.getTarget(),
+      3000,
+      '127.0.0.1',
+      8080
+    )
+    expect(entry).toMatchObject({
+      connectionId: 'conn-1',
+      localPort: 3000,
+      remoteHost: '127.0.0.1',
+      remotePort: 8080
+    })
+    expect(manager.listForwards('conn-1')).toHaveLength(1)
+  })
+
+  it('surfaces early system SSH port forward failures', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    process.stderr.emit('data', Buffer.from('bind: Address already in use'))
+    process.emit('exit', 255)
+
+    await expect(pending).rejects.toThrow('bind: Address already in use')
+    expect(manager.listForwards('conn-1')).toHaveLength(0)
+  })
+
+  it('kills a system SSH tunnel when removing the forward', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    await vi.advanceTimersByTimeAsync(250)
+    const entry = await pending
+
+    expect(manager.removeForward(entry.id)).toMatchObject({ id: entry.id })
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(manager.listForwards('conn-1')).toHaveLength(0)
   })
 
   it('lists forwards filtered by connectionId', async () => {

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events'
+import { createServer } from 'net'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { SshPortForwardManager } from './ssh-port-forward'
 
@@ -59,6 +60,30 @@ function createFakeSystemSshForward() {
     close: vi.fn().mockResolvedValue(undefined),
     dispose: vi.fn()
   }
+}
+
+function createFakeSocket() {
+  const socket = new EventEmitter() as EventEmitter & {
+    destroyed: boolean
+    destroy: ReturnType<typeof vi.fn>
+    pipe: ReturnType<typeof vi.fn>
+  }
+  socket.destroyed = false
+  socket.destroy = vi.fn().mockImplementation(() => {
+    socket.destroyed = true
+    socket.emit('close')
+  })
+  socket.pipe = vi.fn().mockReturnValue(socket)
+  return socket
+}
+
+function getLastMockServer() {
+  const createServerMock = vi.mocked(createServer)
+  return createServerMock.mock.results.at(-1)?.value as
+    | {
+        _connectionHandler: (socket: ReturnType<typeof createFakeSocket>) => void
+      }
+    | undefined
 }
 
 vi.mock('net', () => {
@@ -227,6 +252,57 @@ describe('SshPortForwardManager', () => {
     const removed = manager.removeForward(entry.id)
     expect(removed).toMatchObject({ id: entry.id, localPort: 3000 })
     expect(manager.listForwards()).toHaveLength(0)
+  })
+
+  it('awaits forward close when removing a forward for user actions', async () => {
+    const conn = createMockConn()
+    const entry = await manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)
+
+    await expect(manager.removeForwardAndWait(entry.id)).resolves.toMatchObject({
+      id: entry.id,
+      localPort: 3000
+    })
+    expect(manager.listForwards()).toHaveLength(0)
+  })
+
+  it('destroys local sockets that emit errors', async () => {
+    const conn = createMockConn()
+    await manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)
+    const server = getLastMockServer()
+    const socket = createFakeSocket()
+
+    server?._connectionHandler(socket)
+    socket.emit('error', new Error('client reset'))
+
+    expect(socket.destroy).toHaveBeenCalled()
+  })
+
+  it('closes late ssh2 channels after the forward was removed', async () => {
+    const mockChannel = {
+      pipe: vi.fn().mockReturnThis(),
+      on: vi.fn(),
+      close: vi.fn()
+    }
+    let callback!: (error: Error | undefined, channel: typeof mockChannel) => void
+    const mockClient = {
+      forwardOut: vi.fn().mockImplementation((_bindAddr, _bindPort, _destHost, _destPort, cb) => {
+        callback = cb
+      })
+    }
+    const conn = {
+      getClient: vi.fn().mockReturnValue(mockClient),
+      usesSystemSshTransport: vi.fn().mockReturnValue(false)
+    }
+    const entry = await manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)
+    const server = getLastMockServer()
+    const socket = createFakeSocket()
+
+    server?._connectionHandler(socket)
+    await manager.removeForwardAndWait(entry.id)
+    callback(undefined, mockChannel)
+
+    expect(mockChannel.close).toHaveBeenCalled()
+    expect(socket.destroy).toHaveBeenCalled()
   })
 
   it('returns null when removing nonexistent forward', () => {

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -51,9 +51,13 @@ function createFakeSystemSshProcess() {
   const process = new EventEmitter() as EventEmitter & {
     stderr: EventEmitter
     kill: ReturnType<typeof vi.fn>
+    exitCode: number | null
+    signalCode: NodeJS.Signals | null
   }
   process.stderr = new EventEmitter()
   process.kill = vi.fn()
+  process.exitCode = null
+  process.signalCode = null
   return process
 }
 
@@ -164,6 +168,55 @@ describe('SshPortForwardManager', () => {
     expect(manager.removeForward(entry.id)).toMatchObject({ id: entry.id })
     expect(process.kill).toHaveBeenCalledWith('SIGTERM')
     expect(manager.listForwards('conn-1')).toHaveLength(0)
+  })
+
+  it('waits for system SSH tunnels to exit before async removal resolves', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    await vi.advanceTimersByTimeAsync(250)
+    await pending
+
+    let resolved = false
+    const removal = manager.removeAllForwards('conn-1').then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(resolved).toBe(false)
+
+    process.emit('exit', null)
+    await removal
+    expect(resolved).toBe(true)
+  })
+
+  it('escalates stuck system SSH tunnels to SIGKILL before async removal resolves', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    await vi.advanceTimersByTimeAsync(250)
+    await pending
+
+    let resolved = false
+    const removal = manager.removeAllForwards('conn-1').then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(process.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(resolved).toBe(false)
+
+    process.emit('exit', null)
+    await removal
+    expect(resolved).toBe(true)
   })
 
   it('lists forwards filtered by connectionId', async () => {

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -1,14 +1,18 @@
 import { EventEmitter } from 'events'
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { SshPortForwardManager } from './ssh-port-forward'
 
-const { spawnSystemSshPortForwardMock } = vi.hoisted(() => ({
-  spawnSystemSshPortForwardMock: vi.fn()
+const { startSystemSshPortForwardProcessMock } = vi.hoisted(() => ({
+  startSystemSshPortForwardProcessMock: vi.fn()
 }))
 
-vi.mock('./ssh-system-fallback', () => ({
-  spawnSystemSshPortForward: spawnSystemSshPortForwardMock
-}))
+vi.mock('./system-ssh-forward-process', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    startSystemSshPortForwardProcess: startSystemSshPortForwardProcessMock
+  }
+})
 
 function createMockConn(forwardOutErr?: Error) {
   const mockChannel = {
@@ -47,28 +51,28 @@ function createSystemSshConn() {
   }
 }
 
-function createFakeSystemSshProcess() {
-  const process = new EventEmitter() as EventEmitter & {
-    stderr: EventEmitter
-    kill: ReturnType<typeof vi.fn>
-    exitCode: number | null
-    signalCode: NodeJS.Signals | null
+function createFakeSystemSshForward() {
+  const process = Object.assign(new EventEmitter(), { stderr: new EventEmitter() })
+  return {
+    process,
+    waitForStartup: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn()
   }
-  process.stderr = new EventEmitter()
-  process.kill = vi.fn()
-  process.exitCode = null
-  process.signalCode = null
-  return process
 }
 
-// Mock the net module to avoid real TCP listeners
 vi.mock('net', () => {
-  const listeners = new Map<string, (...args: unknown[]) => void>()
   return {
     createServer: vi.fn().mockImplementation((connectionHandler) => {
+      const listeners = new Map<string, (...args: unknown[]) => void>()
       const server = {
-        listen: vi.fn().mockImplementation((_port, _host, cb) => cb()),
-        close: vi.fn(),
+        listen: vi.fn().mockImplementation(() => {
+          listeners.get('listening')?.()
+        }),
+        close: vi.fn().mockImplementation((cb?: () => void) => cb?.()),
+        once: vi.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+          listeners.set(event, handler)
+        }),
         on: vi.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
           listeners.set(event, handler)
         }),
@@ -86,14 +90,10 @@ describe('SshPortForwardManager', () => {
 
   beforeEach(() => {
     manager = new SshPortForwardManager()
-    spawnSystemSshPortForwardMock.mockReset()
+    startSystemSshPortForwardProcessMock.mockReset()
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('adds a port forward and returns entry', async () => {
+  it('adds an ssh2 port forward and returns entry', async () => {
     const conn = createMockConn()
     const entry = await manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)
 
@@ -106,7 +106,7 @@ describe('SshPortForwardManager', () => {
     expect(entry.id).toBeDefined()
   })
 
-  it('throws when SSH client is not connected', async () => {
+  it('throws when no port forward provider can handle the connection', async () => {
     const conn = {
       getClient: vi.fn().mockReturnValue(null),
       usesSystemSshTransport: vi.fn().mockReturnValue(false)
@@ -117,21 +117,19 @@ describe('SshPortForwardManager', () => {
   })
 
   it('adds a system SSH port forward when no ssh2 client is available', async () => {
-    vi.useFakeTimers()
-    const process = createFakeSystemSshProcess()
-    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const forward = createFakeSystemSshForward()
+    startSystemSshPortForwardProcessMock.mockReturnValue(forward)
     const conn = createSystemSshConn()
 
-    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
-    await vi.advanceTimersByTimeAsync(250)
-    const entry = await pending
+    const entry = await manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
 
-    expect(spawnSystemSshPortForwardMock).toHaveBeenCalledWith(
+    expect(startSystemSshPortForwardProcessMock).toHaveBeenCalledWith(
       conn.getTarget(),
       3000,
       '127.0.0.1',
       8080
     )
+    expect(forward.waitForStartup).toHaveBeenCalled()
     expect(entry).toMatchObject({
       connectionId: 'conn-1',
       localPort: 3000,
@@ -141,82 +139,74 @@ describe('SshPortForwardManager', () => {
     expect(manager.listForwards('conn-1')).toHaveLength(1)
   })
 
-  it('surfaces early system SSH port forward failures', async () => {
-    vi.useFakeTimers()
-    const process = createFakeSystemSshProcess()
-    spawnSystemSshPortForwardMock.mockReturnValue(process)
+  it('does not register a system SSH forward when startup fails', async () => {
+    const forward = createFakeSystemSshForward()
+    forward.waitForStartup.mockRejectedValue(new Error('bind: Address already in use'))
+    startSystemSshPortForwardProcessMock.mockReturnValue(forward)
     const conn = createSystemSshConn()
 
-    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
-    process.stderr.emit('data', Buffer.from('bind: Address already in use'))
-    process.emit('exit', 255)
-
-    await expect(pending).rejects.toThrow('bind: Address already in use')
+    await expect(
+      manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    ).rejects.toThrow('bind: Address already in use')
     expect(manager.listForwards('conn-1')).toHaveLength(0)
   })
 
-  it('kills a system SSH tunnel when removing the forward', async () => {
-    vi.useFakeTimers()
-    const process = createFakeSystemSshProcess()
-    spawnSystemSshPortForwardMock.mockReturnValue(process)
+  it('disposes a system SSH tunnel when removing the forward', async () => {
+    const forward = createFakeSystemSshForward()
+    startSystemSshPortForwardProcessMock.mockReturnValue(forward)
     const conn = createSystemSshConn()
 
-    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
-    await vi.advanceTimersByTimeAsync(250)
-    const entry = await pending
+    const entry = await manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
 
     expect(manager.removeForward(entry.id)).toMatchObject({ id: entry.id })
-    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(forward.dispose).toHaveBeenCalled()
     expect(manager.listForwards('conn-1')).toHaveLength(0)
   })
 
-  it('waits for system SSH tunnels to exit before async removal resolves', async () => {
-    vi.useFakeTimers()
-    const process = createFakeSystemSshProcess()
-    spawnSystemSshPortForwardMock.mockReturnValue(process)
+  it('awaits system SSH tunnel close before async removal resolves', async () => {
+    let resolveClose!: () => void
+    const forward = createFakeSystemSshForward()
+    forward.close.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveClose = resolve
+      })
+    )
+    startSystemSshPortForwardProcessMock.mockReturnValue(forward)
     const conn = createSystemSshConn()
 
-    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
-    await vi.advanceTimersByTimeAsync(250)
-    await pending
+    await manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
 
     let resolved = false
     const removal = manager.removeAllForwards('conn-1').then(() => {
       resolved = true
     })
 
-    await vi.advanceTimersByTimeAsync(1_999)
-    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    await Promise.resolve()
     expect(resolved).toBe(false)
-
-    process.emit('exit', null)
+    resolveClose()
     await removal
     expect(resolved).toBe(true)
   })
 
-  it('escalates stuck system SSH tunnels to SIGKILL before async removal resolves', async () => {
-    vi.useFakeTimers()
-    const process = createFakeSystemSshProcess()
-    spawnSystemSshPortForwardMock.mockReturnValue(process)
+  it('removes an unexpectedly exited system SSH forward and calls the close callback', async () => {
+    const onForwardClosed = vi.fn()
+    manager.setCallbacks({ onForwardClosed })
+    const forward = createFakeSystemSshForward()
+    startSystemSshPortForwardProcessMock.mockReturnValue(forward)
     const conn = createSystemSshConn()
 
-    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
-    await vi.advanceTimersByTimeAsync(250)
-    await pending
+    const entry = await manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    forward.process.stderr.emit('data', Buffer.from('channel open failed'))
+    forward.process.emit('exit', 255)
 
-    let resolved = false
-    const removal = manager.removeAllForwards('conn-1').then(() => {
-      resolved = true
-    })
-
-    await vi.advanceTimersByTimeAsync(2_000)
-    expect(process.kill).toHaveBeenNthCalledWith(1, 'SIGTERM')
-    expect(process.kill).toHaveBeenNthCalledWith(2, 'SIGKILL')
-    expect(resolved).toBe(false)
-
-    process.emit('exit', null)
-    await removal
-    expect(resolved).toBe(true)
+    expect(manager.listForwards('conn-1')).toHaveLength(0)
+    expect(onForwardClosed).toHaveBeenCalledWith(
+      entry,
+      expect.objectContaining({
+        kind: 'unexpected-exit',
+        detail: expect.stringContaining('channel open failed')
+      })
+    )
   })
 
   it('lists forwards filtered by connectionId', async () => {
@@ -249,7 +239,7 @@ describe('SshPortForwardManager', () => {
     await manager.addForward('conn-1', conn as never, 3001, 'localhost', 8081)
     await manager.addForward('conn-2', conn as never, 3002, 'localhost', 8082)
 
-    manager.removeAllForwards('conn-1')
+    await manager.removeAllForwards('conn-1')
     expect(manager.listForwards()).toHaveLength(1)
     expect(manager.listForwards('conn-2')).toHaveLength(1)
   })
@@ -275,5 +265,42 @@ describe('SshPortForwardManager', () => {
     )
 
     expect(entry.label).toBe('Web Server')
+  })
+
+  it('preserves the existing id when updating a forward succeeds', async () => {
+    const conn = createMockConn()
+    const entry = await manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)
+
+    const updated = await manager.updateForward(entry.id, conn as never, 3001, 'localhost', 8081)
+
+    expect(updated.id).toBe(entry.id)
+    expect(updated.localPort).toBe(3001)
+    expect(updated.remotePort).toBe(8081)
+  })
+
+  it('rolls back a failed system SSH update with the original id', async () => {
+    const initialForward = createFakeSystemSshForward()
+    const failedForward = createFakeSystemSshForward()
+    const rollbackForward = createFakeSystemSshForward()
+    failedForward.waitForStartup.mockRejectedValue(new Error('bind failed'))
+    startSystemSshPortForwardProcessMock
+      .mockReturnValueOnce(initialForward)
+      .mockReturnValueOnce(failedForward)
+      .mockReturnValueOnce(rollbackForward)
+    const conn = createSystemSshConn()
+    const entry = await manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+
+    await expect(
+      manager.updateForward(entry.id, conn as never, 3001, '127.0.0.1', 8081)
+    ).rejects.toThrow('bind failed')
+
+    expect(initialForward.close).toHaveBeenCalled()
+    expect(manager.listForwards('conn-1')).toEqual([
+      expect.objectContaining({
+        id: entry.id,
+        localPort: 3000,
+        remotePort: 8080
+      })
+    ])
   })
 })

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -210,8 +210,8 @@ describe('SshPortForwardManager', () => {
     })
 
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
-    expect(process.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(process.kill).toHaveBeenNthCalledWith(1, 'SIGTERM')
+    expect(process.kill).toHaveBeenNthCalledWith(2, 'SIGKILL')
     expect(resolved).toBe(false)
 
     process.emit('exit', null)

--- a/src/main/ssh/ssh-port-forward.ts
+++ b/src/main/ssh/ssh-port-forward.ts
@@ -1,31 +1,40 @@
-import type { ChildProcess } from 'child_process'
-import { createServer, type Server, type Socket } from 'net'
 import type { SshConnection } from './ssh-connection'
-import { spawnSystemSshPortForward } from './ssh-system-fallback'
+import { Ssh2PortForwardProvider } from './ssh2-port-forward-provider'
+import { SystemSshPortForwardProvider } from './system-ssh-port-forward-provider'
 import type { PortForwardEntry } from '../../shared/ssh-types'
+import type {
+  PortForwardCloseReason,
+  SshPortForwardProvider,
+  StartedPortForward
+} from './ssh-port-forward-provider'
 
 export type { PortForwardEntry }
+export type { PortForwardCloseReason }
 
-type ActiveForward = {
-  entry: PortForwardEntry
-} & (
-  | {
-      kind: 'ssh2'
-      server: Server
-      activeSockets: Set<Socket>
-    }
-  | {
-      kind: 'system-ssh'
-      process: ChildProcess
-    }
-)
-
-const SYSTEM_SSH_FORWARD_STARTUP_SETTLE_MS = 250
-const SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS = 2_000
+type SshPortForwardManagerCallbacks = {
+  onForwardClosed?: (entry: PortForwardEntry, reason: PortForwardCloseReason) => void
+}
 
 export class SshPortForwardManager {
-  private forwards = new Map<string, ActiveForward>()
+  private forwards = new Map<string, StartedPortForward>()
   private nextId = 1
+  private providers: SshPortForwardProvider[]
+  private callbacks: SshPortForwardManagerCallbacks
+
+  constructor(
+    callbacks: SshPortForwardManagerCallbacks = {},
+    providers: SshPortForwardProvider[] = [
+      new Ssh2PortForwardProvider(),
+      new SystemSshPortForwardProvider()
+    ]
+  ) {
+    this.callbacks = callbacks
+    this.providers = providers
+  }
+
+  setCallbacks(callbacks: SshPortForwardManagerCallbacks): void {
+    this.callbacks = callbacks
+  }
 
   async addForward(
     connectionId: string,
@@ -55,108 +64,31 @@ export class SshPortForwardManager {
     remotePort: number,
     label?: string
   ): Promise<PortForwardEntry> {
-    const entry: PortForwardEntry = {
-      id,
-      connectionId,
-      localPort,
-      remoteHost,
-      remotePort,
-      label
-    }
-
-    const client = conn.getClient()
-    if (!client && conn.usesSystemSshTransport()) {
-      const target = conn.getTarget()
-      const process = spawnSystemSshPortForward(target, localPort, remoteHost, remotePort)
-      await this.waitForSystemSshForwardStartup(process)
-      const forward: ActiveForward = { kind: 'system-ssh', entry, process }
-      process.once('exit', () => {
-        const active = this.forwards.get(id)
-        if (active === forward) {
-          this.forwards.delete(id)
-        }
-      })
-      this.forwards.set(id, forward)
-      return entry
-    }
-    if (!client) {
+    const provider = this.providers.find((candidate) => candidate.canHandle(conn))
+    if (!provider) {
       throw new Error('SSH connection is not established')
     }
 
-    const activeSockets = new Set<Socket>()
-
-    const server = createServer((socket) => {
-      activeSockets.add(socket)
-      socket.on('close', () => activeSockets.delete(socket))
-
-      client.forwardOut('127.0.0.1', localPort, remoteHost, remotePort, (err, channel) => {
-        if (err) {
-          socket.destroy()
+    let forward: StartedPortForward | null = null
+    forward = await provider.start(conn, {
+      id,
+      connectionId,
+      localHost: '127.0.0.1',
+      localPort,
+      remoteHost,
+      remotePort,
+      label,
+      onUnexpectedClose: (entry, reason) => {
+        const active = this.forwards.get(id)
+        if (active !== forward) {
           return
         }
-        socket.pipe(channel).pipe(socket)
-        channel.on('close', () => socket.destroy())
-        channel.on('error', () => socket.destroy())
-        socket.on('close', () => channel.close())
-      })
+        this.forwards.delete(id)
+        this.callbacks.onForwardClosed?.(entry, reason)
+      }
     })
-
-    await new Promise<void>((resolve, reject) => {
-      server.on('error', reject)
-      server.listen(localPort, '127.0.0.1', () => {
-        server.removeListener('error', reject)
-        resolve()
-      })
-    })
-
-    this.forwards.set(id, { kind: 'ssh2', entry, server, activeSockets })
-    return entry
-  }
-
-  private waitForSystemSshForwardStartup(process: ChildProcess): Promise<void> {
-    return new Promise((resolve, reject) => {
-      let stderr = ''
-      let settled = false
-      const cleanup = (): void => {
-        clearTimeout(timer)
-        process.off('error', onError)
-        process.off('exit', onExit)
-        process.stderr?.off('data', onStderr)
-      }
-      const finish = (callback: () => void): void => {
-        if (settled) {
-          return
-        }
-        settled = true
-        cleanup()
-        callback()
-      }
-      const onStderr = (chunk: Buffer): void => {
-        stderr += chunk.toString('utf-8')
-      }
-      const onError = (error: Error): void => {
-        finish(() => reject(error))
-      }
-      const onExit = (code: number | null): void => {
-        const detail = stderr.trim()
-        finish(() =>
-          reject(
-            new Error(
-              `System SSH port forward failed${code !== null ? ` (exit ${code})` : ''}${
-                detail ? `: ${detail}` : ''
-              }`
-            )
-          )
-        )
-      }
-      const timer = setTimeout(() => {
-        finish(resolve)
-      }, SYSTEM_SSH_FORWARD_STARTUP_SETTLE_MS)
-
-      process.stderr?.on('data', onStderr)
-      process.once('error', onError)
-      process.once('exit', onExit)
-    })
+    this.forwards.set(id, forward)
+    return forward.entry
   }
 
   async updateForward(
@@ -179,7 +111,8 @@ export class SshPortForwardManager {
     await this.removeForwardAsync(id)
 
     try {
-      return await this.addForward(
+      return await this.addForwardWithId(
+        oldEntry.id,
         oldEntry.connectionId,
         conn,
         localPort,
@@ -212,82 +145,20 @@ export class SshPortForwardManager {
     if (!forward) {
       return null
     }
-    this.teardownForward(forward)
+    forward.dispose()
     this.forwards.delete(id)
     return forward.entry
   }
 
-  // Why: server.close() is async — the OS may not release the port until the
-  // callback fires. callers that need to rebind the same port (updateForward)
-  // must await this variant.
+  // Why: server.close()/process exit are async — callers that need to rebind
+  // the same port (update/reconnect) must wait until the owner fully releases it.
   private removeForwardAsync(id: string): Promise<PortForwardEntry | null> {
     const forward = this.forwards.get(id)
     if (!forward) {
       return Promise.resolve(null)
     }
     this.forwards.delete(id)
-    if (forward.kind === 'system-ssh') {
-      return this.waitForSystemSshForwardStop(forward.process).then(() => forward.entry)
-    }
-    for (const socket of forward.activeSockets) {
-      socket.destroy()
-    }
-    return new Promise((resolve) => {
-      forward.server.close(() => resolve(forward.entry))
-    })
-  }
-
-  private waitForSystemSshForwardStop(process: ChildProcess): Promise<void> {
-    return new Promise((resolve) => {
-      let settled = false
-      const cleanup = (): void => {
-        clearTimeout(escalationTimer)
-        process.off('exit', onExit)
-      }
-      const finish = (): void => {
-        if (settled) {
-          return
-        }
-        settled = true
-        cleanup()
-        resolve()
-      }
-      const onExit = (): void => {
-        finish()
-      }
-      const hasExited = (): boolean => process.exitCode !== null || process.signalCode !== null
-      const kill = (signal: NodeJS.Signals): void => {
-        try {
-          const sent = process.kill(signal)
-          if (!sent && hasExited()) {
-            finish()
-          }
-        } catch {
-          if (hasExited()) {
-            finish()
-          }
-        }
-      }
-      const escalationTimer = setTimeout(() => {
-        // Why: update/reconnect callers must not rebind while a stubborn ssh -L
-        // process still owns the local port.
-        kill('SIGKILL')
-      }, SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
-
-      process.once('exit', onExit)
-      kill('SIGTERM')
-    })
-  }
-
-  private teardownForward(forward: ActiveForward): void {
-    if (forward.kind === 'system-ssh') {
-      forward.process.kill('SIGTERM')
-      return
-    }
-    for (const socket of forward.activeSockets) {
-      socket.destroy()
-    }
-    forward.server.close()
+    return forward.close().then(() => forward.entry)
   }
 
   listForwards(connectionId?: string): PortForwardEntry[] {
@@ -304,8 +175,6 @@ export class SshPortForwardManager {
     const toRemove = [...this.forwards.entries()]
       .filter(([, { entry }]) => entry.connectionId === connectionId)
       .map(([id]) => id)
-    // Why: await each removal so the OS fully releases ports before callers
-    // (like restorePortForwards) try to rebind on the same local ports.
     await Promise.all(toRemove.map((id) => this.removeForwardAsync(id)))
   }
 

--- a/src/main/ssh/ssh-port-forward.ts
+++ b/src/main/ssh/ssh-port-forward.ts
@@ -1,14 +1,27 @@
+import type { ChildProcess } from 'child_process'
 import { createServer, type Server, type Socket } from 'net'
 import type { SshConnection } from './ssh-connection'
+import { spawnSystemSshPortForward } from './ssh-system-fallback'
 import type { PortForwardEntry } from '../../shared/ssh-types'
 
 export type { PortForwardEntry }
 
 type ActiveForward = {
   entry: PortForwardEntry
-  server: Server
-  activeSockets: Set<Socket>
-}
+} & (
+  | {
+      kind: 'ssh2'
+      server: Server
+      activeSockets: Set<Socket>
+    }
+  | {
+      kind: 'system-ssh'
+      process: ChildProcess
+    }
+)
+
+const SYSTEM_SSH_FORWARD_STARTUP_SETTLE_MS = 250
+const SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS = 2_000
 
 export class SshPortForwardManager {
   private forwards = new Map<string, ActiveForward>()
@@ -52,6 +65,20 @@ export class SshPortForwardManager {
     }
 
     const client = conn.getClient()
+    if (!client && conn.usesSystemSshTransport()) {
+      const target = conn.getTarget()
+      const process = spawnSystemSshPortForward(target, localPort, remoteHost, remotePort)
+      await this.waitForSystemSshForwardStartup(process)
+      const forward: ActiveForward = { kind: 'system-ssh', entry, process }
+      process.once('exit', () => {
+        const active = this.forwards.get(id)
+        if (active === forward) {
+          this.forwards.delete(id)
+        }
+      })
+      this.forwards.set(id, forward)
+      return entry
+    }
     if (!client) {
       throw new Error('SSH connection is not established')
     }
@@ -82,8 +109,54 @@ export class SshPortForwardManager {
       })
     })
 
-    this.forwards.set(id, { entry, server, activeSockets })
+    this.forwards.set(id, { kind: 'ssh2', entry, server, activeSockets })
     return entry
+  }
+
+  private waitForSystemSshForwardStartup(process: ChildProcess): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let stderr = ''
+      let settled = false
+      const cleanup = (): void => {
+        clearTimeout(timer)
+        process.off('error', onError)
+        process.off('exit', onExit)
+        process.stderr?.off('data', onStderr)
+      }
+      const finish = (callback: () => void): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanup()
+        callback()
+      }
+      const onStderr = (chunk: Buffer): void => {
+        stderr += chunk.toString('utf-8')
+      }
+      const onError = (error: Error): void => {
+        finish(() => reject(error))
+      }
+      const onExit = (code: number | null): void => {
+        const detail = stderr.trim()
+        finish(() =>
+          reject(
+            new Error(
+              `System SSH port forward failed${code !== null ? ` (exit ${code})` : ''}${
+                detail ? `: ${detail}` : ''
+              }`
+            )
+          )
+        )
+      }
+      const timer = setTimeout(() => {
+        finish(resolve)
+      }, SYSTEM_SSH_FORWARD_STARTUP_SETTLE_MS)
+
+      process.stderr?.on('data', onStderr)
+      process.once('error', onError)
+      process.once('exit', onExit)
+    })
   }
 
   async updateForward(
@@ -152,16 +225,42 @@ export class SshPortForwardManager {
     if (!forward) {
       return Promise.resolve(null)
     }
+    this.forwards.delete(id)
+    if (forward.kind === 'system-ssh') {
+      return this.waitForSystemSshForwardStop(forward.process).then(() => forward.entry)
+    }
     for (const socket of forward.activeSockets) {
       socket.destroy()
     }
-    this.forwards.delete(id)
     return new Promise((resolve) => {
       forward.server.close(() => resolve(forward.entry))
     })
   }
 
+  private waitForSystemSshForwardStop(process: ChildProcess): Promise<void> {
+    process.kill('SIGTERM')
+    return new Promise((resolve) => {
+      const cleanup = (): void => {
+        clearTimeout(timer)
+        process.off('exit', onExit)
+      }
+      const onExit = (): void => {
+        cleanup()
+        resolve()
+      }
+      const timer = setTimeout(() => {
+        cleanup()
+        resolve()
+      }, SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
+      process.once('exit', onExit)
+    })
+  }
+
   private teardownForward(forward: ActiveForward): void {
+    if (forward.kind === 'system-ssh') {
+      forward.process.kill('SIGTERM')
+      return
+    }
     for (const socket of forward.activeSockets) {
       socket.destroy()
     }

--- a/src/main/ssh/ssh-port-forward.ts
+++ b/src/main/ssh/ssh-port-forward.ts
@@ -238,21 +238,44 @@ export class SshPortForwardManager {
   }
 
   private waitForSystemSshForwardStop(process: ChildProcess): Promise<void> {
-    process.kill('SIGTERM')
     return new Promise((resolve) => {
+      let settled = false
       const cleanup = (): void => {
-        clearTimeout(timer)
+        clearTimeout(escalationTimer)
         process.off('exit', onExit)
       }
-      const onExit = (): void => {
+      const finish = (): void => {
+        if (settled) {
+          return
+        }
+        settled = true
         cleanup()
         resolve()
       }
-      const timer = setTimeout(() => {
-        cleanup()
-        resolve()
+      const onExit = (): void => {
+        finish()
+      }
+      const hasExited = (): boolean => process.exitCode !== null || process.signalCode !== null
+      const kill = (signal: NodeJS.Signals): void => {
+        try {
+          const sent = process.kill(signal)
+          if (!sent && hasExited()) {
+            finish()
+          }
+        } catch {
+          if (hasExited()) {
+            finish()
+          }
+        }
+      }
+      const escalationTimer = setTimeout(() => {
+        // Why: update/reconnect callers must not rebind while a stubborn ssh -L
+        // process still owns the local port.
+        kill('SIGKILL')
       }, SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
+
       process.once('exit', onExit)
+      kill('SIGTERM')
     })
   }
 

--- a/src/main/ssh/ssh-port-forward.ts
+++ b/src/main/ssh/ssh-port-forward.ts
@@ -150,6 +150,10 @@ export class SshPortForwardManager {
     return forward.entry
   }
 
+  async removeForwardAndWait(id: string): Promise<PortForwardEntry | null> {
+    return this.removeForwardAsync(id)
+  }
+
   // Why: server.close()/process exit are async — callers that need to rebind
   // the same port (update/reconnect) must wait until the owner fully releases it.
   private removeForwardAsync(id: string): Promise<PortForwardEntry | null> {

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -27,10 +27,10 @@ import {
   findSystemSsh,
   spawnSystemSsh,
   spawnSystemSshCommand,
-  spawnSystemSshPortForward,
   uploadDirectoryViaSystemSsh,
   writeFileViaSystemSsh
 } from './ssh-system-fallback'
+import { spawnSystemSshPortForward } from './system-ssh-forward-process'
 import { getRemoteHostPlatform } from './ssh-remote-platform'
 import type { SshTarget } from '../../shared/ssh-types'
 

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -27,6 +27,7 @@ import {
   findSystemSsh,
   spawnSystemSsh,
   spawnSystemSshCommand,
+  spawnSystemSshPortForward,
   uploadDirectoryViaSystemSsh,
   writeFileViaSystemSsh
 } from './ssh-system-fallback'
@@ -249,6 +250,27 @@ describe('spawnSystemSsh', () => {
       SYSTEM_SSH_PATH,
       expect.arrayContaining(['--', 'deploy@fdpass-host', "exec /bin/sh -c 'echo hello'"]),
       expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    )
+  })
+
+  it('spawns port forwards before the ssh destination terminator', () => {
+    spawnSystemSshPortForward(createTarget({ configHost: 'fdpass-host' }), 5173, '127.0.0.1', 3000)
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      SYSTEM_SSH_PATH,
+      [
+        '-o',
+        'BatchMode=no',
+        '-T',
+        '-N',
+        '-o',
+        'ExitOnForwardFailure=yes',
+        '-L',
+        '127.0.0.1:5173:127.0.0.1:3000',
+        '--',
+        'deploy@fdpass-host'
+      ],
+      expect.objectContaining({ stdio: ['ignore', 'ignore', 'pipe'] })
     )
   })
 

--- a/src/main/ssh/ssh-system-fallback.ts
+++ b/src/main/ssh/ssh-system-fallback.ts
@@ -121,9 +121,13 @@ export function spawnSystemSshPortForward(
   if (destinationIndex === -1) {
     args.unshift(...forwardArgs)
   } else {
+    // Why: OpenSSH parses options only before `--`; after it, args are the
+    // destination and optional remote command.
     args.splice(destinationIndex, 0, ...forwardArgs)
   }
 
+  // Why: port-forward ssh processes are not wired to Orca credential prompts;
+  // system SSH forwards must authenticate via OpenSSH config, agent, or control socket.
   return spawn(sshPath, args, {
     stdio: ['ignore', 'ignore', 'pipe'],
     windowsHide: true

--- a/src/main/ssh/ssh-system-fallback.ts
+++ b/src/main/ssh/ssh-system-fallback.ts
@@ -96,44 +96,6 @@ export function spawnSystemSshCommand(
   return wrapCommandProcess(proc)
 }
 
-export function spawnSystemSshPortForward(
-  target: SshTarget,
-  localPort: number,
-  remoteHost: string,
-  remotePort: number
-): ChildProcess {
-  const sshPath = findSystemSsh()
-  if (!sshPath) {
-    throw new Error(
-      'No system ssh binary found. Install OpenSSH to use system SSH port forwarding.'
-    )
-  }
-
-  const args = buildSshArgs(target)
-  const destinationIndex = args.lastIndexOf('--')
-  const forwardArgs = [
-    '-N',
-    '-o',
-    'ExitOnForwardFailure=yes',
-    '-L',
-    `127.0.0.1:${localPort}:${remoteHost}:${remotePort}`
-  ]
-  if (destinationIndex === -1) {
-    args.unshift(...forwardArgs)
-  } else {
-    // Why: OpenSSH parses options only before `--`; after it, args are the
-    // destination and optional remote command.
-    args.splice(destinationIndex, 0, ...forwardArgs)
-  }
-
-  // Why: port-forward ssh processes are not wired to Orca credential prompts;
-  // system SSH forwards must authenticate via OpenSSH config, agent, or control socket.
-  return spawn(sshPath, args, {
-    stdio: ['ignore', 'ignore', 'pipe'],
-    windowsHide: true
-  })
-}
-
 export async function uploadDirectoryViaSystemSsh(
   target: SshTarget,
   localDir: string,

--- a/src/main/ssh/ssh-system-fallback.ts
+++ b/src/main/ssh/ssh-system-fallback.ts
@@ -96,6 +96,40 @@ export function spawnSystemSshCommand(
   return wrapCommandProcess(proc)
 }
 
+export function spawnSystemSshPortForward(
+  target: SshTarget,
+  localPort: number,
+  remoteHost: string,
+  remotePort: number
+): ChildProcess {
+  const sshPath = findSystemSsh()
+  if (!sshPath) {
+    throw new Error(
+      'No system ssh binary found. Install OpenSSH to use system SSH port forwarding.'
+    )
+  }
+
+  const args = buildSshArgs(target)
+  const destinationIndex = args.lastIndexOf('--')
+  const forwardArgs = [
+    '-N',
+    '-o',
+    'ExitOnForwardFailure=yes',
+    '-L',
+    `127.0.0.1:${localPort}:${remoteHost}:${remotePort}`
+  ]
+  if (destinationIndex === -1) {
+    args.unshift(...forwardArgs)
+  } else {
+    args.splice(destinationIndex, 0, ...forwardArgs)
+  }
+
+  return spawn(sshPath, args, {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    windowsHide: true
+  })
+}
+
 export async function uploadDirectoryViaSystemSsh(
   target: SshTarget,
   localDir: string,

--- a/src/main/ssh/ssh2-port-forward-provider.ts
+++ b/src/main/ssh/ssh2-port-forward-provider.ts
@@ -1,0 +1,93 @@
+import { createServer, type Server, type Socket } from 'net'
+import type { SshConnection } from './ssh-connection'
+import type {
+  PortForwardStartOptions,
+  SshPortForwardProvider,
+  StartedPortForward
+} from './ssh-port-forward-provider'
+
+export class Ssh2PortForwardProvider implements SshPortForwardProvider {
+  canHandle(conn: SshConnection): boolean {
+    return conn.getClient() !== null
+  }
+
+  async start(conn: SshConnection, options: PortForwardStartOptions): Promise<StartedPortForward> {
+    const client = conn.getClient()
+    if (!client) {
+      throw new Error('SSH connection is not established')
+    }
+
+    const activeSockets = new Set<Socket>()
+    let closed = false
+
+    const server = createServer((socket) => {
+      activeSockets.add(socket)
+      socket.on('close', () => activeSockets.delete(socket))
+
+      client.forwardOut(
+        options.localHost,
+        options.localPort,
+        options.remoteHost,
+        options.remotePort,
+        (err, channel) => {
+          if (err) {
+            socket.destroy()
+            return
+          }
+          socket.pipe(channel).pipe(socket)
+          channel.on('close', () => socket.destroy())
+          channel.on('error', () => socket.destroy())
+          socket.on('close', () => channel.close())
+        }
+      )
+    })
+
+    await listen(server, options.localHost, options.localPort)
+
+    const entry = {
+      id: options.id,
+      connectionId: options.connectionId,
+      localPort: options.localPort,
+      remoteHost: options.remoteHost,
+      remotePort: options.remotePort,
+      label: options.label
+    }
+
+    const close = (): Promise<void> => {
+      if (closed) {
+        return Promise.resolve()
+      }
+      closed = true
+      for (const socket of activeSockets) {
+        socket.destroy()
+      }
+      return new Promise((resolve) => {
+        server.close(() => resolve())
+      })
+    }
+
+    return {
+      entry,
+      close,
+      dispose: () => {
+        void close()
+      }
+    }
+  }
+}
+
+function listen(server: Server, host: string, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening)
+      reject(new Error(`Failed to listen on ${host}:${port}: ${err.message}`))
+    }
+    const onListening = (): void => {
+      server.removeListener('error', onError)
+      resolve()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port, host)
+  })
+}

--- a/src/main/ssh/ssh2-port-forward-provider.ts
+++ b/src/main/ssh/ssh2-port-forward-provider.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server, type Socket } from 'net'
+import type { ClientChannel } from 'ssh2'
 import type { SshConnection } from './ssh-connection'
 import type {
   PortForwardStartOptions,
@@ -23,6 +24,7 @@ export class Ssh2PortForwardProvider implements SshPortForwardProvider {
     const server = createServer((socket) => {
       activeSockets.add(socket)
       socket.on('close', () => activeSockets.delete(socket))
+      socket.on('error', () => socket.destroy())
 
       client.forwardOut(
         options.localHost,
@@ -31,6 +33,11 @@ export class Ssh2PortForwardProvider implements SshPortForwardProvider {
         options.remotePort,
         (err, channel) => {
           if (err) {
+            socket.destroy()
+            return
+          }
+          if (closed || socket.destroyed) {
+            closeChannel(channel)
             socket.destroy()
             return
           }
@@ -90,4 +97,12 @@ function listen(server: Server, host: string, port: number): Promise<void> {
     server.once('listening', onListening)
     server.listen(port, host)
   })
+}
+
+function closeChannel(channel: ClientChannel): void {
+  try {
+    channel.close()
+  } catch {
+    /* best-effort cleanup for late ssh2 callbacks */
+  }
 }

--- a/src/main/ssh/system-ssh-forward-process.test.ts
+++ b/src/main/ssh/system-ssh-forward-process.test.ts
@@ -1,0 +1,214 @@
+import { EventEmitter } from 'events'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { existsSyncMock, spawnMock, connectMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  spawnMock: vi.fn(),
+  connectMock: vi.fn()
+}))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    existsSync: existsSyncMock
+  }
+})
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('net', () => ({
+  connect: connectMock
+}))
+
+import {
+  SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS,
+  SYSTEM_SSH_FORWARD_STARTUP_GRACE_MS,
+  spawnSystemSshPortForward,
+  waitForSystemSshForwardStartup,
+  waitForSystemSshForwardStop
+} from './system-ssh-forward-process'
+import type { SshTarget } from '../../shared/ssh-types'
+
+const SYSTEM_SSH_PATH =
+  process.platform === 'win32' ? 'C:\\Windows\\System32\\OpenSSH\\ssh.exe' : '/usr/bin/ssh'
+
+type FakeChildProcess = EventEmitter & {
+  stderr: EventEmitter
+  kill: ReturnType<typeof vi.fn>
+  exitCode: number | null
+  signalCode: NodeJS.Signals | null
+}
+
+type FakeSocket = EventEmitter & {
+  setTimeout: ReturnType<typeof vi.fn>
+  destroy: ReturnType<typeof vi.fn>
+}
+
+function createTarget(overrides?: Partial<SshTarget>): SshTarget {
+  return {
+    id: 'target-1',
+    label: 'Test Server',
+    host: 'example.com',
+    port: 22,
+    username: 'deploy',
+    ...overrides
+  }
+}
+
+function createFakeProcess(): FakeChildProcess {
+  const child = new EventEmitter() as FakeChildProcess
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn().mockReturnValue(true)
+  child.exitCode = null
+  child.signalCode = null
+  return child
+}
+
+function createFakeSocket(): FakeSocket {
+  const socket = new EventEmitter() as FakeSocket
+  socket.setTimeout = vi.fn()
+  socket.destroy = vi.fn()
+  return socket
+}
+
+function mockSystemSshExists(): void {
+  existsSyncMock.mockImplementation((p: string) => p === SYSTEM_SSH_PATH)
+}
+
+describe('system SSH forward process', () => {
+  beforeEach(() => {
+    existsSyncMock.mockReset()
+    spawnMock.mockReset()
+    connectMock.mockReset()
+    mockSystemSshExists()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('spawns port forwards before the ssh destination terminator', () => {
+    spawnMock.mockReturnValue(createFakeProcess())
+
+    spawnSystemSshPortForward(createTarget({ configHost: 'fdpass-host' }), 5173, '127.0.0.1', 3000)
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      SYSTEM_SSH_PATH,
+      [
+        '-o',
+        'BatchMode=no',
+        '-T',
+        '-N',
+        '-o',
+        'ExitOnForwardFailure=yes',
+        '-L',
+        '127.0.0.1:5173:127.0.0.1:3000',
+        '--',
+        'deploy@fdpass-host'
+      ],
+      expect.objectContaining({ stdio: ['ignore', 'ignore', 'pipe'] })
+    )
+  })
+
+  it('preserves manual target port and identity options in the forwarded ssh command', () => {
+    spawnMock.mockReturnValue(createFakeProcess())
+
+    spawnSystemSshPortForward(
+      createTarget({ port: 2222, identityFile: '/home/user/.ssh/id_ed25519' }),
+      5173,
+      '127.0.0.1',
+      3000
+    )
+
+    const args = spawnMock.mock.calls[0][1] as string[]
+    expect(args).toEqual(expect.arrayContaining(['-p', '2222', '-i', '/home/user/.ssh/id_ed25519']))
+    expect(args).toContain('deploy@example.com')
+  })
+
+  it('rejects startup when ssh exits early with stderr', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+    const socket = createFakeSocket()
+    connectMock.mockReturnValue(socket)
+
+    const pending = waitForSystemSshForwardStartup(child as never, 3000)
+    child.stderr.emit('data', Buffer.from('bind: Address already in use\n'))
+    child.emit('exit', 255)
+
+    await expect(pending).rejects.toThrow('bind: Address already in use')
+  })
+
+  it('rejects startup when the ssh process emits an error', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+    connectMock.mockReturnValue(createFakeSocket())
+
+    const pending = waitForSystemSshForwardStartup(child as never, 3000)
+    child.emit('error', new Error('spawn failed'))
+
+    await expect(pending).rejects.toThrow('spawn failed')
+  })
+
+  it('resolves startup when the local listener probe connects', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+    const socket = createFakeSocket()
+    connectMock.mockReturnValue(socket)
+
+    const pending = waitForSystemSshForwardStartup(child as never, 3000)
+    await vi.advanceTimersByTimeAsync(SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS)
+    socket.emit('connect')
+
+    await expect(pending).resolves.toBeUndefined()
+    expect(socket.destroy).toHaveBeenCalled()
+  })
+
+  it('resolves startup after the grace period when ssh keeps running', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+    connectMock.mockImplementation(() => {
+      const socket = createFakeSocket()
+      queueMicrotask(() => socket.emit('error', new Error('ECONNREFUSED')))
+      return socket
+    })
+
+    const pending = waitForSystemSshForwardStartup(child as never, 3000)
+    await vi.advanceTimersByTimeAsync(SYSTEM_SSH_FORWARD_STARTUP_GRACE_MS)
+
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('sends SIGTERM then SIGKILL when the process does not exit', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+
+    const pending = waitForSystemSshForwardStop(child as never)
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(child.kill).toHaveBeenNthCalledWith(1, 'SIGTERM')
+    expect(child.kill).toHaveBeenNthCalledWith(2, 'SIGKILL')
+
+    child.emit('exit', null)
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('does not resolve stop until the process exits', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+
+    let resolved = false
+    const pending = waitForSystemSshForwardStop(child as never).then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(resolved).toBe(false)
+
+    child.emit('exit', null)
+    await pending
+    expect(resolved).toBe(true)
+  })
+})

--- a/src/main/ssh/system-ssh-forward-process.test.ts
+++ b/src/main/ssh/system-ssh-forward-process.test.ts
@@ -1,10 +1,11 @@
 import { EventEmitter } from 'events'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 
-const { existsSyncMock, spawnMock, connectMock } = vi.hoisted(() => ({
+const { existsSyncMock, spawnMock, connectMock, createServerMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   spawnMock: vi.fn(),
-  connectMock: vi.fn()
+  connectMock: vi.fn(),
+  createServerMock: vi.fn()
 }))
 
 vi.mock('fs', async (importOriginal) => {
@@ -20,13 +21,15 @@ vi.mock('child_process', () => ({
 }))
 
 vi.mock('net', () => ({
-  connect: connectMock
+  connect: connectMock,
+  createServer: createServerMock
 }))
 
 import {
   SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS,
   SYSTEM_SSH_FORWARD_STARTUP_GRACE_MS,
   spawnSystemSshPortForward,
+  startSystemSshPortForwardProcess,
   waitForSystemSshForwardStartup,
   waitForSystemSshForwardStop
 } from './system-ssh-forward-process'
@@ -74,6 +77,19 @@ function createFakeSocket(): FakeSocket {
   return socket
 }
 
+function createFakeServer() {
+  const server = new EventEmitter() as EventEmitter & {
+    listen: ReturnType<typeof vi.fn>
+    close: ReturnType<typeof vi.fn>
+  }
+  server.listen = vi.fn().mockImplementation(() => {
+    queueMicrotask(() => server.emit('listening'))
+    return server
+  })
+  server.close = vi.fn().mockImplementation((cb?: () => void) => cb?.())
+  return server
+}
+
 function mockSystemSshExists(): void {
   existsSyncMock.mockImplementation((p: string) => p === SYSTEM_SSH_PATH)
 }
@@ -83,6 +99,7 @@ describe('system SSH forward process', () => {
     existsSyncMock.mockReset()
     spawnMock.mockReset()
     connectMock.mockReset()
+    createServerMock.mockReset().mockImplementation(createFakeServer)
     mockSystemSshExists()
   })
 
@@ -126,6 +143,30 @@ describe('system SSH forward process', () => {
     const args = spawnMock.mock.calls[0][1] as string[]
     expect(args).toEqual(expect.arrayContaining(['-p', '2222', '-i', '/home/user/.ssh/id_ed25519']))
     expect(args).toContain('deploy@example.com')
+  })
+
+  it('does not spawn ssh when the requested local forward port is already in use', async () => {
+    const server = createFakeServer()
+    server.listen.mockImplementation(() => {
+      queueMicrotask(() => server.emit('error', new Error('EADDRINUSE')))
+      return server
+    })
+    createServerMock.mockReturnValue(server)
+
+    await expect(
+      startSystemSshPortForwardProcess(createTarget(), 5173, '127.0.0.1', 3000)
+    ).rejects.toThrow('Local port 127.0.0.1:5173 is not available')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('spawns ssh after the requested local forward port preflight succeeds', async () => {
+    const child = createFakeProcess()
+    spawnMock.mockReturnValue(child)
+
+    const forward = await startSystemSshPortForwardProcess(createTarget(), 5173, '127.0.0.1', 3000)
+
+    expect(spawnMock).toHaveBeenCalled()
+    expect(forward.process).toBe(child)
   })
 
   it('rejects startup when ssh exits early with stderr', async () => {

--- a/src/main/ssh/system-ssh-forward-process.ts
+++ b/src/main/ssh/system-ssh-forward-process.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'child_process'
-import { connect } from 'net'
+import { connect, createServer } from 'net'
 import { buildSshArgs, findSystemSsh } from './ssh-system-fallback'
 import type { SshTarget } from '../../shared/ssh-types'
 
@@ -57,20 +57,43 @@ export function startSystemSshPortForwardProcess(
   localPort: number,
   remoteHost: string,
   remotePort: number
-): SystemSshPortForwardProcess {
-  const process = spawnSystemSshPortForward(target, localPort, remoteHost, remotePort)
-  return {
-    process,
-    waitForStartup: () => waitForSystemSshForwardStartup(process, localPort),
-    close: () => waitForSystemSshForwardStop(process),
-    dispose: () => {
-      try {
-        process.kill('SIGTERM')
-      } catch {
-        /* best-effort teardown */
+): Promise<SystemSshPortForwardProcess> {
+  return assertLocalForwardPortAvailable(localPort).then(() => {
+    const process = spawnSystemSshPortForward(target, localPort, remoteHost, remotePort)
+    return {
+      process,
+      waitForStartup: () => waitForSystemSshForwardStartup(process, localPort),
+      close: () => waitForSystemSshForwardStop(process),
+      dispose: () => {
+        try {
+          process.kill('SIGTERM')
+        } catch {
+          /* best-effort teardown */
+        }
       }
     }
-  }
+  })
+}
+
+export function assertLocalForwardPortAvailable(localPort: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    const cleanup = (): void => {
+      server.removeListener('error', onError)
+      server.removeListener('listening', onListening)
+    }
+    const onError = (err: Error): void => {
+      cleanup()
+      reject(new Error(`Local port 127.0.0.1:${localPort} is not available: ${err.message}`))
+    }
+    const onListening = (): void => {
+      cleanup()
+      server.close(() => resolve())
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(localPort, '127.0.0.1')
+  })
 }
 
 export function waitForSystemSshForwardStartup(

--- a/src/main/ssh/system-ssh-forward-process.ts
+++ b/src/main/ssh/system-ssh-forward-process.ts
@@ -1,0 +1,225 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { connect } from 'net'
+import { buildSshArgs, findSystemSsh } from './ssh-system-fallback'
+import type { SshTarget } from '../../shared/ssh-types'
+
+export const SYSTEM_SSH_FORWARD_STARTUP_GRACE_MS = 750
+export const SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS = 50
+export const SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS = 2_000
+
+export type SystemSshPortForwardProcess = {
+  process: ChildProcess
+  waitForStartup: () => Promise<void>
+  close: () => Promise<void>
+  dispose: () => void
+}
+
+export function spawnSystemSshPortForward(
+  target: SshTarget,
+  localPort: number,
+  remoteHost: string,
+  remotePort: number
+): ChildProcess {
+  const sshPath = findSystemSsh()
+  if (!sshPath) {
+    throw new Error(
+      'No system ssh binary found. Install OpenSSH to use system SSH port forwarding.'
+    )
+  }
+
+  const args = buildSshArgs(target)
+  const destinationIndex = args.lastIndexOf('--')
+  const forwardArgs = [
+    '-N',
+    '-o',
+    'ExitOnForwardFailure=yes',
+    '-L',
+    `127.0.0.1:${localPort}:${remoteHost}:${remotePort}`
+  ]
+  if (destinationIndex === -1) {
+    args.unshift(...forwardArgs)
+  } else {
+    // Why: OpenSSH parses options only before `--`; after it, args are the
+    // destination and optional remote command.
+    args.splice(destinationIndex, 0, ...forwardArgs)
+  }
+
+  // Why: port-forward ssh processes are not wired to Orca credential prompts;
+  // system SSH forwards must authenticate via OpenSSH config, agent, or control socket.
+  return spawn(sshPath, args, {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    windowsHide: true
+  })
+}
+
+export function startSystemSshPortForwardProcess(
+  target: SshTarget,
+  localPort: number,
+  remoteHost: string,
+  remotePort: number
+): SystemSshPortForwardProcess {
+  const process = spawnSystemSshPortForward(target, localPort, remoteHost, remotePort)
+  return {
+    process,
+    waitForStartup: () => waitForSystemSshForwardStartup(process, localPort),
+    close: () => waitForSystemSshForwardStop(process),
+    dispose: () => {
+      try {
+        process.kill('SIGTERM')
+      } catch {
+        /* best-effort teardown */
+      }
+    }
+  }
+}
+
+export function waitForSystemSshForwardStartup(
+  process: ChildProcess,
+  localPort: number
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let stderr = ''
+    let settled = false
+    let probeTimer: ReturnType<typeof setTimeout> | null = null
+    let graceTimer: ReturnType<typeof setTimeout> | null = null
+    const cleanup = (): void => {
+      if (probeTimer) {
+        clearTimeout(probeTimer)
+      }
+      if (graceTimer) {
+        clearTimeout(graceTimer)
+      }
+      process.off('error', onError)
+      process.off('exit', onExit)
+      process.stderr?.off('data', onStderr)
+    }
+    const finish = (callback: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      callback()
+    }
+    const onStderr = (chunk: Buffer): void => {
+      stderr += chunk.toString('utf-8')
+    }
+    const onError = (error: Error): void => {
+      finish(() => reject(error))
+    }
+    const onExit = (code: number | null): void => {
+      finish(() => reject(systemSshForwardError(code, stderr)))
+    }
+    const scheduleProbe = (): void => {
+      probeTimer = setTimeout(() => {
+        probeLocalForward(localPort).then(
+          () => finish(resolve),
+          () => {
+            if (!settled) {
+              scheduleProbe()
+            }
+          }
+        )
+      }, SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS)
+    }
+
+    process.stderr?.on('data', onStderr)
+    process.once('error', onError)
+    process.once('exit', onExit)
+    graceTimer = setTimeout(() => {
+      finish(resolve)
+    }, SYSTEM_SSH_FORWARD_STARTUP_GRACE_MS)
+    scheduleProbe()
+  })
+}
+
+export function waitForSystemSshForwardStop(process: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false
+    const cleanup = (): void => {
+      clearTimeout(escalationTimer)
+      process.off('exit', onExit)
+    }
+    const finish = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      resolve()
+    }
+    const onExit = (): void => {
+      finish()
+    }
+    const hasExited = (): boolean => process.exitCode !== null || process.signalCode !== null
+    const kill = (signal: NodeJS.Signals): void => {
+      try {
+        const sent = process.kill(signal)
+        if (!sent && hasExited()) {
+          finish()
+        }
+      } catch {
+        if (hasExited()) {
+          finish()
+        }
+      }
+    }
+    const escalationTimer = setTimeout(() => {
+      // Why: update/reconnect callers must not rebind while a stubborn ssh -L
+      // process still owns the local port.
+      kill('SIGKILL')
+    }, SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
+
+    process.once('exit', onExit)
+    kill('SIGTERM')
+  })
+}
+
+export function systemSshForwardError(code: number | null, stderr: string): Error {
+  const detail = bestErrorLine(stderr)
+  return new Error(
+    `System SSH port forward failed${code !== null ? ` (exit ${code})` : ''}${
+      detail ? `: ${detail}` : ''
+    }`
+  )
+}
+
+function bestErrorLine(stderr: string): string {
+  return (
+    stderr
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .at(-1) ?? ''
+  )
+}
+
+function probeLocalForward(localPort: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const socket = connect({ host: '127.0.0.1', port: localPort })
+    const cleanup = (): void => {
+      socket.off('connect', onConnect)
+      socket.off('error', onError)
+      socket.off('timeout', onTimeout)
+    }
+    const onConnect = (): void => {
+      cleanup()
+      socket.destroy()
+      resolve()
+    }
+    const onError = (err: Error): void => {
+      cleanup()
+      socket.destroy()
+      reject(err)
+    }
+    const onTimeout = (): void => {
+      cleanup()
+      socket.destroy()
+      reject(new Error(`Timed out probing local forward on 127.0.0.1:${localPort}`))
+    }
+    socket.setTimeout(SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS)
+    socket.once('connect', onConnect)
+    socket.once('error', onError)
+    socket.once('timeout', onTimeout)
+  })
+}

--- a/src/main/ssh/system-ssh-port-forward-provider.ts
+++ b/src/main/ssh/system-ssh-port-forward-provider.ts
@@ -1,0 +1,65 @@
+import type { SshConnection } from './ssh-connection'
+import {
+  startSystemSshPortForwardProcess,
+  systemSshForwardError
+} from './system-ssh-forward-process'
+import type {
+  PortForwardStartOptions,
+  SshPortForwardProvider,
+  StartedPortForward
+} from './ssh-port-forward-provider'
+
+export class SystemSshPortForwardProvider implements SshPortForwardProvider {
+  canHandle(conn: SshConnection): boolean {
+    return conn.getClient() === null && conn.usesSystemSshTransport()
+  }
+
+  async start(conn: SshConnection, options: PortForwardStartOptions): Promise<StartedPortForward> {
+    const target = conn.getTarget()
+    const forward = startSystemSshPortForwardProcess(
+      target,
+      options.localPort,
+      options.remoteHost,
+      options.remotePort
+    )
+
+    await forward.waitForStartup()
+    let stderr = ''
+    const onStderr = (chunk: Buffer): void => {
+      stderr += chunk.toString('utf-8')
+    }
+    forward.process.stderr?.on('data', onStderr)
+
+    const entry = {
+      id: options.id,
+      connectionId: options.connectionId,
+      localPort: options.localPort,
+      remoteHost: options.remoteHost,
+      remotePort: options.remotePort,
+      label: options.label
+    }
+
+    forward.process.once('exit', (code) => {
+      forward.process.stderr?.off('data', onStderr)
+      options.onUnexpectedClose?.(entry, {
+        kind: 'unexpected-exit',
+        detail: systemSshForwardError(code, stderr).message
+      })
+    })
+
+    return {
+      entry,
+      close: async () => {
+        try {
+          await forward.close()
+        } finally {
+          forward.process.stderr?.off('data', onStderr)
+        }
+      },
+      dispose: () => {
+        forward.process.stderr?.off('data', onStderr)
+        forward.dispose()
+      }
+    }
+  }
+}

--- a/src/main/ssh/system-ssh-port-forward-provider.ts
+++ b/src/main/ssh/system-ssh-port-forward-provider.ts
@@ -16,7 +16,7 @@ export class SystemSshPortForwardProvider implements SshPortForwardProvider {
 
   async start(conn: SshConnection, options: PortForwardStartOptions): Promise<StartedPortForward> {
     const target = conn.getTarget()
-    const forward = startSystemSshPortForwardProcess(
+    const forward = await startSystemSshPortForwardProcess(
       target,
       options.localPort,
       options.remoteHost,


### PR DESCRIPTION
## Summary
- includes #6499's system SSH port forwarding support, then hardens it with explicit ssh2 and system-ssh providers behind a small manager contract
- moves OpenSSH process lifecycle handling into a focused module with signal/cleanup tests
- persists desired forwards through the SSH IPC layer and broadcasts unexpected forward closures
- hardens the system SSH port forwarding path with focused lifecycle tests

## Context
I first tried to open this as a stacked PR onto #6499's head branch, but GitHub cannot use `kenfdev/orca:fix-system-ssh-port-forwarding` as a same-repo base ref from `stablyai/orca`. This PR therefore targets `main` directly and contains #6499 plus the follow-up provider hardening commit.

## Tests
- [x] `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-port-forward.test.ts src/main/ssh/system-ssh-forward-process.test.ts src/main/ssh/ssh-system-fallback.test.ts src/main/ipc/ssh.test.ts` — 4 files, 82 tests passed
- [x] `pnpm run typecheck` — passed; Node engine warning only because local Node is v26 while repo expects v24
- [x] `pnpm run lint` — passed; existing unrelated warning in `src/renderer/src/components/right-sidebar/useGitStatusPolling.ts`
- [x] `git diff --check` — passed
- [x] `pnpm build:relay` — passed
- [x] Electron E2E launched from exact PR worktree with isolated user data; verified `window.api.app.getIdentity()` returned branch `implement-system-ssh-port-forward-providers`, worktree `review-pr-6499`, and this repo root
- [x] Live SSH E2E against throwaway Linux Docker target, not localhost: registered `/work/demo-project`, connected through system SSH using a `configHost` alias, started a remote server on `127.0.0.1:31234`, added Orca forward `127.0.0.1:43123 -> 127.0.0.1:31234`, and `curl http://127.0.0.1:43123` returned `orca-port-forward-e2e ok`
- [x] Verified backing state: remote repo `git status --short --branch` returned `## master`, remote worktree list contained `/work/demo-project`, remote server process existed, and host process list showed `/usr/bin/ssh ... -N ... -L 127.0.0.1:43123:127.0.0.1:31234 ...`
- [x] Removal path E2E plus lifecycle follow-up: local socket errors are handled, late ssh2 channels are cleaned up, user-facing removals await teardown, system SSH preflights local port availability. Original removal path E2E: removed the forward through `window.api.ssh.removePortForward`, verified Orca forward list became empty, local curl to `43123` failed, and the OpenSSH forward process stopped
- [x] Cleanup complete: removed Orca SSH target and repo, killed remote test server, removed temp SSH config/known_hosts entries, removed Docker container, removed temp directory, stopped only the Electron session started for this test, and confirmed the worktree is clean

Notes: the live remote clone of `stablyai/demo-project` from inside the container was blocked, so the test used the documented fallback of seeding a real git repo at `/work/demo-project` in the throwaway container.

Made with [Orca](https://github.com/stablyai/orca) 🐋


