### PR TITLE
fix: never leave a split-right PTY pinned at 0x0 (white screen)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-size-reconcile.ts
+++ b/src/renderer/src/components/terminal-pane/pty-size-reconcile.ts
@@ -91,6 +91,15 @@ export type PtySizeReconcileHandle = { cancel: () => void }
 const POST_SPAWN_RECONCILE_SETTLE_FRAMES = 8
 const POST_SPAWN_RECONCILE_MAX_FRAMES = 180
 
+// Safe minimum grid forwarded as a last resort when a VISIBLE pane never became
+// measurable within the reconcile window and the PTY is still pinned at the
+// unusable 0×0 it was spawned at. A shell rendering into a 0-row grid shows a
+// blank/white pane (the "split terminal right → white screen" report); 80×24 is
+// the universal terminal default and the live onResize corrects it once the
+// pane finally lays out.
+const POST_SPAWN_RECONCILE_FALLBACK_COLS = 80
+const POST_SPAWN_RECONCILE_FALLBACK_ROWS = 24
+
 export function reconcilePtySizeAcrossFrames(
   options: PtySizeReconcileOptions
 ): PtySizeReconcileHandle {
@@ -194,6 +203,25 @@ export function reconcilePtySizeAcrossFrames(
     const settled = gridStable && appliedVerified
     if (!settled && frame < POST_SPAWN_RECONCILE_MAX_FRAMES) {
       pendingFrame = options.requestFrame(tick)
+      return
+    }
+    // Last resort on termination: a VISIBLE pane that never measured a usable
+    // grid (measure() returned null/zero every frame) and whose PTY is still
+    // pinned at the 0×0 it was spawned at would render blank — the split-right
+    // white-screen report. Forward a safe default so the shell has a real grid;
+    // the live onResize re-syncs the true size once the pane lays out. Skip
+    // while parked (mobile owns the size) and while hidden (a background spawn
+    // legitimately stays 0×0 and re-fits on show).
+    if (
+      !settled &&
+      !options.isParked() &&
+      options.isAuthoritative() &&
+      lastSentCols <= 0 &&
+      lastSentRows <= 0
+    ) {
+      options.resize(POST_SPAWN_RECONCILE_FALLBACK_COLS, POST_SPAWN_RECONCILE_FALLBACK_ROWS)
+      lastSentCols = POST_SPAWN_RECONCILE_FALLBACK_COLS
+      lastSentRows = POST_SPAWN_RECONCILE_FALLBACK_ROWS
     }
   }
 

--- a/src/renderer/src/components/terminal-pane/split-right-white-screen.test.ts
+++ b/src/renderer/src/components/terminal-pane/split-right-white-screen.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  reconcilePtySizeAcrossFrames,
+  type PtySizeReconcileDimensions,
+  type PtySizeReconcileOptions
+} from './pty-size-reconcile'
+
+/**
+ * Regression: "Split terminal right" → new pane shows a white/blank screen.
+ *
+ * Spawn path (pty-connection.ts runDeferredConnect):
+ *   - A split pane's PTY spawn is deferred to a requestAnimationFrame.
+ *   - That frame calls safeFit(pane) then reads pane.terminal.cols/rows and
+ *     spawns with transport.connect({ cols, rows }).
+ *   - For a freshly reparented split-right pane whose container has not laid
+ *     out yet, safeFit is a no-op (canMeasurePaneForFit / getProposedDimensions
+ *     yields nothing), so cols === rows === 0 and the PTY is spawned at 0x0.
+ *
+ * The post-spawn reconcile (reconcilePtySizeAfterSpawn -> this loop) is the
+ * ONLY thing that can heal a 0x0 spawn. Its measure() returns null whenever the
+ * pane is still unmeasurable (the `cols > 0 && rows > 0 ? ... : null` gate).
+ * Before the fix, null frames made no stability progress AND forwarded nothing,
+ * so a pane that stayed unmeasurable through the authoritative window ran to the
+ * hard frame cap and terminated having forwarded NO resize — leaving the PTY
+ * pinned at 0x0. A shell rendering into a 0-row grid is the blank/white pane the
+ * user reported.
+ *
+ * The fix forwards a safe 80×24 fallback on termination when a VISIBLE pane is
+ * still pinned at 0x0, so the shell always has a usable grid; the live onResize
+ * re-syncs the true size once the pane lays out. These tests pin both the
+ * normal settle and the fallback.
+ *
+ * Harness mirrors pty-size-reconcile.test.ts (deterministic frame scheduler).
+ */
+
+function createFrameScheduler() {
+  const queue = new Map<number, () => void>()
+  let nextHandle = 1
+  return {
+    requestFrame: (callback: () => void): number => {
+      const handle = nextHandle++
+      queue.set(handle, callback)
+      return handle
+    },
+    cancelFrame: (handle: number): void => {
+      queue.delete(handle)
+    },
+    run(maxFrames = 5000): number {
+      let ran = 0
+      while (queue.size > 0 && ran < maxFrames) {
+        const [handle, callback] = queue.entries().next().value as [number, () => void]
+        queue.delete(handle)
+        callback()
+        ran += 1
+      }
+      return ran
+    },
+    pending: () => queue.size
+  }
+}
+
+function runReconcile(
+  overrides: Partial<PtySizeReconcileOptions> & Pick<PtySizeReconcileOptions, 'measure'>
+): { resize: ReturnType<typeof vi.fn>; lastSent: PtySizeReconcileDimensions | null } {
+  const scheduler = createFrameScheduler()
+  const resize = vi.fn()
+  let lastSent: PtySizeReconcileDimensions | null = null
+  reconcilePtySizeAcrossFrames({
+    // The freshly split pane was spawned at 0x0 (deferred fit ran before the
+    // reparented container had layout dimensions).
+    spawnCols: 0,
+    spawnRows: 0,
+    isAlive: () => true,
+    isParked: () => false,
+    // Pane is visible (the user just split the active tab to the right), so the
+    // renderer resize path is "authoritative" immediately.
+    isAuthoritative: () => true,
+    resize: (cols, rows) => {
+      lastSent = { cols, rows }
+      resize(cols, rows)
+    },
+    requestFrame: scheduler.requestFrame,
+    cancelFrame: scheduler.cancelFrame,
+    ...overrides
+  })
+  scheduler.run()
+  return { resize, lastSent }
+}
+
+describe('split-right white screen: post-spawn PTY size reconcile', () => {
+  it('recovers a 0x0 spawn whose container is briefly unmeasurable then settles', () => {
+    // Real-world timeline for split-right: the reparented pane has no layout for
+    // the first handful of frames (measure -> null), then the split equalizes
+    // and the pane measures a real grid. The reconcile must forward that grid so
+    // the PTY leaves 0x0; otherwise the shell renders into a 0-row buffer (blank).
+    let frame = 0
+    const SETTLE_AT = 3
+    const { resize, lastSent } = runReconcile({
+      measure: vi.fn((): PtySizeReconcileDimensions | null => {
+        const dims = frame < SETTLE_AT ? null : { cols: 120, rows: 40 }
+        frame += 1
+        return dims
+      }),
+      // Local PTY: applied size readback reflects what was actually forwarded.
+      getAppliedSize: vi.fn(async () => lastSentForApplied)
+    })
+
+    // The settled 120x40 grid is forwarded so the PTY leaves its 0x0 spawn size.
+    expect(resize).toHaveBeenCalledWith(120, 40)
+    expect(lastSent).toEqual({ cols: 120, rows: 40 })
+  })
+
+  it('forwards a safe fallback grid when a visible pane stays unmeasurable (never leaves the PTY at 0x0)', () => {
+    // The reparented split-right pane never becomes measurable within the
+    // reconcile window (0-size container: the documented split-mount race where
+    // layout has not settled). measure() returns null on every frame.
+    const measure = vi.fn((): PtySizeReconcileDimensions | null => null)
+    const { resize, lastSent } = runReconcile({
+      measure,
+      getAppliedSize: vi.fn(async () => ({ cols: 0, rows: 0 }))
+    })
+
+    // The loop ran its full course (hard cap) but never measured a grid.
+    expect(measure.mock.calls.length).toBeGreaterThan(0)
+
+    // The PTY was spawned at 0x0 and the reconcile is the only corrector. With
+    // the fix, on termination a still-0x0 VISIBLE pane is given a safe default
+    // grid so the shell never renders into a 0-row buffer (the white screen);
+    // the live onResize re-syncs the true size once the pane lays out.
+    expect(lastSent, 'reconcile must not leave a split-right PTY pinned at 0x0').not.toBeNull()
+    expect(resize).toHaveBeenCalled()
+    const [cols, rows] = resize.mock.calls.at(-1) ?? [0, 0]
+    expect(cols, 'PTY columns must be non-zero or the shell renders blank').toBeGreaterThan(0)
+    expect(rows, 'PTY rows must be non-zero or the shell renders blank').toBeGreaterThan(0)
+  })
+
+  it('does NOT force a fallback when the pane is hidden (background spawn legitimately stays 0x0)', () => {
+    // A permanently-hidden background spawn at 0x0 is legitimate (orchestration
+    // workers, `terminal create` without --focus); it refits when shown, so the
+    // reconcile must not push a phantom 80x24 onto it.
+    const { resize, lastSent } = runReconcile({
+      isAuthoritative: () => false,
+      measure: vi.fn((): PtySizeReconcileDimensions | null => null),
+      getAppliedSize: vi.fn(async () => ({ cols: 0, rows: 0 }))
+    })
+
+    expect(resize).not.toHaveBeenCalled()
+    expect(lastSent).toBeNull()
+  })
+})
+
+// Stand-in for a local PTY's applied-size readback used by the first test.
+const lastSentForApplied: PtySizeReconcileDimensions = { cols: 120, rows: 40 }


