### PR TITLE
Cover platform-aware host label and direct non-git folder add with regression tests

### DIFF
--- a/src/renderer/src/store/slices/repos.runtime-fallback.test.ts
+++ b/src/renderer/src/store/slices/repos.runtime-fallback.test.ts
@@ -279,4 +279,57 @@ describe('repo slice runtime folder fallback', () => {
       })
     )
   })
+
+  it('adds a local non-git folder directly without runtime metadata or a worktree', async () => {
+    // Local analogue of the runtime fallback above: with no active runtime the add
+    // routes through window.api.repos.add (not runtime RPC). A non-git path returns
+    // Orca's own "Not a valid git repository" sentinel, so addRepoPath surfaces the
+    // confirmation modal with no runtime/SSH metadata instead of throwing.
+    const folderRepo: Repo = {
+      id: 'local-folder',
+      path: '/local/non-git',
+      displayName: 'non-git',
+      badgeColor: '#000',
+      addedAt: 1,
+      kind: 'folder'
+    }
+    const reposAdd = vi.fn(
+      (args: { path: string; kind: string }): { repo: Repo } | { error: string } =>
+        args.kind === 'folder'
+          ? { repo: folderRepo }
+          : { error: 'Not a valid git repository: /local/non-git' }
+    )
+    vi.stubGlobal('window', {
+      api: {
+        repos: { add: reposAdd },
+        runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+      }
+    })
+    const store = createTestStore()
+    // fetchWorktrees is stubbed so the post-add activation chain (which needs
+    // worktrees/onboarding APIs absent from this stub) stays out of scope.
+    store.setState({ fetchWorktrees: vi.fn().mockResolvedValue(undefined) as never })
+
+    await expect(store.getState().addRepoPath('/local/non-git', 'git')).resolves.toBeNull()
+
+    expect(runtimeEnvironmentTransportCall).not.toHaveBeenCalled()
+    expect(reposAdd).toHaveBeenNthCalledWith(1, {
+      path: '/local/non-git',
+      kind: 'git'
+    })
+    expect(store.getState().activeModal).toBe('confirm-non-git-folder')
+    expect(store.getState().modalData).toEqual({ folderPath: '/local/non-git' })
+    expect(store.getState().repos).toEqual([])
+
+    // Completing the flow via "Open as Folder" adds a kind:'folder' project whose
+    // workspace path IS the folder itself — proving no git worktree is created.
+    const added = await store.getState().addNonGitFolder('/local/non-git')
+
+    expect(reposAdd).toHaveBeenNthCalledWith(2, {
+      path: '/local/non-git',
+      kind: 'folder'
+    })
+    expect(added?.kind).toBe('folder')
+    expect(added?.path).toBe('/local/non-git')
+  })
 })

--- a/src/shared/execution-host.test.ts
+++ b/src/shared/execution-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
   LOCAL_EXECUTION_HOST_ID,
