### PR TITLE
Show a GitButler indicator in Source Control for GitButler-managed repos

### DIFF
--- a/src/main/git/gitbutler-detection.test.ts
+++ b/src/main/git/gitbutler-detection.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import * as path from 'path'
+import { detectGitButlerWorkspace } from './gitbutler-detection'
+
+// Real temp dirs: the module probes the filesystem with existsSync/readFile, so
+// we exercise the actual common-dir derivation rather than injecting a result.
+describe('detectGitButlerWorkspace', () => {
+  let root: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'gitbutler-detect-'))
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  // A plain (non-linked) checkout: resolveGitDir returns the .git dir directly,
+  // which is also the common dir.
+  function makePlainGitDir(gitDirName = '.git'): {
+    gitDir: string
+    resolveGitDir: () => Promise<string>
+  } {
+    const gitDir = path.join(root, gitDirName)
+    return { gitDir, resolveGitDir: async () => gitDir }
+  }
+
+  it('(a) workspace branch + common-dir gitbutler/ present → true', async () => {
+    const { gitDir, resolveGitDir } = makePlainGitDir()
+    await mkdir(path.join(gitDir, 'gitbutler'), { recursive: true })
+
+    expect(await detectGitButlerWorkspace(root, 'gitbutler/workspace', resolveGitDir)).toBe(true)
+  })
+
+  it('(a) accepts a refs/heads/-prefixed workspace branch', async () => {
+    const { gitDir, resolveGitDir } = makePlainGitDir()
+    await mkdir(path.join(gitDir, 'gitbutler'), { recursive: true })
+
+    expect(
+      await detectGitButlerWorkspace(root, 'refs/heads/gitbutler/workspace', resolveGitDir)
+    ).toBe(true)
+  })
+
+  it('(b) workspace branch, no metadata → false', async () => {
+    const { gitDir, resolveGitDir } = makePlainGitDir()
+    await mkdir(gitDir, { recursive: true })
+
+    expect(await detectGitButlerWorkspace(root, 'gitbutler/workspace', resolveGitDir)).toBe(false)
+  })
+
+  it('(c) normal branch + metadata present → false', async () => {
+    const { gitDir, resolveGitDir } = makePlainGitDir()
+    await mkdir(path.join(gitDir, 'gitbutler'), { recursive: true })
+
+    expect(await detectGitButlerWorkspace(root, 'main', resolveGitDir)).toBe(false)
+  })
+
+  it('(d) normal repo (no metadata) → false', async () => {
+    const { gitDir, resolveGitDir } = makePlainGitDir()
+    await mkdir(gitDir, { recursive: true })
+
+    expect(await detectGitButlerWorkspace(root, 'main', resolveGitDir)).toBe(false)
+  })
+
+  it('treats a regular file named gitbutler as not-managed (metadata must be a dir)', async () => {
+    const { gitDir, resolveGitDir } = makePlainGitDir()
+    await mkdir(gitDir, { recursive: true })
+    await writeFile(path.join(gitDir, 'gitbutler'), 'not a metadata dir\n', 'utf-8')
+
+    expect(await detectGitButlerWorkspace(root, 'gitbutler/workspace', resolveGitDir)).toBe(false)
+  })
+
+  it('(e) legacy gitbutler/integration branch + metadata → true', async () => {
+    const { gitDir, resolveGitDir } = makePlainGitDir()
+    await mkdir(path.join(gitDir, 'gitbutler'), { recursive: true })
+
+    expect(await detectGitButlerWorkspace(root, 'gitbutler/integration', resolveGitDir)).toBe(true)
+  })
+
+  it('returns false for a null/undefined branch', async () => {
+    const { gitDir, resolveGitDir } = makePlainGitDir()
+    await mkdir(path.join(gitDir, 'gitbutler'), { recursive: true })
+
+    expect(await detectGitButlerWorkspace(root, null, resolveGitDir)).toBe(false)
+    expect(await detectGitButlerWorkspace(root, undefined, resolveGitDir)).toBe(false)
+  })
+
+  it('does no git-dir resolution on a normal branch (gate before any fs work)', async () => {
+    // Why: detection runs on the status hot path; the branch-name gate must
+    // short-circuit before resolveGitDir so normal repos pay zero fs cost.
+    const resolveGitDir = vi.fn(async () => path.join(root, '.git'))
+
+    expect(await detectGitButlerWorkspace(root, 'main', resolveGitDir)).toBe(false)
+    expect(resolveGitDir).not.toHaveBeenCalled()
+  })
+
+  describe('linked worktree (per-worktree dir resolves the common dir via commondir)', () => {
+    // Mirrors git's layout: the common git dir holds `gitbutler/`, and the
+    // linked worktree's per-worktree dir holds a `commondir` file pointing
+    // (relatively) at the common dir.
+    async function makeLinkedWorktree(withMetadata: boolean): Promise<{
+      perWorktreeDir: string
+      resolveGitDir: () => Promise<string>
+    }> {
+      const commonGitDir = path.join(root, 'common', '.git')
+      const perWorktreeDir = path.join(commonGitDir, 'worktrees', 'feature')
+      await mkdir(perWorktreeDir, { recursive: true })
+      await mkdir(withMetadata ? path.join(commonGitDir, 'gitbutler') : commonGitDir, {
+        recursive: true
+      })
+      // git writes the common dir as a relative path (e.g. ../..) inside commondir.
+      const relativeCommonDir = path.relative(perWorktreeDir, commonGitDir)
+      await writeFile(path.join(perWorktreeDir, 'commondir'), `${relativeCommonDir}\n`, 'utf-8')
+      return { perWorktreeDir, resolveGitDir: async () => perWorktreeDir }
+    }
+
+    it('(f) workspace branch + common-dir gitbutler/ → true', async () => {
+      const { resolveGitDir } = await makeLinkedWorktree(true)
+
+      expect(await detectGitButlerWorkspace(root, 'gitbutler/workspace', resolveGitDir)).toBe(true)
+    })
+
+    it('(f) negative: linked worktree on a normal branch → false', async () => {
+      const { resolveGitDir } = await makeLinkedWorktree(true)
+
+      expect(await detectGitButlerWorkspace(root, 'main', resolveGitDir)).toBe(false)
+    })
+
+    it('linked worktree, workspace branch, no metadata → false', async () => {
+      const { resolveGitDir } = await makeLinkedWorktree(false)
+
+      expect(await detectGitButlerWorkspace(root, 'gitbutler/workspace', resolveGitDir)).toBe(false)
+    })
+
+    it('resolves an absolute commondir path (git may write one) → true', async () => {
+      const commonGitDir = path.join(root, 'common', '.git')
+      const perWorktreeDir = path.join(commonGitDir, 'worktrees', 'feature')
+      await mkdir(path.join(commonGitDir, 'gitbutler'), { recursive: true })
+      await mkdir(perWorktreeDir, { recursive: true })
+      // Absolute path variant of commondir (git writes relative by default).
+      await writeFile(path.join(perWorktreeDir, 'commondir'), `${commonGitDir}\n`, 'utf-8')
+
+      expect(
+        await detectGitButlerWorkspace(root, 'gitbutler/workspace', async () => perWorktreeDir)
+      ).toBe(true)
+    })
+  })
+})

