### PR TITLE
Improve toast layout and dev tools

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -295,6 +295,49 @@
   --linear-priority-bar-inactive-fill: color-mix(in srgb, lch(39.576 1.25 282) 62%, transparent);
 }
 
+[data-sonner-toaster] {
+  font-family: var(--font-sans);
+}
+
+[data-sonner-toaster] [data-sonner-toast][data-styled='true'] {
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 14px 16px;
+  box-shadow: 0 10px 24px rgb(0 0 0 / 0.18);
+}
+
+[data-sonner-toaster] [data-sonner-toast][data-styled='true'] [data-icon] {
+  margin-top: 2px;
+}
+
+[data-sonner-toaster] [data-sonner-toast][data-styled='true'] [data-content] {
+  min-width: 0;
+  flex: 1 1 calc(100% - 30px);
+  gap: 6px;
+}
+
+[data-sonner-toaster] [data-sonner-toast][data-styled='true'] [data-button] {
+  /* Why: Sonner's native action slots otherwise share the copy row and squeeze
+     long notices; indent the wrapped footer to align with text after the icon. */
+  margin-top: 2px;
+  margin-left: 26px;
+  margin-right: 0;
+}
+
+[data-sonner-toaster] [data-sonner-toast][data-styled='true'] [data-button] ~ [data-button] {
+  margin-left: 0;
+}
+
+[data-sonner-toaster] [data-sonner-toast][data-styled='true'] [data-title] {
+  line-height: 1.35;
+}
+
+[data-sonner-toaster] [data-sonner-toast][data-styled='true'] [data-description] {
+  color: color-mix(in srgb, var(--popover-foreground) 76%, transparent);
+  line-height: 1.45;
+}
+
 [data-sonner-toaster] [data-sonner-toast][data-styled='true'] [data-close-button] {
   /* Why: Sonner's dark-theme defaults can resolve the close icon and button
      background to the same color; keep the X readable on both Orca themes. */

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -334,7 +334,10 @@
 }
 
 [data-sonner-toaster] [data-sonner-toast][data-styled='true'] [data-description] {
-  color: color-mix(in srgb, var(--popover-foreground) 76%, transparent);
+  /* Why: match the 80% body-copy opacity used by the custom-React toast bodies
+     (delete-worktree-failure, local-base-ref-suggestion) so string and JSX
+     descriptions read at the same weight. */
+  color: color-mix(in srgb, var(--popover-foreground) 80%, transparent);
   line-height: 1.45;
 }
 

--- a/src/renderer/src/components/settings/DevToolsPane.tsx
+++ b/src/renderer/src/components/settings/DevToolsPane.tsx
@@ -221,30 +221,28 @@ export function DevToolsPane(): React.JSX.Element {
   ]
 
   return (
-    <div className="space-y-5">
-      <section className="space-y-3">
-        <div className="flex items-start justify-between gap-3">
-          <SettingsSubsectionHeader
-            title={translate(
-              'auto.components.settings.DevToolsPane.notificationPlayground',
-              'Notification playground'
-            )}
-            description={translate(
-              'auto.components.settings.DevToolsPane.notificationPlaygroundDescription',
-              'Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.'
-            )}
-          />
-          <Badge variant="outline" className="mt-0.5">
-            {translate('auto.components.settings.DevToolsPane.devOnly', 'Dev only')}
-          </Badge>
-        </div>
+    <section className="space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <SettingsSubsectionHeader
+          title={translate(
+            'auto.components.settings.DevToolsPane.notificationPlayground',
+            'Notification playground'
+          )}
+          description={translate(
+            'auto.components.settings.DevToolsPane.notificationPlaygroundDescription',
+            'Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.'
+          )}
+        />
+        <Badge variant="outline" className="mt-0.5">
+          {translate('auto.components.settings.DevToolsPane.devOnly', 'Dev only')}
+        </Badge>
+      </div>
 
-        <div className="grid gap-2 sm:grid-cols-2">
-          {actions.map((action) => (
-            <DevToastActionButton key={action.title} action={action} />
-          ))}
-        </div>
-      </section>
-    </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {actions.map((action) => (
+          <DevToastActionButton key={action.title} action={action} />
+        ))}
+      </div>
+    </section>
   )
 }

