### PR TITLE
Add status quick filters to the Jira issues list header

### DIFF
--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -20,6 +20,7 @@ import type {
   JiraTransition,
   JiraUser
 } from '../../shared/types'
+import { getJiraPresetBaseJql } from '../../shared/jira-preset-jql'
 import {
   acquire,
   clearToken,
@@ -329,16 +330,7 @@ function sortAndLimitIssues(issues: JiraIssue[], limit: number): JiraIssue[] {
 }
 
 function filterToJql(filter: JiraIssueFilter): string {
-  if (filter === 'assigned') {
-    return 'assignee = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
-  }
-  if (filter === 'reported') {
-    return 'reporter = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
-  }
-  if (filter === 'done') {
-    return 'assignee = currentUser() AND resolution IS NOT EMPTY ORDER BY updated DESC'
-  }
-  return 'resolution = Unresolved ORDER BY updated DESC'
+  return getJiraPresetBaseJql(filter)
 }
 
 async function searchIssuesForClient(

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -54,7 +54,13 @@ const TaskResumeState = z
     githubItemsQuery: z.string().optional(),
     githubProjectHiddenFieldIdsByView: z.record(z.string(), z.array(z.string())).optional(),
     linearPreset: z.enum(['assigned', 'created', 'all', 'completed']).optional(),
-    linearQuery: z.string().optional()
+    linearQuery: z.string().optional(),
+    // Jira tab context: the strict schema rejects unknown keys, so the remote
+    // (RPC) ui.set path must list these or it drops the whole taskResumeState
+    // write — including the persisted status quick-filter selection.
+    jiraPreset: z.enum(['assigned', 'reported', 'all', 'done']).optional(),
+    jiraQuery: z.string().optional(),
+    jiraStatuses: z.array(z.string()).optional()
   })
   .strict()
 const WorkspaceCleanupDismissal = z

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -235,6 +235,11 @@ import { deriveTaskPagePRCheckSummary } from '@/components/task-page-pr-check-su
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
 import { buildJiraCreateTextAdf } from '@/components/jira-create-adf'
 import {
+  composeJiraStatusJql,
+  getJiraPresetBaseJql,
+  orderJiraStatusCatalog
+} from '../../../shared/jira-preset-jql'
+import {
   GITHUB_PR_MERGE_METHOD_LABELS,
   resolveGitHubPRMergeMethods
 } from '../../../shared/github-pr-merge-methods'