--- a/src/main/git/gitbutler-detection.ts
+++ b/src/main/git/gitbutler-detection.ts
@@ -1,0 +1,77 @@
+import { existsSync } from 'fs'
+import { readFile, stat } from 'fs/promises'
+import * as path from 'path'
+
+const WORKSPACE_BRANCH = 'gitbutler/workspace'
+// Legacy name GitButler used before renaming the integration branch to workspace.
+const LEGACY_INTEGRATION_BRANCH = 'gitbutler/integration'
+const REFS_HEADS_PREFIX = 'refs/heads/'
+
+function stripRefsHeads(branch: string): string {
+  return branch.startsWith(REFS_HEADS_PREFIX) ? branch.slice(REFS_HEADS_PREFIX.length) : branch
+}
+
+/**
+ * Resolve the repository's COMMON git dir from a worktree's resolved git dir.
+ * Why: `resolveGitDir` returns the per-worktree dir for linked worktrees
+ * (`<common>/.git/worktrees/<name>`), but GitButler stores its metadata in the
+ * common dir. Git writes a `commondir` file inside every linked-worktree dir
+ * pointing (usually relatively) at the common dir; when present, resolve it.
+ * Otherwise the resolved dir already IS the common dir (normal checkout).
+ */
+async function resolveCommonGitDir(resolvedGitDir: string): Promise<string> {
+  const commonDirPointer = path.join(resolvedGitDir, 'commondir')
+  if (!existsSync(commonDirPointer)) {
+    return resolvedGitDir
+  }
+  try {
+    const contents = (await readFile(commonDirPointer, 'utf-8')).trim()
+    return path.resolve(resolvedGitDir, contents)
+  } catch {
+    return resolvedGitDir
+  }
+}
+
+/**
+ * Detect whether a worktree is sitting on an active GitButler workspace.
+ *
+ * Why both conditions (AND, never OR): requiring the workspace branch name AND
+ * the `gitbutler/` metadata avoids two distinct false positives — a branch
+ * coincidentally named `gitbutler/workspace` without GitButler, and stale
+ * `gitbutler/` metadata while the user has a normal branch checked out (Orca's
+ * git actions are not hitting the synthetic branch in either case).
+ *
+ * The filesystem probe is GATED behind the branch-name check so normal repos
+ * pay nothing — no git-dir resolution and no `existsSync` runs unless the
+ * branch matches.
+ */
+export async function detectGitButlerWorkspace(
+  worktreePath: string,
+  branch: string | undefined | null,
+  resolveGitDir: (worktreePath: string) => Promise<string>
+): Promise<boolean> {
+  if (!branch) {
+    return false
+  }
+  const shortBranch = stripRefsHeads(branch)
+  if (shortBranch !== WORKSPACE_BRANCH && shortBranch !== LEGACY_INTEGRATION_BRANCH) {
+    return false
+  }
+
+  const resolvedGitDir = await resolveGitDir(worktreePath)
+  const commonGitDir = await resolveCommonGitDir(resolvedGitDir)
+  return await isDirectory(path.join(commonGitDir, 'gitbutler'))
+}
+
+// Why: GitButler stores its metadata as a directory; an unrelated regular file
+// named `gitbutler` must not count as a match (existsSync alone accepts both).
+async function isDirectory(target: string): Promise<boolean> {
+  if (!existsSync(target)) {
+    return false
+  }
+  try {
+    return (await stat(target)).isDirectory()
+  } catch {
+    return false
+  }
+}

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -1020,6 +1020,7 @@ describe('getStatus', () => {
     lstatMock.mockReset()
     readFileMock.mockReset()
     existsSyncMock.mockReset()
+    statMock.mockReset()
     // Why: after the status call, getStatus may issue `git diff --numstat`
     // calls to attach per-entry line counts. Tests that don't care about counts
     // set only a `mockResolvedValueOnce` for the status output; this default
@@ -1270,6 +1271,35 @@ describe('getStatus', () => {
       head: 'abcdef1234567890',
       branch: 'refs/heads/feature/prompts'
     })
+  })
+
+  it('flags managedBy gitbutler when on the workspace branch with gitbutler metadata', async () => {
+    // `.git` is a real dir here (not a worktree pointer), so resolveGitDir's
+    // readFile throws and the common dir is `/repo/.git`. Metadata dir present;
+    // commondir/conflict markers absent. Proves runGetStatus runs detection.
+    readFileMock.mockRejectedValue(new Error('EISDIR'))
+    existsSyncMock.mockImplementation((target: string) => target.endsWith(`${path.sep}gitbutler`))
+    // Detection requires the gitbutler metadata to be a directory, not a file.
+    statMock.mockResolvedValue({ isDirectory: () => true })
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: '# branch.oid abcdef1234567890\n# branch.head gitbutler/workspace\n'
+    })
+
+    const result = await getStatus('/repo')
+
+    expect(result.managedBy).toBe('gitbutler')
+  })
+
+  it('omits managedBy for a normal branch even when gitbutler metadata exists', async () => {
+    readFileMock.mockRejectedValue(new Error('EISDIR'))
+    existsSyncMock.mockImplementation((target: string) => target.endsWith(`${path.sep}gitbutler`))
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: '# branch.oid abcdef1234567890\n# branch.head feature/prompts\n'
+    })
+
+    const result = await getStatus('/repo')
+
+    expect(result.managedBy).toBeUndefined()
   })
 
   it('folds upstream ahead/behind from porcelain v2 into the status result', async () => {

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -36,6 +36,7 @@ import {
   gitStreamStdout
 } from './runner'
 import { StatusPorcelainParser } from './status-porcelain-parser'
+import { detectGitButlerWorkspace } from './gitbutler-detection'
 import { DEFAULT_GIT_STATUS_LIMIT } from '../../shared/git-status-limit'
 import { describeMaxBufferOverflowError, isMaxBufferOverflowError } from './max-buffer-overflow'
 import {
@@ -278,11 +279,18 @@ async function runGetStatus(
     await attachLineStats(worktreePath, entries, options)
   }
 
+  // Why: detection is gated behind the branch-name check inside the helper, so
+  // normal repos pay nothing (no git-dir resolve, no fs probe) on this path.
+  const managedBy = (await detectGitButlerWorkspace(worktreePath, branch, resolveGitDir))
+    ? ('gitbutler' as const)
+    : undefined
+
   return {
     entries,
     conflictOperation,
     head,
     branch,
+    ...(managedBy ? { managedBy } : {}),
     ...(options.includeIgnored ? { ignoredPaths: parser.ignoredPaths } : {}),
     ...(didHitLimit ? { didHitLimit: true, statusLength: parser.statusLength } : {}),
     ...(statusSucceeded

--- a/src/renderer/src/components/GitButlerManagedBadge.tsx
+++ b/src/renderer/src/components/GitButlerManagedBadge.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Layers } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+type GitButlerManagedBadgeProps = {
+  side?: React.ComponentProps<typeof TooltipContent>['side']
+  className?: string
+}
+
+export function GitButlerManagedBadge({
+  side = 'right',
+  className
+}: GitButlerManagedBadgeProps): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {/* Why: neutral/informational tone (muted token, not warning red) — being
+            on a GitButler workspace is a normal supported state, not an error. */}
+        <Badge
+          variant="outline"
+          className={cn(
+            'h-[18px] shrink-0 gap-1 rounded px-1.5 text-[10px] font-medium leading-none',
+            'border-border bg-muted/40 text-muted-foreground',
+            className
+          )}
+        >
+          <Layers className="size-2.5" />
+          GitButler
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent side={side} sideOffset={8}>
+        This repo is managed by GitButler. Orca&apos;s Source Control acts on the
+        gitbutler/workspace branch, not your virtual branches.
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/GitButlerManagedBadge.tsx
+++ b/src/renderer/src/components/GitButlerManagedBadge.tsx
@@ -30,9 +30,11 @@ export function GitButlerManagedBadge({
           GitButler
         </Badge>
       </TooltipTrigger>
+      {/* Why: detection covers both gitbutler/workspace and the legacy
+          gitbutler/integration branch, so the copy names neither explicitly. */}
       <TooltipContent side={side} sideOffset={8}>
-        This repo is managed by GitButler. Orca&apos;s Source Control acts on the
-        gitbutler/workspace branch, not your virtual branches.
+        This repo is managed by GitButler. Orca&apos;s Source Control acts on the checked-out
+        GitButler workspace branch, not your virtual branches.
       </TooltipContent>
     </Tooltip>
   )

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -820,7 +820,7 @@ function SourceControlInner(): React.JSX.Element {
     activeWorktreeId ? s.gitStatusHugeByWorktree?.[activeWorktreeId] : undefined
   )
   const managedBy = useAppStore((s) =>
-    activeWorktreeId ? s.gitStatusManagedByByWorktree[activeWorktreeId] : undefined
+    activeWorktreeId ? s.gitStatusManagedByByWorktree?.[activeWorktreeId] : undefined
   )
   const branchEntries = useAppStore((s) =>
     activeWorktreeId

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -44,6 +44,7 @@ import { isFolderRepo } from '../../../../shared/repo-kind'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import { DetachedHeadBadge } from '@/components/DetachedHeadBadge'
+import { GitButlerManagedBadge } from '@/components/GitButlerManagedBadge'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -817,6 +818,9 @@ function SourceControlInner(): React.JSX.Element {
   )
   const repositoryHuge = useAppStore((s) =>
     activeWorktreeId ? s.gitStatusHugeByWorktree?.[activeWorktreeId] : undefined
+  )
+  const managedBy = useAppStore((s) =>
+    activeWorktreeId ? s.gitStatusManagedByByWorktree[activeWorktreeId] : undefined
   )
   const branchEntries = useAppStore((s) =>
     activeWorktreeId
@@ -5417,9 +5421,12 @@ function SourceControlInner(): React.JSX.Element {
           upstreamStatus={remoteStatus}
         />
 
-        {detachedHeadDisplay && (
-          <div className="border-b border-border px-3 py-2">
-            <DetachedHeadBadge display={detachedHeadDisplay} side="bottom" />
+        {(detachedHeadDisplay || managedBy) && (
+          <div className="flex flex-wrap items-center gap-1.5 border-b border-border px-3 py-2">
+            {detachedHeadDisplay && (
+              <DetachedHeadBadge display={detachedHeadDisplay} side="bottom" />
+            )}
+            {managedBy && <GitButlerManagedBadge side="bottom" />}
           </div>
         )}
 

--- a/src/renderer/src/store/slices/editor.gitbutler-managed.test.ts
+++ b/src/renderer/src/store/slices/editor.gitbutler-managed.test.ts
@@ -1,0 +1,84 @@
+import { createStore, type StoreApi } from 'zustand/vanilla'
+import { describe, expect, it, vi } from 'vitest'
+import { createEditorSlice } from './editor'
+import type { AppState } from '../types'
+
+function createEditorStore(): StoreApi<AppState> {
+  // Only the editor slice + activeWorktreeId are needed for these tests.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return createStore<any>()((...args: any[]) => ({
+    activeWorktreeId: 'wt-1',
+    tabsByWorktree: {},
+    browserTabsByWorktree: {},
+    activeBrowserTabId: null,
+    activeBrowserTabIdByWorktree: {},
+    recordFeatureInteraction: vi.fn(),
+    ...createEditorSlice(...(args as Parameters<typeof createEditorSlice>))
+  })) as unknown as StoreApi<AppState>
+}
+
+describe('setGitStatus gitStatusManagedByByWorktree', () => {
+  it('populates the map when status.managedBy is set', () => {
+    const store = createEditorStore()
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      branch: 'refs/heads/gitbutler/workspace',
+      managedBy: 'gitbutler'
+    })
+
+    expect(store.getState().gitStatusManagedByByWorktree['wt-1']).toBe('gitbutler')
+  })
+
+  it('clears the key when managedBy is absent on a later status', () => {
+    const store = createEditorStore()
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      managedBy: 'gitbutler'
+    })
+    expect(store.getState().gitStatusManagedByByWorktree['wt-1']).toBe('gitbutler')
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      branch: 'refs/heads/main'
+    })
+
+    expect(store.getState().gitStatusManagedByByWorktree).not.toHaveProperty('wt-1')
+  })
+
+  it('keeps the map referentially stable when managedBy is unchanged', () => {
+    const store = createEditorStore()
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      managedBy: 'gitbutler'
+    })
+    const first = store.getState().gitStatusManagedByByWorktree
+
+    // Re-apply an identical status: nothing about managedBy changed.
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      managedBy: 'gitbutler'
+    })
+
+    expect(store.getState().gitStatusManagedByByWorktree).toBe(first)
+  })
+
+  it('does not populate the map for a normal repo (managedBy absent)', () => {
+    const store = createEditorStore()
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [],
+      branch: 'refs/heads/main'
+    })
+
+    expect(store.getState().gitStatusManagedByByWorktree).not.toHaveProperty('wt-1')
+  })
+})

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -566,6 +566,10 @@ export type EditorSlice = {
   // un-ignored folder), the SCM view shows a "too many changes" state and
   // polling pauses. `{ limit }` when huge, absent otherwise.
   gitStatusHugeByWorktree: Record<string, { limit: number }>
+  // Why: tracks which worktrees are sitting on a GitButler workspace branch so
+  // Source Control can show an informational badge. Keyed by worktree, value is
+  // the detected manager (string enum so a future manager can extend it).
+  gitStatusManagedByByWorktree: Record<string, 'gitbutler'>
   gitIgnoredPathsByWorktree: Record<string, string[]>
   gitConflictOperationByWorktree: Record<string, GitConflictOperation>
   trackedConflictPathsByWorktree: Record<string, Record<string, GitConflictKind>>
@@ -3304,6 +3308,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   gitStatusByWorktree: {},
   gitStatusHeadByWorktree: {},
   gitStatusHugeByWorktree: {},
+  gitStatusManagedByByWorktree: {},
   gitIgnoredPathsByWorktree: {},
   gitConflictOperationByWorktree: {},
   trackedConflictPathsByWorktree: {},
@@ -3408,6 +3413,10 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const nextStatusHead = getKnownGitHead(status.head)
       const statusHeadUnchanged = prevStatusHead === nextStatusHead
 
+      const prevManagedBy = s.gitStatusManagedByByWorktree[worktreeId]
+      const nextManagedBy = status.managedBy
+      const managedByUnchanged = prevManagedBy === nextManagedBy
+
       const prevBranchSummary = s.gitBranchCompareSummaryByWorktree[worktreeId]
       // Why: a compare request can finish after git status has observed a new
       // HEAD; reject that stale snapshot before it can render a false clean state.
@@ -3425,6 +3434,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         ignoredUnchanged &&
         hugeUnchanged &&
         statusHeadUnchanged &&
+        managedByUnchanged &&
         !shouldInvalidateBranchCompare
       ) {
         return s
@@ -3449,6 +3459,15 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
               delete copy[worktreeId]
               return copy
             })()
