### PR TITLE
fix(win): fall back to software rendering after repeated GPU crashes

### DIFF
--- a/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
+  DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
+  GpuCrashFallbackTracker,
+  isGpuChildProcessType
+} from './gpu-crash-fallback-decision'
+
+describe('GpuCrashFallbackTracker', () => {
+  it('engages fallback once GPU crashes hit the threshold inside the window', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 3 })
+    // F0BDNADU79Q / F0BDNRZ5MDG: GPU child dies within seconds of launch.
+    expect(tracker.recordGpuCrash(500)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 1
+    })
+    expect(tracker.recordGpuCrash(8_000)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 2
+    })
+    expect(tracker.recordGpuCrash(16_000)).toEqual({
+      shouldEngageFallback: true,
+      crashesInWindow: 3
+    })
+  })
+
+  it('engages at most once so the relaunch cannot loop', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 2 })
+    tracker.recordGpuCrash(100)
+    expect(tracker.recordGpuCrash(200).shouldEngageFallback).toBe(true)
+    expect(tracker.hasEngaged()).toBe(true)
+    expect(tracker.recordGpuCrash(300)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 2
+    })
+  })
+
+  it('ignores GPU crashes after the post-launch window', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 3 })
+    tracker.recordGpuCrash(1_000)
+    tracker.recordGpuCrash(2_000)
+    // A late hiccup well into the session is normal Chromium churn.
+    expect(tracker.recordGpuCrash(45_000)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 2
+    })
+    expect(tracker.hasEngaged()).toBe(false)
+  })
+
+  it('classifies GPU child process types case-insensitively', () => {
+    expect(isGpuChildProcessType('GPU')).toBe(true)
+    expect(isGpuChildProcessType('gpu')).toBe(true)
+    expect(isGpuChildProcessType('Utility')).toBe(false)
+    expect(isGpuChildProcessType(undefined)).toBe(false)
+  })
+
+  it('ships conservative defaults', () => {
+    expect(DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS).toBe(30_000)
+    expect(DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD).toBe(3)
+  })
+})

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
@@ -3,7 +3,8 @@ import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
   DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
   GpuCrashFallbackTracker,
