### PR TITLE
Polish terminal context menu shortcuts

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import TerminalContextMenu from './TerminalContextMenu'
+import type { KeybindingOverrides } from '../../../../shared/keybindings'
 
 type ItemProps = { onSelect?: () => void; children?: React.ReactNode }
 
 const items = vi.hoisted(() => ({ list: [] as ItemProps[] }))
+const shortcuts = vi.hoisted(() => ({ list: [] as string[] }))
 
 vi.mock('@/components/ui/dropdown-menu', async () => {
   const React_ = await import('react')
@@ -16,7 +18,14 @@ vi.mock('@/components/ui/dropdown-menu', async () => {
     DropdownMenuContent: passthrough,
     DropdownMenuLabel: passthrough,
     DropdownMenuSeparator: () => null,
-    DropdownMenuShortcut: passthrough,
+    DropdownMenuShortcut: ({ children }: { children?: React.ReactNode }) => {
+      shortcuts.list.push(
+        React_.Children.toArray(children)
+          .filter((child): child is string => typeof child === 'string')
+          .join('')
+      )
+      return React_.createElement(React_.Fragment, null, children)
+    },
     DropdownMenuSub: passthrough,
     DropdownMenuSubContent: passthrough,
     DropdownMenuSubTrigger: passthrough,
@@ -29,7 +38,6 @@ vi.mock('@/components/ui/dropdown-menu', async () => {
 })
 vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
 vi.mock('@/lib/agent-catalog', () => ({ AgentIcon: () => null }))
-vi.mock('@/hooks/useShortcutLabel', () => ({ formatShortcutLabel: () => 'X' }))
 vi.mock('./terminal-context-menu-dismiss', () => ({
   shouldIgnoreTerminalMenuPointerDownOutside: () => false
 }))
@@ -82,6 +90,12 @@ function renderMenu(overrides: Record<string, unknown> = {}): void {
 describe('TerminalContextMenu', () => {
   beforeEach(() => {
     items.list = []
+    shortcuts.list = []
+    vi.stubGlobal('navigator', { userAgent: 'Linux' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('renders a "Copy Context" item that triggers onCopyAgentSessionContext (issue #5020)', () => {
@@ -98,5 +112,24 @@ describe('TerminalContextMenu', () => {
     expect(onCopyAgentSessionContext).toHaveBeenCalledTimes(1)
     // Why: copying context must not go through the fork dialog path.
     expect(onForkAgentSession).not.toHaveBeenCalled()
+  })
+
+  it('shows one shortcut per terminal menu action on Windows', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    })
+    const keybindings = {
+      'terminal.copySelection': ['Ctrl+Shift+C', 'Ctrl+Insert', 'Ctrl+C'],
+      'terminal.splitRight': ['Mod+Shift+D', 'Alt+Shift+Right'],
+      'terminal.splitDown': ['Alt+Shift+D', 'Mod+Shift+Minus']
+    } satisfies KeybindingOverrides
+
+    renderMenu({ keybindings })
+
+    expect(shortcuts.list).toContain('Ctrl+Shift+C')
+    expect(shortcuts.list).toContain('Ctrl+V')
+    expect(shortcuts.list).toContain('Ctrl+Shift+D')
+    expect(shortcuts.list).toContain('Alt+Shift+D')
+    expect(shortcuts.list.some((shortcut) => shortcut.includes(','))).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -170,7 +170,7 @@ export default function TerminalContextMenu({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="w-52"
+        className="w-60"
         sideOffset={0}
         align="start"
         onCloseAutoFocus={(e) => {
@@ -293,7 +293,7 @@ export default function TerminalContextMenu({
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onSplitRight}>
+        <DropdownMenuItem className="whitespace-nowrap" onSelect={onSplitRight}>
           <PanelRightClose />
           {translate(
             'auto.components.terminal.pane.TerminalContextMenu.20e565d865',
@@ -301,7 +301,7 @@ export default function TerminalContextMenu({
           )}
           <DropdownMenuShortcut>{shortcuts.splitRight}</DropdownMenuShortcut>
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onSplitDown}>
+        <DropdownMenuItem className="whitespace-nowrap" onSelect={onSplitDown}>
           <PanelBottomClose />
           {translate(
             'auto.components.terminal.pane.TerminalContextMenu.98bccf4fa2',

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -32,7 +32,7 @@ import {
 import { shouldIgnoreTerminalMenuPointerDownOutside } from './terminal-context-menu-dismiss'
 import type { TerminalQuickCommand } from '../../../../shared/types'
 import { isTerminalAgentQuickCommand } from '../../../../shared/terminal-quick-commands'
-import { formatShortcutLabel } from '@/hooks/useShortcutLabel'
+import { formatPrimaryShortcutLabel } from '@/hooks/useShortcutLabel'
 import { AgentIcon } from '@/lib/agent-catalog'
 import type { KeybindingOverrides } from '../../../../shared/keybindings'
 import { translate } from '@/i18n/i18n'
@@ -107,17 +107,19 @@ export default function TerminalContextMenu({
   onCopyTerminalId,
   onCopyPaneId
 }: TerminalContextMenuProps): React.JSX.Element {
+  // Why: Windows/Linux shortcut labels are long; context menu rows should show
+  // the primary binding only so alternative bindings do not force row wraps.
   const shortcuts = useMemo(
     () => ({
-      copy: formatShortcutLabel('terminal.copySelection', keybindings),
-      paste: formatShortcutLabel('terminal.paste', keybindings),
-      splitRight: formatShortcutLabel('terminal.splitRight', keybindings),
-      splitDown: formatShortcutLabel('terminal.splitDown', keybindings),
-      equalize: formatShortcutLabel('terminal.equalizePaneSizes', keybindings),
-      expand: formatShortcutLabel('terminal.expandPane', keybindings),
-      setTitle: formatShortcutLabel('terminal.setTitle', keybindings),
-      clearPaneTitle: formatShortcutLabel('terminal.clearPaneTitle', keybindings),
-      close: formatShortcutLabel('terminal.closePane', keybindings),
+      copy: formatPrimaryShortcutLabel('terminal.copySelection', keybindings),
+      paste: formatPrimaryShortcutLabel('terminal.paste', keybindings),
+      splitRight: formatPrimaryShortcutLabel('terminal.splitRight', keybindings),
+      splitDown: formatPrimaryShortcutLabel('terminal.splitDown', keybindings),
+      equalize: formatPrimaryShortcutLabel('terminal.equalizePaneSizes', keybindings),
+      expand: formatPrimaryShortcutLabel('terminal.expandPane', keybindings),
+      setTitle: formatPrimaryShortcutLabel('terminal.setTitle', keybindings),
+      clearPaneTitle: formatPrimaryShortcutLabel('terminal.clearPaneTitle', keybindings),
+      close: formatPrimaryShortcutLabel('terminal.closePane', keybindings),
       nativeChat: nativeChatToggleShortcutLabel(isMacPlatform())
     }),
     [keybindings]

--- a/src/renderer/src/components/ui/context-menu.tsx
+++ b/src/renderer/src/components/ui/context-menu.tsx
@@ -210,7 +210,10 @@ function ContextMenuShortcut({ className, ...props }: React.ComponentProps<'span
   return (
     <span
       data-slot="context-menu-shortcut"
-      className={cn('ml-auto text-[11px] tracking-normal text-muted-foreground/85', className)}
+      className={cn(
+        'ml-auto shrink-0 whitespace-nowrap text-[11px] tracking-normal text-muted-foreground/85',
+        className
+      )}
       {...props}
     />
   )

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -165,7 +165,10 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'spa
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn('ml-auto text-[11px] tracking-normal text-muted-foreground/85', className)}
+      className={cn(
+        'ml-auto shrink-0 whitespace-nowrap text-[11px] tracking-normal text-muted-foreground/85',
+        className
+      )}
       {...props}
     />
   )

--- a/src/renderer/src/hooks/useShortcutLabel.ts
+++ b/src/renderer/src/hooks/useShortcutLabel.ts
@@ -27,6 +27,15 @@ export function formatShortcutLabel(
   )
 }
 
+export function formatPrimaryShortcutLabel(
+  actionId: KeybindingActionId,
+  overrides?: KeybindingOverrides
+): string {
+  const platform = getShortcutPlatform()
+  const [binding] = getEffectiveKeybindingsForAction(actionId, platform, overrides)
+  return binding ? formatKeybindingList([binding], platform) : 'Unassigned'
+}
+
 export function useShortcutLabel(actionId: KeybindingActionId): string {
   const keybindings = useAppStore((state) => state.keybindings)
   return formatShortcutLabel(actionId, keybindings)


### PR DESCRIPTION
## Summary
- Show only the primary shortcut binding in the terminal context menu so Windows rows do not wrap from comma-separated alternatives
- Keep dropdown/context-menu shortcut labels non-wrapping
- Add a Windows regression test for multi-binding terminal menu shortcuts

## Review
- Reviewed the changed code paths and did not find blocking issues
- Nearby tab context menu split shortcuts still use the full shortcut list; left unchanged because this fix targets the terminal right-click menu

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
- pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx src/renderer/src/hooks/useShortcutLabel.ts src/renderer/src/components/ui/dropdown-menu.tsx src/renderer/src/components/ui/context-menu.tsx
- pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx src/renderer/src/hooks/useShortcutLabel.ts src/renderer/src/components/ui/dropdown-menu.tsx src/renderer/src/components/ui/context-menu.tsx
- git diff --check

## Manual verification
- Launched this worktree in Electron dev and confirmed the terminal surface mounted
- Could not get a stable live context-menu screenshot because the local dev session cleared the transient terminal/menu state before capture; the Windows shortcut behavior is covered by the regression test
