### PR TITLE
chore(lint): adopt unicorn/prefer-import-meta-properties (error)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -61,6 +61,7 @@
     "unicorn/prefer-at": "error",
     "unicorn/prefer-date-now": "error",
     "unicorn/prefer-includes": "error",
+    "unicorn/prefer-import-meta-properties": "error",
     "unicorn/prefer-math-min-max": "error",
     "unicorn/prefer-negative-index": "error",
     "unicorn/prefer-node-protocol": "error",

--- a/config/scripts/build-computer-macos.mjs
+++ b/config/scripts/build-computer-macos.mjs
@@ -1,9 +1,8 @@
 import { spawnSync } from 'node:child_process'
 import { chmodSync, copyFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const repoRoot = path.resolve(import.meta.dirname, '../..')
 const packagePath = path.join(repoRoot, 'native', 'computer-use-macos')
 const binaryPath = path.join(packagePath, '.build', 'release', 'orca-computer-use-macos')
 const appPath = path.join(packagePath, '.build', 'release', 'Orca Computer Use.app')

--- a/config/scripts/build-relay.mjs
+++ b/config/scripts/build-relay.mjs
@@ -11,10 +11,9 @@
 import { build } from 'esbuild'
 import { createHash } from 'node:crypto'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dirname
 // Why: the script lives under config/scripts, so go two levels up to reach the repo root.
 const ROOT = join(__dirname, '..', '..')
 const RELAY_ENTRY = join(ROOT, 'src', 'relay', 'relay.ts')

--- a/config/scripts/check-feature-wall-assets.mjs
+++ b/config/scripts/check-feature-wall-assets.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 import { readdir, stat } from 'node:fs/promises'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dirname
 const ROOT = path.join(__dirname, '..', '..')
 const FEATURE_WALL_ASSET_DIR = path.join(ROOT, 'resources', 'onboarding', 'feature-wall')
 const MAX_BYTES = 11 * 1024 * 1024

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -1,10 +1,9 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
 
-const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const projectDir = resolve(import.meta.dirname, '../..')
 
 describe('computer-use e2e workflow', () => {
   it('runs computer-use e2e files serially because they share desktop focus', () => {

--- a/config/scripts/computer-use-skill-guidance.test.mjs
+++ b/config/scripts/computer-use-skill-guidance.test.mjs
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const projectDir = resolve(import.meta.dirname, '../..')
 const skillPath = join(projectDir, 'skills', 'computer-use', 'SKILL.md')
 
 describe('computer-use skill guidance', () => {

--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -4,12 +4,11 @@ import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { existsSync, readFileSync } from 'node:fs'
 import { release } from 'node:os'
-import { basename, dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { basename, resolve } from 'node:path'
 
 const require = createRequire(import.meta.url)
-const scriptPath = fileURLToPath(import.meta.url)
-const projectDir = resolve(dirname(scriptPath), '../..')
+const scriptPath = import.meta.filename
+const projectDir = resolve(import.meta.dirname, '../..')
 const runtime = readRuntimeArg()
 
 const NATIVE_MODULES = ['node-pty']

--- a/config/scripts/install-dev-cli.mjs
+++ b/config/scripts/install-dev-cli.mjs
@@ -4,9 +4,8 @@
 import { existsSync, lstatSync, readlinkSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const scriptDir = import.meta.dirname
 const source = path.join(scriptDir, 'orca-dev.mjs')
 
 const commandPath =

--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -14,10 +14,9 @@ import {
 import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { platform as osPlatform, tmpdir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 
-const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const projectDir = resolve(import.meta.dirname, '../..')
 const electronPackageDir = resolve(projectDir, 'node_modules/electron')
 const electronRequire = createRequire(resolve(electronPackageDir, 'package.json'))
 const { version: electronVersion } = electronRequire('./package.json')

--- a/config/scripts/locale-ko-key-overrides.mjs
+++ b/config/scripts/locale-ko-key-overrides.mjs
@@ -1,14 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 // Korean key-specific overrides (reviewed in full UI context: product names, git terms, and
 // labels MT mistranslated). Stored as a JSON data file — too many entries to inline under the
 // .mjs max-lines limit — and loaded here so the catalog scripts keep a single ko key-override source.
-const jsonPath = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  'locale-ko-key-overrides.json'
-)
+const jsonPath = path.join(import.meta.dirname, 'locale-ko-key-overrides.json')
 
 let parsed
 try {

--- a/config/scripts/orca-cli-skill-guidance.test.mjs
+++ b/config/scripts/orca-cli-skill-guidance.test.mjs
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const projectDir = resolve(import.meta.dirname, '../..')
 const skillPath = join(projectDir, 'skills', 'orca-cli', 'SKILL.md')
 
 function readSkill() {

--- a/config/scripts/orca-dev.mjs
+++ b/config/scripts/orca-dev.mjs
@@ -3,9 +3,8 @@
 import { spawnSync } from 'node:child_process'
 import { accessSync, constants, existsSync, realpathSync, statSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const scriptPath = realpathSync(fileURLToPath(import.meta.url))
+const scriptPath = realpathSync(import.meta.filename)
 const scriptDir = path.dirname(scriptPath)
 const repoRoot = path.resolve(scriptDir, '..', '..')
 const cliEntry =

--- a/config/scripts/orca-linear-skill-guidance.test.mjs
+++ b/config/scripts/orca-linear-skill-guidance.test.mjs
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const projectDir = resolve(import.meta.dirname, '../..')
 const canonicalSkillPath = join(projectDir, 'skills', 'orca-linear', 'SKILL.md')
 const legacySkillPath = join(projectDir, 'skills', 'linear-tickets', 'SKILL.md')
 const legacyIntro =

--- a/config/scripts/orchestration-skill-guidance.test.mjs
+++ b/config/scripts/orchestration-skill-guidance.test.mjs
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const projectDir = resolve(import.meta.dirname, '../..')
 const skillPath = join(projectDir, 'skills', 'orchestration', 'SKILL.md')
 
 function readSkill() {

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -1,10 +1,9 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
 
-const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const projectDir = resolve(import.meta.dirname, '../..')
 const packageJson = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf8'))
 
 describe('Electron runtime package contract', () => {

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -17,7 +17,6 @@ import {
 import net from 'node:net'
 import { createRequire } from 'node:module'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 // Why: Electron-based hosts (e.g. Claude Code, VS Code) set
 // ELECTRON_RUN_AS_NODE=1 in their terminal environment. If this leaks into
@@ -26,7 +25,7 @@ import { fileURLToPath } from 'node:url'
 delete process.env.ELECTRON_RUN_AS_NODE
 
 const require = createRequire(import.meta.url)
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const repoRoot = path.resolve(import.meta.dirname, '../..')
 const STABLE_NAME_FLAG = '--stable-name'
 const rawForwardedArgs = process.argv.slice(2)
 // Why: keep an escape hatch for tools that key off Electron's stock app name.

--- a/config/scripts/run-idle-cpu-benchmark.mjs
+++ b/config/scripts/run-idle-cpu-benchmark.mjs
@@ -4,7 +4,6 @@ import { execFileSync, spawnSync } from 'node:child_process'
 import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { installSyntheticVisibleSpinners } from './idle-cpu-synthetic-spinners.mjs'
 
 const DEFAULT_WARMUP_MS = 15_000
@@ -454,7 +453,7 @@ function terminateProcesses(processes) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2))
-  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+  const root = path.resolve(import.meta.dirname, '..', '..')
   const mainPath = buildAppIfNeeded(root, options.skipBuild)
   const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-idle-cpu-userdata-'))
   const { repoDir, cleanupDirs } = createIdleRepo(options.worktrees)

--- a/config/scripts/run-internal-dev-setup.mjs
+++ b/config/scripts/run-internal-dev-setup.mjs
@@ -2,7 +2,6 @@
 import { accessSync, constants, existsSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 function isExecutable(filePath, platform, access = accessSync) {
   if (platform === 'win32') {
@@ -59,6 +58,6 @@ export function runInternalDevSetup({
   return 0
 }
 
-if (process.argv[1] && resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])) {
+if (process.argv[1] && resolve(import.meta.filename) === resolve(process.argv[1])) {
   process.exit(runInternalDevSetup())
 }

--- a/config/scripts/run-terminal-scale-perf-report-gate.mjs
+++ b/config/scripts/run-terminal-scale-perf-report-gate.mjs
@@ -2,7 +2,6 @@ import { spawnSync } from 'node:child_process'
 import { closeSync, copyFileSync, mkdirSync, mkdtempSync, openSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 const DEFAULT_REPORT_PATH = 'test-results/terminal-scale-perf-report.json'
 
@@ -118,6 +117,6 @@ export function runTerminalScalePerfReportGate({
   return exitCode(budgetResult)
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (process.argv[1] === import.meta.filename) {
   process.exit(runTerminalScalePerfReportGate())
 }

--- a/config/scripts/trim-windows-icon-source.mjs
+++ b/config/scripts/trim-windows-icon-source.mjs
@@ -5,7 +5,6 @@
 // ~83% of the frame and looks visibly small next to native apps (issue #5357).
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { PNG } from 'pngjs'
 
 // Why: Windows renders the largest ICO frame at small sizes too, so the glyph
@@ -195,7 +194,7 @@ export function buildWindowsIcoFromPng(sourcePngBuffer, sizes = ICO_FRAME_SIZES)
 }
 
 function resolveDefaultPaths() {
-  const scriptDir = dirname(fileURLToPath(import.meta.url))
+  const scriptDir = import.meta.dirname
   const projectDir = dirname(dirname(scriptDir))
   return {
     sourcePng: join(projectDir, 'resources', 'build', 'icon.png'),

--- a/config/scripts/trim-windows-icon-source.test.mjs
+++ b/config/scripts/trim-windows-icon-source.test.mjs
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { PNG } from 'pngjs'
 import {
@@ -11,7 +10,7 @@ import {
   squareWithMargin
 } from './trim-windows-icon-source.mjs'
 
-const scriptDir = dirname(fileURLToPath(import.meta.url))
+const scriptDir = import.meta.dirname
 const projectDir = dirname(dirname(scriptDir))
 const buildDir = join(projectDir, 'resources', 'build')
 

--- a/config/scripts/vendor-feature-wall-assets.mjs
+++ b/config/scripts/vendor-feature-wall-assets.mjs
@@ -3,9 +3,8 @@ import { copyFile, mkdir, writeFile } from 'node:fs/promises'
 import { spawnSync } from 'node:child_process'
 import { homedir } from 'node:os'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dirname
 const ROOT = path.join(__dirname, '..', '..')
 const DEFAULT_MARKETING_REPO = path.join(
   homedir(),

--- a/config/scripts/verify-macos-entitlements.mjs
+++ b/config/scripts/verify-macos-entitlements.mjs
@@ -2,9 +2,8 @@
 
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const __dirname = import.meta.dirname
 const repoRoot = resolve(__dirname, '../..')
 
 const defaultPlists = [

--- a/config/scripts/verify-telemetry-constants.mjs
+++ b/config/scripts/verify-telemetry-constants.mjs
@@ -31,8 +31,7 @@
 // and the Windows `.cmd`-shim/`shell: true` workaround.
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 // Why @electron/asar: canonical replacement for the deprecated `asar` package.
 // It's transitively available via electron-builder (and pnpm's
 // `shamefully-hoist=true` in `.npmrc` flattens it into the root
@@ -45,7 +44,7 @@ import { extractFile, listPackage } from '@electron/asar'
 // Resolving relative to the script's own location turns a misleading
 // "could not parse TELEMETRY_ENABLED flag" parse error into a clear
 // file-not-found error, and decouples the script from the caller's cwd.
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const repoRoot = resolve(import.meta.dirname, '..', '..')
 
 function findAsar(rootDir) {
   // Why: electron-builder produces one `app.asar` per platform-arch combo.

--- a/mobile/scripts/start-expo.mjs
+++ b/mobile/scripts/start-expo.mjs
@@ -3,10 +3,9 @@
 import { spawn } from 'node:child_process'
 import path from 'node:path'
 import process from 'node:process'
-import { fileURLToPath } from 'node:url'
 import { ensureMobileExpoCli } from './mobile-expo-cli.mjs'
 
-const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const scriptDir = import.meta.dirname
 const mobileDir = path.resolve(scriptDir, '..')
 
 function pnpmCommand(args) {

--- a/mobile/src/tasks/mobile-agent-catalog.test.ts
+++ b/mobile/src/tasks/mobile-agent-catalog.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 
 import { MOBILE_AGENT_CATALOG } from './mobile-agent-catalog'
 import { MOBILE_TUI_AGENT_AUTO_PICK_ORDER } from './mobile-tui-agents'
 
-const currentDir = dirname(fileURLToPath(import.meta.url))
+const currentDir = import.meta.dirname
 
 function readDesktopSharedFile(relativePath: string): string {
   return readFileSync(resolve(currentDir, '../../../src/shared', relativePath), 'utf8')

--- a/mobile/vitest.config.ts
+++ b/mobile/vitest.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vitest/config'
-import { fileURLToPath } from 'node:url'
 
 const tsconfigRaw = JSON.stringify({
   compilerOptions: {
@@ -12,7 +11,7 @@ const tsconfigRaw = JSON.stringify({
 })
 
 export default defineConfig({
-  root: fileURLToPath(new URL('.', import.meta.url)),
+  root: import.meta.dirname,
   esbuild: {
     tsconfigRaw
   },

--- a/src/main/startup/__fixtures__/fake-electron-vite-dev-cli.mjs
+++ b/src/main/startup/__fixtures__/fake-electron-vite-dev-cli.mjs
@@ -1,9 +1,8 @@
 import { spawn } from 'node:child_process'
 import { writeFileSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dirname
 const grandchildPath = path.join(__dirname, 'electron-vite-dev-grandchild.mjs')
 const pidFile = process.env.ORCA_DEV_WRAPPER_TEST_PID_FILE
 const envFile = process.env.ORCA_DEV_WRAPPER_TEST_ENV_FILE

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.default-checkout.test.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.default-checkout.test.ts
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const ONBOARDING_FLOW_PATH = join(dirname(fileURLToPath(import.meta.url)), 'use-onboarding-flow.ts')
+const ONBOARDING_FLOW_PATH = join(import.meta.dirname, 'use-onboarding-flow.ts')
 
 describe('useOnboardingFlow project-added handoff', () => {
   it('routes Git repo completion through the shared default-checkout opener', () => {

--- a/src/renderer/src/components/sidebar/AddRepoDialog.default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.default-checkout.test.ts
@@ -1,16 +1,15 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const ADD_REPO_DIALOG_PATH = join(dirname(fileURLToPath(import.meta.url)), 'AddRepoDialog.tsx')
+const ADD_REPO_DIALOG_PATH = join(import.meta.dirname, 'AddRepoDialog.tsx')
 const ADD_REPO_FLOW_PATHS = [
   ADD_REPO_DIALOG_PATH,
-  join(dirname(fileURLToPath(import.meta.url)), 'AddRepoSteps.tsx'),
-  join(dirname(fileURLToPath(import.meta.url)), 'useAddRepoCloneFlow.ts'),
-  join(dirname(fileURLToPath(import.meta.url)), 'useAddRepoLocalFolderFlow.ts'),
-  join(dirname(fileURLToPath(import.meta.url)), 'useAddRepoServerPathFlow.ts'),
-  join(dirname(fileURLToPath(import.meta.url)), 'useAddRepoNestedImportFlow.ts')
+  join(import.meta.dirname, 'AddRepoSteps.tsx'),
+  join(import.meta.dirname, 'useAddRepoCloneFlow.ts'),
+  join(import.meta.dirname, 'useAddRepoLocalFolderFlow.ts'),
+  join(import.meta.dirname, 'useAddRepoServerPathFlow.ts'),
+  join(import.meta.dirname, 'useAddRepoNestedImportFlow.ts')
 ]
 
 function readAddRepoFlowSource(): string {

--- a/src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts
@@ -1,11 +1,10 @@
 import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { WORKTREE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME } from './index'
 
 function getWorktreeSidebarScrollbarPaddingRight(): number {
-  const testDir = dirname(fileURLToPath(import.meta.url))
+  const testDir = import.meta.dirname
   const css = readFileSync(resolve(testDir, '../../assets/main.css'), 'utf8')
   const block = css.match(/\.worktree-sidebar-scrollbar\s*\{(?<body>[^}]*)\}/)?.groups?.body ?? ''
   const value = block.match(/padding-right:\s*(?<px>\d+)px/)?.groups?.px

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import { dirname, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildSettingsNavigationMetadata } from './useSettingsNavigationMetadata'
 import type { Repo } from '../../../shared/types'
@@ -169,7 +168,7 @@ describe('settings navigation metadata', () => {
   })
 
   it('does not import Settings page or pane UI modules from the metadata hook', () => {
-    const testDir = dirname(fileURLToPath(import.meta.url))
+    const testDir = import.meta.dirname
     const hookSource = readFileSync(resolve(testDir, 'useSettingsNavigationMetadata.ts'), 'utf8')
     const importLines = hookSource
       .split('\n')
@@ -182,7 +181,7 @@ describe('settings navigation metadata', () => {
   })
 
   it('does not import Settings page or pane UI modules from the quick action registry', () => {
-    const testDir = dirname(fileURLToPath(import.meta.url))
+    const testDir = import.meta.dirname
     const registrySource = readFileSync(
       resolve(testDir, '../components/cmd-j/quick-actions.ts'),
       'utf8'

--- a/tests/e2e/capture-opencode-tui-repro.mjs
+++ b/tests/e2e/capture-opencode-tui-repro.mjs
@@ -7,12 +7,11 @@
 import { createRequire } from 'node:module'
 import { createWriteStream, existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 const require = createRequire(import.meta.url)
 const pty = require('node-pty')
 
-const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const scriptDir = import.meta.dirname
 const repoRoot = path.resolve(scriptDir, '..', '..')
 
 function readOption(name, fallback) {

--- a/tools/benchmarks/daemon-coldstart-bench.mjs
+++ b/tools/benchmarks/daemon-coldstart-bench.mjs
@@ -21,10 +21,9 @@
 import { spawn, spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 
-const scriptDir = dirname(fileURLToPath(import.meta.url))
+const scriptDir = import.meta.dirname
 const repoRoot = resolve(scriptDir, '..', '..')
 
 const CURRENT_PROTOCOL_VERSION = 12

--- a/tools/benchmarks/startup-time-bench.mjs
+++ b/tools/benchmarks/startup-time-bench.mjs
@@ -29,10 +29,9 @@ import {
 } from 'node:fs'
 import { createRequire } from 'node:module'
 import os from 'node:os'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 
-const scriptDir = dirname(fileURLToPath(import.meta.url))
+const scriptDir = import.meta.dirname
 const repoRoot = resolve(scriptDir, '..', '..')
 const require = createRequire(import.meta.url)
 


### PR DESCRIPTION
## What

Adopt **`unicorn/prefer-import-meta-properties`** at `error`. This is the deferred follow-up from #6841 — it needed manual import cleanup that the autofix can't do alone, so it was held back from the mechanical PR.

Migrates the `fileURLToPath(import.meta.url)` / `path.dirname(...)` boilerplate to the native **`import.meta.dirname`** / **`import.meta.filename`** (Node ≥ 20.11; repo runs 24), then turns the rule on so new code stays on the native form.

```diff
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const repoRoot = resolve(import.meta.dirname, '..', '..')
```

## The non-mechanical part

oxlint's autofix rewrites the *expression* but leaves the now-unused `node:url` / `node:path` imports behind — which the already-enabled `no-unused-vars=error` would then fail CI on. So this PR also removes **34 orphaned imports**: trimming the named import where other names are still used (`{ dirname, join, resolve }` → `{ join, resolve }`), deleting the line where it was the sole import. Verified no dangling references remain.

## Scope

Build scripts + Node-env tests only — `config/scripts/`, `tools/benchmarks/`, `*.test.{ts,mjs}`, vitest configs. **Zero shipped runtime code** (renderer/main/preload/mobile-app). Both root and `mobile/` are covered. The native properties are documented exact equivalents of the replaced expressions, so behavior is unchanged.

## Verification (all green)

| Gate | Result |
|---|---|
| `oxlint` tree-wide (root + mobile) | **0 errors** |
| oxfmt | clean |
| typecheck (node + cli + web) + mobile `tsc` | pass |
| root vitest | **22825 passed**, 0 failed |
| mobile vitest | **1018 passed**, 0 failed |
| ran rewritten scripts directly | `build:relay` (6 targets), `ensure-native-runtime`, `verify-macos-entitlements` all work with `import.meta.dirname` |

## Heads-up (pre-existing, not from this PR)

While verifying, I found that `mobile/app/h/[hostId]/session/[worktreeId].tsx` trips `max-lines` (5015 > 4988) on a clean local lint of `origin/main` — and it was already failing before #6841 (confirmed at the parent commit with mobile's original oxlint 1.67). Mobile CI passes it (the bracket-named Expo-router path appears to be discovered/matched differently in CI than locally), and it's orthogonal to this change, so I've left it alone. Flagging it as a latent issue worth a separate look — that file should probably be split regardless.

Made with [Orca](https://github.com/stablyai/orca) 🐋
