### PR TITLE
Hide Jump to Worktree for sessions in the current worktree

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -43,6 +43,7 @@ export function VaultSessionRow({
   resumeDisabled,
   onToggleDetails,
   onJumpToOriginalPane,
+  showJumpToWorktree,
   onJumpToWorktree,
   onResume,
   resumeLabel,
@@ -63,6 +64,7 @@ export function VaultSessionRow({
   resumeDisabled: boolean
   onToggleDetails: () => void
   onJumpToOriginalPane?: () => void
+  showJumpToWorktree: boolean
   onJumpToWorktree?: () => void
   onResume: () => void
   resumeLabel: string
@@ -146,6 +148,7 @@ export function VaultSessionRow({
               worktreeInfo={worktreeInfo}
               onToggleDetails={onToggleDetails}
               onJumpToOriginalPane={onJumpToOriginalPane}
+              showJumpToWorktree={showJumpToWorktree}
               onJumpToWorktree={onJumpToWorktree}
               onResume={onResume}
               onCopyResume={onCopyResume}
@@ -204,6 +207,7 @@ export function VaultSessionRow({
           resumeDisabled={resumeDisabled}
           resumeLabel={resumeLabel}
           onJumpToOriginalPane={onJumpToOriginalPane}
+          showJumpToWorktree={showJumpToWorktree}
           onJumpToWorktree={onJumpToWorktree}
           onResume={onResume}
           onCopyResume={onCopyResume}
@@ -224,6 +228,7 @@ export function SessionActionMenuItems({
   resumeLabel,
   onResume,
   onJumpToOriginalPane,
+  showJumpToWorktree,
   onJumpToWorktree,
   onCopyResume,
   onCopyId,
@@ -237,6 +242,7 @@ export function SessionActionMenuItems({
   resumeLabel: string
   onResume: () => void
   onJumpToOriginalPane?: () => void
+  showJumpToWorktree: boolean
   onJumpToWorktree?: () => void
   onCopyResume: () => void
   onCopyId: () => void
@@ -259,13 +265,15 @@ export function SessionActionMenuItems({
           )}
         </Item>
       ) : null}
-      <Item disabled={!onJumpToWorktree} onSelect={onJumpToWorktree}>
-        <PanelTopOpen className="size-3.5" />
-        {translate(
-          'auto.components.right.sidebar.AiVaultSessionRow.jumpToWorktree',
-          'Jump to Worktree'
-        )}
-      </Item>
+      {showJumpToWorktree ? (
+        <Item disabled={!onJumpToWorktree} onSelect={onJumpToWorktree}>
+          <PanelTopOpen className="size-3.5" />
+          {translate(
+            'auto.components.right.sidebar.AiVaultSessionRow.jumpToWorktree',
+            'Jump to Worktree'
+          )}
+        </Item>
+      ) : null}
       <Item disabled={resumeDisabled} onSelect={onResume}>
         <Play className="size-3.5" />
         {resumeLabel}

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
@@ -16,6 +16,7 @@ import {
 } from './ai-vault-session-resume'
 import {
   canJumpToAiVaultSessionWorktree,
+  isAiVaultSessionInCurrentWorktree,
   type AiVaultSessionWorktreeInfo
 } from './ai-vault-session-worktree'
 import {
@@ -263,9 +264,14 @@ function AiVaultVirtualRow({
   const isActiveStickyHeader = row.type === 'group' && activeStickyHeaderIndex === index
   const originalPaneTarget = row.type === 'session' ? getOriginalPaneTarget(row.session) : null
   const worktreeInfo = row.type === 'session' ? getWorktreeInfo(row.session) : null
-  const worktreeJumpId = canJumpToAiVaultSessionWorktree(worktreeInfo)
-    ? worktreeInfo?.worktreeId
-    : null
+  // Why: omit the jump affordance when the session already lives in the
+  // worktree on screen — jumping there is a no-op the "Current worktree" badge
+  // already conveys.
+  const showJumpToWorktree = !isAiVaultSessionInCurrentWorktree(worktreeInfo)
+  const worktreeJumpId =
+    showJumpToWorktree && canJumpToAiVaultSessionWorktree(worktreeInfo)
+      ? worktreeInfo?.worktreeId
+      : null
   const resumeState = row.type === 'session' ? getSessionResumeState(row.session) : null
   const resumeActions = row.type === 'session' ? getSessionResumeActions(row.session) : null
   const resumeLabel = resumeState ? aiVaultSessionResumeLabel(resumeState) : ''
@@ -304,6 +310,7 @@ function AiVaultVirtualRow({
           onJumpToOriginalPane={
             originalPaneTarget ? () => onJumpToOriginalPane(row.session) : undefined
           }
+          showJumpToWorktree={showJumpToWorktree}
           onJumpToWorktree={worktreeJumpId ? () => onJumpToWorktree(worktreeJumpId) : undefined}
           onResume={() => {
             if (resumeState?.worktreeId) {

--- a/src/renderer/src/components/right-sidebar/SessionRowTrailingActions.tsx
+++ b/src/renderer/src/components/right-sidebar/SessionRowTrailingActions.tsx
@@ -42,6 +42,7 @@ export function SessionRowTrailingActions({
   worktreeInfo,
   onToggleDetails,
   onJumpToOriginalPane,
+  showJumpToWorktree,
   onJumpToWorktree,
   onResume,
   onCopyResume,
@@ -60,6 +61,7 @@ export function SessionRowTrailingActions({
   worktreeInfo: AiVaultSessionWorktreeInfo | null
   onToggleDetails: () => void
   onJumpToOriginalPane?: () => void
+  showJumpToWorktree: boolean
   onJumpToWorktree?: () => void
   onResume: () => void
   onCopyResume: () => void
@@ -109,16 +111,18 @@ export function SessionRowTrailingActions({
             </TooltipContent>
           </Tooltip>
         ) : null}
-        <Tooltip>
-          <WorktreeJumpTooltipTrigger
-            disabled={!onJumpToWorktree}
-            ariaLabel={jumpToWorktreeTooltip}
-            onJumpToWorktree={onJumpToWorktree}
-          />
-          <TooltipContent side="top" sideOffset={4}>
-            {jumpToWorktreeTooltip}
-          </TooltipContent>
-        </Tooltip>
+        {showJumpToWorktree ? (
+          <Tooltip>
+            <WorktreeJumpTooltipTrigger
+              disabled={!onJumpToWorktree}
+              ariaLabel={jumpToWorktreeTooltip}
+              onJumpToWorktree={onJumpToWorktree}
+            />
+            <TooltipContent side="top" sideOffset={4}>
+              {jumpToWorktreeTooltip}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -208,6 +212,7 @@ export function SessionRowTrailingActions({
             resumeLabel={resumeLabel}
             onResume={onResume}
             onJumpToOriginalPane={onJumpToOriginalPane}
+            showJumpToWorktree={showJumpToWorktree}
             onJumpToWorktree={onJumpToWorktree}
             onCopyResume={onCopyResume}
             onCopyId={onCopyId}

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.test.ts
@@ -5,6 +5,7 @@ import {
   aiVaultWorktreeCompactPath,
   aiVaultWorktreeJumpTooltip,
   canJumpToAiVaultSessionWorktree,
+  isAiVaultSessionInCurrentWorktree,
   extractWorktreePathFromSessionTitle,
   resolveAiVaultSessionWorktreeDisplay,
   resolveAiVaultSessionWorktreeInfo,
@@ -146,6 +147,16 @@ describe('canJumpToAiVaultSessionWorktree', () => {
     expect(canJumpToAiVaultSessionWorktree(makeWorktreeInfo('archived'))).toBe(false)
     expect(canJumpToAiVaultSessionWorktree(makeWorktreeInfo('unavailable'))).toBe(false)
     expect(canJumpToAiVaultSessionWorktree(null)).toBe(false)
+  })
+})
+
+describe('isAiVaultSessionInCurrentWorktree', () => {
+  it('flags only the worktree the user is already viewing', () => {
+    expect(isAiVaultSessionInCurrentWorktree(makeWorktreeInfo('current'))).toBe(true)
+    expect(isAiVaultSessionInCurrentWorktree(makeWorktreeInfo('active'))).toBe(false)
+    expect(isAiVaultSessionInCurrentWorktree(makeWorktreeInfo('archived'))).toBe(false)
+    expect(isAiVaultSessionInCurrentWorktree(makeWorktreeInfo('unavailable'))).toBe(false)
+    expect(isAiVaultSessionInCurrentWorktree(null)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.ts
@@ -150,6 +150,15 @@ export function canJumpToAiVaultSessionWorktree(
   )
 }
 
+// Why: a session in the worktree you're already viewing has nowhere to jump,
+// so we hide the affordance rather than offering a self-jump (the "Current
+// worktree" badge already signals where it lives).
+export function isAiVaultSessionInCurrentWorktree(
+  worktreeInfo: AiVaultSessionWorktreeInfo | null
+): boolean {
+  return worktreeInfo?.status === 'current'
+}
+
 export function aiVaultWorktreeJumpTooltip(
   worktreeInfo: AiVaultSessionWorktreeInfo | null
 ): string {


### PR DESCRIPTION
## Summary

In **Agent Session History** (right sidebar), a session card that belongs to the worktree you are **currently viewing** no longer offers a **Jump to Worktree** action. Jumping there is a no-op, and the **"Current worktree"** badge already tells you where the session lives.

The action is hidden consistently across all three places it appears: the hover/focus icon button, the overflow `…` dropdown item, and the right-click context menu item.

**What does not change:** sessions in *other* worktrees still show an enabled "Jump to Worktree" button; sessions in archived/unavailable worktrees still show the disabled button with its explanatory tooltip; and the "Current worktree" badge, Resume, and all other card actions are untouched.

### Design approach

The signal that renders the "Current worktree" badge is the session's resolved worktree `status === 'current'` (its owning worktree id equals the active worktree id). This change reuses that single source of truth: a new pure predicate `isAiVaultSessionInCurrentWorktree(worktreeInfo)` derives a `showJumpToWorktree` boolean once per row in `AiVaultVirtualRow`, threaded through `VaultSessionRow` → `SessionRowTrailingActions` and `SessionActionMenuItems` (both dropdown and context-menu variants). When `false`, the affordance is removed (not merely disabled), so badge and button stay in lockstep. The existing `canJumpToAiVaultSessionWorktree` predicate is left intact, preserving the deliberate disabled-with-reason state for archived/unavailable worktrees.

### Scope interpretation (please note)

The request was phrased as "if we're sorted by workspace." I gated on **"the session is in the current worktree"** (`status === 'current'`) rather than on the Workspace scope tab. This is a **superset**, not a narrowing:
- Under **Workspace** scope, the panel only shows sessions from the active worktree (its path + that worktree's prior paths), so the button disappears on those cards — exactly the reported case.
- Under **Project/All** scope, the redundant self-jump is also hidden for current-worktree sessions, while genuine **sibling** worktrees (including a worktree physically nested inside the active one, which resolves to `status === 'active'`) keep an enabled button because jumping there actually moves you.

If you'd instead prefer the button gated on the *scope tab itself* (e.g. keep a dead button for current-worktree sessions under All/Project), that's a different, narrower behavior — happy to adjust.

## Screenshots

Manual UI validation in an isolated dev build captured uncropped panel screenshots of: a current-worktree card hovered with **no** jump icon, its overflow menu and context menu **without** the Jump item, and — as a positive control — a sibling-worktree card (`status='active'`) still showing the **enabled** jump button. Evidence is in the validation report below; screenshots are scratch artifacts and intentionally not committed.

## Testing

- [x] `pnpm lint` (oxlint on changed files: clean; pre-commit oxlint + oxfmt hook clean)
- [ ] `pnpm typecheck` (full project typecheck skipped locally — OOM risk; web typecheck of touched files was clean during development)
- [x] `pnpm test` (focused: `ai-vault-session-worktree.test.ts` 13/13; right-sidebar AI Vault suite 98/98)
- [ ] `pnpm build` (not run; renderer-only logic change, no build-surface impact)
- [x] Added/updated tests: new `isAiVaultSessionInCurrentWorktree` unit coverage (current/active/archived/unavailable/null)

> **Note on the `verify` CI check:** the failing test is `terminal-pane/pty-connection.test.ts > "does NOT re-assert while a mobile-fit override parks the PTY at phone dims"`. It is **unrelated to this PR** — this branch touches only the 5 right-sidebar AI Vault files and that terminal test file is byte-identical to `main`. The failure reproduces on a clean `origin/main` checkout, and the production code behind it (`pty-connection.ts` / `pty-size-reconcile.ts`) was last changed by #6785 on main. Filtering to just that test runs it with all 5 of this PR's files un-imported and it still fails. This is a pre-existing main-side regression, not introduced here.

## AI Review Report

This PR went through a structured design → review → implement → verify → perf → code-review → manual-test pipeline:

- **Design review** (Claude + Codex, 2 iterations): clean. Caught and corrected an over-broad claim — a sibling worktree *physically nested* inside the active worktree resolves to `status === 'active'` and correctly keeps an enabled jump button.
- **Completeness verification:** COMPLETE, no blockers. Confirmed all three surfaces gate on the single `showJumpToWorktree` boolean (no surface missed), the disabled-with-reason path is preserved, and sibling/active worktrees are unaffected.
- **Perf audit:** neutral. The new predicate is an O(1) property read on already-computed `worktreeInfo` in the virtualized row; no new allocations, fetches, subscriptions, or effects; no `React.memo` barrier to defeat. Hiding (vs disabling) removes a small DOM subtree on current-worktree rows.
- **Code-review loop** (two `review-code` reviewers in parallel): both clean in round 1, no actionable findings.
- **CodeRabbit:** "No actionable comments were generated."
- **Cross-platform / macOS+Linux+Windows:** the change is pure renderer logic over an already-resolved `status` enum. No keyboard shortcuts, labels, paths, shell behavior, or Electron platform branches are touched. Existing status resolution (incl. WSL UNC ↔ Linux cwd matching and prior-path renames) is unchanged and already cross-platform.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. This is a renderer-only conditional-render gate driven by an existing in-memory worktree-status value; it introduces no new data flow, no new IPC surface, and no new external input. No security follow-up needed.

## Notes

- **Broad app consistency:** the three desktop surfaces (hover icon, overflow menu, context menu) now hide together off one signal. The inline expanded-details view exposes only Resume affordances (no jump control) — unchanged. The standalone mobile app does not expose this session-card jump affordance — no parity gap.
- **Headline behavior status:** implemented in the production render path (not scaffolding/fixture-only). Validated end-to-end live: LAND.
- **SSH/remoting:** session/worktree resolution and `activeWorktreeId` comparison are host-agnostic; no local-only assumptions introduced.
- **Validation gap:** the live `archived` disabled-button branch was not reproduced manually (unchanged by this diff; covered by unit test). The sibling/active case *was* exercised live.
