### PR TITLE
feat(sidebar): decouple groups from Group by with a Show groups toggle

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -655,6 +655,10 @@ function normalizeSortBy(sortBy: unknown): PersistedState['ui']['sortBy'] {
   return getDefaultUIState().sortBy
 }
 
+function normalizeShowGroups(showGroups: unknown): PersistedState['ui']['showGroups'] {
+  return typeof showGroups === 'boolean' ? showGroups : getDefaultUIState().showGroups
+}
+
 function normalizeProjectOrderBy(projectOrderBy: unknown): PersistedState['ui']['projectOrderBy'] {
   if (projectOrderBy === 'manual' || projectOrderBy === 'recent') {
     return projectOrderBy
@@ -4910,6 +4914,7 @@ export class Store {
       ...uiState,
       groupBy: normalizeGroupBy(this.state.ui?.groupBy),
       sortBy: normalizeSortBy(this.state.ui?.sortBy),
+      showGroups: normalizeShowGroups(this.state.ui?.showGroups),
       projectOrderBy: normalizeProjectOrderBy(this.state.ui?.projectOrderBy),
       rightSidebarTab: normalizeRightSidebarTab(this.state.ui?.rightSidebarTab),
       rightSidebarExplorerView: normalizeRightSidebarExplorerView(
@@ -4980,6 +4985,10 @@ export class Store {
       sortBy: sanitizedUpdates.sortBy
         ? normalizeSortBy(sanitizedUpdates.sortBy)
         : normalizeSortBy(this.state.ui?.sortBy),
+      showGroups:
+        sanitizedUpdates.showGroups !== undefined
+          ? normalizeShowGroups(sanitizedUpdates.showGroups)
+          : normalizeShowGroups(this.state.ui?.showGroups),
       projectOrderBy: updates.projectOrderBy
         ? normalizeProjectOrderBy(updates.projectOrderBy)
         : normalizeProjectOrderBy(this.state.ui?.projectOrderBy),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -601,6 +601,7 @@ function App(): React.JSX.Element {
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const groupBy = useAppStore((s) => s.groupBy)
   const sortBy = useAppStore((s) => s.sortBy)
+  const showGroups = useAppStore((s) => s.showGroups)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
@@ -1320,6 +1321,7 @@ function App(): React.JSX.Element {
         markdownTocPanelWidth,
         groupBy,
         sortBy,
+        showGroups,
         projectOrderBy,
         showActiveOnly: false,
         hideSleepingWorkspaces: !showSleepingWorkspaces,
@@ -1348,6 +1350,7 @@ function App(): React.JSX.Element {
     markdownTocPanelWidth,
     groupBy,
     sortBy,
+    showGroups,
     projectOrderBy,
     showSleepingWorkspaces,
     hideDefaultBranchWorkspace,

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
@@ -47,6 +48,9 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const setSortBy = useAppStore((s) => s.setSortBy)
   const groupBy = useAppStore((s) => s.groupBy)
   const setGroupBy = useAppStore((s) => s.setGroupBy)
+  const showGroups = useAppStore((s) => s.showGroups)
+  const setShowGroups = useAppStore((s) => s.setShowGroups)
+  const hasGroups = useAppStore((s) => s.projectGroups.length > 0)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const setProjectOrderBy = useAppStore((s) => s.setProjectOrderBy)
 
@@ -170,6 +174,20 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
         <div className="px-2 pt-0.5 pb-1">
           <SidebarGroupByToggle groupBy={groupBy} setGroupBy={setGroupBy} />
         </div>
+        {/* Why: groups are a persistent structure, so let them frame any lens —
+            only surface the control when the user actually has groups. */}
+        {hasGroups && (
+          <DropdownMenuCheckboxItem
+            checked={showGroups}
+            onCheckedChange={(checked) => setShowGroups(checked === true)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            {translate(
+              'auto.components.sidebar.SidebarWorkspaceOptionsMenu.showGroups',
+              'Show groups'
+            )}
+          </DropdownMenuCheckboxItem>
+        )}
 
         <DropdownMenuSeparator />
         <DropdownMenuSub>

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -4990,6 +4990,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const sortBy = useAppStore((s) => s.sortBy)
   const setSortBy = useAppStore((s) => s.setSortBy)
+  const showGroups = useAppStore((s) => s.showGroups)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
@@ -5620,7 +5621,8 @@ const WorktreeList = React.memo(function WorktreeList({
         pendingCreations,
         projectGrouping,
         visibleFolderWorkspacesForRows,
-        hostLabelById
+        hostLabelById,
+        showGroups
       ),
     [
       groupBy,
@@ -5641,7 +5643,8 @@ const WorktreeList = React.memo(function WorktreeList({
       importedWorktreesByRepo,
       newExternalWorktreesInboxByRepo,
       pendingCreations,
-      hostLabelById
+      hostLabelById,
+      showGroups
     ]
   )
   const orderedHostOptions = useMemo(

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -3075,3 +3075,81 @@ describe('buildRows pending creations', () => {
     expect(rows[0]).toMatchObject({ type: 'pending-creation', creationId: 'c1' })
   })
 })
+
+describe('buildRows show groups in the flat (none) view', () => {
+  const group: ProjectGroup = {
+    id: 'group-1',
+    name: 'Platform',
+    parentPath: '/platform',
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1
+  }
+  const groupedRepo: Repo = { ...repo, id: 'repo-grouped', projectGroupId: group.id }
+  const looseRepo: Repo = { ...repo, id: 'repo-loose', projectGroupId: undefined }
+  const groupedWorktree: Worktree = { ...worktree, id: 'wt-grouped', repoId: groupedRepo.id }
+  const looseWorktree: Worktree = { ...worktree, id: 'wt-loose', repoId: looseRepo.id }
+  const repoMap = new Map([
+    [groupedRepo.id, groupedRepo],
+    [looseRepo.id, looseRepo]
+  ])
+
+  it('frames the flat list with group folders and a trailing Ungrouped folder', () => {
+    // showGroups defaults to true, so passing projectGroups is enough.
+    const rows = buildRows(
+      'none',
+      [groupedWorktree, looseWorktree],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map(),
+      false,
+      undefined,
+      [group]
+    )
+
+    expect(rows).toMatchObject([
+      { type: 'header', key: 'project-group:group-1', label: 'Platform' },
+      { type: 'item', worktree: { id: 'wt-grouped' } },
+      { type: 'header', label: 'Ungrouped' },
+      { type: 'item', worktree: { id: 'wt-loose' } }
+    ])
+  })
+
+  it('renders a single flat list when show groups is off', () => {
+    const rows = buildRows(
+      'none',
+      [groupedWorktree, looseWorktree],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map(),
+      false,
+      undefined,
+      [group],
+      new Set(),
+      new Map(),
+      new Map(),
+      [],
+      undefined,
+      [],
+      undefined,
+      false // showGroups
+    )
+
+    expect(rows[0]).toMatchObject({ type: 'header', key: 'all' })
+    expect(rows.filter((r) => r.type === 'header')).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -807,6 +807,114 @@ function sortProjectEntries(
  * Build the flat row list consumed by the virtualizer.
  * Extracted here to keep WorktreeList.tsx under the line-count lint limit.
  */
+/**
+ * Render group (folder) headers with a flat worktree list under each, for views
+ * that have no repo headers of their own (the 'none' lens with Show groups on).
+ * Mirrors the project-group hierarchy + collapse behavior of the repo lens, but
+ * lists each group's worktrees directly instead of nesting them under repos.
+ */
+function appendFlatGroupedWorktrees(args: {
+  result: Row[]
+  worktrees: Worktree[]
+  projectGroups: readonly ProjectGroup[]
+  repoMap: Map<string, Repo>
+  lineageById: Record<string, WorktreeLineage>
+  worktreeMap: Map<string, Worktree>
+  collapsedGroups: Set<string>
+  nestLineage: boolean
+}): void {
+  const { result, worktrees, projectGroups, repoMap, lineageById, worktreeMap, collapsedGroups } =
+    args
+  const nestLineage = args.nestLineage
+
+  const worktreesByGroupId = new Map<string | null, Worktree[]>()
+  for (const worktree of worktrees) {
+    const groupId = repoMap.get(worktree.repoId)?.projectGroupId ?? null
+    const list = worktreesByGroupId.get(groupId) ?? []
+    list.push(worktree)
+    worktreesByGroupId.set(groupId, list)
+  }
+
+  const projectGroupsById = new Map(projectGroups.map((group) => [group.id, group]))
+  const childGroupsByParentId = new Map<string | null, ProjectGroup[]>()
+  for (const group of projectGroups) {
+    const parentId =
+      group.parentGroupId && projectGroupsById.has(group.parentGroupId) ? group.parentGroupId : null
+    const children = childGroupsByParentId.get(parentId) ?? []
+    children.push(group)
+    childGroupsByParentId.set(parentId, children)
+  }
+  for (const children of childGroupsByParentId.values()) {
+    children.sort((a, b) => a.tabOrder - b.tabOrder || a.name.localeCompare(b.name))
+  }
+
+  const subtreeCount = (groupId: string): number => {
+    const direct = worktreesByGroupId.get(groupId)?.length ?? 0
+    const children = childGroupsByParentId.get(groupId) ?? []
+    return children.reduce((count, child) => count + subtreeCount(child.id), direct)
+  }
+
+  const emitGroup = (group: ProjectGroup, depth: number): void => {
+    const key = getProjectGroupHeaderKey(group.id)
+    result.push({
+      type: 'header',
+      key,
+      label: group.name,
+      count: subtreeCount(group.id),
+      tone: PROJECT_GROUP_META.tone,
+      icon: PROJECT_GROUP_META.icon,
+      projectGroup: group,
+      projectGroupDepth: depth
+    })
+    if (collapsedGroups.has(key)) {
+      return
+    }
+    appendWorktreeRows(result, worktreesByGroupId.get(group.id) ?? [], repoMap, lineageById, worktreeMap, {
+      nestLineage,
+      collapsedGroups,
+      groupDepth: depth + 1,
+      sectionKey: key
+    })
+    for (const child of childGroupsByParentId.get(group.id) ?? []) {
+      emitGroup(child, depth + 1)
+    }
+  }
+
+  for (const group of childGroupsByParentId.get(null) ?? []) {
+    emitGroup(group, 0)
+  }
+
+  // Why: repos with no group (or whose group metadata hasn't loaded) must not
+  // vanish — collect them under a trailing "Ungrouped" folder.
+  const ungrouped: Worktree[] = [...(worktreesByGroupId.get(null) ?? [])]
+  for (const [groupId, list] of worktreesByGroupId) {
+    if (groupId !== null && !projectGroupsById.has(groupId)) {
+      ungrouped.push(...list)
+    }
+  }
+  if (ungrouped.length > 0) {
+    const key = getProjectGroupHeaderKey(null)
+    result.push({
+      type: 'header',
+      key,
+      label: translate('auto.components.sidebar.worktree.list.groups.ungrouped', 'Ungrouped'),
+      count: ungrouped.length,
+      tone: PROJECT_GROUP_META.tone,
+      icon: PROJECT_GROUP_META.icon,
+      projectGroup: { id: null, name: 'Ungrouped', tabOrder: Number.MAX_SAFE_INTEGER },
+      projectGroupDepth: 0
+    })
+    if (!collapsedGroups.has(key)) {
+      appendWorktreeRows(result, ungrouped, repoMap, lineageById, worktreeMap, {
+        nestLineage,
+        collapsedGroups,
+        groupDepth: 1,
+        sectionKey: key
+      })
+    }
+  }
+}
+
 export function buildRows(
   groupBy: WorktreeGroupBy,
   worktrees: Worktree[],
@@ -832,7 +940,11 @@ export function buildRows(
   pendingCreations: readonly PendingCreationRef[] = [],
   projectGrouping?: ProjectGroupingModel,
   folderWorkspaces: readonly FolderWorkspace[] = [],
-  hostLabelById?: ReadonlyMap<string, string>
+  hostLabelById?: ReadonlyMap<string, string>,
+  // Why: groups (folders of projects) are a persistent organizational structure,
+  // not just the 'repo' lens. When on (default), they frame the sidebar in the
+  // flat ('none') view too and wrap the repo lens; when off they collapse away.
+  showGroups = true
 ): Row[] {
   const result: Row[] = []
   const projectIndex = buildProjectGroupingIndex(projectGrouping)
@@ -870,23 +982,39 @@ export function buildRows(
   )
 
   if (groupBy === 'none') {
-    if (worktrees.length > 0) {
-      result.push({
-        type: 'header',
-        key: ALL_GROUP_KEY,
-        label: ALL_GROUP_META.label,
-        count: worktrees.length,
-        tone: ALL_GROUP_META.tone,
-        icon: ALL_GROUP_META.icon
+    if (worktrees.length === 0) {
+      return result
+    }
+    // Why: groups are a persistent structure, so when Show groups is on they
+    // frame even the flat list — each group folder with its worktrees inside.
+    if (showGroups && projectGroups.length > 0) {
+      appendFlatGroupedWorktrees({
+        result,
+        worktrees,
+        projectGroups,
+        repoMap,
+        lineageById,
+        worktreeMap,
+        collapsedGroups,
+        nestLineage
       })
-      if (!collapsedGroups.has(ALL_GROUP_KEY)) {
-        appendWorktreeRows(result, worktrees, repoMap, lineageById, worktreeMap, {
-          nestLineage,
-          collapsedGroups,
-          groupDepth: 0,
-          sectionKey: ALL_GROUP_KEY
-        })
-      }
+      return result
+    }
+    result.push({
+      type: 'header',
+      key: ALL_GROUP_KEY,
+      label: ALL_GROUP_META.label,
+      count: worktrees.length,
+      tone: ALL_GROUP_META.tone,
+      icon: ALL_GROUP_META.icon
+    })
+    if (!collapsedGroups.has(ALL_GROUP_KEY)) {
+      appendWorktreeRows(result, worktrees, repoMap, lineageById, worktreeMap, {
+        nestLineage,
+        collapsedGroups,
+        groupDepth: 0,
+        sectionKey: ALL_GROUP_KEY
+      })
     }
     return result
   }
@@ -1135,7 +1263,9 @@ export function buildRows(
     }
   }
 
-  if (groupBy !== 'repo' || projectGroups.length === 0) {
+  // Why: with Show groups off, the repo lens drops its group-folder wrapper and
+  // renders projects as a flat list of repo headers.
+  if (groupBy !== 'repo' || projectGroups.length === 0 || !showGroups) {
     appendOrderedGroups(
       groupBy === 'repo' ? withRepoSectionDisplayLabels(orderedGroups) : orderedGroups
     )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3868,7 +3868,8 @@
           "2d74665a56": "Ports",
           "65a9820bd1": "Agent statuses",
           "219ebf1961": "Branch name",
-          "folderPathIdentity": "Branch / folder path"
+          "folderPathIdentity": "Branch / folder path",
+          "showGroups": "Show groups"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "Connecting...",
@@ -4276,7 +4277,8 @@
               "682ed5d551": "Closed",
               "7c2f009786": "In progress",
               "6798dc7c94": "In review",
-              "5076efc3d2": "Done"
+              "5076efc3d2": "Done",
+              "ungrouped": "Ungrouped"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3854,7 +3854,8 @@
           "2d74665a56": "Puertos",
           "65a9820bd1": "Estados del agente",
           "219ebf1961": "Nombre de rama",
-          "folderPathIdentity": "Rama / ruta de carpeta"
+          "folderPathIdentity": "Rama / ruta de carpeta",
+          "showGroups": "Show groups"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "Conectando...",
@@ -4262,7 +4263,8 @@
               "682ed5d551": "Cerrado",
               "7c2f009786": "En curso",
               "6798dc7c94": "En revisión",
-              "5076efc3d2": "Hecho"
+              "5076efc3d2": "Hecho",
+              "ungrouped": "Ungrouped"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3835,7 +3835,8 @@
           "65a9820bd1": "Agent ステータス",
           "219ebf1961": "ブランチ名",
           "automation": "自動化",
-          "folderPathIdentity": "ブランチ / フォルダパス"
+          "folderPathIdentity": "ブランチ / フォルダパス",
+          "showGroups": "Show groups"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "接続中...",
@@ -4243,7 +4244,8 @@
               "682ed5d551": "クローズ",
               "7c2f009786": "進行中",
               "6798dc7c94": "レビュー中",
-              "5076efc3d2": "完了"
+              "5076efc3d2": "完了",
+              "ungrouped": "Ungrouped"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3835,7 +3835,8 @@
           "65a9820bd1": "Agent 상태",
           "219ebf1961": "브랜치 이름",
           "automation": "자동화",
-          "folderPathIdentity": "브랜치 / 폴더 경로"
+          "folderPathIdentity": "브랜치 / 폴더 경로",
+          "showGroups": "Show groups"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "연결 중...",
@@ -4243,7 +4244,8 @@
               "682ed5d551": "닫힘",
               "7c2f009786": "진행중",
               "6798dc7c94": "리뷰 중",
-              "5076efc3d2": "완료"
+              "5076efc3d2": "완료",
+              "ungrouped": "Ungrouped"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3835,7 +3835,8 @@
           "65a9820bd1": "智能体状态",
           "219ebf1961": "分支名称",
           "automation": "自动化",
-          "folderPathIdentity": "分支 / 文件夹路径"
+          "folderPathIdentity": "分支 / 文件夹路径",
+          "showGroups": "Show groups"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "正在连接...",
@@ -4243,7 +4244,8 @@
               "682ed5d551": "已关闭",
               "7c2f009786": "进行中",
               "6798dc7c94": "评审中",
-              "5076efc3d2": "完成"
+              "5076efc3d2": "完成",
+              "ungrouped": "Ungrouped"
             }
           }
         },

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -42,6 +42,7 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     markdownTocPanelWidth: 240,
     groupBy: 'repo',
     sortBy: 'name',
+    showGroups: true,
     projectOrderBy: 'manual',
     showActiveOnly: false,
     hideSleepingWorkspaces: DEFAULT_HIDE_SLEEPING_WORKSPACES,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -786,6 +786,8 @@ export type UISlice = {
   setGroupBy: (g: UISlice['groupBy']) => void
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   setSortBy: (s: UISlice['sortBy']) => void
+  showGroups: boolean
+  setShowGroups: (v: boolean) => void
   projectOrderBy: ProjectOrderBy
   setProjectOrderBy: (p: ProjectOrderBy) => void
   showActiveOnly: boolean
@@ -1888,6 +1890,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   sortBy: 'recent',
   setSortBy: (s) => set({ sortBy: s }),
 
+  // Why: groups frame the sidebar by default; the bare set persists via the
+  // debounced window.api.ui.set writer in App.tsx, like setSortBy.
+  showGroups: true,
+  setShowGroups: (v) => set({ showGroups: v }),
+
   // Why: like setSortBy, this is a bare set — it persists only via the
   // debounced window.api.ui.set writer in App.tsx, not on its own.
   projectOrderBy: 'manual',
@@ -2259,6 +2266,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         rightSidebarExplorerView: rightSidebarRoute.rightSidebarExplorerView,
         groupBy: (ui.groupBy as UISlice['groupBy'] | 'parent') === 'parent' ? 'repo' : ui.groupBy,
         sortBy,
+        showGroups: ui.showGroups,
         // Why: main-process getUI() already normalized this to a valid value
         // (defaulting to 'manual'); read it through without migrating sortBy.
         projectOrderBy: ui.projectOrderBy,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -453,6 +453,7 @@ export function getDefaultUIState(): PersistedUIState {
     markdownTocPanelWidth: 240,
     groupBy: 'repo',
     sortBy: 'recent',
+    showGroups: true,
     projectOrderBy: 'manual',
     showActiveOnly: false,
     hideSleepingWorkspaces: DEFAULT_HIDE_SLEEPING_WORKSPACES,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3120,6 +3120,10 @@ export type PersistedUIState = {
   markdownTocPanelWidth?: number
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
+  /** Whether group (folder) headers frame the sidebar. On (default) shows group
+   *  folders even in the flat 'none' view and wraps the repo lens; off collapses
+   *  them so the repo lens is a flat list and 'none' is a single flat list. */
+  showGroups: boolean
   /** Project header ordering in `groupBy: 'repo'`, independent of workspace
    *  `sortBy`. 'manual' (default) uses the persisted repo order and enables
    *  header drag; 'recent' orders by each project's most recent visible


### PR DESCRIPTION
## What

**Groups** (folders of projects) only rendered in the **Project** lens. Switching **Group by → None / Status / PR** threw the folder structure away entirely — so a deliberate organizational hierarchy vanished the moment you changed how worktrees were arranged.

This decouples groups from the "Group by" lens with a persisted **Show groups** toggle (default **On**), surfaced in the workspace options menu only when groups exist:

- **None + Show groups on:** group folders frame the flat list, each with its worktrees inside, plus a trailing **Ungrouped** folder for repos with no group.
- **Project + Show groups off:** repo headers render flat, without the group-folder wrapper.
- **Project + Show groups on:** unchanged from today (group → repo → worktrees).

## Why — and why a toggle

Groups are a *persistent organizational structure*, not a property of one view. This mirrors a decoupling the project already made deliberately: `docs/reference/project-ordering-mode.md` split **project header order** (`projectOrderBy`) out from **workspace sort** (`sortBy`) for exactly this reason — "header order is currently *coupled* to workspace sorting instead of having its own user choice." Groups carry their own `ProjectGroup.tabOrder` and are treated as first-class structure.

The toggle (rather than always-on) is deliberate: it preserves the **flat firehose** that `None` gives today (show everything, no hierarchy), so both behaviors stay reachable. Default On so existing Project-view behavior is unchanged.

## Scope / cross-cutting

- Renderer + one main-process normalizer (`normalizeShowGroups`); no new IPC surface (rides the existing `ui.set` persistence path, like `sortBy`/`projectOrderBy`).
- Cross-platform, SSH/remote, agent- and provider-neutral: pure row construction + UI state.
- Performance: group bucketing is one pass over the already-sorted worktrees in the `none` lens; the repo lens is unchanged when on.

## Deliberately out of scope (follow-ups)

- **Status / PR** views don't yet wrap groups (that's a 2-level outer/inner nesting change).
- Group headers in the `none` lens render as plain folder headers; the full group context menu (rename/delete) stays gated to the Project lens for now.

## Tests

`worktree-list-groups.test.ts` covers: None + Show groups builds group folders + a trailing Ungrouped folder with the right worktrees; Show groups off falls back to the single flat `all` list. Full `pnpm lint`, `tsgo` typecheck (node + web), and localization catalog/coverage pass; strings added across en/es/ja/ko/zh.

## Visual

UI change (Show groups toggle + grouped None view) — screenshots to attach to the PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6903">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Project groups (folders of projects) no longer disappear when you change “Group by.” A separate “Show groups” toggle keeps your folder hierarchy visible across None, Status, and PR views.
