### PR TITLE
fix(ssh): surface stdout alongside stderr in execCommand errors instead of masking

### DIFF
--- a/src/main/ssh/ssh-relay-deploy-helpers.test.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.test.ts
@@ -192,6 +192,26 @@ describe('execCommand', () => {
     expect(channel.stderr.listenerCount('data')).toBe(0)
   })
 
+  it('surfaces stdout alongside stderr on nonzero exit instead of masking it', async () => {
+    const channel = createMockChannel()
+    const conn = {
+      exec: vi.fn().mockResolvedValue(channel)
+    }
+    const commandPromise = execCommand(conn as never, 'npm install 2>&1')
+
+    await Promise.resolve()
+    // Why: the system-ssh transport routes the local OpenSSH client's own
+    // diagnostics to channel.stderr while the remote command's merged output
+    // arrives on stdout. stderr must not mask the real failure.
+    channel.stderr.emit('data', Buffer.from("Warning: Permanently added 'host' (ED25519)\n"))
+    channel.emit('data', Buffer.from("npm error g++: unrecognized '-std=gnu++20'\n"))
+    channel.emit('close', 1)
+
+    const error = await commandPromise.catch((err: Error) => err)
+    expect(error.message).toContain('Permanently added')
+    expect(error.message).toContain('gnu++20')
+  })
+
   it('cleans command channel listeners when a command times out', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/ssh/ssh-relay-deploy-helpers.test.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 import type { ClientChannel } from 'ssh2'
 import { execCommand, waitForSentinel } from './ssh-relay-deploy-helpers'
+import { shouldProbeBuildToolchainAfterNativeDepsFailure } from './ssh-relay-build-toolchain'
 import { RELAY_SENTINEL } from './relay-protocol'
 import {
   RelayVersionMismatchError,
@@ -14,6 +15,17 @@ function createMockChannel(): ClientChannel {
     stdin: { write: vi.fn() },
     close: vi.fn()
   }) as unknown as ClientChannel
+}
+
+// execCommand only rejects with Error; narrow the caught reason (its resolve
+// type is string) and fail loudly if the command unexpectedly succeeds.
+async function execCommandRejection(promise: Promise<string>): Promise<Error> {
+  return promise.then(
+    () => {
+      throw new Error('expected execCommand to reject')
+    },
+    (err: Error) => err
+  )
 }
 
 describe('waitForSentinel', () => {
@@ -207,9 +219,33 @@ describe('execCommand', () => {
     channel.emit('data', Buffer.from("npm error g++: unrecognized '-std=gnu++20'\n"))
     channel.emit('close', 1)
 
-    const error = await commandPromise.catch((err: Error) => err)
+    const error = await execCommandRejection(commandPromise)
     expect(error.message).toContain('Permanently added')
     expect(error.message).toContain('gnu++20')
+  })
+
+  it('keeps the merged error message greppable by the build-toolchain probe', async () => {
+    const channel = createMockChannel()
+    const conn = {
+      exec: vi.fn().mockResolvedValue(channel)
+    }
+    const commandPromise = execCommand(conn as never, 'npm install 2>&1')
+
+    await Promise.resolve()
+    // Why: the OpenSSH banner alone never matches the probe, so the old
+    // `stderr || stdout` masking suppressed the actionable "install build
+    // tools" hint. The merged message keeps the node-gyp failure visible.
+    channel.stderr.emit('data', Buffer.from("Warning: Permanently added 'host' (ED25519)\n"))
+    channel.emit(
+      'data',
+      Buffer.from(
+        'npm error gyp ERR! configure error\nnpm error gyp ERR! stack Error: not found: make\n'
+      )
+    )
+    channel.emit('close', 1)
+
+    const error = await execCommandRejection(commandPromise)
+    expect(shouldProbeBuildToolchainAfterNativeDepsFailure(error.message)).toBe(true)
   })
 
   it('cleans command channel listeners when a command times out', async () => {

--- a/src/main/ssh/ssh-relay-deploy-helpers.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.ts
@@ -289,7 +289,9 @@ export async function execCommand(
     }
     const onClose = (code: number): void => {
       if (code !== 0) {
-        const output = stderr.trim() || stdout.trim()
+        // Why: on the system-ssh transport channel.stderr carries local OpenSSH
+        // client noise; preferring it masks the real failure in stdout (2>&1).
+        const output = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n')
         settle(reject, new Error(`Command "${command}" failed (exit ${code}): ${output}`))
       } else {
         settle(resolve, stdout)


### PR DESCRIPTION
## Problem

When connecting to a remote over SSH fails during relay native-deps install, the surfaced error showed only OpenSSH client banner noise instead of the real failure:

```
Error invoking remote method 'ssh:connect': Error: Command "export PATH=... && cd ... && npm install --omit=dev --no-audit --no-fund 'node-pty@1.1.0' '@parcel/watcher@2.5.6' 2>&1" failed (exit 1): Warning: Permanently added '[host]:80' (ED25519) to the list of known hosts. ... ** WARNING: connection is not using a post-quantum key exchange algorithm. **
```

The actual npm/node-gyp error (captured on stdout, since the install command appends `2>&1`) was never shown.

## Root cause

`execCommand` builds nonzero-exit errors from \`stderr.trim() || stdout.trim()\`, preferring stderr.

On the **system-ssh transport** (the fallback used when ssh2's direct TCP connection is blocked, e.g. by macOS network policy — `isSystemSshFallbackError`), \`wrapCommandProcess\` wires \`channel.stderr\` to the local \`/usr/bin/ssh\` process's stderr. That stream carries the OpenSSH client's own diagnostics — \`Permanently added …\` and the post-quantum notice — which are non-empty whenever the user's \`~/.ssh/config\` sets \`UserKnownHostsFile=/dev/null\` (every connection re-logs a new host). That noise wins the \`||\`, silently masking the real failure on stdout.

Knock-on effect: \`installNativeDeps\`' build-toolchain probe (\`shouldProbeBuildToolchainAfterNativeDepsFailure\`) inspects this masked message, so it never matches and the actionable "install build tools" hint never fires.

## Why not suppress the noise at the source

\`-q\` and \`LogLevel=QUIET\` do **not** suppress \`Permanently added\` (the \`/dev/null\` known_hosts file re-logs it every connection — verified empirically). So filtering at the ssh layer is unreliable and config-dependent.

## Fix

Surface **both** streams joined by a newline so neither can mask the other. This is transport-agnostic (for the ssh2 path it simply shows more context; for system-ssh it stops the masking) and also unblocks the toolchain probe.

\`\`\`diff
- const output = stderr.trim() || stdout.trim()
+ const output = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n')
\`\`\`

## Test

Adds a regression test that emits both stderr noise and a stdout error and asserts both appear in the rejection. Verified it **fails on the old** \`stderr || stdout\` logic (error is \`...failed (exit 1): Warning: Permanently added 'host' (ED25519)\` — \`gnu++20\` masked) and **passes after** the fix.

- \`vitest run ssh-relay-deploy-helpers.test.ts ssh-relay-native-deps-install.test.ts\` → 30 passed
- \`oxlint\` on changed files → 0 warnings, 0 errors

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6865">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->