### PR TITLE
Connect Azure DevOps with the Azure CLI without a PAT

### DIFF
--- a/src/main/azure-devops/az-cli-token.test.ts
+++ b/src/main/azure-devops/az-cli-token.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _resetAzCliTokenCache, getAzureDevOpsAzCliAccessToken } from './az-cli-token'
+
+const { execLocalPreflightCommandMock, isCommandAvailableMock } = vi.hoisted(() => ({
+  execLocalPreflightCommandMock: vi.fn(),
+  isCommandAvailableMock: vi.fn()
+}))
+
+vi.mock('../ipc/preflight-command-exec', () => ({
+  execLocalPreflightCommand: execLocalPreflightCommandMock,
+  isCommandAvailable: isCommandAvailableMock
+}))
+
+function tokenJson(accessToken = 'az-token', expiresOnSeconds?: number): string {
+  return JSON.stringify({
+    accessToken,
+    ...(expiresOnSeconds === undefined ? {} : { expires_on: expiresOnSeconds })
+  })
+}
+
+describe('Azure DevOps az CLI token', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-29T12:00:00Z'))
+    execLocalPreflightCommandMock.mockReset()
+    isCommandAvailableMock.mockReset()
+    _resetAzCliTokenCache()
+  })
+
+  afterEach(() => {
+    _resetAzCliTokenCache()
+    vi.useRealTimers()
+  })
+
+  it('returns and caches a valid token with an epoch-seconds expiry', async () => {
+    const expiresOnSeconds = Math.floor(Date.now() / 1000) + 3600
+    execLocalPreflightCommandMock.mockResolvedValue({
+      stdout: tokenJson('az-token', expiresOnSeconds),
+      stderr: ''
+    })
+
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toEqual({
+      token: 'az-token',
+      expiresAtMs: expiresOnSeconds * 1000
+    })
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toEqual({
+      token: 'az-token',
+      expiresAtMs: expiresOnSeconds * 1000
+    })
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledOnce()
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledWith('az', [
+      'account',
+      'get-access-token',
+      '--resource',
+      '499b84ac-1321-427f-aa17-267ca6975798',
+      '--output',
+      'json'
+    ])
+  })
+
+  it('uses a fixed five-minute cache when expires_on is missing', async () => {
+    execLocalPreflightCommandMock
+      .mockResolvedValueOnce({ stdout: tokenJson('first-token'), stderr: '' })
+      .mockResolvedValueOnce({ stdout: tokenJson('second-token'), stderr: '' })
+
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toEqual({
+      token: 'first-token',
+      expiresAtMs: null
+    })
+    vi.setSystemTime(new Date(Date.now() + 299_000))
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toMatchObject({
+      token: 'first-token'
+    })
+    vi.setSystemTime(new Date(Date.now() + 2_000))
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toMatchObject({
+      token: 'second-token'
+    })
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null when az exits non-zero', async () => {
+    execLocalPreflightCommandMock.mockRejectedValue(new Error('not logged in'))
+
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toBeNull()
+  })
+
+  it('returns null when az is missing', async () => {
+    execLocalPreflightCommandMock.mockRejectedValue(
+      Object.assign(new Error('spawn az ENOENT'), { code: 'ENOENT' })
+    )
+
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toBeNull()
+  })
+
+  it('caches a failure briefly so a status poll does not re-spawn az for every call', async () => {
+    execLocalPreflightCommandMock.mockRejectedValue(new Error('not logged in'))
+
+    // Why: one PR-status poll makes several sequential REST calls — without a
+    // negative cache, each would re-spawn `az` when it is installed-but-logged-out.
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toBeNull()
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toBeNull()
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toBeNull()
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledOnce()
+
+    // Re-spawns once the 30s negative window elapses.
+    vi.setSystemTime(new Date(Date.now() + 31_000))
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toBeNull()
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null for malformed JSON', async () => {
+    execLocalPreflightCommandMock.mockResolvedValue({ stdout: '{', stderr: '' })
+
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toBeNull()
+  })
+
+  it('returns null for an empty access token', async () => {
+    execLocalPreflightCommandMock.mockResolvedValue({
+      stdout: tokenJson('   ', Math.floor(Date.now() / 1000) + 3600),
+      stderr: ''
+    })
+
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toBeNull()
+  })
+
+  it('refreshes the cache after the safety-window TTL expires', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    execLocalPreflightCommandMock
+      .mockResolvedValueOnce({ stdout: tokenJson('first-token', nowSeconds + 120), stderr: '' })
+      .mockResolvedValueOnce({ stdout: tokenJson('second-token', nowSeconds + 3600), stderr: '' })
+
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toMatchObject({
+      token: 'first-token'
+    })
+    vi.setSystemTime(new Date(Date.now() + 59_000))
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toMatchObject({
+      token: 'first-token'
+    })
+    vi.setSystemTime(new Date(Date.now() + 2_000))
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toMatchObject({
+      token: 'second-token'
+    })
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares one spawn for concurrent callers', async () => {
+    let resolveCommand = (_value: { stdout: string; stderr: string }): void => {}
+    const commandResult = new Promise<{ stdout: string; stderr: string }>((resolve) => {
+      resolveCommand = resolve
+    })
+    execLocalPreflightCommandMock.mockReturnValue(commandResult)
+
+    const first = getAzureDevOpsAzCliAccessToken()
+    const second = getAzureDevOpsAzCliAccessToken()
+
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledOnce()
+    resolveCommand({
+      stdout: tokenJson('az-token', Math.floor(Date.now() / 1000) + 3600),
+      stderr: ''
+    })
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { token: 'az-token', expiresAtMs: (Math.floor(Date.now() / 1000) + 3600) * 1000 },
+      { token: 'az-token', expiresAtMs: (Math.floor(Date.now() / 1000) + 3600) * 1000 }
+    ])
+  })
+
+  it('clears cached tokens when reset', async () => {
+    execLocalPreflightCommandMock
+      .mockResolvedValueOnce({
+        stdout: tokenJson('first-token', Math.floor(Date.now() / 1000) + 3600),
+        stderr: ''
+      })
+      .mockResolvedValueOnce({
+        stdout: tokenJson('second-token', Math.floor(Date.now() / 1000) + 3600),
+        stderr: ''
+      })
+
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toMatchObject({
+      token: 'first-token'
+    })
+    _resetAzCliTokenCache()
+    await expect(getAzureDevOpsAzCliAccessToken()).resolves.toMatchObject({
+      token: 'second-token'
+    })
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/azure-devops/az-cli-token.ts
+++ b/src/main/azure-devops/az-cli-token.ts
@@ -1,0 +1,85 @@
+import { execLocalPreflightCommand } from '../ipc/preflight-command-exec'
+
+// Why: fixed Azure DevOps OAuth resource GUID accepted by Azure DevOps REST APIs.
+const AZURE_DEVOPS_RESOURCE = '499b84ac-1321-427f-aa17-267ca6975798'
+const EXPIRY_SAFETY_MS = 60_000
+const UNKNOWN_EXPIRY_CACHE_MS = 300_000
+// Why: also cache the "no token" outcome briefly so an installed-but-logged-out
+// `az` (or any failure) isn't re-spawned for every REST call in a status poll.
+const NEGATIVE_CACHE_MS = 30_000
+
+type AzCliToken = { token: string; expiresAtMs: number | null }
+
+// Why: cache both success and failure outcomes. A separate validity flag avoids
+// conflating "cached negative result" with "cache empty", so a negative result
+// suppresses re-spawns until NEGATIVE_CACHE_MS elapses.
+let cachedResult: AzCliToken | null = null
+let hasCachedResult = false
+let cacheUsableUntilMs = 0
+let inFlightTokenRequest: Promise<AzCliToken | null> | null = null
+
+function parseExpiresAtMs(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null
+  }
+  const expiresAtMs = value * 1000
+  return Number.isFinite(expiresAtMs) ? expiresAtMs : null
+}
+
+async function acquireAzCliToken(): Promise<AzCliToken | null> {
+  try {
+    const { stdout } = await execLocalPreflightCommand('az', [
+      'account',
+      'get-access-token',
+      '--resource',
+      AZURE_DEVOPS_RESOURCE,
+      '--output',
+      'json'
+    ])
+    const parsed = JSON.parse(stdout) as { accessToken?: unknown; expires_on?: unknown }
+    const token = typeof parsed.accessToken === 'string' ? parsed.accessToken.trim() : ''
+    if (!token) {
+      return null
+    }
+    return { token, expiresAtMs: parseExpiresAtMs(parsed.expires_on) }
+  } catch {
+    return null
+  }
+}
+
+export async function getAzureDevOpsAzCliAccessToken(): Promise<AzCliToken | null> {
+  const now = Date.now()
+  if (hasCachedResult && now < cacheUsableUntilMs) {
+    return cachedResult
+  }
+  if (inFlightTokenRequest) {
+    return inFlightTokenRequest
+  }
+
+  inFlightTokenRequest = acquireAzCliToken().then((token) => {
+    cachedResult = token
+    hasCachedResult = true
+    if (token) {
+      cacheUsableUntilMs =
+        token.expiresAtMs === null
+          ? Date.now() + UNKNOWN_EXPIRY_CACHE_MS
+          : token.expiresAtMs - EXPIRY_SAFETY_MS
+    } else {
+      cacheUsableUntilMs = Date.now() + NEGATIVE_CACHE_MS
+    }
+    return token
+  })
+
+  try {
+    return await inFlightTokenRequest
+  } finally {
+    inFlightTokenRequest = null
+  }
+}
+
+export function _resetAzCliTokenCache(): void {
+  cachedResult = null
+  hasCachedResult = false
+  cacheUsableUntilMs = 0
+  inFlightTokenRequest = null
+}

--- a/src/main/azure-devops/azure-devops-api-request.test.ts
+++ b/src/main/azure-devops/azure-devops-api-request.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _resetAzCliTokenCache } from './az-cli-token'
+import { authHeaders, resolveAzureDevOpsAuth } from './azure-devops-api-request'
+
+const { execLocalPreflightCommandMock, isCommandAvailableMock } = vi.hoisted(() => ({
+  execLocalPreflightCommandMock: vi.fn(),
+  isCommandAvailableMock: vi.fn()
+}))
+
+vi.mock('../ipc/preflight-command-exec', () => ({
+  execLocalPreflightCommand: execLocalPreflightCommandMock,
+  isCommandAvailable: isCommandAvailableMock
+}))
+
+const OLD_ENV = process.env
+
+describe('Azure DevOps API auth resolver', () => {
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_AZURE_DEVOPS_TOKEN
+    delete process.env.ORCA_AZURE_DEVOPS_PAT
+    delete process.env.ORCA_AZURE_DEVOPS_ACCESS_TOKEN
+    delete process.env.ORCA_AZURE_DEVOPS_USERNAME
+    execLocalPreflightCommandMock.mockReset()
+    isCommandAvailableMock.mockReset()
+    _resetAzCliTokenCache()
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+    _resetAzCliTokenCache()
+  })
+
+  it('prefers env access tokens without spawning az', async () => {
+    process.env.ORCA_AZURE_DEVOPS_ACCESS_TOKEN = 'env-access-token'
+
+    await expect(resolveAzureDevOpsAuth()).resolves.toMatchObject({
+      accessToken: 'env-access-token',
+      source: 'env-token'
+    })
+    expect(execLocalPreflightCommandMock).not.toHaveBeenCalled()
+  })
+
+  it('prefers env PATs without spawning az', async () => {
+    process.env.ORCA_AZURE_DEVOPS_TOKEN = 'env-pat'
+
+    const auth = await resolveAzureDevOpsAuth()
+
+    expect(auth).toMatchObject({ pat: 'env-pat', source: 'env-pat' })
+    expect(authHeaders(auth).Authorization).toMatch(/^Basic /)
+    expect(execLocalPreflightCommandMock).not.toHaveBeenCalled()
+  })
+
+  it('uses az CLI tokens as Bearer auth when env auth is absent', async () => {
+    execLocalPreflightCommandMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        accessToken: 'az-token',
+        expires_on: Math.floor(Date.now() / 1000) + 3600
+      }),
+      stderr: ''
+    })
+
+    const auth = await resolveAzureDevOpsAuth()
+
+    expect(auth).toMatchObject({ accessToken: 'az-token', source: 'az-cli' })
+    expect(authHeaders(auth)).toEqual({ Authorization: 'Bearer az-token' })
+  })
+
+  it('returns source null and empty headers when no auth source is available', async () => {
+    execLocalPreflightCommandMock.mockRejectedValue(new Error('not logged in'))
+
+    const auth = await resolveAzureDevOpsAuth()
+
+    expect(auth.source).toBeNull()
+    expect(authHeaders(auth)).toEqual({})
+  })
+})

