### PR TITLE
Add keyboard shortcut to close all editor tabs in a split group

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 import { useShallow } from 'zustand/react/shallow'
 import {
   BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,
+  CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT,
   TOGGLE_TERMINAL_PANE_EXPAND_EVENT,
   type BackgroundMountTerminalWorktreeDetail
 } from '@/constants/terminal'
@@ -1469,6 +1470,30 @@ function Terminal(): React.JSX.Element | null {
         notifyTerminalCapture('tab.closeAll')
         handleCloseAllFiles()
         return
+      }
+
+      // Cmd/Ctrl+Alt+Shift+W - close every editor tab in the focused split group only.
+      // Why: dispatch to the per-group hook, which owns pinned/dirty-safe close
+      // behavior, via the focused groupId instead of duplicating close logic here.
+      if (!e.repeat && matchShortcut('tab.closeAllInGroup')) {
+        const state = useAppStore.getState()
+        const worktreeId = state.activeWorktreeId
+        // Why: activeGroupIdByWorktree can be undefined after cold restore before
+        // first pane focus; the first group is the established fallback target.
+        const focusedGroupId = worktreeId
+          ? (state.activeGroupIdByWorktree[worktreeId] ??
+            state.groupsByWorktree[worktreeId]?.[0]?.id)
+          : undefined
+        if (focusedGroupId) {
+          e.preventDefault()
+          notifyTerminalCapture('tab.closeAllInGroup')
+          window.dispatchEvent(
+            new CustomEvent(CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT, {
+              detail: { groupId: focusedGroupId }
+            })
+          )
+          return
+        }
       }
 
       // Ctrl+Tab - quick-toggle to the previously focused tab in this group.

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -12,6 +12,7 @@ import { useRepoById, useWorktreeById } from '@/store/selectors'
 import { useAppStore } from '@/store'
 import { STATUS_COLORS, STATUS_LABELS } from '../right-sidebar/status-display'
 import type { GitFileStatus } from '../../../../shared/types'
+import type { KeybindingActionId } from '../../../../shared/keybindings'
 import type { OpenFile } from '../../store/slices/editor'
 import { getUntitledFileRoot } from '@/components/editor/untitled-file-rename-path'
 import { preventMiddleButtonDefault } from './middle-button-default-guard'
