### PR TITLE
Add AdaL (SylphAI) as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Works with **any CLI agent** — if it runs in a terminal, it runs in Orca.
   <a href="https://github.com/mistralai/mistral-vibe"><kbd><img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=64" alt="Mistral Vibe logo" width="16" valign="middle" /> Mistral Vibe</kbd></a> &nbsp;
   <a href="https://github.com/QwenLM/qwen-code"><kbd><img src="https://www.google.com/s2/favicons?domain=qwenlm.github.io&sz=64" alt="Qwen Code logo" width="16" valign="middle" /> Qwen Code</kbd></a> &nbsp;
   <a href="https://support.atlassian.com/rovo/docs/install-and-run-rovo-dev-cli-on-your-device/"><kbd><img src="https://www.google.com/s2/favicons?domain=atlassian.com&sz=64" alt="Rovo Dev logo" width="16" valign="middle" /> Rovo Dev</kbd></a> &nbsp;
+  <a href="https://docs.sylph.ai"><kbd><img src="https://www.google.com/s2/favicons?domain=sylph.ai&sz=64" alt="AdaL logo" width="16" valign="middle" /> AdaL</kbd></a> &nbsp;
   <kbd>+ any CLI agent</kbd>
 </p>
 

--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -37,7 +37,8 @@ export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
   'rovo',
   'hermes',
   'devin',
-  'openclaw'
+  'openclaw',
+  'adal'
 ] as const satisfies readonly TuiAgent[]
 
 export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
@@ -74,7 +75,8 @@ export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
   rovo: 'Rovo Dev',
   hermes: 'Hermes',
   devin: 'Devin',
-  openclaw: 'OpenClaw'
+  openclaw: 'OpenClaw',
+  adal: 'AdaL'
 }
 
 export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>> = {
@@ -106,7 +108,8 @@ export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>>
   rovo: 'atlassian.com',
   hermes: 'nousresearch.com',
   devin: 'devin.ai',
-  openclaw: 'openclaw.ai'
+  openclaw: 'openclaw.ai',
+  adal: 'sylph.ai'
 }
 
 export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
@@ -144,7 +147,8 @@ export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
   rovo: 'rovo',
   hermes: 'hermes',
   devin: 'devin',
-  openclaw: 'openclaw'
+  openclaw: 'openclaw',
+  adal: 'adal'
 }
 
 export function isMobileTuiAgent(value: unknown): value is TuiAgent {

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -217,7 +217,8 @@ export const getGeneralAgentSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.general.search.f472e97440', 'aider'),
       ...translateSearchKeyword('auto.components.settings.general.search.5d9ba08673', 'copilot'),
       ...translateSearchKeyword('auto.components.settings.general.search.c61b14be7c', 'grok'),
-      ...translateSearchKeyword('auto.lib.agent.catalog.fc80296033', 'devin')
+      ...translateSearchKeyword('auto.lib.agent.catalog.fc80296033', 'devin'),
+      ...translateSearchKeyword('auto.lib.agent.catalog.adal', 'adal')
     ]
   }
 ])

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -34,6 +34,7 @@ const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   'GitHub Copilot': 'copilot',
   Grok: 'grok',
   Devin: 'devin',
+  AdaL: 'adal',
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
   Aider: 'aider',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -294,7 +294,8 @@
           "0708ed89f1": "Claude",
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "adal": "AdaL"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -294,7 +294,8 @@
           "0708ed89f1": "Claude",
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "adal": "AdaL"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -294,7 +294,8 @@
           "0708ed89f1": "Claude",
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "adal": "AdaL"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -294,7 +294,8 @@
           "0708ed89f1": "Claude",
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "adal": "AdaL"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -294,7 +294,8 @@
           "0708ed89f1": "Claude",
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "adal": "AdaL"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -288,6 +288,13 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     cmd: 'openclaw',
     faviconDomain: 'openclaw.ai',
     homepageUrl: 'https://github.com/openclaw/openclaw'
