### PR TITLE
Add customizable workspace folder name template

### DIFF
--- a/src/main/agent-hooks/first-work-folder-rename.ts
+++ b/src/main/agent-hooks/first-work-folder-rename.ts
@@ -9,6 +9,7 @@ import type { GlobalSettings, Repo } from '../../shared/types'
 import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { planWorktreeFolderRename } from '../ipc/worktree-folder-rename-target'
+import { getEffectiveWorktreeFolderNameTemplate } from '../ipc/worktree-logic'
 
 export type FirstWorkFolderRenameDeps = {
   getRepo: (repoId: string) => Repo | undefined
@@ -39,12 +40,14 @@ export async function renameWorktreeFolderOnFirstWork(
   if (!repo || !parsed) {
     return false
   }
+  const settings = deps.getSettings()
   const plan = planWorktreeFolderRename({
     repoId: repo.id,
     repoPath: repo.path,
     oldWorktreePath: parsed.worktreePath,
     newLeaf,
-    settings: deps.getSettings(),
+    settings,
+    worktreeFolderNameTemplate: getEffectiveWorktreeFolderNameTemplate(repo, settings),
     platform: process.platform,
     isRemote: getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID
   })

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -145,6 +145,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalWindowsPowerShellImplementation: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides,
+    worktreeFolderNameTemplate: overrides.worktreeFolderNameTemplate ?? '',
     diffWordWrap: overrides.diffWordWrap ?? false,
     localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' },
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -149,6 +149,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalWindowsPowerShellImplementation: 'powershell.exe',
     enableGitHubAttribution: true,
     ...overrides,
+    worktreeFolderNameTemplate: overrides.worktreeFolderNameTemplate ?? '',
     diffWordWrap: overrides.diffWordWrap ?? false,
     localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' },
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -1936,6 +1936,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
             | 'hookSettings'
             | 'worktreeBaseRef'
             | 'worktreeBasePath'
+            | 'worktreeFolderNameTemplate'
             | 'kind'
             | 'symlinkPaths'
             | 'issueSourcePreference'
@@ -1998,6 +1999,17 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
           delete updates.worktreeBasePath
         } else {
           updates.worktreeBasePath = v.trim() || undefined
+        }
+      }
+      if (
+        'worktreeFolderNameTemplate' in updates &&
+        updates.worktreeFolderNameTemplate !== undefined
+      ) {
+        const v = updates.worktreeFolderNameTemplate as unknown
+        if (typeof v !== 'string') {
+          delete updates.worktreeFolderNameTemplate
+        } else {
+          updates.worktreeFolderNameTemplate = v.trim() || undefined
         }
       }
       if ('repoIcon' in updates) {

--- a/src/main/ipc/worktree-folder-name-template.test.ts
+++ b/src/main/ipc/worktree-folder-name-template.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildWorktreeFolderNameTokens,
+  expandWorktreeFolderName,
+  type WorktreeFolderNameTokens
+} from './worktree-folder-name-template'
+
+const BASE_TOKENS: WorktreeFolderNameTokens = {
+  projectName: 'my-project',
+  workspaceName: 'feature',
+  gitBranchName: 'alice/fix-login',
+  gitBranchSlug: 'alice-fix-login',
+  branchPrefix: 'alice',
+  gitUsername: 'alice',
+  date: '2026-06-29',
+  shortId: 'deadbeef'
+}
+
+describe('expandWorktreeFolderName', () => {
+  it('expands every supported token and the repoName alias', () => {
+    expect(
+      expandWorktreeFolderName(
+        [
+          '%projectName%',
+          '%repoName%',
+          '%workspaceName%',
+          '%gitBranchName%',
+          '%gitBranchSlug%',
+          '%branchPrefix%',
+          '%gitUsername%',
+          '%date%',
+          '%shortId%'
+        ].join('_'),
+        BASE_TOKENS
+      )
+    ).toBe(
+      'my-project_my-project_feature_alice-fix-login_alice-fix-login_alice_alice_2026-06-29_deadbeef'
+    )
+  })
+
+  it('strips unknown and typoed tokens before sanitizing the remaining text', () => {
+    expect(expandWorktreeFolderName('%projectname%_%workspaceName%', BASE_TOKENS)).toBe('_feature')
+  })
+
+  it('collapses slashes to a single folder segment', () => {
+    expect(expandWorktreeFolderName('team/%workspaceName%', BASE_TOKENS)).toBe('team-feature')
+  })
+
+  it('returns null for empty and whitespace-only templates', () => {
+    expect(expandWorktreeFolderName('', BASE_TOKENS)).toBeNull()
+    expect(expandWorktreeFolderName('   ', BASE_TOKENS)).toBeNull()
+    expect(expandWorktreeFolderName(undefined, BASE_TOKENS)).toBeNull()
+  })
+
+  it('returns null when expansion sanitizes to empty', () => {
+    expect(
+      expandWorktreeFolderName('%gitUsername%', { ...BASE_TOKENS, gitUsername: '' })
+    ).toBeNull()
+  })
+
+  it('sanitizes traversal-looking template output safely', () => {
+    expect(expandWorktreeFolderName('..%workspaceName%', BASE_TOKENS)).toBe('feature')
+  })
+
+  it('produces identical leaves for branch name and branch slug after sanitization', () => {
+    expect(expandWorktreeFolderName('%gitBranchName%', BASE_TOKENS)).toBe('alice-fix-login')
+    expect(expandWorktreeFolderName('%gitBranchSlug%', BASE_TOKENS)).toBe('alice-fix-login')
+  })
+})
+
+describe('buildWorktreeFolderNameTokens', () => {
+  it('derives token values from repo, branch, settings, username, date, and short id', () => {
+    const now = new Date(2026, 5, 29, 9, 30, 0).getTime()
+
+    expect(
+      buildWorktreeFolderNameTokens({
+        repoPath: '/repos/my-project.git',
+        sanitizedName: 'feature',
+        branchName: 'alice/fix-login',
+        settings: { branchPrefix: 'git-username', branchPrefixCustom: '' },
+        username: 'alice',
+        now,
+        shortId: 'deadbeef'
+      })
+    ).toEqual({
+      projectName: 'my-project',
+      workspaceName: 'feature',
+      gitBranchName: 'alice/fix-login',
+      gitBranchSlug: 'alice-fix-login',
+      branchPrefix: 'alice',
+      gitUsername: 'alice',
+      date: '2026-06-29',
+      shortId: 'deadbeef'
+    })
+  })
+
+  it('uses an override branch verbatim instead of recomputing from the workspace name', () => {
+    const tokens = buildWorktreeFolderNameTokens({
+      repoPath: 'C:\\repos\\my-project.git',
+      sanitizedName: 'feature',
+      branchName: 'alice/fix-login',
+      settings: { branchPrefix: 'custom', branchPrefixCustom: 'team' },
+      username: null,
+      now: new Date(2026, 5, 29).getTime(),
+      shortId: 'cafebabe'
+    })
+
+    expect(tokens.projectName).toBe('my-project')
+    expect(tokens.gitBranchName).toBe('alice/fix-login')
+    expect(tokens.gitBranchSlug).toBe('alice-fix-login')
+    expect(tokens.branchPrefix).toBe('team')
+    expect(tokens.gitUsername).toBe('')
+    expect(tokens.shortId).toBe('cafebabe')
+  })
+})

