### PR TITLE
Fix explicit PowerShell 7 terminal selection on Windows

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1374,7 +1374,7 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('falls back to powershell.exe when PowerShell 7 is selected but unavailable on Windows', () => {
+  it('keeps PowerShell 7 selected when the pwsh availability probe is cold-false on Windows', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -1397,13 +1397,14 @@ describe('createPtySubprocess', () => {
     }
 
     expect(spawnMock).toHaveBeenCalledWith(
-      WINDOWS_POWERSHELL_ABS,
+      PWSH7_ABS,
       POWERSHELL_OSC133_COMMAND_ARGS,
       expect.any(Object)
     )
+    expect(isPwshAvailableMock).not.toHaveBeenCalled()
   })
 
-  it('falls back to powershell.exe when shellOverride requests pwsh.exe but pwsh is unavailable on Windows', () => {
+  it('keeps a pwsh.exe shellOverride when the pwsh availability probe is cold-false on Windows', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -1426,10 +1427,11 @@ describe('createPtySubprocess', () => {
     }
 
     expect(spawnMock).toHaveBeenCalledWith(
-      WINDOWS_POWERSHELL_ABS,
+      PWSH7_ABS,
       POWERSHELL_OSC133_COMMAND_ARGS,
       expect.any(Object)
     )
+    expect(isPwshAvailableMock).not.toHaveBeenCalled()
   })
 
   it('ignores the PowerShell implementation setting for cmd.exe on Windows', () => {
@@ -2215,25 +2217,28 @@ describe('checkPtySpawnHealth (retry on transient failure)', () => {
   // Why: a busy machine right after an upgrade can make one probe fail; the
   // retry must keep a genuinely healthy daemon out of degraded mode. Windows
   // short-circuits checkPtySpawnHealth, so this is a POSIX-only behavior.
-  itOnPosixHost('retries once and resolves when the first probe fails but the second succeeds', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    spawnMock
-      .mockImplementationOnce(() => {
-        const proc = mockPtyProcess()
-        queueMicrotask(() => proc._simulateExit(1))
-        return proc
-      })
-      .mockImplementationOnce(() => {
-        const proc = mockPtyProcess()
-        queueMicrotask(() => proc._simulateExit(0))
-        return proc
-      })
+  itOnPosixHost(
+    'retries once and resolves when the first probe fails but the second succeeds',
+    async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      spawnMock
+        .mockImplementationOnce(() => {
+          const proc = mockPtyProcess()
+          queueMicrotask(() => proc._simulateExit(1))
+          return proc
+        })
+        .mockImplementationOnce(() => {
+          const proc = mockPtyProcess()
+          queueMicrotask(() => proc._simulateExit(0))
+          return proc
+        })
 
-    await expect(checkPtySpawnHealth()).resolves.toBeUndefined()
-    expect(spawnMock).toHaveBeenCalledTimes(2)
-    expect(warn).toHaveBeenCalled()
-    warn.mockRestore()
-  })
+      await expect(checkPtySpawnHealth()).resolves.toBeUndefined()
+      expect(spawnMock).toHaveBeenCalledTimes(2)
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    }
+  )
 
   itOnPosixHost('rejects after exhausting retries when every probe fails', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -17,7 +17,11 @@ import {
   validateWorkingDirectory
 } from '../providers/local-pty-utils'
 import { resolveWindowsShellLaunchArgs } from '../providers/windows-shell-args'
-import { resolveEffectiveWindowsPowerShell } from '../providers/windows-powershell'
+import {
+  resolveEffectiveWindowsPowerShell,
+  shouldProbeWindowsPowerShellAvailability,
+  type WindowsPowerShellShellFamily
+} from '../providers/windows-powershell'
 import {
   buildWindowsPowerShellSpawnAttempts,
   type WindowsShellSpawnAttempt
@@ -589,6 +593,16 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     // one-off override. Normalize both forms back to the PowerShell family so
     // the shared resolver can still fall back to inbox powershell.exe when
     // pwsh.exe was requested but is unavailable.
+    const resolvedShellFamily: WindowsPowerShellShellFamily =
+      normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
+        ? normalizedShellFamily
+        : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
+          ? normalizedShellFamily
+          : undefined
+    const shouldProbePwsh = shouldProbeWindowsPowerShellAvailability({
+      shellFamily: resolvedShellFamily,
+      implementation: opts.terminalWindowsPowerShellImplementation
+    })
     const shouldResolvePowerShellFamily =
       opts.terminalWindowsPowerShellImplementation !== undefined ||
       pathWin32.basename(shellPath) === shellPath
@@ -599,14 +613,9 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     } else {
       shellPath = shouldResolvePowerShellFamily
         ? (resolveEffectiveWindowsPowerShell({
-            shellFamily:
-              normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
-                ? 'powershell.exe'
-                : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
-                  ? normalizedShellFamily
-                  : undefined,
+            shellFamily: resolvedShellFamily,
             implementation: opts.terminalWindowsPowerShellImplementation,
-            pwshAvailable: isPwshAvailable()
+            pwshAvailable: shouldProbePwsh ? isPwshAvailable() : false
           }) ?? shellPath)
         : shellPath
     }

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -332,28 +332,33 @@ describe('registerFilesystemHandlers', () => {
     )
   })
 
-  it('records a redacted breadcrumb when fs:readDir throws on a WSL UNC path', async () => {
-    registerFilesystemHandlers(store as never)
-    const wslPath = '\\\\wsl.localhost\\Ubuntu\\home\\user\\repo'
-    // resolveAuthorizedPath authorizes the path, then readdir fails (distro stopped).
-    realpathMock.mockResolvedValue(wslPath)
-    registerWorktreeRootsForRepo(store as never, 'repo-1', [wslPath])
-    readdirMock.mockRejectedValue(Object.assign(new Error('EIO: i/o error'), { code: 'EIO' }))
+  // Why: handler-level WSL UNC authorization depends on native Windows path
+  // resolution; path-shape classification has separate cross-platform coverage.
+  it.runIf(process.platform === 'win32')(
+    'records a redacted breadcrumb when fs:readDir throws on a WSL UNC path',
+    async () => {
+      registerFilesystemHandlers(store as never)
+      const wslPath = path.win32.join('\\\\wsl.localhost\\Ubuntu', 'home', 'user', 'repo')
+      // resolveAuthorizedPath authorizes the path, then readdir fails (distro stopped).
+      realpathMock.mockResolvedValue(wslPath)
+      registerWorktreeRootsForRepo(store as never, 'repo-1', [wslPath])
+      readdirMock.mockRejectedValue(Object.assign(new Error('EIO: i/o error'), { code: 'EIO' }))
 
-    await expect(handlers.get('fs:readDir')!(null, { dirPath: wslPath })).rejects.toThrow(/EIO/)
+      await expect(handlers.get('fs:readDir')!(null, { dirPath: wslPath })).rejects.toThrow(/EIO/)
 
-    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith('fs_readdir_error', {
-      throwSite: 'readdir',
-      errorName: 'Error',
-      errorCode: 'EIO',
-      hasConnectionId: false,
-      isUNC: true,
-      isWsl: true
-    })
-    // The raw path must never appear in the breadcrumb payload.
-    const [, breadcrumbData] = recordCrashBreadcrumbMock.mock.calls[0]
-    expect(JSON.stringify(breadcrumbData)).not.toContain('user')
-  })
+      expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith('fs_readdir_error', {
+        throwSite: 'readdir',
+        errorName: 'Error',
+        errorCode: 'EIO',
+        hasConnectionId: false,
+        isUNC: true,
+        isWsl: true
+      })
+      // The raw path must never appear in the breadcrumb payload.
+      const [, breadcrumbData] = recordCrashBreadcrumbMock.mock.calls[0]
+      expect(JSON.stringify(breadcrumbData)).not.toContain('user')
+    }
+  )
 
   it('records a breadcrumb tagged ssh-provider when the SSH provider is gone', async () => {
     registerFilesystemHandlers(store as never)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -5299,7 +5299,7 @@ describe('registerPtyHandlers', () => {
       )
     })
 
-    it('falls back to powershell.exe when PowerShell 7 is selected but unavailable', async () => {
+    it('keeps PowerShell 7 selected when the pwsh availability probe is cold-false', async () => {
       process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
       isPwshAvailableMock.mockReturnValue(false)
 
@@ -5316,13 +5316,14 @@ describe('registerPtyHandlers', () => {
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
       expect(spawnMock).toHaveBeenCalledWith(
-        RESOLVED_WINDOWS_POWERSHELL,
+        RESOLVED_PWSH7,
         POWERSHELL_OSC133_ARGS,
         expect.any(Object)
       )
+      expect(isPwshAvailableMock).not.toHaveBeenCalled()
     })
 
-    it('falls back to powershell.exe when shellOverride requests pwsh.exe but pwsh is unavailable', async () => {
+    it('keeps a pwsh.exe shellOverride when the pwsh availability probe is cold-false', async () => {
       process.env.COMSPEC = 'C:\\Windows\\system32\\cmd.exe'
       isPwshAvailableMock.mockReturnValue(false)
 
@@ -5339,10 +5340,11 @@ describe('registerPtyHandlers', () => {
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, shellOverride: 'pwsh.exe' })
 
       expect(spawnMock).toHaveBeenCalledWith(
-        RESOLVED_WINDOWS_POWERSHELL,
+        RESOLVED_PWSH7,
         POWERSHELL_OSC133_ARGS,
         expect.any(Object)
       )
+      expect(isPwshAvailableMock).not.toHaveBeenCalled()
     })
 
     it('ignores the PowerShell implementation setting for cmd.exe', async () => {

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -526,6 +526,27 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.HISTFILE).toContain('terminal-history-wsl/Debian')
     })
 
+    it('repro: keeps explicit PowerShell 7 selection when the pwsh probe is cold-false', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const pwshAvailable = vi.fn(() => false)
+      provider.configure({
+        getWindowsShell: () => 'powershell.exe',
+        getWindowsPowerShellImplementation: () => 'pwsh.exe',
+        pwshAvailable
+      })
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\Users\\jin\\repo'
+      })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[0]).toBe(PWSH7_ABS)
+      expect(spawnCall[1]).toContain('-EncodedCommand')
+      expect(pwshAvailable).not.toHaveBeenCalled()
+    })
+
     it('marks Orca terminal handle for WSL import when buildSpawnEnv opts in', async () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
       const savedCodexHome = process.env.CODEX_HOME

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -5,7 +5,11 @@ files without a cleaner ownership seam. */
 import { basename, delimiter } from 'node:path'
 import { win32 as pathWin32 } from 'node:path'
 import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
-import { resolveEffectiveWindowsPowerShell } from './windows-powershell'
+import {
+  resolveEffectiveWindowsPowerShell,
+  shouldProbeWindowsPowerShellAvailability,
+  type WindowsPowerShellShellFamily
+} from './windows-powershell'
 import { buildWindowsPowerShellSpawnAttempts } from './windows-shell-fallback-chain'
 import { resolveProcessCwd } from './process-cwd'
 import { existsSync } from 'node:fs'
@@ -389,6 +393,16 @@ export class LocalPtyProvider implements IPtyProvider {
       // the shared resolver can still fall back to inbox powershell.exe when
       // pwsh.exe was requested but is unavailable.
       const powerShellImplementation = this.opts.getWindowsPowerShellImplementation?.()
+      const resolvedShellFamily: WindowsPowerShellShellFamily =
+        normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
+          ? normalizedShellFamily
+          : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
+            ? normalizedShellFamily
+            : undefined
+      const shouldProbePwsh = shouldProbeWindowsPowerShellAvailability({
+        shellFamily: resolvedShellFamily,
+        implementation: powerShellImplementation
+      })
       const shouldResolvePowerShellFamily =
         powerShellImplementation !== undefined || pathWin32.basename(shellFamily) === shellFamily
       if (resolvedGitBashPath) {
@@ -398,14 +412,9 @@ export class LocalPtyProvider implements IPtyProvider {
       } else {
         shellPath = shouldResolvePowerShellFamily
           ? (resolveEffectiveWindowsPowerShell({
-              shellFamily:
-                normalizedShellFamily === 'powershell.exe' || normalizedShellFamily === 'pwsh.exe'
-                  ? 'powershell.exe'
-                  : normalizedShellFamily === 'cmd.exe' || normalizedShellFamily === 'wsl.exe'
-                    ? normalizedShellFamily
-                    : undefined,
+              shellFamily: resolvedShellFamily,
               implementation: powerShellImplementation,
-              pwshAvailable: this.opts.pwshAvailable?.() ?? false
+              pwshAvailable: shouldProbePwsh ? (this.opts.pwshAvailable?.() ?? false) : false
             }) ?? shellFamily)
           : shellFamily
       }

--- a/src/main/providers/windows-powershell-executable.test.ts
+++ b/src/main/providers/windows-powershell-executable.test.ts
@@ -14,6 +14,7 @@ const WIN_ENV: NodeJS.ProcessEnv = {
 }
 
 const PWSH7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+const PATH_PWSH7 = 'D:\\Tools\\PowerShell\\7\\pwsh.exe'
 const WINDOWS_POWERSHELL = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 // The Microsoft Store App Execution Alias stub for pwsh — a zero-byte reparse
 // point under WindowsApps that ConPTY's CreateProcessW rejects with error 5.
@@ -38,6 +39,23 @@ describe('resolveWindowsPowerShellExecutablePath', () => {
         isRealExecutable: (p) => p === PWSH7
       })
     ).toBe(PWSH7)
+  })
+
+  it('repro: resolves pwsh.exe from a real PATH entry when standard roots miss', () => {
+    expect(
+      resolveWindowsPowerShellExecutablePath('pwsh.exe', {
+        platform: 'win32',
+        env: {
+          ...WIN_ENV,
+          Path: [
+            'relative-tools',
+            'C:\\Users\\dev\\AppData\\Local\\Microsoft\\WindowsApps',
+            'D:\\Tools\\PowerShell\\7'
+          ].join(';')
+        },
+        isRealExecutable: (p) => p === PATH_PWSH7
+      })
+    ).toBe(PATH_PWSH7)
   })
 
   it('resolves powershell.exe to inbox System32 WindowsPowerShell', () => {
@@ -92,6 +110,18 @@ describe('resolveWindowsPowerShellSpawnChain', () => {
     })
     expect(chain).toEqual([WINDOWS_POWERSHELL, WIN_ENV.ComSpec])
     expect(chain).not.toContain(PWSH_STORE_ALIAS)
+  })
+
+  it('orders PATH-resolved pwsh before Windows PowerShell when standard roots miss', () => {
+    const chain = resolveWindowsPowerShellSpawnChain('pwsh.exe', {
+      platform: 'win32',
+      env: {
+        ...WIN_ENV,
+        Path: 'D:\\Tools\\PowerShell\\7'
+      },
+      isRealExecutable: (p) => p === PATH_PWSH7 || p === WINDOWS_POWERSHELL
+    })
+    expect(chain).toEqual([PATH_PWSH7, WINDOWS_POWERSHELL, WIN_ENV.ComSpec])
   })
 
   it('always ends with cmd.exe even when no PowerShell resolves', () => {

--- a/src/main/providers/windows-powershell-executable.ts
+++ b/src/main/providers/windows-powershell-executable.ts
@@ -47,6 +47,26 @@ function readEnv(env: NodeJS.ProcessEnv, names: string[]): string | undefined {
   return undefined
 }
 
+function getPathExecutableCandidates(env: NodeJS.ProcessEnv, executable: string): string[] {
+  const pathValue = readEnv(env, ['PATH', 'Path', 'path'])
+  if (!pathValue) {
+    return []
+  }
+
+  const candidates: string[] = []
+  const seen = new Set<string>()
+  for (const rawPart of pathValue.split(pathWin32.delimiter)) {
+    const dir = rawPart.trim().replace(/^"|"$/g, '')
+    // Why: Windows' implicit current-directory search can pick up repo-local
+    // shims. Only absolute PATH entries become ConPTY launch candidates.
+    if (!pathWin32.isAbsolute(dir)) {
+      continue
+    }
+    pushUniqueCandidate(candidates, seen, pathWin32.join(dir, executable))
+  }
+  return candidates
+}
+
 function pushUniqueCandidate(
   candidates: string[],
   seen: Set<string>,
@@ -94,6 +114,9 @@ function getPwshCandidatePaths(env: NodeJS.ProcessEnv): string[] {
       )
     }
   }
+  for (const candidate of getPathExecutableCandidates(env, 'pwsh.exe')) {
+    pushUniqueCandidate(candidates, seen, candidate)
+  }
   return candidates
 }
 
@@ -138,7 +161,7 @@ export function resolveWindowsPowerShellExecutablePath(
   }
 
   for (const candidate of getPwshCandidatePaths(env)) {
-    if (isRealExecutable(candidate)) {
+    if (!isWindowsAppExecutionAliasPath(candidate) && isRealExecutable(candidate)) {
       return candidate
     }
   }

--- a/src/main/providers/windows-powershell.test.ts
+++ b/src/main/providers/windows-powershell.test.ts
@@ -28,6 +28,16 @@ describe('resolveEffectiveWindowsPowerShell', () => {
     ).toBeNull()
   })
 
+  it('honors a direct pwsh.exe shell request even when the availability probe is false', () => {
+    expect(
+      resolveEffectiveWindowsPowerShell({
+        shellFamily: 'pwsh.exe',
+        implementation: 'powershell.exe',
+        pwshAvailable: false
+      })
+    ).toBe('pwsh.exe')
+  })
+
   it('returns powershell.exe when the saved implementation is powershell.exe', () => {
     expect(
       resolveEffectiveWindowsPowerShell({
@@ -48,14 +58,14 @@ describe('resolveEffectiveWindowsPowerShell', () => {
     ).toBe('pwsh.exe')
   })
 
-  it('falls back to powershell.exe when pwsh is preferred but unavailable', () => {
+  it('keeps an explicit pwsh.exe preference when the availability probe is false', () => {
     expect(
       resolveEffectiveWindowsPowerShell({
         shellFamily: 'powershell.exe',
         implementation: 'pwsh.exe',
         pwshAvailable: false
       })
-    ).toBe('powershell.exe')
+    ).toBe('pwsh.exe')
   })
 
   it('uses pwsh.exe for Auto when pwsh is available', () => {

--- a/src/main/providers/windows-powershell.ts
+++ b/src/main/providers/windows-powershell.ts
@@ -1,25 +1,48 @@
 export type WindowsPowerShellImplementation = 'auto' | 'powershell.exe' | 'pwsh.exe'
+export type WindowsPowerShellShellFamily =
+  | 'powershell.exe'
+  | 'pwsh.exe'
+  | 'cmd.exe'
+  | 'wsl.exe'
+  | undefined
+
+export function shouldProbeWindowsPowerShellAvailability(args: {
+  shellFamily: WindowsPowerShellShellFamily
+  implementation: WindowsPowerShellImplementation | undefined
+}): boolean {
+  return (
+    args.shellFamily === 'powershell.exe' &&
+    (args.implementation === undefined || args.implementation === 'auto')
+  )
+}
 
 /** Resolve which PowerShell executable to spawn right now on Windows.
  *
- * Why: keep the saved pwsh preference intact even when pwsh is temporarily
- * unavailable, so runtime falls back safely without mutating user settings.
+ * Why: explicit pwsh.exe choices must not be downgraded by a transient cold
+ * availability probe; the spawn chain handles true absence with a safe fallback.
  */
 export function resolveEffectiveWindowsPowerShell(args: {
-  shellFamily: 'powershell.exe' | 'cmd.exe' | 'wsl.exe' | undefined
+  shellFamily: WindowsPowerShellShellFamily
   implementation: WindowsPowerShellImplementation | undefined
   pwshAvailable: boolean
 }): 'powershell.exe' | 'pwsh.exe' | null {
+  if (args.shellFamily === 'pwsh.exe') {
+    return 'pwsh.exe'
+  }
+
   if (args.shellFamily !== 'powershell.exe') {
     return null
   }
 
-  if (
-    (args.implementation === undefined ||
-      args.implementation === 'auto' ||
-      args.implementation === 'pwsh.exe') &&
-    args.pwshAvailable
-  ) {
+  if (args.implementation === 'powershell.exe') {
+    return 'powershell.exe'
+  }
+
+  if (args.implementation === 'pwsh.exe') {
+    return 'pwsh.exe'
+  }
+
+  if (args.pwshAvailable) {
     return 'pwsh.exe'
   }
 


### PR DESCRIPTION
﻿## Summary
- Keep explicit `pwsh.exe` / PowerShell 7+ selections from being downgraded by a transient false `isPwshAvailable()` result.
- Avoid calling the cold-start pwsh availability probe for explicit PowerShell 7+ selections in both local and daemon PTY paths; only Auto still probes.
- Teach the Windows PowerShell executable resolver to find real absolute `pwsh.exe` entries on PATH, while still skipping relative PATH entries and WindowsApps App Execution Alias stubs.

Fixes https://github.com/stablyai/orca/issues/6848

## Reproduction Evidence
- Added failing-first regression coverage for the second failure mode: an explicit PowerShell 7+ selection with the pwsh probe returning false used to spawn `powershell.exe`.
- Covered the issue at the shared resolver, in-process `LocalPtyProvider`, daemon `createPtySubprocess`, and IPC spawn wiring.
- Added PATH-install coverage so a real PATH-resolved `pwsh.exe` is not missed when Program Files / LocalAppData standard roots do not contain PowerShell.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/providers/windows-powershell.test.ts src/main/providers/windows-powershell-executable.test.ts src/main/providers/windows-shell-fallback-chain.test.ts src/main/providers/local-pty-provider.test.ts src/main/daemon/pty-subprocess.test.ts` - 151 passed, 4 skipped.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts -t "PowerShell 7|pwsh\.exe shellOverride|PowerShell family keeps"` - 4 passed, 192 skipped.
- `pnpm exec oxlint src/main/providers/windows-powershell.ts src/main/providers/windows-powershell.test.ts src/main/providers/windows-powershell-executable.ts src/main/providers/windows-powershell-executable.test.ts src/main/providers/local-pty-provider.ts src/main/providers/local-pty-provider.test.ts src/main/daemon/pty-subprocess.ts src/main/daemon/pty-subprocess.test.ts src/main/ipc/pty.test.ts`
- `pnpm run typecheck:node`

Note: full `src/main/ipc/pty.test.ts` on this Windows host still has unrelated attribution-shim expectation failures because the file computes its expected shim directory from the real host platform at module load, while its test setup later mocks `process.platform` to `darwin`. The focused PowerShell IPC cases above pass.

## ELI5
When the user picked PowerShell 7, Orca still asked a separate "is PowerShell 7 ready right now?" question. If that check was slow or temporarily said no, Orca opened old Windows PowerShell instead. Now an explicit PowerShell 7 choice goes to the PowerShell 7 launch path directly. If PowerShell 7 truly cannot be launched, the existing safe fallback chain still opens Windows PowerShell/cmd rather than leaving the user with no terminal.

## Tradeoffs
- Auto still uses the availability probe because Auto means "choose based on what is available now." Explicit `pwsh.exe` no longer does.
- PATH lookup only accepts absolute PATH entries and still rejects WindowsApps App Execution Alias stubs, preserving the prior error-code-5 protection. Store-alias-only installs remain on the fallback path until Orca has a safe ConPTY-compatible alias launch strategy.
- SSH/remote PTY behavior is unchanged; this patch only changes local Windows shell resolution before local/daemon PTY spawn.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->