### PR TITLE
Add Update Cooldown setting to delay auto-update offers

### DIFF
--- a/src/main/ipc/settings.test.ts
+++ b/src/main/ipc/settings.test.ts
@@ -306,6 +306,31 @@ describe('registerSettingsHandlers', () => {
     )
   })
 
+  it('normalizes auto update cooldown days from renderer settings IPC', async () => {
+    store.getSettings.mockReturnValue({ autoUpdateCooldownDays: 0 })
+    store.updateSettings.mockReturnValue({ autoUpdateCooldownDays: 30 })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find((call) => call[0] === 'settings:set')?.[1] as (
+      _event: unknown,
+      args: unknown
+    ) => Promise<unknown>
+
+    await handler(settingsInvokeEvent, { autoUpdateCooldownDays: 31.8 })
+
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      { autoUpdateCooldownDays: 30 },
+      { notifyListeners: true, originWebContentsId: 1 }
+    )
+
+    store.updateSettings.mockClear()
+    await handler(settingsInvokeEvent, { autoUpdateCooldownDays: Number.NaN })
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      { autoUpdateCooldownDays: 0 },
+      { notifyListeners: true, originWebContentsId: 1 }
+    )
+  })
+
   it('normalizes custom terminal themes from renderer settings IPC', async () => {
     store.getSettings.mockReturnValue({ terminalCustomThemes: [] })
     store.updateSettings.mockReturnValue({ terminalCustomThemes: [] })

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -8,6 +8,10 @@ import { setMainUiLanguage } from '../i18n/main-i18n'
 import { rebuildAppMenu } from '../menu/register-app-menu'
 import { track } from '../telemetry/client'
 import { SETTINGS_CHANGED_WHITELIST, type SettingsChangedKey } from '../../shared/telemetry-events'
+import {
+  MAX_AUTO_UPDATE_COOLDOWN_DAYS,
+  MIN_AUTO_UPDATE_COOLDOWN_DAYS
+} from '../../shared/constants'
 import type { AgentAwakeService } from '../agent-awake-service'
 import { sanitizeFloatingWorkspaceDirectorySetting } from './floating-workspace-directory'
 import { applyAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
@@ -94,6 +98,15 @@ export function registerSettingsHandlers(
       sanitizedArgs.terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(
         args.terminalScrollbackRows
       )
+    }
+    if ('autoUpdateCooldownDays' in args) {
+      const value = Number(args.autoUpdateCooldownDays)
+      sanitizedArgs.autoUpdateCooldownDays = Number.isFinite(value)
+        ? Math.min(
+            Math.max(Math.trunc(value), MIN_AUTO_UPDATE_COOLDOWN_DAYS),
+            MAX_AUTO_UPDATE_COOLDOWN_DAYS
+          )
+        : MIN_AUTO_UPDATE_COOLDOWN_DAYS
     }
     if ('uiLanguage' in args) {
       sanitizedArgs.uiLanguage = normalizeUiLanguage(args.uiLanguage)

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -20,6 +20,7 @@ type UpdaterHandlerContext = {
   clearBackgroundCheckLaunchPending: () => void
   clearAvailableUpdateContext: () => void
   consumeMissingManifestPrereleaseFallbackResult: () => { userInitiated: boolean } | null
+  getCooldownHoldActive: () => boolean
   getPublishingWindowLastGoodCheck: () => { lastGoodTag: string } | null
   getMissingManifestPrereleaseFallbackUserInitiated: () => boolean | null
   getCurrentStatus: () => UpdateStatus
@@ -57,6 +58,7 @@ export function registerAutoUpdaterHandlers({
   clearBackgroundCheckLaunchPending,
   clearAvailableUpdateContext,
   consumeMissingManifestPrereleaseFallbackResult,
+  getCooldownHoldActive,
   getPublishingWindowLastGoodCheck,
   getMissingManifestPrereleaseFallbackUserInitiated,
   getCurrentStatus,
@@ -161,7 +163,11 @@ export function registerAutoUpdaterHandlers({
           scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
         }
       }
-      sendStatus({ state: 'not-available', userInitiated: wasUserInitiated || undefined })
+      sendStatus({
+        state: 'not-available',
+        userInitiated: wasUserInitiated || undefined,
+        heldByCooldown: getCooldownHoldActive() || undefined
+      })
       return
     }
 
@@ -233,7 +239,11 @@ export function registerAutoUpdaterHandlers({
         scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
       }
     }
-    sendStatus({ state: 'not-available', userInitiated: wasUserInitiated || undefined })
+    sendStatus({
+      state: 'not-available',
+      userInitiated: wasUserInitiated || undefined,
+      heldByCooldown: getCooldownHoldActive() || undefined
+    })
   })
 
   autoUpdater.on('download-progress', (progress) => {

--- a/src/main/updater-fallback.ts
+++ b/src/main/updater-fallback.ts
@@ -7,7 +7,11 @@ export function statusesEqual(left: UpdateStatus, right: UpdateStatus): boolean 
     case 'checking':
       return right.state === 'checking' && left.userInitiated === right.userInitiated
     case 'not-available':
-      return right.state === 'not-available' && left.userInitiated === right.userInitiated
+      return (
+        right.state === 'not-available' &&
+        left.userInitiated === right.userInitiated &&
+        left.heldByCooldown === right.heldByCooldown
+      )
     case 'available':
       return (
         right.state === 'available' &&

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -8,12 +8,27 @@ vi.mock('electron', () => ({
   net: { fetch: netFetchMock }
 }))
 
-function buildAtomFeed(tags: string[]): string {
-  return `<?xml version="1.0" encoding="UTF-8"?><feed>${tags
-    .map(
-      (tag) =>
-        `<entry><link rel="alternate" type="text/html" href="https://github.com/stablyai/orca/releases/tag/${tag}"/><title>${tag}</title></entry>`
-    )
+type AtomFeedEntry = string | { tag: string; updated?: string }
+
+const OLD_UPDATED_AT = '2026-01-01T00:00:00.000Z'
+
+function getAtomFeedEntryTag(entry: AtomFeedEntry): string {
+  return typeof entry === 'string' ? entry : entry.tag
+}
+
+function buildAtomFeed(entries: AtomFeedEntry[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><feed>${entries
+    .map((entry) => {
+      const tag = getAtomFeedEntryTag(entry)
+      const updated = typeof entry === 'string' ? OLD_UPDATED_AT : entry.updated
+      return [
+        '<entry>',
+        `<link rel="alternate" type="text/html" href="https://github.com/stablyai/orca/releases/tag/${tag}"/>`,
+        `<title>${tag}</title>`,
+        updated === undefined ? '' : `<updated>${updated}</updated>`,
+        '</entry>'
+      ].join('')
+    })
     .join('')}</feed>`
 }
 
@@ -33,7 +48,7 @@ function isPlatformManifestRequest(url: string): boolean {
 }
 
 function respondWithAtom(
-  tags: string[],
+  tags: AtomFeedEntry[],
   missingManifestTags: string[] = [],
   missingAssetTags: string[] = []
 ): void {
@@ -282,6 +297,96 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     await expect(fetchNewerReleaseTagsWithReadiness('1.4.27', 1)).resolves.toEqual({
       tags: [],
       state: 'not-ready'
+    })
+  })
+
+  it('reports cooldown when every newer stable release is too fresh', async () => {
+    respondWithAtom([{ tag: 'v1.4.28', updated: '2026-06-28T00:00:00.000Z' }])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(
+      fetchNewerReleaseTagsWithReadiness('1.4.27', 1, {
+        includePrerelease: false,
+        minReleaseAgeMs: 3 * 24 * 60 * 60 * 1000,
+        nowMs: Date.parse('2026-06-29T00:00:00.000Z')
+      })
+    ).resolves.toEqual({
+      tags: [],
+      state: 'cooldown'
+    })
+  })
+
+  it('returns an older newer release when the newest release is inside the cooldown', async () => {
+    respondWithAtom([
+      { tag: 'v1.4.27', updated: '2026-06-28T00:00:00.000Z' },
+      { tag: 'v1.4.26', updated: '2026-06-20T00:00:00.000Z' }
+    ])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(
+      fetchNewerReleaseTagsWithReadiness('1.4.25', 1, {
+        includePrerelease: false,
+        minReleaseAgeMs: 3 * 24 * 60 * 60 * 1000,
+        nowMs: Date.parse('2026-06-29T00:00:00.000Z')
+      })
+    ).resolves.toEqual({
+      tags: ['v1.4.26'],
+      state: 'ready'
+    })
+  })
+
+  it('returns the newest newer release when all newer releases are aged', async () => {
+    respondWithAtom([
+      { tag: 'v1.4.27', updated: '2026-06-20T00:00:00.000Z' },
+      { tag: 'v1.4.26', updated: '2026-06-19T00:00:00.000Z' }
+    ])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(
+      fetchNewerReleaseTagsWithReadiness('1.4.25', 1, {
+        includePrerelease: false,
+        minReleaseAgeMs: 3 * 24 * 60 * 60 * 1000,
+        nowMs: Date.parse('2026-06-29T00:00:00.000Z')
+      })
+    ).resolves.toEqual({
+      tags: ['v1.4.27'],
+      state: 'ready'
+    })
+  })
+
+  it('keeps existing behavior when no minimum release age is configured', async () => {
+    respondWithAtom([{ tag: 'v1.4.27', updated: '2026-06-28T00:00:00.000Z' }])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(
+      fetchNewerReleaseTagsWithReadiness('1.4.26', 1, {
+        includePrerelease: false,
+        nowMs: Date.parse('2026-06-29T00:00:00.000Z')
+      })
+    ).resolves.toEqual({
+      tags: ['v1.4.27'],
+      state: 'ready'
+    })
+  })
+
+  it('excludes newer candidates with missing updated timestamps while cooldown is active', async () => {
+    respondWithAtom([{ tag: 'v1.4.27' }])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(
+      fetchNewerReleaseTagsWithReadiness('1.4.26', 1, {
+        includePrerelease: false,
+        minReleaseAgeMs: 3 * 24 * 60 * 60 * 1000,
+        nowMs: Date.parse('2026-06-29T00:00:00.000Z')
+      })
+    ).resolves.toEqual({
+      tags: [],
+      state: 'cooldown'
     })
   })
 })

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -10,11 +10,18 @@ vi.mock('electron', () => ({
   net: { fetch: netFetchMock }
 }))
 
+const OLD_UPDATED_AT = '2026-01-01T00:00:00.000Z'
+
 function buildAtomFeed(tags: string[]): string {
   const entries = tags
-    .map(
-      (tag) =>
-        `<entry><link rel="alternate" type="text/html" href="https://github.com/stablyai/orca/releases/tag/${tag}"/><title>${tag}</title></entry>`
+    .map((tag) =>
+      [
+        '<entry>',
+        `<link rel="alternate" type="text/html" href="https://github.com/stablyai/orca/releases/tag/${tag}"/>`,
+        `<title>${tag}</title>`,
+        `<updated>${OLD_UPDATED_AT}</updated>`,
+        '</entry>'
+      ].join('')
     )
     .join('')
   return `<?xml version="1.0" encoding="UTF-8"?><feed>${entries}</feed>`

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -10,7 +10,9 @@ const MAX_MANIFEST_PROBE_CANDIDATES = 6
 // Why: GitHub's atom feed lists every release (prerelease or stable) in a
 // single flat list. Each entry has a /releases/tag/<tag> URL we can mine
 // without any channel filtering.
-const TAG_HREF_RE = /href="https:\/\/github\.com\/stablyai\/orca\/releases\/tag\/([^"]+)"/g
+const TAG_HREF_RE = /href="https:\/\/github\.com\/stablyai\/orca\/releases\/tag\/([^"]+)"/
+const ENTRY_RE = /<entry\b[\s\S]*?<\/entry>/gi
+const UPDATED_RE = /<updated>([^<]+)<\/updated>/i
 
 export function getReleaseDownloadUrl(tag: string): string {
   return `${RELEASES_DOWNLOAD_BASE}/${encodeURIComponent(tag)}`
@@ -41,6 +43,7 @@ export function normalizeTagToVersion(tag: string): string {
 type ReleaseFeedTag = {
   tag: string
   version: string
+  publishedAtMs: number | null
 }
 
 async function fetchReleaseFeedTags(): Promise<ReleaseFeedTag[] | null> {
@@ -55,11 +58,19 @@ async function fetchReleaseFeedTags(): Promise<ReleaseFeedTag[] | null> {
     const body = await res.text()
     const tags: ReleaseFeedTag[] = []
 
-    for (const match of body.matchAll(TAG_HREF_RE)) {
-      const tag = match[1]
+    for (const [entry] of body.matchAll(ENTRY_RE)) {
+      const tag = entry.match(TAG_HREF_RE)?.[1]
+      if (!tag) {
+        continue
+      }
       const version = normalizeTagToVersion(tag)
       if (isValidVersion(version)) {
-        tags.push({ tag, version })
+        const publishedAtMs = Date.parse(entry.match(UPDATED_RE)?.[1] ?? '')
+        tags.push({
+          tag,
+          version,
+          publishedAtMs: Number.isFinite(publishedAtMs) ? publishedAtMs : null
+        })
       }
     }
 
@@ -156,11 +167,13 @@ async function hasReadyPlatformManifest(tag: string): Promise<boolean> {
  */
 type FetchNewerReleaseTagOptions = {
   includePrerelease?: boolean
+  minReleaseAgeMs?: number
+  nowMs?: number
 }
 
 export type FetchNewerReleaseTagsResult = {
   tags: string[]
-  state: 'ready' | 'no-newer' | 'not-ready' | 'unavailable'
+  state: 'ready' | 'no-newer' | 'not-ready' | 'unavailable' | 'cooldown'
   lastGoodTag?: string
 }
 
@@ -200,12 +213,28 @@ export async function fetchNewerReleaseTagsWithReadiness(
     return { tags: [], state: 'no-newer' }
   }
 
+  const minReleaseAgeMs = options.minReleaseAgeMs ?? 0
+  const nowMs = options.nowMs ?? Date.now()
+  const releaseCandidates =
+    minReleaseAgeMs > 0
+      ? candidates
+          .slice(newestNewerIndex)
+          .filter(({ version }) => compareVersions(version, currentVersion) > 0)
+          .filter(({ publishedAtMs }) => {
+            if (publishedAtMs === null) {
+              return false
+            }
+            return nowMs - publishedAtMs >= minReleaseAgeMs
+          })
+      : candidates.slice(newestNewerIndex)
+
+  if (minReleaseAgeMs > 0 && releaseCandidates.length === 0) {
+    return { tags: [], state: 'cooldown' }
+  }
+
   // Why: a cancelled release can leave several feed entries without manifests,
   // but update checks must not stall on an unbounded run of 5s probes.
-  const probeCandidates = candidates.slice(
-    newestNewerIndex,
-    newestNewerIndex + MAX_MANIFEST_PROBE_CANDIDATES
-  )
+  const probeCandidates = releaseCandidates.slice(0, MAX_MANIFEST_PROBE_CANDIDATES)
   const manifestResults = await Promise.all(
     probeCandidates.map(async ({ tag, version }) => ({
       tag,

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -885,9 +885,14 @@ describe('updater', () => {
     resolveStableCheck()
 
     await vi.waitFor(() => {
-      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.35', 2, {
-        includePrerelease: true
-      })
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(
+        '1.4.35',
+        2,
+        expect.objectContaining({
+          includePrerelease: true,
+          minReleaseAgeMs: undefined
+        })
+      )
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
     })
     expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
@@ -999,9 +1004,14 @@ describe('updater', () => {
     checkForUpdatesFromMenu({ includePrerelease: true })
 
     await vi.waitFor(() => {
-      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17', 2, {
-        includePrerelease: true
-      })
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(
+        '1.3.17',
+        2,
+        expect.objectContaining({
+          includePrerelease: true,
+          minReleaseAgeMs: undefined
+        })
+      )
       expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
         provider: 'generic',
         url: 'https://github.com/stablyai/orca/releases/download/v1.3.18-rc.1'
@@ -1735,9 +1745,14 @@ describe('updater', () => {
     checkForUpdatesFromMenu()
 
     await vi.waitFor(() => {
-      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17-rc.1', 2, {
-        includePrerelease: true
-      })
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(
+        '1.3.17-rc.1',
+        2,
+        expect.objectContaining({
+          includePrerelease: true,
+          minReleaseAgeMs: undefined
+        })
+      )
       expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
         provider: 'generic',
         url: 'https://github.com/stablyai/orca/releases/download/v1.3.17-rc.2'
@@ -1791,6 +1806,197 @@ describe('updater', () => {
     expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
       provider: 'generic',
       url: 'https://github.com/stablyai/orca/releases/latest/download'
+    })
+  })
+
+  it('passes a minimum release age for ordinary background checks', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-29T12:00:00.000Z'))
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'no-newer' })
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    const mainWindow = { webContents: { send: vi.fn() } }
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => null,
+      getAutoUpdateCooldownDays: () => 3
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.0.51', 1, {
+        includePrerelease: false,
+        minReleaseAgeMs: 3 * 24 * 60 * 60 * 1000,
+        nowMs: Date.parse('2026-06-29T12:00:00.000Z')
+      })
+    })
+  })
+
+  it('bypasses cooldown for manual, prerelease, and nudge-triggered checks', async () => {
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'no-newer' })
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    const mainWindow = { webContents: { send: vi.fn() } }
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getAutoUpdateCooldownDays: () => 7
+    })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(
+        '1.0.51',
+        1,
+        expect.objectContaining({
+          includePrerelease: false,
+          minReleaseAgeMs: undefined
+        })
+      )
+    })
+
+    vi.resetModules()
+    autoUpdaterMock.reset()
+    fetchNewerReleaseTagsMock.mockReset().mockResolvedValue({ tags: [], state: 'no-newer' })
+    appMock.getVersion.mockReturnValue('1.0.52-rc.1')
+
+    const { setupAutoUpdater: setupPrereleaseUpdater } = await import('./updater')
+    setupPrereleaseUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => null,
+      getAutoUpdateCooldownDays: () => 7
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(
+        '1.0.52-rc.1',
+        2,
+        expect.objectContaining({
+          includePrerelease: true,
+          minReleaseAgeMs: undefined
+        })
+      )
+    })
+
+    vi.resetModules()
+    autoUpdaterMock.reset()
+    appMock.getVersion.mockReturnValue('1.0.51')
+    fetchNudgeMock.mockResolvedValue({ id: 'campaign-1', minVersion: '1.0.0' })
+    shouldApplyNudgeMock.mockReturnValue(true)
+    fetchNewerReleaseTagsMock.mockReset().mockResolvedValue({ tags: [], state: 'no-newer' })
+
+    const { setupAutoUpdater: setupNudgeUpdater } = await import('./updater')
+    setupNudgeUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getPendingUpdateNudgeId: () => null,
+      getDismissedUpdateNudgeId: () => null,
+      setPendingUpdateNudgeId: vi.fn(),
+      getAutoUpdateCooldownDays: () => 7
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(
+        '1.0.51',
+        1,
+        expect.objectContaining({
+          includePrerelease: false,
+          minReleaseAgeMs: undefined
+        })
+      )
+    })
+  })
+
+  it('pins to the current release and tags not-available while held by cooldown', async () => {
+    fetchNewerReleaseTagsMock
+      .mockResolvedValueOnce({ tags: [], state: 'cooldown' })
+      .mockResolvedValueOnce({ tags: [], state: 'no-newer' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-not-available')
+      })
+      return Promise.resolve(undefined)
+    })
+    const sendMock = vi.fn()
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    const mainWindow = { webContents: { send: sendMock } }
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => null,
+      getAutoUpdateCooldownDays: () => 3
+    })
+    const feedCallsBeforePreflight = autoUpdaterMock.setFeedURL.mock.calls.length
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'not-available',
+        userInitiated: undefined,
+        heldByCooldown: true
+      })
+    })
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.0.51'
+    })
+    expect(
+      autoUpdaterMock.setFeedURL.mock.calls.slice(feedCallsBeforePreflight)
+    ).not.toContainEqual([
+      {
+        provider: 'generic',
+        url: 'https://github.com/stablyai/orca/releases/latest/download'
+      }
+    ])
+
+    sendMock.mockClear()
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'not-available',
+        userInitiated: true,
+        heldByCooldown: undefined
+      })
+    })
+  })
+
+  it('clears stale cooldown holds before a later no-newer cycle emits', async () => {
+    vi.useFakeTimers()
+    fetchNewerReleaseTagsMock
+      .mockResolvedValueOnce({ tags: [], state: 'cooldown' })
+      .mockResolvedValueOnce({ tags: [], state: 'no-newer' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      if (autoUpdaterMock.checkForUpdates.mock.calls.length === 1) {
+        return new Promise(() => {})
+      }
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-not-available')
+      })
+      return Promise.resolve(undefined)
+    })
+    const sendMock = vi.fn()
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    const mainWindow = { webContents: { send: sendMock } }
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => null,
+      getAutoUpdateCooldownDays: () => 3
+    })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+    await vi.advanceTimersByTimeAsync(45 * 1000)
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'not-available',
+        userInitiated: undefined,
+        heldByCooldown: undefined
+      })
     })
   })
 