@@ -14,6 +14,12 @@ import {
 } from './execution-host'
 
 describe('execution host identity', () => {
+  // Why: the navigator cases below replace globalThis.navigator; restore it after
+  // each test so the stub can't bleed into the rest of the suite.
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('normalizes local, SSH, and runtime host ids', () => {
     expect(parseExecutionHostId('local')).toEqual({ kind: 'local', id: 'local' })
     expect(parseExecutionHostId(toSshExecutionHostId('win vm'))).toEqual({
@@ -28,11 +34,27 @@ describe('execution host identity', () => {
     })
   })
 
-  it('labels the local host by platform', () => {
+  it('labels the local host by platform and by navigator detection', () => {
     expect(getLocalExecutionHostLabel('darwin')).toBe('Local Mac')
     expect(getLocalExecutionHostLabel('win32')).toBe('Local Windows')
     expect(getLocalExecutionHostLabel('linux')).toBe('Local Linux')
     expect(getLocalExecutionHostLabel('freebsd')).toBe('This computer')
+
+    // With no explicit platform, the label is derived from navigator.userAgent
+    // (the path the live host-selector dialog uses).
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' })
+    expect(getLocalExecutionHostLabel()).toBe('Local Windows')
+
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (X11; Linux x86_64)' })
+    expect(getLocalExecutionHostLabel()).toBe('Local Linux')
+
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' })
+    expect(getLocalExecutionHostLabel()).toBe('Local Mac')
+
+    // Non-matching userAgent falls through to process.platform; compare against the
+    // explicit-platform label so the assertion is deterministic on any CI OS.
+    vi.stubGlobal('navigator', { userAgent: 'totally-unknown-agent' })
+    expect(getLocalExecutionHostLabel()).toBe(getLocalExecutionHostLabel(process.platform))
   })
 
   it('falls back invalid scopes to all hosts', () => {
@@ -70,11 +92,5 @@ describe('execution host identity', () => {
     expect(getSettingsFocusedExecutionHostId({ activeRuntimeEnvironmentId: 'runtime-1' })).toBe(
       'runtime:runtime-1'
     )
-  })
-
-  it('labels local execution hosts by platform', () => {
-    expect(getLocalExecutionHostLabel('darwin')).toBe('Local Mac')
-    expect(getLocalExecutionHostLabel('linux')).toBe('Local Linux')
-    expect(getLocalExecutionHostLabel('win32')).toBe('Local Windows')
   })
 })


### PR DESCRIPTION
## What changes

Adds regression test coverage for two Add Project behaviors so they cannot silently regress. **No production behavior change** — both behaviors are already correct on `main`; this PR only locks them in.

**What does not change:** no runtime/production code, no UI, no i18n keys, no telemetry. Tests only.

## Background

Investigating issue `#5361` (Windows: "can no longer add a local project without git" + Add Project shows "Local Mac" on a Windows machine), both reported defects were already resolved in shipped builds:

- The "Local Mac"-on-Windows mislabel was a hardcoded local-host label in the host-selector dialog (shipped ~v1.4.68). It was fixed in v1.4.72 — `getLocalExecutionHostLabel()` now derives the label from the platform (win32 → "Local Windows", linux → "Local Linux", darwin → "Local Mac").
- Adding a local non-git folder directly already works: Browse folder → if not a git repo, the "Open as Folder" confirmation appears → confirming adds a `kind:'folder'` project whose workspace is the folder itself, with no git worktree created.

Neither path had a regression test guarding the exact behavior, so this PR adds two.

## Tests added

- `src/shared/execution-host.test.ts` — `getLocalExecutionHostLabel()` (no explicit platform arg) derives the label from `navigator.userAgent`: Windows → "Local Windows", Linux/X11 → "Local Linux", Mac → "Local Mac"; a non-matching userAgent falls through to `process.platform` (asserted against the explicit-platform label so it's deterministic on any CI OS). `navigator` is stubbed per-case and restored in `afterEach`. Folded into the existing platform case and removed a near-duplicate test.
- `src/renderer/src/store/slices/repos.runtime-fallback.test.ts` — local non-git add: `addRepoPath(path, 'git')` returns `null` and opens the `confirm-non-git-folder` modal with no runtime/SSH metadata; completing via `addNonGitFolder(path)` calls `repos.add({ path, kind: 'folder' })` and yields a `kind:'folder'` repo whose workspace path is the folder (proving no worktree). Placed next to the existing runtime-fallback analogue.

## Design approach

Tests-only, by decision: the user-visible behavior the issue asked for already ships, so adding production code would fabricate a fix for a non-bug. Instead we guard the two behaviors. The new local-folder test was placed in `repos.runtime-fallback.test.ts` (next to its runtime analogue) rather than `repos.test.ts` to keep the latter under the `max-lines` limit without disabling the rule.

## Headline behavior status

**Already implemented in production (not by this PR).** The label fix shipped in v1.4.72; the direct non-git folder-add path is long-standing. This PR adds regression coverage only. No follow-up production work is required for the reported behaviors. Remaining caveat: the "Local Windows" branch is proven by unit test (the win32 path), not on a real Windows host — validation below was on macOS.

## Validation

- Design reviewed via Brennan's PR process (converged clean; scope held at tests-only).
- Completeness verification: confirmed both tests match real production behavior and are non-vacuous (the `addNonGitFolder` activation chain is short-circuited via a stubbed `fetchWorktrees`, so a regression can't pass as a silent `catch`).
- Performance audit: no production hot-path/render/startup/leak surface (tests-only); stubbed globals are restored, no real fs/network/subprocess.
- Code-review loop: two reviewers, clean in one round (nits-only).
- Merge-confidence (Electron, macOS): exercised the real Add Project surface — non-git folder added directly through the actual "Open as Folder" button (no worktree dir created), and the platform-aware label path confirmed live via `navigator.userAgent`. Screenshots captured during validation.
- `vitest run --config config/vitest.config.ts` on the touched + adjacent suites: green. Pre-commit lint (incl. `max-lines`) passes.

## Static checks / focused tests

- `npx vitest run --config config/vitest.config.ts src/shared/execution-host.test.ts src/shared/execution-host-registry.test.ts src/renderer/src/store/slices/repos.runtime-fallback.test.ts` → all green.
- Web typecheck of the touched test files → clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
