### PR TITLE
fix: strip trailing whitespace from PROMPT_COMMAND in bash wrapper

### DIFF
--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -234,4 +234,21 @@ describe('getRelayShellLaunchConfig', () => {
     expect(output).toContain('PROMPT_ARRAY')
     expectBashOsc133Lifecycle(output)
   })
+
+  // Why: RHEL-family /etc/bashrc prepends "history -a; " to PROMPT_COMMAND
+  // outside its BASHRCSOURCED guard (repeated across re-sources), so the value
+  // Orca inherits ends in a ";"+whitespace separator. Prepend/append must not
+  // splice an empty command (";;") that breaks the prompt with a syntax error.
+  itWithBash('normalizes an inherited PROMPT_COMMAND ending in a separator', () => {
+    writeFileSync(
+      join(homeDir, '.bash_profile'),
+      'PROMPT_COMMAND=\'AFTER_SEP_PROMPT=1; printf "PROMPT_SEP\\n"; \'\n'
+    )
+    const config = getRelayShellLaunchConfig('/bin/bash', { HOME: homeDir })
+    const output = runInteractiveBashRcfile(config.args[1] as string, homeDir)
+
+    expect(output).not.toContain('syntax error')
+    expect(output).toContain('PROMPT_SEP')
+    expectBashOsc133Lifecycle(output)
+  })
 })

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -187,7 +187,11 @@ __orca_normalize_prompt_command() {
     done
     PROMPT_COMMAND="$__orca_joined"
   fi
-  PROMPT_COMMAND="\${PROMPT_COMMAND%%[[:space:]]}"
+  # Why: RHEL-family /etc/bashrc can leave an inherited PROMPT_COMMAND ending in
+  # a ";"/whitespace separator; trim it so Orca's prepend/append never form ";;".
+  while [[ "\${PROMPT_COMMAND:-}" == *[[:space:]\\;] ]]; do
+    PROMPT_COMMAND="\${PROMPT_COMMAND%?}"
+  done
 }
 __orca_prepend_prompt_command() {
   __orca_normalize_prompt_command

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -187,6 +187,7 @@ __orca_normalize_prompt_command() {
     done
     PROMPT_COMMAND="$__orca_joined"
   fi
+  PROMPT_COMMAND="\${PROMPT_COMMAND%%[[:space:]]}"
 }
 __orca_prepend_prompt_command() {
   __orca_normalize_prompt_command


### PR DESCRIPTION
**Problem**

On Rocky Linux/RHEL, `/etc/bashrc` line 91 (`export PROMPT_COMMAND="history -a; $PROMPT_COMMAND"`) sits outside the `BASHRCSOURCED` guard and runs every time the file is sourced. Since `/etc/profile` sources `~/.bashrc` which sources `/etc/bashrc` again, the line runs multiple times. The trailing space in the expansion leaves whitespace before orca's appended `;__orca_osc133_prompt_done`, producing `; ;` — a bash syntax error:

```
bash: PROMPT_COMMAND: line 0: syntax error near unexpected token `;'
bash: PROMPT_COMMAND: line 0: `__orca_osc133_precmd;history -a; history -a; history -a; ;__orca_osc133_prompt_done'
```

**Affected distros:** Rocky Linux, RHEL, CentOS, and any distro where `/etc/bashrc` prepends to `PROMPT_COMMAND` outside the guard block.

**Fix**

Strip trailing whitespace in `__orca_normalize_prompt_command` before orca prepends or appends to `PROMPT_COMMAND`.

```diff
 __orca_normalize_prompt_command() {
   local __orca_joined="" __orca_prompt_part
   if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
     for __orca_prompt_part in "${PROMPT_COMMAND[@]}"; do
       [[ -n "$__orca_prompt_part" ]] || continue
       if [[ -n "$__orca_joined" ]]; then
         __orca_joined="$__orca_joined;$__orca_prompt_part"
       else
         __orca_joined="$__orca_prompt_part"
       fi
     done
     PROMPT_COMMAND="$__orca_joined"
   fi
+  PROMPT_COMMAND="${PROMPT_COMMAND%%[[:space:]]}"
 }
```

**Testing**

- Verified on Rocky Linux 10: new terminals open without the syntax error
- `PROMPT_COMMAND` is clean: `__orca_osc133_precmd;history -a;__orca_osc133_prompt_done`