@@ -2885,9 +3091,14 @@ describe('updater', () => {
     checkForUpdatesFromMenu()
 
     await vi.waitFor(() => {
-      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17', 1, {
-        includePrerelease: false
-      })
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(
+        '1.3.17',
+        1,
+        expect.objectContaining({
+          includePrerelease: false,
+          minReleaseAgeMs: undefined
+        })
+      )
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
     })
     expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
@@ -2912,9 +3123,14 @@ describe('updater', () => {
     checkForUpdatesFromMenu({ includePrerelease: true })
 
     await vi.waitFor(() => {
-      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17', 2, {
-        includePrerelease: true
-      })
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(
+        '1.3.17',
+        2,
+        expect.objectContaining({
+          includePrerelease: true,
+          minReleaseAgeMs: undefined
+        })
+      )
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
     })
     expect(autoUpdaterMock.allowPrerelease).toBe(true)

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -3,6 +3,7 @@ import { app, BrowserWindow, powerMonitor } from 'electron'
 import type { NsisUpdater } from 'electron-updater'
 import { is } from '@electron-toolkit/utils'
 import type { UpdateStatus } from '../shared/types'
+import { MAX_AUTO_UPDATE_COOLDOWN_DAYS, MIN_AUTO_UPDATE_COOLDOWN_DAYS } from '../shared/constants'
 import { killAllPty } from './ipc/pty'
 import { withUpdaterSpan } from './observability/instrumentation'
 import { loadElectronAutoUpdater, type ElectronAutoUpdater } from './electron-updater-loader'
