### PR TITLE
Fix performance regressions from bug review

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -613,6 +613,131 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('does not let Claude background tool progress restart a completed turn', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const listener = vi.fn()
+      server.setListener(listener)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'UserPromptSubmit',
+          payload: { state: 'working', prompt: 'write release notes', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(2_000)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hookEventName: 'Stop',
+          payload: {
+            state: 'done',
+            prompt: 'write release notes',
+            agentType: 'claude',
+            lastAssistantMessage: 'Release notes are ready.'
+          }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(30_000)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hookEventName: 'PreToolUse',
+          payload: {
+            state: 'working',
+            prompt: 'write release notes',
+            agentType: 'claude',
+            toolName: 'Write',
+            toolInput: 'CLAUDE.md memory update'
+          }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'done',
+          prompt: 'write release notes',
+          agentType: 'claude',
+          receivedAt: 2_000,
+          stateStartedAt: 2_000
+        })
+      ])
+      expect(listener).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows a fresh Claude prompt to rerun the same text after completion', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'UserPromptSubmit',
+          payload: { state: 'working', prompt: 'write release notes', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(2_000)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hookEventName: 'Stop',
+          payload: { state: 'done', prompt: 'write release notes', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(30_000)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'UserPromptSubmit',
+          payload: { state: 'working', prompt: 'write release notes', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'write release notes',
+          agentType: 'claude',
+          receivedAt: 30_000,
+          stateStartedAt: 30_000
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('allows an immediate same-prompt retry after an inferred interrupt', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -285,6 +285,22 @@ function isToolProgressWorkingAfterInterrupt(next: AgentHookEventPayload): boole
   return next.hookEventName !== undefined && TOOL_PROGRESS_HOOK_EVENTS.has(next.hookEventName)
 }
 
+function isClaudeToolProgressAfterCompletedTurn(
+  previous: EnrichedAgentHookEventPayload | undefined,
+  next: AgentHookEventPayload
+): boolean {
+  return (
+    previous?.payload.state === 'done' &&
+    previous.payload.agentType === 'claude' &&
+    next.payload.state === 'working' &&
+    next.payload.agentType === 'claude' &&
+    previous.payload.prompt === next.payload.prompt &&
+    next.hasExplicitPrompt !== true &&
+    next.hookEventName !== undefined &&
+    TOOL_PROGRESS_HOOK_EVENTS.has(next.hookEventName)
+  )
+}
+
 function paneCacheKeyTabId(key: string): string | null {
   const paneKey = key.split('\0', 1)[0] ?? key
   return parsePaneKey(paneKey)?.tabId ?? parseLegacyNumericPaneKey(paneKey)?.tabId ?? null
@@ -730,6 +746,11 @@ export class AgentHookServer {
           }
     const effectivePayload = attachClaudePermissionToolUseId(previous, identityResolvedPayload)
     if (previous && shouldKeepClaudePermissionVisible(previous, effectivePayload)) {
+      return previous
+    }
+    if (previous && isClaudeToolProgressAfterCompletedTurn(previous, effectivePayload)) {
+      // Why: background Claude hooks (for example memory-update helpers) can run
+      // after Stop; without a fresh prompt they must not restart notifications.
       return previous
     }
     // Why: some TUIs can emit a delayed tool/working hook after Ctrl+C already

--- a/src/main/pty/shell-startup-env.test.ts
+++ b/src/main/pty/shell-startup-env.test.ts
@@ -10,7 +10,11 @@ vi.mock('fs', () => ({
   readFileSync: readFileSyncMock
 }))
 
-import { __resetShellStartupEnvCache, readShellStartupEnvVar } from './shell-startup-env'
+import {
+  __resetShellStartupEnvCache,
+  readShellStartupEnvVar,
+  readShellStartupPathSegments
+} from './shell-startup-env'
 
 describe('readShellStartupEnvVar', () => {
   const originalPlatform = process.platform
@@ -306,5 +310,34 @@ describe('readShellStartupEnvVar', () => {
   it('does not match an OPENCODE_CONFIG_DIR mention in a comment', () => {
     mockStartupFiles({ '.zshrc': '# export OPENCODE_CONFIG_DIR=/from-comment\n' })
     expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice')).toBeUndefined()
+  })
+
+  it('reads exported PATH prepends without spawning the shell', () => {
+    mockStartupFiles({ '.zshrc': 'export PATH="$HOME/.cargo/bin:$PATH"\n' })
+
+    expect(readShellStartupPathSegments('/home/alice', '/bin/zsh', '/usr/bin:/bin')).toEqual([
+      '/home/alice/.cargo/bin',
+      '/usr/bin',
+      '/bin'
+    ])
+  })
+
+  it('reads bare PATH assignments because PATH is already exported', () => {
+    mockStartupFiles({ '.zshrc': 'PATH="$HOME/bin:$PATH"\n' })
+
+    expect(readShellStartupPathSegments('/home/alice', '/bin/zsh', '/usr/bin:/bin')).toEqual([
+      '/home/alice/bin',
+      '/usr/bin',
+      '/bin'
+    ])
+  })
+
+  it('does not expand PATH references inside single quotes', () => {
+    mockStartupFiles({ '.zshrc': "export PATH='$HOME/bin:$PATH'\n" })
+
+    expect(readShellStartupPathSegments('/home/alice', '/bin/zsh', '/usr/bin:/bin')).toEqual([
+      '$HOME/bin',
+      '$PATH'
+    ])
   })
 })

--- a/src/main/pty/shell-startup-env.ts
+++ b/src/main/pty/shell-startup-env.ts
@@ -6,6 +6,7 @@ import { posix } from 'path'
 // a stale .bash_profile on a zsh user would clobber the real .zshrc value.
 const ZSH_ENV_FILE = '.zshenv'
 const ZSH_AFTER_ENV_FILES = ['.zprofile', '.zshrc', '.zlogin']
+const POSIX_PATH_DELIMITER = ':'
 // Why: Orca launches bash as a login shell (see local-pty-shell-ready.ts
 // getBashShellReadyRcfileContent and daemon/shell-ready.ts) which sources
 // .bash_profile / .bash_login / .profile but intentionally does NOT force
@@ -35,6 +36,30 @@ function parseExportedValue(content: string, name: string, home: string): string
   }
 
   return lastMatch
+}
+
+function parsePathValue(content: string, home: string, basePath: string): string | undefined {
+  const assignment = /^(?:export\s+)?PATH=(.+)$/
+  let currentPath = basePath
+  let matched = false
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    const match = assignment.exec(line)
+    if (!match?.[1]) {
+      continue
+    }
+    const decommented = stripTrailingComment(match[1])
+    const { text, quoted } = unquoteShellValue(decommented)
+    const expandedHome = quoted === "'" ? text : expandHome(text, home)
+    const expandedPath = quoted === "'" ? expandedHome : expandPath(expandedHome, currentPath)
+    if (expandedPath.length > 0) {
+      currentPath = expandedPath
+      matched = true
+    }
+  }
+
+  return matched ? currentPath : undefined
 }
 
 function readStartupFile(path: string): string | null {
@@ -121,6 +146,23 @@ function expandHome(value: string, home: string): string {
     .replace(/\$HOME(?![A-Za-z0-9_])/g, home)
 }
 
+function expandPath(value: string, currentPath: string): string {
+  // Why: shell startup files commonly prepend to PATH with "$PATH"; resolving
+  // that statically avoids the macOS interactive-shell spawn on startup.
+  return value.replace(/\$\{PATH\}/g, currentPath).replace(/\$PATH(?![A-Za-z0-9_])/g, currentPath)
+}
+
+function splitPosixPath(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .split(POSIX_PATH_DELIMITER)
+        .map((segment) => segment.trim())
+        .filter(Boolean)
+    )
+  ]
+}
+
 const cache = new Map<string, string | undefined>()
 
 /**
@@ -181,6 +223,41 @@ export function readShellStartupEnvVar(
 
   cache.set(cacheKey, lastMatch)
   return lastMatch
+}
+
+/**
+ * Best-effort static read of PATH assignments from POSIX shell startup files.
+ *
+ * Why: on managed macOS machines an interactive login shell probe can block in
+ * posix_spawn before JavaScript can arm a timeout. A static PATH read preserves
+ * common `PATH="$HOME/bin:$PATH"` customizations without spawning a shell.
+ */
+export function readShellStartupPathSegments(
+  home = process.env.HOME,
+  shell = process.env.SHELL,
+  basePath = process.env.PATH
+): string[] {
+  if (!home || process.platform === 'win32') {
+    return []
+  }
+
+  let currentPath = basePath ?? ''
+  let foundAssignment = false
+
+  for (const path of shellStartupFilePaths(home, shell)) {
+    const content = readStartupFile(path)
+    if (content === null) {
+      continue
+    }
+
+    const nextPath = parsePathValue(content, home, currentPath)
+    if (nextPath !== undefined) {
+      currentPath = nextPath
+      foundAssignment = true
+    }
+  }
+
+  return foundAssignment ? splitPosixPath(currentPath) : []
 }
 
 /**

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -501,6 +501,81 @@ describe('RateLimitService', () => {
     })
   })
 
+  it('keeps a full refresh alive when Claude auth preparation fails', async () => {
+    const service = new RateLimitService()
+    service.setClaudeAuthPreparationResolver(async () => {
+      throw new Error('runtime auth unavailable')
+    })
+
+    vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
+
+    await expect(service.refresh()).resolves.toEqual(expect.objectContaining({}))
+
+    const state = service.getState()
+    expect(fetchClaudeRateLimits).not.toHaveBeenCalled()
+    expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
+    expect(state.claude).toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Failed to prepare Claude auth: runtime auth unavailable'
+    })
+    expect(state.codex).toMatchObject({
+      provider: 'codex',
+      status: 'ok'
+    })
+  })
+
+  it('keeps a full refresh alive when Codex home preparation fails', async () => {
+    const service = new RateLimitService()
+    service.setClaudeAuthPreparationResolver(async () => ({
+      configDir: '/tmp/.claude',
+      runtime: 'host',
+      wslDistro: null,
+      wslLinuxConfigDir: null,
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }))
+    service.setCodexHomePathResolver(() => {
+      throw new Error('runtime home unavailable')
+    })
+
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+
+    await expect(service.refresh()).resolves.toEqual(expect.objectContaining({}))
+
+    const state = service.getState()
+    expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+    expect(fetchCodexRateLimits).not.toHaveBeenCalled()
+    expect(state.claude).toMatchObject({
+      provider: 'claude',
+      status: 'ok'
+    })
+    expect(state.codex).toMatchObject({
+      provider: 'codex',
+      status: 'error',
+      error: 'Failed to prepare Codex home: runtime home unavailable'
+    })
+  })
+
+  it('settles Claude-only refreshes when auth preparation fails', async () => {
+    const service = new RateLimitService()
+    service.setClaudeAuthPreparationResolver(async () => {
+      throw new Error('keychain unavailable')
+    })
+
+    await expect(
+      service.refreshClaudeForTarget({ runtime: 'host', wslDistro: null })
+    ).resolves.toEqual(expect.objectContaining({}))
+
+    expect(fetchClaudeRateLimits).not.toHaveBeenCalled()
+    expect(service.getState().claude).toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Failed to prepare Claude auth: keychain unavailable'
+    })
+  })
+
   it('does not use Claude PTY fallback for WSL system-default usage refreshes', async () => {
     const service = new RateLimitService()
     service.setClaudeFetchTarget({ runtime: 'wsl', wslDistro: 'Ubuntu' })

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -37,6 +37,18 @@ type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
 
+type ClaudeAuthPreparationResolution = {
+  authPreparation: ClaudeRuntimeAuthPreparation | undefined
+  provenance: string
+  error: unknown | null
+}
+
+type CodexHomePathResolution = {
+  homePath: string | null
+  provenance: string
+  error: unknown | null
+}
+
 type OpenCodeGoRateLimitConfig = {
   sessionCookie: string
   workspaceIdOverride: string
@@ -782,6 +794,82 @@ export class RateLimitService {
     return codexHomePath ? `${targetKey}:managed:${codexHomePath}` : `${targetKey}:system`
   }
 
+  private getCodexPreparationErrorProvenance(
+    target: NormalizedCodexAccountSelectionTarget
+  ): string {
+    const targetKey = target.runtime === 'wsl' ? `wsl:${target.wslDistro ?? '__default__'}` : 'host'
+    return `${targetKey}:preparation-error`
+  }
+
+  private getClaudePreparationErrorProvenance(
+    target: NormalizedClaudeAccountSelectionTarget
+  ): string {
+    const targetKey = target.runtime === 'wsl' ? `wsl:${target.wslDistro ?? '__default__'}` : 'host'
+    return `${targetKey}:preparation-error`
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'Unknown error'
+  }
+
+  private resolveCodexHomePath(
+    target: NormalizedCodexAccountSelectionTarget
+  ): CodexHomePathResolution {
+    try {
+      const homePath = this.codexHomePathResolver?.(target) ?? null
+      return {
+        homePath,
+        provenance: this.getCodexProvenance(target, homePath),
+        error: null
+      }
+    } catch (error) {
+      return {
+        homePath: null,
+        provenance: this.getCodexPreparationErrorProvenance(target),
+        error
+      }
+    }
+  }
+
+  private async resolveClaudeAuthPreparation(
+    target: NormalizedClaudeAccountSelectionTarget
+  ): Promise<ClaudeAuthPreparationResolution> {
+    try {
+      const authPreparation = await this.claudeAuthPreparationResolver?.(target)
+      return {
+        authPreparation,
+        provenance: authPreparation?.provenance ?? 'system',
+        error: null
+      }
+    } catch (error) {
+      return {
+        authPreparation: undefined,
+        provenance: this.getClaudePreparationErrorProvenance(target),
+        error
+      }
+    }
+  }
+
+  private buildPreparationErrorState(
+    provider: 'claude' | 'codex',
+    error: unknown,
+    context: string
+  ): ProviderRateLimits {
+    // Why: runtime auth/home preparation can fail during update relaunches;
+    // degrade one provider instead of aborting the whole auto-refresh loop.
+    return {
+      provider,
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: `${context}: ${this.getErrorMessage(error)}`,
+      status: 'error',
+      usageMetadata: {
+        failureKind: 'unknown'
+      }
+    }
+  }
+
   private getMissingWslCodexHomeResult(
     target: NormalizedCodexAccountSelectionTarget
   ): ProviderRateLimits | null {
@@ -837,12 +925,14 @@ export class RateLimitService {
 
   private async runFetchAllCycle(): Promise<void> {
     const claudeTarget = this.claudeFetchTarget
-    const claudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
-    const claudeProvenance = claudeAuthPreparation?.provenance ?? 'system'
+    const claudeAuthResolution = await this.resolveClaudeAuthPreparation(claudeTarget)
+    const claudeAuthPreparation = claudeAuthResolution.authPreparation
+    const claudeProvenance = claudeAuthResolution.provenance
     const claudeGeneration = this.claudeFetchGeneration
     const codexTarget = this.codexFetchTarget
-    const codexHomePath = this.codexHomePathResolver?.(codexTarget) ?? null
-    const codexProvenance = this.getCodexProvenance(codexTarget, codexHomePath)
+    const codexHomeResolution = this.resolveCodexHomePath(codexTarget)
+    const codexHomePath = codexHomeResolution.homePath
+    const codexProvenance = codexHomeResolution.provenance
     const codexGeneration = this.codexFetchGeneration
     const previousState = this.state
     const openCodeGoConfig = this.openCodeGoConfigResolver?.()
@@ -874,20 +964,38 @@ export class RateLimitService {
       kimi: this.withFetchingStatus(previousState.kimi, 'kimi')
     })
 
-    const missingWslCodexHome = codexHomePath
+    const missingWslCodexHome = codexHomeResolution.error
       ? null
-      : this.getMissingWslCodexHomeResult(codexTarget)
+      : codexHomePath
+        ? null
+        : this.getMissingWslCodexHomeResult(codexTarget)
     const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult] =
       await Promise.allSettled([
-        fetchClaudeRateLimits({
-          authPreparation: claudeAuthPreparation,
-          allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation)
-        }),
+        claudeAuthResolution.error
+          ? Promise.resolve(
+              this.buildPreparationErrorState(
+                'claude',
+                claudeAuthResolution.error,
+                'Failed to prepare Claude auth'
+              )
+            )
+          : fetchClaudeRateLimits({
+              authPreparation: claudeAuthPreparation,
+              allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation)
+            }),
         missingWslCodexHome ??
-          fetchCodexRateLimits({
-            codexHomePath,
-            allowPtyFallback: this.shouldAllowCodexPtyFallback()
-          }),
+          (codexHomeResolution.error
+            ? Promise.resolve(
+                this.buildPreparationErrorState(
+                  'codex',
+                  codexHomeResolution.error,
+                  'Failed to prepare Codex home'
+                )
+              )
+            : fetchCodexRateLimits({
+                codexHomePath,
+                allowPtyFallback: this.shouldAllowCodexPtyFallback()
+              })),
         fetchGeminiRateLimits(geminiCliOAuthEnabled),
         fetchOpenCodeGoRateLimits(cookie, workspaceIdOverride || undefined),
         fetchKimiRateLimits()
@@ -960,17 +1068,47 @@ export class RateLimitService {
             status: 'error'
           } satisfies ProviderRateLimits)
 
-    const latestCodexHomePath = this.codexHomePathResolver?.(codexTarget) ?? null
-    const latestClaudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
-    const latestClaudeProvenance = latestClaudeAuthPreparation?.provenance ?? 'system'
-    const latestCodexProvenance = this.getCodexProvenance(codexTarget, latestCodexHomePath)
-    const shouldApplyCodex =
-      codexGeneration === this.codexFetchGeneration && codexProvenance === latestCodexProvenance
-    const shouldApplyClaude =
+    const latestCodexHomeResolution = codexHomeResolution.error
+      ? codexHomeResolution
+      : this.resolveCodexHomePath(codexTarget)
+    const latestClaudeAuthResolution = claudeAuthResolution.error
+      ? claudeAuthResolution
+      : await this.resolveClaudeAuthPreparation(claudeTarget)
+    const latestClaudeProvenance = latestClaudeAuthResolution.provenance
+    const latestCodexProvenance = latestCodexHomeResolution.provenance
+    const codexGenerationStillCurrent = codexGeneration === this.codexFetchGeneration
+    const claudeGenerationStillCurrent =
       claudeGeneration === this.claudeFetchGeneration &&
-      claudeProvenance === latestClaudeProvenance &&
       this.isSameClaudeTarget(claudeTarget, this.claudeFetchTarget)
+    const shouldApplyCodex =
+      codexGenerationStillCurrent &&
+      (codexHomeResolution.error
+        ? true
+        : !latestCodexHomeResolution.error && codexProvenance === latestCodexProvenance)
+    const shouldApplyClaude =
+      claudeGenerationStillCurrent &&
+      (claudeAuthResolution.error
+        ? true
+        : !latestClaudeAuthResolution.error && claudeProvenance === latestClaudeProvenance)
     const shouldApplyOpencode = opencodeGeneration === this.opencodeFetchGeneration
+    const codexPreparationError =
+      codexGenerationStillCurrent && !codexHomeResolution.error && latestCodexHomeResolution.error
+        ? this.buildPreparationErrorState(
+            'codex',
+            latestCodexHomeResolution.error,
+            'Failed to prepare Codex home'
+          )
+        : null
+    const claudePreparationError =
+      claudeGenerationStillCurrent &&
+      !claudeAuthResolution.error &&
+      latestClaudeAuthResolution.error
+        ? this.buildPreparationErrorState(
+            'claude',
+            latestClaudeAuthResolution.error,
+            'Failed to prepare Claude auth'
+          )
+        : null
 
     // Why: account switches can race in-flight Codex fetches. Only apply a
     // Codex result if both the selected-account provenance and the request
@@ -980,10 +1118,14 @@ export class RateLimitService {
       ...previousState,
       claude: shouldApplyClaude
         ? this.applyStalePolicy(claude, previousState.claude)
-        : this.state.claude,
+        : claudePreparationError
+          ? this.applyStalePolicy(claudePreparationError, previousState.claude)
+          : this.state.claude,
       codex: shouldApplyCodex
         ? this.applyStalePolicy(codex, previousState.codex)
-        : this.state.codex,
+        : codexPreparationError
+          ? this.applyStalePolicy(codexPreparationError, previousState.codex)
+          : this.state.codex,
       gemini: this.applyStalePolicy(gemini, previousState.gemini),
       opencodeGo: shouldApplyOpencode
         ? opencodeConfigChanged
@@ -998,8 +1140,9 @@ export class RateLimitService {
 
   private async runFetchCodexOnlyCycle(): Promise<void> {
     const codexTarget = this.codexFetchTarget
-    const codexHomePath = this.codexHomePathResolver?.(codexTarget) ?? null
-    const codexProvenance = this.getCodexProvenance(codexTarget, codexHomePath)
+    const codexHomeResolution = this.resolveCodexHomePath(codexTarget)
+    const codexHomePath = codexHomeResolution.homePath
+    const codexProvenance = codexHomeResolution.provenance
     const codexGeneration = this.codexFetchGeneration
     const previousState = this.state
 
@@ -1008,35 +1151,61 @@ export class RateLimitService {
       codex: this.withFetchingStatus(previousState.codex, 'codex')
     })
 
-    const missingWslCodexHome = codexHomePath
+    const missingWslCodexHome = codexHomeResolution.error
       ? null
-      : this.getMissingWslCodexHomeResult(codexTarget)
-    const codex = await (
-      missingWslCodexHome
-        ? Promise.resolve(missingWslCodexHome)
-        : fetchCodexRateLimits({
-            codexHomePath,
-            allowPtyFallback: this.shouldAllowCodexPtyFallback()
+      : codexHomePath
+        ? null
+        : this.getMissingWslCodexHomeResult(codexTarget)
+    const codex = codexHomeResolution.error
+      ? this.buildPreparationErrorState(
+          'codex',
+          codexHomeResolution.error,
+          'Failed to prepare Codex home'
+        )
+      : await (
+          missingWslCodexHome
+            ? Promise.resolve(missingWslCodexHome)
+            : fetchCodexRateLimits({
+                codexHomePath,
+                allowPtyFallback: this.shouldAllowCodexPtyFallback()
+              })
+        ).catch(
+          (err): ProviderRateLimits => ({
+            provider: 'codex',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error: err instanceof Error ? err.message : 'Unknown error',
+            status: 'error'
           })
-    ).catch(
-      (err): ProviderRateLimits => ({
-        provider: 'codex',
-        session: null,
-        weekly: null,
-        updatedAt: Date.now(),
-        error: err instanceof Error ? err.message : 'Unknown error',
-        status: 'error'
-      })
-    )
+        )
 
-    const latestCodexHomePath = this.codexHomePathResolver?.(codexTarget) ?? null
-    const latestCodexProvenance = this.getCodexProvenance(codexTarget, latestCodexHomePath)
+    const latestCodexHomeResolution = codexHomeResolution.error
+      ? codexHomeResolution
+      : this.resolveCodexHomePath(codexTarget)
+    const codexGenerationStillCurrent = codexGeneration === this.codexFetchGeneration
     const shouldApplyCodex =
-      codexGeneration === this.codexFetchGeneration && codexProvenance === latestCodexProvenance
+      codexGenerationStillCurrent &&
+      (codexHomeResolution.error
+        ? true
+        : !latestCodexHomeResolution.error &&
+          codexProvenance === latestCodexHomeResolution.provenance)
+    const codexPreparationError =
+      codexGenerationStillCurrent && !codexHomeResolution.error && latestCodexHomeResolution.error
+        ? this.buildPreparationErrorState(
+            'codex',
+            latestCodexHomeResolution.error,
+            'Failed to prepare Codex home'
+          )
+        : null
 
     this.updateState({
       ...this.state,
-      codex: shouldApplyCodex ? this.applyStalePolicy(codex, previousState.codex) : this.state.codex
+      codex: shouldApplyCodex
+        ? this.applyStalePolicy(codex, previousState.codex)
+        : codexPreparationError
+          ? this.applyStalePolicy(codexPreparationError, previousState.codex)
+          : this.state.codex
     })
 
     this.lastFetchAt = Date.now()
@@ -1044,8 +1213,9 @@ export class RateLimitService {
 
   private async runFetchClaudeOnlyCycle(): Promise<void> {
     const claudeTarget = this.claudeFetchTarget
-    const claudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
-    const claudeProvenance = claudeAuthPreparation?.provenance ?? 'system'
+    const claudeAuthResolution = await this.resolveClaudeAuthPreparation(claudeTarget)
+    const claudeAuthPreparation = claudeAuthResolution.authPreparation
+    const claudeProvenance = claudeAuthResolution.provenance
     const claudeGeneration = this.claudeFetchGeneration
     const previousState = this.state
 
@@ -1054,32 +1224,56 @@ export class RateLimitService {
       claude: this.withFetchingStatus(previousState.claude, 'claude')
     })
 
-    const claude = await fetchClaudeRateLimits({
-      authPreparation: claudeAuthPreparation,
-      allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation)
-    }).catch(
-      (err): ProviderRateLimits => ({
-        provider: 'claude',
-        session: null,
-        weekly: null,
-        updatedAt: Date.now(),
-        error: err instanceof Error ? err.message : 'Unknown error',
-        status: 'error'
-      })
-    )
+    const claude = claudeAuthResolution.error
+      ? this.buildPreparationErrorState(
+          'claude',
+          claudeAuthResolution.error,
+          'Failed to prepare Claude auth'
+        )
+      : await fetchClaudeRateLimits({
+          authPreparation: claudeAuthPreparation,
+          allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation)
+        }).catch(
+          (err): ProviderRateLimits => ({
+            provider: 'claude',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error: err instanceof Error ? err.message : 'Unknown error',
+            status: 'error'
+          })
+        )
 
-    const latestClaudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
-    const latestClaudeProvenance = latestClaudeAuthPreparation?.provenance ?? 'system'
-    const shouldApplyClaude =
+    const latestClaudeAuthResolution = claudeAuthResolution.error
+      ? claudeAuthResolution
+      : await this.resolveClaudeAuthPreparation(claudeTarget)
+    const claudeGenerationStillCurrent =
       claudeGeneration === this.claudeFetchGeneration &&
-      claudeProvenance === latestClaudeProvenance &&
       this.isSameClaudeTarget(claudeTarget, this.claudeFetchTarget)
+    const shouldApplyClaude =
+      claudeGenerationStillCurrent &&
+      (claudeAuthResolution.error
+        ? true
+        : !latestClaudeAuthResolution.error &&
+          claudeProvenance === latestClaudeAuthResolution.provenance)
+    const claudePreparationError =
+      claudeGenerationStillCurrent &&
+      !claudeAuthResolution.error &&
+      latestClaudeAuthResolution.error
+        ? this.buildPreparationErrorState(
+            'claude',
+            latestClaudeAuthResolution.error,
+            'Failed to prepare Claude auth'
+          )
+        : null
 
     this.updateState({
       ...this.state,
       claude: shouldApplyClaude
         ? this.applyStalePolicy(claude, previousState.claude)
-        : this.state.claude
+        : claudePreparationError
+          ? this.applyStalePolicy(claudePreparationError, previousState.claude)
+          : this.state.claude
     })
 
     this.lastFetchAt = Date.now()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16735,6 +16735,22 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('does not count saved session tabs without live PTYs as current mobile terminals', async () => {
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal()
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const { worktrees } = await runtime.getWorktreePs()
+    expect(worktrees[0]).toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      hasHostSidebarActivity: false,
+      status: 'inactive',
+      liveTerminalCount: 0,
+      hasAttachedPty: false
+    })
+  })
+
   it('falls back to the path-keyed GitHub cache entry', async () => {
     const runtimeStore = {
       ...store,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9057,18 +9057,19 @@ export class OrcaRuntimeService {
       if (!summary) {
         continue
       }
-      // Why: desktop can show terminal tabs that are not mounted as renderer
-      // leaves and are not currently visible in the PTY provider list. Mobile
-      // still needs those worktrees to show as terminal-bearing entries.
-      summary.liveTerminalCount = Math.max(summary.liveTerminalCount, tabs.length)
-      summary.hasAttachedPty = summary.hasAttachedPty || tabs.some((tab) => tab.ptyId !== null)
-      if (tabs.some((tab) => tab.ptyId !== null && this.ptysById.get(tab.ptyId)?.connected)) {
+      // Why: persisted session tabs can outlive their PTY and hook status.
+      // Mobile's worktree.ps projection should show current host activity, not
+      // resurrect stale terminal rows after the real terminal was closed (#6072).
+      const liveSavedTabs = tabs.filter(
+        (tab) => tab.ptyId && this.ptysById.get(tab.ptyId)?.connected
+      )
+      if (liveSavedTabs.length > 0) {
         summary.hasHostSidebarActivity = true
       }
-      for (const tab of tabs) {
+      for (const tab of liveSavedTabs) {
         summary.status = mergeWorktreeStatus(
           summary.status,
-          getSavedTabWorktreeStatus(tab.title, tab.ptyId !== null)
+          getSavedTabWorktreeStatus(tab.title, true)
         )
       }
     }

--- a/src/main/startup/hydrate-shell-path.test.ts
+++ b/src/main/startup/hydrate-shell-path.test.ts
@@ -9,12 +9,17 @@ import {
   type HydrationResult
 } from './hydrate-shell-path'
 
-const { spawnMock } = vi.hoisted(() => ({
+const { readShellStartupPathSegmentsMock, spawnMock } = vi.hoisted(() => ({
+  readShellStartupPathSegmentsMock: vi.fn(),
   spawnMock: vi.fn()
 }))
 
 vi.mock('child_process', () => ({
   spawn: spawnMock
+}))
+
+vi.mock('../pty/shell-startup-env', () => ({
+  readShellStartupPathSegments: readShellStartupPathSegmentsMock
 }))
 
 type HydrationSpawner = (shell: string) => Promise<HydrationResult>
@@ -31,14 +36,27 @@ function createMockShellProcess(): ChildProcessWithoutNullStreams {
 }
 
 describe('hydrateShellPath', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
   const originalPath = process.env.PATH
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: platform
+    })
+  }
 
   beforeEach(() => {
     _resetHydrateShellPathCache()
+    readShellStartupPathSegmentsMock.mockReset()
+    readShellStartupPathSegmentsMock.mockReturnValue([])
     spawnMock.mockReset()
   })
 
   afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
     if (originalPath === undefined) {
       delete process.env.PATH
     } else {
@@ -64,6 +82,36 @@ describe('hydrateShellPath', () => {
     expect(result.ok).toBe(true)
     expect(result.segments).toEqual(['/Users/tester/.opencode/bin', '/Users/tester/.cargo/bin'])
     expect(result.failureReason).toBe('none')
+  })
+
+  it('uses static startup-file PATH hydration on macOS without spawning a shell', async () => {
+    setPlatform('darwin')
+    process.env.PATH = '/usr/bin:/bin'
+    readShellStartupPathSegmentsMock.mockReturnValue(['/Users/tester/.cargo/bin', '/usr/bin'])
+
+    const result = await hydrateShellPath({ shellOverride: '/bin/zsh', force: true })
+
+    expect(result).toEqual({
+      segments: ['/Users/tester/.cargo/bin', '/usr/bin'],
+      ok: true,
+      failureReason: 'none'
+    })
+    expect(readShellStartupPathSegmentsMock).toHaveBeenCalledWith(
+      process.env.HOME,
+      '/bin/zsh',
+      '/usr/bin:/bin'
+    )
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('reports empty_path when macOS static startup-file hydration finds no PATH assignment', async () => {
+    setPlatform('darwin')
+    readShellStartupPathSegmentsMock.mockReturnValue([])
+
+    const result = await hydrateShellPath({ shellOverride: '/bin/zsh', force: true })
+
+    expect(result).toEqual({ segments: [], ok: false, failureReason: 'empty_path' })
+    expect(spawnMock).not.toHaveBeenCalled()
   })
 
   it('caches the hydration result so repeated calls do not re-spawn', async () => {
@@ -139,7 +187,11 @@ describe('hydrateShellPath', () => {
     spawnMock.mockReturnValue(proc)
 
     try {
-      const resultPromise = hydrateShellPath({ shellOverride: '/bin/zsh', force: true })
+      const resultPromise = hydrateShellPath({
+        shellOverride: '/bin/zsh',
+        force: true,
+        strategy: 'interactive'
+      })
       const assertion = expect(resultPromise).resolves.toEqual({
         segments: [],
         ok: false,

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import { delimiter } from 'path'
 import type { ShellHydrationFailureReason } from '../../shared/types'
+import { readShellStartupPathSegments } from '../pty/shell-startup-env'
 
 // Why: GUI-launched Electron on macOS/Linux inherits a minimal PATH from launchd
 // that does not include dirs appended by the user's shell rc files (~/.zshrc,
@@ -153,6 +154,8 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
 
 type HydrateOptions = {
   force?: boolean
+  /** Defaults to static startup-file parsing on macOS and shell spawning elsewhere. */
+  strategy?: 'auto' | 'interactive' | 'startup-files'
   /** Override for tests — defaults to running `spawn` against the real shell. */
   spawner?: (shell: string) => Promise<HydrationResult>
   /** Override for tests — defaults to `pickShell()`. */
@@ -174,6 +177,22 @@ export function hydrateShellPath(options: HydrateOptions = {}): Promise<Hydratio
     // Windows uses cmd/PowerShell rather than a POSIX login shell — the
     // `patchPackagedProcessPath` static list is sufficient there.
     cached = Promise.resolve({ segments: [], ok: false, failureReason: 'no_shell' })
+    return cached
+  }
+  const strategy = options.strategy ?? 'auto'
+  if (
+    !options.spawner &&
+    (strategy === 'startup-files' || (strategy === 'auto' && process.platform === 'darwin'))
+  ) {
+    // Why: macOS Endpoint Security agents can wedge interactive shell probes
+    // inside posix_spawn before JS timers exist. Static PATH parsing keeps
+    // packaged startup non-blocking while preserving common PATH exports.
+    const segments = readShellStartupPathSegments(process.env.HOME, shell, process.env.PATH)
+    cached = Promise.resolve(
+      segments.length > 0
+        ? { segments, ok: true, failureReason: 'none' }
+        : { segments: [], ok: false, failureReason: 'empty_path' }
+    )
     return cached
   }
   cached = (options.spawner ?? spawnShellAndReadPath)(shell)

--- a/src/renderer/src/components/editor/markdown-rich-mode.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.test.ts
@@ -14,6 +14,16 @@ describe('getMarkdownRichModeUnsupportedMessage', () => {
     expect(getMarkdownRichModeUnsupportedMessage('# Title\n\n- one\n- two\n')).toBeNull()
   })
 
+  it('falls back to source mode for emphasis syntax rich editing would rewrite', () => {
+    expect(getMarkdownRichModeUnsupportedMessage('Keep _word_ unchanged.\n')).toContain('rewrite')
+    expect(getMarkdownRichModeUnsupportedMessage('Keep __word__ unchanged.\n')).toContain('rewrite')
+  })
+
+  it('falls back to source mode for alternate unordered-list markers', () => {
+    expect(getMarkdownRichModeUnsupportedMessage('* one\n* two\n')).toContain('rewrite')
+    expect(getMarkdownRichModeUnsupportedMessage('+ one\n+ two\n')).toContain('rewrite')
+  })
+
   it('allows common raw html in markdown files', () => {
     expect(getMarkdownRichModeUnsupportedMessage('Before <span>hi</span> after\n')).toBeNull()
   })
@@ -38,6 +48,11 @@ describe('getMarkdownRichModeUnsupportedMessage', () => {
     expect(getMarkdownRichModeUnsupportedMessage('Use `<Widget />` in docs.\n')).toBeNull()
     expect(getMarkdownRichModeUnsupportedMessage('```tsx\n<Widget />\n```\n')).toBeNull()
     expect(getMarkdownRichModeUnsupportedMessage('```tsx\r\n<Widget />\r\n```\r\n')).toBeNull()
+  })
+
+  it('ignores format-sensitive markdown markers inside code spans and fences', () => {
+    expect(getMarkdownRichModeUnsupportedMessage('Use `_word_` in docs.\n')).toBeNull()
+    expect(getMarkdownRichModeUnsupportedMessage('```md\n* keep this literal\n```\n')).toBeNull()
   })
 
   it('allows angle brackets in ordinary prose', () => {

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -6,6 +6,7 @@ export type MarkdownRichModeUnsupportedReason =
   | 'html-or-jsx'
   | 'reference-links'
   | 'footnotes'
+  | 'format-sensitive-markdown'
   | 'other'
 
 type UnsupportedMatch = {
@@ -47,6 +48,18 @@ const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
       )
     },
     pattern: /^\[\^[^\]]+\]:\s+/m
+  },
+  {
+    reason: 'format-sensitive-markdown',
+    get message() {
+      return translate(
+        'auto.components.editor.markdown.rich.mode.d6a40cbbd2',
+        "Editable only in code mode because rich editing would rewrite this file's markdown syntax."
+      )
+    },
+    // Why: TipTap serializes these valid forms into its canonical markdown
+    // (`_x_` -> `*x*`, `* item` -> `- item`), creating noisy whole-file diffs.
+    pattern: /(^|\n)\s{0,3}[*+]\s+\S|(^|[^\w\\])_{1,2}\S[^\n]*?\S?_{1,2}(?!\w)/
   }
 ]
 