-  isGpuChildProcessType
+  isGpuChildProcessType,
+  isGpuFallbackCrashCandidate
 } from './gpu-crash-fallback-decision'
 
 describe('GpuCrashFallbackTracker', () => {
@@ -47,6 +48,13 @@ describe('GpuCrashFallbackTracker', () => {
     expect(tracker.hasEngaged()).toBe(false)
   })
 
+  it('ignores impossible timestamps', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 1 })
+    expect(tracker.recordGpuCrash(-1).shouldEngageFallback).toBe(false)
+    expect(tracker.recordGpuCrash(Number.NaN).shouldEngageFallback).toBe(false)
+    expect(tracker.hasEngaged()).toBe(false)
+  })
+
   it('classifies GPU child process types case-insensitively', () => {
     expect(isGpuChildProcessType('GPU')).toBe(true)
     expect(isGpuChildProcessType('gpu')).toBe(true)
@@ -57,5 +65,50 @@ describe('GpuCrashFallbackTracker', () => {
   it('ships conservative defaults', () => {
     expect(DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS).toBe(30_000)
     expect(DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD).toBe(3)
+  })
+})
+
+describe('isGpuFallbackCrashCandidate', () => {
+  it('tracks only crash-shaped Windows GPU child failures', () => {
+    for (const reason of ['abnormal-exit', 'crashed', 'launch-failed']) {
+      expect(
+        isGpuFallbackCrashCandidate({
+          platform: 'win32',
+          processType: 'GPU',
+          reason
+        })
+      ).toBe(true)
+    }
+  })
+
+  it('ignores normal GPU exits and non-Windows platforms', () => {
+    expect(
+      isGpuFallbackCrashCandidate({
+        platform: 'win32',
+        processType: 'GPU',
+        reason: 'clean-exit'
+      })
+    ).toBe(false)
+    expect(
+      isGpuFallbackCrashCandidate({
+        platform: 'win32',
+        processType: 'GPU',
+        reason: 'killed'
+      })
+    ).toBe(false)
+    expect(
+      isGpuFallbackCrashCandidate({
+        platform: 'linux',
+        processType: 'GPU',
+        reason: 'crashed'
+      })
+    ).toBe(false)
+    expect(
+      isGpuFallbackCrashCandidate({
+        platform: 'win32',
+        processType: 'Utility',
+        reason: 'crashed'
+      })
+    ).toBe(false)
   })
 })

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.ts
@@ -5,8 +5,10 @@ export type GpuCrashFallbackOptions = {
   threshold: number
 }
 
+const GPU_FALLBACK_CRASH_REASONS = new Set(['abnormal-exit', 'crashed', 'launch-failed'])
+
 // Why: on old/flaky GPU drivers the GPU child process crashes (STATUS_BREAKPOINT
-// / ANGLE-D3D init failure) within seconds of launch, repeatedly — Windows
+// / ANGLE-D3D init failure) within seconds of launch, repeatedly - Windows
 // clusters F0BDNADU79Q and F0BDNRZ5MDG. GPU child deaths are intentionally
 // suppressed as recoverable churn, so Orca never reacted. A burst right after
 // launch is the signal that hardware acceleration is unusable on this machine.
@@ -42,7 +44,12 @@ export class GpuCrashFallbackTracker {
     shouldEngageFallback: boolean
     crashesInWindow: number
   } {
-    if (this.engaged || msSinceLaunch > this.windowMs) {
+    if (
+      this.engaged ||
+      !Number.isFinite(msSinceLaunch) ||
+      msSinceLaunch < 0 ||
+      msSinceLaunch > this.windowMs
+    ) {
       return { shouldEngageFallback: false, crashesInWindow: this.crashesInWindow }
     }
     this.crashesInWindow += 1
@@ -61,4 +68,20 @@ export class GpuCrashFallbackTracker {
 /** True for the Chromium child process types whose crashes should count here. */
 export function isGpuChildProcessType(processType: string | undefined): boolean {
   return (processType ?? '').toLowerCase() === 'gpu'
+}
+
+export function isGpuFallbackCrashCandidate({
+  platform,
+  processType,
+  reason
+}: {
+  platform: NodeJS.Platform
+  processType: string | undefined
+  reason: string
+}): boolean {
+  return (
+    platform === 'win32' &&
+    isGpuChildProcessType(processType) &&
+    GPU_FALLBACK_CRASH_REASONS.has(reason)
+  )
 }

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.ts
@@ -1,0 +1,64 @@
+export type GpuCrashFallbackOptions = {
+  /** Window after launch in which clustered GPU crashes indicate a broken driver. */
+  windowMs: number
+  /** GPU child crashes within the window that trigger software-rendering fallback. */
+  threshold: number
+}
+
+// Why: on old/flaky GPU drivers the GPU child process crashes (STATUS_BREAKPOINT
+// / ANGLE-D3D init failure) within seconds of launch, repeatedly — Windows
+// clusters F0BDNADU79Q and F0BDNRZ5MDG. GPU child deaths are intentionally
+// suppressed as recoverable churn, so Orca never reacted. A burst right after
+// launch is the signal that hardware acceleration is unusable on this machine.
+export const DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS = 30_000
+export const DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD = 3
+
+/**
+ * Tracks GPU child-process crashes relative to launch and decides when to fall
+ * back to software rendering on the next launch. Pure and deterministic:
+ * callers pass `now` (ms since launch) so behavior is testable without timers.
+ *
+ * Only crashes inside the post-launch window count: a one-off GPU hiccup hours
+ * into a session is normal Chromium churn, not a broken-driver signal.
+ */
+export class GpuCrashFallbackTracker {
+  private readonly windowMs: number
+  private readonly threshold: number
+  private crashesInWindow = 0
+  private engaged = false
+
+  constructor(options: GpuCrashFallbackOptions) {
+    this.windowMs = options.windowMs
+    this.threshold = options.threshold
+  }
+
+  /**
+   * Records a GPU child crash at `msSinceLaunch` and reports whether this crash
+   * just pushed the count over the threshold (i.e. fallback should engage now).
+   * Returns false for crashes outside the window or after fallback already
+   * engaged, so the caller relaunches at most once.
+   */
+  recordGpuCrash(msSinceLaunch: number): {
+    shouldEngageFallback: boolean
+    crashesInWindow: number
+  } {
+    if (this.engaged || msSinceLaunch > this.windowMs) {
+      return { shouldEngageFallback: false, crashesInWindow: this.crashesInWindow }
+    }
+    this.crashesInWindow += 1
+    if (this.crashesInWindow >= this.threshold) {
+      this.engaged = true
+      return { shouldEngageFallback: true, crashesInWindow: this.crashesInWindow }
+    }
+    return { shouldEngageFallback: false, crashesInWindow: this.crashesInWindow }
+  }
+
+  hasEngaged(): boolean {
+    return this.engaged
+  }
+}
+
+/** True for the Chromium child process types whose crashes should count here. */
+export function isGpuChildProcessType(processType: string | undefined): boolean {
+  return (processType ?? '').toLowerCase() === 'gpu'
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,6 +63,13 @@ import {
   shouldInstallManagedHooks
 } from './startup/configure-process'
 import { ensureVirtualDisplayForHeadlessServe } from './startup/ensure-virtual-display'
+import { consumeGpuFallbackMarker, writeGpuFallbackMarker } from './startup/gpu-fallback-marker'
+import {
+  DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
+  DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
+  GpuCrashFallbackTracker,
+  isGpuChildProcessType
+} from './crash-reporting/gpu-crash-fallback-decision'
 import {
   shouldSuppressDevEducation,
   suppressDevEducationForStore
@@ -188,6 +195,14 @@ let automations: AutomationService | null = null
 let keybindings: KeybindingService | null = null
 let expectedRendererReload: { webContentsId: number; until: number } | null = null
 let firstWindowStartupServicesReady: Promise<void> = Promise.resolve()
+// Why: GPU child crashes clustered right after launch indicate a broken driver;
+// track them so Orca can relaunch once with hardware acceleration disabled.
+const gpuLaunchTimeMs = Date.now()
+const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
+  windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
+  threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
+})
+let gpuFallbackActiveThisLaunch = false
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
 const isServeMode = process.argv.includes('--serve')
@@ -513,6 +528,7 @@ if (hasSingleInstanceLock) {
   })
   configureElectronNetworkCompatibility()
   enableMainProcessGpuFeatures()
+  maybeApplyGpuFallbackForThisLaunch()
   // Why: headless serve backs browser panes with offscreen BrowserWindows, which
   // need an X display on Linux. Ensure one (Xvfb) before whenReady; the result
   // gates whether the offscreen backend is installed so capability stays honest.
@@ -979,6 +995,56 @@ async function presentRendererRecoveryPrompt(recentRecoveryCount: number): Promi
     isQuitting = true
     app.quit()
   }
+}
+
+// Why: the GPU-fallback marker must be read before app.whenReady() resolves so
+// app.disableHardwareAcceleration() can take effect. Desktop only; headless
+// serve already runs software rendering on the platforms that need it.
+function maybeApplyGpuFallbackForThisLaunch(): void {
+  if (isServeMode) {
+    return
+  }
+  const marker = consumeGpuFallbackMarker(app.getPath('userData'))
+  if (!marker) {
+    return
+  }
+  app.disableHardwareAcceleration()
+  app.commandLine.appendSwitch('disable-gpu')
+  gpuFallbackActiveThisLaunch = true
+  recordCrashBreadcrumb('gpu_fallback_applied', {
+    crashesInWindow: marker.crashesInWindow
+  })
+}
+
+// Why: a burst of GPU child crashes right after launch means hardware
+// acceleration is unusable on this machine. Persist a marker and relaunch once
+// with software rendering instead of letting the GPU keep crashing.
+function handleGpuChildCrash(reason: string, exitCode: number | null): void {
+  // Software rendering already active or shutting down: nothing more to do.
+  if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
+    return
+  }
+  const result = gpuCrashFallbackTracker.recordGpuCrash(Date.now() - gpuLaunchTimeMs)
+  if (!result.shouldEngageFallback) {
+    return
+  }
+  recordCrashBreadcrumb('gpu_fallback_engaged', {
+    reason,
+    exitCode,
+    crashesInWindow: result.crashesInWindow
+  })
+  try {
+    writeGpuFallbackMarker(app.getPath('userData'), {
+      engagedAt: Date.now(),
+      crashesInWindow: result.crashesInWindow
+    })
+  } catch (error) {
+    console.warn('[gpu-fallback] failed to persist marker:', error)
+    return
+  }
+  isQuitting = true
+  app.relaunch()
+  app.exit(0)
 }
 
 function recordProcessGoneCrash(
@@ -1655,6 +1721,9 @@ app.whenReady().then(async () => {
       serviceName: details.serviceName,
       type: details.type
     })
+    if (isGpuChildProcessType(details.type)) {
+      handleGpuChildCrash(details.reason, details.exitCode ?? null)
+    }
   })
 
   logStartupMilestone('services-initialized')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,12 +63,17 @@ import {
   shouldInstallManagedHooks
 } from './startup/configure-process'
 import { ensureVirtualDisplayForHeadlessServe } from './startup/ensure-virtual-display'
