### PR TITLE
fix(mobile): avoid SF Mono fallback on iOS terminal

### DIFF
--- a/mobile/.oxlintrc.json
+++ b/mobile/.oxlintrc.json
@@ -36,7 +36,7 @@
     {
       "files": ["src/terminal/terminal-webview-html.ts"],
       "rules": {
-        "max-lines": ["error", { "max": 1778, "skipBlankLines": true, "skipComments": true }]
+        "max-lines": ["error", { "max": 1784, "skipBlankLines": true, "skipComments": true }]
       }
     },
     {

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -257,11 +257,10 @@ window.onerror = function(msg) {
     if (/iP(ad|hone|od)/.test(navigator.userAgent)) return true;
     return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
   }
-  // Why: iOS WebKit does not reliably resolve "SF Mono" by CSS family name.
-  // Start with WebKit's monospace generic there to avoid script/italic fallback.
-  var terminalFontFamily = isIOSWebView()
-    ? 'ui-monospace, "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", monospace'
-    : '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", monospace';
+  // Why: iOS WebKit does not reliably resolve "SF Mono" by CSS family name and can
+  // fall to a non-monospace face; lead with the ui-monospace generic to avoid that.
+  var TERMINAL_FONT_FALLBACKS = '"Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", monospace';
+  var terminalFontFamily = (isIOSWebView() ? 'ui-monospace, ' : '"SF Mono", ') + TERMINAL_FONT_FALLBACKS;
   // Why: change the real font size, then resize the grid to fit the viewport at
   // the new cell metrics so the text shows at its true size immediately. RN's
   // refit (measure → updateViewport) then makes the server reflow the PTY to the

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -253,6 +253,15 @@ window.onerror = function(msg) {
   function fontPxForScale(scale) {
     return Math.max(MIN_FONT_PX, Math.round(BASE_FONT_PX * scale));
   }
+  function isIOSWebView() {
+    if (/iP(ad|hone|od)/.test(navigator.userAgent)) return true;
+    return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+  }
+  // Why: iOS WebKit does not reliably resolve "SF Mono" by CSS family name.
+  // Start with WebKit's monospace generic there to avoid script/italic fallback.
+  var terminalFontFamily = isIOSWebView()
+    ? 'ui-monospace, "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", monospace'
+    : '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", monospace';
   // Why: change the real font size, then resize the grid to fit the viewport at
   // the new cell metrics so the text shows at its true size immediately. RN's
   // refit (measure → updateViewport) then makes the server reflow the PTY to the
@@ -729,7 +738,7 @@ window.onerror = function(msg) {
       cols: cols || 80,
       rows: rows || 24,
       theme: terminalTheme,
-      fontFamily: '"SF Mono", "Menlo", "Monaco", "Cascadia Mono", "Consolas", "DejaVu Sans Mono", "Liberation Mono", "Symbols Nerd Font Mono", monospace',
+      fontFamily: terminalFontFamily,
       fontSize: fontPxForScale(currentTextScale),
       fontWeight: '300',
       fontWeightBold: '500',

--- a/mobile/src/terminal/terminal-webview-text-zoom.test.ts
+++ b/mobile/src/terminal/terminal-webview-text-zoom.test.ts
@@ -32,6 +32,28 @@ output = chunks.map(function(chunk) { return normalizeStatusDotPresentation(chun
   return context.output ?? ''
 }
 
+function resolveTerminalFontFamily(navigatorValue: {
+  userAgent: string
+  platform: string
+  maxTouchPoints: number
+}) {
+  const functionStart = terminalHtmlSource.indexOf('  function isIOSWebView()')
+  const declarationEnd = terminalHtmlSource.indexOf(
+    '  // Why: change the real font size',
+    functionStart
+  )
+  expect(functionStart).toBeGreaterThanOrEqual(0)
+  expect(declarationEnd).toBeGreaterThan(functionStart)
+  const context: { navigator: typeof navigatorValue; output?: string } = {
+    navigator: navigatorValue
+  }
+  new Script(`
+${terminalHtmlSource.slice(functionStart, declarationEnd)}
+output = terminalFontFamily;
+`).runInNewContext(context)
+  return context.output ?? ''
+}
+
 describe('TerminalWebView text zoom', () => {
   it('pins textZoom to 100 so Android system font scale cannot inflate glyphs past xterm cell metrics', () => {
     const start = terminalWebViewSource.indexOf('<WebView')
@@ -123,12 +145,34 @@ describe('TerminalWebView text zoom', () => {
     expect(replay).toBeGreaterThan(unicode)
   })
 
-  it('uses the bundled WebGL-capable xterm stack and desktop font fallbacks', () => {
+  it('uses the bundled WebGL-capable xterm stack and platform-safe font fallbacks', () => {
     expect(terminalHtmlSource).not.toContain('cdn.jsdelivr.net')
     expect(terminalHtmlSource).toContain('window.WebglAddon.WebglAddon')
-    expect(terminalHtmlSource).toContain('"SF Mono", "Menlo", "Monaco", "Cascadia Mono"')
+    expect(terminalHtmlSource).toContain('function isIOSWebView()')
+    expect(terminalHtmlSource).toContain('\'ui-monospace, "Menlo", "Monaco", "Cascadia Mono"')
+    expect(terminalHtmlSource).toContain('\'"SF Mono", "Menlo", "Monaco", "Cascadia Mono"')
+    expect(terminalHtmlSource).toContain('fontFamily: terminalFontFamily')
     expect(terminalHtmlSource).toContain("fontWeight: '300'")
     expect(terminalHtmlSource).toContain("fontWeightBold: '500'")
     expect(terminalHtmlSource).toContain('new window.WebglAddon.WebglAddon()')
+  })
+
+  it('starts iOS WebViews on a WebKit-safe monospace family instead of SF Mono', () => {
+    const fontFamily = resolveTerminalFontFamily({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) AppleWebKit/605.1.15',
+      platform: 'iPhone',
+      maxTouchPoints: 5
+    })
+    expect(fontFamily.startsWith('ui-monospace, "Menlo"')).toBe(true)
+    expect(fontFamily.startsWith('"SF Mono"')).toBe(false)
+  })
+
+  it('keeps the SF Mono desktop fallback chain outside iOS WebViews', () => {
+    const fontFamily = resolveTerminalFontFamily({
+      userAgent: 'Mozilla/5.0 (Linux; Android 16)',
+      platform: 'Linux armv8l',
+      maxTouchPoints: 5
+    })
+    expect(fontFamily.startsWith('"SF Mono", "Menlo"')).toBe(true)
   })
 })

--- a/mobile/src/terminal/terminal-webview-text-zoom.test.ts
+++ b/mobile/src/terminal/terminal-webview-text-zoom.test.ts
@@ -149,22 +149,30 @@ describe('TerminalWebView text zoom', () => {
     expect(terminalHtmlSource).not.toContain('cdn.jsdelivr.net')
     expect(terminalHtmlSource).toContain('window.WebglAddon.WebglAddon')
     expect(terminalHtmlSource).toContain('function isIOSWebView()')
-    expect(terminalHtmlSource).toContain('\'ui-monospace, "Menlo", "Monaco", "Cascadia Mono"')
-    expect(terminalHtmlSource).toContain('\'"SF Mono", "Menlo", "Monaco", "Cascadia Mono"')
     expect(terminalHtmlSource).toContain('fontFamily: terminalFontFamily')
     expect(terminalHtmlSource).toContain("fontWeight: '300'")
     expect(terminalHtmlSource).toContain("fontWeightBold: '500'")
     expect(terminalHtmlSource).toContain('new window.WebglAddon.WebglAddon()')
   })
 
-  it('starts iOS WebViews on a WebKit-safe monospace family instead of SF Mono', () => {
-    const fontFamily = resolveTerminalFontFamily({
-      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) AppleWebKit/605.1.15',
-      platform: 'iPhone',
-      maxTouchPoints: 5
-    })
+  const IOS_IPHONE_NAVIGATOR = {
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) AppleWebKit/605.1.15',
+    platform: 'iPhone',
+    maxTouchPoints: 5
+  }
+  const ANDROID_NAVIGATOR = {
+    userAgent: 'Mozilla/5.0 (Linux; Android 16)',
+    platform: 'Linux armv8l',
+    maxTouchPoints: 5
+  }
+
+  it('starts iOS WebViews on ui-monospace, never SF Mono, still ending in a generic monospace guarantee', () => {
+    const fontFamily = resolveTerminalFontFamily(IOS_IPHONE_NAVIGATOR)
     expect(fontFamily.startsWith('ui-monospace, "Menlo"')).toBe(true)
     expect(fontFamily.startsWith('"SF Mono"')).toBe(false)
+    // The chain must always terminate in the generic so it can never fall back to
+    // a script/proportional system face — the actual iOS bug being fixed.
+    expect(fontFamily.endsWith(', monospace')).toBe(true)
   })
 
   it('treats touch iPadOS WebViews that report MacIntel as iOS for font fallback', () => {
@@ -175,14 +183,17 @@ describe('TerminalWebView text zoom', () => {
     })
     expect(fontFamily.startsWith('ui-monospace, "Menlo"')).toBe(true)
     expect(fontFamily.startsWith('"SF Mono"')).toBe(false)
+    expect(fontFamily.endsWith(', monospace')).toBe(true)
   })
 
-  it('keeps the SF Mono desktop fallback chain outside iOS WebViews', () => {
-    const fontFamily = resolveTerminalFontFamily({
-      userAgent: 'Mozilla/5.0 (Linux; Android 16)',
-      platform: 'Linux armv8l',
-      maxTouchPoints: 5
-    })
-    expect(fontFamily.startsWith('"SF Mono", "Menlo"')).toBe(true)
+  it('keeps the SF Mono lead outside iOS WebViews and shares the identical fallback tail', () => {
+    const androidFontFamily = resolveTerminalFontFamily(ANDROID_NAVIGATOR)
+    expect(androidFontFamily.startsWith('"SF Mono", "Menlo"')).toBe(true)
+    expect(androidFontFamily.endsWith(', monospace')).toBe(true)
+    // Only the lead family may differ across platforms; the rest of the chain is
+    // shared so the two platforms cannot silently drift apart.
+    const iosFontFamily = resolveTerminalFontFamily(IOS_IPHONE_NAVIGATOR)
+    const tailFrom = (family: string) => family.slice(family.indexOf('"Menlo"'))
+    expect(tailFrom(androidFontFamily)).toBe(tailFrom(iosFontFamily))
   })
 })

--- a/mobile/src/terminal/terminal-webview-text-zoom.test.ts
+++ b/mobile/src/terminal/terminal-webview-text-zoom.test.ts
@@ -37,13 +37,14 @@ function resolveTerminalFontFamily(navigatorValue: {
   platform: string
   maxTouchPoints: number
 }) {
+  // Slice only the font block itself (isIOSWebView + terminalFontFamily), anchored
+  // on font-related markers so unrelated edits below it can't break this extraction.
   const functionStart = terminalHtmlSource.indexOf('  function isIOSWebView()')
-  const declarationEnd = terminalHtmlSource.indexOf(
-    '  // Why: change the real font size',
-    functionStart
-  )
+  const declarationLine = terminalHtmlSource.indexOf('  var terminalFontFamily =', functionStart)
+  const declarationEnd = terminalHtmlSource.indexOf('\n', declarationLine)
   expect(functionStart).toBeGreaterThanOrEqual(0)
-  expect(declarationEnd).toBeGreaterThan(functionStart)
+  expect(declarationLine).toBeGreaterThan(functionStart)
+  expect(declarationEnd).toBeGreaterThan(declarationLine)
   const context: { navigator: typeof navigatorValue; output?: string } = {
     navigator: navigatorValue
   }

--- a/mobile/src/terminal/terminal-webview-text-zoom.test.ts
+++ b/mobile/src/terminal/terminal-webview-text-zoom.test.ts
@@ -167,6 +167,16 @@ describe('TerminalWebView text zoom', () => {
     expect(fontFamily.startsWith('"SF Mono"')).toBe(false)
   })
 
+  it('treats touch iPadOS WebViews that report MacIntel as iOS for font fallback', () => {
+    const fontFamily = resolveTerminalFontFamily({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 15_0) AppleWebKit/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 5
+    })
+    expect(fontFamily.startsWith('ui-monospace, "Menlo"')).toBe(true)
+    expect(fontFamily.startsWith('"SF Mono"')).toBe(false)
+  })
+
   it('keeps the SF Mono desktop fallback chain outside iOS WebViews', () => {
     const fontFamily = resolveTerminalFontFamily({
       userAgent: 'Mozilla/5.0 (Linux; Android 16)',


### PR DESCRIPTION
## Summary
- choose an iOS-safe monospace font chain for the mobile xterm WebView
- keep the existing SF Mono-first chain for non-iOS WebViews
- add regression coverage that executes the platform font selection logic

Fixes #6756.

## Testing
- `/Users/mehmet.turac/Documents/newfixer/orca/node_modules/.bin/vitest run --config mobile/vitest.config.ts mobile/src/terminal/terminal-webview-text-zoom.test.ts`
- `/Users/mehmet.turac/Documents/newfixer/orca/node_modules/.bin/oxfmt --check mobile/src/terminal/terminal-webview-html.ts mobile/src/terminal/terminal-webview-text-zoom.test.ts`
- `/Users/mehmet.turac/Documents/newfixer/orca/node_modules/.bin/oxlint mobile/src/terminal/terminal-webview-html.ts mobile/src/terminal/terminal-webview-text-zoom.test.ts`
- `git diff --check HEAD~1 HEAD`

Note: the focused Vitest run reports an existing warning that `mobile/tsconfig.json` cannot find `expo/tsconfig.base` in this dependency-light worktree. The test still passes. A broader `mobile/src/terminal` run is blocked in this worktree by missing mobile/jsdom dependencies, while the focused regression path above is green.