### PR TITLE
Remove unused dead-code exports

### DIFF
--- a/src/main/computer/desktop-script-provider-test-harness.ts
+++ b/src/main/computer/desktop-script-provider-test-harness.ts
@@ -142,13 +142,6 @@ export function sampleCapabilities(actions: Partial<Record<string, boolean>> = {
   }
 }
 
-export function sampleListWindowsCapabilities() {
-  return sampleCapabilities({
-    hotkey: false,
-    pasteText: false
-  })
-}
-
 export function publicSnapshotKeys(snapshot: unknown): string[] {
   return Object.keys(snapshot as Record<string, unknown>).sort()
 }

--- a/src/main/computer/sidecar-client.ts
+++ b/src/main/computer/sidecar-client.ts
@@ -49,16 +49,6 @@ let sidecar: ComputerSidecarProcess | null = null
 // stale children keep a no-op listener that does not retain the sidecar owner.
 function ignoreStaleChildError(): void {}
 
-export function shouldUseComputerSidecar(): boolean {
-  return (
-    (process.platform === 'darwin' ||
-      process.platform === 'linux' ||
-      process.platform === 'win32') &&
-    typeof process.versions.electron === 'string' &&
-    process.env.ORCA_COMPUTER_SIDECAR !== '1'
-  )
-}
-
 export async function callComputerSidecarListApps(): Promise<ComputerListAppsResult> {
   return (await getComputerSidecar().call('listApps', {})) as ComputerListAppsResult
 }

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -5,10 +5,7 @@ import { hostname } from 'os'
 import { isDeepStrictEqual } from 'util'
 import type { Store } from '../persistence'
 import { getActiveMultiplexer, getSshConnectionStore } from './ssh'
-import {
-  exportRemoteWorkspaceSession,
-  importRemoteWorkspaceSession
-} from '../../shared/remote-workspace-session-projection'
+import { exportRemoteWorkspaceSession } from '../../shared/remote-workspace-session-projection'
 import type {
   RemoteWorkspaceChangedEvent,
   RemoteWorkspaceConnectedClient,
@@ -18,7 +15,7 @@ import type {
 } from '../../shared/remote-workspace-types'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { WorkspaceSessionState } from '../../shared/types'
-import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
+import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
 import { getRemoteWorkspaceNamespace } from './remote-workspace-namespace'
 import { registerRemoteWorkspaceNotificationHandler } from './remote-workspace-events'
 
@@ -235,29 +232,6 @@ function exportSessionForTarget(
 ): RemoteWorkspaceSession {
   return exportRemoteWorkspaceSession(session, {
     isTargetWorktree: (worktreeId) => targetForWorktree(store, worktreeId) === targetId
-  })
-}
-
-function importSessionForTarget(
-  store: Store,
-  targetId: string,
-  remote: RemoteWorkspaceSession
-): WorkspaceSessionState {
-  const repos = store.getRepos().filter((repo) => repo.connectionId === targetId)
-  const repoById = new Map(repos.map((repo) => [repo.id, repo]))
-  return importRemoteWorkspaceSession(remote, {
-    resolveWorktreeId: (worktreePath) => {
-      for (const repo of repoById.values()) {
-        const candidate = `${repo.id}::${worktreePath}`
-        // Main does not own the live worktree list for SSH repos, so resolve
-        // against repo identity only. Renderer hydration later validates IDs
-        // against its fetched worktree list before panes mount.
-        if (splitWorktreeId(candidate)) {
-          return candidate
-        }
-      }
-      return null
-    }
   })
 }
 
@@ -510,12 +484,4 @@ export function registerRemoteWorkspaceHandlers(
   )
 
   ipcMain.handle('remoteWorkspace:clientId', () => CLIENT_ID)
-}
-
-export function materializeRemoteWorkspaceForTarget(
-  store: Store,
-  targetId: string,
-  snapshot: RemoteWorkspaceSnapshot
-): WorkspaceSessionState {
-  return importSessionForTarget(store, targetId, snapshot.session)
 }

--- a/src/main/observability/instrumentation.ts
+++ b/src/main/observability/instrumentation.ts
@@ -184,25 +184,6 @@ export async function withGitSpan<T>(meta: GitSpanArgs, fn: () => Promise<T>): P
   )
 }
 