-import { consumeGpuFallbackMarker, writeGpuFallbackMarker } from './startup/gpu-fallback-marker'
+import {
+  readActiveGpuFallbackMarker,
+  writeGpuFallbackMarker,
+  type GpuFallbackEnvironment,
+  type WindowsGpuFallbackEnvironment
+} from './startup/gpu-fallback-marker'
 import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
   DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
   GpuCrashFallbackTracker,
-  isGpuChildProcessType
+  isGpuFallbackCrashCandidate
 } from './crash-reporting/gpu-crash-fallback-decision'
 import {
   shouldSuppressDevEducation,
@@ -196,7 +201,7 @@ let keybindings: KeybindingService | null = null
 let expectedRendererReload: { webContentsId: number; until: number } | null = null
 let firstWindowStartupServicesReady: Promise<void> = Promise.resolve()
 // Why: GPU child crashes clustered right after launch indicate a broken driver;
-// track them so Orca can relaunch once with hardware acceleration disabled.
+// track them so Orca can move this build onto software rendering.
 const gpuLaunchTimeMs = Date.now()
 const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
@@ -527,8 +532,10 @@ if (hasSingleInstanceLock) {
     platform: process.platform
   })
   configureElectronNetworkCompatibility()
-  enableMainProcessGpuFeatures()
   maybeApplyGpuFallbackForThisLaunch()
