### PR TITLE
Reload working-tree combined diff views on external file changes

### DIFF
--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -57,6 +57,18 @@ export function isExternalReloadableEditorTab(file: OpenFile): boolean {
   )
 }
 
+// Why: combined "Changes"/"All Changes" tabs render working-tree diffs but
+// match no single path (their relativePath is a label, filePath the worktree
+// root). The fs watcher must still notify them so terminal/agent edits reload
+// the affected section. Branch/commit combined diffs compare committed refs, so
+// working-tree changes don't affect them and are intentionally excluded.
+export function isWorkingTreeCombinedDiffTab(file: OpenFile): boolean {
+  return (
+    file.mode === 'diff' &&
+    (file.diffSource === 'combined-uncommitted' || file.diffSource === 'combined-all')
+  )
+}
+
 export function canAutoSaveOpenFile(file: OpenFile): boolean {
   // Why: single-file editors and one-file unstaged diffs have an unambiguous
   // write target. Combined diff and conflict-review tabs can represent multiple

--- a/src/renderer/src/hooks/useEditorExternalWatch.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.test.ts
@@ -456,6 +456,62 @@ describe('createExternalWatchEventHandler tombstone coalescing', () => {
     dispose()
   })
 
+  it('reloads a combined Changes tab even though no single-file tab matches', () => {
+    const combinedDiffTab = {
+      id: 'wt-1::all-diffs::uncommitted',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo',
+      relativePath: 'Changes',
+      mode: 'diff' as const,
+      diffSource: 'combined-uncommitted' as const,
+      isDirty: false
+    }
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      openFiles: [combinedDiffTab],
+      setExternalMutation
+    } as never)
+    // Why: combined tabs match no single path, so the per-path lookup stays empty.
+    vi.mocked(getOpenFilesForExternalFileChange).mockReturnValue([])
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(findTarget)
+
+    handleFsChanged(payload([{ kind: 'update', absolutePath: '/repo/src/foo.ts' }]))
+    vi.advanceTimersByTime(100)
+
+    expect(notifyEditorExternalFileChange).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      relativePath: 'src/foo.ts',
+      runtimeEnvironmentId: null
+    })
+    dispose()
+  })
+
+  it('does not reload a branch-compare combined diff for working-tree changes', () => {
+    const branchDiffTab = {
+      id: 'wt-1::all-diffs::branch',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo',
+      relativePath: 'Branch Changes',
+      mode: 'diff' as const,
+      diffSource: 'combined-branch' as const,
+      isDirty: false
+    }
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      openFiles: [branchDiffTab],
+      setExternalMutation
+    } as never)
+    vi.mocked(getOpenFilesForExternalFileChange).mockReturnValue([])
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(findTarget)
+
+    handleFsChanged(payload([{ kind: 'update', absolutePath: '/repo/src/foo.ts' }]))
+    vi.advanceTimersByTime(100)
+
+    expect(notifyEditorExternalFileChange).not.toHaveBeenCalled()
+    dispose()
+  })
+
   it('tombstones only the matching owner for same-path delete events', () => {
     const localFile = fileNotes
     const runtimeFile = {

--- a/src/renderer/src/hooks/useEditorExternalWatch.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.test.ts
@@ -487,6 +487,40 @@ describe('createExternalWatchEventHandler tombstone coalescing', () => {
     dispose()
   })
 
+  it('reloads a combined Changes tab when the matching single-file tab is dirty', () => {
+    const dirtyFile = {
+      ...fileNotes,
+      isDirty: true
+    }
+    const combinedDiffTab = {
+      id: 'wt-1::all-diffs::uncommitted',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      filePath: '/repo',
+      relativePath: 'Changes',
+      mode: 'diff' as const,
+      diffSource: 'combined-uncommitted' as const,
+      isDirty: false
+    }
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      openFiles: [dirtyFile, combinedDiffTab],
+      setExternalMutation
+    } as never)
+    vi.mocked(getOpenFilesForExternalFileChange).mockReturnValue([dirtyFile] as never)
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(findTarget)
+
+    handleFsChanged(payload([{ kind: 'update', absolutePath: '/repo/notes.md' }]))
+    vi.advanceTimersByTime(100)
+
+    expect(notifyEditorExternalFileChange).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      relativePath: 'notes.md',
+      runtimeEnvironmentId: null
+    })
+    dispose()
+  })
+
   it('does not reload a branch-compare combined diff for working-tree changes', () => {
     const branchDiffTab = {
       id: 'wt-1::all-diffs::branch',

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -10,6 +10,7 @@ import { normalizeRuntimePathForComparison } from '../../../shared/cross-platfor
 import {
   getOpenFilesForExternalFileChange,
   isExternalReloadableEditorTab,
+  isWorkingTreeCombinedDiffTab,
   notifyEditorExternalFileChange
 } from '@/components/editor/editor-autosave'
 import {
@@ -608,6 +609,16 @@ export function createExternalWatchEventHandler(
     // `useFileExplorerHandlers`. Read `openFiles` once per payload to avoid
     // N store reads for large batched events.
     const openFilesSnapshot = useAppStore.getState().openFiles
+    // Why: a combined "Changes" tab matches no single path but renders every
+    // changed file's working-tree diff. This is per-worktree, not per-path, so
+    // compute it once instead of rescanning openFiles for each changed file in
+    // a large batched payload (e.g. a branch switch touching hundreds of files).
+    const hasCombinedDiffConsumer = openFilesSnapshot.some(
+      (f) =>
+        f.worktreeId === target.worktreeId &&
+        openFileRuntimeOwner(f) === target.runtimeEnvironmentId &&
+        isWorkingTreeCombinedDiffTab(f)
+    )
     for (const relativePath of changedFiles) {
       const notification = {
         worktreeId: target.worktreeId,
@@ -617,6 +628,13 @@ export function createExternalWatchEventHandler(
       }
       const matching = getOpenFilesForExternalFileChange(openFilesSnapshot, notification)
       if (matching.length === 0) {
+        // Why: notify the combined-diff tab so its section reloads. Its own
+        // dirty/section guards make a blanket reload safe, and there is no
+        // in-memory editor content to clobber, so self-write suppression is
+        // unnecessary here.
+        if (hasCombinedDiffConsumer) {
+          scheduleDebouncedExternalReload(notification)
+        }
         continue
       }
       if (matching.some((f) => f.isDirty)) {

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -638,6 +638,9 @@ export function createExternalWatchEventHandler(
         continue
       }
       if (matching.some((f) => f.isDirty)) {
+        if (hasCombinedDiffConsumer) {
+          scheduleDebouncedExternalReload(notification)
+        }
         continue
       }
       const absolutePath = joinPath(notification.worktreePath, notification.relativePath)


### PR DESCRIPTION
## Summary

Reloads working-tree combined diff views (such as "Changes" or "All Changes" tabs) on external file changes (e.g. from terminal or agent edits). Combined diff views do not map to any single file path (their relative path is a label like "Changes"), so they were not being matched and reloaded by the standard path-based file watcher.

This PR introduces `isWorkingTreeCombinedDiffTab` to identify active working-tree combined diff views (`combined-uncommitted` or `combined-all`) for the target worktree and schedules a debounced reload when any file in that worktree changes. Branch-compare diffs are intentionally excluded because working-tree changes do not affect them.

## Screenshots

- No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Unit tests have been added in `useEditorExternalWatch.test.ts` to cover both positive and negative cases.

## AI Review Report

Reviewed the reload logic to ensure:
- Working-tree combined diff views reload properly when external file changes occur.
- Static branch-compare views are not unnecessarily reloaded.
- Performance is preserved by checking for combined diff consumers once per batch event instead of inside the file loop.
- Explicitly confirmed cross-platform compatibility across macOS, Linux, and Windows: path comparisons rely on existing normalized cross-platform runtime helper methods.

## Security Audit

- Input/Path handling: Workspace path matching utilizes safe cross-platform helpers; no path traversal or logic bypass risks.
- Command execution: No commands are executed.
- IPC/Secrets: No IPC communications, credentials, or third-party dependencies are added or touched.

## Notes

None