### PR TITLE
Hide droid hook output from the chat view

### DIFF
--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -109,6 +109,92 @@ describe('DroidHookService', () => {
     }
   )
 
+  // Why: #6069 — the managed droid hook must emit Factory's suppressOutput
+  // directive on EVERY exit path so droid hides the hook block, while staying
+  // fail-open (always exit 0). A bare "contains the JSON" check would pass even
+  // if a regression dropped the emit on the listener-down / empty-payload paths,
+  // so these assert the script's path structure, not mere substring presence.
+  describe('managed script suppressOutput structure (#6069)', () => {
+    it('emits suppressOutput before every exit 0 in the POSIX body', () => {
+      // Pin a POSIX platform so this runs host-independently — on a Windows dev
+      // box install() would write droid-hook.cmd and the .sh read would ENOENT.
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+      try {
+        new DroidHookService().install()
+
+        const body = readFileSync(join(homeDir, '.orca', 'agent-hooks', 'droid-hook.sh'), 'utf8')
+        const lines = body.split('\n')
+
+        // Pin the printf one-liner so a future echo swap can't introduce platform escapes.
+        expect(body).toContain(
+          "orca_suppress_output() {\n  printf '%s\\n' '{\"suppressOutput\":true}'\n}"
+        )
+
+        // Every `exit 0` must be immediately preceded by the suppress emission.
+        const exitIndexes = lines
+          .map((line, index) => ({ line: line.trim(), index }))
+          .filter((entry) => entry.line === 'exit 0')
+          .map((entry) => entry.index)
+        expect(exitIndexes.length).toBeGreaterThan(0)
+        for (const index of exitIndexes) {
+          expect(lines[index - 1].trim()).toBe('orca_suppress_output')
+        }
+
+        // Fail-open POST and final exit are still present.
+        expect(body).toContain(
+          'curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/droid"'
+        )
+        expect(body).toContain('>/dev/null 2>&1 || true')
+      } finally {
+        if (originalPlatform) {
+          Object.defineProperty(process, 'platform', originalPlatform)
+        }
+      }
+    })
+
+    it('routes Windows guards through a single :suppress label after the curl block', () => {
+      // getManagedScript() branches on process.platform at call time, so drive
+      // the Windows body directly to keep its fragile caret/label form tested
+      // from non-Windows CI.
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+      try {
+        new DroidHookService().install()
+
+        const body = readFileSync(join(homeDir, '.orca', 'agent-hooks', 'droid-hook.cmd'), 'utf8')
+        const lines = body.split('\r\n')
+
+        // All three env-var guards short-circuit to the shared label.
+        expect(body).toContain('if "%ORCA_AGENT_HOOK_PORT%"=="" goto suppress')
+        expect(body).toContain('if "%ORCA_AGENT_HOOK_TOKEN%"=="" goto suppress')
+        expect(body).toContain('if "%ORCA_PANE_KEY%"=="" goto suppress')
+
+        // Exactly one :suppress label, sitting after the curl block.
+        const labelIndexes = lines
+          .map((line, index) => ({ line, index }))
+          .filter((entry) => entry.line === ':suppress')
+          .map((entry) => entry.index)
+        expect(labelIndexes).toHaveLength(1)
+        const curlIndex = lines.findIndex((line) => line.includes('curl.exe'))
+        expect(curlIndex).toBeGreaterThanOrEqual(0)
+        expect(labelIndexes[0]).toBeGreaterThan(curlIndex)
+
+        // Fail-open guarantee: no exit before the label re-introduces a non-zero path.
+        const firstExitIndex = lines.findIndex((line) => line.trim() === 'exit /b 0')
+        expect(firstExitIndex).toBeGreaterThan(labelIndexes[0])
+
+        // The emitted echo must not carry a trailing space (cmd echoes it verbatim).
+        expect(lines).toContain('echo {"suppressOutput":true}')
+        expect(body).not.toContain('echo {"suppressOutput":true} ')
+      } finally {
+        if (originalPlatform) {
+          Object.defineProperty(process, 'platform', originalPlatform)
+        }
+      }
+    })
+  })
+
   it('reports partial when Factory has hooks disabled globally', () => {
     const configPath = join(homeDir, '.factory', 'settings.json')
     mkdirSync(dirname(configPath), { recursive: true })

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -70,10 +70,16 @@ function getManagedScript(): string {
       '@echo off',
       'setlocal',
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
-      'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0',
-      'if "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0',
-      'if "%ORCA_PANE_KEY%"=="" exit /b 0',
+      // Why: route guard exits through :suppress so every path emits Factory's
+      // suppressOutput directive once; success falls through after the curl. #6069
+      'if "%ORCA_AGENT_HOOK_PORT%"=="" goto suppress',
+      'if "%ORCA_AGENT_HOOK_TOKEN%"=="" goto suppress',
+      'if "%ORCA_PANE_KEY%"=="" goto suppress',
       buildWindowsAgentHookPostCommand('droid'),
+      // Label sits on its own line so cmd.exe finishes the caret-continued curl
+      // before flowing into the no-op label and echoing the directive.
+      ':suppress',
+      'echo {"suppressOutput":true}',
       'exit /b 0',
       ''
     ].join('\r\n')
@@ -81,14 +87,21 @@ function getManagedScript(): string {
 
   return [
     '#!/bin/sh',
+    // Why: emit Factory's suppressOutput so droid hides the managed hook block;
+    // failing hooks always render, so we still exit 0. #6069
+    'orca_suppress_output() {',
+    "  printf '%s\\n' '{\"suppressOutput\":true}'",
+    '}',
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  orca_suppress_output',
     '  exit 0',
     'fi',
     'payload=$(cat)',
     'if [ -z "$payload" ]; then',
+    '  orca_suppress_output',
     '  exit 0',
     'fi',
     // Timeout caps best-effort hook posts if the local listener stalls.
@@ -103,6 +116,7 @@ function getManagedScript(): string {
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
     '  --data-urlencode "payload=${payload}" >/dev/null 2>&1 || true',
+    'orca_suppress_output',
     'exit 0',
     ''
   ].join('\n')


### PR DESCRIPTION
## Summary

Orca's managed **droid** hook fires up to ~6× per turn (PreToolUse, PostToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, SessionStart, Notification). The Factory droid CLI rendered a "hook block" in the chat transcript for each invocation, filling much of the screen and burying the agent's response.

This makes the managed droid hook emit Factory's documented `{"suppressOutput":true}` directive to stdout on **every** exit path, so droid hides the hook block from the chat view.

**What does *not* change:**

- Status still posts to Orca's local listener exactly as before — sidebar agent status is unaffected.
- The block is only **hidden from the chat view**; droid still keeps it in the detailed transcript (Ctrl+O). `suppressOutput` hides, it does not delete.
- The hook stays **fail-open** (always `exit 0`). Per Factory's contract a *failing* (non-zero) hook always renders, so the issue's literal `exit $?` would re-introduce the noise on a slow/dead listener. We suppress unconditionally and keep `exit 0` — the only intentional deviation from the issue's proposed script; behavior is otherwise identical to its intent.

Closes #6069

### Design approach

Single seam: `getManagedScript()` in `src/main/droid/hook-service.ts`, which generates the POSIX `droid-hook.sh` and Windows `droid-hook.cmd` bodies Orca writes to `~/.orca/agent-hooks/`. Droid is local-only (no SSH/remote install path), so there is one script body per platform.

- **POSIX:** added an `orca_suppress_output()` helper (`printf '%s\n' '{"suppressOutput":true}'`) called immediately before each `exit 0` (the two env/payload guards and the post-curl success path).
- **Windows:** routed the three env-var guards through `goto suppress` and added a single `:suppress` label after the caret-continued curl block that `echo`es the directive, then `exit /b 0`.

Pure script-body change — no settings schema, no migration. The next `install()` rewrites the script in place (content-guarded atomic write).

## Screenshots

No visual change in Orca itself — the behavior is in the generated droid hook script, which runs inside the Factory droid CLI process (not an Orca UI surface). The user-visible effect is in the droid CLI transcript, which requires a Factory/droid account to render (see Notes).

## Testing

- [x] `pnpm lint` — clean for changed files
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` (targeted: `pnpm vitest run src/main/droid/hook-service.test.ts src/main/agent-hooks/managed-hook-timeout.test.ts`) — 9 passed, 1 skipped (pre-existing Windows-only #6078 test)
- [ ] `pnpm build` — not run (no build-surface change; pure script-string + test edit)
- [x] Added high-quality regression tests

New tests assert **path structure**, not mere substring presence (a bare "contains the JSON" check would stay green if a regression dropped the emit on the listener-down / empty-payload paths). POSIX: every `exit 0` is immediately preceded by `orca_suppress_output`, and the exact `printf` one-liner is pinned. Windows: all three guards `goto suppress`, exactly one `:suppress` label after the curl block, no pre-label `exit /b 0`, and no trailing space on the echo. Both tests mock `process.platform` so the Windows body is exercised host-independently from non-Windows CI.

Additionally, the exact POSIX body Orca writes was reconstructed (`diff` vs a programmatic extraction of `getManagedScript()` — identical) and executed in real `/bin/sh`:

| Path | stdout (`od -c`) | exit |
|------|------------------|------|
| Missing env vars | `{"suppressOutput":true}\n` | 0 |
| Env set, empty payload | `{"suppressOutput":true}\n` | 0 |
| Env set, payload, dead port (curl fails) | `{"suppressOutput":true}\n` | 0 |
| Env set, payload, live noisy 200 listener | `{"suppressOutput":true}\n` (response body did **not** leak) | 0 |

`JSON.parse` confirmed a single-key object with `.suppressOutput === true` and empty stderr on every path.

## AI Review Report

A two-reviewer code-review loop ran in parallel on the diff; **both reviewers returned clean in round 1** with zero actionable findings. They independently verified: exactly-once suppress emission per exit path; fail-open carried by `exit 0` (not `|| true`); single-valid-JSON-line stdout with curl output redirected away; cmd.exe escaping (`{ } : "` are not metacharacters, no trailing space); and host-independent path-structure tests.

A separate completeness pass mapped every design requirement and edge case (outside-Orca, dead listener, empty payload, endpoint-file sourcing, stdout cleanliness, UserPromptSubmit/SessionStart, idempotent reinstall) to the implementation: complete, no contradictions, no scope creep.

**Cross-platform compatibility was explicitly checked.** This PR's surface is shell behavior on macOS/Linux (POSIX `.sh`) and Windows (`.cmd`). POSIX uses `printf '%s\n'`; Windows uses a `:suppress` label + `echo` after a caret-continued curl block, keeping `\r\n` line endings. No path handling, shortcuts, labels, or Electron platform code changed. SSH: droid is local-only (no remote install path), so nothing remote changes.

A performance audit found the only hot path is the generated script (runs in the droid CLI, ~6×/turn); the change adds one shell **builtin** (`printf`/`echo`) per invocation — no new subprocess, network call, or fd (the script already spawns `curl` + reads stdin). Zero cost to Orca's main/renderer/startup; `writeManagedScript` is content-guarded (one-time rewrite). No actionable perf concern.

## Security Audit

- **Command execution:** no new process is spawned — `printf`/`echo` are shell/cmd builtins. The existing single `curl` invocation is unchanged.
- **Input/stdout handling:** the emitted directive is a fixed literal string (`{"suppressOutput":true}`), not derived from any user/agent input, so there is no injection surface. POSIX uses a single-quoted `printf '%s\n'` (no expansion, no format-string risk); Windows `echo` of a string with no cmd metacharacters. curl stdout/stderr stays redirected to `/dev/null` / `nul`, so no response body leaks into the single JSON line droid parses.
- **Path/auth/secrets/IPC:** untouched. The sourced endpoint file (unchanged) writes only validated `KEY=value` lines and contributes nothing to stdout.
- **Dependencies:** none added.

No follow-up security work needed.

## Notes

- **Accepted gap:** live confirmation that the Factory/droid CLI actually hides the block on receiving the directive needs a Factory/droid account + running session, which isn't available in this environment. The Orca-side contract (emit exactly `{"suppressOutput":true}` + `exit 0` on every path) is fully proven; whether droid honors the documented directive is upstream behavior.
- The Windows `.cmd` body is verified by structure + a unit test driving `getManagedScript()` on a pinned `win32` platform (cmd.exe can't run on the macOS test host).