### PR TITLE
fix(e2e): canonicalize temp repo paths so golden tests pass on macOS

### DIFF
--- a/tests/e2e/add-project-default-checkout.spec.ts
+++ b/tests/e2e/add-project-default-checkout.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process'
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs'
 import { mkdtemp } from 'fs/promises'
 import os from 'os'
 import path from 'path'
@@ -12,7 +12,12 @@ async function createCloneFixture(): Promise<{
   sourcePath: string
   destinationParent: string
 }> {
-  const rootPath = await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-add-project-clone-'))
+  // Why: realpathSync so the path the test asserts on matches the store's
+  // repo.path on macOS, where os.tmpdir() (/var/...) symlinks to /private/var/...
+  // and the app canonicalizes repo.path via `git rev-parse --show-toplevel`.
+  const rootPath = realpathSync(
+    await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-add-project-clone-'))
+  )
   tempRoots.push(rootPath)
 
   const sourcePath = path.join(rootPath, 'default-checkout-source')
@@ -38,7 +43,12 @@ async function createLinkedWorktreeFixture(): Promise<{
   mainPath: string
   siblingPath: string
 }> {
-  const rootPath = await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-add-project-linked-'))
+  // Why: realpathSync so mainPath matches the store's repo.path on macOS, where
+  // os.tmpdir() (/var/...) symlinks to /private/var/... and the app canonicalizes
+  // repo.path via `git rev-parse --show-toplevel` on add.
+  const rootPath = realpathSync(
+    await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-add-project-linked-'))
+  )
   tempRoots.push(rootPath)
 
   const mainPath = path.join(rootPath, 'linked-source')

--- a/tests/e2e/folder-setup-shallow-priority.spec.ts
+++ b/tests/e2e/folder-setup-shallow-priority.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process'
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs'
 import { mkdtemp } from 'fs/promises'
 import os from 'os'
 import path from 'path'
@@ -28,7 +28,12 @@ async function createShallowPriorityTruncationFixture(): Promise<{
   webClientPath: string
   groupName: string
 }> {
-  const parentPath = await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-shallow-priority-'))
+  // Why: realpathSync so the paths the test asserts on match the store's
+  // repo.path / projectGroup.parentPath on macOS, where os.tmpdir() (/var/...)
+  // symlinks to /private/var/... and the app canonicalizes paths on import.
+  const parentPath = realpathSync(
+    await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-shallow-priority-'))
+  )
   tempRoots.push(parentPath)
   const archivePath = path.join(parentPath, 'archive')
   const webClientPath = path.join(parentPath, 'z-web-client')
@@ -54,7 +59,12 @@ async function createCancellableScanFixture(): Promise<{
   webPath: string
   groupName: string
 }> {
-  const parentPath = await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-cancellable-scan-'))
+  // Why: realpathSync so the paths the test asserts on match the store's
+  // canonicalized repo.path / projectGroup.parentPath on macOS (os.tmpdir()
+  // /var/... symlinks to /private/var/...).
+  const parentPath = realpathSync(
+    await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-cancellable-scan-'))
+  )
   tempRoots.push(parentPath)
   const apiPath = path.join(parentPath, 'api')
   const webPath = path.join(parentPath, 'web')

--- a/tests/e2e/folder-setup.spec.ts
+++ b/tests/e2e/folder-setup.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process'
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs'
 import { mkdtemp } from 'fs/promises'
 import os from 'os'
 import path from 'path'
@@ -29,7 +29,11 @@ async function createNestedRepoFixture(): Promise<{
   projectPaths: string[]
   groupName: string
 }> {
-  const parentPath = await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-folder-setup-'))
+  // Why: realpathSync so the projectPaths the test asserts on match the store's
+  // canonicalized repo.path / projectGroup.parentPath on macOS, where
+  // os.tmpdir() (/var/...) symlinks to /private/var/... and the app canonicalizes
+  // imported paths via `git rev-parse --show-toplevel`.
+  const parentPath = realpathSync(await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-folder-setup-')))
   tempRoots.push(parentPath)
   const repoNames = ['api-service', 'web-client']
   const projectPaths = repoNames.map((name) => path.join(parentPath, name))
@@ -51,7 +55,12 @@ async function createLargeNestedRepoFixture(): Promise<{
   groupName: string
   selectedProjectPaths: string[]
 }> {
-  const parentPath = await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-large-folder-setup-'))
+  // Why: realpathSync so the projectPaths the test asserts on match the store's
+  // canonicalized repo.path on macOS (os.tmpdir() /var/... symlinks to
+  // /private/var/...).
+  const parentPath = realpathSync(
+    await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-large-folder-setup-'))
+  )
   tempRoots.push(parentPath)
   const nestedParent = path.join(
     parentPath,

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -12,7 +12,7 @@
 
 import { execSync } from 'child_process'
 import { randomUUID } from 'crypto'
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'fs'
 import path from 'path'
 import os from 'os'
 
@@ -56,7 +56,10 @@ export default function globalSetup(): void {
   // ── 2. Create a seeded test git repo ───────────────────────────────
   // Why: each test run gets its own git repo so the suite is fully
   // idempotent. No test depends on whatever repos the user has open.
-  const testRepoDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-repo-'))
+  // Why: realpathSync so the seeded path matches the store's repo.path on
+  // macOS, where os.tmpdir() (/var/...) symlinks to /private/var/... and the
+  // app canonicalizes repo.path via `git rev-parse --show-toplevel` on add.
+  const testRepoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-repo-')))
 
   execSync('git init', { cwd: testRepoDir, stdio: 'pipe' })
   execSync('git config user.email "e2e@test.local"', { cwd: testRepoDir, stdio: 'pipe' })

--- a/tests/e2e/golden-core-flows.spec.ts
+++ b/tests/e2e/golden-core-flows.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process'
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs'
 import { mkdtemp } from 'fs/promises'
 import os from 'os'
 import path from 'path'
@@ -31,7 +31,10 @@ function escapeRegExp(value: string): string {
 }
 
 async function createGitRepo(prefix: string, name: string): Promise<string> {
-  const rootPath = await mkdtemp(path.join(os.tmpdir(), prefix))
+  // Why: macOS os.tmpdir() (/var/...) symlinks to /private/var/..., and the app
+  // canonicalizes repo.path via `git rev-parse --show-toplevel` on add. Resolve
+  // the symlink here so the path the test asserts on matches what the store holds.
+  const rootPath = realpathSync(await mkdtemp(path.join(os.tmpdir(), prefix)))
   tempRoots.push(rootPath)
   const repoPath = path.join(rootPath, name)
 

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -21,7 +21,15 @@ import {
   type ElectronApplication,
   type TestInfo
 } from '@stablyai/playwright-test'
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from 'fs'
 import { execSync } from 'child_process'
 import { randomUUID } from 'crypto'
 import os from 'os'
@@ -133,7 +141,10 @@ function isValidGitRepo(repoPath: string): boolean {
 }
 
 function createSeededTestRepo(): string {
-  const testRepoDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-repo-'))
+  // Why: realpathSync so the seeded path matches the store's repo.path on
+  // macOS, where os.tmpdir() (/var/...) symlinks to /private/var/... and the
+  // app canonicalizes repo.path via `git rev-parse --show-toplevel` on add.
+  const testRepoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-repo-')))
 
   execSync('git init', { cwd: testRepoDir, stdio: 'pipe' })
   execSync('git config user.email "e2e@test.local"', { cwd: testRepoDir, stdio: 'pipe' })


### PR DESCRIPTION
## Summary

The golden release E2E tests fail **deterministically on macOS** with `Expected e2e repo to be loaded` / `repo did not load`. This is a **test bug, not an app regression** — the app behavior is correct; the tests just assert on the wrong path form.

### Root cause

- PR #6574 (`adcf74a9fb`) made `repos:add` store `repo.path = getGitRepoRoot(path)`, which runs `git rev-parse --show-toplevel`. That **resolves symlinks**.
- On macOS, `os.tmpdir()` returns `/var/folders/...`, which is a symlink to `/private/var/folders/...`. So the app stores the canonical `/private/var/...` path, while the tests create the repo under `/var/...` and assert with strict `candidate.path === rawPath` equality → never matches.
- It passes on **Linux CI** (`/tmp` is not a symlink) but fails on the **macOS golden job**, which is why the release looked green on Linux but the golden gate failed.

The `getGitRepoRoot` canonicalization is intentional, correct production behavior (it fixes monorepo-subfolder imports, #6336/#6574). In production the native folder picker returns already-canonical paths, so users never hit this — it only surfaces because the tests use `os.tmpdir()`, which returns the `/var` symlink.

### Fix

Wrap the temp-repo / parent-dir creation in `realpathSync` at every site that later asserts on the store's canonicalized path. This mirrors the **existing convention** already used in `combined-diff-scroll-restore.spec.ts:51` and `large-diff-repro-fixtures.ts:23`.

Sites covered:

| File | Why |
| --- | --- |
| `golden-core-flows.spec.ts` (`createGitRepo`) | golden gate — `repo.path === targetPath` |
| `global-setup.ts` + `helpers/orca-app.ts` (`createSeededTestRepo`) | seeded fixture used by the terminal golden suite and other specs |
| `add-project-default-checkout.spec.ts` | `repo.path === mainPath` (linked-worktree fixture) |
| `folder-setup.spec.ts` | group-import `projectPaths.includes(repo.path)` + `group.parentPath === parentPath` |
| `folder-setup-shallow-priority.spec.ts` | `repo.path === webClientPath/apiPath/webPath` + `group.parentPath === parentPath` |

The last three were hardened proactively: they exercise the same canonicalize-on-import path and would exhibit the same latent macOS mismatch if run on the macOS job.

### Verification (local, macOS)

- `golden-core-flows.spec.ts` — **5/5 clean runs**, 0 crashes
- `test:e2e:terminal-rendering-golden` — **2/2 pass**
- `add-project-default-checkout.spec.ts` — 2/2 pass
- `folder-setup.spec.ts` — 2/2 pass
- `folder-setup-shallow-priority.spec.ts` — 2/2 pass

Root cause + fix correctness independently confirmed by an adversarial review agent (high confidence).

---

## Known follow-up (NOT addressed here, non-blocking)

During the original failing run, the app **once** hit a native `FATAL ERROR` / `SIGABRT` in `@parcel/watcher`'s `getIgnoreGlobs` during teardown:

```
FATAL ERROR: Error::ThrowAsJavaScriptException napi_throw
 getIgnoreGlobs(...)  [@parcel/watcher-darwin-arm64/watcher.node]
 PromiseRunner::onWorkComplete
 napi_async_cleanup_hook_handle__::Hook -> uv__work_done -> Environment::CleanupHandles
```

Assessment (verified, high confidence): this is a **latent abnormal-shutdown teardown race** in the main-thread worktree-base watcher (`src/main/ipc/worktree-base-directory-watcher.ts` — the only subscription using **glob** ignores, so the only one that reaches `getIgnoreGlobs`). It fires only when the process begins freeing the Node environment with an inflight `@parcel/watcher` subscribe/unsubscribe still queued — i.e. when the app is torn down abnormally mid-watch (as happened when the repo-load assertion failed). It did **not recur across 5 subsequent clean runs**, because the normal `will-quit` path already `preventDefault()`s and awaits `shutdownWatchersOnce()` before exiting.

It is **not a user-facing regression** and should **not block the release**. Suggested follow-up: harden the abnormal-exit path so an inflight glob-watch op can't fault during env teardown (e.g. a best-effort drain/guard equivalent to the worker watcher's). Happy to open a separate issue/PR for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
