### PR TITLE
feat(browser): add Helium as a Chromium cookie-import source

### DIFF
--- a/src/main/browser/browser-cookie-import.helium.test.ts
+++ b/src/main/browser/browser-cookie-import.helium.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as childProcessModule from 'node:child_process'
+import type * as fsModule from 'node:fs'
+
+const { sessionFromPartitionMock, dialogShowOpenDialogMock } = vi.hoisted(() => ({
+  sessionFromPartitionMock: vi.fn(),
+  dialogShowOpenDialogMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: { showOpenDialog: dialogShowOpenDialogMock },
+  session: { fromPartition: sessionFromPartitionMock }
+}))
+
+import { BROWSER_FAMILY_LABELS } from '../../shared/constants'
+
+function slashPath(pathValue: string): string {
+  return pathValue.replaceAll('\\', '/')
+}
+
+describe('detectInstalledBrowsers — Helium', () => {
+  const originalPlatform = process.platform
+  const originalHome = process.env.HOME
+
+  beforeEach(() => {
+    // Why: browser-cookie-import.ts uses destructured named imports from
+    // 'node:fs' which are bound at module-load time. resetModules must run
+    // BEFORE each doMock so the next import() picks up the fresh mock factory.
+    vi.resetModules()
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    process.env.HOME = '/Users/test'
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    process.env.HOME = originalHome
+    vi.restoreAllMocks()
+  })
+
+  it('detects Helium under its bundle-id data dir via the legacy Cookies path', async () => {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: (p: string) => {
+          const normalizedPath = slashPath(p)
+          // Why: Helium stores cookies at the legacy <Profile>/Cookies path, so the
+          // newer Network/Cookies probe must miss and the legacy fallback must fire.
+          if (normalizedPath.includes('net.imput.helium/Default/Network/Cookies')) {
+            return false
+          }
+          if (normalizedPath.endsWith('net.imput.helium/Default/Cookies')) {
+            return true
+          }
+          if (normalizedPath.includes('net.imput.helium/Local State')) {
+            return true
+          }
+          return false
+        },
+        readFileSync: (p: string, enc?: string) => {
+          if (typeof p === 'string' && slashPath(p).includes('net.imput.helium/Local State')) {
+            return JSON.stringify({ profile: { info_cache: { Default: { name: 'Default' } } } })
+          }
+          return actual.readFileSync(p as never, enc as never)
+        }
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const detected = detectInstalledBrowsers()
+    const helium = detected.find((b) => b.family === 'helium')
+    expect(helium).toBeDefined()
+    expect(helium?.label).toBe('Helium')
+    expect(slashPath(helium?.cookiesPath ?? '')).toContain('net.imput.helium/Default/Cookies')
+    expect(slashPath(helium?.cookiesPath ?? '')).not.toContain('Network/Cookies')
+    expect(helium?.keychainService).toBe('Helium Storage Key')
+    expect(helium?.keychainAccount).toBe('Helium')
+  })
+
+  it('does not list Helium when its data directory is absent', async () => {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: () => false
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const detected = detectInstalledBrowsers()
+    expect(detected.find((b) => b.family === 'helium')).toBeUndefined()
+  })
+
+  it('enumerates all Helium profiles from Local State info_cache', async () => {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: (p: string) => {
+          const normalizedPath = slashPath(p)
+          if (normalizedPath.endsWith('net.imput.helium/Default/Cookies')) {
+            return true
+          }
+          if (normalizedPath.includes('net.imput.helium/Local State')) {
+            return true
+          }
+          return false
+        },
+        readFileSync: (p: string, enc?: string) => {
+          if (typeof p === 'string' && slashPath(p).includes('net.imput.helium/Local State')) {
+            return JSON.stringify({
+              profile: {
+                info_cache: {
+                  Default: { name: 'Personal' },
+                  'Profile 1': { name: 'Work' }
+                }
+              }
+            })
+          }
+          return actual.readFileSync(p as never, enc as never)
+        }
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const detected = detectInstalledBrowsers()
+    const helium = detected.find((b) => b.family === 'helium')
+    expect(helium).toBeDefined()
+    const directories = helium!.profiles.map((p) => p.directory).sort()
+    expect(directories).toEqual(['Default', 'Profile 1'])
+  })
+
+  it('rejects explicit Helium profile selections that escape the browser root', async () => {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: (p: string) => slashPath(p).includes('Application Support/Outside/Cookies')
+      }
+    })
+
+    const { selectBrowserProfile } = await import('./browser-cookie-import')
+    const selected = selectBrowserProfile(
+      {
+        family: 'helium',
+        label: 'Helium',
+        cookiesPath: '/Users/test/Library/Application Support/net.imput.helium/Default/Cookies',
+        keychainService: 'Helium Storage Key',
+        keychainAccount: 'Helium',
+        profiles: [{ name: 'Outside', directory: '../Outside' }],
+        selectedProfile: 'Default'
+      },
+      '../Outside'
+    )
+
+    expect(selected).toBeNull()
+  })
+})
+
+describe('getUserAgentForBrowser — Helium', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    vi.resetModules()
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    vi.restoreAllMocks()
+  })
+
+  it('returns a Chrome-shaped UA string when Helium plist version reads successfully', async () => {
+    vi.doMock('node:child_process', async () => {
+      const actual = await vi.importActual<typeof childProcessModule>('node:child_process')
+      return {
+        ...actual,
+        execFileSync: (cmd: string, args: readonly string[]) => {
+          if (cmd === 'defaults' && args[1]?.includes('/Applications/Helium.app/Contents/Info')) {
+            return '120.0.6099.71\n'
+          }
+          return actual.execFileSync(cmd, args as never)
+        }
+      }
+    })
+
+    const { getUserAgentForBrowser } = await import('./browser-cookie-import')
+    const ua = getUserAgentForBrowser('helium')
+
+    expect(ua).not.toBeNull()
+    expect(ua).toContain('Macintosh; Intel Mac OS X 10_15_7')
+    expect(ua).toContain('AppleWebKit/537.36')
+    expect(ua).toContain('Chrome/120.0.6099.71')
+    expect(ua).toContain('Safari/537.36')
+  })
+
+  it('returns null when reading the Helium plist version throws', async () => {
+    vi.doMock('node:child_process', async () => {
+      const actual = await vi.importActual<typeof childProcessModule>('node:child_process')
+      return {
+        ...actual,
+        execFileSync: () => {
+          throw new Error('defaults: domain not found')
+        }
+      }
+    })
+
+    const { getUserAgentForBrowser } = await import('./browser-cookie-import')
+    const ua = getUserAgentForBrowser('helium')
+    expect(ua).toBeNull()
+  })
+})
+
+describe('BROWSER_FAMILY_LABELS — Helium', () => {
+  it('maps the helium family key to the user-facing label "Helium"', () => {
+    expect(BROWSER_FAMILY_LABELS.helium).toBe('Helium')
+  })
+})

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -347,7 +347,16 @@ describe('detectInstalledBrowsers', () => {
 
   it('each detected browser has a valid family', () => {
     const browsers = detectInstalledBrowsers()
-    const validFamilies = ['chrome', 'edge', 'arc', 'chromium', 'firefox', 'safari', 'comet']
+    const validFamilies = [
+      'chrome',
+      'edge',
+      'arc',
+      'chromium',
+      'firefox',
+      'safari',
+      'comet',
+      'helium'
+    ]
     for (const browser of browsers) {
       expect(validFamilies).toContain(browser.family)
     }

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -153,6 +153,16 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
     macRoot: 'Comet',
     winRoot: 'Comet/User Data'
     // linuxRoot intentionally omitted — Comet does not ship a Linux build as of 2026-05-15
+  },
+  {
+    family: 'helium',
+    // Why: Helium deviates from the '<Browser> Safe Storage'/'<Browser>' convention —
+    // its Keychain entry is literally service 'Helium Storage Key', account 'Helium'.
+    label: 'Helium',
+    keychainService: 'Helium Storage Key',
+    keychainAccount: 'Helium',
+    macRoot: 'net.imput.helium'
+    // winRoot/linuxRoot intentionally omitted — only the macOS install is verified
   }
 ]
 
@@ -765,6 +775,12 @@ export function getUserAgentForBrowser(
       // Why: Comet is Chromium-based and ships a Chrome-shaped version in its plist.
       // Use the same UA shape as Chrome itself so Google-bound auth cookies survive import.
       const v = readBrowserVersion('/Applications/Comet.app')
+      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+    }
+    case 'helium': {
+      // Why: Helium is Chromium-based and ships a Chrome-shaped version in its plist.
+      // Use the same UA shape as Chrome itself so Google-bound auth cookies survive import.
+      const v = readBrowserVersion('/Applications/Helium.app')
       return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
     }
     case 'firefox':

--- a/src/renderer/src/components/browser-pane/browser-detected-browsers-summary.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-detected-browsers-summary.test.ts
@@ -7,6 +7,7 @@ const SUPPORTED_LABELS = [
   'Arc',
   'Brave',
   'Comet',
+  'Helium',
   'Firefox',
   'Safari'
 ]
@@ -46,7 +47,7 @@ describe('formatBrowserImportSummary', () => {
         detectedBrowsersLoaded: false,
         supportedImportLabels: SUPPORTED_LABELS
       })
-    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +3 more.')
+    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +4 more.')
   })
 
   it('falls back to supported import sources when detection finds nothing', () => {
@@ -56,6 +57,6 @@ describe('formatBrowserImportSummary', () => {
         detectedBrowsersLoaded: true,
         supportedImportLabels: SUPPORTED_LABELS
       })
-    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +3 more.')
+    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +4 more.')
   })
 })

