### PR TITLE
Prevent regressions in Windows local project adds

### DIFF
--- a/src/renderer/src/store/slices/repos.runtime-fallback.test.ts
+++ b/src/renderer/src/store/slices/repos.runtime-fallback.test.ts
@@ -279,4 +279,57 @@ describe('repo slice runtime folder fallback', () => {
       })
     )
   })
+
+  it('adds a local non-git folder directly without runtime metadata or a worktree', async () => {
+    // Local analogue of the runtime fallback above: with no active runtime the add
+    // routes through window.api.repos.add (not runtime RPC). A non-git path returns
+    // Orca's own "Not a valid git repository" sentinel, so addRepoPath surfaces the
+    // confirmation modal with no runtime/SSH metadata instead of throwing.
+    const folderRepo: Repo = {
+      id: 'local-folder',
+      path: '/local/non-git',
+      displayName: 'non-git',
+      badgeColor: '#000',
+      addedAt: 1,
+      kind: 'folder'
+    }
+    const reposAdd = vi.fn(
+      (args: { path: string; kind: string }): { repo: Repo } | { error: string } =>
+        args.kind === 'folder'
+          ? { repo: folderRepo }
+          : { error: 'Not a valid git repository: /local/non-git' }
+    )
+    vi.stubGlobal('window', {
+      api: {
+        repos: { add: reposAdd },
+        runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+      }
+    })
+    const store = createTestStore()
+    // fetchWorktrees is stubbed so the post-add activation chain (which needs
+    // worktrees/onboarding APIs absent from this stub) stays out of scope.
+    store.setState({ fetchWorktrees: vi.fn().mockResolvedValue(undefined) as never })
+
+    await expect(store.getState().addRepoPath('/local/non-git', 'git')).resolves.toBeNull()
+
+    expect(runtimeEnvironmentTransportCall).not.toHaveBeenCalled()
+    expect(reposAdd).toHaveBeenNthCalledWith(1, {
+      path: '/local/non-git',
+      kind: 'git'
+    })
+    expect(store.getState().activeModal).toBe('confirm-non-git-folder')
+    expect(store.getState().modalData).toEqual({ folderPath: '/local/non-git' })
+    expect(store.getState().repos).toEqual([])
+
+    // Completing the flow via "Open as Folder" adds a kind:'folder' project whose
+    // workspace path IS the folder itself — proving no git worktree is created.
+    const added = await store.getState().addNonGitFolder('/local/non-git')
+
+    expect(reposAdd).toHaveBeenNthCalledWith(2, {
+      path: '/local/non-git',
+      kind: 'folder'
+    })
+    expect(added?.kind).toBe('folder')
+    expect(added?.path).toBe('/local/non-git')
+  })
 })

--- a/src/shared/execution-host.test.ts
+++ b/src/shared/execution-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
   LOCAL_EXECUTION_HOST_ID,
