### PR TITLE
Add Git Graph view showing all branches and commit history

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -2245,4 +2245,32 @@ describe('registerFilesystemHandlers', () => {
       excludePaths: ['/home/user/repo/worktrees/feature']
     })
   })
+
+  // Guards the git:history handler's explicit `{ limit, baseRef, allRefs }`
+  // rebuild — it re-destructures rather than spreading, so a dropped allRefs
+  // would silently break the repo-wide Git Graph on the SSH path.
+  it('git:history forwards allRefs to the SSH git provider', async () => {
+    const getHistoryMock = vi.fn().mockResolvedValue({
+      items: [],
+      hasIncomingChanges: false,
+      hasOutgoingChanges: false,
+      hasMore: false,
+      limit: 200
+    })
+    getSshGitProviderMock.mockReturnValue({ getHistory: getHistoryMock })
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:history')!(null, {
+      worktreePath: '/remote/repo',
+      connectionId: 'conn-1',
+      limit: 200,
+      allRefs: true
+    })
+
+    expect(getHistoryMock).toHaveBeenCalledWith(
+      '/remote/repo',
+      expect.objectContaining({ limit: 200, allRefs: true })
+    )
+  })
 })

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1152,7 +1152,11 @@ export function registerFilesystemHandlers(
       _event,
       args: { worktreePath: string; connectionId?: string } & GitHistoryOptions
     ): Promise<GitHistoryResult> => {
-      const options: GitHistoryOptions = { limit: args.limit, baseRef: args.baseRef }
+      const options: GitHistoryOptions = {
+        limit: args.limit,
+        baseRef: args.baseRef,
+        allRefs: args.allRefs
+      }
       if (args.connectionId) {
         const provider = getSshGitProvider(args.connectionId)
         if (!provider) {

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -69,7 +69,8 @@ export const GitCommitCompare = WorktreeSelector.extend({
 
 export const GitHistory = WorktreeSelector.extend({
   limit: z.number().int().min(1).max(200).optional(),
-  baseRef: z.string().nullable().optional()
+  baseRef: z.string().nullable().optional(),
+  allRefs: z.boolean().optional()
 })
 
 export const GitBranchDiff = GitFilePath.extend({

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -187,7 +187,38 @@ describe('git RPC methods', () => {
 
     expect(runtime.getRuntimeGitHistory).toHaveBeenCalledWith('id:wt-1', {
       limit: 25,
-      baseRef: 'origin/main'
+      baseRef: 'origin/main',
+      allRefs: undefined
+    })
+    expect(response).toMatchObject({ ok: true, result: history })
+  })
+
+  it('forwards allRefs to the runtime git history for the repo-wide graph', async () => {
+    const history = {
+      items: [],
+      hasIncomingChanges: false,
+      hasOutgoingChanges: false,
+      hasMore: false,
+      limit: 200
+    }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRuntimeGitHistory: vi.fn().mockResolvedValue(history)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('git.history', {
+        worktree: 'id:wt-1',
+        limit: 200,
+        allRefs: true
+      })
+    )
+
+    expect(runtime.getRuntimeGitHistory).toHaveBeenCalledWith('id:wt-1', {
+      limit: 200,
+      baseRef: undefined,
+      allRefs: true
     })
     expect(response).toMatchObject({ ok: true, result: history })
   })

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -124,7 +124,8 @@ export const GIT_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) =>
       runtime.getRuntimeGitHistory(params.worktree, {
         limit: params.limit,
-        baseRef: params.baseRef
+        baseRef: params.baseRef,
+        allRefs: params.allRefs
       })
   }),
   defineMethod({

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -351,6 +351,33 @@ describe('GitHandler', () => {
       expect(result.hasMore).toBe(false)
       expect(result.limit).toBe(10)
     })
+
+    it('forwards allRefs over the wire so the repo-wide graph spans all branches', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'base')
+      gitCommit(tmpDir, 'initial')
+      const baseBranch = currentBranch(tmpDir)
+      execFileSync('git', ['checkout', '-b', 'feature'], { cwd: tmpDir, stdio: 'pipe' })
+      writeFileSync(path.join(tmpDir, 'feature.txt'), 'feature')
+      gitCommit(tmpDir, 'feature only')
+      // Return to the base branch so the feature commit is NOT in linear history.
+      execFileSync('git', ['checkout', baseBranch], { cwd: tmpDir, stdio: 'pipe' })
+
+      const linear = (await dispatcher.callRequest('git.history', {
+        worktreePath: tmpDir,
+        limit: 10
+      })) as { items: { subject: string }[] }
+      expect(linear.items.map((item) => item.subject)).toEqual(['initial'])
+
+      // Why: the relay handler must forward allRefs; otherwise this returns the
+      // same linear result and the SSH Git Graph silently shows one branch.
+      const allRefs = (await dispatcher.callRequest('git.history', {
+        worktreePath: tmpDir,
+        limit: 10,
+        allRefs: true
+      })) as { items: { subject: string }[] }
+      expect(allRefs.items.map((item) => item.subject)).toContain('feature only')
+    })
   })
 
   describe('status', () => {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -347,7 +347,10 @@ export class GitHandler {
     const worktreePath = params.worktreePath as string
     return loadGitHistoryFromExecutor(this.git.bind(this), worktreePath, {
       limit: typeof params.limit === 'number' ? params.limit : undefined,
-      baseRef: typeof params.baseRef === 'string' ? params.baseRef : null
+      baseRef: typeof params.baseRef === 'string' ? params.baseRef : null,
+      // Why: the repo-wide Git Graph passes allRefs over the SSH wire; without
+      // forwarding it here the relay host silently runs current-branch history.
+      allRefs: typeof params.allRefs === 'boolean' ? params.allRefs : undefined
     })
   }
 

--- a/src/renderer/src/components/git-graph/GitGraphPane.tsx
+++ b/src/renderer/src/components/git-graph/GitGraphPane.tsx
@@ -1,0 +1,150 @@
+import React, { useCallback, useMemo, useRef } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { Network, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import {
+  buildDefaultGitHistoryColorMap,
+  buildGitHistoryViewModels
+} from '../../../../shared/git-history-graph'
+import { GitHistoryRow } from '../right-sidebar/GitHistoryRow'
+import { useGitHistoryCommitActions } from '../right-sidebar/useGitHistoryCommitActions'
+import { translate } from '@/i18n/i18n'
+import { useGitGraphHistory } from './useGitGraphHistory'
+
+// Why: each Git Graph row is a fixed-height GitHistoryRow (min-h-[26px]); a
+// constant estimate keeps the virtualizer cheap for up to 200 rows.
+const GIT_GRAPH_ROW_HEIGHT = 28
+const GIT_GRAPH_ROW_OVERSCAN = 12
+
+function GitGraphPane({ worktreeId }: { worktreeId: string }): React.JSX.Element {
+  const { state, refresh, context } = useGitGraphHistory(worktreeId)
+  const result = state.result
+  const loading = state.status === 'loading' || state.status === 'refreshing'
+
+  const viewModels = useMemo(() => {
+    if (!result) {
+      return []
+    }
+    // All-refs mode has no incoming/outgoing or remote/base refs (the loader
+    // forks before computing them), so pass currentRef only.
+    return buildGitHistoryViewModels(
+      result.items,
+      buildDefaultGitHistoryColorMap(result),
+      result.currentRef,
+      undefined,
+      undefined
+    )
+  }, [result])
+
+  // Full-pane tab opens commits in its own group; no split target to resolve.
+  const noSplitTarget = useCallback(() => undefined, [])
+  const { openHistoryCommitDiff } = useGitHistoryCommitActions({
+    activeWorktreeId: worktreeId,
+    worktreePath: context?.worktreePath ?? null,
+    activeRepoSettings: context?.settings,
+    resolveSplitTargetGroupId: noSplitTarget
+  })
+
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const virtualizer = useVirtualizer({
+    count: viewModels.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => GIT_GRAPH_ROW_HEIGHT,
+    overscan: GIT_GRAPH_ROW_OVERSCAN,
+    getItemKey: (index) => viewModels[index]?.historyItem.id ?? `missing:${index}`
+  })
+
+  const count = result?.items.length ?? 0
+  const virtualItems = virtualizer.getVirtualItems()
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-background">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-3">
+        <Network className="size-4 text-muted-foreground" aria-hidden="true" />
+        <span className="text-sm font-semibold">
+          {translate('auto.components.git.graph.GitGraphPane.6f0a2d1b84', 'Git Graph')}
+        </span>
+        {result && <span className="text-xs tabular-nums text-muted-foreground">{count}</span>}
+        <div className="ml-auto flex items-center">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={refresh}
+                aria-label={translate(
+                  'auto.components.git.graph.GitGraphPane.b71e9c4d22',
+                  'Refresh graph'
+                )}
+              >
+                <RefreshCw className={cn('size-4', loading && 'animate-spin')} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              {translate('auto.components.git.graph.GitGraphPane.b71e9c4d22', 'Refresh graph')}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {result?.hasMore && (
+        <div className="shrink-0 border-b border-border px-3 py-1 text-[11px] text-muted-foreground">
+          {translate(
+            'auto.components.git.graph.GitGraphPane.9a3f5c2e70',
+            'Showing {{value0}} of many commits across all branches',
+            { value0: result.limit }
+          )}
+        </div>
+      )}
+
+      {state.status === 'error' && !result ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-sm text-destructive">
+          <span className="text-center">{state.error}</span>
+          <Button type="button" variant="outline" size="sm" onClick={refresh}>
+            {translate('auto.components.git.graph.GitGraphPane.5d2e9b7a14', 'Retry')}
+          </Button>
+        </div>
+      ) : (state.status === 'idle' || state.status === 'loading') && !result ? (
+        <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+          <RefreshCw className="size-4 animate-spin" />
+          <span>
+            {translate('auto.components.git.graph.GitGraphPane.2c8b1f0a93', 'Loading graph...')}
+          </span>
+        </div>
+      ) : viewModels.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+          {translate('auto.components.git.graph.GitGraphPane.4e7d6a1c08', 'No commits yet')}
+        </div>
+      ) : (
+        <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto scrollbar-sleek">
+          <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+            {virtualItems.map((virtualRow) => {
+              const viewModel = viewModels[virtualRow.index]
+              if (!viewModel) {
+                return null
+              }
+              return (
+                <div
+                  key={virtualRow.key}
+                  className="absolute left-0 top-0 w-full"
+                  style={{ transform: `translateY(${virtualRow.start}px)` }}
+                >
+                  <GitHistoryRow
+                    viewModel={viewModel}
+                    layout="pane"
+                    onOpenCommit={(item) => void openHistoryCommitDiff(item)}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default React.memo(GitGraphPane)

--- a/src/renderer/src/components/git-graph/GitGraphPane.tsx
+++ b/src/renderer/src/components/git-graph/GitGraphPane.tsx
@@ -94,7 +94,7 @@ function GitGraphPane({ worktreeId }: { worktreeId: string }): React.JSX.Element
         <div className="shrink-0 border-b border-border px-3 py-1 text-[11px] text-muted-foreground">
           {translate(
             'auto.components.git.graph.GitGraphPane.9a3f5c2e70',
-            'Showing {{value0}} of many commits across all branches',
+            'Showing first {{value0}} commits across all branches',
             { value0: result.limit }
           )}
         </div>

--- a/src/renderer/src/components/git-graph/useGitGraphHistory.ts
+++ b/src/renderer/src/components/git-graph/useGitGraphHistory.ts
@@ -49,12 +49,14 @@ export function useGitGraphHistory(worktreeId: string): UseGitGraphHistory {
   }, [repo, settings, worktreeId, worktreePath])
 
   useEffect(() => {
+    // Bump before the null-check so a fetch still in flight from a prior
+    // worktree can't resolve and overwrite this 'idle' state once it clears.
+    const requestId = (requestIdRef.current += 1)
     const ctx = context
     if (!ctx) {
       setState({ status: 'idle' })
       return
     }
-    const requestId = (requestIdRef.current += 1)
     setState((prev) =>
       prev.status === 'ready' || prev.status === 'refreshing'
         ? { status: 'refreshing', result: prev.result }

--- a/src/renderer/src/components/git-graph/useGitGraphHistory.ts
+++ b/src/renderer/src/components/git-graph/useGitGraphHistory.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useRepoById, useWorktreeById } from '@/store/selectors'
+import { useAppStore } from '@/store'
+import { getConnectionId } from '@/lib/connection-context'
+import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
+import { getRuntimeGitHistory, type RuntimeGitContext } from '@/runtime/runtime-git-client'
+import { GIT_HISTORY_MAX_LIMIT, type GitHistoryResult } from '../../../../shared/git-history'
+import { translate } from '@/i18n/i18n'
+
+export type GitGraphHistoryState =
+  | { status: 'idle' | 'loading'; result?: GitHistoryResult; error?: string }
+  | { status: 'refreshing' | 'ready'; result: GitHistoryResult; error?: string }
+  | { status: 'error'; result?: GitHistoryResult; error: string }
+
+export type UseGitGraphHistory = {
+  state: GitGraphHistoryState
+  refresh: () => void
+  context: RuntimeGitContext | null
+}
+
+// Loads the repo-wide (all refs) history for the Git Graph pane. Routes by the
+// repo OWNER host like Source Control, and always requests the MAX limit so the
+// graph isn't silently capped at the linear default.
+export function useGitGraphHistory(worktreeId: string): UseGitGraphHistory {
+  const worktree = useWorktreeById(worktreeId)
+  const repo = useRepoById(worktree?.repoId ?? null)
+  const settings = useAppStore((s) => s.settings)
+  const worktreePath = worktree?.path ?? null
+
+  const [state, setState] = useState<GitGraphHistoryState>({ status: 'idle' })
+  // Bumped on Refresh; also re-runs the load when worktree/path changes.
+  const [reloadToken, setReloadToken] = useState(0)
+  const requestIdRef = useRef(0)
+
+  // Why: memoize the routed context so its identity only changes when a routing
+  // input does. A fresh object each render would (a) re-fire the fetch effect on
+  // every render and (b) rebuild the consumer's commit-action callbacks, which
+  // depend on context.settings, on every render.
+  const context = useMemo<RuntimeGitContext | null>(() => {
+    if (!worktreePath) {
+      return null
+    }
+    return {
+      settings: getRepoOwnerRoutedSettings(settings, repo ?? null),
+      worktreeId,
+      worktreePath,
+      connectionId: getConnectionId(worktreeId) ?? undefined
+    }
+  }, [repo, settings, worktreeId, worktreePath])
+
+  useEffect(() => {
+    const ctx = context
+    if (!ctx) {
+      setState({ status: 'idle' })
+      return
+    }
+    const requestId = (requestIdRef.current += 1)
+    setState((prev) =>
+      prev.status === 'ready' || prev.status === 'refreshing'
+        ? { status: 'refreshing', result: prev.result }
+        : { status: 'loading' }
+    )
+    getRuntimeGitHistory(ctx, { allRefs: true, limit: GIT_HISTORY_MAX_LIMIT })
+      .then((result) => {
+        if (requestId !== requestIdRef.current) {
+          return
+        }
+        setState({ status: 'ready', result })
+      })
+      .catch((error: unknown) => {
+        if (requestId !== requestIdRef.current) {
+          return
+        }
+        setState({
+          status: 'error',
+          error:
+            error instanceof Error
+              ? error.message
+              : translate(
+                  'auto.components.git.graph.useGitGraphHistory.3d9c2e7b41',
+                  'Failed to load git graph'
+                )
+        })
+      })
+  }, [context, reloadToken])
+
+  const refresh = useCallback(() => {
+    setReloadToken((token) => token + 1)
+  }, [])
+
+  return { state, refresh, context }
+}

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronDown, CircleHelp, RefreshCw } from 'lucide-react'
+import { ChevronDown, CircleHelp, Network, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -17,6 +17,11 @@ import {
   type GitHistoryCommitAction
 } from './GitHistoryCommitContextMenu'
 import type { SourceControlRowOpenEvent } from './source-control-split-open'
+import {
+  MAX_GIT_HISTORY_PANEL_HEIGHT,
+  MIN_GIT_HISTORY_PANEL_HEIGHT,
+  useGitHistoryPanelResize
+} from './useGitHistoryPanelResize'
 import { translate } from '@/i18n/i18n'
 
 export type GitHistoryPanelState =
@@ -24,27 +29,12 @@ export type GitHistoryPanelState =
   | { status: 'refreshing' | 'ready'; result: GitHistoryResult; error?: string }
   | { status: 'error'; result?: GitHistoryResult; error: string }
 
-const DEFAULT_GIT_HISTORY_PANEL_HEIGHT = 256
-const MIN_GIT_HISTORY_PANEL_HEIGHT = 96
-const MAX_GIT_HISTORY_PANEL_HEIGHT = 520
-const MAX_GIT_HISTORY_PANEL_VIEWPORT_HEIGHT = '33vh'
-
-type GitHistoryResizeSession = {
-  startY: number
-  startHeight: number
-  previousCursor: string
-  previousUserSelect: string
-}
-
-function clampGitHistoryPanelHeight(height: number): number {
-  return Math.min(MAX_GIT_HISTORY_PANEL_HEIGHT, Math.max(MIN_GIT_HISTORY_PANEL_HEIGHT, height))
-}
-
 export function GitHistoryPanel({
   state,
   collapsed,
   onToggle,
   onRefresh,
+  onOpenGraph,
   onOpenCommit,
   onLoadCommitFiles,
   onOpenCommitFile,
@@ -54,6 +44,8 @@ export function GitHistoryPanel({
   collapsed: boolean
   onToggle: () => void
   onRefresh: () => void
+  // Opens the repo-wide Git Graph full-pane tab; Cmd/Ctrl-click splits.
+  onOpenGraph?: (event: SourceControlRowOpenEvent) => void
   onOpenCommit?: (item: GitHistoryItem) => void
   onLoadCommitFiles?: (item: GitHistoryItem) => Promise<GitBranchChangeEntry[]>
   onOpenCommitFile?: (
@@ -82,8 +74,8 @@ export function GitHistoryPanel({
 
   const loading = state.status === 'loading' || state.status === 'refreshing'
   const count = result?.items.length ?? 0
-  const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
-  const resizeSessionRef = useRef<GitHistoryResizeSession | null>(null)
+  const { panelHeight, startResize, handleResizeKeyDown, expandedBodyStyle } =
+    useGitHistoryPanelResize(collapsed)
 
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   const [filesByCommit, setFilesByCommit] = useState<Record<string, GitHistoryCommitFilesState>>({})
@@ -141,78 +133,7 @@ export function GitHistoryPanel({
     [expanded, onLoadCommitFiles]
   )
 
-  const stopResize = useCallback((): void => {
-    const session = resizeSessionRef.current
-    if (!session) {
-      return
-    }
-    resizeSessionRef.current = null
-    document.body.style.cursor = session.previousCursor
-    document.body.style.userSelect = session.previousUserSelect
-  }, [])
-
-  const handleResizePointerMove = useCallback((event: PointerEvent): void => {
-    const session = resizeSessionRef.current
-    if (!session) {
-      return
-    }
-    setPanelHeight(clampGitHistoryPanelHeight(session.startHeight + session.startY - event.clientY))
-  }, [])
-
-  useEffect(() => {
-    window.addEventListener('pointermove', handleResizePointerMove)
-    window.addEventListener('pointerup', stopResize)
-    window.addEventListener('pointercancel', stopResize)
-    window.addEventListener('blur', stopResize)
-    return () => {
-      window.removeEventListener('pointermove', handleResizePointerMove)
-      window.removeEventListener('pointerup', stopResize)
-      window.removeEventListener('pointercancel', stopResize)
-      window.removeEventListener('blur', stopResize)
-      stopResize()
-    }
-  }, [handleResizePointerMove, stopResize])
-
-  const startResize = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>): void => {
-      if (collapsed) {
-        return
-      }
-      event.preventDefault()
-      resizeSessionRef.current = {
-        startY: event.clientY,
-        startHeight: panelHeight,
-        previousCursor: document.body.style.cursor,
-        previousUserSelect: document.body.style.userSelect
-      }
-      document.body.style.cursor = 'row-resize'
-      document.body.style.userSelect = 'none'
-      event.currentTarget.setPointerCapture(event.pointerId)
-    },
-    [collapsed, panelHeight]
-  )
-
-  const handleResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>): void => {
-    const step = event.shiftKey ? 32 : 16
-    if (event.key === 'ArrowUp') {
-      event.preventDefault()
-      setPanelHeight((height) => clampGitHistoryPanelHeight(height + step))
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault()
-      setPanelHeight((height) => clampGitHistoryPanelHeight(height - step))
-    } else if (event.key === 'Home') {
-      event.preventDefault()
-      setPanelHeight(MIN_GIT_HISTORY_PANEL_HEIGHT)
-    } else if (event.key === 'End') {
-      event.preventDefault()
-      setPanelHeight(MAX_GIT_HISTORY_PANEL_HEIGHT)
-    }
-  }, [])
-
   const expandedBodyClassName = 'overflow-y-auto scrollbar-sleek'
-  const expandedBodyStyle = {
-    height: `min(${panelHeight}px, ${MAX_GIT_HISTORY_PANEL_VIEWPORT_HEIGHT})`
-  }
 
   return (
     <div className="relative">
@@ -274,6 +195,39 @@ export function GitHistoryPanel({
               )}
             </TooltipContent>
           </Tooltip>
+          {onOpenGraph && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="my-auto h-auto w-auto p-0.5 text-muted-foreground hover:bg-transparent hover:text-muted-foreground dark:hover:bg-transparent [&_svg]:size-3"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onOpenGraph({
+                      altKey: event.altKey,
+                      ctrlKey: event.ctrlKey,
+                      metaKey: event.metaKey,
+                      shiftKey: event.shiftKey
+                    })
+                  }}
+                  aria-label={translate(
+                    'auto.components.right.sidebar.GitHistoryPanel.4b8e2f1a06',
+                    'Open Git Graph'
+                  )}
+                >
+                  <Network className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                {translate(
+                  'auto.components.right.sidebar.GitHistoryPanel.4b8e2f1a06',
+                  'Open Git Graph'
+                )}
+              </TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
@@ -36,6 +36,9 @@ type GitHistoryRowProps = React.HTMLAttributes<HTMLElement> & {
   viewModel: GitHistoryItemViewModel
   expanded?: boolean
   preserveRefIds?: readonly string[]
+  // 'pane' is the wide full-pane Git Graph layout (adds author + short-hash
+  // columns); 'sidebar' (default) keeps the original narrow row unchanged.
+  layout?: 'sidebar' | 'pane'
   onOpenCommit?: (item: GitHistoryItem) => void
   onToggleExpand?: (item: GitHistoryItem) => void
 }
@@ -46,6 +49,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
       viewModel,
       expanded = false,
       preserveRefIds,
+      layout = 'sidebar',
       onOpenCommit,
       onToggleExpand,
       className,
@@ -53,6 +57,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
     },
     ref
   ): React.JSX.Element {
+    const isPaneLayout = layout === 'pane'
     const item = viewModel.historyItem
     const isBoundaryNode =
       viewModel.kind === 'incoming-changes' || viewModel.kind === 'outgoing-changes'
@@ -69,7 +74,12 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
     const hiddenRefs = refs.slice(2)
     const rowTooltip = item.message || item.subject
     const rowClassName = cn(
-      'grid min-h-[26px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-1.5 px-3 py-0.5 text-left text-xs transition-colors',
+      'grid min-h-[26px] w-full min-w-0 items-center gap-x-1.5 px-3 py-0.5 text-left text-xs transition-colors',
+      // Pane adds author + short-hash trailing columns; sidebar keeps the
+      // original 3-column (graph | subject | refs) template byte-identical.
+      isPaneLayout
+        ? 'grid-cols-[auto_minmax(0,1fr)_auto_auto_auto]'
+        : 'grid-cols-[auto_minmax(0,1fr)_auto]',
       isInteractive && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
       !isInteractive && 'cursor-default',
       isBoundaryNode && 'text-muted-foreground',
@@ -77,7 +87,15 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
     )
     const rowContent = (
       <>
-        <GitHistoryGraphSvg viewModel={viewModel} />
+        {isPaneLayout ? (
+          // Cap the graph column and scroll within it so a many-lane repo-wide
+          // graph can't push the subject/author/hash columns out of alignment.
+          <div className="max-w-[200px] overflow-x-auto scrollbar-none">
+            <GitHistoryGraphSvg viewModel={viewModel} />
+          </div>
+        ) : (
+          <GitHistoryGraphSvg viewModel={viewModel} />
+        )}
         <div className="flex min-w-0 items-center gap-1 overflow-hidden">
           {canExpand && (
             <ChevronDown
@@ -99,7 +117,7 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
             </TooltipContent>
           </Tooltip>
         </div>
-        {refs.length > 0 && (
+        {(refs.length > 0 || isPaneLayout) && (
           <div className="flex shrink-0 items-center gap-1 overflow-hidden">
             {visibleRefs.map((ref) => (
               <GitHistoryRefBadge key={ref.id} itemRef={ref} />
@@ -120,6 +138,19 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
               </Tooltip>
             )}
           </div>
+        )}
+        {isPaneLayout && (
+          <span
+            className="ml-2 max-w-[10rem] shrink-0 truncate text-right text-[11px] text-muted-foreground"
+            title={item.author}
+          >
+            {item.author}
+          </span>
+        )}
+        {isPaneLayout && (
+          <span className="shrink-0 text-right font-mono text-[11px] tabular-nums text-muted-foreground">
+            {item.displayId}
+          </span>
         )}
       </>
     )

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -883,6 +883,7 @@ function SourceControlInner(): React.JSX.Element {
   const openConflictReview = useAppStore((s) => s.openConflictReview)
   const openBranchDiff = useAppStore((s) => s.openBranchDiff)
   const createEmptySplitGroup = useAppStore((s) => s.createEmptySplitGroup)
+  const openGitGraph = useAppStore((s) => s.openGitGraph)
   const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
   const activeGroupIdByWorktree = useAppStore((s) => s.activeGroupIdByWorktree)
   const openAllDiffs = useAppStore((s) => s.openAllDiffs)
@@ -4244,6 +4245,17 @@ function SourceControlInner(): React.JSX.Element {
     [activeGroupIdByWorktree, activeWorktreeId, createEmptySplitGroup, groupsByWorktree, isMac]
   )
 
+  const handleOpenGitGraph = useCallback(
+    (event: SourceControlRowOpenEvent): void => {
+      if (!activeWorktreeId) {
+        return
+      }
+      const targetGroupId = resolveSplitTargetGroupId(event)
+      openGitGraph(activeWorktreeId, targetGroupId ? { targetGroupId } : undefined)
+    },
+    [activeWorktreeId, openGitGraph, resolveSplitTargetGroupId]
+  )
+
   // Why: a stable string signature keeps this selector referentially stable so
   // the panel only re-renders when the active editor file (or its diff source)
   // actually changes. Gated on the visible tab being an editor so the highlight
@@ -6109,6 +6121,7 @@ function SourceControlInner(): React.JSX.Element {
                 collapsed={collapsedSections.has('history')}
                 onToggle={() => toggleSection('history')}
                 onRefresh={() => void refreshGitHistory()}
+                onOpenGraph={handleOpenGitGraph}
                 onOpenCommit={(item) => void openHistoryCommitDiff(item)}
                 onLoadCommitFiles={loadCommitFiles}
                 onOpenCommitFile={openCommitFile}

--- a/src/renderer/src/components/right-sidebar/useGitHistoryPanelResize.ts
+++ b/src/renderer/src/components/right-sidebar/useGitHistoryPanelResize.ts
@@ -1,0 +1,108 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+
+const DEFAULT_GIT_HISTORY_PANEL_HEIGHT = 256
+export const MIN_GIT_HISTORY_PANEL_HEIGHT = 96
+export const MAX_GIT_HISTORY_PANEL_HEIGHT = 520
+const MAX_GIT_HISTORY_PANEL_VIEWPORT_HEIGHT = '33vh'
+
+type GitHistoryResizeSession = {
+  startY: number
+  startHeight: number
+  previousCursor: string
+  previousUserSelect: string
+}
+
+function clampGitHistoryPanelHeight(height: number): number {
+  return Math.min(MAX_GIT_HISTORY_PANEL_HEIGHT, Math.max(MIN_GIT_HISTORY_PANEL_HEIGHT, height))
+}
+
+export type GitHistoryPanelResize = {
+  panelHeight: number
+  startResize: (event: React.PointerEvent<HTMLDivElement>) => void
+  handleResizeKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
+  expandedBodyStyle: { height: string }
+}
+
+// Drag/keyboard resize for the commit-history panel body. Extracted from
+// GitHistoryPanel to keep that component under the max-lines limit.
+export function useGitHistoryPanelResize(collapsed: boolean): GitHistoryPanelResize {
+  const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
+  const resizeSessionRef = useRef<GitHistoryResizeSession | null>(null)
+
+  const stopResize = useCallback((): void => {
+    const session = resizeSessionRef.current
+    if (!session) {
+      return
+    }
+    resizeSessionRef.current = null
+    document.body.style.cursor = session.previousCursor
+    document.body.style.userSelect = session.previousUserSelect
+  }, [])
+
+  const handleResizePointerMove = useCallback((event: PointerEvent): void => {
+    const session = resizeSessionRef.current
+    if (!session) {
+      return
+    }
+    setPanelHeight(clampGitHistoryPanelHeight(session.startHeight + session.startY - event.clientY))
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener('pointermove', handleResizePointerMove)
+    window.addEventListener('pointerup', stopResize)
+    window.addEventListener('pointercancel', stopResize)
+    window.addEventListener('blur', stopResize)
+    return () => {
+      window.removeEventListener('pointermove', handleResizePointerMove)
+      window.removeEventListener('pointerup', stopResize)
+      window.removeEventListener('pointercancel', stopResize)
+      window.removeEventListener('blur', stopResize)
+      stopResize()
+    }
+  }, [handleResizePointerMove, stopResize])
+
+  const startResize = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>): void => {
+      if (collapsed) {
+        return
+      }
+      event.preventDefault()
+      resizeSessionRef.current = {
+        startY: event.clientY,
+        startHeight: panelHeight,
+        previousCursor: document.body.style.cursor,
+        previousUserSelect: document.body.style.userSelect
+      }
+      document.body.style.cursor = 'row-resize'
+      document.body.style.userSelect = 'none'
+      event.currentTarget.setPointerCapture(event.pointerId)
+    },
+    [collapsed, panelHeight]
+  )
+
+  const handleResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>): void => {
+    const step = event.shiftKey ? 32 : 16
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setPanelHeight((height) => clampGitHistoryPanelHeight(height + step))
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setPanelHeight((height) => clampGitHistoryPanelHeight(height - step))
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setPanelHeight(MIN_GIT_HISTORY_PANEL_HEIGHT)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setPanelHeight(MAX_GIT_HISTORY_PANEL_HEIGHT)
+    }
+  }, [])
+
+  return {
+    panelHeight,
+    startResize,
+    handleResizeKeyDown,
+    expandedBodyStyle: {
+      height: `min(${panelHeight}px, ${MAX_GIT_HISTORY_PANEL_VIEWPORT_HEIGHT})`
+    }
+  }
+}

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -44,7 +44,8 @@ export default function EditorFileTab({
   onTogglePin,
   dragData,
   dropIndicator,
-  includeTopTabBorder = true
+  includeTopTabBorder = true,
+  isVirtual = false
 }: {
   file: OpenFile & { tabId?: string }
   isActive: boolean
@@ -60,6 +61,10 @@ export default function EditorFileTab({
   dragData: TabDragItemData
   dropIndicator?: DropIndicator
   includeTopTabBorder?: boolean
+  // Why: callers reuse this tab chrome for synthetic, non-file tabs (Git Graph,
+  // mobile emulator) whose filePath is a display label, not an on-disk path.
+  // Such tabs must never expose rename/reveal/copy-path file operations.
+  isVirtual?: boolean
 }): React.JSX.Element {
   const worktree = useWorktreeById(file.worktreeId)
   const repo = useRepoById(worktree?.repoId ?? null)
@@ -103,7 +108,7 @@ export default function EditorFileTab({
   const renameCancelledRef = useRef(false)
   // Only on-disk edit tabs are renameable. Diff, conflict-review, and
   // combined/virtual views don't point at a single concrete file we can safely rename.
-  const canRename = file.mode === 'edit' && !file.diffSource && !file.conflict
+  const canRename = !isVirtual && file.mode === 'edit' && !file.diffSource && !file.conflict
 
   const openRenameInput = (): void => {
     if (!canRename) {
@@ -386,6 +391,7 @@ export default function EditorFileTab({
         isRenaming={isRenaming}
         hasTabsToRight={hasTabsToRight}
         canRename={canRename}
+        isVirtual={isVirtual}
         canShowMarkdownPreview={canShowMarkdownPreview}
         resolvedLanguage={resolvedLanguage}
         repoConnectionId={repo?.connectionId ?? null}

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
@@ -172,7 +172,7 @@ function extractText(node: unknown): string {
   return el.props && 'children' in el.props ? extractText(el.props.children) : ''
 }
 
-async function renderMenu(): Promise<unknown> {
+async function renderMenu(overrides: Record<string, unknown> = {}): Promise<unknown> {
   const module = await import('./EditorFileTabContextMenu')
   return module.EditorFileTabContextMenu({
     open: true,
@@ -204,7 +204,8 @@ async function renderMenu(): Promise<unknown> {
     onClose: vi.fn(),
     onCloseAll: vi.fn(),
     onCloseToRight: vi.fn(),
-    onOpenMarkdownPreview: vi.fn()
+    onOpenMarkdownPreview: vi.fn(),
+    ...overrides
   })
 }
 
@@ -259,6 +260,23 @@ describe('EditorFileTabContextMenu close-all shortcut', () => {
     }
 
     expect(findElementsByType(tree, 'DropdownMenuShortcut')).toHaveLength(3)
+  })
+
+  it('hides path-based actions for a virtual (non-file) tab', async () => {
+    // A synthetic tab (Git Graph, mobile emulator) has a label, not an on-disk
+    // path, so Copy Path / Copy Relative Path / Reveal must not be offered.
+    const tree = expandNode(await renderMenu({ isVirtual: true, canRename: false }))
+    const labels = findElementsByType(tree, 'DropdownMenuItem').map((item) =>
+      extractText(item.props.children)
+    )
+
+    expect(labels.some((label) => label.includes('Copy Path'))).toBe(false)
+    expect(labels.some((label) => label.includes('Copy Relative Path'))).toBe(false)
+    expect(
+      labels.some((label) => label.includes('Reveal') || label.includes('Open Containing'))
+    ).toBe(false)
+    // Tab-management actions remain available.
+    expect(labels.some((label) => label.includes('Close'))).toBe(true)
   })
 
   it('hides the shortcut chip when close-all is unassigned', async () => {

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -35,6 +35,9 @@ type EditorFileTabContextMenuProps = {
   isRenaming: boolean
   hasTabsToRight: boolean
   canRename: boolean
+  // Why: synthetic non-file tabs (Git Graph, mobile emulator) have a label, not
+  // an on-disk path, so path-based actions (copy path, reveal) must be hidden.
+  isVirtual?: boolean
   canShowMarkdownPreview: boolean
   resolvedLanguage: string
   repoConnectionId: string | null
@@ -68,6 +71,7 @@ export function EditorFileTabContextMenu({
   isRenaming,
   hasTabsToRight,
   canRename,
+  isVirtual = false,
   canShowMarkdownPreview,
   resolvedLanguage,
   repoConnectionId,
@@ -147,7 +151,9 @@ export function EditorFileTabContextMenu({
             'Close Tabs To The Right'
           )}
         </DropdownMenuItem>
-        <DropdownMenuSeparator />
+        {/* Only separate the close actions from a section that actually follows;
+            a fully virtual tab has neither markdown preview nor path actions. */}
+        {canShowMarkdownPreview || !isVirtual ? <DropdownMenuSeparator /> : null}
         {canShowMarkdownPreview ? (
           <>
             <DropdownMenuItem
@@ -173,44 +179,53 @@ export function EditorFileTabContextMenu({
             <DropdownMenuSeparator />
           </>
         ) : null}
-        <DropdownMenuItem
-          onSelect={() => {
-            void window.api.ui.writeClipboardText(file.filePath)
-          }}
-        >
-          <Copy className="w-3.5 h-3.5 mr-1.5" />
-          {translate('auto.components.tab.bar.EditorFileTabContextMenu.5b85754786', 'Copy Path')}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={() => {
-            void window.api.ui.writeClipboardText(file.relativePath)
-          }}
-        >
-          <Copy className="w-3.5 h-3.5 mr-1.5" />
-          {translate(
-            'auto.components.tab.bar.EditorFileTabContextMenu.52ce4f4605',
-            'Copy Relative Path'
-          )}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          onSelect={() => {
-            if (
-              shouldBlockEditorTabLocalOpen(
-                useAppStore.getState().settings,
-                file.runtimeEnvironmentId,
-                repoConnectionId
-              )
-            ) {
-              showLocalPathOpenBlockedToast()
-              return
-            }
-            window.api.shell.openPath(file.filePath)
-          }}
-        >
-          <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
-          {revealLabel}
-        </DropdownMenuItem>
+        {/* Path-based actions are meaningless for synthetic non-file tabs whose
+            filePath is a display label, not an on-disk path. */}
+        {!isVirtual ? (
+          <>
+            <DropdownMenuItem
+              onSelect={() => {
+                void window.api.ui.writeClipboardText(file.filePath)
+              }}
+            >
+              <Copy className="w-3.5 h-3.5 mr-1.5" />
+              {translate(
+                'auto.components.tab.bar.EditorFileTabContextMenu.5b85754786',
+                'Copy Path'
+              )}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => {
+                void window.api.ui.writeClipboardText(file.relativePath)
+              }}
+            >
+              <Copy className="w-3.5 h-3.5 mr-1.5" />
+              {translate(
+                'auto.components.tab.bar.EditorFileTabContextMenu.52ce4f4605',
+                'Copy Relative Path'
+              )}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() => {
+                if (
+                  shouldBlockEditorTabLocalOpen(
+                    useAppStore.getState().settings,
+                    file.runtimeEnvironmentId,
+                    repoConnectionId
+                  )
+                ) {
+                  showLocalPathOpenBlockedToast()
+                  return
+                }
+                window.api.shell.openPath(file.filePath)
+              }}
+            >
+              <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+              {revealLabel}
+            </DropdownMenuItem>
+          </>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -513,6 +513,55 @@ describe('TabBar context menu wiring', () => {
     expect(tooltip).toBeTruthy()
   })
 
+  it('renders a git-graph unified tab as an ordered, activatable, closeable chip', async () => {
+    // Why: git-graph is a no-OpenFile full-pane tab. Without a TabBar render
+    // branch it had no chip and vanished from the strip once another tab was
+    // active. It must render like simulator: a draggable EditorFileTab chip.
+    appStoreSnapshot.activeTabId = null
+    appStoreSnapshot.activeTabType = 'editor'
+    appStoreSnapshot.unifiedTabsByWorktree = {
+      'wt-1': [
+        {
+          id: 'gg-1',
+          entityId: 'wt-1::git-graph',
+          groupId: 'wt-1',
+          worktreeId: 'wt-1',
+          contentType: 'git-graph',
+          label: 'Git Graph',
+          customLabel: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 0
+        }
+      ]
+    }
+
+    const onActivateFile = vi.fn()
+    const onCloseFile = vi.fn()
+    const element = await renderTabBar({
+      tabs: [],
+      editorFiles: [],
+      browserTabs: [],
+      tabBarOrder: ['gg-1'],
+      // git-graph routes through activeTabType 'editor' with activeFileId set
+      // to the unified tab id (see TabGroupPanel).
+      activeTabType: 'editor',
+      activeFileId: 'gg-1',
+      onActivateFile,
+      onCloseFile
+    })
+
+    const chips = findChildrenByType(element, 'EditorFileTab')
+    expect(chips).toHaveLength(1)
+    expect(chips[0].props.isActive).toBe(true)
+    expect((chips[0].props.file as { language: string }).language).toBe('git-graph')
+
+    ;(chips[0].props.onActivate as () => void)()
+    expect(onActivateFile).toHaveBeenCalledWith('gg-1')
+    ;(chips[0].props.onClose as () => void)()
+    expect(onCloseFile).toHaveBeenCalledWith('gg-1')
+  })
+
   it('cancels delayed menu focus when the tab bar root unmounts', async () => {
     vi.useFakeTimers()
     Object.assign(window, { setTimeout, clearTimeout })

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -175,6 +175,13 @@ type TabItem =
       isPinned: boolean
       data: Tab
     }
+  | {
+      type: 'git-graph'
+      id: string
+      unifiedTabId: string
+      isPinned: boolean
+      data: Tab
+    }
 
 function getTabDragLabel(item: TabItem, generatedTitlesEnabled: boolean): string {
   if (item.type === 'terminal') {
@@ -185,6 +192,9 @@ function getTabDragLabel(item: TabItem, generatedTitlesEnabled: boolean): string
   }
   if (item.type === 'simulator') {
     return item.data.label || 'Mobile Emulator'
+  }
+  if (item.type === 'git-graph') {
+    return item.data.label || 'Git Graph'
   }
   return getEditorDisplayLabel(item.data)
 }
@@ -865,6 +875,13 @@ function TabBarInner({
         .map((t) => t.id),
     [unifiedTabs, resolvedGroupId]
   )
+  const gitGraphTabIds = useMemo(
+    () =>
+      (unifiedTabs ?? [])
+        .filter((t) => t.groupId === resolvedGroupId && t.contentType === 'git-graph')
+        .map((t) => t.id),
+    [unifiedTabs, resolvedGroupId]
+  )
 
   // Build the unified ordered list, reconciling stored order with current items
   const orderedItems = useMemo(() => {
@@ -873,7 +890,8 @@ function TabBarInner({
       terminalIds,
       editorFileIds,
       browserTabIds,
-      simulatorTabIds
+      simulatorTabIds,
+      gitGraphTabIds
     )
     const items: TabItem[] = []
     for (const id of ids) {
@@ -924,6 +942,17 @@ function TabBarInner({
         })
         continue
       }
+      const gitGraphUnified = unifiedTabByVisibleId.get(id)
+      if (gitGraphUnified && gitGraphUnified.contentType === 'git-graph') {
+        items.push({
+          type: 'git-graph',
+          id,
+          unifiedTabId: gitGraphUnified.id,
+          isPinned: gitGraphUnified.isPinned === true,
+          data: gitGraphUnified
+        })
+        continue
+      }
     }
     return items
   }, [
@@ -932,6 +961,7 @@ function TabBarInner({
     editorFileIds,
     browserTabIds,
     simulatorTabIds,
+    gitGraphTabIds,
     terminalMap,
     editorMap,
     browserMap,
@@ -965,6 +995,11 @@ function TabBarInner({
       }
       if (item.type === 'simulator') {
         return activeTabType === 'simulator' && item.id === activeSimulatorTabId
+      }
+      if (item.type === 'git-graph') {
+        // git-graph routes through activeTabType 'editor' with activeFileId set
+        // to the unified tab id (see TabGroupPanel), so match that pairing.
+        return activeTabType === 'editor' && activeFileId === item.id
       }
       return (
         (activeTabType === 'editor' || activeTabType === 'simulator') && activeFileId === item.id
@@ -1192,6 +1227,43 @@ function TabBarInner({
                     key={item.id}
                     file={simFile}
                     isActive={activeTabType === 'simulator' && item.id === activeSimulatorTabId}
+                    isPinned={item.isPinned}
+                    hasTabsToRight={index < orderedItems.length - 1}
+                    statusByRelativePath={statusByRelativePath}
+                    onActivate={() => onActivateFile?.(item.id)}
+                    onClose={() => onCloseFile?.(item.id)}
+                    onCloseToRight={() => onCloseToRight(item.id)}
+                    onCloseAll={() => onCloseAllFiles?.()}
+                    onMakePermanent={() => {}}
+                    onTogglePin={() => togglePinned(item)}
+                    dragData={dragData}
+                    dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
+                    includeTopTabBorder={includeTopTabBorder}
+                  />
+                )
+              }
+              if (item.type === 'git-graph') {
+                // Why: git-graph is a no-OpenFile full-pane tab (like simulator),
+                // so synthesize a minimal OpenFile to reuse the editor chip. It
+                // routes through activeTabType 'editor' with activeFileId === the
+                // unified tab id (see TabGroupPanel).
+                const gitGraphLabel = item.data.label || 'Git Graph'
+                const gitGraphFile: OpenFile & { tabId: string } = {
+                  id: item.id,
+                  tabId: item.id,
+                  filePath: gitGraphLabel,
+                  relativePath: gitGraphLabel,
+                  worktreeId,
+                  language: 'git-graph',
+                  isPreview: false,
+                  isDirty: false,
+                  mode: 'edit'
+                }
+                return (
+                  <EditorFileTab
+                    key={item.id}
+                    file={gitGraphFile}
+                    isActive={activeTabType === 'editor' && activeFileId === item.id}
                     isPinned={item.isPinned}
                     hasTabsToRight={index < orderedItems.length - 1}
                     statusByRelativePath={statusByRelativePath}

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -1239,6 +1239,7 @@ function TabBarInner({
                     dragData={dragData}
                     dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
                     includeTopTabBorder={includeTopTabBorder}
+                    isVirtual
                   />
                 )
               }
@@ -1276,6 +1277,7 @@ function TabBarInner({
                     dragData={dragData}
                     dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
                     includeTopTabBorder={includeTopTabBorder}
+                    isVirtual
                   />
                 )
               }

--- a/src/renderer/src/components/tab-bar/group-tab-order.test.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.test.ts
@@ -63,6 +63,21 @@ function simulatorTab(id: string, groupId: string, sortOrder: number): Tab {
   }
 }
 
+function gitGraphTab(id: string, groupId: string, sortOrder: number): Tab {
+  return {
+    id,
+    entityId: `${groupId}::git-graph`,
+    groupId,
+    worktreeId: 'wt',
+    contentType: 'git-graph',
+    label: 'Git Graph',
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
 describe('getGroupVisibleTabOrder', () => {
   it('returns active-group refs with backing ids plus unified tab ids', () => {
     const group: TabGroup = {
@@ -186,6 +201,25 @@ describe('getGroupVisibleTabOrder', () => {
       { type: 'terminal', id: 'term-1', tabId: 'tab-t1' },
       { type: 'simulator', id: 'tab-s1', tabId: 'tab-s1' },
       { type: 'editor', id: '/repo/file.md', tabId: 'tab-e1' }
+    ])
+  })
+
+  it('includes git-graph tabs as editor-typed refs keyed by unified tab id', () => {
+    // git-graph has no backing OpenFile entity, so it would be skipped by the
+    // editor branch's entity-presence guard. It must still appear so keyboard
+    // cycling can land on it; it routes through activeTabType 'editor'.
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-gg1',
+      tabOrder: ['tab-t1', 'tab-gg1']
+    }
+    const tabs: Tab[] = [terminalTab('tab-t1', 'g1', 'term-1', 0), gitGraphTab('tab-gg1', 'g1', 1)]
+    expect(
+      getGroupVisibleTabOrder(group, tabs, new Set(['term-1']), new Set(), new Set(), new Set())
+    ).toEqual([
+      { type: 'terminal', id: 'term-1', tabId: 'tab-t1' },
+      { type: 'editor', id: 'tab-gg1', tabId: 'tab-gg1' }
     ])
   })
 })

--- a/src/renderer/src/components/tab-bar/group-tab-order.test.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.test.ts
@@ -337,4 +337,21 @@ describe('getActiveTabNavOrder', () => {
       { type: 'terminal', id: 'term-2' }
     ])
   })
+
+  it('keeps git-graph tabs in the legacy reconciled order (no active group)', () => {
+    // Guards the legacy fallback path: without forwarding gitGraphIds the tab is
+    // dropped from keyboard nav, so it must surface as an editor-typed ref here.
+    const state = makeState({
+      tabBarOrderByWorktree: { wt: ['term-1', 'tab-gg1'] },
+      unifiedTabsByWorktree: { wt: [gitGraphTab('tab-gg1', 'g1', 1)] },
+      tabsByWorktree: {
+        // @ts-expect-error — minimal shape
+        wt: [{ id: 'term-1' }]
+      }
+    })
+    expect(getActiveTabNavOrder(state, 'wt')).toEqual([
+      { type: 'terminal', id: 'term-1' },
+      { type: 'editor', id: 'tab-gg1' }
+    ])
+  })
 })

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -88,6 +88,16 @@ export function getGroupVisibleTabOrder(
       }
       seenSimulators.add(tab.id)
       result.push({ type: 'simulator', id: tab.id, tabId: tab.id })
+    } else if (tab.contentType === 'git-graph') {
+      // git-graph has no backing entity in editorEntityIds, but it is a real
+      // visible chip that routes through activeTabType 'editor'. Emit it as an
+      // editor-typed ref keyed by the unified tab id so keyboard cycling lands
+      // on it and activateCyclableTab's editor branch re-activates it via tabId.
+      if (seenEditors.has(tab.id)) {
+        continue
+      }
+      seenEditors.add(tab.id)
+      result.push({ type: 'editor', id: tab.id, tabId: tab.id })
     } else {
       if (!editorEntityIds.has(tab.entityId) || seenEditors.has(tab.id)) {
         continue

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -13,6 +13,7 @@ export type ActiveTabNavOrderIds = {
   editorIds?: string[]
   browserIds?: string[]
   simulatorIds?: string[]
+  gitGraphIds?: string[]
 }
 
 /**
@@ -147,6 +148,11 @@ export function getActiveTabNavOrder(
     (state.unifiedTabsByWorktree[worktreeId] ?? [])
       .filter((tab) => tab.contentType === 'simulator')
       .map((tab) => tab.id)
+  const gitGraphIds =
+    ids.gitGraphIds ??
+    (state.unifiedTabsByWorktree[worktreeId] ?? [])
+      .filter((tab) => tab.contentType === 'git-graph')
+      .map((tab) => tab.id)
 
   const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
   const group = activeGroupId
@@ -173,12 +179,14 @@ export function getActiveTabNavOrder(
     terminalIds,
     editorIds,
     browserIds,
-    simulatorIds
+    simulatorIds,
+    gitGraphIds
   )
   const terminalIdSet = new Set(terminalIds)
   const editorIdSet = new Set(editorIds)
   const browserIdSet = new Set(browserIds)
   const simulatorIdSet = new Set(simulatorIds)
+  const gitGraphIdSet = new Set(gitGraphIds)
   const result: VisibleTabRef[] = []
   for (const id of visibleIds) {
     if (terminalIdSet.has(id)) {
@@ -189,6 +197,9 @@ export function getActiveTabNavOrder(
       result.push({ type: 'browser', id })
     } else if (simulatorIdSet.has(id)) {
       result.push({ type: 'simulator', id })
+    } else if (gitGraphIdSet.has(id)) {
+      // git-graph routes through the editor activation path keyed by tab id.
+      result.push({ type: 'editor', id })
     }
   }
   return result

--- a/src/renderer/src/components/tab-bar/reconcile-order.test.ts
+++ b/src/renderer/src/components/tab-bar/reconcile-order.test.ts
@@ -32,4 +32,15 @@ describe('reconcileTabOrder', () => {
     const stored = ['t1', 'e1', 't2', 'e2']
     expect(reconcileTabOrder(stored, ['t1', 't2'], ['e1', 'e2'])).toEqual(['t1', 'e1', 't2', 'e2'])
   })
+
+  it('includes git-graph ids in the validity set and appends new ones', () => {
+    // git-graph is the 6th tab kind; a stored order referencing it must keep it,
+    // and a brand-new git-graph tab must be appended like any other kind.
+    expect(reconcileTabOrder(['gg1', 't1'], ['t1'], [], [], [], ['gg1'])).toEqual(['gg1', 't1'])
+    expect(reconcileTabOrder(['t1'], ['t1'], [], [], [], ['gg1'])).toEqual(['t1', 'gg1'])
+  })
+
+  it('drops a stored git-graph id once the tab no longer exists', () => {
+    expect(reconcileTabOrder(['gg-gone', 't1'], ['t1'], [], [], [], [])).toEqual(['t1'])
+  })
 })

--- a/src/renderer/src/components/tab-bar/reconcile-order.ts
+++ b/src/renderer/src/components/tab-bar/reconcile-order.ts
@@ -8,9 +8,16 @@ export function reconcileTabOrder(
   terminalIds: string[],
   editorIds: string[],
   browserIds: string[] = [],
-  simulatorIds: string[] = []
+  simulatorIds: string[] = [],
+  gitGraphIds: string[] = []
 ): string[] {
-  const validIds = new Set([...terminalIds, ...editorIds, ...browserIds, ...simulatorIds])
+  const validIds = new Set([
+    ...terminalIds,
+    ...editorIds,
+    ...browserIds,
+    ...simulatorIds,
+    ...gitGraphIds
+  ])
   // Why: storedOrder is persisted group tab order and is mutated by many
   // codepaths (drop/move/reorder/hydrate). A stale or racey write can leave
   // the same tab id twice in the list, which surfaces as React's "two
@@ -25,7 +32,7 @@ export function reconcileTabOrder(
       inResult.add(id)
     }
   }
-  for (const id of [...terminalIds, ...editorIds, ...browserIds, ...simulatorIds]) {
+  for (const id of [...terminalIds, ...editorIds, ...browserIds, ...simulatorIds, ...gitGraphIds]) {
     if (!inResult.has(id)) {
       result.push(id)
       inResult.add(id)

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -21,6 +21,7 @@ import { tabGroupBodyAnchorName } from './tab-group-body-anchor'
 import { translate } from '@/i18n/i18n'
 
 const EditorPanel = lazy(() => import('../editor/EditorPanel'))
+const GitGraphPane = lazy(() => import('../git-graph/GitGraphPane'))
 
 export default function TabGroupPanel({
   groupId,
@@ -336,10 +337,27 @@ export default function TabGroupPanel({
             data-contextual-tour-target="workspace-agent-terminal-tip"
           />
         ) : null}
+        {activeTab && activeTab.contentType === 'git-graph' && (
+          <div className="absolute inset-0 flex min-h-0 min-w-0">
+            <Suspense
+              fallback={
+                <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                  {translate(
+                    'auto.components.tab.group.TabGroupPanel.6b2f0a1c9d',
+                    'Loading graph...'
+                  )}
+                </div>
+              }
+            >
+              <GitGraphPane worktreeId={activeTab.worktreeId} />
+            </Suspense>
+          </div>
+        )}
         {activeTab &&
           activeTab.contentType !== 'terminal' &&
           activeTab.contentType !== 'browser' &&
-          activeTab.contentType !== 'simulator' && (
+          activeTab.contentType !== 'simulator' &&
+          activeTab.contentType !== 'git-graph' && (
             <div className="absolute inset-0 flex min-h-0 min-w-0">
               {/* Why: split groups render editor content inside a plain relative pane body
                   instead of the legacy flex column in Terminal.tsx. */}

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -55,7 +55,7 @@ export type TabDragItemData = {
   groupId: string
   unifiedTabId: string
   visibleTabId: string
-  tabType: 'terminal' | 'editor' | 'browser' | 'simulator'
+  tabType: 'terminal' | 'editor' | 'browser' | 'simulator' | 'git-graph'
   /** Rendered by the DragOverlay ghost that follows the cursor across
    *  groups. Source tab strips use overflow-hidden, so without the overlay
    *  the dragged tab would be invisible once the cursor leaves its own

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -279,7 +279,9 @@ export function useTabGroupWorkspaceModel({
         destroyWorkspaceWebviews(browserState.browserPagesByWorkspace, item.entityId)
         closeBrowserTab(item.entityId)
         closeUnifiedTab(item.id)
-      } else if (item.contentType === 'simulator') {
+      } else if (item.contentType === 'simulator' || item.contentType === 'git-graph') {
+        // git-graph (like simulator) has no backing OpenFile entity, so close
+        // the unified tab directly without touching openFiles.
         closeUnifiedTab(item.id)
       } else {
         const canCloseTab = closeEditorIfUnreferenced(item.entityId, item.id)
@@ -344,7 +346,8 @@ export function useTabGroupWorkspaceModel({
           closeUnifiedTab(item.id)
         } else if (item.contentType === 'terminal') {
           closeTab(item.entityId)
-        } else if (item.contentType === 'simulator') {
+        } else if (item.contentType === 'simulator' || item.contentType === 'git-graph') {
+          // git-graph (like simulator) has no backing OpenFile entity.
           closeUnifiedTab(item.id)
         } else {
           const canCloseTab = closeEditorIfUnreferenced(item.entityId, item.id)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -255,6 +255,9 @@
         },
         "linear": {
           "37d36984d0": "Linear connection was superseded by a newer request."
+        },
+        "tabs": {
+          "7c3f1a9e0d": "Git Graph"
         }
       }
     },
@@ -2531,7 +2534,8 @@
             "1ff1c77616": "browser",
             "586d2ac445": "terminal",
             "addSplitPane": "Add split pane",
-            "closePaneColumn": "Close split pane"
+            "closePaneColumn": "Close split pane",
+            "6b2f0a1c9d": "Loading graph..."
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "Drop onto a terminal pane to resume this session.",
@@ -8647,7 +8651,8 @@
             "62e685d5ec": "idle",
             "111e1d0db4": "error",
             "e5e81e59a6": "Resize commits",
-            "6d1e0a7c3b": "Failed to load commit files"
+            "6d1e0a7c3b": "Failed to load commit files",
+            "4b8e2f1a06": "Open Git Graph"
           },
           "HostedReviewActions": {
             "4d5fb5a284": "Close",
@@ -12085,6 +12090,21 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "Copy"
+        }
+      },
+      "git": {
+        "graph": {
+          "GitGraphPane": {
+            "6f0a2d1b84": "Git Graph",
+            "b71e9c4d22": "Refresh graph",
+            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "2c8b1f0a93": "Loading graph...",
+            "4e7d6a1c08": "No commits yet",
+            "5d2e9b7a14": "Retry"
+          },
+          "useGitGraphHistory": {
+            "3d9c2e7b41": "Failed to load git graph"
+          }
         }
       }
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12097,7 +12097,7 @@
           "GitGraphPane": {
             "6f0a2d1b84": "Git Graph",
             "b71e9c4d22": "Refresh graph",
-            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "9a3f5c2e70": "Showing first {{value0}} commits across all branches",
             "2c8b1f0a93": "Loading graph...",
             "4e7d6a1c08": "No commits yet",
             "5d2e9b7a14": "Retry"

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -255,6 +255,9 @@
         },
         "linear": {
           "37d36984d0": "La conexión de Linear fue reemplazada por una solicitud más reciente."
+        },
+        "tabs": {
+          "7c3f1a9e0d": "Git Graph"
         }
       }
     },
@@ -2531,7 +2534,8 @@
             "1ff1c77616": "navegador",
             "586d2ac445": "terminal",
             "addSplitPane": "Agregar panel dividido",
-            "closePaneColumn": "Cerrar panel dividido"
+            "closePaneColumn": "Cerrar panel dividido",
+            "6b2f0a1c9d": "Loading graph..."
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "Suelta sobre un panel de terminal para reanudar esta sesión.",
@@ -8647,7 +8651,8 @@
             "62e685d5ec": "idle",
             "111e1d0db4": "error",
             "e5e81e59a6": "Cambiar el tamaño de las commits",
-            "6d1e0a7c3b": "No se pudieron cargar los archivos del commit"
+            "6d1e0a7c3b": "No se pudieron cargar los archivos del commit",
+            "4b8e2f1a06": "Open Git Graph"
           },
           "HostedReviewActions": {
             "4d5fb5a284": "Cerca",
@@ -12085,6 +12090,21 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "Copy"
+        }
+      },
+      "git": {
+        "graph": {
+          "GitGraphPane": {
+            "6f0a2d1b84": "Git Graph",
+            "b71e9c4d22": "Refresh graph",
+            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "2c8b1f0a93": "Loading graph...",
+            "4e7d6a1c08": "No commits yet",
+            "5d2e9b7a14": "Retry"
+          },
+          "useGitGraphHistory": {
+            "3d9c2e7b41": "Failed to load git graph"
+          }
         }
       }
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12097,7 +12097,7 @@
           "GitGraphPane": {
             "6f0a2d1b84": "Git Graph",
             "b71e9c4d22": "Refresh graph",
-            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "9a3f5c2e70": "Showing first {{value0}} commits across all branches",
             "2c8b1f0a93": "Loading graph...",
             "4e7d6a1c08": "No commits yet",
             "5d2e9b7a14": "Retry"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -255,6 +255,9 @@
         },
         "linear": {
           "37d36984d0": "Linear 接続は新しいリクエストに置き換えられました。"
+        },
+        "tabs": {
+          "7c3f1a9e0d": "Git Graph"
         }
       }
     },
@@ -2531,7 +2534,8 @@
             "1ff1c77616": "ブラウザ",
             "586d2ac445": "ターミナル",
             "addSplitPane": "分割ペインを追加",
-            "closePaneColumn": "分割ペインを閉じる"
+            "closePaneColumn": "分割ペインを閉じる",
+            "6b2f0a1c9d": "Loading graph..."
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "このセッションを再開するにはターミナルペインにドロップしてください。",
@@ -8647,7 +8651,8 @@
             "62e685d5ec": "idle",
             "111e1d0db4": "エラー",
             "e5e81e59a6": "commits のサイズ変更",
-            "6d1e0a7c3b": "commit ファイルを読み込めませんでした"
+            "6d1e0a7c3b": "commit ファイルを読み込めませんでした",
+            "4b8e2f1a06": "Open Git Graph"
           },
           "HostedReviewActions": {
             "4d5fb5a284": "閉じる",
@@ -12085,6 +12090,21 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "Copy"
+        }
+      },
+      "git": {
+        "graph": {
+          "GitGraphPane": {
+            "6f0a2d1b84": "Git Graph",
+            "b71e9c4d22": "Refresh graph",
+            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "2c8b1f0a93": "Loading graph...",
+            "4e7d6a1c08": "No commits yet",
+            "5d2e9b7a14": "Retry"
+          },
+          "useGitGraphHistory": {
+            "3d9c2e7b41": "Failed to load git graph"
+          }
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -12097,7 +12097,7 @@
           "GitGraphPane": {
             "6f0a2d1b84": "Git Graph",
             "b71e9c4d22": "Refresh graph",
-            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "9a3f5c2e70": "Showing first {{value0}} commits across all branches",
             "2c8b1f0a93": "Loading graph...",
             "4e7d6a1c08": "No commits yet",
             "5d2e9b7a14": "Retry"

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -255,6 +255,9 @@
         },
         "linear": {
           "37d36984d0": "더 새로운 요청이 있어 Linear 연결 요청을 건너뛰었습니다."
+        },
+        "tabs": {
+          "7c3f1a9e0d": "Git Graph"
         }
       }
     },
@@ -2531,7 +2534,8 @@
             "1ff1c77616": "브라우저",
             "586d2ac445": "터미널",
             "addSplitPane": "분할 창 추가",
-            "closePaneColumn": "분할 창 닫기"
+            "closePaneColumn": "분할 창 닫기",
+            "6b2f0a1c9d": "Loading graph..."
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "이 세션을 재개하려면 terminal 창에 놓으세요.",
@@ -8647,7 +8651,8 @@
             "62e685d5ec": "idle",
             "111e1d0db4": "오류",
             "e5e81e59a6": "commits 크기 조정",
-            "6d1e0a7c3b": "commit 파일을 로드하지 못했습니다"
+            "6d1e0a7c3b": "commit 파일을 로드하지 못했습니다",
+            "4b8e2f1a06": "Open Git Graph"
           },
           "HostedReviewActions": {
             "4d5fb5a284": "닫기",
@@ -12085,6 +12090,21 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "Copy"
+        }
+      },
+      "git": {
+        "graph": {
+          "GitGraphPane": {
+            "6f0a2d1b84": "Git Graph",
+            "b71e9c4d22": "Refresh graph",
+            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "2c8b1f0a93": "Loading graph...",
+            "4e7d6a1c08": "No commits yet",
+            "5d2e9b7a14": "Retry"
+          },
+          "useGitGraphHistory": {
+            "3d9c2e7b41": "Failed to load git graph"
+          }
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -12097,7 +12097,7 @@
           "GitGraphPane": {
             "6f0a2d1b84": "Git Graph",
             "b71e9c4d22": "Refresh graph",
-            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "9a3f5c2e70": "Showing first {{value0}} commits across all branches",
             "2c8b1f0a93": "Loading graph...",
             "4e7d6a1c08": "No commits yet",
             "5d2e9b7a14": "Retry"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -255,6 +255,9 @@
         },
         "linear": {
           "37d36984d0": "Linear 连接已被新的请求取代。"
+        },
+        "tabs": {
+          "7c3f1a9e0d": "Git Graph"
         }
       }
     },
@@ -2531,7 +2534,8 @@
             "1ff1c77616": "浏览器",
             "586d2ac445": "终端",
             "addSplitPane": "添加拆分窗格",
-            "closePaneColumn": "关闭拆分窗格"
+            "closePaneColumn": "关闭拆分窗格",
+            "6b2f0a1c9d": "Loading graph..."
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "拖放到终端面板以恢复此会话。",
@@ -8647,7 +8651,8 @@
             "62e685d5ec": "idle",
             "111e1d0db4": "错误",
             "e5e81e59a6": "调整 commits 大小",
-            "6d1e0a7c3b": "无法加载提交文件"
+            "6d1e0a7c3b": "无法加载提交文件",
+            "4b8e2f1a06": "Open Git Graph"
           },
           "HostedReviewActions": {
             "4d5fb5a284": "关闭",
@@ -12085,6 +12090,21 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "Copy"
+        }
+      },
+      "git": {
+        "graph": {
+          "GitGraphPane": {
+            "6f0a2d1b84": "Git Graph",
+            "b71e9c4d22": "Refresh graph",
+            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "2c8b1f0a93": "Loading graph...",
+            "4e7d6a1c08": "No commits yet",
+            "5d2e9b7a14": "Retry"
+          },
+          "useGitGraphHistory": {
+            "3d9c2e7b41": "Failed to load git graph"
+          }
         }
       }
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -12097,7 +12097,7 @@
           "GitGraphPane": {
             "6f0a2d1b84": "Git Graph",
             "b71e9c4d22": "Refresh graph",
-            "9a3f5c2e70": "Showing {{value0}} of many commits across all branches",
+            "9a3f5c2e70": "Showing first {{value0}} commits across all branches",
             "2c8b1f0a93": "Loading graph...",
             "4e7d6a1c08": "No commits yet",
             "5d2e9b7a14": "Retry"

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -1847,7 +1847,85 @@ describe('TabsSlice', () => {
     })
   })
 
+  describe('openGitGraph', () => {
+    it('creates exactly one git-graph tab and re-activates it without duplicating', () => {
+      const first = store.getState().openGitGraph(WT)
+      expect(first).not.toBeNull()
+      expect(first!.contentType).toBe('git-graph')
+      expect(first!.entityId).toBe(`${WT}::git-graph`)
+
+      // Activate a different tab, then reopen — must reuse the same tab.
+      store.getState().createUnifiedTab(WT, 'terminal')
+      const second = store.getState().openGitGraph(WT)
+
+      expect(second!.id).toBe(first!.id)
+      const graphTabs = store
+        .getState()
+        .unifiedTabsByWorktree[WT].filter((tab) => tab.contentType === 'git-graph')
+      expect(graphTabs).toHaveLength(1)
+      expect(store.getState().getActiveTab(WT)?.id).toBe(first!.id)
+    })
+
+    it('re-homes the existing git-graph tab into a split target instead of duplicating', () => {
+      const created = store.getState().openGitGraph(WT)
+      const sourceGroupId = created!.groupId
+      const targetGroupId = store.getState().createEmptySplitGroup(WT, sourceGroupId, 'right')
+      expect(targetGroupId).not.toBeNull()
+
+      const moved = store.getState().openGitGraph(WT, { targetGroupId: targetGroupId! })
+
+      expect(moved!.id).toBe(created!.id)
+      expect(moved!.groupId).toBe(targetGroupId)
+      const graphTabs = store
+        .getState()
+        .unifiedTabsByWorktree[WT].filter((tab) => tab.contentType === 'git-graph')
+      expect(graphTabs).toHaveLength(1)
+    })
+  })
+
   describe('reconcileWorktreeTabModel', () => {
+    it('keeps git-graph tabs because they have no backing OpenFile entity', () => {
+      const groupId = 'g-graph'
+      store.setState({
+        unifiedTabsByWorktree: {
+          [WT]: [
+            {
+              id: 'git-graph-1',
+              entityId: `${WT}::git-graph`,
+              groupId,
+              worktreeId: WT,
+              contentType: 'git-graph',
+              label: 'Git Graph',
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        groupsByWorktree: {
+          [WT]: [
+            {
+              id: groupId,
+              worktreeId: WT,
+              activeTabId: 'git-graph-1',
+              tabOrder: ['git-graph-1']
+            }
+          ]
+        },
+        activeGroupIdByWorktree: { [WT]: groupId },
+        tabsByWorktree: { [WT]: [] }
+      })
+
+      const result = store.getState().reconcileWorktreeTabModel(WT)
+
+      expect(result.renderableTabCount).toBe(1)
+      expect(result.activeRenderableTabId).toBe('git-graph-1')
+      expect(store.getState().unifiedTabsByWorktree[WT].map((tab) => tab.id)).toEqual([
+        'git-graph-1'
+      ])
+    })
+
     it('drops unified tabs whose backing content no longer exists', () => {
       const groupId = 'g-1'
       store.setState({

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -35,6 +35,7 @@ import { createBrowserUuid } from '@/lib/browser-uuid'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import { translate } from '@/i18n/i18n'
 
 export type TabSplitDirection = 'left' | 'right' | 'up' | 'down'
 
@@ -173,6 +174,10 @@ export type TabsSlice = {
     activeRenderableTabId: string | null
   }
   hydrateTabsSession: (session: WorkspaceSessionState) => void
+  // Opens (or reuses) the single repo-wide Git Graph tab for a worktree. With a
+  // targetGroupId (Cmd/Ctrl-click split), re-homes the existing tab into that
+  // group rather than duplicating it — one git-graph tab per worktree.
+  openGitGraph: (worktreeId: string, options?: { targetGroupId?: string }) => Tab | null
 }
 
 // Why: keep the TerminalTab (tabsByWorktree) pin in sync with the unified-tab
@@ -1899,6 +1904,11 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       if (tab.contentType === 'simulator') {
         return true
       }
+      // Repo-wide Git Graph has no backing OpenFile/entity (synthetic entityId),
+      // so it must survive reconcile like simulator or it is pruned each pass.
+      if (tab.contentType === 'git-graph') {
+        return true
+      }
       return liveEditorIds.has(tab.entityId)
     }
 
@@ -2034,6 +2044,37 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       renderableTabCount: validTabs.length,
       activeRenderableTabId
     }
+  },
+
+  openGitGraph: (worktreeId, options) => {
+    const entityId = `${worktreeId}::git-graph`
+    const existing =
+      get().unifiedTabsByWorktree[worktreeId]?.find((tab) => tab.contentType === 'git-graph') ??
+      null
+
+    if (existing) {
+      // One git-graph tab per worktree: re-home it on Cmd/Ctrl-click split
+      // instead of duplicating the (repo-wide, group-independent) view.
+      if (options?.targetGroupId && existing.groupId !== options.targetGroupId) {
+        get().moveUnifiedTabToGroup(existing.id, options.targetGroupId, { activate: true })
+      }
+      get().activateTab(existing.id)
+      const surfaced = get().getTab(existing.id)
+      if (surfaced) {
+        get().focusGroup(worktreeId, surfaced.groupId)
+      }
+      return surfaced
+    }
+
+    const created = get().createUnifiedTab(worktreeId, 'git-graph', {
+      entityId,
+      label: translate('auto.store.slices.tabs.7c3f1a9e0d', 'Git Graph'),
+      ...(options?.targetGroupId ? { targetGroupId: options.targetGroupId } : {}),
+      activate: true
+    })
+    get().activateTab(created.id)
+    get().focusGroup(worktreeId, created.groupId)
+    return created
   },
 
   hydrateTabsSession: (session) => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1503,12 +1503,15 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     // in the web runtime there's no offer, so return no candidates / no-op.
     findHugeFoldersToIgnore: async () => [],
     appendGitignore: async () => false,
-    history: async ({ worktreePath, limit, baseRef }) => {
+    history: async ({ worktreePath, limit, baseRef, allRefs }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       return callRuntimeResult('git.history', {
         worktree: toRuntimeWorktreeSelector(worktree.id),
         limit,
-        baseRef
+        baseRef,
+        // Why: forward the repo-wide Git Graph scope so the web runtime path
+        // enumerates all refs instead of silently falling back to linear history.
+        allRefs
       })
     },
     conflictOperation: async ({ worktreePath }) => {

--- a/src/shared/git-history-graph.test.ts
+++ b/src/shared/git-history-graph.test.ts
@@ -195,6 +195,40 @@ describe('git history graph model', () => {
     )
   })
 
+  it('keeps divergent multi-tip branches on separate lanes (repo-wide all-refs)', () => {
+    // Two branch tips with independent roots and no shared history — the shape an
+    // all-refs Git Graph query produces. The current branch lane must stay put
+    // while the second tip occupies its own lane, and both roots terminate cleanly.
+    const currentRef = branch('main', 'A1')
+    const otherRef = branch('experiment', 'B1')
+    const viewModels = buildGitHistoryViewModels(
+      [
+        item('A1', ['A2'], [currentRef]),
+        item('B1', ['B2'], [otherRef]),
+        item('A2', []),
+        item('B2', [])
+      ],
+      buildDefaultGitHistoryColorMap({ currentRef }),
+      currentRef
+    )
+
+    // A1 is HEAD and feeds its parent into the first lane.
+    expect(viewModels[0]!.kind).toBe('HEAD')
+    expect(viewModels[0]!.outputSwimlanes).toEqual([{ id: 'A2', color: GIT_HISTORY_REF_COLOR }])
+    // B1's parent joins as a distinct second lane that does not collide with A2's.
+    expect(viewModels[1]!.outputSwimlanes).toContainEqual({
+      id: 'A2',
+      color: GIT_HISTORY_REF_COLOR
+    })
+    const b2Lane = viewModels[1]!.outputSwimlanes.find((node) => node.id === 'B2')
+    expect(b2Lane).toBeDefined()
+    expect(b2Lane!.color).not.toBe(GIT_HISTORY_REF_COLOR)
+    // Each root has no parents, so its lane drains rather than continuing.
+    expect(viewModels[2]!.historyItem.parentIds).toEqual([])
+    expect(viewModels[3]!.historyItem.parentIds).toEqual([])
+    expect(viewModels[3]!.outputSwimlanes).toEqual([])
+  })
+
   it('assigns stable colors to current, remote, and base refs', () => {
     const currentRef = branch('feature', 'A')
     const remoteRef = remote('origin/feature', 'R')

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -56,6 +56,9 @@ export type GitHistoryItem = {
 export type GitHistoryOptions = {
   limit?: number
   baseRef?: string | null
+  // When true, scope the log to all refs (local + remote + tags + HEAD) for the
+  // repo-wide Git Graph view instead of the active branch's linear history.
+  allRefs?: boolean
 }
 
 export type GitHistoryResult = {

--- a/src/shared/git-history.test.ts
+++ b/src/shared/git-history.test.ts
@@ -244,6 +244,66 @@ describe('git history loader', () => {
     expect(result.hasMore).toBe(true)
   })
 
+  it('scopes the log to all refs (branches/remotes/tags/HEAD) in allRefs mode', async () => {
+    const { executor, calls } = createHistoryExecutor()
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 50,
+      allRefs: true
+    })
+
+    const logCall = calls.find((args) => args[0] === 'log')
+    expect(logCall).toEqual(
+      expect.arrayContaining([
+        `--format=${GIT_HISTORY_COMMIT_FORMAT}`,
+        '-z',
+        '--topo-order',
+        '--decorate=full',
+        '-n51',
+        '--branches',
+        '--remotes',
+        '--tags',
+        'HEAD'
+      ])
+    )
+    // Must not fall back to the linear single-headOid scope.
+    expect(logCall).not.toContain(HEAD_OID)
+    expect(result.currentRef?.name).toBe('feature')
+  })
+
+  it('emits no incoming/outgoing boundary rows and no remote/base refs in allRefs mode', async () => {
+    const { executor, calls } = createHistoryExecutor()
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 50,
+      allRefs: true
+    })
+
+    expect(result.hasIncomingChanges).toBe(false)
+    expect(result.hasOutgoingChanges).toBe(false)
+    expect(result.remoteRef).toBeUndefined()
+    expect(result.baseRef).toBeUndefined()
+    expect(result.mergeBase).toBeUndefined()
+    // Forked early: no upstream/merge-base round-trips.
+    expect(calls.some((args) => args[0] === 'for-each-ref')).toBe(false)
+    expect(calls.some((args) => args[0] === 'merge-base')).toBe(false)
+  })
+
+  it('still clamps oversized limits in allRefs mode', async () => {
+    const { executor, calls } = createHistoryExecutor(GIT_HISTORY_MAX_LIMIT + 1)
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 500,
+      allRefs: true
+    })
+
+    const logCall = calls.find((args) => args[0] === 'log')
+    expect(logCall).toContain(`-n${GIT_HISTORY_MAX_LIMIT + 1}`)
+    expect(result.items).toHaveLength(GIT_HISTORY_MAX_LIMIT)
+    expect(result.limit).toBe(GIT_HISTORY_MAX_LIMIT)
+    expect(result.hasMore).toBe(true)
+  })
+
   it('returns an empty result for unborn repositories without running git log', async () => {
     const executor = vi.fn(async (args: string[]) => {
       if (args[0] === 'rev-parse') {

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -173,6 +173,41 @@ export async function loadGitHistoryFromExecutor(
   }
 
   const { currentRef, branchName } = await resolveCurrentRef(git, cwd, headOid)
+
+  // Repo-wide Git Graph: fork early so the upstream/merge-base/incoming-outgoing
+  // computation (a "your branch vs upstream" sidebar affordance) never runs — it
+  // is meaningless across all refs. Still resolve currentRef above for the HEAD
+  // marker + color-map key.
+  if (options.allRefs) {
+    const { stdout } = await git(
+      [
+        'log',
+        `--format=${GIT_HISTORY_COMMIT_FORMAT}`,
+        '-z',
+        '--topo-order',
+        '--decorate=full',
+        `-n${limit + 1}`,
+        '--branches',
+        '--remotes',
+        '--tags',
+        'HEAD'
+      ],
+      cwd
+    )
+    const parsed = parseGitHistoryLog(stdout)
+    return {
+      items: parsed.slice(0, limit),
+      currentRef,
+      remoteRef: undefined,
+      baseRef: undefined,
+      mergeBase: undefined,
+      hasIncomingChanges: false,
+      hasOutgoingChanges: false,
+      hasMore: parsed.length > limit,
+      limit
+    }
+  }
+
   const [remoteRef, rawBaseRef] = await Promise.all([
     resolveUpstreamRef(git, cwd, branchName),
     resolveNamedRef(git, cwd, options.baseRef)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -766,6 +766,7 @@ export type TabContentType =
   | 'check-details'
   | 'browser'
   | 'simulator'
+  | 'git-graph'
 
 export type WorkspaceVisibleTabType = 'terminal' | 'editor' | 'browser' | 'simulator'
 export type CtrlTabOrderMode = 'mru' | 'sequential'


### PR DESCRIPTION
## What changes

Adds a **Git Graph** view — a full-pane tab that visualizes the whole repository: all local branches, remote-tracking branches, tags, merges, and where HEAD sits. Today Orca only shows the *current branch's* linear history at the bottom of the Source Control sidebar; this view answers "how do my branches and remotes relate?" across the entire repo, similar to VS Code's Git Graph.

Open it from the new **Open Git Graph** button in the Source Control panel's Commits header (Cmd/Ctrl-click opens it in a split).

**What does not change:** the existing sidebar commit graph is untouched — it stays current-branch-only. This is read-only visualization + commit inspection; it does **not** add branch mutation (checkout/create/delete/rebase) or per-branch filtering from the graph. Those are deferred follow-ups.

Fixes #4521.

## Design approach

The repo-wide data reuses the existing, well-tested git-history pipeline rather than introducing a parallel one. A new opt-in `allRefs` option on the shared history loader switches the `git log` revision set from the current branch's tip to `--branches --remotes --tags HEAD` (the same ref enumeration VS Code's Git Graph uses). The loader forks early in this mode: it resolves the current ref for the HEAD marker but skips the upstream/merge-base/incoming-outgoing computation (a "your branch vs its upstream" sidebar affordance that is meaningless across all refs), so it runs *fewer* git subprocesses than the linear path. The flag threads through the existing local-IPC, SSH-provider, and runtime-RPC boundaries, so it works for local, SSH, and remote-runtime workspaces with no new channel or provider method.

The UI is a new `git-graph` tab content type that renders a full-pane `GitGraphPane` reusing the existing graph SVG + commit-row components, virtualized with `@tanstack/react-virtual`. Clicking a commit opens its combined diff via the existing commit-diff path. The tab is wired into the tab strip as a first-class chip (activate / close / keyboard-cycle), mirroring the `simulator` tab pattern for no-backing-file tabs.

The graph is capped at 200 commits (the existing shared limit); when truncated, an honest banner states "Showing N of many commits across all branches." Raising the cap with incremental loading is a deferred follow-up.

## Design-review outcome

Design doc went through an automated design-review loop (parallel reviewers, 3 rounds, exited clean). Key corrections it caught and that shaped the implementation: the no-backing-file tab precedent is `simulator`/`browser` (not `check-details`, which has a backing `OpenFile`); the `allRefs` flag must be explicitly forwarded through three handlers that re-destructure options rather than spreading them (otherwise it silently drops on local/SSH/runtime); and the pane must request the 200 max limit explicitly (the shared default is 50).

## Implementation & deviations

Implemented as designed. Two focused helper modules were extracted to respect the repo's max-lines rule (`useGitGraphHistory.ts` for the pane's fetch/refresh state, `useGitHistoryPanelResize.ts` extracted verbatim from the sidebar panel). No `max-lines` disables were added.

## Completeness verification

A read-only verification pass confirmed every design requirement is implemented in production code (not just tests): the all-refs fork, three-boundary flag forwarding, tab lifecycle (`isRenderableTab` + one-tab-per-worktree `openGitGraph`), the render seam, the 200-limit fetch, currentRef-only view models, click-to-diff via the combined-diff path, virtualization, the `layout` prop on the reused row, the entry-point button, honest truncation copy, neutral empty state, and full `translate()` coverage.

## Headline behavior status

**Implemented.** Verified on screen in the running app: the Git Graph tab shows commits from multiple branches (main + feature-a + feature-b), with branch pills, a distinct `origin/feature-b` remote-tracking pill (proven by advancing local ahead of origin), tag pills (`v1.0.0`, `v1.1.0`), the merge commit rendered as a multi-parent join, and the HEAD marker. The full chain executes in production code (entry button → `openGitGraph` → tab → pane → `getRuntimeGitHistory({allRefs:true})` → local/SSH/runtime → `git log --branches --remotes --tags HEAD`).

## Perf audit

Touched hot paths: the history loader's git-subprocess count, the pane's fetch/render path, and the virtualized list. Result: **neutral-to-better than status quo** — the all-refs branch runs 3 git subprocesses vs 3–8 for the linear path (it forks before upstream/merge-base resolution), the single `git log` is bounded by `-n201`, and the list is virtualized and lazy-loaded (code-split). One fix applied: the routed context object was rebuilt every render, which churned the commit-action callbacks; converted to a stable `useMemo`. One minor item accepted: an unrelated settings change while the tab is open triggers one extra refetch (same coupling Source Control already has; user-initiated/infrequent, bounded).

## Code-review loop

Two independent reviewers ran in parallel in the same round and both returned clean — no P0/P1, only P2/P3 nits. An earlier round caught one **HIGH** blocker that was fixed: git-graph tabs had no tab-strip chip and became unreachable/uncloseable after switching away; the fix wires git-graph into every `simulator` special-case site (TabBar rail, reconcile-order, close handler, keyboard cycle, drag types). The remaining accepted nit: Cmd/Ctrl+W doesn't close the git-graph tab via keyboard — this is **consistent with the sibling `simulator` tab's behavior**, and the tab closes fine via the chip's X / context menu.

## Validation

- Static: `pnpm run typecheck` (web + node), `pnpm run lint` (incl. localization catalog + coverage) — pass. The one lint warning is in `useGitStatusPolling.ts`, unrelated to this diff.
- Unit: 233 focused tests pass — allRefs log args + early-fork + limit clamp; transport forwarding on the IPC and RPC paths; a divergent multi-tip graph fixture (independent roots don't collide); `openGitGraph` single-tab + reconcile survival; and the TabBar chip render/activate/close/cycle tests.
- Manual (Electron): exercised the real app on a multi-branch repo with a remote, merge, and tags — button → tab → multi-branch graph with remote/tag pills + merge + HEAD, commit→diff, refresh, tab-chip activate/close, and an empty-repo "No commits yet" smoke. Screenshots attached in a follow-up comment.

## Boundaries / remaining risk

- **SSH / remote-runtime not exercised end-to-end manually.** Low risk: the change adds one flag to the existing `getRuntimeGitHistory` RPC that Source Control already uses; the remote host runs the same shared loader. Unit tests cover the forwarding.
- Detached-HEAD was not separately validated beyond the empty-repo smoke; the code path resolves the current ref to the commit and still draws the HEAD marker.
- Deferred follow-ups (out of scope): branch actions from the graph, per-branch filtering, raising the 200-commit cap with incremental loading, keyboard-close parity for no-file tabs (shared with simulator).

## No agent-facing changes

This change touches no commit-message/PR-generation surface and injects no instructions into any agent. The only added strings are localized UI labels and tooltips.

Made with [Orca](https://github.com/stablyai/orca) 🐋
