### PR TITLE
Bump mobile app.json to 0.0.17

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump `mobile/app.json` `expo.version` from `0.0.16` → `0.0.17` to realign the mobile source-of-truth version with what both platforms have already shipped.
  - **Android:** `mobile-android-v0.0.17` is published with a valid APK.
  - **iOS:** `0.0.17` is *Pending Developer Release* in App Store Connect (already passed App Review).
- Leaves the CI-managed `expo.ios.buildNumber` and `expo.android.versionCode` untouched — those are resolved per-release by `prepare-android-release.mjs` / the iOS fastlane lane.

## Why
`app.json` had drifted: both platforms moved to 0.0.17 (Android via the tag-name resolution, iOS via a `workflow_dispatch` build), but the committed version still read `0.0.16`. That stale value would cause the *next* patch bump to resolve `0.0.16 → 0.0.17` and collide with the already-shipped release.

## Verification
- `node -e` confirms `expo.version` reads `0.0.17`; build-number fields unchanged.
- No native or generated files touched; version-only change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
