### PR TITLE
Add opt-in automatic update downloads and install-on-quit

### DIFF
--- a/src/main/ipc/settings.test.ts
+++ b/src/main/ipc/settings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const {
   applyAppIconMock,
+  applyAutomaticUpdatesSettingMock,
   applyElectronProxySettingsMock,
   browserWindowGetAllWindowsMock,
   handleMock,
@@ -11,6 +12,7 @@ const {
   rebuildAppMenuMock
 } = vi.hoisted(() => ({
   applyAppIconMock: vi.fn(),
+  applyAutomaticUpdatesSettingMock: vi.fn(),
   applyElectronProxySettingsMock: vi.fn(),
   browserWindowGetAllWindowsMock: vi.fn(),
   handleMock: vi.fn(),
@@ -42,6 +44,10 @@ vi.mock('../app-icon', () => ({
   applyAppIcon: applyAppIconMock
 }))
 
+vi.mock('../updater', () => ({
+  applyAutomaticUpdatesSetting: applyAutomaticUpdatesSettingMock
+}))
+
 vi.mock('../worktree-root-preparation', () => ({
   prepareLocalWorktreeRootsForRepos: prepareLocalWorktreeRootsForReposMock
 }))
@@ -71,6 +77,7 @@ describe('registerSettingsHandlers', () => {
   beforeEach(() => {
     handleMock.mockClear()
     applyAppIconMock.mockClear()
+    applyAutomaticUpdatesSettingMock.mockClear()
     applyElectronProxySettingsMock.mockClear()
     applyElectronProxySettingsMock.mockResolvedValue({ source: 'settings' })
     previewGhosttyImportMock.mockClear()
@@ -220,6 +227,36 @@ describe('registerSettingsHandlers', () => {
     handler(settingsInvokeEvent, { defaultTuiAgent: 'codex' })
 
     expect(agentAwakeService.setEnabled).not.toHaveBeenCalled()
+  })
+
+  it('applies automatic updates when the setting changes', async () => {
+    store.getSettings.mockReturnValue({ automaticUpdates: false })
+    store.updateSettings.mockReturnValue({ automaticUpdates: true })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find((call) => call[0] === 'settings:set')?.[1] as (
+      _event: unknown,
+      args: unknown
+    ) => Promise<unknown>
+
+    await handler(settingsInvokeEvent, { automaticUpdates: true })
+
+    expect(applyAutomaticUpdatesSettingMock).toHaveBeenCalledWith(true)
+  })
+
+  it('does not apply automatic updates when the setting value is unchanged', async () => {
+    store.getSettings.mockReturnValue({ automaticUpdates: true })
+    store.updateSettings.mockReturnValue({ automaticUpdates: true })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find((call) => call[0] === 'settings:set')?.[1] as (
+      _event: unknown,
+      args: unknown
+    ) => Promise<unknown>
+
+    await handler(settingsInvokeEvent, { automaticUpdates: true })
+
+    expect(applyAutomaticUpdatesSettingMock).not.toHaveBeenCalled()
   })
 
   it('prepares local worktree roots when workspace directory changes', async () => {

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -12,6 +12,7 @@ import type { AgentAwakeService } from '../agent-awake-service'
 import { sanitizeFloatingWorkspaceDirectorySetting } from './floating-workspace-directory'
 import { applyAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
 import { applyElectronProxySettings } from '../network/proxy-settings'
+import { applyAutomaticUpdatesSetting } from '../updater'
 import { normalizeProxyBypassRules, normalizeProxyUrl } from '../../shared/network-proxy'
 import { normalizeAppIconId } from '../../shared/app-icon'
 import { normalizeUiLanguage } from '../../shared/ui-language'
@@ -121,6 +122,16 @@ export function registerSettingsHandlers(
         applyAgentStatusHooksEnabled(result.agentStatusHooksEnabled)
       } catch (error) {
         console.warn('[settings] failed to apply agentStatusHooksEnabled:', error)
+      }
+    }
+    if (
+      'automaticUpdates' in sanitizedArgs &&
+      before.automaticUpdates !== result.automaticUpdates
+    ) {
+      try {
+        applyAutomaticUpdatesSetting(result.automaticUpdates === true)
+      } catch (error) {
+        console.warn('[settings] failed to apply automaticUpdates:', error)
       }
     }
     if ('uiLanguage' in sanitizedArgs && before.uiLanguage !== result.uiLanguage) {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -520,6 +520,21 @@ describe('Store', () => {
     expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
   })
 
+  it('defaults automaticUpdates to false when unset', async () => {
+    const store = await createStore()
+    expect(store.getSettings().automaticUpdates).toBe(false)
+  })
+
+  it('persists automaticUpdates true/false round-trip', async () => {
+    const store = await createStore()
+    store.updateSettings({ automaticUpdates: true })
+    expect(store.getSettings().automaticUpdates).toBe(true)
+    store.flush()
+    expect((readDataFile() as PersistedState).settings.automaticUpdates).toBe(true)
+    store.updateSettings({ automaticUpdates: false })
+    expect(store.getSettings().automaticUpdates).toBe(false)
+  })
+
   it('coerces loaded minimizeToTrayOnClose to false unless stored as true', async () => {
     writeDataFile({
       ...getDefaultPersistedState(testState.dir),

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -533,6 +533,8 @@ describe('Store', () => {
     expect((readDataFile() as PersistedState).settings.automaticUpdates).toBe(true)
     store.updateSettings({ automaticUpdates: false })
     expect(store.getSettings().automaticUpdates).toBe(false)
+    store.flush()
+    expect((readDataFile() as PersistedState).settings.automaticUpdates).toBe(false)
   })
 
   it('coerces loaded minimizeToTrayOnClose to false unless stored as true', async () => {

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -28,6 +28,7 @@ type UpdaterHandlerContext = {
   getPendingInstallVersion: () => string
   getUserInitiatedCheck: () => boolean
   hasNewerDownloadedVersion: () => boolean
+  maybeAutoDownload: () => void
   shouldHandleUpdaterErrorEvent: () => boolean
   clearUpdateAvailableEventPending: (attemptId: number | null) => void
   isActiveUpdateCheckAttempt: (attemptId: number) => boolean
@@ -65,6 +66,7 @@ export function registerAutoUpdaterHandlers({
   getPendingInstallVersion,
   getUserInitiatedCheck,
   hasNewerDownloadedVersion,
+  maybeAutoDownload,
   shouldHandleUpdaterErrorEvent,
   clearUpdateAvailableEventPending,
   isActiveUpdateCheckAttempt,
@@ -205,6 +207,7 @@ export function registerAutoUpdaterHandlers({
         }
 
         sendStatus({ state: 'available', version: info.version, changelog })
+        maybeAutoDownload()
       } finally {
         clearUpdateAvailableEventPending(attemptId)
       }

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1067,6 +1067,217 @@ describe('updater', () => {
     )
   })
 
+  it('auto-downloads a newer available update when automatic updates are enabled', async () => {
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: ['v1.0.61'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => {
+      autoUpdaterMock.emit('download-progress', { percent: 19 })
+      return Promise.resolve(undefined)
+    })
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getAutomaticUpdates: () => true
+    })
+    expect(autoUpdaterMock.autoDownload).toBe(false)
+    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true)
+
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'downloading',
+        percent: 19,
+        version: '1.0.61'
+      })
+    })
+
+    const statusStates = sendMock.mock.calls
+      .filter(([channel]) => channel === 'updater:status')
+      .map(([, status]) => status.state)
+    expect(statusStates).toEqual(['checking', 'available', 'downloading'])
+  })
+
+  it('leaves a newer available update manual when automatic updates are disabled', async () => {
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: ['v1.0.61'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getAutomaticUpdates: () => false
+    })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.61',
+        changelog: null
+      })
+    })
+
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled()
+    expect(autoUpdaterMock.autoDownload).toBe(false)
+    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true)
+  })
+
+  it('starts an available update when automatic updates are enabled live', async () => {
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: ['v1.0.61'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => {
+      autoUpdaterMock.emit('download-progress', { percent: 33 })
+      return Promise.resolve(undefined)
+    })
+    let automaticUpdates = false
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu, applyAutomaticUpdatesSetting } =
+      await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getAutomaticUpdates: () => automaticUpdates
+    })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.61',
+        changelog: null
+      })
+    })
+
+    automaticUpdates = true
+    applyAutomaticUpdatesSetting(true)
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 33,
+      version: '1.0.61'
+    })
+  })
+
+  it('does not cancel or restart an in-flight download when automatic updates are disabled live', async () => {
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: ['v1.0.61'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => {
+      autoUpdaterMock.emit('download-progress', { percent: 44 })
+      return new Promise(() => {})
+    })
+    let automaticUpdates = true
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu, applyAutomaticUpdatesSetting } =
+      await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getAutomaticUpdates: () => automaticUpdates
+    })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'downloading',
+        percent: 44,
+        version: '1.0.61'
+      })
+    })
+
+    automaticUpdates = false
+    applyAutomaticUpdatesSetting(false)
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    expect(sendMock).toHaveBeenLastCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 44,
+      version: '1.0.61'
+    })
+  })
+
+  it('does not auto-download from the helpers in dev or unpackaged runs', async () => {
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: ['v1.0.61'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    let automaticUpdates = false
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const {
+      setupAutoUpdater,
+      checkForUpdatesFromMenu,
+      applyAutomaticUpdatesSetting,
+      maybeAutoDownload
+    } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getAutomaticUpdates: () => automaticUpdates
+    })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.61',
+        changelog: null
+      })
+    })
+
+    automaticUpdates = true
+    isMock.dev = true
+    applyAutomaticUpdatesSetting(true)
+    maybeAutoDownload()
+    isMock.dev = false
+    appMock.isPackaged = false
+    applyAutomaticUpdatesSetting(true)
+    maybeAutoDownload()
+
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled()
+  })
+
   it('defers quitAndInstall through the shared main-process entrypoint', async () => {
     vi.useFakeTimers()
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -58,6 +58,7 @@ let pendingQuitAndInstallTimer: ReturnType<typeof setTimeout> | null = null
 let quitAndInstallInProgress = false
 let persistLastUpdateCheckAt: ((timestamp: number) => void) | null = null
 let _getLastUpdateCheckAt: (() => number | null) | null = null
+let getAutomaticUpdatesEnabled: (() => boolean) | null = null
 let backgroundCheckLaunchPending = false
 // Why: a manually promoted background check can emit an error event before the
 // paired promise catch runs; keep the promotion attached to that launch.
@@ -1132,10 +1133,37 @@ export function dismissNudge(): void {
   }
 }
 
+export function maybeAutoDownload(): void {
+  if (!app.isPackaged || is.dev) {
+    return
+  }
+  // Why: this reuses the manual download path without enabling
+  // electron-updater's eager autoDownload behavior.
+  if (
+    getAutomaticUpdatesEnabled?.() === true &&
+    currentStatus.state === 'available' &&
+    hasNewerDownloadedVersion()
+  ) {
+    downloadUpdate()
+  }
+}
+
+export function applyAutomaticUpdatesSetting(enabled: boolean): void {
+  if (!app.isPackaged || is.dev) {
+    return
+  }
+  // Why: enabling while an update is already offered should start it now;
+  // disabling leaves any in-flight download alone.
+  if (enabled) {
+    maybeAutoDownload()
+  }
+}
+
 export function setupAutoUpdater(
   mainWindow: BrowserWindow,
   opts?: {
     getLastUpdateCheckAt?: () => number | null
+    getAutomaticUpdates?: () => boolean
     onBeforeQuit?: () => void | Promise<void>
     setLastUpdateCheckAt?: (timestamp: number) => void
     getPendingUpdateNudgeId?: () => string | null
@@ -1148,6 +1176,7 @@ export function setupAutoUpdater(
   onBeforeQuitCleanup = opts?.onBeforeQuit ?? null
   persistLastUpdateCheckAt = opts?.setLastUpdateCheckAt ?? null
   _getLastUpdateCheckAt = opts?.getLastUpdateCheckAt ?? null
+  getAutomaticUpdatesEnabled = opts?.getAutomaticUpdates ?? null
   _getPendingUpdateNudgeId = opts?.getPendingUpdateNudgeId ?? null
   _getDismissedUpdateNudgeId = opts?.getDismissedUpdateNudgeId ?? null
   _setPendingUpdateNudgeId = opts?.setPendingUpdateNudgeId ?? null
@@ -1218,6 +1247,7 @@ export function setupAutoUpdater(
     getPendingInstallVersion,
     getUserInitiatedCheck: () => userInitiatedCheck,
     hasNewerDownloadedVersion,
+    maybeAutoDownload,
     shouldHandleUpdaterErrorEvent,
     performQuitAndInstall,
     clearUpdateAvailableEventPending,

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1138,7 +1138,9 @@ export function maybeAutoDownload(): void {
     return
   }
   // Why: this reuses the manual download path without enabling
-  // electron-updater's eager autoDownload behavior.
+  // electron-updater's eager autoDownload behavior. hasNewerDownloadedVersion()
+  // reads availableVersion (set synchronously before the 'available' broadcast
+  // that calls this), so it's true here — it's a defensive guard, not a no-op.
   if (
     getAutomaticUpdatesEnabled?.() === true &&
     currentStatus.state === 'available' &&

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -58,11 +58,11 @@ let pendingQuitAndInstallTimer: ReturnType<typeof setTimeout> | null = null
 let quitAndInstallInProgress = false
 let persistLastUpdateCheckAt: ((timestamp: number) => void) | null = null
 let _getLastUpdateCheckAt: (() => number | null) | null = null
-let getAutomaticUpdatesEnabled: (() => boolean) | null = null
 let backgroundCheckLaunchPending = false
 // Why: a manually promoted background check can emit an error event before the
 // paired promise catch runs; keep the promotion attached to that launch.
 let backgroundCheckPromotedToUserInitiated = false
+let getAutomaticUpdatesEnabled: (() => boolean) | null = null
 let updateCheckStallTimer: ReturnType<typeof setTimeout> | null = null
 let updateCheckSilentSettleTimer: ReturnType<typeof setTimeout> | null = null
 let updateCheckAttemptSequence = 0
@@ -1165,24 +1165,24 @@ export function setupAutoUpdater(
   mainWindow: BrowserWindow,
   opts?: {
     getLastUpdateCheckAt?: () => number | null
-    getAutomaticUpdates?: () => boolean
     onBeforeQuit?: () => void | Promise<void>
     setLastUpdateCheckAt?: (timestamp: number) => void
     getPendingUpdateNudgeId?: () => string | null
     getDismissedUpdateNudgeId?: () => string | null
     setPendingUpdateNudgeId?: (id: string | null) => void
     setDismissedUpdateNudgeId?: (id: string | null) => void
+    getAutomaticUpdates?: () => boolean
   }
 ): void {
   mainWindowRef = mainWindow
   onBeforeQuitCleanup = opts?.onBeforeQuit ?? null
   persistLastUpdateCheckAt = opts?.setLastUpdateCheckAt ?? null
   _getLastUpdateCheckAt = opts?.getLastUpdateCheckAt ?? null
-  getAutomaticUpdatesEnabled = opts?.getAutomaticUpdates ?? null
   _getPendingUpdateNudgeId = opts?.getPendingUpdateNudgeId ?? null
   _getDismissedUpdateNudgeId = opts?.getDismissedUpdateNudgeId ?? null
   _setPendingUpdateNudgeId = opts?.setPendingUpdateNudgeId ?? null
   _setDismissedUpdateNudgeId = opts?.setDismissedUpdateNudgeId ?? null
+  getAutomaticUpdatesEnabled = opts?.getAutomaticUpdates ?? null
 
   if (!app.isPackaged && !is.dev) {
     return
@@ -1249,7 +1249,6 @@ export function setupAutoUpdater(
     getPendingInstallVersion,
     getUserInitiatedCheck: () => userInitiatedCheck,
     hasNewerDownloadedVersion,
-    maybeAutoDownload,
     shouldHandleUpdaterErrorEvent,
     performQuitAndInstall,
     clearUpdateAvailableEventPending,
@@ -1264,6 +1263,7 @@ export function setupAutoUpdater(
     recordCompletedUpdateCheck,
     sendStatus,
     scheduleAutomaticUpdateCheck,
+    maybeAutoDownload,
     clearBackgroundCheckLaunchPending,
     setAvailableReleaseUrl: (releaseUrl) => {
       availableReleaseUrl = releaseUrl

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -118,6 +118,7 @@ export function attachMainWindowServices(
   registerFileDropRelay(mainWindow)
   setupAutoUpdater(mainWindow, {
     getLastUpdateCheckAt: () => store.getUI().lastUpdateCheckAt,
+    getAutomaticUpdates: () => store.getSettings().automaticUpdates === true,
     onBeforeQuit: async () => {
       try {
         await options?.onBeforeUpdateQuit?.()

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -118,7 +118,6 @@ export function attachMainWindowServices(
   registerFileDropRelay(mainWindow)
   setupAutoUpdater(mainWindow, {
     getLastUpdateCheckAt: () => store.getUI().lastUpdateCheckAt,
-    getAutomaticUpdates: () => store.getSettings().automaticUpdates === true,
     onBeforeQuit: async () => {
       try {
         await options?.onBeforeUpdateQuit?.()
@@ -146,7 +145,8 @@ export function attachMainWindowServices(
     },
     setDismissedUpdateNudgeId: (id) => {
       store.updateUI({ dismissedUpdateNudgeId: id })
-    }
+    },
+    getAutomaticUpdates: () => store.getSettings().automaticUpdates === true
   })
   registerRuntimeWindowLifecycle(mainWindow, runtime)
 

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -343,7 +343,11 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
 
   const effectiveVersion = 'version' in status ? status.version : cachedVersion
   if (effectiveVersion && dismissedVersion === effectiveVersion && !updateUserInitiatedCycle) {
-    if (status.state !== 'downloading' && status.state !== 'error') {
+    if (
+      status.state !== 'downloading' &&
+      status.state !== 'downloaded' &&
+      status.state !== 'error'
+    ) {
       return 'hidden'
     }
   }
@@ -463,7 +467,16 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
-  it('hides downloaded when version is dismissed (Settings-initiated, not card)', () => {
+  it('shows auto-staged downloaded when the earlier available nudge was dismissed', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'available', version: '1.2.0', changelog: null },
+        dismissedVersion: '1.2.0',
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false
+      })
+    ).toBe('hidden')
+
     expect(
       computeVisibility({
         status: { state: 'downloaded', version: '1.2.0' },
@@ -471,7 +484,7 @@ describe('UpdateCard visibility gates', () => {
         cachedVersion: '1.2.0',
         hasStartedDownload: false
       })
-    ).toBe('hidden')
+    ).toBe('visible')
   })
 
   it('hides background errors silently', () => {

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -276,7 +276,13 @@ export function UpdateCard() {
   // explicitly asked to check, so they expect to see the result even if they
   // dismissed the same version earlier.
   if (versionRef.current && dismissedVersion === versionRef.current && !updateUserInitiatedCycle) {
-    if (status.state !== 'downloading' && status.state !== 'error') {
+    // Why: a downloaded auto-update is newly staged for install-on-quit, so the
+    // restart affordance should surface even if the old available nudge was dismissed.
+    if (
+      status.state !== 'downloading' &&
+      status.state !== 'downloaded' &&
+      status.state !== 'error'
+    ) {
       return null
     }
   }

--- a/src/renderer/src/components/settings/AutomaticUpdatesSetting.tsx
+++ b/src/renderer/src/components/settings/AutomaticUpdatesSetting.tsx
@@ -1,0 +1,38 @@
+import type React from 'react'
+import { useAppStore } from '../../store'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
+import { translate } from '@/i18n/i18n'
+
+export function AutomaticUpdatesSetting(): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
+  const updateSettings = useAppStore((s) => s.updateSettings)
+  const enabled = settings?.automaticUpdates === true
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.GeneralUpdateSettingsSection.a73f0c19be',
+        'Automatic updates'
+      )}
+      description={translate(
+        'auto.components.settings.GeneralUpdateSettingsSection.b8e724f0d3',
+        'Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.'
+      )}
+      keywords={['update', 'automatic', 'auto', 'background', 'download', 'install']}
+    >
+      <SettingsSwitchRow
+        label={translate(
+          'auto.components.settings.GeneralUpdateSettingsSection.a73f0c19be',
+          'Automatic updates'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralUpdateSettingsSection.b8e724f0d3',
+          'Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.'
+        )}
+        checked={enabled}
+        onChange={() => updateSettings({ automaticUpdates: !enabled })}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -5,11 +5,13 @@ import { toast } from 'sonner'
 import { useAppStore } from '../../store'
 import { Button } from '../ui/button'
 import { SearchableSetting } from './SearchableSetting'
-import { SettingsSubsectionHeader } from './SettingsFormControls'
+import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 
 export function GeneralUpdateSettingsSection(): React.JSX.Element {
   const updateStatus = useAppStore((s) => s.updateStatus)
+  const settings = useAppStore((s) => s.settings)
+  const updateSettings = useAppStore((s) => s.updateSettings)
   // Why: the 'error' variant of UpdateStatus does not carry a `version` field.
   // The main process emits `{ state: 'error' }` for both check failures (no
   // version known yet) and download/install failures (version was known from
@@ -70,6 +72,33 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
           { value0: appVersion ?? '...' }
         )}
       />
+
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.GeneralUpdateSettingsSection.a73f0c19be',
+          'Automatic updates'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralUpdateSettingsSection.b8e724f0d3',
+          'Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.'
+        )}
+        keywords={['update', 'automatic', 'auto', 'background', 'download', 'install']}
+      >
+        <SettingsSwitchRow
+          label={translate(
+            'auto.components.settings.GeneralUpdateSettingsSection.a73f0c19be',
+            'Automatic updates'
+          )}
+          description={translate(
+            'auto.components.settings.GeneralUpdateSettingsSection.b8e724f0d3',
+            'Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.'
+          )}
+          checked={settings?.automaticUpdates === true}
+          onChange={() =>
+            updateSettings({ automaticUpdates: !(settings?.automaticUpdates === true) })
+          }
+        />
+      </SearchableSetting>
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -4,14 +4,13 @@ import { Download, Loader2, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAppStore } from '../../store'
 import { Button } from '../ui/button'
+import { AutomaticUpdatesSetting } from './AutomaticUpdatesSetting'
 import { SearchableSetting } from './SearchableSetting'
-import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
+import { SettingsSubsectionHeader } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 
 export function GeneralUpdateSettingsSection(): React.JSX.Element {
   const updateStatus = useAppStore((s) => s.updateStatus)
-  const settings = useAppStore((s) => s.settings)
-  const updateSettings = useAppStore((s) => s.updateSettings)
   // Why: the 'error' variant of UpdateStatus does not carry a `version` field.
   // The main process emits `{ state: 'error' }` for both check failures (no
   // version known yet) and download/install failures (version was known from
@@ -72,33 +71,6 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
           { value0: appVersion ?? '...' }
         )}
       />
-
-      <SearchableSetting
-        title={translate(
-          'auto.components.settings.GeneralUpdateSettingsSection.a73f0c19be',
-          'Automatic updates'
-        )}
-        description={translate(
-          'auto.components.settings.GeneralUpdateSettingsSection.b8e724f0d3',
-          'Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.'
-        )}
-        keywords={['update', 'automatic', 'auto', 'background', 'download', 'install']}
-      >
-        <SettingsSwitchRow
-          label={translate(
-            'auto.components.settings.GeneralUpdateSettingsSection.a73f0c19be',
-            'Automatic updates'
-          )}
-          description={translate(
-            'auto.components.settings.GeneralUpdateSettingsSection.b8e724f0d3',
-            'Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.'
-          )}
-          checked={settings?.automaticUpdates === true}
-          onChange={() =>
-            updateSettings({ automaticUpdates: !(settings?.automaticUpdates === true) })
-          }
-        />
-      </SearchableSetting>
 
       <SearchableSetting
         title={translate(
@@ -271,6 +243,8 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
                 ))}
         </p>
       </SearchableSetting>
+
+      <AutomaticUpdatesSetting />
     </section>
   )
 }

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -190,6 +190,21 @@ export const getGeneralUpdateSearchEntries = createLocalizedCatalog(() => [
       ),
       ...translateSearchKeyword('auto.components.settings.general.search.e49e739a59', 'download')
     ]
+  },
+  {
+    // Why: this section is gated on its search descriptor, so the Automatic
+    // updates row needs its own entry here or "automatic" hides the whole section.
+    title: translate('auto.components.settings.general.search.a1c4e7f209', 'Automatic updates'),
+    description: translate(
+      'auto.components.settings.general.search.b2d5f8a310',
+      'Download and install updates automatically in the background.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.c3e6a9b421', 'automatic'),
+      ...translateSearchKeyword('auto.components.settings.general.search.d4f7b0c532', 'auto'),
+      ...translateSearchKeyword('auto.components.settings.general.search.e5a8c1d643', 'background'),
+      ...translateSearchKeyword('auto.components.settings.general.search.f6b9d2e754', 'install')
+    ]
   }
 ])
 

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -176,6 +176,21 @@ export const getGeneralCliSearchEntries = createLocalizedCatalog(() => [
 
 export const getGeneralUpdateSearchEntries = createLocalizedCatalog(() => [
   {
+    // Why: this section is gated on its search descriptor, so the Automatic
+    // updates row needs its own entry here or "automatic" hides the whole section.
+    title: translate('auto.components.settings.general.search.a1c4e7f209', 'Automatic updates'),
+    description: translate(
+      'auto.components.settings.general.search.b2d5f8a310',
+      'Download and install updates automatically in the background.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.c3e6a9b421', 'automatic'),
+      ...translateSearchKeyword('auto.components.settings.general.search.d4f7b0c532', 'auto'),
+      ...translateSearchKeyword('auto.components.settings.general.search.e5a8c1d643', 'background'),
+      ...translateSearchKeyword('auto.components.settings.general.search.f6b9d2e754', 'install')
+    ]
+  },
+  {
     title: translate('auto.components.settings.general.search.e15af4eb64', 'Check for Updates'),
     description: translate(
       'auto.components.settings.general.search.79ff46776e',
@@ -189,21 +204,6 @@ export const getGeneralUpdateSearchEntries = createLocalizedCatalog(() => [
         'release notes'
       ),
       ...translateSearchKeyword('auto.components.settings.general.search.e49e739a59', 'download')
-    ]
-  },
-  {
-    // Why: this section is gated on its search descriptor, so the Automatic
-    // updates row needs its own entry here or "automatic" hides the whole section.
-    title: translate('auto.components.settings.general.search.a1c4e7f209', 'Automatic updates'),
-    description: translate(
-      'auto.components.settings.general.search.b2d5f8a310',
-      'Download and install updates automatically in the background.'
-    ),
-    keywords: [
-      ...translateSearchKeyword('auto.components.settings.general.search.c3e6a9b421', 'automatic'),
-      ...translateSearchKeyword('auto.components.settings.general.search.d4f7b0c532', 'auto'),
-      ...translateSearchKeyword('auto.components.settings.general.search.e5a8c1d643', 'background'),
-      ...translateSearchKeyword('auto.components.settings.general.search.f6b9d2e754', 'install')
     ]
   }
 ])

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5125,7 +5125,9 @@
           "31fd7150cf": "Checking for updates...",
           "3394d1f663": "checking",
           "d69a09b672": "Updates are checked automatically on launch.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Choose apps available from a workspace's Open in menu.",
@@ -7340,7 +7342,9 @@
             "161a86a9da": "Confirm before closing pinned tabs",
             "8e593f04fc": "Show a confirmation dialog before a pinned tab is closed.",
             "defaultProjectRuntime": "Default Project Runtime",
-            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects."
+            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "a1c4e7f209": "Automatic updates",
+            "b2d5f8a310": "Download and install updates automatically in the background."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5109,6 +5109,8 @@
           "f44299636f": "Restart to Update (",
           "42717918f4": "Install Update (",
           "02dc082e70": "Could not start the update download.",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.",
           "e1a647adc5": "Check for Updates",
           "ceb579abaf": "Check for app updates and install a newer Orca version.",
           "d91ebfb87e": "Current version: {{value0}}",
@@ -5125,9 +5127,7 @@
           "31fd7150cf": "Checking for updates...",
           "3394d1f663": "checking",
           "d69a09b672": "Updates are checked automatically on launch.",
-          "7173352632": "idle",
-          "a73f0c19be": "Automatic updates",
-          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
+          "7173352632": "idle"
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Choose apps available from a workspace's Open in menu.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5125,7 +5125,9 @@
           "31fd7150cf": "Buscando actualizaciones...",
           "3394d1f663": "de cheques",
           "d69a09b672": "Las actualizaciones se verifican automáticamente al iniciarse.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Elija las aplicaciones disponibles en el menú Abrir en de un espacio de trabajo.",
@@ -7303,7 +7305,9 @@
             "161a86a9da": "Confirmar antes de cerrar pestañas fijadas",
             "8e593f04fc": "Muestra un diálogo de confirmación antes de cerrar una pestaña fijada.",
             "defaultProjectRuntime": "Default Project Runtime",
-            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects."
+            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "a1c4e7f209": "Automatic updates",
+            "b2d5f8a310": "Download and install updates automatically in the background."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5109,6 +5109,8 @@
           "f44299636f": "Reiniciar para actualizar (",
           "42717918f4": "Instalar actualización (",
           "02dc082e70": "No se pudo iniciar la descarga de la actualización.",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.",
           "e1a647adc5": "Buscar actualizaciones",
           "ceb579abaf": "Busque actualizaciones de la aplicación e instale una versión más reciente de Orca.",
           "d91ebfb87e": "Versión actual: {{value0}}",
@@ -5125,9 +5127,7 @@
           "31fd7150cf": "Buscando actualizaciones...",
           "3394d1f663": "de cheques",
           "d69a09b672": "Las actualizaciones se verifican automáticamente al iniciarse.",
-          "7173352632": "idle",
-          "a73f0c19be": "Automatic updates",
-          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
+          "7173352632": "idle"
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Elija las aplicaciones disponibles en el menú Abrir en de un espacio de trabajo.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5110,7 +5110,9 @@
           "31fd7150cf": "アップデートをチェックしています...",
           "3394d1f663": "チェック中",
           "d69a09b672": "アップデートは起動時に自動的にチェックされます。",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "ワークスペースの「開く」メニューから利用可能なアプリを選択します。",
@@ -7325,7 +7327,9 @@
             "161a86a9da": "ピン留めしたタブを閉じる前に確認",
             "8e593f04fc": "ピン留めしたタブを閉じる前に確認ダイアログを表示します。",
             "defaultProjectRuntime": "Default Project Runtime",
-            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects."
+            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "a1c4e7f209": "Automatic updates",
+            "b2d5f8a310": "Download and install updates automatically in the background."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5094,6 +5094,8 @@
           "f44299636f": "再起動してアップデート (",
           "42717918f4": "アップデートのインストール (",
           "02dc082e70": "アップデートのダウンロードを開始できませんでした。",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.",
           "e1a647adc5": "アップデートをチェックする",
           "ceb579abaf": "アプリのアップデートを確認し、新規 Orca バージョンをインストールします。",
           "d91ebfb87e": "現在のバージョン: {{value0}}",
@@ -5110,9 +5112,7 @@
           "31fd7150cf": "アップデートをチェックしています...",
           "3394d1f663": "チェック中",
           "d69a09b672": "アップデートは起動時に自動的にチェックされます。",
-          "7173352632": "idle",
-          "a73f0c19be": "Automatic updates",
-          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
+          "7173352632": "idle"
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "ワークスペースの「開く」メニューから利用可能なアプリを選択します。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5110,7 +5110,9 @@
           "31fd7150cf": "업데이트 확인 중...",
           "3394d1f663": "확인 중",
           "d69a09b672": "업데이트는 시작 시 자동으로 확인됩니다.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "워크스페이스의 열기 메뉴에서 사용 가능한 앱을 선택하세요.",
@@ -7288,7 +7290,9 @@
             "161a86a9da": "고정된 탭을 닫기 전에 확인",
             "8e593f04fc": "고정된 탭을 닫기 전에 확인 대화상자를 표시합니다.",
             "defaultProjectRuntime": "기본 프로젝트 런타임",
-            "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다."
+            "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다.",
+            "a1c4e7f209": "Automatic updates",
+            "b2d5f8a310": "Download and install updates automatically in the background."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5094,6 +5094,8 @@
           "f44299636f": "업데이트하려면 다시 시작하세요(",
           "42717918f4": "업데이트 설치(",
           "02dc082e70": "업데이트 다운로드를 시작할 수 없습니다.",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.",
           "e1a647adc5": "업데이트 확인",
           "ceb579abaf": "앱 업데이트를 확인하고 최신 Orca 버전을 설치하세요.",
           "d91ebfb87e": "현재 버전: {{value0}}",
@@ -5110,9 +5112,7 @@
           "31fd7150cf": "업데이트 확인 중...",
           "3394d1f663": "확인 중",
           "d69a09b672": "업데이트는 시작 시 자동으로 확인됩니다.",
-          "7173352632": "idle",
-          "a73f0c19be": "Automatic updates",
-          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
+          "7173352632": "idle"
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "워크스페이스의 열기 메뉴에서 사용 가능한 앱을 선택하세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5110,7 +5110,9 @@
           "31fd7150cf": "正在检查更新...",
           "3394d1f663": "检查中",
           "d69a09b672": "启动时会自动检查更新。",
-          "7173352632": "空闲"
+          "7173352632": "空闲",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "从工作区的“打开方式”菜单中选择可用的应用程序。",
@@ -7288,7 +7290,9 @@
             "161a86a9da": "关闭固定标签页前确认",
             "8e593f04fc": "关闭固定标签页前显示确认对话框。",
             "defaultProjectRuntime": "默认项目运行时",
-            "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。"
+            "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。",
+            "a1c4e7f209": "Automatic updates",
+            "b2d5f8a310": "Download and install updates automatically in the background."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5094,6 +5094,8 @@
           "f44299636f": "重新启动以更新（",
           "42717918f4": "安装更新（",
           "02dc082e70": "无法开始更新下载。",
+          "a73f0c19be": "Automatic updates",
+          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted.",
           "e1a647adc5": "检查更新",
           "ceb579abaf": "检查应用程序更新并安装较新的 Orca 版本。",
           "d91ebfb87e": "当前版本：{{value0}}",
@@ -5110,9 +5112,7 @@
           "31fd7150cf": "正在检查更新...",
           "3394d1f663": "检查中",
           "d69a09b672": "启动时会自动检查更新。",
-          "7173352632": "空闲",
-          "a73f0c19be": "Automatic updates",
-          "b8e724f0d3": "Download new updates automatically in the background. Once an update is downloaded, Orca installs it the next time you quit — your terminal sessions are never interrupted."
+          "7173352632": "空闲"
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "从工作区的“打开方式”菜单中选择可用的应用程序。",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -265,6 +265,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     httpProxyUrl: '',
     httpProxyBypassRules: '',
     electronHttp1CompatibilityMode: false,
+    automaticUpdates: false,
     openLinksInApp: false,
     openLinksInAppPreferencePrompted: false,
     openAgentTabsInChatByDefault: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2554,6 +2554,9 @@ export type GlobalSettings = {
   /** Why: corporate TLS-intercepting proxies can break Electron HTTP/2 downloads;
    *  this opt-in compatibility mode applies Chromium's process-wide HTTP/1.1 switch. */
   electronHttp1CompatibilityMode?: boolean
+  /** Why: opt-in automatic updates. When on, available updates download in the
+   *  background and install on the next natural quit; off preserves manual flow. */
+  automaticUpdates?: boolean
   /** Why: opening arbitrary links inside Orca uses an isolated guest browser surface.
    *  The setting stays opt-in so existing workflows continue to use the system browser
    *  until the user explicitly wants worktree-scoped in-app browsing. */


### PR DESCRIPTION
## What changes

Adds an opt-in **Automatic updates** toggle (Settings → General → Updates, **default off**). When enabled, an available update **downloads in the background with no manual click** and **installs on the next natural quit** — without the user clicking **Update** or **Restart to Update**.

**What does not change:** with the toggle off, the update flow is exactly as before (manual click-to-download, click-to-restart). Nothing force-quits or interrupts active work — install happens on a natural quit, and the renderer shows a non-blocking "Restart when you're ready" nudge, never a forced relaunch. The optional *timed idle/grace-period auto-relaunch* from the issue is intentionally **not** included (see Headline status).

Closes #5974.

## Design approach

The issue suggested setting `autoUpdater.autoDownload = true`. This PR deliberately does **not** do that. Instead it keeps `autoDownload = false` / `autoInstallOnAppQuit = true` unchanged and, when the setting is on, self-triggers the existing, tested `downloadUpdate()` from the `update-available` handler right after the `available` status is broadcast (`maybeAutoDownload()`). This is "programmatically click Update for the user."

Why this mechanism: enabling electron-updater's eager `autoDownload` makes it start downloading *synchronously* right after `update-available`, which can race the handler's async changelog fetch (~5s) — a `download-progress` event lands mid-fetch, flips state to `downloading`, and the post-`await` guard then drops `availableVersion`, the check-cadence bookkeeping, and the changelog (the downloading card would even show an empty version). Self-triggering after the broadcast sidesteps that race entirely (no `download-progress` can fire before our call) and preserves the rich changelog on the auto path — with **no reorder of the fragile updater event handler**.

Enabling the toggle while an update is already in the `available` state starts the download immediately (`applyAutomaticUpdatesSetting`), rather than waiting for the next 24h check.

## Compatibility with #5259 (update cooldown, in parallel)

Orthogonal layers: cooldown gates *which versions are offered* (at the check/feed-resolution seam); this PR gates *whether the offered update downloads automatically*. If cooldown filters a version out, `update-available` never fires for it, so auto-download has nothing to download — it honors cooldown for free. No shared setting key, store field, or function signature beyond an additive `setupAutoUpdater` opt.

## Implementation & deviations

- `automaticUpdates?: boolean` on `GlobalSettings` (default `false`); persists/round-trips via the existing store.
- `maybeAutoDownload()` + `applyAutomaticUpdatesSetting()` in `src/main/updater.ts`; one-line call in `src/main/updater-events.ts`; live-toggle apply-hook in the settings IPC (fires only when the value actually changes).
- Renderer: an "Automatic updates" switch in the Updates settings section; a one-line `UpdateCard` change so an auto-staged `downloaded` for a previously-dismissed version still surfaces the restart nudge; a settings-search descriptor entry so the toggle is discoverable.

No deviations from the reviewed design.

## Headline behavior status

**Implemented.** Auto-download runs on the live update-check event path (gated only by `app.isPackaged && !is.dev`, as all updater code is); auto-install reuses the always-on `autoInstallOnAppQuit`.

**Deferred / not implemented:** the issue's *optional* "auto-apply after an idle/grace period" (a timed auto-relaunch). The acceptance criteria require install "either on quit, or via an auto-apply grace period" — install-on-quit satisfies that, and a timed force-relaunch risks interrupting active work (AC: no forced interruption). Left as possible follow-up.

## Completeness verification

Read-only pass confirmed every design requirement and acceptance criterion is implemented (not scaffolded), with file:line evidence, and that only the intended files changed.

## Perf audit

**Performance-neutral.** No new timers/polling/subprocess/network work — reuses the existing one-shot `downloadUpdate()` and does not enable eager `autoDownload`. The new main-process accessor is a cheap closure called only during a check. The Settings section's new `settings` store selector re-renders only on actual settings writes and only while the General pane is mounted; `UpdateCard` adds no new subscription.

## Code-review loop

Two rounds, two `review-code` reviewers in parallel each round. Round 1 found one blocker — the new i18n keys weren't synced into the locale catalog (`pnpm lint`'s catalog gate would have failed CI); fixed via the repo's sync script. Round 2: both reviewers clean. A suggestion to "just set `autoDownload = true`" was rejected for the race reason above.

## Validation (Electron, manual)

Launched the PR worktree in Electron and verified identity, then exercised the real UI:

- Toggle renders in Settings → General → Updates, consistent with neighboring switch rows (STYLEGUIDE).
- Clicking it ON sets `settings.automaticUpdates = true` in the backing store; OFF returns it to `false`; visual state tracks the store both ways (persistence round-trip).
- Settings search for "automatic" / "background" / "install" surfaces the toggle (after a follow-up fix to the section search descriptor — the section is gated separately from the row's own keywords); "version" still surfaces the section (no regression).
- No console errors during interactions.

**Accepted validation gap:** a true end-to-end auto-download/install cannot run in a dev build (`setupAutoUpdater`/`maybeAutoDownload`/`applyAutomaticUpdatesSetting` early-return when unpackaged). The auto-download trigger, manual-mode-unchanged behavior, live toggle, dev no-op, and `autoDownload`/`autoInstallOnAppQuit` invariants are covered by main-process unit tests instead.

## Static checks & focused tests

- `pnpm typecheck` — pass
- oxlint on touched files — pass
- localization catalog verify — pass
- `pnpm vitest run` on `updater.test.ts`, `persistence.test.ts`, `ipc/settings.test.ts`, `UpdateCard.test.ts` — **460 passed**
- `git diff --check` — clean

## Risks / notes

- Default-off; no migration (absent key reads as `false`). Reversible — toggling off restores manual mode for the next cycle.
- No telemetry added (could add `automaticUpdates` to the settings-changed whitelist later for adoption metrics).
