### PR TITLE
Send all Changes-view notes to a terminal or agent at once

### DIFF
--- a/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import type React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiffComment } from '../../../../shared/types'
+import type { OpenFile } from '@/store/slices/editor'
+import { EditorPanelHeader } from './EditorPanelHeader'
+
+const storeState = {
+  activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+  agentSendPopoverTargetMode: null,
+  clearDeliveredDiffComments: vi.fn(),
+  closeAgentSendPopoverTargetMode: vi.fn(),
+  getDiffComments: vi.fn(),
+  keybindings: {},
+  openAgentSendPopoverTargetMode: vi.fn(),
+  settings: { diffWordWrap: false },
+  updateSettings: vi.fn(),
+  worktreesByRepo: {}
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (s: typeof storeState) => unknown) => selector(storeState)
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, values?: Record<string, string>) =>
+    fallback.replace(/\{\{value0\}\}/g, values?.value0 ?? '')
+}))
+
+vi.mock('./EditorPanelHeaderPath', () => ({
+  EditorPanelHeaderPath: () => <div data-testid="editor-header-path" />
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuCheckboxItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  DropdownMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('./ReviewNotesSendMenuContent', () => ({
+  ReviewNotesSendMenuContent: () => null
+}))
+
+const activeFile: OpenFile = {
+  id: '/repo/src/app.ts',
+  filePath: '/repo/src/app.ts',
+  relativePath: 'src/app.ts',
+  worktreeId: 'wt-1',
+  language: 'typescript',
+  isDirty: false,
+  mode: 'edit'
+}
+
+const diffComment: DiffComment = {
+  id: 'comment-1',
+  worktreeId: 'wt-1',
+  filePath: 'src/app.ts',
+  source: 'diff',
+  lineNumber: 12,
+  body: 'Please adjust this',
+  createdAt: 1,
+  side: 'modified'
+}
+
+const defaultHeaderProps = {
+  activeFile,
+  copiedPathVisible: false,
+  isSingleDiff: false,
+  isDiffSurface: true,
+  isMarkdown: false,
+  isCsv: false,
+  isNotebook: false,
+  hasEditorToggle: false,
+  availableEditorToggleModes: [],
+  effectiveToggleValue: 'edit' as const,
+  canOpenPreviewToSide: false,
+  canShowMarkdownPreview: false,
+  canShowMarkdownTableOfContents: false,
+  isMarkdownTableOfContentsDisabled: false,
+  shouldShowMarkdownExportAction: false,
+  canExportMarkdownToPdf: false,
+  showMarkdownTableOfContents: false,
+  canShowMarkdownFrontmatterToggle: false,
+  markdownFrontmatterVisible: false,
+  sideBySide: false,
+  openFileState: { canOpen: false },
+  onCopyPath: vi.fn(),
+  onOpenDiffTargetFile: vi.fn(),
+  onOpenPreviewToSide: vi.fn(),
+  onOpenMarkdownPreview: vi.fn(),
+  onOpenContainingFolder: vi.fn(),
+  onToggleSideBySide: vi.fn(),
+  onEditorToggleChange: vi.fn(),
+  onToggleMarkdownTableOfContents: vi.fn(),
+  onToggleMarkdownFrontmatter: vi.fn(),
+  onExportMarkdownToPdf: vi.fn()
+}
+
+function renderHeader(
+  comments: readonly DiffComment[],
+  props: Partial<React.ComponentProps<typeof EditorPanelHeader>> = {}
+): void {
+  storeState.getDiffComments.mockReturnValue(comments)
+  render(<EditorPanelHeader {...defaultHeaderProps} {...props} />)
+}
+
+describe('EditorPanelHeader diff notes send gate', () => {
+  beforeEach(() => {
+    storeState.getDiffComments.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows the batch-send control for Changes mode when the active file has diff comments', () => {
+    renderHeader([diffComment], { isDiffSurface: true, isSingleDiff: false })
+
+    expect(screen.getByRole('button', { name: 'Send AI notes to an agent' })).not.toBeNull()
+  })
+
+  it('hides the batch-send control for Changes mode when the active file has no diff comments', () => {
+    renderHeader([], { isDiffSurface: true, isSingleDiff: false })
+
+    expect(screen.queryByRole('button', { name: 'Send AI notes to an agent' })).toBeNull()
+  })
+
+  it('keeps showing the batch-send control for single-file diff tabs with comments', () => {
+    renderHeader([diffComment], { isDiffSurface: true, isSingleDiff: true })
+
+    expect(screen.getByRole('button', { name: 'Send AI notes to an agent' })).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -136,7 +136,8 @@ export function EditorPanelHeader({
           </Tooltip>
         </TooltipProvider>
       )}
-      {isSingleDiff && fileDiffComments.length > 0 && (
+      {/* Why: Changes mode is a diff surface too, so batch-send stays at parity (#6048). */}
+      {isDiffSurface && fileDiffComments.length > 0 && (
         <DiffNotesSendMenu
           worktreeId={activeFile.worktreeId}
           groupId={activeGroupId ?? activeFile.worktreeId}


### PR DESCRIPTION
## What changes

The editor **Changes view** (the editable "Changes" toggle that shows a HEAD-vs-working-tree diff for a file) now shows the batch **"AI notes"** send control in its header, so you can send **all** unsent line notes to a terminal or the active agent in one action. Previously this view only let you send line notes one at a time.

## What does not change

- This reuses the existing shared `DiffNotesSendMenu` / send pipeline already used by single-file diff tabs, the combined diff viewer, the source-control sidebar, and the markdown viewer. There is **no new send logic, formatting, or store change** — only the editor header's render gate was widened so the existing control also appears in the Changes view once a file has line notes.
- It does **not** change single-comment send, the markdown viewer, or the combined-diff/source-control surfaces.
- It does **not** add rendering of notes inside the diff body beyond the existing comment cards (out of scope; the headline ask was the batch-send option).

## Design approach

The batch-send control already rendered in the editor header, but only when `isSingleDiff` was true. The Changes view is `isChangesMode` (an edit-mode diff surface), which `isSingleDiff` excludes. Since `isDiffSurface = isSingleDiff || isChangesMode` is already computed and threaded into the header, the fix widens the gate from `isSingleDiff && fileDiffComments.length > 0` to `isDiffSurface && fileDiffComments.length > 0`. The combined-diff surface renders its own header (the editor header is suppressed when `isCombinedDiff`), so widening cannot double-show the menu there.

## Design-review outcome

Design doc reviewed via Brennan's PR process (two independent reviewers, two iterations to clean). Review corrected three doc-wording items (the exact prompt-serialization format, a pre-existing path-only-count vs. source-filtered-render note that this change does not worsen, and tightening the test requirement to assert the gate rather than the render model). No design changes resulted; all central code claims were verified accurate.

## Implementation and deviations

- `src/renderer/src/components/editor/EditorPanelHeader.tsx`: gate widened from `isSingleDiff` to `isDiffSurface` (1 line + a one-line "why" comment). No other change.
- `src/renderer/src/components/editor/EditorPanelHeader.test.tsx` (new): focused render test asserting the gate directly — control shows in Changes mode (`isDiffSurface=true, isSingleDiff=false`) with file notes, hidden without notes, and still shows for single-diff (regression anchor). It renders the real `DiffNotesSendMenu` and queries its accessible trigger, so it would fail if the gate regressed to `isSingleDiff`.

No deviations from the design.

## Completeness verification

Independent read-only pass confirmed **COMPLETE**: gate correct, `isDiffSurface` is an existing wired prop (not invented), combined-diff not double-affected, no unintended changes to the send pipeline/store/formatting, and the test asserts the real gate. All listed edge cases hold.

## Headline behavior status

**Implemented.** Validated end-to-end in the running app: in the Changes view of a file with uncommitted changes, the "AI notes" control is absent before any notes exist, appears after adding line notes, opens to offer "This file" / "All unsent notes" scopes with the full terminal/agent target set (parity with the other surfaces), and on send actually spawned an agent and cleared the unsent notes.

## Performance

Audited before code review. Touched hot path: `EditorPanelHeader` (renders per editor tab header). **No actionable findings** — the change adds no new store subscriptions, selectors, effects, timers, RPC-on-mount, or imports; it reuses the existing `getDiffComments` selector and `fileDiffComments` memo. The newly-reachable `DiffNotesSendMenu` is the same component already mounting on other surfaces and cleans up its agent-send target on unmount. Existing source evidence covers the suspected work/leak paths; no new measurement was warranted.

## Code review

One round, two reviewers in parallel — both returned clean. No P0/P1/P2/P3. One reviewer empirically confirmed the test is non-tautological by reverting the gate and observing the Changes-mode case fail, then restoring.

## Validation (merge confidence)

Driven in the real Electron app via CDP:
- Changes view, file with uncommitted changes: control **absent** with no notes → added two line notes → control **appeared** ("AI notes 2").
- Opened menu: "This file (2)" and "All unsent notes (2)" scopes; target list matched the other surfaces (Claude, Codex, etc.).
- Sent "This file" → an agent terminal spawned and the unsent-notes control cleared (backing-state proof of delivery).

Accepted gap: the pasted prompt text was not eyeballed inside the agent terminal (the CLI was still booting at screenshot time); delivery was confirmed via the spawned session + cleared notes, and the injection plumbing is the unchanged shared component already proven on sibling surfaces.

## Static checks and tests

- `pnpm typecheck` — pass (exit 0)
- `oxlint` on touched files — clean; pre-commit `oxlint` + `oxfmt` — clean
- `pnpm exec vitest run … EditorPanelHeader.test.tsx` — 3/3 pass

## SSH / cross-platform

Pure React render-condition change: no new platform branches, path handling, keyboard shortcuts, or local-only assumptions. The send/persistence path already routes through runtime RPC vs. local IPC per the worktree's runtime target, unchanged.

## Residual risks

- Pre-existing (not introduced here): the header note count and "This file" send scope filter by path only, while the diff body renders only `source: 'diff'` notes — a same-path markdown note could be counted/sent while invisible in the diff. This already exists identically on single-diff tabs; deliberately left unchanged to preserve parity. Out of scope for this issue.

Closes #6048

Made with [Orca](https://github.com/stablyai/orca) 🐋