+  },
+  {
+    id: 'adal',
+    label: translate('auto.lib.agent.catalog.adal', 'AdaL'),
+    cmd: 'adal',
+    faviconDomain: 'sylph.ai',
+    homepageUrl: 'https://docs.sylph.ai'
   }
 ])
 

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -239,6 +239,13 @@ describe('detectAgentStatusFromTitle', () => {
     expect(detectAgentStatusFromTitle('Devin working')).toBe('working')
   })
 
+  it('classifies synthesized AdaL titles', () => {
+    expect(detectAgentStatusFromTitle('⠋ AdaL')).toBe('working')
+    expect(detectAgentStatusFromTitle('AdaL ready')).toBe('idle')
+    expect(detectAgentStatusFromTitle('AdaL - action required')).toBe('permission')
+    expect(detectAgentStatusFromTitle('AdaL working')).toBe('working')
+  })
+
   it('does not treat Factory Droid native needs-input titles as completion', () => {
     expect(detectAgentStatusFromTitle('Factory Droid needs input')).toBeNull()
     expect(detectAgentStatusFromTitle('Factory Droid needs your input')).toBeNull()
@@ -281,6 +288,11 @@ describe('detectAgentStatusFromTitle', () => {
   it('does not treat path fragments containing Hermes as agent activity', () => {
     expect(detectAgentStatusFromTitle('~/hermes/working')).not.toBe('working')
     expect(detectAgentStatusFromTitle('C:\\hermes\\ready')).toBeNull()
+  })
+
+  it('does not treat path fragments containing AdaL as agent activity', () => {
+    expect(detectAgentStatusFromTitle('~/adal/working')).not.toBe('working')
+    expect(detectAgentStatusFromTitle('C:\\adal\\ready')).toBeNull()
   })
 })
 
@@ -439,6 +451,8 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('Hermes ready')).toBe('Hermes')
     expect(getAgentLabel('⠋ Devin')).toBe('Devin')
     expect(getAgentLabel('Devin ready')).toBe('Devin')
+    expect(getAgentLabel('⠋ AdaL')).toBe('AdaL')
+    expect(getAgentLabel('AdaL ready')).toBe('AdaL')
   })
 
   it('does not label the Claude agents management title', () => {
@@ -466,6 +480,7 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('~/cursor-rules')).toBeNull()
     expect(getAgentLabel('grok-fixtures')).toBeNull()
     expect(getAgentLabel('devin-fixtures')).toBeNull()
+    expect(getAgentLabel('C:\\adal\\ready')).toBeNull()
     expect(getAgentLabel('aider-config')).toBeNull()
   })
 
@@ -476,6 +491,7 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('⠋ Codex')).toBe('Codex')
     expect(getAgentLabel('Aider idle')).toBe('Aider')
     expect(getAgentLabel('Devin working')).toBe('Devin')
+    expect(getAgentLabel('AdaL ready')).toBe('AdaL')
   })
 })
 
@@ -827,6 +843,10 @@ describe('formatAgentTypeLabel', () => {
     expect(formatAgentTypeLabel('ante')).toBe('Ante')
   })
 
+  it("maps 'adal' to 'AdaL'", () => {
+    expect(formatAgentTypeLabel('adal')).toBe('AdaL')
+  })
+
   it('passes through arbitrary custom agent names as-is', () => {
     expect(formatAgentTypeLabel('weirdo')).toBe('weirdo')
   })