--- a/src/shared/browser-cookie-import-sources.test.ts
+++ b/src/shared/browser-cookie-import-sources.test.ts
@@ -9,6 +9,7 @@ describe('getBrowserCookieImportSourceLabels', () => {
       'Arc',
       'Brave',
       'Comet',
+      'Helium',
       'Firefox',
       'Safari'
     ])

--- a/src/shared/browser-cookie-import-sources.ts
+++ b/src/shared/browser-cookie-import-sources.ts
@@ -5,7 +5,8 @@ const CHROMIUM_COOKIE_IMPORT_SOURCES = [
   { label: 'Microsoft Edge', mac: true, win: true, linux: true },
   { label: 'Arc', mac: true, win: false, linux: false },
   { label: 'Brave', mac: true, win: true, linux: true },
-  { label: 'Comet', mac: true, win: true, linux: false }
+  { label: 'Comet', mac: true, win: true, linux: false },
+  { label: 'Helium', mac: true, win: false, linux: false }
 ] as const
 
 export function getBrowserCookieImportSourceLabels(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -73,6 +73,7 @@ export const BROWSER_FAMILY_LABELS: Record<string, string> = {
   chrome: 'Google Chrome',
   chromium: 'Chromium',
   comet: 'Comet',
+  helium: 'Helium',
   arc: 'Arc',
   edge: 'Microsoft Edge',
   brave: 'Brave',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -938,7 +938,16 @@ export type BrowserTab = BrowserWorkspace
 export type BrowserSessionProfileScope = 'default' | 'isolated' | 'imported'
 
 export type BrowserSessionProfileSource = {
-  browserFamily: 'chrome' | 'chromium' | 'arc' | 'edge' | 'firefox' | 'safari' | 'comet' | 'manual'
+  browserFamily:
+    | 'chrome'
+    | 'chromium'
+    | 'arc'
+    | 'edge'
+    | 'firefox'
+    | 'safari'
+    | 'comet'
+    | 'helium'
+    | 'manual'
   profileName?: string
   importedAt: number
 }


### PR DESCRIPTION
## Summary

Helium (the privacy browser by imput, bundle id `net.imput.helium`) is Chromium-based, but until now Orca could only pull its cookies through the generic "From File..." JSON path. This registers Helium as a detected import source so it shows up in the browser picker on macOS and imports directly, the same way Chrome, Edge, Arc, Brave, and Comet already do.

Helium reuses the existing macOS Chromium decryption path unchanged (PBKDF2 `saltysalt` / 1003 iterations / 16-byte key, AES-128-CBC, 32-byte HMAC prefix stripped by `stripHmac`). I verified an end-to-end import against a real macOS install, so no crypto changes were needed. The work is registering the browser definition and threading a new `helium` family through the types and the user-agent helper.

Two Helium quirks drove the non-obvious values, both verified on a real install:

- Its Keychain entry breaks the usual `<Browser> Safe Storage` / `<Browser>` convention. The generic-password item is service `Helium Storage Key`, account `Helium`. Wrong values fail key retrieval silently.
- It stores its data under its bundle id (`~/Library/Application Support/net.imput.helium`) rather than a vendor path like `Google/Chrome`, and keeps cookies at the legacy `<Profile>/Cookies` location. The existing resolver already probes `Network/Cookies` first and falls back to `Cookies`, so the legacy path works without new code (covered by a test).

I only verified macOS. Helium ships Windows and Linux builds, but I have not confirmed their data directories, so I left `winRoot` and `linuxRoot` off the definition and defaulted Helium to mac-only in the import-source list. Adding the other platforms later is a one-line change per platform once someone confirms the paths.

## Screenshots

The only visual change is a new `Helium` entry in the existing "Import Cookies" picker on macOS; the picker layout and components are untouched.

<img width="1318" height="306" alt="image" src="https://github.com/user-attachments/assets/4f750716-501d-4ba5-86a9-f7b78164eef2" />

Verified end-to-end on a real macOS install: imported from a live Helium profile (Default, ~805 cookies), the macOS Keychain released the `Helium Storage Key`, decryption succeeded through the existing path, and an authenticated session carried over in the Orca browser.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (cookie-import suites + see note on unrelated environmental failures)
- [x] `pnpm build`
- [x] Added tests that fail without the change

- `pnpm lint` passed (one pre-existing `react-hooks/exhaustive-deps` warning in `useGitStatusPolling.ts`, unrelated to this change and non-failing). The switch-exhaustiveness pass confirms the only `switch` on `browserFamily` (`getUserAgentForBrowser`) stays exhaustive after the new `helium` case.
- `pnpm typecheck` passed clean (tsgo over `tsconfig.node.json`, `tsconfig.tc.cli.json`, `tsconfig.tc.web.json`).
- `pnpm build` passed clean (exit 0).
- `pnpm test`: 22,594 passed. The cookie-import suites all pass, including the new Helium tests.

New and updated coverage:

- `src/main/browser/browser-cookie-import.helium.test.ts` (new) asserts detection resolves the legacy `Default/Cookies` path and not `Network/Cookies`, the `Helium Storage Key` / `Helium` Keychain values, multi-profile enumeration, rejection of profile selections that escape the browser root, the Chrome-shaped UA on darwin (and null when the plist read throws), and the `BROWSER_FAMILY_LABELS.helium` mapping.
- `src/shared/browser-cookie-import-sources.test.ts` now expects `Helium` in the darwin list and absent from win32/linux.
- `src/main/browser/browser-cookie-import.test.ts` adds `helium` to its `validFamilies` assertion.
- `src/renderer/src/components/browser-pane/browser-detected-browsers-summary.test.ts` adds `Helium` to the supported-sources fixture so the "Import from..." summary count stays in sync with the darwin source list (same fixture Comet was added to).

Note on the 16 residual failures: four renderer suites (`SidebarToolbar`, `pr-comment-presentation`, `pr-comments-list-selection`, `LinearAgentSkillSetupPrompt`) fail with `localStorage is not available because --localstorage-file was not provided`. That is a local Node-version gap (Node 26 vs the repo's pinned Node 24), not a code issue: they reproduce on a clean tree with this change stashed, and none touch cookie import, browser detection, `types.ts`, or `constants.ts`. (A separate larger cluster of git/relay failures on this machine came from a local `commit.gpgsign=true` config blocking temp-repo commits; running with signing disabled cleared all of them.)

## AI Review Report

I ran a review of the diff with the following focus and outcomes:

- **Correctness.** Detection routes through the same `CHROMIUM_BROWSERS` definition and resolver path as the other browsers, so Helium reuses the verified decrypt, staging, and integrity-cookie-skip logic without a new branch. The one added `getUserAgentForBrowser` case mirrors the Comet case (read `/Applications/Helium.app` version, return a Chrome-shaped UA, return null when the read fails or the platform is not darwin).
- **Cross-platform (macOS / Linux / Windows).** Helium is gated to macOS by design: only `macRoot` is set, so `browserRootPath()` returns null on Windows and Linux and Helium never gets detected there, and the import-source list marks it mac-only. No hardcoded paths (uses `path.join` via the existing helpers), no shortcuts, no labels, no shell assumptions beyond the existing `security` and `defaults` calls already used for every Chromium browser.
- **SSH / remote / local.** Cookie import already runs against the machine hosting the browser stores and reads the local Keychain. Helium adds no new assumption here; it flows through the identical code path as Chrome and Comet.
- **Performance.** One extra entry in a small static array iterated once at detection time. No hot-path or allocation impact.

What I changed as a result: I trimmed my initial inline comments on the new browser definition to match the surrounding terseness (the array carries at most a single short note per entry), keeping only the genuinely non-obvious Keychain-deviation and mac-only-verification notes.

## Security Audit

No new security surface. The change registers another browser definition that reuses the existing key-retrieval, decryption, and cookie-staging code:

- **Secrets / auth.** Reads the Helium encryption key via the same `security find-generic-password` call used for every Chromium browser. No new credential handling, storage, or logging of secret material.
- **Path handling.** Profile directory names from `Local State` still pass through `isSafeBrowserProfileDirectory`, which rejects traversal and separators; the Helium tests include the escape-rejection behavior inherited from the shared path.
- **Command execution.** No new commands. The added UA case calls the same `defaults read` on a fixed app path as the other browsers.
- **IPC / dependencies.** No new IPC surface and no new dependencies.

No follow-up needed.

## Notes

- Helium is macOS-only in this PR because that is the only platform I verified. Confirming the Windows (`LOCALAPPDATA`) and Linux (`XDG_CONFIG_HOME`) data directories and flipping `win` / `linux` in `CHROMIUM_COOKIE_IMPORT_SOURCES` plus adding `winRoot` / `linuxRoot` would extend it, but I did not want to guess those paths.
- I did not touch the Google integrity-cookie skip set (`SIDCC`, `__Secure-1PSIDCC`, and friends). That handling is source-agnostic and already applies to Helium imports.

X handle: https://x.com/NicholasZolton