@@ -4468,6 +4473,11 @@ export default function TaskPage(): React.JSX.Element {
   const [jiraSearchInput, setJiraSearchInput] = useState('')
   const [appliedJiraSearch, setAppliedJiraSearch] = useState('')
   const [activeJiraPreset, setActiveJiraPreset] = useState<JiraPresetId>('assigned')
+  const [selectedJiraStatuses, setSelectedJiraStatuses] = useState<string[]>([])
+  const [jiraStatusCatalog, setJiraStatusCatalog] = useState<
+    { name: string; categoryKey: string }[]
+  >([])
+  const jiraStatusCatalogPresetRef = useRef<JiraPresetId | null>(null)
   const [jiraRefreshNonce, setJiraRefreshNonce] = useState(0)
 
   useEffect(() => {
@@ -4510,6 +4520,7 @@ export default function TaskPage(): React.JSX.Element {
     setActiveJiraPreset(jiraPreset)
     setJiraSearchInput(jiraQuery)
     setAppliedJiraSearch(jiraQuery)
+    setSelectedJiraStatuses(taskResumeState?.jiraStatuses ?? [])
 
     // Why: settings and persisted UI hydrate asynchronously. Apply the restored
     // Tasks context exactly once so later source/filter clicks remain local.
@@ -5428,6 +5439,86 @@ export default function TaskPage(): React.JSX.Element {
       ),
     [jiraIssues, jiraCacheSnapshot.issueCache, jiraCacheSnapshot.searchCache, jiraTaskSourceContext]
   )
+
+  useEffect(() => {
+    if (
+      !taskResumeApplied ||
+      taskSource !== 'jira' ||
+      !jiraConnected ||
+      appliedJiraSearch.trim() !== '' ||
+      selectedJiraStatuses.length > 0
+    ) {
+      return
+    }
+
+    const statusByName = new Map<string, { name: string; categoryKey: string }>()
+    for (const issue of displayedJiraIssues) {
+      if (!statusByName.has(issue.status.name)) {
+        statusByName.set(issue.status.name, {
+          name: issue.status.name,
+          categoryKey: issue.status.categoryKey
+        })
+      }
+    }
+
+    setJiraStatusCatalog(orderJiraStatusCatalog([...statusByName.values()]))
+    jiraStatusCatalogPresetRef.current = activeJiraPreset
+  }, [
+    activeJiraPreset,
+    appliedJiraSearch,
+    displayedJiraIssues,
+    jiraConnected,
+    selectedJiraStatuses.length,
+    taskResumeApplied,
+    taskSource
+  ])
+
+  const renderedJiraStatusChips = useMemo(() => {
+    const seen = new Set<string>()
+    const chips: { name: string; categoryKey: string }[] = []
+
+    for (const status of jiraStatusCatalog) {
+      if (!seen.has(status.name)) {
+        seen.add(status.name)
+        chips.push(status)
+      }
+    }
+
+    for (const name of selectedJiraStatuses) {
+      if (!seen.has(name)) {
+        seen.add(name)
+        chips.push({ name, categoryKey: 'other' })
+      }
+    }
+
+    return orderJiraStatusCatalog(chips)
+  }, [jiraStatusCatalog, selectedJiraStatuses])
+
+  const effectiveJiraStatusJql = useMemo(
+    () =>
+      selectedJiraStatuses.length > 0
+        ? composeJiraStatusJql(getJiraPresetBaseJql(activeJiraPreset), selectedJiraStatuses)
+        : '',
+    [activeJiraPreset, selectedJiraStatuses]
+  )
+
+  const toggleJiraStatusFilter = useCallback(
+    (statusName: string): void => {
+      const next = selectedJiraStatuses.includes(statusName)
+        ? selectedJiraStatuses.filter((name) => name !== statusName)
+        : [...selectedJiraStatuses, statusName]
+      setSelectedJiraStatuses(next)
+      setTaskResumeState({ jiraStatuses: next })
+      setJiraRefreshNonce((n) => n + 1)
+    },
+    [selectedJiraStatuses, setTaskResumeState]
+  )
+
+  const clearJiraStatusFilters = useCallback((): void => {
+    setSelectedJiraStatuses([])
+    setTaskResumeState({ jiraStatuses: [] })
+    setJiraRefreshNonce((n) => n + 1)
+  }, [setTaskResumeState])
 
   // New Linear project dialog state
   const [newLinearProjectOpen, setNewLinearProjectOpen] = useState(false)
@@ -7587,9 +7678,15 @@ export default function TaskPage(): React.JSX.Element {
     const request =
       trimmed.length > 0
         ? searchJiraIssues(trimmed, JIRA_ITEM_LIMIT, { sourceContext: jiraTaskSourceContext })
-        : listJiraIssues(activeJiraPreset, JIRA_ITEM_LIMIT, {
-            sourceContext: jiraTaskSourceContext
-          })
+        : selectedJiraStatuses.length > 0
+          ? searchJiraIssues(
+              composeJiraStatusJql(getJiraPresetBaseJql(activeJiraPreset), selectedJiraStatuses),
+              JIRA_ITEM_LIMIT,
+              { sourceContext: jiraTaskSourceContext }
+            )
+          : listJiraIssues(activeJiraPreset, JIRA_ITEM_LIMIT, {
+              sourceContext: jiraTaskSourceContext
+            })
 
     void request
       .then((issues) => {
@@ -7619,6 +7716,7 @@ export default function TaskPage(): React.JSX.Element {
     selectedJiraSiteId,
     appliedJiraSearch,
     activeJiraPreset,
+    selectedJiraStatuses,
     jiraRefreshNonce,
     taskResumeApplied,
     jiraTaskSourceContext
@@ -8611,7 +8709,11 @@ export default function TaskPage(): React.JSX.Element {
                                 setJiraSearchInput('')
                                 setAppliedJiraSearch('')
                                 setActiveJiraPreset(preset.id)
-                                setTaskResumeState({ jiraPreset: preset.id, jiraQuery: '' })
+                                setTaskResumeState({
+                                  jiraPreset: preset.id,
+                                  jiraQuery: '',
+                                  jiraStatuses: selectedJiraStatuses
+                                })
                                 setJiraRefreshNonce((n) => n + 1)
                               }}
                               className={cn(
@@ -8694,55 +8796,136 @@ export default function TaskPage(): React.JSX.Element {
                         </Tooltip>
                       </div>
                     </div>
-                    <div className="mt-3 flex items-center gap-3">
-                      <div className="relative min-w-[320px] flex-1">
-                        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                        <Input
-                          value={jiraSearchInput}
-                          onChange={(e) => setJiraSearchInput(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') {
-                              if (
-                                shouldSuppressEnterSubmit(
-                                  { isComposing: e.nativeEvent.isComposing, shiftKey: e.shiftKey },
-                                  false
-                                )
-                              ) {
-                                return
-                              }
-                              e.preventDefault()
-                              const trimmed = jiraSearchInput.trim()
-                              setJiraSearchInput(trimmed)
-                              setAppliedJiraSearch(trimmed)
-                              setTaskResumeState({ jiraQuery: trimmed })
-                              setJiraRefreshNonce((n) => n + 1)
-                            }
-                          }}
-                          placeholder={translate(
-                            'auto.components.TaskPage.99c2755218',
-                            'Jira JQL, e.g. project = ABC AND statusCategory != Done'
-                          )}
-                          className="h-8 rounded-md border-border/50 bg-background pl-8 pr-8 text-xs"
-                        />
-                        {jiraSearchInput ? (
-                          <button
+                    {jiraSearchInput.trim() === '' &&
+                    (renderedJiraStatusChips.length > 0 || selectedJiraStatuses.length > 0) ? (
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        {renderedJiraStatusChips.map((status) => {
+                          const active = selectedJiraStatuses.includes(status.name)
+                          return (
+                            <button
+                              key={status.name}
+                              type="button"
+                              aria-pressed={active}
+                              onClick={() => toggleJiraStatusFilter(status.name)}
+                              className={cn(
+                                'rounded-md border px-2 py-1 text-xs transition',
+                                active
+                                  ? 'border-border bg-accent text-accent-foreground'
+                                  : 'border-border/50 bg-transparent text-foreground hover:bg-muted/50'
+                              )}
+                            >
+                              {status.name}
+                            </button>
+                          )
+                        })}
+                        {selectedJiraStatuses.length > 0 ? (
+                          <Button
                             type="button"
-                            aria-label={translate(
-                              'auto.components.TaskPage.b797bdd7c3',
-                              'Clear search'
-                            )}
-                            onClick={() => {
-                              setJiraSearchInput('')
-                              setAppliedJiraSearch('')
-                              setTaskResumeState({ jiraQuery: '' })
-                              setJiraRefreshNonce((n) => n + 1)
-                            }}
-                            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition hover:text-foreground"
+                            variant="ghost"
+                            size="xs"
+                            onClick={clearJiraStatusFilters}
+                            className="h-6 px-2 text-xs"
                           >
-                            <X className="size-4" />
-                          </button>
+                            {translate('auto.components.TaskPage.1e45ef3e8a', 'Clear')}
+                          </Button>
+                        ) : null}
+                        {selectedJiraStatuses.length > 0 &&
+                        (jiraStatusCatalogPresetRef.current === null ||
+                          jiraStatusCatalogPresetRef.current !== activeJiraPreset) ? (
+                          <span className="text-[11px] text-muted-foreground">
+                            {translate(
+                              'auto.components.TaskPage.692d2ea305',
+                              'Clear to see all statuses'
+                            )}
+                          </span>
                         ) : null}
                       </div>
+                    ) : null}
+                    <div className="mt-3 space-y-1.5">
+                      <div className="flex items-center gap-3">
+                        <div className="relative min-w-[320px] flex-1">
+                          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                          <Input
+                            value={jiraSearchInput}
+                            onChange={(e) => setJiraSearchInput(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                if (
+                                  shouldSuppressEnterSubmit(
+                                    {
+                                      isComposing: e.nativeEvent.isComposing,
+                                      shiftKey: e.shiftKey
+                                    },
+                                    false
+                                  )
+                                ) {
+                                  return
+                                }
+                                e.preventDefault()
+                                const trimmed = jiraSearchInput.trim()
+                                setJiraSearchInput(trimmed)
+                                setAppliedJiraSearch(trimmed)
+                                setTaskResumeState({ jiraQuery: trimmed })
+                                setJiraRefreshNonce((n) => n + 1)
+                              }
+                            }}
+                            placeholder={translate(
+                              'auto.components.TaskPage.99c2755218',
+                              'Jira JQL, e.g. project = ABC AND statusCategory != Done'
+                            )}
+                            className="h-8 rounded-md border-border/50 bg-background pl-8 pr-8 text-xs"
+                          />
+                          {jiraSearchInput ? (
+                            <button
+                              type="button"
+                              aria-label={translate(
+                                'auto.components.TaskPage.b797bdd7c3',
+                                'Clear search'
+                              )}
+                              onClick={() => {
+                                setJiraSearchInput('')
+                                setAppliedJiraSearch('')
+                                setTaskResumeState({ jiraQuery: '' })
+                                setJiraRefreshNonce((n) => n + 1)
+                              }}
+                              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition hover:text-foreground"
+                            >
+                              <X className="size-4" />
+                            </button>
+                          ) : null}
+                        </div>
+                      </div>
+                      {jiraSearchInput.trim() === '' && selectedJiraStatuses.length > 0 ? (
+                        <div className="flex min-w-0 items-center gap-2">
+                          <div className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground">
+                            {effectiveJiraStatusJql}
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="xs"
+                            onClick={() => {
+                              const composed = effectiveJiraStatusJql
+                              setJiraSearchInput(composed)
+                              setAppliedJiraSearch(composed)
+                              setSelectedJiraStatuses([])
+                              setTaskResumeState({ jiraQuery: composed, jiraStatuses: [] })
+                              setJiraRefreshNonce((n) => n + 1)
+                            }}
+                            className="h-6 px-2 text-xs"
+                          >
+                            {translate('auto.components.TaskPage.57ac72bb8e', 'Edit as JQL')}
+                          </Button>
+                        </div>
+                      ) : null}
+                      {jiraSearchInput.trim() !== '' && selectedJiraStatuses.length > 0 ? (
+                        <div className="text-[11px] text-muted-foreground">
+                          {translate(
+                            'auto.components.TaskPage.a35c52c86e',
+                            'Status chips apply to preset views — clear the search to use them'
+                          )}
+                        </div>
+                      ) : null}
                     </div>
                   </div>
                 ) : taskSource === 'gitlab' ? (

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1665,7 +1665,11 @@
         "searchIssues": "Search issues",
         "useIssueNumber": "Use issue #{{value0}}",
         "noMatchingIssuesLoaded": "No matching issues loaded.",
-        "editReviewersWithCurrent": "Edit reviewers: {{value0}}"
+        "editReviewersWithCurrent": "Edit reviewers: {{value0}}",
+        "1e45ef3e8a": "Clear",
+        "692d2ea305": "Clear to see all statuses",
+        "57ac72bb8e": "Edit as JQL",
+        "a35c52c86e": "Status chips apply to preset views — clear the search to use them"
       },
       "Terminal": {
         "73768427cf": "Close",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1665,7 +1665,11 @@
         "searchIssues": "Buscar issues",
         "useIssueNumber": "Usar issue #{{value0}}",
         "noMatchingIssuesLoaded": "No se cargaron issues coincidentes.",
-        "editReviewersWithCurrent": "Editar revisores: {{value0}}"
+        "editReviewersWithCurrent": "Editar revisores: {{value0}}",
+        "1e45ef3e8a": "Clear",
+        "692d2ea305": "Clear to see all statuses",
+        "57ac72bb8e": "Edit as JQL",
+        "a35c52c86e": "Status chips apply to preset views — clear the search to use them"
       },
       "Terminal": {
         "73768427cf": "Cerca",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1665,7 +1665,11 @@
         "searchIssues": "Issue を検索",
         "useIssueNumber": "Issue #{{value0}} を使用",
         "noMatchingIssuesLoaded": "一致する issue は読み込まれていません。",
-        "editReviewersWithCurrent": "レビュアーを編集: {{value0}}"
+        "editReviewersWithCurrent": "レビュアーを編集: {{value0}}",
+        "1e45ef3e8a": "Clear",
+        "692d2ea305": "Clear to see all statuses",
+        "57ac72bb8e": "Edit as JQL",
+        "a35c52c86e": "Status chips apply to preset views — clear the search to use them"
       },
       "Terminal": {
         "73768427cf": "閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1665,7 +1665,11 @@
         "searchIssues": "이슈 검색",
         "useIssueNumber": "이슈 #{{value0}} 사용",
         "noMatchingIssuesLoaded": "일치하는 이슈를 불러오지 않았습니다.",
-        "editReviewersWithCurrent": "리뷰어 편집: {{value0}}"
+        "editReviewersWithCurrent": "리뷰어 편집: {{value0}}",
+        "1e45ef3e8a": "Clear",
+        "692d2ea305": "Clear to see all statuses",
+        "57ac72bb8e": "Edit as JQL",
+        "a35c52c86e": "Status chips apply to preset views — clear the search to use them"
       },
       "Terminal": {
         "73768427cf": "닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1665,7 +1665,11 @@
         "searchIssues": "搜索议题",
         "useIssueNumber": "使用议题 #{{value0}}",
         "noMatchingIssuesLoaded": "没有加载到匹配的议题。",
-        "editReviewersWithCurrent": "编辑评审人：{{value0}}"
+        "editReviewersWithCurrent": "编辑评审人：{{value0}}",
+        "1e45ef3e8a": "Clear",
+        "692d2ea305": "Clear to see all statuses",
+        "57ac72bb8e": "Edit as JQL",
+        "a35c52c86e": "Status chips apply to preset views — clear the search to use them"
       },
       "Terminal": {
         "73768427cf": "关闭",

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -746,6 +746,36 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().rightSidebarOpen).toBe(false)
   })
 
+  it('hydrates persisted Jira status quick filters so they survive restart', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        taskResumeState: {
+          jiraPreset: 'assigned',
+          jiraQuery: '',
+          jiraStatuses: ['In Progress', 'Developed']
+        }
+      })
+    )
+
+    expect(store.getState().taskResumeState?.jiraStatuses).toEqual(['In Progress', 'Developed'])
+  })
+
+  it('drops non-string Jira status entries during hydration', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        taskResumeState: {
+          jiraStatuses: ['In Progress', 42, null] as unknown as string[]
+        }
+      })
+    )
+
+    expect(store.getState().taskResumeState?.jiraStatuses).toEqual(['In Progress'])
+  })
+
   it('hydrates a persisted open right sidebar preference', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -520,6 +520,14 @@ function sanitizeTaskResumeState(value: unknown): TaskResumeState | undefined {
   if (typeof input.jiraQuery === 'string') {
     next.jiraQuery = input.jiraQuery
   }
+  if (Array.isArray(input.jiraStatuses)) {
+    const statuses = input.jiraStatuses.filter(
+      (status): status is string => typeof status === 'string'
+    )
+    if (statuses.length > 0) {
+      next.jiraStatuses = statuses
+    }
+  }
 
   return Object.keys(next).length > 0 ? next : undefined
 }

--- a/src/shared/jira-preset-jql.test.ts
+++ b/src/shared/jira-preset-jql.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  composeJiraStatusJql,
+  getJiraPresetBaseJql,
+  orderJiraStatusCatalog
+} from './jira-preset-jql'
+
+describe('getJiraPresetBaseJql', () => {
+  it('returns the assigned preset JQL', () => {
+    expect(getJiraPresetBaseJql('assigned')).toBe(
+      'assignee = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
+    )
+  })
+
+  it('returns the reported preset JQL', () => {
+    expect(getJiraPresetBaseJql('reported')).toBe(
+      'reporter = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
+    )
+  })
+
+  it('returns the done preset JQL', () => {
+    expect(getJiraPresetBaseJql('done')).toBe(
+      'assignee = currentUser() AND resolution IS NOT EMPTY ORDER BY updated DESC'
+    )
+  })
+
+  it('returns the all preset JQL', () => {
+    expect(getJiraPresetBaseJql('all')).toBe('resolution = Unresolved ORDER BY updated DESC')
+  })
+})
+
+describe('composeJiraStatusJql', () => {
+  it('passes through the base JQL when no statuses are selected', () => {
+    const baseJql = 'project = ORCA ORDER BY updated DESC'
+
+    expect(composeJiraStatusJql(baseJql, [])).toBe(baseJql)
+  })
+
+  it('inserts a single status before ORDER BY', () => {
+    expect(composeJiraStatusJql('project = ORCA ORDER BY updated DESC', ['In Progress'])).toBe(
+      'project = ORCA AND status in ("In Progress") ORDER BY updated DESC'
+    )
+  })
+
+  it('inserts multiple statuses as an OR list before ORDER BY', () => {
+    expect(
+      composeJiraStatusJql('project = ORCA ORDER BY updated DESC', ['In Progress', 'Blocked'])
+    ).toBe('project = ORCA AND status in ("In Progress", "Blocked") ORDER BY updated DESC')
+  })
+
+  it('preserves the trailing sort clause', () => {
+    expect(
+      composeJiraStatusJql('assignee = currentUser() ORDER BY priority DESC, updated ASC', ['Done'])
+    ).toBe('assignee = currentUser() AND status in ("Done") ORDER BY priority DESC, updated ASC')
+  })
+
+  it('appends the status clause when ORDER BY is absent', () => {
+    expect(composeJiraStatusJql('project = ORCA', ['To Do'])).toBe(
+      'project = ORCA AND status in ("To Do")'
+    )
+  })
+
+  it('escapes quotes and backslashes in status names', () => {
+    expect(
+      composeJiraStatusJql('project = ORCA ORDER BY updated DESC', ['Needs "QA" \\ Review'])
+    ).toBe('project = ORCA AND status in ("Needs \\"QA\\" \\\\ Review") ORDER BY updated DESC')
+  })
+
+  it('uses the last ORDER BY token in the base JQL', () => {
+    expect(
+      composeJiraStatusJql(
+        'summary ~ "write ORDER BY docs" AND project = ORCA ORDER BY updated DESC',
+        ['ORDER BY Cleanup']
+      )
+    ).toBe(
+      'summary ~ "write ORDER BY docs" AND project = ORCA AND status in ("ORDER BY Cleanup") ORDER BY updated DESC'
+    )
+  })
+})
+
+describe('orderJiraStatusCatalog', () => {
+  it('orders statuses by category bucket and then name', () => {
+    expect(
+      orderJiraStatusCatalog([
+        { name: 'Ready', categoryKey: 'indeterminate' },
+        { name: 'Done', categoryKey: 'done' },
+        { name: 'Backlog', categoryKey: 'new' },
+        { name: 'Blocked', categoryKey: 'indeterminate' },
+        { name: 'Archived', categoryKey: 'other' },
+        { name: 'Open', categoryKey: 'new' }
+      ])
+    ).toEqual([
+      { name: 'Backlog', categoryKey: 'new' },
+      { name: 'Open', categoryKey: 'new' },
+      { name: 'Blocked', categoryKey: 'indeterminate' },
+      { name: 'Ready', categoryKey: 'indeterminate' },
+      { name: 'Done', categoryKey: 'done' },
+      { name: 'Archived', categoryKey: 'other' }
+    ])
+  })
+})

