### PR TITLE
fix(mobile): bump session max-lines ratchet to unbreak mobile lint

### DIFF
--- a/mobile/.oxlintrc.json
+++ b/mobile/.oxlintrc.json
@@ -22,7 +22,7 @@
     {
       "files": ["app/h/*/session/*.tsx"],
       "rules": {
-        "max-lines": ["error", { "max": 4988, "skipBlankLines": true, "skipComments": true }]
+        "max-lines": ["error", { "max": 5015, "skipBlankLines": true, "skipComments": true }]
       }
     },
     {


### PR DESCRIPTION
## What

`mobile/app/h/[hostId]/session/[worktreeId].tsx` exceeds its `max-lines` ratchet (**5015 > 4988** counted lines), so **`origin/main` is currently red on mobile lint** — blocking every PR that touches `mobile/`.

## Root cause

PR #6659 (*Show the git primary action on mobile Source Control*) grew this file from 5560 → 5605 raw lines, past its 4988 counted-line ratchet, **without bumping the override**. Its own mobile CI passed because it branched off stale main where the file was smaller. Once it merged, main went red — but `mobile.yml` only runs on PRs touching `mobile/**`, so no main-push build surfaced it. The next mobile-touching PR (#6847) is where it showed up.

## Fix

Bump the per-file override `4988 → 5015` to match the file's actual size — exactly what #6659 should have done. One-line config change, no code touched.

Per AGENTS.md this file must not carry a `max-lines` *disable*; the tight per-file ratchet stays. The 5600-line file is a good candidate for a future split, but that's a separate owner-driven refactor, not a main-unbreaking hotfix.

## Verification

- mobile `oxlint`: **0 errors**
- root `oxlint` (descends into mobile): **0 errors**

Made with [Orca](https://github.com/stablyai/orca) 🐋
