### PR TITLE
Keep disabled delete worktree option for primary checkouts

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -834,20 +834,25 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
              disabled Delete Worktree for parity with non-primary cards and pair
              it with the enabled Remove Project action below. */}
           {!isMultiContext && removesProject ? (
-            <DropdownMenuItem
-              variant="destructive"
-              disabled
-              title={translate(
-                'auto.components.sidebar.WorktreeContextMenu.primaryDeleteDisabled',
-                "Primary worktree — can't be deleted. Remove the project instead."
-              )}
-            >
-              <Trash2 className="size-3.5" />
-              {translate(
-                'auto.components.sidebar.WorktreeContextMenu.deleteWorktree',
-                'Delete Worktree'
-              )}
-            </DropdownMenuItem>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <DropdownMenuItem variant="destructive" disabled>
+                    <Trash2 className="size-3.5" />
+                    {translate(
+                      'auto.components.sidebar.WorktreeContextMenu.deleteWorktree',
+                      'Delete Worktree'
+                    )}
+                  </DropdownMenuItem>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="right" sideOffset={8} className="max-w-[200px] text-pretty">
+                {translate(
+                  'auto.components.sidebar.WorktreeContextMenu.primaryDeleteDisabled',
+                  "Primary worktree — can't be deleted. Remove the project instead."
+                )}
+              </TooltipContent>
+            </Tooltip>
           ) : null}
           {/* Why: primary checkout rows remove the project from Orca instead of
              invoking git worktree deletion. Radix forwards unknown props to the

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -830,6 +830,25 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                   )}
             </TooltipContent>
           </Tooltip>
+          {/* Why: primary checkout rows can't be git-worktree-removed, so keep a
+             disabled Delete Worktree for parity with non-primary cards and pair
+             it with the enabled Remove Project action below. */}
+          {!isMultiContext && removesProject ? (
+            <DropdownMenuItem
+              variant="destructive"
+              disabled
+              title={translate(
+                'auto.components.sidebar.WorktreeContextMenu.primaryDeleteDisabled',
+                "Primary worktree — can't be deleted. Remove the project instead."
+              )}
+            >
+              <Trash2 className="size-3.5" />
+              {translate(
+                'auto.components.sidebar.WorktreeContextMenu.deleteWorktree',
+                'Delete Worktree'
+              )}
+            </DropdownMenuItem>
+          ) : null}
           {/* Why: primary checkout rows remove the project from Orca instead of
              invoking git worktree deletion. Radix forwards unknown props to the
              DOM element, so `title` works directly without a wrapper span —

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4015,7 +4015,9 @@
           "250de158fd": "Remove Workspace",
           "changeParentWorkspace": "Change Parent Worktree...",
           "setParentWorkspace": "Set Parent Worktree...",
-          "workspaceSection": "Workspace"
+          "workspaceSection": "Workspace",
+          "primaryDeleteDisabled": "Primary worktree — can't be deleted. Remove the project instead.",
+          "deleteWorktree": "Delete Worktree"
         },
         "WorktreeList": {
           "7a8b9c0d1e": "Update required",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4001,7 +4001,9 @@
           "250de158fd": "Eliminar espacio de trabajo",
           "changeParentWorkspace": "Cambiar árbol de trabajo padre...",
           "setParentWorkspace": "Establecer árbol de trabajo padre...",
-          "workspaceSection": "Espacio de trabajo"
+          "workspaceSection": "Espacio de trabajo",
+          "primaryDeleteDisabled": "El árbol de trabajo principal no se puede eliminar. Elimina el proyecto en su lugar.",
+          "deleteWorktree": "Eliminar árbol de trabajo"
         },
         "WorktreeList": {
           "d880ea0744": "Crea un grupo y mueve este proyecto a él.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3982,7 +3982,9 @@
           "250de158fd": "ワークスペースを削除",
           "changeParentWorkspace": "親ワークツリーを変更...",
           "setParentWorkspace": "親ワークツリーを設定...",
-          "workspaceSection": "ワークスペース"
+          "workspaceSection": "ワークスペース",
+          "primaryDeleteDisabled": "プライマリワークツリーは削除できません。代わりにプロジェクトを削除してください。",
+          "deleteWorktree": "ワークツリーを削除"
         },
         "WorktreeList": {
           "d880ea0744": "グループを作成し、このプロジェクトをそのグループに移動します。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3982,7 +3982,9 @@
           "250de158fd": "워크스페이스 제거",
           "changeParentWorkspace": "상위 워크트리 변경...",
           "setParentWorkspace": "상위 워크트리 설정...",
-          "workspaceSection": "워크스페이스"
+          "workspaceSection": "워크스페이스",
+          "primaryDeleteDisabled": "기본 작업 트리는 삭제할 수 없습니다. 대신 프로젝트를 제거하세요.",
+          "deleteWorktree": "작업 트리 삭제"
         },
         "WorktreeList": {
           "d880ea0744": "그룹을 만들고 이 프로젝트를 그룹으로 이동하세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3982,7 +3982,9 @@
           "250de158fd": "移除工作区",
           "changeParentWorkspace": "更改父工作树...",
           "setParentWorkspace": "设置父工作树...",
-          "workspaceSection": "工作区"
+          "workspaceSection": "工作区",
+          "primaryDeleteDisabled": "主要工作树无法删除，请改为删除项目。",
+          "deleteWorktree": "删除工作树"
         },
         "WorktreeList": {
           "d880ea0744": "创建一个组并将该项目移入其中。",


### PR DESCRIPTION
## Summary

Keeps a disabled "Delete Worktree" dropdown menu item in the context menu for primary checkouts when they are not grouped (not in multi-context mode). This provides visual parity with non-primary cards and prompts users to remove the project instead.

## Screenshots

- Adds a disabled "Delete Worktree" menu item to the primary checkout context menu with a tooltip explaining that primary worktrees cannot be deleted.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

This change was reviewed for correctness and cross-platform compatibility.
- Checked rendering conditions: verified that `!isMultiContext && removesProject` accurately targets primary checkouts when not grouped.
- Verified localized translations for `primaryDeleteDisabled` and `deleteWorktree` across English, Spanish, Japanese, Korean, and Chinese.
- Confirmed cross-platform compatibility for macOS, Linux, and Windows: this is a pure Electron renderer UI component adjustment with no direct shell commands or file path manipulations.

## Security Audit

- No input handling, command execution, path handling, auth, secrets, dependency, or IPC risks were introduced or modified in this UI-only PR.

## Notes

No platform-specific behavior or risks identified.