### PR TITLE
Keep worktree hover popovers responsive while a workspace is deleting

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -9,8 +9,37 @@ import {
   shouldContinueDeleteSiblingPositionRestore,
   getWorktreeParentPickerAnchor,
   getWorktreeParentPickerLabel,
-  isWorktreeParentPickerDisabled
+  isWorktreeParentPickerDisabled,
+  selectMenuScopedMap
 } from './WorktreeContextMenu'
+
+describe('selectMenuScopedMap (delete-teardown re-render guard)', () => {
+  // Why: the closed menu wrapper must stay inert to delete teardown's high-churn
+  // set()s. The guard is referential stability — when closed, the selector must
+  // return the SAME `empty` reference even as the live map identity changes each
+  // teardown set(), so Zustand's Object.is equality short-circuits the subscription
+  // and the (common) closed wrapper does not re-render. These assertions pin that
+  // contract; if they regress, every visible card re-renders on every teardown set()
+  // and worktree-card hover popovers stall during a delete.
+  it('returns the stable empty sentinel when the menu is closed', () => {
+    const empty = Object.freeze({})
+    const liveA = { 'wt-1': ['pty-1'] }
+    const liveB = { 'wt-2': ['pty-2'] }
+    // Live map identity churns across teardown set()s, yet a closed wrapper keeps
+    // the same reference — no subscription wakeup.
+    expect(selectMenuScopedMap(false, liveA, empty)).toBe(empty)
+    expect(selectMenuScopedMap(false, liveB, empty)).toBe(empty)
+    expect(selectMenuScopedMap(false, liveA, empty)).toBe(selectMenuScopedMap(false, liveB, empty))
+  })
+
+  it('returns the live map synchronously once the menu is open', () => {
+    const empty = Object.freeze({})
+    const live = { 'wt-1': ['pty-1'] }
+    // The render where menuOpen flips true must read real data so menu items
+    // (sleep/delete/lineage) reflect live tabs/ptys/delete state.
+    expect(selectMenuScopedMap(true, live, empty)).toBe(live)
+  })
+})
 
 describe('shouldUseNativeContextMenu', () => {
   it('uses the browser context menu for marked hovercard content', () => {

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -32,6 +32,7 @@ import {
   FolderTree
 } from 'lucide-react'
 import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
 import { useAllWorktrees, useRepoById, useRepoMap, useWorktreeMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import type { Repo, Worktree } from '../../../../shared/types'
@@ -69,6 +70,27 @@ const WORKTREE_NATIVE_CONTEXT_MENU_ATTR = 'data-worktree-native-context-menu'
 const CONTEXT_MENU_CLICK_SUPPRESSION_MS = 500
 const DELETE_POSITION_RESTORE_MAX_FRAMES = 180
 const DELETE_POSITION_RESTORE_STABLE_FRAMES = 6
+
+// Why: stable empty sentinels let closed menu wrappers subscribe to a referentially
+// stable value instead of the high-churn maps that delete teardown replaces. The
+// selector returns these when the menu is closed, so the wrapper stays inert to
+// teardown set() churn. Module-level (one allocation, never recreated per render) so
+// the reference is constant and Zustand's Object.is equality short-circuits.
+const EMPTY_TABS_BY_WORKTREE: AppState['tabsByWorktree'] = {}
+const EMPTY_PTY_IDS_BY_TAB_ID: AppState['ptyIdsByTabId'] = {}
+const EMPTY_BROWSER_TABS_BY_WORKTREE: AppState['browserTabsByWorktree'] = {}
+const EMPTY_DELETE_STATE_BY_WORKTREE_ID: AppState['deleteStateByWorktreeId'] = {}
+const EMPTY_WORKTREE_LINEAGE_BY_ID: AppState['worktreeLineageById'] = {}
+const EMPTY_WORKSPACE_LINEAGE_BY_CHILD_KEY: AppState['workspaceLineageByChildKey'] = {}
+
+// Why: the gating decision for the menu-only store subscriptions. When the menu is
+// closed we MUST return the same `empty` reference every render so Zustand's Object.is
+// equality short-circuits the subscription and the closed wrapper stays inert to delete
+// teardown's high-churn set()s. When open we return the live map so menu items see real
+// data. Extracted as a pure function so the stable-reference contract is unit-testable.
+export function selectMenuScopedMap<T>(menuOpen: boolean, live: T, empty: T): T {
+  return menuOpen ? live : empty
+}
 
 function shouldUseNativeContextMenu(target: EventTarget | null): boolean {
   const maybeElement = target as {
@@ -280,13 +302,35 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const repoMap = useRepoMap()
   const worktreeMap = useWorktreeMap()
   const allWorktrees = useAllWorktrees()
-  const worktreeLineageById = useAppStore((s) => s.worktreeLineageById)
-  const workspaceLineageByChildKey = useAppStore((s) => s.workspaceLineageByChildKey)
+  // Why: these maps feed only items rendered inside the OPEN dropdown, yet delete
+  // teardown replaces them on every set(). Gate them behind menuOpen via stable
+  // empty sentinels so the (common) closed wrapper stays inert to that churn. The
+  // conditional lives INSIDE the selector so useAppStore is always called; the
+  // inline arrow (not a useCallback) re-reads the live map synchronously on the
+  // render where menuOpen flips true, so dependent useMemos recompute with real data.
+  const worktreeLineageById = useAppStore((s) =>
+    selectMenuScopedMap(menuOpen, s.worktreeLineageById, EMPTY_WORKTREE_LINEAGE_BY_ID)
+  )
+  const workspaceLineageByChildKey = useAppStore((s) =>
+    selectMenuScopedMap(
+      menuOpen,
+      s.workspaceLineageByChildKey,
+      EMPTY_WORKSPACE_LINEAGE_BY_CHILD_KEY
+    )
+  )
   const updateWorktreeLineage = useAppStore((s) => s.updateWorktreeLineage)
-  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
-  const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
-  const deleteStateByWorktreeId = useAppStore((s) => s.deleteStateByWorktreeId)
+  const tabsByWorktree = useAppStore((s) =>
+    selectMenuScopedMap(menuOpen, s.tabsByWorktree, EMPTY_TABS_BY_WORKTREE)
+  )
+  const ptyIdsByTabId = useAppStore((s) =>
+    selectMenuScopedMap(menuOpen, s.ptyIdsByTabId, EMPTY_PTY_IDS_BY_TAB_ID)
+  )
+  const browserTabsByWorktree = useAppStore((s) =>
+    selectMenuScopedMap(menuOpen, s.browserTabsByWorktree, EMPTY_BROWSER_TABS_BY_WORKTREE)
+  )
+  const deleteStateByWorktreeId = useAppStore((s) =>
+    selectMenuScopedMap(menuOpen, s.deleteStateByWorktreeId, EMPTY_DELETE_STATE_BY_WORKTREE_ID)
+  )
   const scopeRef = useRef<HTMLDivElement>(null)
   const contextMenuOpenedAtRef = useRef<number | null>(null)
   const activeContextWorktrees = menuOpen ? contextWorktrees : effectiveSelectedWorktrees


### PR DESCRIPTION
## Summary

While a worktree is being deleted, the worktree-card **details popover stopped opening on hover for the other (non-deleting) cards** in the sidebar. This restores prompt hover-popover behavior on those cards during a delete.

**What does not change:** delete semantics, the popover contents, focus handoff, the context menu, and the deleting card's own appearance (it keeps its current blurred, non-interactive "Deleting…" state) are all untouched. This is a behavior-preserving renderer perf fix.

### Root cause

The symptom was renderer main-thread starvation during the delete window, not a deliberate gate. `WorktreeContextMenu` wraps every visible card and subscribed to six whole Zustand maps — `tabsByWorktree`, `ptyIdsByTabId`, `browserTabsByWorktree`, `deleteStateByWorktreeId`, `worktreeLineageById`, `workspaceLineageByChildKey`. Delete teardown replaces those maps across many `set()` calls, so every visible card's menu wrapper re-rendered repeatedly, starving the 100ms hover open-delay timer. (`React.memo` doesn't help — it blocks prop-driven renders, not internal store-subscription updates.)

### Design approach

**Gate the six menu-only subscriptions behind `menuOpen`** via stable module-level empty sentinels, routed through a small pure helper `selectMenuScopedMap(menuOpen, live, empty)`. When the menu is closed the selector returns a constant reference, so Zustand's `Object.is` equality short-circuits the subscription and the closed wrapper stays inert to teardown churn. When the menu opens, the inline-arrow selector reads the live map synchronously on that same render, so every dependent `useMemo` (sleep/delete/lineage items) recomputes with real data. The per-card `deleteState` subscription (each card's own `isDeleting`) stays live and ungated.

**Headline status: Implemented** (production code, no flag/fixture). Honest boundary: the symptom is main-thread saturation; this PR removes the dominant, scaling contributor (re-render churn proportional to visible card count). The teardown's own synchronous cost (xterm dispose, Chromium guest unregister) is bounded per-deletion and intentionally out of scope, so a machine with very many open terminals could still see minor residual jank from that source alone.

**Scope note:** an earlier revision also made the *deleting* card itself hoverable (overlay `pointer-events-none` + a double-click guard). That was dropped — the deleting card is about to disappear and intentionally stays non-interactive, so the only change here is the subscription narrowing, which is what fixes the reported "other cards unhoverable" symptom with zero UX delta.

## Screenshots

`No visual change.` The change is behavioral (hover-popover responsiveness on non-deleting cards during a delete); no layout, color, or component changes. Validated in a self-owned Electron dev instance — with one card showing the "Deleting…" spinner, hovering a *different* card opens its details popover promptly.

## Testing

- [x] `pnpm lint` (oxlint on changed files + pre-commit oxlint/oxfmt: clean)
- [x] `pnpm typecheck` (web config `tsgo -p config/tsconfig.tc.web.json`: 0 errors; full `pnpm typecheck` avoided locally due to OOM, web project covers these files)
- [x] `pnpm test` (`WorktreeContextMenu.test.ts`: 21 passed incl. 2 new contract tests; full sidebar suite: 1279 passed / 152 files, no regressions)
- [ ] `pnpm build` (not run locally; covered by the PR `verify` check)
- [x] Added a deterministic unit test pinning the `selectMenuScopedMap` referential-stability contract (closed → same `empty` ref across changing live identities; open → live)

In-app measurement (the perf property): a MutationObserver recorded **84 churns of the six gated maps → 0 sidebar DOM mutations**, with a positive control (toggling a rendered `isUnread` field → 40 mutations) proving the observer detects re-renders. A real end-to-end delete completed with 0 console errors. Accepted gap: no full mount-based render-count test (brittle here) — a wiring regression swapping a sentinel for a fresh `{}` wouldn't be caught by the unit test alone, but the in-app measurement covers it.

## AI Review Report

Ran a multi-stage AI review (design review to convergence, then two parallel code reviewers, then a perf audit) as part of Brennan's PR process.

- **Design review** flagged that the two lineage maps were initially omitted from the gating list but are replaced by `removeWorktree`'s teardown `set()` — both are now gated.
- **Code review** (two reviewers, parallel): both returned clean, no actionable findings. Confirmed hooks are called unconditionally (conditional is inside the selector, stable order, no TDZ), sentinels are stable module-level constants (no per-render allocation), the per-id `deleteState` stays live, and derived `useMemo`s read the gated locals so open-menu behavior is unchanged.
- **perf audit:** scenarios "React render churn" and "Store subscriber hot path"; achieves the goal with no regressions.
- **Cross-platform:** explicitly reviewed for macOS / Linux / Windows. This is a pure renderer React/Zustand change — no keyboard shortcuts/labels, no `metaKey`/`CmdOrCtrl`, no path handling, no shell, no Electron platform branches. Nothing platform-specific is touched. SSH/remote deletes go through the same renderer state churn and rendering, so the fix applies equally (slower remote deletes widen the bad window, so SSH benefits more).

## Security Audit

Low surface, reviewed:

- **Input handling / command execution / path handling:** none touched. No new user input parsing, no subprocess/command execution, no filesystem path construction.
- **Auth / secrets:** none touched.
- **IPC:** no new IPC. The change only narrows existing renderer-side Zustand store subscriptions; it does not alter the delete IPC (`worktrees.remove` / `worktree.rm` RPC) or its payloads.
- **Data exposure:** the gated selectors return either the live store map (unchanged) or an empty constant; no data crosses a trust boundary that didn't before.
- **Follow-up:** none required.

## Notes

- Branch was renamed from `brennanb2025/ballyhoo` to `brennanb2025/worktree-card-hover` during validation (HEAD unchanged); kept as the more descriptive PR branch name.
- Based on `v1.4.105-rc.4`; none of the newer `main` commits touch the changed file, so it rebases cleanly.
- The teardown's synchronous cost (xterm dispose, Chromium guest unregister) is the remaining, bounded jank source and is intentionally out of scope for this PR.