--- a/src/main/azure-devops/azure-devops-api-request.ts
+++ b/src/main/azure-devops/azure-devops-api-request.ts
@@ -1,18 +1,24 @@
 import { Buffer } from 'buffer'
+import { getAzureDevOpsAzCliAccessToken } from './az-cli-token'
 import type { AzureDevOpsRepoRef } from './repository-ref'
 
 const REQUEST_TIMEOUT_MS = 5000
 
-type AzureDevOpsAuthConfig = {
+export type AzureDevOpsAuthConfig = {
   apiBaseUrl: string | null
   pat: string | null
   accessToken: string | null
   username: string | null
 }
 
+export type AzureDevOpsResolvedAuth = AzureDevOpsAuthConfig & {
+  source: 'env-token' | 'env-pat' | 'az-cli' | null
+}
+
 export type AzureDevOpsRequestOptions = {
   searchParams?: Record<string, string | number>
   timeoutMs?: number
+  allowAzCli?: boolean
 }
 
 function envValue(name: string): string | null {
@@ -40,7 +46,7 @@ export function azureDevOpsTokenConfigured(config: AzureDevOpsAuthConfig): boole
   return Boolean(config.pat || config.accessToken)
 }
 
-function authHeaders(config: AzureDevOpsAuthConfig): Record<string, string> {
+export function authHeaders(config: AzureDevOpsAuthConfig): Record<string, string> {
   if (config.accessToken) {
     return { Authorization: `Bearer ${config.accessToken}` }
   }
@@ -49,6 +55,25 @@ function authHeaders(config: AzureDevOpsAuthConfig): Record<string, string> {
     return { Authorization: `Basic ${encoded}` }
   }
   return {}
+}
+
+export async function resolveAzureDevOpsAuth(options?: {
+  allowAzCli?: boolean
+}): Promise<AzureDevOpsResolvedAuth> {
+  const config = getAzureDevOpsAuthConfig()
+  if (config.accessToken) {
+    return { ...config, source: 'env-token' }
+  }
+  if (config.pat) {
+    return { ...config, source: 'env-pat' }
+  }
+  if (options?.allowAzCli !== false) {
+    const azToken = await getAzureDevOpsAzCliAccessToken()
+    if (azToken) {
+      return { ...config, accessToken: azToken.token, source: 'az-cli' }
+    }
+  }
+  return { ...config, source: null }
 }
 
 function configuredApiBaseUrl(repo: AzureDevOpsRepoRef): string {
@@ -74,14 +99,14 @@ export async function requestAzureDevOpsJsonAtBase<T>(
   path: string,
   options: AzureDevOpsRequestOptions = {}
 ): Promise<T | null> {
-  const config = getAzureDevOpsAuthConfig()
+  const auth = await resolveAzureDevOpsAuth({ allowAzCli: options.allowAzCli })
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
   try {
     const response = await fetch(apiUrl(baseUrl, path, options.searchParams), {
       headers: {
         Accept: 'application/json',
-        ...authHeaders(config)
+        ...authHeaders(auth)
       },
       signal: controller.signal
     })

--- a/src/main/azure-devops/client.test.ts
+++ b/src/main/azure-devops/client.test.ts
@@ -4,12 +4,22 @@ import {
   getAzureDevOpsPullRequestForBranch,
   normalizeAzureDevOpsApiBaseUrl
 } from './client'
+import { _resetAzCliTokenCache } from './az-cli-token'
 import { _resetAzureDevOpsRepoRefCache } from './repository-ref'
 
 const gitExecFileAsyncMock = vi.hoisted(() => vi.fn())
+const { execLocalPreflightCommandMock, isCommandAvailableMock } = vi.hoisted(() => ({
+  execLocalPreflightCommandMock: vi.fn(),
+  isCommandAvailableMock: vi.fn()
+}))
 
 vi.mock('../git/runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('../ipc/preflight-command-exec', () => ({
+  execLocalPreflightCommand: execLocalPreflightCommandMock,
+  isCommandAvailable: isCommandAvailableMock
 }))
 
 const OLD_ENV = process.env
@@ -19,13 +29,17 @@ describe('Azure DevOps client', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV, ORCA_AZURE_DEVOPS_TOKEN: 'pat-token' }
     gitExecFileAsyncMock.mockReset()
+    execLocalPreflightCommandMock.mockReset()
+    isCommandAvailableMock.mockReset()
     _resetAzureDevOpsRepoRefCache()
+    _resetAzCliTokenCache()
   })
 
   afterEach(() => {
     process.env = OLD_ENV
     globalThis.fetch = OLD_FETCH
     _resetAzureDevOpsRepoRefCache()
+    _resetAzCliTokenCache()
   })
 
   it('normalizes configured API base URLs', () => {
@@ -43,6 +57,58 @@ describe('Azure DevOps client', () => {
       baseUrl: null,
       tokenConfigured: true
     })
+  })
+
+  it('reports az-only auth as configured and authenticated when local az can mint a token', async () => {
+    process.env = {
+      ...OLD_ENV,
+      ORCA_AZURE_DEVOPS_API_BASE_URL: 'https://dev.azure.com/acme'
+    }
+    delete process.env.ORCA_AZURE_DEVOPS_TOKEN
+    delete process.env.ORCA_AZURE_DEVOPS_PAT
+    delete process.env.ORCA_AZURE_DEVOPS_ACCESS_TOKEN
+    execLocalPreflightCommandMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        accessToken: 'az-token',
+        expires_on: Math.floor(Date.now() / 1000) + 3600
+      }),
+      stderr: ''
+    })
+    globalThis.fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string>
+      expect(headers.Authorization).toBe('Bearer az-token')
+      return Response.json({
+        authenticatedUser: {
+          providerDisplayName: 'Ada Azure'
+        }
+      })
+    }) as never
+
+    await expect(getAzureDevOpsAuthStatus({ localAzAvailable: true })).resolves.toEqual({
+      configured: true,
+      authenticated: true,
+      account: 'Ada Azure',
+      baseUrl: 'https://dev.azure.com/acme',
+      tokenConfigured: true
+    })
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledOnce()
+  })
+
+  it('does not spawn az when local az is unavailable and no env token is set', async () => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_AZURE_DEVOPS_TOKEN
+    delete process.env.ORCA_AZURE_DEVOPS_PAT
+    delete process.env.ORCA_AZURE_DEVOPS_ACCESS_TOKEN
+    delete process.env.ORCA_AZURE_DEVOPS_API_BASE_URL
+
+    await expect(getAzureDevOpsAuthStatus({ localAzAvailable: false })).resolves.toEqual({
+      configured: false,
+      authenticated: false,
+      account: null,
+      baseUrl: null,
+      tokenConfigured: false
+    })
+    expect(execLocalPreflightCommandMock).not.toHaveBeenCalled()
   })
 
   it('resolves a PR for a branch through repository, PR, and status REST calls', async () => {

--- a/src/main/azure-devops/client.ts
+++ b/src/main/azure-devops/client.ts
@@ -14,6 +14,7 @@ import {
   azureDevOpsTokenConfigured,
   getAzureDevOpsAuthConfig,
   normalizeAzureDevOpsApiBaseUrl,
+  resolveAzureDevOpsAuth,
   requestAzureDevOpsJson,
   requestAzureDevOpsJsonAtBase
 } from './azure-devops-api-request'
@@ -128,10 +129,16 @@ function sortPullRequestsForBranch(
   return Number(rightStatus === 'active') - Number(leftStatus === 'active')
 }
 
-export async function getAzureDevOpsAuthStatus(): Promise<AzureDevOpsAuthStatus> {
+export async function getAzureDevOpsAuthStatus(options?: {
+  localAzAvailable?: boolean
+}): Promise<AzureDevOpsAuthStatus> {
   const config = getAzureDevOpsAuthConfig()
   const baseUrl = config.apiBaseUrl ? normalizeAzureDevOpsApiBaseUrl(config.apiBaseUrl) : null
-  const hasToken = azureDevOpsTokenConfigured(config)
+  const envTokenConfigured = azureDevOpsTokenConfigured(config)
+  const allowAzCli = options?.localAzAvailable === true
+  const hasToken =
+    envTokenConfigured ||
+    (allowAzCli && (await resolveAzureDevOpsAuth({ allowAzCli: true })).source === 'az-cli')
   if (!baseUrl && !hasToken) {
     return {
       configured: false,
@@ -157,7 +164,7 @@ export async function getAzureDevOpsAuthStatus(): Promise<AzureDevOpsAuthStatus>
       customDisplayName?: string | null
       uniqueName?: string | null
     } | null
-  }>(baseUrl, '/_apis/connectionData', { timeoutMs: 4000 })
+  }>(baseUrl, '/_apis/connectionData', { allowAzCli, timeoutMs: 4000 })
   const user = connection?.authenticatedUser
   return {
     configured: hasToken || connection !== null,

--- a/src/main/azure-devops/pull-request-creation.test.ts
+++ b/src/main/azure-devops/pull-request-creation.test.ts
@@ -3,11 +3,19 @@ import {
   createAzureDevOpsPullRequest,
   isAzureDevOpsReviewCreationAuthenticated
 } from './pull-request-creation'
+import { _resetAzCliTokenCache } from './az-cli-token'
 import { _resetAzureDevOpsRepoRefCache } from './repository-ref'
 
-const { gitExecFileAsyncMock, getSshGitProviderMock } = vi.hoisted(() => ({
+const {
+  gitExecFileAsyncMock,
+  getSshGitProviderMock,
+  execLocalPreflightCommandMock,
+  isCommandAvailableMock
+} = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
-  getSshGitProviderMock: vi.fn()
+  getSshGitProviderMock: vi.fn(),
+  execLocalPreflightCommandMock: vi.fn(),
+  isCommandAvailableMock: vi.fn()
 }))
 
 vi.mock('../git/runner', () => ({
@@ -16,6 +24,11 @@ vi.mock('../git/runner', () => ({
 
 vi.mock('../providers/ssh-git-dispatch', () => ({
   getSshGitProvider: getSshGitProviderMock
+}))
+
+vi.mock('../ipc/preflight-command-exec', () => ({
+  execLocalPreflightCommand: execLocalPreflightCommandMock,
+  isCommandAvailable: isCommandAvailableMock
 }))
 
 vi.mock('../source-control/pull-request-template', () => ({
@@ -30,22 +43,52 @@ describe('Azure DevOps pull request creation', () => {
     process.env = { ...OLD_ENV, ORCA_AZURE_DEVOPS_TOKEN: 'pat-token' }
     gitExecFileAsyncMock.mockReset()
     getSshGitProviderMock.mockReset()
+    execLocalPreflightCommandMock.mockReset()
+    isCommandAvailableMock.mockReset()
     gitExecFileAsyncMock.mockResolvedValue({
       stdout: 'https://dev.azure.com/acme/Project/_git/repo\n',
       stderr: ''
     })
     _resetAzureDevOpsRepoRefCache()
+    _resetAzCliTokenCache()
   })
 
   afterEach(() => {
     process.env = OLD_ENV
     globalThis.fetch = OLD_FETCH
     _resetAzureDevOpsRepoRefCache()
+    _resetAzCliTokenCache()
   })
 
-  it('treats token-only auth as sufficient for repo-scoped creation', () => {
+  it('treats token-only auth as sufficient for repo-scoped creation', async () => {
     delete process.env.ORCA_AZURE_DEVOPS_API_BASE_URL
-    expect(isAzureDevOpsReviewCreationAuthenticated()).toBe(true)
+    await expect(isAzureDevOpsReviewCreationAuthenticated()).resolves.toBe(true)
+  })
+
+  it('authenticates creation via an az CLI token when no env auth is set', async () => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_AZURE_DEVOPS_TOKEN
+    delete process.env.ORCA_AZURE_DEVOPS_PAT
+    delete process.env.ORCA_AZURE_DEVOPS_ACCESS_TOKEN
+    execLocalPreflightCommandMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        accessToken: 'az-token',
+        expires_on: Math.floor(Date.now() / 1000) + 3600
+      }),
+      stderr: ''
+    })
+    await expect(isAzureDevOpsReviewCreationAuthenticated()).resolves.toBe(true)
+  })
+
+  it('reports creation unauthenticated when neither env auth nor an az token exists', async () => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_AZURE_DEVOPS_TOKEN
+    delete process.env.ORCA_AZURE_DEVOPS_PAT
+    delete process.env.ORCA_AZURE_DEVOPS_ACCESS_TOKEN
+    execLocalPreflightCommandMock.mockRejectedValue(
+      Object.assign(new Error('spawn az ENOENT'), { code: 'ENOENT' })
+    )
+    await expect(isAzureDevOpsReviewCreationAuthenticated()).resolves.toBe(false)
   })
 
   it('posts a pull request create body to the repository REST endpoint', async () => {
@@ -94,6 +137,49 @@ describe('Azure DevOps pull request creation', () => {
       url: 'https://dev.azure.com/acme/Project/_git/repo/pullrequest/37'
     })
     expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('uses an az CLI token as Bearer auth when creating without env auth', async () => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_AZURE_DEVOPS_TOKEN
+    delete process.env.ORCA_AZURE_DEVOPS_PAT
+    delete process.env.ORCA_AZURE_DEVOPS_ACCESS_TOKEN
+    execLocalPreflightCommandMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        accessToken: 'az-token',
+        expires_on: Math.floor(Date.now() / 1000) + 3600
+      }),
+      stderr: ''
+    })
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string>
+      expect(headers.Authorization).toMatch(/^Bearer /)
+      return Response.json({
+        pullRequestId: 39,
+        title: 'Create with az',
+        status: 'active',
+        creationDate: '2026-06-01T00:00:00Z',
+        _links: {
+          web: {
+            href: 'https://dev.azure.com/acme/Project/_git/repo/pullrequest/39'
+          }
+        }
+      })
+    })
+    globalThis.fetch = fetchMock as never
+
+    await expect(
+      createAzureDevOpsPullRequest('/repo', {
+        provider: 'azure-devops',
+        base: 'main',
+        head: 'feature/azure',
+        title: 'Create with az'
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      number: 39
+    })
+    expect(execLocalPreflightCommandMock).toHaveBeenCalledOnce()
   })
 
   it('resolves Azure DevOps remotes through the SSH git provider', async () => {

--- a/src/main/azure-devops/pull-request-creation.ts
+++ b/src/main/azure-devops/pull-request-creation.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
 import {
   normalizeHostedReviewBaseRef,
@@ -9,59 +8,32 @@ import {
   requestHostedReviewJson
 } from '../source-control/hosted-review-api-request'
 import { readHostedPullRequestTemplate } from '../source-control/pull-request-template'
+import {
+  authHeaders,
+  azureDevOpsTokenConfigured,
+  getAzureDevOpsAuthConfig,
+  normalizeAzureDevOpsApiBaseUrl,
+  resolveAzureDevOpsAuth
+} from './azure-devops-api-request'
 import { getAzureDevOpsPullRequestForBranch } from './client'
 import { mapAzureDevOpsPullRequest, type RawAzureDevOpsPullRequest } from './pull-request-mappers'
 import { getAzureDevOpsRepoRef, type AzureDevOpsRepoRef } from './repository-ref'
 
 const CREATE_REQUEST_TIMEOUT_MS = 60_000
 
-type AzureDevOpsCreateAuthConfig = {
-  apiBaseUrl: string | null
-  pat: string | null
-  accessToken: string | null
-  username: string | null
-}
-
-function envValue(name: string): string | null {
-  const value = process.env[name]?.trim() ?? ''
-  return value.length > 0 ? value : null
-}
-
-function normalizeApiBaseUrl(value: string): string {
-  return value
-    .trim()
-    .replace(/\/+$/, '')
-    .replace(/\/_apis$/i, '')
-}
-
-function getAuthConfig(): AzureDevOpsCreateAuthConfig {
-  return {
-    apiBaseUrl: envValue('ORCA_AZURE_DEVOPS_API_BASE_URL'),
-    pat: envValue('ORCA_AZURE_DEVOPS_TOKEN') ?? envValue('ORCA_AZURE_DEVOPS_PAT'),
-    accessToken: envValue('ORCA_AZURE_DEVOPS_ACCESS_TOKEN'),
-    username: envValue('ORCA_AZURE_DEVOPS_USERNAME')
+export async function isAzureDevOpsReviewCreationAuthenticated(): Promise<boolean> {
+  const config = getAzureDevOpsAuthConfig()
+  if (azureDevOpsTokenConfigured(config)) {
+    return true
   }
-}
-
-export function isAzureDevOpsReviewCreationAuthenticated(): boolean {
-  const config = getAuthConfig()
-  return Boolean(config.pat || config.accessToken)
-}
-
-function authHeaders(config: AzureDevOpsCreateAuthConfig): Record<string, string> {
-  if (config.accessToken) {
-    return { Authorization: `Bearer ${config.accessToken}` }
-  }
-  if (config.pat) {
-    const encoded = Buffer.from(`${config.username ?? ''}:${config.pat}`).toString('base64')
-    return { Authorization: `Basic ${encoded}` }
-  }
-  return {}
+  return (await resolveAzureDevOpsAuth()).source !== null
 }
 
 function apiUrl(repo: AzureDevOpsRepoRef, path: string): URL {
-  const config = getAuthConfig()
-  const baseUrl = config.apiBaseUrl ? normalizeApiBaseUrl(config.apiBaseUrl) : repo.apiBaseUrl
+  const config = getAzureDevOpsAuthConfig()
+  const baseUrl = config.apiBaseUrl
+    ? normalizeAzureDevOpsApiBaseUrl(config.apiBaseUrl)
+    : repo.apiBaseUrl
   const url = new URL(`${baseUrl.replace(/\/+$/, '')}${path}`)
   url.searchParams.set('api-version', '7.1')
   return url
@@ -97,7 +69,7 @@ function classifyCreateError(error: unknown): CreateHostedReviewResult {
       ok: false,
       code: 'auth_required',
       error:
-        'Create PR failed: Azure DevOps is not authenticated. Next step: set ORCA_AZURE_DEVOPS_TOKEN in this environment.'
+        'Create PR failed: Azure DevOps is not authenticated. Next step: set ORCA_AZURE_DEVOPS_TOKEN or sign in with the Azure CLI (az login).'
     }
   }
   if (status === 409 || lower.includes('already exists') || lower.includes('active pull request')) {
@@ -192,6 +164,7 @@ export async function createAzureDevOpsPullRequest(
   }
 
   try {
+    const auth = await resolveAzureDevOpsAuth()
     const raw = await requestHostedReviewJson<RawAzureDevOpsPullRequest>(
       apiUrl(repo, `/_apis/git/repositories/${encodePathSegment(repo.repository)}/pullRequests`),
       {
@@ -199,7 +172,7 @@ export async function createAzureDevOpsPullRequest(
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
-          ...authHeaders(getAuthConfig())
+          ...authHeaders(auth)
         },
         body: JSON.stringify(requestBody)
       },

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -145,13 +145,15 @@ describe('preflight', () => {
   })
 
   // Why: every preflight run probes (in order) `git --version`, `gh --version`,
-  // `glab --version`, then in parallel `gh auth status` + `glab auth status` —
-  // five execFile calls per cycle. Tests below provide values for all five.
+  // `glab --version`, local `az --version`, then in parallel `gh auth status`
+  // + `glab auth status` — six execFile calls per cycle. Tests below provide
+  // values for all six.
   it('marks gh as authenticated when gh auth status exits successfully', async () => {
     execFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'azure-cli 2.60.0\n' })
       .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
@@ -165,11 +167,12 @@ describe('preflight', () => {
       azureDevOps: defaultAzureDevOpsStatus,
       gitea: defaultGiteaStatus
     })
-    expect(execFileAsyncMock).toHaveBeenNthCalledWith(4, 'gh', ['auth', 'status'], {
+    expect(getAzureDevOpsAuthStatusMock).toHaveBeenCalledWith({ localAzAvailable: true })
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(5, 'gh', ['auth', 'status'], {
       encoding: 'utf-8',
       timeout: 5000
     })
-    expect(execFileAsyncMock).toHaveBeenNthCalledWith(5, 'glab', ['auth', 'status'], {
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(6, 'glab', ['auth', 'status'], {
       encoding: 'utf-8',
       timeout: 5000
     })
@@ -180,6 +183,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'azure-cli 2.60.0\n' })
       .mockRejectedValueOnce({ stderr: 'You are not logged into any GitHub hosts.\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
@@ -193,6 +197,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockRejectedValueOnce(Object.assign(new Error('spawn az ENOENT'), { code: 'ENOENT' }))
       .mockRejectedValueOnce({ stderr: 'Logged in to github.com account octocat\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
@@ -206,6 +211,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockRejectedValueOnce(new Error('command not found: glab'))
+      .mockRejectedValueOnce(Object.assign(new Error('spawn az ENOENT'), { code: 'ENOENT' }))
       .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
 
     const status = await runPreflightCheck()
@@ -213,7 +219,8 @@ describe('preflight', () => {
     expect(status.glab).toEqual({ installed: false, authenticated: false })
     // Why: with glab uninstalled, glab auth status must not run — that
     // would surface a misleading "command not found" error in logs.
-    expect(execFileAsyncMock).toHaveBeenCalledTimes(4)
+    expect(getAzureDevOpsAuthStatusMock).toHaveBeenCalledWith({ localAzAvailable: false })
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(5)
   })
 
   it('marks glab as installed but unauthenticated when auth status fails', async () => {
@@ -221,6 +228,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'azure-cli 2.60.0\n' })
       .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
       .mockRejectedValueOnce({ stderr: 'You are not logged into any GitLab hosts.\n' })
 
@@ -325,6 +333,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'azure-cli 2.60.0\n' })
       .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
@@ -396,11 +405,13 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockRejectedValueOnce(Object.assign(new Error('spawn az ENOENT'), { code: 'ENOENT' }))
       .mockRejectedValueOnce({ stderr: 'You are not logged into any GitHub hosts.\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'azure-cli 2.60.0\n' })
       .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
@@ -409,7 +420,7 @@ describe('preflight', () => {
 
     expect(firstStatus.gh).toEqual({ installed: true, authenticated: false })
     expect(refreshedStatus.gh).toEqual({ installed: true, authenticated: true })
-    expect(execFileAsyncMock).toHaveBeenCalledTimes(10)
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(12)
   })
 
   it('registers the preflight handler', async () => {
@@ -417,6 +428,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'azure-cli 2.60.0\n' })
       .mockResolvedValueOnce({ stdout: 'github.com\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
@@ -439,11 +451,13 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockRejectedValueOnce(Object.assign(new Error('spawn az ENOENT'), { code: 'ENOENT' }))
       .mockRejectedValueOnce({ stderr: 'You are not logged into any GitHub hosts.\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'azure-cli 2.60.0\n' })
       .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -3,6 +3,7 @@ import { getTuiAgentDetectCommands, TUI_AGENT_CONFIG } from '../../shared/tui-ag
 import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
+import { _resetAzCliTokenCache } from '../azure-devops/az-cli-token'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
@@ -238,19 +239,24 @@ export async function runPreflightCheck(
     // path in IntegrationsPane forces preflight, so piggyback on that signal
     // to refresh the host list too.
     _resetKnownHostsCache()
+    // Why: same rationale for the Azure DevOps az-CLI token cache — a user who
+    // runs `az login` after Orca starts should see the Re-check pick it up
+    // immediately rather than waiting out the cached negative/expiry window.
+    _resetAzCliTokenCache()
   }
 
-  const [gitProbe, ghProbe, glabProbe] = await Promise.all([
+  const [gitProbe, ghProbe, glabProbe, azAvailable] = await Promise.all([
     detectCommandRuntime('git', context),
     detectCommandRuntime('gh', context),
-    detectCommandRuntime('glab', context)
+    detectCommandRuntime('glab', context),
+    isCommandAvailable('az')
   ])
 
   const [ghAuthenticated, glabAuthenticated, bitbucket, azureDevOps, gitea] = await Promise.all([
     ghProbe.installed ? isGhAuthenticated(ghProbe.wslTarget) : Promise.resolve(false),
     glabProbe.installed ? isGlabAuthenticated(glabProbe.wslTarget) : Promise.resolve(false),
     getBitbucketAuthStatus(),
-    getAzureDevOpsAuthStatus(),
+    getAzureDevOpsAuthStatus({ localAzAvailable: azAvailable }),
     getGiteaAuthStatus()
   ])
 

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -236,7 +236,7 @@ async function isProviderAuthenticated(
     return isGitLabAuthenticated(repoPath, connectionId, options)
   }
   if (provider === 'azure-devops') {
-    return isAzureDevOpsReviewCreationAuthenticated()
+    return await isAzureDevOpsReviewCreationAuthenticated()
   }
   if (provider === 'gitea') {
     return isGiteaReviewCreationAuthenticated()

--- a/src/renderer/src/components/settings/token-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/token-source-control-integration-cards.tsx
@@ -210,6 +210,18 @@ export function AzureDevOpsIntegrationCard(): React.JSX.Element {
                   'auto.components.settings.token.source.control.integration.cards.7bd345e3f6',
                   'only when Orca cannot derive the API base URL from the git remote.'
                 )}
+                {translate(
+                  'auto.components.settings.token.source.control.integration.cards.9c4a0c82e7',
+                  ' Or sign in with the Azure CLI'
+                )}{' '}
+                (
+                <span className="font-mono text-[11px]">
+                  {translate(
+                    'auto.components.settings.token.source.control.integration.cards.a58e8fa2b9',
+                    'az login'
+                  )}
+                </span>
+                ).
               </>
             ) : (
               translate(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8333,7 +8333,9 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "Bitbucket status is not available in this runtime yet.",
                   "a924e8dcd1": "Pull requests and build statuses via Bitbucket Cloud API tokens.",
-                  "0fa5629dad": "Pull requests and build statuses"
+                  "0fa5629dad": "Pull requests and build statuses",
+                  "9c4a0c82e7": " Or sign in with the Azure CLI",
+                  "a58e8fa2b9": "az login"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8325,7 +8325,9 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "Bitbucket status is not available in this runtime yet.",
                   "a924e8dcd1": "Pull requests and build statuses via Bitbucket Cloud API tokens.",
-                  "0fa5629dad": "Pull requests and build statuses"
+                  "0fa5629dad": "Pull requests and build statuses",
+                  "9c4a0c82e7": " Or sign in with the Azure CLI",
+                  "a58e8fa2b9": "az login"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8325,7 +8325,9 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "Bitbucket status is not available in this runtime yet.",
                   "a924e8dcd1": "Pull requests and build statuses via Bitbucket Cloud API tokens.",
-                  "0fa5629dad": "PR とビルドステータス"
+                  "0fa5629dad": "PR とビルドステータス",
+                  "9c4a0c82e7": " Or sign in with the Azure CLI",
+                  "a58e8fa2b9": "az login"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8325,7 +8325,9 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "이 런타임에서는 아직 Bitbucket 상태를 사용할 수 없습니다.",
                   "a924e8dcd1": "Bitbucket Cloud API 토큰을 통한 PR 및 빌드 상태입니다.",
-                  "0fa5629dad": "PR 및 빌드 상태"
+                  "0fa5629dad": "PR 및 빌드 상태",
+                  "9c4a0c82e7": " Or sign in with the Azure CLI",
+                  "a58e8fa2b9": "az login"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8325,7 +8325,9 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "此运行时暂不支持 Bitbucket 状态。",
                   "a924e8dcd1": "通过 Bitbucket Cloud API token 获取 pull request 和构建状态。",
-                  "0fa5629dad": "pull request 和构建状态"
+                  "0fa5629dad": "pull request 和构建状态",
+                  "9c4a0c82e7": " Or sign in with the Azure CLI",
+                  "a58e8fa2b9": "az login"
                 }
               }
             }


### PR DESCRIPTION
## What changes

Adds an **Azure CLI (`az`) authentication path** for Azure DevOps so users can connect **without a Personal Access Token**. PATs are often restricted or forbidden in Azure DevOps orgs (the issue notes Microsoft's own docs discourage them).

When no `ORCA_AZURE_DEVOPS_*` token/PAT env var is set, Orca mints a short-lived Azure DevOps OAuth token from the locally signed-in `az` session (`az account get-access-token --resource <Azure DevOps GUID>`) and uses it as a Bearer token for the **existing** REST calls — PR/branch review status and Create PR.

This follows the existing CLI-provider pattern (`gh` for GitHub, `glab` for GitLab).

## What does NOT change (boundaries)

- **`az` is a token source only** — Orca does not shell out to `az repos`/`az devops` for PR data; the existing REST client is unchanged.
- **Env-var PAT/token keeps priority.** A configured PAT/token always wins and is never overridden by an ambient `az login` (which could point at a different identity/org). No behavior change for existing PAT users.
- **Local-only token acquisition.** The token is minted on the local machine (same as env vars are read today). Remote/SSH `az` sessions and WSL `az` are intentionally out of scope — using them would create a status/REST split-brain. No regression for SSH PAT users.
- No new settings, no telemetry, no new dependencies.

Closes #6073

## Design approach

The seam is the auth layer in `src/main/azure-devops/`. A new `az-cli-token.ts` module mints + caches the token; `resolveAzureDevOpsAuth({ allowAzCli })` layers it underneath the env config (env access-token → env PAT → `az` token → none). The REST read path (`requestAzureDevOpsJsonAtBase`), the create-PR path, the create-PR auth gate (`isAzureDevOpsReviewCreationAuthenticated`, now async), and the auth-status/preflight surface all consume the resolver. Provider-specific behavior stays behind the existing `'azure-devops'` checks.

**Cold-start protection:** the heavier token mint is gated behind a cheap local `isCommandAvailable('az')` probe (run in parallel with the existing `gh`/`glab` probes). Machines with no `az` or with an env token pay no extra subprocess. The token is cached in-process (honoring `expires_on` with a 60s safety margin, a 5-min unknown-expiry fallback, and a 30s negative cache), with a shared in-flight promise so concurrent status polls trigger at most one spawn. The Re-check button clears the cache so a fresh `az login` is picked up immediately.

## Design-review outcome

Ran Brennan's design-review loop (Claude + Codex in parallel, 3 iterations to clean). Notable catch: an early design would have let the env-base-URL status path bypass the cold-start gate and still spawn `az`; the gate was moved to the resolver's spawn site (`allowAzCli`) so it can't be bypassed. Also corrected an honest limitation about account-name display (below).

## Implementation & deviations

Implemented as designed. The duplicate auth helpers in `pull-request-creation.ts` were consolidated to import from `azure-devops-api-request.ts` (single source of truth for `authHeaders`/resolver). One honest boundary: in the **global** Integrations card, the az-only case (no env base URL) shows the integration as **configured but with a blank account name** — the global status path has no org base URL to call `/_apis/connectionData`. The signed-in account name does surface on per-repo views and when `ORCA_AZURE_DEVOPS_API_BASE_URL` is set. We did not add org-base-URL discovery (scope creep).

## Completeness verification

Read-only verification pass confirmed **COMPLETE** — every requirement, edge case, and the critical invariants (no `az` spawn on cold start with env token / absent `az`; env-var priority; base-URL resolution unchanged) hold, with file:line evidence.

## Headline behavior status

**IMPLEMENTED.** A user signed into `az` with no PAT authenticates Azure DevOps PR status and Create-PR via the minted token through the live REST client — not scaffolding/fixture-only. The token flows into the real `Authorization` header on production paths.

## Performance audit

Touched hot path: the 60s PR-status poll (`getAzureDevOpsPullRequestForBranch`, visibility-gated, capped at 3 worktrees). Audit confirmed: env-token users never spawn `az`; az-cli users spawn at most once per cache window; concurrent polls share one spawn; the cold-start `az --version` probe is added to the existing parallel batch (no added wall-clock); the spawn is bounded by a 5s timeout so it can't hang a poll. **One LOW finding fixed in-branch:** an installed-but-logged-out `az` (no env token) was re-spawned for every REST call in a poll because negative results weren't cached — added a 30s negative cache (with a deterministic spawn-count regression test). Cache is O(1) (single account-scoped slot), in-flight promise always settles (no leak).

## Code-review loop

Ran `review-code-fix-loop` — 2 rounds, two `review-code` reviewers in parallel each round. Both reviewers returned **clean** in the final round (verified the real `az account get-access-token` JSON shape against Microsoft docs, token never logged, env-priority assertions are real, no async/await ordering bugs). The only nit (untranslated locale fallbacks for the new card sentence) matches the repo's auto-catalog convention and is deferred to the normal localization pass.

## Validation (`brennan-test-changes`): LAND

- `pnpm run typecheck` clean; `pnpm run lint` clean (incl. localization catalog + coverage parity across en/es/ja/ko/zh).
- Targeted suites green: `src/main/azure-devops` + `src/main/ipc/preflight.test.ts` (74), `src/renderer/.../settings` (487). Logic exercised: token precedence, async create gate, status gating, negative cache, in-flight dedup, expiry/TTL refresh, preflight wiring.
- **Live UI:** launched the app, navigated to Settings → Integrations with no Azure env vars; the Azure DevOps card renders the new "Or sign in with the Azure CLI (`az login`)." copy (monospace `az login`) in the Not-configured state, 0 console errors. (Screenshot evidence captured locally; not committed per repo policy.)

### Manual verification needed (environment lacks `az` + an Azure DevOps org)

A true end-to-end `az login` → real PR status / Create-PR cannot run in the build environment (no `az`, no org). On a machine with `az login` to an Azure DevOps org and **no** `ORCA_AZURE_DEVOPS_*` env vars:
1. Settings → Integrations: Azure DevOps card should read Connected/configured (account name may be blank unless `ORCA_AZURE_DEVOPS_API_BASE_URL` is set — see boundary above).
2. On an Azure DevOps repo: PR/branch review status loads and Create PR succeeds via the minted token.
3. `az logout` → Re-check → card drops to Not configured gracefully (no crash/hang).
4. Set `ORCA_AZURE_DEVOPS_TOKEN` while also `az`-logged-in → PAT is used (env priority).

## Static checks & tests run

`pnpm run typecheck`, `pnpm run lint`, targeted vitest suites (all green). New tests: `az-cli-token.test.ts`, `azure-devops-api-request.test.ts`, plus additions to `client`/`pull-request-creation`/`preflight` suites.

## Residual risks / accepted gaps

- az-only global card shows no account name without an env base URL (documented; functional auth still works).
- No 401-driven proactive cache invalidation (covered by the TTL with 60s margin + negative cache).
- Remote/SSH/WSL `az` token acquisition out of scope (follow-up).

Made with [Orca](https://github.com/stablyai/orca) 🐋