+  if (!gpuFallbackActiveThisLaunch) {
+    enableMainProcessGpuFeatures()
+  }
   // Why: headless serve backs browser panes with offscreen BrowserWindows, which
   // need an X display on Linux. Ensure one (Xvfb) before whenReady; the result
   // gates whether the offscreen backend is installed so capability stays honest.
@@ -997,14 +1004,30 @@ async function presentRendererRecoveryPrompt(recentRecoveryCount: number): Promi
   }
 }
 
+function getGpuFallbackEnvironment(): GpuFallbackEnvironment {
+  return {
+    appVersion: app.getVersion(),
+    electronVersion: process.versions.electron ?? '',
+    platform: process.platform
+  }
+}
+
+function getWindowsGpuFallbackEnvironment(): WindowsGpuFallbackEnvironment | null {
+  const environment = getGpuFallbackEnvironment()
+  if (environment.platform !== 'win32') {
+    return null
+  }
+  return { ...environment, platform: 'win32' }
+}
+
 // Why: the GPU-fallback marker must be read before app.whenReady() resolves so
-// app.disableHardwareAcceleration() can take effect. Desktop only; headless
-// serve already runs software rendering on the platforms that need it.
+// app.disableHardwareAcceleration() can take effect. Windows desktop only -
+// headless serve already runs software rendering on the platforms that need it.
 function maybeApplyGpuFallbackForThisLaunch(): void {
-  if (isServeMode) {
+  if (isServeMode || process.platform !== 'win32') {
     return
   }
-  const marker = consumeGpuFallbackMarker(app.getPath('userData'))
+  const marker = readActiveGpuFallbackMarker(app.getPath('userData'), getGpuFallbackEnvironment())
   if (!marker) {
     return
   }
@@ -1016,9 +1039,9 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   })
 }
 
