### PR TITLE
Suppress parent completion banners while child agents run

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-notification-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-notification-state.ts
@@ -1,4 +1,5 @@
-import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import { detectAgentStatusFromTitle, isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import { resolveRuntimePaneTitleForLeaf } from '@/lib/runtime-pane-title-leaf-id'
 import type { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
@@ -51,6 +52,124 @@ export function hasLivePtyForNotification(
   // list is between renderer hydration states; the pane-key PTY binding is the
   // live terminal source in that path.
   return hasLivePtyForWorktree(state, worktreeId) || hasLivePtyForPaneKey(state, paneKey)
+}
+
+export function hasActiveOrchestrationChildForPaneKey(
+  state: StoreSnapshot,
+  worktreeId: string,
+  parentPaneKey: string
+): boolean {
+  const now = Date.now()
+  const parentTerminalHandle = state.agentStatusByPaneKey?.[parentPaneKey]?.terminalHandle
+  const liveStatusChildIsActive = Object.entries(state.agentStatusByPaneKey ?? {}).some(
+    ([paneKey, entry]) => {
+      if (
+        paneKey === parentPaneKey ||
+        entry.state === 'done' ||
+        !agentStatusEntryBelongsToWorktree(state, worktreeId, entry) ||
+        !isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)
+      ) {
+        return false
+      }
+      return orchestrationContextMatchesParent(
+        entry.orchestration,
+        parentPaneKey,
+        parentTerminalHandle
+      )
+    }
+  )
+  if (liveStatusChildIsActive) {
+    return true
+  }
+
+  return Object.entries(state.runtimeAgentOrchestrationByPaneKey ?? {}).some(
+    ([paneKey, orchestration]) => {
+      if (
+        paneKey === parentPaneKey ||
+        isFreshDoneOrActiveAgentStatus(state, paneKey, now) ||
+        !paneKeyBelongsToWorktree(state, worktreeId, paneKey) ||
+        !orchestrationContextMatchesParent(orchestration, parentPaneKey, parentTerminalHandle)
+      ) {
+        return false
+      }
+      const title = getRuntimeTitleForPaneKey(state, worktreeId, paneKey)
+      const status = title ? detectAgentStatusFromTitle(title) : null
+      return status === 'working' || status === 'permission'
+    }
+  )
+}
+
+function orchestrationContextMatchesParent(
+  orchestration: StoreSnapshot['runtimeAgentOrchestrationByPaneKey'][string] | undefined,
+  parentPaneKey: string,
+  parentTerminalHandle: string | undefined
+): boolean {
+  if (orchestration?.parentPaneKey === parentPaneKey) {
+    return true
+  }
+  return Boolean(
+    parentTerminalHandle &&
+    (orchestration?.parentTerminalHandle === parentTerminalHandle ||
+      orchestration?.coordinatorHandle === parentTerminalHandle)
+  )
+}
+
+function paneKeyBelongsToWorktree(
+  state: StoreSnapshot,
+  worktreeId: string,
+  paneKey: string
+): boolean {
+  const tabId = getPaneKeyTabId(paneKey)
+  return tabId !== null && (state.tabsByWorktree[worktreeId] ?? []).some((tab) => tab.id === tabId)
+}
+
+function getRuntimeTitleForPaneKey(
+  state: StoreSnapshot,
+  worktreeId: string,
+  paneKey: string
+): string | null {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed || !hasLivePtyForPaneKey(state, paneKey)) {
+    return null
+  }
+  const layout = state.terminalLayoutsByTabId?.[parsed.tabId]
+  const runtimeTitle = resolveRuntimePaneTitleForLeaf(
+    layout,
+    state.runtimePaneTitlesByTabId?.[parsed.tabId],
+    parsed.leafId
+  )
+  if (runtimeTitle) {
+    return runtimeTitle
+  }
+  if (layout?.activeLeafId && layout.activeLeafId !== parsed.leafId) {
+    return null
+  }
+  return (
+    (state.tabsByWorktree[worktreeId] ?? []).find((tab) => tab.id === parsed.tabId)?.title ?? null
+  )
+}
+
+function agentStatusEntryBelongsToWorktree(
+  state: StoreSnapshot,
+  worktreeId: string,
+  entry: { paneKey: string; worktreeId?: string }
+): boolean {
+  if (entry.worktreeId) {
+    return entry.worktreeId === worktreeId
+  }
+  return paneKeyBelongsToWorktree(state, worktreeId, entry.paneKey)
+}
+
+function isFreshDoneOrActiveAgentStatus(
+  state: StoreSnapshot,
+  paneKey: string,
+  now: number
+): boolean {
+  const entry = state.agentStatusByPaneKey?.[paneKey]
+  return Boolean(
+    entry &&
+    (entry.state === 'done' || isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS))
+  )
 }
 
 function layoutContainsLeaf(

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -12,6 +12,8 @@ type MockState = {
   ptyIdsByTabId: Record<string, string[]>
   suppressedPtyExitIds: Record<string, boolean>
   terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  runtimeAgentOrchestrationByPaneKey: Record<string, NonNullable<AgentStatusEntry['orchestration']>>
   browserTabsByWorktree: Record<string, unknown[]>
   retainedAgentsByPaneKey: Record<string, { worktreeId: string }>
   agentStatusByPaneKey: Record<string, AgentStatusEntry>
@@ -115,6 +117,8 @@ describe('dispatchTerminalNotification', () => {
           ptyIdsByLeafId: { [liveLeafId]: 'pty-1' }
         }
       },
+      runtimePaneTitlesByTabId: {},
+      runtimeAgentOrchestrationByPaneKey: {},
       browserTabsByWorktree: {},
       retainedAgentsByPaneKey: {},
       agentStatusByPaneKey: {
@@ -258,6 +262,420 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
     expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('suppresses parent OS completion while an orchestration child is active', () => {
+    const childPaneKey = 'tab-child:33333333-3333-4333-8333-333333333333'
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'working',
+      prompt: 'child still running',
+      worktreeId: 'wt-primary',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentPaneKey: paneKey
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+  })
+
+  it.each(['waiting', 'blocked'] as const)(
+    'suppresses parent OS completion while an orchestration child is %s',
+    (childState) => {
+      const childPaneKey = 'tab-child:33333333-3333-4333-8333-333333333333'
+      mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+        state: childState,
+        prompt: 'child needs attention',
+        worktreeId: 'wt-primary',
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          parentPaneKey: paneKey
+        }
+      })
+
+      dispatchTerminalNotification('wt-primary', {
+        source: 'agent-task-complete',
+        terminalTitle: 'codex',
+        paneKey
+      })
+
+      expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+      expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+      expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+      expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    }
+  )
+
+  it('suppresses parent OS completion for child related by parent terminal handle', () => {
+    const childPaneKey = 'tab-child:33333333-3333-4333-8333-333333333333'
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      terminalHandle: 'term-parent'
+    })
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'working',
+      prompt: 'child still running',
+      worktreeId: 'wt-primary',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentTerminalHandle: 'term-parent'
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('suppresses parent OS completion for child related by coordinator handle', () => {
+    const childPaneKey = 'tab-child:33333333-3333-4333-8333-333333333333'
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      terminalHandle: 'term-coordinator'
+    })
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'working',
+      prompt: 'child still running',
+      worktreeId: 'wt-primary',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        coordinatorHandle: 'term-coordinator'
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('still dispatches parent waiting attention while an orchestration child is active', () => {
+    const childPaneKey = 'tab-child:33333333-3333-4333-8333-333333333333'
+    const waitingStartedAt = Date.now()
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'waiting',
+      prompt: 'approval needed',
+      updatedAt: waitingStartedAt,
+      stateStartedAt: waitingStartedAt
+    })
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'working',
+      prompt: 'child still running',
+      worktreeId: 'wt-primary',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentPaneKey: paneKey
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'waiting',
+        prompt: 'approval needed',
+        agentType: 'codex',
+        stateStartedAt: waitingStartedAt
+      }
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        agentState: 'waiting',
+        agentPrompt: 'approval needed'
+      })
+    )
+  })
+
+  it('does not suppress from a handle-matched child in another worktree', () => {
+    const childPaneKey = 'tab-secondary-child:33333333-3333-4333-8333-333333333333'
+    mockState.tabsByWorktree['wt-secondary'] = [
+      { id: 'tab-secondary-child', ptyId: 'pty-secondary-child' }
+    ]
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      terminalHandle: 'term-shared'
+    })
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'working',
+      prompt: 'other worktree child',
+      worktreeId: 'wt-secondary',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentTerminalHandle: 'term-shared'
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey
+      })
+    )
+  })
+
+  it('does not suppress when an explicit child worktree id conflicts with tab membership', () => {
+    const childPaneKey = 'tab-1:33333333-3333-4333-8333-333333333333'
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      terminalHandle: 'term-shared'
+    })
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'working',
+      prompt: 'misattributed child',
+      worktreeId: 'wt-secondary',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentTerminalHandle: 'term-shared'
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey
+      })
+    )
+  })
+
+  it('suppresses parent OS completion for active title-derived orchestration children', () => {
+    const childLeafId = '33333333-3333-4333-8333-333333333333'
+    const childPaneKey = `tab-title-child:${childLeafId}`
+    mockState.tabsByWorktree['wt-primary'].push({
+      id: 'tab-title-child',
+      ptyId: 'pty-title-child'
+    })
+    mockState.ptyIdsByTabId['tab-title-child'] = ['pty-title-child']
+    mockState.terminalLayoutsByTabId['tab-title-child'] = {
+      root: { type: 'leaf', leafId: childLeafId },
+      activeLeafId: childLeafId,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [childLeafId]: 'pty-title-child' }
+    }
+    mockState.runtimePaneTitlesByTabId['tab-title-child'] = {
+      1: '⠋ Claude Code'
+    }
+    mockState.runtimeAgentOrchestrationByPaneKey[childPaneKey] = {
+      taskId: 'task-1',
+      dispatchId: 'ctx-1',
+      parentPaneKey: paneKey
+    }
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('uses active title-derived suppression when a child hook row is stale', () => {
+    const childLeafId = '33333333-3333-4333-8333-333333333333'
+    const childPaneKey = `tab-title-child:${childLeafId}`
+    const staleTime = Date.now() - 31 * 60 * 1_000
+    mockState.tabsByWorktree['wt-primary'].push({
+      id: 'tab-title-child',
+      ptyId: 'pty-title-child'
+    })
+    mockState.ptyIdsByTabId['tab-title-child'] = ['pty-title-child']
+    mockState.terminalLayoutsByTabId['tab-title-child'] = {
+      root: { type: 'leaf', leafId: childLeafId },
+      activeLeafId: childLeafId,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [childLeafId]: 'pty-title-child' }
+    }
+    mockState.runtimePaneTitlesByTabId['tab-title-child'] = {
+      1: '⠋ Claude Code'
+    }
+    mockState.runtimeAgentOrchestrationByPaneKey[childPaneKey] = {
+      taskId: 'task-1',
+      dispatchId: 'ctx-1',
+      parentPaneKey: paneKey
+    }
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'working',
+      prompt: 'stale hook row',
+      updatedAt: staleTime,
+      stateStartedAt: staleTime,
+      worktreeId: 'wt-primary',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentPaneKey: paneKey
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('does not suppress child completion for a sibling linked to the same parent', () => {
+    const completedChildLeafId = '33333333-3333-4333-8333-333333333333'
+    const activeSiblingLeafId = '44444444-4444-4444-8444-444444444444'
+    const completedChildPaneKey = `tab-child-done:${completedChildLeafId}`
+    const activeSiblingPaneKey = `tab-child-working:${activeSiblingLeafId}`
+    mockState.tabsByWorktree['wt-primary'].push(
+      { id: 'tab-child-done', ptyId: 'pty-child-done' },
+      { id: 'tab-child-working', ptyId: 'pty-child-working' }
+    )
+    mockState.ptyIdsByTabId['tab-child-done'] = ['pty-child-done']
+    mockState.ptyIdsByTabId['tab-child-working'] = ['pty-child-working']
+    mockState.terminalLayoutsByTabId['tab-child-done'] = {
+      root: { type: 'leaf', leafId: completedChildLeafId },
+      activeLeafId: completedChildLeafId,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [completedChildLeafId]: 'pty-child-done' }
+    }
+    mockState.terminalLayoutsByTabId['tab-child-working'] = {
+      root: { type: 'leaf', leafId: activeSiblingLeafId },
+      activeLeafId: activeSiblingLeafId,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [activeSiblingLeafId]: 'pty-child-working' }
+    }
+    mockState.agentStatusByPaneKey[completedChildPaneKey] = makeAgentStatus(completedChildPaneKey, {
+      state: 'done',
+      prompt: 'child done',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentPaneKey: paneKey
+      }
+    })
+    mockState.agentStatusByPaneKey[activeSiblingPaneKey] = makeAgentStatus(activeSiblingPaneKey, {
+      state: 'working',
+      prompt: 'sibling still running',
+      orchestration: {
+        taskId: 'task-2',
+        dispatchId: 'ctx-2',
+        parentPaneKey: paneKey
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey: completedChildPaneKey,
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'child done',
+        agentType: 'codex',
+        stateStartedAt: Date.now()
+      }
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey: completedChildPaneKey
+      })
+    )
+  })
+
+  it('allows parent OS completion when orchestration children are done', () => {
+    const childPaneKey = 'tab-child:33333333-3333-4333-8333-333333333333'
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'done',
+      prompt: 'child finished',
+      worktreeId: 'wt-primary',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentPaneKey: paneKey
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey
+      })
+    )
+  })
+
+  it('allows parent OS completion when orchestration child status is stale', () => {
+    const childPaneKey = 'tab-child:33333333-3333-4333-8333-333333333333'
+    const staleTime = Date.now() - 31 * 60 * 1_000
+    mockState.agentStatusByPaneKey[childPaneKey] = makeAgentStatus(childPaneKey, {
+      state: 'working',
+      prompt: 'stale child',
+      worktreeId: 'wt-primary',
+      updatedAt: staleTime,
+      stateStartedAt: staleTime,
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        parentPaneKey: paneKey
+      }
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey
+      })
+    )
   })
 
   it('does not mark the visible focused pane unread', () => {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -9,6 +9,7 @@ import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinat
 import {
   countReposNeedingNotificationDisambiguation,
   getPaneKeyTabId,
+  hasActiveOrchestrationChildForPaneKey,
   hasLivePtyForNotification,
   isCurrentKnownPaneKey,
   isCurrentLivePaneKey
@@ -135,7 +136,18 @@ export function dispatchTerminalNotification(
     }
   }
 
-  if (event.suppressOsNotification) {
+  const isCompletionOsNotification =
+    event.source === 'agent-task-complete' &&
+    (!agentStatus || agentStatus.state === 'done' || eventAgentStatusSnapshot?.state === 'done')
+  const shouldSuppressOsNotification =
+    event.suppressOsNotification === true ||
+    (isCompletionOsNotification &&
+      Boolean(
+        event.paneKey && hasActiveOrchestrationChildForPaneKey(state, worktreeId, event.paneKey)
+      ))
+  // Why: orchestration children are explicit task-tree state; keep in-app
+  // attention but avoid a false native "done" banner while a child is active.
+  if (shouldSuppressOsNotification) {
     return
   }
 


### PR DESCRIPTION
## Summary
- Suppress native OS `agent-task-complete` completion banners for a parent/coordinator pane while a related orchestration child is still active.
- Keep in-app unread and terminal attention marking intact so hidden parent panes still show Orca attention.
- Use Orca's explicit orchestration metadata and runtime title-derived agent rows; do not inspect PTY child processes.

Fixes #6100

## Design Approach
The implementation follows the same parent/child relationship model used by sidebar/dashboard agent rows: direct `parentPaneKey`, plus `parentTerminalHandle` and `coordinatorHandle` resolved through the parent row's `terminalHandle`. It also covers hookless/title-derived child rows when runtime orchestration metadata relates the child pane to the parent and the live pane title is active.

Important boundary: this PR suppresses false parent **completion** OS banners only. It does not add a replacement "child still running" banner, and it does not suppress `waiting`/`blocked` native attention notifications.

## Review Outcome
- Design review initially blocked pane-key-only matching as too narrow; the design was revised to include handle-based lineage.
- Performance/code review found two edge cases: attention snapshots sharing the same notification source, and cross-worktree handle matching. Both were fixed.
- Final review found stale hook rows blocking title-derived suppression and explicit `worktreeId` mismatches falling back to tab membership. Both were fixed and covered.

## Completeness
Headline behavior: **implemented** for explicit Orca orchestration child agents and active title-derived runtime-orchestration child rows.

Deferred/non-goal: arbitrary background shell jobs, provider-internal work without Orca orchestration metadata, MCP/language servers, dev servers, and generic PTY child-process inference. PR #6181 attempted process inspection; this PR intentionally avoids that path because it can suppress completion indefinitely for resident CLIs or unrelated child processes.

## Broad App Consistency
Compared against sidebar/dashboard agent-row lineage behavior. This PR now follows the same relationship semantics for direct parent pane keys, parent terminal handles, coordinator handles, and active title-derived rows, while scoping handle fallback to the same worktree for SSH/cross-worktree safety.

## Perf
The new scan is limited to notification dispatch time for `agent-task-complete` events. It iterates live agent status/runtime orchestration maps only on completion notification attempts, not terminal output or render paths.

## Validation
- `pnpm exec vitest run src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts --config config/vitest.config.ts` (35 tests passed)
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-notification-state.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts --quiet`
- `git diff --check`
- `pnpm exec tsc --noEmit --pretty false --project tsconfig.json`
- Pre-commit hook also ran staged `oxlint`, React-doctor oxlint, and `oxfmt --write`

Attempted broader `pnpm run typecheck:web`; it currently fails in unrelated `MobileNetworkInterfaceSection.test.tsx` Testing Library imports/types, not in this diff.

## Risks
If an agent child has no explicit orchestration metadata and no active runtime-orchestration title row, Orca still cannot reliably know it belongs to the parent. That remains a lifecycle-signal/product follow-up rather than a process-tree heuristic.

## Post-PR Checks
- GitHub checks: `verify` passed; `track-community-pr` passed.
- CodeRabbit: initial automatic review was rate-limited; after the required wait, `@coderabbitai review` completed with no inline/actionable comments.
