### PR TITLE
fix(codex): migrate deprecated codex_hooks in CRLF configs

### DIFF
--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -108,6 +108,24 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     expect(readFileSync(getSystemConfigPath(), 'utf-8')).toContain('codex_hooks = true')
   })
 
+  it('normalizes deprecated codex_hooks in a CRLF system config', () => {
+    // A Windows-authored ~/.codex/config.toml uses CRLF, so split('\n') leaves a
+    // trailing \r on the [features] header line — the migration must still detect it.
+    writeFileSync(
+      getSystemConfigPath(),
+      ['model = "system-model"', '', '[features]', 'codex_hooks = true', ''].join('\r\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig).toContain('[features]')
+    expect(runtimeConfig).toContain('hooks = true')
+    expect(runtimeConfig).not.toContain('codex_hooks')
+    expect(readFileSync(getSystemConfigPath(), 'utf-8')).toContain('codex_hooks = true')
+  })
+
   it('drops deprecated codex_hooks when the new hooks flag already exists', () => {
     writeFileSync(
       getSystemConfigPath(),

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -56,7 +56,9 @@ function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
 
   for (let index = 0; index <= lines.length; index += 1) {
     const line = lines[index]
-    const isHeader = line === undefined || /^[ \t]*\[[^\]]+\][ \t]*(?:#.*)?$/.test(line)
+    // Tolerate a trailing \r: split('\n') leaves CRLF endings intact, so a Windows
+    // config's "[features]\r" header must still match (cf. getProjectTrustLevel).
+    const isHeader = line === undefined || /^[ \t]*\[[^\]]+\][ \t]*(?:#.*)?\r?$/.test(line)
     if (!isHeader) {
       continue
     }
@@ -65,7 +67,7 @@ function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
       featureSections.push({ start: featureStart, end: index })
       featureStart = null
     }
-    if (line !== undefined && /^[ \t]*\[features\][ \t]*(?:#.*)?$/.test(line)) {
+    if (line !== undefined && /^[ \t]*\[features\][ \t]*(?:#.*)?\r?$/.test(line)) {
       featureStart = index
     }
   }


### PR DESCRIPTION
## Summary

On Windows, a `~/.codex/config.toml` authored with CRLF line endings never gets its deprecated `codex_hooks` feature flag migrated to the new `hooks` key in Orca's managed runtime config.

`normalizeDeprecatedCodexHookFeatureFlag` splits the config on `\n`, which leaves a trailing `\r` on every line of a CRLF file. The section-header and `[features]` detection regexes are anchored `[ \t]*…$`, so a `[features]\r` line fails to match — no `[features]` section is detected, and the migration silently no-ops. The deprecated key is then mirrored into Orca's runtime config unchanged, so Codex 0.133 keeps warning and the hook flag is not honored under the new key.

This is an isolated inconsistency: the rest of the same file already tolerates CRLF — `getTomlTableHeader` uses `\s*` (which includes `\r`), and `getProjectTrustLevel` explicitly allows `[ \t\r]*`. Only these two header regexes were missed.

Fix: allow an optional trailing `\r` before `$` in both regexes. LF configs are unaffected; the user's real config is never rewritten (only Orca's runtime mirror).

Reproduced: a system config built with `['[features]', 'codex_hooks = true'].join('\r\n')` leaves `codex_hooks` in the runtime mirror before the fix, and is correctly migrated to `hooks` after.

## Screenshots

No visual change. This is a pure config-parsing fix in `src/main`.

## Testing

- [x] `pnpm lint` — passes (only a pre-existing unrelated `useGitStatusPolling.ts` exhaustive-deps warning)
- [x] `pnpm typecheck` — passes (node + cli + web, exit 0)
- [x] `pnpm test` — `src/main/codex` suite: 15 files / 289 tests pass; the new CRLF test fails on pre-fix code and passes after
- [ ] `pnpm build` — not run locally (native/electron toolchain); change is a pure regex fix with no native or build surface
- [x] Added a CRLF regression test next to the existing LF migration test; it is red before the fix and green after.

## AI Review Report

Reviewed with an AI coding agent. The agent independently traced the whole file's line-ending handling before proposing the fix, to confirm the bug is isolated (not a systemic CRLF rewrite) and the fix matches existing in-file behavior.

- **Cross-platform (macOS / Linux / Windows):** Positive. This *is* a Windows/CRLF correctness fix; LF (mac/Linux) behavior is byte-for-byte unchanged. The fix mirrors the CRLF tolerance already present in `getProjectTrustLevel` in the same file.
- **SSH / remote / local:** No impact. Reads a local config file; identical across local/remote/SSH modes.
- **Agent / integration / git-provider:** Scoped to the Codex config mirror; no other agent or provider code touched. Provider-neutral.
- **Performance:** No impact — same single pass, one optional `\r?` in two regexes.
- **UI:** No visual change.
- **Security:** Neutral. No widening of accepted input beyond tolerating a trailing CR on header lines; the user's real `~/.codex/config.toml` is never modified.

## Security Audit

- **Input handling:** Input is a local user config file. The change only lets a `[features]\r` header be recognized; it does not broaden what sections/keys are accepted or written. Parsing stays bounded and pure.
- **Command execution / paths / auth / secrets / IPC:** None touched. No follow-up needed.

## Notes

Windows/CRLF-specific behavior. No new platform branches were added — the fix is a regex tolerance consistent with the rest of the file.

## ELI5

On Windows, Codex configs with Windows-style line endings never migrated the old `codex_hooks` flag to `hooks`. Migration now handles CRLF so the feature flag update applies correctly.
