### PR TITLE
Mark files as viewed during review

### DIFF
--- a/src/main/ipc/worktree-metadata-merge.ts
+++ b/src/main/ipc/worktree-metadata-merge.ts
@@ -67,6 +67,7 @@ export function mergeWorktree(
     // Why: diff comments are persisted on WorktreeMeta and forwarded verbatim
     // so the renderer store mirrors on-disk state.
     diffComments: meta?.diffComments,
-    mobileDiffReview: meta?.mobileDiffReview
+    mobileDiffReview: meta?.mobileDiffReview,
+    combinedDiffReview: meta?.combinedDiffReview
   }
 }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -774,7 +774,8 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
     ...(meta.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
     workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
     diffComments: meta.diffComments,
-    mobileDiffReview: meta.mobileDiffReview
+    mobileDiffReview: meta.mobileDiffReview,
+    combinedDiffReview: meta.combinedDiffReview
   }
 }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1365,7 +1365,8 @@ function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: Workt
     ...(meta.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
     workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
     diffComments: meta.diffComments,
-    mobileDiffReview: meta.mobileDiffReview
+    mobileDiffReview: meta.mobileDiffReview,
+    combinedDiffReview: meta.combinedDiffReview
   }
 }
 

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -211,6 +211,7 @@ export const WorktreeSet = WorktreeSelector.extend({
     .optional(),
   diffComments: z.array(z.unknown()).optional(),
   mobileDiffReview: z.unknown().optional(),
+  combinedDiffReview: z.unknown().optional(),
   parentWorktree: OptionalString,
   noParent: OptionalBoolean
 }).superRefine((params, ctx) => {

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -180,6 +180,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         pushTarget: params.pushTarget,
         diffComments: params.diffComments,
         mobileDiffReview: params.mobileDiffReview,
+        combinedDiffReview: params.combinedDiffReview,
         lineage:
           params.parentWorktree || params.noParent === true
             ? {

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -2594,6 +2594,20 @@ function PRFilesCombinedDiffViewer({
     [fileByPath, onViewedChange, pendingViewedPaths]
   )
 
+  // Why: the file-tree row toggle drives the same GitHub-native viewed state
+  // as the in-diff checkbox so both stay in sync. The section key is
+  // `combined-commit:<path>`; recover the path to reuse the same mutation.
+  const handleTreeToggleViewed = useCallback(
+    (sectionKey: string) => {
+      const file = fileByPath.get(sectionKey.replace(/^combined-commit:/, ''))
+      if (!file || pendingViewedPaths.has(file.path)) {
+        return
+      }
+      void onViewedChange(file.path, !isPRFileViewed(file))
+    },
+    [fileByPath, onViewedChange, pendingViewedPaths]
+  )
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-background/50 px-3 py-1.5">
@@ -2653,9 +2667,12 @@ function PRFilesCombinedDiffViewer({
           sectionIndexByKey={sectionIndexByKey}
           activeSectionKey={activeTreeSectionKey}
           viewedSectionKeys={viewedSectionKeys}
+          viewedCount={files.filter(isPRFileViewed).length}
+          totalCount={files.length}
           collapsed={fileTreeCollapsed}
           onCollapsedChange={setFileTreeCollapsed}
           onNavigate={handleTreeNavigate}
+          onToggleViewed={handleTreeToggleViewed}
         />
         <div ref={scrollContainerRef} className="min-w-0 flex-1 overflow-auto scrollbar-editor">
           <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -2760,6 +2760,21 @@ function PRFilesCombinedDiffViewer({
     [fileByPath, onViewedChange, pendingViewedPaths]
   )
 
+  // Why: the file-tree row toggle shares one viewed-state source with the
+  // in-diff checkbox — GitHub's native PR "viewed" state — so both controls
+  // stay in sync. The section key is `combined-commit:<path>`; recover the
+  // path to drive the same mutation the in-diff checkbox uses.
+  const handleTreeToggleViewed = useCallback(
+    (sectionKey: string) => {
+      const file = fileByPath.get(sectionKey.replace(/^combined-commit:/, ''))
+      if (!file || pendingViewedPaths.has(file.path)) {
+        return
+      }
+      void onViewedChange(file.path, !isPRFileViewed(file))
+    },
+    [fileByPath, onViewedChange, pendingViewedPaths]
+  )
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <div className="sticky top-0 z-20 flex shrink-0 items-center justify-between gap-3 border-b border-border bg-background px-3 py-1.5">
@@ -2819,9 +2834,12 @@ function PRFilesCombinedDiffViewer({
           sectionIndexByKey={sectionIndexByKey}
           activeSectionKey={activeTreeSectionKey}
           viewedSectionKeys={viewedSectionKeys}
+          viewedCount={files.filter(isPRFileViewed).length}
+          totalCount={files.length}
           collapsed={fileTreeCollapsed}
           onCollapsedChange={setFileTreeCollapsed}
           onNavigate={handleTreeNavigate}
+          onToggleViewed={handleTreeToggleViewed}
         />
         <div ref={scrollContainerRef} className="min-w-0 flex-1 overflow-auto scrollbar-editor">
           <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>

--- a/src/renderer/src/components/editor/CombinedDiffFileTree.test.ts
+++ b/src/renderer/src/components/editor/CombinedDiffFileTree.test.ts
@@ -117,4 +117,28 @@ describe('CombinedDiffFileTree navigation mapping', () => {
       })
     ).toEqual([])
   })
+
+  it('hides viewed entries when the viewed filter is disabled', () => {
+    const viewed: GitStatusEntry = {
+      path: 'src/viewed.ts',
+      status: 'modified',
+      area: 'unstaged'
+    }
+    const unviewed: GitStatusEntry = {
+      path: 'src/unviewed.ts',
+      status: 'modified',
+      area: 'unstaged'
+    }
+
+    expect(
+      getFilteredCombinedDiffFileTreeEntries({
+        entries: [viewed, unviewed],
+        mode: 'uncommitted',
+        query: '',
+        excludedExtensions: new Set(),
+        includeViewed: false,
+        viewedSectionKeys: new Set(['unstaged:src/viewed.ts'])
+      })
+    ).toEqual([unviewed])
+  })
 })

--- a/src/renderer/src/components/editor/CombinedDiffFileTree.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffFileTree.tsx
@@ -80,9 +80,12 @@ export function CombinedDiffFileTree({
   sectionIndexByKey,
   activeSectionKey,
   viewedSectionKeys,
+  viewedCount,
+  totalCount,
   collapsed,
   onCollapsedChange,
-  onNavigate
+  onNavigate,
+  onToggleViewed
 }: {
   mode: CombinedDiffFileTreeMode
   worktreePath: string
@@ -90,9 +93,12 @@ export function CombinedDiffFileTree({
   sectionIndexByKey: ReadonlyMap<string, number>
   activeSectionKey: string | null
   viewedSectionKeys: ReadonlySet<string>
+  viewedCount: number
+  totalCount: number
   collapsed: boolean
   onCollapsedChange: (collapsed: boolean) => void
   onNavigate: (entry: CombinedDiffFileTreeEntry) => void
+  onToggleViewed: (sectionKey: string) => void
 }): React.JSX.Element | null {
   const [collapsedDirectoryKeys, setCollapsedDirectoryKeys] = React.useState<Set<string>>(
     () => new Set()
@@ -172,8 +178,17 @@ export function CombinedDiffFileTree({
     <aside className="flex min-h-0 w-64 shrink-0 flex-col overflow-hidden border-r border-border bg-background">
       <div className="sticky top-0 z-20 shrink-0 bg-background">
         <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-1.5">
-          <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-            {translate('auto.components.editor.CombinedDiffFileTree.481e63ca52', 'Files')}
+          <div className="flex min-w-0 items-baseline gap-2">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+              {translate('auto.components.editor.CombinedDiffFileTree.481e63ca52', 'Files')}
+            </div>
+            <div className="text-[11px] tabular-nums text-muted-foreground">
+              {translate(
+                'auto.components.editor.CombinedDiffFileTree.5c914b4f36',
+                '{{value0}} / {{value1}} viewed',
+                { value0: viewedCount, value1: totalCount }
+              )}
+            </div>
           </div>
           <Button
             type="button"
@@ -300,6 +315,8 @@ export function CombinedDiffFileTree({
                     isCollapsed={collapsedDirectoryKeys.has(node.key)}
                     onToggleDirectory={toggleDirectory}
                     onNavigate={onNavigate}
+                    viewedSectionKeys={viewedSectionKeys}
+                    onToggleViewed={onToggleViewed}
                   />
                 ))}
               </div>
@@ -323,6 +340,8 @@ export function CombinedDiffFileTree({
                     isCollapsed={collapsedDirectoryKeys.has(node.key)}
                     onToggleDirectory={toggleDirectory}
                     onNavigate={onNavigate}
+                    viewedSectionKeys={viewedSectionKeys}
+                    onToggleViewed={onToggleViewed}
                   />
                 ))}
               </div>
@@ -340,6 +359,8 @@ export function CombinedDiffFileTree({
               isCollapsed={collapsedDirectoryKeys.has(node.key)}
               onToggleDirectory={toggleDirectory}
               onNavigate={onNavigate}
+              viewedSectionKeys={viewedSectionKeys}
+              onToggleViewed={onToggleViewed}
             />
           ))
         )}

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -56,6 +56,12 @@ import {
   handleCombinedDiffFileTreeNavigation
 } from './CombinedDiffFileTree'
 import { getCombinedDiffFileTreeSectionKey } from './combined-diff-file-tree-model'
+import { buildCombinedDiffEntryIdentity } from './combined-diff-review-identity'
+import {
+  getViewedSectionKeys,
+  isCombinedDiffFileReviewed,
+  type CombinedDiffReviewPresentFile
+} from './combined-diff-review-state'
 import {
   ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
   type EditorPathMutationTarget
@@ -232,6 +238,9 @@ export default function CombinedDiffViewer({
   const updateSettings = useAppStore((s) => s.updateSettings)
   const clearDiffComments = useAppStore((s) => s.clearDiffComments)
   const diffCommentsForWorktree = useAppStore((s) => s.getDiffComments(file.worktreeId))
+  const combinedDiffReview = useAppStore((s) => s.getCombinedDiffReview(file.worktreeId))
+  const setCombinedDiffFileViewed = useAppStore((s) => s.setCombinedDiffFileViewed)
+  const reconcileCombinedDiffReview = useAppStore((s) => s.reconcileCombinedDiffReview)
   const activeGroupId = useAppStore((s) => s.activeGroupIdByWorktree[file.worktreeId])
   const isDark =
     settings?.theme === 'dark' ||
@@ -466,6 +475,10 @@ export default function CombinedDiffViewer({
     mode: treeMode,
     hasUncommittedEntriesSnapshot
   })
+  const uncommittedStatusSignature = React.useMemo(
+    () => buildCombinedGitStatusSignature(sections, gitStatusEntries),
+    [gitStatusEntries, sections]
+  )
   const entrySignature = React.useMemo(
     () =>
       JSON.stringify({
@@ -508,6 +521,43 @@ export default function CombinedDiffViewer({
       isBranchMode,
       isCommitMode
     ]
+  )
+  const presentReviewFiles = React.useMemo<CombinedDiffReviewPresentFile[]>(() => {
+    const liveStatusByKey = new Map(
+      gitStatusEntries.map((entry) => [`${entry.area}:${entry.path}`, entry])
+    )
+    return entries.map((entry) => {
+      const key = getCombinedDiffFileTreeSectionKey(treeMode, entry)
+      const identityEntry =
+        'area' in entry ? (liveStatusByKey.get(`${entry.area}:${entry.path}`) ?? entry) : entry
+      return {
+        key,
+        diffIdentity: buildCombinedDiffEntryIdentity({
+          mode: treeMode,
+          entry: identityEntry,
+          mergeBase: branchCompare?.mergeBase,
+          headOid: branchCompare?.headOid,
+          commitOid: commitCompare?.commitOid,
+          parentOid: commitCompare?.parentOid
+        })
+      }
+    })
+    // Why: `gitStatusEntries` keeps a stable reference until git status
+    // actually changes (setGitStatus's statusUnchanged guard), so it is a
+    // precise dep on its own — `uncommittedStatusSignature` derives from it
+    // and would be a redundant dep here.
+  }, [
+    branchCompare?.headOid,
+    branchCompare?.mergeBase,
+    commitCompare?.commitOid,
+    commitCompare?.parentOid,
+    entries,
+    gitStatusEntries,
+    treeMode
+  ])
+  const presentReviewIdentityByKey = React.useMemo(
+    () => new Map(presentReviewFiles.map((file) => [file.key, file.diffIdentity])),
+    [presentReviewFiles]
   )
 
   // Why: switching tabs or worktrees unmounts this viewer through the shared
@@ -985,8 +1035,21 @@ export default function CombinedDiffViewer({
     setActiveTreeSectionState({ entrySignature, key: null })
   }
   const viewedSectionKeys = React.useMemo(
-    () => new Set(sections.filter((section) => !section.loading).map((section) => section.key)),
-    [sections]
+    () => getViewedSectionKeys(combinedDiffReview, presentReviewFiles),
+    [combinedDiffReview, presentReviewFiles]
+  )
+  const viewedCount = viewedSectionKeys.size
+  const totalCount = presentReviewFiles.length
+  const handleToggleViewed = useCallback(
+    (sectionKey: string) => {
+      const diffIdentity = presentReviewIdentityByKey.get(sectionKey)
+      if (!diffIdentity) {
+        return
+      }
+      const viewed = isCombinedDiffFileReviewed(combinedDiffReview.files[sectionKey], diffIdentity)
+      void setCombinedDiffFileViewed(file.worktreeId, sectionKey, diffIdentity, !viewed)
+    },
+    [combinedDiffReview, file.worktreeId, presentReviewIdentityByKey, setCombinedDiffFileViewed]
   )
   const handleTreeNavigate = useCallback(
     (entry: GitStatusEntry | GitBranchChangeEntry) => {
@@ -1050,6 +1113,16 @@ export default function CombinedDiffViewer({
       requestCombinedDiffSectionReload(index)
     }
   }, [combinedGitStatusSignature, requestCombinedDiffSectionReload, shouldAutoReloadFromGitStatus])
+
+  useEffect(() => {
+    void reconcileCombinedDiffReview(file.worktreeId, presentReviewFiles)
+  }, [
+    entrySignature,
+    file.worktreeId,
+    presentReviewFiles,
+    reconcileCombinedDiffReview,
+    uncommittedStatusSignature
+  ])
 
   useEffect(() => {
     if (treeMode !== 'all' && treeMode !== 'uncommitted') {
@@ -1847,9 +1920,12 @@ export default function CombinedDiffViewer({
             sectionIndexByKey={sectionIndexByKey}
             activeSectionKey={activeTreeSectionKey}
             viewedSectionKeys={viewedSectionKeys}
+            viewedCount={viewedCount}
+            totalCount={totalCount}
             collapsed={fileTreeCollapsed}
             onCollapsedChange={setFileTreeCollapsed}
             onNavigate={handleTreeNavigate}
+            onToggleViewed={handleToggleViewed}
           />
           <div className="relative min-w-0 flex-1">
             <div
@@ -1903,16 +1979,61 @@ export default function CombinedDiffViewer({
                           const fileNotes = diffCommentsForWorktree.filter(
                             (comment) => comment.filePath === section.path
                           )
-                          return fileNotes.length > 0 ? (
-                            <DiffNotesSendMenu
-                              worktreeId={file.worktreeId}
-                              groupId={activeGroupId ?? file.worktreeId}
-                              comments={diffCommentsForWorktree}
-                              filePath={section.path}
-                              showFileScope
-                              triggerClassName="p-0.5 can-hover:opacity-0 group-hover:opacity-100"
-                            />
-                          ) : null
+                          const diffIdentity = presentReviewIdentityByKey.get(section.key)
+                          const isViewed =
+                            diffIdentity !== undefined &&
+                            isCombinedDiffFileReviewed(
+                              combinedDiffReview.files[section.key],
+                              diffIdentity
+                            )
+                          return (
+                            <>
+                              {diffIdentity !== undefined ? (
+                                <button
+                                  type="button"
+                                  className={`inline-flex h-6 items-center gap-1 rounded border border-border px-1.5 text-[11px] transition-colors hover:text-foreground ${
+                                    isViewed ? 'bg-accent text-foreground' : 'text-muted-foreground'
+                                  }`}
+                                  aria-pressed={isViewed}
+                                  aria-label={
+                                    isViewed
+                                      ? translate(
+                                          'auto.components.editor.CombinedDiffViewer.22f6ebfe75',
+                                          'Mark file unviewed'
+                                        )
+                                      : translate(
+                                          'auto.components.editor.CombinedDiffViewer.b216a43809',
+                                          'Mark file viewed'
+                                        )
+                                  }
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    handleToggleViewed(section.key)
+                                  }}
+                                >
+                                  <span className="flex size-3.5 items-center justify-center rounded-sm border border-border">
+                                    <Check
+                                      className={`size-3 ${isViewed ? 'opacity-100' : 'opacity-0'}`}
+                                    />
+                                  </span>
+                                  {translate(
+                                    'auto.components.editor.CombinedDiffViewer.a25c3d20b1',
+                                    'Viewed'
+                                  )}
+                                </button>
+                              ) : null}
+                              {fileNotes.length > 0 ? (
+                                <DiffNotesSendMenu
+                                  worktreeId={file.worktreeId}
+                                  groupId={activeGroupId ?? file.worktreeId}
+                                  comments={diffCommentsForWorktree}
+                                  filePath={section.path}
+                                  showFileScope
+                                  triggerClassName="p-0.5 can-hover:opacity-0 group-hover:opacity-100"
+                                />
+                              ) : null}
+                            </>
+                          )
                         }}
                       />
                     </div>

--- a/src/renderer/src/components/editor/combined-diff-file-tree-row.tsx
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-row.tsx
@@ -1,11 +1,12 @@
 import type React from 'react'
-import { ChevronDown, Folder, FolderOpen } from 'lucide-react'
+import { Check, ChevronDown, Folder, FolderOpen } from 'lucide-react'
 import { STATUS_COLORS, STATUS_LABELS } from '@/components/right-sidebar/status-display'
 import type { SourceControlTreeNode } from '@/components/right-sidebar/source-control-tree'
 import { getFileTypeIcon } from '@/lib/file-type-icons'
 import { basename, dirname, joinPath } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import { WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
+import { translate } from '@/i18n/i18n'
 import type {
   GitBranchChangeEntry,
   GitFileStatus,
@@ -36,7 +37,9 @@ export function CombinedDiffFileTreeRow({
   sectionIndexByKey,
   isCollapsed,
   onToggleDirectory,
-  onNavigate
+  onNavigate,
+  viewedSectionKeys,
+  onToggleViewed
 }: {
   node: CombinedDiffTreeNode
   mode: CombinedDiffFileTreeMode
@@ -46,6 +49,8 @@ export function CombinedDiffFileTreeRow({
   isCollapsed: boolean
   onToggleDirectory: (key: string) => void
   onNavigate: (entry: CombinedDiffFileTreeEntry) => void
+  viewedSectionKeys: ReadonlySet<string>
+  onToggleViewed: (sectionKey: string) => void
 }): React.JSX.Element {
   if (node.type === 'directory') {
     return (
@@ -90,18 +95,19 @@ export function CombinedDiffFileTreeRow({
   const dirPath = parentDir === '.' ? '' : parentDir
   const status = node.entry.status as GitFileStatus
   const disabled = !sectionIndexByKey.has(sectionKey)
+  const viewed = viewedSectionKeys.has(sectionKey)
 
   return (
-    <button
-      type="button"
+    <div
       className={cn(
-        'group flex w-full min-w-0 cursor-pointer items-center gap-1 py-1 pr-3 text-left text-xs transition-colors hover:bg-accent/40 disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent',
-        activeSectionKey === sectionKey && 'bg-accent/60'
+        'group flex w-full min-w-0 items-center text-xs transition-colors hover:bg-accent/40',
+        activeSectionKey === sectionKey && 'bg-accent/60',
+        viewed && 'text-muted-foreground opacity-60',
+        disabled && 'opacity-50 hover:bg-transparent'
       )}
       style={{
         paddingLeft: `${node.depth * COMBINED_DIFF_TREE_INDENT_PX + COMBINED_DIFF_TREE_FILE_PADDING_PX}px`
       }}
-      disabled={disabled}
       draggable={!disabled}
       onDragStart={(event) => {
         if (disabled) {
@@ -114,19 +120,53 @@ export function CombinedDiffFileTreeRow({
         )
         event.dataTransfer.effectAllowed = 'copy'
       }}
-      onClick={() => onNavigate(node.entry)}
     >
-      <FileIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[status] }} />
-      <span className="min-w-0 flex-1 truncate">
-        <span className="text-foreground">{fileName}</span>
-        {dirPath && <span className="ml-1.5 text-[11px] text-muted-foreground">{dirPath}</span>}
-      </span>
-      <span
-        className="w-4 shrink-0 text-center text-[10px] font-bold"
-        style={{ color: STATUS_COLORS[status] }}
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 py-1 text-left disabled:cursor-default"
+        disabled={disabled}
+        onClick={() => onNavigate(node.entry)}
       >
-        {STATUS_LABELS[status]}
-      </span>
-    </button>
+        <FileIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[status] }} />
+        <span className="min-w-0 flex-1 truncate">
+          <span className={viewed ? 'text-muted-foreground' : 'text-foreground'}>{fileName}</span>
+          {dirPath && <span className="ml-1.5 text-[11px] text-muted-foreground">{dirPath}</span>}
+        </span>
+        <span
+          className="w-4 shrink-0 text-center text-[10px] font-bold"
+          style={{ color: STATUS_COLORS[status] }}
+        >
+          {STATUS_LABELS[status]}
+        </span>
+      </button>
+      <button
+        type="button"
+        className={cn(
+          'mr-2 flex size-4 shrink-0 items-center justify-center rounded-sm border border-border transition-colors hover:text-foreground disabled:cursor-default disabled:opacity-50',
+          viewed ? 'bg-accent text-foreground' : 'text-muted-foreground'
+        )}
+        disabled={disabled}
+        aria-pressed={viewed}
+        aria-label={
+          viewed
+            ? translate(
+                'auto.components.editor.CombinedDiffFileTreeRow.9bb84ca103',
+                'Mark {{value0}} unviewed',
+                { value0: fileName }
+              )
+            : translate(
+                'auto.components.editor.CombinedDiffFileTreeRow.88a36dd41f',
+                'Mark {{value0}} viewed',
+                { value0: fileName }
+              )
+        }
+        onClick={(event) => {
+          event.stopPropagation()
+          onToggleViewed(sectionKey)
+        }}
+      >
+        <Check className={cn('size-3', viewed ? 'opacity-100' : 'opacity-0')} />
+      </button>
+    </div>
   )
 }

--- a/src/renderer/src/components/editor/combined-diff-review-identity.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-review-identity.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import type { GitBranchChangeEntry, GitStatusEntry } from '../../../../shared/types'
+import { buildCombinedDiffEntryIdentity } from './combined-diff-review-identity'
+
+describe('buildCombinedDiffEntryIdentity', () => {
+  it('is stable for identical uncommitted entries', () => {
+    const entry: GitStatusEntry = {
+      path: 'src/app.ts',
+      status: 'modified',
+      area: 'unstaged',
+      added: 2,
+      removed: 1
+    }
+
+    expect(buildCombinedDiffEntryIdentity({ mode: 'uncommitted', entry })).toBe(
+      buildCombinedDiffEntryIdentity({ mode: 'uncommitted', entry: { ...entry } })
+    )
+  })
+
+  it('changes when uncommitted live status counts change', () => {
+    const snapshot: GitStatusEntry = {
+      path: 'src/app.ts',
+      status: 'modified',
+      area: 'unstaged',
+      added: 2,
+      removed: 1
+    }
+    const live: GitStatusEntry = { ...snapshot, added: 3 }
+
+    expect(buildCombinedDiffEntryIdentity({ mode: 'uncommitted', entry: snapshot })).not.toBe(
+      buildCombinedDiffEntryIdentity({ mode: 'uncommitted', entry: live })
+    )
+  })
+
+  it('does not change for content edits with unchanged diff metadata', () => {
+    const entry: GitStatusEntry = {
+      path: 'src/app.ts',
+      status: 'modified',
+      area: 'unstaged',
+      added: 2,
+      removed: 1
+    }
+
+    expect(buildCombinedDiffEntryIdentity({ mode: 'uncommitted', entry })).toBe(
+      buildCombinedDiffEntryIdentity({ mode: 'uncommitted', entry: { ...entry } })
+    )
+  })
+
+  it('changes when branch compare oids change', () => {
+    const entry: GitBranchChangeEntry = {
+      path: 'src/view.ts',
+      status: 'modified',
+      added: 4,
+      removed: 0
+    }
+
+    expect(
+      buildCombinedDiffEntryIdentity({
+        mode: 'branch',
+        entry,
+        mergeBase: 'base-a',
+        headOid: 'head-a'
+      })
+    ).not.toBe(
+      buildCombinedDiffEntryIdentity({
+        mode: 'branch',
+        entry,
+        mergeBase: 'base-a',
+        headOid: 'head-b'
+      })
+    )
+  })
+
+  it('changes when commit compare oids change', () => {
+    const entry: GitBranchChangeEntry = { path: 'src/view.ts', status: 'modified' }
+
+    expect(
+      buildCombinedDiffEntryIdentity({
+        mode: 'commit',
+        entry,
+        commitOid: 'commit-a',
+        parentOid: 'parent-a'
+      })
+    ).not.toBe(
+      buildCombinedDiffEntryIdentity({
+        mode: 'commit',
+        entry,
+        commitOid: 'commit-b',
+        parentOid: 'parent-a'
+      })
+    )
+  })
+
+  it('folds compare oids into branch entries shown in all mode', () => {
+    // Why: in 'all' mode a branch entry (no `area`) must auto-reset on a base
+    // bump, exercising the `mode === 'all' && !('area' in entry)` branch.
+    const entry: GitBranchChangeEntry = { path: 'src/view.ts', status: 'modified' }
+
+    expect(
+      buildCombinedDiffEntryIdentity({ mode: 'all', entry, mergeBase: 'base-a', headOid: 'head-a' })
+    ).not.toBe(
+      buildCombinedDiffEntryIdentity({ mode: 'all', entry, mergeBase: 'base-a', headOid: 'head-b' })
+    )
+  })
+
+  it('ignores compare oids for uncommitted entries shown in all mode', () => {
+    // Why: uncommitted entries (with `area`) in 'all' mode are keyed by live
+    // status only; a branch oid bump must not flip their identity.
+    const entry: GitStatusEntry = {
+      path: 'src/app.ts',
+      status: 'modified',
+      area: 'unstaged',
+      added: 2,
+      removed: 1
+    }
+
+    expect(
+      buildCombinedDiffEntryIdentity({ mode: 'all', entry, mergeBase: 'base-a', headOid: 'head-a' })
+    ).toBe(
+      buildCombinedDiffEntryIdentity({ mode: 'all', entry, mergeBase: 'base-b', headOid: 'head-b' })
+    )
+  })
+
+  it('changes when rename metadata changes', () => {
+    const entry: GitBranchChangeEntry = {
+      path: 'src/new.ts',
+      oldPath: 'src/old.ts',
+      status: 'renamed'
+    }
+
+    expect(buildCombinedDiffEntryIdentity({ mode: 'branch', entry })).not.toBe(
+      buildCombinedDiffEntryIdentity({
+        mode: 'branch',
+        entry: { ...entry, oldPath: 'src/older.ts' }
+      })
+    )
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-review-identity.ts
+++ b/src/renderer/src/components/editor/combined-diff-review-identity.ts
@@ -1,0 +1,50 @@
+import type { GitBranchChangeEntry, GitStatusEntry } from '../../../../shared/types'
+import type { CombinedDiffFileTreeMode } from './combined-diff-file-tree-model'
+
+export type CombinedDiffEntryIdentityInput = {
+  mode: CombinedDiffFileTreeMode
+  entry: GitStatusEntry | GitBranchChangeEntry
+  mergeBase?: string | null
+  headOid?: string | null
+  commitOid?: string | null
+  parentOid?: string | null
+}
+
+function fnv1aHash(parts: readonly string[]): string {
+  let hash = 2166136261
+  for (const part of parts) {
+    hash = Math.imul(hash ^ part.length, 16777619)
+    for (let index = 0; index < part.length; index += 1) {
+      hash = Math.imul(hash ^ part.charCodeAt(index), 16777619)
+    }
+  }
+  return `d${(hash >>> 0).toString(36)}`
+}
+
+export function buildCombinedDiffEntryIdentity({
+  mode,
+  entry,
+  mergeBase,
+  headOid,
+  commitOid,
+  parentOid
+}: CombinedDiffEntryIdentityInput): string {
+  const area =
+    'area' in entry ? entry.area : mode === 'commit' ? 'combined-commit' : 'combined-branch'
+  const parts = [
+    area,
+    entry.status,
+    entry.oldPath ?? '',
+    entry.path,
+    String(entry.added ?? ''),
+    String(entry.removed ?? '')
+  ]
+
+  if (mode === 'branch' || (mode === 'all' && !('area' in entry))) {
+    parts.push(mergeBase ?? '', headOid ?? '')
+  } else if (mode === 'commit') {
+    parts.push(commitOid ?? '', parentOid ?? '')
+  }
+
+  return fnv1aHash(parts)
+}

--- a/src/renderer/src/components/editor/combined-diff-review-state.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-review-state.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import type { CombinedDiffReviewState } from '../../../../shared/types'
+import {
+  getViewedSectionKeys,
+  isCombinedDiffFileReviewed,
+  markCombinedDiffFileReviewed,
+  markCombinedDiffFileUnreviewed,
+  normalizeCombinedDiffReviewState,
+  reconcileCombinedDiffReviewState
+} from './combined-diff-review-state'
+
+function state(files: CombinedDiffReviewState['files']): CombinedDiffReviewState {
+  return { version: 1, updatedAt: 1, files }
+}
+
+describe('combined diff review state', () => {
+  it('marks and unmarks files without tombstones', () => {
+    const reviewed = markCombinedDiffFileReviewed(state({}), 'unstaged:src/a.ts', 'd1', 100)
+
+    expect(reviewed.files['unstaged:src/a.ts']).toEqual({
+      key: 'unstaged:src/a.ts',
+      reviewedAt: 100,
+      diffIdentity: 'd1'
+    })
+
+    const unreviewed = markCombinedDiffFileUnreviewed(reviewed, 'unstaged:src/a.ts', 200)
+
+    expect(unreviewed.files).toEqual({})
+    expect(unreviewed.updatedAt).toBe(200)
+  })
+
+  it('returns the same reference on no-op unreview and reconcile', () => {
+    const initial = state({})
+
+    expect(markCombinedDiffFileUnreviewed(initial, 'missing', 100)).toBe(initial)
+    expect(reconcileCombinedDiffReviewState(initial, [], 100)).toBe(initial)
+  })
+
+  it('gates viewed keys and file state by matching identity', () => {
+    const initial = state({
+      'unstaged:src/a.ts': {
+        key: 'unstaged:src/a.ts',
+        reviewedAt: 100,
+        diffIdentity: 'd1'
+      }
+    })
+
+    expect(
+      getViewedSectionKeys(initial, [{ key: 'unstaged:src/a.ts', diffIdentity: 'd1' }])
+    ).toEqual(new Set(['unstaged:src/a.ts']))
+    expect(
+      getViewedSectionKeys(initial, [{ key: 'unstaged:src/a.ts', diffIdentity: 'd2' }])
+    ).toEqual(new Set())
+    expect(isCombinedDiffFileReviewed(initial.files['unstaged:src/a.ts'], 'd1')).toBe(true)
+    expect(isCombinedDiffFileReviewed(initial.files['unstaged:src/a.ts'], 'd2')).toBe(false)
+  })
+
+  it('deletes present entries whose identity changed but keeps absent entries', () => {
+    const initial = state({
+      'unstaged:src/a.ts': {
+        key: 'unstaged:src/a.ts',
+        reviewedAt: 100,
+        diffIdentity: 'old'
+      },
+      'unstaged:src/absent.ts': {
+        key: 'unstaged:src/absent.ts',
+        reviewedAt: 90,
+        diffIdentity: 'kept'
+      }
+    })
+
+    const reconciled = reconcileCombinedDiffReviewState(
+      initial,
+      [{ key: 'unstaged:src/a.ts', diffIdentity: 'new' }],
+      200
+    )
+
+    expect(reconciled.files).toEqual({
+      'unstaged:src/absent.ts': {
+        key: 'unstaged:src/absent.ts',
+        reviewedAt: 90,
+        diffIdentity: 'kept'
+      }
+    })
+    expect(reconciled.updatedAt).toBe(200)
+  })
+
+  it('cap-prunes the oldest absent entries without evicting present entries', () => {
+    const files: CombinedDiffReviewState['files'] = {}
+    for (let index = 0; index < 501; index += 1) {
+      const key = `unstaged:src/${index}.ts`
+      files[key] = { key, reviewedAt: index, diffIdentity: `d${index}` }
+    }
+
+    const reconciled = reconcileCombinedDiffReviewState(
+      state(files),
+      [{ key: 'unstaged:src/0.ts', diffIdentity: 'd0' }],
+      1_000
+    )
+
+    expect(reconciled.files['unstaged:src/0.ts']).toBeDefined()
+    expect(reconciled.files['unstaged:src/1.ts']).toBeUndefined()
+    expect(Object.keys(reconciled.files)).toHaveLength(500)
+  })
+
+  it('normalizes malformed persisted state', () => {
+    expect(
+      normalizeCombinedDiffReviewState({
+        version: 99,
+        updatedAt: Number.NaN,
+        files: {
+          good: { key: 'good', reviewedAt: 100, diffIdentity: 'd1' },
+          badTime: { key: 'badTime', reviewedAt: '100', diffIdentity: 'd2' },
+          badIdentity: { key: 'badIdentity', reviewedAt: 200, diffIdentity: '' }
+        }
+      })
+    ).toEqual({
+      version: 1,
+      updatedAt: undefined,
+      files: {
+        good: { key: 'good', reviewedAt: 100, diffIdentity: 'd1' }
+      }
+    })
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-review-state.ts
+++ b/src/renderer/src/components/editor/combined-diff-review-state.ts
@@ -1,0 +1,147 @@
+import type { CombinedDiffReviewFileState, CombinedDiffReviewState } from '../../../../shared/types'
+
+export type CombinedDiffReviewPresentFile = {
+  key: string
+  diffIdentity: string
+}
+
+const COMBINED_DIFF_REVIEW_FILE_CAP = 500
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function normalizeFileState(key: string, value: unknown): CombinedDiffReviewFileState | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  const storedKey = typeof value.key === 'string' && value.key ? value.key : key
+  if (
+    typeof value.reviewedAt !== 'number' ||
+    !Number.isFinite(value.reviewedAt) ||
+    typeof value.diffIdentity !== 'string' ||
+    value.diffIdentity.length === 0
+  ) {
+    return null
+  }
+  return {
+    key: storedKey,
+    reviewedAt: value.reviewedAt,
+    diffIdentity: value.diffIdentity
+  }
+}
+
+export function normalizeCombinedDiffReviewState(value: unknown): CombinedDiffReviewState {
+  if (!isRecord(value) || !isRecord(value.files)) {
+    return { version: 1, files: {} }
+  }
+  const files: Record<string, CombinedDiffReviewFileState> = {}
+  for (const [key, candidate] of Object.entries(value.files)) {
+    const state = normalizeFileState(key, candidate)
+    if (state) {
+      files[state.key] = state
+    }
+  }
+  return {
+    version: 1,
+    updatedAt:
+      typeof value.updatedAt === 'number' && Number.isFinite(value.updatedAt)
+        ? value.updatedAt
+        : undefined,
+    files
+  }
+}
+
+export function markCombinedDiffFileReviewed(
+  state: CombinedDiffReviewState,
+  key: string,
+  diffIdentity: string,
+  now: number
+): CombinedDiffReviewState {
+  const previous = state.files[key]
+  if (previous?.diffIdentity === diffIdentity) {
+    return state
+  }
+  return {
+    ...state,
+    version: 1,
+    updatedAt: now,
+    files: {
+      ...state.files,
+      [key]: { key, reviewedAt: now, diffIdentity }
+    }
+  }
+}
+
+export function markCombinedDiffFileUnreviewed(
+  state: CombinedDiffReviewState,
+  key: string,
+  now: number
+): CombinedDiffReviewState {
+  if (!state.files[key]) {
+    return state
+  }
+  const files = { ...state.files }
+  delete files[key]
+  return { ...state, version: 1, updatedAt: now, files }
+}
+
+export function isCombinedDiffFileReviewed(
+  fileState: CombinedDiffReviewFileState | undefined,
+  diffIdentity: string
+): boolean {
+  return fileState !== undefined && fileState.diffIdentity === diffIdentity
+}
+
+export function getViewedSectionKeys(
+  state: CombinedDiffReviewState,
+  present: readonly CombinedDiffReviewPresentFile[]
+): Set<string> {
+  const keys = new Set<string>()
+  for (const file of present) {
+    if (isCombinedDiffFileReviewed(state.files[file.key], file.diffIdentity)) {
+      keys.add(file.key)
+    }
+  }
+  return keys
+}
+
+export function reconcileCombinedDiffReviewState(
+  state: CombinedDiffReviewState,
+  present: readonly CombinedDiffReviewPresentFile[],
+  now: number
+): CombinedDiffReviewState {
+  const presentByKey = new Map(present.map((file) => [file.key, file.diffIdentity]))
+  let files: Record<string, CombinedDiffReviewFileState> | null = null
+  const mutableFiles = (): Record<string, CombinedDiffReviewFileState> => {
+    files ??= { ...state.files }
+    return files
+  }
+
+  for (const [key, stored] of Object.entries(state.files)) {
+    const currentIdentity = presentByKey.get(key)
+    if (currentIdentity !== undefined && stored.diffIdentity !== currentIdentity) {
+      delete mutableFiles()[key]
+    }
+  }
+
+  const nextFiles = files ?? state.files
+  const overCapCount = Object.keys(nextFiles).length - COMBINED_DIFF_REVIEW_FILE_CAP
+  if (overCapCount > 0) {
+    const absent = Object.values(nextFiles)
+      .filter((file) => !presentByKey.has(file.key))
+      .sort((a, b) => a.reviewedAt - b.reviewedAt)
+      .slice(0, overCapCount)
+    if (absent.length > 0) {
+      const target = mutableFiles()
+      for (const file of absent) {
+        delete target[file.key]
+      }
+    }
+  }
+
+  if (!files) {
+    return state
+  }
+  return { ...state, version: 1, updatedAt: now, files }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10690,7 +10690,8 @@
           "21783df79f": "Collapse file tree",
           "481e63ca52": "Files",
           "d5ac717d65": "uncommitted",
-          "39b6b9e4e4": "Committed on Branch"
+          "39b6b9e4e4": "Committed on Branch",
+          "5c914b4f36": "{{value0}} / {{value1}} viewed"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "in Source Control",
@@ -10724,7 +10725,10 @@
           "724a13568d": " in {{value0}}",
           "6094135eec": " vs {{value0}}",
           "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "dde325ddfe": "Wrap Off",
+          "22f6ebfe75": "Mark file unviewed",
+          "b216a43809": "Mark file viewed",
+          "a25c3d20b1": "Viewed"
         },
         "ConflictComponents": {
           "f338288514": "Loading conflict contents...",
@@ -11230,6 +11234,10 @@
         },
         "richMarkdownLargeTextPaste": {
           "tooLarge": "Paste is too large."
+        },
+        "CombinedDiffFileTreeRow": {
+          "9bb84ca103": "Mark {{value0}} unviewed",
+          "88a36dd41f": "Mark {{value0}} viewed"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10690,7 +10690,8 @@
           "21783df79f": "Contraer árbol de archivos",
           "481e63ca52": "Archivos",
           "d5ac717d65": "no comprometido",
-          "39b6b9e4e4": "Committed on Branch"
+          "39b6b9e4e4": "Committed on Branch",
+          "5c914b4f36": "{{value0}} / {{value1}} viewed"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "en control de fuente",
@@ -10724,7 +10725,10 @@
           "724a13568d": "en {{value0}}",
           "6094135eec": "frente a {{value0}}",
           "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "dde325ddfe": "Wrap Off",
+          "22f6ebfe75": "Mark file unviewed",
+          "b216a43809": "Mark file viewed",
+          "a25c3d20b1": "Viewed"
         },
         "ConflictComponents": {
           "f338288514": "Cargando contenidos conflictivos...",
@@ -11230,6 +11234,10 @@
           "3e6c9a2b71": "pending",
           "4f7d0c3e88": "steps failed",
           "5a8e1d4f23": " · "
+        },
+        "CombinedDiffFileTreeRow": {
+          "9bb84ca103": "Mark {{value0}} unviewed",
+          "88a36dd41f": "Mark {{value0}} viewed"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10690,7 +10690,8 @@
           "21783df79f": "ファイルツリーを折りたたむ",
           "481e63ca52": "ファイル",
           "d5ac717d65": "commit されていない",
-          "39b6b9e4e4": "Committed on Branch"
+          "39b6b9e4e4": "Committed on Branch",
+          "5c914b4f36": "{{value0}} / {{value1}} viewed"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "ソース管理内",
@@ -10724,7 +10725,10 @@
           "724a13568d": "{{value0}} に",
           "6094135eec": "vs {{value0}}",
           "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "dde325ddfe": "Wrap Off",
+          "22f6ebfe75": "Mark file unviewed",
+          "b216a43809": "Mark file viewed",
+          "a25c3d20b1": "Viewed"
         },
         "ConflictComponents": {
           "f338288514": "競合するコンテンツを読み込んでいます...",
@@ -11230,6 +11234,10 @@
           "3e6c9a2b71": "pending",
           "4f7d0c3e88": "steps failed",
           "5a8e1d4f23": " · "
+        },
+        "CombinedDiffFileTreeRow": {
+          "9bb84ca103": "Mark {{value0}} unviewed",
+          "88a36dd41f": "Mark {{value0}} viewed"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10690,7 +10690,8 @@
           "21783df79f": "파일 트리 축소",
           "481e63ca52": "파일",
           "d5ac717d65": "commit 안 됨",
-          "39b6b9e4e4": "Committed on Branch"
+          "39b6b9e4e4": "Committed on Branch",
+          "5c914b4f36": "{{value0}} / {{value1}} viewed"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "소스 제어에서",
@@ -10724,7 +10725,10 @@
           "724a13568d": "{{value0}}에서",
           "6094135eec": "대 {{value0}}",
           "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "dde325ddfe": "Wrap Off",
+          "22f6ebfe75": "Mark file unviewed",
+          "b216a43809": "Mark file viewed",
+          "a25c3d20b1": "Viewed"
         },
         "ConflictComponents": {
           "f338288514": "충돌 콘텐츠 로드 중...",
@@ -11230,6 +11234,10 @@
           "3e6c9a2b71": "pending",
           "4f7d0c3e88": "steps failed",
           "5a8e1d4f23": " · "
+        },
+        "CombinedDiffFileTreeRow": {
+          "9bb84ca103": "Mark {{value0}} unviewed",
+          "88a36dd41f": "Mark {{value0}} viewed"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10690,7 +10690,8 @@
           "21783df79f": "折叠文件树",
           "481e63ca52": "文件",
           "d5ac717d65": "未提交",
-          "39b6b9e4e4": "已提交到分支"
+          "39b6b9e4e4": "已提交到分支",
+          "5c914b4f36": "{{value0}} / {{value1}} viewed"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "在源代码控制中",
@@ -10724,7 +10725,10 @@
           "724a13568d": "在 {{value0}}",
           "6094135eec": "与 {{value0}}",
           "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "dde325ddfe": "Wrap Off",
+          "22f6ebfe75": "Mark file unviewed",
+          "b216a43809": "Mark file viewed",
+          "a25c3d20b1": "Viewed"
         },
         "ConflictComponents": {
           "f338288514": "正在加载冲突内容...",
@@ -11230,6 +11234,10 @@
           "3e6c9a2b71": "pending",
           "4f7d0c3e88": "steps failed",
           "5a8e1d4f23": " · "
+        },
+        "CombinedDiffFileTreeRow": {
+          "9bb84ca103": "Mark {{value0}} unviewed",
+          "88a36dd41f": "Mark {{value0}} viewed"
         }
       },
       "diff": {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -25,6 +25,7 @@ import { createRateLimitSlice } from './slices/rate-limits'
 import { createSshSlice } from './slices/ssh'
 import { createAgentStatusSlice } from './slices/agent-status'
 import { createDiffCommentsSlice } from './slices/diffComments'
+import { createCombinedDiffReviewSlice } from './slices/combined-diff-review'
 import { createDetectedAgentsSlice } from './slices/detected-agents'
 import { createWorktreeNavHistorySlice } from './slices/worktree-nav-history'
 import { createDictationSlice } from './slices/dictation'
@@ -62,6 +63,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createSshSlice(...a),
   ...createAgentStatusSlice(...a),
   ...createDiffCommentsSlice(...a),
+  ...createCombinedDiffReviewSlice(...a),
   ...createDetectedAgentsSlice(...a),
   ...createWorktreeNavHistorySlice(...a),
   ...createDictationSlice(...a),

--- a/src/renderer/src/store/slices/combined-diff-review.test.ts
+++ b/src/renderer/src/store/slices/combined-diff-review.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import type { AppState } from '../types'
+import type { CombinedDiffReviewState, Worktree } from '../../../../shared/types'
+import { createCombinedDiffReviewSlice } from './combined-diff-review'
+
+const runtimeMocks = vi.hoisted(() => ({
+  callRuntimeRpc: vi.fn(),
+  getActiveRuntimeTarget: vi.fn((settings: { activeRuntimeEnvironmentId?: string | null }) =>
+    settings?.activeRuntimeEnvironmentId
+      ? { kind: 'remote' as const, runtimeEnvironmentId: settings.activeRuntimeEnvironmentId }
+      : { kind: 'local' as const }
+  )
+}))
+
+vi.mock('../../runtime/runtime-rpc-client', () => runtimeMocks)
+
+const updateMeta = vi.fn().mockResolvedValue(undefined)
+const recordFeatureInteraction = vi.fn()
+
+const mockApi = { worktrees: { updateMeta } }
+
+// @ts-expect-error -- focused store slice test mock
+globalThis.window = { api: mockApi }
+
+const REPO = 'repo1'
+const WT = 'repo1::/path/wt'
+
+function makeWorktree(combinedDiffReview?: CombinedDiffReviewState): Worktree {
+  return {
+    id: WT,
+    repoId: REPO,
+    path: '/path/wt',
+    head: 'abc',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    combinedDiffReview
+  }
+}
+
+function createTestStore() {
+  return create<AppState>()(
+    (...a) =>
+      ({
+        ...createCombinedDiffReviewSlice(...a),
+        worktreesByRepo: { [REPO]: [makeWorktree()] },
+        repos: [],
+        settings: null,
+        recordFeatureInteraction
+      }) as unknown as AppState
+  )
+}
+
+describe('combined diff review slice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(Date, 'now').mockReturnValue(1000)
+    updateMeta.mockResolvedValue(undefined)
+    runtimeMocks.callRuntimeRpc.mockResolvedValue({ ok: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('optimistically marks a file viewed and persists local metadata', async () => {
+    const store = createTestStore()
+
+    await expect(
+      store.getState().setCombinedDiffFileViewed(WT, 'unstaged:src/app.ts', 'd1', true)
+    ).resolves.toBe(true)
+
+    const review = store.getState().getCombinedDiffReview(WT)
+    expect(review.files['unstaged:src/app.ts']).toEqual({
+      key: 'unstaged:src/app.ts',
+      reviewedAt: 1000,
+      diffIdentity: 'd1'
+    })
+    expect(updateMeta).toHaveBeenCalledWith({
+      worktreeId: WT,
+      updates: { combinedDiffReview: review }
+    })
+    expect(recordFeatureInteraction).toHaveBeenCalledWith('review-viewed-files')
+  })
+
+  it('rolls back optimistic state when local persistence fails', async () => {
+    const store = createTestStore()
+    updateMeta.mockRejectedValueOnce(new Error('disk full'))
+
+    await expect(
+      store.getState().setCombinedDiffFileViewed(WT, 'unstaged:src/app.ts', 'd1', true)
+    ).resolves.toBe(false)
+
+    expect(store.getState().getCombinedDiffReview(WT).files).toEqual({})
+    expect(recordFeatureInteraction).not.toHaveBeenCalled()
+  })
+
+  it('reconciles stale identities and persists only when changed', async () => {
+    const stale: CombinedDiffReviewState = {
+      version: 1,
+      files: {
+        'unstaged:src/app.ts': {
+          key: 'unstaged:src/app.ts',
+          reviewedAt: 500,
+          diffIdentity: 'old'
+        }
+      }
+    }
+    const store = createTestStore()
+    store.setState({ worktreesByRepo: { [REPO]: [makeWorktree(stale)] } })
+
+    await store
+      .getState()
+      .reconcileCombinedDiffReview(WT, [{ key: 'unstaged:src/app.ts', diffIdentity: 'new' }])
+
+    expect(store.getState().getCombinedDiffReview(WT).files).toEqual({})
+    expect(updateMeta).toHaveBeenCalledTimes(1)
+    expect(recordFeatureInteraction).not.toHaveBeenCalled()
+
+    await store.getState().reconcileCombinedDiffReview(WT, [])
+
+    expect(updateMeta).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the empty sentinel for malformed persisted state', () => {
+    const store = createTestStore()
+    // Why: cross-version SSH peers / hand-edited orca-data.json can persist a
+    // record with a missing or non-object `files`; the selector must not hand
+    // that to consumers that dereference `.files` directly.
+    store.setState({
+      worktreesByRepo: {
+        [REPO]: [makeWorktree({ version: 1 } as unknown as CombinedDiffReviewState)]
+      }
+    })
+
+    const review = store.getState().getCombinedDiffReview(WT)
+    expect(review.files).toEqual({})
+  })
+
+  it('persists viewed state through the SSH worktree.set path', async () => {
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as AppState['settings'] })
+
+    await store.getState().setCombinedDiffFileViewed(WT, 'combined-branch:src/app.ts', 'd2', true)
+
+    expect(updateMeta).not.toHaveBeenCalled()
+    expect(runtimeMocks.callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'remote', runtimeEnvironmentId: 'env-1' },
+      'worktree.set',
+      {
+        worktree: `id:${WT}`,
+        combinedDiffReview: store.getState().getCombinedDiffReview(WT)
+      },
+      { timeoutMs: 15_000 }
+    )
+  })
+})

--- a/src/renderer/src/store/slices/combined-diff-review.ts
+++ b/src/renderer/src/store/slices/combined-diff-review.ts
@@ -1,0 +1,196 @@
+import type { StateCreator } from 'zustand'
+import type { CombinedDiffReviewState, Worktree } from '../../../../shared/types'
+import { callRuntimeRpc, getActiveRuntimeTarget } from '../../runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
+import {
+  markCombinedDiffFileReviewed,
+  markCombinedDiffFileUnreviewed,
+  normalizeCombinedDiffReviewState,
+  reconcileCombinedDiffReviewState,
+  type CombinedDiffReviewPresentFile
+} from '../../components/editor/combined-diff-review-state'
+import type { AppState } from '../types'
+import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+
+export type CombinedDiffReviewSlice = {
+  getCombinedDiffReview: (worktreeId: string | null | undefined) => CombinedDiffReviewState
+  setCombinedDiffFileViewed: (
+    worktreeId: string,
+    key: string,
+    diffIdentity: string,
+    viewed: boolean
+  ) => Promise<boolean>
+  reconcileCombinedDiffReview: (
+    worktreeId: string,
+    present: readonly CombinedDiffReviewPresentFile[]
+  ) => Promise<void>
+}
+
+const EMPTY_COMBINED_DIFF_REVIEW: CombinedDiffReviewState = Object.freeze({
+  version: 1,
+  files: Object.freeze({})
+})
+
+// Why: persisted values from disk / cross-version SSH peers reach the store
+// un-normalized; consumers dereference `.files` directly, so a malformed record
+// (missing/non-object `files`) would crash the viewer render. Gate to the stable
+// EMPTY sentinel here instead of normalizing per read (which would churn renders).
+function isWellFormedCombinedDiffReview(value: unknown): value is CombinedDiffReviewState {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { files?: unknown }).files === 'object' &&
+    (value as { files?: unknown }).files !== null
+  )
+}
+
+const persistQueueByWorktree: Map<string, Promise<void>> = new Map()
+
+async function persist(
+  settings: AppState['settings'],
+  worktreeId: string,
+  combinedDiffReview: CombinedDiffReviewState
+): Promise<void> {
+  const target = getActiveRuntimeTarget(settings)
+  if (target.kind === 'local') {
+    await window.api.worktrees.updateMeta({
+      worktreeId,
+      updates: { combinedDiffReview }
+    })
+    return
+  }
+  await callRuntimeRpc(
+    target,
+    'worktree.set',
+    { worktree: toRuntimeWorktreeSelector(worktreeId), combinedDiffReview },
+    { timeoutMs: 15_000 }
+  )
+}
+
+function settingsForWorktreeOwner(state: AppState, worktreeId: string): AppState['settings'] {
+  const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  return state.settings
+    ? { ...state.settings, activeRuntimeEnvironmentId: runtimeEnvironmentId }
+    : ({ activeRuntimeEnvironmentId: runtimeEnvironmentId } as AppState['settings'])
+}
+
+function enqueuePersist(worktreeId: string, get: () => AppState): Promise<void> {
+  const prior = persistQueueByWorktree.get(worktreeId) ?? Promise.resolve()
+  const run = async (): Promise<void> => {
+    const state = get()
+    const target = findWorktreeById(state.worktreesByRepo, worktreeId)
+    const latest = normalizeCombinedDiffReviewState(target?.combinedDiffReview)
+    await persist(settingsForWorktreeOwner(state, worktreeId), worktreeId, latest)
+  }
+  const next = prior.then(run, run)
+  persistQueueByWorktree.set(worktreeId, next)
+  const cleanup = (): void => {
+    if (persistQueueByWorktree.get(worktreeId) === next) {
+      persistQueueByWorktree.delete(worktreeId)
+    }
+  }
+  next.then(cleanup, cleanup)
+  return next
+}
+
+function mutateReview(
+  set: Parameters<StateCreator<AppState, [], [], CombinedDiffReviewSlice>>[0],
+  worktreeId: string,
+  mutate: (existing: CombinedDiffReviewState) => CombinedDiffReviewState
+): { previous: CombinedDiffReviewState | undefined; next: CombinedDiffReviewState } | null {
+  const repoId = getRepoIdFromWorktreeId(worktreeId)
+  let previous: CombinedDiffReviewState | undefined
+  let next: CombinedDiffReviewState | null = null
+  set((s) => {
+    const repoList = s.worktreesByRepo[repoId]
+    const target = repoList?.find((w) => w.id === worktreeId)
+    if (!repoList || !target) {
+      return {}
+    }
+    previous = target.combinedDiffReview
+    const existing = normalizeCombinedDiffReviewState(previous)
+    const computed = mutate(existing)
+    if (computed === existing) {
+      return {}
+    }
+    next = computed
+    const nextList: Worktree[] = repoList.map((w) =>
+      w.id === worktreeId ? { ...w, combinedDiffReview: computed } : w
+    )
+    return { worktreesByRepo: { ...s.worktreesByRepo, [repoId]: nextList } }
+  })
+  return next ? { previous, next } : null
+}
+
+function rollback(
+  set: Parameters<StateCreator<AppState, [], [], CombinedDiffReviewSlice>>[0],
+  worktreeId: string,
+  previous: CombinedDiffReviewState | undefined,
+  expectedCurrent: CombinedDiffReviewState
+): void {
+  const repoId = getRepoIdFromWorktreeId(worktreeId)
+  set((s) => {
+    const repoList = s.worktreesByRepo[repoId]
+    const target = repoList?.find((w) => w.id === worktreeId)
+    if (!repoList || !target || target.combinedDiffReview !== expectedCurrent) {
+      return {}
+    }
+    const nextList: Worktree[] = repoList.map((w) =>
+      w.id === worktreeId ? { ...w, combinedDiffReview: previous } : w
+    )
+    return { worktreesByRepo: { ...s.worktreesByRepo, [repoId]: nextList } }
+  })
+}
+
+export const createCombinedDiffReviewSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  CombinedDiffReviewSlice
+> = (set, get) => ({
+  getCombinedDiffReview: (worktreeId) => {
+    if (!worktreeId) {
+      return EMPTY_COMBINED_DIFF_REVIEW
+    }
+    const stored = findWorktreeById(get().worktreesByRepo, worktreeId)?.combinedDiffReview
+    return isWellFormedCombinedDiffReview(stored) ? stored : EMPTY_COMBINED_DIFF_REVIEW
+  },
+
+  setCombinedDiffFileViewed: async (worktreeId, key, diffIdentity, viewed) => {
+    const now = Date.now()
+    const result = mutateReview(set, worktreeId, (state) =>
+      viewed
+        ? markCombinedDiffFileReviewed(state, key, diffIdentity, now)
+        : markCombinedDiffFileUnreviewed(state, key, now)
+    )
+    if (!result) {
+      return true
+    }
+    try {
+      await enqueuePersist(worktreeId, get)
+      get().recordFeatureInteraction?.('review-viewed-files')
+      return true
+    } catch (err) {
+      console.error('Failed to persist combined diff review state:', err)
+      rollback(set, worktreeId, result.previous, result.next)
+      return false
+    }
+  },
+
+  reconcileCombinedDiffReview: async (worktreeId, present) => {
+    const now = Date.now()
+    const result = mutateReview(set, worktreeId, (state) =>
+      reconcileCombinedDiffReviewState(state, present, now)
+    )
+    if (!result) {
+      return
+    }
+    try {
+      await enqueuePersist(worktreeId, get)
+    } catch (err) {
+      console.error('Failed to persist combined diff review state:', err)
+      rollback(set, worktreeId, result.previous, result.next)
+    }
+  }
+})

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -132,6 +132,7 @@ import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
 import { createAgentStatusSlice } from './agent-status'
 import { createDiffCommentsSlice } from './diffComments'
+import { createCombinedDiffReviewSlice } from './combined-diff-review'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
 import { createDictationSlice } from './dictation'
@@ -168,6 +169,7 @@ function createTestStore() {
     ...createSshSlice(...a),
     ...createAgentStatusSlice(...a),
     ...createDiffCommentsSlice(...a),
+    ...createCombinedDiffReviewSlice(...a),
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a),
     ...createDictationSlice(...a),

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -33,6 +33,7 @@ import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
 import { createAgentStatusSlice } from './agent-status'
 import { createDiffCommentsSlice } from './diffComments'
+import { createCombinedDiffReviewSlice } from './combined-diff-review'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
 import { createDictationSlice } from './dictation'
@@ -78,6 +79,7 @@ export function createTestStore() {
     ...createSshSlice(...a),
     ...createAgentStatusSlice(...a),
     ...createDiffCommentsSlice(...a),
+    ...createCombinedDiffReviewSlice(...a),
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a),
     ...createDictationSlice(...a),

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -23,6 +23,7 @@ import type { RateLimitSlice } from './slices/rate-limits'
 import type { SshSlice } from './slices/ssh'
 import type { AgentStatusSlice } from './slices/agent-status'
 import type { DiffCommentsSlice } from './slices/diffComments'
+import type { CombinedDiffReviewSlice } from './slices/combined-diff-review'
 import type { DetectedAgentsSlice } from './slices/detected-agents'
 import type { WorktreeNavHistorySlice } from './slices/worktree-nav-history'
 import type { DictationSlice } from './slices/dictation'
@@ -57,6 +58,7 @@ export type AppState = RepoSlice &
   SshSlice &
   AgentStatusSlice &
   DiffCommentsSlice &
+  CombinedDiffReviewSlice &
   DetectedAgentsSlice &
   WorktreeNavHistorySlice &
   DictationSlice &

--- a/src/shared/feature-interaction-catalog.ts
+++ b/src/shared/feature-interaction-catalog.ts
@@ -43,6 +43,7 @@ export type FeatureInteractionId =
   | 'quick-commands'
   | 'resource-manager'
   | 'review-notes'
+  | 'review-viewed-files'
   | 'ssh'
   | 'terminal-pane-split'
   | 'terminal-panes'
@@ -135,6 +136,7 @@ export const FEATURE_INTERACTIONS = [
   { id: 'quick-commands', interaction: 'terminal quick command created or edited' },
   { id: 'resource-manager', interaction: 'Resource Manager opened or configured' },
   { id: 'review-notes', interaction: 'review note added or sent to an agent' },
+  { id: 'review-viewed-files', interaction: 'review file marked viewed or unviewed' },
   {
     id: 'ssh',
     interaction: 'SSH target added, imported, tested, connected, disconnected, or configured'

--- a/src/shared/feature-interaction-categories.ts
+++ b/src/shared/feature-interaction-categories.ts
@@ -64,6 +64,7 @@ export const FEATURE_INTERACTION_CATEGORY_BY_ID = {
   'quick-commands': 'launcher',
   'resource-manager': 'resource_management',
   'review-notes': 'review',
+  'review-viewed-files': 'review',
   ssh: 'setup',
   'terminal-pane-split': 'terminal',
   'terminal-panes': 'terminal',

--- a/src/shared/feature-interactions.test.ts
+++ b/src/shared/feature-interactions.test.ts
@@ -75,6 +75,7 @@ describe('feature interactions', () => {
       'quick-commands',
       'resource-manager',
       'review-notes',
+      'review-viewed-files',
       'ssh',
       'terminal-pane-split',
       'terminal-panes',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -508,6 +508,7 @@ export type Worktree = {
   workspaceStatus?: WorkspaceStatus
   diffComments?: DiffComment[]
   mobileDiffReview?: MobileDiffReviewState
+  combinedDiffReview?: CombinedDiffReviewState
   automationProvenance?: AutomationWorkspaceProvenance
 } & GitWorktreeInfo
 
@@ -618,6 +619,7 @@ export type WorktreeMeta = {
    *  them. Self-prunes when the worktree is deleted. */
   priorWorktreeIds?: string[]
   mobileDiffReview?: MobileDiffReviewState
+  combinedDiffReview?: CombinedDiffReviewState
   /** System-owned provenance for workspaces created by automation new-per-run dispatches. */
   automationProvenance?: AutomationWorkspaceProvenance
 }
@@ -718,6 +720,18 @@ export type MobileDiffReviewState = {
   updatedAt?: number
   completedAt?: number
   files: Record<string, MobileDiffReviewFileState>
+}
+
+export type CombinedDiffReviewFileState = {
+  key: string
+  reviewedAt: number
+  diffIdentity: string
+}
+
+export type CombinedDiffReviewState = {
+  version: 1
+  updatedAt?: number
+  files: Record<string, CombinedDiffReviewFileState>
 }
 
 export type DiffComment = {


### PR DESCRIPTION
## What changes

Adds a per-file **"viewed"** toggle to the combined diff review viewer (Source Control → Review Changes), mirroring GitHub's PR "Viewed" checkbox. Each file in the Changes file tree — and each diff section header — gets a viewed checkbox; viewed files dim with a filled checkmark so unreviewed files stand out; the file-tree header shows an **"N / M viewed"** progress count; and the previously inert **"Viewed files"** filter now actually hides viewed files.

Viewed state **persists per worktree** across navigation, viewer remount, tab close/reopen, and app restart, and **auto-resets** when a file's diff changes again after being marked viewed.

**What does not change:** This is a local review-progress marker only. Viewed state is never sent to an agent and is independent of the desktop's commit/branch diff content — it is keyed by file + a diff identity, not by full file content. On the hosted GitHub PR review surfaces, the toggle drives GitHub's existing native viewed state, not the new local store (so the two stay in sync rather than diverging).

Closes #4540

## Design approach

Mirror the existing **mobile** per-file "reviewed" system (`MobileDiffReviewState`) on desktop with a dedicated, independent persisted field rather than reusing the mobile record (the file-key schemes differ and cross-surface sync was not requested). State is persisted on the worktree via the same proven path diff notes use: `updateMeta` locally and the `worktree.set` RPC over SSH.

- New persisted shape `CombinedDiffReviewState` (`{ version, updatedAt, files: Record<key, { key, reviewedAt, diffIdentity }> }`) on `Worktree` + `WorktreeMeta`. The map stores only viewed files (no tombstones); a file is "viewed" iff its entry exists **and** its stored `diffIdentity` matches the file's current identity.
- A file's **diff identity** is an FNV-1a hash of its diff-defining fields. For uncommitted files it is derived from **live git status** (status + added/removed), so an in-place edit that changes the diff resets the file even though the tab-open snapshot is intentionally frozen; for branch/commit reviews it folds in the compare oids.
- Pure, unit-tested state/identity modules; a Zustand slice modeled on the diff-notes slice (optimistic update, per-worktree serialized persist queue, rollback on failure); a reconcile pass that drops stale-identity entries and cap-prunes only absent entries.

## Design-review outcome

Ran an automated design-review/fix loop to convergence (clean after 3 iterations, both reviewers). The load-bearing correction: auto-reset for same-area uncommitted edits must key off an **ungated live-git-status signature**, because the tab-open entry snapshot (and `entrySignature`) is deliberately frozen for same-area edits and the existing gated status signature is empty on the snapshot-backed Review Changes surface. Implemented as a separate `uncommittedStatusSignature`, leaving the existing gated memo untouched.

## Implementation & deviations

Implemented per the reviewed design. Deviations, all additive and sound:
- Wired the file-tree toggle on the two **hosted PR review surfaces** (`PullRequestPage`, `GitHubItemDialog`) to their existing GitHub-native viewed mutation, since those surfaces already track viewed state via GitHub and must not diverge.
- Slice persistence routes via the worktree's runtime owner (owner-aware), matching multi-runtime persistence elsewhere.

## Completeness verification

Read-only verification confirmed all four headline behaviors execute in production code (not scaffolding), the data model is on both `Worktree` and `WorktreeMeta`, and `combinedDiffReview` is forwarded at all five metadata sites (a missed one silently drops the field over SSH). No missing or partial items.

## Headline behavior status

**Implemented.** Per-file viewed toggle (tree + diff header), dimmed/checkmark styling, "N / M viewed" count, auto-reset on diff change, and per-worktree persistence (local + SSH) all run in production code and were verified on screen.

## Perf audit

Audited the touched hot path (the virtualized combined diff viewer). No actionable regressions. The new store selector returns a frozen stable-reference sentinel (same pattern as diff notes), so unrelated git polls / worktree updates don't re-render the viewer; the `presentReviewFiles` memo recomputes only when the changeset actually changes; the reconcile effect no-ops (returns the same reference → no IPC) in steady state; toggles persist through a bounded per-worktree serialized queue. No measurements/tests needed beyond the deterministic unit coverage. No fixes applied.

## Code-review loop

Two rounds, two independent reviewers each round. Round 1 surfaced one low-severity finding (the read selector returned persisted state un-normalized, so a malformed cross-version/hand-edited record could crash the viewer); fixed by gating the selector to the empty sentinel for malformed input while preserving referential stability, plus a regression test. Round 2: both reviewers clean (only non-actionable nits).

## brennan-test-changes (merge-confidence)

Validated end-to-end in a dedicated Electron dev instance against a multi-file changeset. PASS on all checks: tree checkbox dims/checks + count increments; in-diff "Viewed" toggle stays in sync with the tree; state persists across closing/reopening the diff (and `combinedDiffReview` populates in the store); **auto-reset fired** when a viewed file's diff changed (count dropped, that file reset, others stayed viewed); the "Viewed files" filter hides viewed files. Recommendation: **land**.

Accepted gap: durable persistence **across a full app restart** could not be verified because the test host's disk was 100% full (ENOSPC broke `orca-data.json` writes for all instances). The in-memory persistence path and persisted shape are correct and unit-tested; a cross-restart check should be redone on a machine with free disk. (Separately flagging the disk-full condition — it appears to have crashed an unrelated dev instance during testing.)

## Static checks & focused tests

- `tsgo` web + node typecheck: pass
- `oxlint`: clean (one pre-existing unrelated warning)
- `verify:localization-catalog`: pass (6 new keys, parity across en/es/ja/ko/zh)
- Focused `vitest`: 52 tests pass across the new identity/state/slice modules, the file-tree filter, the diff-notes slice, and the feature-interaction parity test.

## Validation evidence

Screenshots captured during validation (file tree with viewed count + dimmed/checked row, in-diff toggle, auto-reset before/after, filter hiding viewed files). Available on request; not committed per repo evidence policy.

## Remaining risks / non-actionable notes

- Cross-restart persistence durability unverified due to the host disk-full condition (see above) — code path is correct and unit-tested.
- A content edit that preserves a file's exact status and added/removed line counts will not auto-reset (identity is diff-metadata, not a content hash) — matches the mobile behavior and is by design.
