### PR TITLE
Support respawn-pane in Claude Agent Teams tmux shim

### DIFF
--- a/src/main/runtime/claude-agent-teams-pane-layout.ts
+++ b/src/main/runtime/claude-agent-teams-pane-layout.ts
@@ -1,0 +1,64 @@
+import type { AgentTeam, TeamPane } from './claude-agent-teams-types'
+
+export type SplitTarget = { pane: TeamPane; direction: 'horizontal' | 'vertical' }
+
+export function paneEnv(team: AgentTeam, fakePaneId: string): Record<string, string> {
+  return {
+    ...team.baseEnv,
+    TMUX_PANE: fakePaneId,
+    ORCA_AGENT_TEAMS_LEADER_PANE: team.leaderPane
+  }
+}
+
+export function resolveSplitTarget(
+  team: AgentTeam,
+  targetPane: TeamPane,
+  horizontal: boolean
+): SplitTarget {
+  if (horizontal && team.mainVertical?.lastColumnPane) {
+    return {
+      pane: team.panes.get(team.mainVertical.lastColumnPane) ?? targetPane,
+      direction: 'horizontal'
+    }
+  }
+  // Why: tmux `split-window -h` means left/right panes; Orca names that
+  // layout by the vertical divider it creates.
+  return { pane: targetPane, direction: horizontal ? 'vertical' : 'horizontal' }
+}
+
+export function updateMainVerticalAfterSplit(
+  team: AgentTeam,
+  fakePaneId: string,
+  splitTarget: SplitTarget
+): void {
+  if (team.mainVertical) {
+    team.mainVertical.lastColumnPane = fakePaneId
+  } else if (
+    splitTarget.direction === 'vertical' &&
+    splitTarget.pane.fakePaneId === team.leaderPane
+  ) {
+    team.mainVertical = { mainPane: team.leaderPane, lastColumnPane: fakePaneId }
+  }
+}
+
+export function formatContext(team: AgentTeam, pane: TeamPane): Record<string, string> {
+  return {
+    session_name: team.sessionName,
+    session_id: '$0',
+    window_id: '@0',
+    window_index: team.windowIndex,
+    window_name: 'agent-teams',
+    window_active: '1',
+    window_flags: '*',
+    pane_id: pane.fakePaneId,
+    pane_index: String(pane.index),
+    pane_active: pane.fakePaneId === team.leaderPane ? '1' : '0',
+    pane_title: '',
+    pane_width: '',
+    pane_height: '',
+    pane_left: '',
+    pane_top: '',
+    window_width: '',
+    window_height: ''
+  }
+}

--- a/src/main/runtime/claude-agent-teams-service.test.ts
+++ b/src/main/runtime/claude-agent-teams-service.test.ts
@@ -141,6 +141,66 @@ describe('ClaudeAgentTeamsService', () => {
     ])
   })
 