--- a/src/shared/jira-preset-jql.ts
+++ b/src/shared/jira-preset-jql.ts
@@ -1,0 +1,72 @@
+import type { JiraIssueFilter } from './jira-types'
+
+export type JiraStatusCatalogItem = {
+  name: string
+  categoryKey: string
+}
+
+const STATUS_CATEGORY_ORDER = new Map<string, number>([
+  ['new', 0],
+  ['indeterminate', 1],
+  ['done', 2]
+])
+
+function escapeJiraString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+function compareStatusName(a: string, b: string): number {
+  const aLower = a.toLowerCase()
+  const bLower = b.toLowerCase()
+  if (aLower < bLower) {
+    return -1
+  }
+  if (aLower > bLower) {
+    return 1
+  }
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+function statusCategoryRank(categoryKey: string): number {
+  return STATUS_CATEGORY_ORDER.get(categoryKey) ?? 3
+}
+
+export function getJiraPresetBaseJql(filter: JiraIssueFilter): string {
+  if (filter === 'assigned') {
+    return 'assignee = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
+  }
+  if (filter === 'reported') {
+    return 'reporter = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
+  }
+  if (filter === 'done') {
+    return 'assignee = currentUser() AND resolution IS NOT EMPTY ORDER BY updated DESC'
+  }
+  return 'resolution = Unresolved ORDER BY updated DESC'
+}
+
+export function composeJiraStatusJql(baseJql: string, statusNames: string[]): string {
+  if (statusNames.length === 0) {
+    return baseJql
+  }
+
+  const statusClause = `AND status in (${statusNames
+    .map((name) => `"${escapeJiraString(name)}"`)
+    .join(', ')})`
+  const orderByMatches = [...baseJql.matchAll(/\sORDER\s+BY\s/gi)]
+  const lastOrderByMatch = orderByMatches.at(-1)
+
+  if (lastOrderByMatch?.index === undefined) {
+    return `${baseJql} ${statusClause}`
+  }
+
+  // Split the base first so a status name containing ORDER BY cannot affect placement.
+  const orderByIndex = lastOrderByMatch.index
+  return `${baseJql.slice(0, orderByIndex)} ${statusClause}${baseJql.slice(orderByIndex)}`
+}
+
+export function orderJiraStatusCatalog<T extends JiraStatusCatalogItem>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const categoryDelta = statusCategoryRank(a.categoryKey) - statusCategoryRank(b.categoryKey)
+    return categoryDelta === 0 ? compareStatusName(a.name, b.name) : categoryDelta
+  })
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3073,6 +3073,7 @@ export type TaskResumeState = {
   }
   jiraPreset?: 'assigned' | 'reported' | 'all' | 'done'
   jiraQuery?: string
