### PR TITLE
Reduce CPU from source-control git polling on Windows

### DIFF
--- a/src/main/git/status-upstream-negative-cache.test.ts
+++ b/src/main/git/status-upstream-negative-cache.test.ts
@@ -30,6 +30,14 @@ vi.mock('fs', () => ({
   existsSync: existsSyncMock
 }))
 
+function isConfigListSnapshotCommand(args: string[]): boolean {
+  return args[0] === 'config' && args[1] === '--list' && args[2] === '-z'
+}
+
+function emptyGitConfigSnapshot(): { stdout: string } {
+  return { stdout: 'core.repositoryformatversion\n0\0' }
+}
+
 import {
   clearEffectiveUpstreamNegativeStatusCache,
   clearEffectiveUpstreamStatusCacheForTests,
@@ -61,6 +69,9 @@ describe('local upstream negative cache', () => {
       }
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error('fatal: no upstream configured for branch feature')
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
       }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
         if (originBranchExists) {
@@ -105,6 +116,9 @@ describe('local upstream negative cache', () => {
       }
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error('fatal: no upstream configured for branch feature')
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
       }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
         if (originBranchExists) {
@@ -165,6 +179,9 @@ describe('local upstream negative cache', () => {
       }
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error(`fatal: no upstream configured for branch ${currentBranch}`)
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
       }
       if (args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/origin/'))) {
         if (originBranchExists) {
@@ -227,6 +244,9 @@ describe('local upstream negative cache', () => {
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error(`fatal: no upstream configured for branch ${currentBranch}`)
       }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
+      }
       if (args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/origin/'))) {
         if (originBranchExists) {
           return { stdout: 'abc123\n' }
@@ -282,6 +302,9 @@ describe('local upstream negative cache', () => {
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error(`fatal: no upstream configured for branch ${currentBranch}`)
       }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
+      }
       if (args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/origin/'))) {
         throw new Error('missing remote branch')
       }
@@ -312,6 +335,9 @@ describe('local upstream negative cache', () => {
       }
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error(`fatal: no upstream configured for branch ${currentBranch}`)
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
       }
       if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${currentBranch}`)) {
         return { stdout: 'abc123\n' }

--- a/src/main/git/status-upstream-probe-churn.test.ts
+++ b/src/main/git/status-upstream-probe-churn.test.ts
@@ -41,6 +41,23 @@ function getGitArgs(call: unknown[]): string[] {
   return call[0] as string[]
 }
 
+function isConfigListSnapshotCommand(args: string[]): boolean {
+  return args[0] === 'config' && args[1] === '--list' && args[2] === '-z'
+}
+
+function emptyGitConfigSnapshot(): { stdout: string } {
+  return { stdout: 'core.repositoryformatversion\n0\0' }
+}
+
+function featureFixPushTargetSnapshot(): { stdout: string } {
+  const records = [
+    'branch.feature/fix.pushremote\nfork',
+    'branch.feature/fix.remote\nfork',
+    'branch.feature/fix.merge\nrefs/heads/feature/fix'
+  ]
+  return { stdout: `${records.join('\0')}\0` }
+}
+
 describe('getStatus missing-upstream polling churn', () => {
   beforeEach(() => {
     clearEffectiveUpstreamStatusCacheForTests()
@@ -67,6 +84,9 @@ describe('getStatus missing-upstream polling churn', () => {
       }
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error("fatal: no upstream configured for branch 'Initi-Project'")
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
       }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')) {
         throw new Error('missing remote branch')
@@ -106,6 +126,9 @@ describe('getStatus missing-upstream polling churn', () => {
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error("fatal: no upstream configured for branch 'Initi-Project'")
       }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
+      }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')) {
         throw new Error('missing remote branch')
       }
@@ -137,6 +160,9 @@ describe('getStatus missing-upstream polling churn', () => {
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         await Promise.resolve()
         throw new Error("fatal: no upstream configured for branch 'Initi-Project'")
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
       }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')) {
         await Promise.resolve()
@@ -173,20 +199,8 @@ describe('getStatus missing-upstream polling churn', () => {
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error("fatal: no upstream configured for branch 'feature/fix'")
       }
-      if (args[0] === 'config' && args.includes('branch.feature/fix.pushRemote')) {
-        return { stdout: 'fork\n' }
-      }
-      if (args[0] === 'config' && args.includes('remote.pushDefault')) {
-        throw new Error('missing pushDefault')
-      }
-      if (args[0] === 'config' && args.includes('branch.feature/fix.remote')) {
-        return { stdout: 'fork\n' }
-      }
-      if (args[0] === 'config' && args.includes('branch.feature/fix.merge')) {
-        return { stdout: 'refs/heads/feature/fix\n' }
-      }
-      if (args[0] === 'config' && args.includes('branch.feature/fix.base')) {
-        throw new Error('missing branch base')
+      if (isConfigListSnapshotCommand(args)) {
+        return featureFixPushTargetSnapshot()
       }
       if (args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/'))) {
         throw new Error('missing remote branch')
@@ -222,6 +236,9 @@ describe('getStatus missing-upstream polling churn', () => {
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error('fatal: no upstream configured')
       }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
+      }
       if (args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/origin/'))) {
         throw new Error('missing remote branch')
       }
@@ -240,5 +257,45 @@ describe('getStatus missing-upstream polling churn', () => {
       'refs/remotes/origin/Second-Project',
       'refs/remotes/origin/Other-Project'
     ])
+  })
+
+  it('coalesces no-upstream config reads into one snapshot subprocess', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.includes('status')) {
+        return {
+          stdout: '# branch.oid abcdef1234567890\n# branch.head Initi-Project\n'
+        }
+      }
+      if (args[0] === 'symbolic-ref' && args.includes('HEAD')) {
+        return { stdout: 'Initi-Project\n' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        throw new Error("fatal: no upstream configured for branch 'Initi-Project'")
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/Initi-Project')) {
+        throw new Error('missing remote branch')
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    const status = await getStatus('/repo')
+
+    const configListCalls = gitExecFileAsyncMock.mock.calls.filter((call) =>
+      isConfigListSnapshotCommand(getGitArgs(call))
+    )
+    const configGetCalls = gitExecFileAsyncMock.mock.calls.filter((call) => {
+      const args = getGitArgs(call)
+      return args[0] === 'config' && args[1] === '--get'
+    })
+
+    expect(configListCalls).toHaveLength(1)
+    expect(configGetCalls).toHaveLength(0)
+    if (!status.upstreamStatus) {
+      throw new Error('expected upstream status')
+    }
+    expect(status.upstreamStatus.hasUpstream).toBe(false)
   })
 })

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -21,6 +21,7 @@ import {
   getEffectiveGitUpstreamStatus,
   splitRemoteBranchName
 } from '../../shared/git-effective-upstream'
+import { createGitConfigSnapshotRunner } from '../../shared/git-config-snapshot-runner'
 import { isBinaryBuffer } from '../../shared/binary-buffer'
 import {
   applyLineStats,
@@ -654,11 +655,14 @@ async function probeEffectiveUpstreamStatus(
   options: GitRuntimeOptions = {}
 ): Promise<{ status: GitUpstreamStatus; probedSameNameOriginRef: boolean }> {
   let probedSameNameOriginRef = false
+  const snapshotRunner = createGitConfigSnapshotRunner((args) =>
+    gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options))
+  )
   const status = await getEffectiveGitUpstreamStatus((args) => {
     if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${branchName}`)) {
       probedSameNameOriginRef = true
     }
-    return gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options))
+    return snapshotRunner(args)
   })
   return { status, probedSameNameOriginRef }
 }

