### PR TITLE
Show project path to distinguish same-named projects

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -109,6 +109,8 @@ const SidebarFilter = React.memo(function SidebarFilter({
     (hideAutomationGeneratedWorkspaces ? 1 : 0) +
     selectedCount
 
+  // Why: derive duplicates from the full repo list so same-name path subtitles
+  // stay visible even when the rendered list is narrowed by search.
   const duplicateDisplayNames = useMemo(() => getDuplicateRepoDisplayNames(repos), [repos])
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
   const commandValue =

--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -19,6 +19,10 @@ import {
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import {
+  getDuplicateRepoDisplayNames,
+  normalizeRepoDisplayNameKey
+} from '@/lib/duplicate-repo-display-names'
 import { searchRepos } from '@/lib/repo-search'
 import { cn } from '@/lib/utils'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
@@ -105,6 +109,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
     (hideAutomationGeneratedWorkspaces ? 1 : 0) +
     selectedCount
 
+  const duplicateDisplayNames = useMemo(() => getDuplicateRepoDisplayNames(repos), [repos])
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
   const commandValue =
     commandValueOverride && filteredRepos.some((repo) => repo.id === commandValueOverride)
@@ -274,6 +279,9 @@ const SidebarFilter = React.memo(function SidebarFilter({
                 </CommandEmpty>
                 {filteredRepos.map((r) => {
                   const checked = selectedRepoIdSet.has(r.id)
+                  const showPath = duplicateDisplayNames.has(
+                    normalizeRepoDisplayNameKey(r.displayName)
+                  )
                   return (
                     <CommandItem
                       key={r.id}
@@ -281,19 +289,26 @@ const SidebarFilter = React.memo(function SidebarFilter({
                       onSelect={() => handleToggleRepo(r.id)}
                       className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
                     >
-                      <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                        <RepoBadgeLabel
-                          name={r.displayName}
-                          color={r.badgeColor}
-                          className="max-w-full"
-                        />
-                        {r.connectionId && (
-                          <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
-                            <Server className="size-2.5" />
-                            {translate('auto.components.sidebar.SidebarFilter.81ded53722', 'SSH')}
-                          </span>
+                      <div className="min-w-0 flex-1">
+                        <span className="inline-flex min-w-0 items-center gap-1.5">
+                          <RepoBadgeLabel
+                            name={r.displayName}
+                            color={r.badgeColor}
+                            className="max-w-full"
+                          />
+                          {r.connectionId && (
+                            <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                              <Server className="size-2.5" />
+                              {translate('auto.components.sidebar.SidebarFilter.81ded53722', 'SSH')}
+                            </span>
+                          )}
+                        </span>
+                        {showPath && (
+                          <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                            {r.path}
+                          </p>
                         )}
-                      </span>
+                      </div>
                       {checked && (
                         <Check className="size-3 shrink-0 text-primary" strokeWidth={3} />
                       )}

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.duplicate-path.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.duplicate-path.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store'
+import type { Repo } from '../../../../shared/types'
+import SidebarRepositoryFilterSection from './SidebarRepositoryFilterSection'
+
+const mocks = vi.hoisted(() => ({
+  filterRepoIds: [] as string[],
+  repos: [] as Repo[],
+  setFilterRepoIds: (ids: string[]) => {
+    void ids
+  }
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Partial<AppState>) => unknown) =>
+    selector({
+      filterRepoIds: mocks.filterRepoIds,
+      setFilterRepoIds: mocks.setFilterRepoIds,
+      repos: mocks.repos
+    } as Partial<AppState>)
+}))
+
+// cmdk relies on layout APIs happy-dom lacks; the row markup is what we assert.
+vi.mock('@/components/ui/command', () => ({
+  Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandInput: React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+    (props, ref) => <input ref={ref} {...props} />
+  ),
+  CommandList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandItem: ({
+    children,
+    onSelect,
+    value
+  }: {
+    children: React.ReactNode
+    onSelect?: (value: string) => void
+    value: string
+  }) => (
+    <button type="button" data-command-value={value} onClick={() => onSelect?.(value)}>
+      {children}
+    </button>
+  )
+}))
+
+function repo(id: string, displayName: string, path: string, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path,
+    displayName,
+    badgeColor: '#111111',
+    addedAt: 1,
+    ...overrides
+  }
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  mocks.filterRepoIds = []
+  mocks.repos = []
+  mocks.setFilterRepoIds = vi.fn((ids: string[]) => {
+    mocks.filterRepoIds = ids
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function pathSubtitleFor(repoId: string): string | undefined {
+  const row = container.querySelector<HTMLButtonElement>(`[data-command-value="${repoId}"]`)
+  return row?.querySelector('p')?.textContent ?? undefined
+}
+
+describe('SidebarRepositoryFilterSection same-name path subtitle', () => {
+  it('shows the path subtitle for same-named available rows and hides it for unique names', () => {
+    mocks.repos = [
+      repo('dup-a', 'merchant', '/work/oneship/merchant'),
+      repo('dup-b', 'merchant', '/work/payments/merchant'),
+      repo('unique', 'orca', '/work/orca')
+    ]
+
+    act(() => {
+      root.render(<SidebarRepositoryFilterSection />)
+    })
+
+    expect(pathSubtitleFor('dup-a')).toBe('/work/oneship/merchant')
+    expect(pathSubtitleFor('dup-b')).toBe('/work/payments/merchant')
+    // Unique name → no disambiguating subtitle, keeping the row compact.
+    expect(pathSubtitleFor('unique')).toBeUndefined()
+  })
+
+  it('keeps the surviving row path when its same-named sibling is already selected', () => {
+    // Why: the duplicate set must come from the full repos slice, not the
+    // rendered available subset. The selected sibling moves into a path-less
+    // pill and leaves availableRepos, so a set derived from availableRepos would
+    // re-hide the survivor's disambiguator — the exact multi-select flow #6235
+    // targets. With dup-a pre-selected, dup-b is the only available "merchant"
+    // row yet must still show its path because dup-a is still in `repos`.
+    mocks.filterRepoIds = ['dup-a']
+    mocks.repos = [
+      repo('dup-a', 'merchant', '/work/oneship/merchant'),
+      repo('dup-b', 'merchant', '/work/payments/merchant')
+    ]
+
+    act(() => {
+      root.render(<SidebarRepositoryFilterSection />)
+    })
+
+    // dup-a is a selected pill (no longer an available row); dup-b survives and
+    // must still show its path even though it is now the only "merchant" row.
+    expect(container.querySelector('[data-command-value="dup-a"]')).toBeNull()
+    expect(pathSubtitleFor('dup-b')).toBe('/work/payments/merchant')
+  })
+})

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
@@ -11,6 +11,10 @@ import {
   CommandList
 } from '@/components/ui/command'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
+import {
+  getDuplicateRepoDisplayNames,
+  normalizeRepoDisplayNameKey
+} from '@/lib/duplicate-repo-display-names'
 import { searchRepos } from '@/lib/repo-search'
 import type { Repo } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
@@ -57,6 +61,7 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
   }, [repos, filterRepoIds])
   const selectedCount = selectedRepoIdSet.size
   const hasRepoFilter = selectedCount > 0
+  const duplicateDisplayNames = useMemo(() => getDuplicateRepoDisplayNames(repos), [repos])
   const selectedRepos = useMemo(
     () => repos.filter((repo) => selectedRepoIdSet.has(repo.id)),
     [repos, selectedRepoIdSet]
@@ -179,32 +184,42 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
                   'No projects match'
                 )}
           </CommandEmpty>
-          {availableRepos.map((repo) => (
-            <CommandItem
-              key={repo.id}
-              value={repo.id}
-              keywords={[repo.displayName, repo.path]}
-              onSelect={() => handleSelectRepo(repo.id)}
-              className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
-            >
-              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                <RepoBadgeLabel
-                  name={repo.displayName}
-                  color={repo.badgeColor}
-                  className="max-w-full"
-                />
-                {repo.connectionId && (
-                  <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
-                    <Server className="size-2.5" />
-                    {translate(
-                      'auto.components.sidebar.SidebarRepositoryFilterSection.2656053db4',
-                      'SSH'
+          {availableRepos.map((repo) => {
+            const showPath = duplicateDisplayNames.has(
+              normalizeRepoDisplayNameKey(repo.displayName)
+            )
+            return (
+              <CommandItem
+                key={repo.id}
+                value={repo.id}
+                keywords={[repo.displayName, repo.path]}
+                onSelect={() => handleSelectRepo(repo.id)}
+                className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
+              >
+                <div className="min-w-0 flex-1">
+                  <span className="inline-flex min-w-0 items-center gap-1.5">
+                    <RepoBadgeLabel
+                      name={repo.displayName}
+                      color={repo.badgeColor}
+                      className="max-w-full"
+                    />
+                    {repo.connectionId && (
+                      <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                        <Server className="size-2.5" />
+                        {translate(
+                          'auto.components.sidebar.SidebarRepositoryFilterSection.2656053db4',
+                          'SSH'
+                        )}
+                      </span>
                     )}
                   </span>
-                )}
-              </span>
-            </CommandItem>
-          ))}
+                  {showPath && (
+                    <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{repo.path}</p>
+                  )}
+                </div>
+              </CommandItem>
+            )
+          })}
         </CommandList>
       </Command>
     </>

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
@@ -61,6 +61,8 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
   }, [repos, filterRepoIds])
   const selectedCount = selectedRepoIdSet.size
   const hasRepoFilter = selectedCount > 0
+  // Why: derive duplicates from the full repo list so a surviving same-name row
+  // keeps its path subtitle even after its sibling moves into selected pills.
   const duplicateDisplayNames = useMemo(() => getDuplicateRepoDisplayNames(repos), [repos])
   const selectedRepos = useMemo(
     () => repos.filter((repo) => selectedRepoIdSet.has(repo.id)),

--- a/src/renderer/src/lib/duplicate-repo-display-names.test.ts
+++ b/src/renderer/src/lib/duplicate-repo-display-names.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getDuplicateRepoDisplayNames,
+  normalizeRepoDisplayNameKey
+} from './duplicate-repo-display-names'
+import type { Repo } from '../../../shared/types'
+
+function repo(id: string, displayName: string): Repo {
+  return {
+    id,
+    path: `/tmp/${id}`,
+    displayName,
+    badgeColor: '#111111',
+    addedAt: 1
+  }
+}
+
+describe('normalizeRepoDisplayNameKey', () => {
+  it('trims and lowercases display names', () => {
+    expect(normalizeRepoDisplayNameKey('  Orca  ')).toBe('orca')
+  })
+})
+
+describe('getDuplicateRepoDisplayNames', () => {
+  it('detects case-insensitive trimmed duplicate display names', () => {
+    const duplicates = getDuplicateRepoDisplayNames([
+      repo('repo-1', ' Orca '),
+      repo('repo-2', 'orca'),
+      repo('repo-3', 'Docs')
+    ])
+
+    expect(duplicates).toEqual(new Set(['orca']))
+  })
+
+  it('ignores unique names and returns only names that appear more than once', () => {
+    const duplicates = getDuplicateRepoDisplayNames([
+      repo('repo-1', 'Orca'),
+      repo('repo-2', 'Docs'),
+      repo('repo-3', 'Docs'),
+      repo('repo-4', 'Tools'),
+      repo('repo-5', 'Docs')
+    ])
+
+    expect(duplicates).toEqual(new Set(['docs']))
+  })
+
+  it('handles empty and single-repo lists', () => {
+    expect(getDuplicateRepoDisplayNames([])).toEqual(new Set())
+    expect(getDuplicateRepoDisplayNames([repo('repo-1', 'Orca')])).toEqual(new Set())
+  })
+})

--- a/src/renderer/src/lib/duplicate-repo-display-names.ts
+++ b/src/renderer/src/lib/duplicate-repo-display-names.ts
@@ -1,0 +1,21 @@
+import type { Repo } from '../../../shared/types'
+
+export function normalizeRepoDisplayNameKey(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+export function getDuplicateRepoDisplayNames(repos: readonly Repo[]): Set<string> {
+  const seenNames = new Set<string>()
+  const duplicateNames = new Set<string>()
+
+  for (const repo of repos) {
+    const name = normalizeRepoDisplayNameKey(repo.displayName)
+    if (seenNames.has(name)) {
+      duplicateNames.add(name)
+      continue
+    }
+    seenNames.add(name)
+  }
+
+  return duplicateNames
+}

--- a/src/renderer/src/lib/new-workspace-project-options.test.ts
+++ b/src/renderer/src/lib/new-workspace-project-options.test.ts
@@ -190,6 +190,28 @@ describe('buildNewWorkspaceProjectOptions', () => {
     expect(options[0]?.detail).toBe('Project')
   })
 
+  it('trims whitespace around the representative path detail', () => {
+    const options = buildNewWorkspaceProjectOptions({
+      projects: [
+        localProject({
+          id: 'repo:local-app'
+        })
+      ],
+      projectHostSetups: [
+        setup({
+          id: 'local-setup',
+          projectId: 'repo:local-app',
+          repoId: 'local-repo',
+          path: '  /tmp/local-app  '
+        })
+      ],
+      eligibleRepos: [repo('local-repo')]
+    })
+
+    expect(options).toHaveLength(1)
+    expect(options[0]?.detail).toBe('/tmp/local-app')
+  })
+
   it('excludes projects that do not have a ready eligible setup', () => {
     const options = buildNewWorkspaceProjectOptions({
       projects: [project(), project({ id: 'repo:other', displayName: 'other' })],

--- a/src/renderer/src/lib/new-workspace-project-options.test.ts
+++ b/src/renderer/src/lib/new-workspace-project-options.test.ts
@@ -35,6 +35,18 @@ function project(overrides: Partial<Project> = {}): Project {
   }
 }
 
+function localProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'repo:local-app',
+    displayName: 'orca',
+    badgeColor: '#111111',
+    sourceRepoIds: ['local-repo'],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
 function setup(overrides: Partial<ProjectHostSetup>): ProjectHostSetup {
   return {
     id: overrides.id ?? 'local-setup',
@@ -88,6 +100,94 @@ describe('buildNewWorkspaceProjectOptions', () => {
         detail: 'stablyai/orca'
       }
     ])
+  })
+
+  it('uses a single ready local project setup path as the detail', () => {
+    const options = buildNewWorkspaceProjectOptions({
+      projects: [
+        localProject({
+          id: 'repo:local-app'
+        })
+      ],
+      projectHostSetups: [
+        setup({
+          id: 'local-setup',
+          projectId: 'repo:local-app',
+          repoId: 'local-repo',
+          path: '/tmp/local-app'
+        })
+      ],
+      eligibleRepos: [repo('local-repo')]
+    })
+
+    expect(options).toHaveLength(1)
+    expect(options[0]?.detail).toBe('/tmp/local-app')
+    expect(options[0]?.detail).not.toBe('Project')
+  })
+
+  it('keeps the multi-host detail when a local project has multiple ready setups', () => {
+    const options = buildNewWorkspaceProjectOptions({
+      projects: [
+        localProject({
+          id: 'repo:local-app',
+          sourceRepoIds: ['local-repo', 'ssh-repo']
+        })
+      ],
+      projectHostSetups: [
+        setup({
+          id: 'local-setup',
+          projectId: 'repo:local-app',
+          repoId: 'local-repo',
+          path: '/tmp/local-app'
+        }),
+        setup({
+          id: 'ssh-setup',
+          hostId: 'ssh:builder',
+          projectId: 'repo:local-app',
+          repoId: 'ssh-repo',
+          path: '/srv/local-app'
+        })
+      ],
+      eligibleRepos: [repo('local-repo'), repo('ssh-repo', { connectionId: 'ssh:builder' })]
+    })
+
+    expect(options).toHaveLength(1)
+    expect(options[0]?.detail).toBe('2 hosts configured')
+  })
+
+  it('keeps GitHub project owner and repo detail', () => {
+    const options = buildNewWorkspaceProjectOptions({
+      projects: [project()],
+      projectHostSetups: [
+        setup({ id: 'local-setup', repoId: 'local-repo', path: '/tmp/local-app' })
+      ],
+      eligibleRepos: [repo('local-repo')]
+    })
+
+    expect(options).toHaveLength(1)
+    expect(options[0]?.detail).toBe('stablyai/orca')
+  })
+
+  it('falls back to Project when the only ready setup path is empty', () => {
+    const options = buildNewWorkspaceProjectOptions({
+      projects: [
+        localProject({
+          id: 'repo:local-app'
+        })
+      ],
+      projectHostSetups: [
+        setup({
+          id: 'local-setup',
+          projectId: 'repo:local-app',
+          repoId: 'local-repo',
+          path: '   '
+        })
+      ],
+      eligibleRepos: [repo('local-repo')]
+    })
+
+    expect(options).toHaveLength(1)
+    expect(options[0]?.detail).toBe('Project')
   })
 
   it('excludes projects that do not have a ready eligible setup', () => {

--- a/src/renderer/src/lib/new-workspace-project-options.ts
+++ b/src/renderer/src/lib/new-workspace-project-options.ts
@@ -105,12 +105,13 @@ export function buildNewWorkspaceProjectOptions(
       (readySetupCountsByProjectId.get(setup.projectId) ?? 0) + 1
     )
     // Why: Path fallback disambiguates same-named local projects (issue #6235).
+    const trimmedPath = setup.path?.trim()
     if (
-      setup.path?.trim() &&
+      trimmedPath &&
       (!representativePathByProjectId.has(setup.projectId) ||
         setup.hostId === LOCAL_EXECUTION_HOST_ID)
     ) {
-      representativePathByProjectId.set(setup.projectId, setup.path)
+      representativePathByProjectId.set(setup.projectId, trimmedPath)
     }
   }
 

--- a/src/renderer/src/lib/new-workspace-project-options.ts
+++ b/src/renderer/src/lib/new-workspace-project-options.ts
@@ -1,3 +1,4 @@
+import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
 import type { Project, ProjectGroup, ProjectHostSetup, Repo } from '../../../shared/types'
 import { isClipboardTextByteLengthOverLimit } from '../../../shared/clipboard-text'
@@ -69,12 +70,19 @@ function getProjectModel({
   }
 }
 
-function getProjectDetail(project: Project, readySetupCount: number): string {
+function getProjectDetail(
+  project: Project,
+  readySetupCount: number,
+  representativePath: string | undefined
+): string {
   if (project.providerIdentity) {
     return `${project.providerIdentity.owner}/${project.providerIdentity.repo}`
   }
   if (readySetupCount > 1) {
     return `${readySetupCount} hosts configured`
+  }
+  if (representativePath) {
+    return representativePath
   }
   return 'Project'
 }
@@ -86,6 +94,7 @@ export function buildNewWorkspaceProjectOptions(
   const { projects, projectHostSetups } = getProjectModel(input)
   const eligibleRepoIds = new Set(eligibleRepos.map((repo) => repo.id))
   const readySetupCountsByProjectId = new Map<string, number>()
+  const representativePathByProjectId = new Map<string, string>()
 
   for (const setup of projectHostSetups) {
     if (setup.setupState !== 'ready' || !eligibleRepoIds.has(setup.repoId)) {
@@ -95,6 +104,14 @@ export function buildNewWorkspaceProjectOptions(
       setup.projectId,
       (readySetupCountsByProjectId.get(setup.projectId) ?? 0) + 1
     )
+    // Why: Path fallback disambiguates same-named local projects (issue #6235).
+    if (
+      setup.path?.trim() &&
+      (!representativePathByProjectId.has(setup.projectId) ||
+        setup.hostId === LOCAL_EXECUTION_HOST_ID)
+    ) {
+      representativePathByProjectId.set(setup.projectId, setup.path)
+    }
   }
 
   return projects
@@ -105,7 +122,11 @@ export function buildNewWorkspaceProjectOptions(
       projectId: project.id,
       displayName: project.displayName,
       badgeColor: project.badgeColor,
-      detail: getProjectDetail(project, readySetupCountsByProjectId.get(project.id) ?? 0)
+      detail: getProjectDetail(
+        project,
+        readySetupCountsByProjectId.get(project.id) ?? 0,
+        representativePathByProjectId.get(project.id)
+      )
     }))
     .sort((a, b) => a.displayName.localeCompare(b.displayName) || a.detail.localeCompare(b.detail))
 }


### PR DESCRIPTION
## What changes

When two projects share a display name, the project surfaces now show the project's **path** so you can tell them apart.

- **Create-worktree Project picker:** the subtitle under a project option now shows its path instead of the literal word "Project" for single-host local projects. GitHub-backed projects still show `owner/repo`, and multi-host projects still show `N hosts configured` — those take precedence and are unchanged.
- **Sidebar Project filter** (the workspace-options menu and the Kanban-drawer filter): a project row now shows a path subtitle **only when its display name collides** with another project's. Uniquely-named projects render exactly as before (no subtitle), so the compact common case is untouched.

## What does not change

- Projects with unique names: no new subtitle in the sidebar filter; the picker subtitle is unchanged for GitHub/multi-host projects.
- No change to project identity, grouping, sorting, persistence, or any IPC/main-process behavior. This is a renderer-only display change.
- The collision check is case-insensitive and trimmed, and is computed over the **full** project list (not the currently-rendered subset) so selecting one same-named project doesn't hide the surviving row's path.

Fixes #6235.

## Design approach

The picker already had a subtitle slot that renders `owner/repo` for GitHub projects and the filesystem path for folder sources — only the no-identity fallback was the useless literal `"Project"`. The fix computes a representative ready-setup path per project (preferring the local host for determinism, recording only non-empty paths) and uses it as the fallback. For the sidebar, a small focused helper (`getDuplicateRepoDisplayNames`) flags names that occur more than once, and rows whose name is flagged gain a path subtitle that mirrors the picker's subtitle styling.

## Design-review outcome

Design doc reviewed via Brennan's PR process (parallel Claude + Codex reviewers), 2 rounds, returned clean. The substantive finding it caught: the duplicate-name set must be derived from the full repos list, not the rendered "available" subset — otherwise selecting one same-named sibling (which moves it into a path-less pill) would re-hide the survivor's disambiguator. That rule is implemented and has a dedicated regression test.

## Implementation & deviations

Implemented exactly as designed; no deviations. Touched files:
- `src/renderer/src/lib/new-workspace-project-options.ts` — path fallback in `getProjectDetail` + representative-path map.
- `src/renderer/src/lib/duplicate-repo-display-names.ts` (new) — `getDuplicateRepoDisplayNames` / `normalizeRepoDisplayNameKey`.
- `src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx`, `SidebarFilter.tsx` — collision-gated path subtitle on rows.
- Tests: `new-workspace-project-options.test.ts`, `duplicate-repo-display-names.test.ts`, `SidebarRepositoryFilterSection.duplicate-path.test.tsx`.

## Completeness verification

Verified COMPLETE against the design: both surfaces implemented, branch order correct, non-empty-path guard present, duplicate set over full `repos`, pills unchanged, all four picker test cases + duplicate-name tests present.

## Headline behavior status

**Implemented** in production code (not behind a flag, not fixture-only). Both mockup surfaces from the issue now render the disambiguating path; validated live in Electron (screenshots below).

## Perf audit

Performance-neutral. The sidebar memo is correctly keyed on `[repos]` (replaced by reference only on real repo mutation), so it doesn't recompute on search/filter/selection changes. Per-row work is O(1) (`Set.has` + a short `trim().toLowerCase()`); the helper is a single O(repos) pass. No new store subscriptions, no polling, no IPC/subprocess/main-process work. Existing unit tests cover the single-pass behavior; no additional measurement warranted.

## Code-review loop

2 rounds, two `review-code` reviewers per round, both clean in the final round. No actionable findings. Non-actionable items intentionally left: a documented defensive local-host tiebreak (harmless), and the sans (not mono) font on the path subtitle (deliberate, for slot consistency with the picker's `owner/repo` text).

## Manual validation (brennan-test-changes)

Verdict: **LAND**. Launched a dedicated Electron instance from this worktree (verified branch identity), created two disposable local repos both named `merchant` at different paths, and confirmed live:
- Sidebar filter: both `merchant` rows show their distinct paths; uniquely-named projects show no subtitle.
- Create-worktree combobox: both `merchant` options show their paths instead of "Project".

Screenshots attached in a follow-up comment. Cleanup completed (repos removed, temp dirs deleted, only the launched process stopped).

Accepted gap: the Kanban-drawer `SidebarFilter` was exercised via shared logic + unit test rather than driven separately in the UI (identical code path to the menu variant that was driven live).

## Checks run

- `pnpm run typecheck` (node + cli + web): clean.
- `pnpm run lint` (oxlint + switch-exhaustiveness + styled-scrollbars + localization catalog + localization coverage): clean (path subtitle is data, needs no localization key — coverage check confirms).
- Focused vitest on the 3 test files: 16 tests pass.
- `git diff --check`: clean.

## Cross-platform / SSH

Paths render verbatim from `repo.path` / `setup.path` with no separator parsing, so Windows and POSIX paths both display correctly. SSH/remote repos already store and show their remote path; the SSH badge is preserved. Accepted limitation (out of scope): a path alone may not be globally unique across different SSH hosts since the row doesn't name the host.

Made with [Orca](https://github.com/stablyai/orca) 🐋
