### PR TITLE
Stop new terminal tabs from closing right after they open

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -10445,6 +10445,80 @@ describe('connectPanePty', () => {
       expect(manager.closePane).toHaveBeenCalledWith(2)
     })
 
+    it('does NOT tear down a newborn pane when the snapshot was requested before it bound', async () => {
+      // Why (regression): a snapshot requested before the spawn bound cannot
+      // prove the fresh ptyId dead. Drives the REAL reconcile body to prove the
+      // boundAt wiring, not just forwarding.
+      const { connectPanePty } = await import('./pty-connection')
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      const transport = createMockTransport('pty-pane-2')
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-pane-2'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const manager = createManager(2)
+      const deps = createDeps({
+        restoredLeafId: LEAF_2,
+        paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
+      })
+
+      const binding = connectPanePty(createPane(2) as never, manager as never, deps as never)
+      // Why: clear the freshly-split early-return guard so the ONLY remaining
+      // protection is the freshness guard this test exercises.
+      capturedDataCallback.current?.('shell prompt')
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((ptyId: string) => void)
+        | undefined
+      expect(onPtySpawn).toBeTypeOf('function')
+
+      // Record boundAt via the spawn chokepoint; bracket it with a real timestamp.
+      const beforeSpawn = performance.now()
+      onPtySpawn?.('pty-pane-2')
+
+      // requestedAt < boundAt: stale snapshot can't prove the fresh pane dead.
+      binding.reconcileIfSessionDead(new Set(['pty-pane-1']), beforeSpawn - 1)
+
+      expect(manager.closePane).not.toHaveBeenCalled()
+      expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+    })
+
+    it('tears down the pane when the snapshot was requested after it bound', async () => {
+      const { connectPanePty } = await import('./pty-connection')
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      const transport = createMockTransport('pty-pane-2')
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-pane-2'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const manager = createManager(2)
+      const deps = createDeps({
+        restoredLeafId: LEAF_2,
+        paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
+      })
+
+      const binding = connectPanePty(createPane(2) as never, manager as never, deps as never)
+      // Why: clear the freshly-split early-return guard so onExit reaches close.
+      capturedDataCallback.current?.('shell prompt')
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((ptyId: string) => void)
+        | undefined
+      expect(onPtySpawn).toBeTypeOf('function')
+
+      onPtySpawn?.('pty-pane-2')
+      const afterSpawn = performance.now()
+
+      // requestedAt > boundAt: the snapshot postdates the bind, so absence is real.
+      binding.reconcileIfSessionDead(new Set(['pty-pane-1']), afterSpawn + 1)
+
+      expect(manager.closePane).toHaveBeenCalledWith(2)
+    })
+
     it('routes the last pane through onPtyExitRef when its session is dead', async () => {
       const { connectPanePty } = await import('./pty-connection')
       const transport = createMockTransport('pty-pane-1')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -522,7 +522,7 @@ let inactiveForegroundImmediateBudgetWindowStart = 0
 type PanePtyBinding = IDisposable & {
   syncProcessTracking: () => void
   noteVisibilityResume: () => void
-  reconcileIfSessionDead: (liveSessionIds: Set<string>) => void
+  reconcileIfSessionDead: (liveSessionIds: Set<string>, snapshotRequestedAt?: number) => void
 }
 
 function isAgentTaskCompleteNotificationEnabled(): boolean {
@@ -1308,11 +1308,15 @@ export function connectPanePty(
     pane.container.dataset.ptyId = ptyId
   }
   let activePanePtyBinding: string | null = null
+  // Why: bind time so reconcile can ignore a listSessions snapshot requested
+  // before this PTY bound (newborn race). Null disables the guard (fail-safe).
+  let activePanePtyBindingBoundAt: number | null = null
   const clearPanePtyFitBinding = (): void => {
     // Why: fit bindings live in a module-level map, so pane teardown must
     // clear them explicitly instead of relying on DOM removal.
     bindPanePtyId(pane.id, null, deps.tabId)
     activePanePtyBinding = null
+    activePanePtyBindingBoundAt = null
     delete pane.container.dataset.ptyId
   }
 
@@ -1601,6 +1605,9 @@ export function connectPanePty(
   ): void => {
     setPanePtyFitBinding(ptyId)
     activePanePtyBinding = ptyId
+    // Why: record bind time on the spawn/attach chokepoint so the reconcile
+    // guard knows this binding is newer than any pre-bind snapshot.
+    activePanePtyBindingBoundAt = performance.now()
     deps.syncPanePtyLayoutBinding(pane.id, ptyId)
     const tabPtyIds = useAppStore.getState().ptyIdsByTabId?.[deps.tabId] ?? []
     if (options.updateTabPtyId !== 'if-missing' || !tabPtyIds.includes(ptyId)) {
@@ -4537,7 +4544,10 @@ export function connectPanePty(
   // reattach racing the listSessions snapshot is never clobbered, and respect
   // the remote/SSH guards. Suppression semantics come for free via onExit
   // (which consults consumeSuppressedPtyExit) plus the per-ptyId guard above.
-  const reconcileIfSessionDead = (liveSessionIds: Set<string>): void => {
+  const reconcileIfSessionDead = (
+    liveSessionIds: Set<string>,
+    snapshotRequestedAt?: number
+  ): void => {
     if (disposed) {
       return
     }
@@ -4550,7 +4560,9 @@ export function connectPanePty(
       !shouldReconcileDeadSession({
         ptyId: currentPtyId,
         connectionId: transport.getConnectionId?.(),
-        liveSessionIds
+        liveSessionIds,
+        ptyBoundAt: activePanePtyBindingBoundAt,
+        snapshotRequestedAt
       })
     ) {
       return
@@ -4592,10 +4604,13 @@ export function connectPanePty(
     ) {
       return
     }
+    // Why: capture request time before the round-trip so a pane that bound after
+    // this request is not torn down by its (pre-bind) stale snapshot.
+    const requestedAt = performance.now()
     void window.api.pty
       .listSessions()
       .then((sessions) => {
-        reconcileIfSessionDead(new Set(sessions.map((session) => session.id)))
+        reconcileIfSessionDead(new Set(sessions.map((session) => session.id)), requestedAt)
       })
       // Why: a rejected listing is "unknown" — never close a pane on it.
       .catch(() => {})

--- a/src/renderer/src/components/terminal-pane/terminal-dead-session-reconcile.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-dead-session-reconcile.test.ts
@@ -64,11 +64,76 @@ describe('shouldReconcileDeadSession', () => {
       })
     ).toBe(true)
   })
+
+  it('does NOT reconcile a newborn pane bound after the snapshot was requested', () => {
+    // Why (regression): the snapshot predates this binding (boundAt >= requestedAt),
+    // so the fresh ptyId's absence from it is meaningless — it cannot prove death.
+    expect(
+      shouldReconcileDeadSession({
+        ptyId: 'wt@@newborn',
+        connectionId: null,
+        liveSessionIds: new Set(['wt@@alive']),
+        ptyBoundAt: 1000,
+        snapshotRequestedAt: 900
+      })
+    ).toBe(false)
+  })
+
+  it('does NOT reconcile when the binding and snapshot request share a tick (boundAt === requestedAt)', () => {
+    // Why: the guard is inclusive (>=) — a coarse/clamped performance.now() can
+    // land a same-tick bind and request, and that newborn must still be kept.
+    expect(
+      shouldReconcileDeadSession({
+        ptyId: 'wt@@newborn',
+        connectionId: null,
+        liveSessionIds: new Set(['wt@@alive']),
+        ptyBoundAt: 1000,
+        snapshotRequestedAt: 1000
+      })
+    ).toBe(false)
+  })
+
+  it('reconciles when the binding predates the snapshot request (boundAt < requestedAt)', () => {
+    expect(
+      shouldReconcileDeadSession({
+        ptyId: 'wt@@dead',
+        connectionId: null,
+        liveSessionIds: new Set(['wt@@alive']),
+        ptyBoundAt: 900,
+        snapshotRequestedAt: 1000
+      })
+    ).toBe(true)
+  })
+
+  it('ignores the freshness guard when either timestamp is omitted (back-compat)', () => {
+    // Omitted snapshotRequestedAt: behave exactly as today.
+    expect(
+      shouldReconcileDeadSession({
+        ptyId: 'wt@@dead',
+        connectionId: null,
+        liveSessionIds: new Set(['wt@@alive']),
+        ptyBoundAt: 1000
+      })
+    ).toBe(true)
+    // Omitted ptyBoundAt (null): behave exactly as today.
+    expect(
+      shouldReconcileDeadSession({
+        ptyId: 'wt@@dead',
+        connectionId: null,
+        liveSessionIds: new Set(['wt@@alive']),
+        ptyBoundAt: null,
+        snapshotRequestedAt: 1000
+      })
+    ).toBe(true)
+  })
 })
 
 describe('reconcileDeadSessions', () => {
   function createBinding() {
-    return { reconcileIfSessionDead: vi.fn<(liveSessionIds: Set<string>) => void>() }
+    return {
+      reconcileIfSessionDead:
+        vi.fn<(liveSessionIds: Set<string>, snapshotRequestedAt?: number) => void>()
+    }
   }
 
   it('invokes each binding with the resolved live-session id set', async () => {
@@ -82,8 +147,8 @@ describe('reconcileDeadSessions', () => {
       ]
     })
     const expectedSet = new Set(['wt@@alive', 'wt@@other'])
-    expect(bindingA.reconcileIfSessionDead).toHaveBeenCalledWith(expectedSet)
-    expect(bindingB.reconcileIfSessionDead).toHaveBeenCalledWith(expectedSet)
+    expect(bindingA.reconcileIfSessionDead).toHaveBeenCalledWith(expectedSet, expect.any(Number))
+    expect(bindingB.reconcileIfSessionDead).toHaveBeenCalledWith(expectedSet, expect.any(Number))
   })
 
   it('treats a rejected listSessions as "unknown" and reconciles nothing', async () => {
@@ -103,6 +168,24 @@ describe('reconcileDeadSessions', () => {
       bindings: [binding],
       listSessions: async () => []
     })
-    expect(binding.reconcileIfSessionDead).toHaveBeenCalledWith(new Set())
+    expect(binding.reconcileIfSessionDead).toHaveBeenCalledWith(new Set(), expect.any(Number))
+  })
+
+  it('forwards a requestedAt timestamp captured before listSessions resolves', async () => {
+    // Why (fail-open guard): if requestedAt is not threaded, a fresh pane bound
+    // after the request is wrongly reconciled. Prove a Number reaches each binding
+    // and that it predates a post-call now (captured before, not after, resolve).
+    const binding = createBinding()
+    const before = performance.now()
+    await reconcileDeadSessions({
+      bindings: [binding],
+      listSessions: async () => [{ id: 'wt@@alive', cwd: '/a', title: 'a' }]
+    })
+    const after = performance.now()
+    expect(binding.reconcileIfSessionDead).toHaveBeenCalledTimes(1)
+    const [, requestedAt] = binding.reconcileIfSessionDead.mock.calls[0]!
+    expect(typeof requestedAt).toBe('number')
+    expect(requestedAt).toBeGreaterThanOrEqual(before)
+    expect(requestedAt).toBeLessThanOrEqual(after)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-dead-session-reconcile.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-dead-session-reconcile.ts
@@ -12,7 +12,7 @@ const REMOTE_PTY_ID_PREFIX = 'remote:'
  * the full `PanePtyBinding` shape from pty-connection.
  */
 export type ReconcilableBinding = {
-  reconcileIfSessionDead?: (liveSessionIds: Set<string>) => void
+  reconcileIfSessionDead?: (liveSessionIds: Set<string>, snapshotRequestedAt?: number) => void
 }
 
 /**
@@ -32,8 +32,10 @@ export function shouldReconcileDeadSession(args: {
   ptyId: string | null | undefined
   connectionId: string | null | undefined
   liveSessionIds: Set<string>
+  ptyBoundAt?: number | null
+  snapshotRequestedAt?: number | null
 }): boolean {
-  const { ptyId, connectionId, liveSessionIds } = args
+  const { ptyId, connectionId, liveSessionIds, ptyBoundAt, snapshotRequestedAt } = args
   if (ptyId === null || ptyId === undefined) {
     return false
   }
@@ -43,6 +45,16 @@ export function shouldReconcileDeadSession(args: {
   // Why: only local/daemon-backed ids (connectionId null/undefined) are
   // reconcilable; a non-null connectionId means SSH, which is deferred.
   if (connectionId !== null && connectionId !== undefined) {
+    return false
+  }
+  // Why: a snapshot requested before this binding existed can't prove it dead
+  // (newborn-PTY reconcile race). Omitting either timestamp keeps prior
+  // pure-membership behavior (back-compat).
+  if (
+    typeof ptyBoundAt === 'number' &&
+    typeof snapshotRequestedAt === 'number' &&
+    ptyBoundAt >= snapshotRequestedAt
+  ) {
     return false
   }
   return !liveSessionIds.has(ptyId)
@@ -63,6 +75,9 @@ export async function reconcileDeadSessions(args: {
   listSessions: () => Promise<{ id: string; cwd: string; title: string }[]>
 }): Promise<void> {
   let sessions: { id: string }[]
+  // Why: capture the request time BEFORE the round-trip so the decision can tell
+  // a snapshot that predates a fresh binding from one that postdates it.
+  const requestedAt = performance.now()
   try {
     sessions = await args.listSessions()
   } catch {
@@ -71,6 +86,6 @@ export async function reconcileDeadSessions(args: {
   }
   const liveSessionIds = new Set(sessions.map((session) => session.id))
   for (const binding of args.bindings) {
-    binding.reconcileIfSessionDead?.(liveSessionIds)
+    binding.reconcileIfSessionDead?.(liveSessionIds, requestedAt)
   }
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -343,7 +343,7 @@ describe('scheduleVisibilityReconcilePass', () => {
     await Promise.resolve()
     await Promise.resolve()
     expect(listSessions).toHaveBeenCalledTimes(1)
-    expect(reconcileIfSessionDead).toHaveBeenCalledWith(new Set(['live-1']))
+    expect(reconcileIfSessionDead).toHaveBeenCalledWith(new Set(['live-1']), expect.any(Number))
   })
 
   it('does not schedule on an initially visible mount', () => {


### PR DESCRIPTION
## Summary

New terminal tabs sometimes "pop in for a split second, then close" — and once it starts, it keeps happening until Orca is quit and relaunched.

Root cause is a TOCTOU race in the renderer's dead-session reconcile. `reconcileDeadSessions` / `recheckLivenessAfterInput` call `window.api.pty.listSessions()` (a renderer→main→daemon round-trip) and then ask, for each pane, whether its live PTY id is in the returned set (`shouldReconcileDeadSession`). If a freshly-created tab's PTY **binds after that snapshot was requested but before it resolves**, the new live id is absent from the stale snapshot — so a perfectly healthy newborn pane is judged dead and torn down. For a single-pane tab that teardown closes the whole tab (`onExit → onPtyExitRef → closeTab`).

Why it worsens over a session and clears on relaunch: the race window is how long `listSessions()` takes relative to a fresh bind. As a session accumulates terminals, the daemon enumerates more sessions and more resume/keystroke reconcile passes fire, widening exposure; relaunch resets to ~0 sessions and the window collapses.

### Approach

Make the reconcile decision **freshness-aware**: a snapshot requested *before* a binding existed cannot prove that binding dead.

- Stamp `activePanePtyBindingBoundAt = performance.now()` at the bind chokepoint (`bindActivePanePty`), reset in `clearPanePtyFitBinding`.
- Capture `requestedAt = performance.now()` immediately before each `listSessions()` call (`reconcileDeadSessions` and `recheckLivenessAfterInput`) and thread it through to the decision.
- `shouldReconcileDeadSession` now skips reconcile when `ptyBoundAt >= snapshotRequestedAt` (inclusive). Both timestamps are renderer-local `performance.now()` — same monotonic clock, no cross-process comparison. When either is omitted, behavior is exactly as before (back-compat).

Genuinely dead sessions are unaffected: a session reaped while hidden was bound long before the resume's snapshot request, so `ptyBoundAt < requestedAt` and reconcile still fires; a skipped round is re-evaluated by the next resume/keystroke pass against a fresher snapshot. SSH (`connectionId != null`) and remote-runtime (`remote:`) panes short-circuit *before* the new guard, so those paths are byte-for-byte unchanged.

## Design review

Ran `auto-design-review-fix` (Claude + Codex in parallel, 2 rounds) on a scratch design doc; converged clean. The review independently traced the timestamp ordering to the daemon and confirmed the renderer-local `performance.now()` comparison is provably correct (the renderer→daemon ordering only ever makes the guard *more* conservative). Substantive doc hardening: a full happens-before correctness proof, correcting a "single chokepoint" overstatement (reattach-completion binds via `setPanePtyFitBinding`, intentionally left with null `boundAt` → guard disabled → fail-safe), and fail-open test-coverage requirements.

## Implementation & deviations

Implemented exactly as designed across 5 renderer files (`terminal-dead-session-reconcile.ts`, `pty-connection.ts`, + their tests, and a `use-terminal-pane-lifecycle.test.ts` assertion update). No deviations. Intentional non-change: reattach-completed panes keep `boundAt === null` (guard disabled, pure-membership fallback) — they reuse a pre-existing daemon session id so membership already protects them.

## Completeness verification

A read-only verification pass confirmed every design requirement, edge case, and validation item is satisfied, with no scope creep and no `max-lines` disables.

## Code-review loop

Two independent reviewers per round (`code-review`, high effort), run in parallel:
- **Round 1:** no P0/P1/P2. Actionable: add a `ptyBoundAt === snapshotRequestedAt` boundary test (guards the inclusive `>=`), and trim two over-length "why" comments per AGENTS.md. Both applied.
- **Round 2:** one P2 — an oxfmt `printWidth=100` format failure on a reflowed test line. Fixed with `oxfmt`.
- **Round 3 (confirming):** both reviewers returned **CLEAN — no actionable findings**.

## brennan-test-changes (merge confidence): LAND

Validated in a fresh dev build launched from this worktree (identity verified before interacting); test target was a local non-orca repo, with the session already holding 16 tabs (the long-running condition).

- Reproduced the bug's precondition for real: a freshly-bound PTY id was genuinely absent from a `listSessions()` snapshot captured before the tab was created.
- After the fix: that newborn tab survived 3.5s+; 10 rapidly-created tabs all bound a PTY and **all 10 survived** (screenshot evidence captured). No console/dev-log errors.
- Accepted gap: driving the production visibility/keystroke reconcile through CDP was impractical (the preload exposes `listSessions` as a frozen contextBridge fn, so it can't be wrapped from the renderer console) — binding-level proof is instead carried by the integration tests that drive the real `reconcileIfSessionDead` with explicit timestamps.
- Scope boundary (justified): `brennan-test-ssh` not required — SSH/remote short-circuit before the guard, so they cannot be affected.

## Checks run

- `tsgo` web typecheck: clean (exit 0)
- `oxlint` (touched files): clean
- `oxfmt --check` (all 5 files): clean
- `npx vitest run terminal-dead-session-reconcile.test.ts use-terminal-pane-lifecycle.test.ts`: 35/35 pass
- `pty-connection.test.ts -t "reconcileIfSessionDead"`: 12/12 pass (incl. two new binding-level integration tests that drive the real reconcile body and fail if the guard is removed — verified by temporary revert)
- `git diff --check`: clean

## Tests

- [x] Regression unit tests fail before the fix (verified by reverting the guard)
- [x] Boundary-equality (`===`) and back-compat (omitted-args) cases covered
- [x] Both `listSessions` call sites thread `requestedAt`
- [x] Live Electron survival of fresh + rapidly-created tabs
- [ ] Production visibility/keystroke reconcile driven via CDP (not feasible from renderer console; covered by integration tests) — accepted gap

## Risks / notes

- One pre-existing, unrelated `pty-connection.test.ts` failure ("does NOT re-assert while a mobile-fit override parks the PTY at phone dims") fails identically on the clean pre-diff tree (confirmed via `git stash`) — a `mobile-fit-overrides` global-state leak, not touched here.
- Pure renderer-side logic change: no IPC/schema/persistence/settings changes, no migration.

Made with [Orca](https://github.com/stablyai/orca) 🐋


---

### Relationship to #6796 (just merged)

While this PR was in review, **#6796 "Keep new terminal tabs open during startup"** merged to `main` and targets the same area (`fixes #6773`). The two changes are **complementary, at different layers** — verified by rebasing onto `main` (which includes #6796) and confirming the regression test here still fails when this PR's guard is reverted:

- **#6796 gates *when* reconcile fires:** the dead-session pass and first-input liveness probe now only run after a real hidden→visible resume; fresh mounts start disarmed. This removes the startup-time trigger.
- **This PR makes the *decision itself* freshness-aware** (`shouldReconcileDeadSession`): even when a reconcile pass *legitimately* fires — e.g. a tab created while its worktree is hidden, then resumed, or whose first post-resume keystroke probes liveness — a `listSessions()` snapshot **requested before the PTY bound** can no longer prove that PTY dead.

So #6796 narrows the trigger; this PR closes the residual TOCTOU inside the trigger that still survives. Rebased cleanly on top of #6796; all focused tests, typecheck, lint, and format pass on the merged tree.
