### PR TITLE
fix: recover corrupt lazy-chunk parse errors instead of crashing the boundary

### DIFF
--- a/src/renderer/src/lib/lazy-with-retry.right-sidebar-syntax-error.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.right-sidebar-syntax-error.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { isLazyChunkLoadError, loadLazyWithRetry } from './lazy-with-retry'
+
+// Regression guard for crash report e08749bb-777c-446e-b407-5d1f154b6173 (Orca 1.4.104).
+// boundary_id=right-sidebar, surface=right-sidebar, error_name=SyntaxError,
+// error_message="Unexpected token ')'". component_stack: Lazy -> Suspense ->
+// RightSidebarPanelContent -> ... -> RecoverableRenderErrorBoundary.
+//
+// The right-sidebar source-control panel is loaded via lazyWithRetry:
+//   src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx:6
+//     const SourceControl = lazy(() => import('./SourceControl'))   // lazyWithRetry
+//
+// So the corrupt-chunk recovery IS wired in. The crash was a BLIND SPOT in that
+// recovery: after the single guarded window.location.reload() has already fired
+// once this session (sessionStorage 'orca:lazy-chunk-reload-attempted' === '1'),
+// loadLazyWithRetry only converted the failure into a recoverable
+// LazyChunkLoadError when isKnownDynamicImportFailure(error) was true. A corrupt /
+// truncated chunk that parses as invalid JS rejects import() with a native
+// SyntaxError whose .name is "SyntaxError" (not "ChunkLoadError") and whose
+// message "Unexpected token ')'" matched NONE of the dynamic-import regexes, so
+// it was re-thrown raw to the boundary and killed the right sidebar — the exact
+// reported crash. The fix treats a parse-time SyntaxError as a recoverable
+// corrupt-chunk failure; these tests pin that behavior.
+
+const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
+
+// The exact error the renderer received from the corrupt right-sidebar chunk.
+const reportedCrashError = (): SyntaxError => new SyntaxError("Unexpected token ')'")
+// An equivalent transient fetch failure, for contrast — this one DOES recover.
+const equivalentFetchError = (): TypeError =>
+  new TypeError('Failed to fetch dynamically imported module: file://redacted/SourceControl.js')
+
+function spyOnReload(): ReturnType<typeof vi.fn> {
+  const reload = vi.fn()
+  vi.spyOn(window.location, 'reload').mockImplementation(reload)
+  return reload
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  window.sessionStorage.clear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  try {
+    window.sessionStorage.clear()
+  } catch {
+    // ignore
+  }
+})
+
+describe('right-sidebar lazy chunk SyntaxError crash (regression)', () => {
+  it('recovers a corrupt right-sidebar chunk SyntaxError instead of surfacing it to the boundary', async () => {
+    const reload = spyOnReload()
+    // The one guarded reload already happened earlier this session: the user has
+    // navigated/reloaded once after the stale chunk was first hit.
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+
+    // import('./SourceControl') rejects with the native parse error from the
+    // corrupt chunk — exactly what the crash report captured.
+    const factory = vi.fn(() => Promise.reject(reportedCrashError()))
+
+    const loaded = loadLazyWithRetry(factory, { retries: 2, reloadKey: 'right-sidebar' })
+    // Drain the retry backoff timers first (fake timers), THEN await the result.
+    const settled = loaded.then(
+      () => null,
+      (error: unknown) => error
+    )
+    await vi.advanceTimersByTimeAsync(5000)
+    const caught = await settled
+
+    // A corrupt-chunk parse failure is unrecoverable-by-retry, so it must be
+    // wrapped as a recoverable LazyChunkLoadError, NOT re-thrown raw to the
+    // RecoverableRenderErrorBoundary where its only "Retry" re-runs the same dead
+    // import. With the fix, the parse-time SyntaxError is recovered.
+    expect(reload).not.toHaveBeenCalled() // guard already set: no second reload
+    expect(isLazyChunkLoadError(caught)).toBe(true)
+  })
+
+  it('treats the corrupt chunk SyntaxError the same as an equivalent fetch failure', async () => {
+    // Demonstrates the blind spot is purely error-shape gating: the SAME corrupt
+    // chunk, surfaced as a fetch failure, IS recovered; surfaced as a parse error,
+    // it is not. Both are the same unrecoverable corrupt right-sidebar chunk.
+    const recover = async (makeError: () => Error): Promise<unknown> => {
+      window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+      const factory = vi.fn(() => Promise.reject(makeError()))
+      const loaded = loadLazyWithRetry(factory, { retries: 0, reloadKey: 'right-sidebar' })
+      try {
+        await loaded
+        return null
+      } catch (error) {
+        return error
+      } finally {
+        await vi.advanceTimersByTimeAsync(5000)
+        window.sessionStorage.clear()
+      }
+    }
+
+    spyOnReload()
+    const fetchOutcome = await recover(equivalentFetchError)
+    const parseOutcome = await recover(reportedCrashError)
+
+    expect(isLazyChunkLoadError(fetchOutcome)).toBe(true) // recovered
+    // The parse error from the very same corrupt chunk must be recovered too.
+    expect(isLazyChunkLoadError(parseOutcome)).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/lazy-with-retry.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.test.ts
@@ -144,10 +144,36 @@ describe('loadLazyWithRetry', () => {
     expect(isLazyChunkLoadError(caught)).toBe(false)
   })
 
-  it('preserves bare parse errors so lazy module evaluation bugs still report', async () => {
+  it('recovers a parse error after the reload guard is set (corrupt chunk = recoverable)', async () => {
+    // A native SyntaxError reaching loadLazyWithRetry's catch comes from the
+    // chunk's parse phase — a stale/truncated/corrupt chunk — so after the one
+    // guarded reload it must be wrapped as a recoverable LazyChunkLoadError
+    // rather than re-thrown raw to the boundary (where Retry just re-runs the
+    // same dead import). Regression guard for crash report e08749bb (right
+    // sidebar, "Unexpected token ')'").
     const reload = spyOnReload()
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
     const error = chunkParseError()
+    const factory = vi.fn(() => Promise.reject(error))
+
+    const loaded = loadLazyWithRetry(factory, { retries: 1, baseDelayMs: 100 })
+    const settled = loaded.then(
+      () => null,
+      (rejection: unknown) => rejection
+    )
+    await vi.advanceTimersByTimeAsync(5000)
+    const caught = await settled
+
+    expect(reload).not.toHaveBeenCalled()
+    expect(isLazyChunkLoadError(caught)).toBe(true)
+  })
+
+  it('preserves ordinary (non-parse) module evaluation errors so real bugs still report', async () => {
+    // An ordinary Error from a lazy module is a genuine evaluation bug, not a
+    // corrupt chunk; it must still surface raw after the guard is set.
+    const reload = spyOnReload()
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    const error = new Error('render bug from lazy module evaluation')
     const factory = vi.fn(() => Promise.reject(error))
 
     const loaded = loadLazyWithRetry(factory, { retries: 1, baseDelayMs: 100 })

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -99,12 +99,24 @@ function isKnownDynamicImportFailure(error: unknown): boolean {
     return true
   }
 
+  // Why: a stale/truncated/corrupt chunk parses as invalid JS, so import()
+  // rejects with a native SyntaxError ("Unexpected token ')'", "Unexpected end
+  // of input", …). That reaches this catch only from the chunk's fetch+parse
+  // phase — a recoverable corrupt-chunk failure. Genuine module-evaluation
+  // logic bugs throw ordinary Errors (still surfaced raw) or fail later during
+  // React render (outside this load path), so they are unaffected.
+  if (error.name === 'SyntaxError') {
+    return true
+  }
+
   return [
     /failed to fetch dynamically imported module/i,
     /error loading dynamically imported module/i,
     /importing a module script failed/i,
     /failed to load module script/i,
-    /loading chunk .+ failed/i
+    /loading chunk .+ failed/i,
+    /unexpected token/i,
+    /unexpected end of (input|script|json)/i
   ].some((pattern) => pattern.test(error.message))
 }
 


### PR DESCRIPTION
## Problem

Crash channel report (Orca 1.4.104, macOS): `react-error-boundary` on the right sidebar.

- `boundary_id`: `right-sidebar`, `surface`: `right-sidebar`
- `error_name`: `SyntaxError`, `error_message`: `Unexpected token ')'`
- `component_stack`: `Lazy → Suspense → RightSidebarPanelContent → … → RecoverableRenderErrorBoundary`
- context: `right_sidebar_tab=source-control`, `has_active_worktree=true`

Same family as the previously-fixed lazy-chunk crash (PR #5803): a stale/truncated/corrupt chunk parses as invalid JS, so its dynamic `import()` rejects with a native `SyntaxError`.

## Root cause

The right-sidebar source-control panel **is** loaded via `lazyWithRetry`, so recovery is wired in. The crash was a **blind spot** in that recovery:

`lazyWithRetry` does one guarded `window.location.reload()` per session to refetch fresh chunk bytes. After that guard is set (`sessionStorage 'orca:lazy-chunk-reload-attempted' === '1'`), it only wraps the failure as a recoverable `LazyChunkLoadError` when `isKnownDynamicImportFailure()` is true — which matched `ChunkLoadError` and a set of **fetch-phase** message regexes. A native `SyntaxError` (`name === 'SyntaxError'`, message `Unexpected token ')'`) matched none of them, so it was **re-thrown raw** to the boundary, whose only "Retry" re-runs the same dead import. The sidebar stayed dead.

## Fix

Treat a parse-time `SyntaxError` as a recoverable corrupt-chunk failure in `isKnownDynamicImportFailure()` (`name === 'SyntaxError'`, plus `unexpected token` / `unexpected end of input|script|json` message patterns).

**Why this is safe:** a `SyntaxError` reaching `loadLazyWithRetry`'s catch can only come from the chunk's fetch+parse phase. Genuine module *evaluation* logic bugs throw ordinary `Error`s (still surfaced raw — covered by a retained test) or fail later during React render, outside this load path. So real bugs still report.

## Evidence of fix

```
 Test Files  2 passed (2)   Tests  12 passed (12)
   (lazy-with-retry.test.ts + lazy-with-retry.right-sidebar-syntax-error.test.ts)
```

Key cases:
- `lazy-with-retry.right-sidebar-syntax-error.test.ts` reproduces the **exact** reported error shape (`new SyntaxError("Unexpected token ')'")`) with the reload guard already set → now recovered as `LazyChunkLoadError` (pre-fix: re-thrown raw = the crash).
- A retained sibling test asserts an **ordinary** `Error` from a lazy module still surfaces raw, so genuine evaluation bugs are not hidden.
- The prior `preserves bare parse errors` test (which encoded the buggy re-throw as intended) was updated to assert recovery.

## ELI5

Big parts of the UI are downloaded in small pieces ("chunks") only when needed. Sometimes a piece arrives broken and the browser says "this isn't valid code" (a `SyntaxError`). The app already knows how to recover from broken pieces — reload once to fetch a fresh copy — but it only recognized *some* kinds of "broken". A `SyntaxError` wasn't on the list, so instead of recovering, the whole right sidebar died with no way back except a manual reload. We added `SyntaxError` to the "this is a broken piece, recover from it" list.

## Trade-offs

- A `SyntaxError` thrown by code that runs *inside* a lazy module's top-level (genuinely buggy source, not a corrupt download) would now also be treated as a recoverable chunk failure rather than surfaced raw. In practice this is extremely rare (our source is type-checked and bundled), the recovery still ends at the error boundary if the reload doesn't help, and the alternative — killing the surface on every corrupt-chunk download — is far worse. Ordinary (non-`SyntaxError`) evaluation bugs are unaffected and still report normally.

## Scope / platforms

Renderer-only; platform-agnostic (applies to SSH/remote where chunks load over the relay too).
