### PR TITLE
Add CLI command to set custom per-agent sidebar labels

### DIFF
--- a/mobile/scripts/mobile-lag-scenario.ts
+++ b/mobile/scripts/mobile-lag-scenario.ts
@@ -100,6 +100,7 @@ function createMockAgent(index: number, now: number): RuntimeWorktreeAgentRow {
     prompt: scenarioTitle,
     taskTitle: scenarioTitle,
     displayName: `Mobile lag ${index + 1}`,
+    customAgentLabel: null,
     lastAssistantMessage: index % 6 === 0 ? 'Running focused checks' : null,
     toolName: null,
     toolInput: null,

--- a/mobile/src/worktree/agent-row-display.test.ts
+++ b/mobile/src/worktree/agent-row-display.test.ts
@@ -57,6 +57,21 @@ describe('agentDotState', () => {
 })
 
 describe('agentDisplayLabel', () => {
+  it('prefers an explicit custom label over message and prompt', () => {
+    expect(
+      agentDisplayLabel(
+        row({ customAgentLabel: 'Riset AI', lastAssistantMessage: 'hello there', prompt: 'do it' }),
+        0
+      )
+    ).toBe('Riset AI')
+  })
+
+  it('ignores a blank custom label and falls through to the message/prompt chain', () => {
+    expect(
+      agentDisplayLabel(row({ customAgentLabel: '   ', lastAssistantMessage: 'hello there' }), 0)
+    ).toBe('hello there')
+  })
+
   it('prefers last message, then prompt, then state label', () => {
     expect(agentDisplayLabel(row({ lastAssistantMessage: 'hello there' }), 0)).toBe('hello there')
     expect(agentDisplayLabel(row({ lastAssistantMessage: '   ', prompt: 'do the thing' }), 0)).toBe(

--- a/mobile/src/worktree/agent-row-display.ts
+++ b/mobile/src/worktree/agent-row-display.ts
@@ -50,10 +50,14 @@ export function agentStateLabel(state: AgentDotState): string {
   }
 }
 
-// Primary row text: prefer the agent's last message, then the user prompt, then
-// a human-readable state label so a row is never blank. Matches the desktop
-// DashboardAgentRow displayLabel fallback chain.
+// Primary row text: an explicit user-set CLI label wins (matching desktop's
+// getAgentRowPrimaryText), then the agent's last message, then the user prompt,
+// then a human-readable state label so a row is never blank.
 export function agentDisplayLabel(row: RuntimeWorktreeAgentRow, now: number): string {
+  const label = row.customAgentLabel?.trim()
+  if (label) {
+    return label
+  }
   const message = row.lastAssistantMessage?.trim()
   if (message) {
     return message

--- a/mobile/src/worktree/worktree-list-snapshot.test.ts
+++ b/mobile/src/worktree/worktree-list-snapshot.test.ts
@@ -116,6 +116,13 @@ describe('areWorktreeListsEqual', () => {
     expect(areWorktreeListsEqual(first, second)).toBe(false)
   })
 
+  it('detects a custom agent label change so a CLI label set re-renders', () => {
+    const first = [worktree({ agents: [agent({ customAgentLabel: null })] })]
+    const second = [worktree({ agents: [agent({ customAgentLabel: 'Riset AI' })] })]
+
+    expect(areWorktreeListsEqual(first, second)).toBe(false)
+  })
+
   it('treats missing and empty agent arrays as equivalent for rendering', () => {
     const first = [worktree({ agents: undefined })]
     const second = [worktree({ agents: [] })]

--- a/mobile/src/worktree/worktree-list-snapshot.ts
+++ b/mobile/src/worktree/worktree-list-snapshot.ts
@@ -97,6 +97,9 @@ function areAgentRowsEqual(
       a.state !== b.state ||
       a.agentType !== b.agentType ||
       a.prompt !== b.prompt ||
+      // Why: a CLI `agent label set/clear` between two worktree.ps polls leaves
+      // every other field identical; without this the stale row never re-renders.
+      a.customAgentLabel !== b.customAgentLabel ||
       a.lastAssistantMessage !== b.lastAssistantMessage ||
       a.toolName !== b.toolName ||
       a.toolInput !== b.toolInput ||

--- a/src/cli/agent-format.ts
+++ b/src/cli/agent-format.ts
@@ -1,0 +1,10 @@
+import type { RuntimeAgentLabel } from '../shared/runtime-types'
+
+// Why: always echo the resolved paneKey AND terminal handle so a mis-target
+// (e.g. the active-terminal fallback picked a different agent than intended)
+// is immediately visible in human output, mirroring the JSON shape.
+export function formatAgentLabel(result: { label: RuntimeAgentLabel }): string {
+  const { label, paneKey, terminalHandle } = result.label
+  const action = label ? `Set label "${label}"` : 'Cleared label'
+  return `${action} for agent ${terminalHandle} (pane ${paneKey}).`
+}

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -30,6 +30,7 @@ export {
   formatProjectHostSetupUpdateResult,
   formatProjectList
 } from './project-format'
+export { formatAgentLabel } from './agent-format'
 export {
   formatTerminalClose,
   formatTerminalCreate,

--- a/src/cli/handlers/agent-hooks.test.ts
+++ b/src/cli/handlers/agent-hooks.test.ts
@@ -45,9 +45,19 @@ vi.mock('../runtime-client', () => {
     }
   }
 
+  class RuntimeRpcFailureError extends Error {
+    readonly response: unknown
+
+    constructor(response: unknown) {
+      super('rpc failure')
+      this.response = response
+    }
+  }
+
   return {
     RuntimeClient,
     RuntimeClientError,
+    RuntimeRpcFailureError,
     getDefaultUserDataPath: getDefaultUserDataPathMock
   }
 })
@@ -119,5 +129,83 @@ describe('agent hooks CLI handler', () => {
     await runAgentHooksOff(userDataPath)
 
     expect(readDataFile(userDataPath).settings.experimentalNewWorktreeCardStyle).toBe(false)
+  })
+})
+
+describe('agent label CLI handler', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-agent-label-cli-'))
+    getDefaultUserDataPathMock.mockReturnValue(userDataPath)
+    callMock.mockReset()
+    process.exitCode = undefined
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('calls agent.label.set with the explicit terminal handle and label', async () => {
+    callMock.mockResolvedValue({
+      id: 'set',
+      ok: true,
+      result: { label: { terminalHandle: 'term_abc', paneKey: 'tab-1:leaf', label: 'Reset AI' } },
+      _meta: { runtimeId: 'test' }
+    })
+
+    await main(
+      ['agent', 'label', 'set', '--terminal', 'term_abc', '--label', 'Reset AI', '--json'],
+      userDataPath
+    )
+
+    expect(callMock).toHaveBeenCalledWith('agent.label.set', {
+      terminal: 'term_abc',
+      label: 'Reset AI'
+    })
+  })
+
+  it('calls agent.label.clear with the explicit terminal handle', async () => {
+    callMock.mockResolvedValue({
+      id: 'clear',
+      ok: true,
+      result: { label: { terminalHandle: 'term_abc', paneKey: 'tab-1:leaf', label: null } },
+      _meta: { runtimeId: 'test' }
+    })
+
+    await main(['agent', 'label', 'clear', '--terminal', 'term_abc'], userDataPath)
+
+    expect(callMock).toHaveBeenCalledWith('agent.label.clear', { terminal: 'term_abc' })
+  })
+
+  it('echoes the resolved pane and handle in human output so a mis-target is visible', async () => {
+    const logSpy = vi.spyOn(console, 'log')
+    callMock.mockResolvedValue({
+      id: 'set',
+      ok: true,
+      result: { label: { terminalHandle: 'term_abc', paneKey: 'tab-1:leaf', label: 'Reset AI' } },
+      _meta: { runtimeId: 'test' }
+    })
+
+    await main(
+      ['agent', 'label', 'set', '--terminal', 'term_abc', '--label', 'Reset AI'],
+      userDataPath
+    )
+
+    const output = logSpy.mock.calls.map((args) => String(args[0])).join('\n')
+    expect(output).toContain('term_abc')
+    expect(output).toContain('tab-1:leaf')
+    expect(output).toContain('Reset AI')
+  })
+
+  it('rejects agent label set without a --label flag', async () => {
+    await main(['agent', 'label', 'set', '--terminal', 'term_abc'], userDataPath)
+
+    // Missing required flag short-circuits before any RPC call.
+    expect(callMock).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
   })
 })

--- a/src/cli/handlers/agent-hooks.ts
+++ b/src/cli/handlers/agent-hooks.ts
@@ -3,8 +3,11 @@ import { homedir } from 'os'
 import { dirname, join } from 'path'
 import { randomUUID } from 'crypto'
 import type { CommandHandler } from '../dispatch'
-import { printResult } from '../format'
+import { formatAgentLabel, printResult } from '../format'
 import { RuntimeClientError, type RuntimeClient, type RuntimeRpcSuccess } from '../runtime-client'
+import { getRequiredStringFlag } from '../flags'
+import { getTerminalHandle } from '../selectors'
+import type { RuntimeAgentLabel } from '../../shared/runtime-types'
 import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import { getDefaultPersistedState } from '../../shared/constants'
 import type { PersistedState } from '../../shared/types'
@@ -173,5 +176,18 @@ export const AGENT_HOOK_HANDLERS: Record<string, CommandHandler> = {
   'agent hooks on': async ({ client, json }) => {
     const result = await setAgentHooksEnabled(client, true)
     printResult(localSuccess(result), json, formatAgentHookCommandResult)
+  },
+  'agent label set': async ({ flags, client, cwd, json }) => {
+    const result = await client.call<{ label: RuntimeAgentLabel }>('agent.label.set', {
+      terminal: await getTerminalHandle(flags, cwd, client),
+      label: getRequiredStringFlag(flags, 'label')
+    })
+    printResult(result, json, formatAgentLabel)
+  },
+  'agent label clear': async ({ flags, client, cwd, json }) => {
+    const result = await client.call<{ label: RuntimeAgentLabel }>('agent.label.clear', {
+      terminal: await getTerminalHandle(flags, cwd, client)
+    })
+    printResult(result, json, formatAgentLabel)
   }
 }

--- a/src/cli/specs/agent-hooks.ts
+++ b/src/cli/specs/agent-hooks.ts
@@ -22,5 +22,27 @@ export const AGENT_HOOK_COMMAND_SPECS: CommandSpec[] = [
     usage: 'orca agent hooks on [--json]',
     allowedFlags: [...GLOBAL_FLAGS],
     examples: ['orca agent hooks on']
+  },
+  {
+    path: ['agent', 'label', 'set'],
+    summary: "Set a custom sidebar label for an agent's pane",
+    usage: 'orca agent label set [--terminal <handle>] --label <text> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'label'],
+    notes: [
+      'Targets the active terminal in the current worktree when --terminal is omitted.',
+      'The label wins over orchestration display name / task title / prompt in the sidebar.'
+    ],
+    examples: [
+      'orca agent label set --terminal term_abc123 --label "Reset AI"',
+      'orca agent label set --label "Frontend" --json'
+    ]
+  },
+  {
+    path: ['agent', 'label', 'clear'],
+    summary: "Clear the custom sidebar label for an agent's pane",
+    usage: 'orca agent label clear [--terminal <handle>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'terminal'],
+    notes: ['Reverts the row to its auto-derived label (display name / task title / prompt).'],
+    examples: ['orca agent label clear --terminal term_abc123']
   }
 ]

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -6848,3 +6848,270 @@ describe('AgentHookServer ingestTerminalStatus', () => {
     expect(server.getStatusSnapshot()).toEqual([])
   })
 })
+
+describe('AgentHookServer per-agent custom labels', () => {
+  function emitWorkingStatus(server: AgentHookServer, paneKey = PANE): void {
+    server.ingestTerminalStatus({
+      paneKey,
+      // Why: ingest requires tabId to match the paneKey's tab segment.
+      tabId: paneKey.slice(0, paneKey.indexOf(':')),
+      worktreeId: 'wt-1',
+      payload: { state: 'working', prompt: 'do work', agentType: 'claude' }
+    })
+  }
+
+  it('set/get/clear a label for a pane', () => {
+    const server = new AgentHookServer()
+    expect(server.getCustomAgentLabel(PANE)).toBeNull()
+    expect(server.setCustomAgentLabel(PANE, 'Reset AI')).toBe('Reset AI')
+    expect(server.getCustomAgentLabel(PANE)).toBe('Reset AI')
+    expect(server.setCustomAgentLabel(PANE, null)).toBeNull()
+    expect(server.getCustomAgentLabel(PANE)).toBeNull()
+  })
+
+  it('treats empty/whitespace label as a clear', () => {
+    const server = new AgentHookServer()
+    server.setCustomAgentLabel(PANE, 'Keep')
+    expect(server.setCustomAgentLabel(PANE, '   ')).toBeNull()
+    expect(server.getCustomAgentLabel(PANE)).toBeNull()
+  })
+
+  it('normalizes the label to a single bounded line', () => {
+    const server = new AgentHookServer()
+    expect(server.setCustomAgentLabel(PANE, '  multi   line\nlabel  ')).toBe('multi line label')
+    const long = 'x'.repeat(500)
+    const normalized = server.setCustomAgentLabel(PANE, long)
+    expect(normalized).not.toBeNull()
+    expect(normalized!.length).toBe(160)
+  })
+
+  it('stamps the label onto the status snapshot (set after a status arrives)', () => {
+    const server = new AgentHookServer()
+    emitWorkingStatus(server)
+    expect(server.getStatusSnapshot()[0].customAgentLabel).toBeUndefined()
+    server.setCustomAgentLabel(PANE, 'Frontend')
+    expect(server.getStatusSnapshot()[0].customAgentLabel).toBe('Frontend')
+  })
+
+  it('stamps the label onto the live set push for local and ingested-remote events', () => {
+    const server = new AgentHookServer()
+    server.setCustomAgentLabel(PANE, 'Labeled')
+    const seen: (string | undefined)[] = []
+    // Why: the index.ts listener re-stamps from the map; here assert the map is
+    // authoritative regardless of push origin by reading it on each emission.
+    server.setListener((enriched) => {
+      seen.push(server.getCustomAgentLabel(enriched.paneKey) ?? undefined)
+    })
+    emitWorkingStatus(server)
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'done', prompt: 'remote turn', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+    expect(seen).toContain('Labeled')
+    expect(seen.every((label) => label === 'Labeled')).toBe(true)
+  })
+})
+
+describe('AgentHookServer custom-label persistence and cleanup', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-label-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  function lastStatusPath(): string {
+    return join(userDataPath, 'agent-hooks', 'last-status.json')
+  }
+
+  function recentTs(offsetMs = 0): number {
+    return Date.now() - 60 * 60 * 1000 + offsetMs
+  }
+
+  it('persists labels under an additive customLabels key without bumping version', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      server.setCustomAgentLabel(PANE, 'Persisted')
+      server.flushStatusPersistSync()
+      const file = JSON.parse(readFileSync(lastStatusPath(), 'utf8'))
+      // Version stays 2 — a bump would hard-reject the whole file on older readers.
+      expect(file.version).toBe(2)
+      expect(file.customLabels[PANE]).toMatchObject({
+        label: 'Persisted',
+        updatedAt: expect.any(Number)
+      })
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('omits the customLabels key entirely when no labels are set', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      server.ingestTerminalStatus({
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'working', prompt: 'no label', agentType: 'claude' }
+      })
+      server.flushStatusPersistSync()
+      const file = JSON.parse(readFileSync(lastStatusPath(), 'utf8'))
+      expect('customLabels' in file).toBe(false)
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('round-trips a label across restart via the customLabels key', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {},
+        customLabels: { [PANE]: { label: 'Reloaded', updatedAt: recentTs() } }
+      }),
+      'utf8'
+    )
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      expect(server.getCustomAgentLabel(PANE)).toBe('Reloaded')
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('still hydrates status entries when the file carries labels (no version gate tripped)', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          [GOOD_PANE]: {
+            paneKey: GOOD_PANE,
+            tabId: 'tab-good',
+            receivedAt: recentTs(),
+            stateStartedAt: recentTs(-1000),
+            payload: { state: 'done', prompt: 'survived with labels', agentType: 'claude' }
+          }
+        },
+        customLabels: { [PANE]: { label: 'sibling', updatedAt: recentTs() } }
+      }),
+      'utf8'
+    )
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      const snapshot = server.getStatusSnapshot()
+      expect(snapshot.map((entry) => entry.paneKey)).toContain(GOOD_PANE)
+      expect(server.getCustomAgentLabel(PANE)).toBe('sibling')
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('prunes labels older than the 7-day TTL on hydrate', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {},
+        customLabels: {
+          [PANE]: { label: 'fresh', updatedAt: recentTs() },
+          [GOOD_PANE]: { label: 'stale', updatedAt: eightDaysAgo }
+        }
+      }),
+      'utf8'
+    )
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      expect(server.getCustomAgentLabel(PANE)).toBe('fresh')
+      expect(server.getCustomAgentLabel(GOOD_PANE)).toBeNull()
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('clears a label-only pane on clearPaneState (PTY teardown) even with no status row', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      server.setCustomAgentLabel(PANE, 'Doomed')
+      server.clearPaneState(PANE)
+      expect(server.getCustomAgentLabel(PANE)).toBeNull()
+      server.flushStatusPersistSync()
+      const file = JSON.parse(readFileSync(lastStatusPath(), 'utf8'))
+      expect('customLabels' in file).toBe(false)
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('clears a label-only pane on dropStatusEntriesByTabPrefix (tab close)', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      // Label set, tab closed before any hook fired — must be evicted.
+      server.setCustomAgentLabel(PANE, 'Doomed')
+      server.dropStatusEntriesByTabPrefix('tab-1')
+      expect(server.getCustomAgentLabel(PANE)).toBeNull()
+      server.flushStatusPersistSync()
+      const file = JSON.parse(readFileSync(lastStatusPath(), 'utf8'))
+      expect('customLabels' in file).toBe(false)
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('retains the label on dropStatusEntry (live-pane dismiss)', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      server.ingestTerminalStatus({
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'working', prompt: 'alive', agentType: 'claude' }
+      })
+      server.setCustomAgentLabel(PANE, 'Keep me')
+      server.dropStatusEntry(PANE)
+      // The pane's agent is still alive; only its status row was dismissed.
+      expect(server.getCustomAgentLabel(PANE)).toBe('Keep me')
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('clears the in-memory label map on stop() and does not merge it on re-hydrate', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    server.setCustomAgentLabel(PANE, 'Session A')
+    server.flushStatusPersistSync()
+    server.stop()
+    expect(server.getCustomAgentLabel(PANE)).toBeNull()
+
+    // Disk has Session A's label; re-hydrate must reflect only the disk set.
+    await server.start({ env: 'production', userDataPath })
+    try {
+      expect(server.getCustomAgentLabel(PANE)).toBe('Session A')
+      expect(server._getCustomLabelsForTests().size).toBe(1)
+    } finally {
+      server.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -56,6 +56,10 @@ import {
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../shared/stable-pane-id'
 import type { LegacyPaneKeyAliasEntry } from '../../shared/types'
 import { normalizeAgentProviderSession } from '../../shared/agent-session-resume'
+import {
+  ORCHESTRATION_DISPLAY_NAME_MAX_LENGTH,
+  normalizeSingleLine
+} from '../../shared/orchestration-task-display'
 
 export type { AgentHookSource }
 
@@ -119,9 +123,21 @@ const AGENT_PROMPT_SENT_AGENT_KINDS = new Set<AgentKind>(AGENT_KIND_VALUES)
 // not resurrect on hydrate.
 const HYDRATE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 
+// Why: a custom label has its own lifecycle distinct from the status row — a
+// user can label a pane that has not emitted a hook yet, and the label must
+// survive a TTL-aged / dropped status entry. So it carries its own timestamp.
+type CustomLabelEntry = {
+  label: string
+  updatedAt: number
+}
+
 type LastStatusFile = {
   version: number
   entries: Record<string, EnrichedAgentHookEventPayload>
+  // Why: additive optional sibling key. NOT version-gated — older readers
+  // ignore it and newer readers tolerate its absence, so existing status rows
+  // never get wiped by a version bump on upgrade/downgrade.
+  customLabels?: Record<string, CustomLabelEntry>
 }
 
 type AgentPromptSentDedupeEntry = {
@@ -232,7 +248,34 @@ function sanitizeHydratedEntry(
   }
 }
 
-function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentStatusIpcPayload {
+function sanitizeHydratedCustomLabel(paneKey: string, rawEntry: unknown): CustomLabelEntry | null {
+  if (!parsePaneKey(paneKey)) {
+    return null
+  }
+  if (typeof rawEntry !== 'object' || rawEntry === null) {
+    return null
+  }
+  const record = rawEntry as Record<string, unknown>
+  const updatedAt = record.updatedAt
+  if (typeof updatedAt !== 'number' || !Number.isFinite(updatedAt) || updatedAt <= 0) {
+    return null
+  }
+  if (typeof record.label !== 'string') {
+    return null
+  }
+  // Why: re-normalize on hydrate so a hand-edited / older-format file can't
+  // reintroduce an oversized or multi-line label into the cache.
+  const label = normalizeSingleLine(record.label, ORCHESTRATION_DISPLAY_NAME_MAX_LENGTH)
+  if (label.length === 0) {
+    return null
+  }
+  return { label, updatedAt }
+}
+
+function toAgentStatusIpcPayload(
+  entry: EnrichedAgentHookEventPayload,
+  customAgentLabel?: string
+): AgentStatusIpcPayload {
   return {
     paneKey: entry.paneKey,
     ...(entry.launchToken ? { launchToken: entry.launchToken } : {}),
@@ -242,7 +285,10 @@ function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentSta
     receivedAt: entry.receivedAt,
     stateStartedAt: entry.stateStartedAt,
     ...(entry.providerSession ? { providerSession: entry.providerSession } : {}),
-    ...entry.payload
+    ...entry.payload,
+    // Why: stamp the label AFTER spreading the payload so a payload field can
+    // never shadow it; omit when unset so older peers see no new field.
+    ...(customAgentLabel ? { customAgentLabel } : {})
   }
 }
 
@@ -462,6 +508,11 @@ export class AgentHookServer {
   // exactly match the last successful disk write. Cheap protection against
   // re-firing trailing timers when nothing changed.
   private lastWrittenJson: string | null = null
+  // Why: per-pane user-set sidebar label, keyed by paneKey alongside the status
+  // cache so it rides the existing single source of truth to both consumers
+  // (renderer store + worktree ps). First-class with its own timestamp because
+  // its lifecycle is independent of the status entry it decorates.
+  private customLabelByPaneKey = new Map<string, CustomLabelEntry>()
 
   setListener(listener: ((payload: EnrichedAgentHookEventPayload) => void) | null): void {
     this.onAgentStatus = listener
@@ -500,9 +551,43 @@ export class AgentHookServer {
    *  workspace tabs have hydrated, so the dashboard catches up on any
    *  hook events that fired during startup. */
   getStatusSnapshot(): AgentStatusIpcPayload[] {
-    return Array.from(this.state.lastStatusByPaneKey.values(), (entry) =>
-      toAgentStatusIpcPayload(entry as EnrichedAgentHookEventPayload)
-    )
+    return Array.from(this.state.lastStatusByPaneKey.values(), (entry) => {
+      const enriched = entry as EnrichedAgentHookEventPayload
+      return toAgentStatusIpcPayload(
+        enriched,
+        this.customLabelByPaneKey.get(enriched.paneKey)?.label
+      )
+    })
+  }
+
+  /** Read the current per-pane label. Used by the runtime to surface the label
+   *  on `worktree ps` rows and by tests. */
+  getCustomAgentLabel(paneKey: string): string | null {
+    return this.customLabelByPaneKey.get(this.resolvePaneKeyAlias(paneKey))?.label ?? null
+  }
+
+  /** Set or clear the per-pane custom label. Empty/whitespace/null clears.
+   *  Normalizes to a single bounded line (reuses the orchestration display-name
+   *  cap) so an oversized value cannot bloat the cache or wire payload. */
+  setCustomAgentLabel(paneKey: string, label: string | null): string | null {
+    const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+    const normalized =
+      label === null ? '' : normalizeSingleLine(label, ORCHESTRATION_DISPLAY_NAME_MAX_LENGTH)
+    const existing = this.customLabelByPaneKey.get(resolvedPaneKey)
+    if (normalized.length === 0) {
+      if (!existing) {
+        return null
+      }
+      this.customLabelByPaneKey.delete(resolvedPaneKey)
+      this.scheduleStatusPersist()
+      return null
+    }
+    if (existing?.label === normalized) {
+      return normalized
+    }
+    this.customLabelByPaneKey.set(resolvedPaneKey, { label: normalized, updatedAt: Date.now() })
+    this.scheduleStatusPersist()
+    return normalized
   }
 
   inferInterrupt(request: AgentInterruptInferenceRequest): boolean {
@@ -1280,6 +1365,7 @@ export class AgentHookServer {
     this.promptSentDedupeByPaneKey.clear()
     this.closedAgentStatusTabIds.clear()
     this.legacyPaneKeyAliases.clear()
+    this.customLabelByPaneKey.clear()
     clearAllListenerCaches(this.state)
     this.notifyStatusChangeListeners()
   }
@@ -1359,6 +1445,16 @@ export class AgentHookServer {
       }
     }
 
+    // Why: a label-only pane (labeled, never emitted a hook) is in none of the
+    // status/prompt/tool caches scanned above, so it would be missed. Scan the
+    // label map directly by tab prefix so closing a tab also evicts its labels.
+    let labelChanged = false
+    for (const paneKey of this.customLabelByPaneKey.keys()) {
+      if (paneCacheKeyMatchesTab(paneKey, tabId)) {
+        paneKeysToClear.add(paneKey)
+      }
+    }
+
     let statusChanged = false
     for (const paneKey of paneKeysToClear) {
       if (this.state.lastStatusByPaneKey.has(paneKey)) {
@@ -1368,6 +1464,9 @@ export class AgentHookServer {
       clearPaneCacheState(this.state, paneKey)
       this.runtimeObservedStatusPaneKeys.delete(paneKey)
       this.promptSentDedupeByPaneKey.delete(paneKey)
+      if (this.customLabelByPaneKey.delete(paneKey)) {
+        labelChanged = true
+      }
     }
     if (aliasChanged) {
       this.notifyPaneKeyAliasPersistenceListener()
@@ -1375,6 +1474,10 @@ export class AgentHookServer {
     if (statusChanged) {
       this.scheduleStatusPersist()
       this.notifyStatusChangeListeners()
+    } else if (labelChanged) {
+      // Why: force a persist when only the label section changed so a label-only
+      // pane's removal on tab close reaches disk.
+      this.scheduleStatusPersist()
     }
   }
 
@@ -1388,12 +1491,19 @@ export class AgentHookServer {
     this.clearAssistantMessageRetry(resolvedPaneKey)
     clearPaneCacheState(this.state, resolvedPaneKey)
     this.promptSentDedupeByPaneKey.delete(resolvedPaneKey)
+    // Why: a label-only pane (labeled, then PTY died before any hook) has no
+    // status entry, so deleting the label must be independent of hadStatus —
+    // otherwise a reused paneKey could inherit the stale label.
+    let clearedLabel = this.customLabelByPaneKey.delete(resolvedPaneKey)
     let clearedAlias = false
     for (const [legacyPaneKey, stablePaneKey] of this.legacyPaneKeyAliases) {
       if (stablePaneKey.stablePaneKey === resolvedPaneKey) {
         this.legacyPaneKeyAliases.delete(legacyPaneKey)
         clearPaneCacheState(this.state, legacyPaneKey)
         this.promptSentDedupeByPaneKey.delete(legacyPaneKey)
+        if (this.customLabelByPaneKey.delete(legacyPaneKey)) {
+          clearedLabel = true
+        }
         clearedAlias = true
       }
     }
@@ -1405,6 +1515,10 @@ export class AgentHookServer {
       this.scheduleStatusPersist()
       this.notifyStatusChangeListeners()
       this.onPaneStatusCleared?.(resolvedPaneKey)
+    } else if (clearedLabel) {
+      // Why: no status entry changed, but the on-disk label section did — force
+      // a persist so a label-only pane's removal reaches disk.
+      this.scheduleStatusPersist()
     }
   }
 
@@ -1459,6 +1573,9 @@ export class AgentHookServer {
     // calls; production callers always have an empty map here, but a future
     // re-start path must not silently merge prior-session state.
     this.state.lastStatusByPaneKey.clear()
+    // Why: same idempotency guarantee for the sibling label map — a re-hydrate
+    // must not merge a prior session's in-memory labels with the disk set.
+    this.customLabelByPaneKey.clear()
     let raw: string
     try {
       raw = readFileSync(this.lastStatusFilePath, 'utf8')
@@ -1522,15 +1639,37 @@ export class AgentHookServer {
         `[agent-hooks] last-status hydrate dropped ${dropped} entries (kept ${hydrated})`
       )
     }
-    if (hydrated > 0 && dropped === 0) {
+    // Why: the sibling label map has no `receivedAt`, so the status TTL cannot
+    // govern it. Prune label entries whose own `updatedAt` is older than the
+    // same 7-day cutoff. Absent key (older file / no labels) is a no-op.
+    let labelDropped = 0
+    let labelHydrated = 0
+    if (typeof file.customLabels === 'object' && file.customLabels !== null) {
+      for (const [paneKey, rawEntry] of Object.entries(file.customLabels)) {
+        const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+        const label = sanitizeHydratedCustomLabel(resolvedPaneKey, rawEntry)
+        if (label && label.updatedAt >= ttlCutoff) {
+          this.customLabelByPaneKey.set(resolvedPaneKey, label)
+          labelHydrated += 1
+        } else {
+          labelDropped += 1
+        }
+      }
+    }
+    if (labelDropped > 0) {
+      console.warn(
+        `[agent-hooks] last-status hydrate dropped ${labelDropped} labels (kept ${labelHydrated})`
+      )
+    }
+    if (dropped === 0 && labelDropped === 0 && (hydrated > 0 || labelHydrated > 0)) {
       // Why: prime from the raw on-disk bytes (not a re-serialization) so the
       // dedup is robust against future shape drift in serializeStatusFile.
-      // Only prime when hydration was lossless — if entries were dropped
-      // during sanitize, the in-memory map diverges from the on-disk bytes.
+      // Only prime when hydration was lossless — if entries OR labels were
+      // dropped, the in-memory state diverges from the on-disk bytes.
       this.lastWrittenJson = raw
-    } else if (dropped > 0) {
+    } else if (dropped > 0 || labelDropped > 0) {
       // Why: clean the stale on-disk file now so a user who has not run an
-      // agent in 8+ days does not re-drop the same entries on every cold
+      // agent in 8+ days does not re-drop the same entries/labels on every cold
       // boot. Synchronous variant is safe at start time and avoids
       // unref'd-timer-during-quit edge cases.
       this.runStatusPersist()
@@ -1549,7 +1688,19 @@ export class AgentHookServer {
       const { promptInteractionKey: _promptInteractionKey, ...persistedPayload } = payload
       entries[paneKey] = persistedPayload as EnrichedAgentHookEventPayload
     }
+    const customLabels: Record<string, CustomLabelEntry> = {}
+    for (const [paneKey, entry] of this.customLabelByPaneKey) {
+      if (!isValidPaneKey(paneKey)) {
+        continue
+      }
+      customLabels[paneKey] = entry
+    }
     const file: LastStatusFile = { version: LAST_STATUS_FILE_VERSION, entries }
+    // Why: omit the key entirely when empty so the common no-label file shape
+    // (and its dedup bytes) is identical to before this feature.
+    if (Object.keys(customLabels).length > 0) {
+      file.customLabels = customLabels
+    }
     return JSON.stringify(file)
   }
 
@@ -1630,6 +1781,11 @@ export class AgentHookServer {
 
   _resetPromptSentDedupeForTests(): void {
     this.promptSentDedupeByPaneKey.clear()
+  }
+
+  /** Test/diagnostic accessor for the in-memory custom-label map. */
+  _getCustomLabelsForTests(): ReadonlyMap<string, CustomLabelEntry> {
+    return this.customLabelByPaneKey
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -844,6 +844,10 @@ function openMainWindow(): BrowserWindow {
       maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })
       const orchestration = runtime?.getAgentStatusOrchestrationContextForPaneKey(paneKey)
       const terminalHandle = runtime?.getAgentStatusTerminalHandleForPaneKey(paneKey)
+      // Why: re-stamp the label from the local map on every push (local-origin
+      // and ingestRemote both flow through this listener) so a remote payload
+      // that lacks the field never erases a locally-set label.
+      const customAgentLabel = agentHookServer.getCustomAgentLabel(paneKey)
       mainWindow?.webContents.send('agentStatus:set', {
         ...payload,
         paneKey,
@@ -855,7 +859,8 @@ function openMainWindow(): BrowserWindow {
         receivedAt,
         stateStartedAt,
         ...(providerSession ? { providerSession } : {}),
-        ...(orchestration ? { orchestration } : {})
+        ...(orchestration ? { orchestration } : {}),
+        ...(customAgentLabel ? { customAgentLabel } : {})
       })
       recordAgentStateCrashBreadcrumb(payload.agentType ?? 'unknown', payload.state)
       // Why: some native OSC titles miss terminal idle/permission frames.
@@ -1452,7 +1457,11 @@ app.whenReady().then(async () => {
     },
     // Why: hook-reported agent status is the same source the desktop sidebar
     // reads. worktree.ps pulls it at query time so mobile shows the same agents.
-    getAgentStatusSnapshot: () => agentHookServer.getStatusSnapshot()
+    getAgentStatusSnapshot: () => agentHookServer.getStatusSnapshot(),
+    // Why: the per-agent custom label rides the same hook-server cache, so set
+    // and read it there too (keeps both worktree.ps consumers on one source).
+    setCustomAgentLabel: (paneKey, label) => agentHookServer.setCustomAgentLabel(paneKey, label),
+    getCustomAgentLabel: (paneKey) => agentHookServer.getCustomAgentLabel(paneKey)
   })
   runtime = runtimeService
   automations = new AutomationService(store, {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -24146,3 +24146,155 @@ describe('OrcaRuntimeService', () => {
     })
   })
 })
+
+describe('OrcaRuntimeService per-agent custom labels', () => {
+  function makeLabelStore(): {
+    deps: {
+      getAgentStatusSnapshot: () => never[]
+      setCustomAgentLabel: (paneKey: string, label: string | null) => string | null
+      getCustomAgentLabel: (paneKey: string) => string | null
+    }
+    labels: Map<string, string>
+  } {
+    const labels = new Map<string, string>()
+    return {
+      labels,
+      deps: {
+        getAgentStatusSnapshot: () => [],
+        setCustomAgentLabel: (paneKey, label) => {
+          if (!label || label.trim().length === 0) {
+            labels.delete(paneKey)
+            return null
+          }
+          labels.set(paneKey, label)
+          return label
+        },
+        getCustomAgentLabel: (paneKey) => labels.get(paneKey) ?? null
+      }
+    }
+  }
+
+  function syncSingleTerminalGraph(
+    runtime: OrcaRuntimeService,
+    leafId: string,
+    getSnapshot: () => unknown[]
+  ): void {
+    void getSnapshot
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-1' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'agent',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+  }
+
+  it('resolves a terminal handle to a paneKey, sets the label, and echoes the target', async () => {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const paneKey = makePaneKey('tab-1', leafId)
+    const { deps, labels } = makeLabelStore()
+    const runtime = new OrcaRuntimeService(store, undefined, deps)
+    syncSingleTerminalGraph(runtime, leafId, () => [])
+    const setAgentLabel = vi.fn()
+    runtime.setNotifier({ renameTerminal: vi.fn(), setAgentLabel } as never)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const result = await runtime.setCustomAgentLabel(terminal.handle, 'Reset AI')
+
+    expect(result).toEqual({ terminalHandle: terminal.handle, paneKey, label: 'Reset AI' })
+    expect(labels.get(paneKey)).toBe('Reset AI')
+    // When attached, the notifier pushes the live update keyed by paneKey.
+    expect(setAgentLabel).toHaveBeenCalledWith(paneKey, 'Reset AI')
+  })
+
+  it('clears the label and reports a null result', async () => {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const paneKey = makePaneKey('tab-1', leafId)
+    const { deps, labels } = makeLabelStore()
+    labels.set(paneKey, 'Existing')
+    const runtime = new OrcaRuntimeService(store, undefined, deps)
+    syncSingleTerminalGraph(runtime, leafId, () => [])
+    runtime.setNotifier({ renameTerminal: vi.fn(), setAgentLabel: vi.fn() } as never)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const result = await runtime.setCustomAgentLabel(terminal.handle, null)
+
+    expect(result).toEqual({ terminalHandle: terminal.handle, paneKey, label: null })
+    expect(labels.has(paneKey)).toBe(false)
+  })
+
+  it('throws agent_pane_not_found for an unknown terminal handle', async () => {
+    const { deps } = makeLabelStore()
+    const runtime = new OrcaRuntimeService(store, undefined, deps)
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+
+    await expect(runtime.setCustomAgentLabel('term_does_not_exist', 'X')).rejects.toThrow(
+      'agent_pane_not_found'
+    )
+  })
+
+  it('surfaces the label in the worktree ps row dedicated customAgentLabel field', async () => {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const paneKey = makePaneKey('tab-1', leafId)
+    const now = Date.now()
+    const labels = new Map<string, string>([[paneKey, 'Reset AI']])
+    const runtime = new OrcaRuntimeService(store, undefined, {
+      // Mirror getStatusSnapshot's stamping: the entry carries customAgentLabel.
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey,
+          state: 'working',
+          prompt: 'auto-derived prompt',
+          agentType: 'claude',
+          connectionId: null,
+          receivedAt: now,
+          stateStartedAt: now,
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          customAgentLabel: labels.get(paneKey)
+        }
+      ],
+      setCustomAgentLabel: (key, label) => {
+        if (!label) {
+          labels.delete(key)
+          return null
+        }
+        labels.set(key, label)
+        return label
+      },
+      getCustomAgentLabel: (key) => labels.get(key) ?? null
+    })
+    syncSingleTerminalGraph(runtime, leafId, () => [])
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((w) => w.worktreeId === TEST_WORKTREE_ID)
+    const row = summary?.agents.find((agent) => agent.paneKey === paneKey)
+    expect(row).toBeDefined()
+    // Dedicated field — distinct from displayName/taskTitle which stay null.
+    expect(row?.customAgentLabel).toBe('Reset AI')
+    expect(row?.displayName).toBeNull()
+    expect(row?.taskTitle).toBeNull()
+    expect(row?.prompt).toBe('auto-derived prompt')
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -238,6 +238,7 @@ import type {
   RuntimeRepoSearchRefs,
   RuntimeTerminalRead,
   RuntimeTerminalRename,
+  RuntimeAgentLabel,
   RuntimeTerminalAgentStatus,
   RuntimeTerminalSend,
   RuntimeTerminalCreate,
@@ -1153,6 +1154,9 @@ type RuntimeNotifier = {
     }
   ): void
   renameTerminal(tabId: string, title: string | null): void
+  /** Push a per-agent custom label change to the renderer store. Keyed by
+   *  paneKey (per-pane), not tabId, since labels are per-agent. */
+  setAgentLabel?(paneKey: string, label: string | null): void
   focusTerminal(tabId: string, worktreeId: string, leafId?: string | null): void
   focusEditorTab?(tabId: string, worktreeId: string): void
   closeSessionTab?(tabId: string, worktreeId: string): void
@@ -2167,6 +2171,14 @@ export class OrcaRuntimeService {
   private readonly onPtyStopped: ((ptyId: string) => void) | null
   private readonly onTerminalAgentStatus: ((event: RuntimeTerminalAgentStatusEvent) => void) | null
   private readonly getAgentStatusSnapshotFn: (() => AgentStatusIpcPayload[]) | null
+  // Why: the per-agent custom label lives in the agent hook server (next to the
+  // status cache). The runtime reaches it through these injected fns, mirroring
+  // how getAgentStatusSnapshot is injected, so the runtime keeps no direct
+  // dependency on the hook-server singleton (stays mockable in tests).
+  private readonly setCustomAgentLabelFn:
+    | ((paneKey: string, label: string | null) => string | null)
+    | null
+  private readonly getCustomAgentLabelFn: ((paneKey: string) => string | null) | null
   private accountServices: RuntimeAccountServices | null = null
   private commitMessageAgentEnv: CommitMessageAgentEnvironmentResolvers | null = null
   private automationService: AutomationService | null = null
@@ -2193,6 +2205,9 @@ export class OrcaRuntimeService {
       // terminal output. worktree.ps reads this at query time so mobile shows the
       // same inline agent rows the desktop sidebar does — same source, 1:1.
       getAgentStatusSnapshot?: () => AgentStatusIpcPayload[]
+      // Why: set/read the per-agent custom label in the hook server's map.
+      setCustomAgentLabel?: (paneKey: string, label: string | null) => string | null
+      getCustomAgentLabel?: (paneKey: string) => string | null
     }
   ) {
     this.store = store
@@ -2201,6 +2216,8 @@ export class OrcaRuntimeService {
       this.agentDetector = new AgentDetector(stats)
     }
     this.getAgentStatusSnapshotFn = deps?.getAgentStatusSnapshot ?? null
+    this.setCustomAgentLabelFn = deps?.setCustomAgentLabel ?? null
+    this.getCustomAgentLabelFn = deps?.getCustomAgentLabel ?? null
     // Why: the daemon adapter is installed via `setLocalPtyProvider()` during
     // attachMainWindowServices, AFTER this service is constructed. Capturing
     // `getLocalPtyProvider()` at construction time would freeze a reference to
@@ -9117,6 +9134,7 @@ export class OrcaRuntimeService {
         toolName: string | null
         toolInput: string | null
         interrupted: boolean
+        customAgentLabel: string | null
         stateStartedAt: number
         updatedAt: number
       }
@@ -9133,6 +9151,9 @@ export class OrcaRuntimeService {
         toolName: payload.toolName ?? null,
         toolInput: payload.toolInput ?? null,
         interrupted: payload.interrupted ?? false,
+        // Why: OSC-only panes never pass through getStatusSnapshot's stamping,
+        // so read the label directly from the hook server's map here.
+        customAgentLabel: this.getCustomAgentLabelFn?.(snapshot.paneKey) ?? null,
         stateStartedAt: snapshot.stateStartedAt,
         updatedAt: snapshot.updatedAt
       })
@@ -9148,6 +9169,9 @@ export class OrcaRuntimeService {
         toolName: entry.toolName ?? null,
         toolInput: entry.toolInput ?? null,
         interrupted: entry.interrupted ?? false,
+        // Why: getStatusSnapshot already stamps the label from the hook server's
+        // map onto the entry, so carry it straight through.
+        customAgentLabel: entry.customAgentLabel ?? null,
         stateStartedAt: entry.stateStartedAt,
         updatedAt: entry.receivedAt
       })
@@ -9172,6 +9196,7 @@ export class OrcaRuntimeService {
         prompt: src.prompt,
         taskTitle,
         displayName,
+        customAgentLabel: src.customAgentLabel,
         lastAssistantMessage: src.lastAssistantMessage,
         toolName: src.toolName,
         toolInput: src.toolInput,
@@ -15130,6 +15155,27 @@ export class OrcaRuntimeService {
     const { leaf } = this.getLiveLeafForHandle(handle)
     this.notifier?.renameTerminal(leaf.tabId, title)
     return { handle, tabId: leaf.tabId, title }
+  }
+
+  /** Set or clear the per-agent custom sidebar label for the pane behind a
+   *  terminal handle. Resolves handle→paneKey on the runtime that owns the pane;
+   *  a handle owned by a different runtime resolves to null and fails closed. */
+  async setCustomAgentLabel(handle: string, label: string | null): Promise<RuntimeAgentLabel> {
+    const paneKey = this.getPaneKeyForTerminalHandle(handle)
+    if (!paneKey) {
+      // Why: handle resolution fails closed across runtimes (a remote-owned
+      // pane returns null here), so a CLI cannot write into the wrong map.
+      throw new Error('agent_pane_not_found')
+    }
+    if (!this.setCustomAgentLabelFn) {
+      throw new Error('agent_label_unavailable')
+    }
+    const normalized = this.setCustomAgentLabelFn(paneKey, label)
+    // Why: when attached, push to the live store so the sidebar reflects the
+    // label immediately (mirrors renameTerminal's notifier path); headless runs
+    // skip the notifier and rely on the persisted snapshot.
+    this.notifier?.setAgentLabel?.(paneKey, normalized)
+    return { terminalHandle: handle, paneKey, label: normalized }
   }
 
   async createTerminal(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15173,7 +15173,8 @@ export class OrcaRuntimeService {
     const normalized = this.setCustomAgentLabelFn(paneKey, label)
     // Why: when attached, push to the live store so the sidebar reflects the
     // label immediately (mirrors renameTerminal's notifier path); headless runs
-    // skip the notifier and rely on the persisted snapshot.
+    // have no notifier — subsequent worktree.ps reads pull the label directly
+    // from the hook server's map via getCustomAgentLabelFn.
     this.notifier?.setAgentLabel?.(paneKey, normalized)
     return { terminalHandle: handle, paneKey, label: normalized }
   }

--- a/src/main/runtime/rpc/methods/agent.ts
+++ b/src/main/runtime/rpc/methods/agent.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+import { defineMethod, type RpcAnyMethod } from '../core'
+import { OptionalString, requiredString } from '../schemas'
+
+const AgentLabelSet = z.object({
+  terminal: requiredString('Missing terminal handle'),
+  // Why: label may be an empty string (treated as a clear by the runtime
+  // setter); any non-string shape other than absent is rejected.
+  label: OptionalString
+})
+
+const AgentLabelClear = z.object({
+  terminal: requiredString('Missing terminal handle')
+})
+
+// Why: per-agent custom sidebar label commands. Co-located in their own `agent`
+// namespace (rather than `terminal`) because the label targets the agent in a
+// pane, not the terminal tab title — a separate concept from terminal.rename.
+export const AGENT_METHODS: readonly RpcAnyMethod[] = [
+  defineMethod({
+    name: 'agent.label.set',
+    params: AgentLabelSet,
+    handler: async (params, { runtime }) => ({
+      label: await runtime.setCustomAgentLabel(params.terminal, params.label ?? null)
+    })
+  }),
+  defineMethod({
+    name: 'agent.label.clear',
+    params: AgentLabelClear,
+    handler: async (params, { runtime }) => ({
+      label: await runtime.setCustomAgentLabel(params.terminal, null)
+    })
+  })
+]

--- a/src/main/runtime/rpc/methods/agent.ts
+++ b/src/main/runtime/rpc/methods/agent.ts
@@ -4,8 +4,9 @@ import { OptionalString, requiredString } from '../schemas'
 
 const AgentLabelSet = z.object({
   terminal: requiredString('Missing terminal handle'),
-  // Why: label may be an empty string (treated as a clear by the runtime
-  // setter); any non-string shape other than absent is rejected.
+  // Why: OptionalString coerces non-string or empty-string inputs to undefined
+  // (a no-op, never an error), which the handler then treats as a clear via
+  // `params.label ?? null`. A real label is a non-empty string.
   label: OptionalString
 })
 

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -4,6 +4,7 @@ import { AUTOMATION_METHODS } from './automations'
 import { REPO_METHODS } from './repo'
 import { WORKTREE_METHODS } from './worktree'
 import { TERMINAL_METHODS } from './terminal'
+import { AGENT_METHODS } from './agent'
 import { BROWSER_CORE_METHODS } from './browser-core'
 import { BROWSER_EXTRA_METHODS } from './browser-extras'
 import { BROWSER_SCREENCAST_METHODS } from './browser-screencast'
@@ -43,6 +44,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...REPO_METHODS,
   ...WORKTREE_METHODS,
   ...TERMINAL_METHODS,
+  ...AGENT_METHODS,
   ...BROWSER_CORE_METHODS,
   ...BROWSER_SCREENCAST_METHODS,
   ...BROWSER_EXTRA_METHODS,

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -311,6 +311,7 @@ function registerRuntimeWindowLifecycle(
       })
     },
     renameTerminal: (tabId, title) => send('ui:renameTerminal', { tabId, title }),
+    setAgentLabel: (paneKey, label) => send('ui:setAgentLabel', { paneKey, label }),
     focusTerminal: (tabId, worktreeId, leafId) =>
       send('ui:focusTerminal', { tabId, worktreeId, leafId }),
     focusEditorTab: (tabId, worktreeId) => send('ui:focusEditorTab', { tabId, worktreeId }),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2543,6 +2543,9 @@ export type PreloadApi = {
     onRenameTerminal: (
       callback: (data: { tabId: string; title: string | null }) => void
     ) => () => void
+    onSetAgentLabel: (
+      callback: (data: { paneKey: string; label: string | null }) => void
+    ) => () => void
     onFocusTerminal: (
       callback: (data: {
         tabId: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3261,6 +3261,16 @@ const api = {
       ipcRenderer.on('ui:renameTerminal', listener)
       return () => ipcRenderer.removeListener('ui:renameTerminal', listener)
     },
+    onSetAgentLabel: (
+      callback: (data: { paneKey: string; label: string | null }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { paneKey: string; label: string | null }
+      ) => callback(data)
+      ipcRenderer.on('ui:setAgentLabel', listener)
+      return () => ipcRenderer.removeListener('ui:setAgentLabel', listener)
+    },
     onFocusTerminal: (
       callback: (data: {
         tabId: string

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1685,6 +1685,12 @@ export function useIpcEvents(): void {
     )
 
     unsubs.push(
+      window.api.ui.onSetAgentLabel?.(({ paneKey, label }) => {
+        useAppStore.getState().setCustomAgentLabel(paneKey, label)
+      }) ?? (() => {})
+    )
+
+    unsubs.push(
       window.api.ui.onFocusTerminal(
         ({
           tabId,
@@ -2896,9 +2902,14 @@ export function useIpcEvents(): void {
         return 'dropped'
       }
       const resolvedPayload = resolveHookPayloadAgentType(payload, identityTitle ?? title)
-      const statusPayload = data.orchestration
+      const statusPayloadWithOrchestration = data.orchestration
         ? { ...resolvedPayload, orchestration: data.orchestration }
         : resolvedPayload
+      // Why: main re-stamps the per-agent label on every push from its map, so
+      // carry it through so the entry rebuild reflects the authoritative value.
+      const statusPayload = data.customAgentLabel
+        ? { ...statusPayloadWithOrchestration, customAgentLabel: data.customAgentLabel }
+        : statusPayloadWithOrchestration
       const existingStatus = store.agentStatusByPaneKey[data.paneKey]
       const identity = resolveAgentStatusIdentity({
         existing: existingStatus

--- a/src/renderer/src/lib/agent-row-primary-text.test.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.test.ts
@@ -32,4 +32,35 @@ describe('getAgentRowPrimaryText', () => {
   it('falls back to the raw prompt outside orchestration workers', () => {
     expect(getAgentRowPrimaryText({ prompt: 'Fix checkout race' })).toBe('Fix checkout race')
   })
+
+  it('prefers an explicit custom label over orchestration display name and task title', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt: 'You are working inside Orca, a multi-agent IDE.',
+        customAgentLabel: 'Reset AI',
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          taskTitle: 'Checkout race',
+          displayName: 'Fix checkout race'
+        }
+      })
+    ).toBe('Reset AI')
+  })
+
+  it('prefers a custom label over the raw prompt for non-orchestrated agents', () => {
+    expect(
+      getAgentRowPrimaryText({ prompt: 'Fix checkout race', customAgentLabel: 'Frontend' })
+    ).toBe('Frontend')
+  })
+
+  it('falls through to auto-derived text when the label is empty or whitespace', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt: 'Fix checkout race',
+        customAgentLabel: '   ',
+        orchestration: { taskId: 't', dispatchId: 'd', displayName: 'Fix checkout race' }
+      })
+    ).toBe('Fix checkout race')
+  })
 })

--- a/src/renderer/src/lib/agent-row-primary-text.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.ts
@@ -1,9 +1,12 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 
 export function getAgentRowPrimaryText(
-  entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
+  entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt' | 'customAgentLabel'>
 ): string {
+  // Why: an explicit user-set CLI label is a deliberate override and must win
+  // over every auto-derived label, including orchestration-assigned ones.
   return (
+    entry.customAgentLabel?.trim() ||
     entry.orchestration?.displayName?.trim() ||
     entry.orchestration?.taskTitle?.trim() ||
     entry.prompt.trim()

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -1130,3 +1130,82 @@ describe('agent status retention + prefix sweep', () => {
     expect(retained['tab-b:0']).toBeUndefined()
   })
 })
+
+describe('agent status custom labels', () => {
+  const PANE = 'tab-1:11111111-1111-4111-8111-111111111111'
+
+  it('flows the customAgentLabel payload field into the live entry', () => {
+    const store = createTestStore()
+    store.getState().setAgentStatus(PANE, {
+      state: 'working',
+      prompt: 'do work',
+      agentType: 'claude',
+      customAgentLabel: 'Reset AI'
+    })
+    expect(store.getState().agentStatusByPaneKey[PANE].customAgentLabel).toBe('Reset AI')
+  })
+
+  it('setCustomAgentLabel updates the live entry', () => {
+    const store = createTestStore()
+    store.getState().setAgentStatus(PANE, {
+      state: 'working',
+      prompt: 'do work',
+      agentType: 'claude'
+    })
+    expect(store.getState().agentStatusByPaneKey[PANE].customAgentLabel).toBeUndefined()
+    store.getState().setCustomAgentLabel(PANE, 'Frontend')
+    expect(store.getState().agentStatusByPaneKey[PANE].customAgentLabel).toBe('Frontend')
+    // Clearing reverts the field to absent.
+    store.getState().setCustomAgentLabel(PANE, null)
+    expect(store.getState().agentStatusByPaneKey[PANE].customAgentLabel).toBeUndefined()
+  })
+
+  it('setCustomAgentLabel updates a retained entry', () => {
+    const store = createTestStore()
+    const now = Date.now()
+    const entry: AgentStatusEntry = {
+      state: 'done',
+      prompt: 'finished',
+      updatedAt: now,
+      stateStartedAt: now,
+      paneKey: PANE,
+      stateHistory: []
+    }
+    const retained: RetainedAgentEntry = {
+      entry,
+      worktreeId: 'wt-1',
+      tab: makeTab({ id: 'tab-1', worktreeId: 'wt-1', title: 'claude' }),
+      agentType: 'claude',
+      startedAt: now
+    }
+    store.getState().retainAgents([retained])
+    store.getState().setCustomAgentLabel(PANE, 'Retained label')
+    expect(store.getState().retainedAgentsByPaneKey[PANE].entry.customAgentLabel).toBe(
+      'Retained label'
+    )
+  })
+
+  it('does not clobber a re-stamped label when a later set push arrives', () => {
+    const store = createTestStore()
+    // Main re-stamps the label from its map on every push, so a follow-up push
+    // carries the same label rather than dropping it.
+    store.getState().setAgentStatus(PANE, {
+      state: 'working',
+      prompt: 'turn 1',
+      agentType: 'claude',
+      customAgentLabel: 'Sticky'
+    })
+    store.getState().setAgentStatus(
+      PANE,
+      {
+        state: 'done',
+        prompt: 'turn 1',
+        agentType: 'claude',
+        customAgentLabel: 'Sticky'
+      },
+      undefined,
+      { updatedAt: Date.now() + 10 }
+    )
+    expect(store.getState().agentStatusByPaneKey[PANE].customAgentLabel).toBe('Sticky')
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -122,7 +122,10 @@ export type AgentStatusSlice = {
   /** Update or insert an agent status entry from a status payload. */
   setAgentStatus: (
     paneKey: string,
-    payload: ParsedAgentStatusPayload & { orchestration?: AgentStatusOrchestrationContext },
+    payload: ParsedAgentStatusPayload & {
+      orchestration?: AgentStatusOrchestrationContext
+      customAgentLabel?: string
+    },
     terminalTitle?: string,
     timing?: { updatedAt?: number; stateStartedAt?: number },
     routing?: { tabId?: string; worktreeId?: string; terminalHandle?: string },
@@ -149,6 +152,12 @@ export type AgentStatusSlice = {
   setRuntimeAgentOrchestrationByPaneKey: (
     entries: Record<string, AgentStatusOrchestrationContext>
   ) => void
+
+  /** Set or clear the per-agent custom label (from the `ui:setAgentLabel` push).
+   *  Updates the live entry and any retained snapshot for the pane so the
+   *  sidebar/dashboard reflect it immediately without waiting for the next
+   *  status push. */
+  setCustomAgentLabel: (paneKey: string, label: string | null) => void
 
   setMigrationUnsupportedPty: (entry: MigrationUnsupportedPtyEntry) => void
   clearMigrationUnsupportedPty: (ptyId: string) => void
@@ -881,6 +890,46 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       })
     },
 
+    setCustomAgentLabel: (paneKey, label) => {
+      // Why: normalize empty/whitespace to undefined so the field is absent
+      // (matches main, where a cleared label is no field at all) and clearing
+      // reverts the row to its auto-derived text.
+      const nextLabel = label && label.trim().length > 0 ? label : undefined
+      set((s) => {
+        let nextLive = s.agentStatusByPaneKey
+        let liveChanged = false
+        let nextRetained = s.retainedAgentsByPaneKey
+        let retainedChanged = false
+
+        const liveEntry = nextLive[paneKey]
+        if (liveEntry && liveEntry.customAgentLabel !== nextLabel) {
+          nextLive = { ...nextLive, [paneKey]: { ...liveEntry, customAgentLabel: nextLabel } }
+          liveChanged = true
+        }
+
+        const retainedEntry = nextRetained[paneKey]
+        if (retainedEntry && retainedEntry.entry.customAgentLabel !== nextLabel) {
+          nextRetained = {
+            ...nextRetained,
+            [paneKey]: {
+              ...retainedEntry,
+              entry: { ...retainedEntry.entry, customAgentLabel: nextLabel }
+            }
+          }
+          retainedChanged = true
+        }
+
+        if (!liveChanged && !retainedChanged) {
+          return s
+        }
+        return {
+          ...(liveChanged ? { agentStatusByPaneKey: nextLive } : {}),
+          ...(retainedChanged ? { retainedAgentsByPaneKey: nextRetained } : {}),
+          ...(liveChanged ? { agentStatusEpoch: s.agentStatusEpoch + 1 } : {})
+        }
+      })
+    },
+
     registerAgentLaunchConfig: (paneKey, launchConfig, metadata) => {
       set((s) => {
         const copiedLaunchConfig = copyLaunchConfig(launchConfig)
@@ -1152,7 +1201,12 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           // already clamps it to `undefined` for non-done states, so writing
           // the field through directly preserves truth for done and resets
           // it when a new turn starts (working → Stop reprices it).
-          interrupted: payload.interrupted
+          interrupted: payload.interrupted,
+          // Why: main re-stamps the label from its map on every push, so write
+          // it through directly (no existing fallback). A push that lacks the
+          // field genuinely means "no label", and setCustomAgentLabel handles
+          // immediate local updates between status pushes.
+          customAgentLabel: payload.customAgentLabel
         }
         if (
           isAgentCompletionState(entry.state) &&

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2207,6 +2207,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     replyTerminalCreate: () => {},
     onSplitTerminal: () => noopUnsubscribe,
     onRenameTerminal: () => noopUnsubscribe,
+    onSetAgentLabel: () => noopUnsubscribe,
     onFocusTerminal: () => noopUnsubscribe,
     onFocusEditorTab: () => noopUnsubscribe,
     onCloseSessionTab: () => noopUnsubscribe,

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -129,6 +129,10 @@ export type AgentStatusEntry = {
   /** Provider-owned conversation/session id captured from hook payloads.
    *  Used only for exact CLI resume; Orca terminal ids are not agent-session ids. */
   providerSession?: AgentProviderSessionMetadata
+  /** Explicit per-agent sidebar label set via `orca agent label set`. Wins over
+   *  orchestration display name / task title / prompt at the row-label read site.
+   *  Independent of orchestration metadata so it works for non-orchestrated agents. */
+  customAgentLabel?: string
 }
 
 export type MigrationUnsupportedPtyEntry = {
@@ -193,6 +197,10 @@ export type AgentStatusIpcPayload = ParsedAgentStatusPayload & {
   stateStartedAt: number
   orchestration?: AgentStatusOrchestrationContext
   providerSession?: AgentProviderSessionMetadata
+  /** Explicit per-agent label, re-stamped from main's `customLabelByPaneKey` map
+   *  on every emission (snapshot pull and live push) so a remote-ingested push
+   *  that lacks the field never erases a locally-set label. */
+  customAgentLabel?: string
 }
 
 /** Maximum character length for the prompt field. Truncated on parse. */

--- a/src/shared/orchestration-task-display.ts
+++ b/src/shared/orchestration-task-display.ts
@@ -29,7 +29,9 @@ function deriveTaskTitleFromSpec(spec: string): string {
   return normalizeSingleLine(spec, ORCHESTRATION_TASK_TITLE_MAX_LENGTH)
 }
 
-function normalizeSingleLine(value: string | null | undefined, maxLength: number): string {
+/** Collapse whitespace to single spaces, trim, and cap to `maxLength` (with an
+ *  ellipsis). Shared so per-agent labels normalize identically to task titles. */
+export function normalizeSingleLine(value: string | null | undefined, maxLength: number): string {
   if (!value) {
     return ''
   }

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -432,6 +432,14 @@ export type RuntimeTerminalRename = {
   title: string | null
 }
 
+export type RuntimeAgentLabel = {
+  /** Echoed so a mis-target (wrong active terminal fallback) is visible. */
+  terminalHandle: string
+  paneKey: string
+  /** Normalized label, or null when cleared. */
+  label: string | null
+}
+
 export type RuntimeTerminalSend = {
   handle: string
   accepted: boolean
@@ -518,6 +526,10 @@ export type RuntimeWorktreeAgentRow = {
   taskTitle: string | null
   /** Explicit UI label for orchestration task rows, or null outside dispatch. */
   displayName: string | null
+  /** Explicit per-agent label set via `orca agent label set`, or null. Distinct
+   *  from displayName/taskTitle: consumers branching on those for orchestration
+   *  metadata must not get false positives for manually-labeled agents. */
+  customAgentLabel: string | null
   lastAssistantMessage: string | null
   toolName: string | null
   toolInput: string | null


### PR DESCRIPTION
## What changes

Adds a CLI command to give each agent a custom, scannable sidebar label:

```
orca agent label set   --terminal <handle> --label "Riset AI"
orca agent label clear --terminal <handle>
```

When you run multiple agents in **one** worktree, the sidebar previously rendered each agent row as a truncated preview of its first prompt — there was no way to tell them apart at a glance. This command lets you set a stable per-agent label that:

- becomes that agent's **sidebar row label** (replacing the truncated prompt preview), and
- appears in `orca worktree ps --json` as a new dedicated `customAgentLabel` field.

`clear` reverts the row to the auto-derived preview.

## What does NOT change

- This is the **CLI** path only. The in-app right-click / hotkey affordance sketched in the issue body is intentionally out of scope.
- `displayName` / `taskTitle` in `worktree ps --json` stay **orchestration-only** — the custom label is a separate field, so scripts can still distinguish a user-set label from orchestration-assigned metadata.
- Worktree-level `display-name`/`comment` and terminal tab `customTitle` (`terminal rename`) behavior are untouched.

## Design approach

The label is stored per-pane (keyed by `paneKey`) in the agent hook server, which is the single main-side source of truth that already feeds both the renderer sidebar and `worktree ps`. It is plumbed through the existing `AgentStatusIpcPayload` and surfaced at both read sites with the precedence:

```
customAgentLabel  >  orchestration.displayName  >  orchestration.taskTitle  >  prompt
```

- **Persistence:** stored in the existing on-disk last-status file via an **additive** optional `customLabels` key. The file version is deliberately **not** bumped — hydration hard-rejects on a version mismatch, so bumping it would wipe every user's persisted status rows on upgrade. The additive key is ignored by older readers, keeping it backward compatible across version skew. Labels are TTL-pruned (7 days) like the status cache.
- **Lifecycle:** labels are cleared on pane teardown (PTY death, tab close — including label-only panes that never emitted a hook) and retained on live-pane dismiss, so a label never leaks to a genuinely new pane.
- **Live update:** a `ui:setAgentLabel` IPC updates the renderer immediately when attached; headless/`orca serve`/SSH runs rely on the persisted snapshot and **fail closed** across runtimes (a CLI cannot label an agent owned by a different runtime — it returns `agent_pane_not_found`).

## Validation

**Design review:** ran the iterative design-review loop to convergence (3 rounds, both reviewers clean). Key correctness fixes folded in: not bumping the persisted-file version, teardown-scoped label cleanup, and a dedicated JSON field rather than overloading `displayName`.

**Completeness:** read-only verification confirmed all design requirements are implemented in production code, with a corresponding test for each validation item.

**Headline behavior:** **implemented** (not partial/deferred) — verified the production read paths execute the label in both the sidebar (`getAgentRowPrimaryText`) and `worktree ps` row builder.

**Perf audit:** no concerns. Every hot-path addition (per-push label stamp, per-row `ps` lookup) is an O(1) `Map.get`; no-label files serialize byte-identically to before (dedup preserved); no new timers, polling, or leaks.

**Code review:** two independent `review-code` passes. One latent issue fixed: a non-optional field added to `RuntimeWorktreeAgentRow` required updating a mobile mock-row construction site (`mobile/scripts/mobile-lag-scenario.ts`) so the mobile typecheck CI stays green. Remaining notes were non-actionable by design.

**Merge-confidence (live dev build):** confirmed end-to-end on an isolated dev instance — two agents (Claude + Codex) in one worktree, given distinct labels:
- Sidebar rows updated live to the custom labels, replacing the prompt previews; `clear` reverted one row without affecting the other.
- `worktree ps --json` populated `customAgentLabel` per agent while `taskTitle`/`displayName` stayed `null`.
- Mis-target guardrail: both `--json` and human output echo the resolved `terminalHandle` + `paneKey`. Unknown handle returns `agent_pane_not_found`. On-disk file gained the additive `customLabels` key with `version: 2` unchanged.

**Static checks:** `typecheck:node` / `typecheck:cli` / `typecheck:web` clean; oxlint clean; focused vitest green (295 label-related tests across the hook server, renderer store, primary-text precedence, CLI handler, and runtime `worktree ps`).

## Assumptions / residual risk

- **SSH/remote** was not exercised live. The change is an additive optional payload field with no version gate and fails closed across runtimes, so back-compat risk is low, but a live SSH pass was not performed.
- Same-pane agent swaps with no teardown retain the label until cleared (documented, accepted limitation — the leak-to-a-stranger case requires a new pane, which goes through teardown).

Closes #5978

Made with [Orca](https://github.com/stablyai/orca) 🐋


## Update after review (mobile parity)

A reviewer flagged that the label traveled all the way to the `worktree.ps` wire row consumed by the **mobile** client, but the mobile sidebar ignored it. Fixed in a follow-up commit (originally scoped desktop-only — extended because the data already crosses the wire and a user's explicit override should show on every surface, not just desktop):

- `agentDisplayLabel` (mobile) now returns `customAgentLabel` first, matching desktop's `getAgentRowPrimaryText` precedence.
- The mobile row equality comparator (`areAgentRowsEqual`) now compares `customAgentLabel`, so a CLI `agent label set/clear` between two `worktree.ps` polls actually re-renders the row.
- Added mobile tests (label wins / blank label falls through / equality detects a label change). Mobile typecheck and vitest pass.

Also clarified two code comments to match real behavior (the `agent.label.set` schema coercion, and the headless read path).

**Telemetry:** `customAgentLabel` is user-typed free text that mirrors prompt content, so no telemetry event was added — it is intentionally kept off the wire to PostHog, matching the privacy default.
