### PR TITLE
Prevent sleeping agents from getting stranded in stale terminals

### DIFF
--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -547,8 +547,18 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('launches once and clears skipped duplicates for the same provider session', () => {
-    const first = makeRecord({ paneKey: 'tab-1:leaf-1', capturedAt: 1, updatedAt: 1 })
-    const duplicate = makeRecord({ paneKey: 'tab-2:leaf-1', capturedAt: 2, updatedAt: 2 })
+    const first = makeRecord({
+      paneKey: 'tab-1:leaf-1',
+      capturedAt: 1,
+      updatedAt: 1,
+      launchConfig: { agentArgs: '--older', agentEnv: {} }
+    })
+    const duplicate = makeRecord({
+      paneKey: 'tab-2:leaf-1',
+      capturedAt: 2,
+      updatedAt: 2,
+      launchConfig: { agentArgs: '--newer', agentEnv: {} }
+    })
     useAppStore.setState({
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: {
@@ -562,6 +572,10 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     const state = useAppStore.getState()
     expect(launched).toBe(1)
     expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.launchConfig).toMatchObject({
+      agentArgs: '--newer'
+    })
     expect(state.sleepingAgentSessionsByPaneKey[first.paneKey]).toBeUndefined()
     expect(state.sleepingAgentSessionsByPaneKey[duplicate.paneKey]).toBeUndefined()
   })

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -72,6 +72,15 @@ function makeSplitLayout(
   }
 }
 
+function makeActiveTerminalState(tabId: string, worktreeId = 'wt-1'): Record<string, unknown> {
+  return {
+    activeWorktreeId: worktreeId,
+    activeTabType: 'terminal',
+    activeTabId: tabId,
+    activeTabIdByWorktree: { [worktreeId]: tabId }
+  }
+}
+
 describe('resumeSleepingAgentSessionsForWorktree', () => {
   it('resumes quit-captured records when no preserved pane can own recovery', () => {
     const record = makeRecord({ origin: 'quit' })
@@ -128,6 +137,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     const paneKey = makePaneKey('tab-1', LEAF_ID)
     const record = makeRecord({ paneKey, origin: 'worktree-sleep' })
     useAppStore.setState({
+      ...makeActiveTerminalState('tab-1'),
       tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
       terminalLayoutsByTabId: { 'tab-1': makeLayout(LEAF_ID) },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
@@ -141,10 +151,230 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
   })
 
+  it('skips active stable-pane records owned by a single-leaf tab-level wake hint', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const record = makeRecord({ paneKey, origin: 'worktree-sleep' })
+    useAppStore.setState({
+      ...makeActiveTerminalState('tab-1'),
+      tabsByWorktree: {
+        'wt-1': [{ ...makeTerminalTab('tab-1', 'wt-1'), ptyId: 'tab-level-wake-hint' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('skips active stable-pane records owned by a folder workspace active terminal', () => {
+    const worktreeId = 'folder:folder-1'
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const record = makeRecord({ paneKey, worktreeId, origin: 'worktree-sleep' })
+    useAppStore.setState({
+      ...makeActiveTerminalState('tab-1', worktreeId),
+      tabsByWorktree: { [worktreeId]: [makeTerminalTab('tab-1', worktreeId)] },
+      terminalLayoutsByTabId: { 'tab-1': makeLayout(LEAF_ID) },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree(worktreeId)
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree[worktreeId]).toHaveLength(1)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('resumes active worktree-sleep stable-pane records when the preserved tab is hidden during activation', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const record = makeRecord({ paneKey, origin: 'worktree-sleep' })
+    useAppStore.setState({
+      ...makeActiveTerminalState('tab-2'),
+      tabsByWorktree: {
+        'wt-1': [makeTerminalTab('tab-1', 'wt-1'), makeTerminalTab('tab-2', 'wt-1')]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': makeLayout(LEAF_ID),
+        'tab-2': makeLayout(OTHER_LEAF_ID, 'pty-2')
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.find(
+      (tab) => tab.id !== 'tab-1' && tab.id !== 'tab-2'
+    )
+    expect(launched).toBe(1)
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.showSessionRestoredBanner).toBe(true)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('rechecks pane ownership after an earlier fresh resume activates a new terminal', () => {
+    const initiallyUnownedPaneKey = makePaneKey('missing-tab', OTHER_LEAF_ID)
+    const initiallyOwnedPaneKey = makePaneKey('tab-active', LEAF_ID)
+    const initiallyUnowned = makeRecord({
+      paneKey: initiallyUnownedPaneKey,
+      tabId: 'missing-tab',
+      origin: 'worktree-sleep',
+      providerSession: { key: 'session_id', id: 'sess-first' },
+      capturedAt: 1,
+      updatedAt: 1
+    })
+    const initiallyOwned = makeRecord({
+      paneKey: initiallyOwnedPaneKey,
+      tabId: 'tab-active',
+      origin: 'worktree-sleep',
+      providerSession: { key: 'session_id', id: 'sess-second' },
+      capturedAt: 2,
+      updatedAt: 2
+    })
+    useAppStore.setState({
+      ...makeActiveTerminalState('tab-active'),
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-active', 'wt-1')] },
+      terminalLayoutsByTabId: { 'tab-active': makeLayout(LEAF_ID) },
+      sleepingAgentSessionsByPaneKey: {
+        [initiallyUnowned.paneKey]: initiallyUnowned,
+        [initiallyOwned.paneKey]: initiallyOwned
+      }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    const resumedTabs = (state.tabsByWorktree['wt-1'] ?? []).filter(
+      (tab) => tab.id !== 'tab-active'
+    )
+    expect(launched).toBe(2)
+    expect(resumedTabs).toHaveLength(2)
+    expect(Object.keys(state.pendingStartupByTabId)).toHaveLength(2)
+    expect(state.sleepingAgentSessionsByPaneKey[initiallyUnowned.paneKey]).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[initiallyOwned.paneKey]).toBeUndefined()
+  })
+
+  it('skips active stable-pane records in an inactive split leaf of the active terminal tab', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const record = makeRecord({ paneKey, origin: 'worktree-sleep' })
+    const layout = {
+      ...makeSplitLayout(LEAF_ID, OTHER_LEAF_ID, {
+        [LEAF_ID]: 'pty-1',
+        [OTHER_LEAF_ID]: 'pty-2'
+      }),
+      activeLeafId: OTHER_LEAF_ID
+    }
+    useAppStore.setState({
+      ...makeActiveTerminalState('tab-1'),
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
+      terminalLayoutsByTabId: { 'tab-1': layout },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('skips active stable-pane records owned by a visible non-focused split-group terminal', () => {
+    const paneKey = makePaneKey('tab-right', LEAF_ID)
+    const record = makeRecord({ paneKey, tabId: 'tab-right', origin: 'worktree-sleep' })
+    useAppStore.setState({
+      ...makeActiveTerminalState('tab-left'),
+      activeGroupIdByWorktree: { 'wt-1': 'group-left' },
+      groupsByWorktree: {
+        'wt-1': [
+          { id: 'group-left', worktreeId: 'wt-1', activeTabId: 'unified-left', tabOrder: [] },
+          { id: 'group-right', worktreeId: 'wt-1', activeTabId: 'unified-right', tabOrder: [] }
+        ]
+      },
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'unified-left',
+            entityId: 'tab-left',
+            worktreeId: 'wt-1',
+            groupId: 'group-left',
+            contentType: 'terminal'
+          },
+          {
+            id: 'unified-right',
+            entityId: 'tab-right',
+            worktreeId: 'wt-1',
+            groupId: 'group-right',
+            contentType: 'terminal'
+          }
+        ]
+      },
+      layoutByWorktree: {
+        'wt-1': {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', groupId: 'group-left' },
+          second: { type: 'leaf', groupId: 'group-right' },
+          ratio: 0.5
+        }
+      },
+      tabsByWorktree: {
+        'wt-1': [makeTerminalTab('tab-left', 'wt-1'), makeTerminalTab('tab-right', 'wt-1')]
+      },
+      terminalLayoutsByTabId: { 'tab-right': makeLayout(LEAF_ID) },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(2)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('resumes active worktree-sleep stable-pane records when the preserved leaf has no PTY to cold-restore', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const record = makeRecord({ paneKey, origin: 'worktree-sleep' })
+    useAppStore.setState({
+      ...makeActiveTerminalState('tab-1'),
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.find((tab) => tab.id !== 'tab-1')
+    expect(launched).toBe(1)
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.showSessionRestoredBanner).toBe(true)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
   it('resumes live stable-pane records when the preserved leaf has no PTY to cold-restore', () => {
     const paneKey = makePaneKey('tab-1', LEAF_ID)
     const record = makeRecord({ paneKey, origin: 'live' })
     useAppStore.setState({
+      ...makeActiveTerminalState('tab-1'),
       tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
       terminalLayoutsByTabId: {
         'tab-1': {
@@ -217,6 +447,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   it('skips legacy numeric pane-key records owned by a preserved tab wake hint', () => {
     const record = makeRecord({ paneKey: 'tab-1:0', origin: 'worktree-sleep' })
     useAppStore.setState({
+      ...makeActiveTerminalState('tab-1'),
       tabsByWorktree: {
         'wt-1': [{ ...makeTerminalTab('tab-1', 'wt-1'), ptyId: 'wake-hint' }]
       },
@@ -347,6 +578,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       updatedAt: 2
     })
     useAppStore.setState({
+      ...makeActiveTerminalState('tab-1'),
       tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
       terminalLayoutsByTabId: { 'tab-1': makeLayout(LEAF_ID) },
       sleepingAgentSessionsByPaneKey: {
@@ -376,6 +608,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       updatedAt: 2
     })
     useAppStore.setState({
+      ...makeActiveTerminalState('tab-1'),
       tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
       terminalLayoutsByTabId: { 'tab-1': makeLayout(LEAF_ID) },
       sleepingAgentSessionsByPaneKey: {
@@ -391,6 +624,56 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
     expect(state.sleepingAgentSessionsByPaneKey[owned.paneKey]).toBe(owned)
     expect(state.sleepingAgentSessionsByPaneKey[stale.paneKey]).toBeUndefined()
+  })
+
+  it('does not let completed same-provider hibernation evidence launch before an active fresh resume', () => {
+    const completedPaneKey = makePaneKey('tab-completed', OTHER_LEAF_ID)
+    const activePaneKey = makePaneKey('tab-active', LEAF_ID)
+    const completed = makeRecord({
+      paneKey: completedPaneKey,
+      tabId: 'tab-completed',
+      origin: 'worktree-sleep',
+      state: 'done',
+      capturedAt: 1,
+      updatedAt: 1,
+      launchConfig: { agentArgs: '--completed', agentEnv: {} }
+    })
+    const active = makeRecord({
+      paneKey: activePaneKey,
+      tabId: 'tab-active',
+      origin: 'worktree-sleep',
+      capturedAt: 2,
+      updatedAt: 2,
+      launchConfig: { agentArgs: '--active', agentEnv: {} }
+    })
+    useAppStore.setState({
+      ...makeActiveTerminalState('tab-active'),
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-active', 'wt-1')] },
+      terminalLayoutsByTabId: {
+        'tab-active': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null
+        }
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [completed.paneKey]: completed,
+        [active.paneKey]: active
+      }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.find((tab) => tab.id !== 'tab-active')
+    expect(launched).toBe(1)
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.showSessionRestoredBanner).toBe(true)
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.launchConfig).toMatchObject({
+      agentArgs: '--active'
+    })
+    expect(state.sleepingAgentSessionsByPaneKey[completed.paneKey]).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[active.paneKey]).toBeUndefined()
   })
 
   it('does not let invalid pane-owned records block a valid duplicate resume', () => {
@@ -453,7 +736,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 
-  it('resumes intentional completed worktree-sleep records', () => {
+  it('clears completed worktree-sleep records without preserved panes instead of resuming', () => {
     const record = makeRecord({ origin: 'worktree-sleep', state: 'done' })
     useAppStore.setState({
       tabsByWorktree: { 'wt-1': [] },
@@ -462,9 +745,11 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
 
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
 
-    expect(launched).toBe(1)
-    expect(useAppStore.getState().tabsByWorktree['wt-1']?.[0]?.launchAgent).toBe('claude')
-    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toEqual([])
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 
   it('clears stale manual records without launching a tab', () => {

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -140,6 +140,24 @@ function getCurrentPaneOwnedClaimKeys(records: readonly SleepingAgentSessionReco
   return keys
 }
 
+function getNewestActiveRecordsByClaimKey(
+  records: readonly SleepingAgentSessionRecord[]
+): Map<string, SleepingAgentSessionRecord> {
+  const newestRecords = new Map<string, SleepingAgentSessionRecord>()
+  for (const record of records) {
+    const claimKey = getProviderSessionClaimKey(record)
+    const current = newestRecords.get(claimKey)
+    if (
+      !current ||
+      record.capturedAt > current.capturedAt ||
+      (record.capturedAt === current.capturedAt && record.updatedAt > current.updatedAt)
+    ) {
+      newestRecords.set(claimKey, record)
+    }
+  }
+  return newestRecords
+}
+
 function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
   if (record.interrupted === true) {
     return true
@@ -164,6 +182,7 @@ export function resumeSleepingAgentSessionsForWorktree(worktreeId: string): numb
     (record) => !isPassiveCompletedHibernationEvidence(record)
   )
   const activeClaimKeys = new Set(activeWorktreeRecords.map(getProviderSessionClaimKey))
+  const newestActiveRecordByClaimKey = getNewestActiveRecordsByClaimKey(activeWorktreeRecords)
   const freshlyLaunchedClaimKeys = new Set<string>()
 
   let launched = 0
@@ -186,15 +205,19 @@ export function resumeSleepingAgentSessionsForWorktree(worktreeId: string): numb
       }
       continue
     }
-    if (freshlyLaunchedClaimKeys.has(claimKey)) {
-      state.clearSleepingAgentSession(record.paneKey)
-      continue
-    }
     const paneOwnedClaimKeys = getCurrentPaneOwnedClaimKeys(activeWorktreeRecords)
     if (paneOwnedClaimKeys.has(claimKey)) {
       if (!isPaneOwned) {
         state.clearSleepingAgentSession(record.paneKey)
       }
+      continue
+    }
+    if (freshlyLaunchedClaimKeys.has(claimKey)) {
+      state.clearSleepingAgentSession(record.paneKey)
+      continue
+    }
+    if (newestActiveRecordByClaimKey.get(claimKey) !== record) {
+      state.clearSleepingAgentSession(record.paneKey)
       continue
     }
     if (isPaneOwned) {

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -11,14 +11,13 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
-import type {
-  TerminalLayoutSnapshot,
-  TerminalPaneLayoutNode,
-  TerminalTab
-} from '../../../shared/types'
-import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { translate } from '@/i18n/i18n'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
+import {
+  getProviderSessionClaimKey,
+  isPassiveCompletedHibernationEvidence,
+  recordPaneIsOwnedByPreservedPane
+} from './sleeping-agent-pane-ownership'
 
 function getResumeLaunchPlatform(worktreeId: string): NodeJS.Platform {
   const state = useAppStore.getState()
@@ -107,131 +106,38 @@ function launchSleepingAgentSession(record: SleepingAgentSessionRecord): boolean
   return true
 }
 
-function getProviderSessionClaimKey(record: SleepingAgentSessionRecord): string {
-  return [
-    record.worktreeId,
-    record.agent,
-    record.providerSession.key,
-    record.providerSession.id
-  ].join('\0')
-}
-
-function getLegacyPaneTabId(record: SleepingAgentSessionRecord): string | null {
-  const legacy = parseLegacyNumericPaneKey(record.paneKey)
-  if (!legacy || (record.tabId && record.tabId !== legacy.tabId)) {
-    return null
+function clearPassiveCompletedRecordsForClaimKey(
+  records: readonly SleepingAgentSessionRecord[],
+  claimKey: string,
+  keepPaneKey: string
+): void {
+  const state = useAppStore.getState()
+  for (const record of records) {
+    if (record.paneKey === keepPaneKey || !isPassiveCompletedHibernationEvidence(record)) {
+      continue
+    }
+    if (getProviderSessionClaimKey(record) === claimKey) {
+      state.clearSleepingAgentSession(record.paneKey)
+    }
   }
-  return record.tabId ?? legacy.tabId
 }
 
-function getLegacyProviderSessionKeysForTab(
-  state: ReturnType<typeof useAppStore.getState>,
-  worktreeId: string,
-  tabId: string
-): Set<string> {
+function getCurrentPaneOwnedClaimKeys(records: readonly SleepingAgentSessionRecord[]): Set<string> {
+  const state = useAppStore.getState()
   const keys = new Set<string>()
-  for (const record of Object.values(state.sleepingAgentSessionsByPaneKey)) {
-    if (record.worktreeId === worktreeId && getLegacyPaneTabId(record) === tabId) {
+  for (const record of records) {
+    if (
+      state.sleepingAgentSessionsByPaneKey[record.paneKey] !== record ||
+      isInvalidWorktreeActivationRecord(record) ||
+      isPassiveCompletedHibernationEvidence(record)
+    ) {
+      continue
+    }
+    if (recordPaneIsOwnedByPreservedPane(record, state)) {
       keys.add(getProviderSessionClaimKey(record))
     }
   }
   return keys
-}
-
-function hasRestorableLegacyTabPty(
-  tab: TerminalTab,
-  ptyIdsByTabId: Record<string, string[] | undefined>
-): boolean {
-  return Boolean(tab.ptyId) || (ptyIdsByTabId[tab.id]?.length ?? 0) > 0
-}
-
-function layoutContainsLeaf(
-  node: TerminalPaneLayoutNode | null | undefined,
-  leafId: string
-): boolean {
-  if (!node) {
-    return false
-  }
-  if (node.type === 'leaf') {
-    return node.leafId === leafId
-  }
-  return layoutContainsLeaf(node.first, leafId) || layoutContainsLeaf(node.second, leafId)
-}
-
-function hasMatchingStablePaneLayout(
-  tabId: string,
-  leafId: string,
-  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
-): boolean {
-  // Why: hibernation intentionally clears the live PTY binding after the pane
-  // exits, but the preserved leaf still owns cold-restore for its session.
-  return layoutContainsLeaf(terminalLayoutsByTabId[tabId]?.root, leafId)
-}
-
-function hasRestorableStablePanePty(
-  tab: TerminalTab,
-  tabId: string,
-  leafId: string,
-  ptyIdsByTabId: Record<string, string[] | undefined>,
-  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
-): boolean {
-  const layout = terminalLayoutsByTabId[tabId]
-  const hasLeafPty = Boolean(layout?.ptyIdsByLeafId?.[leafId])
-  const isSingleLeafLayout = layout?.root?.type === 'leaf' && layout.root.leafId === leafId
-
-  return Boolean(
-    hasLeafPty || (isSingleLeafLayout && (tab.ptyId || (ptyIdsByTabId[tabId]?.length ?? 0) > 0))
-  )
-}
-
-function findSameWorktreeTab(
-  worktreeTabs: readonly TerminalTab[],
-  tabId: string
-): TerminalTab | null {
-  return worktreeTabs.find((tab) => tab.id === tabId) ?? null
-}
-
-function recordPaneIsOwnedByPreservedPane(
-  record: SleepingAgentSessionRecord,
-  state: ReturnType<typeof useAppStore.getState>
-): boolean {
-  const worktreeTabs = state.tabsByWorktree[record.worktreeId] ?? []
-  const stable = parsePaneKey(record.paneKey)
-  if (stable) {
-    if (record.tabId && record.tabId !== stable.tabId) {
-      return false
-    }
-    const tabId = record.tabId ?? stable.tabId
-    const tab = findSameWorktreeTab(worktreeTabs, tabId)
-    if (!tab || !hasMatchingStablePaneLayout(tabId, stable.leafId, state.terminalLayoutsByTabId)) {
-      return false
-    }
-    if (record.origin !== 'quit' && record.origin !== 'live') {
-      return true
-    }
-    // Why: live/quit captures rely on pane-level cold restore. A preserved
-    // leaf without a PTY/session id can repaint scrollback but cannot resume.
-    return hasRestorableStablePanePty(
-      tab,
-      tabId,
-      stable.leafId,
-      state.ptyIdsByTabId,
-      state.terminalLayoutsByTabId
-    )
-  }
-
-  const tabId = getLegacyPaneTabId(record)
-  if (!tabId) {
-    return false
-  }
-  const tab = findSameWorktreeTab(worktreeTabs, tabId)
-  const providerKeys = getLegacyProviderSessionKeysForTab(state, record.worktreeId, tabId)
-  // Why: legacy numeric pane keys lack leaf identity, so only a preserved
-  // tab-level wake hint plus a single provider session is strong enough to
-  // claim pane recovery without risking the wrong split-pane session.
-  return Boolean(
-    tab && hasRestorableLegacyTabPty(tab, state.ptyIdsByTabId) && providerKeys.size === 1
-  )
 }
 
 function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
@@ -251,30 +157,53 @@ export function resumeSleepingAgentSessionsForWorktree(worktreeId: string): numb
   const worktreeRecords = Object.values(state.sleepingAgentSessionsByPaneKey)
     .filter((record) => record.worktreeId === worktreeId)
     .sort((a, b) => a.capturedAt - b.capturedAt || a.updatedAt - b.updatedAt)
-
-  const paneOwnedClaimKeys = new Set(
-    worktreeRecords
-      .filter((record) => !isInvalidWorktreeActivationRecord(record))
-      .filter((record) => recordPaneIsOwnedByPreservedPane(record, state))
-      .map(getProviderSessionClaimKey)
+  const validWorktreeRecords = worktreeRecords.filter(
+    (record) => !isInvalidWorktreeActivationRecord(record)
   )
+  const activeWorktreeRecords = validWorktreeRecords.filter(
+    (record) => !isPassiveCompletedHibernationEvidence(record)
+  )
+  const activeClaimKeys = new Set(activeWorktreeRecords.map(getProviderSessionClaimKey))
+  const freshlyLaunchedClaimKeys = new Set<string>()
 
   let launched = 0
   for (const record of worktreeRecords) {
+    const currentState = useAppStore.getState()
+    if (currentState.sleepingAgentSessionsByPaneKey[record.paneKey] !== record) {
+      continue
+    }
     const claimKey = getProviderSessionClaimKey(record)
     if (isInvalidWorktreeActivationRecord(record)) {
       state.clearSleepingAgentSession(record.paneKey)
       continue
     }
-    if (paneOwnedClaimKeys.has(claimKey)) {
-      if (!recordPaneIsOwnedByPreservedPane(record, state)) {
+    const isPaneOwned = recordPaneIsOwnedByPreservedPane(record, currentState)
+    if (isPassiveCompletedHibernationEvidence(record)) {
+      // Why: completed-agent hibernation is passive history; activation should
+      // only keep displayable evidence, never start new work from it.
+      if (!isPaneOwned || activeClaimKeys.has(claimKey)) {
         state.clearSleepingAgentSession(record.paneKey)
       }
       continue
     }
+    if (freshlyLaunchedClaimKeys.has(claimKey)) {
+      state.clearSleepingAgentSession(record.paneKey)
+      continue
+    }
+    const paneOwnedClaimKeys = getCurrentPaneOwnedClaimKeys(activeWorktreeRecords)
+    if (paneOwnedClaimKeys.has(claimKey)) {
+      if (!isPaneOwned) {
+        state.clearSleepingAgentSession(record.paneKey)
+      }
+      continue
+    }
+    if (isPaneOwned) {
+      continue
+    }
     if (launchSleepingAgentSession(record)) {
       launched += 1
-      paneOwnedClaimKeys.add(claimKey)
+      freshlyLaunchedClaimKeys.add(claimKey)
+      clearPassiveCompletedRecordsForClaimKey(worktreeRecords, claimKey, record.paneKey)
     }
   }
   return launched

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -1,0 +1,149 @@
+import type { useAppStore } from '@/store'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import type {
+  TerminalLayoutSnapshot,
+  TerminalPaneLayoutNode,
+  TerminalTab
+} from '../../../shared/types'
+import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
+
+type AppStoreState = ReturnType<typeof useAppStore.getState>
+
+export function getProviderSessionClaimKey(record: SleepingAgentSessionRecord): string {
+  return `${record.worktreeId}\0${record.agent}\0${record.providerSession.key}\0${record.providerSession.id}`
+}
+
+export function isPassiveCompletedHibernationEvidence(record: SleepingAgentSessionRecord): boolean {
+  return record.origin !== 'quit' && record.origin !== 'live' && record.state === 'done'
+}
+
+function getLegacyPaneTabId(record: SleepingAgentSessionRecord): string | null {
+  const legacy = parseLegacyNumericPaneKey(record.paneKey)
+  if (!legacy || (record.tabId && record.tabId !== legacy.tabId)) {
+    return null
+  }
+  return record.tabId ?? legacy.tabId
+}
+
+function getLegacyProviderSessionKeysForTab(
+  state: AppStoreState,
+  worktreeId: string,
+  tabId: string
+): Set<string> {
+  const keys = new Set<string>()
+  for (const record of Object.values(state.sleepingAgentSessionsByPaneKey)) {
+    if (record.worktreeId === worktreeId && getLegacyPaneTabId(record) === tabId) {
+      keys.add(getProviderSessionClaimKey(record))
+    }
+  }
+  return keys
+}
+
+function layoutContainsLeaf(
+  node: TerminalPaneLayoutNode | null | undefined,
+  leafId: string
+): boolean {
+  return Boolean(
+    node &&
+    (node.type === 'leaf'
+      ? node.leafId === leafId
+      : layoutContainsLeaf(node.first, leafId) || layoutContainsLeaf(node.second, leafId))
+  )
+}
+
+function hasMatchingStablePaneLayout(
+  tabId: string,
+  leafId: string,
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
+): boolean {
+  // Why: hibernation intentionally clears the live PTY binding after the pane
+  // exits, but the preserved leaf still owns cold-restore for its session.
+  return layoutContainsLeaf(terminalLayoutsByTabId[tabId]?.root, leafId)
+}
+
+function hasRestorableStablePanePty(
+  tab: TerminalTab,
+  tabId: string,
+  leafId: string,
+  ptyIdsByTabId: Record<string, string[] | undefined>,
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
+): boolean {
+  const layout = terminalLayoutsByTabId[tabId]
+  const hasLeafPty = Boolean(layout?.ptyIdsByLeafId?.[leafId])
+  const isSingleLeafLayout = layout?.root?.type === 'leaf' && layout.root.leafId === leafId
+
+  return Boolean(
+    hasLeafPty || (isSingleLeafLayout && (tab.ptyId || (ptyIdsByTabId[tabId]?.length ?? 0) > 0))
+  )
+}
+
+function paneWillConnectOnActivation(
+  worktreeId: string,
+  tabId: string,
+  state: AppStoreState
+): boolean {
+  if (state.activeWorktreeId !== worktreeId) {
+    return false
+  }
+  if (state.activeTabType === 'terminal' && state.activeTabId === tabId) {
+    return true
+  }
+  // Why: split groups can show multiple terminal tabs at once; each group's
+  // active terminal mounts and connects even when another group has focus.
+  const groups = state.groupsByWorktree[worktreeId] ?? []
+  const unifiedTabs = state.unifiedTabsByWorktree[worktreeId] ?? []
+  return groups.some((group) => {
+    const tab = group.activeTabId
+      ? unifiedTabs.find((candidate) => candidate.id === group.activeTabId)
+      : null
+    return tab?.contentType === 'terminal' && tab.entityId === tabId
+  })
+}
+
+export function recordPaneIsOwnedByPreservedPane(
+  record: SleepingAgentSessionRecord,
+  state: AppStoreState
+): boolean {
+  const worktreeTabs = state.tabsByWorktree[record.worktreeId] ?? []
+  const stable = parsePaneKey(record.paneKey)
+  if (stable) {
+    if (record.tabId && record.tabId !== stable.tabId) {
+      return false
+    }
+    const tabId = record.tabId ?? stable.tabId
+    const tab = worktreeTabs.find((candidate) => candidate.id === tabId) ?? null
+    if (!tab || !hasMatchingStablePaneLayout(tabId, stable.leafId, state.terminalLayoutsByTabId)) {
+      return false
+    }
+    if (isPassiveCompletedHibernationEvidence(record)) {
+      return true
+    }
+    // Why: active sessions rely on pane-level cold restore. A preserved leaf
+    // without a PTY/session id can repaint scrollback but cannot resume.
+    return (
+      hasRestorableStablePanePty(
+        tab,
+        tabId,
+        stable.leafId,
+        state.ptyIdsByTabId,
+        state.terminalLayoutsByTabId
+      ) && paneWillConnectOnActivation(record.worktreeId, tabId, state)
+    )
+  }
+
+  const tabId = getLegacyPaneTabId(record)
+  if (!tabId) {
+    return false
+  }
+  const tab = worktreeTabs.find((candidate) => candidate.id === tabId) ?? null
+  const providerKeys = getLegacyProviderSessionKeysForTab(state, record.worktreeId, tabId)
+  // Why: legacy numeric pane keys lack leaf identity, so only a preserved
+  // tab-level wake hint plus a single provider session is strong enough to
+  // claim pane recovery without risking the wrong split-pane session.
+  return Boolean(
+    tab &&
+    (tab.ptyId || (state.ptyIdsByTabId[tab.id]?.length ?? 0) > 0) &&
+    providerKeys.size === 1 &&
+    paneWillConnectOnActivation(record.worktreeId, tabId, state)
+  )
+}


### PR DESCRIPTION
## Summary

- Prevent active sleeping-agent records from being claimed by preserved terminal panes unless the pane has restorable PTY/session identity and will connect during the current worktree activation.
- Fresh-resume active hidden/layout-only sleep records instead of leaving the worktree with no running agent.
- Keep completed hibernation evidence passive: it can preserve displayable history, but it cannot launch a new agent or suppress an active same-provider wake.

Boundary: this does not change terminal cold-restore command construction or provider resume protocols. It only changes the renderer decision about whether a sleeping agent record is already owned by a preserved pane versus needs a fresh agent tab.

## Design Approach

The failure mode was in `resumeSleepingAgentSessionsForWorktree`: a stable-pane `worktree-sleep` record could be treated as owned just because the tab/layout still existed. If the preserved pane had no restorable PTY/session identity, or was hidden and would not mount/connect during activation, that ownership suppressed fresh launch and stranded the agent record.

The fix extracts pane-ownership checks into `sleeping-agent-pane-ownership.ts` and makes ownership require all of the following for active records:

- matching preserved tab/layout identity
- restorable PTY/session identity for the pane
- evidence the pane will connect now, either as the focused terminal tab or as a visible terminal in another split group

Completed hibernation records are treated as passive evidence: displayable preserved panes may keep them, but they never start work.

## Design Review

Design review completed cleanly after confirming the change targets the activation/resume decision layer instead of terminal cold-restore internals. The reviewed design kept the scope to sleeping-agent activation, stale preserved-pane ownership, split visibility, completed evidence, SSH/cross-platform assumptions, and focused regression tests.

## Implementation

Implemented as designed, with one structural deviation: pane-ownership logic was moved into a dedicated module so the existing resume file did not grow a broad mixed-responsibility helper section.

Notable behavior details:

- ownership is rechecked inside the resume loop because an earlier fresh launch can change active terminal state
- visible non-focused split-group terminals can still own records
- hidden/unmounted tabs with stale preserved state fresh-resume
- passive completed duplicate evidence is cleared when an active same-provider record launches
- duplicate active records for the same provider session launch from the newest active snapshot when no pane owns the session

## Completeness / Headline Status

Headline behavior status: implemented.

Completeness verification found the original issue path covered: stale active sleep records no longer get suppressed by preserved panes that cannot connect, and duplicate/passive evidence no longer blocks active same-provider wake. The exact long-idle wall-clock reproduction was not rerun, but the minimized persisted state that causes the frozen/no-agent outcome is covered by unit and Electron validation.

## Broad App Consistency

Source-of-truth behavior compared: terminal pane cold restore and worktree activation should either reconnect an owned visible preserved pane or fresh-launch the sleeping active agent record. Neighboring surfaces checked were terminal tabs, split-group visible terminals, sleeping-agent session records, completed hibernation evidence, and startup pending agent banners.

The PR preserves split-pane behavior for visible terminal groups, fixes hidden/layout-only preserved panes that incorrectly claimed ownership, and intentionally leaves terminal command construction/cold-restore fallback behavior unchanged.

## Risks / Non-goals / Ambiguities

- Accepted performance shape: the activation path now rechecks pane-owned claim keys in a way that is O(n^2) in sleeping records. That record count is terminal-pane scale, the path runs during worktree activation/startup hydration, and the perf audit accepted this over caching because state can change during the loop.
- No live SSH runtime was exercised because the diff only changes renderer state decisions over opaque tab, pane, PTY, and provider-session IDs; no SSH relay, RPC, auth, or filesystem behavior changed.
- The exact “leave it idle for a long time” timing was not reproduced end to end; validation used deterministic stale-state reproduction instead.
- Non-goal: changing cold-restore command construction or adding a fallback when `connectPanePty` itself cannot build a provider resume command.

## Perf Audit

Perf audit passed. Touched hot path is worktree activation / startup hydration of sleeping-agent records. The accepted O(n^2) gap is bounded by sleeping-record count and avoids stale cached ownership when earlier records fresh-launch and mutate active terminal state.

## Code Review Loop

- Initial code-review loop: 4 rounds, final clean. Fixes included visible split-pane ownership, completed-evidence ordering, and completed-without-pane launch prevention.
- Final post-extraction code-review loop: 2 rounds, final clean. Fix included dynamic ownership recheck after earlier fresh resumes.

## Validation

- `pnpm run typecheck`
- `pnpm run lint` (passed with one unrelated existing warning in `useGitStatusPolling.ts`)
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts` (30 tests)
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "sleeping|cold|preserved|restore"` (37 tests, 198 skipped)
- `pnpm exec oxlint src/renderer/src/lib/resume-sleeping-agent-session.ts src/renderer/src/lib/sleeping-agent-pane-ownership.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/resume-sleeping-agent-session.ts src/renderer/src/lib/sleeping-agent-pane-ownership.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts && git diff --check`
- After CodeRabbit duplicate-record fix: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts`, `pnpm exec oxlint ...`, `pnpm exec oxfmt --check ... && git diff --check`
- Commit hooks also ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` on staged files.

## Product Validation Evidence

Brennan's PR process validation verdict: land.

Electron validation used the exact worktree/branch with a temporary profile and `demo-project`:

- missing PTY binding fresh-resumes and clears active plus completed duplicate records
- visible non-focused split group with restorable PTY does not duplicate fresh resume
- hidden/unmounted tab with PTY fresh-resumes and clears the record
- renderer console had 0 errors; warnings were development noise

Screenshot evidence: `.playwright-cli/page-2026-06-29T22-51-44-780Z.png`.

## Post-PR Stabilization

Completed.

- Initial 8-minute wait found one actionable CodeRabbit comment: duplicate active records for the same provider-session claim could launch the older snapshot first.
- Fixed in `d6cbc98` by selecting the newest active duplicate when no pane owns the provider session, with a regression assertion for newer `launchConfig` metadata.
- Waited 8 minutes again after the push; CodeRabbit marked the comment addressed and reported no new actionable comments.
- `verify` passed. Merge state is clean.
- CodeRabbit still shows a generic docstring-coverage warning in its generated summary; this repo/file style does not require docstrings for these local helpers, and it was not an actionable line comment.