### PR TITLE
Show prompt status for newly launched Codex agents

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -280,6 +280,9 @@ async function spawnLocalStartupAndSetupTerminals(args: {
       env: sequencedStartup.env,
       ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
       ...(isTuiAgent(createdWithAgent) ? { launchAgent: createdWithAgent } : {}),
+      ...(sequencedStartup.initialAgentStatus
+        ? { initialAgentStatus: sequencedStartup.initialAgentStatus }
+        : {}),
       startupCommandDelivery: sequencedStartup.startupCommandDelivery,
       telemetry: sequencedStartup.telemetry,
       activate: true

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -20209,12 +20209,13 @@ describe('OrcaRuntimeService', () => {
       kill: () => true,
       getForegroundProcess: async () => null
     })
+    const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-cli-agent-startup' })
     runtime.setNotifier({
       worktreesChanged: vi.fn(),
       reposChanged: vi.fn(),
       activateWorktree: vi.fn(),
       createTerminal: vi.fn(),
-      revealTerminalSession: vi.fn().mockResolvedValue({ tabId: 'tab-cli-agent-startup' }),
+      revealTerminalSession,
       splitTerminal: vi.fn(),
       renameTerminal: vi.fn(),
       focusTerminal: vi.fn(),
@@ -20252,6 +20253,15 @@ describe('OrcaRuntimeService', () => {
       })
     )
     expect(metaById[result.worktree.id]).toMatchObject({ createdWithAgent: 'codex' })
+    expect(revealTerminalSession).toHaveBeenCalledWith(
+      result.worktree.id,
+      expect.objectContaining({
+        initialAgentStatus: {
+          agent: 'codex',
+          prompt: 'hi'
+        }
+      })
+    )
   })
 
   it('sends follow-up prompts for CLI-created stdin-after-start startup agents', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12,6 +12,7 @@ import type { AgentStatus } from '../../shared/agent-detection'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
+  normalizeAgentStatusPayload,
   type AgentStatusIpcPayload,
   type ParsedAgentStatusPayload,
   type AgentStatusOrchestrationContext,
@@ -65,6 +66,7 @@ import type {
   GitHubCreateIssueFields,
   GitHubOwnerRepo,
   GlobalSettings,
+  InitialAgentStatusSeed,
   PersistedUIState,
   Project,
   ProjectUpdateArgs,
@@ -1131,6 +1133,7 @@ type RuntimeNotifier = {
       launchConfig?: SleepingAgentLaunchConfig
       launchToken?: string
       launchAgent?: TuiAgent
+      initialAgentStatus?: InitialAgentStatusSeed
       activate?: boolean
       presentation?: RuntimeTerminalPresentation
       tabId?: string
@@ -12016,6 +12019,17 @@ export class OrcaRuntimeService {
     }
   }
 
+  private buildInitialAgentStatusSeed(
+    agent: TuiAgent | undefined,
+    prompt: string | undefined
+  ): InitialAgentStatusSeed | undefined {
+    if (!agent) {
+      return undefined
+    }
+    const normalized = normalizeAgentStatusPayload({ state: 'working', prompt, agentType: agent })
+    return normalized?.prompt ? { agent, prompt: normalized.prompt } : undefined
+  }
+
   private markLocalWorkspaceTrustedForAgent(agent: TuiAgent, workspacePath: string): void {
     const preset = TUI_AGENT_CONFIG[agent].preflightTrust
     if (!preset) {
@@ -12459,6 +12473,11 @@ export class OrcaRuntimeService {
       : (agentStartup?.agent ??
         draftStartup?.agent ??
         (requestedAgentEnabled ? requestedAgent : undefined))
+    const effectiveInitialAgentStatus =
+      args.startup?.initialAgentStatus ??
+      (agentStartup
+        ? this.buildInitialAgentStatusSeed(agentStartup.agent, args.startupPrompt)
+        : undefined)
     const effectiveDraftPaste = args.startupDraftPaste ?? draftStartup?.draftPaste
     if (isFolderRepo(repo)) {
       const now = Date.now()
@@ -12524,6 +12543,9 @@ export class OrcaRuntimeService {
               ? { launchConfig: effectiveStartup.launchConfig }
               : {}),
             ...(effectiveCreatedWithAgent ? { launchAgent: effectiveCreatedWithAgent } : {}),
+            ...(effectiveInitialAgentStatus
+              ? { initialAgentStatus: effectiveInitialAgentStatus }
+              : {}),
             startupCommandDelivery: effectiveStartup.startupCommandDelivery,
             telemetry: effectiveStartup.telemetry
           })
@@ -12584,6 +12606,7 @@ export class OrcaRuntimeService {
         ...(effectiveStartup ? { startup: effectiveStartup } : {}),
         ...(effectiveStartupFollowup ? { startupFollowup: effectiveStartupFollowup } : {}),
         ...(effectiveCreatedWithAgent ? { createdWithAgent: effectiveCreatedWithAgent } : {}),
+        ...(effectiveInitialAgentStatus ? { initialAgentStatus: effectiveInitialAgentStatus } : {}),
         ...(effectiveDraftPaste ? { startupDraftPaste: effectiveDraftPaste } : {})
       })
       const recordedLineage = this.recordCreatedWorktreeLineage(result.worktree, lineageResolution)
@@ -13140,6 +13163,9 @@ export class OrcaRuntimeService {
           env: sequencedStartup.env,
           ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
           ...(effectiveCreatedWithAgent ? { launchAgent: effectiveCreatedWithAgent } : {}),
+          ...(effectiveInitialAgentStatus
+            ? { initialAgentStatus: effectiveInitialAgentStatus }
+            : {}),
           startupCommandDelivery: sequencedStartup.startupCommandDelivery,
           telemetry: sequencedStartup.telemetry
         })
@@ -13332,6 +13358,7 @@ export class OrcaRuntimeService {
       automationProvenance?: AutomationWorkspaceProvenance
       startup?: WorktreeStartupLaunch
       startupFollowup?: WorktreeStartupFollowup
+      initialAgentStatus?: InitialAgentStatusSeed
       startupDraftPaste?: WorktreeStartupDraftPaste
     }
   ): Promise<CreateWorktreeResult> {
@@ -13441,6 +13468,7 @@ export class OrcaRuntimeService {
           env: sequencedStartup.env,
           ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
           ...(args.createdWithAgent ? { launchAgent: args.createdWithAgent } : {}),
+          ...(args.initialAgentStatus ? { initialAgentStatus: args.initialAgentStatus } : {}),
           startupCommandDelivery: sequencedStartup.startupCommandDelivery,
           telemetry: sequencedStartup.telemetry
         })
@@ -15141,6 +15169,7 @@ export class OrcaRuntimeService {
       launchConfig?: WorktreeStartupLaunch['launchConfig']
       launchToken?: string
       launchAgent?: TuiAgent
+      initialAgentStatus?: InitialAgentStatusSeed
       startupCommandDelivery?: WorktreeStartupLaunch['startupCommandDelivery']
       telemetry?: WorktreeStartupLaunch['telemetry']
       title?: string
@@ -15329,6 +15358,7 @@ export class OrcaRuntimeService {
             ...(effectiveLaunchConfig ? { launchConfig: effectiveLaunchConfig } : {}),
             ...(launchToken ? { launchToken } : {}),
             ...(opts.launchAgent ? { launchAgent: opts.launchAgent } : {}),
+            ...(opts.initialAgentStatus ? { initialAgentStatus: opts.initialAgentStatus } : {}),
             activate: presentation === 'focused',
             ...(presentation ? { presentation } : {}),
             tabId,
@@ -15396,6 +15426,7 @@ export class OrcaRuntimeService {
         ...(opts.launchConfig ? { launchConfig: opts.launchConfig } : {}),
         ...(opts.launchToken ? { launchToken: opts.launchToken } : {}),
         ...(opts.launchAgent ? { launchAgent: opts.launchAgent } : {}),
+        ...(opts.initialAgentStatus ? { initialAgentStatus: opts.initialAgentStatus } : {}),
         startupCommandDelivery: opts.startupCommandDelivery,
         title: opts.title,
         activate: presentation === 'focused',
@@ -15431,11 +15462,13 @@ export class OrcaRuntimeService {
     } else {
       this.markLocalWorkspaceTrustedForAgent(opts.agent, worktree.path)
     }
+    const initialAgentStatus = this.buildInitialAgentStatusSeed(startup.agent, opts.prompt)
     return await this.createTerminal(`id:${worktree.id}`, {
       command: startup.startup.command,
       env: startup.startup.env,
       ...(startup.startup.launchConfig ? { launchConfig: startup.startup.launchConfig } : {}),
       launchAgent: startup.agent,
+      ...(initialAgentStatus ? { initialAgentStatus } : {}),
       startupCommandDelivery: startup.startup.startupCommandDelivery,
       telemetry: startup.startup.telemetry,
       title: opts.title

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -645,6 +645,12 @@ const TerminalCreateParams = z.object({
     .optional(),
   launchToken: OptionalString,
   launchAgent: z.string().refine(isTuiAgent).optional(),
+  initialAgentStatus: z
+    .object({
+      agent: z.string().refine(isTuiAgent),
+      prompt: z.string().min(1)
+    })
+    .optional(),
   title: OptionalString,
   focus: z.unknown().optional(),
   rendererBacked: z.unknown().optional(),
@@ -1019,6 +1025,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         ...(params.launchConfig ? { launchConfig: params.launchConfig } : {}),
         ...(params.launchToken ? { launchToken: params.launchToken } : {}),
         ...(params.launchAgent ? { launchAgent: params.launchAgent } : {}),
+        ...(params.initialAgentStatus ? { initialAgentStatus: params.initialAgentStatus } : {}),
         title: params.title,
         focus: params.focus === true,
         rendererBacked: params.rendererBacked === true,

--- a/src/main/runtime/rpc/methods/worktree-schemas.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.test.ts
@@ -22,4 +22,17 @@ describe('worktree RPC schemas', () => {
 
     expect(parsed.success).toBe(false)
   })
+
+  it('rejects startup initial status without a startup command', () => {
+    const parsed = WorktreeCreate.safeParse({
+      repo: 'repo-1',
+      name: 'agent-startup',
+      startupInitialAgentStatus: {
+        agent: 'codex',
+        prompt: 'hi'
+      }
+    })
+
+    expect(parsed.success).toBe(false)
+  })
 })

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -152,6 +152,12 @@ export const WorktreeCreate = z
     automationProvenanceRequest: AutomationWorkspaceProvenanceRequest.optional()
   })
   .superRefine((params, ctx) => {
+    if (params.startupInitialAgentStatus && !params.startupCommand) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'startupInitialAgentStatus requires startupCommand'
+      })
+    }
     if ((params.parentWorkspace || params.parentWorktree) && params.noParent === true) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -152,6 +152,8 @@ export const WorktreeCreate = z
     automationProvenanceRequest: AutomationWorkspaceProvenanceRequest.optional()
   })
   .superRefine((params, ctx) => {
+    // Why: runtime only carries initialAgentStatus through the startup payload,
+    // so reject seeds that cannot be attached to a startup launch.
     if (params.startupInitialAgentStatus && !params.startupCommand) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -132,6 +132,12 @@ export const WorktreeCreate = z
     startupEnv: z.record(z.string(), z.string()).optional(),
     startupLaunchConfig: sleepingAgentLaunchConfigSchema,
     startupCommandDelivery: z.enum(['fast', 'shell-ready']).optional(),
+    startupInitialAgentStatus: z
+      .object({
+        agent: z.custom<TuiAgent>(isTuiAgent, { message: 'Unknown TUI agent' }),
+        prompt: z.string().min(1)
+      })
+      .optional(),
     // Why: CLI clients should not hardcode agent launch quoting because SSH
     // workspaces execute in a different shell than the client process.
     startupAgent: OptionalTuiAgent,

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -113,6 +113,9 @@ export const WORKTREE_METHODS: RpcMethod[] = [
                 ...(params.startupLaunchConfig ? { launchConfig: params.startupLaunchConfig } : {}),
                 ...(params.startupCommandDelivery
                   ? { startupCommandDelivery: params.startupCommandDelivery }
+                  : {}),
+                ...(params.startupInitialAgentStatus
+                  ? { initialAgentStatus: params.startupInitialAgentStatus }
                   : {})
               }
             : undefined,

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -287,6 +287,7 @@ function registerRuntimeWindowLifecycle(
           ...(opts.launchConfig ? { launchConfig: opts.launchConfig } : {}),
           ...(opts.launchToken ? { launchToken: opts.launchToken } : {}),
           ...(opts.launchAgent ? { launchAgent: opts.launchAgent } : {}),
+          ...(opts.initialAgentStatus ? { initialAgentStatus: opts.initialAgentStatus } : {}),
           activate: opts.activate !== false,
           ...(opts.presentation ? { presentation: opts.presentation } : {}),
           // Why: pre-minted tabId from main keeps the renderer's tab id aligned

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -157,6 +157,7 @@ import type {
   SearchResult,
   StatsSummary,
   MemorySnapshot,
+  InitialAgentStatusSeed,
   TuiAgent,
   UpdateStatus,
   Worktree,
@@ -2497,6 +2498,7 @@ export type PreloadApi = {
         launchConfig?: SleepingAgentLaunchConfig
         launchToken?: string
         launchAgent?: TuiAgent
+        initialAgentStatus?: InitialAgentStatusSeed
         title?: string
         ptyId?: string
         activate?: boolean
@@ -2519,6 +2521,7 @@ export type PreloadApi = {
         launchConfig?: SleepingAgentLaunchConfig
         launchToken?: string
         launchAgent?: TuiAgent
+        initialAgentStatus?: InitialAgentStatusSeed
         startupCommandDelivery?: StartupCommandDelivery
         title?: string
         activate?: boolean

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -44,6 +44,7 @@ import type {
   OnboardingState,
   PersistedUIState,
   FloatingTerminalCwdRequest,
+  InitialAgentStatusSeed,
   MarkdownDocument,
   SearchResult,
   TuiAgent,
@@ -3148,6 +3149,7 @@ const api = {
         launchConfig?: SleepingAgentLaunchConfig
         launchToken?: string
         launchAgent?: TuiAgent
+        initialAgentStatus?: InitialAgentStatusSeed
         title?: string
         ptyId?: string
         activate?: boolean
@@ -3169,6 +3171,7 @@ const api = {
           launchConfig?: SleepingAgentLaunchConfig
           launchToken?: string
           launchAgent?: TuiAgent
+          initialAgentStatus?: InitialAgentStatusSeed
           title?: string
           ptyId?: string
           activate?: boolean
@@ -3194,6 +3197,7 @@ const api = {
         launchConfig?: SleepingAgentLaunchConfig
         launchToken?: string
         launchAgent?: TuiAgent
+        initialAgentStatus?: InitialAgentStatusSeed
         startupCommandDelivery?: StartupCommandDelivery
         title?: string
         activate?: boolean
@@ -3212,6 +3216,7 @@ const api = {
           launchConfig?: SleepingAgentLaunchConfig
           launchToken?: string
           launchAgent?: TuiAgent
+          initialAgentStatus?: InitialAgentStatusSeed
           startupCommandDelivery?: StartupCommandDelivery
           title?: string
           activate?: boolean

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -646,7 +646,15 @@ export default function TerminalPane({
   // Why: Windows ConPTY does not forward DECSET 2004 from foreground TUIs, so
   // xterm may not know multi-line text needs bracketed-paste protection.
   const forceBracketedMultilineTextPaste = isWindowsUserAgent()
-  const [startup] = useState(() => useAppStore.getState().pendingStartupByTabId[tabId])
+  const [initialAgentStatus] = useState(
+    () => useAppStore.getState().pendingInitialAgentStatusByTabId[tabId] ?? undefined
+  )
+  const [startup] = useState(() => {
+    const pendingStartup = useAppStore.getState().pendingStartupByTabId[tabId]
+    return pendingStartup && initialAgentStatus
+      ? { ...pendingStartup, initialAgentStatus }
+      : pendingStartup
+  })
   const [shouldMeasureHiddenStartup, setShouldMeasureHiddenStartup] = useState(
     () => startup !== undefined && !isVisible
   )
@@ -654,6 +662,7 @@ export default function TerminalPane({
     () => new Set()
   )
   const consumeTabStartupCommand = useAppStore((store) => store.consumeTabStartupCommand)
+  const consumeTabInitialAgentStatus = useAppStore((store) => store.consumeTabInitialAgentStatus)
   const [setupSplit] = useState(() => useAppStore.getState().pendingSetupSplitByTabId[tabId])
   const consumeTabSetupSplit = useAppStore((store) => store.consumeTabSetupSplit)
   const [issueCommandSplit] = useState(
@@ -661,10 +670,11 @@ export default function TerminalPane({
   )
   const consumeTabIssueCommandSplit = useAppStore((store) => store.consumeTabIssueCommandSplit)
   useEffect(() => {
-    if (startup) {
+    if (startup || initialAgentStatus) {
       consumeTabStartupCommand(tabId)
+      consumeTabInitialAgentStatus(tabId)
     }
-  }, [startup, tabId, consumeTabStartupCommand])
+  }, [startup, initialAgentStatus, tabId, consumeTabStartupCommand, consumeTabInitialAgentStatus])
 
   useLayoutEffect(() => {
     if (isVisible && shouldMeasureHiddenStartup) {
@@ -1248,6 +1258,7 @@ export default function TerminalPane({
     worktreeId,
     cwd,
     startup,
+    initialAgentStatus,
     setupSplit,
     issueCommandSplit,
     isActive,

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -4,7 +4,7 @@ import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinat
 import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TerminalColorSchemeMode } from '../../../../shared/terminal-color-scheme-protocol'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
-import type { TuiAgent } from '../../../../shared/types'
+import type { InitialAgentStatusSeed, TuiAgent } from '../../../../shared/types'
 import type { SleepingAgentLaunchConfig } from '../../../../shared/agent-session-resume'
 
 export type PtyConnectionDeps = {
@@ -25,10 +25,11 @@ export type PtyConnectionDeps = {
      *  so main fires the event only after the spawn succeeds. */
     telemetry?: EventProps<'agent_started'>
     /** Initial prompt-start status for agents that lack native prompt hooks. */
-    initialAgentStatus?: { agent: TuiAgent; prompt: string }
+    initialAgentStatus?: InitialAgentStatusSeed
     /** Show the restored-session banner when this startup command mounts. */
     showSessionRestoredBanner?: boolean
   } | null
+  initialAgentStatus?: InitialAgentStatusSeed
   restoredLeafId?: string | null
   restoredPtyIdByLeafId?: Record<string, string>
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -13,6 +13,7 @@ import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 import { YOLO_TUI_AGENT_ARGS } from '../../../../shared/tui-agent-permissions'
 import { SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV } from '../../../../shared/setup-agent-sequencing'
+import { AGENT_STATUS_MAX_FIELD_LENGTH } from '../../../../shared/agent-status-types'
 
 // Repro command:
 //   pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "OpenTUI-style small ANSI redraw"
@@ -1078,6 +1079,108 @@ describe('connectPanePty', () => {
       },
       undefined
     )
+  })
+
+  it('seeds a working status from backend initial agent metadata after spawn', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-codex-backend')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      initialAgentStatus: { agent: 'codex', prompt: 'Fix the status' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks()
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
+    expect(onPtySpawn).toBeTypeOf('function')
+    onPtySpawn?.('pty-codex-backend')
+
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledWith(
+      makePaneKey('tab-1', LEAF_1),
+      {
+        state: 'working',
+        prompt: 'Fix the status',
+        agentType: 'codex'
+      },
+      undefined
+    )
+  })
+
+  it('normalizes backend initial agent metadata before setting status', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-codex-normalized-seed')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+    const longPrompt = `Fix\n${'x'.repeat(AGENT_STATUS_MAX_FIELD_LENGTH + 50)}`
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      initialAgentStatus: { agent: 'codex', prompt: longPrompt }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks()
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
+    expect(onPtySpawn).toBeTypeOf('function')
+    onPtySpawn?.('pty-codex-normalized-seed')
+
+    const statusPayload = mockStoreState.setAgentStatus.mock.calls[0]?.[1] as
+      | { prompt?: string }
+      | undefined
+    expect(statusPayload?.prompt).toHaveLength(AGENT_STATUS_MAX_FIELD_LENGTH)
+    expect(statusPayload?.prompt).not.toContain('\n')
+  })
+
+  it('does not replace hook status with backend initial agent metadata', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-codex-hook-wins')
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: null }],
+      agentStatusByPaneKey: {
+        [paneKey]: {
+          state: 'working',
+          prompt: 'Real hook prompt',
+          agentType: 'codex'
+        }
+      }
+    }
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      initialAgentStatus: { agent: 'codex', prompt: 'Seed prompt' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks()
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
+    expect(onPtySpawn).toBeTypeOf('function')
+    onPtySpawn?.('pty-codex-hook-wins')
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
   })
 
   it('seeds a working status from Command Code thinking output without a startup prompt', async () => {
@@ -3381,7 +3484,8 @@ describe('connectPanePty', () => {
     } as StoreState
     const deps = createDeps({
       restoredLeafId: LEAF_1,
-      restoredPtyIdByLeafId: { [LEAF_1]: eagerPtyId }
+      restoredPtyIdByLeafId: { [LEAF_1]: eagerPtyId },
+      initialAgentStatus: { agent: 'codex', prompt: 'Fix eager status' }
     })
 
     const pane = createPane(1)
@@ -3394,6 +3498,15 @@ describe('connectPanePty', () => {
     expect(pane.container.dataset.ptyId).toBe(eagerPtyId)
     expect(transport.connect).not.toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: eagerPtyId })
+    )
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledWith(
+      makePaneKey('tab-1', LEAF_1),
+      {
+        state: 'working',
+        prompt: 'Fix eager status',
+        agentType: 'codex'
+      },
+      undefined
     )
     const { hasPtySerializer } = await import('./pty-buffer-serializer')
     expect(hasPtySerializer(eagerPtyId)).toBe(true)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -76,7 +76,11 @@ import { createBrowserUuid } from '@/lib/browser-uuid'
 import { makePaneKey, parseLegacyNumericPaneKey } from '../../../../shared/stable-pane-id'
 import { createTerminalCommandLifecycle } from './terminal-command-lifecycle'
 import { e2eConfig } from '@/lib/e2e-config'
-import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
+import {
+  normalizeAgentStatusPayload,
+  type AgentStatusEntry,
+  type AgentType
+} from '../../../../shared/agent-status-types'
 import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
 import {
   createAgentInterruptInference,
@@ -1498,19 +1502,30 @@ export function connectPanePty(
   }
 
   const applyInitialAgentStatus = (terminalTitle?: string): void => {
-    const initialStatus = paneStartup?.initialAgentStatus
+    const initialStatus = paneStartup?.initialAgentStatus ?? deps.initialAgentStatus
     if (!initialStatus) {
+      return
+    }
+    if (useAppStore.getState().agentStatusByPaneKey[cacheKey]) {
+      return
+    }
+    const normalized = normalizeAgentStatusPayload({
+      state: 'working',
+      prompt: initialStatus.prompt,
+      agentType: initialStatus.agent
+    })
+    if (!normalized?.prompt) {
       return
     }
     const statusPayload = {
       state: 'working' as const,
-      prompt: initialStatus.prompt,
+      prompt: normalized.prompt,
       agentType: resolveCompatibleAgentTypeForOwner(
         initialStatus.agent,
         getAuthoritativePaneAgent()
       )
     }
-    if (paneStartup.launchConfig) {
+    if (paneStartup?.launchConfig) {
       useAppStore
         .getState()
         .setAgentStatus(cacheKey, statusPayload, terminalTitle, undefined, undefined, {
@@ -2704,7 +2719,10 @@ export function connectPanePty(
           ) {
             // Why: daemon createOrAttach can turn an apparent fresh spawn into
             // a reattach; the transport skips onPtySpawn there to preserve recency.
-            bindActivePanePty(resolvedPtyId, { updateTabPtyId: 'if-missing' })
+            bindActivePanePty(resolvedPtyId, {
+              seedInitialAgentStatus: true,
+              updateTabPtyId: 'if-missing'
+            })
           }
           if (resolvedPtyId) {
             reconcilePtySizeAfterSpawn(resolvedPtyId, cols, rows)
@@ -4400,7 +4418,10 @@ export function connectPanePty(
             onError: reportError
           }
         })
-        bindActivePanePty(attachPtyId, { updateTabPtyId: 'if-missing' })
+        bindActivePanePty(attachPtyId, {
+          seedInitialAgentStatus: true,
+          updateTabPtyId: 'if-missing'
+        })
         if (attachPtyId === eagerLivePtyId) {
           registerPaneSerializerFor(attachPtyId)
         }
@@ -4454,7 +4475,10 @@ export function connectPanePty(
             })
             // Why: this path reuses a PTY spawned by an earlier mount, so no
             // later spawn event will bind this remounted pane's DOM/container.
-            bindActivePanePty(spawnedPtyId, { updateTabPtyId: 'if-missing' })
+            bindActivePanePty(spawnedPtyId, {
+              seedInitialAgentStatus: true,
+              updateTabPtyId: 'if-missing'
+            })
           })
           .catch((err) => {
             reportError(err instanceof Error ? err.message : String(err))

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -34,8 +34,6 @@ import type {
   TerminalLayoutSnapshot
 } from '../../../../shared/types'
 import type { TerminalPaneSplitSource } from '../../../../shared/feature-education-telemetry'
-import type { EventProps } from '../../../../shared/telemetry-events'
-import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import {
   buildFontFamily,
@@ -75,6 +73,7 @@ import { installMouseHideWhileTyping } from './mouse-hide-while-typing'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { connectPanePty } from './pty-connection'
+import type { PtyConnectionDeps } from './pty-connection-types'
 import { reconcileDeadSessions, type ReconcilableBinding } from './terminal-dead-session-reconcile'
 import type { PtyTransport } from './pty-transport'
 import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
@@ -152,19 +151,8 @@ type UseTerminalPaneLifecycleDeps = {
   tabId: string
   worktreeId: string
   cwd?: string
-  startup?: {
-    command: string
-    /** Renderer-delivered startup input for callers that need xterm paste
-     *  semantics before the submit Enter. */
-    delivery?: 'terminal-paste'
-    startupCommandDelivery?: StartupCommandDelivery
-    env?: Record<string, string>
-    /** Telemetry payload for `agent_started`. Forwarded to `pty:spawn`
-     *  so main fires the event only after the spawn succeeds. */
-    telemetry?: EventProps<'agent_started'>
-    /** Show the restored-session banner when this startup command mounts. */
-    showSessionRestoredBanner?: boolean
-  } | null
+  startup?: PtyConnectionDeps['startup']
+  initialAgentStatus?: PtyConnectionDeps['initialAgentStatus']
   /** When present, the initial pane boots clean and a split pane is created
    *  (vertical or horizontal per the user setting) to run the setup command —
    *  keeping the main terminal interactive. */
@@ -443,6 +431,7 @@ export function useTerminalPaneLifecycle({
   worktreeId,
   cwd,
   startup,
+  initialAgentStatus,
   setupSplit,
   issueCommandSplit,
   isActive,
@@ -671,6 +660,7 @@ export function useTerminalPaneLifecycle({
       worktreeId,
       cwd: startupCwd,
       startup,
+      initialAgentStatus,
       paneTransportsRef,
       paneMode2031Ref,
       paneLastThemeModeRef,
@@ -1025,6 +1015,7 @@ export function useTerminalPaneLifecycle({
         // sets deps.startup immediately before splitPane() and is therefore
         // unaffected by this clear.
         ptyDeps.startup = null
+        ptyDeps.initialAgentStatus = undefined
         const nextInitialCwdState = clearQueuedInitialCwdAfterFirstPane(
           queuedInitialCwdRef.current,
           defaultTabCwd,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -3269,8 +3269,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         platform: selectedRepoAgentLaunchPlatform,
         isRemote: selectedRepoIsRemote
       })
-      const shouldSeedInitialAgentStatus =
-        tuiAgent === 'command-code' && submitStartupPrompt.trim().length > 0
+      const trimmedStartupPrompt = submitStartupPrompt.trim()
+      const shouldSeedInitialAgentStatus = trimmedStartupPrompt.length > 0
 
       // Why: backend startup is safe only when the launch command is
       // self-contained. Agents that need post-ready paste/follow-up stay on
@@ -3289,6 +3289,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
               launchAgent: tuiAgent,
               ...(startupPlan.startupCommandDelivery
                 ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
+                : {}),
+              ...(shouldSeedInitialAgentStatus
+                ? {
+                    initialAgentStatus: {
+                      agent: tuiAgent,
+                      prompt: trimmedStartupPrompt
+                    }
+                  }
                 : {}),
               telemetry: composerTelemetry
             }
@@ -3375,7 +3383,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                   ? {
                       initialAgentStatus: {
                         agent: tuiAgent,
-                        prompt: submitStartupPrompt.trim()
+                        prompt: trimmedStartupPrompt
                       }
                     }
                   : {}),

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2266,6 +2266,30 @@ describe('useIpcEvents updater integration', () => {
     })
 
     createTab.mockClear()
+    queueTabInitialAgentStatus.mockClear()
+    requestTerminalCreateListenerRef.current({
+      requestId: 'req-renderer-backed-status-only',
+      worktreeId: 'wt-2',
+      title: 'Codex',
+      presentation: 'background',
+      initialAgentStatus: { agent: 'codex', prompt: 'Fix the first status' }
+    })
+
+    expect(createTab).toHaveBeenCalledWith('wt-2', undefined, undefined, {
+      activate: false,
+      recordInteraction: false
+    })
+    expect(queueTabInitialAgentStatus).toHaveBeenCalledWith('tab-new', {
+      agent: 'codex',
+      prompt: 'Fix the first status'
+    })
+    expect(replyTerminalCreate).toHaveBeenCalledWith({
+      requestId: 'req-renderer-backed-status-only',
+      tabId: 'tab-new',
+      title: 'Codex'
+    })
+
+    createTab.mockClear()
     registerAgentLaunchConfig.mockClear()
     createTerminalListenerRef.current({
       worktreeId: 'wt-2',

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1637,6 +1637,7 @@ describe('useIpcEvents updater integration', () => {
     const revealWorktreeInSidebar = vi.fn()
     const setTabCustomTitle = vi.fn()
     const queueTabStartupCommand = vi.fn()
+    const queueTabInitialAgentStatus = vi.fn()
     const registerAgentLaunchConfig = vi.fn()
     const clearAgentLaunchConfig = vi.fn()
     const updateTabPtyId = vi.fn()
@@ -1662,6 +1663,7 @@ describe('useIpcEvents updater integration', () => {
       revealWorktreeInSidebar,
       setTabCustomTitle,
       queueTabStartupCommand,
+      queueTabInitialAgentStatus,
       registerAgentLaunchConfig,
       clearAgentLaunchConfig,
       updateTabPtyId,
@@ -1709,6 +1711,7 @@ describe('useIpcEvents updater integration', () => {
             command?: string
             launchConfig?: SleepingAgentLaunchConfig
             launchAgent?: TuiAgent
+            initialAgentStatus?: { agent: TuiAgent; prompt: string }
             title?: string
             ptyId?: string
             activate?: boolean
@@ -1736,6 +1739,7 @@ describe('useIpcEvents updater integration', () => {
             command?: string
             launchConfig?: SleepingAgentLaunchConfig
             launchAgent?: TuiAgent
+            initialAgentStatus?: { agent: TuiAgent; prompt: string }
             title?: string
             activate?: boolean
             presentation?: 'background' | 'focused'
@@ -2271,7 +2275,8 @@ describe('useIpcEvents updater integration', () => {
         agentArgs: '--model gpt-5',
         agentEnv: { CODEX_PROFILE: 'adopted' }
       },
-      launchAgent: 'codex'
+      launchAgent: 'codex',
+      initialAgentStatus: { agent: 'codex', prompt: 'Fix the first status' }
     })
 
     expect(createTab).toHaveBeenCalledWith('wt-2', undefined, undefined, {
@@ -2297,6 +2302,10 @@ describe('useIpcEvents updater integration', () => {
         leafId: '55555555-5555-4555-8555-555555555555'
       }
     )
+    expect(queueTabInitialAgentStatus).toHaveBeenCalledWith('tab-new', {
+      agent: 'codex',
+      prompt: 'Fix the first status'
+    })
 
     createTab.mockClear()
     setActiveView.mockClear()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1645,6 +1645,9 @@ export function useIpcEvents(): void {
           if (data.title) {
             store.setTabCustomTitle(tab.id, data.title, { recordInteraction: false })
           }
+          if (data.initialAgentStatus && !data.command) {
+            store.queueTabInitialAgentStatus(tab.id, data.initialAgentStatus)
+          }
           if (data.command) {
             store.queueTabStartupCommand(tab.id, {
               command: data.command,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1348,6 +1348,7 @@ export function useIpcEvents(): void {
           launchConfig,
           launchToken,
           launchAgent,
+          initialAgentStatus,
           title,
           ptyId,
           activate,
@@ -1521,13 +1522,20 @@ export function useIpcEvents(): void {
                 }
               }
             }
+            if (initialAgentStatus) {
+              // Why: backend-spawned PTYs are already running, so there may be
+              // no startup command to queue. This metadata-only seed lets the
+              // mounted pane show the launch before the first hook event.
+              store.queueTabInitialAgentStatus(tab.id, initialAgentStatus)
+            }
             if (command) {
               store.queueTabStartupCommand(tab.id, {
                 command,
                 ...(env ? { env } : {}),
                 ...(launchConfig ? { launchConfig } : {}),
                 ...(launchToken ? { launchToken } : {}),
-                ...(launchAgent ? { launchAgent } : {})
+                ...(launchAgent ? { launchAgent } : {}),
+                ...(initialAgentStatus ? { initialAgentStatus } : {})
               })
             }
             if (requestId) {
@@ -1644,6 +1652,7 @@ export function useIpcEvents(): void {
               ...(data.launchConfig ? { launchConfig: data.launchConfig } : {}),
               ...(data.launchToken ? { launchToken: data.launchToken } : {}),
               ...(data.launchAgent ? { launchAgent: data.launchAgent } : {}),
+              ...(data.initialAgentStatus ? { initialAgentStatus: data.initialAgentStatus } : {}),
               ...(data.startupCommandDelivery
                 ? { startupCommandDelivery: data.startupCommandDelivery }
                 : {})

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -281,7 +281,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     ...(startupPlan.startupCommandDelivery
       ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
       : {}),
-    ...(agent === 'command-code' && hasPrompt && promptDelivery === 'auto-submit'
+    ...(hasPrompt && promptDelivery === 'auto-submit'
       ? { initialAgentStatus: { agent, prompt: trimmedPrompt } }
       : {}),
     telemetry: {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -2,6 +2,7 @@
 import type {
   FolderWorkspace,
   GlobalSettings,
+  InitialAgentStatusSeed,
   SetupSplitDirection,
   Tab,
   TuiAgent,
@@ -73,7 +74,7 @@ export type WorktreeStartupPayload = {
   launchToken?: string
   launchAgent?: TuiAgent
   startupCommandDelivery?: StartupCommandDelivery
-  initialAgentStatus?: { agent: TuiAgent; prompt: string }
+  initialAgentStatus?: InitialAgentStatusSeed
   telemetry?: AgentStartedTelemetry
 }
 
@@ -118,7 +119,7 @@ type WorktreeActivationStore = Partial<WorktreeRuntimeOwnerState> & {
       launchConfig?: SleepingAgentLaunchConfig
       launchToken?: string
       launchAgent?: TuiAgent
-      initialAgentStatus?: { agent: TuiAgent; prompt: string }
+      initialAgentStatus?: InitialAgentStatusSeed
       showSessionRestoredBanner?: boolean
       telemetry?: AgentStartedTelemetry
     }

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -39,9 +39,9 @@ function buildStartupOpt(
     ...(plan.launchToken ? { launchToken: plan.launchToken } : {}),
     ...(request.agent ? { launchAgent: request.agent } : {}),
     ...(plan.startupCommandDelivery ? { startupCommandDelivery: plan.startupCommandDelivery } : {}),
-    // Why: command-code shows its prompt in the tab status before the first
-    // hook fires, so the prompt is threaded through here.
-    ...(request.agent === 'command-code' && request.quickPrompt.trim().length > 0
+    // Why: backend-spawned agent terminals can mount before the first hook
+    // event, so prompt-backed launches carry a narrow initial status seed.
+    ...(request.agent && request.quickPrompt.trim().length > 0
       ? { initialAgentStatus: { agent: request.agent, prompt: request.quickPrompt.trim() } }
       : {}),
     ...(request.quickTelemetry ? { telemetry: request.quickTelemetry } : {})

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -1803,6 +1803,7 @@ describe('setActiveWorktree', () => {
       'canExpandPaneByTabId',
       'terminalLayoutsByTabId',
       'pendingStartupByTabId',
+      'pendingInitialAgentStatusByTabId',
       'pendingInitialCwdByTabId',
       'pendingSetupSplitByTabId',
       'pendingIssueCommandSplitByTabId',
@@ -1844,6 +1845,9 @@ describe('setActiveWorktree', () => {
       pendingStartupByTabId: {
         [orphanId]: { command: 'codex' }
       },
+      pendingInitialAgentStatusByTabId: {
+        [orphanId]: { agent: 'codex', prompt: 'stale prompt' }
+      },
       pendingInitialCwdByTabId: {
         [orphanId]: '/repo/packages/web'
       },
@@ -1867,6 +1871,7 @@ describe('setActiveWorktree', () => {
     expect(s.runtimePaneTitlesByTabId[orphanId]).toBeUndefined()
     expect(s.terminalLayoutsByTabId[orphanId]).toBeUndefined()
     expect(s.pendingStartupByTabId[orphanId]).toBeUndefined()
+    expect(s.pendingInitialAgentStatusByTabId[orphanId]).toBeUndefined()
     expect(s.pendingInitialCwdByTabId[orphanId]).toBeUndefined()
     expect(s.cacheTimerByKey[`${orphanId}:seed`]).toBeUndefined()
     expect(s.terminalLayoutsByTabId[replacement.id]).toEqual(makeLayout())
@@ -2232,6 +2237,10 @@ describe('setActiveWorktree', () => {
       unreadTerminalTabs: {
         [closing.id]: true as const,
         [surviving.id]: true as const
+      },
+      pendingInitialAgentStatusByTabId: {
+        [closing.id]: { agent: 'codex', prompt: 'stale prompt' },
+        [surviving.id]: { agent: 'codex', prompt: 'keep prompt' }
       }
     })
 
@@ -2239,8 +2248,13 @@ describe('setActiveWorktree', () => {
 
     const s = store.getState()
     expect(s.unreadTerminalTabs[closing.id]).toBeUndefined()
+    expect(s.pendingInitialAgentStatusByTabId[closing.id]).toBeUndefined()
     // Siblings untouched.
     expect(s.unreadTerminalTabs[surviving.id]).toBe(true)
+    expect(s.pendingInitialAgentStatusByTabId[surviving.id]).toEqual({
+      agent: 'codex',
+      prompt: 'keep prompt'
+    })
   })
 
   // Why: shutdownWorktreeTerminals tears down every PTY in the worktree. The
@@ -2265,6 +2279,10 @@ describe('setActiveWorktree', () => {
       unreadTerminalTabs: {
         [tabA.id]: true as const,
         [tabB.id]: true as const
+      },
+      pendingInitialAgentStatusByTabId: {
+        [tabA.id]: { agent: 'codex', prompt: 'a' },
+        [tabB.id]: { agent: 'codex', prompt: 'b' }
       }
     })
 
@@ -2273,6 +2291,8 @@ describe('setActiveWorktree', () => {
     const s = store.getState()
     expect(s.unreadTerminalTabs[tabA.id]).toBeUndefined()
     expect(s.unreadTerminalTabs[tabB.id]).toBeUndefined()
+    expect(s.pendingInitialAgentStatusByTabId[tabA.id]).toBeUndefined()
+    expect(s.pendingInitialAgentStatusByTabId[tabB.id]).toBeUndefined()
   })
 
   // Why: ownership regression (design §1.3). shutdownWorktreeTerminals used to

--- a/src/renderer/src/store/slices/terminal-orphan-helpers.ts
+++ b/src/renderer/src/store/slices/terminal-orphan-helpers.ts
@@ -14,6 +14,7 @@ type OrphanTerminalCleanupState = Pick<
   | 'canExpandPaneByTabId'
   | 'terminalLayoutsByTabId'
   | 'pendingStartupByTabId'
+  | 'pendingInitialAgentStatusByTabId'
   | 'pendingInitialCwdByTabId'
   | 'pendingSetupSplitByTabId'
   | 'pendingIssueCommandSplitByTabId'
@@ -60,6 +61,7 @@ export function buildOrphanTerminalCleanupPatch(
   | 'canExpandPaneByTabId'
   | 'terminalLayoutsByTabId'
   | 'pendingStartupByTabId'
+  | 'pendingInitialAgentStatusByTabId'
   | 'pendingInitialCwdByTabId'
   | 'pendingSetupSplitByTabId'
   | 'pendingIssueCommandSplitByTabId'
@@ -77,6 +79,7 @@ export function buildOrphanTerminalCleanupPatch(
       canExpandPaneByTabId: state.canExpandPaneByTabId,
       terminalLayoutsByTabId: state.terminalLayoutsByTabId,
       pendingStartupByTabId: state.pendingStartupByTabId,
+      pendingInitialAgentStatusByTabId: state.pendingInitialAgentStatusByTabId,
       pendingInitialCwdByTabId: state.pendingInitialCwdByTabId,
       pendingSetupSplitByTabId: state.pendingSetupSplitByTabId,
       pendingIssueCommandSplitByTabId: state.pendingIssueCommandSplitByTabId,
@@ -96,6 +99,7 @@ export function buildOrphanTerminalCleanupPatch(
   const nextCanExpandPaneByTabId = { ...state.canExpandPaneByTabId }
   const nextTerminalLayoutsByTabId = { ...state.terminalLayoutsByTabId }
   const nextPendingStartupByTabId = { ...state.pendingStartupByTabId }
+  const nextPendingInitialAgentStatusByTabId = { ...state.pendingInitialAgentStatusByTabId }
   const nextPendingInitialCwdByTabId = { ...state.pendingInitialCwdByTabId }
   const nextPendingSetupSplitByTabId = { ...state.pendingSetupSplitByTabId }
   const nextPendingIssueCommandSplitByTabId = { ...state.pendingIssueCommandSplitByTabId }
@@ -118,6 +122,7 @@ export function buildOrphanTerminalCleanupPatch(
     delete nextCanExpandPaneByTabId[orphanTabId]
     delete nextTerminalLayoutsByTabId[orphanTabId]
     delete nextPendingStartupByTabId[orphanTabId]
+    delete nextPendingInitialAgentStatusByTabId[orphanTabId]
     delete nextPendingInitialCwdByTabId[orphanTabId]
     delete nextPendingSetupSplitByTabId[orphanTabId]
     delete nextPendingIssueCommandSplitByTabId[orphanTabId]
@@ -146,6 +151,7 @@ export function buildOrphanTerminalCleanupPatch(
     canExpandPaneByTabId: nextCanExpandPaneByTabId,
     terminalLayoutsByTabId: nextTerminalLayoutsByTabId,
     pendingStartupByTabId: nextPendingStartupByTabId,
+    pendingInitialAgentStatusByTabId: nextPendingInitialAgentStatusByTabId,
     pendingInitialCwdByTabId: nextPendingInitialCwdByTabId,
     pendingSetupSplitByTabId: nextPendingSetupSplitByTabId,
     pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId,

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -6,6 +6,7 @@ import type {
   Tab,
   TerminalLayoutSnapshot,
   TerminalTab,
+  InitialAgentStatusSeed,
   TuiAgent,
   Worktree,
   WorkspaceKey,
@@ -340,7 +341,7 @@ export type TerminalSlice = {
       launchToken?: string
       launchAgent?: TuiAgent
       /** Initial prompt-start status for agents that lack native prompt hooks. */
-      initialAgentStatus?: { agent: TuiAgent; prompt: string }
+      initialAgentStatus?: InitialAgentStatusSeed
       /** Show the restored-session banner when this startup command mounts. */
       showSessionRestoredBanner?: boolean
       /** Telemetry metadata for the `agent_started` event. Threaded all the
@@ -349,6 +350,7 @@ export type TerminalSlice = {
       telemetry?: AgentStartedTelemetry
     }
   >
+  pendingInitialAgentStatusByTabId: Record<string, InitialAgentStatusSeed>
   pendingInitialCwdByTabId: Record<string, string>
   /** Queued setup-split requests — when present, TerminalPane creates the
    *  initial pane clean, then splits (vertical or horizontal per user setting)
@@ -500,12 +502,14 @@ export type TerminalSlice = {
       launchConfig?: SleepingAgentLaunchConfig
       launchToken?: string
       launchAgent?: TuiAgent
-      initialAgentStatus?: { agent: TuiAgent; prompt: string }
+      initialAgentStatus?: InitialAgentStatusSeed
       showSessionRestoredBanner?: boolean
       telemetry?: AgentStartedTelemetry
     }
   ) => void
+  queueTabInitialAgentStatus: (tabId: string, seed: InitialAgentStatusSeed) => void
   queueTabInitialCwd: (tabId: string, cwd: string) => void
+  consumeTabInitialAgentStatus: (tabId: string) => InitialAgentStatusSeed | null
   consumeTabInitialCwd: (tabId: string) => string | null
   consumeTabStartupCommand: (tabId: string) => {
     command: string
@@ -515,7 +519,7 @@ export type TerminalSlice = {
     launchConfig?: SleepingAgentLaunchConfig
     launchToken?: string
     launchAgent?: TuiAgent
-    initialAgentStatus?: { agent: TuiAgent; prompt: string }
+    initialAgentStatus?: InitialAgentStatusSeed
     showSessionRestoredBanner?: boolean
     telemetry?: AgentStartedTelemetry
   } | null
@@ -576,6 +580,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   canExpandPaneByTabId: {},
   terminalLayoutsByTabId: {},
   pendingStartupByTabId: {},
+  pendingInitialAgentStatusByTabId: {},
   pendingInitialCwdByTabId: {},
   pendingSetupSplitByTabId: {},
   pendingIssueCommandSplitByTabId: {},
@@ -1021,6 +1026,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
       const nextPendingStartupByTabId = { ...s.pendingStartupByTabId }
       delete nextPendingStartupByTabId[tabId]
+      const nextPendingInitialAgentStatusByTabId = { ...s.pendingInitialAgentStatusByTabId }
+      delete nextPendingInitialAgentStatusByTabId[tabId]
       const nextPendingInitialCwdByTabId = { ...s.pendingInitialCwdByTabId }
       delete nextPendingInitialCwdByTabId[tabId]
       const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
@@ -1097,6 +1104,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         canExpandPaneByTabId: nextCanExpand,
         terminalLayoutsByTabId: nextLayouts,
         pendingStartupByTabId: nextPendingStartupByTabId,
+        pendingInitialAgentStatusByTabId: nextPendingInitialAgentStatusByTabId,
         pendingInitialCwdByTabId: nextPendingInitialCwdByTabId,
         pendingSetupSplitByTabId: nextPendingSetupSplitByTabId,
         pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId,
@@ -2135,6 +2143,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // Why: setup-split and issue-command-split are transient one-shots that
       // drive new-tab UX. They are not sleep-recovery state; clear in both
       // cases.
+      const nextPendingInitialAgentStatusByTabId = { ...s.pendingInitialAgentStatusByTabId }
       const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
       const nextPendingIssueCommandSplitByTabId = { ...s.pendingIssueCommandSplitByTabId }
       // Why: under remove-worktree (default), layout snapshots carry
@@ -2164,6 +2173,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         if (!keepIdentifiers) {
           delete nextRuntimePaneTitlesByTabId[tab.id]
         }
+        delete nextPendingInitialAgentStatusByTabId[tab.id]
         delete nextPendingSetupSplitByTabId[tab.id]
         delete nextPendingIssueCommandSplitByTabId[tab.id]
         if (nextUnreadTerminalTabs[tab.id]) {
@@ -2229,6 +2239,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         suppressedPtyExitIds: nextSuppressedPtyExitIds,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds,
         codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId,
+        pendingInitialAgentStatusByTabId: nextPendingInitialAgentStatusByTabId,
         pendingSetupSplitByTabId: nextPendingSetupSplitByTabId,
         pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId,
         terminalLayoutsByTabId: nextTerminalLayoutsByTabId,
@@ -2437,6 +2448,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     }))
   },
 
+  queueTabInitialAgentStatus: (tabId, seed) => {
+    set((s) => ({
+      pendingInitialAgentStatusByTabId: {
+        ...s.pendingInitialAgentStatusByTabId,
+        [tabId]: seed
+      }
+    }))
+  },
+
   queueTabInitialCwd: (tabId, cwd) => {
     set((s) => ({
       pendingInitialCwdByTabId: {
@@ -2444,6 +2464,21 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         [tabId]: cwd
       }
     }))
+  },
+
+  consumeTabInitialAgentStatus: (tabId) => {
+    const pending = get().pendingInitialAgentStatusByTabId[tabId]
+    if (!pending) {
+      return null
+    }
+
+    set((s) => {
+      const next = { ...s.pendingInitialAgentStatusByTabId }
+      delete next[tabId]
+      return { pendingInitialAgentStatusByTabId: next }
+    })
+
+    return pending
   },
 
   consumeTabInitialCwd: (tabId) => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2689,6 +2689,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                           ...(startup.startupCommandDelivery
                             ? { startupCommandDelivery: startup.startupCommandDelivery }
                             : {}),
+                          ...(startup.initialAgentStatus
+                            ? { startupInitialAgentStatus: startup.initialAgentStatus }
+                            : {}),
                           activate: true
                         }
                       : {})

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1246,6 +1246,9 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
               ...(args.startup.startupCommandDelivery
                 ? { startupCommandDelivery: args.startup.startupCommandDelivery }
                 : {}),
+              ...(args.startup.initialAgentStatus
+                ? { startupInitialAgentStatus: args.startup.initialAgentStatus }
+                : {}),
               activate: true
             }
           : {}),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1956,6 +1956,7 @@ export type WorktreeStartupLaunch = {
   launchConfig?: SleepingAgentLaunchConfig
   launchToken?: string
   launchAgent?: TuiAgent
+  initialAgentStatus?: InitialAgentStatusSeed
   startupCommandDelivery?: StartupCommandDelivery
   telemetry?: { agent_kind: AgentKind; launch_source: LaunchSource; request_kind: RequestKind }
 }
@@ -2304,6 +2305,11 @@ export type TuiAgent =
   | 'grok' // xAI Grok CLI
   | 'devin' // Devin CLI
   | 'ante' // Ante (Antigma Labs)
+
+export type InitialAgentStatusSeed = {
+  agent: TuiAgent
+  prompt: string
+}
 
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'
 


### PR DESCRIPTION
## Summary

Prompt-backed agent launches now carry a narrow `initialAgentStatus` seed from launch creation through runtime IPC/RPC, renderer adoption, and PTY bind paths so newly launched Codex terminals can show the first prompt as `working` before a hook event arrives.

The seed is not inferred from terminal titles or commands, is normalized through the shared agent-status payload rules before display, and real hook status remains authoritative if it arrives first. Fixes #6643.

## Design Approach

- Added a shared `InitialAgentStatusSeed` and threaded it through prompt-backed startup metadata only.
- Covered backend-spawned/adopted PTYs, renderer-queued startups, runtime terminal creation, worktree creation, web/runtime RPC payloads, and attach/reused-spawn PTY bind paths.
- Added transient store cleanup so pending initial status is consumed or removed with closed/orphaned/shutdown terminal tabs.
- Scratch design doc used during implementation: `docs/issue-6643-codex-status-design.md` (ignored scratch context, not shipped in this PR).

## Review Outcome

- Design review was completed from recovered findings before implementation; key constraints were prompt-backed only, no command/title inference, SSH/runtime payload compatibility, and hook-priority preservation.
- Completeness verification initially found normalization and cleanup blockers; both were fixed and the follow-up verification reported no blockers.
- Perf audit reported no blockers across Zustand transient maps, TerminalPane mount reads, PTY bind seeding, and IPC/RPC threading.
- Code-review loop ran two reviewers. Round 1 found attach/reused-spawn and stale split-seed issues; both were fixed. Round 2 from both reviewers was clean.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/store/slices/store-cascades.test.ts src/main/runtime/orca-runtime.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts` - 5 files passed, 938 tests passed.
- `pnpm run typecheck` - passed.
- Pre-commit hook ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` on staged files.

## Consistency And Risk

- Source-of-truth behavior remains hook-based agent status; this PR only seeds initial prompt-backed status until hooks update it.
- Neighboring surfaces checked: runtime terminal creation, worktree creation, renderer tab adoption, TerminalPane startup consumption, PTY fresh/attach/reused-spawn binding, transient tab cleanup, web/runtime RPC payloads, and tests for status/store behavior.
- No screenshots are attached because this is non-visual status plumbing and no manual UI pass was recorded.
- Remaining validation gap: no fresh manual Electron demo-project launch, SSH/remote UI launch, or web/runtime UI pass was recorded. Automated coverage exercises the local/runtime/renderer plumbing and cleanup paths, but merge decision should explicitly accept that manual-live gap or add that pass before landing.

Made with [Orca](https://github.com/stablyai/orca) 🐋
