### PR TITLE
fix: route sidebar hosted-review GitHub actions through owner runtime

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -3723,6 +3723,7 @@ export default function ChecksPanel(): React.JSX.Element {
             githubPR={pr}
             repo={repo}
             worktree={activeWorktree}
+            ownerSettings={ownerSettings}
             onRefreshReview={refreshHostedReviewAfterMutation}
           />
         )}

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuSeparator
 } from '@/components/ui/dropdown-menu'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
-import type { PRInfo, Repo, Worktree } from '../../../../shared/types'
+import type { GlobalSettings, PRInfo, Repo, Worktree } from '../../../../shared/types'
 import { resolveGitHubPRMergeMethods } from '../../../../shared/github-pr-merge-methods'
 import { runWorktreeDelete } from '../sidebar/delete-worktree-flow'
 import { presentGitLabMRMergeState } from './gitlab-mr-merge-state'
@@ -34,12 +34,14 @@ export default function HostedReviewActions({
   githubPR,
   repo,
   worktree,
+  ownerSettings,
   onRefreshReview
 }: {
   review: HostedReviewActionInfo
   githubPR?: PRInfo | null
   repo: Repo
   worktree: Worktree
+  ownerSettings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
   onRefreshReview: () => Promise<void>
 }): React.JSX.Element | null {
   const isDeletingWorktree = useAppStore(
@@ -85,6 +87,7 @@ export default function HostedReviewActions({
     reviewLabel,
     defaultMergeMethod: mergeMethods.defaultMethod,
     autoMergeAction: mergePresentation.autoMergeAction,
+    ownerSettings,
     onRefreshReview
   })
   const isUpdatingReviewState = stateUpdating !== null

--- a/src/renderer/src/components/right-sidebar/hosted-review-actions-host-boundary.test.ts
+++ b/src/renderer/src/components/right-sidebar/hosted-review-actions-host-boundary.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const COMPONENT_ROOT = __dirname
+
+function componentSource(relativePath: string): string {
+  return readFileSync(join(COMPONENT_ROOT, relativePath), 'utf8')
+}
+
+function sourceBetween(source: string, startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('Hosted review action host boundaries', () => {
+  it('routes GitHub merge actions through the review host context', () => {
+    const source = componentSource('use-hosted-review-actions.ts')
+    const mergeSection = sourceBetween(
+      source,
+      'const handleMerge = useCallback(',
+      'const handleAutoMerge = useCallback(async () => {'
+    )
+
+    expect(source).toContain('ownerSettings')
+    expect(source).toContain('getActiveRuntimeTarget(')
+    expect(source).toContain('callRuntimeRpc')
+    expect(source).toContain('reviewTarget.kind === \'environment\'')
+    expect(mergeSection).toContain("'github.mergePR'")
+    expect(source).toContain("'github.setPRAutoMerge'")
+    expect(source).toContain("'github.updatePRState'")
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -3,8 +3,9 @@ import { toast } from 'sonner'
 import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import type { GitHubPRAutoMergeAction } from '@/components/github-pr-merge-state'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
-import type { PRInfo, Repo } from '../../../../shared/types'
+import type { GlobalSettings, PRInfo, Repo } from '../../../../shared/types'
 import type { GitHubPRMergeMethod } from '../../../../shared/types'
+import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { translate } from '@/i18n/i18n'
 
 export type HostedReviewActionInfo = Pick<
@@ -31,6 +32,7 @@ export function useHostedReviewActions({
   reviewLabel,
   defaultMergeMethod,
   autoMergeAction,
+  ownerSettings,
   onRefreshReview
 }: {
   review: HostedReviewActionInfo
@@ -41,6 +43,7 @@ export function useHostedReviewActions({
   reviewLabel: string
   defaultMergeMethod: GitHubPRMergeMethod
   autoMergeAction: GitHubPRAutoMergeAction | null
+  ownerSettings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
   onRefreshReview: () => Promise<void>
 }): {
   merging: boolean
@@ -55,6 +58,9 @@ export function useHostedReviewActions({
   const [merging, setMerging] = useState(false)
   const [stateUpdating, setStateUpdating] = useState<'open' | 'closed' | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
+  // Why: runtime-owned sidebar reviews are not registered in the local Electron
+  // repo store, so GitHub mutations must follow the worktree owner runtime.
+  const reviewTarget = getActiveRuntimeTarget(ownerSettings)
 
   const handleMerge = useCallback(
     async (method: GitHubPRMergeMethod = defaultMergeMethod) => {
@@ -68,13 +74,25 @@ export function useHostedReviewActions({
               iid: review.number,
               method
             })
-          : await window.api.gh.mergePR({
-              repoPath: repo.path,
-              repoId: repo.id,
-              prNumber: review.number,
-              method,
-              prRepo: githubPR?.prRepo ?? null
-            })
+          : reviewTarget.kind === 'environment'
+            ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.mergePR>>>(
+                reviewTarget,
+                'github.mergePR',
+                {
+                  repo: repo.id,
+                  prNumber: review.number,
+                  method,
+                  prRepo: githubPR?.prRepo ?? null
+                },
+                { timeoutMs: 30_000 }
+              )
+            : await window.api.gh.mergePR({
+                repoPath: repo.path,
+                repoId: repo.id,
+                prNumber: review.number,
+                method,
+                prRepo: githubPR?.prRepo ?? null
+              })
         if (!result.ok) {
           setActionError(result.error)
         } else {
@@ -91,6 +109,7 @@ export function useHostedReviewActions({
       isGitLab,
       defaultMergeMethod,
       onRefreshReview,
+      reviewTarget,
       repo.id,
       repo.path,
       review.number
@@ -105,14 +124,28 @@ export function useHostedReviewActions({
     setMerging(true)
     setActionError(null)
     try {
-      const result = await window.api.gh.setPRAutoMerge({
-        repoPath: repo.path,
-        repoId: repo.id,
-        prNumber: review.number,
-        enabled,
-        method: enabled ? defaultMergeMethod : undefined,
-        prRepo: githubPR?.prRepo ?? null
-      })
+      const result =
+        reviewTarget.kind === 'environment'
+          ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.setPRAutoMerge>>>(
+              reviewTarget,
+              'github.setPRAutoMerge',
+              {
+                repo: repo.id,
+                prNumber: review.number,
+                enabled,
+                method: enabled ? defaultMergeMethod : undefined,
+                prRepo: githubPR?.prRepo ?? null
+              },
+              { timeoutMs: 30_000 }
+            )
+          : await window.api.gh.setPRAutoMerge({
+              repoPath: repo.path,
+              repoId: repo.id,
+              prNumber: review.number,
+              enabled,
+              method: enabled ? defaultMergeMethod : undefined,
+              prRepo: githubPR?.prRepo ?? null
+            })
       if (!result.ok) {
         setActionError(result.error)
       } else {
@@ -129,6 +162,7 @@ export function useHostedReviewActions({
     autoMergeAction,
     defaultMergeMethod,
     onRefreshReview,
+    reviewTarget,
     repo.id,
     repo.path,
     review.number
@@ -175,12 +209,23 @@ export function useHostedReviewActions({
                 repoId: repo.id,
                 iid: review.number
               })
-          : await window.api.gh.updatePRState({
-              repoPath: repo.path,
-              repoId: repo.id,
-              prNumber: review.number,
-              updates: { state: nextState }
-            })
+            : reviewTarget.kind === 'environment'
+              ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
+                  reviewTarget,
+                  'github.updatePRState',
+                  {
+                    repo: repo.id,
+                    prNumber: review.number,
+                    updates: { state: nextState }
+                  },
+                  { timeoutMs: 30_000 }
+                )
+              : await window.api.gh.updatePRState({
+                  repoPath: repo.path,
+                  repoId: repo.id,
+                  prNumber: review.number,
+                  updates: { state: nextState }
+                })
         if (!result.ok) {
           setActionError(result.error)
           toast.error(result.error)
@@ -213,6 +258,7 @@ export function useHostedReviewActions({
       confirm,
       isGitLab,
       onRefreshReview,
+      reviewTarget,
       repo.id,
       repo.path,
       review.number,


### PR DESCRIPTION
## Summary

Fixes runtime-owned GitHub hosted review actions in the right sidebar so merge, auto-merge, and PR state updates are routed through the owning runtime instead of local Electron IPC, preventing `Access denied: unknown repository path` for remote-hosted reviews (#6753).

## Screenshots

* No visual change.

## Testing

* [x] `pnpm lint`
* [x] `pnpm typecheck`
* [x] `pnpm test`
* [ ] `pnpm build`
* [x] Added or updated high-quality tests that would catch regressions.

## AI Review Report

Reviewed the host-routing logic for sidebar GitHub review actions. Verified the issue was caused by local IPC being used for runtime-owned reviews, and confirmed the fix preserves existing local and SSH flows.

Cross-platform compatibility was reviewed for Windows, macOS, and Linux. No changes to shortcuts, labels, shell behavior, or platform-specific Electron behavior.

## Security Audit

Reviewed IPC routing, path handling, command execution, and authentication. No new security risks or dependencies introduced.

## Notes

* Scoped to GitHub right-sidebar hosted review actions only.
* No visual or UX changes.

## ELI5

Merge and PR actions in the hosted-review sidebar for remote worktrees ran on the local machine and failed with access errors. Those GitHub actions now run on the runtime that owns the repo.
