### PR TITLE
Auto-color new project folders when enabled

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -145,6 +145,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalWindowsPowerShellImplementation: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides,
+    autoColorNewProjects: overrides.autoColorNewProjects ?? false,
     diffWordWrap: overrides.diffWordWrap ?? false,
     localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' },
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -149,6 +149,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalWindowsPowerShellImplementation: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides,
+    autoColorNewProjects: overrides.autoColorNewProjects ?? false,
     diffWordWrap: overrides.diffWordWrap ?? false,
     localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' },
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',

--- a/src/main/ipc/repos-create.test.ts
+++ b/src/main/ipc/repos-create.test.ts
@@ -277,6 +277,19 @@ describe('repos:create', () => {
     expect(result).toHaveProperty('repo.badgeColor', DEFAULT_REPO_BADGE_COLOR)
   })
 
+  it('returns the auto-assigned color so it reaches the renderer', async () => {
+    // Regression: with autoColorNewProjects on, Store.addRepo recolors the repo
+    // in place before persisting. The handler returns that same object, so the
+    // color must be visible on the returned repo (not the pre-color default).
+    mockStore.addRepo.mockImplementationOnce((repo: { badgeColor?: string }) => {
+      repo.badgeColor = '#ef4444'
+    })
+
+    const result = await callCreate({ parentPath: '/tmp', name: 'auto-color', kind: 'folder' })
+
+    expect(result).toHaveProperty('repo.badgeColor', '#ef4444')
+  })
+
   // ── git repo happy path ───────────────────────────────────────────
 
   it('creates a git repo with an empty initial commit (in order)', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -30,6 +30,8 @@ import { isTerminalLeafId, makePaneKey } from '../shared/stable-pane-id'
 import { TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT } from '../shared/terminal-scrollback-limits'
 import { MAX_BROWSER_HISTORY_ENTRIES } from '../shared/workspace-session-browser-history'
 import {
+  DEFAULT_REPO_BADGE_COLOR,
+  REPO_COLORS,
   getDefaultPersistedState,
   getDefaultWorkspaceSession,
   ONBOARDING_FINAL_STEP,
@@ -483,6 +485,7 @@ describe('Store', () => {
     expect(settings.terminalTuiScrollSensitivity).toBe(3)
     expect(settings.terminalUseSeparateLightTheme).toBe(true)
     expect(settings.rightSidebarOpenByDefault).toBe(true)
+    expect(settings.autoColorNewProjects).toBe(false)
     expect(settings.showTasksButton).toBe(true)
     expect(settings.showAutomationsButton).toBe(true)
     expect(settings.visibleTaskProviders).toEqual(['github', 'gitlab', 'linear', 'jira'])
@@ -1807,6 +1810,7 @@ describe('Store', () => {
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
     expect(store.getSettings().sourceControlViewMode).toBe('list')
     expect(store.getSettings().showGitIgnoredFiles).toBe(true)
+    expect(store.getSettings().autoColorNewProjects).toBe(false)
     expect(store.getSettings().showTasksButton).toBe(true)
     expect(store.getSettings().showAutomationsButton).toBe(true)
     expect(store.getSettings().combinedDiffFileTreeVisibleByDefault).toBe(false)
@@ -2884,6 +2888,59 @@ describe('Store', () => {
     expect(store.getWorktreeLineage('r1::/path/child')).toBeUndefined()
     expect(store.getWorktreeLineage('r2::/other-child')).toBeUndefined()
     expect(store.getWorktreeLineage('r2::/other')).toBeDefined()
+  })
+
+  describe('addRepo auto-color', () => {
+    it('assigns a non-gray palette color when enabled and the incoming color is default gray', async () => {
+      const store = await createStore()
+      store.updateSettings({ autoColorNewProjects: true })
+
+      store.addRepo(makeRepo({ badgeColor: DEFAULT_REPO_BADGE_COLOR }))
+
+      expect(store.getRepo('r1')!.badgeColor).toBe(REPO_COLORS[1])
+      expect(store.getRepo('r1')!.badgeColor).not.toBe(DEFAULT_REPO_BADGE_COLOR)
+    })
+
+    it('uses different palette colors for consecutive adds when enabled', async () => {
+      const store = await createStore()
+      store.updateSettings({ autoColorNewProjects: true })
+
+      store.addRepo(makeRepo({ id: 'r1', path: '/repo1', badgeColor: DEFAULT_REPO_BADGE_COLOR }))
+      store.addRepo(makeRepo({ id: 'r2', path: '/repo2', badgeColor: DEFAULT_REPO_BADGE_COLOR }))
+
+      expect(store.getRepo('r1')!.badgeColor).toBe(REPO_COLORS[1])
+      expect(store.getRepo('r2')!.badgeColor).toBe(REPO_COLORS[2])
+      expect(store.getRepo('r1')!.badgeColor).not.toBe(store.getRepo('r2')!.badgeColor)
+    })
+
+    it('leaves the default gray color unchanged when disabled by default', async () => {
+      const store = await createStore()
+
+      store.addRepo(makeRepo({ badgeColor: DEFAULT_REPO_BADGE_COLOR }))
+
+      expect(store.getRepo('r1')!.badgeColor).toBe(DEFAULT_REPO_BADGE_COLOR)
+    })
+
+    it('preserves an explicit non-default incoming color when enabled', async () => {
+      const store = await createStore()
+      store.updateSettings({ autoColorNewProjects: true })
+
+      store.addRepo(makeRepo({ badgeColor: '#22c55e' }))
+
+      expect(store.getRepo('r1')!.badgeColor).toBe('#22c55e')
+    })
+
+    it('keeps the next auto color based on total repo count after manual recoloring', async () => {
+      const store = await createStore()
+      store.updateSettings({ autoColorNewProjects: true })
+
+      store.addRepo(makeRepo({ id: 'r1', path: '/repo1', badgeColor: DEFAULT_REPO_BADGE_COLOR }))
+      store.updateRepo('r1', { badgeColor: DEFAULT_REPO_BADGE_COLOR })
+      store.addRepo(makeRepo({ id: 'r2', path: '/repo2', badgeColor: DEFAULT_REPO_BADGE_COLOR }))
+
+      expect(store.getRepo('r1')!.badgeColor).toBe(DEFAULT_REPO_BADGE_COLOR)
+      expect(store.getRepo('r2')!.badgeColor).toBe(REPO_COLORS[2])
+    })
   })
 
   // ── 7. updateRepo ──────────────────────────────────────────────────

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -96,6 +96,7 @@ import {
   isDefaultedCompactWorktreeCardProperties,
   normalizeAgentActivityDisplayMode,
   normalizeWorktreeCardProperties,
+  DEFAULT_REPO_BADGE_COLOR,
   ONBOARDING_FLOW_VERSION,
   ONBOARDING_FINAL_STEP
 } from '../shared/constants'
@@ -158,7 +159,7 @@ import {
 import { clampMarkdownTocPanelWidth } from '../shared/markdown-toc-panel-width'
 import { isLegacyRepoForExternalWorktreeVisibility } from '../shared/worktree-ownership'
 import { sanitizeRepoIcon } from '../shared/repo-icon'
-import { normalizeRepoBadgeColor } from '../shared/repo-badge-color'
+import { normalizeRepoBadgeColor, pickRoundRobinRepoBadgeColor } from '../shared/repo-badge-color'
 import {
   clearMissingProjectGroupMemberships,
   createProjectGroup,
@@ -3809,9 +3810,26 @@ export class Store {
   }
 
   addRepo(repo: Repo): void {
+    this.maybeAutoColorNewProject(repo)
     this.state.repos.push(repo)
     this.syncProjectHostSetupCompatibilityState()
     this.scheduleSave()
+  }
+
+  // Why: when the user opts in, give each genuinely-new project a distinct
+  // round-robin color so the sidebar is easier to scan. Only recolor when the
+  // caller left the default gray — never override an explicitly chosen color —
+  // and read count before the push so the first add gets palette[0]. Mutates the
+  // freshly-built repo in place so callers that return it (e.g. repos:add)
+  // hand the colored object to the renderer without a store read-back.
+  private maybeAutoColorNewProject(repo: Repo): void {
+    if (this.state.settings?.autoColorNewProjects !== true) {
+      return
+    }
+    if (repo.badgeColor && repo.badgeColor !== DEFAULT_REPO_BADGE_COLOR) {
+      return
+    }
+    repo.badgeColor = pickRoundRobinRepoBadgeColor(this.state.repos.length)
   }
 
   // Why: returns false on a stale permutation (concurrent add/remove races

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -331,6 +331,35 @@ describe('AppearancePane', () => {
     ).not.toBeNull()
   })
 
+  it('reveals the Auto-Color New Projects toggle when searched and toggles it on', async () => {
+    // Like the other sidebar toggles, this lives behind the Advanced disclosure
+    // and is hidden by default; a matching search must surface it.
+    mocks.state.settingsSearchQuery = ''
+    const collapsedContainer = await renderAppearancePane(getDefaultSettings('/tmp'))
+    expect(
+      collapsedContainer.querySelector(
+        'button[role="switch"][aria-label="Auto-Color New Projects"]'
+      )
+    ).toBeNull()
+
+    mocks.state.settingsSearchQuery = 'color'
+    const updateSettings = vi.fn()
+    const settings = { ...getDefaultSettings('/tmp'), autoColorNewProjects: false }
+    const container = await renderAppearancePane(settings, updateSettings)
+    const switchControl = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="Auto-Color New Projects"]'
+    )
+
+    expect(switchControl).not.toBeNull()
+    expect(switchControl?.getAttribute('aria-checked')).toBe('false')
+
+    await act(async () => {
+      switchControl?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ autoColorNewProjects: true })
+  })
+
   it('keeps description-only search matches visible after helper text is hidden', async () => {
     mocks.state.settingsSearchQuery = 'app window'
     const container = await renderAppearancePane(getDefaultSettings('/tmp'))

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -15,6 +15,7 @@ import { useAvailableStatusBarToggles } from '../status-bar/use-available-status
 import { getLayoutEntries, getSidebarEntries, getStatusBarToggles } from './appearance-search'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
 import {
+  getAutoColorNewProjectsEntry,
   getLeftSidebarAppearanceEntry,
   getWorkspaceCardLayoutEntry
 } from './appearance-sidebar-search'
@@ -57,6 +58,7 @@ export function AppearanceWindowSidebarSection({
   const leftSidebarAppearanceEntry = getLeftSidebarAppearanceEntry()
   const sidebarEntries = getSidebarEntries()
   const workspaceCardLayoutEntry = getWorkspaceCardLayoutEntry()
+  const autoColorEntry = getAutoColorNewProjectsEntry()
   const layoutEntries = getLayoutEntries()
   const statusBarTitle = translate(
     'auto.components.settings.AppearancePane.3e4175e5c6',
@@ -250,6 +252,21 @@ export function AppearanceWindowSidebarSection({
                       checked={settings.showMobileButton !== false}
                       onChange={() =>
                         updateSettings({ showMobileButton: !(settings.showMobileButton !== false) })
+                      }
+                    />
+                  </SearchableSetting>
+
+                  <SearchableSetting
+                    title={autoColorEntry.title}
+                    description={autoColorEntry.description}
+                    keywords={autoColorEntry.keywords}
+                  >
+                    <SettingsSwitchRow
+                      label={autoColorEntry.title}
+                      description={autoColorEntry.description}
+                      checked={settings.autoColorNewProjects === true}
+                      onChange={() =>
+                        updateSettings({ autoColorNewProjects: !settings.autoColorNewProjects })
                       }
                     />
                   </SearchableSetting>

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -1,6 +1,10 @@
 import type { SettingsSearchEntry } from './settings-search'
 import { getTerminalAppearanceSearchEntries } from './terminal-search'
-import { getLeftSidebarAppearanceEntry, getSidebarEntries } from './appearance-sidebar-search'
+import {
+  getAutoColorNewProjectsEntry,
+  getLeftSidebarAppearanceEntry,
+  getSidebarEntries
+} from './appearance-sidebar-search'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { isWebClientLocation } from '@/lib/web-client-location'
@@ -156,7 +160,7 @@ export const getStatusBarEntries = createLocalizedCatalog((): SettingsSearchEntr
   }))
 )
 
-export { getLeftSidebarAppearanceEntry, getSidebarEntries }
+export { getAutoColorNewProjectsEntry, getLeftSidebarAppearanceEntry, getSidebarEntries }
 
 export const getAppIconEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {

--- a/src/renderer/src/components/settings/appearance-sidebar-search.ts
+++ b/src/renderer/src/components/settings/appearance-sidebar-search.ts
@@ -79,6 +79,49 @@ export const getWorkspaceCardLayoutEntry = createLocalizedCatalog(
   })
 )
 
+export const getAutoColorNewProjectsEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate(
+      'auto.components.settings.appearance.search.autoColorNewProjects.title',
+      'Auto-Color New Projects'
+    ),
+    description: translate(
+      'auto.components.settings.appearance.search.autoColorNewProjects.description',
+      'Give each newly added project a different color so the sidebar is easier to scan. Existing projects keep their current color.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.autoColorNewProjects.color',
+        'color'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.autoColorNewProjects.colour',
+        'colour'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.autoColorNewProjects.project',
+        'project'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.autoColorNewProjects.folder',
+        'folder'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.autoColorNewProjects.sidebar',
+        'sidebar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.autoColorNewProjects.auto',
+        'auto'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.autoColorNewProjects.rainbow',
+        'rainbow'
+      )
+    ]
+  })
+)
+
 export const getSidebarEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate('auto.components.settings.appearance.search.155a1e7438', 'Show Tasks Button'),
@@ -144,5 +187,6 @@ export const getSidebarEntries = createLocalizedCatalog((): SettingsSearchEntry[
     ]
   },
   getWorkspaceCardLayoutEntry(),
-  getLeftSidebarAppearanceEntry()
+  getLeftSidebarAppearanceEntry(),
+  getAutoColorNewProjectsEntry()
 ])

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6886,6 +6886,10 @@
               "cardLayout": "card layout",
               "workspaceOptions": "workspace options",
               "detailed": "detailed"
+            },
+            "autoColorNewProjects": {
+              "title": "Auto-Color New Projects",
+              "description": "Give each newly added project a different color so the sidebar is easier to scan. Existing projects keep their current color."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6849,7 +6849,11 @@
               "detailed": "detallado"
             },
             "9a115966d3": "Minimizar a la bandeja al cerrar",
-            "4d5b9427b5": "Cuando está activado, cerrar la ventana mantiene Orca en ejecución en la bandeja del sistema en lugar de salir."
+            "4d5b9427b5": "Cuando está activado, cerrar la ventana mantiene Orca en ejecución en la bandeja del sistema en lugar de salir.",
+            "autoColorNewProjects": {
+              "title": "Auto-Color New Projects",
+              "description": "Give each newly added project a different color so the sidebar is easier to scan. Existing projects keep their current color."
+            }
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6871,7 +6871,11 @@
               "detailed": "詳細"
             },
             "9a115966d3": "閉じるときにトレイへ最小化",