+  it('relaunches a teammate via respawn-pane after a cat holding split', async () => {
+    const { service, teamId, token, leaderPane, api, splitCalls } = createServiceWithLeader()
+    const request = (argv: string[], envPane = leaderPane) =>
+      service.handleTmuxCompat({ teamId, token, envPane, argv }, api)
+
+    // Claude splits a holding pane running `cat`, then respawns it with the
+    // real teammate command (the failure mode before respawn-pane was supported).
+    await expect(
+      request([
+        'split-window',
+        '-d',
+        '-t',
+        leaderPane,
+        '-h',
+        '-l',
+        '70%',
+        '-P',
+        '-F',
+        '#{pane_id}',
+        '--',
+        'cat'
+      ])
+    ).resolves.toMatchObject({ stdout: '%2\n', exitCode: 0 })
+
+    await request(['set-option', '-p', '-t', '%2', 'remain-on-exit', 'failed'])
+
+    const teammateCommand =
+      'cd /repo && env CLAUDECODE=1 claude --agent-id a --teammate-mode auto'
+    await expect(
+      request(['respawn-pane', '-k', '-t', '%2', '--', teammateCommand])
+    ).resolves.toMatchObject({ stdout: '', exitCode: 0 })
+
+    // the placeholder terminal is closed and the pane is recreated, from the same
+    // origin/direction, with the real teammate command.
+    expect(api.closeTerminal).toHaveBeenCalledWith('teammate-1')
+    expect(splitCalls).toEqual([
+      { handle: 'leader-handle', direction: 'vertical', command: 'cat', envPane: '%2' },
+      { handle: 'leader-handle', direction: 'vertical', command: teammateCommand, envPane: '%2' }
+    ])
+
+    // the fake pane id is preserved and now backed by the relaunched terminal.
+    await expect(
+      request(['list-panes', '-t', 'orca:0', '-F', '#{pane_id}'])
+    ).resolves.toMatchObject({ stdout: '%1\n%2\n' })
+
+    await request(['kill-pane', '-t', '%2'])
+    expect(api.closeTerminal).toHaveBeenLastCalledWith('teammate-2')
+  })
+
+  it('refuses to respawn the leader pane', async () => {
+    const { service, teamId, token, leaderPane, api } = createServiceWithLeader()
+
+    await expect(
+      service.handleTmuxCompat(
+        { teamId, token, envPane: leaderPane, argv: ['respawn-pane', '-k', '-t', leaderPane, '--', 'cat'] },
+        api
+      )
+    ).resolves.toMatchObject({ ok: false, exitCode: 1, stderr: 'tmux: refusing to respawn leader pane\n' })
+  })
+
   it('rejects stale or unauthorized shim calls', async () => {
     const { service, teamId, leaderPane, api } = createServiceWithLeader()
 

--- a/src/main/runtime/claude-agent-teams-service.test.ts
+++ b/src/main/runtime/claude-agent-teams-service.test.ts
@@ -190,6 +190,35 @@ describe('ClaudeAgentTeamsService', () => {
     expect(api.closeTerminal).toHaveBeenLastCalledWith('teammate-2')
   })
 
+  it('keeps the placeholder handle when the respawn split fails', async () => {
+    const { service, teamId, token, leaderPane, api } = createServiceWithLeader()
+    const request = (argv: string[], envPane = leaderPane) =>
+      service.handleTmuxCompat({ teamId, token, envPane, argv }, api)
+
+    await request([
+      'split-window',
+      '-d',
+      '-t',
+      leaderPane,
+      '-h',
+      '-P',
+      '-F',
+      '#{pane_id}',
+      '--',
+      'cat'
+    ])
+
+    vi.mocked(api.splitTerminal).mockRejectedValueOnce(new Error('no space for new pane'))
+    await expect(
+      request(['respawn-pane', '-k', '-t', '%2', '--', 'claude --agent-id a'])
+    ).resolves.toMatchObject({ ok: false, exitCode: 1 })
+
+    // the placeholder terminal is left intact and the fake pane id still resolves.
+    expect(api.closeTerminal).not.toHaveBeenCalled()
+    await request(['kill-pane', '-t', '%2'])
+    expect(api.closeTerminal).toHaveBeenCalledWith('teammate-1')
+  })
+
   it('refuses to respawn the leader pane', async () => {
     const { service, teamId, token, leaderPane, api } = createServiceWithLeader()
 

--- a/src/main/runtime/claude-agent-teams-tmux-dispatcher.ts
+++ b/src/main/runtime/claude-agent-teams-tmux-dispatcher.ts
@@ -4,6 +4,12 @@ import {
   tmuxSendKeysText,
   tmuxValue
 } from '../../shared/claude-agent-teams-tmux-compat'
+import {
+  formatContext,
+  paneEnv,
+  resolveSplitTarget,
+  updateMainVerticalAfterSplit
+} from './claude-agent-teams-pane-layout'
 import type { AgentTeam, AgentTeamsTerminalApi, TeamPane } from './claude-agent-teams-types'
 
 type ResolvedTarget = { type: 'pane'; pane: TeamPane } | { type: 'window' }
@@ -31,6 +37,9 @@ export class ClaudeAgentTeamsTmuxDispatcher {
       case 'split-window':
       case 'splitw':
         return await this.splitWindow(team, args, envPane, api)
+      case 'respawn-pane':
+      case 'respawnp':
+        return await this.respawnPane(team, args, envPane, api)
       case 'select-layout':
         return this.selectLayout(team, args, envPane)
       case 'resize-pane':
@@ -86,7 +95,7 @@ export class ClaudeAgentTeamsTmuxDispatcher {
     const pane = target.type === 'window' ? this.resolvePane(team, envPane) : target.pane
     const format =
       parsed.positional.length > 0 ? parsed.positional.join(' ') : tmuxValue(parsed, '-F')
-    return `${renderTmuxFormat(format, this.formatContext(team, pane), '')}\n`
+    return `${renderTmuxFormat(format, formatContext(team, pane), '')}\n`
   }
 
   private async splitWindow(
@@ -103,31 +112,64 @@ export class ClaudeAgentTeamsTmuxDispatcher {
     const targetPane = this.resolvePane(team, tmuxValue(parsed, '-t') ?? envPane)
     const fakePaneId = `%${team.nextPaneNumber}`
     team.nextPaneNumber += 1
-    const splitTarget = this.resolveSplitTarget(team, targetPane, parsed.flags.has('-h'))
-    const env = {
-      ...team.baseEnv,
-      TMUX_PANE: fakePaneId,
-      ORCA_AGENT_TEAMS_LEADER_PANE: team.leaderPane
-    }
+    const splitTarget = resolveSplitTarget(team, targetPane, parsed.flags.has('-h'))
     const split = await api.splitTerminal(splitTarget.pane.handle, {
       direction: splitTarget.direction,
       command: parsed.positional.join(' ') || undefined,
-      env,
+      env: paneEnv(team, fakePaneId),
       envToDelete: ['TERM_PROGRAM', 'ORCA_ATTRIBUTION_SHIM_DIR'],
       activate: false
     })
     const pane: TeamPane = {
       fakePaneId,
       handle: split.handle,
-      index: team.paneOrder.length
+      index: team.paneOrder.length,
+      splitFromPane: splitTarget.pane.fakePaneId,
+      splitDirection: splitTarget.direction
     }
     team.panes.set(fakePaneId, pane)
     team.paneOrder.push(fakePaneId)
-    this.updateMainVerticalAfterSplit(team, fakePaneId, splitTarget)
+    updateMainVerticalAfterSplit(team, fakePaneId, splitTarget)
     if (!parsed.flags.has('-P')) {
       return ''
     }
-    return `${renderTmuxFormat(tmuxValue(parsed, '-F'), this.formatContext(team, pane), fakePaneId)}\n`
+    return `${renderTmuxFormat(tmuxValue(parsed, '-F'), formatContext(team, pane), fakePaneId)}\n`
+  }
+
+  // Why: Claude Code's pane backend creates a teammate pane in two steps — it
+  // splits a holding pane running `cat`, then `respawn-pane -k`s it with the
+  // real teammate command. Orca panes are PTYs that cannot swap their program in
+  // place, so we honor respawn by closing the placeholder terminal and
+  // re-splitting from the same origin with the real command, keeping the fake
+  // pane id stable so later send-keys/kill-pane/list-panes still resolve.
+  private async respawnPane(
+    team: AgentTeam,
+    args: string[],
+    envPane: string,
+    api: AgentTeamsTerminalApi
+  ): Promise<string> {
+    const parsed = parseTmuxArgs(args, ['-c', '-e', '-t'], ['-k'])
+    const pane = this.resolvePane(team, tmuxValue(parsed, '-t') ?? envPane)
+    if (pane.fakePaneId === team.leaderPane) {
+      throw new Error('refusing to respawn leader pane')
+    }
+    const command = parsed.positional.join(' ')
+    if (!command) {
+      return ''
+    }
+    const origin =
+      (pane.splitFromPane ? team.panes.get(pane.splitFromPane) : undefined) ??
+      team.panes.get(team.leaderPane)!
+    await api.closeTerminal(pane.handle)
+    const split = await api.splitTerminal(origin.handle, {
+      direction: pane.splitDirection ?? 'horizontal',
+      command,
+      env: paneEnv(team, pane.fakePaneId),
+      envToDelete: ['TERM_PROGRAM', 'ORCA_ATTRIBUTION_SHIM_DIR'],
+      activate: false
+    })
+    pane.handle = split.handle
+    return ''
   }
 
   private selectLayout(team: AgentTeam, args: string[], envPane: string): string {
@@ -156,7 +198,7 @@ export class ClaudeAgentTeamsTmuxDispatcher {
         const pane = team.panes.get(paneId)!
         return renderTmuxFormat(
           tmuxValue(parsed, '-F'),
-          this.formatContext(team, pane),
+          formatContext(team, pane),
           pane.fakePaneId
         )
       })
@@ -242,37 +284,6 @@ export class ClaudeAgentTeamsTmuxDispatcher {
     return ''
   }
 
-  private updateMainVerticalAfterSplit(
-    team: AgentTeam,
-    fakePaneId: string,
-    splitTarget: { pane: TeamPane; direction: 'horizontal' | 'vertical' }
-  ): void {
-    if (team.mainVertical) {
-      team.mainVertical.lastColumnPane = fakePaneId
-    } else if (
-      splitTarget.direction === 'vertical' &&
-      splitTarget.pane.fakePaneId === team.leaderPane
-    ) {
-      team.mainVertical = { mainPane: team.leaderPane, lastColumnPane: fakePaneId }
-    }
-  }
-
-  private resolveSplitTarget(
-    team: AgentTeam,
-    targetPane: TeamPane,
-    horizontal: boolean
-  ): { pane: TeamPane; direction: 'horizontal' | 'vertical' } {
-    if (horizontal && team.mainVertical?.lastColumnPane) {
-      return {
-        pane: team.panes.get(team.mainVertical.lastColumnPane) ?? targetPane,
-        direction: 'horizontal'
-      }
-    }
-    // Why: tmux `split-window -h` means left/right panes; Orca names that
-    // layout by the vertical divider it creates.
-    return { pane: targetPane, direction: horizontal ? 'vertical' : 'horizontal' }
-  }
-
   private resolvePaneOrWindow(team: AgentTeam, target: string): ResolvedTarget {
     if (target.includes(':') || target === team.sessionName || target.startsWith('@')) {
       return { type: 'window' }
@@ -286,27 +297,5 @@ export class ClaudeAgentTeamsTmuxDispatcher {
       throw new Error(`unknown pane: ${target}`)
     }
     return pane
-  }
-
-  private formatContext(team: AgentTeam, pane: TeamPane): Record<string, string> {
-    return {
-      session_name: team.sessionName,
-      session_id: '$0',
-      window_id: '@0',
-      window_index: team.windowIndex,
-      window_name: 'agent-teams',
-      window_active: '1',
-      window_flags: '*',
-      pane_id: pane.fakePaneId,
-      pane_index: String(pane.index),
-      pane_active: pane.fakePaneId === team.leaderPane ? '1' : '0',
-      pane_title: '',
-      pane_width: '',
-      pane_height: '',
-      pane_left: '',
-      pane_top: '',
-      window_width: '',
-      window_height: ''
-    }
   }
 }

--- a/src/main/runtime/claude-agent-teams-tmux-dispatcher.ts
+++ b/src/main/runtime/claude-agent-teams-tmux-dispatcher.ts
@@ -160,7 +160,10 @@ export class ClaudeAgentTeamsTmuxDispatcher {
     const origin =
       (pane.splitFromPane ? team.panes.get(pane.splitFromPane) : undefined) ??
       team.panes.get(team.leaderPane)!
-    await api.closeTerminal(pane.handle)
+    // Why: create the replacement before destroying the placeholder so a failed
+    // split leaves the fake pane id pointing at a still-live terminal; on cleanup
+    // failure, discard the new split and keep the placeholder registered.
+    const previousHandle = pane.handle
     const split = await api.splitTerminal(origin.handle, {
       direction: pane.splitDirection ?? 'horizontal',
       command,
@@ -168,6 +171,12 @@ export class ClaudeAgentTeamsTmuxDispatcher {
       envToDelete: ['TERM_PROGRAM', 'ORCA_ATTRIBUTION_SHIM_DIR'],
       activate: false
     })
+    try {
+      await api.closeTerminal(previousHandle)
+    } catch (error) {
+      await api.closeTerminal(split.handle).catch(() => {})
+      throw error
+    }
     pane.handle = split.handle
     return ''
   }

--- a/src/main/runtime/claude-agent-teams-types.ts
+++ b/src/main/runtime/claude-agent-teams-types.ts
@@ -54,6 +54,11 @@ export type TeamPane = {
   fakePaneId: string
   handle: string
   index: number
+  // Why: Claude Code splits a holding pane (`-- cat`) then `respawn-pane`s it
+  // with the real teammate command. We remember how the pane was first split so
+  // respawn can recreate it in the same slot while preserving its fake pane id.
+  splitFromPane?: string
+  splitDirection?: 'horizontal' | 'vertical'
 }
 
 export type AgentTeam = {


### PR DESCRIPTION
## Summary

Closes #6778

Claude Code's pane backend spawns each Agent Teams teammate in **two** tmux steps:

1. `split-window -d -t <leader> -h -l 70% -P -F '#{pane_id}' -- cat` — creates a holding pane running `cat`.
2. `respawn-pane -k -t <pane> -- "<real teammate command>"` — kills `cat` and launches the teammate in that pane.

Orca's `agent-teams-tmux` dispatcher (added in #4892) implements step 1 but has **no `respawn-pane` case**, so step 2 hits the `default:` branch and throws. The teammate's real command is silently dropped and the spawn fails with:

```
Failed to send command to pane %2: tmux: unsupported command: respawn-pane
```

The net effect is that **Claude Code Agent Teams are completely broken in Orca** on current Claude Code (verified on 2.1.195): every teammate spawn dies and leaks a placeholder pane. It reproduces from a bare teammate spawn — no skill or wrapper involved — and from the shell directly (`tmux respawn-pane` → `unsupported command`).

### Fix

Honor `respawn-pane` by translating it to Orca's PTY model. Orca panes can't swap their running program in place, so respawn:

- resolves the target pane,
- closes the placeholder (`cat`) terminal,
- re-splits from the pane's **original origin + direction** with the real command,
- preserves the fake pane id, so later `send-keys` / `kill-pane` / `list-panes` / `capture-pane` keep resolving.

To support faithful recreation, `TeamPane` now remembers how it was first split (`splitFromPane`, `splitDirection`), recorded in `split-window`. This is **additive and backward-compatible**: `split-window` behavior is unchanged, and older Claude Code flows that pass the command directly to `split-window` (and never call `respawn-pane`) are unaffected.

Pure pane-geometry/format helpers (`resolveSplitTarget`, `updateMainVerticalAfterSplit`, `formatContext`, `paneEnv`) move to a sibling `claude-agent-teams-pane-layout.ts` module so the dispatcher stays within the 300-line cap.

The leader pane is guarded — `respawn-pane` targeting it is refused, mirroring the existing `kill-pane` guard, so a stray respawn can't tear down the lead session.

## Screenshots

No visual change. (Teammate panes render through the existing native-pane path; this only fixes the launch that previously failed.)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — ran the affected suites: `claude-agent-teams-service.test.ts` (incl. 2 new respawn tests), `claude-agent-teams-tmux-compat.test.ts`, `claude-agent-teams-shim-env.test.ts`, and `orca-runtime.test.ts` (512) all green. Full-suite native-module files weren't built in my sandbox (`--ignore-scripts`); CI covers those.
- [ ] `pnpm build` — desktop+native packaging not run locally (pure dispatcher logic change; no native/build surface touched).
- [x] Added high-quality tests: a test that replays the real `split-window -- cat` → `set-option remain-on-exit` → `respawn-pane -k -- <cmd>` sequence and asserts the placeholder is closed, the pane is recreated from the same origin/direction with the real command, the fake pane id is preserved, and a later `kill-pane` targets the relaunched handle; plus a leader-pane refusal test.

New tests fail without the fix (the sequence throws `unsupported command: respawn-pane`) and pass with it.

## AI Review Report

Reviewed with Claude Code (Opus 4.8):

- **Cross-platform (macOS/Linux/Windows):** No platform-specific code. No new path handling, shell, or accelerator logic. Uses the same `splitTerminal`/`closeTerminal` API and `paneEnv` env shape as the existing `split-window` path; `paneEnv` was factored out unchanged.
- **SSH/remote/local:** Goes through the same `AgentTeamsTerminalApi` the dispatcher already uses; no assumption of local-only processes/files.
- **Agent/integration neutrality:** Scoped to the Claude Agent Teams tmux shim. Matches the exact command sequence emitted by Claude Code's pane backend (`split-window ... -- cat`, `respawn-pane -k -t <pane> -- <cmd>`); no other agent paths touched.
- **Performance:** One extra close+split per teammate spawn (not a hot path). No added work elsewhere.
- **Behavioral risk:** Additive — `respawn-pane` was previously a hard error. Leader pane is guarded. Origin pane lookup falls back to the leader if the recorded origin is gone.

## Security Audit

- **Command execution:** `respawn-pane`'s command comes from Claude Code over the existing authenticated shim channel (`resolveTeam` validates `teamId` + `token`); it's handed to `splitTerminal` exactly as `split-window` already does — no new shell-string construction, interpolation, or parsing beyond the shared `parseTmuxArgs`.
- **Input handling:** Reuses `parseTmuxArgs`/`tmuxValue`; `-t` resolves only known panes (`unknown pane` otherwise), and the leader is refused.
- **Secrets/IPC/auth:** No changes. Env passed to the recreated pane is the same `paneEnv` shape used today. No new dependencies.

## Notes

- Root cause is a command-coverage gap in the shim vs. Claude Code's current spawn protocol — the shim was written against an earlier flow. `new-window` is also unimplemented but is only used by Claude Code's *external* (not-inside-tmux) swarm path; Orca's leader always runs inside the emulated tmux, so it isn't exercised. Left out to keep this change focused; happy to add it if you'd like belt-and-suspenders coverage.
- X handle: @iamadamreed