-// Why: a burst of GPU child crashes right after launch means hardware
-// acceleration is unusable on this machine. Persist a marker and relaunch once
-// with software rendering instead of letting the GPU keep crashing.
+// Why: a burst of crash-shaped Windows GPU child failures right after launch
+// means hardware acceleration is unusable on this machine. Persist a build-
+// scoped marker and relaunch into software rendering instead of looping crashes.
 function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   // Software rendering already active or shutting down: nothing more to do.
   if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
@@ -1033,11 +1056,20 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     exitCode,
     crashesInWindow: result.crashesInWindow
   })
+  const engagedAt = Date.now()
+  const environment = getWindowsGpuFallbackEnvironment()
+  if (!environment) {
+    return
+  }
   try {
-    writeGpuFallbackMarker(app.getPath('userData'), {
-      engagedAt: Date.now(),
-      crashesInWindow: result.crashesInWindow
-    })
+    writeGpuFallbackMarker(
+      app.getPath('userData'),
+      {
+        engagedAt,
+        crashesInWindow: result.crashesInWindow
+      },
+      environment
+    )
   } catch (error) {
     console.warn('[gpu-fallback] failed to persist marker:', error)
     return
@@ -1721,7 +1753,13 @@ app.whenReady().then(async () => {
       serviceName: details.serviceName,
       type: details.type
     })
-    if (isGpuChildProcessType(details.type)) {
+    if (
+      isGpuFallbackCrashCandidate({
+        platform: process.platform,
+        processType: details.type,
+        reason: details.reason
+      })
+    ) {
       handleGpuChildCrash(details.reason, details.exitCode ?? null)
     }
   })

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -4,13 +4,19 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   GPU_FALLBACK_MARKER_FILE,
-  consumeGpuFallbackMarker,
+  clearGpuFallbackMarker,
+  readActiveGpuFallbackMarker,
   readGpuFallbackMarker,
   writeGpuFallbackMarker
 } from './gpu-fallback-marker'
 
 describe('gpu-fallback-marker', () => {
   let userDataPath: string
+  const environment = {
+    appVersion: '1.2.3',
+    electronVersion: '42.3.3',
+    platform: 'win32' as const
+  }
 
   beforeEach(() => {
     userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-fallback-test-'))
@@ -21,38 +27,76 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('round-trips a written marker', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 123, crashesInWindow: 3 })
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 123, crashesInWindow: 3 }, environment)
     expect(readGpuFallbackMarker(userDataPath)).toEqual({
-      schemeVersion: 1,
+      schemeVersion: 2,
       engagedAt: 123,
-      crashesInWindow: 3
+      crashesInWindow: 3,
+      appVersion: '1.2.3',
+      electronVersion: '42.3.3',
+      platform: 'win32'
     })
   })
 
   it('returns null when no marker exists', () => {
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
-    expect(consumeGpuFallbackMarker(userDataPath)).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
   })
 
-  it('consume reads then clears the marker so it applies to exactly one launch', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 })
+  it('keeps an active marker for repeated launches on the same build', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
 
-    const consumed = consumeGpuFallbackMarker(userDataPath)
-    expect(consumed?.crashesInWindow).toBe(4)
-    // Cleared — a second launch must not auto-fallback again.
-    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
-    expect(consumeGpuFallbackMarker(userDataPath)).toBeNull()
+    const firstRead = readActiveGpuFallbackMarker(userDataPath, environment)
+    expect(firstRead?.crashesInWindow).toBe(4)
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
+
+    const secondRead = readActiveGpuFallbackMarker(userDataPath, environment)
+    expect(secondRead?.crashesInWindow).toBe(4)
   })
 
