### PR TITLE
Fix remote host branch diff routing

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -19,6 +19,7 @@ import { joinPath } from '@/lib/path'
 import { detectLanguage } from '@/lib/language-detect'
 import { setWithLRU } from '@/lib/scroll-cache'
 import { getConnectionIdForFile } from '@/lib/connection-context'
+import { getCombinedDiffSectionConnectionId } from './combined-diff-section-connection'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { writeRuntimeFile } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
@@ -622,8 +623,11 @@ export default function CombinedDiffViewer({
       let result: GitDiffResult
       let error: string | undefined
       try {
-        const sectionFilePath = joinPath(file.filePath, entry.path)
-        const connectionId = getConnectionIdForFile(file.worktreeId, sectionFilePath) ?? undefined
+        const connectionId = getCombinedDiffSectionConnectionId(
+          file.worktreeId,
+          file.filePath,
+          entry.path
+        )
         const state = useAppStore.getState()
         const fileSettings = settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId)
         if ((isBranchMode || (isAllMode && !('area' in entry))) && branchCompare) {

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -18,7 +18,7 @@ import { createProgrammaticScrollMarks } from '@/hooks/programmatic-scroll-marks
 import { joinPath } from '@/lib/path'
 import { detectLanguage } from '@/lib/language-detect'
 import { setWithLRU } from '@/lib/scroll-cache'
-import { getConnectionId, getConnectionIdForFile } from '@/lib/connection-context'
+import { getConnectionIdForFile } from '@/lib/connection-context'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { writeRuntimeFile } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
@@ -622,7 +622,7 @@ export default function CombinedDiffViewer({
       let result: GitDiffResult
       let error: string | undefined
       try {
-        const connectionId = getConnectionId(file.worktreeId) ?? undefined
+        const connectionId = getConnectionIdForFile(file.worktreeId, file.filePath) ?? undefined
         const state = useAppStore.getState()
         const fileSettings = settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId)
         if ((isBranchMode || (isAllMode && !('area' in entry))) && branchCompare) {

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -622,7 +622,8 @@ export default function CombinedDiffViewer({
       let result: GitDiffResult
       let error: string | undefined
       try {
-        const connectionId = getConnectionIdForFile(file.worktreeId, file.filePath) ?? undefined
+        const sectionFilePath = joinPath(file.filePath, entry.path)
+        const connectionId = getConnectionIdForFile(file.worktreeId, sectionFilePath) ?? undefined
         const state = useAppStore.getState()
         const fileSettings = settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId)
         if ((isBranchMode || (isAllMode && !('area' in entry))) && branchCompare) {

--- a/src/renderer/src/components/editor/combined-diff-section-connection.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-section-connection.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { FolderWorkspace, ProjectGroup, Repo } from '../../../../shared/types'
+import { useAppStore } from '@/store'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import { getCombinedDiffSectionConnectionId } from './combined-diff-section-connection'
+
+const initialState = useAppStore.getInitialState()
+
+function makeRepo(overrides: Partial<Repo> & { id: string }): Repo {
+  return {
+    path: '/home/neil/repo',
+    displayName: 'repo',
+    badgeColor: '#000',
+    addedAt: 0,
+    ...overrides
+  }
+}
+
+function makeFolderWorkspace(folderPath: string): FolderWorkspace {
+  return {
+    id: 'folder-workspace-1',
+    projectGroupId: 'group-1',
+    name: 'Platform workspace',
+    folderPath,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 0,
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+function makeGroup(parentPath: string): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Platform',
+    parentPath,
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+describe('getCombinedDiffSectionConnectionId', () => {
+  afterEach(() => {
+    useAppStore.setState(initialState, true)
+  })
+
+  it('routes a section to its SSH child repo in a mixed folder workspace (#6688)', () => {
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
+    useAppStore.setState({
+      folderWorkspaces: [makeFolderWorkspace('/home/neil/platform')],
+      projectGroups: [makeGroup('/home/neil/platform')],
+      repos: [
+        makeRepo({ id: 'repo-local', path: '/home/neil/platform/web', projectGroupId: 'group-1' }),
+        makeRepo({
+          id: 'repo-ssh',
+          path: '/home/neil/platform/api',
+          projectGroupId: 'group-1',
+          connectionId: 'ssh-1'
+        })
+      ],
+      worktreesByRepo: {}
+    })
+
+    // Section paths are repo-tree-relative; joined onto the workspace root they
+    // must resolve to the owning child repo, not the ambiguous workspace.
+    expect(
+      getCombinedDiffSectionConnectionId(workspaceKey, '/home/neil/platform', 'api/src/index.ts')
+    ).toBe('ssh-1')
+    // Local child repo -> no connection (local read).
+    expect(
+      getCombinedDiffSectionConnectionId(workspaceKey, '/home/neil/platform', 'web/src/index.ts')
+    ).toBeUndefined()
+    // A path owned by no single child repo stays ambiguous.
+    expect(
+      getCombinedDiffSectionConnectionId(workspaceKey, '/home/neil/platform', 'README.md')
+    ).toBeUndefined()
+  })
+
+  it('composes Windows section paths with the workspace root separator', () => {
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
+    // A mixed local+SSH workspace makes the whole-workspace owner ambiguous, so
+    // resolution must fall through to composing the section path — the behavior
+    // this test guards. A single-SSH workspace would resolve before joinPath.
+    useAppStore.setState({
+      folderWorkspaces: [makeFolderWorkspace('C:\\Users\\neil\\platform')],
+      projectGroups: [makeGroup('C:\\Users\\neil\\platform')],
+      repos: [
+        makeRepo({
+          id: 'repo-local',
+          path: 'C:\\Users\\neil\\platform\\web',
+          projectGroupId: 'group-1'
+        }),
+        makeRepo({
+          id: 'repo-ssh',
+          path: 'C:\\Users\\neil\\platform\\api',
+          projectGroupId: 'group-1',
+          connectionId: 'ssh-1'
+        })
+      ],
+      worktreesByRepo: {}
+    })
+
+    expect(
+      getCombinedDiffSectionConnectionId(
+        workspaceKey,
+        'C:\\Users\\neil\\platform',
+        'api/src/index.ts'
+      )
+    ).toBe('ssh-1')
+    expect(
+      getCombinedDiffSectionConnectionId(
+        workspaceKey,
+        'C:\\Users\\neil\\platform',
+        'web/src/index.ts'
+      )
+    ).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-section-connection.ts
+++ b/src/renderer/src/components/editor/combined-diff-section-connection.ts
@@ -1,0 +1,17 @@
+import { getConnectionIdForFile } from '@/lib/connection-context'
+import { joinPath } from '@/lib/path'
+
+/**
+ * Resolve the SSH connectionId that owns a combined-diff section's file.
+ *
+ * Why: folder workspaces mix local and SSH child repos, so the workspace
+ * worktree is an ambiguous owner; the section must resolve its host by the
+ * concrete child-repo path or a remote read is misrouted locally (#6688).
+ */
+export function getCombinedDiffSectionConnectionId(
+  worktreeId: string | null,
+  worktreeRootPath: string,
+  sectionPath: string
+): string | undefined {
+  return getConnectionIdForFile(worktreeId, joinPath(worktreeRootPath, sectionPath)) ?? undefined
+}

--- a/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
@@ -10,6 +10,7 @@ import type { DiffContent, FileContent } from './editor-panel-content-types'
 const mocks = vi.hoisted(() => ({
   readRuntimeFileContent: vi.fn(),
   getRuntimeGitDiff: vi.fn(),
+  getRuntimeGitBranchDiff: vi.fn(),
   getConnectionId: vi.fn(),
   getConnectionIdForFile: vi.fn(),
   isWorktreeConnectionResolved: vi.fn(() => true),
@@ -28,7 +29,7 @@ vi.mock('@/runtime/runtime-file-client', () => ({
 }))
 
 vi.mock('@/runtime/runtime-git-client', () => ({
-  getRuntimeGitBranchDiff: vi.fn(),
+  getRuntimeGitBranchDiff: mocks.getRuntimeGitBranchDiff,
   getRuntimeGitCommitDiff: vi.fn(),
   getRuntimeGitDiff: mocks.getRuntimeGitDiff,
   getRuntimeGitScope: vi.fn(() => null)
@@ -131,6 +132,7 @@ describe('useEditorPanelContentState', () => {
     latestDiffContents = {}
     mocks.readRuntimeFileContent.mockReset()
     mocks.getRuntimeGitDiff.mockReset()
+    mocks.getRuntimeGitBranchDiff.mockReset()
     mocks.getConnectionId.mockReset()
     mocks.getConnectionId.mockReturnValue(undefined)
     mocks.getConnectionIdForFile.mockReset()
@@ -184,6 +186,60 @@ describe('useEditorPanelContentState', () => {
         relativePath: 'api/src/file.ts',
         worktreeId: 'folder:folder-workspace-1',
         connectionId: 'ssh-1'
+      })
+    )
+  })
+
+  it('loads folder workspace branch diffs through the path-specific SSH connection', async () => {
+    const activeFile = createOpenFile({
+      id: 'branch-diff',
+      filePath: '/home/neil/platform/api/src/file.ts',
+      relativePath: 'api/src/file.ts',
+      worktreeId: 'folder:folder-workspace-1',
+      mode: 'diff',
+      diffSource: 'branch',
+      branchCompare: {
+        baseRef: 'main',
+        compareRef: 'feature',
+        compareVersion: 'feature',
+        baseOid: 'base',
+        headOid: 'head',
+        mergeBase: 'merge-base'
+      }
+    })
+    mocks.getConnectionIdForFile.mockReturnValue('ssh-1')
+    mocks.getRuntimeGitBranchDiff.mockResolvedValue({
+      kind: 'text',
+      originalContent: 'old',
+      modifiedContent: 'remote branch diff',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(<HookProbe activeFile={activeFile} openFiles={[activeFile]} />)
+    })
+
+    await vi.waitFor(() =>
+      expect(latestDiffContents[activeFile.id]?.modifiedContent).toBe('remote branch diff')
+    )
+    expect(mocks.getConnectionIdForFile).toHaveBeenCalledWith(
+      'folder:folder-workspace-1',
+      '/home/neil/platform/api/src/file.ts'
+    )
+    expect(mocks.getRuntimeGitBranchDiff).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: 'folder:folder-workspace-1',
+        worktreePath: '/home/neil/platform',
+        connectionId: 'ssh-1'
+      }),
+      expect.objectContaining({
+        compare: expect.objectContaining({ mergeBase: 'merge-base' }),
+        filePath: 'api/src/file.ts'
       })
     )
   })

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -3,11 +3,7 @@
    make the hook coordination harder to audit. */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { OpenFile } from '@/store/slices/editor'
-import {
-  getConnectionId,
-  getConnectionIdForFile,
-  isWorktreeConnectionResolved
-} from '@/lib/connection-context'
+import { getConnectionIdForFile, isWorktreeConnectionResolved } from '@/lib/connection-context'
 import { joinPath } from '@/lib/path'
 import { useAppStore } from '@/store'
 import { getDiskBaselineSignature } from './diff-content-signature'
@@ -224,7 +220,7 @@ export function useEditorPanelContentState({
             ? file.branchCompare
             : null
         const commitCompare = file.commitCompare?.commitOid ? file.commitCompare : null
-        const connectionId = getConnectionId(file.worktreeId) ?? undefined
+        const connectionId = getConnectionIdForFile(file.worktreeId, file.filePath) ?? undefined
         const activeSettings = useAppStore.getState().settings
         const fileSettings = settingsForRuntimeOwner(activeSettings, file.runtimeEnvironmentId)
         const gitScope = getRuntimeGitScope(fileSettings, connectionId)

--- a/src/renderer/src/lib/connection-context.test.ts
+++ b/src/renderer/src/lib/connection-context.test.ts
@@ -256,6 +256,46 @@ describe('getConnectionId', () => {
     expect(getConnectionIdForFile(workspaceKey, '/home/neil/platform/README.md')).toBeUndefined()
   })
 
+  it('resolves folder workspace combined diff sections by child repo path', () => {
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
+    useAppStore.setState({
+      folderWorkspaces: [makeFolderWorkspace()],
+      projectGroups: [
+        {
+          id: 'group-1',
+          name: 'Platform',
+          parentPath: '/home/neil/platform',
+          parentGroupId: null,
+          createdFrom: 'folder-scan',
+          tabOrder: 0,
+          isCollapsed: false,
+          color: null,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      repos: [
+        makeRepo({
+          id: 'repo-local',
+          path: '/home/neil/platform/web',
+          projectGroupId: 'group-1'
+        }),
+        makeRepo({
+          id: 'repo-ssh',
+          path: '/home/neil/platform/api',
+          projectGroupId: 'group-1',
+          connectionId: 'ssh-1'
+        })
+      ],
+      worktreesByRepo: {}
+    })
+
+    expect(getConnectionIdForFile(workspaceKey, '/home/neil/platform')).toBeUndefined()
+    expect(getConnectionIdForFile(workspaceKey, '/home/neil/platform/api/src/index.ts')).toBe(
+      'ssh-1'
+    )
+  })
+
   it('keeps explicit folder workspace provenance isolated from unrelated same-path SSH repos', () => {
     useAppStore.setState({
       folderWorkspaces: [


### PR DESCRIPTION
## Summary

- resolve editor diff routing with the path-specific SSH connection lookup
- apply the same routing to combined diff section loads
- add regression coverage for folder workspace branch diffs using the SSH connection

Fixes #6688

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted validation:

- `git diff --check origin/main...HEAD`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/connection-context.test.ts src/renderer/src/components/editor/useEditorPanelContentState.test.tsx`
- `pnpm exec oxlint src/renderer/src/lib/connection-context.test.ts src/renderer/src/components/editor/useEditorPanelContentState.test.tsx src/renderer/src/components/editor/useEditorPanelContentState.ts src/renderer/src/components/editor/CombinedDiffViewer.tsx`
- `pnpm exec oxfmt --check src/renderer/src/lib/connection-context.test.ts src/renderer/src/components/editor/useEditorPanelContentState.test.tsx src/renderer/src/components/editor/useEditorPanelContentState.ts src/renderer/src/components/editor/CombinedDiffViewer.tsx`
- `pnpm run typecheck`
- `pnpm build`

Full `pnpm lint` currently stops on `src/main/ipc/notification-authorization-status.ts`, which is outside this PR's diff. The changed files pass the targeted `oxlint` and `oxfmt` checks above.

## Review notes

Review feedback on combined diff sections is covered by resolving the SSH owner from each concrete section path. The branch also exercises folder-workspace path routing through the real connection resolver, while the editor hook test verifies branch diff reads pass the concrete file path into the runtime diff call.

## Security Audit

This change does not alter command execution, authentication, secrets, dependencies, IPC contracts, or network boundaries. It narrows remote connection selection so nested folder workspace diffs route through the connection that owns the concrete file path.

## Compatibility Audit

The changed code only alters renderer-side connection selection for existing diff-loading paths. It does not introduce platform-specific filesystem separators, shell commands, native modules, browser APIs, or OS-gated behavior, so the routing behavior remains platform-neutral for macOS, Linux, and Windows workspaces.

## Notes

- No platform-specific UI behavior changes.
- No follow-up needed beyond maintainer review.
