### PR TITLE
fix(github): count PR diff lines whose added content starts with ++

### DIFF
--- a/src/main/github/pr-review-comment-lines.test.ts
+++ b/src/main/github/pr-review-comment-lines.test.ts
@@ -23,4 +23,22 @@ describe('getPRReviewCommentLineNumbersFromPatch', () => {
   it('returns an empty list when GitHub omits the patch', () => {
     expect(getPRReviewCommentLineNumbersFromPatch(undefined)).toEqual([])
   })
+
+  it('counts added lines whose content begins with ++', () => {
+    // Inside a hunk, GitHub's per-file patch never carries a `+++ b/file` header
+    // (those precede the first @@), so `+++count` is an added line of content `++count`
+    // and must stay comment-eligible.
+    const patch = ['@@ -1,1 +1,2 @@', ' const a = 1', '+++count'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([1, 2])
+  })
+
+  it('does not treat removed lines whose content begins with -- as commentable', () => {
+    // Asymmetry guard: removed lines never advance the new-side counter, so `--count`
+    // (diff line `---count`) must not become commentable. Locks the intended difference
+    // from the added-line case so a future "symmetric" edit can't regress it.
+    const patch = ['@@ -1,2 +1,1 @@', ' const a = 1', '---count'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([1])
+  })
 })

--- a/src/main/github/pr-review-comment-lines.ts
+++ b/src/main/github/pr-review-comment-lines.ts
@@ -21,7 +21,10 @@ export function getPRReviewCommentLineNumbersFromPatch(patch: string | undefined
       continue
     }
 
-    if (line.startsWith('+') && !line.startsWith('+++')) {
+    // Inside a hunk every `+` line is added content. GitHub's per-file patch keeps the
+    // `+++ b/file` header before the first @@, so a `+++…` line here is `++…` content,
+    // not a header, and must stay comment-eligible.
+    if (line.startsWith('+')) {
       lineNumbers.push(nextModifiedLine)
       nextModifiedLine++
       continue


### PR DESCRIPTION
## Summary

When mapping which lines of a GitHub PR diff are eligible for review comments, `getPRReviewCommentLineNumbersFromPatch` silently dropped any **added** line whose *content* begins with `++` — e.g. `++count`, `++i`, `++total` (a leading pre-increment is common in C/C++/JS/Go). Such a line appears in the patch as `+++count`, and the parser mistook it for a `+++ b/file` diff header and excluded it. That line then became un-commentable in the PR-review UI.

Root cause: inside a hunk, every `+` line is added content. GitHub's per-file `patch` (from `GET /repos/{o}/{r}/pulls/{n}/files`) keeps the `+++ b/file` / `--- a/file` headers **before the first `@@`**, which the existing `nextModifiedLine === null` guard already skips. So the `!line.startsWith('+++')` clause could never exclude a real header once inside a hunk — it only ever dropped legitimate added content, and the line then fell through to the trailing branch which advanced the new-side counter without recording the line.

The fix removes the dead guard. The removed-line case (`---content`) is already handled correctly by the existing `line.startsWith('-')` check at the fall-through branch, so it is intentionally left unchanged.

Reproduced (Node):
`getPRReviewCommentLineNumbersFromPatch("@@ -1,1 +1,2 @@\n const a = 1\n+++count")` returns `[1]`; expected `[1, 2]`.

## Screenshots

No visual change. This is a pure parsing fix in `src/main`; it only affects which line numbers are returned as comment-eligible.

## Testing

- [x] `pnpm lint` — passes (pre-existing unrelated `useGitStatusPolling.ts` exhaustive-deps warning only)
- [x] `pnpm typecheck` — passes (node + cli + web, exit 0)
- [x] `pnpm test` — `src/main/github` suite: 22 files / 292 tests pass; new regression test fails on pre-fix code and passes after
- [ ] `pnpm build` — not run locally (native/electron toolchain); change is pure string logic with no native, build, or platform surface
- [x] Added high-quality tests: a regression test that fails before the fix and passes after (the `++` added line), plus a companion test pinning the removed-line asymmetry so a future "symmetric" edit can't silently regress it.

## AI Review Report

Reviewed with an AI coding agent (adversarial: an independent pass tried to refute the bug before the fix was written, and verified the dead-clause argument against the sole caller `work-item-details.ts` which feeds `file.patch` straight from the `pulls/{n}/files` REST API).

- **Cross-platform (macOS / Linux / Windows):** No impact. Pure string logic — no `path` handling, no `e.metaKey`/shortcut, no shell. The patch is split on `\n`; a trailing `\r` (CRLF) only ever touches the line's tail, never its `+` prefix, so behavior is identical across platforms. No Electron platform-specific code touched.
- **SSH / remote / local:** No transport impact. The input *is* remote data (GitHub REST patch); the change makes parsing of author-controlled diff content correct in all of local/remote/SSH modes equally.
- **Agent / integration / git-provider:** No impact. This is the generic GitHub PR-review line-mapping path; no Claude/Codex/Cursor-specific or provider-specific logic touched. (Behavior is GitHub-patch-format specific, which is what the function is for.)
- **Performance:** No impact — removes one `startsWith('+++')` call per added line.
- **UI:** No visual change; downstream, correctly-added lines become comment-eligible as intended.
- **Result:** The flagged concern (could the removed guard ever drop a real header?) was checked and disproven for in-hunk input, and locked in by the companion test.

## Security Audit

- **Input handling:** Input is semi-trusted, author-controllable GitHub diff content. The change *reduces* silent data loss (previously some added lines were dropped) without widening the accepted set beyond "lines inside a valid hunk." Parsing stays bounded and pure (single pass, no regex backtracking added, no unbounded allocation).
- **Command execution / paths / auth / secrets / IPC:** None touched. No new follow-up needed.

## Notes

No platform-specific behavior. The same parser also leaves a trailing `\r` on CRLF patches in a couple of unrelated spots; that is out of scope for this focused fix and can be addressed separately if desired.