-  it('ignores a corrupt or wrong-version marker', () => {
+  it('clears an active marker when the app build changes', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+
+    expect(
+      readActiveGpuFallbackMarker(userDataPath, {
+        ...environment,
+        appVersion: '1.2.4'
+      })
+    ).toBeNull()
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('clears an active marker outside Windows', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+
+    expect(
+      readActiveGpuFallbackMarker(userDataPath, {
+        ...environment,
+        platform: 'linux'
+      })
+    ).toBeNull()
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('clears a corrupt or wrong-version marker', () => {
     writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), '{ not json')
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
 
     writeFileSync(
       join(userDataPath, GPU_FALLBACK_MARKER_FILE),
       JSON.stringify({ schemeVersion: 999, engagedAt: 1, crashesInWindow: 1 })
     )
+    expect(readGpuFallbackMarker(userDataPath)).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('can explicitly clear the marker', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    clearGpuFallbackMarker(userDataPath)
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
   })
 })

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  GPU_FALLBACK_MARKER_FILE,
+  consumeGpuFallbackMarker,
+  readGpuFallbackMarker,
+  writeGpuFallbackMarker
+} from './gpu-fallback-marker'
+
+describe('gpu-fallback-marker', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-fallback-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('round-trips a written marker', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 123, crashesInWindow: 3 })
+    expect(readGpuFallbackMarker(userDataPath)).toEqual({
+      schemeVersion: 1,
+      engagedAt: 123,
+      crashesInWindow: 3
+    })
+  })
+
+  it('returns null when no marker exists', () => {
+    expect(readGpuFallbackMarker(userDataPath)).toBeNull()
+    expect(consumeGpuFallbackMarker(userDataPath)).toBeNull()
+  })
+
+  it('consume reads then clears the marker so it applies to exactly one launch', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 })
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
+
+    const consumed = consumeGpuFallbackMarker(userDataPath)
+    expect(consumed?.crashesInWindow).toBe(4)
+    // Cleared — a second launch must not auto-fallback again.
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+    expect(consumeGpuFallbackMarker(userDataPath)).toBeNull()
+  })
+
+  it('ignores a corrupt or wrong-version marker', () => {
+    writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), '{ not json')
+    expect(readGpuFallbackMarker(userDataPath)).toBeNull()
+
+    writeFileSync(
+      join(userDataPath, GPU_FALLBACK_MARKER_FILE),
+      JSON.stringify({ schemeVersion: 999, engagedAt: 1, crashesInWindow: 1 })
+    )
+    expect(readGpuFallbackMarker(userDataPath)).toBeNull()
+  })
+})

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -2,70 +2,116 @@ import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 /**
- * Persisted "disable hardware acceleration on next launch" marker.
+ * Persisted "disable hardware acceleration for this build" marker.
  *
  * Why a standalone file (not the Store): app.disableHardwareAcceleration() must
  * be called before app.whenReady() resolves, but the settings Store is only
  * constructed inside whenReady. A tiny JSON marker in userData can be read
- * synchronously at module load, mirroring windows-user-data-acl.ts.
+ * synchronously during early startup, mirroring windows-user-data-acl.ts.
  */
 
 export const GPU_FALLBACK_MARKER_FILE = 'gpu-fallback.json'
-export const GPU_FALLBACK_SCHEME_VERSION = 1
+export const GPU_FALLBACK_SCHEME_VERSION = 2
 
