### PR TITLE
Coalesce passive git status refreshes

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1315,7 +1315,7 @@ export default function ChecksPanel(): React.JSX.Element {
       connectionId
     }
     void (async () => {
-      const status = await getRuntimeGitStatus(context)
+      const status = await getRuntimeGitStatus(context, { coalesceInFlight: true })
       if (
         !stale &&
         shouldCommitChecksPanelGitStatusSnapshot(panelContextKeyRef.current, requestContextKey)

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
@@ -155,6 +155,80 @@ describe('refreshGitStatusForWorktree', () => {
     expect(deps.setGitStatus).toHaveBeenCalledWith('wt-3', status)
   })
 
+  it('coalesces repeated passive refreshes for one worktree into one git status request', async () => {
+    const status: GitStatusResult = {
+      entries: [{ path: 'src/index.ts', status: 'modified', area: 'unstaged' }],
+      conflictOperation: 'unknown',
+      head: 'abc123',
+      branch: 'refs/heads/main',
+      upstreamStatus: { hasUpstream: true, upstreamName: 'origin/main', ahead: 0, behind: 0 }
+    }
+    const statusRefresh = deferred<GitStatusResult>()
+    const gitStatus = vi.fn().mockReturnValue(statusRefresh.promise)
+    vi.stubGlobal('window', { api: { git: { status: gitStatus } } })
+    const deps = makeDeps()
+
+    const refreshes = Array.from({ length: 100 }, () =>
+      refreshGitStatusForWorktree({
+        worktreeId: 'wt-passive',
+        worktreePath: '/repo',
+        freshness: 'passive',
+        deps
+      })
+    )
+    await vi.waitFor(() => expect(gitStatus).toHaveBeenCalledTimes(1))
+
+    statusRefresh.resolve(status)
+    await Promise.all(refreshes)
+
+    expect(gitStatus).toHaveBeenCalledTimes(1)
+    expect(deps.setGitStatus).toHaveBeenCalledTimes(100)
+  })
+
+  it('runs a fresh refresh instead of joining an older passive refresh', async () => {
+    const stalePassiveStatus = {
+      entries: [{ path: 'old.ts', status: 'modified', area: 'unstaged' }],
+      conflictOperation: 'unknown',
+      head: 'old',
+      branch: 'refs/heads/main',
+      upstreamStatus: { hasUpstream: true, upstreamName: 'origin/main', ahead: 0, behind: 0 }
+    } satisfies GitStatusResult
+    const freshStatus = {
+      entries: [{ path: 'new.ts', status: 'modified', area: 'unstaged' }],
+      conflictOperation: 'unknown',
+      head: 'new',
+      branch: 'refs/heads/main',
+      upstreamStatus: { hasUpstream: true, upstreamName: 'origin/main', ahead: 1, behind: 0 }
+    } satisfies GitStatusResult
+    const passiveStatus = deferred<GitStatusResult>()
+    const gitStatus = vi
+      .fn()
+      .mockReturnValueOnce(passiveStatus.promise)
+      .mockResolvedValueOnce(freshStatus)
+    vi.stubGlobal('window', { api: { git: { status: gitStatus } } })
+    const deps = makeDeps()
+
+    const passive = refreshGitStatusForWorktree({
+      worktreeId: 'wt-fresh',
+      worktreePath: '/repo',
+      freshness: 'passive',
+      deps
+    })
+    await vi.waitFor(() => expect(gitStatus).toHaveBeenCalledTimes(1))
+
+    await refreshGitStatusForWorktree({
+      worktreeId: 'wt-fresh',
+      worktreePath: '/repo',
+      deps
+    })
+    passiveStatus.resolve(stalePassiveStatus)
+    await passive
+
+    expect(gitStatus).toHaveBeenCalledTimes(2)
+    expect(deps.setGitStatus).toHaveBeenCalledTimes(1)
+    expect(deps.setGitStatus).toHaveBeenCalledWith('wt-fresh', freshStatus)
+  })
+
   it('bypasses automatic no-upstream backoff only for strict refreshes', async () => {
     const status: GitStatusResult = {
       entries: [],

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.ts
@@ -31,6 +31,8 @@ export type GitStatusRefreshDeps = {
   ) => Promise<GitUpstreamStatus | null>
 }
 
+type GitStatusRefreshFreshness = 'fresh' | 'passive'
+
 const MAX_REFRESH_ORDERING_WORKTREES = 1024
 const strictUpstreamRefreshGenerationByWorktree = new Map<string, number>()
 const automaticUpstreamRefreshInFlightByWorktree = new Map<string, number>()
@@ -137,6 +139,7 @@ export async function refreshGitStatusForWorktree({
   worktreePath,
   connectionId,
   pushTarget,
+  freshness = 'fresh',
   deps
 }: {
   settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
@@ -144,16 +147,27 @@ export async function refreshGitStatusForWorktree({
   worktreePath: string
   connectionId?: string
   pushTarget?: GitPushTarget
+  freshness?: GitStatusRefreshFreshness
   deps: GitStatusRefreshDeps
 }): Promise<void> {
+  if (freshness === 'fresh') {
+    beginStrictUpstreamRefresh(worktreeId)
+  }
   const upstreamStartGeneration = beginAutomaticUpstreamRefresh(worktreeId)
   try {
-    const status = (await getRuntimeGitStatus({
-      settings,
-      worktreeId,
-      worktreePath,
-      connectionId
-    })) as GitStatusResult
+    const status = (await getRuntimeGitStatus(
+      {
+        settings,
+        worktreeId,
+        worktreePath,
+        connectionId
+      },
+      {
+        // Why: passive polls and scans may converge on the same expensive
+        // status+numstat snapshot; mutation/manual refreshes must observe fresh state.
+        coalesceInFlight: freshness === 'passive'
+      }
+    )) as GitStatusResult
 
     if (!shouldApplyAutomaticUpstreamRefresh(worktreeId, upstreamStartGeneration)) {
       return

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -106,6 +106,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
         worktreePath,
         connectionId,
         pushTarget: activePushTarget,
+        freshness: 'passive',
         deps: {
           setGitStatus,
           updateWorktreeGitIdentity,

--- a/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
+++ b/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
@@ -1352,6 +1352,7 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
         worktreePath: worktree.path,
         connectionId:
           currentState.repos.find((repo) => repo.id === worktree.repoId)?.connectionId ?? undefined,
+        freshness: 'passive',
         deps: {
           setGitStatus,
           updateWorktreeGitIdentity,

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -122,6 +122,63 @@ export function getRuntimeGitScope(
 
 export async function getRuntimeGitStatus(
   context: RuntimeGitContext,
+  options?: {
+    includeIgnored?: boolean
+    bypassEffectiveUpstreamNegativeCache?: boolean
+    coalesceInFlight?: boolean
+  }
+): Promise<GitStatusResult> {
+  if (options?.coalesceInFlight) {
+    return getCoalescedRuntimeGitStatus(context, options)
+  }
+  return getRuntimeGitStatusUncoalesced(context, options)
+}
+
+const runtimeGitStatusInFlight = new Map<string, Promise<GitStatusResult>>()
+
+function getRuntimeGitStatusCoalescingKey(
+  context: RuntimeGitContext,
+  options?: {
+    includeIgnored?: boolean
+    bypassEffectiveUpstreamNegativeCache?: boolean
+  }
+): string {
+  const target = getActiveRuntimeTarget(context.settings)
+  return JSON.stringify({
+    target,
+    worktreeId: context.worktreeId ?? null,
+    worktreePath: context.worktreePath,
+    connectionId: context.connectionId ?? null,
+    includeIgnored: options?.includeIgnored === true,
+    bypassEffectiveUpstreamNegativeCache: options?.bypassEffectiveUpstreamNegativeCache === true
+  })
+}
+
+async function getCoalescedRuntimeGitStatus(
+  context: RuntimeGitContext,
+  options?: {
+    includeIgnored?: boolean
+    bypassEffectiveUpstreamNegativeCache?: boolean
+  }
+): Promise<GitStatusResult> {
+  const key = getRuntimeGitStatusCoalescingKey(context, options)
+  const inFlight = runtimeGitStatusInFlight.get(key)
+  if (inFlight) {
+    return inFlight
+  }
+  const promise = getRuntimeGitStatusUncoalesced(context, options)
+  runtimeGitStatusInFlight.set(key, promise)
+  try {
+    return await promise
+  } finally {
+    if (runtimeGitStatusInFlight.get(key) === promise) {
+      runtimeGitStatusInFlight.delete(key)
+    }
+  }
+}
+
+async function getRuntimeGitStatusUncoalesced(
+  context: RuntimeGitContext,
   options?: { includeIgnored?: boolean; bypassEffectiveUpstreamNegativeCache?: boolean }
 ): Promise<GitStatusResult> {
   const target = getActiveRuntimeTarget(context.settings)


### PR DESCRIPTION
## Summary
- add opt-in in-flight coalescing for passive `getRuntimeGitStatus` calls
- mark polling, file-watch polling, workspace-space background scans, and Checks eligibility snapshots as passive
- keep manual/mutation refreshes fresh by default, and invalidate older passive results so a slow pre-mutation poll cannot overwrite post-mutation state

## Crash class / root cause
Post-#6736 diagnostics for report `a6feb1b4-bf2e-48f7-8ab8-58a76e2e3576` still show process pressure dominated by status refreshes: `status:4524`, `diff:3856`, with `git.status` attaching line stats through `git diff --numstat -M`. The repeated passive callers can converge on the same worktree while a prior status+numstat chain is still running, spawning duplicate subprocess chains.

## Expected subprocess count impact
- Before: 100 overlapping passive refreshes for one worktree could issue 100 `git.status` RPCs, each capable of running `git status` plus `git diff --numstat -M` when entries exist.
- After: the same 100 passive refreshes join one in-flight snapshot, so one underlying `git.status` RPC and one status+numstat chain.
- Fresh user/mutation refreshes intentionally do not join passive snapshots.

## Tests
- `node_modules\\.bin\\vitest.CMD run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/git-status-refresh.test.ts src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts src/renderer/src/runtime/runtime-git-client.test.ts`
- `node_modules\\.bin\\tsgo.CMD --noEmit -p config/tsconfig.tc.web.json`

## Risks / follow-up
- This reduces duplicate in-flight passive status/diff chains, but does not change the steady 3s polling cadence when there is only one passive caller.
- Branch compare/history refreshes are separate subprocess surfaces and were left untouched.
- SSH/runtime-environment paths are covered through the shared runtime git client; local-only process assumptions were not added.