@@ -40,6 +41,7 @@ export default function EditorFileTab({
   onClose,
   onCloseToRight,
   onCloseAll,
+  closeAllShortcutActionId,
   onMakePermanent,
   onTogglePin,
   dragData,
@@ -55,6 +57,7 @@ export default function EditorFileTab({
   onClose: () => void
   onCloseToRight: () => void
   onCloseAll: () => void
+  closeAllShortcutActionId?: KeybindingActionId
   onMakePermanent?: () => void
   onTogglePin: () => void
   dragData: TabDragItemData
@@ -396,6 +399,7 @@ export default function EditorFileTab({
         onTogglePin={onTogglePin}
         onClose={onClose}
         onCloseAll={onCloseAll}
+        closeAllShortcutActionId={closeAllShortcutActionId}
         onCloseToRight={onCloseToRight}
         onOpenMarkdownPreview={openMarkdownPreview}
       />

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KeybindingActionId } from '../../../../shared/keybindings'
 
 const shortcutLabelMock = vi.hoisted(() => vi.fn())
 
@@ -172,7 +173,9 @@ function extractText(node: unknown): string {
   return el.props && 'children' in el.props ? extractText(el.props.children) : ''
 }
 
-async function renderMenu(): Promise<unknown> {
+async function renderMenu({
+  closeAllShortcutActionId
+}: { closeAllShortcutActionId?: KeybindingActionId } = {}): Promise<unknown> {
   const module = await import('./EditorFileTabContextMenu')
   return module.EditorFileTabContextMenu({
     open: true,
@@ -203,6 +206,7 @@ async function renderMenu(): Promise<unknown> {
     onTogglePin: vi.fn(),
     onClose: vi.fn(),
     onCloseAll: vi.fn(),
+    closeAllShortcutActionId,
     onCloseToRight: vi.fn(),
     onOpenMarkdownPreview: vi.fn()
   })
@@ -216,6 +220,8 @@ function assignedShortcutLabel(actionId: string): string | null {
       return '⌘W'
     case 'tab.closeAll':
       return '⌘⌥W'
+    case 'tab.closeAllInGroup':
+      return '⌘⌥⇧W'
     default:
       return null
   }
@@ -273,5 +279,18 @@ describe('EditorFileTabContextMenu close-all shortcut', () => {
     expect(closeAllItem).toBeTruthy()
     expect(findElementsByType(closeAllItem, 'DropdownMenuShortcut')).toHaveLength(0)
     expect(findElementsByType(tree, 'DropdownMenuShortcut')).toHaveLength(0)
+  })
+
+  it('renders the group close-all shortcut chip when requested', async () => {
+    const tree = expandNode(await renderMenu({ closeAllShortcutActionId: 'tab.closeAllInGroup' }))
+
+    const closeAllItem = findElementsByType(tree, 'DropdownMenuItem').find((item) =>
+      extractText(item.props.children).includes('Close All Editor Tabs')
+    )
+
+    expect(closeAllItem).toBeTruthy()
+    const shortcut = findElementsByType(closeAllItem, 'DropdownMenuShortcut')
+    expect(shortcut).toHaveLength(1)
+    expect(extractText(shortcut[0].props.children)).toBe('⌘⌥⇧W')
   })
 })

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from '@/store'
 import { showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import type { OpenFile } from '../../store/slices/editor'
+import type { KeybindingActionId } from '../../../../shared/keybindings'
 import { shouldBlockEditorTabLocalOpen } from './editor-tab-local-open-guard'
 import { translate } from '@/i18n/i18n'
 import { TabWorkspaceLayoutMenuSection } from './TabWorkspaceLayoutMenuSection'
@@ -45,6 +46,7 @@ type EditorFileTabContextMenuProps = {
   onTogglePin: () => void
   onClose: () => void
   onCloseAll: () => void
+  closeAllShortcutActionId?: KeybindingActionId
   onCloseToRight: () => void
   onOpenMarkdownPreview: (
     file: {
@@ -78,12 +80,13 @@ export function EditorFileTabContextMenu({
   onTogglePin,
   onClose,
   onCloseAll,
+  closeAllShortcutActionId = 'tab.closeAll',
   onCloseToRight,
   onOpenMarkdownPreview
 }: EditorFileTabContextMenuProps): React.JSX.Element {
   const renameShortcut = useOptionalShortcutLabel('tab.rename')
   const closeShortcut = useOptionalShortcutLabel('tab.close')
-  const closeAllShortcut = useOptionalShortcutLabel('tab.closeAll')
+  const closeAllShortcut = useOptionalShortcutLabel(closeAllShortcutActionId)
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -23,6 +23,7 @@ import type {
   TuiAgent,
   WorkspaceVisibleTabType
 } from '../../../../shared/types'
+import type { KeybindingActionId } from '../../../../shared/keybindings'
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
 import { resolveTerminalTabTitle } from '../../../../shared/tab-title-resolution'
 import { useAppStore } from '../../store'
@@ -138,6 +139,7 @@ type TabBarProps = {
   onCloseBrowserTab?: (tabId: string) => void
   onDuplicateBrowserTab?: (tabId: string) => void
   onCloseAllFiles?: () => void
+  closeAllShortcutActionId?: KeybindingActionId
   onMakePreviewFilePermanent?: (fileId: string, tabId?: string) => void
   onPinFile?: (fileId: string, tabId?: string) => void
   tabBarOrder?: string[]
@@ -263,6 +265,7 @@ function TabBarInner({
   onCloseBrowserTab,
   onDuplicateBrowserTab,
   onCloseAllFiles,
+  closeAllShortcutActionId = 'tab.closeAll',
   onMakePreviewFilePermanent,
   onPinFile,
   tabBarOrder,
@@ -1199,6 +1202,7 @@ function TabBarInner({
                     onClose={() => onCloseFile?.(item.id)}
                     onCloseToRight={() => onCloseToRight(item.id)}
                     onCloseAll={() => onCloseAllFiles?.()}
+                    closeAllShortcutActionId={closeAllShortcutActionId}
                     onMakePermanent={() => {}}
                     onTogglePin={() => togglePinned(item)}
                     dragData={dragData}
@@ -1222,6 +1226,7 @@ function TabBarInner({
                   onClose={() => onCloseFile?.(item.id)}
                   onCloseToRight={() => onCloseToRight(item.id)}
                   onCloseAll={() => onCloseAllFiles?.()}
+                  closeAllShortcutActionId={closeAllShortcutActionId}
                   onMakePermanent={() =>
                     onMakePreviewFilePermanent?.(item.data.id, item.data.tabId)
                   }

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -152,6 +152,7 @@ export default function TabGroupPanel({
       }}
       onDuplicateBrowserTab={commands.duplicateBrowserTab}
       onCloseAllFiles={commands.closeAllEditorTabsInGroup}
+      closeAllShortcutActionId={hasSplitGroups ? 'tab.closeAllInGroup' : 'tab.closeAll'}
       onMakePreviewFilePermanent={(_fileId, tabId) => {
         if (!tabId) {
           return

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
+import {
+  CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT,
+  TOGGLE_TERMINAL_PANE_EXPAND_EVENT
+} from '@/constants/terminal'
 
 const mocks = vi.hoisted(() => ({
   activateTab: vi.fn(),
@@ -32,6 +35,9 @@ const mocks = vi.hoisted(() => ({
   setTabCustomTitle: vi.fn()
 }))
 
+const effectCleanups = vi.hoisted(() => [] as (() => void)[])
+const windowListeners = vi.hoisted(() => new Map<string, Set<(event: Event) => void>>())
+
 const storeBox = vi.hoisted(() => ({
   state: null as Record<string, unknown> | null
 }))
@@ -41,6 +47,12 @@ vi.mock('react', async () => {
   return {
     ...actual,
     useCallback: <T>(callback: T) => callback,
+    useEffect: (effect: () => void | (() => void)) => {
+      const cleanup = effect()
+      if (typeof cleanup === 'function') {
+        effectCleanups.push(cleanup)
+      }
+    },
     useMemo: <T>(factory: () => T) => factory()
   }
 })
@@ -168,12 +180,30 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
       callback(0)
       return 1
     })
+    windowListeners.clear()
+    mocks.dispatchEvent.mockImplementation((event: Event) => {
+      for (const listener of windowListeners.get(event.type) ?? []) {
+        listener(event)
+      }
+      return true
+    })
     vi.stubGlobal('window', {
-      dispatchEvent: mocks.dispatchEvent
+      addEventListener: vi.fn((type: string, listener: (event: Event) => void) => {
+        const listeners = windowListeners.get(type) ?? new Set<(event: Event) => void>()
+        listeners.add(listener)
+        windowListeners.set(type, listeners)
+      }),
+      dispatchEvent: mocks.dispatchEvent,
+      removeEventListener: vi.fn((type: string, listener: (event: Event) => void) => {
+        windowListeners.get(type)?.delete(listener)
+      })
     })
   })
 
   afterEach(() => {
+    while (effectCleanups.length > 0) {
+      effectCleanups.pop()?.()
+    }
     vi.unstubAllGlobals()
   })
 
@@ -423,5 +453,125 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
       expect.objectContaining({ worktreeId: 'wt-1', tabId: 'browser-unified-1' })
     )
     expect(mocks.closeUnifiedTab).toHaveBeenCalledWith('browser-unified-1')
+  })
+
+  it('closes all editor tabs only for the matching group event', async () => {
+    storeBox.state = {
+      ...storeBox.state,
+      groupsByWorktree: {
+        'wt-1': [
+          {
+            id: 'group-1',
+            worktreeId: 'wt-1',
+            activeTabId: 'editor-unified-1',
+            tabOrder: ['editor-unified-1']
+          }
+        ]
+      },
+      openFiles: [
+        {
+          id: 'file-1',
+          filePath: '/repo/foo.ts',
+          relativePath: 'foo.ts',
+          worktreeId: 'wt-1',
+          language: 'typescript',
+          isDirty: false,
+          mode: 'edit'
+        }
+      ],
+      tabsByWorktree: { 'wt-1': [] },
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'editor-unified-1',
+            entityId: 'file-1',
+            groupId: 'group-1',
+            worktreeId: 'wt-1',
+            contentType: 'editor',
+            label: 'foo.ts',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    }
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    window.dispatchEvent(
+      new CustomEvent(CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT, {
+        detail: { groupId: 'group-2' }
+      })
+    )
+
+    expect(mocks.closeUnifiedTab).not.toHaveBeenCalled()
+
+    window.dispatchEvent(
+      new CustomEvent(CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT, {
+        detail: { groupId: 'group-1' }
+      })
+    )
+
+    expect(mocks.closeFile).toHaveBeenCalledWith('file-1')
+    expect(mocks.closeUnifiedTab).toHaveBeenCalledWith('editor-unified-1')
+  })
+
+  it('removes the close-all-in-group event listener on unmount', async () => {
+    storeBox.state = {
+      ...storeBox.state,
+      groupsByWorktree: {
+        'wt-1': [
+          {
+            id: 'group-1',
+            worktreeId: 'wt-1',
+            activeTabId: 'editor-unified-1',
+            tabOrder: ['editor-unified-1']
+          }
+        ]
+      },
+      openFiles: [
+        {
+          id: 'file-1',
+          filePath: '/repo/foo.ts',
+          relativePath: 'foo.ts',
+          worktreeId: 'wt-1',
+          language: 'typescript',
+          isDirty: false,
+          mode: 'edit'
+        }
+      ],
+      tabsByWorktree: { 'wt-1': [] },
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'editor-unified-1',
+            entityId: 'file-1',
+            groupId: 'group-1',
+            worktreeId: 'wt-1',
+            contentType: 'editor',
+            label: 'foo.ts',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    }
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    while (effectCleanups.length > 0) {
+      effectCleanups.pop()?.()
+    }
+    window.dispatchEvent(
+      new CustomEvent(CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT, {
+        detail: { groupId: 'group-1' }
+      })
+    )
+
+    expect(mocks.closeUnifiedTab).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the split-group workspace model intentionally keeps
    group-scoped activation, close, split, and tab-order rules together so the extracted
    controller cannot drift from the TabGroupPanel surface it coordinates. */
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { OpenFile } from '@/store/slices/editor'
 import type {
@@ -15,7 +15,10 @@ import { useAppStore } from '../../store'
 import { destroyWorkspaceWebviews } from '../../store/slices/browser-webview-cleanup'
 import { requestEditorFileClose } from '../editor/editor-autosave'
 import { focusTerminalTabSurface } from '../../lib/focus-terminal-tab-surface'
-import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
+import {
+  CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT,
+  TOGGLE_TERMINAL_PANE_EXPAND_EVENT
+} from '@/constants/terminal'
 import {
   activateWebRuntimeSessionTab,
   closeWebRuntimeSessionTab,
@@ -520,6 +523,19 @@ export function useTabGroupWorkspaceModel({
       }
     }
   }, [closeItem, groupTabs])
+
+  useEffect(() => {
+    const handler = (event: Event): void => {
+      const detail = (event as CustomEvent<{ groupId?: string }>).detail
+      // Why: every mounted group listens to this global event; only the
+      // focused target group should run its dirty/pinned-safe close command.
+      if (detail?.groupId === groupId) {
+        closeAllEditorTabsInGroup()
+      }
+    }
+    window.addEventListener(CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT, handler)
+    return () => window.removeEventListener(CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT, handler)
+  }, [closeAllEditorTabsInGroup, groupId])
 
   const closeOthers = useCallback(
     (itemId: string) => {

--- a/src/renderer/src/constants/terminal.ts
+++ b/src/renderer/src/constants/terminal.ts
@@ -1,6 +1,7 @@
 import type { TerminalPaneSplitSource } from '../../../shared/feature-education-telemetry'
 
 export const TOGGLE_TERMINAL_PANE_EXPAND_EVENT = 'orca-toggle-terminal-pane-expand'
+export const CLOSE_ALL_EDITOR_TABS_IN_GROUP_EVENT = 'orca-close-all-editor-tabs-in-group'
 export const FOCUS_TERMINAL_PANE_EVENT = 'orca-focus-terminal-pane'
 export const PASTE_TERMINAL_TEXT_EVENT = 'orca-paste-terminal-text'
 export const SPLIT_TERMINAL_PANE_EVENT = 'orca-split-terminal-pane'

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -402,6 +402,54 @@ describe('keybindings', () => {
     })
   })
 
+  it('binds close-all editor tabs in group to Mod+Alt+Shift+W', () => {
+    expect(getEffectiveKeybindingsForAction('tab.closeAllInGroup', 'darwin')).toEqual([
+      'Mod+Alt+Shift+W'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.closeAllInGroup', 'linux')).toEqual([
+      'Mod+Alt+Shift+W'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.closeAllInGroup', 'win32')).toEqual([
+      'Mod+Alt+Shift+W'
+    ])
+    expect(formatKeybindingList(['Mod+Alt+Shift+W'], 'darwin')).toBe('⌘⌥⇧W')
+    expect(formatKeybindingList(['Mod+Alt+Shift+W'], 'linux')).toBe('Ctrl+Alt+Shift+W')
+
+    const macComposedCloseAllInGroup = {
+      key: '„',
+      code: 'KeyW',
+      meta: true,
+      control: false,
+      alt: true,
+      shift: true
+    }
+    const macCloseAll = {
+      key: '∑',
+      code: 'KeyW',
+      meta: true,
+      control: false,
+      alt: true,
+      shift: false
+    }
+    expect(
+      keybindingMatchesAction('tab.closeAllInGroup', macComposedCloseAllInGroup, 'darwin')
+    ).toBe(true)
+    expect(keybindingMatchesAction('tab.closeAllInGroup', macCloseAll, 'darwin')).toBe(false)
+    expect(keybindingMatchesAction('tab.closeAll', macComposedCloseAllInGroup, 'darwin')).toBe(
+      false
+    )
+
+    const definition = getKeybindingDefinition('tab.closeAllInGroup')
+    expect(definition?.group).toBe('Tabs')
+    expect(definition?.scope).toBe('tabs')
+    expect(
+      findKeybindingConflicts('darwin', { 'tab.closeAllInGroup': ['Mod+Alt+W'] })
+    ).toContainEqual({
+      binding: 'Mod+Alt+W',
+      actionIds: expect.arrayContaining(['tab.closeAll', 'tab.closeAllInGroup'])
+    })
+  })
+
   it('keeps equalize pane sizes unassigned until users customize it', () => {
     expect(getEffectiveKeybindingsForAction('terminal.equalizePaneSizes', 'darwin')).toEqual([])
     expect(

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -67,6 +67,7 @@ export type KeybindingActionId =
   | 'tab.openMarkdown'
   | 'tab.close'
   | 'tab.closeAll'
+  | 'tab.closeAllInGroup'
   | 'tab.rename'
   | 'tab.reopenClosed'
   | 'tab.nextSameType'
@@ -601,6 +602,14 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'tabs',
     searchKeywords: ['shortcut', 'close', 'all', 'tabs', 'files', 'editors'],
     defaultBindings: platformBindings(['Mod+Alt+W'])
+  },
+  {
+    id: 'tab.closeAllInGroup',
+    title: 'Close all editor tabs in group',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'close', 'all', 'tabs', 'editors', 'group', 'split', 'pane'],
+    defaultBindings: platformBindings(['Mod+Alt+Shift+W'])
   },
   {
     id: 'tab.rename',


### PR DESCRIPTION
## What changes

Adds a bindable keyboard shortcut, **`tab.closeAllInGroup`** ("Close all editor tabs in group"), that closes every editor tab in the **currently focused split group** — leaving editor tabs in other split groups, and all terminals/browsers, untouched.

- Default binding: **⌘⌥⇧W** on macOS, **Ctrl+Alt+Shift+W** on Windows/Linux (cross-platform via the `Mod` token — nothing hardcoded per-OS).
- Rebindable from **Settings → Shortcuts** (Tabs group), and the split-pane right-click menu now shows the chord on its "Close All Editor Tabs" item.

## What does NOT change

- The existing worktree-wide **"Close all editor tabs"** shortcut (`tab.closeAll`, ⌘⌥W) is untouched.
- No new close logic: this reuses the existing `closeAllEditorTabsInGroup` command, so pinned-tab and unsaved-file (save/discard dialog) handling are identical to the right-click menu.
- In a single (non-split) pane the focused group is the whole worktree, so the result is visibly equivalent to `tab.closeAll`; the context-menu chip stays ⌘⌥W until an actual split exists, then flips to ⌘⌥⇧W.

This is the optional **"Close All Editors in Group"** variant from the linked issue. The issue's headline ask — a bindable shortcut for the worktree-wide "Close All" — already shipped earlier in PR `#5526`; this PR adds the per-group variant.

## How it works

- New `tab.closeAllInGroup` entry in the shared keybinding registry (`src/shared/keybindings.ts`); it appears in Settings → Shortcuts automatically.
- On keypress, a producer in `Terminal.tsx`'s global keydown handler resolves the focused group id (`activeGroupIdByWorktree[worktreeId] ?? groupsByWorktree[worktreeId][0]`) and dispatches a window `CustomEvent`. The per-group `useTabGroupWorkspaceModel` hook (one instance per mounted group) consumes it and runs the close command **only** when the event's `groupId` matches its own — this id match is what scopes the action to the focused group. This mirrors the existing `TOGGLE_TERMINAL_PANE_EXPAND_EVENT` dispatch pattern rather than duplicating close logic in the keydown handler.

## Design approach & review

Built via Brennan's PR process. A scratch design doc was written and run through the automated design-review loop (two independent reviewers) until clean — that surfaced and fixed three real issues before any code: the focused-group fallback after a session cold-restore, a corrected single-pane vs split surface model for the chip, and the exact prop-threading seam. The design doc is intentionally not shipped in this PR.

## Headline behavior status

**Implemented in production code.** The shortcut fires on real keypress and closes the focused group's editor tabs through the live keydown → event → hook path. Validated on-screen end to end (below), not just in unit tests.

## Perf audit

No actionable regression. Touched hot paths: the global capture-phase `onKeyDown` (one extra `matchShortcut` check, with the store read happening only after it matches) and the per-group window-event listener (one bounded listener per mounted group, cleaned up on unmount; non-matching handlers early-return on a single string compare). The new `closeAllShortcutActionId` prop is a stable string literal and does not defeat `TabBar` memoization. No new polling, subprocesses, timers, or startup work.

## Code-review loop

Two rounds, two independent reviewers each round. All findings were validated against the code and determined non-actionable (a pre-existing chip-hint convention, a harmless no-focused-group fall-through, intentional listener re-binding on tab-set change). No fixes were required; final round clean.

## Validation

`brennan-test-changes` in the Electron dev build (real keyboard surface, not store mutation), verdict **land**:

- In a split with **Group A** (terminal + apple.txt + banana.txt) and focused **Group B** (cherry.txt + date.txt), pressing ⌘⌥⇧W closed **only** Group B's two editor tabs; Group A's terminal and both editor tabs remained. Backing store confirmed `openFiles` dropped to apple/banana only.
- Settings → Shortcuts shows "Close all editor tabs in group" with the ⌘⌥⇧W chip, no conflicts, rebindable (shortcut count 113 → 114).
- No console/runtime errors.

Visual evidence (split-before, single-pane-after, and the Settings → Shortcuts entry) was captured and verified during validation; the screenshot files are available to attach to the PR conversation.

## Static checks & tests

- `pnpm vitest run --config config/vitest.config.ts` on the three affected suites — **70 passed** (keybinding default/match/no-match/conflict; context-menu chip per action id; consumer effect matching/non-matching groupId + listener cleanup).
- Web typecheck clean for all changed files (one pre-existing unrelated error in `useSessionRestoredBannerDismiss.test.tsx` is not from this branch).
- oxlint + oxfmt clean (lint-staged).

## SSH / cross-platform

Pure renderer-side change (in-window `CustomEvent`); it closes the same local editor tabs the right-click menu already closes, with no new host/remote interaction. Cross-platform handled by the `Mod` token and the existing label formatter.

Closes #5269