### PR DESCRIPTION
## Problem

Crash channel report (Orca 1.4.104, macOS), verbatim user note:

> After executing the "split terminal right" operation, the shell did not open properly and a white screen was displayed.

## Root cause

Splitting a terminal to the right reparents the new pane into a flex layout that has **no dimensions on the deferred-rAF frame where the PTY spawns**. `runDeferredConnect` calls `safeFit(pane)` then spawns with `transport.connect({ cols, rows })`; for the not-yet-laid-out pane `safeFit` is a no-op (`canMeasurePaneForFit` yields nothing), so `cols === rows === 0` and **the PTY is born at 0×0**.

The post-spawn reconcile (`reconcilePtySizeAcrossFrames`) is the only thing that can heal a 0×0 spawn, but its `measure()` returns `null` while the pane is unmeasurable. Null frames make no stability progress *and* forward nothing. If the pane stays unmeasurable through the hard frame cap (`POST_SPAWN_RECONCILE_MAX_FRAMES`), the loop terminates **having forwarded no resize at all** — the PTY stays pinned at 0×0, the shell renders into a 0-row grid, and the pane is blank/white.

## Fix

On loop termination, if a **visible** (authoritative) pane is still pinned at 0×0, forward a safe **80×24** fallback so the shell always has a usable grid. The live `onResize`/ResizeObserver path re-syncs the true size as soon as the pane lays out. The fallback is skipped:
- while **parked** (mobile-fit override legitimately owns the size), and
- while **hidden** (a background spawn — orchestration workers, `terminal create` without `--focus` — legitimately stays 0×0 and refits when shown).

