### PR TITLE
Show Kimi Code token analytics in Settings

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ import { StatsCollector, initStatsPath } from './stats/collector'
 import { ClaudeUsageStore, initClaudeUsagePath } from './claude-usage/store'
 import { CodexUsageStore, initCodexUsagePath } from './codex-usage/store'
 import { OpenCodeUsageStore, initOpenCodeUsagePath } from './opencode-usage/store'
+import { KimiUsageStore, initKimiUsagePath } from './kimi-usage/store'
 import { killAllPty } from './ipc/pty'
 import { initDaemonPtyProvider, disconnectDaemon, shutdownDaemon } from './daemon/daemon-init'
 import { closeAllWatchers } from './ipc/filesystem-watcher'
@@ -167,6 +168,7 @@ let stats: StatsCollector | null = null
 let claudeUsage: ClaudeUsageStore | null = null
 let codexUsage: CodexUsageStore | null = null
 let openCodeUsage: OpenCodeUsageStore | null = null
+let kimiUsage: KimiUsageStore | null = null
 let codexAccounts: CodexAccountService | null = null
 let codexRuntimeHome: CodexRuntimeHomeService | null = null
 let claudeAccounts: ClaudeAccountService | null = null
@@ -506,6 +508,7 @@ if (hasSingleInstanceLock) {
   initClaudeUsagePath()
   initCodexUsagePath()
   initOpenCodeUsagePath()
+  initKimiUsagePath()
   crashReports = CrashReportStore.fromUserData()
   recordCrashBreadcrumb('app_started', {
     packaged: app.isPackaged,
@@ -620,6 +623,9 @@ function openMainWindow(): BrowserWindow {
   }
   if (!openCodeUsage) {
     throw new Error('OpenCode usage store must be initialized before opening the main window')
+  }
+  if (!kimiUsage) {
+    throw new Error('Kimi usage store must be initialized before opening the main window')
   }
   if (!rateLimits) {
     throw new Error('Rate limit service must be initialized before opening the main window')
@@ -737,6 +743,7 @@ function openMainWindow(): BrowserWindow {
     claudeUsage,
     codexUsage,
     openCodeUsage,
+    kimiUsage,
     codexAccounts,
     claudeAccounts,
     rateLimits,
@@ -1383,6 +1390,7 @@ app.whenReady().then(async () => {
   claudeUsage = new ClaudeUsageStore(store)
   codexUsage = new CodexUsageStore(store)
   openCodeUsage = new OpenCodeUsageStore(store)
+  kimiUsage = new KimiUsageStore(store)
   rateLimits = new RateLimitService()
   codexRuntimeHome = new CodexRuntimeHomeService(store)
   codexAccounts = new CodexAccountService(store, rateLimits, codexRuntimeHome)

--- a/src/main/ipc/kimi-usage.ts
+++ b/src/main/ipc/kimi-usage.ts
@@ -1,0 +1,48 @@
+import { ipcMain } from 'electron'
+import type { KimiUsageStore } from '../kimi-usage/store'
+import type {
+  KimiUsageBreakdownKind,
+  KimiUsageRange,
+  KimiUsageScope
+} from '../../shared/kimi-usage-types'
+
+export function registerKimiUsageHandlers(kimiUsage: KimiUsageStore): void {
+  ipcMain.handle('kimiUsage:getScanState', () => kimiUsage.getScanState())
+  ipcMain.handle('kimiUsage:setEnabled', (_event, args: { enabled: boolean }) =>
+    kimiUsage.setEnabled(args.enabled)
+  )
+  ipcMain.handle('kimiUsage:refresh', (_event, args?: { force?: boolean }) =>
+    kimiUsage.refresh(args?.force ?? false)
+  )
+  ipcMain.handle(
+    'kimiUsage:getSnapshot',
+    (_event, args: { scope: KimiUsageScope; range: KimiUsageRange; limit?: number }) =>
+      kimiUsage.getSnapshot(args.scope, args.range, args.limit)
+  )
+  ipcMain.handle(
+    'kimiUsage:getSummary',
+    (_event, args: { scope: KimiUsageScope; range: KimiUsageRange }) =>
+      kimiUsage.getSummary(args.scope, args.range)
+  )
+  ipcMain.handle(
+    'kimiUsage:getDaily',
+    (_event, args: { scope: KimiUsageScope; range: KimiUsageRange }) =>
+      kimiUsage.getDaily(args.scope, args.range)
+  )
+  ipcMain.handle(
+    'kimiUsage:getBreakdown',
+    (
+      _event,
+      args: {
+        scope: KimiUsageScope
+        range: KimiUsageRange
+        kind: KimiUsageBreakdownKind
+      }
+    ) => kimiUsage.getBreakdown(args.scope, args.range, args.kind)
+  )
+  ipcMain.handle(
+    'kimiUsage:getRecentSessions',
+    (_event, args: { scope: KimiUsageScope; range: KimiUsageRange; limit?: number }) =>
+      kimiUsage.getRecentSessions(args.scope, args.range, args.limit)
+  )
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -8,6 +8,7 @@ const {
   registerClaudeUsageHandlersMock,
   registerCodexUsageHandlersMock,
   registerOpenCodeUsageHandlersMock,
+  registerKimiUsageHandlersMock,
   registerGitHubHandlersMock,
   registerFeedbackHandlersMock,
   registerStatsHandlersMock,
@@ -61,6 +62,7 @@ const {
   registerClaudeUsageHandlersMock: vi.fn(),
   registerCodexUsageHandlersMock: vi.fn(),
   registerOpenCodeUsageHandlersMock: vi.fn(),
+  registerKimiUsageHandlersMock: vi.fn(),
   registerGitHubHandlersMock: vi.fn(),
   registerFeedbackHandlersMock: vi.fn(),
   registerStatsHandlersMock: vi.fn(),
@@ -136,6 +138,10 @@ vi.mock('./codex-usage', () => ({
 
 vi.mock('./opencode-usage', () => ({
   registerOpenCodeUsageHandlers: registerOpenCodeUsageHandlersMock
+}))
+
+vi.mock('./kimi-usage', () => ({
+  registerKimiUsageHandlers: registerKimiUsageHandlersMock
 }))
 
 vi.mock('./github', () => ({
@@ -315,6 +321,7 @@ describe('registerCoreHandlers', () => {
     registerClaudeUsageHandlersMock.mockReset()
     registerCodexUsageHandlersMock.mockReset()
     registerOpenCodeUsageHandlersMock.mockReset()
+    registerKimiUsageHandlersMock.mockReset()
     registerGitHubHandlersMock.mockReset()
     registerFeedbackHandlersMock.mockReset()
     registerStatsHandlersMock.mockReset()
@@ -370,6 +377,7 @@ describe('registerCoreHandlers', () => {
     const claudeUsage = { marker: 'claudeUsage' }
     const codexUsage = { marker: 'codexUsage' }
     const openCodeUsage = { marker: 'openCodeUsage' }
+    const kimiUsage = { marker: 'kimiUsage' }
     const codexAccounts = { marker: 'codexAccounts' }
     const claudeAccounts = { marker: 'claudeAccounts' }
     const rateLimits = { marker: 'rateLimits' }
@@ -384,6 +392,7 @@ describe('registerCoreHandlers', () => {
       claudeUsage as never,
       codexUsage as never,
       openCodeUsage as never,
+      kimiUsage as never,
       codexAccounts as never,
       claudeAccounts as never,
       rateLimits as never,
@@ -399,6 +408,7 @@ describe('registerCoreHandlers', () => {
     expect(registerClaudeUsageHandlersMock).toHaveBeenCalledWith(claudeUsage)
     expect(registerCodexUsageHandlersMock).toHaveBeenCalledWith(codexUsage)
     expect(registerOpenCodeUsageHandlersMock).toHaveBeenCalledWith(openCodeUsage)
+    expect(registerKimiUsageHandlersMock).toHaveBeenCalledWith(kimiUsage)
     expect(registerAppHandlersMock).toHaveBeenCalledWith(store, { onBeforeRelaunch })
     expect(registerCodexAccountHandlersMock).toHaveBeenCalledWith(codexAccounts)
     expect(registerAgentHookHandlersMock).toHaveBeenCalledWith(runtime)
@@ -455,6 +465,7 @@ describe('registerCoreHandlers', () => {
     const claudeUsage2 = { marker: 'claudeUsage2' }
     const codexUsage2 = { marker: 'codexUsage2' }
     const openCodeUsage2 = { marker: 'openCodeUsage2' }
+    const kimiUsage2 = { marker: 'kimiUsage2' }
     const codexAccounts2 = { marker: 'codexAccounts2' }
     const claudeAccounts2 = { marker: 'claudeAccounts2' }
     const rateLimits2 = { marker: 'rateLimits2' }
@@ -466,6 +477,7 @@ describe('registerCoreHandlers', () => {
       claudeUsage2 as never,
       codexUsage2 as never,
       openCodeUsage2 as never,
+      kimiUsage2 as never,
       codexAccounts2 as never,
       claudeAccounts2 as never,
       rateLimits2 as never,

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -10,6 +10,7 @@ import { registerFilesystemWatcherHandlers } from './filesystem-watcher'
 import { registerClaudeUsageHandlers } from './claude-usage'
 import { registerCodexUsageHandlers } from './codex-usage'
 import { registerOpenCodeUsageHandlers } from './opencode-usage'
+import { registerKimiUsageHandlers } from './kimi-usage'
 import { registerGitHubHandlers } from './github'
 import { registerGitLabHandlers } from './gitlab'
 import { registerHostedReviewHandlers } from './hosted-review'
@@ -59,6 +60,7 @@ import {
 import type { ClaudeUsageStore } from '../claude-usage/store'
 import type { CodexUsageStore } from '../codex-usage/store'
 import type { OpenCodeUsageStore } from '../opencode-usage/store'
+import type { KimiUsageStore } from '../kimi-usage/store'
 import type { RateLimitService } from '../rate-limits/service'
 import type { CodexAccountService } from '../codex-accounts/service'
 import type { ClaudeAccountService } from '../claude-accounts/service'
@@ -81,6 +83,7 @@ export function registerCoreHandlers(
   claudeUsage: ClaudeUsageStore,
   codexUsage: CodexUsageStore,
   openCodeUsage: OpenCodeUsageStore,
+  kimiUsage: KimiUsageStore,
   codexAccounts: CodexAccountService,
   claudeAccounts: ClaudeAccountService,
   rateLimits: RateLimitService,
@@ -111,6 +114,7 @@ export function registerCoreHandlers(
   registerClaudeUsageHandlers(claudeUsage)
   registerCodexUsageHandlers(codexUsage)
   registerOpenCodeUsageHandlers(openCodeUsage)
+  registerKimiUsageHandlers(kimiUsage)
   registerCodexAccountHandlers(codexAccounts)
   registerAgentHookHandlers(runtime)
   registerAgentTrustHandlers()

--- a/src/main/kimi-usage/cost-aggregation.ts
+++ b/src/main/kimi-usage/cost-aggregation.ts
@@ -1,0 +1,6 @@
+export function addCost(left: number | null, right: number | null): number | null {
+  if (left === null && right === null) {
+    return null
+  }
+  return (left ?? 0) + (right ?? 0)
+}

--- a/src/main/kimi-usage/event-attribution.ts
+++ b/src/main/kimi-usage/event-attribution.ts
@@ -1,0 +1,158 @@
+import { realpath } from 'fs/promises'
+import { posix, win32 } from 'path'
+import type { Repo } from '../../shared/types'
+import { areWorktreePathsEqual } from '../ipc/worktree-logic'
+import { canonicalizeUsageWorktreePaths } from '../usage-worktree-canonicalizer'
+import type { KimiUsageAttributedEvent, KimiUsageParsedEvent } from './types'
+
+export type KimiUsageWorktreeRef = {
+  repoId: string
+  worktreeId: string
+  path: string
+  displayName: string
+}
+
+function looksLikeWindowsPath(pathValue: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\')
+}
+
+function normalizeComparablePath(pathValue: string, platform = process.platform): string {
+  const normalized = pathValue.replace(/\\/g, '/')
+  return platform === 'win32' || looksLikeWindowsPath(pathValue)
+    ? normalized.toLowerCase()
+    : normalized
+}
+
+function normalizeFsPath(pathValue: string, platform = process.platform): string {
+  if (platform === 'win32' || looksLikeWindowsPath(pathValue)) {
+    return win32.normalize(win32.resolve(pathValue))
+  }
+  return posix.normalize(posix.resolve(pathValue))
+}
+
+export function getDefaultProjectLabel(cwd: string | null): string {
+  if (!cwd) {
+    return 'Unknown location'
+  }
+  const parts = cwd.replace(/\\/g, '/').split('/').filter(Boolean)
+  if (parts.length >= 2) {
+    return parts.slice(-2).join('/')
+  }
+  return parts.at(-1) ?? cwd
+}
+
+export function localDayFromTimestamp(timestamp: string): string | null {
+  const parsed = new Date(timestamp)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+  const year = parsed.getFullYear()
+  const month = String(parsed.getMonth() + 1).padStart(2, '0')
+  const day = String(parsed.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function isContainingPath(candidatePath: string, targetPath: string): boolean {
+  const useWin32 = looksLikeWindowsPath(candidatePath) || looksLikeWindowsPath(targetPath)
+  const relativePath = useWin32
+    ? win32.relative(candidatePath, targetPath)
+    : posix.relative(candidatePath, targetPath)
+  if (!relativePath) {
+    return true
+  }
+  const isAbsoluteRelative = useWin32
+    ? win32.isAbsolute(relativePath)
+    : posix.isAbsolute(relativePath)
+  const parentPrefix = useWin32 ? `..${win32.sep}` : `..${posix.sep}`
+  // Why: `..name` is a valid child path; only `..` and `../...` escape.
+  return (
+    !isAbsoluteRelative &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(parentPrefix) &&
+    relativePath !== '.'
+  )
+}
+
+export async function canonicalizePath(pathValue: string): Promise<string> {
+  try {
+    return normalizeFsPath(await realpath(pathValue))
+  } catch {
+    return normalizeFsPath(pathValue)
+  }
+}
+
+export async function buildWorktreesWithCanonicalPaths(
+  worktrees: KimiUsageWorktreeRef[]
+): Promise<(KimiUsageWorktreeRef & { canonicalPath: string })[]> {
+  return canonicalizeUsageWorktreePaths(worktrees, canonicalizePath)
+}
+
+export function findContainingWorktree(
+  cwd: string,
+  worktrees: (KimiUsageWorktreeRef & { canonicalPath: string })[]
+): KimiUsageWorktreeRef | null {
+  const normalizedCwd = normalizeFsPath(cwd)
+  for (const worktree of worktrees) {
+    if (areWorktreePathsEqual(worktree.canonicalPath, normalizedCwd)) {
+      return worktree
+    }
+    if (isContainingPath(worktree.canonicalPath, normalizedCwd)) {
+      return worktree
+    }
+  }
+  return null
+}
+
+export async function attributeKimiUsageEvent(
+  event: KimiUsageParsedEvent,
+  worktrees: (KimiUsageWorktreeRef & { canonicalPath: string })[]
+): Promise<KimiUsageAttributedEvent | null> {
+  const day = localDayFromTimestamp(event.timestamp)
+  if (!day) {
+    return null
+  }
+
+  let repoId: string | null = null
+  let worktreeId: string | null = null
+  let projectKey = 'unscoped'
+  let projectLabel = getDefaultProjectLabel(event.cwd)
+
+  if (event.cwd) {
+    const worktree = findContainingWorktree(event.cwd, worktrees)
+    if (worktree) {
+      repoId = worktree.repoId
+      worktreeId = worktree.worktreeId
+      projectKey = `worktree:${worktree.worktreeId}`
+      projectLabel = worktree.displayName
+    } else {
+      projectKey = `cwd:${normalizeComparablePath(event.cwd)}`
+    }
+  }
+
+  return {
+    ...event,
+    day,
+    projectKey,
+    projectLabel,
+    repoId,
+    worktreeId
+  }
+}
+
+export function createWorktreeRefs(
+  repos: Repo[],
+  worktreesByRepo: Map<string, { path: string; worktreeId: string; displayName: string }[]>
+): KimiUsageWorktreeRef[] {
+  const refs: KimiUsageWorktreeRef[] = []
+  for (const repo of repos) {
+    for (const worktree of worktreesByRepo.get(repo.id) ?? []) {
+      refs.push({
+        repoId: repo.id,
+        worktreeId: worktree.worktreeId,
+        path: worktree.path,
+        displayName: worktree.displayName
+      })
+    }
+  }
+  return refs
+}

--- a/src/main/kimi-usage/scanner.test.ts
+++ b/src/main/kimi-usage/scanner.test.ts
@@ -1,0 +1,354 @@
+import { mkdir, mkdtemp, rm, writeFile, stat, utimes } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearKimiSessionIndexCache } from '../ai-vault/session-scanner-kimi-paths'
+import { buildWorktreesWithCanonicalPaths, type KimiUsageWorktreeRef } from './event-attribution'
+import {
+  listKimiUsageSessionFiles,
+  parseKimiUsageWire,
+  scanKimiUsage,
+  type KimiUsageSessionFile
+} from './scanner'
+
+let tempHomes: string[] = []
+const originalKimiHome = process.env.KIMI_CODE_HOME
+
+afterEach(async () => {
+  await Promise.all(tempHomes.map((dir) => rm(dir, { recursive: true, force: true })))
+  tempHomes = []
+  clearKimiSessionIndexCache()
+  if (originalKimiHome === undefined) {
+    delete process.env.KIMI_CODE_HOME
+  } else {
+    process.env.KIMI_CODE_HOME = originalKimiHome
+  }
+})
+
+beforeEach(() => {
+  clearKimiSessionIndexCache()
+})
+
+const DEFAULT_STATE = {
+  createdAt: '2026-06-19T07:19:19.118Z',
+  updatedAt: '2026-06-19T07:19:19.161Z',
+  title: 'Explain this project',
+  agents: { main: { type: 'main', parentAgentId: null } },
+  lastPrompt: 'Explain this project'
+}
+
+// One turn-scoped usage.record carrying its own epoch-ms `time`.
+function turnUsageLine(args: {
+  inputOther: number
+  output: number
+  inputCacheRead?: number
+  inputCacheCreation?: number
+  model?: string
+  time?: number
+}): Record<string, unknown> {
+  return {
+    type: 'usage.record',
+    model: args.model ?? 'kimi-k2',
+    usage: {
+      inputOther: args.inputOther,
+      output: args.output,
+      inputCacheRead: args.inputCacheRead ?? 0,
+      inputCacheCreation: args.inputCacheCreation ?? 0
+    },
+    usageScope: 'turn',
+    ...(args.time === undefined ? {} : { time: args.time })
+  }
+}
+
+async function writeKimiSession(args: {
+  home: string
+  sessionId: string
+  workDir?: string | null
+  state?: Record<string, unknown>
+  wireLines?: unknown[] | null
+}): Promise<{ home: string; statePath: string; wirePath: string }> {
+  const sessionDir = join(args.home, 'sessions', 'wd_proj_36fb0f9f4385', args.sessionId)
+  await mkdir(join(sessionDir, 'agents', 'main'), { recursive: true })
+  const statePath = join(sessionDir, 'state.json')
+  await writeFile(statePath, JSON.stringify(args.state ?? DEFAULT_STATE))
+
+  if (args.workDir !== null) {
+    await writeFile(
+      join(args.home, 'session_index.jsonl'),
+      `${JSON.stringify({ sessionId: args.sessionId, sessionDir, workDir: args.workDir ?? '/private/tmp/proj' })}\n`,
+      { flag: 'a' }
+    )
+  }
+
+  const wirePath = join(sessionDir, 'agents', 'main', 'wire.jsonl')
+  if (args.wireLines !== null) {
+    await writeFile(wirePath, (args.wireLines ?? []).map((line) => JSON.stringify(line)).join('\n'))
+  }
+  return { home: args.home, statePath, wirePath }
+}
+
+async function makeHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'orca-kimi-usage-'))
+  tempHomes.push(home)
+  return home
+}
+
+async function noWorktrees(): Promise<(KimiUsageWorktreeRef & { canonicalPath: string })[]> {
+  return buildWorktreesWithCanonicalPaths([])
+}
+
+describe('parseKimiUsageWire', () => {
+  it('sums a turn-scoped usage.record across all four token buckets', async () => {
+    const home = await makeHome()
+    const { wirePath, statePath } = await writeKimiSession({
+      home,
+      sessionId: 'session_aaa',
+      wireLines: [
+        { type: 'config.update', modelAlias: 'kimi-k2' },
+        turnUsageLine({
+          inputOther: 12,
+          output: 18,
+          inputCacheRead: 5,
+          inputCacheCreation: 3,
+          time: 1781853559177
+        })
+      ]
+    })
+    const file: KimiUsageSessionFile = { ...(await stat(wirePath)), path: wirePath, statePath }
+    const result = await parseKimiUsageWire(file, await noWorktrees())
+
+    expect(result.sessions).toHaveLength(1)
+    const session = result.sessions[0]
+    expect(session.totalInputTokens).toBe(12)
+    expect(session.totalCachedInputTokens).toBe(8) // 5 + 3
+    expect(session.totalOutputTokens).toBe(18)
+    expect(session.totalReasoningOutputTokens).toBe(0)
+    expect(session.totalTokens).toBe(38) // 12 + 8 + 18
+    expect(session.estimatedCostUsd).toBeNull()
+    expect(session.primaryModel).toBe('kimi-k2')
+  })
+
+  it('ignores cumulative session-scoped usage.record to avoid double-counting', async () => {
+    const home = await makeHome()
+    const { wirePath, statePath } = await writeKimiSession({
+      home,
+      sessionId: 'session_bbb',
+      wireLines: [
+        turnUsageLine({ inputOther: 10, output: 10, time: 1781853559177 }),
+        {
+          type: 'usage.record',
+          model: 'kimi-k2',
+          usage: { inputOther: 999, output: 999, inputCacheRead: 0, inputCacheCreation: 0 },
+          usageScope: 'session',
+          time: 1781853559200
+        }
+      ]
+    })
+    const file: KimiUsageSessionFile = { ...(await stat(wirePath)), path: wirePath, statePath }
+    const result = await parseKimiUsageWire(file, await noWorktrees())
+
+    expect(result.sessions[0].totalTokens).toBe(20) // only the turn record
+  })
+
+  it('dates each record by its own day when records carry time', async () => {
+    const home = await makeHome()
+    const day1 = Date.parse('2026-05-14T10:00:00Z')
+    const day2 = Date.parse('2026-05-16T10:00:00Z')
+    const { wirePath, statePath } = await writeKimiSession({
+      home,
+      sessionId: 'session_ccc',
+      wireLines: [
+        turnUsageLine({ inputOther: 5, output: 5, time: day1 }),
+        turnUsageLine({ inputOther: 7, output: 7, time: day2 })
+      ]
+    })
+    const file: KimiUsageSessionFile = { ...(await stat(wirePath)), path: wirePath, statePath }
+    const result = await parseKimiUsageWire(file, await noWorktrees())
+
+    expect(result.dailyAggregates).toHaveLength(2)
+    expect(result.dailyAggregates.map((entry) => entry.day).sort()).toEqual(
+      [localDay(day1), localDay(day2)].sort()
+    )
+  })
+
+  it('falls back to state.json updatedAt when a usage.record has no time', async () => {
+    const home = await makeHome()
+    const { wirePath, statePath } = await writeKimiSession({
+      home,
+      sessionId: 'session_ddd',
+      // No `time` on the record at all.
+      wireLines: [turnUsageLine({ inputOther: 4, output: 6 })]
+    })
+    const file: KimiUsageSessionFile = { ...(await stat(wirePath)), path: wirePath, statePath }
+    const result = await parseKimiUsageWire(file, await noWorktrees())
+
+    expect(result.sessions[0].totalTokens).toBe(10)
+    // updatedAt is 2026-06-19 (local day derived from that ISO timestamp).
+    const expectedDay = localDayFromIso('2026-06-19T07:19:19.161Z')
+    expect(result.dailyAggregates).toHaveLength(1)
+    expect(result.dailyAggregates[0].day).toBe(expectedDay)
+  })
+
+  it('collapses an all-timeless session onto one day without losing tokens', async () => {
+    const home = await makeHome()
+    const { wirePath, statePath } = await writeKimiSession({
+      home,
+      sessionId: 'session_eee',
+      wireLines: [
+        turnUsageLine({ inputOther: 4, output: 6 }),
+        turnUsageLine({ inputOther: 1, output: 9 })
+      ]
+    })
+    const file: KimiUsageSessionFile = { ...(await stat(wirePath)), path: wirePath, statePath }
+    const result = await parseKimiUsageWire(file, await noWorktrees())
+
+    expect(result.dailyAggregates).toHaveLength(1)
+    expect(result.sessions[0].totalTokens).toBe(20) // 10 + 10, nothing dropped
+  })
+
+  it('tolerates malformed lines without aborting the file', async () => {
+    const home = await makeHome()
+    const { wirePath, statePath } = await writeKimiSession({ home, sessionId: 'session_fff' })
+    await writeFile(
+      wirePath,
+      ['{not-json', JSON.stringify(turnUsageLine({ inputOther: 3, output: 7, time: 1 }))].join('\n')
+    )
+    const file: KimiUsageSessionFile = { ...(await stat(wirePath)), path: wirePath, statePath }
+    const result = await parseKimiUsageWire(file, await noWorktrees())
+
+    expect(result.sessions[0].totalTokens).toBe(10)
+  })
+
+  it('attributes a session to a containing worktree and otherwise to unscoped', async () => {
+    const home = await makeHome()
+    const worktreePath = '/private/tmp/proj'
+    const { wirePath, statePath } = await writeKimiSession({
+      home,
+      sessionId: 'session_ggg',
+      workDir: worktreePath,
+      wireLines: [turnUsageLine({ inputOther: 8, output: 2, time: 1781853559177 })]
+    })
+    const worktrees = await buildWorktreesWithCanonicalPaths([
+      { repoId: 'repo1', worktreeId: 'wt1', path: worktreePath, displayName: 'proj' }
+    ])
+    const attributed = await parseKimiUsageWire(
+      { ...(await stat(wirePath)), path: wirePath, statePath },
+      worktrees
+    )
+    expect(attributed.sessions[0].primaryWorktreeId).toBe('wt1')
+
+    // A workDir with no matching worktree → unscoped (never mis-attributed).
+    const unscoped = await parseKimiUsageWire(
+      { ...(await stat(wirePath)), path: wirePath, statePath },
+      await noWorktrees()
+    )
+    expect(unscoped.sessions[0].primaryWorktreeId).toBeNull()
+    expect(unscoped.sessions[0].locationBreakdown[0].locationKey).toMatch(/^cwd:/)
+  })
+
+  it('returns no events for a session whose wire file does not exist', async () => {
+    const home = await makeHome()
+    const { statePath } = await writeKimiSession({
+      home,
+      sessionId: 'session_hhh',
+      wireLines: null
+    })
+    const missingWirePath = join(home, 'sessions', 'missing', 'wire.jsonl')
+    const result = await parseKimiUsageWire(
+      { path: missingWirePath, statePath, mtimeMs: 0, size: 0 },
+      await noWorktrees()
+    )
+    expect(result.sessions).toHaveLength(0)
+  })
+})
+
+describe('scanKimiUsage', () => {
+  it('aggregates multiple sessions across a Kimi home', async () => {
+    const home = await makeHome()
+    process.env.KIMI_CODE_HOME = home
+    await writeKimiSession({
+      home,
+      sessionId: 'session_one',
+      wireLines: [turnUsageLine({ inputOther: 10, output: 5, time: 1781853559177 })]
+    })
+    await writeKimiSession({
+      home,
+      sessionId: 'session_two',
+      wireLines: [turnUsageLine({ inputOther: 20, output: 5, time: 1781853559177 })]
+    })
+
+    const result = await scanKimiUsage([], [])
+    expect(result.sessions).toHaveLength(2)
+    const total = result.sessions.reduce((sum, session) => sum + session.totalTokens, 0)
+    expect(total).toBe(40) // (10+5) + (20+5)
+  })
+
+  it('reuses unchanged files and re-parses a grown wire file', async () => {
+    const home = await makeHome()
+    process.env.KIMI_CODE_HOME = home
+    const { wirePath } = await writeKimiSession({
+      home,
+      sessionId: 'session_grow',
+      wireLines: [turnUsageLine({ inputOther: 10, output: 0, time: 1781853559177 })]
+    })
+
+    const first = await scanKimiUsage([], [])
+    expect(first.sessions[0].totalTokens).toBe(10)
+
+    // Unchanged → reuse yields the same totals.
+    const reused = await scanKimiUsage([], first.processedFiles)
+    expect(reused.sessions[0].totalTokens).toBe(10)
+
+    // Append a second turn; mtime+size bump forces a re-parse.
+    await writeFile(
+      wirePath,
+      [
+        JSON.stringify(turnUsageLine({ inputOther: 10, output: 0, time: 1781853559177 })),
+        JSON.stringify(turnUsageLine({ inputOther: 7, output: 0, time: 1781853559177 }))
+      ].join('\n')
+    )
+    const future = Date.now() / 1000 + 5
+    await utimes(wirePath, future, future)
+
+    const regrown = await scanKimiUsage([], reused.processedFiles)
+    expect(regrown.sessions[0].totalTokens).toBe(17)
+  })
+
+  it('returns an empty result for a Kimi home with no sessions', async () => {
+    const home = await makeHome()
+    process.env.KIMI_CODE_HOME = home
+    await mkdir(join(home, 'sessions'), { recursive: true })
+    const result = await scanKimiUsage([], [])
+    expect(result.sessions).toHaveLength(0)
+    expect(result.dailyAggregates).toHaveLength(0)
+  })
+
+  it('lists one session file per session directory', async () => {
+    const home = await makeHome()
+    process.env.KIMI_CODE_HOME = home
+    await writeKimiSession({
+      home,
+      sessionId: 'session_list_a',
+      wireLines: [turnUsageLine({ inputOther: 1, output: 1, time: 1 })]
+    })
+    await writeKimiSession({
+      home,
+      sessionId: 'session_list_b',
+      wireLines: [turnUsageLine({ inputOther: 1, output: 1, time: 1 })]
+    })
+    const listed = await listKimiUsageSessionFiles(join(home, 'sessions'))
+    expect(listed).toHaveLength(2)
+  })
+})
+
+function localDay(millis: number): string {
+  return localDayFromIso(new Date(millis).toISOString())
+}
+
+function localDayFromIso(iso: string): string {
+  const parsed = new Date(iso)
+  const year = parsed.getFullYear()
+  const month = String(parsed.getMonth() + 1).padStart(2, '0')
+  const day = String(parsed.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/src/main/kimi-usage/scanner.ts
+++ b/src/main/kimi-usage/scanner.ts
@@ -1,0 +1,282 @@
+import { createReadStream } from 'fs'
+import { readdir, readFile, stat } from 'fs/promises'
+import { join } from 'path'
+import { createInterface } from 'readline'
+import {
+  kimiPrimaryAgentWirePath,
+  kimiSessionIdFromStatePath,
+  kimiSessionIndexPathFromStatePath,
+  readKimiWorkDirBySessionId,
+  resolveKimiSessionsDir
+} from '../ai-vault/session-scanner-kimi-paths'
+import {
+  asRecord,
+  extractString,
+  numberValue,
+  parseJsonObject
+} from '../ai-vault/session-scanner-values'
+import {
+  attributeKimiUsageEvent,
+  buildWorktreesWithCanonicalPaths,
+  type KimiUsageWorktreeRef
+} from './event-attribution'
+import { aggregateKimiUsage, finalizeSessions } from './session-aggregation'
+import { mergeDailyAggregates, mergeSessions } from './usage-state-merging'
+import type {
+  KimiUsageAttributedEvent,
+  KimiUsageDailyAggregate,
+  KimiUsageParsedEvent,
+  KimiUsagePersistedFile,
+  KimiUsageProcessedFile,
+  KimiUsageSession
+} from './types'
+
+export { createWorktreeRefs } from './event-attribution'
+
+export type KimiUsageSessionFile = KimiUsageProcessedFile & {
+  statePath: string
+}
+
+const YIELD_EVERY_FILES = 10
+const YIELD_EVERY_DISCOVERY_ENTRIES = 100
+
+async function yieldToEventLoop(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+async function readStateRecord(statePath: string): Promise<Record<string, unknown> | null> {
+  try {
+    return asRecord(JSON.parse(await readFile(statePath, 'utf-8')) as unknown)
+  } catch {
+    return null
+  }
+}
+
+async function discoverStatePaths(sessionsDir: string): Promise<string[]> {
+  const statePaths: string[] = []
+  let visited = 0
+  try {
+    const workspaceEntries = await readdir(sessionsDir, { withFileTypes: true })
+    for (const workspaceEntry of workspaceEntries) {
+      if (!workspaceEntry.isDirectory() || !workspaceEntry.name.startsWith('wd_')) {
+        continue
+      }
+      const workspaceDir = join(sessionsDir, workspaceEntry.name)
+      const sessionEntries = await readdir(workspaceDir, { withFileTypes: true })
+      for (const sessionEntry of sessionEntries) {
+        if (sessionEntry.isDirectory() && sessionEntry.name.startsWith('session_')) {
+          statePaths.push(join(workspaceDir, sessionEntry.name, 'state.json'))
+        }
+        visited++
+        if (visited % YIELD_EVERY_DISCOVERY_ENTRIES === 0) {
+          await yieldToEventLoop()
+        }
+      }
+    }
+  } catch {
+    return []
+  }
+  return statePaths.sort()
+}
+
+export async function listKimiUsageSessionFiles(
+  override?: string
+): Promise<KimiUsageSessionFile[]> {
+  const files: KimiUsageSessionFile[] = []
+  // Why: this reads+parses every session's state.json and stats its wire file
+  // on each scan (it feeds the reuse check, so it runs even when files are
+  // reused). Yield periodically so a large Kimi history can't stall the main
+  // process when Settings → Stats triggers a scan.
+  for (const [index, statePath] of (
+    await discoverStatePaths(resolveKimiSessionsDir(override))
+  ).entries()) {
+    if (index > 0 && index % YIELD_EVERY_DISCOVERY_ENTRIES === 0) {
+      await yieldToEventLoop()
+    }
+    const stateRecord = await readStateRecord(statePath)
+    if (!stateRecord) {
+      continue
+    }
+    const wirePath = kimiPrimaryAgentWirePath(statePath, stateRecord)
+    try {
+      const wireStat = await stat(wirePath)
+      if (wireStat.isFile()) {
+        files.push({
+          statePath,
+          path: wirePath,
+          mtimeMs: wireStat.mtimeMs,
+          size: wireStat.size
+        })
+      }
+    } catch {
+      continue
+    }
+  }
+  return files.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+function normalizeEpochMillis(value: unknown): string | null {
+  const numeric = numberValue(value)
+  return numeric > 0 ? new Date(numeric).toISOString() : null
+}
+
+function fallbackTimestamp(stateRecord: Record<string, unknown> | null): string | null {
+  return extractString(stateRecord?.updatedAt) ?? extractString(stateRecord?.createdAt)
+}
+
+function parseKimiUsageEvent(args: {
+  record: Record<string, unknown>
+  sessionId: string
+  cwd: string | null
+  fallbackTimestamp: string | null
+  latestModel: string | null
+}): KimiUsageParsedEvent | null {
+  if (args.record.usageScope === 'session') {
+    return null
+  }
+  const usage = asRecord(args.record.usage)
+  if (!usage) {
+    return null
+  }
+  const inputTokens = numberValue(usage.inputOther)
+  const cachedInputTokens =
+    numberValue(usage.inputCacheRead) + numberValue(usage.inputCacheCreation)
+  const outputTokens = numberValue(usage.output)
+  const timestamp = normalizeEpochMillis(args.record.time) ?? args.fallbackTimestamp
+  if (!timestamp) {
+    return null
+  }
+  return {
+    sessionId: args.sessionId,
+    timestamp,
+    cwd: args.cwd,
+    model: args.latestModel,
+    estimatedCostUsd: null,
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    reasoningOutputTokens: 0,
+    totalTokens: inputTokens + cachedInputTokens + outputTokens
+  }
+}
+
+async function getProcessedFileInfo(file: KimiUsageSessionFile): Promise<KimiUsageProcessedFile> {
+  try {
+    const wireStat = await stat(file.path)
+    return {
+      path: file.path,
+      mtimeMs: wireStat.mtimeMs,
+      size: wireStat.size
+    }
+  } catch {
+    return {
+      path: file.path,
+      mtimeMs: file.mtimeMs,
+      size: file.size
+    }
+  }
+}
+
+export async function parseKimiUsageWire(
+  file: KimiUsageSessionFile,
+  worktrees: (KimiUsageWorktreeRef & { canonicalPath: string })[]
+): Promise<KimiUsagePersistedFile> {
+  const processedFile = await getProcessedFileInfo(file)
+  const stateRecord = await readStateRecord(file.statePath)
+  if (!stateRecord) {
+    return { ...processedFile, sessions: [], dailyAggregates: [] }
+  }
+  const sessionId = kimiSessionIdFromStatePath(file.statePath)
+  const workDirBySessionId = await readKimiWorkDirBySessionId(
+    kimiSessionIndexPathFromStatePath(file.statePath)
+  )
+  const cwd = workDirBySessionId.get(sessionId) ?? null
+  const fallback = fallbackTimestamp(stateRecord)
+  let configModel: string | null = null
+  let usageModel: string | null = null
+  const events: KimiUsageAttributedEvent[] = []
+
+  try {
+    const lines = createInterface({
+      input: createReadStream(file.path, { encoding: 'utf-8' }),
+      crlfDelay: Infinity
+    })
+    for await (const line of lines) {
+      const record = parseJsonObject(line)
+      if (!record) {
+        continue
+      }
+      if (record.type === 'config.update') {
+        configModel = extractString(record.modelAlias) ?? configModel
+        continue
+      }
+      if (record.type !== 'usage.record') {
+        continue
+      }
+      usageModel = extractString(record.model) ?? usageModel
+      const parsed = parseKimiUsageEvent({
+        record,
+        sessionId,
+        cwd,
+        fallbackTimestamp: fallback,
+        latestModel: usageModel ?? configModel
+      })
+      if (!parsed) {
+        continue
+      }
+      const attributed = await attributeKimiUsageEvent(parsed, worktrees)
+      if (attributed) {
+        events.push(attributed)
+      }
+    }
+  } catch {
+    return { ...processedFile, sessions: [], dailyAggregates: [] }
+  }
+
+  return {
+    ...processedFile,
+    ...aggregateKimiUsage(events)
+  }
+}
+
+export async function scanKimiUsage(
+  worktrees: KimiUsageWorktreeRef[],
+  previousProcessedFiles: KimiUsagePersistedFile[]
+): Promise<{
+  processedFiles: KimiUsagePersistedFile[]
+  sessions: KimiUsageSession[]
+  dailyAggregates: KimiUsageDailyAggregate[]
+}> {
+  const files = await listKimiUsageSessionFiles()
+  const previousByPath = new Map(previousProcessedFiles.map((file) => [file.path, file]))
+  const processedFiles: KimiUsagePersistedFile[] = []
+  const worktreesWithCanonicalPaths = await buildWorktreesWithCanonicalPaths(worktrees)
+  const sessionsById = new Map<string, KimiUsageSession>()
+  const dailyByKey = new Map<string, KimiUsageDailyAggregate>()
+
+  for (const [index, file] of files.entries()) {
+    const previous = previousByPath.get(file.path)
+    const canReuse = previous && previous.mtimeMs === file.mtimeMs && previous.size === file.size
+    const processed = canReuse
+      ? previous
+      : await parseKimiUsageWire(file, worktreesWithCanonicalPaths)
+
+    processedFiles.push(processed)
+    mergeSessions(sessionsById, processed.sessions)
+    mergeDailyAggregates(dailyByKey, processed.dailyAggregates)
+
+    if ((index + 1) % YIELD_EVERY_FILES === 0) {
+      await yieldToEventLoop()
+    }
+  }
+
+  return {
+    processedFiles,
+    sessions: finalizeSessions(sessionsById),
+    dailyAggregates: [...dailyByKey.values()].sort((left, right) =>
+      left.day === right.day
+        ? left.projectLabel.localeCompare(right.projectLabel)
+        : left.day.localeCompare(right.day)
+    )
+  }
+}

--- a/src/main/kimi-usage/session-aggregation.ts
+++ b/src/main/kimi-usage/session-aggregation.ts
@@ -1,0 +1,225 @@
+import type {
+  KimiUsageAttributedEvent,
+  KimiUsageDailyAggregate,
+  KimiUsageLocationBreakdown,
+  KimiUsageLocationModelBreakdown,
+  KimiUsageModelBreakdown,
+  KimiUsageSession
+} from './types'
+import { addCost } from './cost-aggregation'
+
+export function createEmptySession(event: KimiUsageAttributedEvent): KimiUsageSession {
+  return {
+    sessionId: event.sessionId,
+    firstTimestamp: event.timestamp,
+    lastTimestamp: event.timestamp,
+    primaryModel: event.model,
+    hasMixedModels: false,
+    primaryProjectLabel: event.projectLabel,
+    hasMixedLocations: false,
+    primaryWorktreeId: event.worktreeId,
+    primaryRepoId: event.repoId,
+    eventCount: 0,
+    totalInputTokens: 0,
+    totalCachedInputTokens: 0,
+    totalOutputTokens: 0,
+    totalReasoningOutputTokens: 0,
+    totalTokens: 0,
+    estimatedCostUsd: null,
+    locationBreakdown: [],
+    modelBreakdown: [],
+    locationModelBreakdown: []
+  }
+}
+
+export function createEmptyDailyAggregate(
+  event: KimiUsageAttributedEvent
+): KimiUsageDailyAggregate {
+  return {
+    day: event.day,
+    model: event.model,
+    projectKey: event.projectKey,
+    projectLabel: event.projectLabel,
+    repoId: event.repoId,
+    worktreeId: event.worktreeId,
+    eventCount: 0,
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    reasoningOutputTokens: 0,
+    totalTokens: 0,
+    estimatedCostUsd: null
+  }
+}
+
+export function mergeLocationBreakdown(
+  target: KimiUsageLocationBreakdown[],
+  event: KimiUsageAttributedEvent
+): void {
+  const existing = target.find((entry) => entry.locationKey === event.projectKey) ?? null
+  if (existing) {
+    existing.eventCount++
+    existing.inputTokens += event.inputTokens
+    existing.cachedInputTokens += event.cachedInputTokens
+    existing.outputTokens += event.outputTokens
+    existing.reasoningOutputTokens += event.reasoningOutputTokens
+    existing.totalTokens += event.totalTokens
+    existing.estimatedCostUsd = addCost(existing.estimatedCostUsd, event.estimatedCostUsd)
+    return
+  }
+
+  target.push({
+    locationKey: event.projectKey,
+    projectLabel: event.projectLabel,
+    repoId: event.repoId,
+    worktreeId: event.worktreeId,
+    eventCount: 1,
+    inputTokens: event.inputTokens,
+    cachedInputTokens: event.cachedInputTokens,
+    outputTokens: event.outputTokens,
+    reasoningOutputTokens: event.reasoningOutputTokens,
+    totalTokens: event.totalTokens,
+    estimatedCostUsd: event.estimatedCostUsd
+  })
+}
+
+export function mergeModelBreakdown(
+  target: KimiUsageModelBreakdown[],
+  event: KimiUsageAttributedEvent
+): void {
+  const key = event.model ?? 'unknown'
+  const existing = target.find((entry) => entry.modelKey === key) ?? null
+  if (existing) {
+    existing.eventCount++
+    existing.inputTokens += event.inputTokens
+    existing.cachedInputTokens += event.cachedInputTokens
+    existing.outputTokens += event.outputTokens
+    existing.reasoningOutputTokens += event.reasoningOutputTokens
+    existing.totalTokens += event.totalTokens
+    existing.estimatedCostUsd = addCost(existing.estimatedCostUsd, event.estimatedCostUsd)
+    return
+  }
+
+  target.push({
+    modelKey: key,
+    modelLabel: event.model ?? 'Unknown model',
+    eventCount: 1,
+    inputTokens: event.inputTokens,
+    cachedInputTokens: event.cachedInputTokens,
+    outputTokens: event.outputTokens,
+    reasoningOutputTokens: event.reasoningOutputTokens,
+    totalTokens: event.totalTokens,
+    estimatedCostUsd: event.estimatedCostUsd
+  })
+}
+
+export function mergeLocationModelBreakdown(
+  target: KimiUsageLocationModelBreakdown[],
+  event: KimiUsageAttributedEvent
+): void {
+  const modelKey = event.model ?? 'unknown'
+  const existing =
+    target.find((entry) => entry.locationKey === event.projectKey && entry.modelKey === modelKey) ??
+    null
+  if (existing) {
+    existing.eventCount++
+    existing.inputTokens += event.inputTokens
+    existing.cachedInputTokens += event.cachedInputTokens
+    existing.outputTokens += event.outputTokens
+    existing.reasoningOutputTokens += event.reasoningOutputTokens
+    existing.totalTokens += event.totalTokens
+    existing.estimatedCostUsd = addCost(existing.estimatedCostUsd, event.estimatedCostUsd)
+    return
+  }
+
+  target.push({
+    locationKey: event.projectKey,
+    modelKey,
+    modelLabel: event.model ?? 'Unknown model',
+    repoId: event.repoId,
+    worktreeId: event.worktreeId,
+    eventCount: 1,
+    inputTokens: event.inputTokens,
+    cachedInputTokens: event.cachedInputTokens,
+    outputTokens: event.outputTokens,
+    reasoningOutputTokens: event.reasoningOutputTokens,
+    totalTokens: event.totalTokens,
+    estimatedCostUsd: event.estimatedCostUsd
+  })
+}
+
+export function aggregateKimiUsage(events: KimiUsageAttributedEvent[]): {
+  sessions: KimiUsageSession[]
+  dailyAggregates: KimiUsageDailyAggregate[]
+} {
+  const sessionsById = new Map<string, KimiUsageSession>()
+  const dailyByKey = new Map<string, KimiUsageDailyAggregate>()
+
+  for (const event of events) {
+    const session = sessionsById.get(event.sessionId) ?? createEmptySession(event)
+    if (!sessionsById.has(event.sessionId)) {
+      sessionsById.set(event.sessionId, session)
+    }
+    if (event.timestamp < session.firstTimestamp) {
+      session.firstTimestamp = event.timestamp
+    }
+    if (event.timestamp >= session.lastTimestamp) {
+      session.lastTimestamp = event.timestamp
+    }
+    session.eventCount++
+    session.totalInputTokens += event.inputTokens
+    session.totalCachedInputTokens += event.cachedInputTokens
+    session.totalOutputTokens += event.outputTokens
+    session.totalReasoningOutputTokens += event.reasoningOutputTokens
+    session.totalTokens += event.totalTokens
+    session.estimatedCostUsd = addCost(session.estimatedCostUsd, event.estimatedCostUsd)
+    mergeLocationBreakdown(session.locationBreakdown, event)
+    mergeModelBreakdown(session.modelBreakdown, event)
+    mergeLocationModelBreakdown(session.locationModelBreakdown, event)
+
+    const dailyKey = [event.day, event.model ?? 'unknown', event.projectKey].join('::')
+    const daily = dailyByKey.get(dailyKey) ?? createEmptyDailyAggregate(event)
+    if (!dailyByKey.has(dailyKey)) {
+      dailyByKey.set(dailyKey, daily)
+    }
+    daily.eventCount++
+    daily.inputTokens += event.inputTokens
+    daily.cachedInputTokens += event.cachedInputTokens
+    daily.outputTokens += event.outputTokens
+    daily.reasoningOutputTokens += event.reasoningOutputTokens
+    daily.totalTokens += event.totalTokens
+    daily.estimatedCostUsd = addCost(daily.estimatedCostUsd, event.estimatedCostUsd)
+  }
+
+  return {
+    sessions: finalizeSessions(sessionsById),
+    dailyAggregates: [...dailyByKey.values()].sort((left, right) =>
+      left.day === right.day
+        ? left.projectLabel.localeCompare(right.projectLabel)
+        : left.day.localeCompare(right.day)
+    )
+  }
+}
+
+export function finalizeSessions(sessionsById: Map<string, KimiUsageSession>): KimiUsageSession[] {
+  for (const session of sessionsById.values()) {
+    session.locationBreakdown.sort((left, right) => right.totalTokens - left.totalTokens)
+    session.modelBreakdown.sort((left, right) => right.totalTokens - left.totalTokens)
+    const primaryLocation = session.locationBreakdown[0] ?? null
+    const primaryModel = session.modelBreakdown[0] ?? null
+    session.primaryProjectLabel =
+      session.locationBreakdown.length <= 1
+        ? (primaryLocation?.projectLabel ?? 'Unknown location')
+        : 'Multiple locations'
+    session.hasMixedLocations = session.locationBreakdown.length > 1
+    session.primaryWorktreeId = primaryLocation?.worktreeId ?? null
+    session.primaryRepoId = primaryLocation?.repoId ?? null
+    session.primaryModel =
+      session.modelBreakdown.length <= 1 ? (primaryModel?.modelLabel ?? null) : 'Mixed models'
+    session.hasMixedModels = session.modelBreakdown.length > 1
+  }
+
+  return [...sessionsById.values()].sort((left, right) =>
+    right.lastTimestamp.localeCompare(left.lastTimestamp)
+  )
+}

--- a/src/main/kimi-usage/store.test.ts
+++ b/src/main/kimi-usage/store.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KimiUsageDailyAggregate, KimiUsagePersistedState, KimiUsageSession } from './types'
+
+const { getPathMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn(() => '/tmp/orca-test-userdata')
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: getPathMock
+  }
+}))
+
+import { KimiUsageStore, normalizePersistedState } from './store'
+
+function getDefaultState(): KimiUsagePersistedState {
+  return {
+    schemaVersion: 1,
+    worktreeFingerprint: null,
+    processedFiles: [],
+    sessions: [],
+    dailyAggregates: [],
+    scanState: {
+      enabled: false,
+      lastScanStartedAt: null,
+      lastScanCompletedAt: null,
+      lastScanError: null
+    }
+  }
+}
+
+function createStoreWithState(state: Partial<KimiUsagePersistedState>): KimiUsageStore {
+  const store = new KimiUsageStore({
+    getRepos: () => [],
+    getWorktreeMeta: () => undefined
+  } as never)
+
+  ;(store as unknown as { state: KimiUsagePersistedState }).state = {
+    ...getDefaultState(),
+    ...state
+  }
+
+  return store
+}
+
+// Kimi records no cost: estimatedCostUsd is null on every projection level.
+function makeSession(overrides: Partial<KimiUsageSession> = {}): KimiUsageSession {
+  const worktreeId = overrides.primaryWorktreeId ?? 'repo-1::/workspace/repo'
+  const repoId = overrides.primaryRepoId ?? 'repo-1'
+  const projectLabel = overrides.primaryProjectLabel ?? 'Repo'
+  const model = overrides.primaryModel ?? 'kimi-k2'
+  return {
+    sessionId: 'session-1',
+    firstTimestamp: '2026-04-09T10:00:00.000Z',
+    lastTimestamp: '2026-04-09T10:10:00.000Z',
+    primaryModel: model,
+    hasMixedModels: false,
+    primaryProjectLabel: projectLabel,
+    hasMixedLocations: false,
+    primaryWorktreeId: worktreeId,
+    primaryRepoId: repoId,
+    eventCount: 1,
+    totalInputTokens: 1000,
+    totalCachedInputTokens: 400,
+    totalOutputTokens: 250,
+    totalReasoningOutputTokens: 0,
+    totalTokens: 1650,
+    estimatedCostUsd: null,
+    locationBreakdown: [
+      {
+        locationKey: worktreeId ? `worktree:${worktreeId}` : 'cwd:/outside/repo',
+        projectLabel,
+        repoId,
+        worktreeId,
+        eventCount: 1,
+        inputTokens: 1000,
+        cachedInputTokens: 400,
+        outputTokens: 250,
+        reasoningOutputTokens: 0,
+        totalTokens: 1650,
+        estimatedCostUsd: null
+      }
+    ],
+    modelBreakdown: [
+      {
+        modelKey: model ?? 'unknown',
+        modelLabel: model ?? 'Unknown model',
+        eventCount: 1,
+        inputTokens: 1000,
+        cachedInputTokens: 400,
+        outputTokens: 250,
+        reasoningOutputTokens: 0,
+        totalTokens: 1650,
+        estimatedCostUsd: null
+      }
+    ],
+    locationModelBreakdown: [
+      {
+        locationKey: worktreeId ? `worktree:${worktreeId}` : 'cwd:/outside/repo',
+        modelKey: model ?? 'unknown',
+        modelLabel: model ?? 'Unknown model',
+        repoId,
+        worktreeId,
+        eventCount: 1,
+        inputTokens: 1000,
+        cachedInputTokens: 400,
+        outputTokens: 250,
+        reasoningOutputTokens: 0,
+        totalTokens: 1650,
+        estimatedCostUsd: null
+      }
+    ],
+    ...overrides
+  }
+}
+
+function makeDaily(overrides: Partial<KimiUsageDailyAggregate> = {}): KimiUsageDailyAggregate {
+  const worktreeId = overrides.worktreeId ?? 'repo-1::/workspace/repo'
+  return {
+    day: '2026-04-09',
+    model: 'kimi-k2',
+    projectKey: worktreeId ? `worktree:${worktreeId}` : 'cwd:/outside/repo',
+    projectLabel: worktreeId ? 'Repo' : 'outside/repo',
+    repoId: worktreeId ? 'repo-1' : null,
+    worktreeId,
+    eventCount: 1,
+    inputTokens: 1000,
+    cachedInputTokens: 400,
+    outputTokens: 250,
+    reasoningOutputTokens: 0,
+    totalTokens: 1650,
+    estimatedCostUsd: null,
+    ...overrides
+  }
+}
+
+describe('KimiUsageStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-10T12:00:00.000-04:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reports no data for Orca scope when only non-Orca Kimi usage exists', async () => {
+    const store = createStoreWithState({
+      sessions: [
+        makeSession({
+          primaryProjectLabel: 'outside/repo',
+          primaryWorktreeId: null,
+          primaryRepoId: null
+        })
+      ],
+      dailyAggregates: [
+        makeDaily({
+          projectKey: 'cwd:/outside/repo',
+          projectLabel: 'outside/repo',
+          repoId: null,
+          worktreeId: null
+        })
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+
+    expect(summary.hasAnyKimiData).toBe(false)
+    expect(summary.sessions).toBe(0)
+    expect(summary.events).toBe(0)
+  })
+
+  it('filters out usage older than the selected range', async () => {
+    const store = createStoreWithState({
+      sessions: [makeSession()],
+      dailyAggregates: [makeDaily()]
+    })
+
+    // The single day is 2026-04-09; a 7-day window anchored at 2026-04-10 includes it.
+    const within = await store.getSummary('orca', '7d')
+    expect(within.totalTokens).toBe(1650)
+
+    // Push the system clock far ahead so the same day falls outside a 7-day window.
+    vi.setSystemTime(new Date('2026-05-30T12:00:00.000-04:00'))
+    const outside = await store.getSummary('orca', '7d')
+    expect(outside.totalTokens).toBe(0)
+    expect(outside.hasAnyKimiData).toBe(false)
+  })
+
+  it('builds summary, daily, and breakdown projections with null cost', async () => {
+    const store = createStoreWithState({
+      sessions: [
+        makeSession({ sessionId: 'session-1' }),
+        makeSession({
+          sessionId: 'session-2',
+          primaryModel: 'kimi-k2-turbo',
+          totalTokens: 2000,
+          modelBreakdown: [
+            {
+              modelKey: 'kimi-k2-turbo',
+              modelLabel: 'kimi-k2-turbo',
+              eventCount: 1,
+              inputTokens: 1500,
+              cachedInputTokens: 200,
+              outputTokens: 300,
+              reasoningOutputTokens: 0,
+              totalTokens: 2000,
+              estimatedCostUsd: null
+            }
+          ]
+        })
+      ],
+      dailyAggregates: [
+        makeDaily(),
+        makeDaily({
+          model: 'kimi-k2-turbo',
+          eventCount: 2,
+          inputTokens: 1500,
+          cachedInputTokens: 200,
+          outputTokens: 300,
+          reasoningOutputTokens: 0,
+          totalTokens: 2000
+        })
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+    const daily = await store.getDaily('orca', '30d')
+    const modelBreakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(summary).toMatchObject({
+      sessions: 2,
+      events: 3,
+      inputTokens: 2500,
+      cachedInputTokens: 600,
+      outputTokens: 550,
+      reasoningOutputTokens: 0,
+      totalTokens: 3650,
+      estimatedCostUsd: null,
+      topModel: 'kimi-k2-turbo',
+      topProject: 'Repo',
+      hasAnyKimiData: true
+    })
+    expect(daily).toEqual([
+      {
+        day: '2026-04-09',
+        inputTokens: 2500,
+        cachedInputTokens: 600,
+        outputTokens: 550,
+        reasoningOutputTokens: 0,
+        totalTokens: 3650
+      }
+    ])
+    expect(modelBreakdown.find((row) => row.key === 'kimi-k2-turbo')).toMatchObject({
+      sessions: 1,
+      estimatedCostUsd: null
+    })
+  })
+
+  it('returns recent sessions with Kimi event and token fields', async () => {
+    const store = createStoreWithState({
+      sessions: [makeSession()],
+      dailyAggregates: [makeDaily()]
+    })
+
+    const sessions = await store.getRecentSessions('orca', '30d', 5)
+
+    expect(sessions).toEqual([
+      {
+        sessionId: 'session-1',
+        lastActiveAt: '2026-04-09T10:10:00.000Z',
+        durationMinutes: 10,
+        projectLabel: 'Repo',
+        model: 'kimi-k2',
+        events: 1,
+        inputTokens: 1000,
+        cachedInputTokens: 400,
+        outputTokens: 250,
+        reasoningOutputTokens: 0,
+        totalTokens: 1650
+      }
+    ])
+  })
+
+  it('normalizes persisted Kimi state by schema version', () => {
+    expect(
+      normalizePersistedState({
+        ...getDefaultState(),
+        schemaVersion: 0,
+        processedFiles: [
+          {
+            path: '/tmp/wire.jsonl',
+            mtimeMs: 1,
+            size: 2,
+            sessions: [makeSession()],
+            dailyAggregates: [makeDaily()]
+          }
+        ],
+        sessions: [makeSession()],
+        dailyAggregates: [makeDaily()]
+      })
+    ).toEqual(getDefaultState())
+
+    expect(
+      normalizePersistedState({
+        ...getDefaultState(),
+        processedFiles: [
+          {
+            path: '/tmp/wire.jsonl',
+            mtimeMs: 1,
+            size: 2,
+            sessions: [],
+            dailyAggregates: []
+          }
+        ]
+      }).processedFiles
+    ).toHaveLength(1)
+  })
+})

--- a/src/main/kimi-usage/store.ts
+++ b/src/main/kimi-usage/store.ts
@@ -1,0 +1,296 @@
+import { app } from 'electron'
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+import type {
+  KimiUsageBreakdownKind,
+  KimiUsageBreakdownRow,
+  KimiUsageDailyPoint,
+  KimiUsageRange,
+  KimiUsageScanState,
+  KimiUsageScope,
+  KimiUsageSessionRow,
+  KimiUsageSnapshot,
+  KimiUsageSummary
+} from '../../shared/kimi-usage-types'
+import type { Store } from '../persistence'
+import { loadKnownUsageWorktreesByRepo, type UsageWorktreeRef } from '../usage-worktree-metadata'
+import { createWorktreeRefs, scanKimiUsage } from './scanner'
+import type { KimiUsageDailyAggregate, KimiUsagePersistedState } from './types'
+import {
+  buildBreakdown,
+  buildDaily,
+  buildRecentSessions,
+  buildSummary
+} from './usage-query-projections'
+
+const SCHEMA_VERSION = 1
+const STALE_MS = 5 * 60_000
+
+let _kimiUsageFile: string | null = null
+
+function getDefaultState(): KimiUsagePersistedState {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    worktreeFingerprint: null,
+    processedFiles: [],
+    sessions: [],
+    dailyAggregates: [],
+    scanState: {
+      enabled: false,
+      lastScanStartedAt: null,
+      lastScanCompletedAt: null,
+      lastScanError: null
+    }
+  }
+}
+
+function normalizeDailyAggregateCost(entry: KimiUsageDailyAggregate): KimiUsageDailyAggregate {
+  return {
+    ...entry,
+    estimatedCostUsd: entry.estimatedCostUsd ?? null
+  }
+}
+
+function normalizeSessionCost(
+  session: KimiUsagePersistedState['sessions'][number]
+): KimiUsagePersistedState['sessions'][number] {
+  return {
+    ...session,
+    estimatedCostUsd: session.estimatedCostUsd ?? null,
+    locationBreakdown: (session.locationBreakdown ?? []).map((entry) => ({
+      ...entry,
+      estimatedCostUsd: entry.estimatedCostUsd ?? null
+    })),
+    modelBreakdown: (session.modelBreakdown ?? []).map((entry) => ({
+      ...entry,
+      estimatedCostUsd: entry.estimatedCostUsd ?? null
+    })),
+    locationModelBreakdown: (session.locationModelBreakdown ?? []).map((entry) => ({
+      ...entry,
+      estimatedCostUsd: entry.estimatedCostUsd ?? null
+    }))
+  }
+}
+
+export function normalizePersistedState(state: KimiUsagePersistedState): KimiUsagePersistedState {
+  if (state.schemaVersion !== SCHEMA_VERSION) {
+    return getDefaultState()
+  }
+  return {
+    ...state,
+    processedFiles: (state.processedFiles ?? []).map((file) => ({
+      ...file,
+      sessions: (file.sessions ?? []).map(normalizeSessionCost),
+      dailyAggregates: (file.dailyAggregates ?? []).map(normalizeDailyAggregateCost)
+    })),
+    sessions: state.sessions.map(normalizeSessionCost),
+    dailyAggregates: state.dailyAggregates.map(normalizeDailyAggregateCost)
+  }
+}
+
+export function initKimiUsagePath(): void {
+  _kimiUsageFile = join(app.getPath('userData'), 'orca-kimi-usage.json')
+}
+
+function getKimiUsageFile(): string {
+  if (!_kimiUsageFile) {
+    _kimiUsageFile = join(app.getPath('userData'), 'orca-kimi-usage.json')
+  }
+  return _kimiUsageFile
+}
+
+function getWorktreeFingerprint(worktreesByRepo: Map<string, UsageWorktreeRef[]>): string {
+  const rows = [...worktreesByRepo.entries()]
+    .flatMap(([repoId, worktrees]) =>
+      worktrees.map((worktree) =>
+        JSON.stringify({
+          repoId,
+          worktreeId: worktree.worktreeId,
+          path: worktree.path,
+          displayName: worktree.displayName
+        })
+      )
+    )
+    .sort()
+  return JSON.stringify(rows)
+}
+
+export class KimiUsageStore {
+  private state: KimiUsagePersistedState
+  private readonly store: Store
+  private scanPromise: Promise<void> | null = null
+
+  constructor(store: Store) {
+    this.store = store
+    this.state = this.load()
+  }
+
+  private load(): KimiUsagePersistedState {
+    try {
+      const usageFile = getKimiUsageFile()
+      if (!existsSync(usageFile)) {
+        return getDefaultState()
+      }
+      const parsed = JSON.parse(readFileSync(usageFile, 'utf-8')) as KimiUsagePersistedState
+      return normalizePersistedState({
+        ...getDefaultState(),
+        ...parsed,
+        scanState: {
+          ...getDefaultState().scanState,
+          ...parsed.scanState
+        }
+      })
+    } catch (error) {
+      console.error('[kimi-usage] Failed to load persisted state, starting fresh:', error)
+      return getDefaultState()
+    }
+  }
+
+  private writeToDisk(): void {
+    const usageFile = getKimiUsageFile()
+    const dir = dirname(usageFile)
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+    const tmpFile = `${usageFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
+    writeFileSync(tmpFile, JSON.stringify(this.state, null, 2), 'utf-8')
+    renameSync(tmpFile, usageFile)
+  }
+
+  async setEnabled(enabled: boolean): Promise<KimiUsageScanState> {
+    this.state.scanState.enabled = enabled
+    this.writeToDisk()
+    return this.getScanState()
+  }
+
+  getScanState(): KimiUsageScanState {
+    return {
+      ...this.state.scanState,
+      isScanning: this.scanPromise !== null,
+      hasAnyKimiData: this.state.sessions.length > 0 || this.state.dailyAggregates.length > 0
+    }
+  }
+
+  getSnapshot(
+    scope: KimiUsageScope,
+    range: KimiUsageRange,
+    recentSessionLimit = 10
+  ): KimiUsageSnapshot {
+    return {
+      scanState: this.getScanState(),
+      summary: this.buildSummary(scope, range),
+      daily: this.buildDaily(scope, range),
+      modelBreakdown: this.buildBreakdown(scope, range, 'model'),
+      projectBreakdown: this.buildBreakdown(scope, range, 'project'),
+      recentSessions: this.buildRecentSessions(scope, range, recentSessionLimit)
+    }
+  }
+
+  async refresh(force = false): Promise<KimiUsageScanState> {
+    if (!this.state.scanState.enabled) {
+      return this.getScanState()
+    }
+    const currentWorktreeFingerprint = await this.getCurrentWorktreeFingerprint()
+    if (!force && this.state.scanState.lastScanCompletedAt) {
+      const ageMs = Date.now() - this.state.scanState.lastScanCompletedAt
+      if (ageMs < STALE_MS && this.state.worktreeFingerprint === currentWorktreeFingerprint) {
+        return this.getScanState()
+      }
+    }
+    await this.runScan()
+    return this.getScanState()
+  }
+
+  private async runScan(): Promise<void> {
+    if (this.scanPromise) {
+      await this.scanPromise
+      return
+    }
+    this.state.scanState.lastScanStartedAt = Date.now()
+    this.state.scanState.lastScanError = null
+    this.writeToDisk()
+    this.scanPromise = this.runScanOnce()
+    await this.scanPromise
+  }
+
+  private async runScanOnce(): Promise<void> {
+    try {
+      const repos = this.store.getRepos()
+      const worktreesByRepo = loadKnownUsageWorktreesByRepo(this.store, repos)
+      const worktreeFingerprint = getWorktreeFingerprint(worktreesByRepo)
+      const result = await scanKimiUsage(
+        createWorktreeRefs(repos, worktreesByRepo),
+        this.state.worktreeFingerprint === worktreeFingerprint ? this.state.processedFiles : []
+      )
+      this.state.processedFiles = result.processedFiles
+      this.state.sessions = result.sessions
+      this.state.dailyAggregates = result.dailyAggregates
+      this.state.worktreeFingerprint = worktreeFingerprint
+      this.state.scanState.lastScanCompletedAt = Date.now()
+      this.state.scanState.lastScanError = null
+      this.writeToDisk()
+    } catch (error) {
+      this.state.scanState.lastScanError = error instanceof Error ? error.message : String(error)
+      this.writeToDisk()
+    } finally {
+      this.scanPromise = null
+    }
+  }
+
+  async getSummary(scope: KimiUsageScope, range: KimiUsageRange): Promise<KimiUsageSummary> {
+    await this.refresh(false)
+    return this.buildSummary(scope, range)
+  }
+
+  private buildSummary(scope: KimiUsageScope, range: KimiUsageRange): KimiUsageSummary {
+    return buildSummary(this.state.sessions, this.state.dailyAggregates, scope, range)
+  }
+
+  async getDaily(scope: KimiUsageScope, range: KimiUsageRange): Promise<KimiUsageDailyPoint[]> {
+    await this.refresh(false)
+    return this.buildDaily(scope, range)
+  }
+
+  private buildDaily(scope: KimiUsageScope, range: KimiUsageRange): KimiUsageDailyPoint[] {
+    return buildDaily(this.state.sessions, this.state.dailyAggregates, scope, range)
+  }
+
+  async getBreakdown(
+    scope: KimiUsageScope,
+    range: KimiUsageRange,
+    kind: KimiUsageBreakdownKind
+  ): Promise<KimiUsageBreakdownRow[]> {
+    await this.refresh(false)
+    return this.buildBreakdown(scope, range, kind)
+  }
+
+  private buildBreakdown(
+    scope: KimiUsageScope,
+    range: KimiUsageRange,
+    kind: KimiUsageBreakdownKind
+  ): KimiUsageBreakdownRow[] {
+    return buildBreakdown(this.state.sessions, this.state.dailyAggregates, scope, range, kind)
+  }
+
+  async getRecentSessions(
+    scope: KimiUsageScope,
+    range: KimiUsageRange,
+    limit = 10
+  ): Promise<KimiUsageSessionRow[]> {
+    await this.refresh(false)
+    return this.buildRecentSessions(scope, range, limit)
+  }
+
+  private buildRecentSessions(
+    scope: KimiUsageScope,
+    range: KimiUsageRange,
+    limit = 10
+  ): KimiUsageSessionRow[] {
+    return buildRecentSessions(this.state.sessions, this.state.dailyAggregates, scope, range, limit)
+  }
+
+  private async getCurrentWorktreeFingerprint(): Promise<string> {
+    const repos = this.store.getRepos()
+    return getWorktreeFingerprint(loadKnownUsageWorktreesByRepo(this.store, repos))
+  }
+}

--- a/src/main/kimi-usage/types.ts
+++ b/src/main/kimi-usage/types.ts
@@ -1,0 +1,124 @@
+export type KimiUsageProcessedFile = {
+  path: string
+  mtimeMs: number
+  size: number
+}
+
+export type KimiUsageLocationBreakdown = {
+  locationKey: string
+  projectLabel: string
+  repoId: string | null
+  worktreeId: string | null
+  eventCount: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+  estimatedCostUsd: number | null
+}
+
+export type KimiUsageModelBreakdown = {
+  modelKey: string
+  modelLabel: string
+  estimatedCostUsd: number | null
+  eventCount: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+}
+
+export type KimiUsageLocationModelBreakdown = {
+  locationKey: string
+  modelKey: string
+  modelLabel: string
+  repoId: string | null
+  worktreeId: string | null
+  eventCount: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+  estimatedCostUsd: number | null
+}
+
+export type KimiUsageSession = {
+  sessionId: string
+  firstTimestamp: string
+  lastTimestamp: string
+  primaryModel: string | null
+  hasMixedModels: boolean
+  primaryProjectLabel: string
+  hasMixedLocations: boolean
+  primaryWorktreeId: string | null
+  primaryRepoId: string | null
+  eventCount: number
+  totalInputTokens: number
+  totalCachedInputTokens: number
+  totalOutputTokens: number
+  totalReasoningOutputTokens: number
+  totalTokens: number
+  estimatedCostUsd: number | null
+  locationBreakdown: KimiUsageLocationBreakdown[]
+  modelBreakdown: KimiUsageModelBreakdown[]
+  locationModelBreakdown: KimiUsageLocationModelBreakdown[]
+}
+
+export type KimiUsageDailyAggregate = {
+  day: string
+  model: string | null
+  projectKey: string
+  projectLabel: string
+  repoId: string | null
+  worktreeId: string | null
+  eventCount: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+  estimatedCostUsd: number | null
+}
+
+export type KimiUsagePersistedFile = KimiUsageProcessedFile & {
+  sessions: KimiUsageSession[]
+  dailyAggregates: KimiUsageDailyAggregate[]
+}
+
+export type KimiUsagePersistedState = {
+  schemaVersion: number
+  worktreeFingerprint: string | null
+  processedFiles: KimiUsagePersistedFile[]
+  sessions: KimiUsageSession[]
+  dailyAggregates: KimiUsageDailyAggregate[]
+  scanState: {
+    enabled: boolean
+    lastScanStartedAt: number | null
+    lastScanCompletedAt: number | null
+    lastScanError: string | null
+  }
+}
+
+export type KimiUsageParsedEvent = {
+  sessionId: string
+  timestamp: string
+  model: string | null
+  cwd: string | null
+  estimatedCostUsd: number | null
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+}
+
+export type KimiUsageAttributedEvent = KimiUsageParsedEvent & {
+  day: string
+  projectKey: string
+  projectLabel: string
+  repoId: string | null
+  worktreeId: string | null
+}

--- a/src/main/kimi-usage/usage-query-projections.ts
+++ b/src/main/kimi-usage/usage-query-projections.ts
@@ -1,0 +1,246 @@
+import type {
+  KimiUsageBreakdownKind,
+  KimiUsageBreakdownRow,
+  KimiUsageDailyPoint,
+  KimiUsageRange,
+  KimiUsageScope,
+  KimiUsageSessionRow,
+  KimiUsageSummary
+} from '../../shared/kimi-usage-types'
+import { addCost } from './cost-aggregation'
+import type { KimiUsageDailyAggregate, KimiUsageSession } from './types'
+
+function getRangeCutoff(range: KimiUsageRange): string | null {
+  if (range === 'all') {
+    return null
+  }
+  const days = range === '7d' ? 7 : range === '30d' ? 30 : 90
+  const now = new Date()
+  now.setHours(0, 0, 0, 0)
+  now.setDate(now.getDate() - (days - 1))
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function getLocalDay(timestamp: string): string | null {
+  const parsed = new Date(timestamp)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+  const year = parsed.getFullYear()
+  const month = String(parsed.getMonth() + 1).padStart(2, '0')
+  const day = String(parsed.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function getFilteredDaily(
+  dailyAggregates: KimiUsageDailyAggregate[],
+  scope: KimiUsageScope,
+  range: KimiUsageRange
+): KimiUsageDailyAggregate[] {
+  const cutoff = getRangeCutoff(range)
+  return dailyAggregates.filter((row) => {
+    if (scope === 'orca' && !row.worktreeId) {
+      return false
+    }
+    if (cutoff && row.day < cutoff) {
+      return false
+    }
+    return true
+  })
+}
+
+export function getFilteredSessions(
+  sessions: KimiUsageSession[],
+  scope: KimiUsageScope,
+  range: KimiUsageRange
+): KimiUsageSession[] {
+  const cutoff = getRangeCutoff(range)
+  return sessions.filter((session) => {
+    if (scope === 'orca' && !session.primaryWorktreeId) {
+      return false
+    }
+    if (cutoff) {
+      const day = getLocalDay(session.lastTimestamp)
+      if (!day || day < cutoff) {
+        return false
+      }
+    }
+    return true
+  })
+}
+
+export function buildSummary(
+  sessions: KimiUsageSession[],
+  dailyAggregates: KimiUsageDailyAggregate[],
+  scope: KimiUsageScope,
+  range: KimiUsageRange
+): KimiUsageSummary {
+  const filteredDaily = getFilteredDaily(dailyAggregates, scope, range)
+  const filteredSessions = getFilteredSessions(sessions, scope, range)
+
+  let inputTokens = 0
+  let cachedInputTokens = 0
+  let outputTokens = 0
+  let reasoningOutputTokens = 0
+  let totalTokens = 0
+  let events = 0
+  let estimatedCostUsd: number | null = null
+  const byModel = new Map<string, number>()
+  const byProject = new Map<string, number>()
+
+  for (const row of filteredDaily) {
+    inputTokens += row.inputTokens
+    cachedInputTokens += row.cachedInputTokens
+    outputTokens += row.outputTokens
+    reasoningOutputTokens += row.reasoningOutputTokens
+    totalTokens += row.totalTokens
+    events += row.eventCount
+    estimatedCostUsd = addCost(estimatedCostUsd, row.estimatedCostUsd)
+    byModel.set(
+      row.model ?? 'Unknown model',
+      (byModel.get(row.model ?? 'Unknown model') ?? 0) + row.totalTokens
+    )
+    byProject.set(row.projectLabel, (byProject.get(row.projectLabel) ?? 0) + row.totalTokens)
+  }
+
+  const topModel = [...byModel.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
+  const topProject =
+    [...byProject.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
+
+  return {
+    scope,
+    range,
+    sessions: filteredSessions.length,
+    events,
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    reasoningOutputTokens,
+    totalTokens,
+    estimatedCostUsd,
+    topModel,
+    topProject,
+    hasAnyKimiData: filteredSessions.length > 0 || filteredDaily.length > 0
+  }
+}
+
+export function buildDaily(
+  _sessions: KimiUsageSession[],
+  dailyAggregates: KimiUsageDailyAggregate[],
+  scope: KimiUsageScope,
+  range: KimiUsageRange
+): KimiUsageDailyPoint[] {
+  const byDay = new Map<string, KimiUsageDailyPoint>()
+  for (const row of getFilteredDaily(dailyAggregates, scope, range)) {
+    const existing = byDay.get(row.day) ?? {
+      day: row.day,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+      totalTokens: 0
+    }
+    existing.inputTokens += row.inputTokens
+    existing.cachedInputTokens += row.cachedInputTokens
+    existing.outputTokens += row.outputTokens
+    existing.reasoningOutputTokens += row.reasoningOutputTokens
+    existing.totalTokens += row.totalTokens
+    byDay.set(row.day, existing)
+  }
+  return [...byDay.values()].sort((left, right) => left.day.localeCompare(right.day))
+}
+
+export function buildBreakdown(
+  sessions: KimiUsageSession[],
+  dailyAggregates: KimiUsageDailyAggregate[],
+  scope: KimiUsageScope,
+  range: KimiUsageRange,
+  kind: KimiUsageBreakdownKind
+): KimiUsageBreakdownRow[] {
+  const rows = new Map<string, KimiUsageBreakdownRow>()
+  const filteredDaily = getFilteredDaily(dailyAggregates, scope, range)
+  const filteredSessions = getFilteredSessions(sessions, scope, range)
+
+  for (const daily of filteredDaily) {
+    const key = kind === 'model' ? (daily.model ?? 'unknown') : daily.projectKey
+    const label = kind === 'model' ? (daily.model ?? 'Unknown model') : daily.projectLabel
+    const existing = rows.get(key) ?? {
+      key,
+      label,
+      sessions: 0,
+      events: 0,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+      totalTokens: 0,
+      estimatedCostUsd: null
+    }
+    existing.events += daily.eventCount
+    existing.inputTokens += daily.inputTokens
+    existing.cachedInputTokens += daily.cachedInputTokens
+    existing.outputTokens += daily.outputTokens
+    existing.reasoningOutputTokens += daily.reasoningOutputTokens
+    existing.totalTokens += daily.totalTokens
+    existing.estimatedCostUsd = addCost(existing.estimatedCostUsd, daily.estimatedCostUsd)
+    rows.set(key, existing)
+  }
+
+  if (kind === 'model') {
+    for (const session of filteredSessions) {
+      for (const entry of session.modelBreakdown) {
+        const row = rows.get(entry.modelKey)
+        if (row) {
+          row.sessions++
+        }
+      }
+    }
+  } else {
+    for (const session of filteredSessions) {
+      for (const entry of session.locationBreakdown) {
+        const row = rows.get(entry.locationKey)
+        if (row) {
+          row.sessions++
+        }
+      }
+    }
+  }
+
+  return [...rows.values()].sort((left, right) => right.totalTokens - left.totalTokens)
+}
+
+export function buildRecentSessions(
+  sessions: KimiUsageSession[],
+  _dailyAggregates: KimiUsageDailyAggregate[],
+  scope: KimiUsageScope,
+  range: KimiUsageRange,
+  limit = 10
+): KimiUsageSessionRow[] {
+  return getFilteredSessions(sessions, scope, range)
+    .slice(0, limit)
+    .map(
+      (session): KimiUsageSessionRow => ({
+        sessionId: session.sessionId,
+        lastActiveAt: session.lastTimestamp,
+        durationMinutes: Math.max(
+          0,
+          Math.round(
+            (new Date(session.lastTimestamp).getTime() -
+              new Date(session.firstTimestamp).getTime()) /
+              60_000
+          )
+        ),
+        projectLabel: session.primaryProjectLabel,
+        model: session.primaryModel,
+        events: session.eventCount,
+        inputTokens: session.totalInputTokens,
+        cachedInputTokens: session.totalCachedInputTokens,
+        outputTokens: session.totalOutputTokens,
+        reasoningOutputTokens: session.totalReasoningOutputTokens,
+        totalTokens: session.totalTokens
+      })
+    )
+}

--- a/src/main/kimi-usage/usage-state-merging.ts
+++ b/src/main/kimi-usage/usage-state-merging.ts
@@ -1,0 +1,114 @@
+import { addCost } from './cost-aggregation'
+import type { KimiUsageDailyAggregate, KimiUsageSession } from './types'
+
+export function mergeSessions(
+  target: Map<string, KimiUsageSession>,
+  sessions: KimiUsageSession[]
+): void {
+  for (const session of sessions) {
+    const existing = target.get(session.sessionId)
+    if (!existing) {
+      target.set(session.sessionId, structuredClone(session))
+      continue
+    }
+
+    existing.firstTimestamp =
+      session.firstTimestamp < existing.firstTimestamp
+        ? session.firstTimestamp
+        : existing.firstTimestamp
+    existing.lastTimestamp =
+      session.lastTimestamp > existing.lastTimestamp
+        ? session.lastTimestamp
+        : existing.lastTimestamp
+    existing.eventCount += session.eventCount
+    existing.totalInputTokens += session.totalInputTokens
+    existing.totalCachedInputTokens += session.totalCachedInputTokens
+    existing.totalOutputTokens += session.totalOutputTokens
+    existing.totalReasoningOutputTokens += session.totalReasoningOutputTokens
+    existing.totalTokens += session.totalTokens
+    existing.estimatedCostUsd = addCost(existing.estimatedCostUsd, session.estimatedCostUsd)
+
+    for (const location of session.locationBreakdown) {
+      const existingLocation =
+        existing.locationBreakdown.find((entry) => entry.locationKey === location.locationKey) ??
+        null
+      if (existingLocation) {
+        existingLocation.eventCount += location.eventCount
+        existingLocation.inputTokens += location.inputTokens
+        existingLocation.cachedInputTokens += location.cachedInputTokens
+        existingLocation.outputTokens += location.outputTokens
+        existingLocation.reasoningOutputTokens += location.reasoningOutputTokens
+        existingLocation.totalTokens += location.totalTokens
+        existingLocation.estimatedCostUsd = addCost(
+          existingLocation.estimatedCostUsd,
+          location.estimatedCostUsd
+        )
+      } else {
+        existing.locationBreakdown.push({ ...location })
+      }
+    }
+
+    for (const model of session.modelBreakdown) {
+      const existingModel =
+        existing.modelBreakdown.find((entry) => entry.modelKey === model.modelKey) ?? null
+      if (existingModel) {
+        existingModel.eventCount += model.eventCount
+        existingModel.inputTokens += model.inputTokens
+        existingModel.cachedInputTokens += model.cachedInputTokens
+        existingModel.outputTokens += model.outputTokens
+        existingModel.reasoningOutputTokens += model.reasoningOutputTokens
+        existingModel.totalTokens += model.totalTokens
+        existingModel.estimatedCostUsd = addCost(
+          existingModel.estimatedCostUsd,
+          model.estimatedCostUsd
+        )
+      } else {
+        existing.modelBreakdown.push({ ...model })
+      }
+    }
+
+    for (const locationModel of session.locationModelBreakdown) {
+      const existingLocationModel =
+        existing.locationModelBreakdown.find(
+          (entry) =>
+            entry.locationKey === locationModel.locationKey &&
+            entry.modelKey === locationModel.modelKey
+        ) ?? null
+      if (existingLocationModel) {
+        existingLocationModel.eventCount += locationModel.eventCount
+        existingLocationModel.inputTokens += locationModel.inputTokens
+        existingLocationModel.cachedInputTokens += locationModel.cachedInputTokens
+        existingLocationModel.outputTokens += locationModel.outputTokens
+        existingLocationModel.reasoningOutputTokens += locationModel.reasoningOutputTokens
+        existingLocationModel.totalTokens += locationModel.totalTokens
+        existingLocationModel.estimatedCostUsd = addCost(
+          existingLocationModel.estimatedCostUsd,
+          locationModel.estimatedCostUsd
+        )
+      } else {
+        existing.locationModelBreakdown.push({ ...locationModel })
+      }
+    }
+  }
+}
+
+export function mergeDailyAggregates(
+  target: Map<string, KimiUsageDailyAggregate>,
+  dailyAggregates: KimiUsageDailyAggregate[]
+): void {
+  for (const aggregate of dailyAggregates) {
+    const key = [aggregate.day, aggregate.model ?? 'unknown', aggregate.projectKey].join('::')
+    const existing = target.get(key)
+    if (!existing) {
+      target.set(key, { ...aggregate })
+      continue
+    }
+    existing.eventCount += aggregate.eventCount
+    existing.inputTokens += aggregate.inputTokens
+    existing.cachedInputTokens += aggregate.cachedInputTokens
+    existing.outputTokens += aggregate.outputTokens
+    existing.reasoningOutputTokens += aggregate.reasoningOutputTokens
+    existing.totalTokens += aggregate.totalTokens
+    existing.estimatedCostUsd = addCost(existing.estimatedCostUsd, aggregate.estimatedCostUsd)
+  }
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -363,6 +363,17 @@ import type {
   OpenCodeUsageSnapshot,
   OpenCodeUsageSummary
 } from '../shared/opencode-usage-types'
+import type {
+  KimiUsageBreakdownKind,
+  KimiUsageBreakdownRow,
+  KimiUsageDailyPoint,
+  KimiUsageRange,
+  KimiUsageScanState,
+  KimiUsageScope,
+  KimiUsageSessionRow,
+  KimiUsageSnapshot,
+  KimiUsageSummary
+} from '../shared/kimi-usage-types'
 import type { AiVaultListArgs, AiVaultListResult } from '../shared/ai-vault-types'
 import type { AgentType, NativeChatMessage } from '../shared/native-chat-types'
 import type { TelemetryConsentState } from '../shared/telemetry-consent-types'
@@ -735,6 +746,32 @@ export type OpenCodeUsageApi = {
     range: OpenCodeUsageRange
     limit?: number
   }) => Promise<OpenCodeUsageSessionRow[]>
+}
+
+export type KimiUsageApi = {
+  getScanState: () => Promise<KimiUsageScanState>
+  setEnabled: (args: { enabled: boolean }) => Promise<KimiUsageScanState>
+  refresh: (args?: { force?: boolean }) => Promise<KimiUsageScanState>
+  getSnapshot: (args: {
+    scope: KimiUsageScope
+    range: KimiUsageRange
+    limit?: number
+  }) => Promise<KimiUsageSnapshot>
+  getSummary: (args: { scope: KimiUsageScope; range: KimiUsageRange }) => Promise<KimiUsageSummary>
+  getDaily: (args: {
+    scope: KimiUsageScope
+    range: KimiUsageRange
+  }) => Promise<KimiUsageDailyPoint[]>
+  getBreakdown: (args: {
+    scope: KimiUsageScope
+    range: KimiUsageRange
+    kind: KimiUsageBreakdownKind
+  }) => Promise<KimiUsageBreakdownRow[]>
+  getRecentSessions: (args: {
+    scope: KimiUsageScope
+    range: KimiUsageRange
+    limit?: number
+  }) => Promise<KimiUsageSessionRow[]>
 }
 
 export type AiVaultApi = {
@@ -2085,6 +2122,7 @@ export type PreloadApi = {
   claudeUsage: ClaudeUsageApi
   codexUsage: CodexUsageApi
   openCodeUsage: OpenCodeUsageApi
+  kimiUsage: KimiUsageApi
   aiVault: AiVaultApi
   nativeChat: NativeChatApi
   fs: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3572,6 +3572,24 @@ const api = {
       ipcRenderer.invoke('openCodeUsage:getRecentSessions', args)
   },
 
+  kimiUsage: {
+    getScanState: (): Promise<unknown> => ipcRenderer.invoke('kimiUsage:getScanState'),
+    setEnabled: (args: { enabled: boolean }): Promise<unknown> =>
+      ipcRenderer.invoke('kimiUsage:setEnabled', args),
+    refresh: (args?: { force?: boolean }): Promise<unknown> =>
+      ipcRenderer.invoke('kimiUsage:refresh', args),
+    getSnapshot: (args: { scope: string; range: string; limit?: number }): Promise<unknown> =>
+      ipcRenderer.invoke('kimiUsage:getSnapshot', args),
+    getSummary: (args: { scope: string; range: string }): Promise<unknown> =>
+      ipcRenderer.invoke('kimiUsage:getSummary', args),
+    getDaily: (args: { scope: string; range: string }): Promise<unknown> =>
+      ipcRenderer.invoke('kimiUsage:getDaily', args),
+    getBreakdown: (args: { scope: string; range: string; kind: string }): Promise<unknown> =>
+      ipcRenderer.invoke('kimiUsage:getBreakdown', args),
+    getRecentSessions: (args: { scope: string; range: string; limit?: number }): Promise<unknown> =>
+      ipcRenderer.invoke('kimiUsage:getRecentSessions', args)
+  },
+
   aiVault: {
     listSessions: (args?: AiVaultListArgs): Promise<unknown> =>
       ipcRenderer.invoke('aiVault:listSessions', args)

--- a/src/renderer/src/components/stats/KimiUsageDetails.tsx
+++ b/src/renderer/src/components/stats/KimiUsageDetails.tsx
@@ -1,0 +1,64 @@
+import type {
+  KimiUsageBreakdownRow,
+  KimiUsageDailyPoint,
+  KimiUsageSessionRow,
+  KimiUsageSummary
+} from '../../../../shared/kimi-usage-types'
+import { CodexUsageDailyChart } from './CodexUsageDailyChart'
+import { KimiUsageRecentSessionsTable } from './KimiUsageRecentSessionsTable'
+import { UsageBreakdownSection } from './UsageBreakdownSection'
+import { translate } from '@/i18n/i18n'
+
+type KimiUsageDetailsProps = {
+  daily: KimiUsageDailyPoint[]
+  modelBreakdown: KimiUsageBreakdownRow[]
+  projectBreakdown: KimiUsageBreakdownRow[]
+  recentSessions: KimiUsageSessionRow[]
+  summary: KimiUsageSummary | null | undefined
+}
+
+export function KimiUsageDetails({
+  daily,
+  modelBreakdown,
+  projectBreakdown,
+  recentSessions,
+  summary
+}: KimiUsageDetailsProps): React.JSX.Element {
+  return (
+    <>
+      <CodexUsageDailyChart daily={daily} />
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <UsageBreakdownSection
+          title={translate('auto.components.stats.KimiUsagePane.040c044d39', 'By model')}
+          topLabel={translate('auto.components.stats.KimiUsagePane.a15206a63a', 'Top model:')}
+          topValue={summary?.topModel}
+          rows={modelBreakdown.map((row) => ({
+            key: row.key,
+            label: row.label,
+            tokens: row.totalTokens,
+            sessions: row.sessions,
+            eventsOrTurns: row.events,
+            estimatedCostUsd: row.estimatedCostUsd
+          }))}
+          eventsOrTurns="events"
+        />
+        <UsageBreakdownSection
+          title={translate('auto.components.stats.KimiUsagePane.0f0a1684bb', 'By project')}
+          topLabel={translate('auto.components.stats.KimiUsagePane.048ffe4d65', 'Top project:')}
+          topValue={summary?.topProject}
+          rows={projectBreakdown.map((row) => ({
+            key: row.key,
+            label: row.label,
+            tokens: row.totalTokens,
+            sessions: row.sessions,
+            eventsOrTurns: row.events
+          }))}
+          eventsOrTurns="events"
+        />
+      </div>
+
+      <KimiUsageRecentSessionsTable recentSessions={recentSessions} />
+    </>
+  )
+}

--- a/src/renderer/src/components/stats/KimiUsagePane.tsx
+++ b/src/renderer/src/components/stats/KimiUsagePane.tsx
@@ -1,0 +1,310 @@
+import { useEffect } from 'react'
+import {
+  Activity,
+  Brain,
+  Coins,
+  DatabaseZap,
+  FolderKanban,
+  RefreshCw,
+  SlidersHorizontal,
+  Sparkles
+} from 'lucide-react'
+import type { KimiUsageRange, KimiUsageScope } from '../../../../shared/kimi-usage-types'
+import { useAppStore } from '../../store'
+import { Button } from '../ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '../ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import { ClaudeUsageLoadingState } from './ClaudeUsageLoadingState'
+import { KimiUsageDetails } from './KimiUsageDetails'
+import { StatCard } from './StatCard'
+import { formatCost, formatTokens, formatUpdatedAt } from './usage-formatters'
+import { translate } from '@/i18n/i18n'
+
+const RANGE_OPTIONS: KimiUsageRange[] = ['7d', '30d', '90d', 'all']
+const SCOPE_OPTIONS: { value: KimiUsageScope; label: string }[] = [
+  {
+    value: 'orca',
+    get label() {
+      return translate('auto.components.stats.KimiUsagePane.e04c58327c', 'Orca worktrees only')
+    }
+  },
+  {
+    value: 'all',
+    get label() {
+      return translate('auto.components.stats.KimiUsagePane.144a6050e9', 'All local Kimi usage')
+    }
+  }
+]
+const RANGE_LABELS: Record<KimiUsageRange, string> = {
+  get '7d'() {
+    return translate('auto.components.stats.KimiUsagePane.rangeLast7Days', 'Last 7 days')
+  },
+  get '30d'() {
+    return translate('auto.components.stats.KimiUsagePane.rangeLast30Days', 'Last 30 days')
+  },
+  get '90d'() {
+    return translate('auto.components.stats.KimiUsagePane.rangeLast90Days', 'Last 90 days')
+  },
+  get all() {
+    return translate('auto.components.stats.KimiUsagePane.rangeAllTime', 'All time')
+  }
+}
+
+export function KimiUsagePane(): React.JSX.Element {
+  const scanState = useAppStore((state) => state.kimiUsageScanState)
+  const summary = useAppStore((state) => state.kimiUsageSummary)
+  const daily = useAppStore((state) => state.kimiUsageDaily)
+  const modelBreakdown = useAppStore((state) => state.kimiUsageModelBreakdown)
+  const projectBreakdown = useAppStore((state) => state.kimiUsageProjectBreakdown)
+  const recentSessions = useAppStore((state) => state.kimiUsageRecentSessions)
+  const scope = useAppStore((state) => state.kimiUsageScope)
+  const range = useAppStore((state) => state.kimiUsageRange)
+  const fetchKimiUsage = useAppStore((state) => state.fetchKimiUsage)
+  const setKimiUsageEnabled = useAppStore((state) => state.setKimiUsageEnabled)
+  const refreshKimiUsage = useAppStore((state) => state.refreshKimiUsage)
+  const setKimiUsageScope = useAppStore((state) => state.setKimiUsageScope)
+  const setKimiUsageRange = useAppStore((state) => state.setKimiUsageRange)
+  const recordFeatureInteraction = useAppStore((state) => state.recordFeatureInteraction)
+
+  useEffect(() => {
+    void fetchKimiUsage()
+  }, [fetchKimiUsage])
+
+  const handleSetEnabled = (enabled: boolean): void => {
+    recordFeatureInteraction('usage-tracking')
+    void setKimiUsageEnabled(enabled)
+  }
+
+  if (!scanState?.enabled) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-card/40 p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold text-foreground">
+              {translate('auto.components.stats.KimiUsagePane.bea80ceae0', 'Kimi Usage Tracking')}
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              {translate(
+                'auto.components.stats.KimiUsagePane.b8b3522436',
+                'Reads local Kimi usage logs to show token, model, and session stats.'
+              )}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={false}
+            aria-label={translate(
+              'auto.components.stats.KimiUsagePane.f04131b3be',
+              'Enable Kimi usage analytics'
+            )}
+            onClick={() => handleSetEnabled(true)}
+            className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-muted-foreground/30 transition-colors"
+          >
+            <span className="pointer-events-none block size-3.5 translate-x-0.5 rounded-full bg-background shadow-sm transition-transform" />
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!summary && (scanState.isScanning || scanState.lastScanCompletedAt === null)) {
+    return (
+      <ClaudeUsageLoadingState
+        title={translate('auto.components.stats.KimiUsagePane.bea80ceae0', 'Kimi Usage Tracking')}
+        summaryCardCount={6}
+        summaryGridClassName="md:grid-cols-3"
+      />
+    )
+  }
+
+  const hasAnyData = summary?.hasAnyKimiData ?? scanState.hasAnyKimiData
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border/60 bg-card/30 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-foreground">
+            {translate('auto.components.stats.KimiUsagePane.bea80ceae0', 'Kimi Usage Tracking')}
+          </h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {formatUpdatedAt(scanState.lastScanCompletedAt)}
+            {scanState.lastScanError
+              ? translate(
+                  'auto.components.stats.KimiUsagePane.6cc7782458',
+                  ' • Last scan error: {{value0}}',
+                  { value0: scanState.lastScanError }
+                )
+              : ''}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 self-start">
+          <DropdownMenu>
+            <TooltipProvider delayDuration={250}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      aria-label={translate(
+                        'auto.components.stats.KimiUsagePane.230d6de108',
+                        'Kimi usage options'
+                      )}
+                    >
+                      <SlidersHorizontal className="size-3.5" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  {translate('auto.components.stats.KimiUsagePane.01583b30aa', 'Filters')}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <DropdownMenuContent align="end" className="w-60">
+              <DropdownMenuLabel>
+                {translate('auto.components.stats.KimiUsagePane.40d283c837', 'Scope')}
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={scope}
+                onValueChange={(value) => void setKimiUsageScope(value as KimiUsageScope)}
+              >
+                {SCOPE_OPTIONS.map((option) => (
+                  <DropdownMenuRadioItem key={option.value} value={option.value}>
+                    {option.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>
+                {translate('auto.components.stats.KimiUsagePane.b5ed5c9fd0', 'Range')}
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={range}
+                onValueChange={(value) => void setKimiUsageRange(value as KimiUsageRange)}
+              >
+                {RANGE_OPTIONS.map((option) => (
+                  <DropdownMenuRadioItem key={option} value={option}>
+                    {RANGE_LABELS[option]}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <TooltipProvider delayDuration={250}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => void refreshKimiUsage()}
+                  disabled={scanState.isScanning}
+                  aria-label={translate(
+                    'auto.components.stats.KimiUsagePane.bed558df0b',
+                    'Refresh Kimi usage'
+                  )}
+                >
+                  <RefreshCw className={`size-3.5 ${scanState.isScanning ? 'animate-spin' : ''}`} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                {translate('auto.components.stats.KimiUsagePane.603cd138dc', 'Refresh')}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={true}
+            aria-label={translate(
+              'auto.components.stats.KimiUsagePane.f04131b3be',
+              'Enable Kimi usage analytics'
+            )}
+            onClick={() => handleSetEnabled(false)}
+            className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-foreground transition-colors"
+          >
+            <span className="pointer-events-none block size-3.5 translate-x-4 rounded-full bg-background shadow-sm transition-transform" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          {SCOPE_OPTIONS.find((option) => option.value === scope)?.label} • {RANGE_LABELS[range]}
+        </p>
+      </div>
+
+      {!hasAnyData ? (
+        <div className="rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-6 text-sm text-muted-foreground">
+          {translate(
+            'auto.components.stats.KimiUsagePane.bb6363e08c',
+            'No local Kimi usage found yet for this scope.'
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-3 md:grid-cols-3">
+            <StatCard
+              label={translate('auto.components.stats.KimiUsagePane.d637a892ed', 'Input tokens')}
+              value={formatTokens(summary?.inputTokens ?? 0)}
+              icon={<Sparkles className="size-4" />}
+            />
+            <StatCard
+              label={translate('auto.components.stats.KimiUsagePane.7aa4d8ce35', 'Output tokens')}
+              value={formatTokens(summary?.outputTokens ?? 0)}
+              icon={<Activity className="size-4" />}
+            />
+            <StatCard
+              label={translate('auto.components.stats.KimiUsagePane.603504ee3b', 'Cached input')}
+              value={formatTokens(summary?.cachedInputTokens ?? 0)}
+              icon={<DatabaseZap className="size-4" />}
+            />
+            <StatCard
+              label={translate(
+                'auto.components.stats.KimiUsagePane.5a65d68b77',
+                'Reasoning output'
+              )}
+              value={formatTokens(summary?.reasoningOutputTokens ?? 0)}
+              icon={<Brain className="size-4" />}
+            />
+            <StatCard
+              label={translate(
+                'auto.components.stats.KimiUsagePane.7e9433469a',
+                'Sessions / Events'
+              )}
+              value={`${(summary?.sessions ?? 0).toLocaleString()} / ${(summary?.events ?? 0).toLocaleString()}`}
+              icon={<FolderKanban className="size-4" />}
+            />
+            <StatCard
+              label={translate('auto.components.stats.KimiUsagePane.15c34d4b08', 'Recorded cost')}
+              value={formatCost(summary?.estimatedCostUsd ?? null)}
+              icon={<Coins className="size-4" />}
+            />
+          </div>
+          <p className="px-1 text-xs text-muted-foreground">
+            {translate(
+              'auto.components.stats.KimiUsagePane.e5bb23d85e',
+              'Kimi wire transcripts do not record cost, so recorded cost stays unavailable.'
+            )}
+          </p>
+
+          <KimiUsageDetails
+            daily={daily}
+            modelBreakdown={modelBreakdown}
+            projectBreakdown={projectBreakdown}
+            recentSessions={recentSessions}
+            summary={summary}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/stats/KimiUsageRecentSessionsTable.tsx
+++ b/src/renderer/src/components/stats/KimiUsageRecentSessionsTable.tsx
@@ -1,0 +1,74 @@
+import type { KimiUsageSessionRow } from '../../../../shared/kimi-usage-types'
+import { translate } from '@/i18n/i18n'
+import { formatSessionTime, formatTokens } from './usage-formatters'
+
+export function KimiUsageRecentSessionsTable({
+  recentSessions
+}: {
+  recentSessions: KimiUsageSessionRow[]
+}): React.JSX.Element {
+  return (
+    <section className="rounded-lg border border-border/60 bg-card/40 p-4">
+      <div className="mb-3">
+        <h4 className="text-sm font-semibold text-foreground">
+          {translate('auto.components.stats.KimiUsagePane.4799177b1c', 'Recent sessions')}
+        </h4>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.stats.KimiUsagePane.81817a641a',
+            'Most recent local Kimi sessions in this scope.'
+          )}
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b border-border/60 text-left text-xs text-muted-foreground">
+              <th className="px-2 py-2 font-medium">
+                {translate('auto.components.stats.KimiUsagePane.d97bdf6e27', 'Last active')}
+              </th>
+              <th className="px-2 py-2 font-medium">
+                {translate('auto.components.stats.KimiUsagePane.a4738de041', 'Project')}
+              </th>
+              <th className="px-2 py-2 font-medium">
+                {translate('auto.components.stats.KimiUsagePane.08c78441b7', 'Model')}
+              </th>
+              <th className="px-2 py-2 font-medium">
+                {translate('auto.components.stats.KimiUsagePane.d416f5cf92', 'Events')}
+              </th>
+              <th className="px-2 py-2 font-medium">
+                {translate('auto.components.stats.KimiUsagePane.0f2f266c9d', 'Input')}
+              </th>
+              <th className="px-2 py-2 font-medium">
+                {translate('auto.components.stats.KimiUsagePane.dfc4513657', 'Output')}
+              </th>
+              <th className="px-2 py-2 font-medium">
+                {translate('auto.components.stats.KimiUsagePane.349f7c3f5c', 'Total')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {recentSessions.map((row) => (
+              <tr key={row.sessionId} className="border-b border-border/40 last:border-b-0">
+                <td className="px-2 py-2 text-muted-foreground">
+                  {formatSessionTime(row.lastActiveAt)}
+                </td>
+                <td className="px-2 py-2 text-foreground">{row.projectLabel}</td>
+                <td className="px-2 py-2 text-muted-foreground">
+                  {row.model ??
+                    translate('auto.components.stats.KimiUsagePane.362231082f', 'Unknown')}
+                </td>
+                <td className="px-2 py-2 text-muted-foreground">{row.events}</td>
+                <td className="px-2 py-2 text-muted-foreground">{formatTokens(row.inputTokens)}</td>
+                <td className="px-2 py-2 text-muted-foreground">
+                  {formatTokens(row.outputTokens)}
+                </td>
+                <td className="px-2 py-2 text-muted-foreground">{formatTokens(row.totalTokens)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/stats/StatsPane.tsx
+++ b/src/renderer/src/components/stats/StatsPane.tsx
@@ -5,6 +5,7 @@ import { StatCard } from './StatCard'
 import { ClaudeUsagePane } from './ClaudeUsagePane'
 import { CodexUsagePane } from './CodexUsagePane'
 import { OpenCodeUsagePane } from './OpenCodeUsagePane'
+import { KimiUsagePane } from './KimiUsagePane'
 import { UsageOverviewPane } from './UsageOverviewPane'
 import { Button } from '../ui/button'
 import {
@@ -45,7 +46,7 @@ function formatTrackingSince(timestamp: number | null): string {
   return `Tracking since ${date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`
 }
 
-type UsageTab = 'overview' | 'claude' | 'codex' | 'opencode'
+type UsageTab = 'overview' | 'claude' | 'codex' | 'opencode' | 'kimi'
 
 const USAGE_ANALYTICS_OPTIONS = [
   {
@@ -71,6 +72,12 @@ const USAGE_ANALYTICS_OPTIONS = [
     get label() {
       return translate('auto.components.stats.StatsPane.1e696db2f6', 'OpenCode')
     }
+  },
+  {
+    id: 'kimi',
+    get label() {
+      return translate('auto.components.stats.StatsPane.3cf75f0eb0', 'Kimi')
+    }
   }
 ] as const satisfies readonly { id: UsageTab; label: string }[]
 
@@ -79,6 +86,21 @@ function UsageAnalyticsOptionIcon({ tab }: { tab: UsageTab }): React.JSX.Element
     return <BarChart3 className="size-3.5 text-muted-foreground" />
   }
   return <AgentIcon agent={tab} size={14} />
+}
+
+function UsageAnalyticsPanel({ tab }: { tab: UsageTab }): React.JSX.Element {
+  switch (tab) {
+    case 'overview':
+      return <UsageOverviewPane />
+    case 'claude':
+      return <ClaudeUsagePane />
+    case 'codex':
+      return <CodexUsagePane />
+    case 'opencode':
+      return <OpenCodeUsagePane />
+    case 'kimi':
+      return <KimiUsagePane />
+  }
 }
 
 export function StatsPane(): React.JSX.Element {
@@ -187,15 +209,7 @@ export function StatsPane(): React.JSX.Element {
             active panel mounted avoids hidden tab-content layout/focus churn that produced a visible
             vertical jitter below the usage card when switching disabled providers. */}
         <div>
-          {activeUsageTab === 'overview' ? (
-            <UsageOverviewPane />
-          ) : activeUsageTab === 'claude' ? (
-            <ClaudeUsagePane />
-          ) : activeUsageTab === 'codex' ? (
-            <CodexUsagePane />
-          ) : (
-            <OpenCodeUsagePane />
-          )}
+          <UsageAnalyticsPanel tab={activeUsageTab} />
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/stats/UsageOverviewPane.tsx
+++ b/src/renderer/src/components/stats/UsageOverviewPane.tsx
@@ -40,22 +40,29 @@ export function UsageOverviewPane(): React.JSX.Element {
   const openCodeScanState = useAppStore((state) => state.openCodeUsageScanState)
   const openCodeSummary = useAppStore((state) => state.openCodeUsageSummary)
   const openCodeDaily = useAppStore((state) => state.openCodeUsageDaily)
+  const kimiScanState = useAppStore((state) => state.kimiUsageScanState)
+  const kimiSummary = useAppStore((state) => state.kimiUsageSummary)
+  const kimiDaily = useAppStore((state) => state.kimiUsageDaily)
   const fetchClaudeUsage = useAppStore((state) => state.fetchClaudeUsage)
   const fetchCodexUsage = useAppStore((state) => state.fetchCodexUsage)
   const fetchOpenCodeUsage = useAppStore((state) => state.fetchOpenCodeUsage)
+  const fetchKimiUsage = useAppStore((state) => state.fetchKimiUsage)
   const refreshClaudeUsage = useAppStore((state) => state.refreshClaudeUsage)
   const refreshCodexUsage = useAppStore((state) => state.refreshCodexUsage)
   const refreshOpenCodeUsage = useAppStore((state) => state.refreshOpenCodeUsage)
+  const refreshKimiUsage = useAppStore((state) => state.refreshKimiUsage)
   const enableClaudeUsage = useAppStore((state) => state.enableClaudeUsage)
   const enableCodexUsage = useAppStore((state) => state.enableCodexUsage)
   const enableOpenCodeUsage = useAppStore((state) => state.enableOpenCodeUsage)
+  const enableKimiUsage = useAppStore((state) => state.enableKimiUsage)
   const recordFeatureInteraction = useAppStore((state) => state.recordFeatureInteraction)
 
   useEffect(() => {
     void fetchClaudeUsage()
     void fetchCodexUsage()
     void fetchOpenCodeUsage()
-  }, [fetchClaudeUsage, fetchCodexUsage, fetchOpenCodeUsage])
+    void fetchKimiUsage()
+  }, [fetchClaudeUsage, fetchCodexUsage, fetchOpenCodeUsage, fetchKimiUsage])
 
   const overview = useMemo(
     () =>
@@ -74,6 +81,11 @@ export function UsageOverviewPane(): React.JSX.Element {
           scanState: openCodeScanState,
           summary: openCodeSummary,
           daily: openCodeDaily
+        },
+        kimi: {
+          scanState: kimiScanState,
+          summary: kimiSummary,
+          daily: kimiDaily
         }
       }),
     [
@@ -83,6 +95,9 @@ export function UsageOverviewPane(): React.JSX.Element {
       codexDaily,
       codexScanState,
       codexSummary,
+      kimiDaily,
+      kimiScanState,
+      kimiSummary,
       openCodeDaily,
       openCodeScanState,
       openCodeSummary
@@ -98,7 +113,8 @@ export function UsageOverviewPane(): React.JSX.Element {
     void Promise.all([
       claudeScanState?.enabled ? refreshClaudeUsage() : Promise.resolve(),
       codexScanState?.enabled ? refreshCodexUsage() : Promise.resolve(),
-      openCodeScanState?.enabled ? refreshOpenCodeUsage() : Promise.resolve()
+      openCodeScanState?.enabled ? refreshOpenCodeUsage() : Promise.resolve(),
+      kimiScanState?.enabled ? refreshKimiUsage() : Promise.resolve()
     ])
   }
 
@@ -191,6 +207,16 @@ export function UsageOverviewPane(): React.JSX.Element {
                     'Enable OpenCode'
                   )}
                 </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    recordFeatureInteraction('usage-tracking')
+                    void enableKimiUsage()
+                  }}
+                >
+                  {translate('auto.components.stats.UsageOverviewPane.9b53df065e', 'Enable Kimi')}
+                </Button>
               </div>
             </div>
           </div>
@@ -232,7 +258,7 @@ export function UsageOverviewPane(): React.JSX.Element {
               <div className="mt-4 rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-5 text-sm text-muted-foreground">
                 {translate(
                   'auto.components.stats.UsageOverviewPane.60002bb22f',
-                  'No local Claude, Codex, or OpenCode usage found yet. The overview will populate after the next agent session writes token logs.'
+                  'No local Claude, Codex, OpenCode, or Kimi usage found yet. The overview will populate after the next agent session writes token logs.'
                 )}
               </div>
             ) : (
@@ -276,8 +302,10 @@ export function UsageOverviewPane(): React.JSX.Element {
                   void enableClaudeUsage()
                 } else if (provider.id === 'codex') {
                   void enableCodexUsage()
-                } else {
+                } else if (provider.id === 'opencode') {
                   void enableOpenCodeUsage()
+                } else {
+                  void enableKimiUsage()
                 }
               }}
             />

--- a/src/renderer/src/components/stats/usage-overview-model.test.ts
+++ b/src/renderer/src/components/stats/usage-overview-model.test.ts
@@ -14,6 +14,11 @@ import type {
   OpenCodeUsageScanState,
   OpenCodeUsageSummary
 } from '../../../../shared/opencode-usage-types'
+import type {
+  KimiUsageDailyPoint,
+  KimiUsageScanState,
+  KimiUsageSummary
+} from '../../../../shared/kimi-usage-types'
 import {
   buildUsageOverview,
   formatUsageCost,
@@ -51,6 +56,17 @@ function enabledOpenCodeScanState(): OpenCodeUsageScanState {
     lastScanCompletedAt: 600,
     lastScanError: null,
     hasAnyOpenCodeData: true
+  }
+}
+
+function enabledKimiScanState(): KimiUsageScanState {
+  return {
+    enabled: true,
+    isScanning: false,
+    lastScanStartedAt: 700,
+    lastScanCompletedAt: 800,
+    lastScanError: null,
+    hasAnyKimiData: true
   }
 }
 
@@ -146,6 +162,32 @@ describe('usage overview model', () => {
         totalTokens: 1_600
       }
     ]
+    // Kimi records no cost (estimatedCostUsd null) and no reasoning tokens.
+    const kimiSummary: KimiUsageSummary = {
+      scope: 'orca',
+      range: '30d',
+      sessions: 1,
+      events: 2,
+      inputTokens: 600,
+      cachedInputTokens: 200,
+      outputTokens: 400,
+      reasoningOutputTokens: 0,
+      totalTokens: 1_200,
+      estimatedCostUsd: null,
+      topModel: 'kimi-k2',
+      topProject: 'orca-kimi',
+      hasAnyKimiData: true
+    }
+    const kimiDaily: KimiUsageDailyPoint[] = [
+      {
+        day: '2026-05-16',
+        inputTokens: 600,
+        cachedInputTokens: 200,
+        outputTokens: 400,
+        reasoningOutputTokens: 0,
+        totalTokens: 1_200
+      }
+    ]
 
     const overview = buildUsageOverview({
       claude: {
@@ -162,25 +204,33 @@ describe('usage overview model', () => {
         scanState: enabledOpenCodeScanState(),
         summary: openCodeSummary,
         daily: openCodeDaily
+      },
+      kimi: {
+        scanState: enabledKimiScanState(),
+        summary: kimiSummary,
+        daily: kimiDaily
       }
     })
 
-    expect(overview.totalTokens).toBe(10_800)
-    expect(overview.newInputTokens).toBe(2_950)
-    expect(overview.cacheTokens).toBe(5_550)
-    expect(overview.outputTokens).toBe(2_200)
+    expect(overview.totalTokens).toBe(12_000)
+    expect(overview.newInputTokens).toBe(3_550)
+    expect(overview.cacheTokens).toBe(5_750)
+    expect(overview.outputTokens).toBe(2_600)
     expect(overview.reasoningTokens).toBe(400)
-    expect(overview.sessions).toBe(4)
-    expect(overview.activityCount).toBe(9)
-    expect(overview.activeDays).toBe(3)
+    expect(overview.sessions).toBe(5)
+    expect(overview.activityCount).toBe(11)
+    expect(overview.activeDays).toBe(4)
+    // Kimi cost stays null, so the combined cost is unchanged from the other three.
     expect(overview.estimatedCostUsd).toBeCloseTo(0.09)
-    expect(overview.cacheShare).toBeCloseTo(5_550 / 8_500)
+    expect(overview.hasPartialCost).toBe(true)
+    expect(overview.cacheShare).toBeCloseTo(5_750 / 9_300)
     expect(overview.bestDay).toMatchObject({
       day: '2026-05-14',
       totalTokens: 4_500,
       claudeTokens: 2_500,
       codexTokens: 2_000,
       openCodeTokens: 0,
+      kimiTokens: 0,
       intensity: 4
     })
     expect(overview.providers.find((provider) => provider.id === 'codex')).toMatchObject({
@@ -193,6 +243,18 @@ describe('usage overview model', () => {
       cacheTokens: 250,
       totalTokens: 1_600
     })
+    expect(overview.providers.find((provider) => provider.id === 'kimi')).toMatchObject({
+      newInputTokens: 600,
+      cacheTokens: 200,
+      totalTokens: 1_200,
+      estimatedCostUsd: null,
+      activityLabel: 'events'
+    })
+    expect(overview.daily.find((entry) => entry.day === '2026-05-16')).toMatchObject({
+      day: '2026-05-16',
+      totalTokens: 1_200,
+      kimiTokens: 1_200
+    })
   })
 
   it('pads recent usage days with zero-token cells', () => {
@@ -204,6 +266,7 @@ describe('usage overview model', () => {
           claudeTokens: 2_500,
           codexTokens: 2_000,
           openCodeTokens: 0,
+          kimiTokens: 0,
           intensity: 4
         }
       ],
@@ -218,6 +281,7 @@ describe('usage overview model', () => {
         claudeTokens: 0,
         codexTokens: 0,
         openCodeTokens: 0,
+        kimiTokens: 0,
         intensity: 0
       },
       {
@@ -226,6 +290,7 @@ describe('usage overview model', () => {
         claudeTokens: 2_500,
         codexTokens: 2_000,
         openCodeTokens: 0,
+        kimiTokens: 0,
         intensity: 4
       },
       {
@@ -234,6 +299,7 @@ describe('usage overview model', () => {
         claudeTokens: 0,
         codexTokens: 0,
         openCodeTokens: 0,
+        kimiTokens: 0,
         intensity: 0
       }
     ])
@@ -243,7 +309,8 @@ describe('usage overview model', () => {
     const overview = buildUsageOverview({
       claude: { scanState: null, summary: null, daily: [] },
       codex: { scanState: null, summary: null, daily: [] },
-      opencode: { scanState: null, summary: null, daily: [] }
+      opencode: { scanState: null, summary: null, daily: [] },
+      kimi: { scanState: null, summary: null, daily: [] }
     })
 
     expect(overview.hasAnyEnabledProvider).toBe(false)
@@ -273,7 +340,8 @@ describe('usage overview model', () => {
         summary: null,
         daily: codexDaily
       },
-      opencode: { scanState: null, summary: null, daily: [] }
+      opencode: { scanState: null, summary: null, daily: [] },
+      kimi: { scanState: null, summary: null, daily: [] }
     })
 
     expect(overview.daily).toHaveLength(130_000)

--- a/src/renderer/src/components/stats/usage-overview-model.ts
+++ b/src/renderer/src/components/stats/usage-overview-model.ts
@@ -15,9 +15,14 @@ import type {
   OpenCodeUsageScanState,
   OpenCodeUsageSummary
 } from '../../../../shared/opencode-usage-types'
+import type {
+  KimiUsageDailyPoint,
+  KimiUsageScanState,
+  KimiUsageSummary
+} from '../../../../shared/kimi-usage-types'
 import { translate } from '@/i18n/i18n'
 
-export type UsageProviderId = 'claude' | 'codex' | 'opencode'
+export type UsageProviderId = 'claude' | 'codex' | 'opencode' | 'kimi'
 
 export type UsageProviderOverview = {
   id: UsageProviderId
@@ -47,6 +52,7 @@ export type UsageOverviewDailyPoint = {
   claudeTokens: number
   codexTokens: number
   openCodeTokens: number
+  kimiTokens: number
   intensity: 0 | 1 | 2 | 3 | 4
 }
 
@@ -88,6 +94,11 @@ export type UsageOverviewInput = {
     summary: OpenCodeUsageSummary | null
     daily: OpenCodeUsageDailyPoint[]
   }
+  kimi: {
+    scanState: KimiUsageScanState | null
+    summary: KimiUsageSummary | null
+    daily: KimiUsageDailyPoint[]
+  }
 }
 
 function getClaudeDailyTotal(entry: ClaudeUsageDailyPoint): number {
@@ -106,6 +117,13 @@ function getOpenCodeNewInputTokens(summary: OpenCodeUsageSummary | null): number
     return 0
   }
   return Math.max(summary.inputTokens - summary.cachedInputTokens, 0)
+}
+
+function getKimiNewInputTokens(summary: KimiUsageSummary | null): number {
+  // Why: Kimi (like Claude) reports inputTokens as the non-cached bucket already
+  // — cachedInputTokens is separate and totalTokens sums all buckets. Subtracting
+  // cache (as Codex/OpenCode do for their cache-inclusive input) would undercount.
+  return summary?.inputTokens ?? 0
 }
 
 function getIntensity(totalTokens: number, maxTokens: number): 0 | 1 | 2 | 3 | 4 {
@@ -218,6 +236,34 @@ function createOpenCodeProvider(input: UsageOverviewInput['opencode']): UsagePro
   }
 }
 
+function createKimiProvider(input: UsageOverviewInput['kimi']): UsageProviderOverview {
+  const summary = input.summary
+  const dailyActiveDays = input.daily
+    .filter((entry) => entry.totalTokens > 0)
+    .map((entry) => entry.day)
+  return {
+    id: 'kimi',
+    label: translate('auto.components.stats.usage.overview.model.6f712fcb4f', 'Kimi'),
+    enabled: input.scanState?.enabled ?? false,
+    isScanning: input.scanState?.isScanning ?? false,
+    hasData: summary?.hasAnyKimiData ?? input.scanState?.hasAnyKimiData ?? false,
+    lastScanCompletedAt: input.scanState?.lastScanCompletedAt ?? null,
+    lastScanError: input.scanState?.lastScanError ?? null,
+    sessions: summary?.sessions ?? 0,
+    activityLabel: 'events',
+    activityCount: summary?.events ?? 0,
+    totalTokens: summary?.totalTokens ?? 0,
+    newInputTokens: getKimiNewInputTokens(summary),
+    outputTokens: summary?.outputTokens ?? 0,
+    cacheTokens: summary?.cachedInputTokens ?? 0,
+    reasoningTokens: summary?.reasoningOutputTokens ?? 0,
+    estimatedCostUsd: summary?.estimatedCostUsd ?? null,
+    topModel: summary?.topModel ?? null,
+    topProject: summary?.topProject ?? null,
+    activeDays: countActiveDays(dailyActiveDays)
+  }
+}
+
 function buildDailyOverview(input: UsageOverviewInput): UsageOverviewDailyPoint[] {
   const byDay = new Map<string, Omit<UsageOverviewDailyPoint, 'intensity'>>()
 
@@ -227,7 +273,8 @@ function buildDailyOverview(input: UsageOverviewInput): UsageOverviewDailyPoint[
       totalTokens: 0,
       claudeTokens: 0,
       codexTokens: 0,
-      openCodeTokens: 0
+      openCodeTokens: 0,
+      kimiTokens: 0
     }
     const total = getClaudeDailyTotal(entry)
     current.totalTokens += total
@@ -241,7 +288,8 @@ function buildDailyOverview(input: UsageOverviewInput): UsageOverviewDailyPoint[
       totalTokens: 0,
       claudeTokens: 0,
       codexTokens: 0,
-      openCodeTokens: 0
+      openCodeTokens: 0,
+      kimiTokens: 0
     }
     current.totalTokens += entry.totalTokens
     current.codexTokens += entry.totalTokens
@@ -254,10 +302,25 @@ function buildDailyOverview(input: UsageOverviewInput): UsageOverviewDailyPoint[
       totalTokens: 0,
       claudeTokens: 0,
       codexTokens: 0,
-      openCodeTokens: 0
+      openCodeTokens: 0,
+      kimiTokens: 0
     }
     current.totalTokens += entry.totalTokens
     current.openCodeTokens += entry.totalTokens
+    byDay.set(entry.day, current)
+  }
+
+  for (const entry of input.kimi.daily) {
+    const current = byDay.get(entry.day) ?? {
+      day: entry.day,
+      totalTokens: 0,
+      claudeTokens: 0,
+      codexTokens: 0,
+      openCodeTokens: 0,
+      kimiTokens: 0
+    }
+    current.totalTokens += entry.totalTokens
+    current.kimiTokens += entry.totalTokens
     byDay.set(entry.day, current)
   }
 
@@ -304,6 +367,7 @@ export function getRecentUsageDays(
         claudeTokens: 0,
         codexTokens: 0,
         openCodeTokens: 0,
+        kimiTokens: 0,
         intensity: 0
       }
     )
@@ -315,7 +379,8 @@ export function buildUsageOverview(input: UsageOverviewInput): UsageOverviewMode
   const providers = [
     createClaudeProvider(input.claude),
     createCodexProvider(input.codex),
-    createOpenCodeProvider(input.opencode)
+    createOpenCodeProvider(input.opencode),
+    createKimiProvider(input.kimi)
   ]
   const daily = buildDailyOverview(input)
   const bestDay =

--- a/src/renderer/src/components/stats/usage-overview-sections.tsx
+++ b/src/renderer/src/components/stats/usage-overview-sections.tsx
@@ -18,6 +18,13 @@ const INTENSITY_CLASS: Record<UsageOverviewDailyPoint['intensity'], string> = {
   4: 'border-border/60 bg-foreground/75'
 }
 
+const PROVIDER_BAR_CLASS: Record<UsageProviderOverview['id'], string> = {
+  claude: 'bg-foreground/75',
+  codex: 'bg-muted-foreground',
+  opencode: 'bg-border',
+  kimi: 'bg-primary'
+}
+
 function translateActivityLabel(label: UsageProviderOverview['activityLabel']): string {
   if (label === 'turns') {
     return translate('auto.components.stats.usage.overview.sections.c8f3a2d1e0b4', 'turns')
@@ -141,7 +148,7 @@ export function DailyIntensityGrid({
           <p className="text-xs text-muted-foreground">
             {translate(
               'auto.components.stats.usage.overview.sections.f28ff1f852',
-              'Recent combined Claude, Codex, and OpenCode token activity.'
+              'Recent combined Claude, Codex, OpenCode, and Kimi token activity.'
             )}
           </p>
         </div>
@@ -245,7 +252,7 @@ export function ProviderUsageRow({
       </div>
       <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
         <div
-          className="h-full rounded-full bg-foreground/75"
+          className={`h-full rounded-full ${PROVIDER_BAR_CLASS[provider.id]}`}
           style={{ width: `${Math.max(share * 100, provider.totalTokens > 0 ? 2 : 0)}%` }}
         />
       </div>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3233,7 +3233,8 @@
           "b2cf4310ce": "Overview",
           "908c470587": "codex",
           "eb6a066185": "claude",
-          "eee19cfade": "overview"
+          "eee19cfade": "overview",
+          "3cf75f0eb0": "Kimi"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "sessions",
@@ -3253,7 +3254,8 @@
           "ca6bc5fded": "Refresh",
           "e06d1baf5c": "Refresh usage overview",
           "c760c481c5": "Usage Overview",
-          "55c910f4f1": "- some model prices are unavailable"
+          "55c910f4f1": "- some model prices are unavailable",
+          "9b53df065e": "Enable Kimi"
         },
         "share": {
           "card": {
@@ -3293,7 +3295,8 @@
             "model": {
               "bc474051e5": "OpenCode",
               "eb220d193b": "Codex",
-              "544d6d4c16": "Claude"
+              "544d6d4c16": "Claude",
+              "6f712fcb4f": "Kimi"
             },
             "sections": {
               "9564a3b21b": "sessions -",
@@ -3335,6 +3338,46 @@
           "faf3444859": "Input",
           "a8b7487ff7": "Output",
           "cfe2282ffa": "Unknown"
+        },
+        "KimiUsagePane": {
+          "040c044d39": "By model",
+          "a15206a63a": "Top model:",
+          "0f0a1684bb": "By project",
+          "048ffe4d65": "Top project:",
+          "e04c58327c": "Orca worktrees only",
+          "144a6050e9": "All local Kimi usage",
+          "rangeLast7Days": "Last 7 days",
+          "rangeLast30Days": "Last 30 days",
+          "rangeLast90Days": "Last 90 days",
+          "rangeAllTime": "All time",
+          "bea80ceae0": "Kimi Usage Tracking",
+          "b8b3522436": "Reads local Kimi usage logs to show token, model, and session stats.",
+          "f04131b3be": "Enable Kimi usage analytics",
+          "6cc7782458": " • Last scan error: {{value0}}",
+          "230d6de108": "Kimi usage options",
+          "01583b30aa": "Filters",
+          "40d283c837": "Scope",
+          "b5ed5c9fd0": "Range",
+          "bed558df0b": "Refresh Kimi usage",
+          "603cd138dc": "Refresh",
+          "bb6363e08c": "No local Kimi usage found yet for this scope.",
+          "d637a892ed": "Input tokens",
+          "7aa4d8ce35": "Output tokens",
+          "603504ee3b": "Cached input",
+          "5a65d68b77": "Reasoning output",
+          "7e9433469a": "Sessions / Events",
+          "15c34d4b08": "Recorded cost",
+          "e5bb23d85e": "Kimi wire transcripts do not record cost, so recorded cost stays unavailable.",
+          "4799177b1c": "Recent sessions",
+          "81817a641a": "Most recent local Kimi sessions in this scope.",
+          "d97bdf6e27": "Last active",
+          "a4738de041": "Project",
+          "08c78441b7": "Model",
+          "d416f5cf92": "Events",
+          "0f2f266c9d": "Input",
+          "dfc4513657": "Output",
+          "349f7c3f5c": "Total",
+          "362231082f": "Unknown"
         }
       },
       "sparse": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3233,7 +3233,8 @@
           "b2cf4310ce": "Descripción general",
           "908c470587": "codex",
           "eb6a066185": "claude",
-          "eee19cfade": "descripción general"
+          "eee19cfade": "descripción general",
+          "3cf75f0eb0": "Kimi"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "sesiones",
@@ -3253,7 +3254,8 @@
           "ca6bc5fded": "Refrescar",
           "e06d1baf5c": "Actualizar descripción general de uso",
           "c760c481c5": "Descripción general de uso",
-          "55c910f4f1": "- los precios de algunos modelos no están disponibles"
+          "55c910f4f1": "- los precios de algunos modelos no están disponibles",
+          "9b53df065e": "Enable Kimi"
         },
         "share": {
           "card": {
@@ -3293,7 +3295,8 @@
             "model": {
               "bc474051e5": "OpenCode",
               "eb220d193b": "Codex",
-              "544d6d4c16": "Claude"
+              "544d6d4c16": "Claude",
+              "6f712fcb4f": "Kimi"
             },
             "sections": {
               "9564a3b21b": "sesiones -",
@@ -3335,6 +3338,46 @@
           "faf3444859": "Entrada",
           "a8b7487ff7": "Salida",
           "cfe2282ffa": "Desconocido"
+        },
+        "KimiUsagePane": {
+          "040c044d39": "By model",
+          "a15206a63a": "Top model:",
+          "0f0a1684bb": "By project",
+          "048ffe4d65": "Top project:",
+          "e04c58327c": "Orca worktrees only",
+          "144a6050e9": "All local Kimi usage",
+          "rangeLast7Days": "Last 7 days",
+          "rangeLast30Days": "Last 30 days",
+          "rangeLast90Days": "Last 90 days",
+          "rangeAllTime": "All time",
+          "bea80ceae0": "Kimi Usage Tracking",
+          "b8b3522436": "Reads local Kimi usage logs to show token, model, and session stats.",
+          "f04131b3be": "Enable Kimi usage analytics",
+          "6cc7782458": " • Last scan error: {{value0}}",
+          "230d6de108": "Kimi usage options",
+          "01583b30aa": "Filters",
+          "40d283c837": "Scope",
+          "b5ed5c9fd0": "Range",
+          "bed558df0b": "Refresh Kimi usage",
+          "603cd138dc": "Refresh",
+          "bb6363e08c": "No local Kimi usage found yet for this scope.",
+          "d637a892ed": "Input tokens",
+          "7aa4d8ce35": "Output tokens",
+          "603504ee3b": "Cached input",
+          "5a65d68b77": "Reasoning output",
+          "7e9433469a": "Sessions / Events",
+          "15c34d4b08": "Recorded cost",
+          "e5bb23d85e": "Kimi wire transcripts do not record cost, so recorded cost stays unavailable.",
+          "4799177b1c": "Recent sessions",
+          "81817a641a": "Most recent local Kimi sessions in this scope.",
+          "d97bdf6e27": "Last active",
+          "a4738de041": "Project",
+          "08c78441b7": "Model",
+          "d416f5cf92": "Events",
+          "0f2f266c9d": "Input",
+          "dfc4513657": "Output",
+          "349f7c3f5c": "Total",
+          "362231082f": "Unknown"
         }
       },
       "sparse": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3233,7 +3233,8 @@
           "b2cf4310ce": "概要",
           "908c470587": "codex",
           "eb6a066185": "claude",
-          "eee19cfade": "概要"
+          "eee19cfade": "概要",
+          "3cf75f0eb0": "Kimi"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "セッション",
@@ -3253,7 +3254,8 @@
           "ca6bc5fded": "更新",
           "e06d1baf5c": "リフレッシュの使用法の概要",
           "c760c481c5": "使用方法の概要",
-          "55c910f4f1": "- 一部のモデルの価格は利用できません"
+          "55c910f4f1": "- 一部のモデルの価格は利用できません",
+          "9b53df065e": "Enable Kimi"
         },
         "share": {
           "card": {
@@ -3293,7 +3295,8 @@
             "model": {
               "bc474051e5": "OpenCode",
               "eb220d193b": "Codex",
-              "544d6d4c16": "Claude"
+              "544d6d4c16": "Claude",
+              "6f712fcb4f": "Kimi"
             },
             "sections": {
               "9564a3b21b": "セッション -",
@@ -3335,6 +3338,46 @@
           "faf3444859": "入力",
           "a8b7487ff7": "出力",
           "cfe2282ffa": "不明"
+        },
+        "KimiUsagePane": {
+          "040c044d39": "By model",
+          "a15206a63a": "Top model:",
+          "0f0a1684bb": "By project",
+          "048ffe4d65": "Top project:",
+          "e04c58327c": "Orca worktrees only",
+          "144a6050e9": "All local Kimi usage",
+          "rangeLast7Days": "Last 7 days",
+          "rangeLast30Days": "Last 30 days",
+          "rangeLast90Days": "Last 90 days",
+          "rangeAllTime": "All time",
+          "bea80ceae0": "Kimi Usage Tracking",
+          "b8b3522436": "Reads local Kimi usage logs to show token, model, and session stats.",
+          "f04131b3be": "Enable Kimi usage analytics",
+          "6cc7782458": " • Last scan error: {{value0}}",
+          "230d6de108": "Kimi usage options",
+          "01583b30aa": "Filters",
+          "40d283c837": "Scope",
+          "b5ed5c9fd0": "Range",
+          "bed558df0b": "Refresh Kimi usage",
+          "603cd138dc": "Refresh",
+          "bb6363e08c": "No local Kimi usage found yet for this scope.",
+          "d637a892ed": "Input tokens",
+          "7aa4d8ce35": "Output tokens",
+          "603504ee3b": "Cached input",
+          "5a65d68b77": "Reasoning output",
+          "7e9433469a": "Sessions / Events",
+          "15c34d4b08": "Recorded cost",
+          "e5bb23d85e": "Kimi wire transcripts do not record cost, so recorded cost stays unavailable.",
+          "4799177b1c": "Recent sessions",
+          "81817a641a": "Most recent local Kimi sessions in this scope.",
+          "d97bdf6e27": "Last active",
+          "a4738de041": "Project",
+          "08c78441b7": "Model",
+          "d416f5cf92": "Events",
+          "0f2f266c9d": "Input",
+          "dfc4513657": "Output",
+          "349f7c3f5c": "Total",
+          "362231082f": "Unknown"
         }
       },
       "sparse": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3233,7 +3233,8 @@
           "b2cf4310ce": "개요",
           "908c470587": "codex",
           "eb6a066185": "claude",
-          "eee19cfade": "개요"
+          "eee19cfade": "개요",
+          "3cf75f0eb0": "Kimi"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "세션",
@@ -3253,7 +3254,8 @@
           "ca6bc5fded": "새로고침",
           "e06d1baf5c": "사용량 개요 새로고침",
           "c760c481c5": "사용량 개요",
-          "55c910f4f1": "- 일부 모델 가격 확인 불가"
+          "55c910f4f1": "- 일부 모델 가격 확인 불가",
+          "9b53df065e": "Enable Kimi"
         },
         "share": {
           "card": {
@@ -3293,7 +3295,8 @@
             "model": {
               "bc474051e5": "OpenCode",
               "eb220d193b": "Codex",
-              "544d6d4c16": "Claude"
+              "544d6d4c16": "Claude",
+              "6f712fcb4f": "Kimi"
             },
             "sections": {
               "9564a3b21b": "세션 -",
@@ -3335,6 +3338,46 @@
           "faf3444859": "입력",
           "a8b7487ff7": "출력",
           "cfe2282ffa": "알 수 없음"
+        },
+        "KimiUsagePane": {
+          "040c044d39": "By model",
+          "a15206a63a": "Top model:",
+          "0f0a1684bb": "By project",
+          "048ffe4d65": "Top project:",
+          "e04c58327c": "Orca worktrees only",
+          "144a6050e9": "All local Kimi usage",
+          "rangeLast7Days": "Last 7 days",
+          "rangeLast30Days": "Last 30 days",
+          "rangeLast90Days": "Last 90 days",
+          "rangeAllTime": "All time",
+          "bea80ceae0": "Kimi Usage Tracking",
+          "b8b3522436": "Reads local Kimi usage logs to show token, model, and session stats.",
+          "f04131b3be": "Enable Kimi usage analytics",
+          "6cc7782458": " • Last scan error: {{value0}}",
+          "230d6de108": "Kimi usage options",
+          "01583b30aa": "Filters",
+          "40d283c837": "Scope",
+          "b5ed5c9fd0": "Range",
+          "bed558df0b": "Refresh Kimi usage",
+          "603cd138dc": "Refresh",
+          "bb6363e08c": "No local Kimi usage found yet for this scope.",
+          "d637a892ed": "Input tokens",
+          "7aa4d8ce35": "Output tokens",
+          "603504ee3b": "Cached input",
+          "5a65d68b77": "Reasoning output",
+          "7e9433469a": "Sessions / Events",
+          "15c34d4b08": "Recorded cost",
+          "e5bb23d85e": "Kimi wire transcripts do not record cost, so recorded cost stays unavailable.",
+          "4799177b1c": "Recent sessions",
+          "81817a641a": "Most recent local Kimi sessions in this scope.",
+          "d97bdf6e27": "Last active",
+          "a4738de041": "Project",
+          "08c78441b7": "Model",
+          "d416f5cf92": "Events",
+          "0f2f266c9d": "Input",
+          "dfc4513657": "Output",
+          "349f7c3f5c": "Total",
+          "362231082f": "Unknown"
         }
       },
       "sparse": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3233,7 +3233,8 @@
           "b2cf4310ce": "概览",
           "908c470587": "codex",
           "eb6a066185": "claude",
-          "eee19cfade": "概览"
+          "eee19cfade": "概览",
+          "3cf75f0eb0": "Kimi"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "会话",
@@ -3253,7 +3254,8 @@
           "ca6bc5fded": "刷新",
           "e06d1baf5c": "刷新使用概览",
           "c760c481c5": "使用概述",
-          "55c910f4f1": "- 部分型号价格不详"
+          "55c910f4f1": "- 部分型号价格不详",
+          "9b53df065e": "Enable Kimi"
         },
         "share": {
           "card": {
@@ -3293,7 +3295,8 @@
             "model": {
               "bc474051e5": "OpenCode",
               "eb220d193b": "Codex",
-              "544d6d4c16": "Claude"
+              "544d6d4c16": "Claude",
+              "6f712fcb4f": "Kimi"
             },
             "sections": {
               "9564a3b21b": "会话 -",
@@ -3335,6 +3338,46 @@
           "faf3444859": "输入",
           "a8b7487ff7": "输出",
           "cfe2282ffa": "未知"
+        },
+        "KimiUsagePane": {
+          "040c044d39": "By model",
+          "a15206a63a": "Top model:",
+          "0f0a1684bb": "By project",
+          "048ffe4d65": "Top project:",
+          "e04c58327c": "Orca worktrees only",
+          "144a6050e9": "All local Kimi usage",
+          "rangeLast7Days": "Last 7 days",
+          "rangeLast30Days": "Last 30 days",
+          "rangeLast90Days": "Last 90 days",
+          "rangeAllTime": "All time",
+          "bea80ceae0": "Kimi Usage Tracking",
+          "b8b3522436": "Reads local Kimi usage logs to show token, model, and session stats.",
+          "f04131b3be": "Enable Kimi usage analytics",
+          "6cc7782458": " • Last scan error: {{value0}}",
+          "230d6de108": "Kimi usage options",
+          "01583b30aa": "Filters",
+          "40d283c837": "Scope",
+          "b5ed5c9fd0": "Range",
+          "bed558df0b": "Refresh Kimi usage",
+          "603cd138dc": "Refresh",
+          "bb6363e08c": "No local Kimi usage found yet for this scope.",
+          "d637a892ed": "Input tokens",
+          "7aa4d8ce35": "Output tokens",
+          "603504ee3b": "Cached input",
+          "5a65d68b77": "Reasoning output",
+          "7e9433469a": "Sessions / Events",
+          "15c34d4b08": "Recorded cost",
+          "e5bb23d85e": "Kimi wire transcripts do not record cost, so recorded cost stays unavailable.",
+          "4799177b1c": "Recent sessions",
+          "81817a641a": "Most recent local Kimi sessions in this scope.",
+          "d97bdf6e27": "Last active",
+          "a4738de041": "Project",
+          "08c78441b7": "Model",
+          "d416f5cf92": "Events",
+          "0f2f266c9d": "Input",
+          "dfc4513657": "Output",
+          "349f7c3f5c": "Total",
+          "362231082f": "Unknown"
         }
       },
       "sparse": {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -20,6 +20,7 @@ import { createWorkspaceSpaceSlice } from './slices/workspace-space'
 import { createClaudeUsageSlice } from './slices/claude-usage'
 import { createCodexUsageSlice } from './slices/codex-usage'
 import { createOpenCodeUsageSlice } from './slices/opencode-usage'
+import { createKimiUsageSlice } from './slices/kimi-usage'
 import { createBrowserSlice } from './slices/browser'
 import { createRateLimitSlice } from './slices/rate-limits'
 import { createSshSlice } from './slices/ssh'
@@ -57,6 +58,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createClaudeUsageSlice(...a),
   ...createCodexUsageSlice(...a),
   ...createOpenCodeUsageSlice(...a),
+  ...createKimiUsageSlice(...a),
   ...createBrowserSlice(...a),
   ...createRateLimitSlice(...a),
   ...createSshSlice(...a),

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -127,6 +127,7 @@ import { createWorkspaceSpaceSlice } from './workspace-space'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createOpenCodeUsageSlice } from './opencode-usage'
+import { createKimiUsageSlice } from './kimi-usage'
 import { createBrowserSlice } from './browser'
 import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
@@ -163,6 +164,7 @@ function createTestStore() {
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createOpenCodeUsageSlice(...a),
+    ...createKimiUsageSlice(...a),
     ...createBrowserSlice(...a),
     ...createRateLimitSlice(...a),
     ...createSshSlice(...a),

--- a/src/renderer/src/store/slices/kimi-usage.ts
+++ b/src/renderer/src/store/slices/kimi-usage.ts
@@ -1,0 +1,162 @@
+import type { StateCreator } from 'zustand'
+import type {
+  KimiUsageBreakdownRow,
+  KimiUsageDailyPoint,
+  KimiUsageRange,
+  KimiUsageScanState,
+  KimiUsageScope,
+  KimiUsageSessionRow,
+  KimiUsageSnapshot,
+  KimiUsageSummary
+} from '../../../../shared/kimi-usage-types'
+import type { AppState } from '../types'
+
+export type KimiUsageSlice = {
+  kimiUsageScope: KimiUsageScope
+  kimiUsageRange: KimiUsageRange
+  kimiUsageScanState: KimiUsageScanState | null
+  kimiUsageSummary: KimiUsageSummary | null
+  kimiUsageDaily: KimiUsageDailyPoint[]
+  kimiUsageModelBreakdown: KimiUsageBreakdownRow[]
+  kimiUsageProjectBreakdown: KimiUsageBreakdownRow[]
+  kimiUsageRecentSessions: KimiUsageSessionRow[]
+  setKimiUsageEnabled: (enabled: boolean) => Promise<void>
+  setKimiUsageScope: (scope: KimiUsageScope) => Promise<void>
+  setKimiUsageRange: (range: KimiUsageRange) => Promise<void>
+  fetchKimiUsage: (opts?: { forceRefresh?: boolean }) => Promise<void>
+  enableKimiUsage: () => Promise<void>
+  refreshKimiUsage: () => Promise<void>
+}
+
+export const createKimiUsageSlice: StateCreator<AppState, [], [], KimiUsageSlice> = (set, get) => ({
+  kimiUsageScope: 'orca',
+  kimiUsageRange: '30d',
+  kimiUsageScanState: null,
+  kimiUsageSummary: null,
+  kimiUsageDaily: [],
+  kimiUsageModelBreakdown: [],
+  kimiUsageProjectBreakdown: [],
+  kimiUsageRecentSessions: [],
+
+  setKimiUsageEnabled: async (enabled) => {
+    try {
+      const nextScanState = (await window.api.kimiUsage.setEnabled({
+        enabled
+      })) as KimiUsageScanState
+      set({
+        kimiUsageScanState: enabled
+          ? {
+              ...nextScanState,
+              isScanning: true,
+              lastScanCompletedAt: null,
+              lastScanError: null
+            }
+          : nextScanState,
+        kimiUsageSummary: null,
+        kimiUsageDaily: [],
+        kimiUsageModelBreakdown: [],
+        kimiUsageProjectBreakdown: [],
+        kimiUsageRecentSessions: []
+      })
+      if (enabled) {
+        await get().fetchKimiUsage({ forceRefresh: true })
+      }
+    } catch (error) {
+      console.error('Failed to update Kimi usage setting:', error)
+    }
+  },
+
+  setKimiUsageScope: async (scope) => {
+    set({ kimiUsageScope: scope })
+    await get().fetchKimiUsage()
+  },
+
+  setKimiUsageRange: async (range) => {
+    set({ kimiUsageRange: range })
+    await get().fetchKimiUsage()
+  },
+
+  fetchKimiUsage: async (opts) => {
+    try {
+      const scanState = (await window.api.kimiUsage.getScanState()) as KimiUsageScanState
+      const currentScanState = get().kimiUsageScanState
+      const shouldPreserveLoadingState =
+        opts?.forceRefresh === true &&
+        currentScanState?.enabled === true &&
+        get().kimiUsageSummary === null
+      set({
+        kimiUsageScanState: shouldPreserveLoadingState
+          ? {
+              ...scanState,
+              isScanning: true,
+              lastScanCompletedAt: null,
+              lastScanError: null
+            }
+          : scanState
+      })
+      if (!scanState.enabled) {
+        return
+      }
+
+      const { kimiUsageScope, kimiUsageRange } = get()
+      const snapshot = (await window.api.kimiUsage.getSnapshot({
+        scope: kimiUsageScope,
+        range: kimiUsageRange,
+        limit: 10
+      })) as KimiUsageSnapshot
+      const hasCachedSnapshot =
+        snapshot.scanState.lastScanCompletedAt !== null || snapshot.scanState.hasAnyKimiData
+
+      if (hasCachedSnapshot) {
+        set({
+          kimiUsageScanState:
+            opts?.forceRefresh === true
+              ? { ...snapshot.scanState, isScanning: true }
+              : snapshot.scanState,
+          kimiUsageSummary: snapshot.summary,
+          kimiUsageDaily: snapshot.daily,
+          kimiUsageModelBreakdown: snapshot.modelBreakdown,
+          kimiUsageProjectBreakdown: snapshot.projectBreakdown,
+          kimiUsageRecentSessions: snapshot.recentSessions
+        })
+      } else {
+        set({
+          kimiUsageScanState: {
+            ...scanState,
+            isScanning: true,
+            lastScanError: null
+          }
+        })
+      }
+
+      await window.api.kimiUsage.refresh({
+        force: opts?.forceRefresh ?? false
+      })
+      const { kimiUsageScope: refreshedScope, kimiUsageRange: refreshedRange } = get()
+      const refreshedSnapshot = (await window.api.kimiUsage.getSnapshot({
+        scope: refreshedScope,
+        range: refreshedRange,
+        limit: 10
+      })) as KimiUsageSnapshot
+
+      set({
+        kimiUsageScanState: refreshedSnapshot.scanState,
+        kimiUsageSummary: refreshedSnapshot.summary,
+        kimiUsageDaily: refreshedSnapshot.daily,
+        kimiUsageModelBreakdown: refreshedSnapshot.modelBreakdown,
+        kimiUsageProjectBreakdown: refreshedSnapshot.projectBreakdown,
+        kimiUsageRecentSessions: refreshedSnapshot.recentSessions
+      })
+    } catch (error) {
+      console.error('Failed to fetch Kimi usage:', error)
+    }
+  },
+
+  enableKimiUsage: async () => {
+    await get().setKimiUsageEnabled(true)
+  },
+
+  refreshKimiUsage: async () => {
+    await get().fetchKimiUsage({ forceRefresh: true })
+  }
+})

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -28,6 +28,7 @@ import { createWorkspaceSpaceSlice } from './workspace-space'
 import { createClaudeUsageSlice } from './claude-usage'
 import { createCodexUsageSlice } from './codex-usage'
 import { createOpenCodeUsageSlice } from './opencode-usage'
+import { createKimiUsageSlice } from './kimi-usage'
 import { createBrowserSlice } from './browser'
 import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
@@ -73,6 +74,7 @@ export function createTestStore() {
     ...createClaudeUsageSlice(...a),
     ...createCodexUsageSlice(...a),
     ...createOpenCodeUsageSlice(...a),
+    ...createKimiUsageSlice(...a),
     ...createBrowserSlice(...a),
     ...createRateLimitSlice(...a),
     ...createSshSlice(...a),

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -18,6 +18,7 @@ import type { WorkspaceSpaceSlice } from './slices/workspace-space'
 import type { ClaudeUsageSlice } from './slices/claude-usage'
 import type { CodexUsageSlice } from './slices/codex-usage'
 import type { OpenCodeUsageSlice } from './slices/opencode-usage'
+import type { KimiUsageSlice } from './slices/kimi-usage'
 import type { BrowserSlice } from './slices/browser'
 import type { RateLimitSlice } from './slices/rate-limits'
 import type { SshSlice } from './slices/ssh'
@@ -52,6 +53,7 @@ export type AppState = RepoSlice &
   ClaudeUsageSlice &
   CodexUsageSlice &
   OpenCodeUsageSlice &
+  KimiUsageSlice &
   BrowserSlice &
   RateLimitSlice &
   SshSlice &

--- a/src/shared/kimi-usage-types.ts
+++ b/src/shared/kimi-usage-types.ts
@@ -1,0 +1,73 @@
+export type KimiUsageScope = 'orca' | 'all'
+export type KimiUsageRange = '7d' | '30d' | '90d' | 'all'
+export type KimiUsageBreakdownKind = 'model' | 'project'
+
+export type KimiUsageScanState = {
+  enabled: boolean
+  isScanning: boolean
+  lastScanStartedAt: number | null
+  lastScanCompletedAt: number | null
+  lastScanError: string | null
+  hasAnyKimiData: boolean
+}
+
+export type KimiUsageSummary = {
+  scope: KimiUsageScope
+  range: KimiUsageRange
+  sessions: number
+  events: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+  estimatedCostUsd: number | null
+  topModel: string | null
+  topProject: string | null
+  hasAnyKimiData: boolean
+}
+
+export type KimiUsageDailyPoint = {
+  day: string
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+}
+
+export type KimiUsageBreakdownRow = {
+  key: string
+  label: string
+  sessions: number
+  events: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+  estimatedCostUsd: number | null
+}
+
+export type KimiUsageSessionRow = {
+  sessionId: string
+  lastActiveAt: string
+  durationMinutes: number
+  projectLabel: string
+  model: string | null
+  events: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+  totalTokens: number
+}
+
+export type KimiUsageSnapshot = {
+  scanState: KimiUsageScanState
+  summary: KimiUsageSummary
+  daily: KimiUsageDailyPoint[]
+  modelBreakdown: KimiUsageBreakdownRow[]
+  projectBreakdown: KimiUsageBreakdownRow[]
+  recentSessions: KimiUsageSessionRow[]
+}


### PR DESCRIPTION
## What changes

Adds a **Kimi** provider to **Settings → Stats** so Kimi Code sessions show per-session token analytics at parity with Claude, Codex, and OpenCode:

- A dedicated **Kimi usage pane** — input / cached / output / reasoning tokens, sessions & events, recorded cost, a daily token chart, by-model and by-project breakdowns, and a recent-sessions table.
- Kimi now appears in the combined **Usage Overview** (totals, cache share, active-days heatmap, provider row, and the daily intensity grid).

**What this does not do:** it does not change the already-merged Kimi *live agent status* (the worktree icon) or *status-bar subscription usage* — those shipped earlier (`#4641`, and follow-up commits). This PR is only the third item from the linked issue: token analytics in Settings. It also does not infer cost — the Kimi Code wire records none, so Kimi cost always shows `n/a` (same behavior as OpenCode when a session has no recorded cost).

Resolves the remaining item in the linked feature request `#4570`.

## How it works

A new main-process scanner reads Kimi Code's on-disk JSONL transcripts under `~/.kimi-code/sessions/wd_*/session_*/agents/<id>/wire.jsonl` (honoring `KIMI_CODE_HOME`). It sums **turn-scoped** `usage.record` events and **skips cumulative session-scoped** records so totals aren't double-counted. Token buckets map to `inputOther` (new input), `inputCacheRead + inputCacheCreation` (cached), `output` (output); reasoning is `0` and cost is `null` because the wire reports neither. This token interpretation is the same one the already-shipped AI-Vault Kimi parser uses, so Stats and the AI Vault agree.

The feature mirrors the existing OpenCode/Codex token-analytics verticals: a per-provider store with persisted state (`orca-kimi-usage.json`), IPC handlers, a renderer store slice, and stats UI. Tracking is **off by default** and opt-in per provider. Scans reuse unchanged wire files by `{path, mtime, size}`, honor the same 5-minute staleness + worktree-fingerprint policy as the other providers, and yield to the event loop during discovery and parsing so opening Settings never stalls the main process on a large history.

## Design approach

Token analytics is a regular per-agent vertical (scanner → store → IPC → preload → renderer slice → stats UI). OpenCode was the closest template because, like Kimi, it derives cost from the data (returns `null` when absent) rather than from a local pricing table. Kimi is actually simpler than both templates: it emits independent per-turn deltas, so there's no Codex-style monotonic-totals reconciliation, and it's JSONL, so there's no OpenCode-style SQLite/multi-schema handling. New main-process files were split (`scanner`, `event-attribution`, `cost-aggregation`, `session-aggregation`, `usage-state-merging`, `store`, `usage-query-projections`) to stay under the repo's 300-line cap without disabling the lint rule.

## Design review

Reviewed via Brennan's PR process (independent dual review of the design doc). Outcome: **ready**. The main correction was re-deriving the file split against the exact `max-lines` rule so each module lands under the cap without an `eslint-disable`. One decision was flagged and resolved conservatively: sub-agent token usage is **not** summed (only the primary agent's wire is read), matching the AI-Vault parser so the two surfaces report the same per-session totals; revisiting that is a possible follow-up if delegation-heavy sessions prove to under-report.

## Implementation & deviations

Implemented as designed. Minor deviations: the design doc anticipated two `registerCoreHandlers` call sites but `main` currently has one (wired correctly); and a few test-store builders not named in the doc (`store-test-helpers.ts`, `diffComments.test.ts`) needed the new slice added to keep `AppState` complete. Completeness verification against the design doc: **complete** — every new file, registration touchpoint, edge case, and validation item is present.

## Headline behavior status

**Implemented.** The user-visible behavior (Kimi sessions appear in Settings → Stats and in the combined overview, with real token aggregation from Kimi's own transcripts) runs in production code, not scaffolding — verified live in Electron against a synthetic Kimi home (see validation).

## Performance

`perf` audit: **ship**. No timers, watchers, or subprocesses are introduced; parsing is streamed (readline), aggregation is O(n) and avoids spreading large arrays into `Math.max`/`push`, the session-index read is memoized by path+mtime, and incremental reuse avoids re-parsing unchanged files. One finding was folded into this branch before review: the session-discovery metadata loop now yields to the event loop every 100 entries so a very large Kimi history can't stall the main process during a scan.

## Code review

`review-code` loop, two reviewers per round, 3 rounds to clean. Two real findings fixed: (1) Kimi "new input" was being computed by subtracting cached tokens (the Codex/OpenCode convention), but Kimi reports input as the non-cached bucket already (Claude convention) — corrected so the overview reconciles; (2) the new `translate()` keys were missing from the locale catalogs — added across all five locales so the localization CI gate passes. Final round: both reviewers clean.

## Validation

- **Static:** `typecheck` (node + cli + web configs), full `lint` chain (oxlint, switch-exhaustiveness, localization catalog + coverage) — all clean.
- **Tests:** new `src/main/kimi-usage/scanner.test.ts` (token model, session-scope dedup, multi-day split, timestamp fallback, malformed-line tolerance, missing wire, worktree-vs-unscoped attribution, incremental reuse + re-parse on growth) and `store.test.ts` (scope/range filtering, projections, null cost, schema reset); extended `usage-overview-model.test.ts` for the Kimi provider and `kimiTokens` daily field; updated `register-core-handlers.test.ts`. All targeted suites pass.
- **Product surface (`brennan-test-changes`):** launched the app and confirmed the **Kimi** entry in the provider dropdown, the disabled/enabled empty states, and — using a synthetic `KIMI_CODE_HOME` laid out like a real Kimi session — the **populated** pane (stat cards, model/project breakdowns, daily chart, recent sessions, cost `n/a`) and the Kimi row in the combined overview. Verdict: **land**.

## Manual verification still needed

This environment has no real Kimi Code account/CLI, so live data could not be exercised; the populated UI above was driven by a synthetic transcript matching the test fixtures. Before relying on the numbers, please verify against a **real** Kimi Code install that:

1. Real `wire.jsonl` uses the expected shape — `usage.record` with `usageScope: 'turn'|'session'` and `usage.{inputOther,inputCacheRead,inputCacheCreation,output}`, `time` in epoch-ms, `config.update.modelAlias`, `state.json.agents.<id>.type === 'main'`, and a root `session_index.jsonl` with `sessionId`/`workDir`.
2. Aggregated tokens/sessions/model/project match what Kimi actually consumed, and worktree attribution (`workDir` → Orca worktree) is correct.
3. The on-disk path (`~/.kimi-code/sessions/...`) matches the installed CLI on the target OS.

If the live wire shape differs from the fixtures, the scanner's field mapping is the single place to adjust (`parseKimiUsageEvent` in `src/main/kimi-usage/scanner.ts`).

Made with [Orca](https://github.com/stablyai/orca) 🐋
