### PR TITLE
fix(win): release PR-refresh aliases when a worktree is removed

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -917,4 +917,65 @@ describe('pr-refresh-coordinator', () => {
 
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(3)
   })
+
+  describe('pruneWorktreePRRefreshAliases', () => {
+    // Several local worktrees tracking the same linked PR coalesce into one
+    // queue entry (same refreshKey) whose alias map keeps one entry each.
+    const LINKED_PR_KEY = 'local::runtime:host::/repo::pr::42'
+
+    function makeLinkedCandidate(worktreeId: string): GitHubPRRefreshCandidate {
+      return makeCandidate({
+        worktreeId,
+        cacheKey: `/repo::${worktreeId}`,
+        branch: `feature/${worktreeId}`,
+        linkedPRNumber: 42
+      })
+    }
+
+    it('drops a removed worktree alias and deletes the entry when it was the last', async () => {
+      const { enqueuePRRefresh, pruneWorktreePRRefreshAliases, _getPRRefreshAliasCountForTests } =
+        await import('./pr-refresh-coordinator')
+
+      enqueuePRRefresh(makeLinkedCandidate('wt-1'), 'visible', 40, 1)
+      enqueuePRRefresh(makeLinkedCandidate('wt-2'), 'visible', 40, 1)
+      enqueuePRRefresh(makeLinkedCandidate('wt-3'), 'visible', 40, 1)
+      expect(_getPRRefreshAliasCountForTests(LINKED_PR_KEY)).toBe(3)
+
+      pruneWorktreePRRefreshAliases('wt-2')
+      expect(_getPRRefreshAliasCountForTests(LINKED_PR_KEY)).toBe(2)
+
+      pruneWorktreePRRefreshAliases('wt-1')
+      pruneWorktreePRRefreshAliases('wt-3')
+      // Last alias gone -> the whole queue entry is dropped.
+      expect(_getPRRefreshAliasCountForTests(LINKED_PR_KEY)).toBe(0)
+    })
+
+    it('keeps the entry alive and rebinds the candidate when other aliases remain', async () => {
+      const {
+        enqueuePRRefresh,
+        pruneWorktreePRRefreshAliases,
+        _getPRRefreshAliasCountForTests,
+        _getPRRefreshQueueSizeForTests
+      } = await import('./pr-refresh-coordinator')
+
+      // wt-1 becomes the entry's representative candidate (enqueued first).
+      enqueuePRRefresh(makeLinkedCandidate('wt-1'), 'visible', 40, 1)
+      enqueuePRRefresh(makeLinkedCandidate('wt-2'), 'visible', 40, 1)
+      expect(_getPRRefreshQueueSizeForTests()).toBe(1)
+
+      // Removing the representative worktree must not orphan the entry.
+      pruneWorktreePRRefreshAliases('wt-1')
+      expect(_getPRRefreshAliasCountForTests(LINKED_PR_KEY)).toBe(1)
+      expect(_getPRRefreshQueueSizeForTests()).toBe(1)
+    })
+
+    it('is a no-op for a worktree with no queued aliases', async () => {
+      const { enqueuePRRefresh, pruneWorktreePRRefreshAliases, _getPRRefreshAliasCountForTests } =
+        await import('./pr-refresh-coordinator')
+
+      enqueuePRRefresh(makeLinkedCandidate('wt-1'), 'visible', 40, 1)
+      pruneWorktreePRRefreshAliases('wt-unknown')
+      expect(_getPRRefreshAliasCountForTests(LINKED_PR_KEY)).toBe(1)
+    })
+  })
 })

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -148,6 +148,50 @@ export function clearVisiblePRRefreshWindow(windowId: number): void {
   }
 }
 