+      const nextManagedByMap = managedByUnchanged
+        ? s.gitStatusManagedByByWorktree
+        : nextManagedBy
+          ? { ...s.gitStatusManagedByByWorktree, [worktreeId]: nextManagedBy }
+          : (() => {
+              const copy = { ...s.gitStatusManagedByByWorktree }
+              delete copy[worktreeId]
+              return copy
+            })()
       const nextBranchCompareSummaries = shouldInvalidateBranchCompare
         ? {
             ...s.gitBranchCompareSummaryByWorktree,
@@ -3463,6 +3482,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: nextOpenFiles,
         gitStatusHugeByWorktree: nextHugeMap,
         gitStatusHeadByWorktree: nextStatusHeadMap,
+        gitStatusManagedByByWorktree: nextManagedByMap,
         gitStatusByWorktree: statusUnchanged
           ? s.gitStatusByWorktree
           : { ...s.gitStatusByWorktree, [worktreeId]: nextEntries },

--- a/src/shared/git-status-types.ts
+++ b/src/shared/git-status-types.ts
@@ -69,6 +69,10 @@ export type GitStatusResult = {
   // "too many changes" state.
   didHitLimit?: boolean
   statusLength?: number
+  // Why: string enum (not boolean) so a future manager (e.g. 'jj') can extend it
+  // without a new field; optional + absent-by-default keeps un-upgraded consumers
+  // and the wire protocol backward compatible.
+  managedBy?: 'gitbutler'
 }
 
 // Why: when hasUpstream is false, ahead/behind are placeholder zeros, not a


### PR DESCRIPTION
## What changes

When a worktree is checked out on GitButler's workspace branch (`gitbutler/workspace`, or the legacy `gitbutler/integration`) **and** the repository has GitButler metadata in its common git dir, the Source Control panel now shows a small informational **GitButler** badge. Its tooltip explains the practical consequence: *Orca's Source Control acts on the `gitbutler/workspace` branch, not your virtual branches.*

## What does NOT change (important boundary)

This is **awareness only**, not integration. Orca keeps using plain git. The badge:
- does **not** read, render, or write GitButler virtual branches / stacks,
- does **not** delegate any Orca git action to GitButler,
- does **not** block, disable, or gate any Source Control action.

It exists to prevent the most likely footgun — committing through Orca while expecting GitButler virtual-branch semantics — and to give Orca a detected signal to build on.

This PR is the small, safe **foundation slice** of the linked feature request. The two headline options in that request (full GitButler integration, or a generic source-control extension/provider API) are both genuinely XL one-way-door designs and are **deferred** — I've posted a concrete proposal as a comment on the issue and flagged that they need a product scoping decision before any code.

## Design approach

- Detection is filesystem-only and lives in a small focused module (`src/main/git/gitbutler-detection.ts`). It requires **both** the workspace branch name (after stripping `refs/heads/`) **and** a `gitbutler` *directory* in the repo's **common** git dir. The AND is load-bearing: branch-name-only would false-positive on a coincidentally named branch; metadata-only would false-positive on stale metadata while a normal branch is checked out.
- For linked worktrees, `resolveGitDir` returns the per-worktree dir, so detection derives the **common** dir from git's `commondir` file (GitButler stores metadata in the common dir). Since Orca is worktree-centric, getting this right is the common case, not a corner case.
- The filesystem probe is **gated behind the branch-name check**, so normal repos do zero extra fs work on the git-status path.
- The signal rides a new optional `GitStatusResult.managedBy?: 'gitbutler'` (string enum so a future manager can extend it; optional + absent-by-default keeps consumers and the wire protocol backward compatible), flows through the existing `setGitStatus` reducer into a `gitStatusManagedByByWorktree` map, and renders via a `<GitButlerManagedBadge>` modeled on the existing `DetachedHeadBadge`.

## Headline behavior status

**Implemented end-to-end in production code** (local provider). Verified in the running app: the badge appears on a `gitbutler/workspace` worktree with metadata and disappears when a normal branch is checked out — even with `.git/gitbutler` still present (the AND guard working live). The `runGetStatus` path emitting `managedBy` is covered by an integration test, not just the helper in isolation.

**Accepted boundary:** detection runs on the **local provider only**. On SSH/remote, `managedBy` is simply absent → no badge (graceful, not wrong — GitButler is a desktop-local tool). Remote parity would need a remote `.git/gitbutler` probe; noted as follow-up, not built here.

## Validation

- **Design review:** ran an automated design-review/fix loop. It caught a real correctness bug (linked-worktree detection would have silently never fired because it probed the per-worktree dir instead of the common dir) — fixed before implementation.
- **Completeness verification:** confirmed every design requirement, edge case, and validation item is present; closed the one gap (added the `runGetStatus` integration test proving the production path).
- **Perf audit:** performance-neutral. No added git subprocess; zero fs work for non-GitButler repos (branch-name gate before any fs call); the new store map mirrors the existing `gitStatusHeadByWorktree` change-detection so an unchanged status doesn't perturb store identity or re-render. Added a test asserting the gate short-circuits before any git-dir resolution.
- **Code-review loop:** two independent reviewers per round. Round 1 surfaced a P2 (the metadata check must require a *directory*, not accept a regular file named `gitbutler`) — fixed with an `isDirectory` check plus file-vs-dir and absolute-`commondir` tests. A flagged P1 (a common-dir resolver "already exists") was assessed and deliberately not consolidated: the two prior copies aren't clean drop-ins (one takes a `Repo` and uses a path heuristic rather than reading the authoritative `commondir`; the other is a private inner block of a GitHub-config function), so consolidating would reach into unrelated subsystems for no behavioral gain. Final round: both reviewers clean.
- **Merge-confidence (real app):** validated end-to-end in Electron with screenshots of badge-present, tooltip, and badge-absent states (attached to this PR conversation).
- **Static checks + tests:** `pnpm run typecheck` clean; oxlint clean on changed files; 93 targeted tests pass (`gitbutler-detection`, `status`, `editor` reducer).

## Files

- `src/main/git/gitbutler-detection.ts` (+ test) — detection helper
- `src/main/git/status.ts` (+ test) — wires `managedBy` into `runGetStatus`
- `src/shared/git-status-types.ts` — `managedBy?: 'gitbutler'` on `GitStatusResult`
- `src/renderer/src/store/slices/editor.ts` (+ test) — `gitStatusManagedByByWorktree` map + reducer
- `src/renderer/src/components/GitButlerManagedBadge.tsx` — the badge
- `src/renderer/src/components/right-sidebar/SourceControl.tsx` — selector + conditional render

## Remaining risks / non-actionable notes

- SSH/remote shows no badge (accepted, documented above).
- Three independent common-git-dir resolvers now exist in the tree; consolidating them is a reasonable follow-up but out of scope here.

Made with [Orca](https://github.com/stablyai/orca) 🐋
