### PR TITLE
fix(claude-hooks): write managed hooks to settings.local.json

### DIFF
--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -1,8 +1,8 @@
-// Why: locks in the remote-install contract so a refactor cannot silently
-// drift the produced settings.json shape, the wrapper-quoted command path,
-// or the script body that lands on the remote box. Local install behavior
-// is exercised through `installer-utils.test.ts` and the per-CLI status
-// audit; this file covers ONLY the SFTP-backed path added in commit #8.
+// Why: locks in the install/remove contract so a refactor cannot silently
+// drift the produced settings shape, the wrapper-quoted command path, or the
+// script body. Local installs write managed hooks to settings.local.json and
+// migrate stale entries out of the shared settings.json; the remote SFTP path
+// keeps writing the box-local settings.json. Both contracts live here.
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -109,15 +109,16 @@ function createFakeSftp(): { sftp: SFTPWrapper; fs: FakeFs } {
 }
 
 describe('ClaudeHookService.install', () => {
-  it('installs managed hooks into Claude settings and preserves user Bedrock settings', () => {
+  it('writes managed hooks to settings.local.json and migrates them out of the shared settings.json', () => {
     const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-hooks-'))
     vi.stubEnv('HOME', tmpHome)
     vi.stubEnv('USERPROFILE', tmpHome)
     try {
-      const legacyPath = join(tmpHome, '.claude', 'settings.json')
+      const sharedPath = join(tmpHome, '.claude', 'settings.json')
+      const localPath = join(tmpHome, '.claude', 'settings.local.json')
       mkdirSync(join(tmpHome, '.claude'), { recursive: true })
       writeFileSync(
-        legacyPath,
+        sharedPath,
         JSON.stringify({
           apiKeyHelper: '/opt/company/claude-key-helper',
           awsAuthRefresh: '/opt/company/aws-refresh',
@@ -146,9 +147,17 @@ describe('ClaudeHookService.install', () => {
 
       const status = new ClaudeHookService().install()
       expect(status.state).toBe('installed')
+      expect(status.configPath).toBe(localPath)
 
-      const legacy = JSON.parse(readFileSync(legacyPath, 'utf-8'))
-      expect(legacy).toMatchObject({
+      const local = JSON.parse(readFileSync(localPath, 'utf-8'))
+      expect(local.hooks.StopFailure[0].hooks[0].command).toMatch(
+        process.platform === 'win32'
+          ? WINDOWS_POWERSHELL_LAUNCHER
+          : new RegExp(CLAUDE_SCRIPT_FILE_NAME)
+      )
+
+      const shared = JSON.parse(readFileSync(sharedPath, 'utf-8'))
+      expect(shared).toMatchObject({
         apiKeyHelper: '/opt/company/claude-key-helper',
         awsAuthRefresh: '/opt/company/aws-refresh',
         awsCredentialExport: '/opt/company/aws-export',
@@ -157,28 +166,14 @@ describe('ClaudeHookService.install', () => {
           AWS_REGION: 'us-west-2'
         }
       })
-      const legacyCommands = legacy.hooks.Stop.flatMap(
+      const sharedCommands = shared.hooks.Stop.flatMap(
         (definition: { hooks: { command: string }[] }) =>
           definition.hooks.map((hook) => hook.command)
       )
-      expect(legacyCommands).toContain('/usr/local/bin/user-hook')
+      expect(sharedCommands).toContain('/usr/local/bin/user-hook')
       expect(
-        legacyCommands.some((command: string) =>
-          process.platform === 'win32'
-            ? WINDOWS_POWERSHELL_LAUNCHER.test(command)
-            : command.includes(CLAUDE_SCRIPT_FILE_NAME)
-        )
-      ).toBe(true)
-      expect(
-        legacyCommands.some((command: string) =>
-          command.includes('/Users/old/.orca/agent-hooks/claude-hook.sh')
-        )
+        sharedCommands.some((command: string) => command.includes('.orca/agent-hooks/claude-hook'))
       ).toBe(false)
-      expect(legacy.hooks.StopFailure[0].hooks[0].command).toMatch(
-        process.platform === 'win32'
-          ? WINDOWS_POWERSHELL_LAUNCHER
-          : new RegExp(CLAUDE_SCRIPT_FILE_NAME)
-      )
       expect(
         readFileSync(join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME), 'utf-8')
       ).toContain('DEVIN_PROJECT_DIR')
@@ -202,7 +197,7 @@ describe('ClaudeHookService.install', () => {
         expect(new ClaudeHookService().install().state).toBe('installed')
 
         const settings = JSON.parse(
-          readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8')
+          readFileSync(join(tmpHome, '.claude', 'settings.local.json'), 'utf-8')
         ) as { hooks: Record<string, { hooks: { command: string }[] }[]> }
 
         for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
@@ -241,6 +236,59 @@ describe('ClaudeHookService.install', () => {
       }
     }
   )
+})
+
+describe('ClaudeHookService.remove', () => {
+  it('removes managed hooks from settings.local.json and the legacy shared settings.json', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-remove-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      mkdirSync(join(tmpHome, '.claude'), { recursive: true })
+      const service = new ClaudeHookService()
+      service.install()
+
+      const sharedPath = join(tmpHome, '.claude', 'settings.json')
+      writeFileSync(
+        sharedPath,
+        JSON.stringify({
+          hooks: {
+            Stop: [
+              { hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] },
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command: '/Users/old/.orca/agent-hooks/claude-hook.sh'
+                  }
+                ]
+              }
+            ]
+          }
+        })
+      )
+
+      const status = service.remove()
+      expect(status.state).toBe('not_installed')
+
+      const local = JSON.parse(
+        readFileSync(join(tmpHome, '.claude', 'settings.local.json'), 'utf-8')
+      )
+      expect(local.hooks ?? {}).toEqual({})
+
+      const shared = JSON.parse(readFileSync(sharedPath, 'utf-8'))
+      const sharedCommands = (shared.hooks.Stop as { hooks: { command: string }[] }[]).flatMap(
+        (definition) => definition.hooks.map((hook) => hook.command)
+      )
+      expect(sharedCommands).toContain('/usr/local/bin/user-hook')
+      expect(
+        sharedCommands.some((command) => command.includes('.orca/agent-hooks/claude-hook'))
+      ).toBe(false)
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('ClaudeHookService.installRemote', () => {
@@ -337,7 +385,7 @@ describe('OpenClaudeHookService-compatible install', () => {
     vi.stubEnv('HOME', tmpHome)
     vi.stubEnv('USERPROFILE', tmpHome)
     try {
-      const openClaudeSettings = join(tmpHome, '.openclaude', 'settings.json')
+      const openClaudeSettings = join(tmpHome, '.openclaude', 'settings.local.json')
       mkdirSync(join(tmpHome, '.openclaude'), { recursive: true })
       writeFileSync(openClaudeSettings, JSON.stringify({ hooks: {} }))
 

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -21,6 +21,7 @@ import {
   getManagedScriptPath,
   getPosixManagedScriptFileName,
   getRemoteConfigPath,
+  getSharedSettingsPath,
   getRemoteManagedCommand,
   removeManagedHooks,
   type ClaudeCompatibleHookSettings
@@ -211,7 +212,23 @@ export class ClaudeHookService {
       getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
     )
     writeHooksJson(configPath, nextConfig)
+    this.sweepLegacyManagedHooksFromSharedSettings()
     return this.getStatus()
+  }
+
+  private sweepLegacyManagedHooksFromSharedSettings(): void {
+    const sharedSettingsPath = getSharedSettingsPath(this.options.settings)
+    const sharedConfig = readHooksJson(sharedSettingsPath)
+    if (!sharedConfig) {
+      return
+    }
+    const { config: sweptConfig, changed } = removeManagedHooks(
+      sharedConfig,
+      getManagedScriptFileName(this.options.settings)
+    )
+    if (changed) {
+      writeHooksJson(sharedSettingsPath, sweptConfig)
+    }
   }
 
   // Why: install Orca's Claude hook settings on the remote box rather than the
@@ -301,6 +318,7 @@ export class ClaudeHookService {
     if (changed) {
       writeHooksJson(configPath, nextConfig)
     }
+    this.sweepLegacyManagedHooksFromSharedSettings()
     return this.getStatus()
   }
 }

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -216,6 +216,10 @@ export class ClaudeHookService {
     return this.getStatus()
   }
 
+  // Why: older installs wrote managed hooks to the git-synced shared
+  // settings.json. Strip only those entries (user-authored hooks stay) and
+  // never create the file: readHooksJson returns null when it is unparseable
+  // and {} when missing, so the early return avoids resurrecting/clobbering it.
   private sweepLegacyManagedHooksFromSharedSettings(): void {
     const sharedSettingsPath = getSharedSettingsPath(this.options.settings)
     const sharedConfig = readHooksJson(sharedSettingsPath)

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -216,10 +216,12 @@ export class ClaudeHookService {
     return this.getStatus()
   }
 
-  // Why: older installs wrote managed hooks to the git-synced shared
-  // settings.json. Strip only those entries (user-authored hooks stay) and
-  // never create the file: readHooksJson returns null when it is unparseable
-  // and {} when missing, so the early return avoids resurrecting/clobbering it.
+  /**
+   * Why: older installs wrote managed hooks to the git-synced shared
+   * settings.json. Strip only those entries (user-authored hooks stay) and
+   * never create the file: readHooksJson returns null when it is unparseable
+   * and {} when missing, so the early return avoids resurrecting/clobbering it.
+   */
   private sweepLegacyManagedHooksFromSharedSettings(): void {
     const sharedSettingsPath = getSharedSettingsPath(this.options.settings)
     const sharedConfig = readHooksJson(sharedSettingsPath)

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -52,14 +52,18 @@ export const CLAUDE_EVENTS = [
   }
 ] as const
 
-// Why: managed hooks are machine-specific, so they belong in the never-synced
-// settings.local.json, not the git-synced settings.json shared across machines.
+/**
+ * Why: managed hooks are machine-specific, so they belong in the never-synced
+ * settings.local.json, not the git-synced settings.json shared across machines.
+ */
 export function getConfigPath(settings = CLAUDE_HOOK_SETTINGS): string {
   return join(homedir(), settings.configDirName, 'settings.local.json')
 }
 
-// Why: the legacy, git-synced settings.json that older installs polluted with
-// managed hooks; kept only so install/remove can sweep those stale entries out.
+/**
+ * Why: the legacy, git-synced settings.json that older installs polluted with
+ * managed hooks; kept only so install/remove can sweep those stale entries out.
+ */
 export function getSharedSettingsPath(settings = CLAUDE_HOOK_SETTINGS): string {
   return join(homedir(), settings.configDirName, 'settings.json')
 }

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -53,6 +53,10 @@ export const CLAUDE_EVENTS = [
 ] as const
 
 export function getConfigPath(settings = CLAUDE_HOOK_SETTINGS): string {
+  return join(homedir(), settings.configDirName, 'settings.local.json')
+}
+
+export function getSharedSettingsPath(settings = CLAUDE_HOOK_SETTINGS): string {
   return join(homedir(), settings.configDirName, 'settings.json')
 }
 

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -52,10 +52,14 @@ export const CLAUDE_EVENTS = [
   }
 ] as const
 
+// Why: managed hooks are machine-specific, so they belong in the never-synced
+// settings.local.json, not the git-synced settings.json shared across machines.
 export function getConfigPath(settings = CLAUDE_HOOK_SETTINGS): string {
   return join(homedir(), settings.configDirName, 'settings.local.json')
 }
 
+// Why: the legacy, git-synced settings.json that older installs polluted with
+// managed hooks; kept only so install/remove can sweep those stale entries out.
 export function getSharedSettingsPath(settings = CLAUDE_HOOK_SETTINGS): string {
   return join(homedir(), settings.configDirName, 'settings.json')
 }


### PR DESCRIPTION
## Summary

Orca's managed agent hooks were installed into `~/.claude/settings.json` — the **shared, git-synced** config. For users who version-control their `.claude` directory this pollutes the synced config, spreads machine-specific hooks to machines that may not run Orca, and can double-fire hooks when Claude Code also writes the same managed entry into `settings.local.json`.

This moves the managed-hook target to the machine-local file, matching Claude Code's own design intent (`settings.json` = shared/synced, `settings.local.json` = machine-specific overrides):

- `getConfigPath()` now returns `~/.claude/settings.local.json` (applies to both Claude and OpenClaude, which share this service).
- `install()` and `remove()` sweep any stale Orca-managed entries out of the legacy shared `settings.json`, so the shared config is cleaned without orphaned, double-firing hooks. Non-managed, user-authored entries in `settings.json` are preserved untouched.
- The sweep is idempotent and only ever reads-and-cleans the shared `settings.json`; it never creates it. A missing or unparseable file is a no-op.

## Migration behavior

Every fresh install writes to `settings.local.json` immediately. For existing installs, the sweep of the legacy `settings.json` happens the next time managed hooks are (re)applied — i.e. via `installManagedAgentHooks()` when the agent-status-hooks setting is toggled. It does **not** run on every boot, so an upgraded user's hooks stay in the old `settings.json` (env-guarded, harmless) and `getStatus()` will report `not_installed` until hooks are re-applied.

If maintainers prefer a fully-automatic, boot-time migration (a one-time legacy sweep + reinstall on startup, or making `getStatus()` legacy-aware), I'm happy to extend this PR — left out here to keep the change minimal and matching the issue's suggested fix.

## Reproduction

1. Git-manage `~/.claude` with `!settings.json` whitelisted in `.gitignore`.
2. Let Orca install its managed Claude hooks.
3. `~/.claude/settings.json` now contains Orca's hook commands and gets synced to every machine — including ones without Orca. If Claude Code also writes `settings.local.json`, the managed hook fires twice per event.

After this change, managed hooks land in `settings.local.json` (never synced) and the stale `settings.json` entries are swept when hooks are next applied.

## Scope

Remote SSH installs (`installRemote`) intentionally keep writing the box-local `~/.claude/settings.json`: the remote settings/local-override split is a separate concern from local git-synced dotfiles, and the existing remote-install contract is unchanged. This PR is scoped to local installs, where the reported pollution happens.

## Verification

```
pnpm exec vitest run --config config/vitest.config.ts src/main/claude/hook-service.test.ts src/main/agent-hooks/managed-hook-timeout.test.ts src/main/devin/hook-service.test.ts src/main/kimi/hook-service.test.ts src/main/ipc/agent-hooks.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts
pnpm exec oxlint src/main/claude/hook-settings.ts src/main/claude/hook-service.ts src/main/claude/hook-service.test.ts
pnpm run typecheck:node
```

- Updated the local-install tests to assert managed hooks land in `settings.local.json` and that the shared `settings.json` keeps user-authored entries while stale managed ones are swept.
- Added a `ClaudeHookService.remove` regression covering removal from both files.
- All suites pass, lint and `typecheck:node` clean.

Fixes #6879