@@ -32,6 +33,7 @@ type PrimaryEventSuppression = { failureKey: string; error: unknown }
 
 const AUTO_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
 const AUTO_UPDATE_RETRY_INTERVAL_MS = 60 * 60 * 1000
+const MS_PER_DAY = 24 * 60 * 60 * 1000
 const NUDGE_POLL_INTERVAL_MS = 30 * 60 * 1000
 const NUDGE_ACTIVATION_COOLDOWN_MS = 5 * 60 * 1000
 const QUIT_AND_INSTALL_DELAY_MS = 100
@@ -58,6 +60,7 @@ let pendingQuitAndInstallTimer: ReturnType<typeof setTimeout> | null = null
 let quitAndInstallInProgress = false
 let persistLastUpdateCheckAt: ((timestamp: number) => void) | null = null
 let _getLastUpdateCheckAt: (() => number | null) | null = null
+let _getAutoUpdateCooldownDays: (() => number) | null = null
 let backgroundCheckLaunchPending = false
 // Why: a manually promoted background check can emit an error event before the
 // paired promise catch runs; keep the promotion attached to that launch.
@@ -75,6 +78,7 @@ let awaitingNudgeCheckOutcome = false
 let nudgeCheckInFlight = false
 let lastNudgeCheckAt = 0
 let publishingWindowLastGoodCheck: { lastGoodTag: string } | null = null