-export type IpcSpanArgs = {
-  readonly channel: string
-}
-
-/** Wrap an ipcMain handler invocation in an `ipc.handle` span. Used by
- *  the highest-traffic handlers — `git`, `runtime`, `pty`, `worktree`,
- *  `agent` — not every handler. Tracing every IPC call would explode the
- *  trace tree and obscure the spans that matter. */
-export async function withIpcSpan<T>(meta: IpcSpanArgs, fn: () => Promise<T> | T): Promise<T> {
-  return withSpan(
-    'ipc.handle',
-    async (span) => {
-      span.setAttribute('ipc.channel', meta.channel)
-      return await fn()
-    },
-    { attributes: { kind: 'ipc' } }
-  )
-}
-
 export type WorktreeSpanArgs = {
   readonly stage: 'clone' | 'checkout' | 'install' | 'create' | 'remove'
   readonly path?: string
@@ -249,47 +230,6 @@ export async function withPtySpan<T>(meta: PtySpanArgs, fn: () => Promise<T> | T
       return await fn()
     },
     { attributes: { kind: 'pty' } }
-  )
-}
-
-export type AgentSpanArgs = {
-  readonly stage: 'start' | 'turn' | 'stop' | 'recover'
-  readonly agentKind?: string
-}
-
-export async function withAgentSpan<T>(meta: AgentSpanArgs, fn: () => Promise<T> | T): Promise<T> {
-  return withSpan(
-    `agent.${meta.stage}`,
-    async (span) => {
-      span.setAttribute('agent.stage', meta.stage)
-      if (meta.agentKind) {
-        span.setAttribute('agent.kind', meta.agentKind)
-      }
-      return await fn()
-    },
-    { attributes: { kind: 'agent' } }
-  )
-}
-
-export type ExternalEditorSpanArgs = {
-  readonly editor: string
-  readonly path?: string
-}
-
-export async function withExternalEditorSpan<T>(
-  meta: ExternalEditorSpanArgs,
-  fn: () => Promise<T> | T
-): Promise<T> {
-  return withSpan(
-    'external_editor.launch',
-    async (span) => {
-      span.setAttribute('editor', meta.editor)
-      if (meta.path) {
-        span.setAttribute('path', meta.path)
-      }
-      return await fn()
-    },
-    { attributes: { kind: 'external_editor' } }
   )
 }
 

--- a/src/main/pty/omp-sqlite-overlay.ts
+++ b/src/main/pty/omp-sqlite-overlay.ts
@@ -10,15 +10,6 @@ export const OMP_PERSISTENT_SQLITE_FILES = ['agent.db'] as const
 
 const SQLITE_SIDECAR_SUFFIXES = ['-wal', '-shm'] as const
 
-export function isOmpPersistentSqliteEntry(entryName: string): boolean {
-  return OMP_PERSISTENT_SQLITE_FILES.some(
-    (databaseName) =>
-      entryName === databaseName ||
-      entryName === `${databaseName}-wal` ||
-      entryName === `${databaseName}-shm`
-  )
-}
-
 function ensureEmptyFile(path: string): void {
   closeSync(openSync(path, 'a'))
 }

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -1,9 +1,5 @@
 import type { HostedReviewInfo } from '../../shared/hosted-review'
-import {
-  getForgeProviderById,
-  getForgeProviderForRepository,
-  type ForgeProviderId
-} from './forge-provider'
+import { getForgeProviderForRepository, type ForgeProviderId } from './forge-provider'
 import type { HostedReviewExecutionOptions } from './hosted-review-git-options'
 
 function reviewLinkForProvider(
@@ -72,12 +68,4 @@ export async function getHostedReviewForBranch(
     githubCurrentHeadOid: input.currentHeadOid ?? null,
     ...reviewLinkForProvider(input, provider.id)
   })
-}
-
-export async function getHostedReviewByNumber(input: {
-  repoPath: string
-  provider: ForgeProviderId
-  number: number
-}): Promise<HostedReviewInfo | null> {
-  return getForgeProviderById(input.provider).getReviewByNumber(input)
 }

--- a/src/renderer/src/components/editor/details-markdown-html.ts
+++ b/src/renderer/src/components/editor/details-markdown-html.ts
@@ -1,7 +1,5 @@
 import type { MarkdownToken } from '@tiptap/core'
 