--- a/src/main/ipc/worktree-folder-name-template.ts
+++ b/src/main/ipc/worktree-folder-name-template.ts
@@ -1,0 +1,98 @@
+import { getRuntimePathBasename } from '../../shared/cross-platform-path'
+import {
+  computeBranchName,
+  getConfiguredBranchPrefix,
+  sanitizeWorktreeName
+} from './worktree-logic'
+
+export type WorktreeFolderNameTokens = {
+  projectName: string
+  workspaceName: string
+  gitBranchName: string
+  gitBranchSlug: string
+  branchPrefix: string
+  gitUsername: string
+  date: string
+  shortId: string
+}
+
+type WorktreeFolderNameSettings = { branchPrefix: string; branchPrefixCustom?: string }
+
+const TOKEN_PATTERN = /%(\w+)%/g
+
+export function expandWorktreeFolderName(
+  template: string | undefined,
+  tokens: WorktreeFolderNameTokens
+): string | null {
+  if (!template?.trim()) {
+    return null
+  }
+
+  const expanded = template.replace(TOKEN_PATTERN, (_match, tokenName: string) =>
+    readTokenValue(tokenName, tokens)
+  )
+
+  try {
+    const sanitized = sanitizeWorktreeName(expanded)
+    return sanitized || null
+  } catch {
+    return null
+  }
+}
+
+export function buildWorktreeFolderNameTokens(input: {
+  repoPath: string
+  sanitizedName: string
+  branchName: string | undefined
+  settings: WorktreeFolderNameSettings
+  username: string | null
+  now: number
+  shortId: string
+}): WorktreeFolderNameTokens {
+  const username = input.username ?? null
+  const gitBranchName =
+    input.branchName?.trim() || computeBranchName(input.sanitizedName, input.settings, username)
+
+  return {
+    projectName: getRuntimePathBasename(input.repoPath).replace(/\.git$/, ''),
+    workspaceName: input.sanitizedName,
+    gitBranchName,
+    gitBranchSlug: gitBranchName.replace(/\//g, '-'),
+    branchPrefix: getConfiguredBranchPrefix(input.settings, username) ?? '',
+    gitUsername: username ?? '',
+    date: formatLocalDate(input.now),
+    shortId: input.shortId
+  }
+}
+
+function readTokenValue(tokenName: string, tokens: WorktreeFolderNameTokens): string {
+  switch (tokenName) {
+    case 'projectName':
+    case 'repoName':
+      return tokens.projectName
+    case 'workspaceName':
+      return tokens.workspaceName
+    case 'gitBranchName':
+      return tokens.gitBranchName
+    case 'gitBranchSlug':
+      return tokens.gitBranchSlug
+    case 'branchPrefix':
+      return tokens.branchPrefix
+    case 'gitUsername':
+      return tokens.gitUsername
+    case 'date':
+      return tokens.date
+    case 'shortId':
+      return tokens.shortId
+    default:
+      return ''
+  }
+}
+
+function formatLocalDate(now: number): string {
+  const date = new Date(now)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/src/main/ipc/worktree-folder-rename-target.test.ts
+++ b/src/main/ipc/worktree-folder-rename-target.test.ts
@@ -65,4 +65,30 @@ describe('planWorktreeFolderRename', () => {
       })
     ).toBeNull()
   })
+
+  it('skips when a folder-name template is configured (folder leaf is user-authored)', () => {
+    expect(
+      planWorktreeFolderRename({
+        ...base,
+        oldWorktreePath: '/ws/cunner',
+        newLeaf: 'fix-auth',
+        worktreeFolderNameTemplate: '%projectName%_%workspaceName%'
+      })
+    ).toBeNull()
+  })
+
+  it('still plans a rename when the template override is blank/whitespace', () => {
+    expect(
+      planWorktreeFolderRename({
+        ...base,
+        oldWorktreePath: '/ws/cunner',
+        newLeaf: 'fix-auth',
+        worktreeFolderNameTemplate: '   '
+      })
+    ).toEqual({
+      oldPath: '/ws/cunner',
+      newPath: '/ws/fix-auth',
+      newWorktreeId: 'repo1::/ws/fix-auth'
+    })
+  })
 })

--- a/src/main/ipc/worktree-folder-rename-target.ts
+++ b/src/main/ipc/worktree-folder-rename-target.ts
@@ -28,9 +28,15 @@ export function planWorktreeFolderRename(args: {
   oldWorktreePath: string
   newLeaf: string
   settings: WorktreePathSettings
+  worktreeFolderNameTemplate?: string
   platform: NodeJS.Platform
   isRemote: boolean
 }): WorktreeFolderRenamePlan | null {
+  // Why: a configured folder-name template makes the folder leaf user-authored,
+  // so first-work auto-rename should not fight it.
+  if (args.worktreeFolderNameTemplate?.trim()) {
+    return null
+  }
   if (args.isRemote || args.platform === 'win32') {
     return null
   }

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -12,6 +12,7 @@ import {
   computeWorktreePath,
   computeRemoteWorktreePath,
   computeWorkspaceRoot,
+  getEffectiveWorktreeFolderNameTemplate,
   getWorktreeCreationLayout,
   getWorktreePathSettings,
   shouldSetDisplayName,
@@ -277,6 +278,44 @@ describe('computeWorktreePath', () => {
         { useConfiguredAbsolutePath: true }
       )
     ).toBe('C:\\Remote\\worktrees\\feature')
+  })
+})
+
+describe('getEffectiveWorktreeFolderNameTemplate', () => {
+  it('prefers a non-empty repo template over the global template', () => {
+    expect(
+      getEffectiveWorktreeFolderNameTemplate(
+        { worktreeFolderNameTemplate: '  %projectName%_%workspaceName%  ' },
+        { worktreeFolderNameTemplate: '%workspaceName%' }
+      )
+    ).toBe('%projectName%_%workspaceName%')
+  })
+
+  it('falls back to the trimmed global template when the repo template is empty', () => {
+    expect(
+      getEffectiveWorktreeFolderNameTemplate(
+        { worktreeFolderNameTemplate: '   ' },
+        { worktreeFolderNameTemplate: '  %workspaceName%  ' }
+      )
+    ).toBe('%workspaceName%')
+  })
+
+  it('returns an empty string when no template is configured', () => {
+    expect(
+      getEffectiveWorktreeFolderNameTemplate(
+        { worktreeFolderNameTemplate: undefined },
+        { worktreeFolderNameTemplate: '   ' }
+      )
+    ).toBe('')
+  })
+
+  it('tolerates a global settings object missing the field (pre-existing persisted settings)', () => {
+    // Why: settings persisted before this field existed omit it entirely;
+    // resolving the template must not throw on the absent global.
+    expect(getEffectiveWorktreeFolderNameTemplate({}, {})).toBe('')
+    expect(
+      getEffectiveWorktreeFolderNameTemplate({ worktreeFolderNameTemplate: '%workspaceName%' }, {})
+    ).toBe('%workspaceName%')
   })
 })
 

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -7,6 +7,11 @@ import { getWslHome, parseWslPath } from '../wsl'
 
 type WorktreePathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'>
 type WorktreeBasePathRepo = Pick<Repo, 'path' | 'worktreeBasePath'>
