### PR TITLE
Clarify auto-merge UI and errors when direct merge is available

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -3379,6 +3379,24 @@ describe('GitHub GraphQL rate-limit guard', () => {
     ).toBe(false)
   })
 
+  it('translates the GitHub clean-status rejection into an actionable message', async () => {
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ id: 'PR_kwDO123', headRefOid: 'head-oid' })
+      })
+      .mockRejectedValueOnce(new Error('GraphQL: Pull request is in clean status'))
+
+    await expect(
+      setPRAutoMerge('/repo-root', 7, true, 'squash', undefined, {
+        owner: 'stablyai',
+        repo: 'orca'
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: 'This pull request can already be merged. Use Merge instead of auto-merge.'
+    })
+  })
+
   it('uses the queue-aware gh merge path when the base branch has a merge queue', async () => {
     ghExecFileAsyncMock
       .mockResolvedValueOnce({

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -3982,10 +3982,20 @@ export async function setPRAutoMerge(
   } catch (err) {
     const message =
       err instanceof Error ? err.message : typeof err === 'string' ? err : 'Unknown error'
-    return { ok: false, error: classifyGhError(message).message }
+    return { ok: false, error: classifySetAutoMergeError(message) }
   } finally {
     release()
   }
+}
+
+// Why: GitHub rejects enabling auto-merge on a PR that can already merge with
+// "Pull request is in clean status". Surface the actionable next step (merge
+// directly) instead of the raw GraphQL error.
+function classifySetAutoMergeError(message: string): string {
+  if (/in clean status/i.test(message)) {
+    return 'This pull request can already be merged. Use Merge instead of auto-merge.'
+  }
+  return classifyGhError(message).message
 }
 
 type PRAutoMergeIdentity = {

--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -92,6 +92,24 @@ describe('presentGitHubPRMergeState', () => {
     })
   })
 
+  it('suppresses enable auto-merge but keeps disable when direct merge is available', () => {
+    // Why: enabling auto-merge on a directly-mergeable PR fails with GitHub's
+    // "clean status" error, so the dropdown must not offer it.
+    expect(
+      presentGitHubPRMergeState({
+        state: 'open',
+        checksSummary: { state: 'success', total: 1, passed: 1, failed: 0, pending: 0 }
+      })
+    ).toMatchObject({ label: 'Checks passed', directMergeAvailable: true, autoMergeAction: null })
+    expect(presentGitHubPRMergeState(pr())).toMatchObject({
+      directMergeAvailable: true,
+      autoMergeAction: null
+    })
+    expect(presentGitHubPRMergeState(pr({ autoMergeEnabled: true })).autoMergeAction).toMatchObject(
+      { kind: 'disable' }
+    )
+  })
+
   it('blocks conflicts and behind branches, but not optional aggregate check failures', () => {
     expect(
       presentGitHubPRMergeState(pr({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }))

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -62,6 +62,16 @@ function canEnableAutoMerge(item: GitHubPRMergeStateInput): boolean {
   return canEnableGitHubPRAutoMerge(item)
 }
 
+// Why: when GitHub already allows a direct merge, offering "Enable auto-merge"
+// only yields a "clean status" rejection. Keep the Disable action so users can
+// still turn off an existing auto-merge request; merge-queue "Merge when ready"
+// paths set directMergeAvailable=false and never reach here.
+function autoMergeActionWhenDirectMergeAvailable(
+  autoMergeAction: GitHubPRAutoMergeAction | null
+): GitHubPRAutoMergeAction | null {
+  return autoMergeAction?.kind === 'disable' ? autoMergeAction : null
+}
+
 function passedChecksMergePresentation(
   autoMergeAction: GitHubPRAutoMergeAction | null
 ): GitHubPRMergeStatePresentation {
@@ -73,7 +83,7 @@ function passedChecksMergePresentation(
       'Checks passed. Merge eligibility will be checked again before merging.'
     ),
     directMergeAvailable: true,
-    autoMergeAction
+    autoMergeAction: autoMergeActionWhenDirectMergeAvailable(autoMergeAction)
   }
 }
 
@@ -280,7 +290,7 @@ export function presentGitHubPRMergeState(
           ? 'GitHub says this PR can merge and checks passed'
           : 'GitHub says this PR can merge'),
       directMergeAvailable: true,
-      autoMergeAction
+      autoMergeAction: autoMergeActionWhenDirectMergeAvailable(autoMergeAction)
     }
   }
   // Why: GitHub may still report intermediate mergeability while checks are


### PR DESCRIPTION
## Summary

Clarifies the auto-merge UI flow and error handling when a pull request can already be merged directly.

- Translates GitHub's "Pull request is in clean status" GraphQL rejection into an actionable message: `This pull request can already be merged. Use Merge instead of auto-merge.`
- Suppresses the "Enable auto-merge" option in the UI dropdown when a direct merge is available, preventing users from encountering the clean-status rejection, while still allowing "Disable auto-merge" if auto-merge is already enabled.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Unit tests were added and updated:
- `src/main/github/client.test.ts`: verified the translated clean-status error message.
- `src/renderer/src/components/github-pr-merge-state.test.ts`: verified suppression of the "Enable auto-merge" action and retention of "Disable auto-merge".

## AI Review Report

The AI review analyzed the state handling of pull request merge actions. It verified that the regex-based error parsing correctly captures the GraphQL error and safely maps it. Cross-platform compatibility for macOS, Linux, and Windows has been verified, as all updated modules use standard platform-independent TypeScript and standard regex checks with no reliance on platform-specific shells or APIs.

## Security Audit

Reviewed input handling, IPC, and potential security vectors. The error classification uses a simple regex test (`/in clean status/i.test(message)`) on API error strings, which is safe against ReDoS. No command execution, file system access, authentication changes, or IPC messages were modified or introduced.

## Notes

No platform-specific risks or follow-up work needed.