### PR TITLE
feat(sidebar): add "Open as folder" to nested-repo import

### DIFF
--- a/src/renderer/src/components/settings/RepositoryIconPicker.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconPicker.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { RotateCcw } from 'lucide-react'
 import type { Repo } from '../../../../shared/types'
+import { isFolderRepo } from '../../../../shared/repo-kind'
 import { githubAvatarIcon, type RepoIcon } from '../../../../shared/repo-icon'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../../../shared/constants'
 import { normalizeRepoBadgeColor } from '../../../../shared/repo-badge-color'
@@ -38,8 +39,16 @@ export function RepositoryIconPicker({
   const selectedLucideName = repo.repoIcon?.type === 'lucide' ? repo.repoIcon.name : null
   const selectedEmoji = repo.repoIcon?.type === 'emoji' ? repo.repoIcon.emoji : ''
   const selectedBadgeColor = normalizeRepoBadgeColor(repo.badgeColor) ?? DEFAULT_REPO_BADGE_COLOR
-  const initialTab =
-    repo.repoIcon?.type === 'emoji' ? 'emoji' : repo.repoIcon?.type === 'lucide' ? 'icon' : 'avatar'
+  const initialTab: 'avatar' | 'icon' | 'emoji' =
+    repo.repoIcon?.type === 'emoji'
+      ? 'emoji'
+      : repo.repoIcon?.type === 'lucide'
+        ? 'icon'
+        : // Why: non-git folders have no GitHub remote, so the Avatar tab's
+          // primary action can't resolve one — start on the Icon grid instead.
+          isFolderRepo(repo)
+          ? 'icon'
+          : 'avatar'
   const runtimeTarget = useMemo(
     () => getActiveRuntimeTarget({ activeRuntimeEnvironmentId }),
     [activeRuntimeEnvironmentId]

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -193,22 +193,26 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     onGitRepoReady: completeGitRepoAdd,
     setAddProjectBusyLabel
   })
-  const { handleImportNestedRepos, resetNestedImportFlow, trackNestedBackAction } =
-    useAddRepoNestedImportFlow({
-      nestedAttemptId,
-      nestedScan,
-      nestedSelectedPaths,
-      nestedRuntimeKind,
-      nestedConnectionId,
-      nestedGroupName,
-      nestedImportScanId,
-      activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId,
-      fetchWorktrees,
-      importNestedRepos,
-      getNestedRepoRuntimeKind,
-      onGitRepoReady: completeGitRepoAdd,
-      setIsAdding
-    })
+  const {
+    handleImportNestedRepos,
+    handleOpenNestedAsFolder,
+    resetNestedImportFlow,
+    trackNestedBackAction
+  } = useAddRepoNestedImportFlow({
+    nestedAttemptId,
+    nestedScan,
+    nestedSelectedPaths,
+    nestedRuntimeKind,
+    nestedConnectionId,
+    nestedGroupName,
+    nestedImportScanId,
+    activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId,
+    fetchWorktrees,
+    importNestedRepos,
+    getNestedRepoRuntimeKind,
+    onGitRepoReady: completeGitRepoAdd,
+    setIsAdding
+  })
 
   const resetState = useCallback(() => {
     // Why: kill the git clone process if one is running, so backing out
@@ -258,6 +262,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     onResetClosed: resetState,
     onResetHostScopedState: resetHostScopedState
   })
+
+  const canOpenNestedAsFolder = !nestedConnectionId && !isRuntimeEnvironmentActive
 
   const handleBack = useCallback(() => {
     if (step === 'nested') {
@@ -381,6 +387,9 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
         onNestedGroupNameChange={setNestedGroupName}
         onNestedSelectedPathsChange={setNestedSelectedPaths}
         onImportNestedRepos={(mode) => void handleImportNestedRepos(mode)}
+        onOpenNestedAsFolder={
+          canOpenNestedAsFolder ? () => void handleOpenNestedAsFolder() : undefined
+        }
         onCreateNameChange={(value) => {
           setCreateName(value)
           setCreateError(null)

--- a/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
@@ -72,6 +72,7 @@ type AddRepoDialogStepContentProps = {
   onNestedGroupNameChange: (name: string) => void
   onNestedSelectedPathsChange: Dispatch<SetStateAction<Set<string>>>
   onImportNestedRepos: (mode: 'group' | 'separate') => void
+  onOpenNestedAsFolder?: () => void
   onCreateNameChange: (name: string) => void
   onCreateParentChange: (parent: string) => void
   onPickCreateParent: () => void
@@ -140,6 +141,7 @@ export function AddRepoDialogStepContent({
   onNestedGroupNameChange,
   onNestedSelectedPathsChange,
   onImportNestedRepos,
+  onOpenNestedAsFolder,
   onCreateNameChange,
   onCreateParentChange,
   onPickCreateParent,
@@ -237,6 +239,7 @@ export function AddRepoDialogStepContent({
         onGroupNameChange={onNestedGroupNameChange}
         onSelectedPathsChange={onNestedSelectedPathsChange}
         onImport={onImportNestedRepos}
+        {...(onOpenNestedAsFolder ? { onOpenAsFolder: onOpenNestedAsFolder } : {})}
         onStopScan={onStopNestedScan}
       />
     )

--- a/src/renderer/src/components/sidebar/AddRepoNestedImportStep.test.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoNestedImportStep.test.tsx
@@ -92,6 +92,58 @@ describe('AddRepoNestedImportStep', () => {
     expect(html).not.toContain('Project group')
   })
 
+  it('omits the open-as-folder action when no handler is provided', () => {
+    const html = renderStepMarkup()
+
+    expect(html).not.toContain('Open as folder')
+  })
+
+  it('invokes the open-as-folder handler without importing repos', () => {
+    const onImport = vi.fn()
+    const onOpenAsFolder = vi.fn()
+    const host = document.createElement('div')
+    container = host
+    document.body.appendChild(host)
+    root = createRoot(host)
+
+    act(() => {
+      root?.render(
+        <TooltipProvider>
+          <Dialog open>
+            <AddRepoNestedImportStep
+              scan={scan}
+              groupName=""
+              selectedPaths={new Set(scan.repos.map((repo) => repo.path))}
+              isAdding={false}
+              scanInProgress={false}
+              onGroupNameChange={vi.fn()}
+              onSelectedPathsChange={vi.fn()}
+              onImport={onImport}
+              onOpenAsFolder={onOpenAsFolder}
+              onStopScan={vi.fn()}
+            />
+          </Dialog>
+        </TooltipProvider>
+      )
+    })
+
+    act(() => {
+      findButton(host, 'Open as folder').click()
+    })
+
+    expect(onOpenAsFolder).toHaveBeenCalledTimes(1)
+    expect(onImport).not.toHaveBeenCalled()
+  })
+
+  it('keeps the open-as-folder action enabled even when no repos are selected', () => {
+    const html = renderStepMarkup({ selectedPaths: new Set(), onOpenAsFolder: vi.fn() })
+
+    // Why: the folder shortcut ignores the per-repo selection, so it must stay
+    // usable when the separate/group buttons are disabled by an empty selection.
+    expect(html).toMatch(/<button[^>]*>[^<]*Open as folder<\/button>/)
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>No, import separately<\/button>/)
+  })
+
   it('disables both import actions while scanning', () => {
     const html = renderStepMarkup({ scanInProgress: true })
 

--- a/src/renderer/src/components/sidebar/AddRepoNestedImportStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoNestedImportStep.tsx
@@ -20,6 +20,9 @@ type AddRepoNestedImportStepProps = {
   onGroupNameChange: (value: string) => void
   onSelectedPathsChange: Dispatch<SetStateAction<Set<string>>>
   onImport: (mode: 'group' | 'separate') => void
+  // Why: optional escape hatch (local scans only) — add the scanned parent as a
+  // single non-git folder project instead of importing the repos found inside it.
+  onOpenAsFolder?: () => void
   onStopScan: () => void
 }
 
@@ -32,23 +35,30 @@ export function AddRepoNestedImportStep({
   onGroupNameChange,
   onSelectedPathsChange,
   onImport,
+  onOpenAsFolder,
   onStopScan
 }: AddRepoNestedImportStepProps): React.JSX.Element {
   const folderName = getRuntimePathBasename(scan.selectedPath) || scan.selectedPath
   const groupNameInputId = useId()
-  const [pendingImportMode, setPendingImportMode] = useState<'group' | 'separate' | null>(null)
-  const showSeparateSpinner = isAdding && pendingImportMode === 'separate'
-  const showGroupSpinner = isAdding && pendingImportMode === 'group'
+  const [pendingAction, setPendingAction] = useState<'group' | 'separate' | 'folder' | null>(null)
+  const showSeparateSpinner = isAdding && pendingAction === 'separate'
+  const showGroupSpinner = isAdding && pendingAction === 'group'
+  const showFolderSpinner = isAdding && pendingAction === 'folder'
 
   useEffect(() => {
     if (!isAdding) {
-      setPendingImportMode(null)
+      setPendingAction(null)
     }
   }, [isAdding])
 
   const handleImport = (mode: 'group' | 'separate'): void => {
-    setPendingImportMode(mode)
+    setPendingAction(mode)
     onImport(mode)
+  }
+
+  const handleOpenAsFolder = (): void => {
+    setPendingAction('folder')
+    onOpenAsFolder?.()
   }
   const repoCountLabel =
     scan.repos.length === 1
@@ -137,7 +147,32 @@ export function AddRepoNestedImportStep({
             placeholder={folderName}
           />
         </div>
-        <div className="flex shrink-0 flex-wrap justify-end gap-2">
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          {onOpenAsFolder ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  onClick={handleOpenAsFolder}
+                  disabled={isAdding || scanInProgress}
+                  variant="outline"
+                  className="mr-auto"
+                >
+                  {showFolderSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                  {translate(
+                    'auto.components.sidebar.AddRepoNestedImportStep.e41565e2bb',
+                    'Open as folder'
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4} className="max-w-xs">
+                {translate(
+                  'auto.components.sidebar.AddRepoNestedImportStep.b42b7b062c',
+                  'Add {{value0}} as a single folder project without importing the repositories inside it.',
+                  { value0: folderName }
+                )}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
           <Button
             onClick={() => handleImport('separate')}
             disabled={isAdding || scanInProgress || selectedPaths.size === 0}

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
@@ -50,10 +50,13 @@ export function useAddRepoNestedImportFlow({
   setIsAdding: (isAdding: boolean) => void
 }): {
   handleImportNestedRepos: (mode: 'group' | 'separate') => Promise<void>
+  handleOpenNestedAsFolder: () => Promise<void>
   resetNestedImportFlow: () => void
   trackNestedBackAction: () => void
 } {
   const nestedImportGenRef = useRef(0)
+  const addNonGitFolder = useAppStore((s) => s.addNonGitFolder)
+  const closeModal = useAppStore((s) => s.closeModal)
 
   const resetNestedImportFlow = useCallback((): void => {
     nestedImportGenRef.current++
@@ -236,5 +239,31 @@ export function useAddRepoNestedImportFlow({
     ]
   )
 
-  return { handleImportNestedRepos, resetNestedImportFlow, trackNestedBackAction }
+  // Why: escape hatch from the nested-repo review — add the scanned parent as a
+  // single non-git folder project instead of importing each repo found inside.
+  // Gated by the caller to local scans; addNonGitFolder routes local-only.
+  const handleOpenNestedAsFolder = useCallback(async (): Promise<void> => {
+    if (!nestedScan) {
+      return
+    }
+    const gen = ++nestedImportGenRef.current
+    setIsAdding(true)
+    try {
+      const repo = await addNonGitFolder(nestedScan.selectedPath)
+      if (repo) {
+        closeModal()
+      }
+    } finally {
+      if (gen === nestedImportGenRef.current) {
+        setIsAdding(false)
+      }
+    }
+  }, [addNonGitFolder, closeModal, nestedScan, setIsAdding])
+
+  return {
+    handleImportNestedRepos,
+    handleOpenNestedAsFolder,
+    resetNestedImportFlow,
+    trackNestedBackAction
+  }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3483,7 +3483,9 @@
           "8401a7a0d0": "1 repository",
           "d4f1df62ef": "{{value0}} repositories",
           "b4263a2ac4": "Found {{value0}} in {{value1}}.",
-          "24eda6c8b2": "Scanning... {{value0}}"
+          "24eda6c8b2": "Scanning... {{value0}}",
+          "e41565e2bb": "Open as folder",
+          "b42b7b062c": "Add {{value0}} as a single folder project without importing the repositories inside it."
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "Stop scan",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3477,7 +3477,9 @@
           "8401a7a0d0": "1 repositorio",
           "d4f1df62ef": "{{value0}} repositorios",
           "b4263a2ac4": "Se encontraron {{value0}} en {{value1}}.",
-          "24eda6c8b2": "Explorando... {{value0}}"
+          "24eda6c8b2": "Explorando... {{value0}}",
+          "e41565e2bb": "Open as folder",
+          "b42b7b062c": "Add {{value0}} as a single folder project without importing the repositories inside it."
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "Detener escaneo",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3458,7 +3458,9 @@
           "8401a7a0d0": "1 個の repos",
           "d4f1df62ef": "{{value0}} 個の repos",
           "b4263a2ac4": "{{value1}} で {{value0}} が見つかりました。",
-          "24eda6c8b2": "スキャン中... {{value0}}"
+          "24eda6c8b2": "スキャン中... {{value0}}",
+          "e41565e2bb": "Open as folder",
+          "b42b7b062c": "Add {{value0}} as a single folder project without importing the repositories inside it."
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "スキャンの停止",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3458,7 +3458,9 @@
           "8401a7a0d0": "repos 1개",
           "d4f1df62ef": "repos {{value0}}개",
           "b4263a2ac4": "{{value1}}에서 {{value0}}을(를) 찾았습니다.",
-          "24eda6c8b2": "스캔 중... {{value0}}"
+          "24eda6c8b2": "스캔 중... {{value0}}",
+          "e41565e2bb": "Open as folder",
+          "b42b7b062c": "Add {{value0}} as a single folder project without importing the repositories inside it."
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "스캔 중지",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3458,7 +3458,9 @@
           "8401a7a0d0": "1 个仓库",
           "d4f1df62ef": "{{value0}} 个仓库",
           "b4263a2ac4": "在 {{value1}} 中找到 {{value0}}。",
-          "24eda6c8b2": "正在扫描... {{value0}}"
+          "24eda6c8b2": "正在扫描... {{value0}}",
+          "e41565e2bb": "Open as folder",
+          "b42b7b062c": "Add {{value0}} as a single folder project without importing the repositories inside it."
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "停止扫描",


### PR DESCRIPTION
## What

When you add a local folder that contains nested git repositories, the **"Import repositories from folder"** review only offered to import those repos — either *separately* (one project each) or *as a group*. There was no way to take the **selected parent folder itself as a single project**.

This adds an **"Open as folder"** action to that review. It adds the scanned parent as a single non-git folder project (`addNonGitFolder`) and skips the per-repo import entirely.

It also includes a small companion fix so folder projects get a sensible icon picker (see below).

## Details

**"Open as folder" action**
- New optional `onOpenAsFolder` action on `AddRepoNestedImportStep`, rendered as an outline button on the left of the footer with a tooltip explaining it.
- The button **ignores the per-repo checklist selection**, so it stays usable even when nothing is checked (unlike the import buttons).
- The handler lives in `useAddRepoNestedImportFlow` (`handleOpenNestedAsFolder`) and is **gated to local scans** in `AddRepoDialog` (`!nestedConnectionId && !isRuntimeEnvironmentActive`) — `addNonGitFolder` routes through the local provider only, so SSH/runtime scans don't show the action.

**Folder icon-picker default**
- A non-git folder repo has no GitHub remote, so the icon picker's Avatar tab (which fetches a remote avatar) is a dead end for it. `RepositoryIconPicker` now defaults folder repos to the **Icon** grid instead of Avatar.

## Tests

- Added 3 cases to `AddRepoNestedImportStep.test.tsx`: action hidden when no handler is provided, fires the handler without triggering an import, and stays enabled with an empty selection.
- `oxlint`, web `tsgo` typecheck, localization catalog/coverage, and the Add-Project test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

When importing a folder with nested git repos, you can choose “Open as folder” to add the parent as one non-git project instead of importing every nested repo. Handy when you want the outer folder as a single workspace.