-            "4d5b9427b5": "有効にすると、ウィンドウを閉じてもOrcaは終了せず、システムトレイで実行を続けます。"
+            "4d5b9427b5": "有効にすると、ウィンドウを閉じてもOrcaは終了せず、システムトレイで実行を続けます。",
+            "autoColorNewProjects": {
+              "title": "Auto-Color New Projects",
+              "description": "Give each newly added project a different color so the sidebar is easier to scan. Existing projects keep their current color."
+            }
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6834,6 +6834,10 @@
               "cardLayout": "카드 레이아웃",
               "workspaceOptions": "워크스페이스 옵션",
               "detailed": "상세"
+            },
+            "autoColorNewProjects": {
+              "title": "Auto-Color New Projects",
+              "description": "Give each newly added project a different color so the sidebar is easier to scan. Existing projects keep their current color."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6834,7 +6834,11 @@
               "detailed": "详细"
             },
             "9a115966d3": "关闭时最小化到托盘",
-            "4d5b9427b5": "启用后，关闭窗口会让 Orca 继续在系统托盘中运行，而不是退出。"
+            "4d5b9427b5": "启用后，关闭窗口会让 Orca 继续在系统托盘中运行，而不是退出。",
+            "autoColorNewProjects": {
+              "title": "Auto-Color New Projects",
+              "description": "Give each newly added project a different color so the sidebar is easier to scan. Existing projects keep their current color."
+            }
           }
         },
         "auto": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -276,6 +276,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     sourceControlGroupOrder: DEFAULT_SOURCE_CONTROL_GROUP_ORDER,
     sourceControlCompareAgainstUpstream: false,
     showTitlebarAppName: true,