@@ -851,6 +871,7 @@ describe('agentTypeToIconAgent', () => {
     expect(agentTypeToIconAgent('antigravity')).toBe('antigravity')
     expect(agentTypeToIconAgent('command-code')).toBe('command-code')
     expect(agentTypeToIconAgent('ante')).toBe('ante')
+    expect(agentTypeToIconAgent('adal')).toBe('adal')
   })
 
   it('returns null for arbitrary non-iconable strings', () => {

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -132,6 +132,7 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   hermes: 'Hermes',
   devin: 'Devin',
   ante: 'Ante',
+  adal: 'AdaL',
   kimi: 'Kimi'
 }
 
@@ -190,7 +191,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   copilot: true,
   grok: true,
   devin: true,
-  ante: true
+  ante: true,
+  adal: true
 }
 
 export function agentTypeToIconAgent(agentType: AgentType | null | undefined): TuiAgent | null {

--- a/src/renderer/src/lib/terminal-title-agent-type.test.ts
+++ b/src/renderer/src/lib/terminal-title-agent-type.test.ts
@@ -9,6 +9,7 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
     expect(resolveExplicitTerminalTitleAgentType('MiMo Code')).toBe('mimo-code')
     expect(resolveExplicitTerminalTitleAgentType('⠋ OpenClaude')).toBe('openclaude')
     expect(resolveExplicitTerminalTitleAgentType('OMP')).toBe('omp')
+    expect(resolveExplicitTerminalTitleAgentType('⠋ AdaL')).toBe('adal')
   })
 
   it('treats Claude generic status prefixes as activity-only, not identity', () => {

--- a/src/renderer/src/lib/terminal-title-agent-type.ts
+++ b/src/renderer/src/lib/terminal-title-agent-type.ts
@@ -13,6 +13,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   'GitHub Copilot': 'copilot',
   Grok: 'grok',
   Devin: 'devin',
+  AdaL: 'adal',
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
   'MiMo Code': 'mimo-code',

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -205,6 +205,23 @@ describe('buildAgentStartupPlan', () => {
     })
   })
 
