### PR TITLE
feat(sidebar): show project name on worktree rows in header-less views

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.project-identity.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.project-identity.test.tsx
@@ -1,0 +1,181 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings, Repo, Worktree, WorktreeCardProperty } from '../../../../shared/types'
+import type WorktreeCardComponent from './WorktreeCard'
+import type * as WorkspaceDeleteQuickAction from './workspace-delete-quick-action'
+
+const fetchHostedReviewForBranch = vi.fn()
+const fetchIssue = vi.fn()
+const openModal = vi.fn()
+const updateWorktreeMeta = vi.fn()
+
+let worktreeCardProperties: WorktreeCardProperty[] = ['status']
+let settings: Partial<GlobalSettings> | null = null
+let WorktreeCard: typeof WorktreeCardComponent
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      deleteStateByWorktreeId: {},
+      fetchHostedReviewForBranch,
+      fetchIssue,
+      gitConflictOperationByWorktree: {},
+      hostedReviewCache: {},
+      issueCache: {},
+      openModal,
+      projectGroups: [],
+      remoteBranchConflictByWorktreeId: {},
+      settings,
+      sshConnectionStates: new Map(),
+      sshTargetLabels: new Map(),
+      browserTabsByWorktree: {},
+      ptyIdsByTabId: {},
+      tabsByWorktree: {},
+      updateWorktreeMeta,
+      worktreeCardProperties
+    })
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('./use-worktree-activity-status', () => ({
+  useWorktreeActivityStatus: () => 'idle'
+}))
+
+vi.mock('./CacheTimer', () => ({
+  default: () => null,
+  usePromptCacheCountdownStartedAt: () => null
+}))
+
+vi.mock('./WorktreeCardAgents', () => ({
+  default: () => null
+}))
+
+vi.mock('./SshDisconnectedDialog', () => ({
+  SshDisconnectedDialog: () => null
+}))
+
+vi.mock('./WorktreeContextMenu', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+  CLOSE_ALL_CONTEXT_MENUS_EVENT: 'orca:test-close-context-menus',
+  WORKTREE_CONTEXT_MENU_SCOPE_ATTR: 'data-orca-context-menu-scope',
+  WORKTREE_NATIVE_CONTEXT_MENU_ATTR: 'data-worktree-native-context-menu'
+}))
+
+vi.mock('./workspace-delete-quick-action', async (importOriginal) => {
+  const actual = await importOriginal<typeof WorkspaceDeleteQuickAction>()
+  return {
+    ...actual,
+    useWorkspaceDeleteModifierPressed: () => false
+  }
+})
+
+const PROJECT_PREFIX_ATTR = 'data-worktree-card-project-prefix='
+const STATUS_SLOT_ATTR = 'data-worktree-card-status-slot='
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'orca',
+    badgeColor: '#999999',
+    addedAt: 1
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'repo-1::/repo/worktrees/feature',
+    repoId: 'repo-1',
+    path: '/repo/worktrees/feature',
+    displayName: 'hawksbill',
+    branch: 'hawksbill',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    ...overrides
+  }
+}
+
+describe('WorktreeCard project identity (header-less views)', () => {
+  beforeAll(async () => {
+    WorktreeCard = (await import('./WorktreeCard')).default
+  }, 20_000)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    worktreeCardProperties = ['status']
+    settings = null
+  })
+
+  it('prefixes the project name and keeps the status lane on a worktree row', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    // Why: the project prefix makes the row identifiable without a project header.
+    expect(markup).toContain(PROJECT_PREFIX_ATTR)
+    // A worktree keeps its branch-glyph status lane.
+    expect(markup).toContain(STATUS_SLOT_ATTR)
+  })
+
+  it('drops the status lane for the primary worktree so it reads as a different level', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({
+          id: 'repo-1::/repo',
+          path: '/repo',
+          displayName: 'main',
+          branch: 'main',
+          isMainWorktree: true
+        })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain(PROJECT_PREFIX_ATTR)
+    // Primary worktree omits the status lane entirely so it sits flush-left.
+    expect(markup).not.toContain(STATUS_SLOT_ATTR)
+  })
+
+  it('does not prefix the project in the grouped Project view, and keeps the primary status lane', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({
+          id: 'repo-1::/repo',
+          path: '/repo',
+          displayName: 'main',
+          branch: 'main',
+          isMainWorktree: true
+        })}
+        repo={makeRepo()}
+        isActive={false}
+        // hideRepoBadge is set by the list only when grouped by project (a header
+        // already names the project), so the prefix and lane-omission turn off.
+        hideRepoBadge
+      />
+    )
+
+    expect(markup).not.toContain(PROJECT_PREFIX_ATTR)
+    expect(markup).toContain(STATUS_SLOT_ATTR)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1194,6 +1194,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // toggle, while the experimental card keeps the status glyph passive.
   const showCombinedStatusSlot = showStatus
   const showTitleRowPrimary = compactCards && worktree.isMainWorktree && !isFolder
+  // Why: in header-less views the primary worktree drops its status lane entirely so
+  // its content sits flush-left and the branch-glyph worktrees read as a nested level.
+  const primaryRowOmitsStatusLane = worktree.isMainWorktree && !isFolder && !hideRepoBadge
   const showMetaRowDetails = !newCardStyle && !compactCards && (hasDetails || hasPorts)
   const showTitleRowIndicators = (newCardStyle || compactCards) && (hasDetails || hasPorts)
   // Why: detailed cards need a stable metadata lane only when it has content.
