### PR TITLE
Keep new terminal tabs open during startup

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -10699,7 +10699,7 @@ describe('connectPanePty', () => {
       }
     }
 
-    it('fires listSessions at most once across many keystrokes in one resume window', async () => {
+    it('does not fire listSessions for first input on a fresh mount', async () => {
       const listSessions = vi.mocked(window.api.pty.listSessions)
       listSessions.mockClear()
       const { typeKeystroke } = await connectActivePaneWithInput()
@@ -10708,19 +10708,31 @@ describe('connectPanePty', () => {
         typeKeystroke('x')
       }
 
-      expect(listSessions).toHaveBeenCalledTimes(1)
+      expect(listSessions).not.toHaveBeenCalled()
     })
 
-    it('re-arms one re-check after a visibility resume', async () => {
+    it('fires listSessions once for the first input after a visibility resume', async () => {
       const listSessions = vi.mocked(window.api.pty.listSessions)
       listSessions.mockClear()
       const { binding, typeKeystroke } = await connectActivePaneWithInput()
 
+      binding.noteVisibilityResume()
+      typeKeystroke('a')
+      typeKeystroke('b')
+
+      expect(listSessions).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-arms one re-check after a second visibility resume', async () => {
+      const listSessions = vi.mocked(window.api.pty.listSessions)
+      listSessions.mockClear()
+      const { binding, typeKeystroke } = await connectActivePaneWithInput()
+
+      binding.noteVisibilityResume()
       typeKeystroke('a')
       typeKeystroke('b')
       expect(listSessions).toHaveBeenCalledTimes(1)
 
-      // Resume re-arms exactly one more re-check.
       binding.noteVisibilityResume()
       typeKeystroke('c')
       typeKeystroke('d')
@@ -10743,8 +10755,35 @@ describe('connectPanePty', () => {
         paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
       })
       const pane = createPane(2)
-      connectPanePty(pane as never, manager as never, deps as never)
+      const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
+        noteVisibilityResume: () => void
+      }
 
+      binding.noteVisibilityResume()
+      sendTerminalInputThroughPane(pane, 'x')
+      sendTerminalInputThroughPane(pane, 'y')
+
+      expect(listSessions).not.toHaveBeenCalled()
+    })
+
+    it('never fires listSessions for an SSH pane after resume', async () => {
+      const listSessions = vi.mocked(window.api.pty.listSessions)
+      listSessions.mockClear()
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('ssh-pty-2')
+      transport.getConnectionId.mockReturnValue('ssh-connection-1')
+      transportFactoryQueue.push(transport)
+      const manager = createManager(2)
+      const deps = createDeps({
+        restoredLeafId: LEAF_2,
+        paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
+      })
+      const pane = createPane(2)
+      const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
+        noteVisibilityResume: () => void
+      }
+
+      binding.noteVisibilityResume()
       sendTerminalInputThroughPane(pane, 'x')
       sendTerminalInputThroughPane(pane, 'y')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2282,7 +2282,11 @@ export function connectPanePty(
         const rows = pane.terminal.rows
         return cols > 0 && rows > 0 ? { cols, rows } : null
       },
-      resize: (cols, rows) => transport.resize(cols, rows),
+      resize: (cols, rows) => {
+        if (!shouldSuppressDesktopPtyResize()) {
+          transport.resize(cols, rows)
+        }
+      },
       // Why: confirm the PTY actually applied the size we forwarded before the
       // reconcile hands off. transport.resize is fire-and-forget for daemon/SSH
       // PTYs, so the loop can otherwise settle on a size the PTY dropped, leaving
@@ -4550,19 +4554,11 @@ export function connectPanePty(
     onExit(currentPtyId)
   }
 
-  // Why (perf): the only moment a daemon session can be reaped behind the
-  // renderer's back is while the pane was surface-hidden. So the input-driven
-  // re-check is only useful in the window right after a resume — once it (or
-  // the resume pass) has confirmed liveness for this resume, re-polling on
-  // every subsequent keystroke is pure waste: listSessions() is a
-  // renderer→main→daemon round-trip (DaemonPtyAdapter.listProcesses requests
-  // `listSessions` from the daemon subprocess), so an ungated per-keystroke
-  // re-check would put a process-enumeration round-trip on the typing hot path
-  // for every healthy local pane. Fire at most ONCE per resume window; reset
-  // on the next hide→show. This preserves the "reduces not eliminates the
-  // first-keystroke drop" intent — the first keystroke after a resume still
-  // triggers exactly one re-check.
-  let livenessRecheckFiredSinceResume = false
+  // Why (perf + startup correctness): listSessions() is authoritative only
+  // after a real visibility resume. Fresh PTY startup can briefly lag the daemon
+  // listing, so newborn terminals start disarmed and noteVisibilityResume grants
+  // exactly one first-input liveness probe for the next resume window.
+  let livenessRecheckArmedForResume = false
 
   // Why (Defect #2 defense-in-depth): in the broken state sendInput returns
   // true (connected/ptyId still set) so the dropped keystroke is invisible to
@@ -4571,9 +4567,13 @@ export function connectPanePty(
   // pass alone. It REDUCES but cannot eliminate the first-keystroke drop (that
   // byte is already gone daemon-side).
   const recheckLivenessAfterInput = (): void => {
-    if (disposed || livenessRecheckFiredSinceResume) {
+    if (disposed || !livenessRecheckArmedForResume) {
       return
     }
+    // Why: consume the resume token before inspecting provider details so SSH,
+    // remote-runtime, and concurrent keystrokes cannot retry this hot-path check
+    // until the lifecycle reports another true hidden-to-visible resume.
+    livenessRecheckArmedForResume = false
     const currentPtyId = transport.getPtyId()
     const currentConnectionId = transport.getConnectionId?.()
     if (
@@ -4588,9 +4588,6 @@ export function connectPanePty(
     ) {
       return
     }
-    // Why: set BEFORE the IPC so concurrent keystrokes coalesce to one in-flight
-    // request rather than fanning out a round-trip per byte typed.
-    livenessRecheckFiredSinceResume = true
     void window.api.pty
       .listSessions()
       .then((sessions) => {
@@ -4608,7 +4605,7 @@ export function connectPanePty(
     // visible again. Called from the lifecycle visibility effect; the gate
     // keeps the typing hot path off the listSessions IPC between resumes.
     noteVisibilityResume() {
-      livenessRecheckFiredSinceResume = false
+      livenessRecheckArmedForResume = true
       // Why: re-assert the PTY size on resume so a resize that was dropped while
       // this pane was hidden self-heals on show, instead of waiting for a manual
       // resize that may never change xterm's column count.

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   applyTerminalScrollbackRowsToMountedPanes,
   clearQueuedInitialCwdAfterFirstPane,
+  getPreviousVisibleForTerminalPane,
   isTerminalPaneVisibilityResume,
   mapRestoredPaneTitlesByPaneId,
   resolvePaneLinkCwd,
@@ -291,6 +292,30 @@ describe('suppressIntentionalPaneCloseExit', () => {
 })
 
 describe('scheduleVisibilityReconcilePass', () => {
+  it('ignores previous visibility from a different terminal identity', () => {
+    expect(
+      getPreviousVisibleForTerminalPane({
+        previous: { tabId: 'tab-old', cwd: '/repo', isVisible: false },
+        tabId: 'tab-new',
+        cwd: '/repo'
+      })
+    ).toBeNull()
+    expect(
+      getPreviousVisibleForTerminalPane({
+        previous: { tabId: 'tab-1', cwd: '/repo-old', isVisible: false },
+        tabId: 'tab-1',
+        cwd: '/repo-new'
+      })
+    ).toBeNull()
+    expect(
+      getPreviousVisibleForTerminalPane({
+        previous: { tabId: 'tab-1', cwd: '/repo', isVisible: false },
+        tabId: 'tab-1',
+        cwd: '/repo'
+      })
+    ).toBe(false)
+  })
+
   it('identifies only hidden-to-visible changes as visibility resumes', () => {
     expect(isTerminalPaneVisibilityResume({ previousIsVisible: null, isVisible: true })).toBe(false)
     expect(isTerminalPaneVisibilityResume({ previousIsVisible: true, isVisible: true })).toBe(false)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   applyTerminalScrollbackRowsToMountedPanes,
   clearQueuedInitialCwdAfterFirstPane,
+  isTerminalPaneVisibilityResume,
   mapRestoredPaneTitlesByPaneId,
   resolvePaneLinkCwd,
   resolvePaneSeedCwd,
@@ -290,6 +291,15 @@ describe('suppressIntentionalPaneCloseExit', () => {
 })
 
 describe('scheduleVisibilityReconcilePass', () => {
+  it('identifies only hidden-to-visible changes as visibility resumes', () => {
+    expect(isTerminalPaneVisibilityResume({ previousIsVisible: null, isVisible: true })).toBe(false)
+    expect(isTerminalPaneVisibilityResume({ previousIsVisible: true, isVisible: true })).toBe(false)
+    expect(isTerminalPaneVisibilityResume({ previousIsVisible: true, isVisible: false })).toBe(
+      false
+    )
+    expect(isTerminalPaneVisibilityResume({ previousIsVisible: false, isVisible: true })).toBe(true)
+  })
+
   it('schedules a reconcile pass over the bindings when becoming visible', async () => {
     const reconcileIfSessionDead = vi.fn()
     const listSessions = vi
@@ -297,6 +307,7 @@ describe('scheduleVisibilityReconcilePass', () => {
       .mockResolvedValue([{ id: 'live-1', cwd: '/a', title: 'a' }])
 
     const scheduled = scheduleVisibilityReconcilePass({
+      previousIsVisible: false,
       isVisible: true,
       bindings: [{ reconcileIfSessionDead }],
       listSessions
@@ -310,12 +321,29 @@ describe('scheduleVisibilityReconcilePass', () => {
     expect(reconcileIfSessionDead).toHaveBeenCalledWith(new Set(['live-1']))
   })
 
+  it('does not schedule on an initially visible mount', () => {
+    const listSessions = vi
+      .fn<() => Promise<{ id: string; cwd: string; title: string }[]>>()
+      .mockResolvedValue([])
+
+    const scheduled = scheduleVisibilityReconcilePass({
+      previousIsVisible: null,
+      isVisible: true,
+      bindings: [{ reconcileIfSessionDead: vi.fn() }],
+      listSessions
+    })
+
+    expect(scheduled).toBe(false)
+    expect(listSessions).not.toHaveBeenCalled()
+  })
+
   it('self-gates: does not schedule when hiding (isVisible false)', () => {
     const listSessions = vi
       .fn<() => Promise<{ id: string; cwd: string; title: string }[]>>()
       .mockResolvedValue([])
 
     const scheduled = scheduleVisibilityReconcilePass({
+      previousIsVisible: true,
       isVisible: false,
       bindings: [{ reconcileIfSessionDead: vi.fn() }],
       listSessions

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -446,6 +446,23 @@ export function isTerminalPaneVisibilityResume(args: {
   return args.previousIsVisible === false && args.isVisible
 }
 
+type TerminalPaneVisibilitySnapshot = {
+  tabId: string
+  cwd: string | null | undefined
+  isVisible: boolean
+}
+
+export function getPreviousVisibleForTerminalPane(args: {
+  previous: TerminalPaneVisibilitySnapshot | null
+  tabId: string
+  cwd: string | null | undefined
+}): boolean | null {
+  if (args.previous?.tabId !== args.tabId || args.previous.cwd !== args.cwd) {
+    return null
+  }
+  return args.previous.isVisible
+}
+
 export function scheduleVisibilityReconcilePass(args: {
   previousIsVisible: boolean | null
   isVisible: boolean
@@ -524,7 +541,7 @@ export function useTerminalPaneLifecycle({
   )
   const systemPrefersDarkRef = useRef(systemPrefersDark)
   systemPrefersDarkRef.current = systemPrefersDark
-  const previousVisibleForReconcileRef = useRef<boolean | null>(null)
+  const previousVisibleForReconcileRef = useRef<TerminalPaneVisibilitySnapshot | null>(null)
   const linkProviderDisposablesRef = useRef(new Map<number, IDisposable>())
   const terminalHandleLinkDisposablesRef = useRef(new Map<number, IDisposable>())
   const fileLinkClickFallbackDisposablesRef = useRef(new Map<number, IDisposable>())
@@ -1649,8 +1666,12 @@ export function useTerminalPaneLifecycle({
   }, [tabId, cwd])
 
   useEffect(() => {
-    const previousIsVisible = previousVisibleForReconcileRef.current
-    previousVisibleForReconcileRef.current = isVisible
+    const previousIsVisible = getPreviousVisibleForTerminalPane({
+      previous: previousVisibleForReconcileRef.current,
+      tabId,
+      cwd
+    })
+    previousVisibleForReconcileRef.current = { tabId, cwd, isVisible }
     isVisibleRef.current = isVisible
     const resumedFromHidden = isTerminalPaneVisibilityResume({ previousIsVisible, isVisible })
     for (const panePtyBinding of panePtyBindingsRef.current.values()) {
@@ -1676,8 +1697,8 @@ export function useTerminalPaneLifecycle({
       bindings: panePtyBindingsRef.current.values() as Iterable<ReconcilableBinding>,
       listSessions: () => window.api.pty.listSessions()
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Why: visibility flips must refresh existing PTY process tracking even though the ref object identity is stable.
-  }, [isVisible, isVisibleRef, panePtyBindingsRef])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Why: visibility and terminal identity changes must refresh existing PTY process tracking even though the ref object identity is stable.
+  }, [cwd, isVisible, isVisibleRef, panePtyBindingsRef, tabId])
 
   useEffect(() => {
     const manager = managerRef.current

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -435,15 +435,24 @@ export function shouldDetachPaneTransportOnUnmount(args: {
 /**
  * Self-gating dead-session reconcile pass scheduled from the isVisible effect.
  * Why self-gate: the effect fires on BOTH isVisible true and false, but we only
- * reconcile on resume (becoming visible), never on hide. Returns true when the
- * pass was scheduled so the resume-unit test can assert the gate.
+ * reconcile on resume (hidden to visible), never on hide or initial mount.
+ * Returns true when the pass was scheduled so the resume-unit test can assert
+ * the gate.
  */
+export function isTerminalPaneVisibilityResume(args: {
+  previousIsVisible: boolean | null
+  isVisible: boolean
+}): boolean {
+  return args.previousIsVisible === false && args.isVisible
+}
+
 export function scheduleVisibilityReconcilePass(args: {
+  previousIsVisible: boolean | null
   isVisible: boolean
   bindings: Iterable<ReconcilableBinding>
   listSessions: () => Promise<{ id: string; cwd: string; title: string }[]>
 }): boolean {
-  if (!args.isVisible) {
+  if (!isTerminalPaneVisibilityResume(args)) {
     return false
   }
   // Why: fire-and-forget so the async listSessions IPC never blocks the
@@ -515,6 +524,7 @@ export function useTerminalPaneLifecycle({
   )
   const systemPrefersDarkRef = useRef(systemPrefersDark)
   systemPrefersDarkRef.current = systemPrefersDark
+  const previousVisibleForReconcileRef = useRef<boolean | null>(null)
   const linkProviderDisposablesRef = useRef(new Map<number, IDisposable>())
   const terminalHandleLinkDisposablesRef = useRef(new Map<number, IDisposable>())
   const fileLinkClickFallbackDisposablesRef = useRef(new Map<number, IDisposable>())
@@ -1639,7 +1649,10 @@ export function useTerminalPaneLifecycle({
   }, [tabId, cwd])
 
   useEffect(() => {
+    const previousIsVisible = previousVisibleForReconcileRef.current
+    previousVisibleForReconcileRef.current = isVisible
     isVisibleRef.current = isVisible
+    const resumedFromHidden = isTerminalPaneVisibilityResume({ previousIsVisible, isVisible })
     for (const panePtyBinding of panePtyBindingsRef.current.values()) {
       const bindingWithVisibility = panePtyBinding as IDisposable & {
         syncProcessTracking?: () => void
@@ -1649,15 +1662,16 @@ export function useTerminalPaneLifecycle({
       // Why: re-arm the once-per-resume input liveness re-check so the typing
       // hot path stays off the listSessions IPC between resumes (the re-check
       // is only useful right after a hidden→visible flip).
-      if (isVisible) {
+      if (resumedFromHidden) {
         bindingWithVisibility.noteVisibilityResume?.()
       }
     }
     // Why: the reconcile pass self-gates on becoming visible (resume) — the
-    // effect also fires on hide — and runs fire-and-forget alongside
-    // syncProcessTracking. reconcileDeadSessions re-validates identity at apply
-    // time so a racing reattach is not clobbered.
+    // effect also fires on hide and initial mount. Initial visible mounts are
+    // fresh PTY startup, so an early listSessions snapshot must not close the
+    // newborn tab before the daemon lists it.
     scheduleVisibilityReconcilePass({
+      previousIsVisible,
       isVisible,
       bindings: panePtyBindingsRef.current.values() as Iterable<ReconcilableBinding>,
       listSessions: () => window.api.pty.listSessions()


### PR DESCRIPTION
## Summary

Prevents newly created local terminal tabs and agent terminal tabs from being mistaken for dead sessions during startup. The dead-session reconciler now runs only after a real hidden-to-visible resume, while fresh mounts start with resume-only liveness probes disarmed until a true resume re-arms one check.

This does not change normal shell or agent process failures after startup. If Codex/Claude needs trust/auth/quota input, the terminal tab should persist and show that prompt rather than closing immediately.

Fixes #6773.

## Design Approach

- Treat `previousIsVisible === false && isVisible === true` as the only visibility resume edge.
- Gate both the dead-session reconcile pass and `noteVisibilityResume()` behind that edge.
- Start input-triggered liveness rechecks disarmed on a fresh PTY binding, then let `noteVisibilityResume()` grant exactly one post-resume input probe.
- Preserve existing SSH and `remote:` web-runtime skips because local `listSessions()` is not authoritative for those PTYs.
- Route spawn-time size reconcile resize forwarding through the existing mobile-fit/PTY-lock suppression.

## Design Review Outcome

Design review was clean after tightening the plan around input-triggered liveness: fresh mounts must not arm `listSessions()` from the first terminal input, and real agent terminal Electron validation is required.

## Implementation

- Added `isTerminalPaneVisibilityResume` and passed previous visibility into `scheduleVisibilityReconcilePass`.
- Updated the lifecycle visibility effect to call resume-only binding hooks only on true hidden-to-visible transitions.
- Reworked PTY input liveness to use a resume token that starts disarmed, is consumed before provider checks, and is re-armed by the next resume.
- Added focused tests for initial mount, true resume, fresh input, one-shot post-resume input, second-resume re-arm, SSH skip, and remote-runtime skip.

No deviations from the reviewed design.

## Completeness Verification

Read-only completeness verification found the headline behavior implemented with no blockers. It confirmed startup-time dead-session reconciliation no longer applies to fresh terminal/agent launches, while real hidden-session cleanup remains available on resume.

## Headline Behavior Status

Implemented. The shared local terminal startup path used by `New Terminal` and tab-menu agent launches no longer runs authoritative dead-session checks during PTY birth.

## Broad App Consistency

Source-of-truth behavior compared: desktop active-workspace tab bar `New tab` menu.

Compared neighboring surfaces:
- `New tab -> New Terminal`
- `New tab -> Codex` agent terminal launch
- keyboard/new-terminal path through the same lifecycle
- split/floating terminal neighboring PTY startup behavior
- status/resource backing state
- SSH and web-runtime liveness ownership

This PR fixes the local desktop terminal/agent tab persistence mismatch without changing visible labels, menu order, shortcuts, remote ownership, or mobile terminal behavior.

## Risks, Ambiguities, And Non-Goals

- Agent command success is not guaranteed by this change. Auth, trust, missing CLI, or quota prompts can still appear inside the persistent terminal.
- Natural PTY exits after startup still use existing exit handling.
- Remote/web-runtime and SSH reconciliation are intentionally unchanged.
- The first input into a genuinely dead newborn PTY will not run the resume-only liveness probe; normal startup/exit handling owns that case because daemon `listSessions()` can lag during PTY birth.

## Perf Audit

Perf audit found no performance bug. The diff reduces initial-mount daemon listing work, avoids fresh-input `listSessions()` polling, preserves one-shot post-resume checks, and keeps mobile-fit resize suppression in the spawn reconcile path. Existing deterministic call-count tests were considered sufficient.

## Code Review

Code-review loop ran one round with two parallel reviewers. Both returned clean, with no actionable findings and no fixes required.

## Brennan Test Changes Result

Verdict: land.

Electron validation used a separate dev app launched from this worktree with CDP, a temporary user-data path, and a disposable local git repo/workspace. App identity confirmed `devRepoRoot: /Users/thebr/orca/workspaces/orca/seabiscuit`.

Manual validation screenshots:
- New terminal tab persisted: `/var/folders/nk/tt6kt56s3hn9rv32dj7kymv00000gn/T/orca-terminal-validation.TQ4LPl/new-terminal-terminal-2.png`
- Real Codex agent terminal persisted at trust prompt: `/var/folders/nk/tt6kt56s3hn9rv32dj7kymv00000gn/T/orca-terminal-validation.TQ4LPl/codex-agent-terminal-3.png`

Observed:
- `New tab -> New Terminal`: after 6s, `Terminal 2` remained selected with shell prompt and a backing PTY listed by `window.api.pty.listSessions()`.
- `New tab -> Codex`: after 12s, `Terminal 3` remained selected, `launchAgent: "codex"`, with Codex trust prompt visible and a backing PTY listed by `window.api.pty.listSessions()`.

## Checks

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts src/renderer/src/components/terminal-pane/terminal-dead-session-reconcile.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-size-reconcile.test.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json`
- `pnpm run lint` passed with one existing warning in `useGitStatusPolling.ts` outside this diff
- `git diff --check`

## Post-PR Stabilization

CodeRabbit stabilization completed: one actionable comment was addressed in commit `82f3239`, and the refreshed CodeRabbit review reported no actionable comments. PR checks are passing: `verify` and `wayland terminal input`.

Made with [Orca](https://github.com/stablyai/orca) 🐋

