### PR TITLE
Fix startup terminal color replies for hidden Codex panes

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -5822,6 +5822,279 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('answers agent startup OSC color queries before renderer batching', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        launchAgent: 'codex',
+        terminalColorQueryReplies: {
+          foreground: '#eeeeee',
+          background: '#111111'
+        }
+      })) as { id: string }
+      mockProc.proc.write.mockClear()
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('\x1b]10;?\x1b\\\x1b]11;?\x1b\\ready')
+
+      expect(mockProc.proc.write).toHaveBeenCalledWith('\x1b]10;rgb:eeee/eeee/eeee\x1b\\')
+      expect(mockProc.proc.write).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'ready'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('answers combined agent startup OSC foreground and background color queries', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        launchAgent: 'codex',
+        terminalColorQueryReplies: {
+          foreground: '#eeeeee',
+          background: '#111111'
+        }
+      })) as { id: string }
+      mockProc.proc.write.mockClear()
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('\x1b]10;?;?\x1b\\ready')
+
+      expect(mockProc.proc.write).toHaveBeenCalledWith('\x1b]10;rgb:eeee/eeee/eeee\x1b\\')
+      expect(mockProc.proc.write).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'ready'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not answer ordinary terminal OSC color queries in main', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        terminalColorQueryReplies: {
+          foreground: '#eeeeee',
+          background: '#111111'
+        }
+      })) as { id: string }
+      mainWindow.webContents.send.mockClear()
+
+      const query = '\x1b]10;?\x1b\\\x1b]11;?\x1b\\'
+      mockProc.emitData(`${query}ready`)
+
+      expect(mockProc.proc.write).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: `${query}ready`
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not answer agent OSC color commands that only start like startup queries', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        launchAgent: 'codex',
+        terminalColorQueryReplies: {
+          foreground: '#eeeeee',
+          background: '#111111'
+        }
+      })) as { id: string }
+      mockProc.proc.write.mockClear()
+      mainWindow.webContents.send.mockClear()
+
+      const command = '\x1b]10;?not-a-query\x1b\\'
+      mockProc.emitData(`${command}ready`)
+
+      expect(mockProc.proc.write).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: `${command}ready`
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('answers daemon agent startup OSC color queries before spawn resolves', async () => {
+    vi.useFakeTimers()
+    let dataHandler: ((payload: { id: string; data: string }) => void) | null = null
+    const write = vi.fn()
+    const spawn = vi.fn(async (options: { sessionId?: string }) => {
+      const id = options.sessionId ?? 'daemon-pty'
+      dataHandler?.({ id, data: '\x1b]10;?\x1b\\\x1b]11;?\x1b\\daemon-ready' })
+      return { id }
+    })
+    setLocalPtyProvider({
+      spawn,
+      write,
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn((handler: (payload: { id: string; data: string }) => void) => {
+        dataHandler = handler
+        return () => {}
+      }),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        launchAgent: 'codex',
+        terminalColorQueryReplies: {
+          foreground: '#eeeeee',
+          background: '#111111'
+        }
+      })) as { id: string }
+
+      expect(write).toHaveBeenCalledWith(spawnResult.id, '\x1b]10;rgb:eeee/eeee/eeee\x1b\\')
+      expect(write).toHaveBeenCalledWith(spawnResult.id, '\x1b]11;rgb:1111/1111/1111\x1b\\')
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'daemon-ready'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('drops renderer sequence metadata when an answered OSC query is batched', async () => {
+    vi.useFakeTimers()
+    const providerEvents: {
+      dataHandler?: (payload: { id: string; data: string }) => void
+    } = {}
+    const write = vi.fn()
+    const spawn = vi.fn(async (options: { sessionId?: string }) => ({
+      id: options.sessionId ?? 'daemon-pty'
+    }))
+    setLocalPtyProvider({
+      spawn,
+      write,
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn((handler: (payload: { id: string; data: string }) => void) => {
+        providerEvents.dataHandler = handler
+        return () => {}
+      }),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    let seq = 0
+    const runtime = {
+      setPtyController: vi.fn(),
+      createPreAllocatedTerminalHandle: vi.fn(() => null),
+      onPtyData: vi.fn((_id: string, data: string) => {
+        seq += data.length
+        return seq
+      }),
+      registerPty: vi.fn()
+    }
+
+    try {
+      registerPtyHandlers(mainWindow as never, runtime as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        launchAgent: 'codex',
+        terminalColorQueryReplies: {
+          foreground: '#eeeeee',
+          background: '#111111'
+        }
+      })) as { id: string }
+      mainWindow.webContents.send.mockClear()
+
+      providerEvents.dataHandler?.({ id: spawnResult.id, data: 'prefix' })
+      providerEvents.dataHandler?.({
+        id: spawnResult.id,
+        data: '\x1b]10;?\x1b\\\x1b]11;?\x1b\\ready'
+      })
+      vi.advanceTimersByTime(8)
+
+      expect(write).toHaveBeenCalledWith(spawnResult.id, '\x1b]10;rgb:eeee/eeee/eeee\x1b\\')
+      expect(write).toHaveBeenCalledWith(spawnResult.id, '\x1b]11;rgb:1111/1111/1111\x1b\\')
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'prefixready'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('sends small PTY redraws immediately after terminal input', async () => {
     vi.useFakeTimers()
     const mockProc = createMockProc()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -89,6 +89,13 @@ import { buildConfiguredProxyEnv, type NetworkProxySettings } from '../../shared
 import { resolveSetupAgentSequenceLaunchCommand } from '../../shared/setup-agent-sequencing'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import {
+  answerStartupTerminalColorQueries,
+  clearStartupTerminalColorQueryReplies,
+  getStartupTerminalColorQueryReplyColors,
+  moveStartupTerminalColorQueryReplies,
+  registerStartupTerminalColorQueryReplies
+} from './terminal-startup-color-query-replies'
+import {
   assertFolderWorkspacePathUsable,
   getFolderWorkspacePathStatus
 } from '../project-groups/folder-workspace-path-status'
@@ -368,6 +375,22 @@ function tryGetProviderForPty(ptyId: string): IPtyProvider | undefined {
   } catch {
     return undefined
   }
+}
+
+function getProviderForStartupTerminalColorReply(ptyId: string): IPtyProvider | undefined {
+  const ownedConnectionId = ptyOwnership.get(ptyId)
+  if (ownedConnectionId !== undefined) {
+    return getProvider(ownedConnectionId)
+  }
+  const parsedSshId = parseAppSshPtyId(ptyId)
+  if (parsedSshId) {
+    return getProvider(parsedSshId.connectionId)
+  }
+  return localProvider
+}
+
+export function answerStartupTerminalColorQueriesForPty(ptyId: string, data: string): string {
+  return answerStartupTerminalColorQueries(ptyId, data, getProviderForStartupTerminalColorReply)
 }
 
 function normalizeNodePtySpawnError(err: unknown): Error {
@@ -999,6 +1022,7 @@ export function clearProviderPtyState(id: string): void {
   lastInputAtByPty.delete(id)
   interactiveOutputCharsByPty.delete(id)
   activeRendererPtys.delete(id)
+  clearStartupTerminalColorQueryReplies(id)
   const paneKey = ptyPaneKey.get(id)
   const stillOwnsPaneKey = paneKey ? paneKeyPtyId.get(paneKey) === id : false
   // Why: drop the memory-collector registration so a dead PTY does not keep
@@ -1445,16 +1469,18 @@ export function registerPtyHandlers(
   function appendPendingPtyData(
     existing: PendingPtyData | undefined,
     data: string,
-    startSeq: number | undefined
+    startSeq: number | undefined,
+    preservesSeq: boolean
   ): PendingPtyData {
+    if (!preservesSeq) {
+      return { data: (existing?.data ?? '') + data }
+    }
     if (!existing) {
       return typeof startSeq === 'number' ? { data, startSeq } : { data }
     }
     const next: PendingPtyData = { data: existing.data + data }
     if (typeof existing.startSeq === 'number') {
       next.startSeq = existing.startSeq
-    } else if (typeof startSeq === 'number') {
-      next.startSeq = startSeq
     }
     return next
   }
@@ -1536,7 +1562,9 @@ export function registerPtyHandlers(
       const outputSeq = isLocalProvider
         ? runtime?.getPtyOutputSequence(payload.id)
         : runtime?.onPtyData(payload.id, payload.data, Date.now())
-      const startSeq = getChunkStartSeq(outputSeq, payload.data)
+      const rendererData = answerStartupTerminalColorQueriesForPty(payload.id, payload.data)
+      const preservesSeq = rendererData === payload.data
+      const startSeq = preservesSeq ? getChunkStartSeq(outputSeq, payload.data) : undefined
       if (mainWindow.isDestroyed()) {
         // Why: clear the pending flush timer so it doesn't fire after the window
         // is gone. Without this, macOS app re-activation leaks orphaned timers
@@ -1551,8 +1579,11 @@ export function registerPtyHandlers(
         recordPtyRendererDeliveryPressure()
         return
       }
+      if (rendererData.length === 0) {
+        return
+      }
       const existing = pendingData.get(payload.id)
-      const pending = appendPendingPtyData(existing, payload.data, startSeq)
+      const pending = appendPendingPtyData(existing, rendererData, startSeq, preservesSeq)
       const nextData = pending.data
       const isInteractiveOutput = shouldSendInteractiveOutputNow(
         payload.id,
@@ -2271,6 +2302,10 @@ export function registerPtyHandlers(
         sessionId?: string
         shellOverride?: string
         projectRuntime?: ProjectExecutionRuntimeResolution
+        terminalColorQueryReplies?: {
+          foreground?: unknown
+          background?: unknown
+        }
         // Why: closes the SIGKILL race documented in INVESTIGATION.md by
         // letting main patch + sync-flush the (worktreeId, tabId, leafId →
         // ptyId) binding before pty:spawn returns. Only the renderer's
@@ -2367,6 +2402,11 @@ export function registerPtyHandlers(
         effectiveSessionId !== undefined
           ? getRelayPtyId(args.connectionId, effectiveSessionId)
           : undefined
+      const startupTerminalColorQueryReplyColors = getStartupTerminalColorQueryReplyColors(args)
+      const preSpawnStartupTerminalColorReplyPtyId =
+        startupTerminalColorQueryReplyColors && effectiveSessionId !== undefined
+          ? (effectiveSessionAppId ?? effectiveSessionId)
+          : null
       // Why: the renderer sets pane env for SSH too. Only forward it to the
       // remote when the relay hook path is enabled; otherwise a newer relay
       // could emit statuses this Orca build is not prepared to route.
@@ -2619,10 +2659,21 @@ export function registerPtyHandlers(
           if (preAllocatedHandle) {
             trustedTerminalHandleEnv.add(preAllocatedHandle)
           }
+          if (preSpawnStartupTerminalColorReplyPtyId && startupTerminalColorQueryReplyColors) {
+            // Why: Codex probes OSC 10/11 with a 100 ms timeout and daemon PTYs
+            // can emit that query before spawn() resolves to the renderer.
+            registerStartupTerminalColorQueryReplies(
+              preSpawnStartupTerminalColorReplyPtyId,
+              startupTerminalColorQueryReplyColors
+            )
+          }
           result = await provider.spawn(spawnOptions)
         } catch (err) {
           const rawMessage = err instanceof Error ? err.message : String(err)
           const spawnError = normalizeNodePtySpawnError(err)
+          if (preSpawnStartupTerminalColorReplyPtyId) {
+            clearStartupTerminalColorQueryReplies(preSpawnStartupTerminalColorReplyPtyId)
+          }
           if (effectiveSessionAppId !== undefined) {
             ptySizes.delete(effectiveSessionAppId)
           }
@@ -2678,6 +2729,20 @@ export function registerPtyHandlers(
           }
         }
         ptyOwnership.set(result.id, args.connectionId ?? null)
+        if (startupTerminalColorQueryReplyColors) {
+          if (result.isReattach) {
+            if (preSpawnStartupTerminalColorReplyPtyId) {
+              clearStartupTerminalColorQueryReplies(preSpawnStartupTerminalColorReplyPtyId)
+            }
+          } else if (preSpawnStartupTerminalColorReplyPtyId) {
+            moveStartupTerminalColorQueryReplies(preSpawnStartupTerminalColorReplyPtyId, result.id)
+          } else {
+            registerStartupTerminalColorQueryReplies(
+              result.id,
+              startupTerminalColorQueryReplyColors
+            )
+          }
+        }
         const relayResultId = getRelayPtyId(args.connectionId, result.id)
         if (store && args.connectionId) {
           // Why: remote PTYs live in the SSH relay grace window after Orca

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -155,6 +155,7 @@ vi.mock('./pty', () => ({
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),
   setPtyOwnership: vi.fn(),
+  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data),
   getSshPtyProvider: vi.fn(),
   getPtyIdsForConnection: vi.fn().mockReturnValue([]),
   isRendererPtyOutputPaused: vi.fn().mockReturnValue(false)

--- a/src/main/ipc/terminal-startup-color-query-replies.ts
+++ b/src/main/ipc/terminal-startup-color-query-replies.ts
@@ -1,0 +1,197 @@
+import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
+import { isTuiAgent } from '../../shared/tui-agent-config'
+import { agentKindSchema } from '../../shared/telemetry-events'
+import type { SleepingAgentLaunchConfig } from '../../shared/agent-session-resume'
+import {
+  parseTerminalOscColorQuery,
+  terminalOscColorQueryReplies,
+  terminalOscColorQueryReply,
+  type TerminalOscColorQueryReplyColors,
+  type TerminalOscColorQuerySlot
+} from '../../shared/terminal-osc-color-reply'
+
+type StartupTerminalColorQueryProvider = {
+  write(id: string, data: string): void
+}
+
+type StartupTerminalColorQueryReplyState = {
+  colors: TerminalOscColorQueryReplyColors
+  pending: string
+  answeredSlots: Set<TerminalOscColorQuerySlot>
+  timeout: ReturnType<typeof setTimeout>
+}
+
+const STARTUP_TERMINAL_COLOR_QUERY_REPLY_WINDOW_MS = 5_000
+const STARTUP_TERMINAL_COLOR_QUERY_PENDING_CHARS = 64
+const startupTerminalColorQueryRepliesByPty = new Map<string, StartupTerminalColorQueryReplyState>()
+
+export function clearStartupTerminalColorQueryReplies(ptyId: string): void {
+  const state = startupTerminalColorQueryRepliesByPty.get(ptyId)
+  if (!state) {
+    return
+  }
+  clearTimeout(state.timeout)
+  startupTerminalColorQueryRepliesByPty.delete(ptyId)
+}
+
+export function moveStartupTerminalColorQueryReplies(fromPtyId: string, toPtyId: string): void {
+  if (fromPtyId === toPtyId) {
+    return
+  }
+  const state = startupTerminalColorQueryRepliesByPty.get(fromPtyId)
+  if (!state) {
+    return
+  }
+  startupTerminalColorQueryRepliesByPty.delete(fromPtyId)
+  clearStartupTerminalColorQueryReplies(toPtyId)
+  startupTerminalColorQueryRepliesByPty.set(toPtyId, state)
+}
+
+export function registerStartupTerminalColorQueryReplies(
+  ptyId: string,
+  colors: TerminalOscColorQueryReplyColors
+): void {
+  if (!terminalOscColorQueryReply(colors, 10) || !terminalOscColorQueryReply(colors, 11)) {
+    return
+  }
+  clearStartupTerminalColorQueryReplies(ptyId)
+  const timeout = setTimeout(
+    () => clearStartupTerminalColorQueryReplies(ptyId),
+    STARTUP_TERMINAL_COLOR_QUERY_REPLY_WINDOW_MS
+  )
+  timeout.unref?.()
+  startupTerminalColorQueryRepliesByPty.set(ptyId, {
+    colors,
+    pending: '',
+    answeredSlots: new Set(),
+    timeout
+  })
+}
+
+function normalizeTerminalColorQueryReplyColors(
+  value: unknown
+): TerminalOscColorQueryReplyColors | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const record = value as { foreground?: unknown; background?: unknown }
+  const colors = {
+    ...(typeof record.foreground === 'string' ? { foreground: record.foreground } : {}),
+    ...(typeof record.background === 'string' ? { background: record.background } : {})
+  }
+  if (!terminalOscColorQueryReply(colors, 10) || !terminalOscColorQueryReply(colors, 11)) {
+    return null
+  }
+  return colors
+}
+
+function shouldReplyToStartupTerminalColorQueries(args: {
+  launchAgent?: unknown
+  telemetry?: { agent_kind?: unknown } | undefined
+  command?: string
+  launchConfig?: SleepingAgentLaunchConfig
+}): boolean {
+  if (isTuiAgent(args.launchAgent)) {
+    return true
+  }
+  const agentKindParse =
+    args.telemetry?.agent_kind !== undefined
+      ? agentKindSchema.safeParse(args.telemetry.agent_kind)
+      : null
+  if (agentKindParse?.success && agentKindParse.data !== 'other') {
+    return true
+  }
+  const command = args.launchConfig?.agentCommand?.trim() || args.command?.trim() || ''
+  return recognizeAgentProcessFromCommandLine(command) !== null
+}
+
+export function getStartupTerminalColorQueryReplyColors(args: {
+  launchAgent?: unknown
+  telemetry?: { agent_kind?: unknown } | undefined
+  command?: string
+  launchConfig?: SleepingAgentLaunchConfig
+  terminalColorQueryReplies?: unknown
+}): TerminalOscColorQueryReplyColors | null {
+  if (!shouldReplyToStartupTerminalColorQueries(args)) {
+    return null
+  }
+  return normalizeTerminalColorQueryReplyColors(args.terminalColorQueryReplies)
+}
+
+function writeStartupTerminalColorQueryReplies(
+  ptyId: string,
+  slots: readonly TerminalOscColorQuerySlot[],
+  state: StartupTerminalColorQueryReplyState,
+  getProvider: (ptyId: string) => StartupTerminalColorQueryProvider | undefined
+): boolean {
+  const replies = terminalOscColorQueryReplies(state.colors, slots)
+  let provider: StartupTerminalColorQueryProvider | undefined
+  try {
+    provider = replies ? getProvider(ptyId) : undefined
+  } catch {
+    provider = undefined
+  }
+  if (!replies || !provider) {
+    return false
+  }
+  try {
+    for (const [index, reply] of replies.entries()) {
+      const slot = slots[index]
+      if (slot === undefined) {
+        return false
+      }
+      provider.write(ptyId, reply)
+      state.answeredSlots.add(slot)
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function answerStartupTerminalColorQueries(
+  ptyId: string,
+  data: string,
+  getProvider: (ptyId: string) => StartupTerminalColorQueryProvider | undefined
+): string {
+  const state = startupTerminalColorQueryRepliesByPty.get(ptyId)
+  if (!state || data.length === 0) {
+    return data
+  }
+  const input = state.pending + data
+  let pending = ''
+  let output = ''
+  let offset = 0
+  while (offset < input.length) {
+    const candidateIndex = input.indexOf('\x1b', offset)
+    if (candidateIndex === -1) {
+      output += input.slice(offset)
+      break
+    }
+    output += input.slice(offset, candidateIndex)
+    const query = parseTerminalOscColorQuery(input, candidateIndex)
+    if (query.kind === 'none') {
+      output += input[candidateIndex]
+      offset = candidateIndex + 1
+      continue
+    }
+    if (query.kind === 'partial') {
+      const candidate = input.slice(candidateIndex)
+      if (candidate.length <= STARTUP_TERMINAL_COLOR_QUERY_PENDING_CHARS) {
+        pending = candidate
+      } else {
+        output += candidate
+      }
+      break
+    }
+    if (!writeStartupTerminalColorQueryReplies(ptyId, query.slots, state, getProvider)) {
+      output += input.slice(candidateIndex, query.endIndex)
+    }
+    offset = query.endIndex
+  }
+  state.pending = pending
+  if (state.answeredSlots.has(10) && state.answeredSlots.has(11)) {
+    clearStartupTerminalColorQueryReplies(ptyId)
+  }
+  return output
+}

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -58,7 +58,8 @@ vi.mock('../ipc/pty', () => ({
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),
-  setPtyOwnership: vi.fn()
+  setPtyOwnership: vi.fn(),
+  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data)
 }))
 
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -75,7 +75,8 @@ vi.mock('../ipc/pty', () => ({
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),
-  setPtyOwnership: vi.fn()
+  setPtyOwnership: vi.fn(),
+  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data)
 }))
 
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -37,7 +37,8 @@ import {
   clearPtyOwnershipForConnection,
   clearProviderPtyState,
   deletePtyOwnership,
-  setPtyOwnership
+  setPtyOwnership,
+  answerStartupTerminalColorQueriesForPty
 } from '../ipc/pty'
 import {
   registerSshFilesystemProvider,
@@ -941,11 +942,15 @@ export class SshRelaySession {
   private wireUpPtyEvents(ptyProvider: SshPtyProvider): void {
     ptyProvider.onData((payload) => {
       const seq = this.runtime?.onPtyData(payload.id, payload.data, Date.now())
+      const rendererData = answerStartupTerminalColorQueriesForPty(payload.id, payload.data)
       const win = this.getMainWindow()
-      if (win && !win.isDestroyed()) {
+      if (win && !win.isDestroyed() && rendererData.length > 0) {
         win.webContents.send('pty:data', {
           ...payload,
-          ...(typeof seq === 'number' ? { seq, rawLength: payload.data.length } : {})
+          data: rendererData,
+          ...(rendererData === payload.data && typeof seq === 'number'
+            ? { seq, rawLength: payload.data.length }
+            : {})
         })
       }
     })

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1110,6 +1110,7 @@ export type PreloadApi = {
       // single-source-of-truth collapse (see docs/preload-typecheck-hole.md §1).
       shellOverride?: string
       projectRuntime?: ProjectExecutionRuntimeResolution
+      terminalColorQueryReplies?: { foreground?: string; background?: string }
       // Why: closes the SIGKILL race documented in INVESTIGATION.md — main
       // sync-flushes the (worktreeId, tabId, leafId → ptyId) binding before
       // pty:spawn returns. Only the renderer's daemon-host path threads these.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -756,6 +756,7 @@ const api = {
       sessionId?: string
       shellOverride?: string
       projectRuntime?: ProjectExecutionRuntimeResolution
+      terminalColorQueryReplies?: { foreground?: string; background?: string }
       // Why: closes the SIGKILL race documented in INVESTIGATION.md by
       // letting main patch + sync-flush the (worktreeId, tabId, leafId →
       // ptyId) binding before pty:spawn returns. Only the renderer's

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -323,7 +323,11 @@ function createPane(paneId: number) {
         bracketedPasteMode: false
       },
       options: {
-        ignoreBracketedPasteMode: false
+        ignoreBracketedPasteMode: false,
+        theme: {
+          foreground: '#eeeeee',
+          background: '#111111'
+        }
       },
       write: vi.fn(),
       resize: vi.fn(),
@@ -5158,7 +5162,8 @@ describe('connectPanePty', () => {
 
     capturedDataCallback.current?.('\x1b]11;?\x1b\\startup frame\r\n')
 
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
       '\x1b]11;?\x1b\\startup frame\r\n',
       expect.any(Function)
@@ -5200,7 +5205,8 @@ describe('connectPanePty', () => {
 
     capturedDataCallback.current?.('\x1b]11;?\x1b\\startup frame\r\n')
 
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
       '\x1b]11;?\x1b\\startup frame\r\n',
       expect.any(Function)
@@ -5235,7 +5241,8 @@ describe('connectPanePty', () => {
 
     capturedDataCallback.current?.('\x1b]11;?\x1b\\startup frame\r\n')
 
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
       '\x1b]11;?\x1b\\startup frame\r\n',
       expect.any(Function)
@@ -5270,7 +5277,8 @@ describe('connectPanePty', () => {
 
     capturedDataCallback.current?.('\x1b]11;?\x1b\\startup frame\r\n')
 
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
       '\x1b]11;?\x1b\\startup frame\r\n',
       expect.any(Function)
@@ -5534,7 +5542,7 @@ describe('connectPanePty', () => {
     binding.dispose()
   })
 
-  it('keeps a Yazi-style hidden capability-query burst on the live xterm path', async () => {
+  it('answers hidden OSC color queries directly inside a mixed capability-query burst', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
@@ -5560,8 +5568,48 @@ describe('connectPanePty', () => {
     const coalescedChunk = `${queryBurst}\x1b[?2026h${'codex redraw '.repeat(8_000)}`
     capturedDataCallback.current?.(coalescedChunk)
 
-    expect(pane.terminal.write).toHaveBeenCalledWith(queryBurst, expect.any(Function))
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b[c\x1b[>q\x1b[14t\x1b[16t',
+      expect.any(Function)
+    )
     expect(pane.terminal.write).not.toHaveBeenCalledWith(coalescedChunk, expect.any(Function))
+
+    binding.dispose()
+  })
+
+  it('answers adjacent hidden Codex OSC color queries directly', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const binding = connectPanePty(
+      pane as never,
+      manager as never,
+      createDeps({
+        isVisibleRef: { current: false },
+        startup: { command: 'codex' }
+      }) as never
+    )
+    await flushAsyncTicks(6)
+
+    const queries = '\x1b]10;?\x1b\\\x1b]11;?\x1b\\'
+    capturedDataCallback.current?.(`${queries}startup frame\r\n`)
+
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]10;rgb:eeee/eeee/eeee\x1b\\')
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(queries, expect.any(Function))
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      `${queries}startup frame\r\n`,
+      expect.any(Function)
+    )
 
     binding.dispose()
   })
@@ -5876,7 +5924,7 @@ describe('connectPanePty', () => {
     binding.dispose()
   })
 
-  it('keeps split hidden Codex OSC color queries on the live xterm path', async () => {
+  it('answers split hidden Codex OSC color queries directly', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
@@ -5901,7 +5949,8 @@ describe('connectPanePty', () => {
     capturedDataCallback.current?.('\x1b]11;?')
     capturedDataCallback.current?.(`\x1b\\\x1b[?2026h${'codex redraw '.repeat(8_000)}`)
 
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
       `\x1b\\\x1b[?2026h${'codex redraw '.repeat(8_000)}`,
       expect.any(Function)
@@ -5910,7 +5959,7 @@ describe('connectPanePty', () => {
     binding.dispose()
   })
 
-  it('keeps hidden Codex OSC color queries split before the prefix on the live xterm path', async () => {
+  it('answers hidden Codex OSC color queries split before the prefix directly', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
@@ -5935,7 +5984,8 @@ describe('connectPanePty', () => {
     capturedDataCallback.current?.('\x1b]')
     capturedDataCallback.current?.(`11;?\x1b\\\x1b[?2026h${'codex redraw '.repeat(8_000)}`)
 
-    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/1111/1111\x1b\\')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b]11;?\x1b\\', expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
       `11;?\x1b\\\x1b[?2026h${'codex redraw '.repeat(8_000)}`,
       expect.any(Function)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -11,6 +11,7 @@ import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
+import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-color-reply'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
@@ -110,7 +111,8 @@ import { createTerminalGitHubPRLinkDetector } from '@/lib/terminal-github-pr-lin
 import {
   CONPTY_DA1_RESPONSE,
   createTerminalPixelSizeQueryResponder,
-  installTerminalCapabilityReplyHandlers
+  installTerminalCapabilityReplyHandlers,
+  sendTerminalOscColorQueryReplies
 } from './terminal-capability-replies'
 import {
   cancelScheduledHiddenOutputRestore,
@@ -351,28 +353,20 @@ function containsHiddenStartupRendererQuery(data: string): boolean {
 }
 
 const HIDDEN_STARTUP_RENDERER_QUERY_PENDING_CHARS = 64
-const HIDDEN_STARTUP_OSC_COLOR_QUERY_PREFIXES = ['\x1b]10;?', '\x1b]11;?'] as const
-
-function findOscTerminatorIndex(data: string, offset: number): number {
-  for (let index = offset; index < data.length; index++) {
-    const code = data.charCodeAt(index)
-    if (code === 0x07) {
-      return index + 1
-    }
-    if (code === 0x1b && data[index + 1] === '\\') {
-      return index + 2
-    }
-  }
-  return -1
-}
 
 function extractHiddenStartupRendererQueryData(
   data: string,
   pending: string
-): { statelessQueryData: string; statefulQueryData: string; pending: string } {
+): {
+  statelessQueryData: string
+  statefulQueryData: string
+  oscColorQueryData: string
+  pending: string
+} {
   const input = pending + data
   let statelessQueryData = ''
   let statefulQueryData = ''
+  let oscColorQueryData = ''
   let offset = 0
 
   while (offset < input.length) {
@@ -381,7 +375,12 @@ function extractHiddenStartupRendererQueryData(
       break
     }
     if (candidateIndex + 1 >= input.length) {
-      return { statelessQueryData, statefulQueryData, pending: input.slice(candidateIndex) }
+      return {
+        statelessQueryData,
+        statefulQueryData,
+        oscColorQueryData,
+        pending: input.slice(candidateIndex)
+      }
     }
     if (input.startsWith('\x1b[', candidateIndex)) {
       const finalByteIndex = findCsiFinalByteIndex(input, candidateIndex + 2)
@@ -389,6 +388,7 @@ function extractHiddenStartupRendererQueryData(
         return {
           statelessQueryData,
           statefulQueryData,
+          oscColorQueryData,
           pending: input.slice(
             candidateIndex,
             candidateIndex + HIDDEN_STARTUP_RENDERER_QUERY_PENDING_CHARS
@@ -406,42 +406,34 @@ function extractHiddenStartupRendererQueryData(
     }
 
     if (input.startsWith('\x1b]', candidateIndex)) {
-      const remaining = input.slice(candidateIndex)
-      const matchingPrefix = HIDDEN_STARTUP_OSC_COLOR_QUERY_PREFIXES.find((prefix) =>
-        remaining.startsWith(prefix)
-      )
-      if (!matchingPrefix) {
-        if (
-          HIDDEN_STARTUP_OSC_COLOR_QUERY_PREFIXES.some((prefix) => prefix.startsWith(remaining))
-        ) {
-          return { statelessQueryData, statefulQueryData, pending: remaining }
-        }
-        offset = candidateIndex + 2
-        continue
-      }
-
-      const terminatorIndex = findOscTerminatorIndex(input, candidateIndex + matchingPrefix.length)
-      if (terminatorIndex === -1) {
+      const query = parseTerminalOscColorQuery(input, candidateIndex)
+      if (query.kind === 'partial') {
         return {
           statelessQueryData,
           statefulQueryData,
+          oscColorQueryData,
           pending: input.slice(
             candidateIndex,
             candidateIndex + HIDDEN_STARTUP_RENDERER_QUERY_PENDING_CHARS
           )
         }
       }
-      statelessQueryData += input.slice(candidateIndex, terminatorIndex)
-      offset = terminatorIndex
+      if (query.kind === 'none') {
+        offset = candidateIndex + 2
+        continue
+      }
+      oscColorQueryData += input.slice(candidateIndex, query.endIndex)
+      offset = query.endIndex
       continue
     }
 
-    if (
-      HIDDEN_STARTUP_OSC_COLOR_QUERY_PREFIXES.some((prefix) =>
-        prefix.startsWith(input.slice(candidateIndex))
-      )
-    ) {
-      return { statelessQueryData, statefulQueryData, pending: input.slice(candidateIndex) }
+    if (parseTerminalOscColorQuery(input, candidateIndex).kind === 'partial') {
+      return {
+        statelessQueryData,
+        statefulQueryData,
+        oscColorQueryData,
+        pending: input.slice(candidateIndex)
+      }
     }
 
     {
@@ -450,7 +442,7 @@ function extractHiddenStartupRendererQueryData(
     }
   }
 
-  return { statelessQueryData, statefulQueryData, pending: '' }
+  return { statelessQueryData, statefulQueryData, oscColorQueryData, pending: '' }
 }
 
 function containsCsiRendererQuery(data: string): boolean {
@@ -1947,6 +1939,10 @@ export function connectPanePty(
     markTerminalInputSent()
     recordAcceptedTerminalInputForHibernation()
   }
+  const terminalTheme = pane.terminal.options.theme
+  const terminalColorQueryReplies = terminalTheme
+    ? { foreground: terminalTheme.foreground, background: terminalTheme.background }
+    : undefined
   const transportOptions = {
     cwd: deps.cwd,
     env: paneEnv,
@@ -1965,6 +1961,7 @@ export function connectPanePty(
     activate: deps.isActiveRef.current && deps.isVisibleRef.current,
     ...(shellOverride ? { shellOverride } : {}),
     ...(projectRuntime ? { projectRuntime } : {}),
+    ...(terminalColorQueryReplies ? { terminalColorQueryReplies } : {}),
     ...(paneStartup?.launchConfig ? { launchConfig: paneStartup.launchConfig } : {}),
     ...(launchToken ? { launchToken } : {}),
     ...(paneStartup?.launchAgent ? { launchAgent: paneStartup.launchAgent } : {}),
@@ -3198,6 +3195,13 @@ export function connectPanePty(
         hiddenStartupRendererQueryPending
       )
       hiddenStartupRendererQueryPending = extracted.pending
+      if (extracted.oscColorQueryData) {
+        // Why: Codex's startup palette probe has a 100 ms budget. Answer
+        // hidden color queries directly so renderer scheduling cannot miss it.
+        sendTerminalOscColorQueryReplies(extracted.oscColorQueryData, pane.terminal, (reply) =>
+          transport.sendInput(reply)
+        )
+      }
       if (extracted.statelessQueryData) {
         writePtyOutputToXterm(extracted.statelessQueryData, false, {
           hiddenStartupRendererQuery: true
@@ -3210,6 +3214,7 @@ export function connectPanePty(
     function takeHiddenStartupRendererQueryPendingForForeground(data: string): {
       statelessQueryData: string
       statefulQueryData: string
+      oscColorQueryData: string
       remainingData: string
       consumedCurrentChars: number
     } {
@@ -3219,6 +3224,7 @@ export function connectPanePty(
         return {
           statelessQueryData: '',
           statefulQueryData: '',
+          oscColorQueryData: '',
           remainingData: data,
           consumedCurrentChars: 0
         }
@@ -3227,6 +3233,7 @@ export function connectPanePty(
       const input = pending + data
       let statelessQueryData = ''
       let statefulQueryData = ''
+      let oscColorQueryData = ''
       let consumedInputChars = pending.length
       let nextPending = ''
       if (input.startsWith('\x1b[')) {
@@ -3244,24 +3251,15 @@ export function connectPanePty(
           consumedInputChars = finalByteIndex + 1
         }
       } else if (input.startsWith('\x1b]')) {
-        const matchingPrefix = HIDDEN_STARTUP_OSC_COLOR_QUERY_PREFIXES.find((prefix) =>
-          input.startsWith(prefix)
-        )
-        const terminatorIndex = findOscTerminatorIndex(input, 2)
-        if (
-          !matchingPrefix &&
-          HIDDEN_STARTUP_OSC_COLOR_QUERY_PREFIXES.some((prefix) => prefix.startsWith(input))
-        ) {
-          nextPending = input
-          consumedInputChars = input.length
-        } else if (terminatorIndex === -1) {
+        const query = parseTerminalOscColorQuery(input, 0)
+        if (query.kind === 'partial') {
           nextPending = input.slice(0, HIDDEN_STARTUP_RENDERER_QUERY_PENDING_CHARS)
           consumedInputChars = input.length
+        } else if (query.kind === 'match') {
+          oscColorQueryData = input.slice(0, query.endIndex)
+          consumedInputChars = query.endIndex
         } else {
-          if (matchingPrefix) {
-            statelessQueryData = input.slice(0, terminatorIndex)
-          }
-          consumedInputChars = terminatorIndex
+          consumedInputChars = pending.length
         }
       } else if (input.length === 1) {
         nextPending = input
@@ -3275,6 +3273,7 @@ export function connectPanePty(
       return {
         statelessQueryData,
         statefulQueryData,
+        oscColorQueryData,
         remainingData: data.slice(consumedCurrentChars),
         consumedCurrentChars
       }
@@ -3827,6 +3826,13 @@ export function connectPanePty(
         writePtyOutputToXterm(pendingForegroundQuery.statelessQueryData, true, {
           hiddenStartupRendererQuery: true
         })
+      }
+      if (pendingForegroundQuery?.oscColorQueryData) {
+        sendTerminalOscColorQueryReplies(
+          pendingForegroundQuery.oscColorQueryData,
+          pane.terminal,
+          (reply) => transport.sendInput(reply)
+        )
       }
       const restoreAppliesToCurrentPty =
         hiddenOutputRestorePtyId !== null && transport.getPtyId() === hiddenOutputRestorePtyId

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -3,6 +3,7 @@ import type { SleepingAgentLaunchConfig } from '../../../../shared/agent-session
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
 import type { EventProps } from '../../../../shared/telemetry-events'
+import type { TerminalOscColorQueryReplyColors } from '../../../../shared/terminal-osc-color-reply'
 import type { TuiAgent } from '../../../../shared/types'
 import type { PtyDataMeta } from './pty-dispatcher'
 
@@ -97,6 +98,7 @@ export type IpcPtyTransportOptions = {
   activate?: boolean
   shellOverride?: string
   projectRuntime?: ProjectExecutionRuntimeResolution
+  terminalColorQueryReplies?: TerminalOscColorQueryReplyColors
   telemetry?: EventProps<'agent_started'>
   onPtyExit?: (ptyId: string) => void
   onTitleChange?: (title: string, rawTitle: string) => void

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -442,6 +442,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     leafId,
     shellOverride,
     projectRuntime,
+    terminalColorQueryReplies,
     telemetry,
     onPtyExit,
     onTitleChange,
@@ -704,6 +705,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           ...(leafId ? { leafId } : {}),
           ...(shellOverride ? { shellOverride } : {}),
           ...(projectRuntime ? { projectRuntime } : {}),
+          ...(terminalColorQueryReplies ? { terminalColorQueryReplies } : {}),
           ...(telemetry ? { telemetry } : {})
         })
         const spawnResult = result as PtyConnectResult & { isReattach?: boolean }

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
@@ -4,7 +4,8 @@ import {
   CONPTY_DA1_RESPONSE,
   DEFAULT_DA1_RESPONSE,
   createTerminalPixelSizeQueryResponder,
-  installTerminalCapabilityReplyHandlers
+  installTerminalCapabilityReplyHandlers,
+  sendTerminalOscColorQueryReplies
 } from './terminal-capability-replies'
 
 function writeTerminal(term: Terminal, data: string): Promise<void> {
@@ -110,6 +111,93 @@ describe('installTerminalCapabilityReplyHandlers', () => {
       disposable.dispose()
       term.dispose()
     }
+  })
+
+  it('answers combined OSC foreground and background color queries from the active theme', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    term.options.theme = {
+      foreground: '#2e3434',
+      background: '#ffffff'
+    }
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const disposable = installTerminalCapabilityReplyHandlers({
+      terminal: term as never,
+      parser: term.parser,
+      sendInput,
+      isReplaying: () => false
+    })
+
+    try {
+      await writeTerminal(term, '\x1b]10;?;?\x1b\\')
+
+      expect(sendInput).toHaveBeenCalledWith('\x1b]10;rgb:2e2e/3434/3434\x1b\\')
+      expect(sendInput).toHaveBeenCalledWith('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
+    } finally {
+      disposable.dispose()
+      term.dispose()
+    }
+  })
+
+  it('answers extracted OSC color queries without waiting for xterm parsing', () => {
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+
+    const sent = sendTerminalOscColorQueryReplies(
+      '\x1b]10;?\x1b\\ordinary text\x1b]11;?\x07',
+      {
+        options: {
+          theme: {
+            foreground: '#2e3434',
+            background: '#ffffff'
+          }
+        }
+      } as never,
+      sendInput
+    )
+
+    expect(sent).toBe(true)
+    expect(sendInput).toHaveBeenCalledWith('\x1b]10;rgb:2e2e/3434/3434\x1b\\')
+    expect(sendInput).toHaveBeenCalledWith('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
+  })
+
+  it('answers extracted combined OSC foreground and background color queries', () => {
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+
+    const sent = sendTerminalOscColorQueryReplies(
+      '\x1b]10;?;?\x1b\\',
+      {
+        options: {
+          theme: {
+            foreground: '#2e3434',
+            background: '#ffffff'
+          }
+        }
+      } as never,
+      sendInput
+    )
+
+    expect(sent).toBe(true)
+    expect(sendInput).toHaveBeenCalledWith('\x1b]10;rgb:2e2e/3434/3434\x1b\\')
+    expect(sendInput).toHaveBeenCalledWith('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
+  })
+
+  it('does not answer extracted OSC color commands that only start like queries', () => {
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+
+    const sent = sendTerminalOscColorQueryReplies(
+      '\x1b]10;?not-a-query\x1b\\ordinary text\x1b]11;?still-not-a-query\x07\x1b]10;?;?;?\x1b\\',
+      {
+        options: {
+          theme: {
+            foreground: '#2e3434',
+            background: '#ffffff'
+          }
+        }
+      } as never,
+      sendInput
+    )
+
+    expect(sent).toBe(false)
+    expect(sendInput).not.toHaveBeenCalled()
   })
 
   it('leaves non-query OSC color commands to other handlers', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
@@ -1,4 +1,10 @@
 import type { IDisposable, IParser, Terminal } from '@xterm/xterm'
+import {
+  sendTerminalOscColorQueryReplies as sendTerminalOscColorQueryRepliesForColors,
+  terminalOscColorQueryReplies,
+  terminalOscColorQuerySlotsForBody,
+  type TerminalOscColorQuerySlot
+} from '../../../../shared/terminal-osc-color-reply'
 
 export const DEFAULT_DA1_RESPONSE = '\x1b[?1;2c'
 export const CONPTY_DA1_RESPONSE = '\x1b[?61;4c'
@@ -46,75 +52,27 @@ function disposeAll(disposables: IDisposable[]): void {
   }
 }
 
-function cssColorToOscRgb(value: string | undefined): string | null {
-  if (!value) {
-    return null
-  }
-  const trimmed = value.trim()
-  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimmed)?.[1]
-  if (hex) {
-    const expanded =
-      hex.length === 3
-        ? hex
-            .split('')
-            .map((char) => `${char}${char}`)
-            .join('')
-        : hex
-    return `rgb:${byteHexToWord(expanded.slice(0, 2))}/${byteHexToWord(
-      expanded.slice(2, 4)
-    )}/${byteHexToWord(expanded.slice(4, 6))}`
-  }
-  const rgb = /^rgba?\(\s*([^)]+)\)$/i.exec(trimmed)
-  if (!rgb) {
-    return null
-  }
-  const channels = parseCssRgbChannels(rgb[1])
-  if (!channels) {
-    return null
-  }
-  const [red, green, blue] = channels.map((byte) => byte.toString(16).padStart(2, '0').repeat(2))
-  return `rgb:${red}/${green}/${blue}`
+export function sendTerminalOscColorQueryReplies(
+  data: string,
+  terminal: Pick<Terminal, 'options'>,
+  sendInput: (data: string) => boolean | void
+): boolean {
+  return sendTerminalOscColorQueryRepliesForColors(data, terminal.options.theme ?? {}, sendInput)
 }
 
-function byteHexToWord(byte: string): string {
-  return byte.repeat(2)
-}
-
-function parseCssRgbChannels(body: string): [number, number, number] | null {
-  const colorPart = body.split('/')[0]?.trim()
-  if (!colorPart) {
-    return null
+function sendTerminalOscColorQueryRepliesForSlots(
+  slots: readonly TerminalOscColorQuerySlot[],
+  terminal: Pick<Terminal, 'options'>,
+  sendInput: (data: string) => boolean | void
+): boolean {
+  const replies = terminalOscColorQueryReplies(terminal.options.theme ?? {}, slots)
+  if (!replies) {
+    return false
   }
-  const components = colorPart.includes(',')
-    ? colorPart.split(',').slice(0, 3)
-    : colorPart.split(/\s+/).slice(0, 3)
-  if (components.length !== 3) {
-    return null
+  for (const reply of replies) {
+    sendInput(reply)
   }
-  const channels = components.map((component) => parseCssRgbChannel(component.trim()))
-  if (channels.some((channel) => channel === null)) {
-    return null
-  }
-  return channels as [number, number, number]
-}
-
-function parseCssRgbChannel(component: string): number | null {
-  const percent = /^(\d+(?:\.\d+)?)%$/.exec(component)?.[1]
-  if (percent !== undefined) {
-    return clampByte((Number(percent) / 100) * 255)
-  }
-  if (!/^\d+(?:\.\d+)?$/.test(component)) {
-    return null
-  }
-  return clampByte(Number(component))
-}
-
-function clampByte(value: number): number {
-  return Math.min(255, Math.max(0, Math.round(value)))
-}
-
-function isOscColorQuery(data: string): boolean {
-  return data.trim() === '?'
+  return true
 }
 
 export function createTerminalPixelSizeQueryResponder(
@@ -172,32 +130,24 @@ export function installTerminalCapabilityReplyHandlers(
       return true
     }),
     deps.parser.registerOscHandler(10, (data) => {
-      if (!isOscColorQuery(data)) {
+      const slots = terminalOscColorQuerySlotsForBody(10, data.trim())
+      if (!slots) {
         return false
       }
       if (deps.isReplaying()) {
         return true
       }
-      const foreground = cssColorToOscRgb(deps.terminal.options.theme?.foreground)
-      if (!foreground) {
-        return false
-      }
-      deps.sendInput(`\x1b]10;${foreground}\x1b\\`)
-      return true
+      return sendTerminalOscColorQueryRepliesForSlots(slots, deps.terminal, deps.sendInput)
     }),
     deps.parser.registerOscHandler(11, (data) => {
-      if (!isOscColorQuery(data)) {
+      const slots = terminalOscColorQuerySlotsForBody(11, data.trim())
+      if (!slots) {
         return false
       }
       if (deps.isReplaying()) {
         return true
       }
-      const background = cssColorToOscRgb(deps.terminal.options.theme?.background)
-      if (!background) {
-        return false
-      }
-      deps.sendInput(`\x1b]11;${background}\x1b\\`)
-      return true
+      return sendTerminalOscColorQueryRepliesForSlots(slots, deps.terminal, deps.sendInput)
     })
   ]
 

--- a/src/shared/terminal-osc-color-reply.test.ts
+++ b/src/shared/terminal-osc-color-reply.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { parseTerminalOscColorQuery } from './terminal-osc-color-reply'
+
+describe('parseTerminalOscColorQuery', () => {
+  it('matches exact OSC color queries terminated by ST or BEL', () => {
+    const foregroundQuery = '\x1b]10;?\x1b\\'
+    const backgroundQuery = '\x1b]11;?\x07'
+
+    expect(parseTerminalOscColorQuery(foregroundQuery, 0)).toEqual({
+      kind: 'match',
+      slots: [10],
+      endIndex: foregroundQuery.length
+    })
+    expect(parseTerminalOscColorQuery(backgroundQuery, 0)).toEqual({
+      kind: 'match',
+      slots: [11],
+      endIndex: backgroundQuery.length
+    })
+  })
+
+  it('matches complete combined foreground and background queries', () => {
+    const query = '\x1b]10;?;?\x1b\\'
+
+    expect(parseTerminalOscColorQuery(query, 0)).toEqual({
+      kind: 'match',
+      slots: [10, 11],
+      endIndex: query.length
+    })
+  })
+
+  it('keeps a split ST terminator pending', () => {
+    expect(parseTerminalOscColorQuery('\x1b]10;?\x1b', 0)).toEqual({ kind: 'partial' })
+    expect(parseTerminalOscColorQuery('\x1b]10;?;?\x1b', 0)).toEqual({ kind: 'partial' })
+  })
+
+  it('rejects OSC color commands that only start like queries', () => {
+    expect(parseTerminalOscColorQuery('\x1b]10;?not-a-query\x1b\\', 0)).toEqual({
+      kind: 'none'
+    })
+    expect(parseTerminalOscColorQuery('\x1b]11;?\x1bX', 0)).toEqual({ kind: 'none' })
+    expect(parseTerminalOscColorQuery('\x1b]10;?;#123456\x1b\\', 0)).toEqual({ kind: 'none' })
+    expect(parseTerminalOscColorQuery('\x1b]10;?;?;?\x1b\\', 0)).toEqual({ kind: 'none' })
+    expect(parseTerminalOscColorQuery('\x1b]11;?;?\x1b\\', 0)).toEqual({ kind: 'none' })
+  })
+
+  it('rejects unsupported query-shaped bodies without waiting for a terminator', () => {
+    expect(parseTerminalOscColorQuery(`\x1b]10;?${'x'.repeat(10_000)}`, 0)).toEqual({
+      kind: 'none'
+    })
+  })
+})

--- a/src/shared/terminal-osc-color-reply.ts
+++ b/src/shared/terminal-osc-color-reply.ts
@@ -1,0 +1,240 @@
+export type TerminalOscColorQueryReplyColors = {
+  foreground?: string
+  background?: string
+}
+
+export type TerminalOscColorQuerySlot = 10 | 11
+
+const OSC = '\u001b]'
+const BEL = '\u0007'
+const STRING_TERMINATOR = '\u001b\\'
+const TERMINAL_OSC_COLOR_QUERY_PREFIXES = [
+  { slot: 10, prefix: `${OSC}10;` },
+  { slot: 11, prefix: `${OSC}11;` }
+] as const
+const TERMINAL_OSC_COLOR_QUERY_BODIES = {
+  10: [
+    { body: '?', slots: [10] },
+    { body: '?;?', slots: [10, 11] }
+  ],
+  11: [{ body: '?', slots: [11] }]
+} as const satisfies Record<
+  TerminalOscColorQuerySlot,
+  readonly { body: string; slots: readonly TerminalOscColorQuerySlot[] }[]
+>
+
+export type TerminalOscColorQueryParseResult =
+  | { kind: 'match'; slots: readonly TerminalOscColorQuerySlot[]; endIndex: number }
+  | { kind: 'partial' }
+  | { kind: 'none' }
+
+type TerminalOscTerminatorParseResult =
+  | { kind: 'complete'; endIndex: number }
+  | { kind: 'partial' }
+  | { kind: 'none' }
+
+export function cssColorToOscRgb(value: string | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  const trimmed = value.trim()
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimmed)?.[1]
+  if (hex) {
+    const expanded =
+      hex.length === 3
+        ? hex
+            .split('')
+            .map((char) => `${char}${char}`)
+            .join('')
+        : hex
+    return `rgb:${byteHexToWord(expanded.slice(0, 2))}/${byteHexToWord(
+      expanded.slice(2, 4)
+    )}/${byteHexToWord(expanded.slice(4, 6))}`
+  }
+  const rgb = /^rgba?\(\s*([^)]+)\)$/i.exec(trimmed)
+  if (!rgb) {
+    return null
+  }
+  const channels = parseCssRgbChannels(rgb[1])
+  if (!channels) {
+    return null
+  }
+  const [red, green, blue] = channels.map((byte) => byte.toString(16).padStart(2, '0').repeat(2))
+  return `rgb:${red}/${green}/${blue}`
+}
+
+function byteHexToWord(byte: string): string {
+  return byte.repeat(2)
+}
+
+function parseCssRgbChannels(body: string): [number, number, number] | null {
+  const colorPart = body.split('/')[0]?.trim()
+  if (!colorPart) {
+    return null
+  }
+  const components = colorPart.includes(',')
+    ? colorPart.split(',').slice(0, 3)
+    : colorPart.split(/\s+/).slice(0, 3)
+  if (components.length !== 3) {
+    return null
+  }
+  const channels = components.map((component) => parseCssRgbChannel(component.trim()))
+  if (channels.some((channel) => channel === null)) {
+    return null
+  }
+  return channels as [number, number, number]
+}
+
+function parseCssRgbChannel(component: string): number | null {
+  const percent = /^(\d+(?:\.\d+)?)%$/.exec(component)?.[1]
+  if (percent !== undefined) {
+    return clampByte((Number(percent) / 100) * 255)
+  }
+  if (!/^\d+(?:\.\d+)?$/.test(component)) {
+    return null
+  }
+  return clampByte(Number(component))
+}
+
+function clampByte(value: number): number {
+  return Math.min(255, Math.max(0, Math.round(value)))
+}
+
+export function terminalOscColorQueryReply(
+  colors: TerminalOscColorQueryReplyColors,
+  slot: TerminalOscColorQuerySlot
+): string | null {
+  const color =
+    slot === 10 ? cssColorToOscRgb(colors.foreground) : cssColorToOscRgb(colors.background)
+  if (!color) {
+    return null
+  }
+  return `\x1b]${slot};${color}\x1b\\`
+}
+
+function isTerminalOscColorQueryReply(reply: string | null): reply is string {
+  return reply !== null
+}
+
+export function terminalOscColorQueryReplies(
+  colors: TerminalOscColorQueryReplyColors,
+  slots: readonly TerminalOscColorQuerySlot[]
+): string[] | null {
+  const replies = slots.map((slot) => terminalOscColorQueryReply(colors, slot))
+  return replies.every(isTerminalOscColorQueryReply) ? replies : null
+}
+
+export function terminalOscColorQuerySlotsForBody(
+  slot: TerminalOscColorQuerySlot,
+  body: string
+): readonly TerminalOscColorQuerySlot[] | null {
+  return TERMINAL_OSC_COLOR_QUERY_BODIES[slot].find((entry) => entry.body === body)?.slots ?? null
+}
+
+function parseTerminalOscTerminator(
+  data: string,
+  offset: number
+): TerminalOscTerminatorParseResult {
+  if (offset >= data.length) {
+    return { kind: 'partial' }
+  }
+  if (data[offset] === BEL) {
+    return { kind: 'complete', endIndex: offset + BEL.length }
+  }
+  if (data.startsWith(STRING_TERMINATOR, offset)) {
+    return { kind: 'complete', endIndex: offset + STRING_TERMINATOR.length }
+  }
+  if (data[offset] === '\x1b' && offset + 1 >= data.length) {
+    // Why: streamed PTY chunks can split the ST terminator between ESC and \\.
+    return { kind: 'partial' }
+  }
+  return { kind: 'none' }
+}
+
+function completeTerminalOscColorQuery(
+  slot: TerminalOscColorQuerySlot,
+  body: string,
+  terminator: TerminalOscTerminatorParseResult
+): TerminalOscColorQueryParseResult {
+  if (terminator.kind !== 'complete') {
+    return terminator
+  }
+  const slots = terminalOscColorQuerySlotsForBody(slot, body)
+  return slots ? { kind: 'match', slots, endIndex: terminator.endIndex } : { kind: 'none' }
+}
+
+function parseTerminalOscColorQueryBody(
+  data: string,
+  bodyStart: number,
+  slot: TerminalOscColorQuerySlot
+): TerminalOscColorQueryParseResult {
+  if (bodyStart >= data.length) {
+    return { kind: 'partial' }
+  }
+  if (data[bodyStart] !== '?') {
+    return { kind: 'none' }
+  }
+  const singleQueryTerminator = parseTerminalOscTerminator(data, bodyStart + 1)
+  if (singleQueryTerminator.kind !== 'none') {
+    return completeTerminalOscColorQuery(slot, '?', singleQueryTerminator)
+  }
+  if (slot !== 10 || data[bodyStart + 1] !== ';') {
+    return { kind: 'none' }
+  }
+  if (bodyStart + 2 >= data.length) {
+    return { kind: 'partial' }
+  }
+  if (data[bodyStart + 2] !== '?') {
+    return { kind: 'none' }
+  }
+  return completeTerminalOscColorQuery(slot, '?;?', parseTerminalOscTerminator(data, bodyStart + 3))
+}
+
+export function parseTerminalOscColorQuery(
+  data: string,
+  offset: number
+): TerminalOscColorQueryParseResult {
+  const entry = TERMINAL_OSC_COLOR_QUERY_PREFIXES.find(({ prefix }) =>
+    data.startsWith(prefix, offset)
+  )
+  if (!entry) {
+    const fragment = data.slice(offset)
+    return TERMINAL_OSC_COLOR_QUERY_PREFIXES.some(({ prefix }) => prefix.startsWith(fragment))
+      ? { kind: 'partial' }
+      : { kind: 'none' }
+  }
+  const bodyStart = offset + entry.prefix.length
+  return parseTerminalOscColorQueryBody(data, bodyStart, entry.slot)
+}
+
+export function sendTerminalOscColorQueryReplies(
+  data: string,
+  colors: TerminalOscColorQueryReplyColors,
+  sendInput: (data: string) => boolean | void
+): boolean {
+  let sent = false
+  let offset = 0
+  while (offset < data.length) {
+    const oscIndex = data.indexOf(OSC, offset)
+    if (oscIndex === -1) {
+      break
+    }
+    const query = parseTerminalOscColorQuery(data, oscIndex)
+    if (query.kind === 'match') {
+      const replies = terminalOscColorQueryReplies(colors, query.slots)
+      if (replies) {
+        for (const reply of replies) {
+          sendInput(reply)
+        }
+        sent = true
+      }
+      offset = query.endIndex
+      continue
+    }
+    if (query.kind === 'partial') {
+      break
+    }
+    offset = oscIndex + OSC.length
+  }
+  return sent
+}

--- a/tests/e2e/terminal-codex-hidden-startup-background.spec.ts
+++ b/tests/e2e/terminal-codex-hidden-startup-background.spec.ts
@@ -1,0 +1,375 @@
+import { Buffer } from 'node:buffer'
+import { PNG } from 'pngjs'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getActiveWorktreeId,
+  getAllWorktreeIds,
+  switchToWorktree,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import { getTerminalContent, waitForActiveTerminalManager } from './helpers/terminal'
+import { BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT } from '../../src/renderer/src/constants/terminal'
+
+type HiddenOutputDebugSnapshot = {
+  hiddenRendererSkipCount: number
+  hiddenRendererSkippedChars: number
+  hiddenRendererMode2031ReplyCount: number
+}
+
+type CodexStartupBackgroundTarget = {
+  clip: { x: number; y: number; width: number; height: number }
+  cellWidth: number
+  cellHeight: number
+  cols: number
+  row: number
+  modelBackgroundCells: number
+}
+
+type CodexStartupBackgroundWindow = Window & {
+  __terminalPtyOutputDebug?: {
+    reset: () => void
+    snapshot: () => HiddenOutputDebugSnapshot
+  }
+}
+
+const COMPOSER_BG = { red: 72, green: 72, blue: 72 }
+
+function codexLikeStartupCommand(marker: string): string {
+  const script = [
+    'const marker = process.argv[1];',
+    'const width = Math.max(60, process.stdout.columns || 100);',
+    'const pad = (text) => (text + " ".repeat(width)).slice(0, width);',
+    'const bg = "\\x1b[48;2;72;72;72m\\x1b[38;2;235;235;235m";',
+    'const reset = "\\x1b[0m";',
+    'let reply = "";',
+    'const hasColor = (slot) => new RegExp("\\\\x1b\\\\]" + slot + ";rgba?:[0-9a-fA-F]{2,4}/[0-9a-fA-F]{2,4}/[0-9a-fA-F]{2,4}(?:/[0-9a-fA-F]{2,4})?(?:\\\\x07|\\\\x1b\\\\\\\\)").test(reply);',
+    'const render = () => {',
+    '  const colorsOk = hasColor(10) && hasColor(11);',
+    '  const status = colorsOk ? "OSC_COLORS_OK" : "OSC_COLORS_MISSING";',
+    '  const prefix = colorsOk ? bg : "";',
+    '  const suffix = colorsOk ? reset : "";',
+    '  process.stdout.write("\\x1b[?2026h\\x1b[2J\\x1b[H");',
+    '  process.stdout.write("Codex hidden startup background repro " + status + "\\r\\n\\r\\n");',
+    '  process.stdout.write(prefix + pad("> " + marker + " " + status + " type here") + suffix + "\\r\\n");',
+    '  process.stdout.write("\\x1b[?2026l");',
+    '};',
+    'if (process.stdin.isTTY && typeof process.stdin.setRawMode === "function") {',
+    '  process.stdin.setRawMode(true);',
+    '}',
+    'process.stdin.resume();',
+    'process.stdin.on("data", (chunk) => {',
+    '  reply += chunk.toString("binary");',
+    '});',
+    'process.stdout.write("\\x1b]10;?\\x1b\\\\\\x1b]11;?\\x1b\\\\");',
+    'setTimeout(render, 100);',
+    'setInterval(() => {}, 1000);'
+  ].join('')
+  return `node -e ${JSON.stringify(script)} ${JSON.stringify(marker)}`
+}
+
+async function waitForHiddenTabPtyId(page: Page, tabId: string): Promise<string> {
+  let ptyId: string | null = null
+  await expect
+    .poll(
+      async () => {
+        ptyId = await page.evaluate((targetTabId) => {
+          const state = window.__store?.getState()
+          if (!state) {
+            return null
+          }
+          return state.ptyIdsByTabId[targetTabId]?.[0] ?? null
+        }, tabId)
+        return ptyId
+      },
+      {
+        timeout: 20_000,
+        message: `Hidden Codex terminal tab ${tabId} did not receive a PTY binding`
+      }
+    )
+    .not.toBeNull()
+
+  if (!ptyId) {
+    throw new Error(`waitForHiddenTabPtyId: tab ${tabId} has no PTY id`)
+  }
+  return ptyId
+}
+
+async function readHiddenOutputDebug(page: Page): Promise<HiddenOutputDebugSnapshot | null> {
+  return page.evaluate(() => {
+    return (window as CodexStartupBackgroundWindow).__terminalPtyOutputDebug?.snapshot() ?? null
+  })
+}
+
+async function resetHiddenOutputDebug(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    ;(window as CodexStartupBackgroundWindow).__terminalPtyOutputDebug?.reset()
+  })
+}
+
+async function mainSnapshotContains(page: Page, ptyId: string, text: string): Promise<boolean> {
+  return page.evaluate(
+    async ({ targetPtyId, expectedText }) => {
+      const snapshot = await window.api.pty.getMainBufferSnapshot(targetPtyId, {
+        scrollbackRows: 200
+      })
+      return snapshot?.data.includes(expectedText) ?? false
+    },
+    { targetPtyId: ptyId, expectedText: text }
+  )
+}
+
+async function readCodexStartupBackgroundTarget(
+  page: Page,
+  marker: string
+): Promise<CodexStartupBackgroundTarget> {
+  return page.evaluate(
+    ({ marker, expected }) => {
+      const isExpectedBackground = (cell: unknown): boolean => {
+        const record = cell as {
+          isBgRGB?: () => boolean
+          getBgColor?: () => number
+        }
+        if (!record?.isBgRGB?.()) {
+          return false
+        }
+        const color = record.getBgColor?.() ?? 0
+        const red = (color >> 16) & 0xff
+        const green = (color >> 8) & 0xff
+        const blue = color & 0xff
+        return (
+          Math.abs(red - expected.red) <= 3 &&
+          Math.abs(green - expected.green) <= 3 &&
+          Math.abs(blue - expected.blue) <= 3
+        )
+      }
+
+      const state = window.__store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      const tabId =
+        state?.activeTabType === 'terminal'
+          ? state.activeTabId
+          : worktreeId
+            ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const manager = tabId ? window.__paneManagers?.get(tabId) : null
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      if (!pane) {
+        throw new Error('Active Codex terminal pane is unavailable')
+      }
+      const screen = pane.container.querySelector<HTMLElement>('.xterm-screen')
+      const dimensions = pane.terminal._core?._renderService?.dimensions?.css?.cell
+      if (!screen || !dimensions) {
+        throw new Error('Active Codex terminal has no measurable xterm screen')
+      }
+      const rect = screen.getBoundingClientRect()
+      if (rect.width <= 0 || rect.height <= 0) {
+        throw new Error('Active Codex terminal screen is not visible')
+      }
+      const activeBuffer = pane.terminal.buffer.active
+      for (let row = 0; row < pane.terminal.rows; row += 1) {
+        const line = activeBuffer.getLine(activeBuffer.viewportY + row)
+        const rowText = line?.translateToString(true) ?? ''
+        if (!rowText.includes(marker)) {
+          continue
+        }
+        let modelBackgroundCells = 0
+        for (let col = 0; col < pane.terminal.cols; col += 1) {
+          if (isExpectedBackground(line?.getCell(col))) {
+            modelBackgroundCells += 1
+          }
+        }
+        return {
+          clip: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+          cellWidth: dimensions.width,
+          cellHeight: dimensions.height,
+          cols: pane.terminal.cols,
+          row,
+          modelBackgroundCells
+        }
+      }
+      throw new Error(`Could not find Codex startup background marker ${marker}`)
+    },
+    { marker, expected: COMPOSER_BG }
+  )
+}
+
+function isExpectedBackgroundPixel(
+  red: number,
+  green: number,
+  blue: number,
+  alpha: number
+): boolean {
+  return (
+    alpha >= 245 &&
+    Math.abs(red - COMPOSER_BG.red) <= 8 &&
+    Math.abs(green - COMPOSER_BG.green) <= 8 &&
+    Math.abs(blue - COMPOSER_BG.blue) <= 8
+  )
+}
+
+async function countVisibleBackgroundPixels(
+  page: Page,
+  target: CodexStartupBackgroundTarget
+): Promise<number> {
+  const viewport = await page.evaluate(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight
+  }))
+  const screenshot = Buffer.from(await page.screenshot())
+  const image = PNG.sync.read(screenshot)
+  const scaleX = image.width / viewport.width
+  const scaleY = image.height / viewport.height
+  const originX = Math.round(target.clip.x * scaleX)
+  const originY = Math.round(target.clip.y * scaleY)
+  const rowTop = originY + Math.round(target.row * target.cellHeight * scaleY)
+  const yStart = rowTop + Math.round(target.cellHeight * scaleY * 0.25)
+  const yEnd = rowTop + Math.round(target.cellHeight * scaleY * 0.75)
+  const xEnd = Math.min(image.width, originX + Math.round(target.clip.width * scaleX))
+  let count = 0
+  for (let y = yStart; y < yEnd; y += 1) {
+    for (let x = originX; x < xEnd; x += 1) {
+      const offset = (y * image.width + x) * 4
+      if (
+        isExpectedBackgroundPixel(
+          image.data[offset] ?? 0,
+          image.data[offset + 1] ?? 0,
+          image.data[offset + 2] ?? 0,
+          image.data[offset + 3] ?? 0
+        )
+      ) {
+        count += 1
+      }
+    }
+  }
+  return count
+}
+
+test.describe('Codex hidden startup composer background', () => {
+  test('restores the input background when a Codex worktree first becomes visible', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const secondWorktreeId = (await getAllWorktreeIds(orcaPage)).find(
+      (id) => id !== firstWorktreeId
+    )
+    test.skip(!secondWorktreeId, 'Codex hidden startup background repro needs a second worktree')
+    if (!secondWorktreeId) {
+      return
+    }
+
+    const marker = `CODEX_STARTUP_BG_${Date.now()}`
+    const command = codexLikeStartupCommand(marker)
+    await resetHiddenOutputDebug(orcaPage)
+    const hiddenTabId = await orcaPage.evaluate(
+      ({ worktreeId, command, eventName }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('Store unavailable')
+        }
+        window.dispatchEvent(
+          new CustomEvent(eventName, {
+            detail: { worktreeId }
+          })
+        )
+        const state = store.getState()
+        const tab = state.createTab(worktreeId, undefined, undefined, {
+          activate: false,
+          launchAgent: 'codex',
+          recordInteraction: false
+        })
+        state.queueTabStartupCommand(tab.id, {
+          command,
+          launchAgent: 'codex',
+          telemetry: {
+            agent_kind: 'codex',
+            launch_source: 'tab_bar_quick_launch',
+            request_kind: 'new'
+          }
+        })
+        state.setTabCustomTitle(tab.id, 'Codex hidden startup background', {
+          recordInteraction: false
+        })
+        return tab.id
+      },
+      {
+        worktreeId: secondWorktreeId,
+        command,
+        eventName: BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT
+      }
+    )
+
+    const hiddenPtyId = await waitForHiddenTabPtyId(orcaPage, hiddenTabId)
+    await expect
+      .poll(() => mainSnapshotContains(orcaPage, hiddenPtyId, marker), {
+        timeout: 20_000,
+        message: 'Hidden Codex startup background never reached the main buffer snapshot'
+      })
+      .toBe(true)
+    await expect
+      .poll(async () => (await readHiddenOutputDebug(orcaPage))?.hiddenRendererSkipCount ?? 0, {
+        timeout: 10_000,
+        message: 'Codex-marked hidden startup did not take the skipped renderer path'
+      })
+      .toBeGreaterThan(0)
+
+    await switchToWorktree(orcaPage, secondWorktreeId)
+    await expect
+      .poll(() => getActiveWorktreeId(orcaPage), {
+        timeout: 10_000,
+        message: 'Hidden Codex worktree did not become active'
+      })
+      .toBe(secondWorktreeId)
+    await orcaPage.evaluate((tabId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Store unavailable')
+      }
+      const state = store.getState()
+      state.setActiveTab(tabId)
+      state.setActiveTabType('terminal')
+    }, hiddenTabId)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await expect
+      .poll(() => getTerminalContent(orcaPage, 8_000), {
+        timeout: 10_000,
+        message: 'First visible mount did not restore hidden Codex startup content'
+      })
+      .toContain(marker)
+
+    let target: CodexStartupBackgroundTarget | null = null
+    await expect
+      .poll(
+        async () => {
+          try {
+            const nextTarget = await readCodexStartupBackgroundTarget(orcaPage, marker)
+            target = nextTarget
+            return nextTarget.modelBackgroundCells >= Math.min(40, nextTarget.cols)
+          } catch {
+            target = null
+            return false
+          }
+        },
+        {
+          timeout: 10_000,
+          message: 'Hidden Codex startup content restored without the composer background'
+        }
+      )
+      .toBe(true)
+    if (!target) {
+      throw new Error('Codex startup background target was not captured')
+    }
+    const visibleBackgroundPixels = await countVisibleBackgroundPixels(orcaPage, target)
+    const minimumVisiblePixels = Math.round(
+      target.modelBackgroundCells * target.cellWidth * target.cellHeight * 0.2
+    )
+    expect(visibleBackgroundPixels).toBeGreaterThanOrEqual(minimumVisiblePixels)
+  })
+})


### PR DESCRIPTION
## ELI5
Codex asks the terminal, very quickly during startup: "what are your text and background colors?" It only waits about a blink before deciding what its input box should look like.

In Orca, some terminals start hidden, run through the daemon, or come through SSH. In those cases the question could sit in a renderer queue too long, so Codex would miss the answer and draw its composer without the right background.

This PR teaches Orca to answer those startup color questions immediately, close to where the terminal output first appears. It also keeps the renderer-side fallback for hidden panes, so hidden Codex panes still get the answer even when their normal xterm parsing is delayed.

## What changed
- Added one shared OSC 10/11 color-query parser/reply helper used by both main and renderer.
- Main now registers a short-lived startup responder for recognized TUI agents, including daemon and SSH relay paths.
- Hidden renderer output now extracts exact foreground/background color probes and replies before xterm scheduling can miss Codex's startup timeout.
- The parser handles the usual single-query form plus the complete combined foreground/background query form. It only inspects the few bytes that can form those supported bodies, so unsupported cursor/palette/mixed set/query forms are ignored immediately and stay on the normal terminal path.
- Answered startup probes are removed from renderer-visible output so they do not replay later as stale terminal input.
- Added focused unit coverage plus an e2e regression for the hidden Codex composer background.

## Tradeoffs
- There is a small amount of extra scanning, but it is bounded: main only watches registered agent PTYs during a short startup window, keeps at most a tiny pending fragment, and stops after both colors are answered. Hidden-pane scanning only runs on output Orca is already choosing not to render immediately.
- There is a little more terminal-protocol complexity, but the exact OSC parsing and all-or-nothing reply construction are centralized in `src/shared/terminal-osc-color-reply.ts` so main and renderer do not drift. The parser is deliberately constant-bounded for the supported startup bodies rather than scanning arbitrary OSC payloads.
- Orca intentionally strips the answered startup color probes from visible output. That means those control sequences will not appear in scrollback/replay, which is the desired behavior because they were answered internally and would be stale if replayed later.
- The fix does not try to implement every color-control OSC. It only replies when Orca can answer the full foreground/background query safely; anything broader is left alone to avoid swallowing a command we cannot fully satisfy.
- The fix only replies when Orca has valid foreground and background colors and the PTY looks like a TUI agent startup. Ordinary shells and non-query OSC color commands are left alone.

## Test plan
- `pnpm exec oxlint src/shared/terminal-osc-color-reply.ts src/shared/terminal-osc-color-reply.test.ts src/main/ipc/terminal-startup-color-query-replies.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/terminal-capability-replies.ts src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-osc-color-reply.test.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/ipc/ssh.test.ts src/main/ssh/ssh-relay-session.test.ts src/main/ssh/ssh-relay-session-terminal-error.test.ts`
- `pnpm run typecheck`
- `pnpm exec playwright test tests/e2e/terminal-codex-hidden-startup-background.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1`
