### PR TITLE
feat(sidebar): add ascending/descending order to workspace sort

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -662,6 +662,13 @@ function normalizeProjectOrderBy(projectOrderBy: unknown): PersistedState['ui'][
   return getDefaultUIState().projectOrderBy
 }
 
+function normalizeSortDirection(sortDirection: unknown): PersistedState['ui']['sortDirection'] {
+  if (sortDirection === 'asc' || sortDirection === 'desc') {
+    return sortDirection
+  }
+  return getDefaultUIState().sortDirection
+}
+
 function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['rightSidebarTab'] {
   if (
     tab === 'explorer' ||
@@ -4910,6 +4917,7 @@ export class Store {
       ...uiState,
       groupBy: normalizeGroupBy(this.state.ui?.groupBy),
       sortBy: normalizeSortBy(this.state.ui?.sortBy),
+      sortDirection: normalizeSortDirection(this.state.ui?.sortDirection),
       projectOrderBy: normalizeProjectOrderBy(this.state.ui?.projectOrderBy),
       rightSidebarTab: normalizeRightSidebarTab(this.state.ui?.rightSidebarTab),
       rightSidebarExplorerView: normalizeRightSidebarExplorerView(
@@ -4980,6 +4988,9 @@ export class Store {
       sortBy: sanitizedUpdates.sortBy
         ? normalizeSortBy(sanitizedUpdates.sortBy)
         : normalizeSortBy(this.state.ui?.sortBy),
+      sortDirection: sanitizedUpdates.sortDirection
+        ? normalizeSortDirection(sanitizedUpdates.sortDirection)
+        : normalizeSortDirection(this.state.ui?.sortDirection),
       projectOrderBy: updates.projectOrderBy
         ? normalizeProjectOrderBy(updates.projectOrderBy)
         : normalizeProjectOrderBy(this.state.ui?.projectOrderBy),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -601,6 +601,7 @@ function App(): React.JSX.Element {
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const groupBy = useAppStore((s) => s.groupBy)
   const sortBy = useAppStore((s) => s.sortBy)
+  const sortDirection = useAppStore((s) => s.sortDirection)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
@@ -1320,6 +1321,7 @@ function App(): React.JSX.Element {
         markdownTocPanelWidth,
         groupBy,
         sortBy,
+        sortDirection,
         projectOrderBy,
         showActiveOnly: false,
         hideSleepingWorkspaces: !showSleepingWorkspaces,
@@ -1348,6 +1350,7 @@ function App(): React.JSX.Element {
     markdownTocPanelWidth,
     groupBy,
     sortBy,
+    sortDirection,
     projectOrderBy,
     showSleepingWorkspaces,
     hideDefaultBranchWorkspace,

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -45,6 +45,8 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const setVisibleWorkspaceHostIds = useAppStore((s) => s.setVisibleWorkspaceHostIds)
   const sortBy = useAppStore((s) => s.sortBy)
   const setSortBy = useAppStore((s) => s.setSortBy)
+  const sortDirection = useAppStore((s) => s.sortDirection)
+  const setSortDirection = useAppStore((s) => s.setSortDirection)
   const groupBy = useAppStore((s) => s.groupBy)
   const setGroupBy = useAppStore((s) => s.setGroupBy)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
@@ -217,6 +219,36 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
                 )
               })}
             </DropdownMenuRadioGroup>
+            {/* Why: 'manual' is a fixed drag order, so a direction toggle would
+                be meaningless there; only offer it for the comparator sorts. */}
+            {sortBy !== 'manual' && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-[11px] font-medium text-muted-foreground">
+                  {translate(
+                    'auto.components.sidebar.SidebarWorkspaceOptionsMenu.sortOrderLabel',
+                    'Order'
+                  )}
+                </DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={sortDirection}
+                  onValueChange={(v) => setSortDirection(v as typeof sortDirection)}
+                >
+                  <DropdownMenuRadioItem value="asc" onSelect={(e) => e.preventDefault()}>
+                    {translate(
+                      'auto.components.sidebar.SidebarWorkspaceOptionsMenu.sortAscending',
+                      'Ascending'
+                    )}
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="desc" onSelect={(e) => e.preventDefault()}>
+                    {translate(
+                      'auto.components.sidebar.SidebarWorkspaceOptionsMenu.sortDescending',
+                      'Descending'
+                    )}
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </>
+            )}
           </DropdownMenuSubContent>
         </DropdownMenuSub>
 

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -63,7 +63,7 @@ import type {
   WorkspaceStatusDefinition
 } from '../../../../shared/types'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
-import { buildWorktreeComparator } from './smart-sort'
+import { applySortDirection, buildWorktreeComparator } from './smart-sort'
 import {
   buildAttentionByWorktree,
   type SmartClass,
@@ -4989,6 +4989,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const setWorkspaceHostOrder = useAppStore((s) => s.setWorkspaceHostOrder)
   const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const sortBy = useAppStore((s) => s.sortBy)
+  const sortDirection = useAppStore((s) => s.sortDirection)
   const setSortBy = useAppStore((s) => s.setSortBy)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
@@ -5219,13 +5220,19 @@ const WorktreeList = React.memo(function WorktreeList({
           )
         : new Map<string, WorktreeAttention>()
     lastAttentionByWorktreeRef.current = sortBy === 'smart' ? attentionByWorktree : null
-    nonArchivedWorktrees.sort(buildWorktreeComparator(sortBy, repoMap, now, attentionByWorktree))
+    nonArchivedWorktrees.sort(
+      // Why: 'manual' is a fixed user-defined order, so direction never reverses it.
+      applySortDirection(
+        buildWorktreeComparator(sortBy, repoMap, now, attentionByWorktree),
+        sortBy === 'manual' ? 'asc' : sortDirection
+      )
+    )
     return nonArchivedWorktrees.map((w) => w.id)
     // debouncedSortEpoch is an intentional trigger: it's not read inside the
     // memo, but its change signals that the sort order should be recomputed.
     // The debounce prevents jarring mid-interaction position shifts.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedSortEpoch, repoMap, sortBy])
+  }, [debouncedSortEpoch, repoMap, sortBy, sortDirection])
 
   // Why a ref of prior class per worktree: smart_sort_class_1_promotion must
   // fire only on transitions INTO Class 1, not on every recompute that keeps

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import {
+  applySortDirection,
   buildWorktreeComparator,
   CREATE_GRACE_MS,
   effectiveRecentActivity,
@@ -730,5 +731,28 @@ describe('buildWorktreeComparator — recent with createdAt grace window', () =>
     worktrees.sort(buildWorktreeComparator('recent', repoMap, NOW, new Map()))
 
     expect(worktrees.map((w) => w.id)).toEqual(['bravo', 'alpha'])
+  })
+})
+
+describe('applySortDirection', () => {
+  const repoMap = new Map<string, Repo>()
+  const makeNamed = (id: string): Worktree => ({ id, displayName: id }) as unknown as Worktree
+  const alpha = makeNamed('alpha')
+  const bravo = makeNamed('bravo')
+
+  it('keeps the natural comparator order for asc', () => {
+    const comparator = applySortDirection(
+      buildWorktreeComparator('name', repoMap, 0, new Map()),
+      'asc'
+    )
+    expect([bravo, alpha].sort(comparator).map((w) => w.id)).toEqual(['alpha', 'bravo'])
+  })
+
+  it('reverses the comparator order for desc', () => {
+    const comparator = applySortDirection(
+      buildWorktreeComparator('name', repoMap, 0, new Map()),
+      'desc'
+    )
+    expect([alpha, bravo].sort(comparator).map((w) => w.id)).toEqual(['bravo', 'alpha'])
   })
 })

--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -8,6 +8,21 @@ import { IDLE, buildAttentionByWorktree, type WorktreeAttention } from './smart-
 
 export type SortBy = 'name' | 'smart' | 'recent' | 'repo' | 'manual'
 
+export type SortDirection = 'asc' | 'desc'
+
+/**
+ * Wrap a worktree comparator to honor the chosen sort direction. Each sort
+ * mode defines a natural ("ascending") order in `buildWorktreeComparator`;
+ * `desc` flips it. Manual order has no comparator (user-defined drag order),
+ * so callers skip direction entirely there.
+ */
+export function applySortDirection(
+  comparator: (a: Worktree, b: Worktree) => number,
+  direction: SortDirection
+): (a: Worktree, b: Worktree) => number {
+  return direction === 'desc' ? (a, b) => -comparator(a, b) : comparator
+}
+
 // Why: a newly-created worktree's lastActivityAt is stamped at the moment
 // createLocalWorktree finishes git + setup-runner prep (often several seconds
 // after the user clicked Create). During and after that window, ambient PTY

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3868,7 +3868,10 @@
           "2d74665a56": "Ports",
           "65a9820bd1": "Agent statuses",
           "219ebf1961": "Branch name",
-          "folderPathIdentity": "Branch / folder path"
+          "folderPathIdentity": "Branch / folder path",
+          "sortOrderLabel": "Order",
+          "sortAscending": "Ascending",
+          "sortDescending": "Descending"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "Connecting...",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3854,7 +3854,10 @@
           "2d74665a56": "Puertos",
           "65a9820bd1": "Estados del agente",
           "219ebf1961": "Nombre de rama",
-          "folderPathIdentity": "Rama / ruta de carpeta"
+          "folderPathIdentity": "Rama / ruta de carpeta",
+          "sortOrderLabel": "Order",
+          "sortAscending": "Ascending",
+          "sortDescending": "Descending"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "Conectando...",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3835,7 +3835,10 @@
           "65a9820bd1": "Agent ステータス",
           "219ebf1961": "ブランチ名",
           "automation": "自動化",
-          "folderPathIdentity": "ブランチ / フォルダパス"
+          "folderPathIdentity": "ブランチ / フォルダパス",
+          "sortOrderLabel": "Order",
+          "sortAscending": "Ascending",
+          "sortDescending": "Descending"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "接続中...",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3835,7 +3835,10 @@
           "65a9820bd1": "Agent 상태",
           "219ebf1961": "브랜치 이름",
           "automation": "자동화",
-          "folderPathIdentity": "브랜치 / 폴더 경로"
+          "folderPathIdentity": "브랜치 / 폴더 경로",
+          "sortOrderLabel": "Order",
+          "sortAscending": "Ascending",
+          "sortDescending": "Descending"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "연결 중...",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3835,7 +3835,10 @@
           "65a9820bd1": "智能体状态",
           "219ebf1961": "分支名称",
           "automation": "自动化",
-          "folderPathIdentity": "分支 / 文件夹路径"
+          "folderPathIdentity": "分支 / 文件夹路径",
+          "sortOrderLabel": "Order",
+          "sortAscending": "Ascending",
+          "sortDescending": "Descending"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "正在连接...",

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -42,6 +42,7 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     markdownTocPanelWidth: 240,
     groupBy: 'repo',
     sortBy: 'name',
+    sortDirection: 'asc',
     projectOrderBy: 'manual',
     showActiveOnly: false,
     hideSleepingWorkspaces: DEFAULT_HIDE_SLEEPING_WORKSPACES,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -786,6 +786,8 @@ export type UISlice = {
   setGroupBy: (g: UISlice['groupBy']) => void
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   setSortBy: (s: UISlice['sortBy']) => void
+  sortDirection: 'asc' | 'desc'
+  setSortDirection: (d: UISlice['sortDirection']) => void
   projectOrderBy: ProjectOrderBy
   setProjectOrderBy: (p: ProjectOrderBy) => void
   showActiveOnly: boolean
@@ -1890,6 +1892,9 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
 
   // Why: like setSortBy, this is a bare set — it persists only via the
   // debounced window.api.ui.set writer in App.tsx, not on its own.
+  sortDirection: 'asc',
+  setSortDirection: (d) => set({ sortDirection: d }),
+
   projectOrderBy: 'manual',
   setProjectOrderBy: (p) => set({ projectOrderBy: p }),
 
@@ -2259,6 +2264,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         rightSidebarExplorerView: rightSidebarRoute.rightSidebarExplorerView,
         groupBy: (ui.groupBy as UISlice['groupBy'] | 'parent') === 'parent' ? 'repo' : ui.groupBy,
         sortBy,
+        sortDirection: ui.sortDirection,
         // Why: main-process getUI() already normalized this to a valid value
         // (defaulting to 'manual'); read it through without migrating sortBy.
         projectOrderBy: ui.projectOrderBy,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -453,6 +453,7 @@ export function getDefaultUIState(): PersistedUIState {
     markdownTocPanelWidth: 240,
     groupBy: 'repo',
     sortBy: 'recent',
+    sortDirection: 'asc',
     projectOrderBy: 'manual',
     showActiveOnly: false,
     hideSleepingWorkspaces: DEFAULT_HIDE_SLEEPING_WORKSPACES,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3120,6 +3120,10 @@ export type PersistedUIState = {
   markdownTocPanelWidth?: number
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
+  /** Direction applied to `sortBy`. 'asc' is each mode's natural order
+   *  (name A→Z, recent newest-first, …); 'desc' reverses it. Ignored for
+   *  `sortBy: 'manual'`, which is a fixed user-defined order. */
+  sortDirection: 'asc' | 'desc'
   /** Project header ordering in `groupBy: 'repo'`, independent of workspace
    *  `sortBy`. 'manual' (default) uses the persisted repo order and enables
    *  header drag; 'recent' orders by each project's most recent visible


### PR DESCRIPTION
## What

The workspace options menu (Workspaces → ⚙️ → **Sort by**) lets you choose a sort *mode* — Name, Recent, Smart, Project — but not a *direction*. This adds an **Order** control (**Ascending / Descending**) beneath the sort modes.

- `asc` is each mode's natural order (Name A→Z, Recent newest-first, …); `desc` reverses it.
- Default is `asc`, so existing ordering is unchanged until you flip it.
- Hidden for **Manual** sort — that's a fixed, user-dragged order, so a direction toggle would be meaningless (and it's never applied there).
- Wraps the shared worktree comparator, so it works in every view (flat **and** grouped).

## Why

Several sort modes only make sense in both directions (e.g. oldest-first vs newest-first by activity, or Z→A by name), but there was no way to reverse them.

## How

- New persisted `sortDirection: 'asc' | 'desc'` UI state, plumbed through `PersistedUIState`, the default UI state, the main-process normalizer (mirroring `sortBy`), the store slice, hydration, and the debounced UI writer.
- `applySortDirection(comparator, direction)` in `smart-sort.ts` reverses the comparator for `desc`; the sort site passes `'asc'` for `manual` so the fixed order is never touched.

## Review summary (cross-cutting checks)

- **Cross-platform:** no platform branches; menu + comparator only.
- **SSH / remote:** unaffected — UI state + client-side sort, no runtime/IPC surface beyond the existing `ui.set` persistence path.
- **Agents / integrations / git providers:** neutral.
- **Performance:** the comparator wrapper is an O(1) negation; no extra passes over the worktree list.
- **UI quality:** reuses the existing dropdown radio-group pattern in the Sort-by submenu; no new tokens.
- **Security:** none.

## Tests

`smart-sort.test.ts` adds coverage for `applySortDirection` (asc keeps order, desc reverses). Full `pnpm lint`, `tsgo` typecheck (node + web), `oxfmt`, and localization catalog/coverage all pass. Localization strings added across en/es/ja/ko/zh.

## Visual

UI change (new Order control in the Sort-by submenu) — screenshot to be attached to the PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6900">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Workspace sort gets Ascending/Descending in addition to Name, Recent, Smart, and Project. Manual sort hides the direction control because drag order already defines sequence.
