### PR TITLE
fix(native-chat): gate view toggle to supported agents (Claude/Codex)

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-availability.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-availability.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { canToggleNativeChat } from './native-chat-availability'
 
 describe('canToggleNativeChat', () => {
-  it('allows a terminal launched with a coding agent', () => {
+  it('allows a terminal launched with a supported coding agent', () => {
     expect(
       canToggleNativeChat({
         experimentalNativeChatEnabled: true,
@@ -12,24 +12,34 @@ describe('canToggleNativeChat', () => {
     ).toBe(true)
   })
 
-  it('allows a terminal with a live detected agent but no launchAgent', () => {
+  it('allows a terminal with a live detected supported agent but no launchAgent', () => {
     expect(
       canToggleNativeChat({
         experimentalNativeChatEnabled: true,
         contentType: 'terminal',
         launchAgent: null,
-        hasDetectedAgent: true
+        detectedAgent: 'codex'
       })
     ).toBe(true)
   })
 
-  it('allows a terminal with a resolved title/foreground agent before hooks arrive', () => {
+  it('allows a terminal with a resolved title/foreground supported agent before hooks arrive', () => {
     expect(
       canToggleNativeChat({
         experimentalNativeChatEnabled: true,
         contentType: 'terminal',
         launchAgent: null,
-        hasResolvedAgent: true
+        resolvedAgent: 'claude'
+      })
+    ).toBe(true)
+  })
+
+  it('allows the OpenClaude variant', () => {
+    expect(
+      canToggleNativeChat({
+        experimentalNativeChatEnabled: true,
+        contentType: 'terminal',
+        launchAgent: 'openclaude'
       })
     ).toBe(true)
   })
@@ -43,6 +53,38 @@ describe('canToggleNativeChat', () => {
         isChatViewMode: true
       })
     ).toBe(true)
+  })
+
+  it('rejects an unsupported launch agent (Grok)', () => {
+    expect(
+      canToggleNativeChat({
+        experimentalNativeChatEnabled: true,
+        contentType: 'terminal',
+        launchAgent: 'grok'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects an unsupported agent detected live (Gemini)', () => {
+    expect(
+      canToggleNativeChat({
+        experimentalNativeChatEnabled: true,
+        contentType: 'terminal',
+        launchAgent: null,
+        detectedAgent: 'gemini'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects an unsupported agent resolved from the title', () => {
+    expect(
+      canToggleNativeChat({
+        experimentalNativeChatEnabled: true,
+        contentType: 'terminal',
+        launchAgent: null,
+        resolvedAgent: 'grok'
+      })
+    ).toBe(false)
   })
 
   it('rejects otherwise eligible terminals while the experimental flag is off', () => {
@@ -61,7 +103,7 @@ describe('canToggleNativeChat', () => {
         experimentalNativeChatEnabled: true,
         contentType: 'terminal',
         launchAgent: null,
-        hasDetectedAgent: false
+        detectedAgent: null
       })
     ).toBe(false)
   })
@@ -72,13 +114,13 @@ describe('canToggleNativeChat', () => {
     ).toBe(false)
   })
 
-  it('rejects an editor tab even if an agent hint were somehow present', () => {
+  it('rejects an editor tab even if a supported agent hint were somehow present', () => {
     expect(
       canToggleNativeChat({
         experimentalNativeChatEnabled: true,
         contentType: 'editor',
         launchAgent: 'codex',
-        hasDetectedAgent: true
+        detectedAgent: 'codex'
       })
     ).toBe(false)
   })
@@ -88,7 +130,7 @@ describe('canToggleNativeChat', () => {
       canToggleNativeChat({
         experimentalNativeChatEnabled: true,
         contentType: 'browser',
-        hasDetectedAgent: true
+        detectedAgent: 'claude'
       })
     ).toBe(false)
   })

--- a/src/renderer/src/components/native-chat/native-chat-availability.ts
+++ b/src/renderer/src/components/native-chat/native-chat-availability.ts
@@ -1,8 +1,29 @@
 import type { Tab, TuiAgent } from '../../../../shared/types'
+import type { AgentType } from '../../../../shared/agent-status-types'
+
+/** Agents whose transcripts the native chat view can actually parse and render.
+ *  Native chat depends on provider-specific transcript/streaming parsing, so the
+ *  toggle must stay limited to the providers we support — currently Claude
+ *  (including the OpenClaude variant) and Codex. Other agents (Grok, Gemini, …)
+ *  run fine in the terminal but have no native-chat rendering, so they must not
+ *  show the toggle. */
+const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set<string>([
+  'claude',
+  'openclaude',
+  'codex'
+])
+
+/** Whether the given agent identity (from any signal: launch hint, live
+ *  detection, or title resolution) is one native chat can render. */
+export function isNativeChatSupportedAgent(
+  agent: TuiAgent | AgentType | null | undefined
+): boolean {
+  return agent != null && NATIVE_CHAT_SUPPORTED_AGENTS.has(agent)
+}
 
 /** Inputs that decide whether a tab may toggle into the native chat view.
  *  Kept as a plain shape (not the live store) so the decision stays pure and
- *  unit-testable; call sites resolve `launchAgent`/`hasDetectedAgent` from the
+ *  unit-testable; call sites resolve `launchAgent`/`detectedAgent` from the
  *  terminal tab + agent-status before calling. */
 export type NativeChatAvailabilityInput = {
   /** Feature flag: hidden unless enabled from Settings > Experimental. */
@@ -10,23 +31,26 @@ export type NativeChatAvailabilityInput = {
   contentType: Tab['contentType']
   /** The coding-agent Orca launched in this terminal, if any (from TerminalTab). */
   launchAgent?: TuiAgent | null
-  /** True when a live agent-status entry exists for any pane of this tab — i.e.
-   *  an agent was detected at runtime even though `launchAgent` was not set
-   *  (manually-started agents, resumed sessions). */
-  hasDetectedAgent?: boolean
-  /** True when another trusted tab signal (for example the terminal title
-   *  resolver) identifies the foreground as an agent before hooks arrive. */
-  hasResolvedAgent?: boolean
+  /** The agent identity from a live agent-status entry for any pane of this tab,
+   *  when one exists — i.e. an agent detected at runtime even though
+   *  `launchAgent` was not set (manually-started agents, resumed sessions). */
+  detectedAgent?: AgentType | null
+  /** The agent identity from another trusted tab signal (for example the
+   *  terminal title resolver) when it identifies the foreground as an agent
+   *  before hooks arrive. */
+  resolvedAgent?: TuiAgent | null
   /** Already-chat tabs must always be allowed to toggle back to terminal, even
    *  if live hook state was lost during a dev/app restart. */
   isChatViewMode?: boolean
 }
 
 /** Native chat is a rendering of a coding-agent conversation, so the toggle is
- *  only meaningful on terminals that actually run an agent. Plain shells and
- *  non-terminal surfaces (editor, browser, …) never qualify. Eligibility is the
- *  union of the launch-time hint and live detection so the control appears both
- *  for Orca-launched agents and for agents the user started themselves. */
+ *  only meaningful on terminals that actually run an agent we can parse. Plain
+ *  shells, non-terminal surfaces (editor, browser, …), and unsupported agents
+ *  (Grok, Gemini, …) never qualify. Eligibility is the union of the launch-time
+ *  hint, live detection, and title resolution — but only when that signal names
+ *  a supported agent — so the control appears for both Orca-launched and
+ *  user-started Claude/Codex sessions. */
 export function canToggleNativeChat(input: NativeChatAvailabilityInput): boolean {
   if (input.experimentalNativeChatEnabled !== true) {
     return false
@@ -36,8 +60,8 @@ export function canToggleNativeChat(input: NativeChatAvailabilityInput): boolean
   }
   return (
     input.isChatViewMode === true ||
-    Boolean(input.launchAgent) ||
-    input.hasDetectedAgent === true ||
-    input.hasResolvedAgent === true
+    isNativeChatSupportedAgent(input.launchAgent) ||
+    isNativeChatSupportedAgent(input.detectedAgent) ||
+    isNativeChatSupportedAgent(input.resolvedAgent)
   )
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.ts
@@ -33,18 +33,21 @@ export function useNativeChatToggleShortcut(worktreeId: string, isWorktreeActive
       const terminalTab = (state.tabsByWorktree[worktreeId] ?? []).find(
         (candidate) => candidate.id === tab.entityId
       )
-      const hasDetectedAgent = Object.keys(state.agentStatusByPaneKey).some((paneKey) =>
-        paneKey.startsWith(`${tab.id}:`)
-      )
+      // Carry the agent identity (not just "an agent exists") so the chord stays
+      // inert on unsupported agents like Grok, matching the menu/header gate.
+      const detectedAgent =
+        Object.entries(state.agentStatusByPaneKey).find(([paneKey]) =>
+          paneKey.startsWith(`${tab.id}:`)
+        )?.[1].agentType ?? null
       if (
         !canToggleNativeChat({
           experimentalNativeChatEnabled: state.settings?.experimentalNativeChat === true,
           contentType: 'terminal',
           launchAgent: terminalTab?.launchAgent,
-          hasDetectedAgent,
-          hasResolvedAgent:
-            resolveTabAgentFromTitle(tab.label ?? '') !== null ||
-            (terminalTab ? resolveTabAgentFromTitle(terminalTab.title) !== null : false),
+          detectedAgent,
+          resolvedAgent:
+            resolveTabAgentFromTitle(tab.label ?? '') ??
+            (terminalTab ? resolveTabAgentFromTitle(terminalTab.title) : null),
           isChatViewMode: tab.viewMode === 'chat'
         })
       ) {

--- a/src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.ts
@@ -35,9 +35,11 @@ export function useNativeChatToggleShortcut(worktreeId: string, isWorktreeActive
       )
       // Carry the agent identity (not just "an agent exists") so the chord stays
       // inert on unsupported agents like Grok, matching the menu/header gate.
+      // Pane keys are `${entityId}:${leafId}` — the backing terminal tab id, not
+      // the unified tab id.
       const detectedAgent =
         Object.entries(state.agentStatusByPaneKey).find(([paneKey]) =>
-          paneKey.startsWith(`${tab.id}:`)
+          paneKey.startsWith(`${tab.entityId}:`)
         )?.[1].agentType ?? null
       if (
         !canToggleNativeChat({

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -1105,10 +1105,11 @@ function TabBarInner({
                 const resolvedAgent =
                   resolveTabAgentFromTitle(unifiedTabForItem?.label ?? '') ??
                   resolveTabAgentFromTitle(terminalTab.title)
-                const detectedAgent = unifiedTabForItem
-                  ? (findTabAgentEntry(agentStatusByPaneKey ?? {}, unifiedTabForItem.id)
-                      ?.agentType ?? null)
-                  : null
+                // Key the live-agent lookup by the backing terminal tab id —
+                // agent-status pane keys are `${terminalTab.id}:${leafId}`, and
+                // the unified tab id can differ from it.
+                const detectedAgent =
+                  findTabAgentEntry(agentStatusByPaneKey ?? {}, terminalTab.id)?.agentType ?? null
                 const canToggleViewMode =
                   unifiedTabForItem !== undefined &&
                   canToggleNativeChat({

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -78,6 +78,7 @@ import { useTabStripOverflowNavigation } from './tab-strip-overflow-navigation'
 import { useTabStripDragScrollHandlers } from './tab-strip-drag-scroll'
 import { shouldShowWindowsShellMenu } from './windows-shell-menu-visibility'
 import { canToggleNativeChat } from '../native-chat/native-chat-availability'
+import { findTabAgentEntry } from '../native-chat/native-chat-tab-agent-entry'
 import { resolveTabAgentFromTitle } from '@/lib/use-tab-agent'
 
 const isWindows = navigator.userAgent.includes('Windows')
@@ -455,16 +456,6 @@ function TabBarInner({
   const toggleTabViewMode = useAppStore((s) => s.toggleTabViewMode)
   const agentStatusByPaneKey = useAppStore((s) => s.agentStatusByPaneKey)
   const nativeChatEnabled = useAppStore((s) => s.settings?.experimentalNativeChat === true)
-  const tabIdsWithLiveAgent = useMemo(() => {
-    const ids = new Set<string>()
-    for (const paneKey of Object.keys(agentStatusByPaneKey ?? {})) {
-      const separator = paneKey.indexOf(':')
-      if (separator > 0) {
-        ids.add(paneKey.slice(0, separator))
-      }
-    }
-    return ids
-  }, [agentStatusByPaneKey])
 
   // Why: Electron <webview> elements run in a separate process, so clicking
   // inside one never dispatches a pointerdown on the renderer document.
@@ -1109,17 +1100,23 @@ function TabBarInner({
                   )
                 }
                 const unifiedTabForItem = unifiedTabByVisibleId.get(item.id)
-                const hasResolvedAgent =
-                  resolveTabAgentFromTitle(unifiedTabForItem?.label ?? '') !== null ||
-                  resolveTabAgentFromTitle(terminalTab.title) !== null
+                // Carry the agent *identity* (not just "an agent exists") so the
+                // native-chat gate can reject unsupported agents like Grok.
+                const resolvedAgent =
+                  resolveTabAgentFromTitle(unifiedTabForItem?.label ?? '') ??
+                  resolveTabAgentFromTitle(terminalTab.title)
+                const detectedAgent = unifiedTabForItem
+                  ? (findTabAgentEntry(agentStatusByPaneKey ?? {}, unifiedTabForItem.id)
+                      ?.agentType ?? null)
+                  : null
                 const canToggleViewMode =
                   unifiedTabForItem !== undefined &&
                   canToggleNativeChat({
                     experimentalNativeChatEnabled: nativeChatEnabled,
                     contentType: 'terminal',
                     launchAgent: terminalTab.launchAgent,
-                    hasDetectedAgent: tabIdsWithLiveAgent.has(unifiedTabForItem.id),
-                    hasResolvedAgent,
+                    detectedAgent,
+                    resolvedAgent,
                     isChatViewMode: unifiedTabForItem.viewMode === 'chat'
                   })
                 return (

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -559,14 +559,18 @@ export default function TerminalPane({
       )?.label
   )
   // The native-chat toggle joins the pane header's split/close cluster. Eligible
-  // when Orca launched an agent here or one was detected live (any pane of this
-  // tab has an agent-status entry, keyed `${tabId}:…`).
-  const hasDetectedAgent = useAppStore((store) =>
-    Object.keys(store.agentStatusByPaneKey).some((paneKey) => {
+  // when Orca launched a *supported* agent here or one was detected live (a pane
+  // of this tab has an agent-status entry, keyed `${tabId}:…`). Carry the agent
+  // identity, not just "an agent exists", so the gate can reject Grok et al.
+  const detectedAgent = useAppStore((store) => {
+    for (const [paneKey, entry] of Object.entries(store.agentStatusByPaneKey)) {
       const sep = paneKey.indexOf(':')
-      return sep > 0 && paneKey.slice(0, sep) === tabId
-    })
-  )
+      if (sep > 0 && paneKey.slice(0, sep) === tabId) {
+        return entry.agentType ?? null
+      }
+    }
+    return null
+  })
   const toggleTabViewMode = useAppStore((store) => store.toggleTabViewMode)
   const savedLayout = useAppStore((store) => store.terminalLayoutsByTabId[tabId] ?? EMPTY_LAYOUT)
   const terminalTab = useAppStore((store) =>
@@ -581,8 +585,8 @@ export default function TerminalPane({
     experimentalNativeChatEnabled: nativeChatEnabled,
     contentType: 'terminal',
     launchAgent: terminalTab?.launchAgent,
-    hasDetectedAgent,
-    hasResolvedAgent: titleResolvedAgent !== null,
+    detectedAgent,
+    resolvedAgent: titleResolvedAgent,
     isChatViewMode
   })
   const toggleNativeChatForLeaf = useCallback(


### PR DESCRIPTION
## Problem

The experimental **Native Chat** view is only meant to work for Claude and Codex (its transcript/streaming parser is provider-specific). But the **"Switch to chat view"** toggle was showing for *every* agent terminal — Grok, Gemini, and the rest — even though native chat can't render those.

## Root cause

`canToggleNativeChat` only checked *whether* a terminal was running an agent, never *which* one. The agent's identity was discarded at every call site before the gate could see it:

- `launchAgent` was passed but never inspected
- live detection and title resolution were collapsed to bare booleans (`hasDetectedAgent` / `hasResolvedAgent`)

So any truthy agent signal — regardless of provider — satisfied the gate.

## Fix

Make the gate agent-aware:

- Add a `NATIVE_CHAT_SUPPORTED_AGENTS` allowlist (`claude`, `openclaude`, `codex`) and an `isNativeChatSupportedAgent()` helper in `native-chat-availability.ts`.
- Change the input shape from booleans to agent-identity values (`detectedAgent`, `resolvedAgent`) and require a *supported* agent on every signal path.
- Thread the real agent identity through **all three** call sites that drive the toggle:
  - `TabBar.tsx` — tab context menu (resolves the live `agentType` via `findTabAgentEntry`; removed the now-dead `tabIdsWithLiveAgent` memo)
  - `TerminalPane.tsx` — pane header + context menu
  - `use-native-chat-toggle-shortcut.ts` — keyboard chord (stays inert on unsupported agents)

All three mattered: fixing only the menu would still let Grok enter native chat via the header or the shortcut.

> **Note:** `openclaude` is included as supported (Claude variant, already in the image-attachment allowlist). Easy to drop if native chat shouldn't cover it.

## Testing

- Added negative cases to `native-chat-availability.test.ts` (Grok/Gemini rejected via launch hint, live detection, and title resolution) — **13/13** pass.
- Related shortcut/context-menu tests pass (**9/9**).
- `pnpm typecheck` (web project) and `oxlint` on the changed files are clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
