### PR TITLE
fix(win): guard xterm link providers so a RangeError can't kill the renderer

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -12,6 +12,7 @@ import type { ManagedPaneInternal, PaneManagerOptions } from './pane-manager-typ
 import { buildDefaultTerminalOptions } from './pane-terminal-options'
 import { shouldFocusTerminalFromPanePointerDown } from './pane-pointer-focus'
 import { ENABLE_WEBGL_RENDERER } from './pane-webgl-renderer'
+import { installGuardedLinkProviderRegistration } from './terminal-link-provider-guard'
 
 function getTerminalUrlOpenHint(): string {
   return navigator.userAgent.includes('Mac')
@@ -49,6 +50,11 @@ export function createPaneDOM(
   }
 
   const terminal = new Terminal(terminalOpts)
+  // Why: a synchronous throw inside any link provider's provideLinks (notably
+  // xterm web-links' LinkComputer raising RangeError on a pathological wrapped
+  // line) escapes to window.onerror and gets the renderer killed. Guard every
+  // provider registered after this point — addon-internal and Orca's own.
+  installGuardedLinkProviderRegistration(terminal)
   const fitAddon = new FitAddon()
   const searchAddon = new SearchAddon()
   const unicode11Addon = new Unicode11Addon()

--- a/src/renderer/src/lib/pane-manager/terminal-link-provider-guard.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-link-provider-guard.test.ts
@@ -1,0 +1,111 @@
+import type { ILink, ILinkProvider, Terminal } from '@xterm/xterm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  guardLinkProvider,
+  installGuardedLinkProviderRegistration
+} from './terminal-link-provider-guard'
+
+const mocks = vi.hoisted(() => ({
+  recordRendererCrashBreadcrumb: vi.fn()
+}))
+
+vi.mock('@/lib/crash-diagnostics', () => ({
+  recordRendererCrashBreadcrumb: mocks.recordRendererCrashBreadcrumb
+}))
+
+beforeEach(() => {
+  mocks.recordRendererCrashBreadcrumb.mockClear()
+})
+
+function collectLinks(provider: ILinkProvider, bufferLineNumber = 1): ILink[] | undefined {
+  let result: ILink[] | undefined
+  let called = false
+  provider.provideLinks(bufferLineNumber, (links) => {
+    called = true
+    result = links
+  })
+  expect(called).toBe(true)
+  return result
+}
+
+describe('guardLinkProvider', () => {
+  it('reproduces the xterm web-links RangeError without letting it escape', () => {
+    // Why: this is the F0BDKBHDAUE crash — LinkComputer._getWindowedLineStrings
+    // allocates an array of invalid length on a pathological wrapped line.
+    const provider: ILinkProvider = {
+      provideLinks: () => {
+        throw new RangeError('Invalid array length')
+      }
+    }
+    const guarded = guardLinkProvider(provider, 'web-links')
+
+    expect(() => collectLinks(guarded)).not.toThrow()
+    expect(collectLinks(guarded)).toBeUndefined()
+    expect(mocks.recordRendererCrashBreadcrumb).toHaveBeenCalledWith(
+      'terminal_link_provider_error',
+      {
+        provider: 'web-links',
+        bufferLineNumber: 1,
+        errorName: 'RangeError',
+        errorMessage: 'Invalid array length'
+      }
+    )
+  })
+
+  it('passes provided links through unchanged when the provider succeeds', () => {
+    const links = [{ text: 'term_abc' }] as unknown as ILink[]
+    const provider: ILinkProvider = {
+      provideLinks: (_lineNumber, callback) => callback(links)
+    }
+    const guarded = guardLinkProvider(provider, 'orca-handle')
+
+    expect(collectLinks(guarded)).toBe(links)
+    expect(mocks.recordRendererCrashBreadcrumb).not.toHaveBeenCalled()
+  })
+
+  it('does not double-invoke the callback when the provider throws after resolving', () => {
+    const links = [{ text: 'file.ts' }] as unknown as ILink[]
+    const provider: ILinkProvider = {
+      provideLinks: (_lineNumber, callback) => {
+        callback(links)
+        throw new RangeError('Invalid array length')
+      }
+    }
+    const guarded = guardLinkProvider(provider, 'orca-file')
+
+    const callback = vi.fn()
+    expect(() => guarded.provideLinks(1, callback)).not.toThrow()
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(links)
+    expect(mocks.recordRendererCrashBreadcrumb).toHaveBeenCalledOnce()
+  })
+})
+
+describe('installGuardedLinkProviderRegistration', () => {
+  it('guards every provider registered after install (addon-internal included)', () => {
+    const registered: ILinkProvider[] = []
+    const terminal = {
+      registerLinkProvider: (provider: ILinkProvider) => {
+        registered.push(provider)
+        return { dispose: vi.fn() }
+      }
+    } as unknown as Terminal
+
+    installGuardedLinkProviderRegistration(terminal)
+
+    // Simulate the web-links addon's loadAddon -> registerLinkProvider path.
+    terminal.registerLinkProvider({
+      provideLinks: () => {
+        throw new RangeError('Invalid array length')
+      }
+    })
+
+    expect(registered).toHaveLength(1)
+    expect(() => collectLinks(registered[0])).not.toThrow()
+    expect(collectLinks(registered[0])).toBeUndefined()
+    expect(mocks.recordRendererCrashBreadcrumb).toHaveBeenCalledWith(
+      'terminal_link_provider_error',
+      expect.objectContaining({ provider: 'provider-1', errorName: 'RangeError' })
+    )
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-link-provider-guard.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-link-provider-guard.ts
@@ -1,0 +1,60 @@
+import type { ILinkProvider, Terminal } from '@xterm/xterm'
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-diagnostics'
+
+/**
+ * Wrap a link provider so a synchronous throw inside `provideLinks` is reported
+ * as "no links" instead of escaping to `window.onerror`.
+ *
+ * Why: xterm's web-links `LinkComputer._getWindowedLineStrings` can raise
+ * `RangeError: Invalid array length` while scanning a pathological wrapped line
+ * (e.g. agent CLI output with very wide/control-mangled buffers). That throw
+ * propagates out of the synchronously-invoked provider and wedges the renderer,
+ * which Chromium then kills (`killed` exit 1). Degrading to "no link this hover"
+ * keeps the renderer alive; the user can retry by moving the mouse.
+ */
+export function guardLinkProvider(provider: ILinkProvider, label: string): ILinkProvider {
+  return {
+    provideLinks(bufferLineNumber, callback) {
+      let callbackInvoked = false
+      const trackedCallback: typeof callback = (links) => {
+        callbackInvoked = true
+        callback(links)
+      }
+      try {
+        provider.provideLinks(bufferLineNumber, trackedCallback)
+      } catch (error: unknown) {
+        recordRendererCrashBreadcrumb('terminal_link_provider_error', {
+          provider: label,
+          bufferLineNumber,
+          errorName: error instanceof Error ? error.name : typeof error,
+          errorMessage: error instanceof Error ? error.message : String(error)
+        })
+        // Why: only resolve the link request if the provider threw before it
+        // already delivered links, so we never double-invoke the callback.
+        if (!callbackInvoked) {
+          callback(undefined)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Patch `terminal.registerLinkProvider` so every provider registered afterward
+ * — including xterm addons' internal providers loaded via `loadAddon` (notably
+ * the web-links `LinkComputer`) — is wrapped by {@link guardLinkProvider}.
+ * Must run before any `loadAddon`/`registerLinkProvider` call for the terminal.
+ */
+export function installGuardedLinkProviderRegistration(terminal: Terminal): void {
+  // Why: never let the guard itself break pane creation if a Terminal stub or a
+  // future xterm build lacks registerLinkProvider.
+  if (typeof terminal.registerLinkProvider !== 'function') {
+    return
+  }
+  const register = terminal.registerLinkProvider.bind(terminal)
+  let providerCount = 0
+  terminal.registerLinkProvider = (provider: ILinkProvider) => {
+    providerCount += 1
+    return register(guardLinkProvider(provider, `provider-${providerCount}`))
+  }
+}


### PR DESCRIPTION
## What & why

Windows crash cluster **`killed` (renderer exit 1)** — report `F0BDKBHDAUE`. ~34s before the renderer died, this fired:

```
Uncaught RangeError: Invalid array length
  at Array.push (<anonymous>)
  at l2._getWindowedLineStrings (...)
  at l2.computeLink (...)
  at u.provideLinks (...)
```

That stack is inside **xterm's web-links addon `LinkComputer`** (`@xterm/addon-web-links`), which xterm calls **synchronously** to scan a buffer line for URLs. The user was opening the `opencode` agent CLI, whose banner/streaming output can produce a pathological wrapped line; `_getWindowedLineStrings` then allocates an array of invalid length and throws.

Because `provideLinks` is invoked synchronously by xterm, the throw escapes to `window.onerror`, wedges the renderer, and Chromium kills it (`reason=killed`, `exitCode=1`, which `process-gone-classification.ts` correctly treats as a reportable crash).

## ELI5

The terminal has little helpers that scan each line looking for clickable links (URLs, file paths, `term_…` handles). One of them (xterm's built-in URL scanner) can trip over a weird super-wide line and throw an error. That error wasn't caught, so the whole terminal window crashed. This PR wraps **every** link scanner in a safety net: if one trips, we log a breadcrumb and just show "no link for that hover" — the window stays alive. Move the mouse again and it retries.

## The fix

`createPaneDOM` patches `terminal.registerLinkProvider` right after the `Terminal` is constructed (before any `loadAddon`). Every provider registered afterward — the web-links addon's internal provider (the actual culprit) **and** Orca's own file-path / terminal-handle providers — gets its `provideLinks` wrapped in a try/catch that:

- records a `terminal_link_provider_error` crash breadcrumb (provider label, buffer line, error name/message), and
- calls the link callback with `undefined` (only if the provider hadn't already delivered links), instead of letting the error escape.

A single chokepoint (`registerLinkProvider`) covers all current and future providers, including addon-internal ones we don't construct ourselves.

## Fixed evidence

Standalone repro of the exact mechanism (`provideLinks` throwing `RangeError` while xterm invokes it synchronously):

```
=== BEFORE FIX (unguarded) ===
THROW escapes to window.onerror -> RangeError: Invalid array length -> renderer killed (exit 1)

=== AFTER FIX (guarded) ===
[breadcrumb] terminal_link_provider_error provider=web-links RangeError: Invalid array length
no throw; renderer stays alive; links = undefined
```

New unit tests (`terminal-link-provider-guard.test.ts`, 4 tests) reproduce the `RangeError`, assert it no longer escapes, assert successful providers pass links through unchanged, assert the callback is never double-invoked, and assert the install-patch wraps providers registered after install (the addon path). Existing `pane-dom-creation`, `pane-lifecycle`, `terminal-handle-links`, `terminal-link-handlers` suites stay green (124 tests). Web typecheck + lint clean.

## Trade-offs

- **Degrade vs crash**: on a genuinely corrupt buffer line, link detection for that hover is silently skipped (logged as a breadcrumb, no user toast). Link highlighting is a non-critical enhancement; keeping the renderer (and all terminal/agent state) alive is the right call.
- **Tiny per-call wrapper**: every `provideLinks` now goes through one extra closure and an `invoked` flag. Negligible — these run on hover, not per frame.
- **Doesn't fix the upstream xterm bug**: the web-links `LinkComputer` can still mis-handle the pathological line; we contain its blast radius rather than patching the beta addon. Pinning/auditing `@xterm/addon-web-links` remains worthwhile as a follow-up.
- **Cross-platform/SSH neutral**: the guard wraps the provider regardless of platform or local/remote runtime; no behavior change on the success path.