--- a/src/renderer/src/components/sidebar/worktree-agent-row-closed-tab-selectors.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-closed-tab-selectors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { selectLiveAgentStatusEntriesForWorktree } from './worktree-agent-row-selectors'
+
+const PANE_KEY = makePaneKey('tab-1', '22222222-2222-4222-8222-222222222222')
+const CHILD_PANE_KEY = makePaneKey('tab-child', '33333333-3333-4333-8333-333333333333')
+
+function makeEntry(overrides?: Partial<AgentStatusEntry>): AgentStatusEntry {
+  return {
+    paneKey: PANE_KEY,
+    state: 'working',
+    stateStartedAt: 1_000,
+    updatedAt: 1_000,
+    stateHistory: [],
+    prompt: 'agent prompt',
+    agentType: 'pi',
+    worktreeId: 'wt-1',
+    tabId: 'tab-1',
+    ...overrides
+  }
+}
+
+describe('selectLiveAgentStatusEntriesForWorktree closed-tab filtering', () => {
+  it('does not render a completed live row whose tab is no longer current', () => {
+    const staleDone = makeEntry({ state: 'done' })
+
+    expect(
+      selectLiveAgentStatusEntriesForWorktree(
+        {
+          tabsByWorktree: { 'wt-1': [] },
+          agentStatusByPaneKey: { [PANE_KEY]: staleDone },
+          migrationUnsupportedByPtyId: {},
+          retainedAgentsByPaneKey: {}
+        },
+        'wt-1'
+      )
+    ).toEqual([])
+  })
+
+  it('does not render late child-agent rows routed to a closed tab', () => {
+    const lateWorking = makeEntry({
+      paneKey: CHILD_PANE_KEY,
+      state: 'working',
+      tabId: 'tab-closed'
+    })
+
+    expect(
+      selectLiveAgentStatusEntriesForWorktree(
+        {
+          tabsByWorktree: { 'wt-1': [] },
+          agentStatusByPaneKey: { [CHILD_PANE_KEY]: lateWorking },
+          migrationUnsupportedByPtyId: {},
+          recentlyClosedAgentStatusTabIds: { 'tab-closed': true },
+          retainedAgentsByPaneKey: {}
+        },
+        'wt-1'
+      )
+    ).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
@@ -22,7 +22,8 @@ type WorktreeAgentRowsState = Pick<
   | 'migrationUnsupportedByPtyId'
   | 'retainedAgentsByPaneKey'
   | 'tabsByWorktree'
->
+> &
+  Partial<Pick<AppState, 'recentlyClosedAgentStatusTabIds'>>
 
 type TabWorktreeIndexCache = {
   tabsByWorktree: WorktreeAgentRowsState['tabsByWorktree']
@@ -32,6 +33,7 @@ type TabWorktreeIndexCache = {
 type LiveEntriesByWorktreeCache = {
   tabsByWorktree: WorktreeAgentRowsState['tabsByWorktree']
   agentStatusByPaneKey: WorktreeAgentRowsState['agentStatusByPaneKey']
+  recentlyClosedAgentStatusTabIds: WorktreeAgentRowsState['recentlyClosedAgentStatusTabIds']
   entriesByWorktree: Map<string, AgentStatusEntry[]>
 }
 
@@ -82,9 +84,11 @@ function getTabIdToWorktreeId(
 function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, AgentStatusEntry[]> {
   const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_RECORD
   const tabsByWorktree = state.tabsByWorktree ?? EMPTY_RECORD
+  const recentlyClosedAgentStatusTabIds = state.recentlyClosedAgentStatusTabIds ?? EMPTY_RECORD
   if (
     liveEntriesByWorktreeCache?.tabsByWorktree === tabsByWorktree &&
-    liveEntriesByWorktreeCache.agentStatusByPaneKey === agentStatusByPaneKey
+    liveEntriesByWorktreeCache.agentStatusByPaneKey === agentStatusByPaneKey &&
+    liveEntriesByWorktreeCache.recentlyClosedAgentStatusTabIds === recentlyClosedAgentStatusTabIds
   ) {
     return liveEntriesByWorktreeCache.entriesByWorktree
   }
@@ -97,7 +101,19 @@ function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, Ag
     if (!parsed) {
       continue
     }
-    const worktreeId = tabIdToWorktreeId.get(parsed.tabId) ?? entry.worktreeId
+    if (
+      recentlyClosedAgentStatusTabIds[parsed.tabId] ||
+      (entry.tabId && recentlyClosedAgentStatusTabIds[entry.tabId])
+    ) {
+      continue
+    }
+    const currentTabWorktreeId = tabIdToWorktreeId.get(parsed.tabId)
+    if (!currentTabWorktreeId && entry.state === 'done') {
+      // Why: worktreeId fallback is for early live child-agent attribution.
+      // A completed row whose tab is gone is stale and should not render live.
+      continue
+    }
+    const worktreeId = currentTabWorktreeId ?? entry.worktreeId
     if (!worktreeId) {
       continue
     }
@@ -114,6 +130,7 @@ function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, Ag
   liveEntriesByWorktreeCache = {
     tabsByWorktree,
     agentStatusByPaneKey,
+    recentlyClosedAgentStatusTabIds,
     entriesByWorktree
   }
   return entriesByWorktree

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -12,6 +12,10 @@ import {
 import TerminalPane from './TerminalPane'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { useNativeChatToggleShortcut } from '../native-chat/use-native-chat-toggle-shortcut'
+import {
+  shouldObserveTerminalOverlayFallbackRect,
+  shouldUseTerminalOverlayCssAnchorPositioning
+} from './terminal-overlay-positioning'
 
 type TerminalOverlayAssignment = {
   unifiedTabId: string
@@ -23,26 +27,30 @@ const EMPTY_TERMINAL_TABS: readonly TerminalTab[] = []
 const EMPTY_UNIFIED_TABS: readonly Tab[] = []
 const EMPTY_GROUPS: readonly TabGroup[] = []
 const EMPTY_ACTIVITY_PORTALS: ActivityTerminalPortalTarget[] = []
-const HAS_CSS_ANCHOR_POSITIONING =
-  typeof CSS !== 'undefined' &&
-  CSS.supports('position-anchor', '--orca-terminal-overlay-probe') &&
-  CSS.supports('top', 'anchor(--orca-terminal-overlay-probe top)') &&
-  CSS.supports('width', 'anchor-size(--orca-terminal-overlay-probe width)')
 const MIN_OVERLAY_FIT_WIDTH_PX = 48
 const MIN_OVERLAY_FIT_HEIGHT_PX = 24
-
-function shouldUseCssAnchorPositioning(): boolean {
-  return (
-    HAS_CSS_ANCHOR_POSITIONING &&
-    (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
-  )
-}
 
 type MeasuredFallbackRect = {
   top: number
   left: number
   width: number
   height: number
+}
+
+function areMeasuredFallbackRectsEqual(
+  a: MeasuredFallbackRect | null,
+  b: MeasuredFallbackRect | null
+): boolean {
+  return (
+    a?.top === b?.top && a?.left === b?.left && a?.width === b?.width && a?.height === b?.height
+  )
+}
+
+function updateMeasuredFallbackRect(
+  setRect: React.Dispatch<React.SetStateAction<MeasuredFallbackRect | null>>,
+  nextRect: MeasuredFallbackRect | null
+): void {
+  setRect((prev) => (areMeasuredFallbackRectsEqual(prev, nextRect) ? prev : nextRect))
 }
 
 type TerminalOverlaySlotProps = {
@@ -84,13 +92,19 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   const [shouldMeasureHiddenStartup, setShouldMeasureHiddenStartup] = useState(
     () => useAppStore.getState().pendingStartupByTabId[terminalTabId] !== undefined
   )
+  const shouldObserveFallbackRect = shouldObserveTerminalOverlayFallbackRect({
+    anchorName,
+    groupId,
+    isVisible,
+    shouldMeasureHiddenStartup
+  })
   useLayoutEffect(() => {
     if (isVisible && shouldMeasureHiddenStartup) {
       setShouldMeasureHiddenStartup(false)
     }
   }, [isVisible, shouldMeasureHiddenStartup])
   useLayoutEffect(() => {
-    if (!anchorName || shouldUseCssAnchorPositioning() || !groupId) {
+    if (!shouldObserveFallbackRect || !groupId) {
       return
     }
 
@@ -108,12 +122,12 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       const parent = overlay?.parentElement
       const body = findBody()
       if (!parent || !body) {
-        setMeasuredFallbackRect(null)
+        updateMeasuredFallbackRect(setMeasuredFallbackRect, null)
         return
       }
       const parentRect = parent.getBoundingClientRect()
       const bodyRect = body.getBoundingClientRect()
-      setMeasuredFallbackRect({
+      updateMeasuredFallbackRect(setMeasuredFallbackRect, {
         top: bodyRect.top - parentRect.top,
         left: bodyRect.left - parentRect.left,
         width: bodyRect.width,
@@ -136,7 +150,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       resizeObserver.disconnect()
       window.removeEventListener('resize', updateRect)
     }
-  }, [anchorName, groupId, isVisible])
+  }, [groupId, shouldObserveFallbackRect])
 
   useLayoutEffect(() => {
     if (!isVisible || !anchorName) {
@@ -175,7 +189,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
 
   const style: React.CSSProperties = useMemo(
     () =>
-      anchorName && shouldUseCssAnchorPositioning()
+      anchorName && shouldUseTerminalOverlayCssAnchorPositioning()
         ? {
             position: 'absolute',
             positionAnchor: anchorName,

--- a/src/renderer/src/components/terminal-pane/terminal-overlay-positioning.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-overlay-positioning.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  shouldObserveTerminalOverlayFallbackRect,
+  shouldUseTerminalOverlayCssAnchorPositioning
+} from './terminal-overlay-positioning'
+
+describe('terminal overlay positioning', () => {
+  it('keeps native CSS anchor positioning disabled by default', () => {
+    expect(shouldUseTerminalOverlayCssAnchorPositioning()).toBe(false)
+  })
+
+  it('observes fallback geometry only while the terminal slot is measurable', () => {
+    const base = {
+      anchorName: '--tab-body',
+      groupId: 'group-1'
+    }
+
+    expect(
+      shouldObserveTerminalOverlayFallbackRect({
+        ...base,
+        isVisible: false,
+        shouldMeasureHiddenStartup: false
+      })
+    ).toBe(false)
+    expect(
+      shouldObserveTerminalOverlayFallbackRect({
+        ...base,
+        isVisible: false,
+        shouldMeasureHiddenStartup: true
+      })
+    ).toBe(true)
+    expect(
+      shouldObserveTerminalOverlayFallbackRect({
+        ...base,
+        isVisible: true,
+        shouldMeasureHiddenStartup: false
+      })
+    ).toBe(true)
+  })
+
+  it('does not observe fallback geometry when CSS anchors are active', () => {
+    expect(
+      shouldObserveTerminalOverlayFallbackRect({
+        anchorName: '--tab-body',
+        groupId: 'group-1',
+        isVisible: true,
+        shouldMeasureHiddenStartup: false,
+        useCssAnchorPositioning: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-overlay-positioning.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-overlay-positioning.ts
@@ -1,0 +1,42 @@
+type TerminalOverlayGlobalScope = typeof globalThis & {
+  __ORCA_WEB_CLIENT__?: boolean
+}
+
+const TERMINAL_OVERLAY_CSS_ANCHORS_ENABLED = false
+
+function hasTerminalOverlayCssAnchorPositioning(): boolean {
+  return (
+    typeof CSS !== 'undefined' &&
+    CSS.supports('position-anchor', '--orca-terminal-overlay-probe') &&
+    CSS.supports('top', 'anchor(--orca-terminal-overlay-probe top)') &&
+    CSS.supports('width', 'anchor-size(--orca-terminal-overlay-probe width)')
+  )
+}
+
+export function shouldUseTerminalOverlayCssAnchorPositioning(
+  globalScope: TerminalOverlayGlobalScope = globalThis as TerminalOverlayGlobalScope
+): boolean {
+  // Why: native CSS anchor positioning has shown idle renderer CPU/jitter on
+  // newer Electron/macOS builds (#4364, #6655). The fallback is
+  // ResizeObserver-driven and already covers unsupported/web-client runtimes.
+  return (
+    TERMINAL_OVERLAY_CSS_ANCHORS_ENABLED &&
+    hasTerminalOverlayCssAnchorPositioning() &&
+    globalScope.__ORCA_WEB_CLIENT__ !== true
+  )
+}
+
+export function shouldObserveTerminalOverlayFallbackRect(args: {
+  anchorName: string | undefined
+  groupId: string | undefined
+  isVisible: boolean
+  shouldMeasureHiddenStartup: boolean
+  useCssAnchorPositioning?: boolean
+}): boolean {
+  return Boolean(
+    args.anchorName &&
+    args.groupId &&
+    (args.isVisible || args.shouldMeasureHiddenStartup) &&
+    !(args.useCssAnchorPositioning ?? shouldUseTerminalOverlayCssAnchorPositioning())
+  )
+}

--- a/src/renderer/src/store/slices/agent-status-drop-ipc.test.ts
+++ b/src/renderer/src/store/slices/agent-status-drop-ipc.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { type AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalTab } from '../../../../shared/types'
 import type { RetainedAgentEntry } from './agent-status'
 import { createTestStore } from './store-test-helpers'
@@ -118,6 +119,25 @@ describe('dropAgentStatusByTabPrefix -> IPC fan-out', () => {
       'tab-old': true,
       'tab-new': true
     })
+  })
+
+  it('ignores late statuses routed to a closed tab even when the pane key differs', () => {
+    stubWindowApi()
+    const store = createTestStore()
+    const childPaneKey = makePaneKey('tab-child', '33333333-3333-4333-8333-333333333333')
+
+    store.getState().dropAgentStatusByTabPrefix('tab-closed')
+    store
+      .getState()
+      .setAgentStatus(
+        childPaneKey,
+        { state: 'done', prompt: 'p', agentType: 'pi' },
+        'Pi',
+        { updatedAt: 1_000, stateStartedAt: 1_000 },
+        { tabId: 'tab-closed', worktreeId: 'wt-1' }
+      )
+
+    expect(store.getState().agentStatusByPaneKey[childPaneKey]).toBeUndefined()
   })
 })
 

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -968,12 +968,15 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
 
     setAgentStatus: (paneKey, payload, terminalTitle, timing, routing, metadata) => {
       const updatedAt = timing?.updatedAt ?? Date.now()
+      const paneTabId = getTabIdFromPaneKey(paneKey)
       if (
         // Why: a closed terminal tab is no longer a valid destination for hook
         // replays or late status events, even if main still receives them.
+        // Some child-agent rows carry the closed tab only in routing metadata.
+        isRecentlyClosedAgentStatusTab(get().recentlyClosedAgentStatusTabIds, paneTabId) ||
         isRecentlyClosedAgentStatusTab(
           get().recentlyClosedAgentStatusTabIds,
-          getTabIdFromPaneKey(paneKey)
+          routing?.tabId ?? null
         )
       ) {
         return

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -4839,6 +4839,67 @@ describe('worktree remote runtime mutations', () => {
     )
   })
 
+  it('coalesces rapid background activity stamps to avoid sidebar re-sort churn', async () => {
+    vi.useFakeTimers()
+    try {
+      mockApi.worktrees.updateMeta.mockClear()
+      const store = createTestStore()
+      const wt = makeWorktree({
+        id: 'repo1::/path/wt1',
+        repoId: 'repo1',
+        path: '/path/wt1',
+        lastActivityAt: 1_000
+      })
+      store.setState({
+        activeWorktreeId: 'repo1::/path/other',
+        sortEpoch: 7,
+        worktreesByRepo: { repo1: [wt] }
+      } as Partial<AppState>)
+
+      vi.setSystemTime(10_000)
+      store.getState().bumpWorktreeActivity(wt.id)
+      await Promise.resolve()
+
+      expect(store.getState().worktreesByRepo.repo1[0]?.lastActivityAt).toBe(1_000)
+      expect(store.getState().sortEpoch).toBe(7)
+      expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('persists background activity once the coalescing window has elapsed', async () => {
+    vi.useFakeTimers()
+    try {
+      mockApi.worktrees.updateMeta.mockClear()
+      const store = createTestStore()
+      const wt = makeWorktree({
+        id: 'repo1::/path/wt1',
+        repoId: 'repo1',
+        path: '/path/wt1',
+        lastActivityAt: 1_000
+      })
+      store.setState({
+        activeWorktreeId: 'repo1::/path/other',
+        sortEpoch: 7,
+        worktreesByRepo: { repo1: [wt] }
+      } as Partial<AppState>)
+
+      vi.setSystemTime(17_000)
+      store.getState().bumpWorktreeActivity(wt.id)
+      await Promise.resolve()
+
+      expect(store.getState().worktreesByRepo.repo1[0]?.lastActivityAt).toBe(17_000)
+      expect(store.getState().sortEpoch).toBe(8)
+      expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+        worktreeId: wt.id,
+        updates: { lastActivityAt: 17_000 }
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('clears stale hosted review cache and force-refetches when removing linked PR metadata', async () => {
     const store = createTestStore()
     const wt = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -69,6 +69,7 @@ const ACTIVE_WORKTREE_TERMINAL_PREP_DELAY_MS = 300
 const ACTIVE_WORKTREE_TERMINAL_PREP_INPUT_QUIET_MS = 450
 const ACTIVE_WORKTREE_TERMINAL_PREP_IDLE_TIMEOUT_MS = 180
 const WORKTREE_REFRESH_CONCURRENCY = 5
+const WORKTREE_ACTIVITY_RESTAMP_MIN_INTERVAL_MS = 15_000
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
@@ -3739,6 +3740,17 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const worktree = findKnownWorktreeById(s, worktreeId)
       if (!worktree) {
         return {}
+      }
+      const msSinceLastActivity = now - worktree.lastActivityAt
+      if (
+        Number.isFinite(worktree.lastActivityAt) &&
+        worktree.lastActivityAt > 0 &&
+        msSinceLastActivity >= 0 &&
+        msSinceLastActivity < WORKTREE_ACTIVITY_RESTAMP_MIN_INTERVAL_MS
+      ) {
+        // Why: bursty PTY lifecycle events from multiple agents can otherwise
+        // rewrite metadata and re-sort the sidebar several times per moment.
+        return s
       }
       shouldPersist = true
       // Skip sortEpoch bump for the active worktree. Terminal events


### PR DESCRIPTION
## Summary

This PR bundles concrete fixes from a full open performance/memory-leak issue review, while intentionally skipping pure terminal rendering/input reports that are being handled separately.

Branch: `nwparker/bug-review`  
Commit: `7e97f1be75`

## What Changed

- Reduced sidebar/worktree activity thrash by rate-limiting repeated activity restamps, avoiding rapid metadata writes and sort epoch churn when many agents update together.
- Reworked macOS shell PATH hydration so the default startup path uses static startup-file parsing instead of spawning an interactive shell during launch; explicit `interactive` strategy remains available.
- Added static shell startup PATH parsing coverage for common POSIX patterns including `$HOME`, `~`, `$PATH`, and quoted assignments.
- Prevented rich markdown mode from saving through TipTap for format-sensitive Markdown that would be canonicalized into a full-file rewrite.
- Mitigated terminal overlay renderer CPU/jitter by keeping native CSS anchor positioning disabled by default and only measuring fallback geometry when the overlay slot is measurable.
- Avoided stale mobile/session state by excluding saved-but-not-live session tabs from live terminal/agent status inflation.
- Suppressed background Claude hook progress after a completed turn from restarting notification cycles without a fresh prompt.
- Dropped late agent status updates routed to recently closed terminal tabs, and filtered stale closed-tab rows from compact sidebar selectors.
- Kept rate-limit auto-refresh alive when Claude auth preparation or Codex home preparation fails during update/relaunch paths, degrading only the affected provider instead of aborting the refresh cycle.

## Issue Coverage

Refs #6803, #5657, #6080, #6655, #4364, #6072, #4630, #5913, #5355.

Reviewed but left for repro/evidence or separate terminal work: #6814, #6795, #6691, #5107, plus pure terminal/input/rendering reports such as #5365, #5787, #6756, #6491, #6144, #4436, #5096, #4932, and #6698.

## Review Notes

Self-review found no blocking issues. The terminal overlay change is a mitigation for renderer idle CPU/jitter rather than proof of full closure for every high-CPU report. The broader slow-start/100%-CPU reports still need Resource Manager/process evidence before making behavior changes.

## Tradeoffs / User-visible Changes

- Sidebar activity order now updates at most once every 15 seconds for rapid repeated activity on the same worktree. This reduces flicker and disk/store churn, but the exact “most recently active” ordering can lag briefly while several agents are working at once.
- macOS startup PATH hydration no longer runs a full interactive shell by default. This avoids Jamf/CrowdStrike-style startup hangs, but users with very dynamic shell startup files that compute PATH by running commands may not get those dynamic PATH additions unless the explicit interactive strategy is used.
- Some Markdown files with format-sensitive patterns (`_word_`, `__word__`, `* item`, `+ item`) will avoid the rich-mode save path. That may feel like the rich editor is more conservative, but it prevents TipTap from rewriting the whole file or changing Markdown style unexpectedly.
- Native CSS anchor positioning for terminal overlays is disabled by default. The fallback uses measured geometry instead, which may update one layout tick later in edge cases, but avoids the renderer CPU/jitter seen on affected Electron/macOS builds.
- Saved/restored session tabs that no longer have a live PTY are no longer counted as live mobile agent rows. A disconnected saved session may disappear from “active” mobile/status surfaces sooner, but stale closed-session rows should stop hanging around.
- Claude hook progress after a completed turn is ignored unless a fresh prompt appears. This can suppress a rare background-only progress notification, but prevents completed agents from repeatedly restarting notification cycles.
- Late agent-status IPC updates for recently closed tabs are dropped. If a closed tab sends a final late update, it will not be shown; the intended behavior is that closed tabs do not keep compact agent rows alive.
- Rate-limit refresh now degrades per provider when runtime preparation fails. For example, Claude can show a Claude-specific refresh error while Codex/Gemini/OpenCode/Kimi continue updating. This is more honest than silently keeping the whole refresh loop stuck, but users may see a provider-specific error instead of stale-looking global state.

## ELI5

Before this PR, several background systems were too eager: they kept reordering rows, launching shells, measuring overlays, accepting late status messages, or aborting a whole usage refresh when only one provider failed. This PR makes those systems more patient and more local: only update when it matters, only measure when visible, only keep live things live, and if one provider has a bad day, do not stop everyone else from refreshing.

The main tradeoff is that a few UI updates are less instant or less aggressive by design. In exchange, users should see less flicker, fewer stale rows, fewer notification loops, fewer startup hangs, and a status bar that recovers better after update/relaunch failures.

## Benchmarks / Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts src/main/pty/shell-startup-env.test.ts src/main/startup/hydrate-shell-path.test.ts src/renderer/src/components/editor/markdown-rich-mode.test.ts src/renderer/src/components/terminal-pane/terminal-overlay-positioning.test.ts src/main/agent-hooks/server.test.ts src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts src/renderer/src/components/sidebar/worktree-agent-row-closed-tab-selectors.test.ts src/renderer/src/store/slices/agent-status-drop-ipc.test.ts src/main/rate-limits/service.test.ts` - 10 files, 529 tests passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --testNamePattern "worktree ps|saved session tabs"` - 2 passed, 511 skipped.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/service.test.ts src/renderer/src/components/terminal-pane/terminal-overlay-positioning.test.ts src/renderer/src/components/sidebar/worktree-agent-row-closed-tab-selectors.test.ts` - post-commit smoke, 36 passed.
- `pnpm run typecheck:web` - passed.
- `pnpm run typecheck:node` - passed.
- `pnpm exec oxlint <all touched ts/tsx files>` - passed.
- `git diff --check` - passed.
- `git diff --check HEAD~1 HEAD` - passed.
- Pre-commit hook also ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` over staged files.