### PR TITLE
fix(terminal): reclaim xterm focus after window blur (#6814), pane-scoped + guarded

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1715,8 +1715,12 @@ export default function TerminalPane({
       return
     }
     let ownsRegularTerminalFocus = false
+    let releasedMirrorOnWindowBlur = false
     const syncFocused = (focused: boolean): void => {
       ownsRegularTerminalFocus = focused
+      if (focused) {
+        releasedMirrorOnWindowBlur = false
+      }
       setRegularTerminalInputFocusAttribute(focused)
       window.api.ui.setTerminalInputFocused?.(focused)
     }
@@ -1745,7 +1749,7 @@ export default function TerminalPane({
     const onWindowBlur = (): void => {
       // Why: webview/browser handoff leaves the helper textarea as DOM focus,
       // so clear only the main-process mirror and let guest focus proceed.
-      releaseTerminalFocusForWindowBlur({
+      releasedMirrorOnWindowBlur = releaseTerminalFocusForWindowBlur({
         container,
         activeElement: document.activeElement,
         syncFocused
@@ -1753,12 +1757,17 @@ export default function TerminalPane({
     }
     const onWindowFocus = (): void => {
       // Why: app reactivation can preserve DOM focus on xterm after blur
-      // cleared the process-wide shortcut mirror.
-      resyncTerminalFocusForWindowFocus({
-        container,
-        activeElement: document.activeElement,
-        syncFocused
-      })
+      // cleared the process-wide shortcut mirror, or move focus to body/null.
+      if (
+        resyncTerminalFocusForWindowFocus({
+          container,
+          activeElement: document.activeElement,
+          syncFocused,
+          releasedMirrorOnWindowBlur
+        })
+      ) {
+        releasedMirrorOnWindowBlur = false
+      }
     }
 
     if (

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1715,11 +1715,11 @@ export default function TerminalPane({
       return
     }
     let ownsRegularTerminalFocus = false
-    let releasedMirrorOnWindowBlur = false
+    let releasedHelperOnWindowBlur: HTMLElement | null = null
     const syncFocused = (focused: boolean): void => {
       ownsRegularTerminalFocus = focused
       if (focused) {
-        releasedMirrorOnWindowBlur = false
+        releasedHelperOnWindowBlur = null
       }
       setRegularTerminalInputFocusAttribute(focused)
       window.api.ui.setTerminalInputFocused?.(focused)
@@ -1749,7 +1749,7 @@ export default function TerminalPane({
     const onWindowBlur = (): void => {
       // Why: webview/browser handoff leaves the helper textarea as DOM focus,
       // so clear only the main-process mirror and let guest focus proceed.
-      releasedMirrorOnWindowBlur = releaseTerminalFocusForWindowBlur({
+      releasedHelperOnWindowBlur = releaseTerminalFocusForWindowBlur({
         container,
         activeElement: document.activeElement,
         syncFocused
@@ -1763,10 +1763,10 @@ export default function TerminalPane({
           container,
           activeElement: document.activeElement,
           syncFocused,
-          releasedMirrorOnWindowBlur
+          releasedHelper: releasedHelperOnWindowBlur
         })
       ) {
-        releasedMirrorOnWindowBlur = false
+        releasedHelperOnWindowBlur = null
       }
     }
 

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
@@ -110,6 +110,54 @@ describe('regular terminal focus ownership', () => {
     expect(document.activeElement).toBe(helper)
   })
 
+  it('reclaims mirror and refocuses the helper when window blur dropped focus to body', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const syncFocused = vi.fn()
+    const focus = vi.spyOn(helper, 'focus')
+    helper.focus()
+
+    releaseTerminalFocusForWindowBlur({
+      container: pane,
+      activeElement: helper,
+      syncFocused
+    })
+    syncFocused.mockClear()
+    document.body.focus()
+    focus.mockClear()
+
+    const synced = resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      releasedMirrorOnWindowBlur: true,
+      isMac: false
+    })
+
+    expect(synced).toBe(true)
+    expect(syncFocused).toHaveBeenCalledWith(true)
+    expect(focus).toHaveBeenCalledOnce()
+    expect(document.activeElement).toBe(helper)
+  })
+
+  it('does not reclaim focus on window focus without a prior blur mirror release', () => {
+    const pane = appendPane()
+    appendHelper(pane)
+    const syncFocused = vi.fn()
+    document.body.focus()
+
+    const synced = resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      releasedMirrorOnWindowBlur: false,
+      isMac: false
+    })
+
+    expect(synced).toBe(false)
+    expect(syncFocused).not.toHaveBeenCalled()
+  })
+
   it('resyncs terminal ownership on renderer focus when the same helper remains active', () => {
     const pane = appendPane()
     const helper = appendHelper(pane)

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
@@ -104,43 +104,170 @@ describe('regular terminal focus ownership', () => {
       syncFocused
     })
 
-    expect(released).toBe(true)
+    expect(released).toBe(helper)
     expect(syncFocused).toHaveBeenCalledWith(false)
     expect(blur).not.toHaveBeenCalled()
     expect(document.activeElement).toBe(helper)
   })
 
-  it('reclaims mirror and refocuses the helper when window blur dropped focus to body', () => {
+  it('returns null on renderer blur when this pane did not own the active helper', () => {
+    const pane = appendPane()
+    appendHelper(pane)
+    const syncFocused = vi.fn()
+    document.body.focus()
+
+    const released = releaseTerminalFocusForWindowBlur({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused
+    })
+
+    expect(released).toBeNull()
+    expect(syncFocused).not.toHaveBeenCalled()
+  })
+
+  it('reclaims and refocuses the released helper (next frame) when blur dropped focus to body', () => {
     const pane = appendPane()
     const helper = appendHelper(pane)
     const syncFocused = vi.fn()
     const focus = vi.spyOn(helper, 'focus')
     helper.focus()
 
-    releaseTerminalFocusForWindowBlur({
+    const releasedHelper = releaseTerminalFocusForWindowBlur({
       container: pane,
       activeElement: helper,
       syncFocused
     })
+    expect(releasedHelper).toBe(helper)
     syncFocused.mockClear()
     document.body.focus()
     focus.mockClear()
+    const scheduled: (() => void)[] = []
 
     const synced = resyncTerminalFocusForWindowFocus({
       container: pane,
       activeElement: document.activeElement,
       syncFocused,
-      releasedMirrorOnWindowBlur: true,
-      isMac: false
+      releasedHelper,
+      isMac: false,
+      scheduleRefocus: (callback) => scheduled.push(callback)
     })
 
     expect(synced).toBe(true)
     expect(syncFocused).toHaveBeenCalledWith(true)
+    // Why: reclaim is deferred so a newer focus owner during reactivation wins.
+    expect(focus).not.toHaveBeenCalled()
+    for (const run of scheduled) {
+      run()
+    }
     expect(focus).toHaveBeenCalledOnce()
     expect(document.activeElement).toBe(helper)
   })
 
-  it('does not reclaim focus on window focus without a prior blur mirror release', () => {
+  it('reclaims the exact split helper that was released, not the first one in the container', () => {
+    // Why: a single TerminalPane hosts every split as siblings under one
+    // container, so a first-match querySelector would refocus the wrong split.
+    const pane = appendPane()
+    const firstHelper = appendHelper(pane)
+    const secondHelper = appendHelper(pane)
+    const syncFocused = vi.fn()
+    const firstFocus = vi.spyOn(firstHelper, 'focus')
+    const secondFocus = vi.spyOn(secondHelper, 'focus')
+    secondHelper.focus()
+
+    const releasedHelper = releaseTerminalFocusForWindowBlur({
+      container: pane,
+      activeElement: secondHelper,
+      syncFocused
+    })
+    expect(releasedHelper).toBe(secondHelper)
+    document.body.focus()
+    firstFocus.mockClear()
+    secondFocus.mockClear()
+    const scheduled: (() => void)[] = []
+
+    resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      releasedHelper,
+      isMac: false,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+    for (const run of scheduled) {
+      run()
+    }
+
+    expect(secondFocus).toHaveBeenCalledOnce()
+    expect(firstFocus).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(secondHelper)
+  })
+
+  it('does not yank focus back into the terminal if the user clicked elsewhere during reactivation', () => {
+    // Why: the Linux reclaim path must honor the same "newer focus owner wins"
+    // guard the macOS path uses, so a click into the sidebar/dialog isn't stolen.
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const outside = document.createElement('input')
+    document.body.appendChild(outside)
+    const syncFocused = vi.fn()
+    const focus = vi.spyOn(helper, 'focus')
+    helper.focus()
+
+    const releasedHelper = releaseTerminalFocusForWindowBlur({
+      container: pane,
+      activeElement: helper,
+      syncFocused
+    })
+    document.body.focus()
+    focus.mockClear()
+    const scheduled: (() => void)[] = []
+
+    resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      releasedHelper,
+      isMac: false,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+    // User clicks into another field before the deferred reclaim runs.
+    outside.focus()
+    for (const run of scheduled) {
+      run()
+    }
+
+    expect(focus).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(outside)
+  })
+
+  it('does not reclaim a released helper that was detached from the DOM before refocus', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const syncFocused = vi.fn()
+    helper.focus()
+
+    const releasedHelper = releaseTerminalFocusForWindowBlur({
+      container: pane,
+      activeElement: helper,
+      syncFocused
+    })
+    // The split that owned focus was closed during the blur.
+    helper.remove()
+    document.body.focus()
+
+    const synced = resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      releasedHelper,
+      isMac: false
+    })
+
+    expect(synced).toBe(false)
+  })
+
+  it('does not reclaim focus on window focus without a prior blur release', () => {
     const pane = appendPane()
     appendHelper(pane)
     const syncFocused = vi.fn()
@@ -150,7 +277,7 @@ describe('regular terminal focus ownership', () => {
       container: pane,
       activeElement: document.activeElement,
       syncFocused,
-      releasedMirrorOnWindowBlur: false,
+      releasedHelper: null,
       isMac: false
     })
 

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
@@ -35,6 +35,15 @@ export function getPaneOwnedActiveHelperTextarea(
   return activeElement
 }
 
+function getPaneHelperTextarea(container: HTMLElement): HTMLElement | null {
+  const helper = container.querySelector('.xterm-helper-textarea')
+  return helper instanceof HTMLElement ? helper : null
+}
+
+function isDocumentBodyOrNull(activeElement: Element | null, ownerDocument: Document): boolean {
+  return activeElement === null || activeElement === ownerDocument.body
+}
+
 export function releaseTerminalFocusForOutsidePointerDown(args: {
   container: HTMLElement
   activeElement: Element | null
@@ -72,17 +81,42 @@ export function resyncTerminalFocusForWindowFocus(args: {
   container: HTMLElement
   activeElement: Element | null
   syncFocused: TerminalInputFocusSync
+  /**
+   * Set when this pane cleared the shortcut mirror on window blur while the
+   * helper was still (or had been) the typing surface — allows reclaim after
+   * Chromium moves focus to body/null on app reactivation.
+   */
+  releasedMirrorOnWindowBlur?: boolean
   /** Override the macOS check (tests). Defaults to the navigator user agent. */
   isMac?: boolean
   /** Override the refocus scheduler (tests). Defaults to requestAnimationFrame. */
   scheduleRefocus?: RefocusScheduler
 }): boolean {
-  const helper = getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)
+  const ownedActive = getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)
+  let helper = ownedActive
+  let needsProgrammaticFocus = false
+
   if (!helper) {
-    return false
+    const ownerDocument = args.container.ownerDocument
+    if (
+      args.releasedMirrorOnWindowBlur &&
+      isDocumentBodyOrNull(args.activeElement, ownerDocument)
+    ) {
+      helper = getPaneHelperTextarea(args.container)
+      if (!helper) {
+        return false
+      }
+      needsProgrammaticFocus = true
+    } else {
+      return false
+    }
   }
 
   args.syncFocused(true)
+
+  if (needsProgrammaticFocus) {
+    helper.focus()
+  }
 
   // Why: on macOS, reactivating the app leaves Chromium's NSTextInputContext
   // stale on the still-focused helper textarea, so the IME is stranded in ASCII

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
@@ -35,11 +35,6 @@ export function getPaneOwnedActiveHelperTextarea(
   return activeElement
 }
 
-function getPaneHelperTextarea(container: HTMLElement): HTMLElement | null {
-  const helper = container.querySelector('.xterm-helper-textarea')
-  return helper instanceof HTMLElement ? helper : null
-}
-
 function isDocumentBodyOrNull(activeElement: Element | null, ownerDocument: Document): boolean {
   return activeElement === null || activeElement === ownerDocument.body
 }
@@ -68,13 +63,17 @@ export function releaseTerminalFocusForWindowBlur(args: {
   container: HTMLElement
   activeElement: Element | null
   syncFocused: TerminalInputFocusSync
-}): boolean {
-  if (!getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)) {
-    return false
+}): HTMLElement | null {
+  // Why: return the exact helper that owned focus so window-focus reclaim can
+  // refocus *that* split, not whichever helper happens to be first in the DOM
+  // (a single TerminalPane hosts every split as siblings under one container).
+  const releasedHelper = getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)
+  if (!releasedHelper) {
+    return null
   }
 
   args.syncFocused(false)
-  return true
+  return releasedHelper
 }
 
 export function resyncTerminalFocusForWindowFocus(args: {
@@ -82,11 +81,11 @@ export function resyncTerminalFocusForWindowFocus(args: {
   activeElement: Element | null
   syncFocused: TerminalInputFocusSync
   /**
-   * Set when this pane cleared the shortcut mirror on window blur while the
-   * helper was still (or had been) the typing surface — allows reclaim after
-   * Chromium moves focus to body/null on app reactivation.
+   * The exact helper textarea this pane released on window blur. When focus
+   * settled on body/null during app reactivation, reclaim *this* split's
+   * helper rather than whichever helper is first in the DOM.
    */
-  releasedMirrorOnWindowBlur?: boolean
+  releasedHelper?: HTMLElement | null
   /** Override the macOS check (tests). Defaults to the navigator user agent. */
   isMac?: boolean
   /** Override the refocus scheduler (tests). Defaults to requestAnimationFrame. */
@@ -98,14 +97,14 @@ export function resyncTerminalFocusForWindowFocus(args: {
 
   if (!helper) {
     const ownerDocument = args.container.ownerDocument
+    const releasedHelper = args.releasedHelper
     if (
-      args.releasedMirrorOnWindowBlur &&
+      releasedHelper &&
+      releasedHelper.isConnected &&
+      args.container.contains(releasedHelper) &&
       isDocumentBodyOrNull(args.activeElement, ownerDocument)
     ) {
-      helper = getPaneHelperTextarea(args.container)
-      if (!helper) {
-        return false
-      }
+      helper = releasedHelper
       needsProgrammaticFocus = true
     } else {
       return false
@@ -114,8 +113,23 @@ export function resyncTerminalFocusForWindowFocus(args: {
 
   args.syncFocused(true)
 
+  const reclaimedHelper = helper
+  const isMac = args.isMac ?? isMacUserAgent()
+
+  // Why: defer the reclaim refocus to the next frame and only take focus if
+  // nothing newer grabbed it — so a click into the sidebar/dialog/rename input
+  // during reactivation isn't yanked back into the terminal. Applies on every
+  // platform (the reporter's bug is Linux); macOS additionally needs the blur
+  // first to rebuild a stale NSTextInputContext (see below).
   if (needsProgrammaticFocus) {
-    helper.focus()
+    const schedule = args.scheduleRefocus ?? scheduleNextFrame
+    schedule(() => {
+      const active = reclaimedHelper.ownerDocument.activeElement
+      if (active === reclaimedHelper || isDocumentBodyOrNull(active, reclaimedHelper.ownerDocument)) {
+        reclaimedHelper.focus()
+      }
+    })
+    return true
   }
 
   // Why: on macOS, reactivating the app leaves Chromium's NSTextInputContext
@@ -123,16 +137,15 @@ export function resyncTerminalFocusForWindowFocus(args: {
   // with no way to switch back to CJK (electron#32307/#34952). Forcing a
   // blur → next-frame refocus rebuilds the input context so the IME works again.
   // Other platforms don't hit this and shouldn't pay the flicker cost.
-  const isMac = args.isMac ?? isMacUserAgent()
   if (isMac) {
-    helper.blur()
+    reclaimedHelper.blur()
     const schedule = args.scheduleRefocus ?? scheduleNextFrame
     schedule(() => {
       // Why: only reclaim focus if nothing else grabbed it during the frame, so
       // a click into another field mid-reactivation isn't yanked back.
-      const active = helper.ownerDocument.activeElement
-      if (active === helper || active === helper.ownerDocument.body || active === null) {
-        helper.focus()
+      const active = reclaimedHelper.ownerDocument.activeElement
+      if (active === reclaimedHelper || isDocumentBodyOrNull(active, reclaimedHelper.ownerDocument)) {
+        reclaimedHelper.focus()
       }
     })
   }


### PR DESCRIPTION
## Summary

Renderer-side fix for **#6814** Symptom A: after blurring and re-focusing the Orca window (e.g. reading a file in another app and coming back), the existing terminal can stop accepting input. Based on #6826, with two regression fixes applied.

## Root cause

On window blur, `releaseTerminalFocusForWindowBlur` clears the main-process `terminalInputFocused` mirror but doesn't blur the xterm helper. On re-focus, Chromium often moves `document.activeElement` to `body`, so the existing resync no-ops and the mirror stays cleared — terminal-context shortcut routing is lost until restart.

## Changes

- Reclaim focus on window-focus when the mirror was released on blur and focus settled on `body`/null.
- **Reclaim the exact split helper that owned focus**, not `container.querySelector('.xterm-helper-textarea')` first-match. A single `TerminalPane` hosts every split as siblings under one container, so first-match would refocus the wrong split.
- **Defer the reclaim refocus to the next frame with a "don't steal from a newer focus owner" guard on every platform** (the original only guarded macOS). The reporter is on Linux; without the guard, a click into the sidebar/dialog/rename input during reactivation could be yanked back into the terminal.
- Skip reclaim if the released helper was detached before refocus.

## Test

`regular-terminal-focus-ownership.test.ts` — 16 passing, including new cases for: pane-scoped reclaim of the correct split, the cross-platform focus-steal guard, and detached-helper safety.

## Verification

- `pnpm exec vitest run` on the focus suite — 16 passing.
- `oxlint@1.71.0` (CI version) clean; `typecheck:web` clean.

## Caveat

Verified via unit tests, not a live window-manager repro (the trigger needs a real desktop session). Note also that the `terminalInputFocused` mirror only selects keybinding context, so under the default `orca-first` shortcut policy this is a no-op; it matters most for `terminal-first` users.

Refs #6814. Based on #6826.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6867">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->