### PR TITLE
Fix startup routing test for diagnostic wrappers

### DIFF
--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -6,16 +6,15 @@ describe('renderer startup runtime routing', () => {
   it('loads settings before repo and worktree hydration', () => {
     const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
     const startupBlockStart = source.indexOf('void (async () => {')
-    const startupBlockEnd = source.indexOf('const persistedUI = await window.api.ui.get()')
+    const startupBlockEnd = source.indexOf(
+      "const persistedUI = await timeRendererStartupStep('ui-get'"
+    )
     const startupBlock = source.slice(startupBlockStart, startupBlockEnd)
 
-    expect(startupBlock.indexOf('await actions.fetchSettings()')).toBeGreaterThanOrEqual(0)
-    expect(startupBlock.indexOf('await actions.fetchSettings()')).toBeLessThan(
-      startupBlock.indexOf('await actions.fetchReposForAllHosts()')
-    )
-    expect(startupBlock.indexOf('await actions.fetchSettings()')).toBeLessThan(
-      startupBlock.indexOf('await actions.fetchAllWorktrees()')
-    )
+    const settingsIndex = startupBlock.indexOf('actions.fetchSettings()')
+    expect(settingsIndex).toBeGreaterThanOrEqual(0)
+    expect(settingsIndex).toBeLessThan(startupBlock.indexOf('actions.fetchReposForAllHosts()'))
+    expect(settingsIndex).toBeLessThan(startupBlock.indexOf('actions.fetchAllWorktrees()'))
   })
 
   it('waits for first-window startup services before terminal reconnect', () => {


### PR DESCRIPTION
## Summary
- update the source-order startup routing test to recognize the diagnostic wrapper shape added by #6836
- keep the same invariant: settings must load before repo/worktree hydration

## Why
#6836 merged the runtime behavior correctly, but this source-string test still looked for the old literal `await actions.fetchSettings()` call. The test should guard ordering, not the exact instrumentation wrapper shape.

## Startup follow-up evaluation
I reran the merged startup benchmark and did not find another zero-regression-worthy optimization target.

Empty/cache-shaped profile, 5 iterations, waiting for `renderer-startup-hydration-done`:
- `totalToWorkspaceReady`: 824.1ms median
- `totalToDidFinishLoad`: 706.4ms median
- `rendererReconnectTerminalsMs`: 3ms median
- `startupJsonParseMs`: 0ms; `startupStoreLoadMs`: 3ms

500 restored local terminal tabs, 5 iterations:
- `rendererReconnectTerminalsMs`: 22ms median, so #6836 held
- `startupJsonParseMs`: 1ms; `startupStoreLoadMs`: 6ms
- remaining renderer startup work is now a spread of small serial IPC/store fetches, not one obvious waste source

I’m not proposing a second perf change right now because the plausible next step would be overlapping startup fetches, and that has real ordering/remote-runtime risk for only small tens-of-ms upside.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/app-startup-routing.test.ts src/renderer/src/store/slices/terminals-hydration.test.ts`
- `git diff --check`