--- a/src/relay/git-status-upstream-negative-cache.test.ts
+++ b/src/relay/git-status-upstream-negative-cache.test.ts
@@ -7,6 +7,14 @@ import {
   readOrProbeNoEffectiveUpstreamStatus
 } from './git-status-upstream-negative-cache'
 
+function isConfigListSnapshotCommand(args: string[]): boolean {
+  return args[0] === 'config' && args[1] === '--list' && args[2] === '-z'
+}
+
+function emptyGitConfigSnapshot(): { stdout: string } {
+  return { stdout: 'core.repositoryformatversion\n0\0' }
+}
+
 describe('relay upstream negative cache', () => {
   beforeEach(() => {
     clearNoEffectiveUpstreamStatusCache()
@@ -24,6 +32,9 @@ describe('relay upstream negative cache', () => {
       }
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error('fatal: no upstream configured for branch feature')
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
       }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
         if (originBranchExists) {
@@ -64,6 +75,9 @@ describe('relay upstream negative cache', () => {
       }
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error('fatal: no upstream configured for branch feature')
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
       }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
         if (originBranchExists) {
@@ -114,6 +128,9 @@ describe('relay upstream negative cache', () => {
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error('fatal: no upstream configured for branch feature')
       }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
+      }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
         if (originBranchExists) {
           return { stdout: 'abc123\n' }
@@ -146,6 +163,9 @@ describe('relay upstream negative cache', () => {
           }
           if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
             throw new Error(`fatal: no upstream configured for branch ${branchName}`)
+          }
+          if (isConfigListSnapshotCommand(args)) {
+            return emptyGitConfigSnapshot()
           }
           if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${branchName}`)) {
             return { stdout: 'abc123\n' }
@@ -185,6 +205,9 @@ describe('relay upstream negative cache', () => {
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
         throw new Error('fatal: no upstream configured for branch feature')
       }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
+      }
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
         if (originBranchExists) {
           return { stdout: 'abc123\n' }
@@ -215,6 +238,9 @@ describe('relay upstream negative cache', () => {
           }
           if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
             throw new Error(`fatal: no upstream configured for branch ${branchName}`)
+          }
+          if (isConfigListSnapshotCommand(args)) {
+            return emptyGitConfigSnapshot()
           }
           if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${branchName}`)) {
             return { stdout: 'abc123\n' }
@@ -255,6 +281,9 @@ describe('relay upstream negative cache', () => {
           if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
             throw new Error(`fatal: no upstream configured for branch ${branchName}`)
           }
+          if (isConfigListSnapshotCommand(args)) {
+            return emptyGitConfigSnapshot()
+          }
           if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${branchName}`)) {
             throw new Error('missing remote branch')
           }
@@ -279,6 +308,9 @@ describe('relay upstream negative cache', () => {
           if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
             throw new Error(`fatal: no upstream configured for branch ${branchName}`)
           }
+          if (isConfigListSnapshotCommand(args)) {
+            return emptyGitConfigSnapshot()
+          }
           if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${branchName}`)) {
             return { stdout: 'abc123\n' }
           }
@@ -293,5 +325,39 @@ describe('relay upstream negative cache', () => {
 
     expect(getNoEffectiveUpstreamStatusCacheCountForTests()).toBe(0)
     expect(getNoEffectiveUpstreamStatusGenerationCountForTests()).toBe(512)
+  })
+
+  it('coalesces no-upstream config reads into one snapshot subprocess', async () => {
+    const runGit = vi.fn(async (args: string[]): Promise<{ stdout: string }> => {
+      if (args[0] === 'symbolic-ref') {
+        return { stdout: 'feature\n' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        throw new Error('fatal: no upstream configured for branch feature')
+      }
+      if (isConfigListSnapshotCommand(args)) {
+        return emptyGitConfigSnapshot()
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
+        throw new Error('missing remote branch')
+      }
+      throw new Error(`No upstream fixture for git ${args.join(' ')}`)
+    })
+
+    const status = await readOrProbeNoEffectiveUpstreamStatus(
+      { worktreePath: '/repo', branchName: 'feature' },
+      runGit
+    )
+    const configListCalls = runGit.mock.calls.filter((call) =>
+      isConfigListSnapshotCommand(call[0] as string[])
+    )
+    const configGetCalls = runGit.mock.calls.filter((call) => {
+      const args = call[0] as string[]
+      return args[0] === 'config' && args[1] === '--get'
+    })
+
+    expect(configListCalls).toHaveLength(1)
+    expect(configGetCalls).toHaveLength(0)
+    expect(status.hasUpstream).toBe(false)
   })
 })

--- a/src/relay/git-status-upstream-negative-cache.ts
+++ b/src/relay/git-status-upstream-negative-cache.ts
@@ -1,3 +1,4 @@
+import { createGitConfigSnapshotRunner } from '../shared/git-config-snapshot-runner'
 import { getEffectiveGitUpstreamStatus } from '../shared/git-effective-upstream'
 import type { GitCommandRunner } from '../shared/git-effective-upstream'
 import type { GitUpstreamStatus } from '../shared/types'
@@ -115,12 +116,13 @@ export async function readOrProbeNoEffectiveUpstreamStatus(
   }
 
   let probedSameNameOriginRef = false
+  const snapshotRunner = createGitConfigSnapshotRunner(runGit)
   const writeGeneration = noEffectiveUpstreamWriteGeneration.get(cacheKey) ?? 0
   const probe = getEffectiveGitUpstreamStatus((args) => {
     if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${identity.branchName}`)) {
       probedSameNameOriginRef = true
     }
-    return runGit(args)
+    return snapshotRunner(args)
   }).then((status) => {
     cacheNoEffectiveUpstreamStatus(cacheKey, status, probedSameNameOriginRef, writeGeneration)
     return status

--- a/src/shared/git-config-snapshot-runner.test.ts
+++ b/src/shared/git-config-snapshot-runner.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createGitConfigSnapshotRunner } from './git-config-snapshot-runner'
+import {
+  createGitConfigSnapshotRunner,
+  GitConfigSnapshotKeyNotFoundError
+} from './git-config-snapshot-runner'
 
 function listSnapshot(records: string[]): string {
   return `${records.join('\0')}\0`
@@ -130,6 +133,29 @@ describe('createGitConfigSnapshotRunner', () => {
     await expect(runner(['config', '--get', 'remote.origin.url'])).resolves.toEqual({
       stdout: 'git@example.com:org/repo.git'
     })
+  })
+
+  it('rejects an absent key from a loaded snapshot instead of returning empty success', async () => {
+    // Why: real `git config --get` exits non-zero for a missing key; a loaded
+    // snapshot must preserve that contract (not turn a miss into '' success),
+    // and must NOT fall back to a real config --get (that would re-spawn the
+    // subprocess this runner exists to coalesce away).
+    const runGit = vi.fn(async () => ({
+      stdout: listSnapshot(['branch.main.remote\norigin'])
+    }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['config', '--get', 'branch.main.merge'])).rejects.toThrow(
+      GitConfigSnapshotKeyNotFoundError
+    )
+    // The miss is served from the loaded snapshot — no passthrough config --get.
+    expect(countCalls(runGit, ['config', '--list', '-z'])).toBe(1)
+    expect(
+      runGit.mock.calls.filter((call) => {
+        const args = getGitArgs(call)
+        return args[0] === 'config' && args[1] === '--get'
+      })
+    ).toHaveLength(0)
   })
 
   it('single-flights concurrent first config --get lookups', async () => {

--- a/src/shared/git-config-snapshot-runner.test.ts
+++ b/src/shared/git-config-snapshot-runner.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createGitConfigSnapshotRunner } from './git-config-snapshot-runner'
+
+function listSnapshot(records: string[]): string {
+  return `${records.join('\0')}\0`
+}
+
+function getGitArgs(call: unknown[]): string[] {
+  return call[0] as string[]
+}
+
+function countCalls(runGit: ReturnType<typeof vi.fn>, expectedArgs: string[]): number {
+  return runGit.mock.calls.filter((call) => {
+    const args = getGitArgs(call)
+    return (
+      args.length === expectedArgs.length && args.every((arg, index) => arg === expectedArgs[index])
+    )
+  }).length
+}
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolveDeferred: (value: T) => void = () => undefined
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve
+  })
+  return { promise, resolve: resolveDeferred }
+}
+
+describe('createGitConfigSnapshotRunner', () => {
+  it('serves many config --get lookups from one config --list -z call', async () => {
+    const runGit = vi.fn(async () => ({
+      stdout: listSnapshot([
+        'branch.main.remote\norigin',
+        'branch.main.merge\nrefs/heads/main',
+        'remote.pushdefault\nfork'
+      ])
+    }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await runner(['config', '--get', 'branch.main.remote'])
+    await runner(['config', '--get', 'branch.main.merge'])
+    await runner(['config', '--get', 'remote.pushDefault'])
+
+    expect(countCalls(runGit, ['config', '--list', '-z'])).toBe(1)
+    expect(runGit.mock.calls.filter((call) => getGitArgs(call)[1] === '--get')).toHaveLength(0)
+  })
+
+  it('returns branch and remote values from a representative snapshot', async () => {
+    const runGit = vi.fn(async () => ({
+      stdout: listSnapshot([
+        'branch.feature.remote\norigin',
+        'branch.feature.merge\nrefs/heads/feature',
+        'remote.origin.url\ngit@example.com:org/repo.git'
+      ])
+    }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['config', '--get', 'branch.feature.remote'])).resolves.toEqual({
+      stdout: 'origin'
+    })
+    await expect(runner(['config', '--get', 'branch.feature.merge'])).resolves.toEqual({
+      stdout: 'refs/heads/feature'
+    })
+    await expect(runner(['config', '--get', 'remote.origin.url'])).resolves.toEqual({
+      stdout: 'git@example.com:org/repo.git'
+    })
+  })
+
+  it('passes remote commands through unchanged', async () => {
+    const runGit = vi.fn(async (args: string[]) => ({ stdout: args.join(' ') }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['remote'])).resolves.toEqual({ stdout: 'remote' })
+    await expect(runner(['remote', 'get-url', 'origin'])).resolves.toEqual({
+      stdout: 'remote get-url origin'
+    })
+
+    expect(countCalls(runGit, ['remote'])).toBe(1)
+    expect(countCalls(runGit, ['remote', 'get-url', 'origin'])).toBe(1)
+  })
+
+  it('case-folds the requested section and key', async () => {
+    const runGit = vi.fn(async () => ({
+      stdout: listSnapshot(['remote.pushdefault\nfork'])
+    }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['config', '--get', 'remote.pushDefault'])).resolves.toEqual({
+      stdout: 'fork'
+    })
+  })
+
+  it('preserves subsections with dots in lookup keys', async () => {
+    const runGit = vi.fn(async () => ({
+      stdout: listSnapshot(['branch.feature.x.merge\nrefs/heads/feature.x'])
+    }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['config', '--get', 'branch.feature.x.merge'])).resolves.toEqual({
+      stdout: 'refs/heads/feature.x'
+    })
+  })
+
+  it('returns the last multivar value for config --get', async () => {
+    const runGit = vi.fn(async () => ({
+      stdout: listSnapshot([
+        'branch.main.merge\nrefs/heads/old',
+        'branch.main.merge\nrefs/heads/new'
+      ])
+    }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['config', '--get', 'branch.main.merge'])).resolves.toEqual({
+      stdout: 'refs/heads/new'
+    })
+  })
+
+  it('parses valueless boolean keys without corrupting adjacent records', async () => {
+    const runGit = vi.fn(async () => ({
+      stdout: listSnapshot([
+        'remote.origin.mirror',
+        'remote.origin.url\ngit@example.com:org/repo.git'
+      ])
+    }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['config', '--get', 'remote.origin.mirror'])).resolves.toEqual({
+      stdout: ''
+    })
+    await expect(runner(['config', '--get', 'remote.origin.url'])).resolves.toEqual({
+      stdout: 'git@example.com:org/repo.git'
+    })
+  })
+
+  it('single-flights concurrent first config --get lookups', async () => {
+    const snapshot = createDeferred<{ stdout: string }>()
+    const runGit = vi.fn(async () => await snapshot.promise)
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    const lookups = Promise.all([
+      runner(['config', '--get', 'branch.main.remote']),
+      runner(['config', '--get', 'branch.main.merge']),
+      runner(['config', '--get', 'remote.pushDefault'])
+    ])
+    await Promise.resolve()
+
+    expect(countCalls(runGit, ['config', '--list', '-z'])).toBe(1)
+    snapshot.resolve({
+      stdout: listSnapshot([
+        'branch.main.remote\norigin',
+        'branch.main.merge\nrefs/heads/main',
+        'remote.pushdefault\nfork'
+      ])
+    })
+
+    await expect(lookups).resolves.toEqual([
+      { stdout: 'origin' },
+      { stdout: 'refs/heads/main' },
+      { stdout: 'fork' }
+    ])
+    expect(countCalls(runGit, ['config', '--list', '-z'])).toBe(1)
+  })
+
+  it('falls back to real config --get after snapshot fetch failure', async () => {
+    const runGit = vi.fn(async (args: string[]) => {
+      if (args[0] === 'config' && args[1] === '--list') {
+        throw new Error('snapshot failed')
+      }
+      if (args[0] === 'config' && args[1] === '--get') {
+        return { stdout: `real:${args[2]}` }
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['config', '--get', 'branch.main.remote'])).resolves.toEqual({
+      stdout: 'real:branch.main.remote'
+    })
+    await expect(runner(['config', '--get', 'branch.main.merge'])).resolves.toEqual({
+      stdout: 'real:branch.main.merge'
+    })
+
+    expect(countCalls(runGit, ['config', '--list', '-z'])).toBe(1)
+    expect(runGit.mock.calls.filter((call) => getGitArgs(call)[1] === '--get')).toHaveLength(2)
+  })
+
+  it('passes non-config commands through', async () => {
+    const runGit = vi.fn(async (args: string[]) => ({ stdout: args.join(' ') }))
+    const runner = createGitConfigSnapshotRunner(runGit)
+
+    await expect(runner(['rev-parse', '--abbrev-ref', 'HEAD@{u}'])).resolves.toEqual({
+      stdout: 'rev-parse --abbrev-ref HEAD@{u}'
+    })
+    await expect(runner(['symbolic-ref', '--quiet', '--short', 'HEAD'])).resolves.toEqual({
+      stdout: 'symbolic-ref --quiet --short HEAD'
+    })
+
+    expect(countCalls(runGit, ['rev-parse', '--abbrev-ref', 'HEAD@{u}'])).toBe(1)
+    expect(countCalls(runGit, ['symbolic-ref', '--quiet', '--short', 'HEAD'])).toBe(1)
+  })
+})

--- a/src/shared/git-config-snapshot-runner.ts
+++ b/src/shared/git-config-snapshot-runner.ts
@@ -1,0 +1,90 @@
+type GitCommandRunner = (args: string[]) => Promise<{ stdout: string }>
+
+type GitConfigSnapshot = Map<string, string[]>
+
+function isConfigGetCommand(args: string[]): boolean {
+  return args.length === 3 && args[0] === 'config' && args[1] === '--get'
+}
+
+function canonicalizeGitConfigLookupKey(key: string): string {
+  const parts = key.split('.')
+  if (parts.length === 1) {
+    return key.toLowerCase()
+  }
+  const firstPart = parts[0]?.toLowerCase() ?? ''
+  const lastPart = parts.at(-1)?.toLowerCase() ?? ''
+  return [firstPart, ...parts.slice(1, -1), lastPart].join('.')
+}
+
+function parseGitConfigListSnapshot(stdout: string): GitConfigSnapshot {
+  const snapshot: GitConfigSnapshot = new Map()
+  for (const record of stdout.split('\0')) {
+    if (!record.trim()) {
+      continue
+    }
+
+    // Why: config values may contain newlines, so only the first newline
+    // separates git's emitted key from its value.
+    const separatorIndex = record.indexOf('\n')
+    const key = separatorIndex === -1 ? record : record.slice(0, separatorIndex)
+    const value = separatorIndex === -1 ? '' : record.slice(separatorIndex + 1)
+    const values = snapshot.get(key) ?? []
+    values.push(value)
+    snapshot.set(key, values)
+  }
+  return snapshot
+}
+
+export function createGitConfigSnapshotRunner(runGit: GitCommandRunner): GitCommandRunner {
+  let snapshotPromise: Promise<GitConfigSnapshot | null> | null = null
+  let snapshot: GitConfigSnapshot | null = null
+  let interceptionDisabled = false
+
+  const readSnapshot = (): Promise<GitConfigSnapshot | null> => {
+    if (snapshot) {
+      return Promise.resolve(snapshot)
+    }
+    if (!snapshotPromise) {
+      // Why: upstream resolvers read config keys with Promise.all; the first
+      // caller must publish the in-flight snapshot before any await.
+      try {
+        snapshotPromise = runGit(['config', '--list', '-z'])
+          .then(({ stdout }) => {
+            snapshot = parseGitConfigListSnapshot(stdout)
+            return snapshot
+          })
+          .catch(() => {
+            // Why: a snapshot failure should preserve existing real-git
+            // behavior for this round instead of failing the config lookup.
+            interceptionDisabled = true
+            snapshotPromise = null
+            return null
+          })
+      } catch {
+        interceptionDisabled = true
+        snapshotPromise = null
+        return Promise.resolve(null)
+      }
+    }
+    return snapshotPromise
+  }
+
+  return async (args) => {
+    if (interceptionDisabled || !isConfigGetCommand(args)) {
+      return runGit(args)
+    }
+
+    const configSnapshot = await readSnapshot()
+    if (!configSnapshot) {
+      return runGit(args)
+    }
+
+    const values = configSnapshot.get(canonicalizeGitConfigLookupKey(args[2] ?? ''))
+    if (!values?.length) {
+      return { stdout: '' }
+    }
+
+    // Why: git config --get resolves multivar keys using the last occurrence.
+    return { stdout: values.at(-1) ?? '' }
+  }
+}

--- a/src/shared/git-config-snapshot-runner.ts
+++ b/src/shared/git-config-snapshot-runner.ts
@@ -2,6 +2,15 @@ type GitCommandRunner = (args: string[]) => Promise<{ stdout: string }>
 
 type GitConfigSnapshot = Map<string, string[]>
 
+// Why: mirror `git config --get`'s exit-1-on-absent-key so an intercepted miss
+// rejects (matching real git) instead of resolving an empty success value.
+export class GitConfigSnapshotKeyNotFoundError extends Error {
+  constructor(key: string) {
+    super(`git config --get found no value for '${key}'`)
+    this.name = 'GitConfigSnapshotKeyNotFoundError'
+  }
+}
+
 function isConfigGetCommand(args: string[]): boolean {
   return args.length === 3 && args[0] === 'config' && args[1] === '--get'
 }
@@ -79,9 +88,13 @@ export function createGitConfigSnapshotRunner(runGit: GitCommandRunner): GitComm
       return runGit(args)
     }
 
-    const values = configSnapshot.get(canonicalizeGitConfigLookupKey(args[2] ?? ''))
+    const key = args[2] ?? ''
+    const values = configSnapshot.get(canonicalizeGitConfigLookupKey(key))
     if (!values?.length) {
-      return { stdout: '' }
+      // Why: real `git config --get` exits non-zero for an absent key (it does
+      // not return empty success), so reject here to stay a faithful drop-in —
+      // callers branch on the rejection just as they would for real git.
+      throw new GitConfigSnapshotKeyNotFoundError(key)
     }
 
     // Why: git config --get resolves multivar keys using the last occurrence.


### PR DESCRIPTION
## What changes

Source-control polling's background upstream check used to spawn a burst of short-lived `git` processes each time it ran for a branch with no upstream — up to ~8 separate `git config --get` calls per probe round (plus the `rev-parse`/`symbolic-ref` reads). On Windows, every spawn is scanned by Windows Defender, so the churn surfaced as periodic CPU. This collapses all of a probe round's `git config --get` reads into **one** `git config --list -z` snapshot, dropping a no-upstream probe round from ~10 to ~4 `git` processes.

## What does NOT change

No change to **how often** the probe runs (the 3 s poll cadence and the 5-minute no-upstream negative cache are untouched), no change to caching/staleness, and **no change to the resolved upstream or push-target** — only the number of `git` subprocesses spawned per round. `git remote` / `git remote get-url` are intentionally left as real-git calls (they are not on the steady-state polling path).

Closes #6381.

## Background

This is the residual tail of the source-control git-burst work. Prior releases (v1.4.94–v1.4.101 and the upstream/push-target fix that followed) already eliminated the recurring bursts; the reporter confirmed on v1.4.103 that peak concurrent git dropped from ~10 to 3 with no sustained bursts, leaving only a low-rate `config` / `rev-parse @{u}` probe set. This change targets that remaining per-round fan-out so each residual refresh spawns materially fewer processes — which is what the on-access AV scanning cost scales with.

## Design approach

A small `runGit` wrapper, `createGitConfigSnapshotRunner`, intercepts only `git config --get <key>` calls. On the first such call in a round it lazily fetches `git config --list -z` once (single-flighting the in-flight promise so the resolvers' concurrent `Promise.all` reads share one fetch), parses it into a key → ordered-values map, and serves every subsequent `config --get` from that snapshot. Lookups apply git's key canonicalization (lowercase the section and final key segment, preserve the subsection) and multivar `--get` last-wins semantics, so a served value is byte-identical to what real `git config --get` would return. If the snapshot fetch fails for any reason, interception is disabled for the round and calls fall back to real git, preserving today's behavior exactly. The wrapper is created fresh per probe round, so there is no cross-round config caching (staleness is unchanged).

Wired into the two polling probe sites that drive the residual churn: `probeEffectiveUpstreamStatus` (local, `src/main/git/status.ts`) and `readOrProbeNoEffectiveUpstreamStatus` (SSH relay, `src/relay/git-status-upstream-negative-cache.ts`). The same-name-origin `rev-parse` detection stays on the outer runner in both, so the negative-cache write gate is unaffected.

## Design-review outcome

Ran an iterative design review on the doc. It caught a real correctness bug in an earlier draft (a multivar value would have been resolved first-wins when `git config --get` is actually last-wins) and a single-flight gap (memoizing the parsed value instead of the in-flight promise would have let concurrent first-calls each spawn `config --list`); both were fixed before implementation. The review also flagged that synthesizing `git remote` output in the wrapper re-implemented too much git behavior with silent wrong-resolution risk — so the final scope was narrowed to intercept only `config --get` and leave `remote`/`remote get-url` as real-git pass-through, which keeps the full per-round saving for the common case while removing the riskiest surface.

## Implementation & deviations

Implemented as designed. One in-scope addition beyond the listed files: `src/main/git/status-upstream-negative-cache.test.ts` mocks needed to handle the new `config --list -z` subprocess shape, so it was updated alongside the churn tests. No other deviations.

## Completeness verification

A read-only verification pass mapped every design requirement, edge case, and validation item to a PASS with file:line evidence, and empirically confirmed against real git that the served values match for the queried key shapes (including the `feature/fix` slash subsection). Verdict: complete, no behavior change beyond subprocess-count reduction.

## Headline behavior status

**Implemented** in production code on the real polling path (both local and relay probe sites execute the coalescing — not behind a flag or fixture). The deterministic churn tests assert the spawn-count reduction on the production path.

## Perf audit

Touched hot paths: the 3 s source-control poll's upstream probe and its SSH-relay equivalent. The audit confirmed the change strictly reduces spawn count with no new per-poll cost (the wrapper only instantiates inside a probe round, which is itself gated by the negative cache), no leak (per-round closure, fallback `.catch` observed so no unhandled rejection), and correct composition with the existing in-flight dedup / negative cache. A large-config timing check (~88 KB, 2300+ entries) showed `git config --list -z` runs in ~0.05 s — process spawn dominates, so one `--list` is cheaper than the several `--get`s it replaces even on big configs. No measurement gap: the deterministic "exactly one `config --list`, zero `config --get` per round" tests are the correct proxy for the churn-reduction claim.

## Code-review loop

Two independent reviewers in one round (one Codex, one Claude), both adversarially targeting any case where a snapshot-served value could diverge from real `git config --get`. Both returned clean — no P0/P1/P2 actionable findings. Each independently validated the parser, key canonicalization, single-flight, fallback, and the `.trim()` consumer equivalence against the real git binary.

## Validation

- `pnpm run typecheck` — pass.
- `pnpm exec oxlint` (repo-wide) — 0 errors (one pre-existing unrelated warning in `useGitStatusPolling.ts`, not modified here).
- Focused: `git-config-snapshot-runner.test.ts`, `status-upstream-probe-churn.test.ts`, `status-upstream-negative-cache.test.ts`, relay `git-status-upstream-negative-cache.test.ts` — 29 pass.
- Broader git suites (`src/main/git/` + `git-effective-upstream` + `git-configured-branch-target`) — 384 pass.
- Real-git integration check (scratch, not shipped): snapshot runner byte-identical to real `git config --get` across mixed-case / slash-subsection / dotted-name / multivar / missing keys; `getEffectiveGitUpstreamStatus` resolves identically with vs without the wrapper while spawning 1 `config --list` + 0 `config --get`.

## Cross-platform & SSH

Pure shift in git argument shape behind `runGit` — no OS-specific code, no path assumptions, no shell. The reduction is real on macOS/Linux too; it's largest on Windows where each spawn carries the Defender-scan cost. The SSH relay probe path is wired with the same wrapper, so remote worktrees get the same one-for-one reduction.

## Accepted gaps

The actual Windows-Defender CPU drop can't be observed from a macOS dev box; this issue is Windows-specific. The root cause the reporter identified is spawn cadence ("the same churn would tax any on-access AV"), and that reduction is proven deterministically and against real git.

Made with [Orca](https://github.com/stablyai/orca) 🐋

## Post-PR stabilization

- CI: `verify` and `track-community-pr` pass.
- CodeRabbit raised two findings on the config-snapshot runner, both addressed in 56dedc96e and acknowledged by CodeRabbit: (1) Major — an absent key now throws a typed `GitConfigSnapshotKeyNotFoundError` to match `git config --get`'s exit-1 contract (without re-spawning real-git, which would defeat the coalescing); (2) Minor — added a loaded-snapshot missing-key regression test. No remaining actionable comments.