+  jiraStatuses?: string[]
 }
 
 export type RightSidebarTab =


### PR DESCRIPTION
## ELI5

If you use the Tasks page with Jira, narrowing the list by workflow status today means hand-writing a JQL query. This adds clickable status chips under the Assigned / Reported / All Open / Done tabs: tap one or more to filter, tap again to unselect, Clear to reset. Your picks persist between sessions, combine with the active tab, and run as a real Jira search so long backlogs stay accurate. Typing your own query hides the chips — your query is never rewritten — and an "Edit as JQL" button hands you the composed query for free editing.

## What changes

Adds multi-selectable **status quick-filter chips** to the Jira issues list header in the Tasks page, under the existing Assigned / Reported / All Open / Done scope tabs. Clicking a chip narrows the list to that workflow status; multiple chips OR together; the selection composes into the active scope tab's JQL and persists across sessions.

**What does not change:** chips apply only in preset mode. When you type your own JQL in the box, the chips hide (that's full manual control) and a one-line helper says so — typed queries are never silently rewritten by chips. The composed query is shown in a read-only preview with an **"Edit as JQL"** button that drops it into the box for free editing.

Closes #5669

## How it works

- Status options are **harvested from the loaded issues' statuses** (deduped, ordered by category then name). Jira exposes no per-project status list endpoint, so there is no extra fetch — chips reflect what's actually in the current scope.
- A new shared module `src/shared/jira-preset-jql.ts` holds `getJiraPresetBaseJql` (the four preset base queries) and `composeJiraStatusJql`, which inserts `AND status in ("…")` immediately before the last `ORDER BY` (appends if none) and escapes status names. The main-process `filterToJql` now delegates to it, so renderer and main share one source of truth. Selecting chips runs the composed query through the existing `searchJiraIssues` path (server-side), so filtering stays correct even when the backlog exceeds the load window.
- Selection persists via `TaskResumeState.jiraStatuses`. Clearing all chips falls back to the tab's default `listJiraIssues` query.

## Design approach & review

Server-side JQL composition (not client-side filtering of the loaded page) so filters genuinely "compose into the underlying JQL" and stay correct past the 50-issue window. Catalog harvested from loaded issues because no status-list endpoint exists. Criterion "reflected in the JQL box and remain editable" is satisfied via the read-only composed preview + "Edit as JQL" bridge rather than live-writing chip text into the box, which would create a chip↔text sync trap. Design review converged clean over two iterations (the load-bearing fix was rendering `catalog ∪ selectedStatuses` so a persisted selection always shows chips + a reachable Clear).

## Implementation & deviations

Implemented per the reviewed design with no deviations. Completeness verification against every acceptance criterion: **COMPLETE**.

## Headline behavior status: **IMPLEMENTED**

The chips render in the production header, toggling them runs the composed query through the real fetch path, and the selection persists. Verified live on screen (see below), not just via fixtures.

## perf audit: PERF-CLEAN

Touched hot paths: the Tasks page render, the Jira fetch effect, the catalog-harvest effect. No actionable findings — memo deps use the primitive `selectedJiraStatuses.length` where array identity would over-fire; no new store subscription; chip toggles reuse the store's existing 60s cache + in-flight dedup; the harvest effect is a guarded ≤50-item sort; no timers/listeners/polling/startup work added. Existing deterministic unit coverage is sufficient.

## Code-review loop

One round, two `review-code` reviewers in parallel — both returned CLEAN (no actionable findings). A second focused review of the post-validation fix delta (below) also returned CLEAN.

## brennan-test-changes (live Electron validation)

Validated all behaviors on screen in a dedicated dev instance (Jira IPC boundary stubbed with a fixture so the real renderer code runs; the JQL/main path is covered by unit tests): chips populate from statuses, single + multi-select narrowing, scope-tab + chip composition in the JQL preview, "Edit as JQL", Clear restores default, **persistence across a full reload** (chip restored active, list pre-narrowed), and manual-JQL hides chips + shows the helper. Screenshot evidence attached as a PR comment.

This pass found and fixed **two persistence bugs** in the read/hydration half of the persist-across-sessions behavior, which the write-side implementation and unit/code review missed:

1. **Renderer hydration dropped `jiraStatuses`.** `sanitizeTaskResumeState` allow-listed `jiraPreset`/`jiraQuery` but not `jiraStatuses`, so the selection was written to disk yet discarded on restart. Fixed + regression tests added.
2. **Remote (RPC) `ui.set` schema rejected the write.** The `.strict()` `TaskResumeState` Zod schema omitted the jira fields; on the environment/SSH runtime path a strict schema rejects unknown keys, dropping the whole `taskResumeState` write. Added the optional fields (widening a strict schema is back-compatible) — this covers the SSH/remote use case.

## Static checks & tests

- `pnpm run typecheck` — pass
- `pnpm run lint` (oxlint + switch-exhaustiveness + scrollbars + localization catalog/coverage) — pass; locale parity across en/es/ja/ko/zh
- Vitest: new `src/shared/jira-preset-jql.test.ts` (composition, ORDER BY placement, escaping, ordering, byte-identical preset strings) + new `ui.test.ts` regression tests (hydration round-trip, non-string drop); jira store/main suites green

## Assumptions / residual risk

- The chip catalog reflects loaded issues; on a persisted-active first load only the selected statuses show as chips until the unfiltered view is observed (clearing reveals the rest) — documented behavior with a "Clear to see all statuses" hint, not a defect. No status-list endpoint exists to pre-populate.
- Multi-site (`all`): a status present on one site but not another yields a swallowed per-site 400 (pre-existing fan-out behavior); partial results still render.
- Cross-platform: pure string/state logic, no path or keyboard-shortcut code.

Made with [Orca](https://github.com/stablyai/orca) 🐋
