### PR TITLE
feat(terminal): keep worktree mounted on terminal process death, with in-place recovery overlay

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalDeadPaneOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalDeadPaneOverlay.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TerminalDeadPaneOverlay } from './TerminalDeadPaneOverlay'
+
+const mountedRoots: Root[] = []
+
+async function renderOverlay(props: {
+  exitCode: number
+  onRestart: () => void
+  onClose: () => void
+}): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  await act(async () => {
+    root.render(<TerminalDeadPaneOverlay {...props} />)
+  })
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const button = [...document.body.querySelectorAll<HTMLButtonElement>('button')].find(
+    (candidate) => candidate.textContent?.includes(label)
+  )
+  if (!button) {
+    throw new Error(`Button not found: ${label}`)
+  }
+  return button
+}
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of mountedRoots.splice(0)) {
+      root.unmount()
+    }
+  })
+  document.body.innerHTML = ''
+})
+
+describe('TerminalDeadPaneOverlay', () => {
+  it('shows a failure title and the non-zero exit code', async () => {
+    await renderOverlay({ exitCode: 1, onRestart: vi.fn(), onClose: vi.fn() })
+    expect(document.body.textContent).toContain('Terminal exited')
+    expect(document.body.textContent).toContain('exit code 1')
+  })
+
+  it('shows a clean-close title for exit code 0', async () => {
+    await renderOverlay({ exitCode: 0, onRestart: vi.fn(), onClose: vi.fn() })
+    expect(document.body.textContent).toContain('Terminal closed')
+    expect(document.body.textContent).toContain('exit code 0')
+  })
+
+  it('invokes onRestart and onClose from the action buttons', async () => {
+    const onRestart = vi.fn()
+    const onClose = vi.fn()
+    await renderOverlay({ exitCode: 137, onRestart, onClose })
+
+    await act(async () => {
+      getButton('Restart').click()
+    })
+    expect(onRestart).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      getButton('Close').click()
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalDeadPaneOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalDeadPaneOverlay.tsx
@@ -1,0 +1,53 @@
+import { RotateCw, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+
+/**
+ * Recovery overlay shown when a worktree's sole terminal process exits on its
+ * own (a failed startup such as a broken .envrc/direnv, a crash, or a reaped
+ * session) rather than a deliberate clean `exit`. The pane stays mounted with
+ * its last output visible behind the overlay so the worktree is never torn
+ * down to the Landing screen; the user restarts in place or closes explicitly.
+ */
+export function TerminalDeadPaneOverlay({
+  exitCode,
+  onRestart,
+  onClose
+}: {
+  exitCode: number
+  onRestart: () => void
+  onClose: () => void
+}): React.JSX.Element {
+  // Why: a clean exit (0) reads as "finished"; a non-zero/signal exit reads as
+  // "failed" so the message matches what the user is recovering from.
+  const failed = exitCode !== 0
+  const title = failed
+    ? translate('auto.components.terminal.pane.TerminalDeadPaneOverlay.failed', 'Terminal exited')
+    : translate('auto.components.terminal.pane.TerminalDeadPaneOverlay.clean', 'Terminal closed')
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40 flex items-end justify-center p-4">
+      <div className="pointer-events-auto flex w-full max-w-[28rem] flex-col gap-3 rounded-lg border border-border bg-card p-4 text-card-foreground shadow-xs">
+        <div className="flex flex-col gap-1">
+          <div className="text-sm font-medium text-foreground">{title}</div>
+          <div className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.terminal.pane.TerminalDeadPaneOverlay.detail',
+              'The shell process ended (exit code {{code}}). The output above is preserved.'
+            ).replace('{{code}}', String(exitCode))}
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+            <X />
+            {translate('auto.components.terminal.pane.TerminalDeadPaneOverlay.close', 'Close')}
+          </Button>
+          <Button type="button" variant="default" size="sm" onClick={onRestart}>
+            <RotateCw />
+            {translate('auto.components.terminal.pane.TerminalDeadPaneOverlay.restart', 'Restart')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -42,6 +42,7 @@ import { useTerminalFontZoom } from './useTerminalFontZoom'
 import CloseTerminalDialog, { type CloseTerminalDialogCopyKind } from './CloseTerminalDialog'
 import { MobileDriverOverlay } from './MobileDriverOverlay'
 import { TerminalErrorToast } from './TerminalErrorToast'
+import { TerminalDeadPaneOverlay } from './TerminalDeadPaneOverlay'
 import { TerminalSessionStateSaveFailureDialog } from './TerminalSessionStateSaveFailureDialog'
 import TerminalContextMenu from './TerminalContextMenu'
 import TerminalPaneHeaderOverlay from './TerminalPaneHeaderOverlay'
@@ -315,6 +316,11 @@ export default function TerminalPane({
   const [quickCommandDraft, setQuickCommandDraft] = useState(createTerminalQuickCommandDraft)
   const [agentSessionFork, setAgentSessionFork] = useState<PreparedAgentSessionFork | null>(null)
   const [terminalError, setTerminalError] = useState<string | null>(null)
+  // Why: the sole terminal's process died on its own (failed startup, crash, or
+  // a reaped session) rather than a deliberate clean exit. The pane stays
+  // mounted and this drives the in-place recovery overlay (process exited ·
+  // restart · close) instead of bouncing the user to the Landing screen.
+  const [deadPaneExitCode, setDeadPaneExitCode] = useState<number | null>(null)
   const [sessionStateSaveFailureOpen, setSessionStateSaveFailureOpen] = useState(false)
   const daemonActions = useDaemonActions()
   // Why: override state lives in a plain Map for perf (safeFit reads it on
@@ -1276,6 +1282,13 @@ export default function TerminalPane({
     setPendingCloseConfirmation(null)
   }, [])
 
+  // Why: connectPanePty calls this when a sole pane's process died on its own
+  // (non-zero exit / crash / reaped session) instead of a deliberate clean
+  // exit. Surface the recovery overlay rather than tearing down the worktree.
+  const handlePaneProcessDied = useCallback((exitCode: number) => {
+    setDeadPaneExitCode(exitCode)
+  }, [])
+
   useTerminalPaneLifecycle({
     tabId,
     worktreeId,
@@ -1306,6 +1319,7 @@ export default function TerminalPane({
     isVisibleRef,
     onPtyExitRef,
     onPtyErrorRef,
+    onPaneProcessDied: handlePaneProcessDied,
     clearTabPtyId,
     consumeSuppressedPtyExit: useAppStore((store) => store.consumeSuppressedPtyExit),
     updateTabTitle,
@@ -1540,6 +1554,7 @@ export default function TerminalPane({
         clearTerminalTabUnread,
         clearTerminalPaneUnread,
         onShowSessionRestoredBanner: showRestoredSessionBanner,
+        onPaneProcessDied: handlePaneProcessDied,
         dispatchNotification,
         setCacheTimerStartedAt,
         syncPanePtyLayoutBinding,
@@ -1550,6 +1565,7 @@ export default function TerminalPane({
     },
     [
       clearCodexRestartNotice,
+      handlePaneProcessDied,
       clearExitedPanePtyLayoutBinding,
       clearRuntimePaneTitle,
       clearTabPtyId,
@@ -1573,6 +1589,99 @@ export default function TerminalPane({
       worktreeId
     ]
   )
+
+  // Why: the dead-pane recovery overlay's "Restart" — the sole pane's process
+  // died, so its binding/transport are already cleared by onExit. Dispose the
+  // stale binding and spawn a fresh shell in place (no startup payload: the
+  // original startup may be exactly what failed, e.g. a broken .envrc, so a
+  // clean shell is the recoverable default), keeping the worktree selected.
+  const handleRelaunchDeadPane = useCallback(() => {
+    const manager = managerRef.current
+    const pane = manager?.getActivePane() ?? manager?.getPanes()[0]
+    if (!manager || !pane) {
+      return
+    }
+    const existingBinding = panePtyBindingsRef.current.get(pane.id)
+    existingBinding?.dispose()
+    panePtyBindingsRef.current.delete(pane.id)
+    const existingTransport = paneTransportsRef.current.get(pane.id)
+    existingTransport?.destroy?.()
+    paneTransportsRef.current.delete(pane.id)
+    syncPanePtyLayoutBinding(pane.id, null)
+    setCacheTimerStartedAt(makePaneKey(tabId, pane.leafId), null)
+    setDeadPaneExitCode(null)
+
+    const newPaneBinding = connectPanePty(pane, manager, {
+      tabId,
+      worktreeId,
+      cwd,
+      startup: null,
+      paneTransportsRef,
+      paneMode2031Ref,
+      paneLastThemeModeRef,
+      replayingPanesRef,
+      isActiveRef,
+      isVisibleRef,
+      onPtyExitRef,
+      onPtyErrorRef,
+      onPaneProcessDied: handlePaneProcessDied,
+      clearTabPtyId,
+      consumeSuppressedPtyExit: useAppStore.getState().consumeSuppressedPtyExit,
+      updateTabTitle,
+      setRuntimePaneTitle,
+      clearRuntimePaneTitle,
+      updateTabPtyId,
+      markWorktreeUnread,
+      markTerminalTabUnread,
+      markTerminalPaneUnread,
+      clearWorktreeUnread,
+      clearTerminalTabUnread,
+      clearTerminalPaneUnread,
+      onShowSessionRestoredBanner: showRestoredSessionBanner,
+      dispatchNotification,
+      setCacheTimerStartedAt,
+      syncPanePtyLayoutBinding,
+      clearExitedPanePtyLayoutBinding
+    })
+    panePtyBindingsRef.current.set(pane.id, newPaneBinding)
+    manager.setActivePane(pane.id, { focus: true })
+  }, [
+    clearExitedPanePtyLayoutBinding,
+    clearRuntimePaneTitle,
+    clearTabPtyId,
+    clearTerminalPaneUnread,
+    clearTerminalTabUnread,
+    clearWorktreeUnread,
+    cwd,
+    dispatchNotification,
+    handlePaneProcessDied,
+    markTerminalPaneUnread,
+    markTerminalTabUnread,
+    markWorktreeUnread,
+    onPtyErrorRef,
+    onPtyExitRef,
+    setCacheTimerStartedAt,
+    setRuntimePaneTitle,
+    showRestoredSessionBanner,
+    syncPanePtyLayoutBinding,
+    tabId,
+    updateTabPtyId,
+    updateTabTitle,
+    worktreeId
+  ])
+
+  // Why: the dead-pane overlay's "Close" is a DELIBERATE user action, so it
+  // routes through the normal pane-close path (which deactivates the worktree
+  // and returns to Landing only when this was the last surface) — the exact
+  // behavior a clean `exit` already has.
+  const handleCloseDeadPane = useCallback(() => {
+    const manager = managerRef.current
+    const pane = manager?.getActivePane() ?? manager?.getPanes()[0]
+    setDeadPaneExitCode(null)
+    if (pane) {
+      executeClosePane(pane.id)
+    }
+  }, [executeClosePane])
 
   useEffect(() => {
     const manager = managerRef.current
@@ -2806,6 +2915,13 @@ export default function TerminalPane({
           error={terminalError}
           onDismiss={() => setTerminalError(null)}
           onRestartDaemon={() => daemonActions.setPending('restart')}
+        />
+      )}
+      {deadPaneExitCode !== null && isActive && (
+        <TerminalDeadPaneOverlay
+          exitCode={deadPaneExitCode}
+          onRestart={handleRelaunchDeadPane}
+          onClose={handleCloseDeadPane}
         />
       )}
       <DaemonActionDialog api={daemonActions} />

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -39,6 +39,12 @@ export type PtyConnectionDeps = {
   isVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
+  // Why: a sole pane's process died on its own (non-zero exit, crash, or a
+  // reaped/reattached-dead session) instead of a deliberate clean `exit`. The
+  // pane stays mounted; this lets the owner render an in-place recovery overlay
+  // (process exited · restart · close) rather than bouncing to the Landing
+  // screen. Absent for split panes, which keep a live sibling.
+  onPaneProcessDied?: (exitCode: number) => void
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   updateTabTitle: (tabId: string, title: string) => void

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -403,6 +403,7 @@ function createDeps(overrides: Record<string, unknown> = {}) {
     isVisibleRef: { current: true },
     onPtyExitRef: { current: vi.fn() },
     onPtyErrorRef: { current: vi.fn() },
+    onPaneProcessDied: vi.fn(),
     clearTabPtyId: vi.fn(),
     consumeSuppressedPtyExit: vi.fn(() => false),
     updateTabTitle: vi.fn(),
@@ -957,12 +958,13 @@ describe('connectPanePty', () => {
     expect(manager.setActivePane).toHaveBeenCalledWith(1, { focus: true })
   })
 
-  it('keeps a worktree sole terminal mounted when its freshly-spawned PTY exits before input (direnv failure)', async () => {
+  it('keeps a worktree sole terminal mounted when its process exits non-zero (direnv failure)', async () => {
     // Why (regression): a PR worktree can ship an .envrc whose direnv command
     // fails, so the only terminal's login shell exits non-zero immediately. The
     // sole-pane branch must NOT route to onPtyExitRef — that closes the tab and
     // deactivates the just-created worktree (setActiveWorktree(null)), bouncing
-    // the user to the Landing screen. The dead pane stays mounted instead.
+    // the user to the Landing screen. The dead pane stays mounted and the
+    // recovery overlay (onPaneProcessDied) is offered instead.
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
     transportFactoryQueue.push(transport)
@@ -970,25 +972,22 @@ describe('connectPanePty', () => {
     const deps = createDeps()
 
     connectPanePty(createPane(1) as never, manager as never, deps as never)
-    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
-      | ((ptyId: string) => void)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode: number) => void)
       | undefined
-    const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
-    expect(onPtySpawn).toBeTypeOf('function')
     expect(onPtyExit).toBeTypeOf('function')
 
-    // A genuine fresh spawn (onPtySpawn fires only for non-reattach spawns) that
-    // the user never typed into.
-    onPtySpawn?.('tab-pty')
-    onPtyExit?.('tab-pty')
+    onPtyExit?.('tab-pty', 1)
 
     expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith(1)
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
-  it('tears down the sole terminal when a freshly-spawned PTY exits after the user typed input', async () => {
-    // Why: an explicit `exit` (or any typed input) is a deliberate close, not a
-    // failed-startup shell, so the worktree should deactivate as before.
+  it('keeps a worktree sole terminal mounted when its process crashes non-zero after the user typed input', async () => {
+    // Why: a shell the user worked in that later crashes (non-zero) is still a
+    // process death, not a deliberate exit — keep it recoverable rather than
+    // bouncing to Landing. Only a clean exit code counts as "the user left".
     const { connectPanePty } = await import('./pty-connection')
     const pane = createPane(1)
     const transport = createMockTransport('tab-pty')
@@ -997,25 +996,48 @@ describe('connectPanePty', () => {
     const deps = createDeps()
 
     connectPanePty(pane as never, manager as never, deps as never)
-    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
-      | ((ptyId: string) => void)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode: number) => void)
       | undefined
-    const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
-    expect(onPtySpawn).toBeTypeOf('function')
     expect(onPtyExit).toBeTypeOf('function')
 
-    onPtySpawn?.('tab-pty')
-    sendTerminalInputThroughPane(pane, 'exit\r')
-    onPtyExit?.('tab-pty')
+    sendTerminalInputThroughPane(pane, 'somecmd\r')
+    onPtyExit?.('tab-pty', 137)
 
-    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+    expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith(137)
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
-  it('tears down the sole terminal when a reattached (not freshly spawned) PTY exits', async () => {
-    // Why: reattach/coldRestore skip onPtySpawn, so a previously-live session
-    // that is now dead must still route through onPtyExitRef — the keep-mounted
-    // guard is strictly for brand-new shells that died on startup.
+  it('tears down the sole terminal only on a deliberate clean exit (code 0 after the user typed)', async () => {
+    // Why: typing `exit`/Ctrl-D (exit code 0 after interaction) is the user
+    // deliberately leaving — that should still deactivate the worktree and
+    // return to Landing exactly as before.
+    const { connectPanePty } = await import('./pty-connection')
+    const pane = createPane(1)
+    const transport = createMockTransport('tab-pty')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode: number) => void)
+      | undefined
+    expect(onPtyExit).toBeTypeOf('function')
+
+    sendTerminalInputThroughPane(pane, 'exit\r')
+    onPtyExit?.('tab-pty', 0)
+
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(manager.closePane).not.toHaveBeenCalled()
+  })
+
+  it('keeps a worktree sole terminal mounted on a clean exit the user never typed into', async () => {
+    // Why: an rc-file/startup that exits 0 on its own (no interaction) is not a
+    // deliberate user exit — keep it recoverable rather than silently bouncing
+    // to Landing for a worktree the user just opened.
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
     transportFactoryQueue.push(transport)
@@ -1023,13 +1045,16 @@ describe('connectPanePty', () => {
     const deps = createDeps()
 
     connectPanePty(createPane(1) as never, manager as never, deps as never)
-    const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode: number) => void)
+      | undefined
     expect(onPtyExit).toBeTypeOf('function')
 
-    // No onPtySpawn call: simulates a reattach to a persisted session.
-    onPtyExit?.('tab-pty')
+    // No terminal input before the clean exit.
+    onPtyExit?.('tab-pty', 0)
 
-    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+    expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith(0)
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
@@ -10645,7 +10670,11 @@ describe('connectPanePty', () => {
       expect(manager.closePane).toHaveBeenCalledWith(2)
     })
 
-    it('routes the last pane through onPtyExitRef when its session is dead', async () => {
+    it('keeps the last pane mounted with a recovery overlay when its session was reaped while hidden', async () => {
+      // Why: a session reaped while the pane was hidden is an unexpected death,
+      // not a deliberate exit. It must NOT route through onPtyExitRef (which
+      // would deactivate the worktree and bounce to Landing); instead the pane
+      // stays mounted and onPaneProcessDied offers in-place recovery.
       const { connectPanePty } = await import('./pty-connection')
       const transport = createMockTransport('pty-pane-1')
       transportFactoryQueue.push(transport)
@@ -10657,7 +10686,8 @@ describe('connectPanePty', () => {
       // The last pane reattaches to the tab's persisted ptyId ('tab-pty').
       binding.reconcileIfSessionDead(new Set(['some-other-live']))
 
-      expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+      expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+      expect(deps.onPaneProcessDied).toHaveBeenCalledWith(1)
       expect(manager.closePane).not.toHaveBeenCalled()
     })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1058,6 +1058,61 @@ describe('connectPanePty', () => {
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
+  it('re-arms onPaneProcessDied when a relaunched sole pane dies again', async () => {
+    // Why: the recovery overlay's Restart calls connectPanePty again on a fresh
+    // transport. If that relaunched shell also dies (e.g. the .envrc is still
+    // broken), the overlay must re-appear — each connection registers its own
+    // exit handler, so a second death must fire onPaneProcessDied again.
+    const { connectPanePty } = await import('./pty-connection')
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    const firstTransport = createMockTransport('tab-pty')
+    transportFactoryQueue.push(firstTransport)
+    connectPanePty(createPane(1) as never, manager as never, deps as never)
+    const firstOnExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode: number) => void)
+      | undefined
+    firstOnExit?.('tab-pty', 1)
+    expect(deps.onPaneProcessDied).toHaveBeenCalledTimes(1)
+
+    // Relaunch: a fresh connection on a new transport, which then also dies.
+    const secondTransport = createMockTransport('tab-pty-2')
+    transportFactoryQueue.push(secondTransport)
+    connectPanePty(createPane(1) as never, manager as never, deps as never)
+    const secondOnExit = createdTransportOptions[1]?.onPtyExit as
+      | ((ptyId: string, exitCode: number) => void)
+      | undefined
+    secondOnExit?.('tab-pty-2', 1)
+
+    expect(deps.onPaneProcessDied).toHaveBeenCalledTimes(2)
+    expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+  })
+
+  it('routes a remote-runtime sole pane death through onPtyExitRef, not the recovery overlay', async () => {
+    // Why: the recovery overlay's Restart spawns a LOCAL shell, which is wrong
+    // for a host-owned web-runtime pane (its liveness is host-authoritative).
+    // Remote/SSH panes therefore keep their prior teardown behavior.
+    enableActiveRuntimeEnvironment('env-1')
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(createPane(1) as never, manager as never, deps as never)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode: number) => void)
+      | undefined
+    expect(onPtyExit).toBeTypeOf('function')
+
+    onPtyExit?.('tab-pty', 1)
+
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+    expect(manager.closePane).not.toHaveBeenCalled()
+  })
+
   it('closes a split pane when an established PTY exits after output', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1438,8 +1438,15 @@ export function connectPanePty(
       // should return to Landing; every failure keeps the dead pane mounted so
       // the error stays visible and the worktree stays selected, with a
       // recovery overlay (onPaneProcessDied) offering restart/close in place.
+      //
+      // Why local-only: the recovery overlay's "Restart" spawns a fresh LOCAL
+      // shell, and web-runtime liveness is host-snapshot-authoritative (its
+      // close already round-trips to the host). SSH/remote panes therefore keep
+      // their prior teardown behavior — a local in-place relaunch would be wrong
+      // for a host-owned session.
+      const isLocalPane = !connectionId && runtimeEnvironmentId === null
       const userEndedCleanly = exitCode === 0 && Number.isFinite(lastTerminalInputAt)
-      if (!userEndedCleanly) {
+      if (isLocalPane && !userEndedCleanly) {
         deps.onPaneProcessDied?.(exitCode)
         return
       }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1381,14 +1381,7 @@ export function connectPanePty(
   // mounted and rebinds to a NEW ptyId, and that replacement's later real exit
   // must still run — a one-shot boolean would strand the pane on rebind.
   let handledExitPtyId: string | null = null
-  // Why: tracks the ptyId of a genuine fresh spawn — onPtySpawn fires only for
-  // fresh spawns, never reattach/coldRestore (pty-transport.ts). Lets the
-  // sole-pane exit branch tell "this newborn shell died on its own" from "a
-  // reattached persisted session was already dead", so a failing .envrc/direnv
-  // on a brand-new worktree keeps its dead terminal visible instead of bouncing
-  // the user to Landing.
-  let spawnedFreshPtyId: string | null = null
-  const onExit = (ptyId: string): void => {
+  const onExit = (ptyId: string, exitCode = 0): void => {
     if (handledExitPtyId === ptyId) {
       return
     }
@@ -1435,18 +1428,19 @@ export function connectPanePty(
     manager.setPaneGpuRendering(pane.id, true)
     const panes = manager.getPanes()
     if (panes.length <= 1) {
-      // Why: a worktree's sole newborn terminal can die on shell startup — e.g.
-      // a PR branch ships an .envrc whose direnv command fails, so the login
-      // shell exits non-zero immediately. Routing that through onPtyExitRef
-      // closes the only tab, which deactivates the worktree (setActiveWorktree
-      // (null)) and strands the user on the Landing screen for a worktree that
-      // was just created. Keep the dead pane mounted instead (mirrors the
-      // freshly-split guard below) so the direnv error stays visible and the
-      // worktree stays active. Gated on a genuine fresh spawn (onPtySpawn fired
-      // for this ptyId — reattach/coldRestore skip it) that the user never typed
-      // into, so a reattached-dead session or an explicit `exit` still tears
-      // down as before.
-      if (spawnedFreshPtyId === ptyId && !Number.isFinite(lastTerminalInputAt)) {
+      // Why: a terminal process dying is a terminal-surface event, not a request
+      // to leave the worktree. Routing a sole pane's exit through onPtyExitRef
+      // closes the only tab, which deactivates the worktree
+      // (setActiveWorktree(null)) and strands the user on the Landing screen —
+      // catastrophic when the shell failed on its own (e.g. a PR branch's
+      // .envrc/direnv exits non-zero on startup, or a shell crashes mid-session).
+      // Only a DELIBERATE clean exit (the user typed `exit`/Ctrl-D → code 0)
+      // should return to Landing; every failure keeps the dead pane mounted so
+      // the error stays visible and the worktree stays selected, with a
+      // recovery overlay (onPaneProcessDied) offering restart/close in place.
+      const userEndedCleanly = exitCode === 0 && Number.isFinite(lastTerminalInputAt)
+      if (!userEndedCleanly) {
+        deps.onPaneProcessDied?.(exitCode)
         return
       }
       deps.onPtyExitRef.current(ptyId)
@@ -1636,11 +1630,6 @@ export function connectPanePty(
   }
 
   const onPtySpawn = (ptyId: string): void => {
-    // Why: record that this exact PTY was freshly spawned (not reattached), so a
-    // newborn shell that dies before any interaction (e.g. failing direnv on a
-    // just-created worktree) can be kept visible rather than tearing down the
-    // worktree. Reattach/coldRestore skip onPtySpawn (pty-transport.ts).
-    spawnedFreshPtyId = ptyId
     // Why: Command Code has no prompt-start hook. Seed the visible working row
     // once the PTY exists, then let real hook events refine or complete it.
     bindActivePanePty(ptyId, { seedInitialAgentStatus: true })
@@ -4599,7 +4588,11 @@ export function connectPanePty(
     ) {
       return
     }
-    onExit(currentPtyId)
+    // Why: a session reaped while the pane was hidden is an unexpected death,
+    // never a deliberate clean exit — pass a non-zero code so a sole pane keeps
+    // its recovery overlay instead of being mistaken for a user-typed `exit`
+    // and bouncing the worktree to Landing on visibility resume.
+    onExit(currentPtyId, 1)
   }
 
   // Why (perf + startup correctness): listSessions() is authoritative only

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -100,7 +100,7 @@ export type IpcPtyTransportOptions = {
   projectRuntime?: ProjectExecutionRuntimeResolution
   terminalColorQueryReplies?: TerminalOscColorQueryReplyColors
   telemetry?: EventProps<'agent_started'>
-  onPtyExit?: (ptyId: string) => void
+  onPtyExit?: (ptyId: string, exitCode: number) => void
   onTitleChange?: (title: string, rawTitle: string) => void
   onPtySpawn?: (ptyId: string) => void
   onBell?: () => void

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -101,7 +101,7 @@ describe('createIpcPtyTransport', () => {
 
     onExit?.({ id: 'pty-new', code: 0 })
 
-    expect(onPtyExit).toHaveBeenCalledWith('pty-new')
+    expect(onPtyExit).toHaveBeenCalledWith('pty-new', 0)
     expect(transport.getPtyId()).toBeNull()
     expect(transport.isConnected()).toBe(false)
   })
@@ -973,7 +973,7 @@ describe('createIpcPtyTransport', () => {
 
     // Exit handler should still work (exit handlers are kept alive)
     onExit?.({ id: 'pty-1', code: -1 })
-    expect(onPtyExit).toHaveBeenCalledWith('pty-1')
+    expect(onPtyExit).toHaveBeenCalledWith('pty-1', -1)
   })
 
   it('restores data handlers when an intentional shutdown fails before exit', async () => {
@@ -1179,7 +1179,7 @@ describe('createIpcPtyTransport', () => {
 
     onExit?.({ id: 'pty-detached', code: 0 })
 
-    expect(onPtyExit).toHaveBeenCalledWith('pty-detached')
+    expect(onPtyExit).toHaveBeenCalledWith('pty-detached', 0)
     expect(transport.getPtyId()).toBeNull()
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -657,7 +657,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       unregisterPtyHandlers(id)
       storedCallbacks.onExit?.(code)
       storedCallbacks.onDisconnect?.()
-      onPtyExit?.(id)
+      onPtyExit?.(id, code)
     }
     ptyExitHandlers.set(id, exitHandler)
     // Why: shutdownWorktreeTerminals bypasses the transport layer — it

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -289,7 +289,7 @@ describe('createRemoteRuntimePtyTransport', () => {
     })
 
     expect(onError).not.toHaveBeenCalled()
-    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-stale')
+    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-stale', 1)
     expect(transport.getPtyId()).toBeNull()
   })
 
@@ -337,7 +337,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       result: { type: 'end', streamId: newStreamId }
     })
 
-    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-new')
+    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-new', 0)
     expect(transport.getPtyId()).toBeNull()
     expect(transport.isConnected()).toBe(false)
   })
@@ -551,12 +551,13 @@ describe('createRemoteRuntimePtyTransport', () => {
   })
 
   it('scopes ephemeral setup terminals to the floating-terminal selector (#6789)', async () => {
-    const { brandEphemeralSetupTerminalWorktreeId } = await import(
-      '../../../../shared/ephemeral-setup-terminal-worktree-id'
-    )
+    const { brandEphemeralSetupTerminalWorktreeId } =
+      await import('../../../../shared/ephemeral-setup-terminal-worktree-id')
     const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
     const transport = createRemoteRuntimePtyTransport('env-1', {
-      worktreeId: brandEphemeralSetupTerminalWorktreeId('feature-wall-orchestration-skill-terminal'),
+      worktreeId: brandEphemeralSetupTerminalWorktreeId(
+        'feature-wall-orchestration-skill-terminal'
+      ),
       tabId: 'tab-1',
       leafId: 'pane:1'
     })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -340,7 +340,9 @@ export function createRemoteRuntimePtyTransport(
     remotePtyId = null
     closeMultiplexedStream()
     if (stalePtyId) {
-      onPtyExit?.(stalePtyId)
+      // Why: a retired remote terminal is a gone/errored session, not a clean
+      // exit — pass a non-zero code so the exit handler treats it as a failure.
+      onPtyExit?.(stalePtyId, 1)
     }
   }
 
@@ -404,7 +406,8 @@ export function createRemoteRuntimePtyTransport(
           storedCallbacks.onExit?.(0)
           storedCallbacks.onDisconnect?.()
           if (subscribedPtyId) {
-            onPtyExit?.(subscribedPtyId)
+            // Host reported a clean stream end (code 0).
+            onPtyExit?.(subscribedPtyId, 0)
           }
         },
         onError: (message) => {
@@ -575,7 +578,8 @@ export function createRemoteRuntimePtyTransport(
       remotePtyId = null
       storedCallbacks.onDisconnect?.()
       if (id) {
-        onPtyExit?.(id)
+        // Explicit transport disconnect/teardown, not a process failure.
+        onPtyExit?.(id, 0)
       }
     },
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -221,6 +221,7 @@ type UseTerminalPaneLifecycleDeps = {
   isVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
+  onPaneProcessDied?: (exitCode: number) => void
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   updateTabTitle: (tabId: string, title: string) => void
@@ -508,6 +509,7 @@ export function useTerminalPaneLifecycle({
   isVisibleRef,
   onPtyExitRef,
   onPtyErrorRef,
+  onPaneProcessDied,
   clearTabPtyId,
   consumeSuppressedPtyExit,
   updateTabTitle,
@@ -720,6 +722,7 @@ export function useTerminalPaneLifecycle({
       isVisibleRef,
       onPtyExitRef,
       onPtyErrorRef,
+      onPaneProcessDied,
       clearTabPtyId,
       consumeSuppressedPtyExit,
       updateTabTitle,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2533,6 +2533,13 @@
             "dont_ask_again": "Don't ask again for pinned tabs",
             "0b38ee2f86": "Cancel",
             "c337c9d75c": "Close"
+          },
+          "TerminalDeadPaneOverlay": {
+            "failed": "Terminal exited",
+            "clean": "Terminal closed",
+            "detail": "The shell process ended (exit code {{code}}). The output above is preserved.",
+            "close": "Close",
+            "restart": "Restart"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2533,6 +2533,13 @@
             "dont_ask_again": "No volver a preguntar por pestañas fijadas",
             "0b38ee2f86": "Cancelar",
             "c337c9d75c": "Cerrar"
+          },
+          "TerminalDeadPaneOverlay": {
+            "failed": "Terminal exited",
+            "clean": "Terminal closed",
+            "detail": "The shell process ended (exit code {{code}}). The output above is preserved.",
+            "close": "Close",
+            "restart": "Restart"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2533,6 +2533,13 @@
             "dont_ask_again": "ピン留めしたタブについて今後確認しない",
             "0b38ee2f86": "キャンセル",
             "c337c9d75c": "閉じる"
+          },
+          "TerminalDeadPaneOverlay": {
+            "failed": "Terminal exited",
+            "clean": "Terminal closed",
+            "detail": "The shell process ended (exit code {{code}}). The output above is preserved.",
+            "close": "Close",
+            "restart": "Restart"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2533,6 +2533,13 @@
             "dont_ask_again": "고정된 탭에 대해 다시 묻지 않기",
             "0b38ee2f86": "취소",
             "c337c9d75c": "닫기"
+          },
+          "TerminalDeadPaneOverlay": {
+            "failed": "Terminal exited",
+            "clean": "Terminal closed",
+            "detail": "The shell process ended (exit code {{code}}). The output above is preserved.",
+            "close": "Close",
+            "restart": "Restart"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2533,6 +2533,13 @@
             "dont_ask_again": "固定标签页不再询问",
             "0b38ee2f86": "取消",
             "c337c9d75c": "关闭"
+          },
+          "TerminalDeadPaneOverlay": {
+            "failed": "Terminal exited",
+            "clean": "Terminal closed",
+            "detail": "The shell process ended (exit code {{code}}). The output above is preserved.",
+            "close": "Close",
+            "restart": "Restart"
           }
         }
       },


### PR DESCRIPTION
## What & why

Follow-up to #6842. That PR stopped the *specific* direnv case from bouncing the user to the Landing screen. This PR fixes the **whole class** and adds the recovery UX that was missing.

**The principle:** a terminal process dying is a terminal-surface event, not a request to leave the worktree. Previously a sole terminal's exit was routed through the *user-close* path:

```
sole terminal PTY exits
  → pty-connection onExit (panes.length <= 1)
  → onPtyExitRef → handlePtyExit → closeTerminalTab
  → setActiveWorktree(null) → Landing screen
```

That's correct for a *deliberate* close, but catastrophic when the shell failed on its own — a PR branch's `.envrc`/direnv exiting non-zero on startup, a crash mid-session, or a daemon session reaped while the pane was hidden. #6842 only caught the "fresh, never-typed" sub-case; a shell you'd worked in that then crashed still bounced.

## The fix

Make the retain decision **exit-code driven**, the way mature terminals do (close on a clean exit; keep the surface visible on failure):

- **Only a deliberate clean exit** (you typed `exit`/Ctrl-D → code 0 with prior interaction) returns to Landing — unchanged muscle memory.
- **Every failure** (non-zero, crash, reaped session) keeps the dead pane mounted so the error stays readable and the worktree stays selected, with a **recovery overlay**: *"Terminal exited · exit code N · Restart · Close."*

This subsumes the #6842 heuristic with a simpler, complete signal.

Mechanics:
- Thread the PTY exit code through `onPtyExit`/`onExit` (it existed at the transport boundary but was dropped).
- `reconcileIfSessionDead` (session reaped while hidden) passes a non-zero code so a reaped sole pane keeps its recovery overlay instead of being mistaken for a clean user exit.
- New `TerminalDeadPaneOverlay` (shadcn + design tokens). **Restart** reuses the existing in-place relaunch pattern (fresh shell, no startup payload — the original startup may be what failed); **Close** routes through the deliberate close path (→ Landing if it was the last surface).

## ELI5

Your worktree is a room; the terminal is the light. Before, if the bulb blew the instant you walked in (a bad `.envrc`), the app dragged you back out to the hallway. Now the room stays, the blown bulb is shown with a "try again" button, and you only leave when *you* decide to.

## How it was verified

Live in the running app (real CDP-driven session):
- **Non-zero exit (`exit 1`)** → worktree stayed selected (`activeWorktreeId` non-null), recovery overlay rendered with the exit code, scrollback preserved. (screenshot in comments)
- **Restart** → a fresh live shell respawned in place; overlay dismissed; worktree still selected.
- **Real typed `exit` (code 0)** → returned to the Landing screen exactly as before.

Tests: `pty-connection.test.ts` (exit-code matrix: non-zero kept, crash-after-typing kept, clean-typed → Landing, clean-untyped kept), updated `reconcileIfSessionDead` test, `pty-transport.test.ts` (code threading), `TerminalDeadPaneOverlay.test.tsx` (titles/code/buttons), plus the `tabs.test.ts` invariant from #6842. The exit-code tests were confirmed to fail without the guard. Full terminal/tab suite: 1476 pass. Typecheck clean.

## Trade-offs / risks of merging

1. **Behavior change for a clean exit you never typed into.** An rc-file/startup that exits 0 *on its own* (no interaction) now leaves a recoverable "Terminal closed (code 0)" pane instead of silently bouncing to Landing. This is intentional — we can't tell a self-terminating clean startup from a healthy one except by interaction — but it's a visible change. (A real user typing `exit` is unaffected: that sets the interaction timestamp and still goes to Landing.)
2. **Dead pane has no auto-close timer.** Unlike some terminals' configurable "wait-after-command", the dead pane stays until the user clicks Restart/Close. Deliberate: an agent IDE shouldn't silently discard a worktree's surface. No new setting was added (kept scope tight); a future "auto-close on clean exit" preference is easy to add if wanted.
3. **`onPtyExit` signature changed** from `(ptyId)` to `(ptyId, exitCode)`. Internal to the terminal-pane module; all call sites + tests updated. The `onExit` code param defaults to `0` so any missed caller fails safe toward the old "clean" behavior.
4. **i18n:** 5 new `en.json` keys; es/ja/ko/zh got English placeholders via the catalog sync (the repo's standard flow — real translations land later). The `{{code}}` placeholder is preserved across locales.
5. **Restart spawns a clean shell, not a re-run of the original startup.** If the original startup (e.g. an agent launch) is what you wanted, you'd relaunch it manually. Re-running the exact failed startup is a deliberate non-goal (it may just fail again, e.g. the broken `.envrc`).

## Files
- `pty-connection.ts` / `pty-connection-types.ts` — exit-code-driven retain decision + `onPaneProcessDied` dep
- `pty-transport.ts` / `pty-transport-types.ts` — thread the exit code
- `use-terminal-pane-lifecycle.ts` — pass the callback through
- `TerminalPane.tsx` — dead-pane state, Restart/Close handlers, overlay render
- `TerminalDeadPaneOverlay.tsx` (+ test) — the recovery UI
- tests + i18n catalogs

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6884">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->