### PR TITLE
Reliably deliver the issue prompt into opencode's composer

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -184,6 +184,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../shared/tui-agent-launch-defaults'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
+import { createDraftPasteReadyScanner } from '../../shared/draft-paste-ready-scanner'
 import { detectInstalledAgentsWithShellPathHydration, detectRemoteAgents } from '../ipc/preflight'
 import {
   markCodexProjectTrusted,
@@ -1067,8 +1068,6 @@ function getAgentLaunchPlatformForRepo(
 
 const FOREGROUND_AGENT_WRAPPER_RETRY_INTERVAL_MS = 150
 const FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS = 6_500
-const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
-const CODEX_COMPOSER_PROMPT = '›'
 const BRACKETED_PASTE_BEGIN = '\x1b[200~'
 const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
@@ -12298,9 +12297,7 @@ export class OrcaRuntimeService {
       TUI_AGENT_CONFIG[agent].draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'
     return new Promise<string | null>((resolve) => {
       let settled = false
-      let recent = ''
-      let postHandshakeRecent = ''
-      let saw2004 = false
+      const scanner = createDraftPasteReadyScanner(readySignal)
       let quietTimer: NodeJS.Timeout | null = null
       let hardTimer: NodeJS.Timeout | null = null
       let unsubscribe: (() => void) | null = null
@@ -12328,36 +12325,12 @@ export class OrcaRuntimeService {
       }
 
       const observeData = (data: string): void => {
-        const combined = recent + data
-        recent = combined.slice(-512)
-        if (!saw2004) {
-          const markerIndex = combined.indexOf(DECSET_BRACKETED_PASTE)
-          if (markerIndex === -1) {
-            return
-          }
-          saw2004 = true
-          const postHandshakeChunk = combined.slice(markerIndex + DECSET_BRACKETED_PASTE.length)
-          if (readySignal === 'codex-composer-prompt') {
-            if (postHandshakeChunk.includes(CODEX_COMPOSER_PROMPT)) {
-              finish(ptyId)
-              return
-            }
-            postHandshakeRecent = postHandshakeChunk.slice(-512)
-            return
-          }
-          postHandshakeRecent = postHandshakeChunk.slice(-512)
-        } else {
-          if (
-            readySignal === 'codex-composer-prompt' &&
-            (data.includes(CODEX_COMPOSER_PROMPT) ||
-              (postHandshakeRecent + data).includes(CODEX_COMPOSER_PROMPT))
-          ) {
-            finish(ptyId)
-            return
-          }
-          postHandshakeRecent = (postHandshakeRecent + data).slice(-512)
+        const { ready, armQuietTimer: shouldArm } = scanner.observe(data)
+        if (ready) {
+          finish(ptyId)
+          return
         }
-        if (readySignal !== 'codex-composer-prompt' && saw2004) {
+        if (shouldArm) {
           armQuietTimer()
         }
       }

--- a/src/renderer/src/lib/agent-draft-readiness.ts
+++ b/src/renderer/src/lib/agent-draft-readiness.ts
@@ -3,9 +3,8 @@ import type { GlobalSettings } from '../../../shared/types'
 import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import { subscribeToRuntimeTerminalData } from '@/runtime/runtime-terminal-stream'
+import { createDraftPasteReadyScanner } from '../../../shared/draft-paste-ready-scanner'
 
-const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
-const CODEX_COMPOSER_PROMPT = '›'
 const BRACKETED_PASTE_QUIET_MS = 1500
 
 /**
@@ -26,9 +25,7 @@ export function waitForAgentDraftInputReady(
 ): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     let settled = false
-    let recent = ''
-    let postHandshakeRecent = ''
-    let saw2004 = false
+    const scanner = createDraftPasteReadyScanner(readySignal)
     let quietTimer: number | null = null
     let hardTimer: number | null = null
     let unsubscribe: (() => void) | null = null
@@ -56,41 +53,12 @@ export function waitForAgentDraftInputReady(
     }
 
     const observeData = (data: string): void => {
-      // Why: 512 bytes covers split escape sequences and Codex's styled prompt
-      // without retaining a large terminal scrollback copy.
-      const combined = recent + data
-      recent = combined.slice(-512)
-      if (!saw2004) {
-        const markerIndex = combined.indexOf(DECSET_BRACKETED_PASTE)
-        if (markerIndex === -1) {
-          return
-        }
-        saw2004 = true
-        const postHandshakeChunk = combined.slice(markerIndex + DECSET_BRACKETED_PASTE.length)
-        if (readySignal === 'codex-composer-prompt') {
-          if (postHandshakeChunk.includes(CODEX_COMPOSER_PROMPT)) {
-            finish(true)
-            return
-          }
-          postHandshakeRecent = postHandshakeChunk.slice(-512)
-          return
-        }
-        postHandshakeRecent = postHandshakeChunk.slice(-512)
-      } else {
-        if (
-          readySignal === 'codex-composer-prompt' &&
-          (data.includes(CODEX_COMPOSER_PROMPT) ||
-            (postHandshakeRecent + data).includes(CODEX_COMPOSER_PROMPT))
-        ) {
-          finish(true)
-          return
-        }
-        postHandshakeRecent = (postHandshakeRecent + data).slice(-512)
-      }
-      if (readySignal === 'codex-composer-prompt') {
+      const { ready, armQuietTimer: shouldArm } = scanner.observe(data)
+      if (ready) {
+        finish(true)
         return
       }
-      if (saw2004) {
+      if (shouldArm) {
         armQuietTimer()
       }
     }

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -261,7 +261,45 @@ describe('pasteDraftWhenAgentReady', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('falls back to the quiet window for opencode when show-cursor never arrives', async () => {
+  it('does not paste on the quiet window for opencode (it never arms one)', async () => {
+    // Why: opencode is silent for ~1.5-2s between enabling bracketed paste and
+    // mounting its composer. A quiet window would fire during that gap and paste
+    // before the composer exists (the original bug), so the cursor signal must
+    // not arm one. With process inspection failing, delivery times out instead.
+    testState.inspectRuntimeTerminalProcess.mockResolvedValue(null)
+    const onTimeout = vi.fn()
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'opencode',
+      onTimeout
+    })
+    await flushMicrotasks()
+
+    testState.ptyObserver?.(DECSET_BRACKETED_PASTE)
+    await flushMicrotasks()
+
+    // Quiet-window duration elapses with no show-cursor: must NOT paste.
+    await vi.advanceTimersByTimeAsync(1500)
+    await flushMicrotasks()
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    // Only the hard timeout (and failed process check) resolves it — to false.
+    await vi.advanceTimersByTimeAsync(8000)
+    await flushMicrotasks(5)
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(promise).resolves.toBe(false)
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('best-effort pastes for opencode at the hard timeout when its process is running', async () => {
+    // Why: with no quiet window, the hard-timeout process-ownership check is the
+    // backstop if show-cursor is somehow missed — same model as Codex.
+    testState.inspectRuntimeTerminalProcess.mockResolvedValue({
+      foregroundProcess: 'opencode',
+      hasChildProcesses: false
+    })
     const promise = pasteDraftWhenAgentReady({
       tabId: 'tab-1',
       content: ISSUE_URL,
@@ -270,13 +308,7 @@ describe('pasteDraftWhenAgentReady', () => {
     await flushMicrotasks()
 
     testState.ptyObserver?.(DECSET_BRACKETED_PASTE)
-    await flushMicrotasks()
-    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
-
-    await vi.advanceTimersByTimeAsync(1499)
-    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
-
-    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(8000)
 
     await expect(promise).resolves.toBe(true)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -52,6 +52,7 @@ vi.mock('@/runtime/runtime-terminal-stream', () => ({
 }))
 
 const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
+const SHOW_CURSOR = '\x1b[?25h'
 const CODEX_COMPOSER_PROMPT_RENDER = '\x1b[1m›\x1b[0m Ask Codex to do anything'
 const ISSUE_URL = 'https://github.com/stablyai/orca/issues/123'
 const PASTED_ISSUE_URL = `\x1b[200~${ISSUE_URL}\x1b[201~`
@@ -143,6 +144,124 @@ describe('pasteDraftWhenAgentReady', () => {
   })
 
   it('keeps the render-quiet wait for agents without the Codex ready signal', async () => {
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'gemini'
+    })
+    await flushMicrotasks()
+
+    testState.ptyObserver?.(DECSET_BRACKETED_PASTE)
+    await flushMicrotasks()
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1499)
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      PASTED_ISSUE_URL
+    )
+  })
+
+  it('pastes into opencode as soon as show-cursor renders after bracketed paste is enabled', async () => {
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'opencode'
+    })
+    await flushMicrotasks()
+
+    testState.ptyObserver?.(DECSET_BRACKETED_PASTE)
+    await flushMicrotasks()
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    testState.ptyObserver?.(SHOW_CURSOR)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      PASTED_ISSUE_URL
+    )
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('detects opencode show-cursor inside a large first render chunk', async () => {
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'opencode'
+    })
+    await flushMicrotasks()
+
+    testState.ptyObserver?.(`${DECSET_BRACKETED_PASTE}${SHOW_CURSOR}${'x'.repeat(900)}`)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      PASTED_ISSUE_URL
+    )
+  })
+
+  it('detects opencode show-cursor split across a later chunk', async () => {
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'opencode'
+    })
+    await flushMicrotasks()
+
+    testState.ptyObserver?.(DECSET_BRACKETED_PASTE)
+    await flushMicrotasks()
+    testState.ptyObserver?.('render noise \x1b[?')
+    await flushMicrotasks()
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    testState.ptyObserver?.('25h')
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      PASTED_ISSUE_URL
+    )
+  })
+
+  it('rescues opencode delivery under never-settling output churn', async () => {
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'opencode'
+    })
+    await flushMicrotasks()
+
+    testState.ptyObserver?.(DECSET_BRACKETED_PASTE)
+    await flushMicrotasks()
+    for (let index = 0; index < 5; index += 1) {
+      await vi.advanceTimersByTimeAsync(1499)
+      testState.ptyObserver?.(`setup output ${index}`)
+      await flushMicrotasks()
+      expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+    }
+
+    testState.ptyObserver?.(SHOW_CURSOR)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      PASTED_ISSUE_URL
+    )
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('falls back to the quiet window for opencode when show-cursor never arrives', async () => {
     const promise = pasteDraftWhenAgentReady({
       tabId: 'tab-1',
       content: ISSUE_URL,

--- a/src/shared/draft-paste-ready-scanner.test.ts
+++ b/src/shared/draft-paste-ready-scanner.test.ts
@@ -18,12 +18,17 @@ describe('createDraftPasteReadyScanner', () => {
 
     it('does not fire on bracketed paste alone, then fires once show-cursor arrives', () => {
       const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
-      // Why: opencode enables bracketed paste ~2s before its composer mounts;
-      // the cursor must gate delivery, but the quiet-window must still arm.
-      expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({ ready: false, armQuietTimer: true })
+      // Why: opencode enables bracketed paste ~1.5-2s before its composer mounts
+      // and stays SILENT in between. The cursor gates delivery and must NOT arm
+      // the quiet window, which would otherwise fire during that silent gap and
+      // paste before the composer exists.
+      expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({
+        ready: false,
+        armQuietTimer: false
+      })
       expect(scanner.observe('startup banner output')).toEqual({
         ready: false,
-        armQuietTimer: true
+        armQuietTimer: false
       })
       expect(scanner.observe(SHOW_CURSOR)).toEqual({ ready: true, armQuietTimer: false })
     })
@@ -40,11 +45,11 @@ describe('createDraftPasteReadyScanner', () => {
 
     it('detects a bracketed-paste handshake split across a chunk boundary', () => {
       // Why: the pre-handshake `recent` ring must reassemble a \x1b[?2004h that
-      // straddles two PTY packets, or both quiet-window arming and cursor-gated
-      // readiness break for fragmented startup output.
+      // straddles two PTY packets, or cursor-gated readiness breaks for
+      // fragmented startup output.
       const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
       expect(scanner.observe('\x1b[?20')).toEqual({ ready: false, armQuietTimer: false })
-      expect(scanner.observe('04h')).toEqual({ ready: false, armQuietTimer: true })
+      expect(scanner.observe('04h')).toEqual({ ready: false, armQuietTimer: false })
       expect(scanner.observe(SHOW_CURSOR)).toEqual({ ready: true, armQuietTimer: false })
     })
 
@@ -52,17 +57,18 @@ describe('createDraftPasteReadyScanner', () => {
       const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
       scanner.observe(DECSET_BRACKETED_PASTE)
       // The escape sequence is split mid-bytes across two separate chunks.
-      expect(scanner.observe('render noise \x1b[?')).toEqual({ ready: false, armQuietTimer: true })
+      expect(scanner.observe('render noise \x1b[?')).toEqual({ ready: false, armQuietTimer: false })
       expect(scanner.observe('25h')).toEqual({ ready: true, armQuietTimer: false })
     })
 
-    it('keeps arming the quiet-window fallback when show-cursor never arrives', () => {
+    it('never arms the quiet window during the silent pre-composer gap', () => {
       const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
       scanner.observe(DECSET_BRACKETED_PASTE)
-      // Every subsequent noisy chunk must re-arm the fallback (no early-return
-      // that would starve it), so delivery is never worse than the default.
+      // Why: opencode is silent here; arming the quiet window would fire before
+      // the composer mounts and pre-empt the cursor signal (the original bug).
+      // Delivery waits for show-cursor, bounded by the caller's hard timeout.
       for (let i = 0; i < 5; i += 1) {
-        expect(scanner.observe(`setup output ${i}`)).toEqual({ ready: false, armQuietTimer: true })
+        expect(scanner.observe(`setup output ${i}`)).toEqual({ ready: false, armQuietTimer: false })
       }
     })
 
@@ -71,7 +77,7 @@ describe('createDraftPasteReadyScanner', () => {
       // \x1b[?25l (hide) must not be mistaken for \x1b[?25h (show).
       expect(scanner.observe(`${DECSET_BRACKETED_PASTE}${HIDE_CURSOR}`)).toEqual({
         ready: false,
-        armQuietTimer: true
+        armQuietTimer: false
       })
     })
 
@@ -81,7 +87,7 @@ describe('createDraftPasteReadyScanner', () => {
       expect(scanner.observe(SHOW_CURSOR)).toEqual({ ready: false, armQuietTimer: false })
       expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({
         ready: false,
-        armQuietTimer: true
+        armQuietTimer: false
       })
     })
   })

--- a/src/shared/draft-paste-ready-scanner.test.ts
+++ b/src/shared/draft-paste-ready-scanner.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { createDraftPasteReadyScanner } from './draft-paste-ready-scanner'
+
+const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
+const SHOW_CURSOR = '\x1b[?25h'
+const HIDE_CURSOR = '\x1b[?25l'
+const CODEX_PROMPT = '\x1b[1m›\x1b[0m Ask Codex to do anything'
+
+describe('createDraftPasteReadyScanner', () => {
+  describe('render-cursor-after-bracketed-paste (opencode / mimo-code)', () => {
+    it('is ready when show-cursor renders after bracketed paste in one chunk', () => {
+      const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
+      expect(scanner.observe(`${DECSET_BRACKETED_PASTE}${SHOW_CURSOR}`)).toEqual({
+        ready: true,
+        armQuietTimer: false
+      })
+    })
+
+    it('does not fire on bracketed paste alone, then fires once show-cursor arrives', () => {
+      const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
+      // Why: opencode enables bracketed paste ~2s before its composer mounts;
+      // the cursor must gate delivery, but the quiet-window must still arm.
+      expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({ ready: false, armQuietTimer: true })
+      expect(scanner.observe('startup banner output')).toEqual({
+        ready: false,
+        armQuietTimer: true
+      })
+      expect(scanner.observe(SHOW_CURSOR)).toEqual({ ready: true, armQuietTimer: false })
+    })
+
+    it('resolves from a single replayed buffer holding both markers (SSH/remote replay path)', () => {
+      // Why: the runtime waiter feeds recentPtyOutputById as one observe() call
+      // when the agent emitted 2004 + show-cursor before the subscription
+      // attached; a single combined buffer must still resolve.
+      const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
+      expect(
+        scanner.observe(`banner\n${DECSET_BRACKETED_PASTE}composer\n${SHOW_CURSOR}rest`)
+      ).toEqual({ ready: true, armQuietTimer: false })
+    })
+
+    it('detects show-cursor split across a later chunk boundary', () => {
+      const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
+      scanner.observe(DECSET_BRACKETED_PASTE)
+      // The escape sequence is split mid-bytes across two separate chunks.
+      expect(scanner.observe('render noise \x1b[?')).toEqual({ ready: false, armQuietTimer: true })
+      expect(scanner.observe('25h')).toEqual({ ready: true, armQuietTimer: false })
+    })
+
+    it('keeps arming the quiet-window fallback when show-cursor never arrives', () => {
+      const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
+      scanner.observe(DECSET_BRACKETED_PASTE)
+      // Every subsequent noisy chunk must re-arm the fallback (no early-return
+      // that would starve it), so delivery is never worse than the default.
+      for (let i = 0; i < 5; i += 1) {
+        expect(scanner.observe(`setup output ${i}`)).toEqual({ ready: false, armQuietTimer: true })
+      }
+    })
+
+    it('does not treat hide-cursor as the ready signal', () => {
+      const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
+      // \x1b[?25l (hide) must not be mistaken for \x1b[?25h (show).
+      expect(scanner.observe(`${DECSET_BRACKETED_PASTE}${HIDE_CURSOR}`)).toEqual({
+        ready: false,
+        armQuietTimer: true
+      })
+    })
+
+    it('ignores show-cursor that appears before bracketed paste is enabled', () => {
+      const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
+      // A pre-handshake cursor toggle must not trip readiness.
+      expect(scanner.observe(SHOW_CURSOR)).toEqual({ ready: false, armQuietTimer: false })
+      expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({
+        ready: false,
+        armQuietTimer: true
+      })
+    })
+  })
+
+  describe('codex-composer-prompt (unchanged behavior)', () => {
+    it('is ready on the composer glyph after bracketed paste and never arms the quiet timer', () => {
+      const scanner = createDraftPasteReadyScanner('codex-composer-prompt')
+      expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({
+        ready: false,
+        armQuietTimer: false
+      })
+      expect(scanner.observe(CODEX_PROMPT)).toEqual({ ready: true, armQuietTimer: false })
+    })
+
+    it('detects the composer glyph inside a large first render chunk', () => {
+      const scanner = createDraftPasteReadyScanner('codex-composer-prompt')
+      expect(scanner.observe(`${DECSET_BRACKETED_PASTE}${CODEX_PROMPT}${'x'.repeat(900)}`)).toEqual(
+        { ready: true, armQuietTimer: false }
+      )
+    })
+
+    it('never arms the quiet-window fallback', () => {
+      const scanner = createDraftPasteReadyScanner('codex-composer-prompt')
+      expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({
+        ready: false,
+        armQuietTimer: false
+      })
+      expect(scanner.observe('noise')).toEqual({ ready: false, armQuietTimer: false })
+    })
+  })
+
+  describe('render-quiet-after-bracketed-paste (default)', () => {
+    it('arms the quiet timer after bracketed paste and never reports a signal', () => {
+      const scanner = createDraftPasteReadyScanner('render-quiet-after-bracketed-paste')
+      expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({ ready: false, armQuietTimer: true })
+      // Show-cursor is not a signal for the default path; it just keeps arming.
+      expect(scanner.observe(SHOW_CURSOR)).toEqual({ ready: false, armQuietTimer: true })
+    })
+
+    it('does nothing until bracketed paste is enabled', () => {
+      const scanner = createDraftPasteReadyScanner('render-quiet-after-bracketed-paste')
+      expect(scanner.observe('pre-handshake output')).toEqual({
+        ready: false,
+        armQuietTimer: false
+      })
+    })
+  })
+})

--- a/src/shared/draft-paste-ready-scanner.test.ts
+++ b/src/shared/draft-paste-ready-scanner.test.ts
@@ -38,6 +38,16 @@ describe('createDraftPasteReadyScanner', () => {
       ).toEqual({ ready: true, armQuietTimer: false })
     })
 
+    it('detects a bracketed-paste handshake split across a chunk boundary', () => {
+      // Why: the pre-handshake `recent` ring must reassemble a \x1b[?2004h that
+      // straddles two PTY packets, or both quiet-window arming and cursor-gated
+      // readiness break for fragmented startup output.
+      const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
+      expect(scanner.observe('\x1b[?20')).toEqual({ ready: false, armQuietTimer: false })
+      expect(scanner.observe('04h')).toEqual({ ready: false, armQuietTimer: true })
+      expect(scanner.observe(SHOW_CURSOR)).toEqual({ ready: true, armQuietTimer: false })
+    })
+
     it('detects show-cursor split across a later chunk boundary', () => {
       const scanner = createDraftPasteReadyScanner('render-cursor-after-bracketed-paste')
       scanner.observe(DECSET_BRACKETED_PASTE)

--- a/src/shared/draft-paste-ready-scanner.ts
+++ b/src/shared/draft-paste-ready-scanner.ts
@@ -1,0 +1,89 @@
+import type { DraftPasteReadySignal } from './tui-agent-config'
+
+// Why: agents enable bracketed paste (DECSET 2004) before their composer is
+// actually mounted/focused. These markers let the scanner detect the real
+// "input is ready" moment per agent instead of guessing from output silence.
+const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
+const CODEX_COMPOSER_PROMPT = '›'
+// Why: opencode emits the DECTCEM show-cursor only once the composer row is
+// mounted and the text cursor is placed in it — a "composer ready" signal,
+// analogous to Codex's prompt glyph. It fires ~2s after bracketed paste is
+// enabled, so gating on it (instead of a quiet window) stops the paste from
+// racing the composer mount under slow/noisy startup. mimo-code uses the same
+// signal by parity; the quiet-window fallback covers any agent that differs.
+const DECTCEM_SHOW_CURSOR = '\x1b[?25h'
+
+export type DraftPasteReadyScanResult = {
+  /** The agent-specific ready signal fired — caller should deliver the paste now. */
+  ready: boolean
+  /** Caller should (re)arm the quiet-window fallback timer for this chunk. */
+  armQuietTimer: boolean
+}
+
+/**
+ * Pure, incremental scanner shared by the renderer and main-process draft-paste
+ * readiness waiters so the two delivery paths (desktop-local vs runtime/SSH/
+ * remote) cannot drift. It only parses the PTY byte stream; timers, the PTY
+ * subscription, and resolution stay with each caller because their transports
+ * and return types differ.
+ *
+ * Per agent signal:
+ *   - `codex-composer-prompt`: ready when the `›` glyph renders after DECSET
+ *     2004; never falls back to a quiet window (`armQuietTimer` stays false).
+ *   - `render-cursor-after-bracketed-paste`: ready when DECTCEM show-cursor
+ *     (`\x1b[?25h`) renders after DECSET 2004; on a miss it still arms the
+ *     quiet-window fallback so delivery is never worse than the default.
+ *   - `render-quiet-after-bracketed-paste` (default): no signal marker; arms the
+ *     quiet window once DECSET 2004 is seen.
+ *
+ * A 512-byte ring (`recent` / `postHandshakeRecent`) covers escape sequences
+ * split across chunk boundaries without retaining terminal scrollback.
+ */
+export function createDraftPasteReadyScanner(readySignal: DraftPasteReadySignal): {
+  observe: (data: string) => DraftPasteReadyScanResult
+} {
+  let recent = ''
+  let postHandshakeRecent = ''
+  let saw2004 = false
+
+  const signalMarker =
+    readySignal === 'codex-composer-prompt'
+      ? CODEX_COMPOSER_PROMPT
+      : readySignal === 'render-cursor-after-bracketed-paste'
+        ? DECTCEM_SHOW_CURSOR
+        : null
+
+  return {
+    observe(data: string): DraftPasteReadyScanResult {
+      const combined = recent + data
+      recent = combined.slice(-512)
+      if (!saw2004) {
+        const markerIndex = combined.indexOf(DECSET_BRACKETED_PASTE)
+        if (markerIndex === -1) {
+          return { ready: false, armQuietTimer: false }
+        }
+        saw2004 = true
+        const postHandshakeChunk = combined.slice(markerIndex + DECSET_BRACKETED_PASTE.length)
+        if (signalMarker !== null && postHandshakeChunk.includes(signalMarker)) {
+          return { ready: true, armQuietTimer: false }
+        }
+        postHandshakeRecent = postHandshakeChunk.slice(-512)
+      } else {
+        if (
+          signalMarker !== null &&
+          (data.includes(signalMarker) || (postHandshakeRecent + data).includes(signalMarker))
+        ) {
+          return { ready: true, armQuietTimer: false }
+        }
+        postHandshakeRecent = (postHandshakeRecent + data).slice(-512)
+      }
+      // Why: Codex resolves only on its composer glyph and must never fall back
+      // to a quiet window; every other signal arms the quiet window once
+      // bracketed paste is enabled.
+      if (readySignal === 'codex-composer-prompt') {
+        return { ready: false, armQuietTimer: false }
+      }
+      return { ready: false, armQuietTimer: saw2004 }
+    }
+  }
+}

--- a/src/shared/draft-paste-ready-scanner.ts
+++ b/src/shared/draft-paste-ready-scanner.ts
@@ -29,10 +29,14 @@ export type DraftPasteReadyScanResult = {
  *
  * Per agent signal:
  *   - `codex-composer-prompt`: ready when the `›` glyph renders after DECSET
- *     2004; never falls back to a quiet window (`armQuietTimer` stays false).
+ *     2004; never arms the quiet window (`armQuietTimer` stays false).
  *   - `render-cursor-after-bracketed-paste`: ready when DECTCEM show-cursor
- *     (`\x1b[?25h`) renders after DECSET 2004; on a miss it still arms the
- *     quiet-window fallback so delivery is never worse than the default.
+ *     (`\x1b[?25h`) renders after DECSET 2004. Like Codex it does NOT arm the
+ *     quiet window: opencode stays silent for ~1.5-2s between enabling
+ *     bracketed paste and mounting its composer, so a quiet window would fire
+ *     during that gap and pre-empt the marker. opencode re-emits show-cursor on
+ *     every render frame once mounted, so the marker is effectively guaranteed;
+ *     the caller's hard timeout is the backstop if it never appears.
  *   - `render-quiet-after-bracketed-paste` (default): no signal marker; arms the
  *     quiet window once DECSET 2004 is seen.
  *
@@ -77,13 +81,14 @@ export function createDraftPasteReadyScanner(readySignal: DraftPasteReadySignal)
         }
         postHandshakeRecent = (postHandshakeRecent + data).slice(-512)
       }
-      // Why: Codex resolves only on its composer glyph and must never fall back
-      // to a quiet window; every other signal arms the quiet window once
-      // bracketed paste is enabled.
-      if (readySignal === 'codex-composer-prompt') {
-        return { ready: false, armQuietTimer: false }
-      }
-      return { ready: false, armQuietTimer: saw2004 }
+      // Why: marker-based signals (Codex glyph, opencode show-cursor) must NOT
+      // arm the quiet window. opencode goes silent for ~1.5-2s between enabling
+      // bracketed paste and mounting its composer, so a quiet window would fire
+      // during that gap — before the composer exists — and pre-empt the marker.
+      // These signals wait for their marker, bounded only by the caller's hard
+      // timeout (and the caller's best-effort process-ownership paste after it).
+      // Only the default signal, which has no marker, uses the quiet window.
+      return { ready: false, armQuietTimer: signalMarker === null && saw2004 }
     }
   }
 }

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -8,7 +8,10 @@ export type AgentPromptInjectionMode =
   | 'flag-interactive'
   | 'stdin-after-start'
 
-export type DraftPasteReadySignal = 'render-quiet-after-bracketed-paste' | 'codex-composer-prompt'
+export type DraftPasteReadySignal =
+  | 'render-quiet-after-bracketed-paste'
+  | 'codex-composer-prompt'
+  | 'render-cursor-after-bracketed-paste'
 
 export type TuiAgentConfig = {
   detectCmd: string
@@ -114,13 +117,20 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     detectCmd: 'opencode',
     launchCmd: 'opencode',
     expectedProcess: 'opencode',
-    promptInjectionMode: 'flag-prompt'
+    promptInjectionMode: 'flag-prompt',
+    // Why: opencode enables bracketed paste before its composer mounts; wait
+    // for post-\x1b[?2004h show-cursor (\x1b[?25h) so paste hits mounted input.
+    draftPasteReadySignal: 'render-cursor-after-bracketed-paste'
   },
   'mimo-code': {
     detectCmd: 'mimo',
     launchCmd: 'mimo',
     expectedProcess: 'mimo',
-    promptInjectionMode: 'flag-prompt'
+    promptInjectionMode: 'flag-prompt',
+    // Why: mimo-code shares opencode's flag-prompt paste route, so it gets the
+    // same cursor-gated signal by parity (its startup stream is not separately
+    // validated); the quiet-window fallback bounds the risk if it differs.
+    draftPasteReadySignal: 'render-cursor-after-bracketed-paste'
   },
   pi: {
     detectCmd: 'pi',

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -5,6 +5,7 @@ import {
   buildAgentStartupPlan,
   buildShellCommandFromArgv
 } from './tui-agent-startup'
+import { TUI_AGENT_CONFIG } from './tui-agent-config'
 import { normalizeTuiAgentArgsRecord, resolveTuiAgentLaunchArgs } from './tui-agent-launch-defaults'
 
 describe('tui agent startup plans', () => {
@@ -334,6 +335,37 @@ describe('tui agent startup plans', () => {
     })
 
     expect(plan?.launchCommand).toBe("opencode --prompt 'fix it'")
+  })
+
+  it('keeps opencode and mimo-code on the cursor-gated paste draft route', () => {
+    expect(TUI_AGENT_CONFIG.opencode.draftPasteReadySignal).toBe(
+      'render-cursor-after-bracketed-paste'
+    )
+    expect(TUI_AGENT_CONFIG.opencode.draftPromptFlag).toBeUndefined()
+    expect(TUI_AGENT_CONFIG.opencode.draftPromptEnvVar).toBeUndefined()
+    expect(TUI_AGENT_CONFIG['mimo-code'].draftPasteReadySignal).toBe(
+      'render-cursor-after-bracketed-paste'
+    )
+    expect(TUI_AGENT_CONFIG['mimo-code'].draftPromptFlag).toBeUndefined()
+    expect(TUI_AGENT_CONFIG['mimo-code'].draftPromptEnvVar).toBeUndefined()
+    // Why: no native draft launch plan means both agents fall through to the
+    // cursor-gated paste-after-ready route, where the new signal applies.
+    expect(
+      buildAgentDraftLaunchPlan({
+        agent: 'opencode',
+        draft: 'x',
+        cmdOverrides: {},
+        platform: 'darwin'
+      })
+    ).toBeNull()
+    expect(
+      buildAgentDraftLaunchPlan({
+        agent: 'mimo-code',
+        draft: 'x',
+        cmdOverrides: {},
+        platform: 'darwin'
+      })
+    ).toBeNull()
   })
 
   it('appends Kiro trust defaults to the chat subcommand that accepts them', () => {


### PR DESCRIPTION
## What changes

"Start workspace from issue" seeds the issue URL as an **editable, unsubmitted draft** and pastes it into the launched agent's composer once the TUI is ready. For **opencode** (and other flag-prompt agents with no prefill flag, e.g. `mimo-code`) that draft frequently never arrived. This PR makes it land reliably, while keeping it editable and unsubmitted.

## What does NOT change

The draft is still **editable and unsubmitted** — opencode is **not** launched with `--prompt` (that would auto-submit the URL immediately). The user still reviews the seeded prompt and presses Enter, exactly as with Claude/codex. No agent's submit behavior changes.

## Root cause

Readiness for paste-after-ready used a quiet-output window after bracketed paste was enabled (DECSET 2004, `\x1b[?2004h`). Measured against real opencode v1.17.11: opencode enables bracketed paste at ~1.4s but its composer doesn't mount until ~3.4s. The 1500ms quiet window therefore resolves at ~2.9s — **~450ms before the composer exists** — so the paste lands in a not-yet-mounted input. A slow setup script churning output keeps resetting the quiet timer until the readiness wait hits its 8s hard timeout and the URL is dropped entirely. This matches the report: with a 20–30s setup script the prompt "often doesn't arrive."

## Fix

Gate opencode's paste on the DECTCEM show-cursor (`\x1b[?25h`) emitted **after** bracketed-paste-enable — the point where opencode's composer row is mounted and focused (analogous to Codex's `›` composer-prompt signal). Crucially, this signal must **not** also arm the quiet window: opencode goes *silent* during the ~1.5–2s between enabling bracketed paste and mounting its composer, so a quiet window armed on that gap fires ~200–400ms **before** the composer exists and pre-empts the cursor signal (this was caught by A/B testing the real opencode CLI end to end, and an earlier revision of this PR had exactly that bug). The cursor signal therefore waits only for its marker, bounded by the existing hard timeout plus the caller's best-effort process-ownership paste — the same model Codex uses. opencode re-emits show-cursor on every render frame once mounted, so the marker is effectively guaranteed.

The readiness scanner was **duplicated**: one copy in the renderer (`waitForAgentDraftInputReady`, desktop-local delivery) and one in the main process (`waitForStartupDraftReady` in `orca-runtime.ts`, the delivery path for runtime/SSH/remote-owned worktrees and mobile "Start workspace from issue"). A renderer-only fix would have been inert on the SSH/remote path. This PR extracts a single pure scanner — `createDraftPasteReadyScanner` in `src/shared/` — that both waiters consume, so the fix applies to every delivery surface and the two copies can't drift again.

## Design approach

Investigated the delivery path end to end, wrote a design doc (scratch, not shipped), and ran it through design review before implementing. The auto-submit-vs-editable-draft decision was surfaced and resolved as **keep editable draft + harden readiness** before any code was written. Empirically grounded the choice with a node-pty probe (`opencode --prompt` auto-submits) and confirmed the new signal with a headless terminal-grid render (URL lands in the editable composer, placeholder replaced, not submitted).

## Design-review outcome

Design review converged clean after hardening two points: the fallback must not be starved (the new signal falls through to arm the quiet timer on a miss, unlike Codex's early-return), and the existing default-path test must keep coverage (re-targeted to a still-default agent rather than deleted).

## Implementation & deviations

Implemented exactly as designed. One addition beyond the original doc, surfaced by code review: extracting the shared scanner (instead of editing the renderer only) so the runtime/SSH/remote/mobile path is also fixed. No other deviations.

## Completeness verification

Verified the full path: issue URL → `draftPrompt` (empty `prompt`, so no `--prompt`) → `pasteDraftToAgentPtyWhenReady` (`forcePaste: true`, no `submit`) → shared scanner gating on `\x1b[?25h`. Submit stays false end to end. opencode + mimo-code both route through the paste path (no native prefill flag/env). Other agents (Claude, codex, gemini, pi, …) are byte-for-byte unchanged.

## Headline behavior status

**Implemented.** Production code delivers the editable, unsubmitted issue draft into opencode's composer reliably, on both the already-ready and racing-fresh-startup cases.

## Broad app consistency

Source-of-truth behavior is "deliver a seeded prompt into the agent composer as an editable, unsubmitted draft," shared by all draft-seeding surfaces (quick "Start workspace from issue", new-workspace composer, direct work-item launch) which all funnel through the readiness waiter. Fixing the shared scanner fixes opencode across all of them at once. No surface special-cases opencode, so there was no divergence to reconcile. Codex (its own signal) and the quiet-window default agents (gemini/cursor/copilot/stdin agents) are intentionally untouched.

## Risks, ambiguities, non-goals

- **Non-goal — auto-submit.** Deliberately not using `--prompt`. The draft stays editable.
- **mimo-code is parity-based.** It shares opencode's exact flag-prompt paste route and failure mode, so it gets the same signal, but its startup stream was not separately validated (binary not installed in the dev env). The quiet-window fallback bounds the risk if it differs.
- **Fallback is a bound, not a guarantee.** If a future opencode/terminal both drops `\x1b[?25h` *and* leaves a long silent pre-composer gap, the quiet window can still fire early — exactly as today. The change strictly improves the common case and never regresses it.
- **`\x1b[?25h` matching** cannot collide with `\x1b[?25l` (hide) or compound sequences like `\x1b[?25;1049h` (terminator differs), and is only honored after `\x1b[?2004h`, so pre-composer cursor toggles don't trip it.

## Perf

Audited the touched hot path (the per-PTY-chunk `observe`). The 512-byte ring bounds are preserved, no O(n²) growth, no new timer churn, subscription/timer teardown unchanged, and zero added cost for agents not using the new signal. No measurement needed; verdict: no perf concerns.

## Code-review loop

Two rounds, two independent reviewers each. Round 1 both reviewers independently flagged one P0 — the un-updated main-process scanner copy (SSH/remote path); fixed by the shared-scanner extraction. Round 2 both reviewers returned clean (byte-for-byte behavior preservation verified across all three signals); two minor advisory nits (docstring wording for mimo-code, an extra replay-path test) were addressed.

## Validation (merge confidence)

- **A/B against the real opencode CLI (v1.17.11)**, end to end: spawned opencode under node-pty, fed its real startup stream through the actual shipped scanner (compiled from source), pasted at the moment each logic reported "ready", and rendered the final terminal grid with `@xterm/headless`. Result — **old quiet-window logic: URL dropped** (resolves before composer mounts); **new cursor-gated logic: URL lands in the editable, unsubmitted composer**, on both clean and noisy (render-churn) startups, repeatably. This test is what surfaced and then confirmed the fix to the quiet-window pre-emption bug above.
- **Live Electron**, against real opencode v1.17.11 inside a dev Orca instance: invoked the production `pasteDraftToAgentPtyWhenReady` with `agent: 'opencode'`. The issue URL landed in opencode's composer, unsubmitted (agent stayed "Idle"), both against an already-ready opencode and when racing a freshly-relaunched opencode. Screenshot evidence captured.
- **Unit**: shared-scanner tests cover all three signals, cross-chunk split (handshake and cursor), the silent-gap-no-quiet-window case, hide-cursor non-match, pre-handshake ignore, and the SSH/remote replay-buffer case; renderer delivery tests (including "best-effort paste at hard timeout" and "no quiet-window paste") and config invariants updated/added. 77 touched-module tests + 512 `orca-runtime` tests pass.

**Validation gap (stated honestly):** the live UI run exercised the renderer/local desktop path. The runtime/SSH/remote and mobile paths use the same shared scanner but were validated via unit tests + byte-for-byte behavior-preservation review, not a live remote run (no SSH remote available in the dev env).

## Static checks

Node + web typecheck clean (no new errors; one unrelated pre-existing TS error in `useSessionRestoredBannerDismiss.test.tsx` exists on the base branch). oxlint and switch-exhaustiveness clean.