+/**
+ * Drop a removed worktree's aliases from every queue entry.
+ *
+ * Why: many local branches/worktrees that resolve to the same PR coalesce into
+ * one queue entry whose `aliases` map keeps one entry per worktree. Aliases are
+ * only pruned when a candidate is re-enqueued as invalid — never when a worktree
+ * is simply removed. Over a long session with churning worktrees these maps grow
+ * unbounded, contributing to the renderer/process memory creep behind the OOM
+ * reports. Called from worktree removal so stale aliases are released promptly.
+ */
+export function pruneWorktreePRRefreshAliases(worktreeId: string): void {
+  for (const [key, entry] of queue) {
+    let removed = false
+    for (const [cacheKey, alias] of entry.aliases) {
+      if (alias.worktreeId === worktreeId) {
+        entry.aliases.delete(cacheKey)
+        removed = true
+      }
+    }
+    if (!removed) {
+      continue
+    }
+    // No aliases left means no worktree still cares about this refresh.
+    if (entry.aliases.size === 0) {
+      queue.delete(key)
+      errorBackoff.delete(key)
+      continue
+    }
+    // Keep the entry alive but ensure its representative candidate is not a
+    // dangling reference to the removed worktree.
+    if (entry.candidate.worktreeId === worktreeId) {
+      const replacementAlias = entry.aliases.values().next().value
+      if (replacementAlias) {
+        entry.candidate = {
+          ...entry.candidate,
+          cacheKey: replacementAlias.cacheKey,
+          branch: replacementAlias.branch,
+          worktreeId: replacementAlias.worktreeId
+        }
+      }
+    }
+  }
+}
+
 function nextSequence(): number {
   sequence += 1
   return sequence
@@ -807,6 +851,14 @@ export function _getVisiblePRRefreshWindowCountForTests(): number {
 
 export function _getPRRefreshErrorBackoffCountForTests(): number {
   return errorBackoff.size
+}
+
+export function _getPRRefreshQueueSizeForTests(): number {
+  return queue.size
+}
+
+export function _getPRRefreshAliasCountForTests(key: string): number {
+  return queue.get(key)?.aliases.size ?? 0
 }
 
 export async function refreshPRNow(candidate: GitHubPRRefreshCandidate): Promise<PRRefreshOutcome> {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -44,6 +44,7 @@ import { gitExecFileAsync } from '../git/runner'
 import { withWorktreeSpan } from '../observability/instrumentation'
 import { resolveGitHubPrStartPoint } from '../github/pr-start-point'
 import { fetchPrHeadTrackingRef } from '../github/pr-head-tracking-ref'
+import { pruneWorktreePRRefreshAliases } from '../github/pr-refresh-coordinator'
 import { getDefaultRemote } from '../git/repo'
 import { listRepoWorktrees } from '../repo-worktrees'
 import { getSshGitProvider, requireSshGitProvider } from '../providers/ssh-git-dispatch'
@@ -161,6 +162,9 @@ function removeWorktreeMetadataAndTransientState(store: Store, worktreeId: strin
   store.removeWorktreeMeta(worktreeId)
   advertisedUrlWatcher.forgetWorktree(worktreeId)
   deleteWorktreeHistoryDir(worktreeId)
+  // Why: release the removed worktree's PR-refresh aliases so coalesced queue
+  // entries do not retain it for the rest of the session (memory creep).
+  pruneWorktreePRRefreshAliases(worktreeId)
 }
 
 async function closeLocalWatcherForRemoval(worktreePath: string): Promise<void> {


### PR DESCRIPTION
## What & why

Windows **`oom`** cluster — `F0BDMD16LJ2` (a single Tab → 2.6 GB) and the `taifunk` many-worktree sessions where the renderer/Browser memory creeps over hours. The dossier flagged `pr-refresh-coordinator`'s per-entry `aliases` maps as a suspected unbounded-growth vector; this PR fixes that vector.

**Confirmed in current code:** when several local worktrees track the **same** linked PR, they all hash to the same `refreshKey` and coalesce into one `QueueEntry`. That entry's `aliases: Map<cacheKey, alias>` keeps **one alias per worktree** (so every worktree keeps getting cache updates). Aliases are only ever removed in `removeQueuedAliasForInvalidCandidate` (when a candidate is re-enqueued and fails validation) — **never when a worktree is simply removed/closed**. Over a long session that creates and deletes many worktrees/branches, these maps grow without bound.

(Note: terminal scrollback is already capped at 5k rows / 50k max via `terminal-scrollback-policy.ts`, so it is *not* the leak here — the actionable fix is the alias maps.)

## ELI5

Orca keeps a little to-do list of "PRs to refresh." When several of your worktrees point at the same PR, they share one to-do item, and each worktree pins a sticky note to it. When you deleted a worktree, its sticky note was never removed — so over a long day of making and deleting worktrees, that item collected hundreds of dead sticky notes that never went away. This PR throws away a worktree's sticky notes the moment it's removed.

## The fix

- New `pruneWorktreePRRefreshAliases(worktreeId)` in the coordinator: removes that worktree's aliases from every queue entry; deletes the entry entirely when it has no aliases left; rebinds the entry's representative candidate if the removed worktree happened to own it.
- Called from `removeWorktreeMetadataAndTransientState` in `worktrees.ts` — the existing central worktree-removal cleanup that already drops the other process-local caches (`removeWorktreeMeta`, `advertisedUrlWatcher.forgetWorktree`, `deleteWorktreeHistoryDir`).

## Fixed evidence

Simulated 200 create→remove worktree cycles on a shared linked-PR entry:

```
=== BEFORE FIX (no prune on worktree removal) ===
  created+removed 200 worktrees -> entry.aliases.size = 200 (all retained, grows unbounded)

=== AFTER FIX (prune on worktree removal) ===
  created+removed 200 worktrees -> entry.aliases.size = 0 (released as worktrees close)
```

Tests: 3 new coordinator tests — accumulate 3 aliases then prune them one-by-one (entry deleted when empty); prune the *representative* worktree and assert the entry survives with the candidate rebound; no-op for an unknown worktree. Plus two test-only inspection helpers. Full coordinator suite green (25 tests). Node typecheck + lint clean.

## Trade-offs

- **Scoped fix, not a rewrite**: this releases aliases on the explicit removal path rather than redesigning alias storage to a worktreeId-indexed structure. Lower risk, directly targets the accumulation vector, and integrates with the existing cleanup function. A bigger refactor wasn't justified by the evidence.
- **Doesn't fully explain the 2.6 GB single-Tab report** (`F0BDMD16LJ2`): that one is likely renderer-side (detached DOM / canvas / agent Tab state) and is a separate investigation; this PR removes one concrete main-process growth source that fits the long-session creep in the `taifunk` reports. Per-Tab memory attribution is a sensible follow-up (the dossier suggests it).
- **In-flight safety**: pruning during an in-flight refresh for that worktree is safe — the in-flight request already captured its alias array by value; pruning only mutates the queued entry, and deleting a non-existent alias is a no-op (idempotent), which also covers async SSH/remote worktree teardown.
- **Provider-agnostic**: keyed purely on `worktreeId`; no GitHub/GitLab-specific assumptions.