+let cooldownHoldActive = false
 let pendingPrereleaseFallback: {
   primaryTag: string
   fallbackTag: string
@@ -136,6 +140,21 @@ function clearPublishingWindowLastGoodCheck(): void {
 
 function getPublishingWindowLastGoodCheck(): { lastGoodTag: string } | null {
   return publishingWindowLastGoodCheck
+}
+
+function getCooldownHoldActive(): boolean {
+  return cooldownHoldActive
+}
+
+function getAutoUpdateCooldownDays(): number {
+  const rawCooldownDays = _getAutoUpdateCooldownDays?.() ?? 0
+  if (!Number.isFinite(rawCooldownDays)) {
+    return MIN_AUTO_UPDATE_COOLDOWN_DAYS
+  }
+  return Math.min(
+    Math.max(Math.trunc(rawCooldownDays), MIN_AUTO_UPDATE_COOLDOWN_DAYS),
+    MAX_AUTO_UPDATE_COOLDOWN_DAYS
+  )
 }
 
 function getPersistedPendingUpdateNudgeId(): string | null {
@@ -769,7 +788,7 @@ function markMissingManifestPrereleaseFallbackPromiseHandled(message: string): v
   )
 }
 
-async function pinDefaultReleaseFeed(): Promise<void> {
+async function pinDefaultReleaseFeed(opts: { bypassCooldown?: boolean } = {}): Promise<void> {
   const autoUpdater = getAutoUpdater()
   // Why: the /releases/latest/download/ redirect can move between the update
   // check and the later manual download click. Pinning to the concrete tag
@@ -779,11 +798,16 @@ async function pinDefaultReleaseFeed(): Promise<void> {
   // newer RC or the next stable. Stable users should only resolve stable tags.
   const currentVersion = app.getVersion()
   const includePrerelease = includePrereleaseActive || isPrereleaseVersion(currentVersion)
+  const cooldownDays = getAutoUpdateCooldownDays()
+  const applyCooldown = !opts.bypassCooldown && !includePrerelease && cooldownDays > 0
+  cooldownHoldActive = false
   const releaseTagsResult = await fetchNewerReleaseTagsWithReadiness(
     currentVersion,
     includePrerelease ? 2 : 1,
     {
-      includePrerelease
+      includePrerelease,
+      minReleaseAgeMs: applyCooldown ? cooldownDays * MS_PER_DAY : undefined,
+      nowMs: Date.now()
     }
   )
   const newerTag = releaseTagsResult.tags[0] ?? null
@@ -832,6 +856,15 @@ async function pinDefaultReleaseFeed(): Promise<void> {
       `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are still publishing`
     )
     throw new Error('Latest release assets are still publishing')
+  } else if (releaseTagsResult.state === 'cooldown') {
+    clearPrereleaseFallbackContext()
+    clearPublishingWindowLastGoodCheck()
+    cooldownHoldActive = true
+    const url = getReleaseDownloadUrl(`v${currentVersion}`)
+    console.info(
+      `[updater] release feed held by cooldown: current=${currentVersion} cooldownDays=${cooldownDays}`
+    )
+    autoUpdater.setFeedURL({ provider: 'generic', url })
   } else {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()
@@ -936,7 +969,7 @@ function runBackgroundUpdateCheck(
     markUpdateCheckLaunched(attemptId)
     return autoUpdater.checkForUpdates()
   }
-  const run = pinDefaultReleaseFeed().then(launch)
+  const run = pinDefaultReleaseFeed({ bypassCooldown: awaitingNudgeCheckOutcome }).then(launch)
   void Promise.resolve(run)
     .then(() => handleSettledUpdateCheckPromise(attemptId))
     .catch((err) => {
@@ -1026,7 +1059,7 @@ export function checkForUpdatesFromMenu(options?: { includePrerelease?: boolean 
     markUpdateCheckLaunched(attemptId)
     return autoUpdater.checkForUpdates()
   }
-  const run = pinDefaultReleaseFeed().then(launch)
+  const run = pinDefaultReleaseFeed({ bypassCooldown: true }).then(launch)
   void Promise.resolve(run)
     .then(() => handleSettledUpdateCheckPromise(attemptId))
     .catch((err) => {
@@ -1136,6 +1169,7 @@ export function setupAutoUpdater(
   mainWindow: BrowserWindow,
   opts?: {
     getLastUpdateCheckAt?: () => number | null
+    getAutoUpdateCooldownDays?: () => number
     onBeforeQuit?: () => void | Promise<void>
     setLastUpdateCheckAt?: (timestamp: number) => void
     getPendingUpdateNudgeId?: () => string | null
@@ -1148,6 +1182,7 @@ export function setupAutoUpdater(
   onBeforeQuitCleanup = opts?.onBeforeQuit ?? null
   persistLastUpdateCheckAt = opts?.setLastUpdateCheckAt ?? null
   _getLastUpdateCheckAt = opts?.getLastUpdateCheckAt ?? null
+  _getAutoUpdateCooldownDays = opts?.getAutoUpdateCooldownDays ?? null
   _getPendingUpdateNudgeId = opts?.getPendingUpdateNudgeId ?? null
   _getDismissedUpdateNudgeId = opts?.getDismissedUpdateNudgeId ?? null
   _setPendingUpdateNudgeId = opts?.setPendingUpdateNudgeId ?? null
@@ -1210,6 +1245,7 @@ export function setupAutoUpdater(
     autoUpdater,
     clearAvailableUpdateContext,
     consumeMissingManifestPrereleaseFallbackResult,
+    getCooldownHoldActive,
     getMissingManifestPrereleaseFallbackUserInitiated,
     getPublishingWindowLastGoodCheck,
     getActiveUpdateCheckEventAttemptId,

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -258,6 +258,23 @@ describe('attachMainWindowServices', () => {
     expect(store.flush).toHaveBeenCalledTimes(1)
   })
 
+  it('wires the live auto update cooldown setting into the auto-updater', () => {
+    let autoUpdateCooldownDays: number | undefined = 4
+    const store = {
+      ...createStore(),
+      getSettings: vi.fn(() => ({ autoUpdateCooldownDays }))
+    }
+
+    attachMainWindowServices(createMainWindow() as never, store as never, createRuntime() as never)
+
+    expect(setupAutoUpdaterMock).toHaveBeenCalledTimes(1)
+    const opts = setupAutoUpdaterMock.mock.calls[0][1]
+    expect(opts.getAutoUpdateCooldownDays()).toBe(4)
+
+    autoUpdateCooldownDays = undefined
+    expect(opts.getAutoUpdateCooldownDays()).toBe(0)
+  })
+
   it('flushes the store before update quit when no cleanup is injected', async () => {
     const store = createStore()
 

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -5,6 +5,7 @@ import { app, ipcMain } from 'electron'
 import type { BrowserWindow } from 'electron'
 import type { Store } from '../persistence'
 import type { CreateWorktreeResult, WorktreeStartupLaunch } from '../../shared/types'
+import { DEFAULT_AUTO_UPDATE_COOLDOWN_DAYS } from '../../shared/constants'
 import { registerRepoHandlers } from '../ipc/repos'
 import { registerWorktreeHandlers } from '../ipc/worktrees'
 import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
@@ -118,6 +119,8 @@ export function attachMainWindowServices(
   registerFileDropRelay(mainWindow)
   setupAutoUpdater(mainWindow, {
     getLastUpdateCheckAt: () => store.getUI().lastUpdateCheckAt,
+    getAutoUpdateCooldownDays: () =>
+      store.getSettings().autoUpdateCooldownDays ?? DEFAULT_AUTO_UPDATE_COOLDOWN_DAYS,
     onBeforeQuit: async () => {
       try {
         await options?.onBeforeUpdateQuit?.()

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -190,7 +190,11 @@ export function GeneralPane({
       />
     ) : null,
     matchesSettingsSearch(searchQuery, getGeneralUpdateSearchEntries()) ? (
-      <GeneralUpdateSettingsSection key="updates" />
+      <GeneralUpdateSettingsSection
+        key="updates"
+        settings={settings}
+        updateSettings={updateSettings}
+      />
     ) : null
     // Note: the Support section is rendered outside this array so it can own
     // its own loading placeholder and its own collapsing Separator. Without

--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -2,14 +2,98 @@ import type React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { Download, Loader2, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
+import type { GlobalSettings } from '../../../../shared/types'
+import {
+  DEFAULT_AUTO_UPDATE_COOLDOWN_DAYS,
+  MAX_AUTO_UPDATE_COOLDOWN_DAYS,
+  MIN_AUTO_UPDATE_COOLDOWN_DAYS
+} from '../../../../shared/constants'
 import { useAppStore } from '../../store'
+import { clampNumber } from '@/lib/terminal-theme'
 import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 
-export function GeneralUpdateSettingsSection(): React.JSX.Element {
+type CooldownDraftState = {
+  sourceDays: number
+  draft: string
+}
+
+function getCooldownDaysSetting(settings: GlobalSettings): number {
+  return settings.autoUpdateCooldownDays ?? DEFAULT_AUTO_UPDATE_COOLDOWN_DAYS
+}
+
+function createCooldownDraftState(days: number): CooldownDraftState {
+  return {
+    sourceDays: days,
+    draft: String(days)
+  }
+}
+
+function resolveCooldownDraftState(
+  state: CooldownDraftState,
+  cooldownDays: number
+): CooldownDraftState {
+  return state.sourceDays === cooldownDays ? state : createCooldownDraftState(cooldownDays)
+}
+
+type GeneralUpdateSettingsSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function GeneralUpdateSettingsSection({
+  settings,
+  updateSettings
+}: GeneralUpdateSettingsSectionProps): React.JSX.Element {
   const updateStatus = useAppStore((s) => s.updateStatus)
+  const cooldownDays = getCooldownDaysSetting(settings)
+  const [cooldownDraftState, setCooldownDraftState] = useState(() =>
+    createCooldownDraftState(cooldownDays)
+  )
+  const resolvedCooldownDraftState = resolveCooldownDraftState(cooldownDraftState, cooldownDays)
+  if (resolvedCooldownDraftState !== cooldownDraftState) {
+    // Why: settings may change from another window; keep the visible draft
+    // aligned with the persisted value before paint.
+    setCooldownDraftState(resolvedCooldownDraftState)
+  }
+  const cooldownDraft = resolvedCooldownDraftState.draft
+
+  const updateCooldownDraft = (draft: string): void => {
+    setCooldownDraftState((current) => ({
+      ...resolveCooldownDraftState(current, cooldownDays),
+      draft
+    }))
+  }
+
+  const commitCooldownDraft = (): void => {
+    const trimmed = cooldownDraft.trim()
+    if (trimmed === '') {
+      setCooldownDraftState(createCooldownDraftState(cooldownDays))
+      return
+    }
+
+    const value = Number(trimmed)
+    if (!Number.isFinite(value)) {
+      setCooldownDraftState(createCooldownDraftState(cooldownDays))
+      return
+    }
+
+    const next = clampNumber(
+      Math.round(value),
+      MIN_AUTO_UPDATE_COOLDOWN_DAYS,
+      MAX_AUTO_UPDATE_COOLDOWN_DAYS
+    )
+    updateSettings({ autoUpdateCooldownDays: next })
+    setCooldownDraftState((current) => ({
+      ...resolveCooldownDraftState(current, cooldownDays),
+      draft: String(next)
+    }))
+  }
+
   // Why: the 'error' variant of UpdateStatus does not carry a `version` field.
   // The main process emits `{ state: 'error' }` for both check failures (no
   // version known yet) and download/install failures (version was known from
@@ -70,6 +154,62 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
           { value0: appVersion ?? '...' }
         )}
       />
+
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.GeneralUpdateSettingsSection.ed46a7cfcf',
+          'Update cooldown'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralUpdateSettingsSection.4c35dc5ec5',
+          'Automatic update checks wait this many days after a stable release is published before offering it. Manual checks ignore the cooldown. Set to 0 to disable. Nothing is installed automatically.'
+        )}
+        keywords={[
+          'cooldown',
+          'security',
+          'supply chain',
+          'delay',
+          'days',
+          'stable',
+          'auto update'
+        ]}
+        className="flex items-center justify-between gap-4 py-2"
+      >
+        <div className="min-w-0 flex-1 space-y-0.5">
+          <Label>
+            {translate(
+              'auto.components.settings.GeneralUpdateSettingsSection.ed46a7cfcf',
+              'Update cooldown'
+            )}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.GeneralUpdateSettingsSection.4c35dc5ec5',
+              'Automatic update checks wait this many days after a stable release is published before offering it. Manual checks ignore the cooldown. Set to 0 to disable. Nothing is installed automatically.'
+            )}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Input
+            type="number"
+            min={MIN_AUTO_UPDATE_COOLDOWN_DAYS}
+            max={MAX_AUTO_UPDATE_COOLDOWN_DAYS}
+            step={1}
+            value={cooldownDraft}
+            onChange={(event) => updateCooldownDraft(event.target.value)}
+            onBlur={commitCooldownDraft}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                commitCooldownDraft()
+              }
+            }}
+            className="number-input-clean w-20 text-right tabular-nums"
+          />
+          <span className="text-xs text-muted-foreground">
+            {translate('auto.components.settings.GeneralUpdateSettingsSection.62d7b3afec', 'days')}
+          </span>
+        </div>
+      </SearchableSetting>
 
       <SearchableSetting
         title={translate(
@@ -186,10 +326,15 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
             </>
           )}
           {updateStatus.state === 'not-available' &&
-            translate(
-              'auto.components.settings.GeneralUpdateSettingsSection.f40d88390d',
-              'You’re on the latest version.'
-            )}
+            (updateStatus.heldByCooldown
+              ? translate(
+                  'auto.components.settings.GeneralUpdateSettingsSection.updateCooldownHeld',
+                  'A newer stable release is available but is being held by your update cooldown. Use Check for Updates to install it now.'
+                )
+              : translate(
+                  'auto.components.settings.GeneralUpdateSettingsSection.f40d88390d',
+                  'You’re on the latest version.'
+                ))}
           {updateStatus.state === 'downloading' &&
             translate(
               'auto.components.settings.GeneralUpdateSettingsSection.2a48034c4c',

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -190,6 +190,46 @@ export const getGeneralUpdateSearchEntries = createLocalizedCatalog(() => [
       ),
       ...translateSearchKeyword('auto.components.settings.general.search.e49e739a59', 'download')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.general.search.updateCooldownTitle',
+      'Update cooldown'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.updateCooldownDescription',
+      'Delay automatic stable update offers for supply-chain safety.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.updateCooldownKeywordCooldown',
+        'cooldown'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.updateCooldownKeywordSecurity',
+        'security'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.updateCooldownKeywordSupplyChain',
+        'supply chain'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.updateCooldownKeywordDelay',
+        'delay'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.updateCooldownKeywordDays',
+        'days'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.updateCooldownKeywordStable',
+        'stable'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.updateCooldownKeywordAutoUpdate',
+        'auto update'
+      )
+    ]
   }
 ])
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5125,7 +5125,11 @@
           "31fd7150cf": "Checking for updates...",
           "3394d1f663": "checking",
           "d69a09b672": "Updates are checked automatically on launch.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "62d7b3afec": "days",
+          "4c35dc5ec5": "Automatic update checks wait this many days after a stable release is published before offering it. Manual checks ignore the cooldown. Set to 0 to disable. Nothing is installed automatically.",
+          "ed46a7cfcf": "Update cooldown",
+          "updateCooldownHeld": "A newer stable release is available but is being held by your update cooldown. Use Check for Updates to install it now."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Choose apps available from a workspace's Open in menu.",
@@ -7232,6 +7236,15 @@
             "f89a94773c": "update",
             "79ff46776e": "Check for app updates and install a newer Orca version.",
             "e15af4eb64": "Check for Updates",
+            "updateCooldownKeywordAutoUpdate": "auto update",
+            "updateCooldownKeywordStable": "stable",
+            "updateCooldownKeywordDays": "days",
+            "updateCooldownKeywordDelay": "delay",
+            "updateCooldownKeywordSupplyChain": "supply chain",
+            "updateCooldownKeywordSecurity": "security",
+            "updateCooldownKeywordCooldown": "cooldown",
+            "updateCooldownDescription": "Delay automatic stable update offers for supply-chain safety.",
+            "updateCooldownTitle": "Update cooldown",
             "6382fe9724": "npx",
             "baa263d6d8": "agents",
             "bda108e66c": "skill",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5125,7 +5125,11 @@
           "31fd7150cf": "Buscando actualizaciones...",
           "3394d1f663": "de cheques",
           "d69a09b672": "Las actualizaciones se verifican automáticamente al iniciarse.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "62d7b3afec": "days",
+          "4c35dc5ec5": "Automatic update checks wait this many days after a stable release is published before offering it. Manual checks ignore the cooldown. Set to 0 to disable. Nothing is installed automatically.",
+          "ed46a7cfcf": "Update cooldown",
+          "updateCooldownHeld": "A newer stable release is available but is being held by your update cooldown. Use Check for Updates to install it now."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Elija las aplicaciones disponibles en el menú Abrir en de un espacio de trabajo.",
@@ -7296,7 +7300,16 @@
             "161a86a9da": "Confirmar antes de cerrar pestañas fijadas",
             "8e593f04fc": "Muestra un diálogo de confirmación antes de cerrar una pestaña fijada.",
             "defaultProjectRuntime": "Default Project Runtime",
-            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects."
+            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "updateCooldownKeywordAutoUpdate": "auto update",
+            "updateCooldownKeywordStable": "stable",
+            "updateCooldownKeywordDays": "days",
+            "updateCooldownKeywordDelay": "delay",
+            "updateCooldownKeywordSupplyChain": "supply chain",
+            "updateCooldownKeywordSecurity": "security",
+            "updateCooldownKeywordCooldown": "cooldown",
+            "updateCooldownDescription": "Delay automatic stable update offers for supply-chain safety.",
+            "updateCooldownTitle": "Update cooldown"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5110,7 +5110,11 @@
           "31fd7150cf": "アップデートをチェックしています...",
           "3394d1f663": "チェック中",
           "d69a09b672": "アップデートは起動時に自動的にチェックされます。",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "62d7b3afec": "days",
+          "4c35dc5ec5": "Automatic update checks wait this many days after a stable release is published before offering it. Manual checks ignore the cooldown. Set to 0 to disable. Nothing is installed automatically.",
+          "ed46a7cfcf": "Update cooldown",
+          "updateCooldownHeld": "A newer stable release is available but is being held by your update cooldown. Use Check for Updates to install it now."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "ワークスペースの「開く」メニューから利用可能なアプリを選択します。",
@@ -7318,7 +7322,16 @@
             "161a86a9da": "ピン留めしたタブを閉じる前に確認",
             "8e593f04fc": "ピン留めしたタブを閉じる前に確認ダイアログを表示します。",
             "defaultProjectRuntime": "Default Project Runtime",
-            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects."
+            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "updateCooldownKeywordAutoUpdate": "auto update",
+            "updateCooldownKeywordStable": "stable",
+            "updateCooldownKeywordDays": "days",
+            "updateCooldownKeywordDelay": "delay",
+            "updateCooldownKeywordSupplyChain": "supply chain",
+            "updateCooldownKeywordSecurity": "security",
+            "updateCooldownKeywordCooldown": "cooldown",
+            "updateCooldownDescription": "Delay automatic stable update offers for supply-chain safety.",
+            "updateCooldownTitle": "Update cooldown"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5110,7 +5110,11 @@
           "31fd7150cf": "업데이트 확인 중...",
           "3394d1f663": "확인 중",
           "d69a09b672": "업데이트는 시작 시 자동으로 확인됩니다.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "62d7b3afec": "days",
+          "4c35dc5ec5": "Automatic update checks wait this many days after a stable release is published before offering it. Manual checks ignore the cooldown. Set to 0 to disable. Nothing is installed automatically.",
+          "ed46a7cfcf": "Update cooldown",
+          "updateCooldownHeld": "A newer stable release is available but is being held by your update cooldown. Use Check for Updates to install it now."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "워크스페이스의 열기 메뉴에서 사용 가능한 앱을 선택하세요.",
@@ -7281,7 +7285,16 @@
             "161a86a9da": "고정된 탭을 닫기 전에 확인",
             "8e593f04fc": "고정된 탭을 닫기 전에 확인 대화상자를 표시합니다.",
             "defaultProjectRuntime": "기본 프로젝트 런타임",
-            "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다."
+            "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다.",
+            "updateCooldownKeywordAutoUpdate": "auto update",
+            "updateCooldownKeywordStable": "stable",
+            "updateCooldownKeywordDays": "days",
+            "updateCooldownKeywordDelay": "delay",
+            "updateCooldownKeywordSupplyChain": "supply chain",
+            "updateCooldownKeywordSecurity": "security",
+            "updateCooldownKeywordCooldown": "cooldown",
+            "updateCooldownDescription": "Delay automatic stable update offers for supply-chain safety.",
+            "updateCooldownTitle": "Update cooldown"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5110,7 +5110,11 @@
           "31fd7150cf": "正在检查更新...",
           "3394d1f663": "检查中",
           "d69a09b672": "启动时会自动检查更新。",
-          "7173352632": "空闲"
+          "7173352632": "空闲",
+          "62d7b3afec": "days",
+          "4c35dc5ec5": "Automatic update checks wait this many days after a stable release is published before offering it. Manual checks ignore the cooldown. Set to 0 to disable. Nothing is installed automatically.",
+          "ed46a7cfcf": "Update cooldown",
+          "updateCooldownHeld": "A newer stable release is available but is being held by your update cooldown. Use Check for Updates to install it now."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "从工作区的“打开方式”菜单中选择可用的应用程序。",
@@ -7281,7 +7285,16 @@
             "161a86a9da": "关闭固定标签页前确认",
             "8e593f04fc": "关闭固定标签页前显示确认对话框。",
             "defaultProjectRuntime": "默认项目运行时",
-            "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。"
+            "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。",
+            "updateCooldownKeywordAutoUpdate": "auto update",
+            "updateCooldownKeywordStable": "stable",
+            "updateCooldownKeywordDays": "days",
+            "updateCooldownKeywordDelay": "delay",
+            "updateCooldownKeywordSupplyChain": "supply chain",
+            "updateCooldownKeywordSecurity": "security",
+            "updateCooldownKeywordCooldown": "cooldown",
+            "updateCooldownDescription": "Delay automatic stable update offers for supply-chain safety.",
+            "updateCooldownTitle": "Update cooldown"
           }
         },
         "git": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -110,6 +110,9 @@ export const RICH_MARKDOWN_MAX_SIZE_BYTES = 300 * 1024
 export const DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS = 1000
 export const MIN_EDITOR_AUTO_SAVE_DELAY_MS = 250
 export const MAX_EDITOR_AUTO_SAVE_DELAY_MS = 10_000
+export const DEFAULT_AUTO_UPDATE_COOLDOWN_DAYS = 0
+export const MIN_AUTO_UPDATE_COOLDOWN_DAYS = 0
+export const MAX_AUTO_UPDATE_COOLDOWN_DAYS = 30
 
 // Why: initial threshold of agents spawned (since last update) before we show
 // the star-on-GitHub notification. Doubles each time the user dismisses
@@ -201,6 +204,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     appFontFamily: DEFAULT_APP_FONT_FAMILY,
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
+    autoUpdateCooldownDays: DEFAULT_AUTO_UPDATE_COOLDOWN_DAYS,
     editorMinimapEnabled: false,
     markdownReviewToolsEnabled: true,
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2162,7 +2162,7 @@ export type UpdateStatus =
       // checks straightforward.
       changelog: ChangelogData | null
     }
-  | { state: 'not-available'; userInitiated?: boolean }
+  | { state: 'not-available'; userInitiated?: boolean; heldByCooldown?: boolean }
   | { state: 'downloading'; percent: number; version: string; activeNudgeId?: string }
   | { state: 'downloaded'; version: string; releaseUrl?: string; activeNudgeId?: string }
   | { state: 'error'; message: string; userInitiated?: boolean; activeNudgeId?: string }
@@ -2435,6 +2435,8 @@ export type GlobalSettings = {
   appFontFamily: string
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number
+  /** Supply-chain safety: automatic update checks only offer a stable release once it has been published at least this many days. 0 disables. Manual checks, prerelease, and nudges bypass it. */
+  autoUpdateCooldownDays?: number
   editorMinimapEnabled: boolean
   /** Whether local markdown review note controls and the review panel are shown. */
   markdownReviewToolsEnabled: boolean


### PR DESCRIPTION
## What changes

Adds an **Update Cooldown** setting (Settings → General → Updates). When set to N days, Orca's **automatic** update checks only offer a stable release once it has been published for at least N days. This narrows the window in which a freshly published bad or later-pulled release could be offered for one-click acceptance before the community or maintainers flag it.

## What does NOT change

- **Nothing installs silently.** `autoDownload` is already off; the cooldown only delays when a release is *offered*, never an install.
- **Default is 0 (off)** — existing behavior is unchanged until a user opts in. Optional setting; existing profiles resolve to 0.
- **Manual "Check for Updates", prerelease/RC checks (shift-click), and update nudges bypass the cooldown** — a deliberate or maintainer-directed action always offers the newest release immediately. The cooldown gates only automatic, undirected checks.
- This is **not** a canary/stable channel split; it is a time-based delay on stable auto-update offers (the cooldown approach from the issue).

## Threat model (honest boundary)

Defends against a good-faith bad/broken stable release caught and pulled within the cooldown window. It does **not** defend against an attacker who controls the release pipeline (they could backdate release timestamps). The benefit is "reduce the window during which a too-fresh release is auto-offered," not "block a compromised pipeline."

## How it works

Gating happens at the single feed chokepoint both automatic and manual checks already share (`fetchNewerReleaseTagsWithReadiness` → `pinDefaultReleaseFeed`). The GitHub releases atom feed (already fetched there) carries a per-entry `<updated>` timestamp — parsed per-entry and used to compute release age with no new network calls or API tokens. Because the stable cadence is near-daily, the walker selects the newest release that is **both newer and aged past the cooldown**, falling through to an older eligible release rather than freezing updates. When every newer release is still too fresh it returns a `cooldown` state; the updater then pins the running version's own release tag so electron-updater reports `update-not-available` instead of falling through to `/latest/download` (which would re-expose the too-fresh release). A missing/unparseable timestamp is treated as too-fresh (fail-closed). The Updates section shows a held-state hint in that case so the result isn't mistaken for "you're on the latest version."

## Design approach

Local numeric setting (0–30 days) plus main-process gating of which release automatic checks surface. No server-side or channel-infrastructure changes. Setting is read live each check (no restart). Renderer input clamps; the IPC handler re-clamps so main never trusts renderer input. The production `setupAutoUpdater` call site wires the live settings read.

## Design review

Ran an iterative design-review loop to convergence. Key outcomes folded in: an honest threat-model boundary; per-entry timestamp binding documented as a correctness requirement (a global regex would mis-bind timestamps to the wrong release); and the held-state flag wired to the terminal `update-not-available` event with a set-or-clear-every-branch discipline so a held cycle can never leak its flag into a later up-to-date check.

## Implementation notes / deviations

Implemented as designed. One intentional choice: the held-state flag is threaded to the event handler via the existing handler-context object (rather than a cross-module import) to avoid an import cycle. The held-state hint is a single optional boolean on the existing `not-available` status payload plus one hint string — no new IPC channel or status state.

## Completeness verification

A separate read-only pass confirmed all requirements, edge cases, and validation items are implemented, with the targeted suite green.

## Headline behavior status

**Implemented.** Automatic update checks gate too-fresh stable releases in production code (wiring → background/startup/wake checks → feed walker → current-tag pin). Two honest boundaries: like the whole updater, the cooldown applies only in packaged builds (dev never auto-updates), and the live release-age gating is covered by unit tests because it can't be triggered deterministically against live GitHub in dev. The renderer held-state hint branch was verified live in the running app.

## Performance

Perf-neutral. The change adds no new network requests, timers, polling, subprocesses, listeners, or render churn; the cooldown filter can only reduce the number of manifest probes. Atom-feed parsing remains sub-millisecond on feeds far larger than reality and runs at most ~once/24h; the regexes are single-quantifier (no catastrophic-backtracking risk) over a trusted, timeout-capped GitHub response.

## Code review

Two-reviewer rounds to clean. Round 1 caught real unrelated locale-catalog churn (the catalog tooling had reverted hundreds of existing es/ja/ko/zh translations to English) — reverted those files to HEAD and re-added only the additive cooldown keys. Round 2: both reviewers clean.

## Validation

- `pnpm run typecheck` (node + cli + web): pass
- Targeted vitest (updater feed/readiness, updater, settings IPC, main-window wiring): **158 passed**, including cooldown-state selection, aged-older fallback, no-gating when disabled, missing-timestamp fail-closed, held-flag tagging on the terminal event, and a leak regression.
- i18n gates (`verify-localization-catalog`, `audit-localization-coverage --check`): pass
- `pnpm run lint`: pass (one pre-existing unrelated warning)
- Manual Electron validation (own dedicated dev instance): control renders with correct label/help/suffix; persists and round-trips; clamps high→30 and negative→0; surfaces in settings search ("cooldown", "supply chain"); default 0; "Check for Updates" unaffected; held-state hint renders correctly. Verdict: land.

## Cross-platform / SSH

All gating is local main-process logic; the input is plain renderer UI. No platform-specific branches; manifest selection and the atom feed are unchanged across macOS/Linux/Windows. The updater governs the desktop app's own auto-update, so the SSH/remote-host path is unaffected; the setting is a global local preference.

Closes #5259

Made with [Orca](https://github.com/stablyai/orca) 🐋