+    autoColorNewProjects: false,
     showTasksButton: true,
     showAutomationsButton: true,
     showMobileButton: true,

--- a/src/shared/repo-badge-color.test.ts
+++ b/src/shared/repo-badge-color.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_REPO_BADGE_COLOR } from './constants'
-import { normalizeRepoBadgeColor, resolveRepoBadgeColor } from './repo-badge-color'
+import { DEFAULT_REPO_BADGE_COLOR, REPO_COLORS } from './constants'
+import {
+  normalizeRepoBadgeColor,
+  pickRoundRobinRepoBadgeColor,
+  resolveRepoBadgeColor
+} from './repo-badge-color'
 
 describe('repo badge color normalization', () => {
   it('normalizes six-digit hex colors', () => {
@@ -20,5 +24,35 @@ describe('repo badge color normalization', () => {
 
   it('falls back to the default repo color when resolving invalid input', () => {
     expect(resolveRepoBadgeColor('blue')).toBe(DEFAULT_REPO_BADGE_COLOR)
+  })
+})
+
+describe('round-robin repo badge color selection', () => {
+  const nonDefaultPalette = REPO_COLORS.slice(1)
+
+  it('starts with the first non-gray palette color', () => {
+    expect(pickRoundRobinRepoBadgeColor(0)).toBe('#ef4444')
+  })
+
+  it('cycles through all non-gray palette colors', () => {
+    expect(
+      Array.from({ length: nonDefaultPalette.length }, (_, count) =>
+        pickRoundRobinRepoBadgeColor(count)
+      )
+    ).toEqual(['#ef4444', '#f97316', '#eab308', '#22c55e', '#14b8a6', '#8b5cf6', '#ec4899'])
+  })
+
+  it('wraps after the non-gray palette', () => {
+    expect(pickRoundRobinRepoBadgeColor(nonDefaultPalette.length)).toBe('#ef4444')
+  })
+
+  it('never returns the gray default color', () => {
+    for (let count = 0; count < nonDefaultPalette.length * 3; count += 1) {
+      expect(pickRoundRobinRepoBadgeColor(count)).not.toBe(DEFAULT_REPO_BADGE_COLOR)
+    }
+  })
+
+  it('wraps negative counts into the non-gray palette', () => {
+    expect(pickRoundRobinRepoBadgeColor(-1)).toBe('#ec4899')
   })
 })

--- a/src/shared/repo-badge-color.ts
+++ b/src/shared/repo-badge-color.ts
@@ -27,3 +27,12 @@ export function normalizeRepoBadgeColor(value: unknown): string | null {
 export function resolveRepoBadgeColor(value: unknown): string {
   return normalizeRepoBadgeColor(value) ?? DEFAULT_REPO_BADGE_COLOR
 }
+
+// Round-robin over the non-default palette colors so each new project gets a
+// visually distinct badge. Index 0 is the neutral "uncolored" gray default, so
+// it is excluded; cycling is by how many projects already exist.
+export function pickRoundRobinRepoBadgeColor(existingProjectCount: number): string {
+  const palette = REPO_COLORS.slice(1) // exclude neutral gray default
+  const index = ((existingProjectCount % palette.length) + palette.length) % palette.length
+  return palette[index]
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2584,6 +2584,9 @@ export type GlobalSettings = {
   sourceControlCompareAgainstUpstream: boolean
   /** Whether to show the Orca app name in the titlebar. */
   showTitlebarAppName: boolean
+  /** Why: opt-in, default-off project coloring only affects new adds at add
+   *  time so existing projects keep their current color. */
+  autoColorNewProjects: boolean
   /** Why: some users do not use the Tasks feature and prefer to keep the
    *  left sidebar free of its button entirely. Hiding the button here also
    *  removes it from keyboard navigation. */


### PR DESCRIPTION
## What changes

Adds an opt-in **"Auto-Color New Projects"** setting (default **off**). When enabled, each newly added or created project folder is given a distinct color from Orca's existing repo color palette, cycled round-robin, so a sidebar full of projects is easier to scan. Closes #5828.

**What does NOT change:** existing projects are never recolored — toggling the setting on only affects projects added afterward. With the setting off, behavior is identical to today (new projects use the default neutral gray). Manual color choices are always preserved. No new color values were introduced; the feature reuses the existing `REPO_COLORS` palette.

## Design approach

- New `autoColorNewProjects: boolean` on `GlobalSettings` (default `false`), defaulted in `getDefaultSettings()`.
- A pure `pickRoundRobinRepoBadgeColor(count)` helper cycles the 7 non-gray palette colors (index 0 = neutral gray is excluded), keyed on the **total** project count so the auto-sequence is independent of manual color choices.
- Applied at the single chokepoint every creation flow funnels through — `Store.addRepo` — via a guarded `maybeAutoColorNewProject`. It only colors when the setting is on **and** the caller left the default gray (an explicitly chosen color is never overridden), and reads the count before the push so the first add gets the first palette color. The repo is colored in place so the same object the add/create/clone IPC handlers return to the renderer already carries the color.
- The disk **load** path assigns repo state directly (it does not route through `addRepo`), so existing projects are never recolored on startup. `Project.badgeColor` is projected from `Repo.badgeColor`, and the sidebar already renders that color — so coloring the repo at creation is sufficient with no rendering changes.
- Settings toggle + searchable entry under **Appearance → Window & Sidebar → Sidebar**.

## Validation

**Design review:** ran the design-review loop to clean (2 rounds, both reviewers converged). One direction change adopted: cycle on total project count rather than colored-count, to decouple the auto-sequence from the manual color picker.

**Completeness:** verified against the design doc — all items present; added the settings-UI test the plan called for.

**Headline behavior:** fully implemented in production code paths (not scaffolding). Directly observed in the running app.

**Performance:** audited — no concerns. `addRepo` is a rare user-initiated action, not a hot/render/startup path; the added work is one settings read + a small palette lookup. No new polling, timers, persistence writes, or leaks.

**Code review:** two-reviewer loop. First round surfaced a real bug — `addRepo` recolored a copy while the IPC handlers returned the pre-color object, so a newly added project would render gray until a refetch. Fixed by coloring the freshly-built repo in place. Re-review round: both reviewers clean, with an added regression test asserting the returned repo carries the auto color.

**Electron validation:** exercised end-to-end in the running app. With the setting on, three added folders rendered yellow → green → teal (distinct round-robin); a folder added with the setting off rendered gray; pre-existing projects kept their original colors. Confirmed both visually and via the rendered icons' computed styles. Limitation: the native "Add Project" OS folder picker can't be driven over CDP, so projects were added through the same `repos.add` IPC path the picker funnels into — only the GUI dialog step was bypassed; coloring, persistence, and rendering were all exercised.

**Static checks / tests:** `typecheck`, `lint` (incl. localization catalog + coverage verifiers), and the touched vitest suites all pass (1081 tests across the touched files), including the unit tests for the round-robin helper, the `Store.addRepo` auto-color behavior, and the settings toggle/search UI.

## Notes

- New i18n keys are seeded with English; non-English catalogs mirror English for now (search keyword fallbacks degrade gracefully), consistent with the existing pattern for sidebar appearance entries.
- Two `codex-accounts` test fixtures gained the now-required `autoColorNewProjects` field (mechanical).

Made with [Orca](https://github.com/stablyai/orca) 🐋
