### PR TITLE
Prevent false mobile reconnects during active runtime traffic

### DIFF
--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -11,7 +11,7 @@ vi.mock('./e2ee', () => ({
   publicKeyFromBase64: () => new Uint8Array(32),
   publicKeyToBase64: () => 'client-public-key',
   encrypt: (plaintext: string) => `encrypted:${plaintext}`,
-  decrypt: (raw: string) => raw.replace(/^encrypted:/, ''),
+  decrypt: (raw: string) => (raw === 'undecryptable' ? null : raw.replace(/^encrypted:/, '')),
   decryptBytes: (bytes: Uint8Array) => bytes
 }))
 
@@ -260,11 +260,14 @@ describe('mobile rpc-client connection timeout', () => {
       })}`
     )
 
+    client.notifyForeground()
     socket.receive(encodeBrowserFrame())
     await Promise.resolve()
     await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(8_000)
 
     expect(frames).toHaveLength(1)
+    expect(socket.close).not.toHaveBeenCalled()
     expect(frames[0]).toMatchObject({
       seq: 7,
       format: 'jpeg',
@@ -608,6 +611,12 @@ describe('mobile rpc-client connection timeout', () => {
       socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
       socket.receive('encrypted:{"type":"e2ee_authenticated"}')
     }
+    function connectAuthenticated() {
+      const client = connect('ws://desktop.invalid', 'token', 'server-key')
+      const socket = mockSockets[0]!
+      openAndAuthenticate(socket)
+      return { client, socket }
+    }
 
     it('repro: a parked reconnect loop never retries on its own', async () => {
       const client = connect('ws://desktop.invalid', 'token', 'server-key')
@@ -685,9 +694,7 @@ describe('mobile rpc-client connection timeout', () => {
     })
 
     it('keeps a healthy connection when the foreground probe is answered', async () => {
-      const client = connect('ws://desktop.invalid', 'token', 'server-key')
-      const socket = mockSockets[0]!
-      openAndAuthenticate(socket)
+      const { client, socket } = connectAuthenticated()
 
       client.notifyForeground()
       const probe = sentRequest(socket, 'status.get')
@@ -700,9 +707,114 @@ describe('mobile rpc-client connection timeout', () => {
       client.close()
     })
 
+    it('keeps a healthy connection when another response arrives while the probe is pending', async () => {
+      const { client, socket } = connectAuthenticated()
+
+      client.notifyForeground()
+      expect(sentRequests(socket, 'status.get')).toHaveLength(1)
+
+      const poll = client.sendRequest('speech.models.list')
+      await Promise.resolve()
+      const pollRequest = sentRequest(socket, 'speech.models.list')
+      socket.receive(
+        `encrypted:${JSON.stringify({
+          id: pollRequest.id,
+          ok: true,
+          result: { enabled: false, selectedModelId: '', dictationMode: 'toggle', models: [] }
+        })}`
+      )
+      await expect(poll).resolves.toMatchObject({ ok: true })
+
+      await vi.advanceTimersByTimeAsync(8_000)
+      expect(socket.close).not.toHaveBeenCalled()
+      expect(client.getState()).toBe('connected')
+
+      await vi.advanceTimersByTimeAsync(12_000)
+      expect(sentRequests(socket, 'status.get')).toHaveLength(2)
+      await vi.advanceTimersByTimeAsync(7_999)
+      expect(socket.close).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
+      expect(socket.close).toHaveBeenCalled()
+      expect(client.getState()).toBe('reconnecting')
+
+      client.close()
+    })
+
+    it('keeps a healthy connection when a non-auth RPC failure arrives while the probe is pending', async () => {
+      const { client, socket } = connectAuthenticated()
+
+      client.notifyForeground()
+      expect(sentRequests(socket, 'status.get')).toHaveLength(1)
+
+      const poll = client.sendRequest('speech.models.list')
+      await Promise.resolve()
+      const pollRequest = sentRequest(socket, 'speech.models.list')
+      socket.receive(
+        `encrypted:${JSON.stringify({
+          id: pollRequest.id,
+          ok: false,
+          error: { code: 'download_failed', message: 'model download failed' }
+        })}`
+      )
+      await expect(poll).resolves.toMatchObject({
+        ok: false,
+        error: { code: 'download_failed' }
+      })
+
+      await vi.advanceTimersByTimeAsync(8_000)
+      expect(socket.close).not.toHaveBeenCalled()
+      expect(client.getState()).toBe('connected')
+
+      client.close()
+    })
+
+    it('keeps a healthy connection when a binary stream frame arrives while the probe is pending', async () => {
+      const { client, socket } = connectAuthenticated()
+      const events: unknown[] = []
+
+      client.subscribe('terminal.subscribe', { terminal: 'term-1' }, (event) => {
+        events.push(event)
+      })
+      const subscribe = sentRequest(socket, 'terminal.subscribe')
+      socket.receive(
+        `encrypted:${JSON.stringify({
+          id: subscribe.id,
+          ok: true,
+          streaming: true,
+          result: { type: 'subscribed', streamId: 42 }
+        })}`
+      )
+
+      client.notifyForeground()
+      socket.receive(encodeTerminalOutput(42, 'still alive'))
+      await Promise.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(8_000)
+
+      expect(events).toContainEqual({ type: 'data', streamId: 42, chunk: 'still alive' })
+      expect(socket.close).not.toHaveBeenCalled()
+      expect(client.getState()).toBe('connected')
+
+      client.close()
+    })
+
+    it('does not count malformed or undecryptable inbound payloads as probe activity', async () => {
+      const { client, socket } = connectAuthenticated()
+
+      client.notifyForeground()
+      socket.receive('undecryptable')
+      socket.receive('encrypted:{"unexpected":true}')
+      socket.receive(new Uint8Array([0xff, 0x00, 0x01]))
+
+      await vi.advanceTimersByTimeAsync(8_000)
+      expect(socket.close).toHaveBeenCalled()
+      expect(client.getState()).toBe('reconnecting')
+
+      client.close()
+    })
+
     it('is a no-op after the client is closed', () => {
-      const client = connect('ws://desktop.invalid', 'token', 'server-key')
-      openAndAuthenticate(mockSockets[0]!)
+      const { client } = connectAuthenticated()
       client.close()
 
       const socketsBefore = mockSockets.length
@@ -721,6 +833,9 @@ describe('mobile rpc-client connection timeout', () => {
       socket.open()
       socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
       socket.receive('encrypted:{"type":"e2ee_authenticated"}')
+    }
+    function unauthorizedResponsePayload(id: string): string {
+      return `encrypted:${JSON.stringify({ id, ok: false, error: { code: 'unauthorized', message: 'Unauthorized' } })}`
     }
 
     it('retries the handshake on a transient e2ee_error instead of latching auth-failed', async () => {
@@ -784,9 +899,7 @@ describe('mobile rpc-client connection timeout', () => {
       // sendRequest awaits waitForConnected before sending — let it flush.
       await Promise.resolve()
       const id = sentRequest(live, 'status.get').id
-      live.receive(
-        `encrypted:${JSON.stringify({ id, ok: false, error: { code: 'unauthorized' } })}`
-      )
+      live.receive(unauthorizedResponsePayload(id))
       await request
       expect(client.getState()).toBe('reconnecting')
 
@@ -811,9 +924,7 @@ describe('mobile rpc-client connection timeout', () => {
       const request = client.sendRequest('status.get').catch(() => undefined)
       await Promise.resolve()
       const id = sentRequest(first, 'status.get').id
-      first.receive(
-        `encrypted:${JSON.stringify({ id, ok: false, error: { code: 'unauthorized' } })}`
-      )
+      first.receive(unauthorizedResponsePayload(id))
       await request
       expect(client.getState()).toBe('reconnecting')
 

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -804,6 +804,7 @@ describe('mobile rpc-client connection timeout', () => {
       client.notifyForeground()
       socket.receive('undecryptable')
       socket.receive('encrypted:{"unexpected":true}')
+      socket.receive('encrypted:{"id":"rpc-incomplete","ok":true}')
       socket.receive(new Uint8Array([0xff, 0x00, 0x01]))
 
       await vi.advanceTimersByTimeAsync(8_000)

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -29,6 +29,8 @@ import {
   updateTerminalSubscriptionViewport as updateCachedTerminalSubscriptionViewport
 } from './rpc-client-terminal-subscription'
 import { describeSocketEvent } from './socket-event-debug'
+import { isRpcResponse } from './rpc-response-shape'
+import { websocketPayloadToUint8 } from './websocket-payload-bytes'
 
 type PendingRequest = {
   resolve: (response: RpcResponse) => void
@@ -135,17 +137,10 @@ const HANDSHAKE_TIMEOUT_MS = 5_000
 // constants, but the protocol value for CONNECTING is stable across runtimes.
 const WEBSOCKET_CONNECTING_STATE = 0
 
-// Why: app-level liveness probe. The server runs its own ping/pong sweep
-// at 15s, but RN's WebSocket runtime auto-pongs at the native layer
-// without surfacing anything to JS — so the mobile side can't *see* that
-// the server thinks the link is fine. To detect a half-open socket from
-// the mobile direction (e.g. server crashed, phone moved between wifi
-// and cellular without TCP RST) we periodically round-trip a tiny RPC.
-// If two consecutive probes time out we force-close the WS, which fires
-// the existing reconnect path. 20s cadence + the 30s request timeout =
-// worst-case ~50s before mobile decides the link is dead and kicks
-// reconnect, which is still inside the user's perceived "responsive"
-// window and well below iOS's typical background-disconnect window.
+// Why: RN auto-pongs WebSocket pings natively, so JS needs an app-level
+// liveness probe to detect half-open sockets. Any inbound app traffic after
+// a probe starts proves the link is alive; otherwise an unanswered probe
+// force-closes the socket so the reconnect path can recover.
 const ACTIVITY_PROBE_INTERVAL_MS = 20_000
 
 export type ConnectOptions = {
@@ -197,15 +192,10 @@ export function connect(
   // every 'connected'.
   let authRejectionCount = 0
   let lastConnectedAt: number | null = null
-  // Why: diagnostic — when the rpc-client gets stuck in a state where every
-  // openConnection fails with code 1006 and only a force-quit recovers, we
-  // need to see whether (a) the new attempts even differ from the old ones,
-  // (b) anything is happening at the OS / RN-bridge layer between attempts,
-  // and (c) what the timing pattern is (instant 1006 = port closed / route
-  // dead, slow 1006 = packet drop / timeout). These three timestamps + the
-  // ws-construction counter are the cheapest visibility into RN/OkHttp
-  // process-state poisoning hypotheses.
+  // Why: cheap diagnostics for RN/OkHttp process-state poisoning: do retry
+  // attempts differ, is anything inbound, and are closes instant or slow?
   let lastInboundAt: number | null = null
+  let inboundSequence = 0
   let lastWsClosedAt: number | null = null
   let wsConstructionCounter = 0
   let currentWsOpenedAt: number | null = null
@@ -443,8 +433,6 @@ export function connect(
     }
 
     async function handleSocketMessage(rawData: unknown) {
-      // Why: track last-inbound for the openConnection diagnostic. Server
-      // pongs and stream events both bump this — anything from the wire.
       lastInboundAt = Date.now()
       const raw = typeof rawData === 'string' ? rawData : null
 
@@ -543,7 +531,9 @@ export function connect(
         if (!plaintextBytes) {
           return
         }
-        handleBinaryFrame(plaintextBytes)
+        if (handleBinaryFrame(plaintextBytes)) {
+          recordValidatedInboundTraffic()
+        }
         return
       }
 
@@ -552,12 +542,16 @@ export function connect(
         return
       }
 
-      let response: RpcResponse
+      let response: unknown
       try {
         response = JSON.parse(plaintext)
       } catch {
         return
       }
+      if (!isRpcResponse(response)) {
+        return
+      }
+      recordValidatedInboundTraffic()
 
       // Why: a mid-session unauthorized may be a transient glitch, not a dead
       // pairing (issue #5200). handleAuthRejection retries the handshake a few
@@ -827,30 +821,21 @@ export function connect(
   // state, sends a tiny status.get, and force-closes the WS if the probe
   // fails (which the existing onclose path then turns into a reconnect).
   function runActivityProbe() {
-    // Why: only probe while the channel is actually in 'connected'. The
-    // sendRequest path itself waits for connected, but a probe scheduled
-    // during a reconnect would just stack up timeouts and confuse logs.
     if (state !== 'connected' || !ws) {
       return
     }
     const probeWs = ws
-    // Why: short timeout (8s) — server's heartbeat is 15s, so if we
-    // don't see *anything* back within 8s the link is almost certainly
-    // half-open. Using REQUEST_TIMEOUT_MS (30s) here would make the
-    // user wait nearly a minute before reconnect kicks in.
     const id = nextId()
-    const probeStart = Date.now()
+    const probeInboundSequence = inboundSequence
     let timedOut = false
     const timeout = setTimeout(() => {
       timedOut = true
       pending.delete(id)
-      console.log('[net] activity-probe TIMEOUT — forcing reconnect', {
-        waitedMs: Date.now() - probeStart,
-        state
-      })
-      // Why: only force-close if this is still the same socket the
-      // probe was sent on; a normal close that already swapped `ws`
-      // shouldn't trigger a redundant terminate.
+      if (inboundSequence > probeInboundSequence) {
+        return
+      }
+      console.log('[net] activity-probe TIMEOUT — forcing reconnect', { state })
+      // Why: stale probe timers must not close a replacement socket.
       if (probeWs === ws && probeWs.readyState === WebSocket.OPEN) {
         probeWs.close()
       }
@@ -948,13 +933,17 @@ export function connect(
     }
   }
 
-  function handleBinaryFrame(bytes: Uint8Array) {
+  function recordValidatedInboundTraffic(): void {
+    inboundSequence++
+  }
+
+  function handleBinaryFrame(bytes: Uint8Array): boolean {
     const browserFrame = decodeBrowserScreencastFrame(bytes)
     if (browserFrame) {
       handleBrowserBinaryFrame(browserFrame)
-      return
+      return true
     }
-    handleTerminalBinaryFrame(bytes)
+    return handleTerminalBinaryFrame(bytes)
   }
 
   function handleBrowserBinaryFrame(frame: BrowserScreencastFrame) {
@@ -968,14 +957,14 @@ export function connect(
     stream.onBinaryFrame?.(frame)
   }
 
-  function handleTerminalBinaryFrame(bytes: Uint8Array) {
+  function handleTerminalBinaryFrame(bytes: Uint8Array): boolean {
     const frame = decodeTerminalStreamFrame(bytes)
     if (!frame) {
-      return
+      return false
     }
     const listener = terminalStreamListeners.get(frame.streamId)
     if (!listener) {
-      return
+      return true
     }
     if (frame.opcode === TerminalStreamOpcode.Output) {
       listener({
@@ -983,28 +972,28 @@ export function connect(
         streamId: frame.streamId,
         chunk: decodeTerminalStreamText(frame.payload)
       })
-      return
+      return true
     }
     if (frame.opcode === TerminalStreamOpcode.SnapshotStart) {
       const meta = decodeTerminalStreamJson<Record<string, unknown>>(frame.payload)
       if (!meta) {
-        return
+        return false
       }
       terminalSnapshots.set(frame.streamId, { streamId: frame.streamId, meta, chunks: [] })
-      return
+      return true
     }
     if (frame.opcode === TerminalStreamOpcode.SnapshotChunk) {
       const snapshot = terminalSnapshots.get(frame.streamId)
       if (!snapshot) {
-        return
+        return true
       }
       snapshot.chunks.push(decodeTerminalStreamText(frame.payload))
-      return
+      return true
     }
     if (frame.opcode === TerminalStreamOpcode.SnapshotEnd) {
       const snapshot = terminalSnapshots.get(frame.streamId)
       if (!snapshot) {
-        return
+        return true
       }
       terminalSnapshots.delete(frame.streamId)
       const kind = snapshot.meta.kind === 'resized' ? 'resized' : 'scrollback'
@@ -1014,19 +1003,19 @@ export function connect(
         streamId: frame.streamId,
         serialized: snapshot.chunks.join('')
       })
-      return
+      return true
     }
     if (frame.opcode === TerminalStreamOpcode.Resized) {
       const meta = decodeTerminalStreamJson<Record<string, unknown>>(frame.payload)
       if (!meta) {
-        return
+        return false
       }
       listener({
         ...meta,
         type: 'resized',
         streamId: frame.streamId
       })
-      return
+      return true
     }
     if (frame.opcode === TerminalStreamOpcode.Error) {
       listener({
@@ -1034,7 +1023,9 @@ export function connect(
         streamId: frame.streamId,
         message: decodeTerminalStreamText(frame.payload)
       })
+      return true
     }
+    return false
   }
 
   function sendEncrypted(request: unknown): boolean {
@@ -1301,28 +1292,4 @@ function isBrowserScreencastReadyResult(
     (value as { type?: unknown }).type === 'ready' &&
     typeof (value as { subscriptionId?: unknown }).subscriptionId === 'string'
   )
-}
-
-async function websocketPayloadToUint8(value: unknown): Promise<Uint8Array | null> {
-  if (value instanceof Uint8Array) {
-    return value
-  }
-  if (value instanceof ArrayBuffer) {
-    return new Uint8Array(value)
-  }
-  if (value && typeof value === 'object' && 'arrayBuffer' in value) {
-    const blob = value as { arrayBuffer: () => Promise<ArrayBuffer> }
-    return new Uint8Array(await blob.arrayBuffer())
-  }
-  if (typeof FileReader !== 'undefined' && value instanceof Blob) {
-    return new Promise((resolve) => {
-      const reader = new FileReader()
-      reader.onload = () => {
-        resolve(reader.result instanceof ArrayBuffer ? new Uint8Array(reader.result) : null)
-      }
-      reader.onerror = () => resolve(null)
-      reader.readAsArrayBuffer(value)
-    })
-  }
-  return null
 }

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -531,9 +531,7 @@ export function connect(
         if (!plaintextBytes) {
           return
         }
-        if (handleBinaryFrame(plaintextBytes)) {
-          recordValidatedInboundTraffic()
-        }
+        handleBinaryFrame(plaintextBytes)
         return
       }
 
@@ -937,13 +935,14 @@ export function connect(
     inboundSequence++
   }
 
-  function handleBinaryFrame(bytes: Uint8Array): boolean {
+  function handleBinaryFrame(bytes: Uint8Array): void {
     const browserFrame = decodeBrowserScreencastFrame(bytes)
     if (browserFrame) {
+      recordValidatedInboundTraffic()
       handleBrowserBinaryFrame(browserFrame)
-      return true
+      return
     }
-    return handleTerminalBinaryFrame(bytes)
+    handleTerminalBinaryFrame(bytes)
   }
 
   function handleBrowserBinaryFrame(frame: BrowserScreencastFrame) {
@@ -957,43 +956,48 @@ export function connect(
     stream.onBinaryFrame?.(frame)
   }
 
-  function handleTerminalBinaryFrame(bytes: Uint8Array): boolean {
+  function handleTerminalBinaryFrame(bytes: Uint8Array): void {
     const frame = decodeTerminalStreamFrame(bytes)
     if (!frame) {
-      return false
+      return
     }
     const listener = terminalStreamListeners.get(frame.streamId)
     if (!listener) {
-      return true
+      recordValidatedInboundTraffic()
+      return
     }
     if (frame.opcode === TerminalStreamOpcode.Output) {
+      recordValidatedInboundTraffic()
       listener({
         type: 'data',
         streamId: frame.streamId,
         chunk: decodeTerminalStreamText(frame.payload)
       })
-      return true
+      return
     }
     if (frame.opcode === TerminalStreamOpcode.SnapshotStart) {
       const meta = decodeTerminalStreamJson<Record<string, unknown>>(frame.payload)
       if (!meta) {
-        return false
+        return
       }
+      recordValidatedInboundTraffic()
       terminalSnapshots.set(frame.streamId, { streamId: frame.streamId, meta, chunks: [] })
-      return true
+      return
     }
     if (frame.opcode === TerminalStreamOpcode.SnapshotChunk) {
+      recordValidatedInboundTraffic()
       const snapshot = terminalSnapshots.get(frame.streamId)
       if (!snapshot) {
-        return true
+        return
       }
       snapshot.chunks.push(decodeTerminalStreamText(frame.payload))
-      return true
+      return
     }
     if (frame.opcode === TerminalStreamOpcode.SnapshotEnd) {
+      recordValidatedInboundTraffic()
       const snapshot = terminalSnapshots.get(frame.streamId)
       if (!snapshot) {
-        return true
+        return
       }
       terminalSnapshots.delete(frame.streamId)
       const kind = snapshot.meta.kind === 'resized' ? 'resized' : 'scrollback'
@@ -1003,29 +1007,29 @@ export function connect(
         streamId: frame.streamId,
         serialized: snapshot.chunks.join('')
       })
-      return true
+      return
     }
     if (frame.opcode === TerminalStreamOpcode.Resized) {
       const meta = decodeTerminalStreamJson<Record<string, unknown>>(frame.payload)
       if (!meta) {
-        return false
+        return
       }
+      recordValidatedInboundTraffic()
       listener({
         ...meta,
         type: 'resized',
         streamId: frame.streamId
       })
-      return true
+      return
     }
     if (frame.opcode === TerminalStreamOpcode.Error) {
+      recordValidatedInboundTraffic()
       listener({
         type: 'error',
         streamId: frame.streamId,
         message: decodeTerminalStreamText(frame.payload)
       })
-      return true
     }
-    return false
   }
 
   function sendEncrypted(request: unknown): boolean {

--- a/mobile/src/transport/rpc-response-shape.test.ts
+++ b/mobile/src/transport/rpc-response-shape.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { isRpcResponse } from './rpc-response-shape'
+
+describe('isRpcResponse', () => {
+  it('requires success responses to include a result field', () => {
+    expect(isRpcResponse({ id: 'rpc-1', ok: true, result: null })).toBe(true)
+    expect(isRpcResponse({ id: 'rpc-1', ok: true })).toBe(false)
+  })
+
+  it('requires failure responses to include code and message', () => {
+    expect(
+      isRpcResponse({
+        id: 'rpc-1',
+        ok: false,
+        error: { code: 'failed', message: 'Nope' }
+      })
+    ).toBe(true)
+    expect(isRpcResponse({ id: 'rpc-1', ok: false, error: { code: 'failed' } })).toBe(false)
+  })
+})

--- a/mobile/src/transport/rpc-response-shape.ts
+++ b/mobile/src/transport/rpc-response-shape.ts
@@ -1,0 +1,24 @@
+import type { RpcResponse } from './types'
+
+export function isRpcResponse(value: unknown): value is RpcResponse {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const response = value as {
+    id?: unknown
+    ok?: unknown
+    error?: { code?: unknown; message?: unknown }
+  }
+  if (typeof response.id !== 'string') {
+    return false
+  }
+  if (response.ok === true) {
+    return true
+  }
+  return (
+    response.ok === false &&
+    !!response.error &&
+    typeof response.error.code === 'string' &&
+    typeof response.error.message === 'string'
+  )
+}

--- a/mobile/src/transport/rpc-response-shape.ts
+++ b/mobile/src/transport/rpc-response-shape.ts
@@ -13,7 +13,7 @@ export function isRpcResponse(value: unknown): value is RpcResponse {
     return false
   }
   if (response.ok === true) {
-    return true
+    return Object.prototype.hasOwnProperty.call(response, 'result')
   }
   return (
     response.ok === false &&

--- a/mobile/src/transport/websocket-payload-bytes.test.ts
+++ b/mobile/src/transport/websocket-payload-bytes.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { websocketPayloadToUint8 } from './websocket-payload-bytes'
+
+describe('websocketPayloadToUint8', () => {
+  it('returns null when a blob-like payload rejects arrayBuffer conversion', async () => {
+    await expect(
+      websocketPayloadToUint8({
+        arrayBuffer: async () => {
+          throw new Error('conversion failed')
+        }
+      })
+    ).resolves.toBeNull()
+  })
+})

--- a/mobile/src/transport/websocket-payload-bytes.ts
+++ b/mobile/src/transport/websocket-payload-bytes.ts
@@ -1,0 +1,23 @@
+export async function websocketPayloadToUint8(value: unknown): Promise<Uint8Array | null> {
+  if (value instanceof Uint8Array) {
+    return value
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value)
+  }
+  if (value && typeof value === 'object' && 'arrayBuffer' in value) {
+    const blob = value as { arrayBuffer: () => Promise<ArrayBuffer> }
+    return new Uint8Array(await blob.arrayBuffer())
+  }
+  if (typeof FileReader !== 'undefined' && value instanceof Blob) {
+    return new Promise((resolve) => {
+      const reader = new FileReader()
+      reader.onload = () => {
+        resolve(reader.result instanceof ArrayBuffer ? new Uint8Array(reader.result) : null)
+      }
+      reader.onerror = () => resolve(null)
+      reader.readAsArrayBuffer(value)
+    })
+  }
+  return null
+}

--- a/mobile/src/transport/websocket-payload-bytes.ts
+++ b/mobile/src/transport/websocket-payload-bytes.ts
@@ -7,7 +7,11 @@ export async function websocketPayloadToUint8(value: unknown): Promise<Uint8Arra
   }
   if (value && typeof value === 'object' && 'arrayBuffer' in value) {
     const blob = value as { arrayBuffer: () => Promise<ArrayBuffer> }
-    return new Uint8Array(await blob.arrayBuffer())
+    try {
+      return new Uint8Array(await blob.arrayBuffer())
+    } catch {
+      return null
+    }
   }
   if (typeof FileReader !== 'undefined' && value instanceof Blob) {
     return new Promise((resolve) => {


### PR DESCRIPTION
## Summary

Prevents the mobile runtime client from force-closing a healthy WebSocket when an activity probe is pending but other validated Orca runtime traffic is still arriving.

This does not claim that speech model downloads survive every desktop stall or real network outage. If no app-level runtime traffic arrives during a probe window, the existing reconnect behavior still runs.

## Design approach

The mobile client already uses an app-level `status.get` probe because React Native WebSocket ping/pong is handled below JS. The design changes the liveness proof from “the probe response itself arrived” to “any validated app-level runtime message arrived after the probe started.”

Implementation details:
- Track an inbound sequence for validated runtime traffic.
- Snapshot that sequence when sending an activity probe.
- If the probe times out but newer validated traffic arrived, delete the pending probe and keep the socket open.
- If no validated traffic arrived, preserve the existing close-and-reconnect path.
- Count only decrypted/validated RPC responses or decoded binary stream frames; malformed or undecryptable payloads do not count as liveness.

## Design review outcome

Design review completed with no P0/P1 issues. It tightened the scope to false reconnects while validated runtime traffic is flowing and explicitly kept arbitrary desktop stalls/network outages out of scope.

## Implementation

Changed:
- `mobile/src/transport/rpc-client.ts`
- `mobile/src/transport/rpc-client.test.ts`
- `mobile/src/transport/rpc-response-shape.ts`
- `mobile/src/transport/rpc-response-shape.test.ts`
- `mobile/src/transport/websocket-payload-bytes.ts`
- `mobile/src/transport/websocket-payload-bytes.test.ts`

No deviations from the reviewed design.

## Completeness verification

Result: implemented.

Verified that:
- JSON liveness counts only after decrypt + RPC response-shape validation.
- Binary liveness counts only after decrypt + browser/terminal frame decode.
- Auth/RPC failures still route through existing handlers.
- A later periodic probe still reconnects a truly quiet socket.
- UI/product scope is unchanged.

## Headline behavior status

Implemented: mobile stays connected when a pending activity probe is unanswered but newer validated runtime traffic proves the WebSocket is alive.

Deferred/not claimed: proof that this fixes every speech-model-download disconnect on real iOS hardware. The strongest live path would be a paired iOS/simulator run starting a speech model download and observing no reconnect while polling continues.

## Broad app consistency result

Source of truth compared: mobile runtime connection liveness should be based on JS-visible Orca runtime traffic, not only on one specific probe response.

Neighboring surfaces considered:
- Mobile Voice settings model download/poll flow.
- Mobile session, terminal, and browser surfaces using the same `RpcClient`.
- Mobile host connection state UI.
- Desktop runtime/model-manager speech state.

Mismatch fixed: code comments/product intent said app-level traffic proves liveness, but implementation only accepted the probe response. This PR fixes that mismatch while preserving reconnect for no-traffic windows.

## Risks, ambiguities, and non-goals

Risks/gaps:
- Reporter logs were not available, so this is high-confidence deterministic transport coverage, not live proof of the exact field report.
- One valid frame can save the current probe window, but the next scheduled probe re-tests the socket.

Non-goals:
- Replacing Orca dictation with iOS native dictation.
- Changing model download/extraction behavior, model catalog, progress UI, OpenAI setup, reconnect backoff, auth retry policy, or stream replay semantics.

## Perf audit result

Perf audit: clear.

Touched hot paths:
- Mobile WebSocket inbound message handling.
- Activity probe timeout handling.
- Browser/terminal binary frame decode path.

No new polling, subprocess work, render/store work, buffering, or cache behavior was introduced. Existing fake-timer tests cover reconnect count/timeout behavior.

## Code review loop

One review/fix round completed with two independent reviewers. Both returned clean; no actionable findings and no fixes were required before PR creation.

After PR creation, CodeRabbit posted three actionable comments. All three were fixed in `a61dd2f24` and CodeRabbit’s refreshed review reported no new actionable comments.

## Merge-confidence validation

Verdict from validation pass: land.

Electron/demo-project validation and screenshot evidence are not applicable because this is mobile transport runtime code with no visible UI/layout change and no Electron user control exercises `mobile/src/transport/rpc-client.ts`.

## Screenshots

Not applicable: no visible UI/layout changed.

## Security audit

No auth scope, token storage, encryption primitive, or provider permission model changed. The response-shape guard only validates decrypted runtime envelopes before treating them as liveness evidence.

## Tests

Passed:
- `pnpm exec vitest run --config mobile/vitest.config.ts src/transport/rpc-client.test.ts`
- `pnpm exec vitest run --config mobile/vitest.config.ts src/transport/rpc-client.test.ts src/transport/rpc-response-shape.test.ts src/transport/websocket-payload-bytes.test.ts`
- `pnpm exec oxlint mobile/src/transport/rpc-client.ts mobile/src/transport/rpc-client.test.ts mobile/src/transport/rpc-response-shape.ts mobile/src/transport/rpc-response-shape.test.ts mobile/src/transport/websocket-payload-bytes.ts mobile/src/transport/websocket-payload-bytes.test.ts`
- `git diff --check`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm --dir mobile exec tsc --noEmit -p tsconfig.json`
- `pnpm --dir mobile run lint`
- Focused adjacent tests:
  - `mobile/src/transport/rpc-client-live-recovery.test.ts`
  - `mobile/src/dictation/mobile-dictation-setup.test.ts`
  - `src/main/runtime/rpc/methods/speech.test.ts`
  - `src/main/speech/model-manager-progress-callback.test.ts`
  - `src/main/speech/model-manager-download-error.test.ts`

Known validation gap:
- Full mobile Vitest suite was not counted as passed because an unrelated environment issue (`jsdom` missing) stopped `terminal-webview-tap-routing.test.ts` after 143 files / 957 tests had passed.

## Post-PR stabilization

Completed:
- Waited 8 minutes after PR creation before reviewing CodeRabbit and checks.
- Fixed all three actionable CodeRabbit comments.
- Pushed the fix commit and waited 8 minutes again.
- Waited an additional 8 minutes while PR Checks were still pending.
- Final PR checks passed:
  - Mobile Checks / `verify`
  - PR Checks / `verify`
- CodeRabbit refreshed review reported no new actionable comments.
