### PR TITLE
fix(browser): mount floating-workspace browser webview via a slot viewport root

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingBrowserSlot.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingBrowserSlot.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FloatingBrowserSlot } from './FloatingBrowserSlot'
+import { getBrowserOverlaySlotViewport } from '@/components/browser-pane/browser-page-viewport'
+import type { BrowserTab } from '../../../../shared/types'
+
+// Why: BrowserPane mounts a real Electron <webview> we can't run in jsdom; stub
+// it so the test isolates the slot-root registration that BrowserPane depends on.
+vi.mock('@/components/browser-pane/BrowserPane', () => ({
+  default: () => null
+}))
+
+function makeBrowserTab(id: string): BrowserTab {
+  return {
+    id,
+    worktreeId: 'global-floating-terminal',
+    activePageId: id,
+    pageIds: [id],
+    url: 'https://google.com',
+    title: 'Google',
+    loading: true,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    loadError: null,
+    createdAt: 0
+  }
+}
+
+describe('FloatingBrowserSlot', () => {
+  let container: HTMLDivElement | null = null
+  let root: Root | null = null
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    container?.remove()
+    root = null
+    container = null
+  })
+
+  it('registers a browser overlay slot viewport keyed by the tab id so BrowserPane can mount its webview', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    expect(getBrowserOverlaySlotViewport('floating-browser-1')).toBeNull()
+
+    act(() => {
+      root!.render(
+        <FloatingBrowserSlot browserTab={makeBrowserTab('floating-browser-1')} isActive />
+      )
+    })
+
+    // Without this registration ensureBrowserPageViewport returns null, the
+    // webview is never created, and the page spins on "loading" forever.
+    expect(getBrowserOverlaySlotViewport('floating-browser-1')).not.toBeNull()
+  })
+
+  it('unregisters the slot viewport when the tab unmounts', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root!.render(
+        <FloatingBrowserSlot browserTab={makeBrowserTab('floating-browser-2')} isActive />
+      )
+    })
+    expect(getBrowserOverlaySlotViewport('floating-browser-2')).not.toBeNull()
+
+    act(() => {
+      root!.unmount()
+    })
+    root = null
+
+    expect(getBrowserOverlaySlotViewport('floating-browser-2')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/floating-terminal/FloatingBrowserSlot.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingBrowserSlot.tsx
@@ -1,0 +1,33 @@
+import { useCallback } from 'react'
+import BrowserPane from '@/components/browser-pane/BrowserPane'
+import { registerBrowserOverlaySlotViewport } from '@/components/browser-pane/browser-page-viewport'
+import type { BrowserTab as BrowserTabState } from '../../../../shared/types'
+
+// Why: BrowserPane mounts its persistent Electron <webview> into a slot viewport
+// root keyed by the browser tab id. The main workspace registers that root via
+// BrowserPaneOverlayLayer, but the floating panel renders BrowserPane directly
+// and has no overlay layer — so without registering a root here,
+// ensureBrowserPageViewport returns null, the webview is never created, and the
+// page spins on "loading" forever. Mirror BrowserOverlaySlot's slot-root div so
+// the guest mounts and survives tab switches (the root must not be reparented).
+export function FloatingBrowserSlot({
+  browserTab,
+  isActive
+}: {
+  browserTab: BrowserTabState
+  isActive: boolean
+}): React.JSX.Element {
+  const setSlotViewportRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      registerBrowserOverlaySlotViewport(browserTab.id, node)
+    },
+    [browserTab.id]
+  )
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div ref={setSlotViewportRef} className="absolute inset-0 flex min-h-0 flex-col" />
+      <BrowserPane browserTab={browserTab} isActive={isActive} />
+    </div>
+  )
+}

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -6,7 +6,6 @@ import { Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, use
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { FileText, Globe, Minus, TerminalSquare } from 'lucide-react'
 import { toast } from 'sonner'
-import BrowserPane from '@/components/browser-pane/BrowserPane'
 import EmulatorPane from '@/components/emulator-pane/EmulatorPane'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { useContextualTour } from '@/components/contextual-tours/use-contextual-tour'
@@ -75,6 +74,7 @@ import type {
   TerminalTab
 } from '../../../../shared/types'
 import { resolveUnifiedTabLabel } from '../../../../shared/tab-title-resolution'
+import { FloatingBrowserSlot } from './FloatingBrowserSlot'
 import { FloatingTerminalOrchestrationDialog } from './FloatingTerminalOrchestrationDialog'
 import { FloatingTerminalResizeHandles } from './FloatingTerminalResizeHandles'
 import { FloatingTerminalWindowControls } from './FloatingTerminalWindowControls'
@@ -1624,7 +1624,7 @@ export function FloatingTerminalPanel({
                 className={isActive ? 'absolute inset-0 flex' : 'absolute inset-0 hidden'}
                 aria-hidden={!isActive}
               >
-                <BrowserPane browserTab={tab} isActive={open && isActive} />
+                <FloatingBrowserSlot browserTab={tab} isActive={open && isActive} />
               </div>
             )
           })}


