### PR TITLE
refactor(settings): unify network-address picker across mobile & server-share

### DIFF
--- a/src/renderer/src/components/mobile/NetworkInterfacePicker.tsx
+++ b/src/renderer/src/components/mobile/NetworkInterfacePicker.tsx
@@ -1,27 +1,15 @@
-import React, { useState } from 'react'
-import { Plus } from 'lucide-react'
+import React, { useMemo } from 'react'
 import { translate } from '@/i18n/i18n'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue
-} from '../ui/select'
-import { CustomNetworkAddressDialog } from './CustomNetworkAddressDialog'
+import { AddressPicker, type AddressOption } from '../network/AddressPicker'
+import { parseManualNetworkAddress } from '../../../../shared/network/manual-address'
 import type { MobileNetworkInterface } from '../settings/mobile-network-interface-selection'
 
 // Why: MobileHero (mobile pairing screen) and MobileNetworkInterfaceSection
-// (Settings → Mobile → Network Interface section) both need the same network
-// selector. Discovered interfaces come from the OS; the "Add custom address…"
-// footer opens a dialog for a Tailscale hostname or static IP the OS didn't
-// surface — the only way to pair across networks. Shared here so both surfaces
-// pick up the behavior automatically.
-
-// Why: a sentinel Select value for the footer action. It is never committed as
-// a real address; selecting it opens the custom-address dialog instead.
-const ADD_CUSTOM_VALUE = '__add_custom_address__'
+// (Settings → Mobile) both need the same network selector. This wraps the
+// generic AddressPicker with the mobile grammar (IPv4 / Tailscale *.ts.net)
+// and copy. Discovered interfaces come from the OS; "Add custom address…"
+// opens a dialog for an address the OS didn't surface — the only way to pair
+// across networks.
 
 export type NetworkInterfacePickerProps = {
   networkInterfaces: readonly MobileNetworkInterface[]
@@ -32,10 +20,6 @@ export type NetworkInterfacePickerProps = {
   id?: string
 }
 
-function formatInterfaceLabel(iface: MobileNetworkInterface): string {
-  return `${iface.address} (${iface.name})`
-}
-
 export function NetworkInterfacePicker({
   networkInterfaces,
   selectedAddress,
@@ -44,76 +28,68 @@ export function NetworkInterfacePicker({
   className,
   id
 }: NetworkInterfacePickerProps): React.JSX.Element {
-  const [dialogOpen, setDialogOpen] = useState(false)
-
-  // Why: a selected address that isn't an OS-enumerated interface is a custom
-  // entry. Render it as a "(custom)" option so the trigger can display it —
-  // Radix Select only shows values that have a matching item.
-  const isCustomSelection =
-    selectedAddress !== undefined &&
-    !networkInterfaces.some((iface) => iface.address === selectedAddress)
-
-  const handleValueChange = (value: string): void => {
-    if (value === ADD_CUSTOM_VALUE) {
-      setDialogOpen(true)
-      return
-    }
-    onSelectedAddressChange(value)
-  }
+  const options = useMemo<AddressOption[]>(
+    () =>
+      networkInterfaces.map((iface) => ({
+        value: iface.address,
+        label: `${iface.address} (${iface.name})`
+      })),
+    [networkInterfaces]
+  )
 
   return (
-    <>
-      <Select value={selectedAddress ?? ''} onValueChange={handleValueChange} disabled={disabled}>
-        <SelectTrigger
-          id={id}
-          size="sm"
-          className={className}
-          aria-label={translate(
-            'auto.components.mobile.NetworkInterfacePicker.trigger-label',
-            'Network address to advertise'
-          )}
-        >
-          <SelectValue
-            placeholder={translate(
-              'auto.components.settings.MobileNetworkInterfaceSection.b2c384cfd6',
-              'No interfaces found'
-            )}
-          />
-        </SelectTrigger>
-        <SelectContent>
-          {networkInterfaces.map((iface) => (
-            <SelectItem key={`${iface.name}-${iface.address}`} value={iface.address}>
-              {formatInterfaceLabel(iface)}
-            </SelectItem>
-          ))}
-          {isCustomSelection ? (
-            <SelectItem value={selectedAddress}>
-              {translate(
-                'auto.components.mobile.NetworkInterfacePicker.custom-option',
-                '{{address}} (custom)',
-                { address: selectedAddress }
-              )}
-            </SelectItem>
-          ) : null}
-          {networkInterfaces.length > 0 || isCustomSelection ? <SelectSeparator /> : null}
-          <SelectItem
-            value={ADD_CUSTOM_VALUE}
-            className="text-muted-foreground focus:text-foreground"
-          >
-            <Plus className="size-3.5" />
-            {translate(
-              'auto.components.mobile.NetworkInterfacePicker.add-custom',
-              'Add custom address…'
-            )}
-          </SelectItem>
-        </SelectContent>
-      </Select>
-      <CustomNetworkAddressDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        initialValue={isCustomSelection ? selectedAddress : undefined}
-        onConfirm={onSelectedAddressChange}
-      />
-    </>
+    <AddressPicker
+      options={options}
+      value={selectedAddress}
+      onValueChange={onSelectedAddressChange}
+      disabled={disabled}
+      className={className}
+      id={id}
+      formatCustomLabel={(address) =>
+        translate(
+          'auto.components.mobile.NetworkInterfacePicker.custom-option',
+          '{{address}} (custom)',
+          { address }
+        )
+      }
+      addCustomLabel={translate(
+        'auto.components.mobile.NetworkInterfacePicker.add-custom',
+        'Add custom address…'
+      )}
+      placeholder={translate(
+        'auto.components.settings.MobileNetworkInterfaceSection.b2c384cfd6',
+        'No interfaces found'
+      )}
+      triggerAriaLabel={translate(
+        'auto.components.mobile.NetworkInterfacePicker.trigger-label',
+        'Network address to advertise'
+      )}
+      customInputId="custom-network-address-input"
+      validateCustom={(input) => {
+        const parsed = parseManualNetworkAddress(input)
+        return parsed.ok ? { ok: true, value: parsed.address } : { ok: false }
+      }}
+      customDialogCopy={{
+        title: translate(
+          'auto.components.mobile.CustomNetworkAddressDialog.title',
+          'Custom network address'
+        ),
+        description: translate(
+          'auto.components.mobile.CustomNetworkAddressDialog.description',
+          'Advertise an address your phone can reach when it is not on the same Wi-Fi — for example a Tailscale hostname or a static IP.'
+        ),
+        inputLabel: translate('auto.components.mobile.CustomNetworkAddressDialog.label', 'Address'),
+        placeholder: translate(
+          'auto.components.mobile.CustomNetworkAddressDialog.placeholder',
+          'my-mac.ts.net or 192.168.1.50'
+        ),
+        hint: translate(
+          'auto.components.mobile.CustomNetworkAddressDialog.hint',
+          'Enter an IP address or a Tailscale hostname (ends in .ts.net).'
+        ),
+        cancel: translate('auto.components.mobile.CustomNetworkAddressDialog.cancel', 'Cancel'),
+        confirm: translate('auto.components.mobile.CustomNetworkAddressDialog.use', 'Use address')
+      }}
+    />
   )
 }

--- a/src/renderer/src/components/network/AddressPicker.tsx
+++ b/src/renderer/src/components/network/AddressPicker.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react'
+import { Plus } from 'lucide-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue
+} from '../ui/select'
+import {
+  CustomAddressDialog,
+  type CustomAddressDialogCopy,
+  type CustomAddressValidator
+} from './CustomAddressDialog'
+
+export type AddressOption = {
+  value: string
+  label: string
+}
+
+// Why: a sentinel Select value for the footer action. It is never committed as
+// a real address; selecting it opens the custom-address dialog instead.
+const ADD_CUSTOM_VALUE = '__add_custom_address__'
+
+export type AddressPickerProps = {
+  options: readonly AddressOption[]
+  value: string | undefined
+  onValueChange: (value: string) => void
+  // Why: a value that isn't one of `options` is a custom entry; this renders
+  // its display label (e.g. `${value} (custom)`) so the Select can show it —
+  // Radix Select only displays values that have a matching item.
+  formatCustomLabel: (value: string) => string
+  addCustomLabel: string
+  customDialogCopy: CustomAddressDialogCopy
+  validateCustom: CustomAddressValidator
+  customInputId: string
+  placeholder: string
+  triggerAriaLabel: string
+  disabled?: boolean
+  className?: string
+  id?: string
+}
+
+export function AddressPicker({
+  options,
+  value,
+  onValueChange,
+  formatCustomLabel,
+  addCustomLabel,
+  customDialogCopy,
+  validateCustom,
+  customInputId,
+  placeholder,
+  triggerAriaLabel,
+  disabled = false,
+  className,
+  id
+}: AddressPickerProps): React.JSX.Element {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const isCustomSelection =
+    value !== undefined && value !== '' && !options.some((option) => option.value === value)
+
+  const handleValueChange = (next: string): void => {
+    if (next === ADD_CUSTOM_VALUE) {
+      setDialogOpen(true)
+      return
+    }
+    onValueChange(next)
+  }
+
+  return (
+    <>
+      <Select value={value ?? ''} onValueChange={handleValueChange} disabled={disabled}>
+        <SelectTrigger id={id} size="sm" className={className} aria-label={triggerAriaLabel}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+          {isCustomSelection ? (
+            <SelectItem value={value}>{formatCustomLabel(value)}</SelectItem>
+          ) : null}
+          {options.length > 0 || isCustomSelection ? <SelectSeparator /> : null}
+          <SelectItem
+            value={ADD_CUSTOM_VALUE}
+            className="text-muted-foreground focus:text-foreground"
+          >
+            <Plus className="size-3.5" />
+            {addCustomLabel}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+      <CustomAddressDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        initialValue={isCustomSelection ? value : undefined}
+        validate={validateCustom}
+        copy={customDialogCopy}
+        inputId={customInputId}
+        onConfirm={onValueChange}
+      />
+    </>
+  )
+}

--- a/src/renderer/src/components/network/CustomAddressDialog.tsx
+++ b/src/renderer/src/components/network/CustomAddressDialog.tsx
@@ -10,24 +10,44 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { translate } from '@/i18n/i18n'
-import { parseManualNetworkAddress } from '../../../../shared/network/manual-address'
 
-type CustomNetworkAddressDialogProps = {
+export type CustomAddressValidator = (input: string) => { ok: true; value: string } | { ok: false }
+
+export type CustomAddressDialogCopy = {
+  title: string
+  description: string
+  inputLabel: string
+  placeholder: string
+  hint: string
+  cancel: string
+  confirm: string
+}
+
+type CustomAddressDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
   // Why: prefill from the current selection when it is already a custom value
   // so reopening to edit shows what is in use rather than a blank field.
   initialValue?: string
-  onConfirm: (address: string) => void
+  validate: CustomAddressValidator
+  copy: CustomAddressDialogCopy
+  inputId: string
+  onConfirm: (value: string) => void
 }
 
-export function CustomNetworkAddressDialog({
+// Why: shared single-field modal for entering a custom address/endpoint. The
+// grammar differs per surface (mobile takes IPv4/Tailscale; the server-share
+// form takes host / host:port / wss URLs), so validation and copy are injected
+// rather than baked in.
+export function CustomAddressDialog({
   open,
   onOpenChange,
   initialValue,
+  validate,
+  copy,
+  inputId,
   onConfirm
-}: CustomNetworkAddressDialogProps): React.JSX.Element {
+}: CustomAddressDialogProps): React.JSX.Element {
   const [value, setValue] = useState(initialValue ?? '')
 
   // Why: reseed each time the dialog opens so a prior cancelled edit doesn't
@@ -38,16 +58,16 @@ export function CustomNetworkAddressDialog({
     }
   }, [open, initialValue])
 
-  const parsed = parseManualNetworkAddress(value)
+  const parsed = validate(value)
   // Why: only flag invalid input once the user has typed something — an empty
   // field on open shouldn't read as an error.
-  const showError = value.trim() !== '' && !parsed.ok
+  const showInvalid = value.trim() !== '' && !parsed.ok
 
   const submit = (): void => {
     if (!parsed.ok) {
       return
     }
-    onConfirm(parsed.address)
+    onConfirm(parsed.value)
     onOpenChange(false)
   }
 
@@ -55,32 +75,17 @@ export function CustomNetworkAddressDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>
-            {translate(
-              'auto.components.mobile.CustomNetworkAddressDialog.title',
-              'Custom network address'
-            )}
-          </DialogTitle>
-          <DialogDescription>
-            {translate(
-              'auto.components.mobile.CustomNetworkAddressDialog.description',
-              'Advertise an address your phone can reach when it is not on the same Wi-Fi — for example a Tailscale hostname or a static IP.'
-            )}
-          </DialogDescription>
+          <DialogTitle>{copy.title}</DialogTitle>
+          <DialogDescription>{copy.description}</DialogDescription>
         </DialogHeader>
         <div className="space-y-2">
-          <Label htmlFor="custom-network-address-input">
-            {translate('auto.components.mobile.CustomNetworkAddressDialog.label', 'Address')}
-          </Label>
+          <Label htmlFor={inputId}>{copy.inputLabel}</Label>
           <Input
-            id="custom-network-address-input"
+            id={inputId}
             autoFocus
             value={value}
-            aria-invalid={showError}
-            placeholder={translate(
-              'auto.components.mobile.CustomNetworkAddressDialog.placeholder',
-              'my-mac.ts.net or 192.168.1.50'
-            )}
+            aria-invalid={showInvalid}
+            placeholder={copy.placeholder}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
@@ -90,21 +95,16 @@ export function CustomNetworkAddressDialog({
             }}
           />
           {/* Why: neutral helper copy that doubles as validation guidance —
-              kept muted (not destructive-red) so a half-typed address doesn't
+              kept muted (not destructive-red) so a half-typed value doesn't
               feel like a hard error. */}
-          <p className="text-xs text-muted-foreground">
-            {translate(
-              'auto.components.mobile.CustomNetworkAddressDialog.hint',
-              'Enter an IP address or a Tailscale hostname (ends in .ts.net).'
-            )}
-          </p>
+          <p className="text-xs text-muted-foreground">{copy.hint}</p>
         </div>
         <DialogFooter>
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            {translate('auto.components.mobile.CustomNetworkAddressDialog.cancel', 'Cancel')}
+            {copy.cancel}
           </Button>
           <Button type="button" disabled={!parsed.ok} onClick={submit}>
-            {translate('auto.components.mobile.CustomNetworkAddressDialog.use', 'Use address')}
+            {copy.confirm}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/renderer/src/components/settings/RuntimePairingGeneratorForm.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingGeneratorForm.tsx
@@ -60,10 +60,13 @@ export function RuntimePairingGeneratorForm({
               'Connection address'
             )}
           </Label>
-          <div className="flex min-w-0 items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <AddressPicker
               id="runtime-pairing-address"
-              className="min-w-0 flex-1"
+              // Why: bounded width so a short value like "This computer
+              // (127.0.0.1)" doesn't stretch the trigger across the whole card;
+              // the value can grow up to the card edge before truncating.
+              className="min-w-[240px] max-w-full"
               triggerAriaLabel={translate(
                 'auto.components.settings.RuntimePairingUrlGenerator.de77eb1b65',
                 'Connection address'

--- a/src/renderer/src/components/settings/RuntimePairingGeneratorForm.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingGeneratorForm.tsx
@@ -1,9 +1,9 @@
 import { Loader2, RefreshCw } from 'lucide-react'
 import { Button } from '../ui/button'
-import { Input } from '../ui/input'
 import { Label } from '../ui/label'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { AddressPicker, type AddressOption } from '../network/AddressPicker'
+import { parseServerShareAddress } from '../../../../shared/network/server-share-address'
 import { GeneratedUrlRow, UnavailableUrlRow } from './RuntimePairingGeneratedUrlRows'
 import { translate } from '@/i18n/i18n'
 
@@ -11,14 +11,12 @@ type RuntimePairingGeneratorFormProps = {
   loopbackAddress: string
   networkInterfaces: { name: string; address: string }[]
   selectedAddress: string
-  customAddress: string
   refreshingNetworkInterfaces: boolean
   isGeneratingPairing: boolean
   webClientUrl: string | null
   runtimePairingUrl: string | null
   copiedTarget: 'web' | 'pairing' | null
   onSelectedAddressChange: (address: string) => void
-  onCustomAddressChange: (address: string) => void
   onRefreshNetworkInterfaces: () => void
   onGenerate: () => void
   onCopy: (target: 'web' | 'pairing', value: string) => void
@@ -28,102 +26,122 @@ export function RuntimePairingGeneratorForm({
   loopbackAddress,
   networkInterfaces,
   selectedAddress,
-  customAddress,
   refreshingNetworkInterfaces,
   isGeneratingPairing,
   webClientUrl,
   runtimePairingUrl,
   copiedTarget,
   onSelectedAddressChange,
-  onCustomAddressChange,
   onRefreshNetworkInterfaces,
   onGenerate,
   onCopy
 }: RuntimePairingGeneratorFormProps): React.JSX.Element {
+  const options: AddressOption[] = [
+    {
+      value: loopbackAddress,
+      label: `${translate(
+        'auto.components.settings.RuntimePairingUrlGenerator.de6d5cff95',
+        'This computer ('
+      )}${loopbackAddress})`
+    },
+    ...networkInterfaces.map((networkInterface) => ({
+      value: networkInterface.address,
+      label: `${networkInterface.name} (${networkInterface.address})`
+    }))
+  ]
+
   return (
     <>
       <div className="space-y-3">
-        <div className="grid gap-3 sm:grid-cols-[minmax(0,260px)_minmax(0,1fr)]">
-          <div className="space-y-1">
-            <Label id="runtime-pairing-address-label" htmlFor="runtime-pairing-address">
-              {translate(
+        <div className="space-y-1">
+          <Label id="runtime-pairing-address-label" htmlFor="runtime-pairing-address">
+            {translate(
+              'auto.components.settings.RuntimePairingUrlGenerator.de77eb1b65',
+              'Connection address'
+            )}
+          </Label>
+          <div className="flex min-w-0 items-center gap-2">
+            <AddressPicker
+              id="runtime-pairing-address"
+              className="min-w-0 flex-1"
+              triggerAriaLabel={translate(
                 'auto.components.settings.RuntimePairingUrlGenerator.de77eb1b65',
                 'Connection address'
               )}
-            </Label>
-            <div className="flex min-w-0 items-center gap-2">
-              <Select value={selectedAddress} onValueChange={onSelectedAddressChange}>
-                <SelectTrigger
-                  id="runtime-pairing-address"
-                  size="sm"
-                  className="min-w-0 flex-1"
-                  aria-labelledby="runtime-pairing-address-label"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={loopbackAddress}>
-                    {translate(
-                      'auto.components.settings.RuntimePairingUrlGenerator.de6d5cff95',
-                      'This computer ('
-                    )}
-                    {loopbackAddress})
-                  </SelectItem>
-                  {networkInterfaces.map((networkInterface, index) => (
-                    <SelectItem
-                      key={`${networkInterface.name}:${networkInterface.address}:${index}`}
-                      value={networkInterface.address}
-                    >
-                      {networkInterface.name} ({networkInterface.address})
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {/* Why: server sharing uses the same interface list as Mobile,
-                  and VPN/tailnet addresses can appear after Settings opens. */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={onRefreshNetworkInterfaces}
-                    disabled={refreshingNetworkInterfaces}
-                    aria-label={translate(
-                      'auto.components.settings.RuntimePairingUrlGenerator.360c548cf3',
-                      'Refresh connection addresses'
-                    )}
-                    className="text-muted-foreground"
-                  >
-                    <RefreshCw className={refreshingNetworkInterfaces ? 'animate-spin' : ''} />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  {translate(
+              options={options}
+              value={selectedAddress}
+              onValueChange={onSelectedAddressChange}
+              placeholder=""
+              customInputId="runtime-pairing-custom-address"
+              formatCustomLabel={(address) =>
+                translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.custom-option',
+                  '{{address}} (custom)',
+                  { address }
+                )
+              }
+              addCustomLabel={translate(
+                'auto.components.settings.RuntimePairingUrlGenerator.add-custom',
+                'Add custom address…'
+              )}
+              validateCustom={parseServerShareAddress}
+              customDialogCopy={{
+                title: translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.custom-title',
+                  'Custom connection address'
+                ),
+                description: translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.custom-description',
+                  'Advertise an address another device can reach — a LAN or Tailscale host, or a full ws(s):// URL.'
+                ),
+                inputLabel: translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.4531ea3158',
+                  'Custom address'
+                ),
+                placeholder: translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.45cf476df3',
+                  'host, host:port, or wss://host/path'
+                ),
+                hint: translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.custom-hint',
+                  'Enter a host, host:port, or a ws(s):// URL.'
+                ),
+                cancel: translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.custom-cancel',
+                  'Cancel'
+                ),
+                confirm: translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.custom-use',
+                  'Use address'
+                )
+              }}
+            />
+            {/* Why: server sharing uses the same interface list as Mobile,
+                and VPN/tailnet addresses can appear after Settings opens. */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={onRefreshNetworkInterfaces}
+                  disabled={refreshingNetworkInterfaces}
+                  aria-label={translate(
                     'auto.components.settings.RuntimePairingUrlGenerator.360c548cf3',
                     'Refresh connection addresses'
                   )}
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
-          <div className="min-w-0 space-y-1">
-            <Label htmlFor="runtime-pairing-custom-address">
-              {translate(
-                'auto.components.settings.RuntimePairingUrlGenerator.4531ea3158',
-                'Custom address'
-              )}
-            </Label>
-            <Input
-              id="runtime-pairing-custom-address"
-              value={customAddress}
-              onChange={(event) => onCustomAddressChange(event.target.value)}
-              placeholder={translate(
-                'auto.components.settings.RuntimePairingUrlGenerator.45cf476df3',
-                'host, host:port, or wss://host/path'
-              )}
-              className="h-8 font-mono text-xs"
-            />
+                  className="text-muted-foreground"
+                >
+                  <RefreshCw className={refreshingNetworkInterfaces ? 'animate-spin' : ''} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                {translate(
+                  'auto.components.settings.RuntimePairingUrlGenerator.360c548cf3',
+                  'Refresh connection addresses'
+                )}
+              </TooltipContent>
+            </Tooltip>
           </div>
         </div>
         <p className="text-xs text-muted-foreground">

--- a/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
@@ -13,13 +13,11 @@ const LOOPBACK_ADDRESS = '127.0.0.1'
 // last displayed URL across settings collapse/navigation without less-protected storage.
 const runtimePairingUrlCache: {
   selectedAddress: string
-  customAddress: string
   runtimePairingUrl: string | null
   webClientUrl: string | null
   runtimePairingDeviceId: string | null
 } = {
   selectedAddress: LOOPBACK_ADDRESS,
-  customAddress: '',
   runtimePairingUrl: null,
   webClientUrl: null,
   runtimePairingDeviceId: null
@@ -40,7 +38,6 @@ export function RuntimePairingUrlGenerator({
     []
   )
   const [selectedAddress, setSelectedAddress] = useState(runtimePairingUrlCache.selectedAddress)
-  const [customAddress, setCustomAddress] = useState(runtimePairingUrlCache.customAddress)
   const [runtimePairingUrl, setRuntimePairingUrl] = useState<string | null>(
     runtimePairingUrlCache.runtimePairingUrl
   )
@@ -178,9 +175,8 @@ export function RuntimePairingUrlGenerator({
   const generateRuntimePairingUrl = async (): Promise<void> => {
     setIsGeneratingPairing(true)
     try {
-      const advertiseAddress = customAddress.trim() || selectedAddress
       const result = await window.api.mobile.getRuntimePairingUrl({
-        address: advertiseAddress,
+        address: selectedAddress,
         rotate: true
       })
       if (!result.available) {
@@ -333,11 +329,6 @@ export function RuntimePairingUrlGenerator({
     setSelectedAddress(address)
   }
 
-  const updateCustomAddress = (address: string): void => {
-    runtimePairingUrlCache.customAddress = address
-    setCustomAddress(address)
-  }
-
   return (
     <div ref={setContainerNode} className={containerClassName}>
       {showHeader ? (
@@ -361,14 +352,12 @@ export function RuntimePairingUrlGenerator({
           loopbackAddress={LOOPBACK_ADDRESS}
           networkInterfaces={networkInterfaces}
           selectedAddress={selectedAddress}
-          customAddress={customAddress}
           refreshingNetworkInterfaces={refreshingNetworkInterfaces}
           isGeneratingPairing={isGeneratingPairing}
           webClientUrl={webClientUrl}
           runtimePairingUrl={runtimePairingUrl}
           copiedTarget={copiedTarget}
           onSelectedAddressChange={updateSelectedAddress}
-          onCustomAddressChange={updateCustomAddress}
           onRefreshNetworkInterfaces={() => void loadNetworkInterfaces({ showToastOnError: true })}
           onGenerate={() => void generateRuntimePairingUrl()}
           onCopy={(target, value) => void copyGeneratedUrl(target, value)}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5998,7 +5998,14 @@
           "2752126f3e": "Runtime pairing is unavailable.",
           "95b8be4cea": "Failed to refresh network interfaces.",
           "1b4e0bbcc5": "Failed to load shared access grants.",
-          "b91e36a986": "web"
+          "b91e36a986": "web",
+          "custom-option": "{{address}} (custom)",
+          "add-custom": "Add custom address…",
+          "custom-title": "Custom connection address",
+          "custom-description": "Advertise an address another device can reach — a LAN or Tailscale host, or a full ws(s):// URL.",
+          "custom-hint": "Enter a host, host:port, or a ws(s):// URL.",
+          "custom-cancel": "Cancel",
+          "custom-use": "Use address"
         },
         "Settings": {
           "3bf149e873": "Project Settings > {{value0}}",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5961,7 +5961,14 @@
           "2752126f3e": "El emparejamiento en tiempo de ejecución no está disponible.",
           "95b8be4cea": "No se pudieron actualizar las interfaces de red.",
           "1b4e0bbcc5": "No se pudieron cargar las concesiones de acceso compartido.",
-          "b91e36a986": "web"
+          "b91e36a986": "web",
+          "custom-option": "{{address}} (personalizada)",
+          "add-custom": "Añadir dirección personalizada…",
+          "custom-title": "Dirección de conexión personalizada",
+          "custom-description": "Anuncia una dirección que otro dispositivo pueda alcanzar: un host de LAN o Tailscale, o una URL ws(s):// completa.",
+          "custom-hint": "Introduce un host, host:puerto o una URL ws(s)://.",
+          "custom-cancel": "Cancelar",
+          "custom-use": "Usar dirección"
         },
         "Settings": {
           "3bf149e873": "Configuración del proyecto > {{value0}}",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5983,7 +5983,14 @@
           "2752126f3e": "ランタイムペアリングは利用できません。",
           "95b8be4cea": "ネットワークインターフェースの更新に失敗しました。",
           "1b4e0bbcc5": "共有アクセス許可のロードに失敗しました。",
-          "b91e36a986": "ウェブ"
+          "b91e36a986": "ウェブ",
+          "custom-option": "{{address}}（カスタム）",
+          "add-custom": "カスタムアドレスを追加…",
+          "custom-title": "カスタム接続アドレス",
+          "custom-description": "他のデバイスから到達できるアドレスを指定します。LAN や Tailscale のホスト、または完全な ws(s):// URL です。",
+          "custom-hint": "ホスト、host:port、または ws(s):// URL を入力してください。",
+          "custom-cancel": "キャンセル",
+          "custom-use": "アドレスを使用"
         },
         "Settings": {
           "3bf149e873": "プロジェクト設定 > {{value0}}",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5946,7 +5946,14 @@
           "2752126f3e": "런타임 페어링을 사용할 수 없습니다.",
           "95b8be4cea": "네트워크 인터페이스를 새로고침하지 못했습니다.",
           "1b4e0bbcc5": "공유 액세스 권한을 로드하지 못했습니다.",
-          "b91e36a986": "웹"
+          "b91e36a986": "웹",
+          "custom-option": "{{address}} (사용자 지정)",
+          "add-custom": "사용자 지정 주소 추가…",
+          "custom-title": "사용자 지정 연결 주소",
+          "custom-description": "다른 기기가 연결할 수 있는 주소를 알립니다. LAN 또는 Tailscale 호스트, 또는 전체 ws(s):// URL입니다.",
+          "custom-hint": "호스트, host:port 또는 ws(s):// URL을 입력하세요.",
+          "custom-cancel": "취소",
+          "custom-use": "주소 사용"
         },
         "Settings": {
           "3bf149e873": "프로젝트 설정 > {{value0}}",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5946,7 +5946,14 @@
           "2752126f3e": "运行时配对不可用。",
           "95b8be4cea": "刷新网络接口失败。",
           "1b4e0bbcc5": "无法加载共享访问授权。",
-          "b91e36a986": "网络"
+          "b91e36a986": "网络",
+          "custom-option": "{{address}}（自定义）",
+          "add-custom": "添加自定义地址…",
+          "custom-title": "自定义连接地址",
+          "custom-description": "公布其他设备可以访问的地址：LAN 或 Tailscale 主机，或完整的 ws(s):// URL。",
+          "custom-hint": "请输入主机、host:port 或 ws(s):// URL。",
+          "custom-cancel": "取消",
+          "custom-use": "使用地址"
         },
         "Settings": {
           "3bf149e873": "项目设置 > {{value0}}",

--- a/src/shared/network/server-share-address.test.ts
+++ b/src/shared/network/server-share-address.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { parseServerShareAddress } from './server-share-address'
+
+describe('parseServerShareAddress', () => {
+  it('accepts a bare hostname or IP', () => {
+    expect(parseServerShareAddress('my-host')).toEqual({ ok: true, value: 'my-host' })
+    expect(parseServerShareAddress('my-mac.tail-abcd.ts.net').ok).toBe(true)
+    expect(parseServerShareAddress('192.168.1.50').ok).toBe(true)
+  })
+
+  it('accepts host:port', () => {
+    expect(parseServerShareAddress('192.168.1.50:6768')).toEqual({
+      ok: true,
+      value: '192.168.1.50:6768'
+    })
+    expect(parseServerShareAddress('my-host:443').ok).toBe(true)
+  })
+
+  it('accepts ws:// and wss:// URLs', () => {
+    expect(parseServerShareAddress('wss://my-host/path').ok).toBe(true)
+    expect(parseServerShareAddress('ws://192.168.1.50:6768').ok).toBe(true)
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(parseServerShareAddress('  my-host:8080  ')).toEqual({ ok: true, value: 'my-host:8080' })
+  })
+
+  it('rejects empty, whitespace-containing, and malformed input', () => {
+    for (const bad of ['', '   ', 'has space', 'http://my-host', 'wss://', ':6768']) {
+      expect(parseServerShareAddress(bad).ok).toBe(false)
+    }
+  })
+
+  it('rejects an out-of-range port', () => {
+    expect(parseServerShareAddress('my-host:70000').ok).toBe(false)
+  })
+})

--- a/src/shared/network/server-share-address.ts
+++ b/src/shared/network/server-share-address.ts
@@ -1,0 +1,42 @@
+// Why: shared validator for the "Share this Orca server" custom address. The
+// field accepts a bare host, host:port, or a full ws(s):// URL — looser than
+// the mobile pairing grammar because the target is a transport endpoint, not
+// just an IP. Kept pure so the renderer and any future caller agree.
+
+export type ParseServerShareAddressResult = { ok: true; value: string } | { ok: false }
+
+const HOST_LABEL = '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
+const HOSTNAME = `${HOST_LABEL}(?:\\.${HOST_LABEL})*`
+const IPV4 = '(?:\\d{1,3}\\.){3}\\d{1,3}'
+const HOST = `(?:${HOSTNAME}|${IPV4})`
+const PORT = '[0-9]{1,5}'
+
+const HOST_OR_HOST_PORT = new RegExp(`^${HOST}(?::${PORT})?$`)
+
+export function parseServerShareAddress(input: string): ParseServerShareAddressResult {
+  const trimmed = input.trim()
+  if (trimmed === '' || /\s/.test(trimmed)) {
+    return { ok: false }
+  }
+
+  // Full ws(s):// URL — defer to the URL parser, which validates host/port/path.
+  if (/^wss?:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed)
+      return url.hostname !== '' ? { ok: true, value: trimmed } : { ok: false }
+    } catch {
+      return { ok: false }
+    }
+  }
+
+  // Bare host or host:port. Reject an out-of-range port early.
+  const match = trimmed.match(HOST_OR_HOST_PORT)
+  if (!match) {
+    return { ok: false }
+  }
+  const portPart = trimmed.includes(':') ? trimmed.slice(trimmed.lastIndexOf(':') + 1) : null
+  if (portPart !== null && Number(portPart) > 65535) {
+    return { ok: false }
+  }
+  return { ok: true, value: trimmed }
+}


### PR DESCRIPTION
## Summary

Applies the network-address picker pattern from #6501 (mobile pairing) to the **"Share this Orca server"** form in Settings → Runtime Environments.

That form had the same UX smell #6501 fixed on mobile: a dropdown of discovered interfaces sitting next to an always-visible raw **Custom address** text field — uneven, and the two could disagree.

**Before:** dropdown + side-by-side `host, host:port, or wss://host/path` text input.

**After:** a single **Connection address** dropdown (`This computer (127.0.0.1)` + discovered interfaces) with an **"Add custom address…"** footer row that opens a small dialog. The dialog validates the input and shows `<address> (custom)` in the trigger on confirm.

## What changed

- **Generalized one component.** Extracted `AddressPicker` + `CustomAddressDialog` (in `src/renderer/src/components/network/`) with the **validator and copy injected as props**, so both surfaces share one implementation:
  - **Mobile** keeps its IPv4 / Tailscale `*.ts.net` grammar (`NetworkInterfacePicker` now wraps the generic picker — its existing render tests still pass unchanged).
  - **Server-share** gets a looser grammar: bare `host`, `host:port`, or a full `ws(s)://host/path` URL, via a new pure `parseServerShareAddress` validator (with tests).
- **Collapsed the server form's state.** Removed the separate `customAddress` field; a custom value is now just a `selectedAddress` that isn't one of the listed options (same model as mobile). The generate path uses `selectedAddress` directly.
- Muted (non-red) validation hint; **Use address** disabled until input validates.
- All new strings localized across en/es/ja/ko/zh.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` — clean (incl. localization catalog + coverage)
- `pnpm vitest run` (settings + `src/shared/network/`) — 503 passed, incl. new `parseServerShareAddress` cases and the unchanged mobile picker render tests
- **Real dev build (macOS):** opened Settings → Runtime Environments → "Advertise this app as a server" → New Link. Confirmed the dropdown shows `This computer (127.0.0.1)` + interfaces + "Add custom address…"; entered `wss://my-server.tail-abc.ts.net:6768/path` → committed and shown as `… (custom)`; invalid input keeps "Use address" disabled with a muted hint.

Screenshots attached to the conversation (not committed, per AGENTS.md).

## Notes

Follow-up to #6501. No main-process/IPC changes — the form still calls `getRuntimePairingUrl({ address })` with the same contract.

Made with [Orca](https://github.com/stablyai/orca) 🐋