--- a/src/renderer/src/components/settings/DevToolsPane.tsx
+++ b/src/renderer/src/components/settings/DevToolsPane.tsx
@@ -1,0 +1,250 @@
+import { toast } from 'sonner'
+import { Bell, Info, OctagonX, Sparkles, Trash2 } from 'lucide-react'
+import { Button } from '../ui/button'
+import { Badge } from '../ui/badge'
+import { SettingsSubsectionHeader } from './SettingsFormControls'
+import { showDeleteWorktreeFailureToast } from '../sidebar/delete-worktree-failure-toast'
+import { showLocalBaseRefUpdateSuggestionToast } from '../sidebar/local-base-ref-suggestion-toast'
+import { translate } from '@/i18n/i18n'
+import type { AppState } from '@/store/types'
+
+const LONG_WORKSPACE_NAME = 'feature/dev-toast-layout-with-a-long-workspace-name'
+const DEV_TOAST_DESCRIPTION =
+  'This is intentionally long copy for checking width, line wrapping, icon alignment, action placement, and close-button overlap in the shared toast frame.'
+
+type DevToastAction = {
+  title: string
+  description: string
+  icon: React.ReactNode
+  onClick: () => void
+}
+
+function DevToastActionButton({ action }: { action: DevToastAction }): React.JSX.Element {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={action.onClick}
+      className="h-auto min-h-9 justify-start gap-2 whitespace-normal px-3 py-2 text-left"
+    >
+      <span className="mt-0.5 text-muted-foreground">{action.icon}</span>
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-foreground">{action.title}</span>
+        <span className="block text-xs leading-4 text-muted-foreground">{action.description}</span>
+      </span>
+    </Button>
+  )
+}
+
+function showNativeActionToast(): void {
+  toast.info(
+    translate(
+      'auto.components.settings.DevToolsPane.nativeActionLayoutCheck',
+      'Native action layout check'
+    ),
+    {
+      description: DEV_TOAST_DESCRIPTION,
+      duration: 10000,
+      cancel: {
+        label: translate('auto.components.settings.DevToolsPane.secondary', 'Secondary'),
+        onClick: () =>
+          toast.message(
+            translate(
+              'auto.components.settings.DevToolsPane.secondaryActionClicked',
+              'Secondary action clicked'
+            )
+          )
+      },
+      action: {
+        label: translate('auto.components.settings.DevToolsPane.primaryAction', 'Primary action'),
+        onClick: () =>
+          toast.success(
+            translate(
+              'auto.components.settings.DevToolsPane.primaryActionClicked',
+              'Primary action clicked'
+            )
+          )
+      }
+    }
+  )
+}
+
+function showBehindBaseRefToast(): void {
+  let enabled = false
+  showLocalBaseRefUpdateSuggestionToast(
+    {
+      baseRef: 'origin/canary',
+      localBranch: 'canary',
+      behind: 2
+    },
+    {
+      updateSettings: async (updates) => {
+        enabled = updates.refreshLocalBaseRefOnWorktreeCreate === true
+      },
+      getSettings: () =>
+        ({
+          refreshLocalBaseRefOnWorktreeCreate: enabled
+        }) as AppState['settings'],
+      openSettingsPage: () => {},
+      openSettingsTarget: () => {}
+    }
+  )
+}
+
+function showDeleteFailureToast(): void {
+  showDeleteWorktreeFailureToast({
+    error: translate(
+      'auto.components.settings.DevToolsPane.branchHasChanges',
+      'branch has changes'
+    ),
+    canForceDelete: true,
+    onViewChanges: () =>
+      toast.message(
+        translate(
+          'auto.components.settings.DevToolsPane.viewChangesClicked',
+          'View Changes clicked'
+        )
+      ),
+    onForceDelete: () =>
+      toast.error(
+        translate(
+          'auto.components.settings.DevToolsPane.forceDeleteClicked',
+          'Force Delete clicked'
+        ),
+        {
+          description: translate(
+            'auto.components.settings.DevToolsPane.devOnlyCallback',
+            'Dev-only callback.'
+          )
+        }
+      ),
+    worktreeId: 'dev-toast-worktree',
+    worktreeName: LONG_WORKSPACE_NAME
+  })
+}
+
+export function DevToolsPane(): React.JSX.Element {
+  const actions: DevToastAction[] = [
+    {
+      title: translate('auto.components.settings.DevToolsPane.infoToast', 'Info toast'),
+      description: translate(
+        'auto.components.settings.DevToolsPane.infoToastDescription',
+        'Long informational copy with no explicit action.'
+      ),
+      icon: <Info className="size-4" />,
+      onClick: () =>
+        toast.info(
+          translate(
+            'auto.components.settings.DevToolsPane.localCanaryBehind',
+            'Local canary is behind origin/canary'
+          ),
+          {
+            description: DEV_TOAST_DESCRIPTION,
+            duration: 10000
+          }
+        )
+    },
+    {
+      title: translate('auto.components.settings.DevToolsPane.successToast', 'Success toast'),
+      description: translate(
+        'auto.components.settings.DevToolsPane.successToastDescription',
+        'Short confirmation state.'
+      ),
+      icon: <Sparkles className="size-4" />,
+      onClick: () =>
+        toast.success(
+          translate('auto.components.settings.DevToolsPane.settingsSaved', 'Settings saved'),
+          {
+            description: translate(
+              'auto.components.settings.DevToolsPane.shortSuccessCopy',
+              'Short success copy.'
+            )
+          }
+        )
+    },
+    {
+      title: translate('auto.components.settings.DevToolsPane.errorToast', 'Error toast'),
+      description: translate(
+        'auto.components.settings.DevToolsPane.errorToastDescription',
+        'Long error copy without recovery actions.'
+      ),
+      icon: <OctagonX className="size-4" />,
+      onClick: () =>
+        toast.error(
+          translate(
+            'auto.components.settings.DevToolsPane.failedToSyncWorkspaceMetadata',
+            'Failed to sync workspace metadata'
+          ),
+          {
+            description: DEV_TOAST_DESCRIPTION,
+            duration: 10000
+          }
+        )
+    },
+    {
+      title: translate(
+        'auto.components.settings.DevToolsPane.nativeActionToast',
+        'Native action toast'
+      ),
+      description: translate(
+        'auto.components.settings.DevToolsPane.nativeActionToastDescription',
+        'Uses Sonner action and cancel slots.'
+      ),
+      icon: <Bell className="size-4" />,
+      onClick: showNativeActionToast
+    },
+    {
+      title: translate(
+        'auto.components.settings.DevToolsPane.deleteFailureToast',
+        'Delete failure toast'
+      ),
+      description: translate(
+        'auto.components.settings.DevToolsPane.deleteFailureToastDescription',
+        'Custom footer with View and Force Delete.'
+      ),
+      icon: <Trash2 className="size-4" />,
+      onClick: showDeleteFailureToast
+    },
+    {
+      title: translate(
+        'auto.components.settings.DevToolsPane.behindBaseRefToast',
+        'Behind base ref toast'
+      ),
+      description: translate(
+        'auto.components.settings.DevToolsPane.behindBaseRefToastDescription',
+        'Persistent prompt with an inline Settings link and footer action.'
+      ),
+      icon: <Bell className="size-4" />,
+      onClick: showBehindBaseRefToast
+    }
+  ]
+
+  return (
+    <div className="space-y-5">
+      <section className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <SettingsSubsectionHeader
+            title={translate(
+              'auto.components.settings.DevToolsPane.notificationPlayground',
+              'Notification playground'
+            )}
+            description={translate(
+              'auto.components.settings.DevToolsPane.notificationPlaygroundDescription',
+              'Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.'
+            )}
+          />
+          <Badge variant="outline" className="mt-0.5">
+            {translate('auto.components.settings.DevToolsPane.devOnly', 'Dev only')}
+          </Badge>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {actions.map((action) => (
+            <DevToastActionButton key={action.title} action={action} />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -1,5 +1,14 @@
 /* eslint-disable max-lines */
-import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react'
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject
+} from 'react'
 import { toast } from 'sonner'
 import type { GlobalSettings, OrcaHooks } from '../../../../shared/types'
 import type { SpeechModelState } from '../../../../shared/speech-types'
@@ -90,6 +99,10 @@ import {
 } from './settings-load-performance'
 import { translate } from '@/i18n/i18n'
 import { getProjectHostSetupProjectionFromState } from '../../store/selectors'
+
+const DevToolsPane = import.meta.env.DEV
+  ? lazy(() => import('./DevToolsPane').then((module) => ({ default: module.DevToolsPane })))
+  : null
 
 const SETTINGS_NAV_GROUPS = [
   {
@@ -1560,6 +1573,24 @@ function Settings(): React.JSX.Element {
                   >
                     {isSectionMounted('advanced') ? (
                       <AdvancedPane settings={settings} updateSettings={updateSettings} />
+                    ) : null}
+                  </SettingsSection>
+                ) : null}
+
+                {showDesktopOnlySettings && import.meta.env.DEV ? (
+                  <SettingsSection
+                    id="dev"
+                    title={translate('auto.components.settings.Settings.dev', 'Dev Tools')}
+                    description={translate(
+                      'auto.components.settings.Settings.devDescription',
+                      'Dev-only tools for exercising UI states.'
+                    )}
+                    searchEntries={getSectionSearchEntries('dev')}
+                  >
+                    {DevToolsPane && isSectionMounted('dev') ? (
+                      <Suspense fallback={null}>
+                        <DevToolsPane />
+                      </Suspense>
                     ) : null}
                   </SettingsSection>
                 ) : null}

--- a/src/renderer/src/components/sidebar/delete-worktree-failure-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/delete-worktree-failure-toast.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { showDeleteWorktreeFailureToast } from './delete-worktree-failure-toast'
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    dismiss: vi.fn()
+  }
+}))
+
+const mountedRoots: Root[] = []
+
+function renderToastBody(method: 'error' | 'info'): HTMLElement {
+  const description = vi.mocked(toast[method]).mock.calls.at(-1)?.[1]
+    ?.description as React.ReactElement
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  act(() => {
+    root.render(description)
+  })
+  return container
+}
+
+function clickButton(container: HTMLElement, label: string): void {
+  const button = [...container.querySelectorAll('button')].find(
+    (el) => el.textContent?.trim() === label
+  )
+  if (!button) {
+    throw new Error(`button "${label}" not found`)
+  }
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+afterEach(() => {
+  mountedRoots.splice(0).forEach((root) => act(() => root.unmount()))
+  document.body.innerHTML = ''
+  vi.clearAllMocks()
+})
+
+describe('showDeleteWorktreeFailureToast', () => {
+  it('uses a persistent in-body action footer when force delete is available', () => {
+    const onViewChanges = vi.fn()
+    const onForceDelete = vi.fn()
+
+    showDeleteWorktreeFailureToast({
+      error: 'branch has changes',
+      canForceDelete: true,
+      onViewChanges,
+      onForceDelete,
+      worktreeId: 'wt-1',
+      worktreeName: 'feature/foo'
+    })
+
+    expect(toast.info).toHaveBeenCalledWith(
+      'Failed to delete workspace feature/foo',
+      expect.objectContaining({
+        id: 'delete-worktree-failure:wt-1',
+        dismissible: true,
+        duration: Infinity
+      })
+    )
+    const options = vi.mocked(toast.info).mock.calls.at(-1)?.[1] as
+      | { action?: unknown; cancel?: unknown }
+      | undefined
+    expect(options?.action).toBeUndefined()
+    expect(options?.cancel).toBeUndefined()
+
+    const body = renderToastBody('info')
+    expect(body.textContent).toContain('It has changed files.')
+
+    clickButton(body, 'View')
+    expect(toast.dismiss).toHaveBeenCalledWith('delete-worktree-failure:wt-1')
+    expect(onViewChanges).toHaveBeenCalled()
+
+    clickButton(body, 'Force Delete')
+    expect(toast.dismiss).toHaveBeenCalledWith('delete-worktree-failure:wt-1')
+    expect(onForceDelete).toHaveBeenCalled()
+  })
+
+  it('keeps non-forceable failures destructive without a force action', () => {
+    showDeleteWorktreeFailureToast({
+      error: 'permission denied',
+      canForceDelete: false,
+      onViewChanges: vi.fn(),
+      onForceDelete: vi.fn(),
+      worktreeId: 'wt-2',
+      worktreeName: 'feature/bar'
+    })
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to delete workspace feature/bar',
+      expect.objectContaining({
+        id: 'delete-worktree-failure:wt-2',
+        dismissible: true,
+        duration: 10000
+      })
+    )
+
+    const body = renderToastBody('error')
+    expect(body.textContent).toContain('permission denied')
+    expect(body.textContent).toContain('View')
+    expect(body.textContent).not.toContain('Force Delete')
+  })
+})

--- a/src/renderer/src/components/sidebar/delete-worktree-failure-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/delete-worktree-failure-toast.test.tsx
@@ -88,10 +88,12 @@ describe('showDeleteWorktreeFailureToast', () => {
   })
 
   it('keeps non-forceable failures destructive without a force action', () => {
+    const onViewChanges = vi.fn()
+
     showDeleteWorktreeFailureToast({
       error: 'permission denied',
       canForceDelete: false,
-      onViewChanges: vi.fn(),
+      onViewChanges,
       onForceDelete: vi.fn(),
       worktreeId: 'wt-2',
       worktreeName: 'feature/bar'
@@ -108,7 +110,10 @@ describe('showDeleteWorktreeFailureToast', () => {
 
     const body = renderToastBody('error')
     expect(body.textContent).toContain('permission denied')
-    expect(body.textContent).toContain('View')
     expect(body.textContent).not.toContain('Force Delete')
+
+    clickButton(body, 'View')
+    expect(toast.dismiss).toHaveBeenCalledWith('delete-worktree-failure:wt-2')
+    expect(onViewChanges).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/sidebar/delete-worktree-failure-toast.tsx
+++ b/src/renderer/src/components/sidebar/delete-worktree-failure-toast.tsx
@@ -1,0 +1,88 @@
+import { toast } from 'sonner'
+import { Button } from '../ui/button'
+import { getDeleteWorktreeToastCopy } from './delete-worktree-toast'
+import { translate } from '@/i18n/i18n'
+
+type DeleteWorktreeFailureToastOptions = {
+  error: string
+  canForceDelete: boolean
+  onViewChanges: () => void
+  onForceDelete: () => void
+  worktreeId: string
+  worktreeName: string
+}
+
+function deleteWorktreeFailureToastId(worktreeId: string): string {
+  return `delete-worktree-failure:${worktreeId}`
+}
+
+function DeleteWorktreeFailureToastBody({
+  description,
+  canForceDelete,
+  onViewChanges,
+  onForceDelete,
+  toastId
+}: {
+  description?: string
+  canForceDelete: boolean
+  onViewChanges: () => void
+  onForceDelete: () => void
+  toastId: string
+}): React.JSX.Element {
+  const viewChanges = (): void => {
+    toast.dismiss(toastId)
+    onViewChanges()
+  }
+  const forceDelete = (): void => {
+    toast.dismiss(toastId)
+    onForceDelete()
+  }
+
+  return (
+    <div className="flex w-full max-w-[28rem] flex-col gap-3">
+      {description ? (
+        <p className="text-sm leading-5 text-popover-foreground/80">{description}</p>
+      ) : null}
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={viewChanges}>
+          {translate('auto.components.sidebar.delete.worktree.flow.7488ed8711', 'View')}
+        </Button>
+        {canForceDelete ? (
+          <Button type="button" variant="destructive" size="sm" onClick={forceDelete}>
+            {translate('auto.components.sidebar.delete.worktree.flow.2b20ce87b3', 'Force Delete')}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export function showDeleteWorktreeFailureToast({
+  error,
+  canForceDelete,
+  onViewChanges,
+  onForceDelete,
+  worktreeId,
+  worktreeName
+}: DeleteWorktreeFailureToastOptions): void {
+  const toastCopy = getDeleteWorktreeToastCopy(worktreeName, canForceDelete, error)
+  const showToast = toastCopy.isDestructive ? toast.error : toast.info
+  const id = deleteWorktreeFailureToastId(worktreeId)
+
+  // Why: Sonner's native action/cancel slots share the title row and squeeze
+  // multi-line delete errors. Custom content gives the copy its own line.
+  showToast(toastCopy.title, {
+    id,
+    description: (
+      <DeleteWorktreeFailureToastBody
+        description={toastCopy.description}
+        canForceDelete={canForceDelete}
+        onViewChanges={onViewChanges}
+        onForceDelete={onForceDelete}
+        toastId={id}
+      />
+    ),
+    duration: canForceDelete ? Infinity : 10000,
+    dismissible: true
+  })
+}

--- a/src/renderer/src/components/sidebar/delete-worktree-failure-toast.tsx
+++ b/src/renderer/src/components/sidebar/delete-worktree-failure-toast.tsx
@@ -39,7 +39,7 @@ function DeleteWorktreeFailureToastBody({
   }
 
   return (
-    <div className="flex w-full max-w-[28rem] flex-col gap-3">
+    <div className="flex w-full flex-col gap-3">
       {description ? (
         <p className="text-sm leading-5 text-popover-foreground/80">{description}</p>
       ) : null}

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -60,7 +60,12 @@ vi.mock('sonner', () => ({
   }
 }))
 
+vi.mock('./delete-worktree-failure-toast', () => ({
+  showDeleteWorktreeFailureToast: vi.fn()
+}))
+
 import { toast } from 'sonner'
+import { showDeleteWorktreeFailureToast } from './delete-worktree-failure-toast'
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 
 function setWorktrees(
@@ -100,6 +105,7 @@ describe('runWorktreeBatchDelete', () => {
     mocks.state.repos = []
     vi.mocked(toast.error).mockClear()
     vi.mocked(toast.info).mockClear()
+    vi.mocked(showDeleteWorktreeFailureToast).mockClear()
     setWorktrees([])
   })
 
@@ -178,11 +184,9 @@ describe('runWorktreeBatchDelete', () => {
 
     expect(runWorktreeBatchDelete(['wt-1'], { onDeleted })).toBe(true)
 
-    await vi.waitFor(() => expect(toast.info).toHaveBeenCalled())
-    const toastOptions = vi.mocked(toast.info).mock.calls[0]?.[1] as
-      | { action?: { onClick?: () => void } }
-      | undefined
-    toastOptions?.action?.onClick?.()
+    await vi.waitFor(() => expect(showDeleteWorktreeFailureToast).toHaveBeenCalled())
+    const toastOptions = vi.mocked(showDeleteWorktreeFailureToast).mock.calls[0]?.[0]
+    toastOptions?.onForceDelete()
 
     await vi.waitFor(() => {
       expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-1', true)

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -3,7 +3,7 @@ import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { prepareActiveWorktreeFocusAfterDelete } from './active-worktree-focus-after-delete'
-import { getDeleteWorktreeToastCopy } from './delete-worktree-toast'
+import { showDeleteWorktreeFailureToast } from './delete-worktree-failure-toast'
 import { getWorkspaceDeleteLineage } from './workspace-delete-lineage'
 import {
   isPathInsideOrEqual,
@@ -145,73 +145,62 @@ export function runWorktreeDeleteWithToast(
       }
       const state = useAppStore.getState().deleteStateByWorktreeId[worktreeId]
       const canForceDelete = state?.canForceDelete ?? false
-      const toastCopy = getDeleteWorktreeToastCopy(worktreeName, canForceDelete, result.error)
-      const showToast = toastCopy.isDestructive ? toast.error : toast.info
-      showToast(toastCopy.title, {
-        description: toastCopy.description,
-        duration: 10000,
-        cancel: {
-          label: translate('auto.components.sidebar.delete.worktree.flow.7488ed8711', 'View'),
-          onClick: () => viewWorktreeDiff(worktreeId)
-        },
-        action: canForceDelete
-          ? {
-              label: translate(
-                'auto.components.sidebar.delete.worktree.flow.2b20ce87b3',
-                'Force Delete'
-              ),
-              onClick: () => {
-                // Why: recapture at click time — the user may have navigated away
-                // while the failed-delete toast was open, so focus only hands off
-                // when this is still the workspace they are viewing.
-                const commitForceFocus = prepareActiveWorktreeFocusAfterDelete(worktreeId)
-                useAppStore
-                  .getState()
-                  .removeWorktree(worktreeId, true)
-                  .then((forceResult) => {
-                    if (!forceResult.ok) {
-                      toast.error(
-                        translate(
-                          'auto.components.sidebar.delete.worktree.flow.4f3876c0f5',
-                          'Force delete failed'
-                        ),
-                        {
-                          description: forceResult.error,
-                          action: {
-                            label: translate(
-                              'auto.components.sidebar.delete.worktree.flow.7488ed8711',
-                              'View'
-                            ),
-                            onClick: () => viewWorktreeDiff(worktreeId)
-                          }
-                        }
-                      )
-                      return
-                    }
-                    commitForceFocus()
-                    options.onForceDeleted?.(worktreeId)
-                  })
-                  .catch((err: unknown) => {
-                    toast.error(
-                      translate(
-                        'auto.components.sidebar.delete.worktree.flow.ae57cbf6e4',
-                        'Failed to delete workspace'
+      showDeleteWorktreeFailureToast({
+        error: result.error,
+        canForceDelete,
+        onViewChanges: () => viewWorktreeDiff(worktreeId),
+        onForceDelete: () => {
+          // Why: recapture at click time — the user may have navigated away
+          // while the failed-delete toast was open, so focus only hands off
+          // when this is still the workspace they are viewing.
+          const commitForceFocus = prepareActiveWorktreeFocusAfterDelete(worktreeId)
+          useAppStore
+            .getState()
+            .removeWorktree(worktreeId, true)
+            .then((forceResult) => {
+              if (!forceResult.ok) {
+                toast.error(
+                  translate(
+                    'auto.components.sidebar.delete.worktree.flow.4f3876c0f5',
+                    'Force delete failed'
+                  ),
+                  {
+                    description: forceResult.error,
+                    action: {
+                      label: translate(
+                        'auto.components.sidebar.delete.worktree.flow.7488ed8711',
+                        'View'
                       ),
-                      {
-                        description: err instanceof Error ? err.message : String(err),
-                        action: {
-                          label: translate(
-                            'auto.components.sidebar.delete.worktree.flow.7488ed8711',
-                            'View'
-                          ),
-                          onClick: () => viewWorktreeDiff(worktreeId)
-                        }
-                      }
-                    )
-                  })
+                      onClick: () => viewWorktreeDiff(worktreeId)
+                    }
+                  }
+                )
+                return
               }
-            }
-          : undefined
+              commitForceFocus()
+              options.onForceDeleted?.(worktreeId)
+            })
+            .catch((err: unknown) => {
+              toast.error(
+                translate(
+                  'auto.components.sidebar.delete.worktree.flow.ae57cbf6e4',
+                  'Failed to delete workspace'
+                ),
+                {
+                  description: err instanceof Error ? err.message : String(err),
+                  action: {
+                    label: translate(
+                      'auto.components.sidebar.delete.worktree.flow.7488ed8711',
+                      'View'
+                    ),
+                    onClick: () => viewWorktreeDiff(worktreeId)
+                  }
+                }
+              )
+            })
+        },
+        worktreeId,
+        worktreeName
       })
       return false
     })

--- a/src/renderer/src/components/sidebar/local-base-ref-suggestion-toast.tsx
+++ b/src/renderer/src/components/sidebar/local-base-ref-suggestion-toast.tsx
@@ -87,8 +87,8 @@ function SuggestionToastBody({
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      <p className="text-sm text-popover-foreground/80">
+    <div className="flex w-full flex-col gap-3">
+      <p className="text-sm leading-5 text-popover-foreground/80">
         {translate(
           'auto.components.sidebar.local.base.ref.suggestion.toast.f15fd80989',
           'Your new worktree is current, but local {{value0}} is {{value1}} {{value2}} behind, so AI diffs may compare to stale history. Let Orca keep it up to date automatically. Change this anytime in',
@@ -109,7 +109,6 @@ function SuggestionToastBody({
             { value0: keepLocalMainUpToDateTitle }
           )}
         </button>
-        .
       </p>
       <div className="flex justify-end">
         {/* No explicit Dismiss: the toast is persistent and sonner's close (X)

--- a/src/renderer/src/components/ui/sonner.tsx
+++ b/src/renderer/src/components/ui/sonner.tsx
@@ -15,6 +15,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps['theme']}
       position="bottom-right"
+      // Why: Orca has persistent bottom chrome, so bottom-right toasts need
+      // breathing room above the status bar instead of sitting on its edge.
+      offset={{ bottom: 'calc(2.5rem + env(safe-area-inset-bottom, 0px))' }}
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,
@@ -28,7 +31,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
           '--normal-bg': 'var(--popover)',
           '--normal-text': 'var(--popover-foreground)',
           '--normal-border': 'var(--border)',
-          '--border-radius': 'var(--radius)'
+          '--border-radius': 'var(--radius)',
+          '--width': 'min(26rem, calc(100vw - 2rem))'
         } as React.CSSProperties
       }
       {...props}

--- a/src/renderer/src/components/ui/sonner.tsx
+++ b/src/renderer/src/components/ui/sonner.tsx
@@ -17,7 +17,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
       position="bottom-right"
       // Why: Orca has persistent bottom chrome, so bottom-right toasts need
       // breathing room above the status bar instead of sitting on its edge.
+      // mobileOffset keeps that clearance below Sonner's 600px breakpoint
+      // (narrow/resized windows and the web client), which otherwise reverts
+      // to Sonner's default 16px and lets toasts crowd the status bar again.
       offset={{ bottom: 'calc(2.5rem + env(safe-area-inset-bottom, 0px))' }}
+      mobileOffset={{ bottom: 'calc(2.5rem + env(safe-area-inset-bottom, 0px))' }}
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -13,11 +13,14 @@ const repo = {
   addedAt: 0
 } satisfies Repo
 
-function ids(args: { isMac?: boolean; isWindows?: boolean; isWebClient?: boolean } = {}): string[] {
+function ids(
+  args: { isMac?: boolean; isWindows?: boolean; isWebClient?: boolean; isDev?: boolean } = {}
+): string[] {
   return buildSettingsNavigationMetadata({
     isMac: args.isMac ?? false,
     isWindows: args.isWindows ?? false,
     isWebClient: args.isWebClient ?? false,
+    isDev: args.isDev ?? false,
     repos: [repo]
   }).map((section) => section.id)
 }
@@ -147,6 +150,12 @@ describe('settings navigation metadata', () => {
     expect(desktopIds).toContain('advanced')
     expect(desktopIds.indexOf('advanced')).toBeLessThan(desktopIds.indexOf('experimental'))
     expect(desktopIds.indexOf('privacy')).toBeLessThan(desktopIds.indexOf('advanced'))
+  })
+
+  it('shows Dev tools only in desktop development metadata', () => {
+    expect(ids()).not.toContain('dev')
+    expect(ids({ isDev: true })).toContain('dev')
+    expect(ids({ isDev: true, isWebClient: true })).not.toContain('dev')
   })
 
   it('keeps macOS permissions mac-only', () => {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -152,6 +152,11 @@ describe('settings navigation metadata', () => {
     expect(desktopIds.indexOf('privacy')).toBeLessThan(desktopIds.indexOf('advanced'))
   })
 
+  // Note: this exercises the isDev parameter and isWebClient branches only.
+  // Production safety rests on the hard `import.meta.env.DEV` term in the
+  // builder, which is compile-time-inlined per build and cannot be flipped from
+  // a test (vitest always runs with DEV=true) — don't mistake this for full
+  // prod-gate coverage. The bundle exclusion is what guarantees prod safety.
   it('shows Dev tools only in desktop development metadata', () => {
     expect(ids()).not.toContain('dev')
     expect(ids({ isDev: true })).toContain('dev')

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -9,6 +9,7 @@ import {
   Bell,
   Blocks,
   Bot,
+  Bug,
   Cable,
   FlaskConical,
   GitBranch,
@@ -516,7 +517,9 @@ export function buildSettingsNavigationMetadata({
               'auto.hooks.useSettingsNavigationMetadata.devDescription',
               'Dev-only tools for exercising UI states.'
             ),
-            icon: Wrench,
+            // Why: distinct from the sibling Advanced section's Wrench so the two
+            // entries in the same 'advanced' group stay visually distinguishable.
+            icon: Bug,
             searchEntries: getDevToolsPaneSearchEntries(),
             group: 'advanced',
             badge: translate('auto.hooks.useSettingsNavigationMetadata.devBadge', 'Dev')

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -80,17 +80,44 @@ import { translate } from '@/i18n/i18n'
 
 export { isWebClientLocation } from '@/lib/web-client-location'
 
+function getDevToolsPaneSearchEntries(): SettingsNavSection['searchEntries'] {
+  return [
+    {
+      title: translate(
+        'auto.hooks.useSettingsNavigationMetadata.devSearchNotificationPlayground',
+        'Notification playground'
+      ),
+      description: translate(
+        'auto.hooks.useSettingsNavigationMetadata.devSearchNotificationPlaygroundDescription',
+        'Trigger representative toast and notification UI states.'
+      ),
+      keywords: [
+        translate('auto.hooks.useSettingsNavigationMetadata.devSearchKeywordDev', 'dev'),
+        translate('auto.hooks.useSettingsNavigationMetadata.devSearchKeywordToast', 'toast'),
+        translate('auto.hooks.useSettingsNavigationMetadata.devSearchKeywordSonner', 'sonner'),
+        translate('auto.hooks.useSettingsNavigationMetadata.devSearchKeywordError', 'error'),
+        translate(
+          'auto.hooks.useSettingsNavigationMetadata.devSearchKeywordNotification',
+          'notification'
+        )
+      ]
+    }
+  ]
+}
+
 export function buildSettingsNavigationMetadata({
   isMac,
   isWindows,
   isWindowsTerminalHost = isWindows,
   isWebClient,
+  isDev = import.meta.env.DEV,
   repos
 }: {
   isMac: boolean
   isWindows: boolean
   isWindowsTerminalHost?: boolean
   isWebClient: boolean
+  isDev?: boolean
   repos: readonly Repo[]
 }): SettingsNavSection[] {
   const showDesktopOnlySettings = !isWebClient
@@ -478,6 +505,24 @@ export function buildSettingsNavigationMetadata({
           }
         ]
       : []),
+    // Why: dev tooling must not be reachable from packaged/web builds even if
+    // this pure metadata builder is called manually with isDev=true.
+    ...(showDesktopOnlySettings && import.meta.env.DEV && isDev
+      ? [
+          {
+            id: 'dev',
+            title: translate('auto.hooks.useSettingsNavigationMetadata.dev', 'Dev Tools'),
+            description: translate(
+              'auto.hooks.useSettingsNavigationMetadata.devDescription',
+              'Dev-only tools for exercising UI states.'
+            ),
+            icon: Wrench,
+            searchEntries: getDevToolsPaneSearchEntries(),
+            group: 'advanced',
+            badge: translate('auto.hooks.useSettingsNavigationMetadata.devBadge', 'Dev')
+          }
+        ]
+      : []),
     {
       id: 'experimental',
       title: translate('auto.hooks.useSettingsNavigationMetadata.225071c560', 'Experimental'),
@@ -533,6 +578,7 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
         isWindows,
         isWindowsTerminalHost,
         isWebClient,
+        isDev: import.meta.env.DEV,
         repos
       }),
     [isMac, isWindows, isWindowsTerminalHost, isWebClient, repos]

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -638,7 +638,17 @@
         "b1c2f8b0ac": "Optional account switching for Claude, Codex, Gemini, and OpenCode Go.",
         "f70ac54d38": "AI Provider Accounts",
         "4121f7a0a2": "Manage AI agents, set a default, and customize commands.",
-        "b49abbd2f7": "Agents"
+        "b49abbd2f7": "Agents",
+        "dev": "Dev Tools",
+        "devDescription": "Dev-only tools for exercising UI states.",
+        "devBadge": "Dev",
+        "devSearchNotificationPlayground": "Notification playground",
+        "devSearchNotificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+        "devSearchKeywordDev": "dev",
+        "devSearchKeywordToast": "toast",
+        "devSearchKeywordSonner": "sonner",
+        "devSearchKeywordError": "error",
+        "devSearchKeywordNotification": "notification"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "Paste is too large."
@@ -6084,7 +6094,9 @@
           "9abb9be3bc": "Set Up",
           "23c6874fdf": "AI Capabilities",
           "2309068a6f": "destructive",
-          "65358016ea": "Discard"
+          "65358016ea": "Discard",
+          "dev": "Dev Tools",
+          "devDescription": "Dev-only tools for exercising UI states."
         },
         "SettingsFormControls": {
           "42a4d15a30": "No matching fonts.",
@@ -8512,6 +8524,45 @@
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "Advanced"
+        },
+        "DevToolsPane": {
+          "nativeActionLayoutCheck": "Native action layout check",
+          "secondary": "Secondary",
+          "secondaryActionClicked": "Secondary action clicked",
+          "primaryAction": "Primary action",
+          "primaryActionClicked": "Primary action clicked",
+          "branchHasChanges": "branch has changes",
+          "viewChangesClicked": "View Changes clicked",
+          "forceDeleteClicked": "Force Delete clicked",
+          "devOnlyCallback": "Dev-only callback.",
+          "infoToast": "Info toast",
+          "infoToastDescription": "Long informational copy with no explicit action.",
+          "localCanaryBehind": "Local canary is behind origin/canary",
+          "successToast": "Success toast",
+          "successToastDescription": "Short confirmation state.",
+          "settingsSaved": "Settings saved",
+          "shortSuccessCopy": "Short success copy.",
+          "errorToast": "Error toast",
+          "errorToastDescription": "Long error copy without recovery actions.",
+          "failedToSyncWorkspaceMetadata": "Failed to sync workspace metadata",
+          "nativeActionToast": "Native action toast",
+          "nativeActionToastDescription": "Uses Sonner action and cancel slots.",
+          "deleteFailureToast": "Delete failure toast",
+          "deleteFailureToastDescription": "Custom footer with View and Force Delete.",
+          "behindBaseRefToast": "Behind base ref toast",
+          "behindBaseRefToastDescription": "Persistent prompt with an inline Settings link and footer action.",
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
+          "devOnly": "Dev only"
+        },
+        "devToolsSearch": {
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+          "keywordDev": "dev",
+          "keywordToast": "toast",
+          "keywordSonner": "sonner",
+          "keywordError": "error",
+          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8554,15 +8554,6 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
-        },
-        "devToolsSearch": {
-          "notificationPlayground": "Notification playground",
-          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
-          "keywordDev": "dev",
-          "keywordToast": "toast",
-          "keywordSonner": "sonner",
-          "keywordError": "error",
-          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -638,7 +638,17 @@
         "b1c2f8b0ac": "Cambio de cuenta opcional para Claude, Codex, Gemini y OpenCode Go.",
         "f70ac54d38": "Cuentas de proveedores de IA",
         "4121f7a0a2": "Administre agents de IA, establezca un valor predeterminado y personalice comandos.",
-        "b49abbd2f7": "Agentes"
+        "b49abbd2f7": "Agentes",
+        "dev": "Dev Tools",
+        "devDescription": "Dev-only tools for exercising UI states.",
+        "devBadge": "Dev",
+        "devSearchNotificationPlayground": "Notification playground",
+        "devSearchNotificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+        "devSearchKeywordDev": "dev",
+        "devSearchKeywordToast": "toast",
+        "devSearchKeywordSonner": "sonner",
+        "devSearchKeywordError": "error",
+        "devSearchKeywordNotification": "notification"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "El contenido pegado es demasiado grande."
@@ -6047,7 +6057,9 @@
           "9abb9be3bc": "Configuración",
           "23c6874fdf": "Capacidades de IA",
           "2309068a6f": "destructivo",
-          "65358016ea": "Desechar"
+          "65358016ea": "Desechar",
+          "dev": "Dev Tools",
+          "devDescription": "Dev-only tools for exercising UI states."
         },
         "SettingsFormControls": {
           "42a4d15a30": "No hay fuentes coincidentes.",
@@ -8512,6 +8524,45 @@
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "Avanzado"
+        },
+        "DevToolsPane": {
+          "nativeActionLayoutCheck": "Native action layout check",
+          "secondary": "Secondary",
+          "secondaryActionClicked": "Secondary action clicked",
+          "primaryAction": "Primary action",
+          "primaryActionClicked": "Primary action clicked",
+          "branchHasChanges": "branch has changes",
+          "viewChangesClicked": "View Changes clicked",
+          "forceDeleteClicked": "Force Delete clicked",
+          "devOnlyCallback": "Dev-only callback.",
+          "infoToast": "Info toast",
+          "infoToastDescription": "Long informational copy with no explicit action.",
+          "localCanaryBehind": "Local canary is behind origin/canary",
+          "successToast": "Success toast",
+          "successToastDescription": "Short confirmation state.",
+          "settingsSaved": "Settings saved",
+          "shortSuccessCopy": "Short success copy.",
+          "errorToast": "Error toast",
+          "errorToastDescription": "Long error copy without recovery actions.",
+          "failedToSyncWorkspaceMetadata": "Failed to sync workspace metadata",
+          "nativeActionToast": "Native action toast",
+          "nativeActionToastDescription": "Uses Sonner action and cancel slots.",
+          "deleteFailureToast": "Delete failure toast",
+          "deleteFailureToastDescription": "Custom footer with View and Force Delete.",
+          "behindBaseRefToast": "Behind base ref toast",
+          "behindBaseRefToastDescription": "Persistent prompt with an inline Settings link and footer action.",
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
+          "devOnly": "Dev only"
+        },
+        "devToolsSearch": {
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+          "keywordDev": "dev",
+          "keywordToast": "toast",
+          "keywordSonner": "sonner",
+          "keywordError": "error",
+          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8554,15 +8554,6 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
-        },
-        "devToolsSearch": {
-          "notificationPlayground": "Notification playground",
-          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
-          "keywordDev": "dev",
-          "keywordToast": "toast",
-          "keywordSonner": "sonner",
-          "keywordError": "error",
-          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -638,7 +638,17 @@
         "b1c2f8b0ac": "Claude、Codex、Gemini、OpenCode Go のオプションのアカウント切り替え。",
         "f70ac54d38": "AI プロバイダー アカウント",
         "4121f7a0a2": "AI agents を管理し、デフォルトを設定し、コマンドをカスタマイズします。",
-        "b49abbd2f7": "エージェント"
+        "b49abbd2f7": "エージェント",
+        "dev": "Dev Tools",
+        "devDescription": "Dev-only tools for exercising UI states.",
+        "devBadge": "Dev",
+        "devSearchNotificationPlayground": "Notification playground",
+        "devSearchNotificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+        "devSearchKeywordDev": "dev",
+        "devSearchKeywordToast": "toast",
+        "devSearchKeywordSonner": "sonner",
+        "devSearchKeywordError": "error",
+        "devSearchKeywordNotification": "notification"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "貼り付け内容が大きすぎます。"
@@ -6069,7 +6079,9 @@
           "9abb9be3bc": "セットアップ",
           "23c6874fdf": "AI 機能",
           "2309068a6f": "破壊的な",
-          "65358016ea": "破棄"
+          "65358016ea": "破棄",
+          "dev": "Dev Tools",
+          "devDescription": "Dev-only tools for exercising UI states."
         },
         "SettingsFormControls": {
           "42a4d15a30": "一致するフォントがありません。",
@@ -8512,6 +8524,45 @@
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "詳細設定"
+        },
+        "DevToolsPane": {
+          "nativeActionLayoutCheck": "Native action layout check",
+          "secondary": "Secondary",
+          "secondaryActionClicked": "Secondary action clicked",
+          "primaryAction": "Primary action",
+          "primaryActionClicked": "Primary action clicked",
+          "branchHasChanges": "branch has changes",
+          "viewChangesClicked": "View Changes clicked",
+          "forceDeleteClicked": "Force Delete clicked",
+          "devOnlyCallback": "Dev-only callback.",
+          "infoToast": "Info toast",
+          "infoToastDescription": "Long informational copy with no explicit action.",
+          "localCanaryBehind": "Local canary is behind origin/canary",
+          "successToast": "Success toast",
+          "successToastDescription": "Short confirmation state.",
+          "settingsSaved": "Settings saved",
+          "shortSuccessCopy": "Short success copy.",
+          "errorToast": "Error toast",
+          "errorToastDescription": "Long error copy without recovery actions.",
+          "failedToSyncWorkspaceMetadata": "Failed to sync workspace metadata",
+          "nativeActionToast": "Native action toast",
+          "nativeActionToastDescription": "Uses Sonner action and cancel slots.",
+          "deleteFailureToast": "Delete failure toast",
+          "deleteFailureToastDescription": "Custom footer with View and Force Delete.",
+          "behindBaseRefToast": "Behind base ref toast",
+          "behindBaseRefToastDescription": "Persistent prompt with an inline Settings link and footer action.",
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
+          "devOnly": "Dev only"
+        },
+        "devToolsSearch": {
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+          "keywordDev": "dev",
+          "keywordToast": "toast",
+          "keywordSonner": "sonner",
+          "keywordError": "error",
+          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8554,15 +8554,6 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
-        },
-        "devToolsSearch": {
-          "notificationPlayground": "Notification playground",
-          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
-          "keywordDev": "dev",
-          "keywordToast": "toast",
-          "keywordSonner": "sonner",
-          "keywordError": "error",
-          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -638,7 +638,17 @@
         "b1c2f8b0ac": "Claude, Codex, Gemini 및 OpenCode Go에 대한 선택적 계정 전환.",
         "f70ac54d38": "AI 제공업체 계정",
         "4121f7a0a2": "AI agents를 관리하고, 기본값을 설정하고, 명령을 사용자 정의하세요.",
-        "b49abbd2f7": "에이전트"
+        "b49abbd2f7": "에이전트",
+        "dev": "Dev Tools",
+        "devDescription": "Dev-only tools for exercising UI states.",
+        "devBadge": "Dev",
+        "devSearchNotificationPlayground": "Notification playground",
+        "devSearchNotificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+        "devSearchKeywordDev": "dev",
+        "devSearchKeywordToast": "toast",
+        "devSearchKeywordSonner": "sonner",
+        "devSearchKeywordError": "error",
+        "devSearchKeywordNotification": "notification"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "붙여넣기 내용이 너무 큽니다."
@@ -6032,7 +6042,9 @@
           "9abb9be3bc": "설정 시작",
           "23c6874fdf": "AI 기능",
           "2309068a6f": "파괴적",
-          "65358016ea": "버리기"
+          "65358016ea": "버리기",
+          "dev": "Dev Tools",
+          "devDescription": "Dev-only tools for exercising UI states."
         },
         "SettingsFormControls": {
           "42a4d15a30": "일치하는 글꼴이 없습니다.",
@@ -8512,6 +8524,45 @@
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "고급"
+        },
+        "DevToolsPane": {
+          "nativeActionLayoutCheck": "Native action layout check",
+          "secondary": "Secondary",
+          "secondaryActionClicked": "Secondary action clicked",
+          "primaryAction": "Primary action",
+          "primaryActionClicked": "Primary action clicked",
+          "branchHasChanges": "branch has changes",
+          "viewChangesClicked": "View Changes clicked",
+          "forceDeleteClicked": "Force Delete clicked",
+          "devOnlyCallback": "Dev-only callback.",
+          "infoToast": "Info toast",
+          "infoToastDescription": "Long informational copy with no explicit action.",
+          "localCanaryBehind": "Local canary is behind origin/canary",
+          "successToast": "Success toast",
+          "successToastDescription": "Short confirmation state.",
+          "settingsSaved": "Settings saved",
+          "shortSuccessCopy": "Short success copy.",
+          "errorToast": "Error toast",
+          "errorToastDescription": "Long error copy without recovery actions.",
+          "failedToSyncWorkspaceMetadata": "Failed to sync workspace metadata",
+          "nativeActionToast": "Native action toast",
+          "nativeActionToastDescription": "Uses Sonner action and cancel slots.",
+          "deleteFailureToast": "Delete failure toast",
+          "deleteFailureToastDescription": "Custom footer with View and Force Delete.",
+          "behindBaseRefToast": "Behind base ref toast",
+          "behindBaseRefToastDescription": "Persistent prompt with an inline Settings link and footer action.",
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
+          "devOnly": "Dev only"
+        },
+        "devToolsSearch": {
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+          "keywordDev": "dev",
+          "keywordToast": "toast",
+          "keywordSonner": "sonner",
+          "keywordError": "error",
+          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8554,15 +8554,6 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
-        },
-        "devToolsSearch": {
-          "notificationPlayground": "Notification playground",
-          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
-          "keywordDev": "dev",
-          "keywordToast": "toast",
-          "keywordSonner": "sonner",
-          "keywordError": "error",
-          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -638,7 +638,17 @@
         "b1c2f8b0ac": "Claude、Codex、Gemini 和 OpenCode Go 的可选账户切换。",
         "f70ac54d38": "AI 提供商账户",
         "4121f7a0a2": "管理 AI 智能体、设置默认值并自定义命令。",
-        "b49abbd2f7": "智能体"
+        "b49abbd2f7": "智能体",
+        "dev": "Dev Tools",
+        "devDescription": "Dev-only tools for exercising UI states.",
+        "devBadge": "Dev",
+        "devSearchNotificationPlayground": "Notification playground",
+        "devSearchNotificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+        "devSearchKeywordDev": "dev",
+        "devSearchKeywordToast": "toast",
+        "devSearchKeywordSonner": "sonner",
+        "devSearchKeywordError": "error",
+        "devSearchKeywordNotification": "notification"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "粘贴内容过大。"
@@ -6032,7 +6042,9 @@
           "9abb9be3bc": "初始设置",
           "23c6874fdf": "AI 能力",
           "2309068a6f": "destructive",
-          "65358016ea": "放弃"
+          "65358016ea": "放弃",
+          "dev": "Dev Tools",
+          "devDescription": "Dev-only tools for exercising UI states."
         },
         "SettingsFormControls": {
           "42a4d15a30": "没有匹配的字体。",
@@ -8512,6 +8524,45 @@
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "高级"
+        },
+        "DevToolsPane": {
+          "nativeActionLayoutCheck": "Native action layout check",
+          "secondary": "Secondary",
+          "secondaryActionClicked": "Secondary action clicked",
+          "primaryAction": "Primary action",
+          "primaryActionClicked": "Primary action clicked",
+          "branchHasChanges": "branch has changes",
+          "viewChangesClicked": "View Changes clicked",
+          "forceDeleteClicked": "Force Delete clicked",
+          "devOnlyCallback": "Dev-only callback.",
+          "infoToast": "Info toast",
+          "infoToastDescription": "Long informational copy with no explicit action.",
+          "localCanaryBehind": "Local canary is behind origin/canary",
+          "successToast": "Success toast",
+          "successToastDescription": "Short confirmation state.",
+          "settingsSaved": "Settings saved",
+          "shortSuccessCopy": "Short success copy.",
+          "errorToast": "Error toast",
+          "errorToastDescription": "Long error copy without recovery actions.",
+          "failedToSyncWorkspaceMetadata": "Failed to sync workspace metadata",
+          "nativeActionToast": "Native action toast",
+          "nativeActionToastDescription": "Uses Sonner action and cancel slots.",
+          "deleteFailureToast": "Delete failure toast",
+          "deleteFailureToastDescription": "Custom footer with View and Force Delete.",
+          "behindBaseRefToast": "Behind base ref toast",
+          "behindBaseRefToastDescription": "Persistent prompt with an inline Settings link and footer action.",
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
+          "devOnly": "Dev only"
+        },
+        "devToolsSearch": {
+          "notificationPlayground": "Notification playground",
+          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
+          "keywordDev": "dev",
+          "keywordToast": "toast",
+          "keywordSonner": "sonner",
+          "keywordError": "error",
+          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8554,15 +8554,6 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
-        },
-        "devToolsSearch": {
-          "notificationPlayground": "Notification playground",
-          "notificationPlaygroundDescription": "Trigger representative toast and notification UI states.",
-          "keywordDev": "dev",
-          "keywordToast": "toast",
-          "keywordSonner": "sonner",
-          "keywordError": "error",
-          "keywordNotification": "notification"
         }
       },
       "right": {

--- a/src/renderer/src/lib/settings-navigation-types.ts
+++ b/src/renderer/src/lib/settings-navigation-types.ts
@@ -22,6 +22,7 @@ export type SettingsNavTarget =
   | 'developer-permissions'
   | 'privacy'
   | 'advanced'
+  | 'dev'
   | 'voice'
   | 'shortcuts'
   | 'stats'


### PR DESCRIPTION
## Summary

Improves Orca toast/error presentation and adds a development-only Settings surface for exercising notification states.

Before:
<img width="800" height="496" alt="before" src="https://github.com/user-attachments/assets/2b047595-5d57-4c27-9682-40bcf9d1ecfe" />

After:
<img width="800" height="496" alt="after" src="https://github.com/user-attachments/assets/58819e42-579b-4257-a00f-8205c2918d3f" />

### Changes
- Restyles shared Sonner toasts so long descriptions and native action buttons wrap cleanly.
- Raises bottom-right toasts above Orca bottom chrome/status bar (and keeps that clearance below Sonner's 600px breakpoint via `mobileOffset`, so narrow/resized windows and the web client don't lose it).
- Replaces delete-worktree failure action/cancel layout with a custom toast body/footer.
- Removes the dangling period from the local-base-ref suggestion toast copy.
- Adds a dev-only Dev Tools Settings pane for representative notification/toast states.
- Gates Dev Tools behind `import.meta.env.DEV` and lazy-loads the pane.

## Screenshots

Dev Tools pane (dev-only) and the restyled delete-failure toast, verified live in the Electron dev build:

- Notification playground renders with the "Dev only" badge and a 2-column grid of toast triggers.
- Delete-failure toast: wrapping title, 80%-opacity description, full-width footer with `View` (outline) + `Force Delete` (destructive), close X with no overlap, and ~40px clearance above the status bar.

(Author's before/after above. Reviewer re-verified the after-state in-app; measured `gapBelowToast = 40px`, frame width `416px` = `min(26rem, …)`, and description color at `0.8` alpha.)

## Testing

- [x] `pnpm lint` (oxlint, switch-exhaustiveness, styled-scrollbars, localization catalog + coverage — all pass; one pre-existing exhaustive-deps warning in `useGitStatusPolling.ts`, not touched here)
- [x] `pnpm typecheck:web`
- [x] Focused `vitest` suite: `delete-worktree-failure-toast`, `delete-worktree-flow`, `useSettingsNavigationMetadata`, `cmd-j/palette-results` — 70 tests pass
- [x] `pnpm build:web` (production bundle builds; verified DevToolsPane code symbols are **absent** from `out/web` — only inert i18n catalog data ships)
- [x] Added/updated tests: cover the `View` action on the non-forceable failure path; documented that the metadata test exercises the param/web branches but the compile-time `import.meta.env.DEV` guard + bundle exclusion is what enforces prod safety

## AI Review Report

Ran an exhaustive multi-dimensional adversarial review (correctness, dev-gating/prod-safety, localization, design-system/styling, reuse/dead-code, cross-platform/web/SSH/tests). Each finding was independently verified against the code before action. Cross-platform was explicitly checked: keyboard/label/path concerns (none introduced), `env(safe-area-inset-bottom, 0px)` resolves to 0 on desktop macOS/Linux/Windows and in the web client, and the `mobileOffset` gap below 600px (web/narrow windows) was found and fixed.

Fixed as a result:
- **`mobileOffset` missing** — bottom-chrome clearance was silently lost below Sonner's 600px breakpoint (web client / narrow & resized windows). Added.
- **Dead `devToolsSearch` locale block** — 35 orphan keys across 5 locale files with zero code references (live search keys live under `useSettingsNavigationMetadata.devSearch*`). Removed.
- **Toast description opacity** drifted (76%) from the 80% used by every sibling toast body — string vs JSX descriptions now read identically.
- **Dead `max-w-[28rem]` cap** on the failure-toast body (the 26rem frame always wins) → `w-full`, matching the sibling local-base-ref toast.
- **Redundant outer wrapper** around DevToolsPane's single section — removed.
- **Dev Tools nav icon** reused `Wrench` (same as the Advanced sibling in the same group) → distinct `Bug` icon.
- **Test gap** — the non-forceable failure path never asserted the `View` button; added.

Verified-not-a-bug:
- CodeRabbit flagged the force-delete focus handoff as ignoring `focusSuccessorOnDelete: false`. Compared byte-for-byte against `origin/main`: this is pre-existing behavior (carried over verbatim from the native-action slot), not a regression, and benign in practice (focus is re-captured at click time and no-ops unless the deleted worktree is still active). Out of scope; replied on the thread.

Deliberately not changed: untranslated es/ja/ko/zh values for the new **dev-only** strings — see Notes.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or IPC surface. The only sensitivity is the dev-only gating, which was verified end-to-end:
- `DevToolsPane` is lazy-imported only under `import.meta.env.DEV`; the nav section is triple-gated (`showDesktopOnlySettings && import.meta.env.DEV && isDev`).
- Built the production web bundle and confirmed **no** DevToolsPane code symbols (`DevToastActionButton`, `showNativeActionToast`, `showDeleteFailureToast`, `showBehindBaseRefToast`, `DEV_TOAST_DESCRIPTION`, `dev-toast-worktree`) are present — only inert i18n catalog strings, which never render in prod.
- No reachable navigation path (deep-link or jump palette) to the `'dev'` target in web/packaged builds.

## Notes

- **Localization (intentional):** the new dev-only strings ship with English values in es/ja/ko/zh. These are gated behind `import.meta.env.DEV` and never reach end users in packaged/web builds; English-on-new-keys is the repo's standard interim state (catalog parity is satisfied; CI green). Running the repo translator would hit the network and churn all ~9.9k strings with no cache present, so it was deliberately skipped for a screen no user sees.
- **Pre-existing follow-up (optional, out of scope):** the force-delete success path calls `commitForceFocus()` without consulting `focusSuccessorOnDelete`. Unchanged by this PR; could be tightened in a dedicated change if desired.
- **Cross-platform:** `env(safe-area-inset-bottom, 0px)` degrades to 0 on non-notch desktops and in the browser; no platform-specific shortcuts/paths introduced.