### PR TITLE
Keep mobile-fit terminals at phone size during post-spawn size sync

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-size-reconcile.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-size-reconcile.test.ts
@@ -434,5 +434,43 @@ describe('reconcilePtySizeAcrossFrames', () => {
       expect(getAppliedSize).not.toHaveBeenCalled()
       expect(resize).not.toHaveBeenCalled()
     })
+
+    it('does NOT re-forward when a mobile-fit override parks the PTY mid-verification', async () => {
+      const scheduler = createFrameScheduler()
+      // The race: the applied-size read is issued while NOT parked (desktop owns
+      // the PTY), but a mobile client takes it over and parks it at phone dims
+      // before the async read resolves. The resolution must re-check parked and
+      // skip the re-forward — otherwise it clobbers the phone dims with a
+      // desktop SIGWINCH. Regression for the visibility-resume mobile-fit leak.
+      let parked = false
+      const resize = vi.fn()
+      const pane = createTimelinePane(() => ({ cols: 79, rows: 50 }))
+      reconcilePtySizeAcrossFrames({
+        spawnCols: 203,
+        spawnRows: 50,
+        isAlive: () => true,
+        isParked: () => parked,
+        isAuthoritative: () => true,
+        measure: pane.measure,
+        resize,
+        // The PTY reports the stale wide size, so a parked-blind loop would
+        // re-forward the narrow desktop grid on resolution.
+        getAppliedSize: async () => {
+          // Park the PTY while this read is in flight.
+          parked = true
+          return { cols: 203, rows: 50 }
+        },
+        requestFrame: scheduler.requestFrame,
+        cancelFrame: scheduler.cancelFrame
+      })
+      await runAsync(scheduler, 400)
+
+      // The only forwards allowed are the pre-park settle ones (79x50 while
+      // desktop owned the PTY); no forward may fire AFTER the override parked it.
+      // With the fix, the verify-driven re-forward at 79x50 is suppressed, so the
+      // narrow size is forwarded at most once (the initial settle), never again.
+      const narrowForwards = resize.mock.calls.filter((c) => c[0] === 79 && c[1] === 50)
+      expect(narrowForwards.length).toBeLessThanOrEqual(1)
+    })
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-size-reconcile.ts
+++ b/src/renderer/src/components/terminal-pane/pty-size-reconcile.ts
@@ -166,6 +166,14 @@ export function reconcilePtySizeAcrossFrames(
           if (cancelled || !options.isAlive()) {
             return
           }
+          // Why: the override can flip to parked while this async read is in
+          // flight (a mobile client takes the PTY mid-verification). Re-check
+          // here — the synchronous guard above only gated issuing the read, not
+          // this resolution — so we never re-forward desktop dims onto a PTY
+          // that is now legitimately parked at phone dims.
+          if (options.isParked()) {
+            return
+          }
           if (applied && (applied.cols !== lastSentCols || applied.rows !== lastSentRows)) {
             // The PTY never took our size — re-forward and keep the loop running.
             options.resize(lastSentCols, lastSentRows)


### PR DESCRIPTION
## What changes

Fixes a flaky/failing test on `main` — `pty-connection.test.ts > "does NOT re-assert while a mobile-fit override parks the PTY at phone dims"` — by closing the real race it was catching.

## The bug

The post-spawn PTY size reconcile (`reconcilePtySizeAcrossFrames`) verifies the PTY's *applied* size before handing off: it issues an async `getAppliedSize()` read, and on divergence re-forwards the desktop grid. The synchronous guard only skipped issuing that read while the PTY was parked (mobile-fit override active) — it did **not** re-check parked state when the async read *resolved*.

So if a mobile client takes the PTY over and parks it at phone dims *while the applied-size read is in flight*, the resolution re-forwarded the desktop dimensions, sending a spurious `SIGWINCH` that clobbers the phone-fit size the mobile client is driving (TUI flicker / wrap corruption on the phone).

## The fix

Re-check `isParked()` inside the `getAppliedSize().then(...)` resolution before re-forwarding, mirroring the synchronous gate that already guards issuing the read. One guard, 8 lines.

## Why it surfaced as a flaky check

The test sets the mobile-fit override after connecting the pane; under the suite's synchronous rAF mock the reconcile's verify read resolves after the override is set, so the unguarded re-forward fired `resize(120, 40)` and failed the "must not re-assert" assertion. It was order/timing-sensitive (flaky on CI, intermittently green locally), and became deterministic once the surrounding reconcile commits landed.

## Tests

- The existing `pty-connection.test.ts` case now passes.
- Added a focused reconcile regression test — "does NOT re-forward when a mobile-fit override parks the PTY mid-verification" — that fails without the guard and passes with it.
- Full `pty-size-reconcile.test.ts` (19) + `pty-connection.test.ts` (235) pass; renderer typecheck + oxlint clean.

No production behavior changes beyond suppressing the incorrect re-forward; the desktop mount-time reconcile path is otherwise unchanged.

Made with [Orca](https://github.com/stablyai/orca) 🐋
