### PR TITLE
Prevent and recover from degraded terminal daemon spawns

### DIFF
--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -6,6 +6,7 @@ import { createServer, connect, type Server } from 'net'
 import { DaemonServer } from './daemon-server'
 import { getDaemonPidPath, serializeDaemonPidFile } from './daemon-spawner'
 import {
+  checkDaemonHealth,
   getProcessStartedAtMs,
   healthCheckDaemon,
   killStaleDaemon,
@@ -92,8 +93,9 @@ describe('daemon health', () => {
     await server.start()
 
     try {
+      await expect(checkDaemonHealth(socketPath, tokenPath)).resolves.toBe('healthy')
       await expect(healthCheckDaemon(socketPath, tokenPath)).resolves.toBe(true)
-      expect(ptySpawnHealthCheck).toHaveBeenCalledOnce()
+      expect(ptySpawnHealthCheck).toHaveBeenCalledTimes(2)
     } finally {
       await server.shutdown()
     }
@@ -111,6 +113,7 @@ describe('daemon health', () => {
     await server.start()
 
     try {
+      await expect(checkDaemonHealth(socketPath, tokenPath)).resolves.toBe('pty-spawn-unhealthy')
       await expect(healthCheckDaemon(socketPath, tokenPath)).resolves.toBe(false)
     } finally {
       await server.shutdown()
@@ -118,6 +121,7 @@ describe('daemon health', () => {
   })
 
   it('fails when the token file is missing', async () => {
+    await expect(checkDaemonHealth(socketPath, tokenPath)).resolves.toBe('unreachable')
     await expect(healthCheckDaemon(socketPath, tokenPath)).resolves.toBe(false)
   })
 

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -25,6 +25,8 @@ const KILL_WAIT_MS = 3_000
 const KILL_POLL_MS = 100
 const START_TIME_TOLERANCE_MS = 1_500
 
+export type DaemonHealth = 'healthy' | 'unreachable' | 'pty-spawn-unhealthy'
+
 type ParsedDaemonPid = {
   pid: number
   startedAtMs: number | null
@@ -69,10 +71,10 @@ function canConnectSocket(socketPath: string): Promise<boolean> {
   })
 }
 
-export function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boolean> {
+export function checkDaemonHealth(socketPath: string, tokenPath: string): Promise<DaemonHealth> {
   return new Promise((resolve) => {
     if (process.platform !== 'win32' && !existsSync(socketPath)) {
-      resolve(false)
+      resolve('unreachable')
       return
     }
 
@@ -80,13 +82,13 @@ export function healthCheckDaemon(socketPath: string, tokenPath: string): Promis
     try {
       token = readFileSync(tokenPath, 'utf8').trim()
     } catch {
-      resolve(false)
+      resolve('unreachable')
       return
     }
 
     let settled = false
     let sock: Socket | null = null
-    const settle = (result: boolean): void => {
+    const settle = (result: DaemonHealth): void => {
       if (settled) {
         return
       }
@@ -101,7 +103,7 @@ export function healthCheckDaemon(socketPath: string, tokenPath: string): Promis
       sock?.off('connect', onConnect)
       sock?.off('data', onData)
     }
-    const onError = (): void => settle(false)
+    const onError = (): void => settle('unreachable')
     const onConnect = (): void => {
       const hello: HelloMessage = {
         type: 'hello',
@@ -132,13 +134,13 @@ export function healthCheckDaemon(socketPath: string, tokenPath: string): Promis
         try {
           message = JSON.parse(line) as Record<string, unknown>
         } catch {
-          settle(false)
+          settle('unreachable')
           return
         }
 
         if (message.type === 'hello') {
           if (!(message as HelloResponse).ok) {
-            settle(false)
+            settle('unreachable')
             return
           }
           // Why: a protocol-live daemon with a stale cwd or node-pty helper
@@ -149,12 +151,12 @@ export function healthCheckDaemon(socketPath: string, tokenPath: string): Promis
         }
 
         if (message.id === 'health-1') {
-          settle(message.ok === true)
+          settle(message.ok === true ? 'healthy' : 'pty-spawn-unhealthy')
           return
         }
       }
     }
-    const timer = setTimeout(() => settle(false), HEALTH_CHECK_TIMEOUT_MS)
+    const timer = setTimeout(() => settle('unreachable'), HEALTH_CHECK_TIMEOUT_MS)
 
     sock = connect({ path: socketPath })
     sock.on('error', onError)
@@ -163,6 +165,10 @@ export function healthCheckDaemon(socketPath: string, tokenPath: string): Promis
     let buffer = ''
     sock.on('data', onData)
   })
+}
+
+export async function healthCheckDaemon(socketPath: string, tokenPath: string): Promise<boolean> {
+  return (await checkDaemonHealth(socketPath, tokenPath)) === 'healthy'
 }
 
 function isSystemResolverHealth(value: unknown): value is SystemResolverHealth {

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -38,6 +38,8 @@ const {
   spawnerInstances,
   ensureRunningOverrides,
   adapterInstances,
+  getLocalPtyProviderMock,
+  localFallbackProvider,
   setLocalPtyProviderMock,
   unbindLocalProviderListenersMock,
   rebindLocalProviderListenersMock
@@ -93,11 +95,42 @@ const {
   // Why: every DaemonSpawner constructed under test pushes into this array so
   // assertions can check "was the *same* spawner reused across restart?".
   const spawnerInstances: MockSpawner[] = []
-  const ensureRunningOverrides: (() => Promise<{ socketPath: string; tokenPath: string }>)[] = []
+  const ensureRunningOverrides: (() => Promise<{
+    socketPath: string
+    tokenPath: string
+    mode?: 'degraded-new-pty-fallback'
+  }>)[] = []
   // Same for DaemonPtyAdapter. The test asserts the replacement adapter is a
   // fresh instance whose respawn closure targets the *original* spawner.
   const adapterInstances: MockAdapter[] = []
 
+  const localFallbackProvider = {
+    routesFreshSpawnsToLocalProvider: undefined,
+    spawn: vi.fn(async (opts: { sessionId?: string }) => ({
+      id: opts.sessionId ?? 'local-fallback-pty'
+    })),
+    attach: vi.fn(async () => {}),
+    hasPty: vi.fn(() => false),
+    write: vi.fn(),
+    resize: vi.fn(),
+    shutdown: vi.fn(async () => {}),
+    sendSignal: vi.fn(async () => {}),
+    getCwd: vi.fn(async () => ''),
+    getInitialCwd: vi.fn(async () => ''),
+    clearBuffer: vi.fn(async () => {}),
+    acknowledgeDataEvent: vi.fn(),
+    hasChildProcesses: vi.fn(async () => false),
+    getForegroundProcess: vi.fn(async () => null),
+    serialize: vi.fn(async () => '{}'),
+    revive: vi.fn(async () => {}),
+    listProcesses: vi.fn(async () => []),
+    getDefaultShell: vi.fn(async () => '/bin/zsh'),
+    getProfiles: vi.fn(async () => []),
+    onData: vi.fn(() => () => {}),
+    onReplay: vi.fn(() => () => {}),
+    onExit: vi.fn(() => () => {})
+  }
+  const getLocalPtyProviderMock = vi.fn(() => localFallbackProvider)
   const setLocalPtyProviderMock = vi.fn()
   const unbindLocalProviderListenersMock = vi.fn()
   const rebindLocalProviderListenersMock = vi.fn()
@@ -121,6 +154,8 @@ const {
     spawnerInstances,
     ensureRunningOverrides,
     adapterInstances,
+    getLocalPtyProviderMock,
+    localFallbackProvider,
     setLocalPtyProviderMock,
     unbindLocalProviderListenersMock,
     rebindLocalProviderListenersMock
@@ -131,6 +166,7 @@ type MockSpawner = {
   ensureRunning: ReturnType<typeof vi.fn>
   resetHandle: ReturnType<typeof vi.fn>
   shutdown: ReturnType<typeof vi.fn>
+  getHandle: ReturnType<typeof vi.fn>
   launcher: unknown
 }
 
@@ -199,19 +235,31 @@ vi.mock('./daemon-spawner', () => ({
     readonly ensureRunning: ReturnType<typeof vi.fn>
     readonly resetHandle: ReturnType<typeof vi.fn>
     readonly shutdown: ReturnType<typeof vi.fn>
+    readonly getHandle: ReturnType<typeof vi.fn>
     private socketCounter: number
+    private handle: { mode?: 'degraded-new-pty-fallback'; shutdown: () => Promise<void> } | null
     constructor(opts: { runtimeDir: string; launcher: unknown }) {
       this.launcher = opts.launcher
       this.socketCounter = 0
+      this.handle = null
       // Why: each ensureRunning bumps a counter into the returned socketPath
       // so the test can verify the *replacement* adapter is constructed with
       // info from the second ensureRunning call, not stale info from the first.
       this.ensureRunning = vi.fn(async () => {
         const override = ensureRunningOverrides.shift()
         if (override) {
-          return override()
+          const result = await override()
+          this.handle = { shutdown: vi.fn(async () => {}) }
+          if (result.mode) {
+            this.handle.mode = result.mode
+          }
+          return {
+            socketPath: result.socketPath,
+            tokenPath: result.tokenPath
+          }
         }
         this.socketCounter += 1
+        this.handle = { shutdown: vi.fn(async () => {}) }
         return {
           socketPath: `/fake/socket-${this.socketCounter}`,
           tokenPath: `/fake/token-${this.socketCounter}`
@@ -219,6 +267,7 @@ vi.mock('./daemon-spawner', () => ({
       })
       this.resetHandle = vi.fn()
       this.shutdown = vi.fn(async () => {})
+      this.getHandle = vi.fn(() => this.handle)
       spawnerInstances.push(this as unknown as MockSpawner)
     }
   },
@@ -266,6 +315,7 @@ vi.mock('./daemon-pty-adapter', () => ({
 }))
 
 vi.mock('../ipc/pty', () => ({
+  getLocalPtyProvider: getLocalPtyProviderMock,
   setLocalPtyProvider: setLocalPtyProviderMock,
   unbindLocalProviderListeners: unbindLocalProviderListenersMock,
   rebindLocalProviderListeners: rebindLocalProviderListenersMock
@@ -276,6 +326,11 @@ async function importFresh() {
   spawnerInstances.length = 0
   ensureRunningOverrides.length = 0
   adapterInstances.length = 0
+  getLocalPtyProviderMock.mockClear()
+  localFallbackProvider.spawn.mockClear()
+  localFallbackProvider.write.mockClear()
+  localFallbackProvider.onData.mockClear()
+  localFallbackProvider.onExit.mockClear()
   setLocalPtyProviderMock.mockClear()
   unbindLocalProviderListenersMock.mockClear()
   rebindLocalProviderListenersMock.mockClear()
@@ -367,6 +422,29 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(setLocalPtyProviderMock).not.toHaveBeenCalled()
     expect(rebindLocalProviderListenersMock).not.toHaveBeenCalled()
     expect(mod.getDaemonProvider()).toBeNull()
+  })
+
+  it('routes fresh PTYs to the local fallback when a preserved daemon cannot spawn new PTYs', async () => {
+    const mod = await importFresh()
+    ensureRunningOverrides.push(async () => ({
+      socketPath: '/fake/degraded-socket',
+      tokenPath: '/fake/degraded-token',
+      mode: 'degraded-new-pty-fallback'
+    }))
+
+    await mod.initDaemonPtyProvider()
+
+    const { DegradedDaemonPtyProvider } = await import('./degraded-daemon-pty-provider')
+    const provider = mod.getDaemonProvider()
+    expect(provider).toBeInstanceOf(DegradedDaemonPtyProvider)
+    expect(getLocalPtyProviderMock).toHaveBeenCalledOnce()
+    expect(setLocalPtyProviderMock).toHaveBeenCalledWith(provider)
+
+    const result = await provider!.spawn({ cols: 80, rows: 24 })
+
+    expect(result.id).toBe('local-fallback-pty')
+    expect(localFallbackProvider.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
+    expect(adapterInstances[0].listProcesses).toHaveBeenCalled()
   })
 
   it('fans pty:exit for every active session *before* unbinding listeners, and killedCount is captured pre-fanout', async () => {
@@ -1059,7 +1137,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     probeSocketExistsMock.mockImplementation((p?: string) => p === FAKE_DAEMON_ENTRY_PATH)
     const mod = await importFresh()
     getAppPathMock.mockReturnValue(FAKE_APP_OUT_MAIN_PATH)
-    healthCheckDaemonMock.mockResolvedValue(false)
+    checkDaemonHealthMock.mockResolvedValue('unreachable')
     await mod.initDaemonPtyProvider()
 
     const launcher = spawnerInstances[0].launcher as (
@@ -1101,7 +1179,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
   it('removes detached daemon startup listeners after readiness', async () => {
     const mod = await importFresh()
-    healthCheckDaemonMock.mockResolvedValue(false)
+    checkDaemonHealthMock.mockResolvedValue('unreachable')
     await mod.initDaemonPtyProvider()
 
     const launcher = spawnerInstances[0].launcher as (
@@ -1156,7 +1234,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
   it('removes detached daemon startup listeners after startup error', async () => {
     const mod = await importFresh()
-    healthCheckDaemonMock.mockResolvedValue(false)
+    checkDaemonHealthMock.mockResolvedValue('unreachable')
     await mod.initDaemonPtyProvider()
 
     const launcher = spawnerInstances[0].launcher as (
@@ -1224,12 +1302,46 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       socketPath: string,
       tokenPath: string
     ) => Promise<{ shutdown(): Promise<void> }>
-    healthCheckDaemonMock.mockResolvedValueOnce(false)
+    checkDaemonHealthMock.mockResolvedValueOnce('unreachable')
 
     await launcher('/fake/socket', '/fake/token')
 
     expect(requestMock).toHaveBeenCalledWith('listSessions', undefined)
     expect(disconnectMock).toHaveBeenCalledOnce()
+    expect(killStaleDaemonMock).not.toHaveBeenCalled()
+    expect(forkMock).not.toHaveBeenCalled()
+  })
+
+  it('marks a preserved daemon as degraded when its PTY spawn health check fails', async () => {
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+
+    const requestMock = vi.fn(async (method: string) => {
+      if (method === 'listSessions') {
+        return {
+          sessions: [{ sessionId: 'wt-1@@live', isAlive: true }]
+        }
+      }
+      return {}
+    })
+    daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        request: requestMock,
+        disconnect: vi.fn()
+      }
+    })
+
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string
+    ) => Promise<{ mode?: 'degraded-new-pty-fallback'; shutdown(): Promise<void> }>
+    checkDaemonHealthMock.mockResolvedValueOnce('pty-spawn-unhealthy')
+
+    const handle = await launcher('/fake/socket', '/fake/token')
+
+    expect(requestMock).toHaveBeenCalledWith('listSessions', undefined)
+    expect(handle.mode).toBe('degraded-new-pty-fallback')
     expect(killStaleDaemonMock).not.toHaveBeenCalled()
     expect(forkMock).not.toHaveBeenCalled()
   })
@@ -1252,7 +1364,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       socketPath: string,
       tokenPath: string
     ) => Promise<{ shutdown(): Promise<void> }>
-    healthCheckDaemonMock.mockResolvedValueOnce(false)
+    checkDaemonHealthMock.mockResolvedValueOnce('unreachable')
     forkMock.mockImplementationOnce(() => ({
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
@@ -1286,7 +1398,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       socketPath: string,
       tokenPath: string
     ) => Promise<{ shutdown(): Promise<void> }>
-    healthCheckDaemonMock.mockResolvedValueOnce(false)
+    checkDaemonHealthMock.mockResolvedValueOnce('unreachable')
     forkMock.mockImplementationOnce(() => {
       const handlers: Record<string, ((arg?: unknown) => void)[]> = {
         message: [],

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -481,6 +481,45 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(order).toEqual(['fanout', 'unbind'])
   })
 
+  it('fans exits for preserved degraded current-daemon sessions during restart', async () => {
+    const mod = await importFresh()
+    ensureRunningOverrides.push(async () => ({
+      socketPath: '/fake/degraded-socket',
+      tokenPath: '/fake/degraded-token',
+      mode: 'degraded-new-pty-fallback'
+    }))
+    await mod.initDaemonPtyProvider()
+
+    const { DegradedDaemonPtyProvider } = await import('./degraded-daemon-pty-provider')
+    const provider = mod.getDaemonProvider()
+    expect(provider).toBeInstanceOf(DegradedDaemonPtyProvider)
+    const degradedProvider = provider as InstanceType<typeof DegradedDaemonPtyProvider>
+
+    const originalAdapter = adapterInstances[0]
+    originalAdapter.listProcesses.mockResolvedValueOnce([
+      { id: 'preserved-current-session', cwd: '/repo', title: 'shell' }
+    ])
+    await degradedProvider.discoverDaemonSessions()
+
+    const order: string[] = []
+    degradedProvider.onExit((payload) => {
+      if (payload.id === 'preserved-current-session') {
+        order.push('degraded-fanout')
+      }
+    })
+    originalAdapter.fanoutSyntheticExits.mockImplementation(() => {
+      order.push('adapter-fanout')
+    })
+    unbindLocalProviderListenersMock.mockImplementation(() => {
+      order.push('unbind')
+    })
+
+    const result = await mod.restartDaemon()
+
+    expect(result.killedCount).toBe(1)
+    expect(order).toEqual(['adapter-fanout', 'degraded-fanout', 'unbind'])
+  })
+
   it('reuses the existing DaemonSpawner across restart (resetHandle + ensureRunning on same instance)', async () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -535,8 +535,17 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
     currentAdapter instanceof DegradedDaemonPtyProvider
       ? await currentAdapter.shutdownFallbackSessions()
       : 0
-  const killedCount = currentOnly.getActiveSessionIds().length + fallbackKilledCount
+  const currentDaemonSessionIds =
+    currentAdapter instanceof DegradedDaemonPtyProvider
+      ? currentAdapter.getCurrentDaemonSessionIds()
+      : []
+  const killedCount =
+    new Set([...currentOnly.getActiveSessionIds(), ...currentDaemonSessionIds]).size +
+    fallbackKilledCount
   currentOnly.fanoutSyntheticExits(-1)
+  if (currentAdapter instanceof DegradedDaemonPtyProvider) {
+    currentAdapter.fanoutCurrentDaemonSyntheticExits(-1)
+  }
 
   // Step 2: detach renderer listeners from the current adapter. Must happen
   // AFTER step 1 so the synthesized exits actually reach the renderer, and

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -17,7 +17,8 @@ import {
   getDaemonSocketPath,
   getDaemonTokenPath,
   serializeDaemonPidFile,
-  type DaemonLauncher
+  type DaemonLauncher,
+  type DaemonProcessHandle
 } from './daemon-spawner'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { DaemonPtyRouter } from './daemon-pty-router'
@@ -31,11 +32,13 @@ import {
   getMacDaemonSystemResolverHealth,
   getDaemonLaunchIdentity,
   getProcessStartedAtMs,
-  healthCheckDaemon,
+  checkDaemonHealth,
   isDaemonStaleForCurrentBundle,
   killStaleDaemon
 } from './daemon-health'
+import { DegradedDaemonPtyProvider } from './degraded-daemon-pty-provider'
 import {
+  getLocalPtyProvider,
   setLocalPtyProvider,
   unbindLocalProviderListeners,
   rebindLocalProviderListeners
@@ -52,7 +55,9 @@ function logDaemonMilestone(event: string, details: Record<string, unknown> = {}
 }
 
 let spawner: DaemonSpawner | null = null
-let adapter: DaemonPtyRouter | DaemonPtyAdapter | null = null
+type DaemonProvider = DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProvider
+
+let adapter: DaemonProvider | null = null
 // Why: coalesce concurrent restartDaemon() calls so two clicks (or a UI
 // click racing an internal caller) can't both enter the 7-step sequence —
 // the second entry would read the already-disposed current adapter and
@@ -145,13 +150,18 @@ async function getAliveDaemonSessionCount(
 
 function createPreservedDaemonHandle(
   runtimeDir: string,
-  protocolVersion = PROTOCOL_VERSION
-): { shutdown(): Promise<void> } {
-  return {
+  protocolVersion = PROTOCOL_VERSION,
+  mode?: 'degraded-new-pty-fallback'
+): DaemonProcessHandle {
+  const handle: DaemonProcessHandle = {
     shutdown: async () => {
       await cleanupDaemonForProtocol(runtimeDir, protocolVersion)
     }
   }
+  if (mode) {
+    handle.mode = mode
+  }
+  return handle
 }
 
 async function shouldPreserveDaemonWithLiveSessions(
@@ -174,8 +184,8 @@ async function shouldPreserveDaemonWithLiveSessions(
 function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
   return async (socketPath, tokenPath) => {
     const entryPath = getDaemonEntryPath()
-    const healthy = await healthCheckDaemon(socketPath, tokenPath)
-    if (healthy) {
+    const health = await checkDaemonHealth(socketPath, tokenPath)
+    if (health === 'healthy') {
       const resolverHealth = await getMacDaemonSystemResolverHealth(socketPath, tokenPath)
       if (resolverHealth === 'unhealthy') {
         const liveSessionCount = await getAliveDaemonSessionCount(socketPath, tokenPath)
@@ -228,6 +238,16 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
       // only recovery.
       const liveSessionCount = await getAliveDaemonSessionCount(socketPath, tokenPath)
       if (liveSessionCount !== null && liveSessionCount > 0) {
+        if (health === 'pty-spawn-unhealthy') {
+          console.warn(
+            `[daemon] Preserving daemon that failed the PTY spawn health check because it owns ${liveSessionCount} live session${liveSessionCount === 1 ? '' : 's'}; fresh terminals will use the local provider until the daemon is restarted`
+          )
+          return createPreservedDaemonHandle(
+            runtimeDir,
+            PROTOCOL_VERSION,
+            'degraded-new-pty-fallback'
+          )
+        }
         console.warn(
           `[daemon] Preserving daemon that failed the health check because it owns ${liveSessionCount} live session${liveSessionCount === 1 ? '' : 's'}`
         )
@@ -374,6 +394,7 @@ export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void>
   // throws, a stale spawner would prevent shutdownDaemon() from cleaning up
   // correctly on retry.
   const info = await newSpawner.ensureRunning()
+  const launchMode = newSpawner.getHandle()?.mode
   logDaemonMilestone('daemon-current-ready')
   if (signal?.aborted) {
     // Why: startup fail-open may already have allowed fallback LocalPtyProvider
@@ -398,13 +419,24 @@ export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void>
 
   const legacyAdapters = await createLegacyDaemonAdapters(runtimeDir)
   const routedAdapter =
-    legacyAdapters.length > 0
-      ? new DaemonPtyRouter({
+    launchMode === 'degraded-new-pty-fallback'
+      ? new DegradedDaemonPtyProvider({
           current: newAdapter,
-          legacy: legacyAdapters
+          legacy: legacyAdapters,
+          fallback: getLocalPtyProvider()
         })
-      : newAdapter
-  if (routedAdapter instanceof DaemonPtyRouter) {
+      : legacyAdapters.length > 0
+        ? new DaemonPtyRouter({
+            current: newAdapter,
+            legacy: legacyAdapters
+          })
+        : newAdapter
+  if (routedAdapter instanceof DegradedDaemonPtyProvider) {
+    // Why: the preserved daemon cannot create fresh terminals, but its live
+    // sessions may still be writable. Discover those ids so only known old
+    // sessions route to the degraded daemon; fresh panes fall back locally.
+    await routedAdapter.discoverDaemonSessions()
+  } else if (routedAdapter instanceof DaemonPtyRouter) {
     await routedAdapter.discoverLegacySessions()
   }
   if (signal?.aborted) {
@@ -427,7 +459,7 @@ export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void>
 // adapter/router to list sessions, kill them, etc. Exposed as a narrow getter
 // rather than exporting the module-level variable to keep the "swap on
 // restart" invariant in one place (replaceDaemonProvider).
-export function getDaemonProvider(): DaemonPtyRouter | DaemonPtyAdapter | null {
+export function getDaemonProvider(): DaemonProvider | null {
   return adapter
 }
 
@@ -435,9 +467,33 @@ export function getDaemonProvider(): DaemonPtyRouter | DaemonPtyAdapter | null {
 // must update both the module-level `adapter` singleton here and the
 // `localProvider` reference inside ipc/pty.ts. Without this helper they could
 // drift — app-quit would dispose a stale adapter reference.
-export function replaceDaemonProvider(newAdapter: DaemonPtyAdapter | DaemonPtyRouter): void {
+export function replaceDaemonProvider(newAdapter: DaemonProvider): void {
   adapter = newAdapter
   setLocalPtyProvider(newAdapter)
+}
+
+function getCurrentDaemonAdapter(provider: DaemonProvider): DaemonPtyAdapter {
+  if (provider instanceof DaemonPtyRouter || provider instanceof DegradedDaemonPtyProvider) {
+    return provider.getCurrentAdapter()
+  }
+  return provider
+}
+
+function getLegacyDaemonAdapters(provider: DaemonProvider): DaemonPtyAdapter[] {
+  if (provider instanceof DaemonPtyRouter || provider instanceof DegradedDaemonPtyProvider) {
+    return [...provider.getLegacyAdapters()]
+  }
+  return []
+}
+
+function disposeProviderSubscriptionsOnly(provider: DaemonProvider): void {
+  if (provider instanceof DaemonPtyRouter) {
+    provider.disposeRouterOnly()
+    return
+  }
+  if (provider instanceof DegradedDaemonPtyProvider) {
+    provider.disposeProviderOnly()
+  }
 }
 
 export type RestartDaemonResult = {
@@ -467,17 +523,19 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
   }
 
   const runtimeDir = getRuntimeDir()
-  const currentOnly =
-    currentAdapter instanceof DaemonPtyRouter ? currentAdapter.getCurrentAdapter() : currentAdapter
-  const legacyAdapters =
-    currentAdapter instanceof DaemonPtyRouter ? [...currentAdapter.getLegacyAdapters()] : []
+  const currentOnly = getCurrentDaemonAdapter(currentAdapter)
+  const legacyAdapters = getLegacyDaemonAdapters(currentAdapter)
 
   // Step 1: synthesize pty:exit for every active session on the current
   // adapter BEFORE any teardown. The daemon's kill-all-and-shutdown path
   // explicitly does not fan onExit to clients (session.ts:246-252), so
   // without this the renderer would never see exits and would black-hole
   // writes against the disposed adapter.
-  const killedCount = currentOnly.getActiveSessionIds().length
+  const fallbackKilledCount =
+    currentAdapter instanceof DegradedDaemonPtyProvider
+      ? await currentAdapter.shutdownFallbackSessions()
+      : 0
+  const killedCount = currentOnly.getActiveSessionIds().length + fallbackKilledCount
   currentOnly.fanoutSyntheticExits(-1)
 
   // Step 2: detach renderer listeners from the current adapter. Must happen
@@ -525,9 +583,7 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
   // the narrow window, and *before* replaceDaemonProvider so the swap is
   // atomic from the renderer's perspective. Plain dispose() would also tear
   // down the legacy adapters themselves — use the router-only variant.
-  if (currentAdapter instanceof DaemonPtyRouter) {
-    currentAdapter.disposeRouterOnly()
-  }
+  disposeProviderSubscriptionsOnly(currentAdapter)
 
   // Step 6: swap module state (adapter + localProvider) atomically.
   replaceDaemonProvider(newProvider)

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -15,6 +15,7 @@ export type DaemonPidFile = {
 }
 
 export type DaemonProcessHandle = {
+  mode?: 'degraded-new-pty-fallback'
   shutdown(): Promise<void>
 }
 
@@ -47,6 +48,10 @@ export class DaemonSpawner {
     this.handle = await this.launcher(this.socketPath, this.tokenPath)
 
     return { socketPath: this.socketPath, tokenPath: this.tokenPath }
+  }
+
+  getHandle(): DaemonProcessHandle | null {
+    return this.handle
   }
 
   // Why: after the daemon process dies unexpectedly, the cached handle is

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DegradedDaemonPtyProvider } from './degraded-daemon-pty-provider'
+import type { DaemonPtyAdapter } from './daemon-pty-adapter'
+import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+
+type ProviderMock = IPtyProvider & {
+  emitData: (id: string, data: string) => void
+  emitExit: (id: string, code: number) => void
+}
+
+function createProvider(label: string, sessions: string[] = []): ProviderMock {
+  const dataListeners: ((payload: { id: string; data: string }) => void)[] = []
+  const exitListeners: ((payload: { id: string; code: number }) => void)[] = []
+  return {
+    spawn: vi.fn(async (opts: PtySpawnOptions): Promise<PtySpawnResult> => {
+      const id = opts.sessionId ?? `${label}-new`
+      sessions.push(id)
+      return { id }
+    }),
+    attach: vi.fn(async () => {}),
+    hasPty: vi.fn((id: string) => sessions.includes(id)),
+    write: vi.fn(),
+    resize: vi.fn(),
+    shutdown: vi.fn(async (id: string) => {
+      const idx = sessions.indexOf(id)
+      if (idx !== -1) {
+        sessions.splice(idx, 1)
+      }
+    }),
+    sendSignal: vi.fn(async () => {}),
+    getCwd: vi.fn(async () => ''),
+    getInitialCwd: vi.fn(async () => ''),
+    clearBuffer: vi.fn(async () => {}),
+    acknowledgeDataEvent: vi.fn(),
+    hasChildProcesses: vi.fn(async () => false),
+    getForegroundProcess: vi.fn(async () => null),
+    serialize: vi.fn(async () => '{}'),
+    revive: vi.fn(async () => {}),
+    listProcesses: vi.fn(async () => sessions.map((id) => ({ id, cwd: '', title: label }))),
+    getDefaultShell: vi.fn(async () => '/bin/zsh'),
+    getProfiles: vi.fn(async () => []),
+    onData: vi.fn((callback: (payload: { id: string; data: string }) => void) => {
+      dataListeners.push(callback)
+      return () => {
+        const idx = dataListeners.indexOf(callback)
+        if (idx !== -1) {
+          dataListeners.splice(idx, 1)
+        }
+      }
+    }),
+    onReplay: vi.fn(() => () => {}),
+    onExit: vi.fn((callback: (payload: { id: string; code: number }) => void) => {
+      exitListeners.push(callback)
+      return () => {
+        const idx = exitListeners.indexOf(callback)
+        if (idx !== -1) {
+          exitListeners.splice(idx, 1)
+        }
+      }
+    }),
+    emitData: (id: string, data: string) => {
+      for (const listener of dataListeners) {
+        listener({ id, data })
+      }
+    },
+    emitExit: (id: string, code: number) => {
+      for (const listener of exitListeners) {
+        listener({ id, code })
+      }
+    }
+  }
+}
+
+function createDaemonAdapter(
+  label: string,
+  sessions: string[] = []
+): DaemonPtyAdapter & ProviderMock {
+  return {
+    ...createProvider(label, sessions),
+    protocolVersion: 13,
+    listSessions: vi.fn(async () => []),
+    ackColdRestore: vi.fn(),
+    clearTombstone: vi.fn(),
+    reconcileOnStartup: vi.fn(async () => ({ alive: sessions, killed: [] })),
+    dispose: vi.fn(),
+    disconnectOnly: vi.fn(async () => {}),
+    getActiveSessionIds: vi.fn(() => []),
+    fanoutSyntheticExits: vi.fn()
+  } as unknown as DaemonPtyAdapter & ProviderMock
+}
+
+describe('DegradedDaemonPtyProvider', () => {
+  it('routes discovered daemon sessions to the daemon and fresh PTYs to the fallback', async () => {
+    const current = createDaemonAdapter('daemon', ['daemon-session'])
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+
+    await provider.discoverDaemonSessions()
+
+    await provider.spawn({ sessionId: 'daemon-session', cols: 80, rows: 24 })
+    const fresh = await provider.spawn({ cols: 80, rows: 24 })
+    provider.write('daemon-session', 'old\n')
+    provider.write(fresh.id, 'new\n')
+
+    expect(current.spawn).toHaveBeenCalledWith({ sessionId: 'daemon-session', cols: 80, rows: 24 })
+    expect(fallback.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
+    expect(current.write).toHaveBeenCalledWith('daemon-session', 'old\n')
+    expect(fallback.write).toHaveBeenCalledWith(fresh.id, 'new\n')
+  })
+
+  it('routes a previously daemon-backed id to fallback after daemon exit removes the mapping', async () => {
+    const current = createDaemonAdapter('daemon', ['daemon-session'])
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+
+    await provider.discoverDaemonSessions()
+    current.emitExit('daemon-session', 0)
+    await provider.spawn({ sessionId: 'daemon-session', cols: 80, rows: 24 })
+
+    expect(fallback.spawn).toHaveBeenCalledWith({
+      sessionId: 'daemon-session',
+      cols: 80,
+      rows: 24
+    })
+  })
+
+  it('detaches provider subscriptions without disposing the underlying providers', () => {
+    const current = createDaemonAdapter('daemon')
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+    const dataSpy = vi.fn()
+    const exitSpy = vi.fn()
+    provider.onData(dataSpy)
+    provider.onExit(exitSpy)
+
+    provider.disposeProviderOnly()
+    current.emitData('daemon-session', 'data')
+    fallback.emitExit('fallback-session', 0)
+
+    expect(dataSpy).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(current.dispose).not.toHaveBeenCalled()
+  })
+
+  it('shuts down fallback sessions before a daemon-provider swap', async () => {
+    const current = createDaemonAdapter('daemon')
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+
+    const fresh = await provider.spawn({ cols: 80, rows: 24 })
+    const killedCount = await provider.shutdownFallbackSessions()
+
+    expect(killedCount).toBe(1)
+    expect(fallback.shutdown).toHaveBeenCalledWith(fresh.id, { immediate: true })
+    expect(provider.hasPty(fresh.id)).toBe(false)
+  })
+})

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -5,11 +5,13 @@ import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers
 
 type ProviderMock = IPtyProvider & {
   emitData: (id: string, data: string) => void
+  emitReplay: (id: string, data: string) => void
   emitExit: (id: string, code: number) => void
 }
 
 function createProvider(label: string, sessions: string[] = []): ProviderMock {
   const dataListeners: ((payload: { id: string; data: string }) => void)[] = []
+  const replayListeners: ((payload: { id: string; data: string }) => void)[] = []
   const exitListeners: ((payload: { id: string; code: number }) => void)[] = []
   return {
     spawn: vi.fn(async (opts: PtySpawnOptions): Promise<PtySpawnResult> => {
@@ -48,7 +50,15 @@ function createProvider(label: string, sessions: string[] = []): ProviderMock {
         }
       }
     }),
-    onReplay: vi.fn(() => () => {}),
+    onReplay: vi.fn((callback: (payload: { id: string; data: string }) => void) => {
+      replayListeners.push(callback)
+      return () => {
+        const idx = replayListeners.indexOf(callback)
+        if (idx !== -1) {
+          replayListeners.splice(idx, 1)
+        }
+      }
+    }),
     onExit: vi.fn((callback: (payload: { id: string; code: number }) => void) => {
       exitListeners.push(callback)
       return () => {
@@ -60,6 +70,11 @@ function createProvider(label: string, sessions: string[] = []): ProviderMock {
     }),
     emitData: (id: string, data: string) => {
       for (const listener of dataListeners) {
+        listener({ id, data })
+      }
+    },
+    emitReplay: (id: string, data: string) => {
+      for (const listener of replayListeners) {
         listener({ id, data })
       }
     },
@@ -124,6 +139,41 @@ describe('DegradedDaemonPtyProvider', () => {
     })
   })
 
+  it('caches a provider discovered by hasPty before routing later operations', () => {
+    const current = createDaemonAdapter('daemon', ['daemon-session'])
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+
+    expect(provider.hasPty('daemon-session')).toBe(true)
+    provider.write('daemon-session', 'kept-on-daemon\n')
+
+    expect(current.write).toHaveBeenCalledWith('daemon-session', 'kept-on-daemon\n')
+    expect(fallback.write).not.toHaveBeenCalled()
+  })
+
+  it('forwards replay output from fallback and daemon providers', () => {
+    const current = createDaemonAdapter('daemon')
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+    const replaySpy = vi.fn()
+
+    const unsubscribe = provider.onReplay(replaySpy)
+    current.emitReplay('daemon-session', 'daemon replay')
+    fallback.emitReplay('fallback-session', 'fallback replay')
+    unsubscribe()
+    current.emitReplay('daemon-session', 'after unsubscribe')
+
+    expect(replaySpy).toHaveBeenCalledTimes(2)
+    expect(replaySpy).toHaveBeenNthCalledWith(1, {
+      id: 'daemon-session',
+      data: 'daemon replay'
+    })
+    expect(replaySpy).toHaveBeenNthCalledWith(2, {
+      id: 'fallback-session',
+      data: 'fallback replay'
+    })
+  })
+
   it('detaches provider subscriptions without disposing the underlying providers', () => {
     const current = createDaemonAdapter('daemon')
     const fallback = createProvider('fallback')
@@ -153,5 +203,36 @@ describe('DegradedDaemonPtyProvider', () => {
     expect(killedCount).toBe(1)
     expect(fallback.shutdown).toHaveBeenCalledWith(fresh.id, { immediate: true })
     expect(provider.hasPty(fresh.id)).toBe(false)
+  })
+
+  it('throws instead of counting fallback sessions that fail to shut down', async () => {
+    const current = createDaemonAdapter('daemon')
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+    const fresh = await provider.spawn({ cols: 80, rows: 24 })
+    vi.mocked(fallback.shutdown).mockRejectedValueOnce(new Error('still alive'))
+
+    await expect(provider.shutdownFallbackSessions()).rejects.toThrow(
+      'Failed to shut down 1 fallback PTY session(s)'
+    )
+
+    expect(provider.hasPty(fresh.id)).toBe(true)
+  })
+
+  it('fans synthetic exits for discovered current-daemon sessions only', async () => {
+    const current = createDaemonAdapter('daemon', ['current-session'])
+    const legacy = createDaemonAdapter('legacy', ['legacy-session'])
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [legacy], fallback })
+    const exitSpy = vi.fn()
+    provider.onExit(exitSpy)
+
+    await provider.discoverDaemonSessions()
+    provider.fanoutCurrentDaemonSyntheticExits(-1)
+
+    expect(exitSpy).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith({ id: 'current-session', code: -1 })
+    expect(provider.getCurrentDaemonSessionIds()).toEqual([])
+    expect(provider.hasPty('legacy-session')).toBe(true)
   })
 })

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -73,7 +73,7 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     if (mapped) {
       return mapped.hasPty?.(id) ?? true
     }
-    return this.allProviders().some((provider) => provider.hasPty?.(id) === true)
+    return this.findProviderForExistingSession(id) !== null
   }
 
   write(id: string, data: string): void {
@@ -157,7 +157,7 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
   }
 
   onReplay(callback: (payload: { id: string; data: string }) => void): () => void {
-    const unsubscribe = this.fallback.onReplay(callback)
+    const unsubscribes = this.allProviders().map((provider) => provider.onReplay(callback))
     let active = true
     const trackedUnsubscribe = (): void => {
       if (!active) {
@@ -168,7 +168,9 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
       if (idx !== -1) {
         this.unsubscribers.splice(idx, 1)
       }
-      unsubscribe()
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe()
+      }
     }
     this.unsubscribers.push(trackedUnsubscribe)
     return trackedUnsubscribe
@@ -229,13 +231,33 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     const ids = [...this.sessionProviders]
       .filter(([, provider]) => provider === this.fallback)
       .map(([id]) => id)
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       ids.map(async (id) => {
         await this.fallback.shutdown(id, { immediate: true })
         this.sessionProviders.delete(id)
       })
     )
+    const failedCount = results.filter((result) => result.status === 'rejected').length
+    if (failedCount > 0) {
+      throw new Error(`Failed to shut down ${failedCount} fallback PTY session(s)`)
+    }
     return ids.length
+  }
+
+  getCurrentDaemonSessionIds(): string[] {
+    return this.sessionIdsForProvider(this.current)
+  }
+
+  fanoutCurrentDaemonSyntheticExits(code: number): void {
+    for (const id of this.getCurrentDaemonSessionIds()) {
+      this.sessionProviders.delete(id)
+      // Why: sessions discovered from listProcesses may not exist in the
+      // adapter's active-session set, but restart still kills that daemon.
+      // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
+      for (const listener of [...this.exitListeners]) {
+        listener({ id, code })
+      }
+    }
   }
 
   async disconnectOnly(): Promise<void> {
@@ -256,7 +278,27 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
   }
 
   private providerFor(sessionId: string): ManagedPtyProvider {
-    return this.sessionProviders.get(sessionId) ?? this.fallback
+    return (
+      this.sessionProviders.get(sessionId) ??
+      this.findProviderForExistingSession(sessionId) ??
+      this.fallback
+    )
+  }
+
+  private findProviderForExistingSession(sessionId: string): ManagedPtyProvider | null {
+    for (const provider of this.allProviders()) {
+      if (provider.hasPty?.(sessionId) === true) {
+        this.sessionProviders.set(sessionId, provider)
+        return provider
+      }
+    }
+    return null
+  }
+
+  private sessionIdsForProvider(provider: ManagedPtyProvider): string[] {
+    return [...this.sessionProviders]
+      .filter(([, mappedProvider]) => mappedProvider === provider)
+      .map(([id]) => id)
   }
 
   private daemonAdapterFor(sessionId: string): DaemonPtyAdapter | null {

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -1,0 +1,276 @@
+import type { DaemonPtyAdapter } from './daemon-pty-adapter'
+import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+
+type ManagedPtyProvider = IPtyProvider & {
+  disconnectOnly?: () => Promise<void>
+  dispose?: () => void
+}
+
+export class DegradedDaemonPtyProvider implements IPtyProvider {
+  readonly routesFreshSpawnsToLocalProvider = true
+
+  private current: DaemonPtyAdapter
+  private legacy: DaemonPtyAdapter[]
+  private fallback: ManagedPtyProvider
+  private sessionProviders = new Map<string, ManagedPtyProvider>()
+  private unsubscribers: (() => void)[] = []
+  private dataListeners: ((payload: { id: string; data: string }) => void)[] = []
+  private exitListeners: ((payload: { id: string; code: number }) => void)[] = []
+
+  constructor(opts: {
+    current: DaemonPtyAdapter
+    legacy: DaemonPtyAdapter[]
+    fallback: ManagedPtyProvider
+  }) {
+    this.current = opts.current
+    this.legacy = opts.legacy
+    this.fallback = opts.fallback
+
+    for (const provider of this.allProviders()) {
+      this.unsubscribers.push(
+        provider.onData((payload) => {
+          for (const listener of this.dataListeners) {
+            listener(payload)
+          }
+        }),
+        provider.onExit((payload) => {
+          this.sessionProviders.delete(payload.id)
+          for (const listener of this.exitListeners) {
+            listener(payload)
+          }
+        })
+      )
+    }
+  }
+
+  async discoverDaemonSessions(): Promise<void> {
+    for (const adapter of this.allDaemonAdapters()) {
+      try {
+        const sessions = await adapter.listProcesses()
+        for (const session of sessions) {
+          this.sessionProviders.set(session.id, adapter)
+        }
+      } catch (error) {
+        console.warn('[daemon] Failed to discover degraded daemon sessions', error)
+      }
+    }
+  }
+
+  async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
+    const mapped = opts.sessionId ? this.sessionProviders.get(opts.sessionId) : undefined
+    const target = mapped ?? this.fallback
+    const result = await target.spawn(opts)
+    this.sessionProviders.set(result.id, target)
+    return result
+  }
+
+  async attach(id: string): Promise<void> {
+    await this.providerFor(id).attach(id)
+  }
+
+  hasPty(id: string): boolean {
+    const mapped = this.sessionProviders.get(id)
+    if (mapped) {
+      return mapped.hasPty?.(id) ?? true
+    }
+    return this.allProviders().some((provider) => provider.hasPty?.(id) === true)
+  }
+
+  write(id: string, data: string): void {
+    this.providerFor(id).write(id, data)
+  }
+
+  resize(id: string, cols: number, rows: number): void {
+    this.providerFor(id).resize(id, cols, rows)
+  }
+
+  async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
+    await this.providerFor(id).shutdown(id, opts)
+    if (!opts.keepHistory) {
+      this.sessionProviders.delete(id)
+    }
+  }
+
+  async sendSignal(id: string, signal: string): Promise<void> {
+    await this.providerFor(id).sendSignal(id, signal)
+  }
+
+  async getCwd(id: string): Promise<string> {
+    return this.providerFor(id).getCwd(id)
+  }
+
+  async getInitialCwd(id: string): Promise<string> {
+    return this.providerFor(id).getInitialCwd(id)
+  }
+
+  async getAppliedSize(id: string): Promise<{ cols: number; rows: number } | null> {
+    return (await this.providerFor(id).getAppliedSize?.(id)) ?? null
+  }
+
+  async clearBuffer(id: string): Promise<void> {
+    await this.providerFor(id).clearBuffer(id)
+  }
+
+  acknowledgeDataEvent(id: string, charCount: number): void {
+    this.providerFor(id).acknowledgeDataEvent(id, charCount)
+  }
+
+  async hasChildProcesses(id: string): Promise<boolean> {
+    return this.providerFor(id).hasChildProcesses(id)
+  }
+
+  async getForegroundProcess(id: string): Promise<string | null> {
+    return this.providerFor(id).getForegroundProcess(id)
+  }
+
+  async serialize(ids: string[]): Promise<string> {
+    return this.fallback.serialize(ids)
+  }
+
+  async revive(state: string): Promise<void> {
+    await this.fallback.revive(state)
+  }
+
+  async listProcesses(): Promise<{ id: string; cwd: string; title: string }[]> {
+    const results = await Promise.all(
+      this.allProviders().map((provider) => provider.listProcesses())
+    )
+    return results.flat()
+  }
+
+  async getDefaultShell(): Promise<string> {
+    return this.fallback.getDefaultShell()
+  }
+
+  async getProfiles(): Promise<{ name: string; path: string }[]> {
+    return this.fallback.getProfiles()
+  }
+
+  onData(callback: (payload: { id: string; data: string }) => void): () => void {
+    this.dataListeners.push(callback)
+    return () => {
+      const idx = this.dataListeners.indexOf(callback)
+      if (idx !== -1) {
+        this.dataListeners.splice(idx, 1)
+      }
+    }
+  }
+
+  onReplay(callback: (payload: { id: string; data: string }) => void): () => void {
+    const unsubscribe = this.fallback.onReplay(callback)
+    let active = true
+    const trackedUnsubscribe = (): void => {
+      if (!active) {
+        return
+      }
+      active = false
+      const idx = this.unsubscribers.indexOf(trackedUnsubscribe)
+      if (idx !== -1) {
+        this.unsubscribers.splice(idx, 1)
+      }
+      unsubscribe()
+    }
+    this.unsubscribers.push(trackedUnsubscribe)
+    return trackedUnsubscribe
+  }
+
+  onExit(callback: (payload: { id: string; code: number }) => void): () => void {
+    this.exitListeners.push(callback)
+    return () => {
+      const idx = this.exitListeners.indexOf(callback)
+      if (idx !== -1) {
+        this.exitListeners.splice(idx, 1)
+      }
+    }
+  }
+
+  ackColdRestore(sessionId: string): void {
+    this.daemonAdapterFor(sessionId)?.ackColdRestore(sessionId)
+  }
+
+  clearTombstone(sessionId: string): void {
+    this.daemonAdapterFor(sessionId)?.clearTombstone(sessionId)
+  }
+
+  async reconcileOnStartup(validWorktreeIds: Set<string>): Promise<{
+    alive: string[]
+    killed: string[]
+  }> {
+    const alive: string[] = []
+    const killed: string[] = []
+    for (const adapter of this.allDaemonAdapters()) {
+      const result = await adapter.reconcileOnStartup(validWorktreeIds)
+      for (const id of result.alive) {
+        alive.push(id)
+        this.sessionProviders.set(id, adapter)
+      }
+      for (const id of result.killed) {
+        killed.push(id)
+        this.sessionProviders.delete(id)
+      }
+    }
+    return { alive, killed }
+  }
+
+  dispose(): void {
+    this.disposeProviderOnly()
+    for (const adapter of this.allDaemonAdapters()) {
+      adapter.dispose()
+    }
+  }
+
+  disposeProviderOnly(): void {
+    for (const unsubscribe of this.unsubscribers.splice(0)) {
+      unsubscribe()
+    }
+  }
+
+  async shutdownFallbackSessions(): Promise<number> {
+    const ids = [...this.sessionProviders]
+      .filter(([, provider]) => provider === this.fallback)
+      .map(([id]) => id)
+    await Promise.allSettled(
+      ids.map(async (id) => {
+        await this.fallback.shutdown(id, { immediate: true })
+        this.sessionProviders.delete(id)
+      })
+    )
+    return ids.length
+  }
+
+  async disconnectOnly(): Promise<void> {
+    this.disposeProviderOnly()
+    await Promise.all(this.allDaemonAdapters().map((adapter) => adapter.disconnectOnly()))
+  }
+
+  getCurrentAdapter(): DaemonPtyAdapter {
+    return this.current
+  }
+
+  getLegacyAdapters(): readonly DaemonPtyAdapter[] {
+    return this.legacy
+  }
+
+  getAllAdapters(): readonly DaemonPtyAdapter[] {
+    return this.allDaemonAdapters()
+  }
+
+  private providerFor(sessionId: string): ManagedPtyProvider {
+    return this.sessionProviders.get(sessionId) ?? this.fallback
+  }
+
+  private daemonAdapterFor(sessionId: string): DaemonPtyAdapter | null {
+    const provider = this.sessionProviders.get(sessionId)
+    return provider && this.allDaemonAdapters().includes(provider as DaemonPtyAdapter)
+      ? (provider as DaemonPtyAdapter)
+      : null
+  }
+
+  private allProviders(): ManagedPtyProvider[] {
+    return [this.fallback, ...this.allDaemonAdapters()]
+  }
+
+  private allDaemonAdapters(): DaemonPtyAdapter[] {
+    return [this.current, ...this.legacy]
+  }
+}

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -73,6 +73,7 @@ const POWERSHELL_OSC133_COMMAND_ARGS = ['-NoLogo', '-NoExit', '-EncodedCommand',
 const ZSH_SHELL_READY_DIR = /shell-ready[\\/]zsh/
 const POWERLEVEL10K_WIZARD_DISABLE_ENV = 'POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD'
 const itOnMacHost = process.platform === 'darwin' ? it : it.skip
+const itOnPosixHost = process.platform === 'win32' ? it.skip : it
 
 function mockPtyProcess(pid = 12345) {
   const onDataListeners: ((data: string) => void)[] = []
@@ -205,6 +206,41 @@ describe('createPtySubprocess', () => {
     const originalCwd = process.cwd()
     const deletedDaemonCwd = mkdtempSync(join(tmpdir(), 'orca-deleted-daemon-cwd-'))
     Object.defineProperty(process, 'platform', { value: 'darwin' })
+
+    try {
+      process.chdir(deletedDaemonCwd)
+      rmSync(deletedDaemonCwd, { recursive: true, force: true })
+
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: originalCwd,
+        env: { SHELL: '/bin/bash' }
+      })
+
+      expect(process.cwd()).toBe(realpathSync(userDataPath))
+    } finally {
+      process.chdir(originalCwd)
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/bash',
+      expect.any(Array),
+      expect.objectContaining({ cwd: originalCwd })
+    )
+  })
+
+  itOnPosixHost('repairs a deleted POSIX daemon cwd before Linux node-pty spawn', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    const originalCwd = process.cwd()
+    const deletedDaemonCwd = mkdtempSync(join(tmpdir(), 'orca-deleted-daemon-cwd-'))
+    Object.defineProperty(process, 'platform', { value: 'linux' })
 
     try {
       process.chdir(deletedDaemonCwd)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -309,12 +309,19 @@ function formatPtySpawnError(err: unknown, shellPath: string, spawnCwd: string):
  * Runs a short native PTY spawn probe for daemon health checks.
  */
 export async function checkPtySpawnHealth(): Promise<void> {
-  if (process.platform !== 'darwin') {
+  if (process.platform === 'win32') {
     return
   }
 
-  ensureNodePtySpawnHelperExecutable()
-  preflightMacNodePtySpawnEnvironment()
+  // Why: Linux/macOS daemons can outlive an app update with a deleted cwd or
+  // stale native PTY path. A real short-lived spawn catches that before the
+  // main process routes fresh panes to a daemon that cannot create terminals.
+  if (process.platform === 'darwin') {
+    ensureNodePtySpawnHelperExecutable()
+    preflightMacNodePtySpawnEnvironment()
+  } else {
+    preflightDaemonCwd()
+  }
 
   const cwd = isExistingDirectory(process.env.ORCA_USER_DATA_PATH)
     ? process.env.ORCA_USER_DATA_PATH

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -244,8 +244,6 @@ function preflightMacNodePtySpawnEnvironment(): void {
     return
   }
 
-  preflightDaemonCwd()
-
   let candidates: string[]
   try {
     candidates = getNodePtySpawnHelperCandidates()
@@ -264,6 +262,20 @@ function preflightMacNodePtySpawnEnvironment(): void {
   }
 
   throw formatMissingDaemonPathError('helper', candidates[0] ?? '<unresolved>')
+}
+
+/**
+ * Ensures POSIX daemon-owned native PTY spawn prerequisites are still valid.
+ */
+function preflightUnixPtySpawnEnvironment(): void {
+  if (process.platform === 'win32') {
+    return
+  }
+
+  // Why: detached daemons can outlive their launch cwd; repair before every
+  // PTY spawn so Linux/macOS do not wait for startup health recovery.
+  preflightDaemonCwd()
+  preflightMacNodePtySpawnEnvironment()
 }
 
 /**
@@ -318,10 +330,8 @@ export async function checkPtySpawnHealth(): Promise<void> {
   // main process routes fresh panes to a daemon that cannot create terminals.
   if (process.platform === 'darwin') {
     ensureNodePtySpawnHelperExecutable()
-    preflightMacNodePtySpawnEnvironment()
-  } else {
-    preflightDaemonCwd()
   }
+  preflightUnixPtySpawnEnvironment()
 
   const cwd = isExistingDirectory(process.env.ORCA_USER_DATA_PATH)
     ? process.env.ORCA_USER_DATA_PATH
@@ -715,7 +725,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   // binary. The main process fixes this via LocalPtyProvider, but the daemon
   // runs in a separate forked process with its own code path.
   ensureNodePtySpawnHelperExecutable()
-  preflightMacNodePtySpawnEnvironment()
+  preflightUnixPtySpawnEnvironment()
   preflightWindowsPtySpawnEnvironment({
     validationCwd,
     cwdWasExplicit: opts.cwd !== undefined

--- a/src/main/ipc/pty-management.ts
+++ b/src/main/ipc/pty-management.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron'
 import { DaemonPtyRouter } from '../daemon/daemon-pty-router'
+import { DegradedDaemonPtyProvider } from '../daemon/degraded-daemon-pty-provider'
 import type { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
 import { getDaemonProvider, restartDaemon } from '../daemon/daemon-init'
 import type { DaemonSessionInfo } from '../daemon/types'
@@ -25,7 +26,7 @@ function getDaemonAdapters(): DaemonPtyAdapter[] {
   if (!provider) {
     return []
   }
-  if (provider instanceof DaemonPtyRouter) {
+  if (provider instanceof DaemonPtyRouter || provider instanceof DegradedDaemonPtyProvider) {
     return [...provider.getAllAdapters()]
   }
   return [provider]

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -100,6 +100,9 @@ import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtim
 // SSH providers will be registered here in Phase 1.
 
 let localProvider: IPtyProvider = new LocalPtyProvider()
+type FreshLocalFallbackProvider = IPtyProvider & {
+  routesFreshSpawnsToLocalProvider?: true
+}
 const sshProviders = new Map<string, IPtyProvider>()
 // Why: PTY IDs are assigned at spawn time with a connectionId, but subsequent
 // write/resize/kill calls only carry the PTY ID. This map lets us route
@@ -919,6 +922,12 @@ function isClaudeLaunchCommand(command: string | undefined): boolean {
   return /(^|[\s;&|('"`])(?:[^\s;&|('"`]*[\\/])?claude(?:\.cmd|\.exe)?($|[\s;&|)'"`])/i.test(
     command
   )
+}
+
+function routesFreshSpawnsToLocalProvider(
+  provider: IPtyProvider
+): provider is FreshLocalFallbackProvider {
+  return (provider as FreshLocalFallbackProvider).routesFreshSpawnsToLocalProvider === true
 }
 
 /** Register an SSH PTY provider for a connection. */
@@ -1786,7 +1795,10 @@ export function registerPtyHandlers(
         )
       }
 
-      const isDaemonHostSpawn = !args.connectionId && !(provider instanceof LocalPtyProvider)
+      const isDaemonHostSpawn =
+        !args.connectionId &&
+        !(provider instanceof LocalPtyProvider) &&
+        !routesFreshSpawnsToLocalProvider(provider)
       const requestedSessionId = args.sessionId?.trim()
       const sessionId =
         requestedSessionId ?? (isDaemonHostSpawn ? mintPtySessionId(args.worktreeId) : undefined)
@@ -2341,7 +2353,10 @@ export function registerPtyHandlers(
       // local filesystem (OpenCode plugin dir, Pi/OMP extension paths, Codex
       // home, dev CLI bin, attribution shim dir) that would resolve to
       // nothing — or something misleading — on the remote machine.
-      const isDaemonHostSpawn = !args.connectionId && !(provider instanceof LocalPtyProvider)
+      const isDaemonHostSpawn =
+        !args.connectionId &&
+        !(provider instanceof LocalPtyProvider) &&
+        !routesFreshSpawnsToLocalProvider(provider)
       // Why: daemon host-env setup needs a stable id BEFORE provider.spawn so
       // provider hooks and legacy Pi overlay cleanup can run in buildPtyHostEnv.
       // DaemonPtyAdapter.doSpawn mints an id the same way when sessionId is
@@ -2414,10 +2429,13 @@ export function registerPtyHandlers(
           launchConfig: args.launchConfig
         })
       let effectiveLaunchConfig = args.launchConfig
-      const preAllocatedHandle =
-        runtime && (!(provider instanceof LocalPtyProvider) || shouldRefreshAgentTeamsEnv)
-          ? runtime.createPreAllocatedTerminalHandle()
-          : null
+      const shouldPreAllocateTerminalHandle =
+        runtime !== undefined &&
+        ((!(provider instanceof LocalPtyProvider) && !routesFreshSpawnsToLocalProvider(provider)) ||
+          shouldRefreshAgentTeamsEnv)
+      const preAllocatedHandle = shouldPreAllocateTerminalHandle
+        ? runtime.createPreAllocatedTerminalHandle()
+        : null
       if (shouldRefreshAgentTeamsEnv && preAllocatedHandle) {
         // Why: native Agent Teams team ids/tokens are process-local. A sleeping
         // record preserves the user's native launch shape, but the team env

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -19,6 +19,7 @@
 
 import { getDaemonProvider } from '../daemon/daemon-init'
 import { DaemonPtyRouter } from '../daemon/daemon-pty-router'
+import { DegradedDaemonPtyProvider } from '../daemon/degraded-daemon-pty-provider'
 import type { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
 import type { SessionInfo } from '../daemon/types'
 import { listRegisteredPtys, registerPty } from './pty-registry'
@@ -140,13 +141,15 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
 }
 
 async function collectSessionInfos(
-  provider: DaemonPtyRouter | DaemonPtyAdapter
+  provider: DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProvider
 ): Promise<SessionInfo[]> {
   // Why: the router fans `listSessions` out across current + legacy adapters
   // so we get every protocol-version daemon's sessions; the bare-adapter
   // fallback is only the in-process restart edge case.
   const adapters: readonly DaemonPtyAdapter[] =
-    provider instanceof DaemonPtyRouter ? provider.getAllAdapters() : [provider]
+    provider instanceof DaemonPtyRouter || provider instanceof DegradedDaemonPtyProvider
+      ? provider.getAllAdapters()
+      : [provider]
   const out: SessionInfo[] = []
   for (const adapter of adapters) {
     try {


### PR DESCRIPTION
## Summary
- Add a daemon health result that distinguishes a slow/unreachable daemon from a daemon that answers protocol requests but fails a real PTY-spawn health probe.
- Prevent one known degraded state by repairing the detached daemon's POSIX cwd before every Linux/macOS daemon PTY spawn, not only during startup health checks.
- Extend the daemon PTY-spawn health probe to Linux/macOS so stale cwd/native PTY issues after an upgrade are caught before fresh panes are routed to that daemon.
- Add a degraded daemon provider: discovered live daemon sessions stay routed to the preserved daemon, while fresh terminals fall back to the local PTY provider instead of opening blank/no-cursor panes.
- Tighten degraded-wrapper lifecycle after review: cache providers discovered by `hasPty`, forward replay from daemon-backed sessions, fail provider swap if fallback shutdown fails, and synthesize exits for preserved current-daemon sessions during restart.
- Keep session management and boot-time memory hydration aware of the degraded wrapper.

## Issue / Repro / Scope
Related to #6814. This PR addresses a daemon-spawn failure mode that matches the reported Linux symptoms: after an upgrade, existing terminals can remain owned by an old daemon while new terminals open frozen/blank with no cursor.

What is now prevented:
- Detached POSIX daemons can outlive the cwd they were launched from, especially in dev/update/worktree replacement flows.
- Before this follow-up, Linux only repaired that cwd during the startup health probe. The actual `createPtySubprocess` path could still try to spawn from a deleted daemon cwd later.
- Now every Linux/macOS daemon PTY spawn runs the cwd repair before calling node-pty.

What is still a fallback:
- If a preserved daemon can still answer protocol requests and still owns live sessions, but it cannot spawn PTYs due to another native failure such as stale helper/app bits, Orca should not kill the user's existing sessions just to get a fresh daemon.
- In that case, the PR marks the daemon as degraded: known old sessions continue through the daemon, and new terminals use the local PTY provider until the daemon is restarted.

Deterministic repro added in unit coverage:
- `pty-subprocess.test.ts` simulates a Linux daemon whose process cwd was deleted, then verifies `createPtySubprocess` repairs to `ORCA_USER_DATA_PATH` before spawning.
- `daemon-init.test.ts` simulates startup where daemon health returns `pty-spawn-unhealthy` while `listSessions` proves the daemon still owns a live session.
- `daemon-init.test.ts` also verifies restart fans synthetic exits for preserved degraded current-daemon sessions before listener unbind/daemon cleanup.
- Before this change, a preserved degraded daemon was installed as the normal local provider, so fresh terminals were sent back to the daemon that had already proven it could not create PTYs.
- After this change, startup installs `DegradedDaemonPtyProvider`; known old session ids still route to the preserved daemon, and fresh spawns route to the local fallback.
- `degraded-daemon-pty-provider.test.ts` verifies routing, exit cleanup, replay forwarding, provider-swap cleanup, fallback shutdown failure handling, and that fresh PTYs do not use the degraded daemon.

Is #6814 fully resolved? This PR resolves the concrete daemon-spawn degradation path we can reproduce from the symptoms. If users still see "existing pane accepts no input and new pane has no cursor" after this, while daemon PTY-spawn health is healthy, then #6814 has a deeper second cause in the renderer -> IPC -> daemon -> PTY input path and should get a follow-up PR with instrumentation around that path.

## Tradeoffs / User Impact
ELI5: Orca has a background terminal builder. If the builder's workshop folder disappeared, Orca now updates the builder's folder before asking it to build a terminal. If the old builder is still alive but still cannot build new terminals, Orca leaves the old terminals alone and asks the normal local builder to make new ones.

Tradeoffs:
- Existing daemon sessions are preserved instead of force-killed. If an existing PTY process is itself truly wedged, this does not revive that specific terminal; the user may still need Restart daemon / kill session for that pane.
- Fresh terminals opened during degraded mode use the local in-process PTY provider. Those fallback terminals do not get daemon persistence/cold-restore until the daemon is restarted.
- Restart daemon now explicitly shuts down local fallback sessions before swapping providers so they do not become orphaned, and it fails loudly if a fallback PTY cannot be shut down.
- Linux/macOS startup health now performs one short `/bin/sh -c exit 0` PTY probe. This adds a tiny startup health-check cost, but only to avoid routing users into a daemon that cannot create terminals. Windows behavior is unchanged.
- The prevention layer covers deleted daemon cwd drift. Other native spawn failures are detected and contained rather than preemptively fixed because replacing a live daemon would destroy user sessions.

## Review Follow-Up
Addressed review feedback on the degraded wrapper:
- Preserved current-daemon sessions discovered via `listProcesses()` now receive synthetic exits during Restart daemon.
- `hasPty()` now caches the provider it discovers so later `write`/`resize`/`shutdown` calls do not fall back to the wrong provider.
- Replay output is forwarded from daemon-backed sessions, not just local fallback sessions.
- Failed fallback shutdowns now abort the provider swap instead of being reported as successfully killed.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/degraded-daemon-pty-provider.test.ts src/main/daemon/daemon-init.test.ts` (2 files / 40 tests)
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-health.test.ts src/main/daemon/degraded-daemon-pty-provider.test.ts src/main/daemon/daemon-init.test.ts src/main/daemon/pty-subprocess.test.ts src/main/ipc/pty-management.test.ts src/main/memory/hydrate-local-pty-registry.test.ts src/main/ipc/pty.test.ts` (7 files / 344 tests)
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/daemon/daemon-health.test.ts src/main/daemon/daemon-health.ts src/main/daemon/daemon-init.test.ts src/main/daemon/daemon-init.ts src/main/daemon/daemon-spawner.ts src/main/daemon/degraded-daemon-pty-provider.test.ts src/main/daemon/degraded-daemon-pty-provider.ts src/main/daemon/pty-subprocess.ts src/main/daemon/pty-subprocess.test.ts src/main/ipc/pty-management.ts src/main/ipc/pty.ts src/main/memory/hydrate-local-pty-registry.ts`
- `git diff --check`
- Pre-commit ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` on staged files.

## Benchmarks
No dedicated performance benchmark was run. The intentional runtime cost is limited to a short Linux/macOS daemon startup health PTY probe plus a lightweight cwd check before POSIX daemon spawns; this path is not a terminal throughput/rendering hot path.