@@ -14,6 +14,12 @@ import {
 } from './execution-host'
 
 describe('execution host identity', () => {
+  // Why: the navigator cases below replace globalThis.navigator; restore it after
+  // each test so the stub can't bleed into the rest of the suite.
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('normalizes local, SSH, and runtime host ids', () => {
     expect(parseExecutionHostId('local')).toEqual({ kind: 'local', id: 'local' })
     expect(parseExecutionHostId(toSshExecutionHostId('win vm'))).toEqual({
@@ -28,11 +34,27 @@ describe('execution host identity', () => {
     })
   })
 
-  it('labels the local host by platform', () => {
+  it('labels the local host by platform and by navigator detection', () => {
     expect(getLocalExecutionHostLabel('darwin')).toBe('Local Mac')
     expect(getLocalExecutionHostLabel('win32')).toBe('Local Windows')
     expect(getLocalExecutionHostLabel('linux')).toBe('Local Linux')
     expect(getLocalExecutionHostLabel('freebsd')).toBe('This computer')
+
+    // With no explicit platform, the label is derived from navigator.userAgent
+    // (the path the live host-selector dialog uses).
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' })
+    expect(getLocalExecutionHostLabel()).toBe('Local Windows')
+
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (X11; Linux x86_64)' })
+    expect(getLocalExecutionHostLabel()).toBe('Local Linux')
+
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' })
+    expect(getLocalExecutionHostLabel()).toBe('Local Mac')
+
+    // Non-matching userAgent falls through to process.platform; compare against the
+    // explicit-platform label so the assertion is deterministic on any CI OS.
+    vi.stubGlobal('navigator', { userAgent: 'totally-unknown-agent' })
+    expect(getLocalExecutionHostLabel()).toBe(getLocalExecutionHostLabel(process.platform))
   })
 
   it('falls back invalid scopes to all hosts', () => {
@@ -70,11 +92,5 @@ describe('execution host identity', () => {
     expect(getSettingsFocusedExecutionHostId({ activeRuntimeEnvironmentId: 'runtime-1' })).toBe(
       'runtime:runtime-1'
     )
-  })
-
-  it('labels local execution hosts by platform', () => {
-    expect(getLocalExecutionHostLabel('darwin')).toBe('Local Mac')
-    expect(getLocalExecutionHostLabel('linux')).toBe('Local Linux')
-    expect(getLocalExecutionHostLabel('win32')).toBe('Local Windows')
   })
 })


### PR DESCRIPTION
## Summary

Adds regression coverage for issue #5361 so Windows/local project behavior stays locked in:

- local host labels are derived from the browser/runtime platform path, including Windows user agents
- local non-git folders open through the direct folder confirmation path without runtime metadata or a git worktree

This PR does not change production behavior. The source fix for platform-aware labels and the direct `kind: folder` add path are already present on `main`; this PR preserves those behaviors with focused tests.

Closes #5361.

## Design and Review

- Design approach: tests-only regression coverage after confirming the product behavior already exists on current `main`.
- Design review: prior scratch design review was clean after tightening the non-vacuous folder assertion and navigator-stub isolation.
- Implementation: added one local non-git folder test and folded navigator-based platform detection into the execution-host label test. A CodeRabbit tightening was applied so the initial local `git` add is asserted to use `window.api.repos.add` and never runtime RPC.
- Completeness verification: clean; verifier confirmed the headline behavior is implemented in production source and the branch correctly adds regression tests only.
- Headline behavior status: implemented already on `main`; this PR prevents regression.
- Broad app consistency: compared Add Project local folder fallback, runtime fallback, execution-host labels, synthetic folder workspaces, and SSH/runtime boundaries. The PR preserves existing behavior and does not alter UI or provider-specific flows.
- Risks/non-goals: no production behavior change; the local-folder test proves the renderer/store contract, not main-process workspace synthesis, which is unchanged.

## Screenshots

Not applicable: tests-only PR with no visual UI or layout changes.

## AI Review Report

- Perf audit: clean; tests-only diff, no production hot paths, polling, subprocess, render, or cleanup risk.
- Code review loop: one round with two independent reviewers; both returned clean.
- Merge-confidence validation: land after branch refresh; branch was rebased/pushed after validation.
- CodeRabbit: one actionable test assertion was fixed; final review reported no actionable comments.

## Security Audit

Tests-only change. No auth, provider, filesystem permission, network, SSH/remoting, telemetry, or secret-handling behavior changed.

## Tests

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/execution-host.test.ts src/renderer/src/store/slices/repos.runtime-fallback.test.ts`
- [x] `pnpm exec oxlint src/shared/execution-host.test.ts src/renderer/src/store/slices/repos.runtime-fallback.test.ts`
- [x] `git diff --check origin/main...HEAD`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (passed with one pre-existing unrelated warning in `src/renderer/src/components/right-sidebar/useGitStatusPolling.ts`)
- [x] GitHub PR check `verify`

## Notes

No Electron/demo-project validation was run because this PR has no production UI/source changes. No SSH live pass was run because SSH/remoting code is untouched.

## Post-PR Stabilization

CI is passing. CodeRabbit has no unresolved actionable comments.