### PR TITLE
fix(browser): route focused guest zoom shortcuts to page zoom

### DIFF
--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -469,7 +469,7 @@ describe('setupGuestShortcutForwarding', () => {
     }
   })
 
-  it('forwards app zoom shortcuts from focused guest pages', () => {
+  it('forwards browser page zoom shortcuts from focused guest pages', () => {
     setupGuestShortcutForwarding({
       browserTabId,
       guest: makeGuest(),
@@ -497,12 +497,12 @@ describe('setupGuestShortcutForwarding', () => {
     expect(numpadSubtractPreventDefault).toHaveBeenCalledTimes(1)
     expect(resetPreventDefault).toHaveBeenCalledTimes(1)
     expect(repeatPreventDefault).toHaveBeenCalledTimes(1)
-    expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'terminal:zoom', 'in')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'terminal:zoom', 'in')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'terminal:zoom', 'out')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'terminal:zoom', 'out')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'terminal:zoom', 'reset')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'terminal:zoom', 'in')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:zoomBrowserPage', 'in')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:zoomBrowserPage', 'in')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:zoomBrowserPage', 'out')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:zoomBrowserPage', 'out')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:zoomBrowserPage', 'reset')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:zoomBrowserPage', 'in')
   })
 
   it('forwards browser history shortcuts from focused guest pages', () => {
@@ -558,7 +558,7 @@ describe('setupGuestShortcutForwarding', () => {
 
     expect(defaultPreventDefault).not.toHaveBeenCalled()
     expect(customPreventDefault).toHaveBeenCalledTimes(1)
-    expect(rendererSendMock).toHaveBeenCalledWith('terminal:zoom', 'in')
+    expect(rendererSendMock).toHaveBeenCalledWith('ui:zoomBrowserPage', 'in')
   })
 
   it('forwards double-tap window shortcuts from focused guest pages', () => {

--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -414,6 +414,26 @@ describe('setupGuestShortcutForwarding', () => {
     return preventDefault
   }
 
+  function triggerZoomChanged(direction: 'in' | 'out' | 'reset'): ReturnType<typeof vi.fn> {
+    const handler = guestOnMock.mock.calls.find((call) => call[0] === 'zoom-changed')?.[1] as
+      | ((event: Electron.Event, direction: 'in' | 'out' | 'reset') => void)
+      | undefined
+    expect(handler).toBeTypeOf('function')
+    const preventDefault = vi.fn()
+    handler!({ preventDefault } as unknown as Electron.Event, direction)
+    return preventDefault
+  }
+
+  function triggerBeforeMouse(mouse: Electron.MouseInputEvent): ReturnType<typeof vi.fn> {
+    const handler = guestOnMock.mock.calls.find((call) => call[0] === 'before-mouse-event')?.[1] as
+      | ((event: Electron.Event, mouse: Electron.MouseInputEvent) => void)
+      | undefined
+    expect(handler).toBeTypeOf('function')
+    const preventDefault = vi.fn()
+    handler!({ preventDefault } as unknown as Electron.Event, mouse)
+    return preventDefault
+  }
+
   function triggerGuestBlur(): void {
     const handler = guestOnMock.mock.calls.find((call) => call[0] === 'blur')?.[1] as
       | (() => void)
@@ -559,6 +579,72 @@ describe('setupGuestShortcutForwarding', () => {
     expect(defaultPreventDefault).not.toHaveBeenCalled()
     expect(customPreventDefault).toHaveBeenCalledTimes(1)
     expect(rendererSendMock).toHaveBeenCalledWith('ui:zoomBrowserPage', 'in')
+  })
+
+  it('forwards native guest zoom commands to browser page zoom when default zoom keys are bound', () => {
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest: makeGuest(),
+      resolveRenderer: () => makeRenderer()
+    })
+
+    const zoomOutPreventDefault = triggerZoomChanged('out')
+    const zoomInPreventDefault = triggerZoomChanged('in')
+    const resetPreventDefault = triggerZoomChanged('reset')
+
+    expect(zoomOutPreventDefault).toHaveBeenCalledTimes(1)
+    expect(zoomInPreventDefault).toHaveBeenCalledTimes(1)
+    expect(resetPreventDefault).not.toHaveBeenCalled()
+    expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:zoomBrowserPage', 'out')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:zoomBrowserPage', 'in')
+  })
+
+  it('does not double-forward ctrl wheel when Electron also emits a native zoom command', () => {
+    const guest = makeGuest()
+
+    setupGuestMouseWheelZoomForwarding({
+      browserTabId,
+      guest,
+      resolveRenderer: () => makeRenderer()
+    })
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest,
+      resolveRenderer: () => makeRenderer()
+    })
+
+    const wheelPreventDefault = triggerBeforeMouse({
+      type: 'mouseWheel',
+      x: 0,
+      y: 0,
+      deltaY: -120,
+      modifiers: ['ctrl']
+    } as Electron.MouseWheelInputEvent)
+    const zoomCommandPreventDefault = triggerZoomChanged('in')
+
+    expect(wheelPreventDefault).toHaveBeenCalledTimes(1)
+    expect(zoomCommandPreventDefault).toHaveBeenCalledTimes(1)
+    expect(rendererSendMock).toHaveBeenCalledTimes(1)
+    expect(rendererSendMock).toHaveBeenCalledWith('ui:zoomBrowserPage', 'in')
+  })
+
+  it('ignores native guest zoom commands when matching default zoom keys are unbound', () => {
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest: makeGuest(),
+      resolveRenderer: () => makeRenderer(),
+      getKeybindings: () => ({
+        'zoom.in': ['Mod+Alt+Z'],
+        'zoom.out': []
+      })
+    })
+
+    const zoomOutPreventDefault = triggerZoomChanged('out')
+    const zoomInPreventDefault = triggerZoomChanged('in')
+
+    expect(zoomOutPreventDefault).not.toHaveBeenCalled()
+    expect(zoomInPreventDefault).not.toHaveBeenCalled()
+    expect(rendererSendMock).not.toHaveBeenCalled()
   })
 
   it('forwards double-tap window shortcuts from focused guest pages', () => {

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -279,11 +279,11 @@ export function setupGuestShortcutForwarding(args: {
   ): boolean => {
     const keybindings = getKeybindings?.()
     if (action?.type === 'zoom') {
-      // Why: keyboard zoom is Orca chrome zoom. Focused guests bypass the
-      // main-window shortcut path, so forward to the shared renderer zoom router.
+      // Why: focused browser guests own page zoom, but their key events never
+      // reach the renderer-owned webview ref that can apply Orca's page zoom.
       event.preventDefault()
       const renderer = resolveRenderer(browserTabId)
-      renderer?.send('terminal:zoom', action.direction)
+      renderer?.send('ui:zoomBrowserPage', action.direction)
       return true
     }
     if (input.isAutoRepeat) {

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -11,6 +11,7 @@ import {
 import {
   isRecentTabSwitcherCommitRelease,
   matchesRecentTabSwitcherChord,
+  nativeZoomCommandMatchesKeybindings,
   resolveWindowShortcutAction,
   type WindowShortcutInput
 } from '../../shared/window-shortcut-policy'
@@ -29,6 +30,38 @@ type IsMobileEmulatorEnabled = () => boolean
 const CONTROL_MODIFIERS = new Set(['control', 'ctrl'])
 const MAC_COMMAND_MODIFIERS = new Set(['meta', 'command', 'cmd'])
 const WHEEL_ZOOM_BLOCKING_MODIFIERS = new Set(['alt', 'shift'])
+const GUEST_WHEEL_ZOOM_DEDUPE_MS = 250
+
+type GuestWheelZoomDirection = Exclude<BrowserPageZoomDirection, 'reset'>
+
+const recentGuestWheelZoomByGuest = new WeakMap<
+  Electron.WebContents,
+  { direction: GuestWheelZoomDirection; at: number }
+>()
+
+function markGuestWheelZoom(guest: Electron.WebContents, direction: GuestWheelZoomDirection): void {
+  recentGuestWheelZoomByGuest.set(guest, { direction, at: Date.now() })
+}
+
+function consumeRecentGuestWheelZoom(
+  guest: Electron.WebContents,
+  direction: GuestWheelZoomDirection
+): boolean {
+  const recent = recentGuestWheelZoomByGuest.get(guest)
+  if (!recent) {
+    return false
+  }
+  const elapsed = Date.now() - recent.at
+  if (elapsed < 0 || elapsed > GUEST_WHEEL_ZOOM_DEDUPE_MS) {
+    recentGuestWheelZoomByGuest.delete(guest)
+    return false
+  }
+  if (recent.direction !== direction) {
+    return false
+  }
+  recentGuestWheelZoomByGuest.delete(guest)
+  return true
+}
 
 function hasModifier(mouse: Electron.MouseInputEvent, modifiers: ReadonlySet<string>): boolean {
   return mouse.modifiers?.some((modifier) => modifiers.has(modifier)) ?? false
@@ -37,7 +70,7 @@ function hasModifier(mouse: Electron.MouseInputEvent, modifiers: ReadonlySet<str
 export function resolveGuestMouseWheelZoomDirection(
   mouse: Electron.MouseInputEvent,
   platform: NodeJS.Platform = process.platform
-): BrowserPageZoomDirection | null {
+): GuestWheelZoomDirection | null {
   if (mouse.type !== 'mouseWheel') {
     return null
   }
@@ -272,6 +305,15 @@ export function setupGuestShortcutForwarding(args: {
   const resetDoubleTapDetector = (): void => doubleTapDetector.reset()
   type GuestShortcutInput = WindowShortcutInput & { isAutoRepeat?: boolean }
 
+  const forwardBrowserPageZoom = (
+    event: Electron.Event,
+    direction: BrowserPageZoomDirection
+  ): void => {
+    event.preventDefault()
+    const renderer = resolveRenderer(browserTabId)
+    renderer?.send('ui:zoomBrowserPage', direction)
+  }
+
   const forwardShortcutInput = (
     event: Electron.Event,
     input: GuestShortcutInput,
@@ -281,9 +323,7 @@ export function setupGuestShortcutForwarding(args: {
     if (action?.type === 'zoom') {
       // Why: focused browser guests own page zoom, but their key events never
       // reach the renderer-owned webview ref that can apply Orca's page zoom.
-      event.preventDefault()
-      const renderer = resolveRenderer(browserTabId)
-      renderer?.send('ui:zoomBrowserPage', action.direction)
+      forwardBrowserPageZoom(event, action.direction)
       return true
     }
     if (input.isAutoRepeat) {
@@ -514,11 +554,32 @@ export function setupGuestShortcutForwarding(args: {
     forwardShortcutInput(event, input, action)
   }
 
+  const zoomCommandHandler = (
+    event: Electron.Event,
+    zoomDirection: 'in' | 'out' | 'reset'
+  ): void => {
+    if (zoomDirection !== 'in' && zoomDirection !== 'out') {
+      return
+    }
+    // Why: some keyboard layouts/platforms turn Ctrl/Cmd +/- into Electron's
+    // native zoom command before `before-input-event` reaches the guest.
+    if (consumeRecentGuestWheelZoom(guest, zoomDirection)) {
+      event.preventDefault()
+      return
+    }
+    if (!nativeZoomCommandMatchesKeybindings(zoomDirection, process.platform, getKeybindings?.())) {
+      return
+    }
+    forwardBrowserPageZoom(event, zoomDirection)
+  }
+
   guest.on('before-input-event', handler)
+  guest.on('zoom-changed', zoomCommandHandler)
   guest.on('blur', resetDoubleTapDetector)
   return () => {
     try {
       guest.off('before-input-event', handler)
+      guest.off('zoom-changed', zoomCommandHandler)
       guest.off('blur', resetDoubleTapDetector)
     } catch {
       // Why: best-effort — guest may already be destroyed during teardown.
@@ -540,6 +601,7 @@ export function setupGuestMouseWheelZoomForwarding(args: {
     // Why: wheel input over a focused webview does not reach renderer DOM
     // handlers, so consume it here and forward to the existing page-zoom path.
     event.preventDefault()
+    markGuestWheelZoom(guest, direction)
     resolveRenderer(browserTabId)?.send('ui:zoomBrowserPage', direction)
   }
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -25,6 +25,7 @@ import { isCrashReportReason } from '../../shared/crash-reporting'
 import {
   getWindowShortcutActionId,
   matchesRecentTabSwitcherChord,
+  nativeZoomCommandMatchesKeybindings,
   resolveWindowShortcutAction,
   windowShortcutActionCapturesTerminal,
   type WindowShortcutAction
@@ -34,7 +35,6 @@ import {
   toModifierDoubleTapEvent
 } from '../../shared/modifier-double-tap-detector'
 import {
-  keybindingMatchesAction,
   normalizeTerminalShortcutPolicy,
   type KeybindingMatchOptions,
   type KeybindingOverrides
@@ -58,38 +58,6 @@ function forceRepaint(window: BrowserWindow): void {
       window.setSize(width, height)
     }
   }, 32)
-}
-
-function nativeZoomCommandMatchesKeybindings(
-  direction: 'in' | 'out',
-  platform: NodeJS.Platform,
-  keybindings?: KeybindingOverrides,
-  options: KeybindingMatchOptions = {}
-): boolean {
-  const primary =
-    platform === 'darwin' ? { meta: true, control: false } : { meta: false, control: true }
-  const actionId = direction === 'in' ? 'zoom.in' : 'zoom.out'
-  const candidates =
-    direction === 'in'
-      ? [
-          { key: '=', code: 'Equal', shift: false },
-          { key: '+', code: 'Equal', shift: true },
-          { key: 'Add', code: 'NumpadAdd', shift: false }
-        ]
-      : [
-          { key: '-', code: 'Minus', shift: false },
-          { key: 'Subtract', code: 'NumpadSubtract', shift: false }
-        ]
-
-  return candidates.some((candidate) =>
-    keybindingMatchesAction(
-      actionId,
-      { ...primary, alt: false, ...candidate },
-      platform,
-      keybindings,
-      options
-    )
-  )
 }
 
 function isMacAppPasteInput(input: Electron.Input): boolean {

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -132,6 +132,38 @@ function actionMatches(
   return keybindingMatchesAction(actionId, input, platform, keybindings, options)
 }
 
+export function nativeZoomCommandMatchesKeybindings(
+  direction: 'in' | 'out',
+  platform: NodeJS.Platform,
+  keybindings?: KeybindingOverrides,
+  options: KeybindingMatchOptions = {}
+): boolean {
+  const primary =
+    platform === 'darwin' ? { meta: true, control: false } : { meta: false, control: true }
+  const actionId = direction === 'in' ? 'zoom.in' : 'zoom.out'
+  const candidates =
+    direction === 'in'
+      ? [
+          { key: '=', code: 'Equal', shift: false },
+          { key: '+', code: 'Equal', shift: true },
+          { key: 'Add', code: 'NumpadAdd', shift: false }
+        ]
+      : [
+          { key: '-', code: 'Minus', shift: false },
+          { key: 'Subtract', code: 'NumpadSubtract', shift: false }
+        ]
+
+  return candidates.some((candidate) =>
+    keybindingMatchesAction(
+      actionId,
+      { ...primary, alt: false, ...candidate },
+      platform,
+      keybindings,
+      options
+    )
+  )
+}
+
 export function resolveWindowShortcutAction(
   input: WindowShortcutInput,
   platform: NodeJS.Platform,


### PR DESCRIPTION
## Summary
- Route zoom shortcuts from focused browser guest pages to the browser page zoom IPC path
- Keep the existing shortcut keybinding resolution and prevent-default behavior
- Update guest shortcut coverage for default and customized zoom bindings

Closes #6652

## Testing
- pnpm exec vitest run src/main/browser/browser-guest-ui.test.ts --config config/vitest.config.ts
- pnpm exec oxlint src/main/browser/browser-guest-ui.ts src/main/browser/browser-guest-ui.test.ts
- pnpm exec oxfmt --check src/main/browser/browser-guest-ui.ts src/main/browser/browser-guest-ui.test.ts
- pnpm run lint
- pnpm run typecheck
- git diff --check