+  it('launches AdaL first and injects the prompt after startup', () => {
+    expect(
+      buildAgentStartupPlan({
+        agent: 'adal',
+        prompt: 'Trace the failing test',
+        cmdOverrides: {},
+        platform: 'linux'
+      })
+    ).toEqual({
+      agent: 'adal',
+      launchCommand: 'adal',
+      expectedProcess: 'adal',
+      followupPrompt: 'Trace the failing test',
+      launchConfig: emptyLaunchConfig('adal')
+    })
+  })
+
   it('launches Command Code by its unambiguous binary with a positional prompt', () => {
     expect(
       buildAgentStartupPlan({

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -354,6 +354,9 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'devin')) {
     return 'Devin'
   }
+  if (titleHasAgentName(title, 'adal')) {
+    return 'AdaL'
+  }
   if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
   }

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -47,7 +47,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   copilot: 'copilot',
   grok: 'grok',
   devin: 'devin',
-  ante: 'ante'
+  ante: 'ante',
+  adal: 'adal'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -26,7 +26,8 @@ export const AGENT_NAMES = [
   'openclaw',
   'aider',
   'grok',
-  'devin'
+  'devin',
+  'adal'
 ]
 
 // Why: Windows agent titles can surface launcher process names such as

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -135,6 +135,14 @@ describe('agent process recognition', () => {
     expect(isRecognizedAgentType('vibe')).toBe(true)
   })
 
+  it('recognizes AdaL from a Windows npm global bin path', () => {
+    expect(recognizeAgentProcess(String.raw`C:\Users\dev\AppData\Roaming\npm\adal.cmd`)).toEqual({
+      agent: 'adal',
+      processName: 'adal'
+    })
+    expect(isRecognizedAgentType('adal')).toBe(true)
+  })
+
   it('recognizes Qwen Code by its installed qwen executable', () => {
     expect(recognizeAgentProcess('/home/dev/.local/bin/qwen')).toEqual({
       agent: 'qwen-code',

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -33,6 +33,7 @@ export type WellKnownAgentType =
   | 'hermes'
   | 'devin'
   | 'ante'
+  | 'adal'
   | 'unknown'
 export type AgentType = WellKnownAgentType | (string & {})
 

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -103,6 +103,7 @@ export const AGENT_KIND_VALUES = [
   'grok',
   'devin',
   'ante',
+  'adal',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -335,6 +335,14 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // `followupPrompt` to the PTY as plain input + Enter after startup (not
     // bracketed paste). Use `draftPrompt` / agent-paste-draft for review-before-send.
     promptInjectionMode: 'stdin-after-start'
+  },
+  adal: {
+    detectCmd: 'adal',
+    launchCmd: 'adal',
+    expectedProcess: 'adal',
+    // Why: AdaL has no documented prompt-prefill flag, so Orca starts the
+    // interactive TUI and injects the initial prompt after startup.
+    promptInjectionMode: 'stdin-after-start'
   }
 }
 

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -39,7 +39,8 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   hermes: 'Hermes',
   openclaw: 'OpenClaw',
   copilot: 'GitHub Copilot',
-  grok: 'Grok'
+  grok: 'Grok',
+  adal: 'AdaL'
 }
 
 /** Canonical agent id list derived from the exhaustive display-name record,

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -37,7 +37,8 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'rovo',
   'hermes',
   'devin',
-  'openclaw'
+  'openclaw',
+  'adal'
 ] as const satisfies readonly TuiAgent[]
 
 // Why: fresh installs should expose Claude Agent Teams in agent pickers; the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2304,6 +2304,7 @@ export type TuiAgent =
   | 'grok' // xAI Grok CLI
   | 'devin' // Devin CLI
   | 'ante' // Ante (Antigma Labs)
+  | 'adal' // AdaL (SylphAI)
 
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'
 


### PR DESCRIPTION
## What changes

Adds **AdaL** (by SylphAI — npm `@sylphai/adal-cli`, binary `adal`, docs https://docs.sylph.ai) as a supported catalog agent. After this change AdaL appears as a selectable agent in Orca with the SylphAI favicon and label "AdaL", is detected on PATH, launches via `adal`, has its terminal-title status/identity inferred, and is attributed in telemetry — on both desktop and mobile. It follows the exact registration pattern used by `grok`/`devin`.

**What does not change:** this is pure agent registration only. It intentionally does **not** add the deeper opt-in integrations some agents have (agent hook services, AI-vault session scanning, synthetic animated titles, session resume). Those are separate per-agent features and are out of scope for "add as a supported agent". Like every other catalog agent, AdaL only surfaces in the new-workspace quick picker once the `adal` binary is detected on PATH; it always appears in Settings → Agents.

Resolves issue `#3085`.

## Design approach

Add `adal` to every exhaustive `Record<TuiAgent, …>` / union and every catalog-or-parity list that registers an agent, mirroring `grok`/`devin`:
- Core: `TuiAgent` union, `AGENT_KIND_VALUES`, `TUI_AGENT_KIND_BY_AGENT`, `TUI_AGENT_CONFIG` (`launchCmd`/`detectCmd`/`expectedProcess` = `adal`, `promptInjectionMode: 'stdin-after-start'` — AdaL has no documented prefill flag), `TUI_AGENT_DISPLAY_NAMES`, `WellKnownAgentType`.
- Renderer: catalog entry (favicon `sylph.ai`, homepage `https://docs.sylph.ai`), `ICONABLE_AGENT_TYPES` + `WELL_KNOWN_LABELS`, the title→label branch in `getAgentLabel`, the reverse label→id maps in `terminal-title-agent-type.ts` and `worktree-title-derived-agent-rows.ts`, the default-agent settings-search keyword, and the `adal` token in `AGENT_NAMES`.
- Mobile: the four `mobile-tui-agents.ts` records + auto-pick parity.
- i18n: `auto.lib.agent.catalog.adal: "AdaL"` across en/es/ja/ko/zh (brand name verbatim, via the repo's `sync:localization-catalog` tool).
- README badge.

## Design-review outcome

Reviewed via Brennan's PR process design loop. Converged clean after fixing two real gaps it surfaced: (1) `getAgentLabel` is an explicit per-agent if-chain (not a generic lookup), so an explicit `adal` branch placed **before** the Claude braille fallback is required — without it `⠋ AdaL` would mislabel as "Claude Code" (the same class as a prior agent-icon mislabel bug); (2) the `en.json` catalog subtree holds every agent's label, so the key must be added across all locales for parity.

## Implementation & deviations

Implemented exactly as designed. One addition discovered after a mid-flight rebase onto latest `main`: a newly-landed `terminal-title-agent-type.ts` introduced a label→`TuiAgent` reverse map that needed an `AdaL: 'adal'` entry (plus a test) so synthesized AdaL titles resolve to the `adal` identity/icon. Code review also added the parallel `worktree-title-derived-agent-rows.ts` map entry so AdaL's favicon shows on title-derived sidebar rows.

## Completeness verification

A read-only pass confirmed all touch-points present and correct and swept the whole repo for any exhaustive `Record<TuiAgent>`/switch the diff might have missed — none. Verdict: complete.

## Headline behavior status

**Implemented** and verified live. Screenshot evidence (Settings → Agents pane) shows AdaL rendering with the SylphAI favicon, label "AdaL", command `adal`, "Not installed" badge, and Enabled/Disabled toggle, positioned alongside its peers. The one item not exercisable in CI is launching the real `adal` process (the binary isn't installed in the validation environment) — see manual verification below.

## perf audit

Perf-neutral. All touched structures (name-match regex alternation, process-recognition map, catalogs) are built once at module load or memoized by an unchanged locale cache key; the only per-title-change additions are one regex-alternation branch and one short-circuiting `if`, both O(1) relative to work that already scans the full agent set. No polling, subprocess churn, render churn, subscriber work, startup latency, leak, or cache-invalidation impact. No new measurement warranted.

## Code-review loop

Two rounds, two parallel reviewers each. Round 1 found and fixed two Low issues (a dangling i18n search key → repointed to the shared catalog key; the missing `worktree-title-derived-agent-rows.ts` favicon-map entry). Round 2: both reviewers returned clean.

## Validation

merge-confidence pass verdict: **LAND**.

- `pnpm typecheck` — pass (exhaustive `satisfies Record<TuiAgent>` constraints compile, proving no enum was missed).
- `pnpm lint` — pass, including both localization verifiers (catalog parity across all 5 locales + coverage) and switch-exhaustiveness.
- Targeted vitest (desktop): `agent-status`, `tui-agent-startup`, `agent-process-recognition`, `agent-kind`, `terminal-title-agent-type`, `worktree-title-derived-agent-rows` — 179 tests pass.
- Mobile: `mobile-agent-catalog.test.ts` (desktop↔mobile parity) — pass.
- Electron: launched this branch's Orca on an isolated CDP port/profile; confirmed AdaL renders in Settings → Agents with the correct icon/label/command. New-workspace quick picker correctly gates AdaL on PATH detection (identical to `devin`/`openclaw`), so it doesn't show there until the CLI is installed.

## Cross-platform / SSH

Additive registration only — no local-only assumptions. Detection/launch run against whatever host the terminal runs on (SSH/remote safe). Windows `adal.cmd` from the npm global bin normalizes to `adal` (covered by a process-recognition test). No keyboard shortcuts touched.

## Manual verification needed (binary not installed in CI)

Please confirm end-to-end with the real CLI on a machine where it's installed:

```bash
npm install -g @sylphai/adal-cli   # requires Node 20+
```

Then in Orca: confirm AdaL shows as **detected/installed** in Settings → Agents and appears in the new-workspace agent picker; launch a worktree with AdaL selected and confirm the `adal` TUI starts, the initial prompt is injected after startup, and the tab reflects working/idle status with the SylphAI icon.

## Notes / accepted risks

- New-workspace quick picker only lists detected agents — expected, matches all peers.
- Follow-up (out of scope): `TITLE_AGENT_LABEL_TO_TYPE` in `worktree-title-derived-agent-rows.ts` still omits `ante`/`mimo-code`; could be made exhaustive or derived from the display-name registry to prevent future favicon-fallback drift.

Made with [Orca](https://github.com/stablyai/orca) 🐋
