### PR TITLE
Improve styling and scannability of PR and task pages

### DIFF
--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -15,6 +15,7 @@ import { useShallow } from 'zustand/react/shallow'
 import type { editor as monacoEditor } from 'monaco-editor'
 import {
   ArrowDown,
+  ArrowLeft,
   ArrowRight,
   ArrowUp,
   Braces,
@@ -30,6 +31,7 @@ import {
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
+  GitPullRequestDraft,
   ListChecks,
   LoaderCircle,
   MessageSquare,
@@ -6759,7 +6761,18 @@ export default function PullRequestPage({
     refetchTick
   ])
 
-  const Icon = workItem?.type === 'pr' ? GitPullRequest : CircleDot
+  // Why: the state pill's icon must track the resolved state so a merged PR
+  // reads as merged (purple GitMerge) rather than wearing the open-PR glyph.
+  const Icon =
+    workItem?.type === 'pr'
+      ? localState === 'merged'
+        ? GitMerge
+        : localState === 'closed'
+          ? GitPullRequestClosed
+          : localState === 'draft'
+            ? GitPullRequestDraft
+            : GitPullRequest
+      : CircleDot
   const displayWorkItem = useMemo<GitHubWorkItem | null>(() => {
     if (!workItem) {
       return null
@@ -6984,15 +6997,15 @@ export default function PullRequestPage({
             <ChevronLeft className="size-4" />
             {backLabel}
           </Button>
-          <span className="text-border">·</span>
+          <span className="text-muted-foreground/40">·</span>
           {ownerRepo ? (
             <>
               <span className="truncate">
                 <span className="text-muted-foreground">{ownerRepo.owner}</span>
-                <span className="mx-1 text-muted-foreground/60">/</span>
+                <span className="mx-1 text-muted-foreground/40">/</span>
                 <span className="font-medium text-foreground">{ownerRepo.repo}</span>
               </span>
-              <span className="text-muted-foreground/60">·</span>
+              <span className="text-muted-foreground/40">·</span>
             </>
           ) : null}
           <span className="font-mono text-muted-foreground">#{workItem.number}</span>
@@ -7046,11 +7059,13 @@ export default function PullRequestPage({
       </div>
 
       {/* Row 2: PR title block — large weight-400 title + state row, mirrors Primer pr-title-block */}
-      <div className="flex-none border-b border-border/60 px-6 py-4">
+      <div className="flex-none border-b border-border/60 px-6 py-5">
         <div className="flex items-start gap-4">
-          <h1 className="min-w-0 flex-1 text-[28px] font-medium leading-tight text-foreground">
+          <h1 className="min-w-0 flex-1 text-[26px] font-medium leading-snug text-foreground">
             <span className="break-words">{workItem.title}</span>
-            <span className="ml-2 font-light text-muted-foreground">#{workItem.number}</span>
+            <span className="ml-2 align-baseline text-[20px] font-normal text-muted-foreground/70">
+              #{workItem.number}
+            </span>
           </h1>
           <div className="flex shrink-0 items-center gap-2">
             {/* Why: Orca's signature affordance — keep this primary so it stands out
@@ -7059,9 +7074,8 @@ export default function PullRequestPage({
               <ButtonGroup>
                 <Button
                   type="button"
-                  size="sm"
                   onClick={handleOpenOrUsePR}
-                  className="gap-1.5 whitespace-nowrap font-semibold"
+                  className="w-[180px] justify-center gap-1.5 whitespace-nowrap"
                   aria-label={
                     attachedWorkspace
                       ? translate(
@@ -7076,22 +7090,19 @@ export default function PullRequestPage({
                 >
                   {attachedWorkspace
                     ? translate('auto.components.PullRequestPage.c9e7094a7b', 'Resume workspace')
-                    : translate(
-                        'auto.components.PullRequestPage.25690a3855',
-                        'Start workspace from PR'
-                      )}
-                  <ArrowRight className="size-3.5" />
+                    : translate('auto.components.PullRequestPage.71a3c0f9d2', 'Start workspace')}
+                  <ArrowRight className="size-4" />
                 </Button>
                 <DropdownMenuTrigger asChild>
                   <Button
                     type="button"
-                    size="icon-sm"
+                    size="icon"
                     aria-label={translate(
                       'auto.components.PullRequestPage.57c13a5aa4',
                       'More PR workspace actions'
                     )}
                   >
-                    <ChevronDown className="size-3.5" />
+                    <ChevronDown className="size-4" />
                   </Button>
                 </DropdownMenuTrigger>
               </ButtonGroup>
@@ -7110,7 +7121,7 @@ export default function PullRequestPage({
             </DropdownMenu>
           </div>
         </div>
-        <div className="mt-3 flex flex-wrap items-center gap-2 text-[13px] text-muted-foreground">
+        <div className="mt-4 flex flex-wrap items-center gap-x-2.5 gap-y-2 text-[13px] text-muted-foreground">
           <span
             className={cn(
               'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[12px] font-medium',
@@ -7120,16 +7131,26 @@ export default function PullRequestPage({
             <Icon className="size-3.5" />
             {stateBadgeLabel}
           </span>
-          <span className="flex flex-wrap items-center gap-1.5">
+          <span className="flex min-w-0 items-center gap-1.5">
+            {workItem.author ? (
+              <img
+                src={githubAvatarUrl(workItem.author)}
+                alt=""
+                loading="lazy"
+                decoding="async"
+                className="size-5 shrink-0 rounded-full border border-border/50 bg-muted object-cover"
+              />
+            ) : null}
             <span className="font-semibold text-foreground">
               {workItem.author ??
                 translate('auto.components.PullRequestPage.77d9388fb0', 'unknown')}
             </span>
-            <span>
-              {translate('auto.components.PullRequestPage.b0e80f083d', 'wants to merge into')}
-            </span>
+          </span>
+          {/* Why: the scannable base ← head idiom reads faster than a prose
+              sentence and matches how reviewers think about merge direction. */}
+          <span className="flex flex-wrap items-center gap-1.5">
             {baseBranch ? (
-              <span className="rounded-md bg-accent/40 px-1.5 py-0.5 font-mono text-[12px] text-accent-foreground">
+              <span className="rounded-md border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-[12px] text-foreground">
                 {baseBranch}
               </span>
             ) : (
@@ -7137,9 +7158,9 @@ export default function PullRequestPage({
                 {translate('auto.components.PullRequestPage.c44b70352b', 'base branch')}
               </span>
             )}
-            <span>{translate('auto.components.PullRequestPage.e1f3641bfd', 'from')}</span>
+            <ArrowLeft className="size-3.5 shrink-0 text-muted-foreground/70" />
             {headBranch ? (
-              <span className="rounded-md bg-accent/40 px-1.5 py-0.5 font-mono text-[12px] text-accent-foreground">
+              <span className="rounded-md border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-[12px] text-foreground">
                 {headBranch}
               </span>
             ) : (
@@ -7147,16 +7168,21 @@ export default function PullRequestPage({
                 {translate('auto.components.PullRequestPage.00b7b82329', 'head branch')}
               </span>
             )}
-            <span className="text-muted-foreground/80">
-              {translate('auto.components.PullRequestPage.e6996f4024', '· updated')}
-              {formatRelativeTime(workItem.updatedAt)}
-            </span>
+          </span>
+          <span className="text-muted-foreground/40">·</span>
+          <span className="text-muted-foreground/80">
+            {translate('auto.components.PullRequestPage.dd5d9a4f17', 'updated {{value0}}', {
+              value0: formatRelativeTime(workItem.updatedAt)
+            })}
           </span>
           {attachedWorkspaceLabel ? (
-            <span className="inline-flex min-w-0 items-center gap-1.5">
-              <FolderKanban className="size-3.5 shrink-0" />
-              <span className="truncate">{attachedWorkspaceLabel}</span>
-            </span>
+            <>
+              <span className="text-muted-foreground/40">·</span>
+              <span className="inline-flex min-w-0 items-center gap-1.5">
+                <FolderKanban className="size-3.5 shrink-0" />
+                <span className="truncate">{attachedWorkspaceLabel}</span>
+              </span>
+            </>
           ) : null}
         </div>
       </div>

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -466,9 +466,10 @@ function getTaskPageRepoCacheInput(repo: Repo): {
   }
 }
 
-// Why: the row's px-3 left padding leaves a 12px gap between the scroll-viewport
-// edge and the sticky ID column; without a covering ::before, scrolled cell text
-// bleeds through that strip. Same trick as the title column for its 8px gap.
+// Why: the sticky header's bg must be opaque (GITHUB_TASK_ROW_SURFACE_CLASS, not
+// bg-muted/50) or vertically-scrolled rows bleed through it. These left-sticky
+// cells additionally need a ::before gap-cover so horizontally-scrolled header
+// columns don't show through the row's px-3 padding strip.
 const GITHUB_TASK_STICKY_ID_HEADER_CLASS = cn(
   'sticky left-3 z-30 before:absolute before:-left-3 before:top-0 before:bottom-0 before:w-3 before:bg-inherit',
   GITHUB_TASK_ROW_SURFACE_CLASS
@@ -7823,12 +7824,12 @@ export default function TaskPage(): React.JSX.Element {
             icon). Matching that here needs 6px top padding above the 32px
             cluster (6 + 16 = 22). The previous pt-3 placed the cluster 6px
             too low, breaking the visual band across the top chrome. */}
-        <div className="mx-auto flex min-h-0 min-w-0 w-full flex-1 flex-col px-5 pt-1.5 pb-5 md:px-8 md:pt-1.5 md:pb-7">
+        <div className="mx-auto flex min-h-0 min-w-0 w-full flex-1 flex-col px-5 pt-1.5 pb-4 md:px-8 md:pt-1.5 md:pb-5">
           <div
-            className={cn('flex-none flex flex-col gap-3', taskPageListChromeHidden && 'hidden')}
+            className={cn('flex-none flex flex-col gap-2', taskPageListChromeHidden && 'hidden')}
           >
-            <section className="flex flex-col gap-3">
-              <div className="flex flex-col gap-3">
+            <section className="flex flex-col gap-2">
+              <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between gap-2">
                   <div
                     className="flex min-w-0 flex-wrap items-center gap-2"
@@ -8142,10 +8143,10 @@ export default function TaskPage(): React.JSX.Element {
 
                 {taskSource === 'github' && githubMode === 'items' ? (
                   <div
-                    className="min-w-0 rounded-md rounded-b-none border border-border/50 bg-muted/50 p-3 shadow-sm"
+                    className="min-w-0 rounded-md rounded-b-none border border-border/50 bg-muted/50 px-3 pt-2 pb-0 shadow-sm"
                     data-contextual-tour-target="tasks-search-presets"
                   >
-                    <div className="mb-3 flex flex-wrap gap-2">
+                    <div className="mb-2 flex flex-wrap gap-2">
                       {getGitHubTaskKindPresets(activeGithubTaskKind).map((option) => {
                         const active = activeTaskPreset === option.id
                         return (
@@ -8371,7 +8372,7 @@ export default function TaskPage(): React.JSX.Element {
                   </div>
                 ) : taskSource === 'linear' && linearConnected ? (
                   <div
-                    className="min-w-0 rounded-md rounded-b-none border border-border/50 bg-muted/50 p-3 shadow-sm"
+                    className="min-w-0 rounded-md rounded-b-none border border-border/50 bg-muted/50 px-3 pt-2 pb-0 shadow-sm"
                     data-contextual-tour-target="tasks-search-presets"
                   >
                     <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
@@ -8598,7 +8599,7 @@ export default function TaskPage(): React.JSX.Element {
                     ) : null}
                   </div>
                 ) : taskSource === 'jira' && jiraConnected ? (
-                  <div className="rounded-md rounded-b-none border border-border/50 bg-muted/50 p-3 shadow-sm">
+                  <div className="rounded-md rounded-b-none border border-border/50 bg-muted/50 px-3 pt-2 pb-0 shadow-sm">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div className="flex flex-wrap gap-2">
                         {jiraPresets.map((preset) => {
@@ -8806,7 +8807,7 @@ export default function TaskPage(): React.JSX.Element {
                       </div>
                     </div>
                     <div
-                      className="min-w-0 rounded-md rounded-b-none border border-border/50 bg-muted/50 p-3 shadow-sm"
+                      className="min-w-0 rounded-md rounded-b-none border border-border/50 bg-muted/50 px-3 pt-2 pb-0 shadow-sm"
                       data-contextual-tour-target="tasks-search-presets"
                     >
                       <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
@@ -8935,8 +8936,12 @@ export default function TaskPage(): React.JSX.Element {
                 style={{ scrollbarGutter: 'stable' }}
               >
                 <div
+                  // Why: z-40 must beat the data rows' sticky left cells (z-20);
+                  // this container is a stacking context, so its z sets the whole
+                  // header's level — at z-10 the rows' sticky cells painted over it.
                   className={cn(
-                    'sticky top-0 z-10 grid gap-2 border-b border-border/50 bg-muted/50 px-3 py-2 text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground',
+                    'sticky top-0 z-40 grid gap-2 border-b border-border/50 px-3 py-2 text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground',
+                    GITHUB_TASK_ROW_SURFACE_CLASS,
                     githubTaskGridClass
                   )}
                 >
@@ -9157,7 +9162,10 @@ export default function TaskPage(): React.JSX.Element {
                             }
                           }}
                           className={cn(
-                            'group/github-task-row grid cursor-pointer gap-2 px-3 py-2 text-left transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+                            // Why: hover uses the same opaque muted-70% mix as the sticky
+                            // ID/Title cells (GITHUB_TASK_ROW_HOVER_SURFACE_CLASS) so the
+                            // left columns don't show a different shade than the rest of the row.
+                            'group/github-task-row grid cursor-pointer gap-2 px-3 py-2 text-left transition-colors hover:[background:color-mix(in_srgb,var(--muted)_70%,var(--background))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
                             githubTaskGridClass
                           )}
                         >
@@ -9198,7 +9206,7 @@ export default function TaskPage(): React.JSX.Element {
                                 />
                               ) : null}
                             </div>
-                            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
                               <span>
                                 {item.author ??
                                   translate(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1172,6 +1172,8 @@
         "94d95cf1f7": "Checks",
         "9e8d45700e": "Conversation",
         "e6996f4024": "· updated",
+        "dd5d9a4f17": "updated {{value0}}",
+        "71a3c0f9d2": "Start workspace",
         "00b7b82329": "head branch",
         "e1f3641bfd": "from",
         "c44b70352b": "base branch",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1334,7 +1334,9 @@
         "8ff5ae8866": "Responsables",
         "82c87eceb9": "Editar responsables",
         "1ff5d979df": "Nadie asignado",
-        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked."
+        "checkActionRequiredHint": "Esta comprobación requiere una acción manual en GitHub (por ejemplo, aprobar la ejecución del flujo de trabajo) antes de poder desbloquear la fusión.",
+        "dd5d9a4f17": "actualizado {{value0}}",
+        "71a3c0f9d2": "Iniciar espacio de trabajo"
       },
       "QuickOpen": {
         "1dbd3f59ff": "Mover",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1334,7 +1334,9 @@
         "8ff5ae8866": "担当者",
         "82c87eceb9": "担当者を編集",
         "1ff5d979df": "担当者なし",
-        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked."
+        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked.",
+        "dd5d9a4f17": "{{value0}}に更新",
+        "71a3c0f9d2": "ワークスペースを開始"
       },
       "QuickOpen": {
         "1dbd3f59ff": "移動",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1334,7 +1334,9 @@
         "8ff5ae8866": "담당자",
         "82c87eceb9": "담당자 편집",
         "1ff5d979df": "할당된 사람이 없음",
-        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked."
+        "checkActionRequiredHint": "이 검사는 병합 차단을 해제하기 전에 GitHub에서 수동 작업(예: 워크플로 실행 승인)이 필요합니다.",
+        "dd5d9a4f17": "{{value0}}에 업데이트됨",
+        "71a3c0f9d2": "워크스페이스 시작"
       },
       "QuickOpen": {
         "1dbd3f59ff": "이동",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1334,7 +1334,9 @@
         "8ff5ae8866": "负责人",
         "82c87eceb9": "编辑负责人",
         "1ff5d979df": "未分配任何人",
-        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked."
+        "checkActionRequiredHint": "此检查需要在 GitHub 上执行手动操作（例如，批准工作流运行），然后才能解除合并阻止。",
+        "dd5d9a4f17": "{{value0}}更新",
+        "71a3c0f9d2": "启动工作区"
       },
       "QuickOpen": {
         "1dbd3f59ff": "手机",


### PR DESCRIPTION
## Summary

Refines the styling, typography, and scannability of the Pull Request and Task pages:
- **Pull Request Page**:
  - The PR status badge icon now dynamically reflects the resolved local state (merged, closed, draft, or open).
  - Displays the author's GitHub avatar next to their username in the PR status row.
  - Improves scannability of the merge target direction using a concise visual layout (`base_branch` <- `head_branch`) instead of a prose sentence.
  - Adjusted title typography sizing and unified the primary "Start/Resume workspace" button actions.
- **Task Page**:
  - Resolves vertical and horizontal scrolling bleed-through issues with sticky cells and headers by defining opaque backgrounds and appropriate stacking context (`z-40`).
  - Aligns row hover styling across sticky and non-sticky cells via a robust `color-mix` background.
  - Refines padding and scannability on contextual search preset panels and metadata sizing.
- **Localization**: Updates localization catalogs (`en`, `es`, `ja`, `ko`, `zh`) with dynamic updated timestamps and unified button labels.

## Screenshots

- TODO

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Analyzed visual layouts, layout alignments, and typography adjustments. The review explicitly verified that cross-platform layout rendering across macOS, Linux, and Windows remains consistent. Paths, system-level shortcut actions, labels, and shell behavior remain platform-neutral with no platform-specific risks detected.

## Security Audit

Performed an automated security check over visual rendering files. Verified that no user-input processing, command executions, authentication, secrets, or inter-process communication (IPC) routines are introduced. Profile avatars are resolved cleanly via secure HTTPS from GitHub assets.

## Notes

None. All visual layout and translation modifications behave identically across platform viewports.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6870">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->