## Evidence of fix

`split-right-white-screen.test.ts` drives the **real** `reconcilePtySizeAcrossFrames` with a deterministic frame scheduler (same harness as the existing `pty-size-reconcile.test.ts`):

```
✓ recovers a 0x0 spawn whose container is briefly unmeasurable then settles
✓ forwards a safe fallback grid when a visible pane stays unmeasurable (never leaves the PTY at 0x0)
✓ does NOT force a fallback when the pane is hidden (background spawn legitimately stays 0x0)
```

Full reconcile suite stays green (no regression in the convergence loop):

```
 Test Files  2 passed (2)   Tests  22 passed (22)
   (split-right-white-screen.test.ts + pty-size-reconcile.test.ts)
```

Pre-fix, the "stays unmeasurable" case forwarded nothing (`resize` never called) — the reported white screen. Post-fix it forwards 80×24.

## ELI5

When you split a terminal to the right, the new panel is created a split-second before the screen figures out how big it should be. In that instant the program asks "how many rows and columns?" and the answer is "zero". Normally a follow-up measurement fixes it — but if the panel takes too long to get a real size, the follow-up gives up and the shell is left thinking it has a **0-row screen**, so it draws nothing: a white pane. The fix says "if we're about to give up and the panel is visible but still zero-sized, hand the shell a normal 80×24 screen so it can draw something" — and the moment the real size arrives, it snaps to that.

## Trade-offs

- In the rare worst case (a visible split pane that never measures within ~3s at 60fps), the shell briefly renders at **80×24** before the real size lands and `onResize` corrects it. A momentary default-size flash is strictly better than a permanently blank pane, and in practice the pane usually measures within a few frames (the "briefly unmeasurable then settles" path, unchanged).
- The fallback only fires for **visible** panes, so hidden/background spawns keep their legitimate 0×0 (no phantom 80×24 pushed onto orchestration workers). This is covered by a dedicated test.
- 80×24 is the universal terminal default; it is not derived from the user's real pane size, but it is immediately superseded by the authoritative `onResize` once layout settles.

## Scope / platforms

Renderer-only; platform-agnostic. The reconcile path is shared by local, SSH, and remote-runtime PTYs — the fallback uses the same authoritative `resize()` the loop already uses, with the existing parked/remote guards intact. Cannot be reproduced in headless Electron (the unit test on the real reconcile loop is the harness), consistent with prior terminal-sizing fixes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
