### PR TITLE
fix: repaint terminals on worktree switch to stop garbled render

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -162,6 +162,12 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
   } else {
     fitPanes(manager)
   }
+  // Why: a worktree (surface) switch can re-show a pane whose container size
+  // did not change while hidden, so safeFit early-returns and DOM-renderer
+  // panes (no WebGL repaint) keep a stale/garbled canvas until a manual zoom
+  // forces a refit+refresh. Force the repaint here, matching the window-wake
+  // path, so switching workspaces renders correctly without the zoom dance.
+  manager.refreshAllPanes?.()
 }
 
 function enforceTerminalViewportIntents(manager: PaneManager): void {

--- a/src/renderer/src/components/terminal-pane/worktree-switch-stale-render.test.ts
+++ b/src/renderer/src/components/terminal-pane/worktree-switch-stale-render.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Reproduction: switching worktrees leaves a Claude Code (DOM-renderer) terminal
+ * rendered garbled until a manual zoom forces a refit + full refresh.
+ *
+ * User report (Orca 1.4.104, macOS): "Every time I switch between workspaces the
+ * claude code terminal tab is all jumbled and broken, I have to zoom out and zoom
+ * in to get it to render properly." Diagnostic shows many rapid
+ * `sidebar_worktree_activate` breadcrumbs.
+ *
+ * Root cause hypothesis (pinned here):
+ * On a worktree (surface) switch, the now-visible terminal resumes via
+ * resumeTerminalVisibility() -> heavy path -> manager.resumeRendering() +
+ * fitPanes(). For a DOM-renderer pane (GPU off / auto->DOM / context-loss
+ * fallback):
+ *   - resumePaneRendering() only repaints WebGL panes (attachWebgl ->
+ *     refreshTerminalAfterWebglAttach). A DOM pane has no webglAddon, so
+ *     reattachWebglIfNeeded() is a no-op: NO refresh.
+ *   - fitPanes() -> fitAllPanes() -> safeFit() early-returns when the container
+ *     dimensions are unchanged (proposeDimensions === current cols/rows), so it
+ *     never calls fit() and never repaints.
+ *   - resetAllTerminalWebglAtlases() is a no-op for DOM panes.
+ * Net: the stale canvas (not painted while hidden) is shown without any
+ * repaint. A manual zoom changes font metrics -> proposeDimensions differs ->
+ * fit() runs -> refresh() -> correct render, which is why zoom "fixes" it.
+ *
+ * This test drives the REAL resumeTerminalVisibility() through the heavy path
+ * with a DOM-renderer pane whose container size did not change while hidden, and
+ * delegates fitAllPanes() to the REAL fitAllPanesInternal/safeFit so the
+ * dimensions-match early-return is exercised authentically. It asserts the pane
+ * is repainted on resume (refresh) — regression guard for the fix that adds
+ * manager.refreshAllPanes() to the heavy resume path.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resumeTerminalVisibility } from './terminal-visibility-resume'
+import { fitAllPanesInternal } from '@/lib/pane-manager/pane-tree-ops'
+import {
+  registerLivePaneManager,
+  unregisterLivePaneManager
+} from '@/lib/pane-manager/pane-manager-registry'
+
+// The container/PTY size is unchanged across the worktree switch, so xterm's
+// fit addon proposes the same cols/rows the terminal already has.
+const STEADY_COLS = 120
+const STEADY_ROWS = 30
+
+type FakeTerminal = {
+  cols: number
+  rows: number
+  refresh: ReturnType<typeof vi.fn<(start: number, end: number) => void>>
+  focus: ReturnType<typeof vi.fn<() => void>>
+}
+
+type FakePane = {
+  id: number
+  // DOM-renderer pane: GPU rendering off, no WebGL addon attached.
+  gpuRenderingEnabled: boolean
+  webglAddon: null
+  webglAttachmentDeferred: boolean
+  webglDisabledAfterContextLoss: boolean
+  terminal: FakeTerminal
+  container: { getBoundingClientRect: () => { width: number; height: number } }
+  fitAddon: {
+    proposeDimensions: () => { cols: number; rows: number }
+    fit: ReturnType<typeof vi.fn>
+  }
+}
+
+function makeDomRendererPane(id: number): FakePane {
+  const terminal: FakeTerminal = {
+    cols: STEADY_COLS,
+    rows: STEADY_ROWS,
+    refresh: vi.fn(),
+    focus: vi.fn()
+  }
+  return {
+    id,
+    gpuRenderingEnabled: false,
+    webglAddon: null,
+    webglAttachmentDeferred: true, // suspended while the worktree was hidden
+    webglDisabledAfterContextLoss: false,
+    terminal,
+    // A real, comfortably-sized pane (passes canMeasurePaneForFit).
+    container: { getBoundingClientRect: () => ({ width: 800, height: 480 }) },
+    fitAddon: {
+      // Container did not change while hidden -> same dims the terminal has.
+      proposeDimensions: () => ({ cols: STEADY_COLS, rows: STEADY_ROWS }),
+      fit: vi.fn()
+    }
+  }
+}
+
+function makeManager(panes: FakePane[]) {
+  const paneMap = new Map<number, FakePane>(panes.map((pane) => [pane.id, pane]))
+  return {
+    panes,
+    getPanes: () => panes,
+    getActivePane: () => panes[0] ?? null,
+    // Delegate to the REAL fit so safeFit()'s dimensions-match early-return runs.
+    fitAllPanes: () => fitAllPanesInternal(paneMap as never),
+    refreshAllPanes: () => {
+      for (const pane of panes) {
+        pane.terminal.refresh(0, pane.terminal.rows - 1)
+      }
+    },
+    // resumeRendering -> resumePaneRendering: only WebGL panes get a repaint.
+    resumeRendering: () => {
+      for (const pane of panes) {
+        pane.webglAttachmentDeferred = false
+        // reattachWebglIfNeeded: no-op for a DOM pane (gpuRenderingEnabled=false).
+      }
+    },
+    suspendRendering: vi.fn(),
+    resetWebglTextureAtlases: vi.fn() // no-op for DOM panes (no atlas)
+  }
+}
+
+describe('worktree switch resume (DOM-renderer Claude Code terminal)', () => {
+  const registered: { resetWebglTextureAtlases(): void }[] = []
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    for (const manager of registered.splice(0)) {
+      unregisterLivePaneManager(manager)
+    }
+  })
+
+  it('repaints the terminal on worktree-switch resume even when dimensions are unchanged', () => {
+    const pane = makeDomRendererPane(1)
+    const manager = makeManager([pane])
+    registerLivePaneManager(manager as never)
+    registered.push(manager as never)
+
+    // Heavy (surface) resume: the worktree just became active again after being
+    // hidden by a sidebar_worktree_activate to another workspace. wasVisible is
+    // false because the pane's surface was hidden; shouldUseLightTabResume is
+    // false because the hidden reason was 'surface', not 'tab'.
+    resumeTerminalVisibility({
+      manager: manager as never,
+      isActive: true,
+      wasVisible: false,
+      shouldUseLightTabResume: false,
+      captureViewportPositions: () => new Map(),
+      withSuppressedScrollTracking: (cb) => cb()
+    })
+
+    // The container size did not change, so the real safeFit() early-returned and
+    // never called fit(). For a DOM pane nothing else repainted the canvas, so it
+    // shows the stale (garbled) buffer until the user zooms.
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+
+    // The fix forces a repaint on resume regardless of whether the fit changed
+    // dimensions (manager.refreshAllPanes() in the heavy path), so the worktree
+    // switch renders correctly without the manual zoom the user reported.
+    expect(pane.terminal.refresh).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

Crash channel report (Orca 1.4.104, macOS), verbatim user note:

> Every time I switch between workspaces the claude code terminal tab is all jumbled and broken, I have to zoom out and zoom in to get it to render properly.

The diagnostic bundle showed many rapid `sidebar_worktree_activate` breadcrumbs (worktree switching).

## Root cause

On a worktree (surface) switch, the now-visible terminal resumes via `resumeTerminalVisibility()` → heavy path → `resumeRendering()` + `fitPanes()`. For a **DOM-renderer pane** (GPU off / auto→DOM / context-loss fallback):

- `resumeRendering()` only repaints WebGL panes; a DOM pane has no `webglAddon`, so nothing repaints.
- `fitPanes()` → `safeFit()` **early-returns when container dimensions are unchanged** (the common case across a worktree switch), so `fit()` never runs and never repaints.

Net: the stale canvas (not painted while hidden) is shown garbled. A manual zoom changes font metrics → `proposeDimensions` differs → `fit()` runs → `refresh()` → correct render. That's exactly why zoom "fixes" it.

The window-wake recovery path (`recoverVisibleTerminalWindowWake`) already calls `manager.refreshAllPanes()` for this reason — the heavy resume path was simply missing the same call.

## Fix

Add `manager.refreshAllPanes?.()` to the end of the heavy resume path so the pane is repainted on every surface resume, regardless of whether the fit changed dimensions.

## Evidence of fix

`worktree-switch-stale-render.test.ts` drives the **real** `resumeTerminalVisibility()` heavy path with a DOM-renderer pane whose container size did not change while hidden, delegating to the real `fitAllPanesInternal`/`safeFit` so the dimensions-match early-return is exercised authentically:

```
✓ repaints the terminal on worktree-switch resume even when dimensions are unchanged
 Test Files  1 passed (1)
```

The existing global-effects suite (which pins the window-wake path's `refreshAllPanes` call) stays green — 21 tests pass across the related files. Pre-fix the assertion `expect(pane.terminal.refresh).toHaveBeenCalled()` failed (nothing repainted); post-fix it passes.

## ELI5

Each terminal draws itself onto a canvas. When you switch workspaces and come back, the app tries to re-show the terminal — but it only repaints if the window changed size, and switching workspaces usually keeps the same size. So you get the old, smeared picture until you zoom (which changes the size and forces a fresh repaint). The fix just tells the terminal "repaint yourself now" every time you return to it, so it looks right immediately — no zoom dance.

## Trade-offs

- Adds one `refreshAllPanes()` call per **surface resume** (worktree switch), which forces an xterm repaint of visible panes. This is the same operation the window-wake path already performs and is cheap relative to a worktree switch; it does not run on the lightweight intra-worktree tab-switch path. No measurable downside.

## Scope / platforms

Renderer-only; applies to macOS/Linux/Windows. No SSH-specific behavior (works the same for remote terminals). Cannot be reproduced in headless Electron — the unit test on the real resume path is the harness, consistent with prior terminal-rendering fixes.
