### PR TITLE
fix(claude-auth): recover stale managed accounts via cross-store token reconcile

### DIFF
--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -745,6 +745,33 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(refreshedCredentials)
   })
 
+  it('reconcileActiveManagedAuthFromRuntime adopts a terminal-rotated token into the managed store', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const originalCredentials = createClaudeCredentialsJson('user@example.com', 'original')
+    const rotatedCredentials = createClaudeCredentialsJson('user@example.com', 'rotated')
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      originalCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [createClaudeAccount('account-1', managedAuthPath)]
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    settings.activeClaudeManagedAccountId = 'account-1'
+    await service.syncForCurrentSelection()
+
+    // Simulate a terminal Claude session rotating the shared ~/.claude token.
+    writeFileSync(runtimeCredentialsPath, rotatedCredentials, 'utf-8')
+    await service.reconcileActiveManagedAuthFromRuntime()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(rotatedCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(rotatedCredentials)
+  })
+
   it('rejects wrong-shaped refreshed credentials during read-back', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const originalCredentials = createClaudeCredentialsJson('user@example.com', 'original')

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -125,6 +125,23 @@ export class ClaudeRuntimeAuthService {
     return this.getPreparation(effectiveTarget)
   }
 
+  // Why: Claude OAuth refresh tokens are single-use and rotating, and Orca's
+  // managed store shares the same lineage as the terminal's ~/.claude. When a
+  // terminal Claude session rotates the token, the managed copy goes stale and
+  // a usage fetch fails with invalid_grant. Re-running the sync adopts the
+  // terminal's rotated token back into the managed store (the read-back path),
+  // and proactively refreshes when no live PTY owns the credentials — so a
+  // failed fetch can recover without forcing an interactive re-auth. The
+  // live-PTY guard inside the sync is preserved, so this never races a live
+  // session's own rotation.
+  async reconcileActiveManagedAuthFromRuntime(
+    target?: ClaudeAccountSelectionTarget
+  ): Promise<ClaudeRuntimeAuthPreparation> {
+    const effectiveTarget = target ?? this.getDefaultAccountSelectionTarget()
+    await this.syncForCurrentSelection(effectiveTarget)
+    return this.getPreparation(effectiveTarget)
+  }
+
   async syncForCurrentSelection(target?: ClaudeAccountSelectionTarget): Promise<void> {
     await this.serializeMutation(() =>
       this.doSyncForCurrentSelection(target ?? this.getDefaultAccountSelectionTarget())

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1396,6 +1396,9 @@ app.whenReady().then(async () => {
   rateLimits.setClaudeAuthPreparationResolver((target) =>
     claudeRuntimeAuth!.prepareForRateLimitFetch(target)
   )
+  rateLimits.setClaudeAuthReconcileResolver((target) =>
+    claudeRuntimeAuth!.reconcileActiveManagedAuthFromRuntime(target)
+  )
   rateLimits.setOpenCodeGoConfigResolver(() => {
     const settings = store!.getSettings()
     return {

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -522,6 +522,218 @@ describe('fetchClaudeRateLimits', () => {
     )
   })
 
+  it('reconciles a terminal-rotated token and retries OAuth without spawning the CLI', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
+      stripAuthEnv: false,
+      provenance: 'managed:account-1'
+    }
+    // First read: the stale managed token. After reconcile adopts the token a
+    // terminal session already rotated into the shared store, the second read
+    // returns the fresh token.
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'stale-oauth-token',
+            refreshToken: 'refresh-token',
+            expiresAt: Date.now() - 60_000
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'terminal-rotated-token',
+            refreshToken: 'refresh-token-2',
+            expiresAt: Date.now() + 60_000
+          }
+        })
+      )
+    netFetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { type: 'authentication_error', message: 'Invalid OAuth token.' }
+          }),
+          { status: 401 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            five_hour: { utilization: 9 },
+            seven_day: { utilization: 18 }
+          }),
+          { status: 200 }
+        )
+      )
+    const reconcileManagedAuth = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      fetchClaudeRateLimits({ authPreparation, reconcileManagedAuth })
+    ).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: { usedPercent: 9 },
+      weekly: { usedPercent: 18 },
+      usageMetadata: { source: 'oauth' }
+    })
+
+    expect(reconcileManagedAuth).toHaveBeenCalledTimes(1)
+    // Recovered from the rotated token alone — never spawned `claude`.
+    expect(fetchViaPty).not.toHaveBeenCalled()
+    expect(netFetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer terminal-rotated-token' })
+      })
+    )
+  })
+
+  it('reconciles a rotated token even when CLI fallback is disabled (Windows managed accounts)', async () => {
+    // Why: Windows managed accounts disable PTY/CLI fallback, but reconcile
+    // needs no `claude` spawn — it must still recover a terminal-rotated token.
+    // This guards against reconcile being coupled to the allowCliFallback gate.
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
+      stripAuthEnv: false,
+      provenance: 'managed:account-1'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'stale-oauth-token',
+            refreshToken: 'refresh-token',
+            expiresAt: Date.now() - 60_000
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'terminal-rotated-token',
+            refreshToken: 'refresh-token-2',
+            expiresAt: Date.now() + 60_000
+          }
+        })
+      )
+    netFetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { type: 'authentication_error', message: 'Invalid OAuth token.' }
+          }),
+          { status: 401 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            five_hour: { utilization: 7 },
+            seven_day: { utilization: 13 }
+          }),
+          { status: 200 }
+        )
+      )
+    const reconcileManagedAuth = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      fetchClaudeRateLimits({ authPreparation, reconcileManagedAuth, allowPtyFallback: false })
+    ).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: { usedPercent: 7 },
+      weekly: { usedPercent: 13 },
+      usageMetadata: { source: 'oauth' }
+    })
+
+    expect(reconcileManagedAuth).toHaveBeenCalledTimes(1)
+    expect(fetchViaPty).not.toHaveBeenCalled()
+    expect(netFetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer terminal-rotated-token' })
+      })
+    )
+  })
+
+  it('falls through to CLI repair when reconcile yields no fresher token', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
+      stripAuthEnv: false,
+      provenance: 'managed:account-1'
+    }
+    // Reconcile finds no rotation: every read returns the same stale token, so
+    // the OAuth retry after reconcile still 401s and the CLI repair runs.
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'stale-oauth-token',
+          refreshToken: 'refresh-token',
+          expiresAt: Date.now() - 60_000
+        }
+      })
+    )
+    netFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { type: 'authentication_error', message: 'Invalid OAuth token.' }
+        }),
+        { status: 401 }
+      )
+    )
+    const reconcileManagedAuth = vi.fn().mockResolvedValue(undefined)
+
+    await fetchClaudeRateLimits({ authPreparation, reconcileManagedAuth })
+
+    expect(reconcileManagedAuth).toHaveBeenCalledTimes(1)
+    expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
+  })
+
+  it('falls through to CLI repair when reconcile throws', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
+      stripAuthEnv: false,
+      provenance: 'managed:account-1'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'stale-oauth-token',
+          refreshToken: 'refresh-token',
+          expiresAt: Date.now() - 60_000
+        }
+      })
+    )
+    netFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { type: 'authentication_error', message: 'Invalid OAuth token.' }
+        }),
+        { status: 401 }
+      )
+    )
+    const reconcileManagedAuth = vi.fn().mockRejectedValue(new Error('sync failed'))
+
+    await fetchClaudeRateLimits({ authPreparation, reconcileManagedAuth })
+
+    expect(reconcileManagedAuth).toHaveBeenCalledTimes(1)
+    // A failed reconcile must not block recovery — CLI repair still runs.
+    expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
+  })
+
   it('explains auth failures when a live Claude terminal owns managed refresh', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -260,22 +260,22 @@ function resolveOAuthCredentialReadOptions(
 
 function buildClaudeUsageFetchDiagnostic(
   authPreparation: ClaudeRuntimeAuthPreparation | undefined,
-  oauthCredentials: OAuthCredentialReadResult
+  oauthCredentials: OAuthCredentialReadResult | null
 ): Record<string, unknown> {
   return {
     provenance: authPreparation?.provenance ?? 'system',
     runtime: authPreparation?.runtime ?? 'host',
     wslDistro: authPreparation?.wslDistro ?? null,
     hasExplicitClaudeConfigDir: Boolean(authPreparation?.envPatch.CLAUDE_CONFIG_DIR),
-    credentialSource: oauthCredentials.source,
-    keychainUnavailable: oauthCredentials.keychainUnavailable,
-    hasRefreshableCredentials: oauthCredentials.hasRefreshableCredentials
+    credentialSource: oauthCredentials?.source ?? null,
+    keychainUnavailable: oauthCredentials?.keychainUnavailable,
+    hasRefreshableCredentials: oauthCredentials?.hasRefreshableCredentials
   }
 }
 
 function warnClaudeUsageFetchFailure(
   authPreparation: ClaudeRuntimeAuthPreparation | undefined,
-  oauthCredentials: OAuthCredentialReadResult,
+  oauthCredentials: OAuthCredentialReadResult | null,
   error: unknown
 ): void {
   const message = error instanceof Error ? error.message : String(error)
@@ -522,6 +522,48 @@ function errorResultForClassification(input: {
   })
 }
 
+// Why: re-sync runtime auth (adopting a terminal-rotated token into the managed
+// store and proactively refreshing when safe), re-read credentials, and retry
+// the OAuth usage fetch. Returns the successful result, or null to fall through
+// to the heavier CLI-spawn repair. Avoids spawning `claude` against the same
+// dead credentials when the terminal already minted a fresh token.
+async function attemptReconcileThenRetryOAuth(input: {
+  options?: FetchClaudeRateLimitsOptions
+  attempts: ClaudeUsageAttemptState
+}): Promise<ProviderRateLimits | null> {
+  if (!input.options?.reconcileManagedAuth) {
+    return null
+  }
+  try {
+    await input.options.reconcileManagedAuth()
+  } catch (err) {
+    warnClaudeUsageFetchFailure(input.options?.authPreparation, null, err)
+    return null
+  }
+  const reconciledCredentials = await readOAuthCredentials(
+    resolveOAuthCredentialReadOptions(input.options?.authPreparation)
+  )
+  if (!reconciledCredentials.token) {
+    return null
+  }
+  recordAttempt(input.attempts, 'oauth')
+  try {
+    const oauthRetry = await fetchViaOAuth(reconciledCredentials.token)
+    return withClaudeUsageMetadata(
+      oauthRetry,
+      metadataForAttempt({
+        attemptedSources: input.attempts.attemptedSources,
+        oauthCredentials: reconciledCredentials,
+        authPreparation: input.options?.authPreparation,
+        source: 'oauth'
+      })
+    )
+  } catch (err) {
+    warnClaudeUsageFetchFailure(input.options?.authPreparation, reconciledCredentials, err)
+    return null
+  }
+}
+
 async function attemptCliRepairThenRetryOAuth(input: {
   options?: FetchClaudeRateLimitsOptions
   attempts: ClaudeUsageAttemptState
@@ -569,6 +611,12 @@ async function attemptCliRepairThenRetryOAuth(input: {
 export type FetchClaudeRateLimitsOptions = {
   authPreparation?: ClaudeRuntimeAuthPreparation
   allowPtyFallback?: boolean
+  // Why: when a usage fetch fails with a stale managed token, a terminal Claude
+  // session may have already rotated the shared ~/.claude token. This callback
+  // re-syncs runtime auth so the rotated token is adopted into the managed
+  // store before retrying — recovering without an interactive re-auth. It
+  // preserves the live-PTY guard, so it never races a live session's rotation.
+  reconcileManagedAuth?: () => Promise<ClaudeRuntimeAuthPreparation | void>
 }
 
 export async function fetchClaudeRateLimits(
@@ -620,6 +668,18 @@ export async function fetchClaudeRateLimits(
           oauthCredentials,
           authPreparation: options?.authPreparation
         })
+      }
+
+      // Why: try the cheap cross-store reconcile first — when a terminal session
+      // already rotated the shared token, adopting it recovers without a `claude`
+      // spawn or interactive re-auth. Runs on every platform (unlike the CLI
+      // repair below, which is gated by allowCliFallback / unreliable on Windows)
+      // because reconcile needs no PTY — just file/network token adoption.
+      if (classification.shouldAttemptDelegatedRefresh) {
+        const reconciled = await attemptReconcileThenRetryOAuth({ options, attempts })
+        if (reconciled) {
+          return reconciled
+        }
       }
 
       if (classification.shouldAttemptDelegatedRefresh && allowCliFallback) {

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -333,6 +333,63 @@ describe('RateLimitService', () => {
     expect(fetchCodexRateLimits).toHaveBeenCalledTimes(2)
   })
 
+  it('passes a reconcile callback for managed Claude accounts that routes to the reconcile resolver', async () => {
+    const service = new RateLimitService()
+    const managedPreparation = {
+      configDir: '/Users/test/.claude',
+      runtime: 'host' as const,
+      envPatch: {},
+      stripAuthEnv: true,
+      provenance: 'managed:account-1'
+    }
+    const claudeTarget = { runtime: 'host' as const }
+    service.setClaudeFetchTarget(claudeTarget)
+    service.setClaudeAuthPreparationResolver(async () => managedPreparation)
+    const reconcileResolver = vi.fn(async () => managedPreparation)
+    service.setClaudeAuthReconcileResolver(reconcileResolver)
+
+    let capturedOptions: Parameters<typeof fetchClaudeRateLimits>[0] | undefined
+    vi.mocked(fetchClaudeRateLimits).mockImplementationOnce(async (options) => {
+      capturedOptions = options
+      return okProvider('claude', 10, Date.now())
+    })
+    vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
+
+    await service.refresh()
+
+    expect(capturedOptions?.reconcileManagedAuth).toBeTypeOf('function')
+    // The callback must route to the reconcile resolver with the active target.
+    await capturedOptions?.reconcileManagedAuth?.()
+    expect(reconcileResolver).toHaveBeenCalledWith(expect.objectContaining({ runtime: 'host' }))
+  })
+
+  it('omits the reconcile callback for system-default Claude auth', async () => {
+    const service = new RateLimitService()
+    service.setClaudeAuthPreparationResolver(async () => ({
+      configDir: '/Users/test/.claude',
+      runtime: 'host' as const,
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }))
+    const reconcileResolver = vi.fn()
+    service.setClaudeAuthReconcileResolver(reconcileResolver)
+
+    let capturedOptions: Parameters<typeof fetchClaudeRateLimits>[0] | undefined
+    vi.mocked(fetchClaudeRateLimits).mockImplementationOnce(async (options) => {
+      capturedOptions = options
+      return okProvider('claude', 10, Date.now())
+    })
+    vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
+
+    await service.refresh()
+
+    // System-default auth is owned by the user's terminal — Orca must not
+    // re-sync/refresh it, so no reconcile callback is wired.
+    expect(capturedOptions?.reconcileManagedAuth).toBeUndefined()
+    expect(reconcileResolver).not.toHaveBeenCalled()
+  })
+
   it('fetches Gemini and OpenCode Go alongside Claude and Codex', async () => {
     const service = new RateLimitService()
     service.setOpenCodeGoConfigResolver(() => ({

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -37,6 +37,13 @@ type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
 
+// Why: re-sync runtime auth after a failed Claude usage fetch so a token a
+// terminal session already rotated is adopted into the managed store before
+// retrying — recovering a stale managed account without an interactive re-auth.
+type ClaudeAuthReconcileResolver = (
+  target?: ClaudeAccountSelectionTarget
+) => Promise<ClaudeRuntimeAuthPreparation>
+
 type OpenCodeGoRateLimitConfig = {
   sessionCookie: string
   workspaceIdOverride: string
@@ -113,6 +120,7 @@ export class RateLimitService {
     wslDistro: null
   }
   private claudeAuthPreparationResolver: ClaudeAuthPreparationResolver | null = null
+  private claudeAuthReconcileResolver: ClaudeAuthReconcileResolver | null = null
   private claudeFetchTarget: NormalizedClaudeAccountSelectionTarget = {
     runtime: 'host',
     wslDistro: null
@@ -150,6 +158,10 @@ export class RateLimitService {
 
   setClaudeAuthPreparationResolver(resolver: ClaudeAuthPreparationResolver): void {
     this.claudeAuthPreparationResolver = resolver
+  }
+
+  setClaudeAuthReconcileResolver(resolver: ClaudeAuthReconcileResolver): void {
+    this.claudeAuthReconcileResolver = resolver
   }
 
   setClaudeFetchTarget(target?: ClaudeAccountSelectionTarget): void {
@@ -818,6 +830,20 @@ export class RateLimitService {
     return !isSystemDefaultClaudeAuth(authPreparation)
   }
 
+  // Why: build the cross-store reconcile callback for the active managed
+  // account. Scoped to managed accounts — system-default auth is owned by the
+  // user's terminal, not Orca, so Orca must not re-sync/refresh it.
+  private buildClaudeReconcileCallback(
+    target: ClaudeAccountSelectionTarget,
+    authPreparation: ClaudeRuntimeAuthPreparation | undefined
+  ): (() => Promise<ClaudeRuntimeAuthPreparation | void>) | undefined {
+    if (!this.claudeAuthReconcileResolver || isSystemDefaultClaudeAuth(authPreparation)) {
+      return undefined
+    }
+    const resolver = this.claudeAuthReconcileResolver
+    return () => resolver(target)
+  }
+
   private withFetchingStatus(
     current: ProviderRateLimits | null,
     provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi'
@@ -881,7 +907,11 @@ export class RateLimitService {
       await Promise.allSettled([
         fetchClaudeRateLimits({
           authPreparation: claudeAuthPreparation,
-          allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation)
+          allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+          reconcileManagedAuth: this.buildClaudeReconcileCallback(
+            claudeTarget,
+            claudeAuthPreparation
+          )
         }),
         missingWslCodexHome ??
           fetchCodexRateLimits({
@@ -1056,7 +1086,8 @@ export class RateLimitService {
 
     const claude = await fetchClaudeRateLimits({
       authPreparation: claudeAuthPreparation,
-      allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation)
+      allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+      reconcileManagedAuth: this.buildClaudeReconcileCallback(claudeTarget, claudeAuthPreparation)
     }).catch(
       (err): ProviderRateLimits => ({
         provider: 'claude',


### PR DESCRIPTION
## Summary

Fixes the root cause of #6234: Orca's **managed** Claude account requires re-authentication ~daily/overnight, while the user's **terminal** Claude Code (`~/.claude`) stays logged in. PR #6828 added a one-click "Re-authenticate" button — a good stopgap — but this addresses *why* re-auth is needed at all.

### Root cause (verified)

Claude Code OAuth uses **single-use, rotating refresh tokens** (corroborated by `anthropics/claude-code` issues #61923, #54443, #64232; matches OAuth 2.1 rotation). A host managed account is materialized into the **shared `~/.claude`** — deliberately, with **no per-account `CLAUDE_CONFIG_DIR`**, so session history/projects stay shared (#5318). But Orca also keeps the account's credentials in a **separate managed store**. Both copies share one refresh-token lineage at the backend.

When a terminal Claude session refreshes, it **rotates the shared refresh token and invalidates the copy in Orca's managed store**. The next managed usage fetch fails with `invalid_grant`, and the existing CLI-spawn fallback can't help because it reuses the *same dead credentials* — only an interactive re-auth recovers. The ~10 prior fixes (#1286→#5995) only ever reconciled Orca's *own* materialized runtime file, never a **terminal-owned rotation while Orca was idle**. (Codex avoids this via an ~8-day refresh cadence **and** explicit cross-instance disk reconciliation — it rotates too.)

### The fix

A **cross-store reconcile-then-retry**, mirroring how Codex survives (*"some other instance already refreshed it → reload from disk"*):

On a recoverable-auth usage failure (401 / non-scope 403), Orca re-runs `syncForCurrentSelection` — whose existing read-back **adopts the terminal's rotated, same-identity token back into the managed store** — then re-reads credentials and retries the OAuth fetch, **before** any `claude` spawn. Recovers without an interactive re-auth.

- **`runtime-auth-service.ts`** — new `reconcileActiveManagedAuthFromRuntime()`, a thin wrapper over the serialized sync. The **live-PTY guard inside the sync is preserved**, so it never races a live session's own single-use rotation.
- **`claude-fetcher.ts`** — reconcile runs gated on `shouldAttemptDelegatedRefresh` and **after** the live-PTY defer check, but **independent of `allowCliFallback`** — so it works on **Windows managed accounts** (where PTY/CLI fallback is disabled), since reconcile needs no spawn, only file/network token adoption.
- **`rate-limits/service.ts`** — reconcile callback scoped to **managed accounts only**; system-default auth is owned by the user's terminal and must not be re-synced/refreshed by Orca.
- **WSL** managed accounts are isolated by their own Linux `CLAUDE_CONFIG_DIR`, so the shared-store rotation war doesn't apply — reconcile is a safe no-op there.

### Testing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (1 pre-existing warning in an untouched file)
- [x] `pnpm build` — clean
- [x] `pnpm vitest run src/main/rate-limits/ src/main/claude-accounts/` — **304 passed**

New tests:
- Terminal-rotated token **adopted into the managed store** on real temp files (`runtime-auth-service.test.ts`).
- Reconcile **recovers with `allowPtyFallback: false`** (Windows regression — this test fails without the gating fix).
- Reconcile + retry succeeds **without spawning the CLI**; falls through to CLI repair when no fresher token; reconcile failure is **non-fatal** (`claude-fetcher.test.ts`).
- Resolver wiring routes **managed → reconcile**, **system-default → no callback** (`service.test.ts`).

### Verification honesty
This was verified through layered tests exercising every real seam **except the live Anthropic endpoint** — a true overnight repro needs a real subscription + a real terminal rotation + waiting for token expiry, which isn't reproducible in CI/dev. The change was also run through an adversarial review pass, which caught a real defect (reconcile being dead code on Windows because it was nested under the `allowCliFallback` gate); that's fixed and covered by the Windows regression test above.

### AI Review Report
- **Cross-platform:** no new platform branches; reconcile delegates to `syncForCurrentSelection`, already tested on darwin (Keychain) and linux/win32 (file store). Now reachable on Windows managed accounts.
- **Remote/SSH/WSL:** the normalized fetch target is threaded through the reconcile resolver, so the correct runtime reconciles. WSL is isolated → safe no-op.
- **Provider neutrality:** Claude-only; Codex/others untouched.
- **Live-session safety:** reconcile runs only after the live-PTY defer early-return, and the sync's own live-PTY gate skips refresh while a `claude` PTY owns the creds — no double-rotation.
- **Performance:** one extra file-read + at most one extra OAuth retry, only on a recoverable-auth failure; no new polling.
- **Security:** no new IPC; no secrets logged (diagnostics widened to nullable creds, only `console.warn`).

Relates to #6234. Complements #6828.

Made with [Orca](https://github.com/stablyai/orca) 🐋
