### PR TITLE
Fix multi-second input lag after pressing Enter in Windows terminals

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8260,11 +8260,8 @@ describe('connectPanePty', () => {
   })
 
   it('does not leak the interactive latch across a same-chunk close+open to a stale frame', async () => {
-    // Why (STA-1041 hardening): a single chunk can close the active submit frame
-    // and open a new one (`…?2026l…?2026h…`). The new frame opened long after the
-    // keystroke, so it must NOT inherit the prior frame's interactive latch and
-    // fast-path; it must coalesce behind the 1s fallback. Without first opening a
-    // genuinely interactive frame, there is no latch to leak and the test is moot.
+    // Why: a same-chunk close+open must re-evaluate the new frame from its own
+    // open time so a stale frame can't inherit the prior frame's fast path.
     const restoreNavigator = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     )
@@ -8326,11 +8323,8 @@ describe('connectPanePty', () => {
   })
 
   it('coalesces a second synchronized frame that opens after the window with no keystroke', async () => {
-    // Why (STA-1041 hardening, complementary guard): two synchronized frames in
-    // SEPARATE chunks — the first interactive (recent keystroke), the second
-    // opening after the 400ms window with no keystroke. The second frame's START
-    // must re-evaluate interactivity from its own open time and coalesce behind
-    // the 1s fallback. Passes pre- and post-hardening; guards against regressions.
+    // Why: the second frame opens after the interactive window, so its START must
+    // be judged independently and stay on the 1s fallback path.
     const restoreNavigator = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     )

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8259,6 +8259,128 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('does not leak the interactive latch across a same-chunk close+open to a stale frame', async () => {
+    // Why (STA-1041 hardening): a single chunk can close the active submit frame
+    // and open a new one (`…?2026l…?2026h…`). The new frame opened long after the
+    // keystroke, so it must NOT inherit the prior frame's interactive latch and
+    // fast-path; it must coalesce behind the 1s fallback. Without first opening a
+    // genuinely interactive frame, there is no latch to leak and the test is moot.
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      vi.useFakeTimers()
+      // Load-bearing setup: Enter submits and opens an INTERACTIVE frame so the
+      // latch (synchronizedForegroundFrameInteractive) genuinely becomes true. The
+      // frame stays OPEN (active) — no end marker yet — which is the precondition
+      // for the leak: the buggy set-branch is gated on !active.
+      sendTerminalInputThroughPane(pane, '\r')
+      const repaintBody = 'opencode repaint '.repeat(200)
+      expect(repaintBody.length).toBeGreaterThan(2048)
+      capturedDataCallback.current?.(`\x1b[?2026h${repaintBody}`)
+      // Move well past the 400ms interactive window WITHOUT closing the frame, so
+      // any NEW frame opening now must be classified non-interactive.
+      vi.advanceTimersByTime(500)
+      pane.terminal.write.mockClear()
+
+      // A single chunk closes the still-active prior frame AND opens a new one.
+      // The new frame opened ~500ms after the keystroke. Pre-hardening, the prior
+      // frame's active flag skips the set-branch and the end marker skips the
+      // reset-branch, so the new frame leaks interactive=true; the recompute must
+      // judge it from its own open time and yield false.
+      capturedDataCallback.current?.(`\x1b[?2026l\x1b[?2026h${repaintBody}`)
+      vi.advanceTimersByTime(40)
+      pane.terminal.write.mockClear()
+
+      // The new frame's split restore + end marker arrive in a later chunk.
+      const staleEndChunk = `${repaintBody}\x1b[?25l\x1b[13;14H\x1b[?25h\x1b[?2026l`
+      expect(staleEndChunk.length).toBeGreaterThan(2048)
+      capturedDataCallback.current?.(staleEndChunk)
+
+      // The fast ~16ms window must NOT flush this stale non-interactive frame.
+      vi.advanceTimersByTime(20)
+      expect(pane.terminal.write).not.toHaveBeenCalled()
+
+      // Only the full 1s coalesce fallback drains it, restoring the protection.
+      vi.advanceTimersByTime(1000)
+      expect(pane.terminal.write).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+      restoreNavigator()
+    }
+  })
+
+  it('coalesces a second synchronized frame that opens after the window with no keystroke', async () => {
+    // Why (STA-1041 hardening, complementary guard): two synchronized frames in
+    // SEPARATE chunks — the first interactive (recent keystroke), the second
+    // opening after the 400ms window with no keystroke. The second frame's START
+    // must re-evaluate interactivity from its own open time and coalesce behind
+    // the 1s fallback. Passes pre- and post-hardening; guards against regressions.
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      vi.useFakeTimers()
+      // Frame 1: submit-driven and interactive; opens and closes cleanly.
+      sendTerminalInputThroughPane(pane, '\r')
+      const repaintBody = 'opencode repaint '.repeat(200)
+      expect(repaintBody.length).toBeGreaterThan(2048)
+      capturedDataCallback.current?.(`\x1b[?2026h${repaintBody}\x1b[?2026l`)
+      vi.advanceTimersByTime(40)
+
+      // Move past the 400ms window with no further keystroke, then open frame 2.
+      vi.advanceTimersByTime(500)
+      capturedDataCallback.current?.(`\x1b[?2026h${repaintBody}`)
+      vi.advanceTimersByTime(40)
+      pane.terminal.write.mockClear()
+
+      // Frame 2's split cursor restore + end marker arrive in a later chunk.
+      const secondEndChunk = `${repaintBody}\x1b[?25l\x1b[13;14H\x1b[?25h\x1b[?2026l`
+      capturedDataCallback.current?.(secondEndChunk)
+
+      // The fast ~16ms window must NOT flush this non-interactive second frame.
+      vi.advanceTimersByTime(20)
+      expect(pane.terminal.write).not.toHaveBeenCalled()
+
+      // The full 1s coalesce fallback drains it so the frame is never lost.
+      vi.advanceTimersByTime(1000)
+      expect(pane.terminal.write).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+      restoreNavigator()
+    }
+  })
+
   it('keeps terminal UI drawing glyphs on the active renderer', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8160,6 +8160,105 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('drains a post-submit synchronized frame on the fast path when its end marker arrives late', async () => {
+    // Why (STA-1041): OpenCode wraps each submit repaint in a DEC 2026 frame.
+    // Under CPU contention ConPTY splits the closing chunk past the 150ms redraw
+    // window, so classifying only by the end chunk's own arrival time would judge
+    // it non-latency-sensitive and stall the repaint behind the 1s coalesce
+    // fallback. The frame opened right after Enter, so it must drain in ~16ms.
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      vi.useFakeTimers()
+      // Enter submits; the synchronized repaint frame opens immediately after.
+      sendTerminalInputThroughPane(pane, '\r')
+      const repaintBody = 'opencode repaint '.repeat(200)
+      expect(repaintBody.length).toBeGreaterThan(2048)
+      capturedDataCallback.current?.(`\x1b[?2026h${repaintBody}`)
+      // The frame body holds, then its hold-safety fallback drains it.
+      vi.advanceTimersByTime(40)
+      pane.terminal.write.mockClear()
+
+      // ConPTY delivers the closing chunk well past the 150ms redraw window.
+      vi.advanceTimersByTime(300)
+      const endChunk = `${repaintBody}\x1b[?25l\x1b[13;14H\x1b[?25h\x1b[?2026l`
+      expect(endChunk.length).toBeGreaterThan(2048)
+      capturedDataCallback.current?.(endChunk)
+
+      // Fast path: the latency-sensitive coalesce window is ~16ms, not 1000ms.
+      vi.advanceTimersByTime(20)
+      expect(pane.terminal.write).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+      restoreNavigator()
+    }
+  })
+
+  it('keeps coalescing a synchronized frame end with no recent input behind the 1s fallback', async () => {
+    // Why (STA-1041): the fast-path relaxation only applies when the frame opened
+    // right after a keystroke. A background synchronized redraw (no recent input)
+    // whose cursor restore is genuinely split must still wait the full coalesce
+    // fallback so Windows never rasterizes the transient cursor position.
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      vi.useFakeTimers()
+      // No terminal input: this synchronized redraw is not submit-driven.
+      const repaintBody = 'opencode repaint '.repeat(200)
+      capturedDataCallback.current?.(`\x1b[?2026h${repaintBody}`)
+      // Let the non-latency-sensitive frame body drain via its hold-safety
+      // fallback (250ms) before isolating the closing chunk.
+      vi.advanceTimersByTime(300)
+      pane.terminal.write.mockClear()
+
+      const endChunk = `${repaintBody}\x1b[?25l\x1b[13;14H\x1b[?25h\x1b[?2026l`
+      capturedDataCallback.current?.(endChunk)
+
+      // The fast 16ms window must NOT flush a background split-restore frame.
+      vi.advanceTimersByTime(20)
+      expect(pane.terminal.write).not.toHaveBeenCalled()
+
+      // The full coalesce fallback still drains it so the frame is never lost.
+      vi.advanceTimersByTime(1000)
+      expect(pane.terminal.write).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+      restoreNavigator()
+    }
+  })
+
   it('keeps terminal UI drawing glyphs on the active renderer', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3164,14 +3164,12 @@ export function connectPanePty(
         isForeground: foreground,
         isInPlaceRewrite: renderRefreshDecision.inPlaceRewrite
       })
