### PR TITLE
fix(win): stop renderer crash-loop with an auto-recovery circuit breaker

### DIFF
--- a/src/main/crash-reporting/renderer-recovery-circuit-breaker.test.ts
+++ b/src/main/crash-reporting/renderer-recovery-circuit-breaker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES,
+  DEFAULT_RENDERER_RECOVERY_WINDOW_MS,
+  RendererRecoveryCircuitBreaker
+} from './renderer-recovery-circuit-breaker'
+
+describe('RendererRecoveryCircuitBreaker', () => {
+  it('allows recoveries up to the limit, then opens', () => {
+    const breaker = new RendererRecoveryCircuitBreaker({ windowMs: 60_000, maxRecoveries: 3 })
+
+    // A tight crash loop: renderer dies and is reloaded every ~800ms.
+    expect(breaker.registerRecoveryAttempt(0)).toEqual({ allowed: true, recentRecoveryCount: 1 })
+    expect(breaker.registerRecoveryAttempt(800)).toEqual({ allowed: true, recentRecoveryCount: 2 })
+    expect(breaker.registerRecoveryAttempt(1_600)).toEqual({
+      allowed: true,
+      recentRecoveryCount: 3
+    })
+    // 4th within the window: breaker is open, no further auto-reload.
+    expect(breaker.registerRecoveryAttempt(2_400)).toEqual({
+      allowed: false,
+      recentRecoveryCount: 3
+    })
+    expect(breaker.registerRecoveryAttempt(3_200)).toEqual({
+      allowed: false,
+      recentRecoveryCount: 3
+    })
+  })
+
+  it('reopens once stale attempts age out of the rolling window', () => {
+    const breaker = new RendererRecoveryCircuitBreaker({ windowMs: 60_000, maxRecoveries: 3 })
+
+    // Stored attempts after the loop: [0, 1000, 2000] (the 4th is rejected).
+    breaker.registerRecoveryAttempt(0)
+    breaker.registerRecoveryAttempt(1_000)
+    breaker.registerRecoveryAttempt(2_000)
+    expect(breaker.registerRecoveryAttempt(3_000).allowed).toBe(false)
+
+    // At t=60_500 (cutoff 500), only 1000 and 2000 are still in the window.
+    expect(breaker.recentRecoveryCount(60_500)).toBe(2)
+    // Renderer survived long enough that all three attempts have aged out.
+    expect(breaker.recentRecoveryCount(62_001)).toBe(0)
+    expect(breaker.registerRecoveryAttempt(62_001).allowed).toBe(true)
+  })
+
+  it('does not count a single transient crash as a loop', () => {
+    const breaker = new RendererRecoveryCircuitBreaker({ windowMs: 60_000, maxRecoveries: 3 })
+    expect(breaker.registerRecoveryAttempt(0).allowed).toBe(true)
+    // Hours later, an unrelated crash: still allowed (window long expired).
+    expect(breaker.registerRecoveryAttempt(10_000_000).allowed).toBe(true)
+  })
+
+  it('reset() clears history so the next recovery is allowed', () => {
+    const breaker = new RendererRecoveryCircuitBreaker({ windowMs: 60_000, maxRecoveries: 1 })
+    expect(breaker.registerRecoveryAttempt(0).allowed).toBe(true)
+    expect(breaker.registerRecoveryAttempt(100).allowed).toBe(false)
+    breaker.reset()
+    expect(breaker.registerRecoveryAttempt(200).allowed).toBe(true)
+  })
+
+  it('ships conservative defaults', () => {
+    expect(DEFAULT_RENDERER_RECOVERY_WINDOW_MS).toBe(60_000)
+    expect(DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES).toBe(3)
+  })
+})