### PR DESCRIPTION
## ELI5

The floating workspace (the little draggable window with terminal/browser/notes tabs) had a browser that **spun forever** when you went to a site like google.com. Everywhere else the browser was fine.

Here's why: a while back (#6408), we changed how the browser draws its actual web page. The real web page (an Electron `<webview>`) now needs a little "parking spot" in the page that gets set up by a helper layer. The main workspace sets up that parking spot — but the **floating workspace was never taught to**. So the browser had nowhere to put the page, never actually created it, and the loading spinner just spun forever waiting for a page that was never born.

This PR teaches the floating workspace to set up that parking spot (one per browser tab), exactly the way the main workspace already does. Now the page mounts, loads, and the spinner goes away.

**Before:** floating browser → endless spinner, no page ever loads.
**After:** floating browser → loads normally, just like the main browser.

## What changed

- New `FloatingBrowserSlot` component that registers a per-tab slot viewport root (`registerBrowserOverlaySlotViewport(tab.id, node)`), mirroring the main workspace's `BrowserOverlaySlot`, then renders `BrowserPane`.
- `FloatingTerminalPanel` now renders `FloatingBrowserSlot` instead of `BrowserPane` directly.
- Added `FloatingBrowserSlot.test.tsx` regression test (verified it fails against the pre-fix code and passes with the fix).

No CSS anchor positioning is needed (the floating panel has no `TabGroupPanel`), and the remote/SSH screencast browser path is untouched.

## User-facing trade-offs / degradations

**None that regress current behavior** — the floating browser went from "completely broken" to "works." The fix only brings it in line with how the main-workspace browser already behaves. Two honest notes for completeness:

- **Memory:** each *open* floating browser tab now keeps one Electron guest renderer alive while parked (e.g. when the floating panel is minimized or another floating tab is active), instead of nothing existing at all. This is the same cost the main-workspace browser already pays, and it's deliberate — it preserves page state (form text, scroll position, logged-in sessions, SPA state) across tab switches. Closing the tab tears the guest down as before.
- **No behavioral surprises:** inactive floating browser tabs stay hidden-but-alive (matching the main workspace); closing the last floating tab / minimizing with no tabs still cleans up the slot root on unmount.

## Verification

- `typecheck:web` ✅ · `oxlint` ✅
- 93 floating-terminal unit tests pass, including the new regression test.
- **End-to-end in the running Electron app:** opened the floating workspace, created a browser tab → `google.com`. A live `<webview>` appeared, `src` advanced to `https://www.google.com/?zx=…`, `loading` flipped to `false`, and Google rendered on screen (no spinner). Verified attached to this worktree's dev instance.

## Related

Related to #6831 — specifically the *"Browser doesn't work either"* line. That issue's **headline** (editor stuck on *"Connecting to the remote host… retrying once the workspace is ready"*) is a **separate** root cause (the worktree-owner / workspace-ready file-load gate, `WORKTREE_OWNER_NOT_READY_ERROR`), which is being handled separately by @Jinwoo-H. This PR does **not** close #6831 — it only fixes the floating-browser sub-symptom (assuming a local, non-remote-runtime floating browser, which is the broken case here).

Made with [Orca](https://github.com/stablyai/orca) 🐋