-type GpuFallbackMarker = {
+export type GpuFallbackEnvironment = {
+  appVersion: string
+  electronVersion: string
+  platform: NodeJS.Platform
+}
+
+export type WindowsGpuFallbackEnvironment = GpuFallbackEnvironment & { platform: 'win32' }
+
+export type GpuFallbackMarker = {
   schemeVersion: number
   engagedAt: number
   crashesInWindow: number
+  appVersion: string
+  electronVersion: string
+  platform: 'win32'
+}
+
+function markerPath(userDataPath: string): string {
+  return join(userDataPath, GPU_FALLBACK_MARKER_FILE)
 }
 
 export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
   try {
-    const parsed = JSON.parse(
-      readFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), 'utf-8')
-    ) as Partial<GpuFallbackMarker>
-    if (parsed.schemeVersion === GPU_FALLBACK_SCHEME_VERSION) {
-      return {
-        schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
-        engagedAt: typeof parsed.engagedAt === 'number' ? parsed.engagedAt : 0,
-        crashesInWindow: typeof parsed.crashesInWindow === 'number' ? parsed.crashesInWindow : 0
-      }
+    const parsed = JSON.parse(readFileSync(markerPath(userDataPath), 'utf-8')) as Partial<
+      Record<keyof GpuFallbackMarker, unknown>
+    >
+    if (parsed.schemeVersion !== GPU_FALLBACK_SCHEME_VERSION) {
+      return null
+    }
+    if (
+      typeof parsed.engagedAt !== 'number' ||
+      !Number.isFinite(parsed.engagedAt) ||
+      typeof parsed.crashesInWindow !== 'number' ||
+      !Number.isFinite(parsed.crashesInWindow) ||
+      typeof parsed.appVersion !== 'string' ||
+      typeof parsed.electronVersion !== 'string' ||
+      parsed.platform !== 'win32'
+    ) {
+      return null
+    }
+    return {
+      schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
+      engagedAt: parsed.engagedAt,
+      crashesInWindow: parsed.crashesInWindow,
+      appVersion: parsed.appVersion,
+      electronVersion: parsed.electronVersion,
+      platform: parsed.platform
     }
   } catch {
-    // missing or corrupt → no fallback requested
+    // missing or corrupt means no fallback requested
   }
   return null
 }
 
 export function writeGpuFallbackMarker(
   userDataPath: string,
-  info: { engagedAt: number; crashesInWindow: number }
+  info: { engagedAt: number; crashesInWindow: number },
+  environment: WindowsGpuFallbackEnvironment
 ): void {
   const marker: GpuFallbackMarker = {
     schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
     engagedAt: info.engagedAt,
-    crashesInWindow: info.crashesInWindow
+    crashesInWindow: info.crashesInWindow,
+    appVersion: environment.appVersion,
+    electronVersion: environment.electronVersion,
+    platform: 'win32'
   }
-  writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), JSON.stringify(marker))
+  writeFileSync(markerPath(userDataPath), JSON.stringify(marker))
 }
 
-/**
- * Consume the marker: returns whether it was present and clears it.
- *
- * Why clear immediately: the marker applies to exactly one launch. If software
- * rendering still crashes, we must not relaunch-loop — clearing up front means
- * the next launch tries hardware acceleration again unless a fresh GPU crash
- * burst re-arms the marker.
- */
-export function consumeGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
+export function clearGpuFallbackMarker(userDataPath: string): void {
+  try {
+    rmSync(markerPath(userDataPath), { force: true })
+  } catch {
+    // best effort; a stale marker is revalidated on the next launch
+  }
+}
+
+export function readActiveGpuFallbackMarker(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment
+): GpuFallbackMarker | null {
   const marker = readGpuFallbackMarker(userDataPath)
-  if (!existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))) {
+  if (!marker) {
+    if (existsSync(markerPath(userDataPath))) {
+      clearGpuFallbackMarker(userDataPath)
+    }
     return null
   }
-  try {
-    rmSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), { force: true })
-  } catch {
-    // best effort; a stale marker only costs one extra software-render launch
+  if (
+    environment.platform !== 'win32' ||
+    marker.platform !== environment.platform ||
+    marker.appVersion !== environment.appVersion ||
+    marker.electronVersion !== environment.electronVersion
+  ) {
+    // Why: the marker is sticky only for the build that observed the driver
+    // crash burst; updates get one fresh hardware attempt automatically.
+    clearGpuFallbackMarker(userDataPath)
+    return null
   }
   return marker
 }

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -1,0 +1,71 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Persisted "disable hardware acceleration on next launch" marker.
+ *
+ * Why a standalone file (not the Store): app.disableHardwareAcceleration() must
+ * be called before app.whenReady() resolves, but the settings Store is only
+ * constructed inside whenReady. A tiny JSON marker in userData can be read
+ * synchronously at module load, mirroring windows-user-data-acl.ts.
+ */
+
+export const GPU_FALLBACK_MARKER_FILE = 'gpu-fallback.json'
+export const GPU_FALLBACK_SCHEME_VERSION = 1
+
+type GpuFallbackMarker = {
+  schemeVersion: number
+  engagedAt: number
+  crashesInWindow: number
+}
+
+export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), 'utf-8')
+    ) as Partial<GpuFallbackMarker>
+    if (parsed.schemeVersion === GPU_FALLBACK_SCHEME_VERSION) {
+      return {
+        schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
+        engagedAt: typeof parsed.engagedAt === 'number' ? parsed.engagedAt : 0,
+        crashesInWindow: typeof parsed.crashesInWindow === 'number' ? parsed.crashesInWindow : 0
+      }
+    }
+  } catch {
+    // missing or corrupt → no fallback requested
+  }
+  return null
+}
+
+export function writeGpuFallbackMarker(
+  userDataPath: string,
+  info: { engagedAt: number; crashesInWindow: number }
+): void {
+  const marker: GpuFallbackMarker = {
+    schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
+    engagedAt: info.engagedAt,
+    crashesInWindow: info.crashesInWindow
+  }
+  writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), JSON.stringify(marker))
+}
+
+/**
+ * Consume the marker: returns whether it was present and clears it.
+ *
+ * Why clear immediately: the marker applies to exactly one launch. If software
+ * rendering still crashes, we must not relaunch-loop — clearing up front means
+ * the next launch tries hardware acceleration again unless a fresh GPU crash
+ * burst re-arms the marker.
+ */
+export function consumeGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
+  const marker = readGpuFallbackMarker(userDataPath)
+  if (!existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))) {
+    return null
+  }
+  try {
+    rmSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), { force: true })
+  } catch {
+    // best effort; a stale marker only costs one extra software-render launch
+  }
+  return marker
+}