+// Why: optional here on purpose — settings persisted before this field existed
+// can omit it, and partial settings shapes (e.g. the runtime store) type it loose.
+type WorktreeFolderNameTemplateSettings = Partial<
+  Pick<GlobalSettings, 'worktreeFolderNameTemplate'>
+>
 
 export { computeBranchName, getConfiguredBranchPrefix } from './worktree-branch-name'
 export { mergeWorktree } from './worktree-metadata-merge'
@@ -153,6 +158,17 @@ export function hasRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): b
   return getRepoWorktreeBasePath(repo) !== undefined
 }
 
+export function getEffectiveWorktreeFolderNameTemplate(
+  repo: Pick<Repo, 'worktreeFolderNameTemplate'>,
+  settings: WorktreeFolderNameTemplateSettings
+): string {
+  // Why: settings persisted before this field existed (or partial settings
+  // shapes) can omit it, so guard the global before trimming.
+  return (
+    getRepoWorktreeFolderNameTemplate(repo) ?? settings.worktreeFolderNameTemplate?.trim() ?? ''
+  )
+}
+
 export function areWorktreePathsEqual(
   leftPath: string,
   rightPath: string,
@@ -234,6 +250,13 @@ function getEffectiveWorktreeBasePath(
 
 function getRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): string | undefined {
   const trimmed = repo.worktreeBasePath?.trim()
+  return trimmed || undefined
+}
+
+function getRepoWorktreeFolderNameTemplate(
+  repo: Pick<Repo, 'worktreeFolderNameTemplate'>
+): string | undefined {
+  const trimmed = repo.worktreeFolderNameTemplate?.trim()
   return trimmed || undefined
 }
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -10,7 +10,7 @@
 import type { BrowserWindow } from 'electron'
 import { posix, win32 } from 'path'
 import { existsSync } from 'fs'
-import { randomUUID } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
 import type { Store } from '../persistence'
 import type {
   AutomationWorkspaceProvenance,
@@ -72,11 +72,16 @@ import {
   ensurePathWithinWorkspace,
   getWorktreeCreationLayout,
   getWorktreePathSettings,
+  getEffectiveWorktreeFolderNameTemplate,
   hasRepoWorktreeBasePath,
   shouldSetDisplayName,
   mergeWorktree,
   areWorktreePathsEqual
 } from './worktree-logic'
+import {
+  buildWorktreeFolderNameTokens,
+  expandWorktreeFolderName
+} from './worktree-folder-name-template'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import {
@@ -1427,8 +1432,24 @@ export async function createRemoteWorktree(
     settings,
     username
   )
+  const folderNameTemplate = getEffectiveWorktreeFolderNameTemplate(repo, settings)
+  const folderShortId = randomBytes(4).toString('hex')
+  const folderNow = Date.now()
+  const folderLeafBase =
+    expandWorktreeFolderName(
+      folderNameTemplate,
+      buildWorktreeFolderNameTokens({
+        repoPath: repo.path,
+        sanitizedName,
+        branchName,
+        settings,
+        username,
+        now: folderNow,
+        shortId: folderShortId
+      })
+    ) ?? sanitizedName
 
-  let remotePath = computeRemoteWorktreePath(sanitizedName, repo.path, worktreePathSettings, {
+  let remotePath = computeRemoteWorktreePath(folderLeafBase, repo.path, worktreePathSettings, {
     useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
   })
 
@@ -1468,20 +1489,16 @@ export async function createRemoteWorktree(
   let remotePathResolved = !args.branchNameOverride
   for (let suffix = 1; args.branchNameOverride && suffix < 100; suffix += 1) {
     effectiveSanitizedName = suffix === 1 ? sanitizedName : `${sanitizedName}-${suffix}`
+    const effectiveFolderLeaf = suffix === 1 ? folderLeafBase : `${folderLeafBase}-${suffix}`
     effectiveRequestedName =
       suffix === 1
         ? args.name
         : args.name.trim()
           ? `${args.name}-${suffix}`
           : effectiveSanitizedName
-    remotePath = computeRemoteWorktreePath(
-      effectiveSanitizedName,
-      repo.path,
-      worktreePathSettings,
-      {
-        useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
-      }
-    )
+    remotePath = computeRemoteWorktreePath(effectiveFolderLeaf, repo.path, worktreePathSettings, {
+      useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
+    })
     if (!(await remotePathExists(fsProvider, remotePath))) {
       remotePathResolved = true
       break
@@ -1658,9 +1675,7 @@ export async function createRemoteWorktree(
   const gitWorktrees = await timing.time('list_created_worktree', async () =>
     provider.listWorktrees(repo.path)
   )
-  const created = gitWorktrees.find(
-    (gw) => gw.branch?.endsWith(branchName) || gw.path.endsWith(effectiveSanitizedName)
-  )
+  const created = gitWorktrees.find((gw) => areWorktreePathsEqual(gw.path, remotePath))
   if (!created) {
     throw new Error('Worktree created but not found in listing')
   }
@@ -1945,6 +1960,10 @@ export async function createLocalWorktree(
   let effectiveSanitizedName = sanitizedName
   let branchName = ''
   let worktreePath = ''
+  const folderNameTemplate = getEffectiveWorktreeFolderNameTemplate(repo, settings)
+  const folderShortId = randomBytes(4).toString('hex')
+  const folderNow = Date.now()
+  let folderLeafBase = ''
 
   // Why: silently resolve branch/path/PR name collisions by appending -2/-3/etc.
   // instead of failing and forcing the user back to the name picker. This is
@@ -1980,6 +1999,21 @@ export async function createLocalWorktree(
       username,
       localWorktreeGitOptions
     )
+    if (suffix === 1) {
+      folderLeafBase =
+        expandWorktreeFolderName(
+          folderNameTemplate,
+          buildWorktreeFolderNameTokens({
+            repoPath: repo.path,
+            sanitizedName,
+            branchName,
+            settings,
+            username,
+            now: folderNow,
+            shortId: folderShortId
+          })
+        ) ?? sanitizedName
+    }
     checkoutExistingBranch = await canCheckoutExistingLocalBranch(
       repo.path,
       branchName,
@@ -2070,8 +2104,9 @@ export async function createLocalWorktree(
       }
     }
 
+    const effectiveFolderLeaf = suffix === 1 ? folderLeafBase : `${folderLeafBase}-${suffix}`
     worktreePath = ensurePathWithinWorkspace(
-      computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
+      computeWorktreePath(effectiveFolderLeaf, repo.path, worktreePathSettings),
       workspaceRoot
     )
     if (existsSync(worktreePath)) {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -789,6 +789,66 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('expands a configured folder-name template into the on-disk worktree leaf', async () => {
+    // Why: the template must drive the folder leaf passed to path computation
+    // (and therefore `git worktree add`) while leaving the branch name alone.
+    store.getSettings.mockReturnValue({
+      branchPrefix: 'none',
+      nestWorkspaces: false,
+      refreshLocalBaseRefOnWorktreeCreate: false,
+      workspaceDir: '/workspace',
+      worktreeFolderNameTemplate: '%projectName%_%workspaceName%'
+    })
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo_feature',
+        head: 'abc123',
+        branch: 'feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'feature'
+    })) as CreateWorktreeResult
+
+    expect(computeWorktreePathMock).toHaveBeenCalledWith('repo_feature', '/workspace/repo', {
+      nestWorkspaces: false,
+      workspaceDir: '/workspace'
+    })
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/repo_feature',
+      'feature',
+      'origin/main',
+      false
+    )
+    expect(result).toMatchObject({
+      worktree: expect.objectContaining({ path: '/workspace/repo_feature', branch: 'feature' })
+    })
+  })
+
+  it('keeps the legacy sanitized leaf when no folder-name template is set', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/feature',
+        head: 'abc123',
+        branch: 'feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await handlers['worktrees:create'](null, { repoId: 'repo-1', name: 'feature' })
+
+    expect(computeWorktreePathMock).toHaveBeenCalledWith('feature', '/workspace/repo', {
+      nestWorkspaces: false,
+      workspaceDir: '/workspace'
+    })
+  })
+
   it('registers local worktree roots immediately after create', async () => {
     listWorktreesMock.mockResolvedValue([
       {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1254,6 +1254,7 @@ function sanitizeRepoUpdatesForPersistence<
       | 'upstream'
       | 'gitRemoteIdentity'
       | 'worktreeBasePath'
+      | 'worktreeFolderNameTemplate'
       | 'projectHostSetupMethod'
       | 'forkSyncMode'
     >
@@ -1298,6 +1299,17 @@ function sanitizeRepoUpdatesForPersistence<
       sanitized.worktreeBasePath = sanitized.worktreeBasePath.trim() || undefined
     } else {
       delete sanitized.worktreeBasePath
+    }
+  }
+  if (
+    'worktreeFolderNameTemplate' in sanitized &&
+    sanitized.worktreeFolderNameTemplate !== undefined
+  ) {
+    if (typeof sanitized.worktreeFolderNameTemplate === 'string') {
+      sanitized.worktreeFolderNameTemplate =
+        sanitized.worktreeFolderNameTemplate.trim() || undefined
+    } else {
+      delete sanitized.worktreeFolderNameTemplate
     }
   }
   if ('projectHostSetupMethod' in sanitized) {
@@ -3892,6 +3904,7 @@ export class Store {
         | 'hookSettings'
         | 'worktreeBaseRef'
         | 'worktreeBasePath'
+        | 'worktreeFolderNameTemplate'
         | 'kind'
         | 'symlinkPaths'
         | 'issueSourcePreference'
@@ -3948,6 +3961,13 @@ export class Store {
     if ('worktreeBasePath' in sanitizedUpdates && sanitizedUpdates.worktreeBasePath === undefined) {
       delete repo.worktreeBasePath
       delete sanitizedUpdates.worktreeBasePath
+    }
+    if (
+      'worktreeFolderNameTemplate' in sanitizedUpdates &&
+      sanitizedUpdates.worktreeFolderNameTemplate === undefined
+    ) {
+      delete repo.worktreeFolderNameTemplate
+      delete sanitizedUpdates.worktreeFolderNameTemplate
     }
     if (
       'externalWorktreeVisibility' in sanitizedUpdates &&

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -39,7 +39,7 @@ import {
   getClonePathComparisonKey
 } from '../git/repo-clone-path'
 import { getGitCloneFailureMessage } from '../../shared/git-clone-failure-message'
-import { createHash, randomUUID } from 'crypto'
+import { createHash, randomBytes, randomUUID } from 'crypto'
 import { homedir } from 'os'
 import { isAbsolute, join, resolve } from 'path'
 import { mkdir, readFile, readdir, rm, stat } from 'fs/promises'
@@ -624,6 +624,7 @@ import {
   computeWorkspaceRoot,
   ensurePathWithinWorkspace,
   formatWorktreeRemovalError,
+  getEffectiveWorktreeFolderNameTemplate,
   getWorktreeCreationLayout,
   getWorktreePathSettings,
   isOrphanCompatiblePreflightError,
@@ -633,6 +634,10 @@ import {
   shouldSetDisplayName,
   areWorktreePathsEqual
 } from '../ipc/worktree-logic'
+import {
+  buildWorktreeFolderNameTokens,
+  expandWorktreeFolderName
+} from '../ipc/worktree-folder-name-template'
 import {
   assertWorktreeDoesNotContainRegisteredWorktree,
   canCleanupUnregisteredOrcaLeftoverDirectory,
@@ -760,6 +765,7 @@ type RuntimeStore = {
   getSettings(): {
     workspaceDir: string
     nestWorkspaces: boolean
+    worktreeFolderNameTemplate?: string
     refreshLocalBaseRefOnWorktreeCreate: boolean
     localBaseRefSuggestionDismissed?: boolean
     branchPrefix: string
@@ -10032,6 +10038,7 @@ export class OrcaRuntimeService {
         | 'hookSettings'
         | 'worktreeBaseRef'
         | 'worktreeBasePath'
+        | 'worktreeFolderNameTemplate'
         | 'kind'
         | 'symlinkPaths'
         | 'issueSourcePreference'
@@ -10054,6 +10061,12 @@ export class OrcaRuntimeService {
     const sanitizedUpdates = omitUndefinedProperties(updates)
     if ('worktreeBasePath' in updates && updates.worktreeBasePath === undefined) {
       sanitizedUpdates.worktreeBasePath = undefined
+    }
+    if (
+      'worktreeFolderNameTemplate' in updates &&
+      updates.worktreeFolderNameTemplate === undefined
+    ) {
+      sanitizedUpdates.worktreeFolderNameTemplate = undefined
     }
     if (
       'externalWorktreeDiscoverySuppressedAt' in updates &&
@@ -12633,6 +12646,22 @@ export class OrcaRuntimeService {
       username,
       localWorktreeGitOptions
     )
+    const folderNameTemplate = getEffectiveWorktreeFolderNameTemplate(repo, settings)
+    const folderShortId = randomBytes(4).toString('hex')
+    const folderNow = Date.now()
+    const folderLeafBase =
+      expandWorktreeFolderName(
+        folderNameTemplate,
+        buildWorktreeFolderNameTokens({
+          repoPath: repo.path,
+          sanitizedName,
+          branchName,
+          settings,
+          username,
+          now: folderNow,
+          shortId: folderShortId
+        })
+      ) ?? sanitizedName
 
     const baseBranch =
       args.baseBranch ||
@@ -12727,6 +12756,7 @@ export class OrcaRuntimeService {
     let worktreePathResolved = !args.branchNameOverride
     for (let suffix = 1; suffix < 100; suffix += 1) {
       effectiveSanitizedName = suffix === 1 ? sanitizedName : `${sanitizedName}-${suffix}`
+      const effectiveFolderLeaf = suffix === 1 ? folderLeafBase : `${folderLeafBase}-${suffix}`
       effectiveRequestedName =
         suffix === 1
           ? args.name
@@ -12734,7 +12764,7 @@ export class OrcaRuntimeService {
             ? `${args.name}-${suffix}`
             : effectiveSanitizedName
       worktreePath = ensurePathWithinWorkspace(
-        computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
+        computeWorktreePath(effectiveFolderLeaf, repo.path, worktreePathSettings),
         workspaceRoot
       )
       if (!args.branchNameOverride || !(await pathExists(worktreePath))) {

--- a/src/main/runtime/rpc/methods/repo-update-schema.ts
+++ b/src/main/runtime/rpc/methods/repo-update-schema.ts
@@ -46,6 +46,7 @@ export function createRepoUpdateSchema<T extends z.ZodRawShape>(
       hookSettings: z.unknown().optional(),
       worktreeBaseRef: OptionalString,
       worktreeBasePath: OptionalString,
+      worktreeFolderNameTemplate: OptionalString,
       kind: z.enum(['git', 'folder']).optional(),
       symlinkPaths: z.array(z.string()).optional(),
       issueSourcePreference: z.enum(['auto', 'upstream', 'origin']).optional(),

--- a/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.test.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/types'
+import { GeneralWorkspaceSettingsSection } from './GeneralWorkspaceSettingsSection'
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { settingsSearchQuery: string }) => unknown) =>
+    selector({ settingsSearchQuery: '' })
+}))
+
+// Why: these siblings pull in window.api / host-scope hooks that aren't relevant
+// to the folder-name-template control under test; stub them to keep the render
+// focused and deterministic.
+vi.mock('./WorkspaceDirectorySetting', () => ({
+  WorkspaceDirectorySetting: () => null
+}))
+vi.mock('./OpenInMenuSetting', () => ({
+  OpenInMenuSetting: () => null
+}))
+
+const SETTINGS = {
+  worktreeFolderNameTemplate: '',
+  nestWorkspaces: true,
+  skipDeleteWorktreeConfirm: false,
+  skipDeleteAutomationConfirm: false,
+  openInApplications: []
+} as unknown as GlobalSettings
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function render(
+  settings: GlobalSettings,
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+): void {
+  act(() => {
+    root.render(React.createElement(GeneralWorkspaceSettingsSection, { settings, updateSettings }))
+  })
+}
+
+function getTemplateInput(): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>(
+    'input[placeholder="%projectName%_%workspaceName%"]'
+  )
+  if (!input) {
+    throw new Error('folder name template input not found')
+  }
+  return input
+}
+
+function setNativeValue(input: HTMLInputElement, text: string): void {
+  const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  setValue?.call(input, text)
+}
+
+describe('GeneralWorkspaceSettingsSection — folder name template', () => {
+  it('renders a visible label, description, and token hint for the template control', () => {
+    render(SETTINGS, vi.fn())
+
+    // Why: SearchableSetting only uses title/description for search matching, so
+    // the visible label/description must be rendered explicitly (regression: the
+    // control previously rendered as an unlabeled bare input).
+    const text = container.textContent ?? ''
+    expect(text).toContain('Workspace Folder Name Template')
+    expect(text).toContain('Sets the on-disk workspace folder name with tokens')
+    expect(text).toContain('%projectName%')
+    expect(text).toContain('%shortId%')
+  })
+
+  it('associates the visible label with the input via htmlFor/id', () => {
+    render(SETTINGS, vi.fn())
+
+    const input = getTemplateInput()
+    const label = container.querySelector<HTMLLabelElement>(`label[for="${input.id}"]`)
+    expect(input.id).toBeTruthy()
+    expect(label?.textContent).toContain('Workspace Folder Name Template')
+  })
+
+  it('updates the setting as the user edits the template', () => {
+    const updateSettings = vi.fn()
+    render(SETTINGS, updateSettings)
+
+    const input = getTemplateInput()
+    act(() => {
+      setNativeValue(input, '%projectName%_%workspaceName%')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      worktreeFolderNameTemplate: '%projectName%_%workspaceName%'
+    })
+  })
+})

--- a/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
@@ -1,5 +1,8 @@
+import { useId } from 'react'
 import type React from 'react'
 import type { GlobalSettings } from '../../../../shared/types'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
 import { OpenInMenuSetting } from './OpenInMenuSetting'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
@@ -15,6 +18,7 @@ export function GeneralWorkspaceSettingsSection({
   settings,
   updateSettings
 }: GeneralWorkspaceSettingsSectionProps): React.JSX.Element {
+  const folderNameTemplateInputId = useId()
   return (
     <section key="workspace" className="space-y-4">
       <SettingsSubsectionHeader
@@ -29,6 +33,48 @@ export function GeneralWorkspaceSettingsSection({
       />
 
       <WorkspaceDirectorySetting settings={settings} updateSettings={updateSettings} />
+
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.GeneralWorkspaceSettingsSection.worktreeFolderNameTemplateTitle',
+          'Workspace Folder Name Template'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralWorkspaceSettingsSection.worktreeFolderNameTemplateDescription',
+          'Sets the on-disk workspace folder name with tokens. Leave empty for the default name; nesting layout is unchanged.'
+        )}
+        keywords={['folder', 'name', 'template', 'pattern', 'token', 'workspace', 'directory']}
+        className="space-y-2"
+      >
+        <Label htmlFor={folderNameTemplateInputId}>
+          {translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.worktreeFolderNameTemplateTitle',
+            'Workspace Folder Name Template'
+          )}
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.worktreeFolderNameTemplateDescription',
+            'Sets the on-disk workspace folder name with tokens. Leave empty for the default name; nesting layout is unchanged.'
+          )}
+        </p>
+        <Input
+          id={folderNameTemplateInputId}
+          value={settings.worktreeFolderNameTemplate}
+          onChange={(e) => updateSettings({ worktreeFolderNameTemplate: e.target.value })}
+          placeholder={translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.worktreeFolderNameTemplatePlaceholder',
+            '%projectName%_%workspaceName%'
+          )}
+          className="h-9 text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.worktreeFolderNameTemplateTokens',
+            'Tokens: %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, %shortId%.'
+          )}
+        </p>
+      </SearchableSetting>
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
@@ -6,11 +6,14 @@ import { RepoSettingsDraftInput } from './RepositorySettingsDraftInput'
 import { SearchableSetting } from './SearchableSetting'
 import { translate } from '@/i18n/i18n'
 
-type RepositoryWorktreeDefaultsUpdate = Pick<Repo, 'worktreeBasePath' | 'worktreeBaseRef'>
+type RepositoryWorktreeDefaultsUpdate = Pick<
+  Repo,
+  'worktreeBasePath' | 'worktreeBaseRef' | 'worktreeFolderNameTemplate'
+>
 
 type RepositoryWorktreeDefaultsSectionProps = {
   repo: Repo
-  settings: Pick<GlobalSettings, 'workspaceDir'> | null
+  settings: Pick<GlobalSettings, 'workspaceDir' | 'worktreeFolderNameTemplate'> | null
   updateRepo: (repoId: string, updates: Partial<RepositoryWorktreeDefaultsUpdate>) => void
   forceVisible: boolean
 }
@@ -21,6 +24,7 @@ export function RepositoryWorktreeDefaultsSection({
   updateRepo,
   forceVisible
 }: RepositoryWorktreeDefaultsSectionProps): React.JSX.Element {
+  const globalFolderNameTemplate = settings?.worktreeFolderNameTemplate?.trim() || ''
   return (
     <>
       <SearchableSetting
@@ -99,6 +103,79 @@ export function RepositoryWorktreeDefaultsSection({
           {translate(
             'auto.components.settings.RepositoryPane.15a99d9b9f',
             'Relative paths resolve from this project root.'
+          )}
+        </p>
+      </SearchableSetting>
+
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.RepositoryPane.worktreeFolderNameTemplateTitle',
+          'Workspace Folder Name Template'
+        )}
+        description={translate(
+          'auto.components.settings.RepositoryPane.worktreeFolderNameTemplateDescription',
+          'Project-specific on-disk folder name pattern for new workspaces.'
+        )}
+        keywords={[
+          repo.displayName,
+          'worktree folder',
+          'workspace folder',
+          'folder name',
+          'template',
+          'token'
+        ]}
+        className="space-y-2"
+        forceVisible={forceVisible}
+      >
+        <div className="flex items-center justify-between gap-3">
+          <Label className="text-sm font-semibold">
+            {translate(
+              'auto.components.settings.RepositoryPane.worktreeFolderNameTemplateTitle',
+              'Workspace Folder Name Template'
+            )}
+          </Label>
+          {repo.worktreeFolderNameTemplate ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => updateRepo(repo.id, { worktreeFolderNameTemplate: undefined })}
+            >
+              {translate('auto.components.settings.RepositoryPane.8ccacbeb5a', 'Use Global')}
+            </Button>
+          ) : null}
+        </div>
+        <RepoSettingsDraftInput
+          repoId={repo.id}
+          storeValue={repo.worktreeFolderNameTemplate ?? ''}
+          placeholder={
+            globalFolderNameTemplate ||
+            translate(
+              'auto.components.settings.RepositoryPane.worktreeFolderNameTemplateDefaultPlaceholder',
+              'Use global default'
+            )
+          }
+          onTextChange={() => {}}
+          onBlur={(e) => {
+            const worktreeFolderNameTemplate = e.currentTarget.value.trim() || undefined
+            if (
+              worktreeFolderNameTemplate === (repo.worktreeFolderNameTemplate?.trim() || undefined)
+            ) {
+              return
+            }
+            updateRepo(repo.id, { worktreeFolderNameTemplate })
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+              e.currentTarget.blur()
+            }
+          }}
+          className="h-9 text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.RepositoryPane.worktreeFolderNameTemplateTokens',
+            'Tokens include %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, and %shortId%.'
           )}
         </p>
       </SearchableSetting>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5142,7 +5142,11 @@
           "5567191a6e": "Browse",
           "0e9fc0eadc": "Workspace Directory",
           "e2955d9ccb": "Configure where new workspaces are created.",
-          "7511097c5d": "Workspace"
+          "7511097c5d": "Workspace",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Sets the on-disk workspace folder name with tokens. Leave empty for the default name; nesting layout is unchanged.",
+          "worktreeFolderNameTemplatePlaceholder": "%projectName%_%workspaceName%",
+          "worktreeFolderNameTemplateTokens": "Tokens: %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, %shortId%."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "Apply Changes",
@@ -5836,7 +5840,11 @@
           "addPlannedHostToHost": "Add {{host}}",
           "addPlannedHostConfirm": "This only records that the project should be available on this host. You can add the folder or clone later.",
           "projectRuntime": "Project Runtime",
-          "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL."
+          "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Project-specific on-disk folder name pattern for new workspaces.",
+          "worktreeFolderNameTemplateDefaultPlaceholder": "Use global default",
+          "worktreeFolderNameTemplateTokens": "Tokens include %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, and %shortId%."
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "Command template",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5142,7 +5142,11 @@
           "5567191a6e": "Navegar",
           "0e9fc0eadc": "Directorio de espacio de trabajo",
           "e2955d9ccb": "Configure dónde se crean nuevos espacios de trabajo.",
-          "7511097c5d": "Espacio de trabajo"
+          "7511097c5d": "Espacio de trabajo",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Sets the on-disk workspace folder name with tokens. Leave empty for the default name; nesting layout is unchanged.",
+          "worktreeFolderNameTemplatePlaceholder": "%projectName%_%workspaceName%",
+          "worktreeFolderNameTemplateTokens": "Tokens: %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, %shortId%."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "Aplicar cambios",
@@ -5799,7 +5803,11 @@
           "addPlannedHostToHost": "Add {{host}}",
           "addPlannedHostConfirm": "This only records that the project should be available on this host. You can add the folder or clone later.",
           "projectRuntime": "Project Runtime",
-          "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL."
+          "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Project-specific on-disk folder name pattern for new workspaces.",
+          "worktreeFolderNameTemplateDefaultPlaceholder": "Use global default",
+          "worktreeFolderNameTemplateTokens": "Tokens include %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, and %shortId%."
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "Plantilla de comando",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5127,7 +5127,11 @@
           "5567191a6e": "ブラウズ",
           "0e9fc0eadc": "ワークスペースディレクトリ",
           "e2955d9ccb": "新規ワークスペースを作成する場所を構成します。",
-          "7511097c5d": "ワークスペース"
+          "7511097c5d": "ワークスペース",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Sets the on-disk workspace folder name with tokens. Leave empty for the default name; nesting layout is unchanged.",
+          "worktreeFolderNameTemplatePlaceholder": "%projectName%_%workspaceName%",
+          "worktreeFolderNameTemplateTokens": "Tokens: %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, %shortId%."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "変更を適用する",
@@ -5821,7 +5825,11 @@
           "addPlannedHostToHost": "Add {{host}}",
           "addPlannedHostConfirm": "This only records that the project should be available on this host. You can add the folder or clone later.",
           "projectRuntime": "Project Runtime",
-          "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL."
+          "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Project-specific on-disk folder name pattern for new workspaces.",
+          "worktreeFolderNameTemplateDefaultPlaceholder": "Use global default",
+          "worktreeFolderNameTemplateTokens": "Tokens include %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, and %shortId%."
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "コマンドテンプレート",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5127,7 +5127,11 @@
           "5567191a6e": "찾아보기",
           "0e9fc0eadc": "워크스페이스 디렉토리",
           "e2955d9ccb": "새 워크스페이스가 생성되는 위치를 구성합니다.",
-          "7511097c5d": "워크스페이스"
+          "7511097c5d": "워크스페이스",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Sets the on-disk workspace folder name with tokens. Leave empty for the default name; nesting layout is unchanged.",
+          "worktreeFolderNameTemplatePlaceholder": "%projectName%_%workspaceName%",
+          "worktreeFolderNameTemplateTokens": "Tokens: %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, %shortId%."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "변경 사항 적용",
@@ -5784,7 +5788,11 @@
           "addPlannedHostToHost": "{{host}} 추가",
           "addPlannedHostConfirm": "이 프로젝트를 이 호스트에서 사용할 예정이라는 사실만 기록합니다. 폴더 추가나 클론은 나중에 할 수 있습니다.",
           "projectRuntime": "프로젝트 런타임",
-          "projectRuntimeDescription": "이 프로젝트를 Windows에서 실행할지 WSL에서 실행할지 선택합니다."
+          "projectRuntimeDescription": "이 프로젝트를 Windows에서 실행할지 WSL에서 실행할지 선택합니다.",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Project-specific on-disk folder name pattern for new workspaces.",
+          "worktreeFolderNameTemplateDefaultPlaceholder": "Use global default",
+          "worktreeFolderNameTemplateTokens": "Tokens include %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, and %shortId%."
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "명령 템플릿",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5127,7 +5127,11 @@
           "5567191a6e": "浏览",
           "0e9fc0eadc": "工作区目录",
           "e2955d9ccb": "配置创建新工作区的位置。",
-          "7511097c5d": "工作区"
+          "7511097c5d": "工作区",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Sets the on-disk workspace folder name with tokens. Leave empty for the default name; nesting layout is unchanged.",
+          "worktreeFolderNameTemplatePlaceholder": "%projectName%_%workspaceName%",
+          "worktreeFolderNameTemplateTokens": "Tokens: %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, %shortId%."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "应用更改",
@@ -5784,7 +5788,11 @@
           "addPlannedHostToHost": "添加 {{host}}",
           "addPlannedHostConfirm": "这仅记录项目应在此主机上可用。你可以稍后添加文件夹或克隆。",
           "projectRuntime": "项目运行时",
-          "projectRuntimeDescription": "选择此项目运行在 Windows 还是 WSL。"
+          "projectRuntimeDescription": "选择此项目运行在 Windows 还是 WSL。",
+          "worktreeFolderNameTemplateTitle": "Workspace Folder Name Template",
+          "worktreeFolderNameTemplateDescription": "Project-specific on-disk folder name pattern for new workspaces.",
+          "worktreeFolderNameTemplateDefaultPlaceholder": "Use global default",
+          "worktreeFolderNameTemplateTokens": "Tokens include %projectName%, %workspaceName%, %gitBranchName%, %gitBranchSlug%, %branchPrefix%, %gitUsername%, %date%, and %shortId%."
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "命令模板",

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -90,6 +90,7 @@ export type RepoUpdate = Partial<
     | 'hookSettings'
     | 'worktreeBaseRef'
     | 'worktreeBasePath'
+    | 'worktreeFolderNameTemplate'
     | 'kind'
     | 'symlinkPaths'
     | 'issueSourcePreference'
@@ -174,6 +175,12 @@ function sanitizeRepoUpdate(updates: RepoUpdate): RepoUpdate {
   }
   if ('worktreeBasePath' in sanitized && sanitized.worktreeBasePath !== undefined) {
     sanitized.worktreeBasePath = sanitized.worktreeBasePath.trim() || undefined
+  }
+  if (
+    'worktreeFolderNameTemplate' in sanitized &&
+    sanitized.worktreeFolderNameTemplate !== undefined
+  ) {
+    sanitized.worktreeFolderNameTemplate = sanitized.worktreeFolderNameTemplate.trim() || undefined
   }
   if (
     'forkSyncMode' in sanitized &&

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -184,6 +184,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
   return {
     workspaceDir: getDefaultWorkspaceDir(homedir),
     nestWorkspaces: true,
+    worktreeFolderNameTemplate: '',
     workspaceDirHistory: [],
     refreshLocalBaseRefOnWorktreeCreate: false,
     localBaseRefSuggestionDismissed: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -244,6 +244,8 @@ export type Repo = {
   worktreeBaseRef?: string
   /** Optional repo-scoped workspace root override. Relative paths resolve from `path`. */
   worktreeBasePath?: string
+  /** Optional repo-scoped workspace folder-name template override. */
+  worktreeFolderNameTemplate?: string
   hookSettings?: RepoHookSettings
   /** SSH target ID for remote repos. null/undefined = local. */
   connectionId?: string | null
@@ -2410,6 +2412,7 @@ export type GlobalSettings = {
    *  host-varying setting is `host override ?? client default`. */
   hostSettingOverrides?: Partial<Record<ExecutionHostId, HostSettingOverrides>>
   nestWorkspaces: boolean
+  worktreeFolderNameTemplate: string
   workspaceDirHistory?: OrcaWorkspaceLayout[]
   refreshLocalBaseRefOnWorktreeCreate: boolean
   /** Set once the user dismisses the "local main is behind" suggestion toast, so


### PR DESCRIPTION
## What changes

Adds a configurable **workspace folder-name template** so new worktree/workspace folders can be self-describing. A new global setting **Workspace Folder Name Template** (Settings → General → Workspace) plus an optional per-repo override accept `%token%` placeholders. For example, `%projectName%_%workspaceName%` creates the folder `myproject_feature` instead of a bare `feature`.

Supported tokens: `%projectName%` / `%repoName%`, `%workspaceName%`, `%gitBranchName%`, `%gitBranchSlug%`, `%branchPrefix%`, `%gitUsername%`, `%date%` (YYYY-MM-DD), `%shortId%`.

## What does NOT change

- **Default is empty → folder naming is byte-for-byte identical to today.** This is opt-in.
- The **Nest Workspaces** layout is orthogonal and unchanged — the template only sets the final folder *leaf*, never adds new directory levels. The expanded value is sanitized to a single safe path segment (`/`, `..`, and other unsafe chars collapse via the existing `sanitizeWorktreeName`), and `ensurePathWithinWorkspace` remains a backstop.
- The **sidebar label** still shows the workspace name / branch, not the on-disk folder name (the folder basename is only the last-resort label fallback).
- The collision-suffix loop (`-2`, `-3`, …) still applies, now to the templated leaf.

## Design approach

The template is resolved once per creation into a base leaf (`expandWorktreeFolderName(template, tokens) ?? sanitizedName`) and passed where the sanitized name used to go in `computeWorktreePath` / `computeRemoteWorktreePath`. `computeWorktreePath` signatures are unchanged. Applied at all three creation paths — local, SSH/remote, and the runtime/CLI service — with per-site wiring for where the branch name becomes available (pre-loop for SSH/runtime, first-pass-inside-loop for local). The SSH post-create worktree lookup was switched to path-equality (`areWorktreePathsEqual`) to match the templated on-disk path, aligning it with the local and runtime sites. First-work folder auto-rename is skipped when a template is configured, so it doesn't fight the user-authored folder name.

**Design review:** ran an automated design-review loop to convergence (3 rounds, clean exit). It caught the SSH dual-site application (the no-override happy path computes the path before the collision loop), the branch-token override semantics, and the SSH post-create lookup staleness — all folded into the implementation before coding.

**Implementation & completeness:** implemented per the reviewed design; a read-only completeness pass confirmed all requirements, edge cases, and the three creation-site integrations are in production code (not just scaffolding).

**Headline behavior: fully implemented.** Verified end-to-end in Electron — setting `%projectName%_%workspaceName%` and creating workspace `feature` produced the on-disk worktree `<repo>/<repo>_feature` (confirmed via `git worktree list`); clearing the template produced the legacy plain `feature` folder.

**Perf:** audited — all new work is on the one-time create path (pure string ops, no new git/subprocess/network I/O); template resolution and `randomBytes(4)`/`Date.now()` are hoisted once outside the collision loop; the `%(\w+)%` regex is linear over bounded input; the Settings inputs add no per-render/per-keystroke cost. No actionable findings.

**Code review:** two independent review passes in one round, both returned clean of P0/P1/P2. Accepted non-actionable notes: the SSH path-equality lookup shares a pre-existing symlink-realpath limitation already present at the local/runtime sites (not a new regression); no length clamp on the expanded leaf (consistent with regular workspace names, which aren't clamped either); a cosmetic folder/branch one-off suffix difference for override branches on collision (by design, consistent across sites).

**Merge-confidence (brennan test):** Electron validation initially found the global setting rendered without a visible label (`SearchableSetting` uses title/description only for search). Fixed by rendering an explicit `<Label>` + description wired with `htmlFor`/`id`, mirroring the neighboring Workspace Directory control; re-verified in Electron (screenshot attached to the PR conversation) and added a renderer regression test.

## Validation

- New unit tests: `worktree-folder-name-template.test.ts` (token expansion, alias, unknown-token stripping, slash collapse, empty/empty-expansion → fallback, traversal-safe, override-branch verbatim), `getEffectiveWorktreeFolderNameTemplate` precedence + missing-field tolerance, `planWorktreeFolderRename` template short-circuit, and creation-loop integration tests (templated leaf reaches `computeWorktreePath` / `git worktree add`; legacy leaf when unset).
- New renderer test: `GeneralWorkspaceSettingsSection.test.tsx` (visible label/description/token hint, label↔input association, edit updates the setting).
- Full affected suite green (779 tests across worktree logic, creation, runtime, and settings UI).
- `pnpm run typecheck` clean; `pnpm run lint` clean (incl. localization catalog + 5-locale parity).

## Cross-platform / SSH

- All path building stays on the runtime path helpers (posix/win32); the leaf is a single segment so separator semantics don't diverge.
- SSH uses the same expander; the post-create lookup matches the resolved remote path.
- WSL mirroring is leaf-independent and unaffected.

Closes #5082

Made with [Orca](https://github.com/stablyai/orca) 🐋