-export const DETAILS_CLOSE_TAG = '</details>'
-
 export type DetailsHtmlToken = MarkdownToken & {
   attributes?: Record<string, unknown>
   bodyTokens?: MarkdownToken[]

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
@@ -6,12 +6,6 @@ export type PRCommentPresentationVariant = 'flat' | 'cards' | 'focus'
 
 export const DEFAULT_PR_COMMENT_PRESENTATION_VARIANT: PRCommentPresentationVariant = 'cards'
 
-export const PR_COMMENT_PRESENTATION_VARIANTS: PRCommentPresentationVariant[] = [
-  'flat',
-  'cards',
-  'focus'
-]
-
 const STORAGE_KEY = 'orca:pr-comment-presentation'
 
 export type PRCommentPresentationClasses = {

--- a/src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-primary-action-layout.ts
@@ -13,5 +13,3 @@ export const RIGHT_SIDEBAR_PRIMARY_BUTTON_LABEL_CLASS = 'block min-w-0 truncate'
 
 // PR full-page and item-dialog asides share the same merge/state labels.
 export const REVIEW_ACTION_MERGE_BUTTON_CLASS = RIGHT_SIDEBAR_MERGE_PRIMARY_BUTTON_CLASS
-
-export const REVIEW_ACTION_STATE_BUTTON_CLASS = 'w-[11.5rem] min-w-0 max-w-full shrink'

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -4,29 +4,6 @@ export function fitPanes(manager: PaneManager): void {
   manager.fitAllPanes()
 }
 
-/**
- * Returns true if any pane's proposed dimensions differ from its current
- * terminal cols/rows, meaning a fit() call would actually change layout.
- * Used by the epoch-based deduplication in use-terminal-pane-global-effects
- * to allow legitimate resize fits while suppressing redundant ones.
- */
-export function hasDimensionsChanged(manager: PaneManager): boolean {
-  for (const pane of manager.getPanes()) {
-    try {
-      const dims = pane.fitAddon.proposeDimensions()
-      if (!dims) {
-        return true // can't determine — assume changed
-      }
-      if (dims.cols !== pane.terminal.cols || dims.rows !== pane.terminal.rows) {
-        return true
-      }
-    } catch {
-      return true
-    }
-  }
-  return false
-}
-
 export function focusActivePane(manager: PaneManager): void {
   // Why: tab rename focuses the input on the next frame. A queued terminal
   // layout focus can land in between mount and focus, blurring rename closed.

--- a/src/renderer/src/components/terminal-pane/terminal-paste-payload-metadata.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-payload-metadata.ts
@@ -1,16 +1,10 @@
 import {
-  PASTE_PAYLOAD_METADATA_YIELD_CODE_UNITS,
   countPastePayloadLines,
   getPastePayloadUtf8ByteLength,
   hasPastePayloadControlSequence,
   measurePastePayloadMetadata,
-  measurePastePayloadMetadataWithYield,
-  type PastePayloadMetadata
+  measurePastePayloadMetadataWithYield
 } from '@/lib/paste-payload-metadata'
-
-export type TerminalPastePayloadMetadata = PastePayloadMetadata
-
-export const TERMINAL_PASTE_METADATA_YIELD_CODE_UNITS = PASTE_PAYLOAD_METADATA_YIELD_CODE_UNITS
 
 export const measureTerminalPastePayloadMetadata = measurePastePayloadMetadata
 export const measureTerminalPastePayloadMetadataWithYield = measurePastePayloadMetadataWithYield

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -297,7 +297,6 @@ export function getProjectHostSetupProjectionFromState(
 
 // ─── Repos ──────────────────────────────────────────────────────────
 export const useRepos = () => useAppStore((s) => s.repos)
-export const useActiveRepoId = () => useAppStore((s) => s.activeRepoId)
 export const useActiveRepo = () =>
   useAppStore(useShallow((s) => s.repos.find((r) => r.id === s.activeRepoId) ?? null))
 export const useRepoMap = () => useAppStore((s) => getCachedRepoMap(s.repos))
@@ -322,29 +321,3 @@ export const useActiveWorktree = () => {
     activeWorktreeId ? (s.getKnownWorktreeById(activeWorktreeId) ?? null) : null
   )
 }
-
-// ─── Terminals ──────────────────────────────────────────────────────
-export const useActiveTerminalTabs = () =>
-  useAppStore((s) =>
-    s.activeWorktreeId ? (s.tabsByWorktree[s.activeWorktreeId] ?? EMPTY_TABS) : EMPTY_TABS
-  )
-export const useActiveTabId = () => useAppStore((s) => s.activeTabId)
-
-// ─── Settings ───────────────────────────────────────────────────────
-export const useSettings = () => useAppStore((s) => s.settings)
-
-// ─── UI ─────────────────────────────────────────────────────────────
-export const useSidebarOpen = () => useAppStore((s) => s.sidebarOpen)
-export const useSidebarWidth = () => useAppStore((s) => s.sidebarWidth)
-export const useActiveView = () => useAppStore((s) => s.activeView)
-export const useActiveModal = () => useAppStore((s) => s.activeModal)
-export const useModalData = () => useAppStore((s) => s.modalData)
-export const useGroupBy = () => useAppStore((s) => s.groupBy)
-export const useSortBy = () => useAppStore((s) => s.sortBy)
-export const useShowActiveOnly = () => useAppStore((s) => s.showActiveOnly)
-export const useShowSleepingWorkspaces = () => useAppStore((s) => s.showSleepingWorkspaces)
-export const useFilterRepoIds = () => useAppStore((s) => s.filterRepoIds)
-
-// ─── GitHub ─────────────────────────────────────────────────────────
-export const usePRCache = () => useAppStore((s) => s.prCache)
-export const useIssueCache = () => useAppStore((s) => s.issueCache)


### PR DESCRIPTION
## Summary

- Remove unused exported helpers/types/selectors across main and renderer modules
- Drop the now-unreachable remote workspace import/materialization helper chain
- Keep the cleanup deletion-only aside from import formatting

## Verification

- `git diff --check`
- `pnpm exec oxlint --quiet`
- `pnpm run lint` (passes; existing warning outside this diff in `useGitStatusPolling.ts`)
- `pnpm run typecheck`
- Exact `rg` search for every removed symbol returned no matches

## Review

Triple reviewed for safety:

- Electron/Main runtime review: no findings
- Renderer/UI review: no findings
- Cross-cutting dead-code/runtime-contract review: no findings

Reviewers also checked dynamic/runtime entrypoints, IPC/provider contracts, SSH remote workspace paths, Git provider compatibility, tests/mocks, and barrel exports. Focused touched-module tests reported clean in review passes.