@@ -1369,7 +1372,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       }
       data-worktree-card-parent-content=""
     >
-      {showCombinedStatusSlot ? (
+      {showCombinedStatusSlot && !primaryRowOmitsStatusLane ? (
         <div
           className={cn(
             'flex shrink-0 justify-center',
@@ -1388,7 +1391,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
             onToggleUnread={handleToggleUnreadQuick}
             prDisplay={statusLaneReview}
             newCardStyle={newCardStyle}
-            hasBranchIdentity={Boolean(branchIdentityDisplay)}
+            // Why: the branch glyph marks additional worktrees; the primary worktree
+            // is the project's main checkout, so it keeps the status dot instead so
+            // the two read apart at a glance.
+            hasBranchIdentity={Boolean(branchIdentityDisplay) && !worktree.isMainWorktree}
           />
         </div>
       ) : null}
@@ -1480,6 +1486,20 @@ const WorktreeCard = React.memo(function WorktreeCard({
               </RepoIdentityChip>
             )}
 
+            {/* Why: in header-less views (groupBy !== 'repo', so no project header
+                sits above the row) the row title is just a branch/worktree name and
+                gives no project context. Prefix the project name (bold) so every row
+                is identifiable; grouped views already name the project in their header. */}
+            {!hideRepoBadge && !isFolder && repo ? (
+              <span
+                data-worktree-card-project-prefix=""
+                className="flex shrink-0 items-baseline text-[13px] leading-5"
+              >
+                <span className="font-semibold text-foreground">{repo.displayName}</span>
+                <span className="px-1 text-muted-foreground/60">·</span>
+              </span>
+            ) : null}
+
             {/* Why: unread alert lives in the left status lane; weight plus dimmed
                  read titles carry scan contrast in the title row. */}
             <WorktreeTitleInlineRename
@@ -1487,7 +1507,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
               disabled={isDeleting || affiliateListMode}
               showUnreadEmphasis={showUnreadEmphasis}
               dimReadTitle={newCardStyle}
-              className="text-[13px] leading-5"
+              // Why: with the bold project prefix present, the branch/worktree name
+              // is the secondary half of "project · branch", so render it lighter.
+              className={cn(
+                'text-[13px] leading-5',
+                !hideRepoBadge && !isFolder && repo && 'text-muted-foreground'
+              )}
               editingClassName="flex-1"
               titleWrapper={titleWrapper}
               onEditingChange={affiliateListMode ? undefined : setTitleRenaming}
@@ -1532,7 +1557,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 </TooltipContent>
               </Tooltip>
             ) : null}
-            {!compactCards && worktree.isMainWorktree && !isFolder && (
+            {/* Why: the "primary" badge only earns its place in the grouped
+                Project view; in header-less views the project-name prefix already
+                marks the row, so the badge would be redundant noise. */}
+            {!compactCards && worktree.isMainWorktree && !isFolder && hideRepoBadge && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Badge


### PR DESCRIPTION
## What

In the header-less workspace views (**Group by → None / Status / PR**) there is no project header above the rows, so a project's **primary worktree showed only its branch name** (e.g. `main`) and was indistinguishable from every other project's primary. Worktrees created under a project (e.g. a `hawksbill` branch under `orca`) likewise carried no project context.

This prefixes the **project name** (bold) before the branch/worktree name (lighter gray) on every worktree row in those views, so each row is identifiable:

```
orca · main                ← primary: no status lane, flush-left
  ⑂ orca · hawksbill        ← worktree: branch glyph in status lane, nested level
```

The **primary worktree drops its status lane entirely** so it sits flush-left, and the additional worktrees — which keep their branch glyph in the status lane — read as a nested level.

The grouped **Group by → Project** view is unchanged: its header already names the project, so the prefix and lane-omission are gated off there (`hideRepoBadge`).

## Why

The flat "All" view is a common way to scan every workspace, but primary rows all read as just `main` with no way to tell which project they belonged to.

## Review summary (cross-cutting checks)

- **Cross-platform:** pure layout/Tailwind, no platform branches or modifier-key handling. Holds on macOS/Linux/Windows, light/dark.
- **SSH / remote:** presentational only — no runtime, IPC, or `connectionId` paths touched.
- **Agents / integrations / git providers:** provider- and agent-neutral; reads only `repo.displayName` and `worktree.isMainWorktree`.
- **Performance:** no new work in the virtualized row hot path; gating is a couple of boolean checks per card.
- **UI quality:** follows `docs/STYLEGUIDE.md` (existing tokens, no new colors); reuses the status-lane branch glyph rather than adding chrome.
- **Security:** none — renderer-only render change.

## Tests

`WorktreeCard.project-identity.test.tsx`: project prefix + status lane on a worktree row; prefix shown and status lane omitted for the primary; grouped-view case (no prefix, primary keeps its lane). `oxlint`, `tsgo` typecheck, and `oxfmt` all clean.

## Visual

UI change — screenshots to be attached to the PR conversation (before/after of the All view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6898">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

In sidebar views without project headers, each worktree row shows the project name next to the branch so rows from different repos are not ambiguous. Project grouping still uses headers as before.
