### PR TITLE
fix: force render refresh on foreground return after background rewrite (U3)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7619,6 +7619,79 @@ describe('connectPanePty', () => {
     expect(refresh).not.toHaveBeenCalled()
   })
 
+  it('forces a viewport refresh on first foreground chunk after background in-place rewrite', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const isVisibleRef = { current: false }
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const refresh = vi.fn()
+    const terminal = pane.terminal as typeof pane.terminal & {
+      _core?: { refresh: typeof refresh }
+    }
+    terminal._core = { refresh }
+    terminal.write = vi.fn((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+
+    connectPanePty(pane as never, manager as never, createDeps({ isVisibleRef }) as never)
+    await flushAsyncTicks(6)
+
+    // Background: in-place rewrite (CR without LF — the stale-cell pattern)
+    capturedDataCallback.current?.('progress: 50%\r')
+    capturedDataCallback.current?.('progress: 100%\r')
+    expect(refresh).not.toHaveBeenCalled()
+
+    // Foreground return: first chunk after background rewrite triggers refresh
+    isVisibleRef.current = true
+    capturedDataCallback.current?.('done\r\n')
+
+    expect(refresh).toHaveBeenCalled()
+  })
+
+  it('does not force refresh on foreground chunk after background output with no rewrite', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const isVisibleRef = { current: false }
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const refresh = vi.fn()
+    const terminal = pane.terminal as typeof pane.terminal & {
+      _core?: { refresh: typeof refresh }
+    }
+    terminal._core = { refresh }
+    terminal.write = vi.fn((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+
+    connectPanePty(pane as never, manager as never, createDeps({ isVisibleRef }) as never)
+    await flushAsyncTicks(6)
+
+    // Background: normal output (no rewrite)
+    capturedDataCallback.current?.('normal output\r\n')
+    expect(refresh).not.toHaveBeenCalled()
+
+    // Foreground return: no rewrite was queued, so no forced refresh
+    isVisibleRef.current = true
+    capturedDataCallback.current?.('more output\r\n')
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
   it('forces a viewport refresh for native Windows CJK foreground output after terminal input', async () => {
     const restoreNavigator = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7643,15 +7643,18 @@ describe('connectPanePty', () => {
 
     connectPanePty(pane as never, manager as never, createDeps({ isVisibleRef }) as never)
     await flushAsyncTicks(6)
+    if (!capturedDataCallback.current) {
+      throw new Error('Expected PTY onData callback to be captured')
+    }
+    const onData = capturedDataCallback.current
 
     // Background: in-place rewrite (CR without LF — the stale-cell pattern)
-    capturedDataCallback.current?.('progress: 50%\r')
-    capturedDataCallback.current?.('progress: 100%\r')
+    onData('progress: 50%\r')
     expect(refresh).not.toHaveBeenCalled()
 
     // Foreground return: first chunk after background rewrite triggers refresh
     isVisibleRef.current = true
-    capturedDataCallback.current?.('done\r\n')
+    onData('done\r\n')
 
     expect(refresh).toHaveBeenCalled()
   })
@@ -7680,14 +7683,18 @@ describe('connectPanePty', () => {
 
     connectPanePty(pane as never, manager as never, createDeps({ isVisibleRef }) as never)
     await flushAsyncTicks(6)
+    if (!capturedDataCallback.current) {
+      throw new Error('Expected PTY onData callback to be captured')
+    }
+    const onData = capturedDataCallback.current
 
     // Background: normal output (no rewrite)
-    capturedDataCallback.current?.('normal output\r\n')
+    onData('normal output\r\n')
     expect(refresh).not.toHaveBeenCalled()
 
     // Foreground return: no rewrite was queued, so no forced refresh
     isVisibleRef.current = true
-    capturedDataCallback.current?.('more output\r\n')
+    onData('more output\r\n')
 
     expect(refresh).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2720,6 +2720,12 @@ export function connectPanePty(
     let foregroundImmediateBudgetWindowStart = 0
     let foregroundRewriteChunkEndedWithCarriageReturn = false
     let foregroundRewriteCsiScanTail = ''
+    let backgroundRewriteChunkEndedWithCarriageReturn = false
+    let backgroundRewriteCsiScanTail = ''
+    // Why: background-queued output during idle over SSH can carry in-place
+    // rewrites that leave stale renderer cells. Flag so the first foreground
+    // chunk after the violation triggers a refresh (U3, issue #5969).
+    let pendingBackgroundRewriteRefresh = false
     let hiddenMode2031ScanTail = ''
     const shouldSnapshotHiddenCodexOutput = shouldKeepHiddenStartupRendererQueriesLive(paneStartup)
     let hiddenStartupRendererQueryPending = ''
@@ -2920,10 +2926,29 @@ export function connectPanePty(
       // cursor-only restores need row invalidation even outside DEC 2026.
       const nativeWindowsCursorRestore =
         shouldProtectNativeWindowsSynchronizedOutput && foreground && containsCursorRestore(data)
+      if (!foreground) {
+        const backgroundRewriteDecision = terminalRewriteOutputRenderRefreshDecision(data, {
+          previousChunkEndsWithCarriageReturn: backgroundRewriteChunkEndedWithCarriageReturn,
+          previousRewriteCsiScanTail: backgroundRewriteCsiScanTail
+        })
+        if (backgroundRewriteDecision.prefersRenderRefresh) {
+          pendingBackgroundRewriteRefresh = true
+        }
+        backgroundRewriteChunkEndedWithCarriageReturn =
+          backgroundRewriteDecision.nextChunkEndsWithCarriageReturn
+        backgroundRewriteCsiScanTail = backgroundRewriteDecision.nextRewriteCsiScanTail
+      }
       const foregroundOutput = foreground || parseHiddenStartupOutput
-      const renderRefreshDecision = foregroundOutput
-        ? shouldForceForegroundRenderRefresh(data)
-        : { refresh: false, inPlaceRewrite: false }
+      let renderRefreshDecision: { refresh: boolean; inPlaceRewrite: boolean }
+      if (foregroundOutput) {
+        renderRefreshDecision = shouldForceForegroundRenderRefresh(data)
+        if (pendingBackgroundRewriteRefresh) {
+          renderRefreshDecision = { refresh: true, inPlaceRewrite: true }
+          pendingBackgroundRewriteRefresh = false
+        }
+      } else {
+        renderRefreshDecision = { refresh: false, inPlaceRewrite: false }
+      }
       const foregroundRenderRefreshNeeded = renderRefreshDecision.refresh
       // Why: see nativeWindowsRewriteNeedsFollowupRenderRefresh — Claude Code's
       // in-place prompt redraws on Windows ConPTY can paint one frame late, so a
@@ -3330,6 +3355,9 @@ export function connectPanePty(
       hiddenOutputRestoreNeeded = false
       hiddenOutputRestorePtyId = null
       hiddenOutputRestoreGeneration += 1
+      backgroundRewriteChunkEndedWithCarriageReturn = false
+      backgroundRewriteCsiScanTail = ''
+      pendingBackgroundRewriteRefresh = false
     }
 
     function clearPaneMode2031State(): void {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2926,6 +2926,7 @@ export function connectPanePty(
       // cursor-only restores need row invalidation even outside DEC 2026.
       const nativeWindowsCursorRestore =
         shouldProtectNativeWindowsSynchronizedOutput && foreground && containsCursorRestore(data)
+      let backgroundRewriteRefreshOnForeground = false
       if (!foreground) {
         const backgroundRewriteDecision = terminalRewriteOutputRenderRefreshDecision(data, {
           previousChunkEndsWithCarriageReturn: backgroundRewriteChunkEndedWithCarriageReturn,
@@ -2937,12 +2938,23 @@ export function connectPanePty(
         backgroundRewriteChunkEndedWithCarriageReturn =
           backgroundRewriteDecision.nextChunkEndsWithCarriageReturn
         backgroundRewriteCsiScanTail = backgroundRewriteDecision.nextRewriteCsiScanTail
+      } else if (backgroundRewriteChunkEndedWithCarriageReturn || backgroundRewriteCsiScanTail) {
+        const backgroundRewriteDecision = terminalRewriteOutputRenderRefreshDecision(data, {
+          previousChunkEndsWithCarriageReturn: backgroundRewriteChunkEndedWithCarriageReturn,
+          previousRewriteCsiScanTail: backgroundRewriteCsiScanTail
+        })
+        backgroundRewriteRefreshOnForeground = backgroundRewriteDecision.prefersRenderRefresh
+        backgroundRewriteChunkEndedWithCarriageReturn = false
+        backgroundRewriteCsiScanTail = ''
       }
       const foregroundOutput = foreground || parseHiddenStartupOutput
       let renderRefreshDecision: { refresh: boolean; inPlaceRewrite: boolean }
       if (foregroundOutput) {
         renderRefreshDecision = shouldForceForegroundRenderRefresh(data)
-        if (pendingBackgroundRewriteRefresh) {
+        if (
+          foreground &&
+          (pendingBackgroundRewriteRefresh || backgroundRewriteRefreshOnForeground)
+        ) {
           renderRefreshDecision = { refresh: true, inPlaceRewrite: true }
           pendingBackgroundRewriteRefresh = false
         }

--- a/src/renderer/src/components/terminal-pane/replay-guard.ts
+++ b/src/renderer/src/components/terminal-pane/replay-guard.ts
@@ -1,5 +1,5 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
-import { writeForegroundTerminalChunk } from '@/lib/pane-manager/pane-terminal-foreground-render-settle'
+import { writeForegroundTerminalChunk } from '../../lib/pane-manager/pane-terminal-foreground-render-settle'
 
 // Why: xterm.js auto-responds to terminal query sequences (DA1 `CSI c`,
 // DECRQM `CSI ? Ps $ p`, OSC 10/11 color queries, focus events, CPR) by


### PR DESCRIPTION
## Summary

Display artifacts appear in agent TUIs (Codex, Claude Code, OpenCode) left open over SSH for extended periods. Resizing clears them. Issue #5969 originally scoped this to Codex, but it affects any agent whose output goes through Orca's renderer — Claude Code and OpenCode reproduce it identically.

This PR implements **U3** of the fix plan (`docs/plans/2026-06-28-001-fix-tui-display-artifacts-ssh-idle-plan.md`): detect in-place rewrites on background-queued output and force a viewport refresh on the first foreground chunk after idle.

Units U1+U4 (atlas reset on visibility-resume) and U2 (SSH replay dedup) already landed. This closes the remaining trigger gap: background rewrites during idle that would otherwise leave stale cells until resize.

## Root cause

`writePtyOutputToXterm` in `pty-connection.ts` gates the render refresh decision on `foregroundOutput`. Background writes during idle carry in-place rewrites (`\r`, `\b`, erase sequences) that the gate ignores entirely. U1+U4 wired atlas reset on lifecycle events, but per-chunk rewrites still needed detection.

## Changes

- **`pty-connection.ts`**: Added background rewrite detection using existing `terminalRewriteOutputRenderRefreshDecision` with separate tracking state. On first foreground chunk after a flagged background rewrite, force `refresh: true, inPlaceRewrite: true`. Flag auto-clears on PTY change (reuses existing lifecycle).
- **`replay-guard.ts`**: Fixed broken `@/` alias import → relative path. This was blocking `pty-connection.test.ts` from loading under vitest.
- **`pty-connection.test.ts`**: 2 new tests:
  - Background CR rewrite → foreground chunk triggers refresh
  - Background normal output → foreground chunk does **not** trigger refresh (perf guard preserved)

## Scope

- Agent-agnostic: any CLI agent rendering through Orca's xterm.js renderer
- Cross-platform: macOS, Linux, Windows (string analysis, no OS-specific APIs)
- The foreground-only gate is preserved — background writes don't trigger per-chunk refreshes, only the lifecycle-anchored refresh on foreground return

## Verification

- `tsc --noEmit` → clean
- `pnpm vitest run src/renderer/src/components/terminal-pane/` → 1258 tests pass across 105 files
- Manual: confirmed no per-chunk refresh regression on active terminals

Fixes #5969

Made with [Orca](https://github.com/stablyai/orca) 🐋

## ELI5

Long-lived SSH agent terminals could show visual garbage until you resized. Orca detects background in-place screen rewrites and forces a refresh so the TUI paints correctly again.