### PR DESCRIPTION
## What & why

Windows crash clusters `F0BDNADU79Q` (Win11 24H2) and `F0BDNRZ5MDG` (Win10 22H2) show the GPU child process crashing with `STATUS_BREAKPOINT` (`0x80000003`) within seconds of launch. Orca correctly suppresses one-off GPU child exits as recoverable Chromium churn, but that left no recovery path when the GPU process crashes repeatedly at startup.

This PR adds a narrow software-rendering fallback for that startup failure shape.

## The fix

- Count only crash-shaped Windows GPU child failures during the launch window: `abnormal-exit`, `crashed`, and `launch-failed`.
- Trigger after 3 matching GPU child failures in the first 30 seconds.
- Persist a tiny marker in `userData`, then relaunch.
- On the next startup, before `app.whenReady()`, apply `app.disableHardwareAcceleration()` and `--disable-gpu` before normal GPU feature switches are added.
- Keep the marker active for the same app/Electron build, so a persistently broken driver does not crash/relaunch on every app start.
- Clear stale/corrupt markers and automatically retry hardware rendering after an app or Electron build change.

Headless `serve` is excluded.

## Evidence

Before:

```text
t=500ms    GPU child crashed (STATUS_BREAKPOINT) - suppressed as recoverable churn
t=8000ms   GPU child crashed
t=16000ms  GPU child crashed
t=24000ms  GPU child crashed
-> Orca keeps using the broken hardware path with no self-healing path
```

After:

```text
t=500ms    matching GPU child failure
t=8000ms   matching GPU child failure
t=16000ms  matching GPU child failure
            -> gpu_fallback_engaged; write build-scoped marker; relaunch
next boot   -> gpu_fallback_applied; software rendering; no hardware GPU retry for this build
future app/Electron build -> stale marker is cleared; hardware gets one fresh attempt
```

## Tests

- `gpu-crash-fallback-decision.test.ts`: threshold behavior, impossible timestamps, Windows-only crash candidate gating, normal GPU exits ignored.
- `gpu-fallback-marker.test.ts`: round-trip, active marker persistence, stale build/platform cleanup, corrupt/wrong-version cleanup, explicit clear.

Verified with targeted unit tests, targeted lint, `typecheck:node`, and `git diff --check`.

## Trade-offs

- The recovery still requires one relaunch when the breaker first engages.
- Software rendering is slower, but it is the reliable path for machines whose GPU process cannot survive startup.
- The marker is build-scoped rather than permanent, so users get automatic recovery attempts after updates without re-entering a crash loop on the same broken build.