-      // Why: latch keystroke proximity when a synchronized foreground frame opens
-      // so its split end marker stays latency-sensitive; a frame already active
-      // keeps the latch, otherwise reset it once we leave synchronized output.
-      if (
-        synchronizedForegroundOutput &&
-        synchronizedOutputStarted &&
-        !synchronizedForegroundOutputActive
-      ) {
+      // Why: recompute the latch on every synchronized START so each frame's
+      // interactivity is judged by its own open time vs the last keystroke and
+      // can't leak across a same-chunk close+open; an active frame with no new
+      // start retains it (the split-end-marker headline fix), and we only clear
+      // it once we leave synchronized output on a chunk that is not the end.
+      if (synchronizedForegroundOutput && synchronizedOutputStarted) {
         synchronizedForegroundFrameInteractive =
           performance.now() - lastTerminalInputAt <=
           FOREGROUND_SYNCHRONIZED_FRAME_INTERACTIVE_WINDOW_MS

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -163,6 +163,12 @@ const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
 const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 128 * 1024
 const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
+// Why: a submit repaint can take longer than one keystroke echo to fully
+// arrive, so a synchronized frame that *began* this close to a keystroke stays
+// latency-sensitive even when ConPTY splits its end marker past the redraw
+// window — the keystroke is the "user is here, paint now" signal, not the
+// late closing chunk.
+const FOREGROUND_SYNCHRONIZED_FRAME_INTERACTIVE_WINDOW_MS = 400
 // Why: OpenTUI can emit many tiny redraws that each look interactive but
 // collectively starve timers unless foreground writes have a rolling budget.
 const FOREGROUND_IMMEDIATE_BUDGET_CHARS = 128 * 1024
@@ -837,6 +843,10 @@ export function connectPanePty(
   let pendingTerminalBellNotification = false
   let reattachIdleAgentCursorResetTimer: ReturnType<typeof setTimeout> | null = null
   let synchronizedForegroundOutputActive = false
+  // Why: tracks the keystroke proximity captured when the current synchronized
+  // foreground frame opened, so a split end marker that lands after the redraw
+  // window still drains on the fast path instead of the 1s coalesce fallback.
+  let synchronizedForegroundFrameInteractive = false
   let suppressSnapshotReplayPtyResize = false
   // Why: idle callbacks are registered before the deferred PTY output plumbing
   // exists. Start with the shared scheduler, then switch to the PTY writer
@@ -3154,6 +3164,26 @@ export function connectPanePty(
         isForeground: foreground,
         isInPlaceRewrite: renderRefreshDecision.inPlaceRewrite
       })
+      // Why: latch keystroke proximity when a synchronized foreground frame opens
+      // so its split end marker stays latency-sensitive; a frame already active
+      // keeps the latch, otherwise reset it once we leave synchronized output.
+      if (
+        synchronizedForegroundOutput &&
+        synchronizedOutputStarted &&
+        !synchronizedForegroundOutputActive
+      ) {
+        synchronizedForegroundFrameInteractive =
+          performance.now() - lastTerminalInputAt <=
+          FOREGROUND_SYNCHRONIZED_FRAME_INTERACTIVE_WINDOW_MS
+      } else if (!nextSynchronizedForegroundOutputActive && !synchronizedOutputEnded) {
+        synchronizedForegroundFrameInteractive = false
+      }
+      // Why: ConPTY can split the closing chunk of a submit repaint past the
+      // 150ms redraw window. Treat the whole frame as latency-sensitive when it
+      // opened right after a keystroke so the scheduler drains it on the fast
+      // path (~16-32ms) instead of the 1s synchronized-frame coalesce fallback.
+      const synchronizedFrameLatencySensitive =
+        synchronizedForegroundOutput && synchronizedForegroundFrameInteractive
       synchronizedForegroundOutputActive = nextSynchronizedForegroundOutputActive
       if (!foreground && hiddenMode2031ScanTail) {
         respondToSkippedMode2031Subscribe(data)
@@ -3163,7 +3193,9 @@ export function connectPanePty(
         beforeWrite: beforeTerminalOutputWrite,
         onBackgroundBacklogDropped: markHiddenOutputRestoreNeeded,
         latencySensitive:
-          !foreground || parseHiddenStartupOutput ? true : isLatencySensitiveForegroundOutput(data),
+          !foreground || parseHiddenStartupOutput
+            ? true
+            : synchronizedFrameLatencySensitive || isLatencySensitiveForegroundOutput(data),
         forceForegroundRefresh:
           foregroundOutput &&
           (synchronizedForegroundOutput ||


### PR DESCRIPTION
## Summary

Fixes the OpenCode "~1–2s delay after every Enter" lag (Linear STA-1041), reported on a Windows hybrid-CPU machine.

On native Windows ConPTY, OpenCode wraps each submit repaint in a DEC 2026 synchronized-output frame (`\x1b[?2026h`…`\x1b[?2026l`) that ConPTY can split across chunks. The renderer's foreground output scheduler only fast-paths a frame when it's classified *latency-sensitive*, which requires the redraw to land within 150ms of the keystroke. Under CPU contention the **closing** chunk arrives >150ms after Enter, so it was held behind the **1000ms coalesce fallback** — Orca amplified a brief scheduling blip into a multi-second freeze, on every submit.

**What changes:** a submit-triggered synchronized frame drains on the fast path (~16–32ms) even when its closing chunk arrives late.
**What does NOT change:** behavior off native Windows ConPTY (macOS/Linux/SSH/remote/mobile are byte-identical — the path is dead code there); the scheduler itself (untouched); and background/non-interactive repaints, which still coalesce behind the 1000ms fallback.

## Design approach

Latch keystroke proximity when a synchronized frame **opens** (within 400ms of the last input) and carry it through to the closing chunk, so a submit repaint stays latency-sensitive even when ConPTY splits the end marker past the 150ms window. Classification only — the scheduler's split-cursor-restore guard (`!coalescedQueuedDataNeedsCursorRestore`) is preserved, so a genuinely split cursor restore is never rasterized early.

## Latch-leak hardening (the important part of this PR)

An adversarial pre-merge review found the first version could **leak** the interactive latch: when one ConPTY chunk both closes a frame and opens the next (`…?2026l…?2026h…`) while a frame was already active, the new frame inherited the previous frame's `interactive=true`, so a non-interactive repaint could wrongly take the shortened drain path. Note: the cursor-restore guard blocks only the *zero-delay* drain, not the shortened 16/32ms fallback — so this hardening is load-bearing, not defense-in-depth.

Fix: recompute the latch on **every** synchronized START marker, judging each frame by its own open time; keep the load-bearing `!synchronizedOutputEnded` reset guard so the split closing chunk of a real submit frame stays latency-sensitive.

## Implementation / deviations

Two files: `pty-connection.ts` (the latch logic) and `pty-connection.test.ts` (tests). Scheduler unchanged. No deviations from the design — the hardening is a one-condition tightening (drop the `&& !synchronizedForegroundOutputActive` set-guard).

## Completeness verification

Independent read-only pass confirmed: headline fix intact (active frame retains latch on its split closing chunk), leak closed (recompute on any START), reset guard preserved, ordering correct, Scenario 2 (split end marker) correctly left as a documented pre-existing limitation, gating confined to native local Windows ConPTY, and no unrelated edits.

## Headline behavior status: IMPLEMENTED

The input-lag amplifier fix and the latch-leak hardening are both present and verified. Nothing partial or deferred within scope.

## Broad app consistency

Source-of-truth behavior is the renderer foreground output scheduler's latency-sensitive-vs-coalesce decision for DEC 2026 frames on native Windows ConPTY — a single internal seam, agent-agnostic. All desktop TUI agents (Claude/Codex/OpenCode/Pi/OMP/Gemini) share it and benefit equally; none is special-cased. No header/mobile/command-palette/settings surface exposes this timing. No cross-surface inconsistency introduced; the only one removed is the latch leak itself.

## Risks, ambiguities, and non-goals

- **Non-goal — root trigger:** the workload pinning to E-cores on hybrid CPUs (the reporter's actual trigger) is a separate subsystem, tracked separately. This fixes only the amplifier. (Approved.)
- **Non-goal — split-marker detection (Scenario 2):** per-chunk `includes()` marker detection is pre-existing on `main`; a `?2026l` split across reads can leave the latch set. Documented as a known limitation, not expanded here.
- **400ms window** is a heuristic; if a frame's *open* is itself delayed >400ms under extreme load the latch won't engage and behavior degrades to current `main` (never worse).
- **Validation gap (accepted):** no live hybrid-CPU + OpenCode-1.17.11 end-to-end repro from the dev environment; to be confirmed with the reporter post-release.

## perf audit

Touched hot path: `writePtyOutputToXterm` (per foreground PTY chunk). No actionable findings — the change adds zero new per-chunk string scans (only a boolean/arithmetic compare already used elsewhere on the path), the scheduler is byte-identical to `main`, frames still drain once (only *when* changes — no extra render churn), and the latch is a single per-connection boolean (no leak/growth). Dead code off Windows ConPTY.

## Code-review loop

Two rounds, two independent `review-code` reviewers each, fresh per round — **both reviewers clean in both rounds**, zero actionable findings. All adversarial hypotheses (stuck-true leak, reset-on-end regression, vacuous tests, interactive downgrade for other agents, off-gate leakage, NEGATIVE_INFINITY boundary) were refuted by hand-trace + experiment.

## Validation

- Unit tests (real `connectPanePty` + real scheduler, fake timers, forced Windows UA): **247 passed**. The leak-closure test was independently proven a real gate — reverting only the source hardening makes it FAIL, restoring makes it PASS.
- Static: typecheck (node/cli/web) clean; oxlint + oxfmt clean on both files.
- Prior: deterministic before/after (main 1000ms vs branch ~16–20ms on a delayed-END frame); real OpenCode 1.17.11 PTY capture confirmed DEC 2026 synchronized output and natural ConPTY frame splitting; Windows manual test under heavy contention showed no stall and no visual artifacts.
- Not validated here: a live end-to-end run on the reporter's hybrid-CPU box (impossible off-Windows); confirm post-release. No Electron run on macOS — it would not exercise the gated path, so it was skipped rather than presented as misleading evidence.

Made with [Orca](https://github.com/stablyai/orca) 🐋