--- a/src/main/crash-reporting/renderer-recovery-circuit-breaker.ts
+++ b/src/main/crash-reporting/renderer-recovery-circuit-breaker.ts
@@ -1,0 +1,66 @@
+export type RendererRecoveryCircuitBreakerOptions = {
+  /** Rolling window in which auto-recoveries are counted. */
+  windowMs: number
+  /** Max auto-recoveries allowed within the window before the breaker opens. */
+  maxRecoveries: number
+}
+
+// Why: a deterministic per-load renderer fault (bad GPU driver, corrupt chunk,
+// AV interference) crashes on every load. Orca auto-reloads recoverable
+// renderer deaths, so without a breaker it reloads every ~0.25-1.3s forever,
+// burning CPU and spamming breadcrumbs (Windows clusters F0BDRAZN55L /
+// F0BDPCL93UM). 3 reloads in 60s is well above any single transient crash but
+// far below a runaway loop.
+export const DEFAULT_RENDERER_RECOVERY_WINDOW_MS = 60_000
+export const DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES = 3
+
+/**
+ * Tracks recent auto-recovery attempts in a rolling time window and decides
+ * whether another auto-reload should proceed. Pure and deterministic: callers
+ * pass `now` so behavior is testable without timers.
+ *
+ * The window is NOT reset when the renderer reaches `did-finish-load`: a crash
+ * loop renders successfully on every cycle before dying, so a load-based reset
+ * would never let the breaker trip. Stale attempts instead age out of the
+ * window naturally once the renderer survives longer than `windowMs`.
+ */
+export class RendererRecoveryCircuitBreaker {
+  private readonly windowMs: number
+  private readonly maxRecoveries: number
+  private attempts: number[] = []
+
+  constructor(options: RendererRecoveryCircuitBreakerOptions) {
+    this.windowMs = options.windowMs
+    this.maxRecoveries = options.maxRecoveries
+  }
+
+  /** Number of recovery attempts still inside the rolling window at `now`. */
+  recentRecoveryCount(now: number): number {
+    this.pruneExpired(now)
+    return this.attempts.length
+  }
+
+  /**
+   * Records an auto-recovery attempt at `now` and reports whether it is allowed.
+   * Returns `false` once `maxRecoveries` have already occurred within the
+   * window — the caller must then stop auto-reloading.
+   */
+  registerRecoveryAttempt(now: number): { allowed: boolean; recentRecoveryCount: number } {
+    this.pruneExpired(now)
+    if (this.attempts.length >= this.maxRecoveries) {
+      return { allowed: false, recentRecoveryCount: this.attempts.length }
+    }
+    this.attempts.push(now)
+    return { allowed: true, recentRecoveryCount: this.attempts.length }
+  }
+
+  /** Clears history, e.g. after a manual reload or relaunch resolves the loop. */
+  reset(): void {
+    this.attempts = []
+  }
+
+  private pruneExpired(now: number): void {
+    const cutoff = now - this.windowMs
+    this.attempts = this.attempts.filter((timestamp) => timestamp > cutoff)
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,7 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import os from 'node:os'
-import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, nativeTheme } from 'electron'
 import { electronApp, is } from '@electron-toolkit/utils'
 import * as QRCode from 'qrcode'
 import {
@@ -718,6 +718,14 @@ function openMainWindow(): BrowserWindow {
         reason: details.reason,
         expectedTeardown: getExpectedTeardownScope(webContentsId)
       }),
+    onRendererRecoveryExhausted: ({ details, recentRecoveryCount }) => {
+      recordCrashBreadcrumb('renderer_recovery_circuit_breaker_open', {
+        reason: details.reason,
+        exitCode: details.exitCode ?? null,
+        recentRecoveryCount
+      })
+      void presentRendererRecoveryPrompt(recentRecoveryCount)
+    },
     deferLoad: true,
     title: devInstanceIdentity.name,
     getKeybindings: () => keybindings?.getOverrides(),
@@ -942,6 +950,35 @@ function sendOpenCrashReport(targetWindow?: BrowserWindow | null): void {
   const webContents =
     targetWindow && !targetWindow.isDestroyed() ? targetWindow.webContents : mainWindow?.webContents
   webContents?.send('ui:openCrashReport')
+}
+
+// Why: when the renderer crash-loops, the breaker stops auto-reloading and the
+// window is left blank. The renderer is dead, so a main-process dialog is the
+// only surface that can offer a retry or a clean quit instead of a silent loop.
+async function presentRendererRecoveryPrompt(recentRecoveryCount: number): Promise<void> {
+  if (isQuitting) {
+    return
+  }
+  const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
+  const options = {
+    type: 'error' as const,
+    buttons: ['Reload', 'Quit'],
+    defaultId: 0,
+    cancelId: 1,
+    title: 'Orca keeps failing to load',
+    message: 'The app window crashed repeatedly and stopped reloading automatically.',
+    detail: `Orca tried to recover ${recentRecoveryCount} times in a row without success. This is often a graphics-driver or installation problem. Reload to try again, or quit and relaunch Orca.`
+  }
+  const { response } = window
+    ? await dialog.showMessageBox(window, options)
+    : await dialog.showMessageBox(options)
+  if (response === 0 && mainWindow && !mainWindow.isDestroyed()) {
+    recordCrashBreadcrumb('renderer_recovery_manual_retry')
+    loadMainWindow(mainWindow)
+  } else if (response === 1) {
+    isQuitting = true
+    app.quit()
+  }
 }
 
 function recordProcessGoneCrash(

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2551,6 +2551,39 @@ describe('createMainWindow', () => {
     consoleError.mockRestore()
   })
 
+  it('stops auto-reloading after a rapid renderer crash loop trips the breaker', () => {
+    vi.useFakeTimers()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onRendererRecoveryExhausted = vi.fn()
+    const { browserWindowInstance, windowHandlers } = createRendererRecoveryWindowHarness()
+
+    createMainWindow(null, { onRendererRecoveryExhausted })
+
+    const details = { reason: 'crashed', exitCode: 5 } as Electron.RenderProcessGoneDetails
+    // Each cycle: renderer dies, breaker allows the first 3 reloads, then opens.
+    const driveCrashCycle = (): void => {
+      windowHandlers['render-process-gone']?.({} as never, details)
+      vi.advanceTimersByTime(250)
+    }
+    driveCrashCycle()
+    driveCrashCycle()
+    driveCrashCycle()
+    // 1 initial load + 3 recoveries.
+    expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(4)
+    expect(onRendererRecoveryExhausted).not.toHaveBeenCalled()
+
+    // 4th crash within the window: breaker is open, no further reload.
+    driveCrashCycle()
+    expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(4)
+    expect(onRendererRecoveryExhausted).toHaveBeenCalledTimes(1)
+    expect(onRendererRecoveryExhausted).toHaveBeenCalledWith(
+      expect.objectContaining({ recentRecoveryCount: 3 })
+    )
+
+    consoleError.mockRestore()
+  })
+
   function createStartupRevealWindowFixture() {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -23,6 +23,11 @@ import {
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
 import { isCrashReportReason } from '../../shared/crash-reporting'
 import {
+  DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES,
+  DEFAULT_RENDERER_RECOVERY_WINDOW_MS,
+  RendererRecoveryCircuitBreaker
+} from '../crash-reporting/renderer-recovery-circuit-breaker'
+import {
   getWindowShortcutActionId,
   matchesRecentTabSwitcherChord,
   resolveWindowShortcutAction,
@@ -150,6 +155,14 @@ type CreateMainWindowOptions = {
     details: Electron.RenderProcessGoneDetails,
     webContentsId: number
   ) => boolean
+  /** Called when consecutive auto-recoveries hit the circuit-breaker limit, so
+   *  the host can record diagnostics and surface a recovery prompt instead of
+   *  letting Orca crash-loop. */
+  onRendererRecoveryExhausted?: (info: {
+    details: Electron.RenderProcessGoneDetails
+    webContentsId: number
+    recentRecoveryCount: number
+  }) => void
   /** Why: main-process startup must register IPC handlers before the renderer
    *  begins booting, or eager renderer calls can race into missing channels. */
   deferLoad?: boolean
@@ -648,6 +661,14 @@ export function createMainWindow(
   }
   let rendererProcessGone = false
   let rendererRecoveryTimer: ReturnType<typeof setTimeout> | null = null
+  // Why: stop a deterministic per-load renderer fault (bad GPU driver, corrupt
+  // chunk, AV interference) from auto-reloading every ~0.25-1.3s forever
+  // (Windows crash-loop clusters). The breaker opens after too many recoveries
+  // inside a rolling window and hands off to the host's recovery surface.
+  const rendererRecoveryCircuitBreaker = new RendererRecoveryCircuitBreaker({
+    windowMs: DEFAULT_RENDERER_RECOVERY_WINDOW_MS,
+    maxRecoveries: DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES
+  })
   const clearRendererRecoveryTimer = (): void => {
     if (rendererRecoveryTimer) {
       clearTimeout(rendererRecoveryTimer)
@@ -674,6 +695,17 @@ export function createMainWindow(
         opts?.shouldRecoverRenderer?.(details, rendererWebContentsId) === false ||
         mainWindow.isDestroyed()
       ) {
+        return
+      }
+      const recovery = rendererRecoveryCircuitBreaker.registerRecoveryAttempt(Date.now())
+      if (!recovery.allowed) {
+        // Why: too many reloads in the window means reloading again will just
+        // crash again. Stop the loop and let the host surface a recovery prompt.
+        opts?.onRendererRecoveryExhausted?.({
+          details,
+          webContentsId: rendererWebContentsId,
+          recentRecoveryCount: recovery.recentRecoveryCount
+        })
         return
       }
       // Why: a transient Network Service / renderer loss can leave Chromium


### PR DESCRIPTION
## What & why

Two Windows crash clusters share one amplifier — an **unbounded renderer auto-reload loop**:

- **`launch-failed` / F0BDRAZN55L** (Win11 23H2, exit 18): `renderer_bootstrap_started → rendered → main_window_loaded` repeating every ~1.3s, ending in `launch-failed`.
- **`crashed` / F0BDPCL93UM** (Win10 1909 EOL, `0xC0000005` ACCESS_VIOLATION): bootstrap loop every ~0.83s, heap tiny (26 MB → not OOM).

On `render-process-gone`, `createMainWindow` schedules a reload 250ms later. `shouldRecoverRendererAfterProcessGone` only refuses to recover `integrity-failure` and `launch-failed` — **`crashed` and `killed` are always recovered**. So a deterministic per-load fault (old GPU driver, corrupt chunk, AV interference) reloads → renders → dies → reloads… forever, burning CPU and spamming duplicate breadcrumbs.

## ELI5

When the app window dies, Orca quietly reloads it — great for a one-off hiccup. But if something makes it die *every single time it loads*, Orca just kept reloading it forever, like flicking a broken light switch on and off. This PR adds a limit: if the window crashes 3 times in a minute, Orca stops flicking the switch and instead pops up a box that says "Orca keeps failing to load — Reload or Quit?"

## The fix

A small pure `RendererRecoveryCircuitBreaker` (rolling window, **3 recoveries / 60s**) consulted at the reload point:

- Under the limit → reload as before (transient crashes still self-heal).
- At the limit → **stop auto-reloading**, record a `renderer_recovery_circuit_breaker_open` breadcrumb, and call back into the host, which shows a native **Reload / Quit** dialog (the renderer is dead, so a main-process dialog is the only surface).

Key design point: the window is **not** reset on `did-finish-load`. In these loops the renderer renders successfully on every cycle before dying ~1s later, so a load-based reset would never let the breaker trip. Instead, stale attempts age out by time — if the renderer survives past the window, recovery silently resumes.

This is complementary to the existing gate: `launch-failed`/`integrity-failure` still never auto-recover at all; the breaker catches the `crashed`/`killed` loops that the gate lets through.

## Fixed evidence

Simulated deterministic loop (renderer lives ~0.9s then dies):

```
=== BEFORE FIX (no breaker) ===
  t=900ms  crash -> reload #1 (loops forever)
  ...
  t=7200ms crash -> reload #8 (loops forever)
  -> 8+ reloads, never stops (CPU burn, duplicate breadcrumbs)

=== AFTER FIX (circuit breaker, 3 per 60s) ===
  t=900ms  crash -> reload #1 (count=1)
  t=1800ms crash -> reload #2 (count=2)
  t=2700ms crash -> reload #3 (count=3)
  t=3600ms crash -> BREAKER OPEN (count=3); show recovery prompt; STOP
  -> 3 reloads then stops; user sees Reload/Quit prompt
```

Tests: `renderer-recovery-circuit-breaker.test.ts` (5 pure-helper tests: limit, rolling-window re-open, single-transient-not-a-loop, reset, defaults) + a new `createMainWindow.test.ts` integration test that drives 4 crash cycles and asserts `loadFile` stops after 3 recoveries and `onRendererRecoveryExhausted` fires with `recentRecoveryCount: 3`. Full `createMainWindow` + classification suites green (84 tests). Node typecheck + lint clean.

## Trade-offs

- **Thresholds (3 / 60s)** are conservative — well above any single transient crash, well below a runaway loop. Tunable via the two exported constants. A user hitting genuine intermittent crashes 3× in a minute will see the prompt (acceptable: that *is* a degraded state worth surfacing).
- **Native dialog, not in-app UI**: the renderer is dead, so the in-app crash surface can't render. A main-process `dialog.showMessageBox` is the only reliable option; strings are plain English to match the existing main-process dialog convention (`diagnostics.ts`) and avoid touching the localization catalog gate.
- **Per-window state**: the breaker lives in the `createMainWindow` closure, so multiple windows can't false-positive each other.
- **Doesn't fix root causes** (bad GPU driver, corrupt install) — it stops the *loop* and gives the user an exit. The companion GPU-fallback PR addresses the GPU driver case directly.
- **Cross-platform/SSH neutral**: timing constants are platform-agnostic; headless/SSH paths that intentionally tear down the renderer are unaffected (those go through `getIsQuitting`/expected-teardown, checked before the breaker).
