### PR TITLE
feat(sidebar): draggable projects and groups in "project" group by

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
@@ -86,8 +86,7 @@ vi.mock('./project-header-drag', () => ({
   useRepoHeaderDrag: () => ({
     state: { draggingRepoId: null, dropIndicatorY: null },
     onHandlePointerDown: vi.fn()
-  }),
-  isRepoHeaderActionTarget: () => false
+  })
 }))
 
 vi.mock('@/components/ui/hover-card', () => ({

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -4105,6 +4105,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       groupIdForHeader ? (groupHeaderParent ?? '') : undefined
                     }
                     data-project-group-sibling-index={groupSiblingIndex}
+                    data-project-group-project-count={
+                      groupIdForHeader !== undefined
+                        ? (sidebarRepoHeaderIdsByBucket.get(`group:${groupIdForHeader}`)?.length ??
+                          0)
+                        : undefined
+                    }
                     data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
                     data-workspace-status={headerWorkspaceStatus ?? undefined}
                     data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -4123,9 +4123,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
                     data-workspace-status={headerWorkspaceStatus ?? undefined}
                     data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
+                    data-repo-header-drag-handle={isDraggableRepoHeader ? '' : undefined}
+                    data-group-header-drag-handle={isDraggableGroupHeader ? '' : undefined}
                     className={cn(
                       'group relative flex h-7 w-full items-center gap-1.5 pr-2 text-left transition-all',
                       'cursor-pointer',
+                      // Why: the whole header row is the drag handle (like the
+                      // worktree cards), so show the grab affordance across the
+                      // row; action buttons opt out via data-repo-header-action.
+                      (isDraggableRepoHeader || isDraggableGroupHeader) &&
+                        'select-none hover:cursor-grab active:cursor-grabbing',
                       highlightedRevealRowKey === row.key &&
                         'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/50',
                       isDraggingThis &&
@@ -4160,6 +4167,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         ? (event) => handleWorkspaceStatusDrop(event, headerWorkspaceStatus)
                         : undefined
                     }
+                    onPointerDown={
+                      isDraggableRepoHeader && projectIdForHeader
+                        ? (event) => repoDrag.onHandlePointerDown(event, projectIdForHeader)
+                        : isDraggableGroupHeader && groupIdForHeader
+                          ? (event) => groupDrag.onHandlePointerDown(event, groupIdForHeader)
+                          : undefined
+                    }
                     onClick={(event) => {
                       if (shouldIgnoreRepoHeaderToggle(event)) {
                         return
@@ -4178,21 +4192,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   >
                     {row.icon ? (
                       <div
-                        data-repo-header-drag-handle={isDraggableRepoHeader ? '' : undefined}
-                        data-group-header-drag-handle={isDraggableGroupHeader ? '' : undefined}
                         className={cn(
                           'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
-                          repoHeaderColor ? 'text-muted-foreground' : row.tone,
-                          (isDraggableRepoHeader || isDraggableGroupHeader) &&
-                            'hover:cursor-grab active:cursor-grabbing'
+                          repoHeaderColor ? 'text-muted-foreground' : row.tone
                         )}
-                        onPointerDown={
-                          isDraggableRepoHeader && projectIdForHeader
-                            ? (event) => repoDrag.onHandlePointerDown(event, projectIdForHeader)
-                            : isDraggableGroupHeader && groupIdForHeader
-                              ? (event) => groupDrag.onHandlePointerDown(event, groupIdForHeader)
-                              : undefined
-                        }
                       >
                         {row.repo ? (
                           <RepoIconGlyph

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1579,15 +1579,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     }
     return map
   }, [sidebarRepoHeaderIdsByBucket])
-  // Why: matches the drag-session guard in createProjectHeaderDragSession, which
-  // arms whenever the total across all buckets is >1, not just the source bucket.
-  const totalRepoHeaderCount = useMemo(() => {
-    let total = 0
-    for (const ids of sidebarRepoHeaderIdsByBucket.values()) {
-      total += ids.length
-    }
-    return total
-  }, [sidebarRepoHeaderIdsByBucket])
+  // Why: count ALL projects (including those hidden inside collapsed groups),
+  // not just visible headers, so a project stays draggable when other groups
+  // are collapsed. Matches the createProjectHeaderDragSession arm guard.
+  const totalRepoHeaderCount = allRepoIds.length
   const projectGroupsById = useMemo(
     () => new Map(projectGroups.map((group) => [group.id, group])),
     [projectGroups]
@@ -1632,6 +1627,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     onCommitGroupOrder: commitGroupOrder,
     getScrollContainer: () => scrollRef.current
   })
+  // Project and group drag are mutually exclusive, so one shared drop indicator
+  // (the worktree pill) renders for whichever header drag is active.
+  const headerDropIndicatorY = !canReorderRepoHeaders
+    ? null
+    : repoDrag.state.draggingRepoId !== null
+      ? // Dropping into a collapsed/empty group highlights the group instead of
+        // drawing a line, so suppress the pill in that case.
+        repoDrag.state.dropIntoGroupId !== null
+        ? null
+        : repoDrag.state.dropIndicatorY
+      : groupDrag.state.draggingGroupId !== null
+        ? groupDrag.state.dropIndicatorY
+        : null
   const [primaryActiveWorktreeRow, setPrimaryActiveWorktreeRow] = useState<{
     worktreeId: string
     rowKey: string
@@ -3877,26 +3885,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           className="relative w-full"
           style={{ height: `${virtualizer.getTotalSize()}px` }}
         >
-          {canReorderRepoHeaders &&
-          repoDrag.state.draggingRepoId !== null &&
-          repoDrag.state.dropIndicatorY !== null ? (
+          {headerDropIndicatorY !== null ? (
+            // Why z-30: the sticky pinned header is z-20, so a lower indicator
+            // renders behind it when the drop slot is at the top while scrolled.
+            // Same dot–bar–dot pill the worktree drag uses, for a unified look.
             <div
               role="presentation"
-              // Why z-30 (not z-10): the sticky pinned header is z-20, so a
-              // lower indicator renders behind it whenever the drop slot is at
-              // the top while scrolled. Match the worktree indicator's tier.
-              className="pointer-events-none absolute left-2 right-2 z-30 border-t border-dashed border-muted-foreground/70"
-              style={{ top: `${repoDrag.state.dropIndicatorY}px` }}
-            />
-          ) : null}
-          {canReorderRepoHeaders &&
-          groupDrag.state.draggingGroupId !== null &&
-          groupDrag.state.dropIndicatorY !== null ? (
-            <div
-              role="presentation"
-              className="pointer-events-none absolute left-2 right-2 z-30 border-t border-dashed border-muted-foreground/70"
-              style={{ top: `${groupDrag.state.dropIndicatorY}px` }}
-            />
+              className="pointer-events-none absolute left-3 right-2 z-30 flex h-3 -translate-y-1/2 items-center"
+              style={{ top: `${headerDropIndicatorY}px` }}
+            >
+              <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
+              <span className="h-0.5 flex-1 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
+              <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
+            </div>
           ) : null}
           {hostDrag.state.draggingHostId !== null && hostDrag.state.dropIndicatorY !== null ? (
             <div
@@ -4027,6 +4028,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 canReorderRepoHeaders &&
                 groupDrag.state.draggingGroupId !== null &&
                 groupDrag.state.draggingGroupId === groupIdForHeader
+              const isDropIntoGroupTarget =
+                canReorderRepoHeaders &&
+                groupIdForHeader !== undefined &&
+                repoDrag.state.dropIntoGroupId === groupIdForHeader
               const headerWorkspaceStatus =
                 groupBy === 'workspace-status'
                   ? getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses)
@@ -4135,10 +4140,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         'select-none hover:cursor-grab active:cursor-grabbing',
                       highlightedRevealRowKey === row.key &&
                         'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/50',
-                      isDraggingThis &&
-                        'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
-                      isDraggingThisGroup &&
-                        'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
+                      // Why: while dragging, the floating clone is the visible
+                      // affordance, so hide the source row (matches worktree drag).
+                      (isDraggingThis || isDraggingThisGroup) && 'opacity-0 pointer-events-none',
+                      // Highlight a collapsed/empty group as the drop target when
+                      // a project is dropped into it (instead of a drop line).
+                      isDropIntoGroupTarget &&
+                        'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/40',
                       headerWorkspaceStatus &&
                         dragOverStatus === headerWorkspaceStatus &&
                         'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/40',

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -135,6 +135,7 @@ import {
 } from '@/lib/scroll-to-current-workspace-status'
 import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
 import { computeHeaderDragRowShifts } from './header-drag-row-shifts'
+import { resolveHeaderDragBlockUnits } from './header-drag-block-units'
 import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
 import { useGroupHeaderDrag } from './group-header-drag'
 import { getSiblingGroupIdsByParent } from './group-header-drop'
@@ -985,101 +986,17 @@ function computeHeaderDragRowOffsets(args: {
   renderRows: readonly RenderRow[]
   virtualItems: readonly { index: number; start: number; size: number }[]
 }): { offsets: Map<string, number>; blockKeys: Set<string> } | null {
-  if (args.draggingRepoId === null && args.draggingGroupId === null) {
+  const result = resolveHeaderDragBlockUnits({
+    renderRows: args.renderRows,
+    virtualItems: args.virtualItems,
+    draggingRepoId: args.draggingRepoId,
+    draggingGroupId: args.draggingGroupId,
+    getRowKey: getRenderRowKey
+  })
+  if (result === null) {
     return null
   }
-  const isGroup = args.draggingGroupId !== null
-  let headerIndex = -1
-  for (let i = 0; i < args.renderRows.length; i++) {
-    const row = args.renderRows[i]!
-    if (row.type !== 'header') {
-      continue
-    }
-    if (
-      isGroup ? row.projectGroup?.id === args.draggingGroupId : row.repo?.id === args.draggingRepoId
-    ) {
-      headerIndex = i
-      break
-    }
-  }
-  if (headerIndex === -1) {
-    return null
-  }
-  const headerRow = args.renderRows[headerIndex]!
-  const draggedDepth = headerRow.type === 'header' ? (headerRow.projectGroupDepth ?? 0) : 0
-  // A project block ends at the next header; a group block extends through its
-  // nested rows until a header at the same or shallower group depth.
-  let endIndex = args.renderRows.length
-  for (let i = headerIndex + 1; i < args.renderRows.length; i++) {
-    const row = args.renderRows[i]!
-    if (row.type !== 'header') {
-      continue
-    }
-    if (!isGroup || (row.projectGroupDepth ?? 0) <= draggedDepth) {
-      endIndex = i
-      break
-    }
-  }
-  const startByIndex = new Map<number, number>()
-  const sizeByIndex = new Map<number, number>()
-  for (const item of args.virtualItems) {
-    startByIndex.set(item.index, item.start)
-    sizeByIndex.set(item.index, item.size)
-  }
-  const blockTop = startByIndex.get(headerIndex)
-  if (blockTop === undefined) {
-    return null
-  }
-  let blockBottom = startByIndex.get(endIndex)
-  if (blockBottom === undefined) {
-    let sum = 0
-    for (let i = headerIndex; i < endIndex; i++) {
-      sum += sizeByIndex.get(i) ?? 0
-    }
-    blockBottom = blockTop + sum
-  }
-  const blockKeys = new Set<string>()
-  for (let i = headerIndex; i < endIndex; i++) {
-    blockKeys.add(getRenderRowKey(args.renderRows[i]!))
-  }
-  // Segment the visible rows into movable units (whole blocks) so a block's
-  // children always shift with their header. Project drag treats every header
-  // (project AND group) as its own unit, so the list reflows flatly — group
-  // dividers slide up with everything else, leaving no overlap. Group drag
-  // moves sibling-group blocks (their whole subtree, nested headers included).
-  const startsUnit = (row: RenderRow): boolean =>
-    row.type === 'header' &&
-    (isGroup
-      ? row.projectGroup != null &&
-        row.projectGroup.id !== null &&
-        (row.projectGroupDepth ?? 0) === draggedDepth
-      : true)
-  const continuesUnit = (row: RenderRow): boolean =>
-    isGroup && row.type === 'header' && (row.projectGroupDepth ?? 0) > draggedDepth
-  const units: { headerTop: number; rowKeys: string[] }[] = []
-  let current: { headerTop: number; rowKeys: string[] } | null = null
-  const flush = (): void => {
-    if (current && current.rowKeys.length > 0) {
-      units.push(current)
-    }
-    current = null
-  }
-  for (let i = 0; i < args.renderRows.length; i++) {
-    const row = args.renderRows[i]!
-    const key = getRenderRowKey(row)
-    if (startsUnit(row)) {
-      flush()
-      const top = startByIndex.get(i)
-      current = top === undefined ? null : { headerTop: top, rowKeys: [key] }
-    } else if (row.type === 'header' && !continuesUnit(row)) {
-      // A header that is not part of the current block (e.g. a group header
-      // during project drag) stays put and closes the open unit.
-      flush()
-    } else if (current) {
-      current.rowKeys.push(key)
-    }
-  }
-  flush()
+  const { blockKeys, units, blockTop, blockBottom } = result
   const offsets =
     args.dropY === null
       ? new Map<string, number>()

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -135,7 +135,10 @@ import {
 } from '@/lib/scroll-to-current-workspace-status'
 import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
 import { computeHeaderDragRowShifts } from './header-drag-row-shifts'
-import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
+import {
+  getProjectHeaderDragBucketKey,
+  getSidebarOrderedRepoHeaderIdsByBucket
+} from './project-header-drop'
 import { useGroupHeaderDrag } from './group-header-drag'
 import { getSiblingGroupIdsByParent } from './group-header-drop'
 import {
@@ -982,10 +985,14 @@ function computeHeaderDragRowOffsets(args: {
   draggingRepoId: string | null
   draggingGroupId: string | null
   dropY: number | null
+  // Gap-opening is only well-defined for same-bucket reorders and group
+  // reorders. Cross-group project moves still hide the source block, but skip
+  // the reflow (group dividers make a uniform shift overlap).
+  allowGap: boolean
   renderRows: readonly RenderRow[]
   virtualItems: readonly { index: number; start: number; size: number }[]
 }): { offsets: Map<string, number>; blockKeys: Set<string> } | null {
-  if (args.dropY === null || (args.draggingRepoId === null && args.draggingGroupId === null)) {
+  if (args.draggingRepoId === null && args.draggingGroupId === null) {
     return null
   }
   const isGroup = args.draggingGroupId !== null
@@ -1079,16 +1086,17 @@ function computeHeaderDragRowOffsets(args: {
     }
   }
   flush()
-  return {
-    offsets: computeHeaderDragRowShifts({
-      units,
-      blockKeys,
-      blockTop,
-      blockBottom,
-      dropY: args.dropY
-    }),
-    blockKeys
-  }
+  const offsets =
+    args.dropY !== null && args.allowGap
+      ? computeHeaderDragRowShifts({
+          units,
+          blockKeys,
+          blockTop,
+          blockBottom,
+          dropY: args.dropY
+        })
+      : new Map<string, number>()
+  return { offsets, blockKeys }
 }
 
 function getPointerDropStatusTarget(args: {
@@ -2400,12 +2408,25 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const activeRenderRowKeys = useMemo(() => new Set(renderRows.map(getRenderRowKey)), [renderRows])
   const totalSize = virtualizer.getTotalSize()
   const virtualItems = virtualizer.getVirtualItems()
-  // Gap-opening offsets for an active header reorder drag (suppressed for
-  // drop-into-group, which highlights instead of showing a drop line).
+  // A cross-group project move can't gap-open cleanly (group dividers stay
+  // fixed, so a uniform shift overlaps them) — hide the source block but skip
+  // the reflow there. Same-bucket reorders and group reorders gap-open.
+  const draggedProjectBucket =
+    repoDrag.state.draggingRepoId !== null
+      ? getProjectHeaderDragBucketKey(
+          repoMap.get(repoDrag.state.draggingRepoId) ?? { projectGroupId: null }
+        )
+      : null
+  const isCrossGroupProjectMove =
+    draggedProjectBucket !== null &&
+    repoDrag.state.targetBucketKey !== null &&
+    repoDrag.state.targetBucketKey !== draggedProjectBucket
+  // Gap-opening offsets for an active header reorder drag.
   const headerDragShift = computeHeaderDragRowOffsets({
     draggingRepoId: canReorderRepoHeaders ? repoDrag.state.draggingRepoId : null,
     draggingGroupId: canReorderRepoHeaders ? groupDrag.state.draggingGroupId : null,
     dropY: headerDropIndicatorY,
+    allowGap: !isCrossGroupProjectMove,
     renderRows,
     virtualItems
   })
@@ -4111,7 +4132,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             }
 
             if (row.type === 'header') {
-              const isActiveStickyHeader = activeStickyHeaderIndexRef.current === vItem.index
+              // Why: a sticky (pinned) header is position:sticky with no
+              // transform, so it can't receive the gap-opening offset — it would
+              // stay pinned while its block's children slide. Drop stickiness
+              // during a header reorder drag so the whole block moves together.
+              const isActiveStickyHeader =
+                activeStickyHeaderIndexRef.current === vItem.index && !isHeaderReorderDragging
               // Why: when a host card is pinned, the group tier pins flush
               // beneath it instead of at the viewport top.
               const stickyTopClass =

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -135,6 +135,8 @@ import {
 } from '@/lib/scroll-to-current-workspace-status'
 import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
 import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
+import { useGroupHeaderDrag } from './group-header-drag'
+import { getSiblingGroupIdsByParent } from './group-header-drop'
 import {
   buildManualOrderUpdatesForGroupDrop,
   buildManualOrderUpdatesForVisibleGroups,
@@ -1385,6 +1387,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const settings = useAppStore((s) => s.settings)
   const newCardStyle = settings?.experimentalNewWorktreeCardStyle === true
   const reorderRepos = useAppStore((s) => s.reorderRepos)
+  const updateProjectGroup = useAppStore((s) => s.updateProjectGroup)
   const folderBackedProjectGroupIds = useMemo(
     () =>
       new Set(
@@ -1576,6 +1579,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     }
     return map
   }, [sidebarRepoHeaderIdsByBucket])
+  const projectGroupsById = useMemo(
+    () => new Map(projectGroups.map((group) => [group.id, group])),
+    [projectGroups]
+  )
+  const siblingGroupIdsByParent = useMemo(
+    () => getSiblingGroupIdsByParent(rows.filter((row): row is Row => row.type !== 'host-header')),
+    [rows]
+  )
+  const groupSiblingIndexByGroupId = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const groupIds of siblingGroupIdsByParent.values()) {
+      groupIds.forEach((groupId, index) => map.set(groupId, index))
+    }
+    return map
+  }, [siblingGroupIdsByParent])
   const commitProjectGroupOrder = useCallback(
     (repoId: string, projectGroupId: string | null, order: number) => {
       void moveProjectToGroup(repoId, projectGroupId, order)
@@ -1591,6 +1609,18 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     usesProjectGroupOrdering: hasProjectGroups,
     onCommitRepoOrder: commitRepoReorder,
     onCommitProjectGroupOrder: commitProjectGroupOrder,
+    getScrollContainer: () => scrollRef.current
+  })
+  const commitGroupOrder = useCallback(
+    (groupId: string, tabOrder: number) => {
+      void updateProjectGroup(groupId, { tabOrder })
+    },
+    [updateProjectGroup]
+  )
+  const groupDrag = useGroupHeaderDrag({
+    groupsById: projectGroupsById,
+    siblingGroupIdsByParent,
+    onCommitGroupOrder: commitGroupOrder,
     getScrollContainer: () => scrollRef.current
   })
   const [primaryActiveWorktreeRow, setPrimaryActiveWorktreeRow] = useState<{
@@ -3854,6 +3884,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               style={{ top: `${repoDrag.state.dropIndicatorY}px` }}
             />
           ) : null}
+          {canReorderRepoHeaders &&
+          groupDrag.state.draggingGroupId !== null &&
+          groupDrag.state.dropIndicatorY !== null ? (
+            <div
+              className="pointer-events-none absolute left-2 right-2 z-30 h-0.5 rounded-full bg-worktree-sidebar-ring"
+              style={{ top: `${groupDrag.state.dropIndicatorY}px` }}
+            />
+          ) : null}
           {hostDrag.state.draggingHostId !== null && hostDrag.state.dropIndicatorY !== null ? (
             <div
               role="presentation"
@@ -3962,6 +4000,27 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 canReorderRepoHeaders &&
                 repoDrag.state.draggingRepoId !== null &&
                 repoDrag.state.draggingRepoId === projectIdForHeader
+              const groupIdForHeader =
+                isProjectGroupHeader && row.projectGroup && row.projectGroup.id !== null
+                  ? row.projectGroup.id
+                  : undefined
+              const groupHeaderParent =
+                groupIdForHeader && projectGroupsById.get(groupIdForHeader)?.parentGroupId
+                  ? projectGroupsById.get(groupIdForHeader)!.parentGroupId
+                  : null
+              const groupSiblingIndex =
+                groupIdForHeader !== undefined
+                  ? groupSiblingIndexByGroupId.get(groupIdForHeader)
+                  : undefined
+              const isDraggableGroupHeader = Boolean(
+                canReorderRepoHeaders &&
+                groupIdForHeader &&
+                (siblingGroupIdsByParent.get(groupHeaderParent)?.length ?? 0) > 1
+              )
+              const isDraggingThisGroup =
+                canReorderRepoHeaders &&
+                groupDrag.state.draggingGroupId !== null &&
+                groupDrag.state.draggingGroupId === groupIdForHeader
               const headerWorkspaceStatus =
                 groupBy === 'workspace-status'
                   ? getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses)
@@ -4044,6 +4103,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     data-repo-header-id={projectIdForHeader}
                     data-repo-header-index={repoHeaderIndex}
                     data-repo-header-bucket={repoHeaderBucketKey}
+                    data-project-group-header-id={groupIdForHeader}
+                    data-project-group-parent={
+                      groupIdForHeader ? (groupHeaderParent ?? '') : undefined
+                    }
+                    data-project-group-sibling-index={groupSiblingIndex}
                     data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
                     data-workspace-status={headerWorkspaceStatus ?? undefined}
                     data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
@@ -4053,6 +4117,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       highlightedRevealRowKey === row.key &&
                         'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/50',
                       isDraggingThis &&
+                        'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
+                      isDraggingThisGroup &&
                         'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
                       headerWorkspaceStatus &&
                         dragOverStatus === headerWorkspaceStatus &&
@@ -4101,15 +4167,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     {row.icon ? (
                       <div
                         data-repo-header-drag-handle={isDraggableRepoHeader ? '' : undefined}
+                        data-group-header-drag-handle={isDraggableGroupHeader ? '' : undefined}
                         className={cn(
                           'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
                           repoHeaderColor ? 'text-muted-foreground' : row.tone,
-                          isDraggableRepoHeader && 'hover:cursor-grab active:cursor-grabbing'
+                          (isDraggableRepoHeader || isDraggableGroupHeader) &&
+                            'hover:cursor-grab active:cursor-grabbing'
                         )}
                         onPointerDown={
                           isDraggableRepoHeader && projectIdForHeader
                             ? (event) => repoDrag.onHandlePointerDown(event, projectIdForHeader)
-                            : undefined
+                            : isDraggableGroupHeader && groupIdForHeader
+                              ? (event) => groupDrag.onHandlePointerDown(event, groupIdForHeader)
+                              : undefined
                         }
                       >
                         {row.repo ? (

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -134,6 +134,7 @@ import {
   type ScrollToCurrentWorkspaceRevealRequestDetail
 } from '@/lib/scroll-to-current-workspace-status'
 import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
+import { computeHeaderDragRowShifts } from './header-drag-row-shifts'
 import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
 import { useGroupHeaderDrag } from './group-header-drag'
 import { getSiblingGroupIdsByParent } from './group-header-drop'
@@ -971,6 +972,90 @@ function updateLatestWorktreeStatusDropTarget(
 function getWorktreeVirtualRowTransform(start: number, previewOffset: number): string {
   const base = getVirtualRowTransform(start)
   return previewOffset === 0 ? base : `${base} translateY(${previewOffset}px)`
+}
+
+/** Resolve which rows make up the dragged header's block (a project + its
+ *  worktrees, or a group + its subtree) and the gap-opening offsets for the
+ *  rows between it and the drop line. Returns null when no header reorder drag
+ *  is active or the dragged header is off-screen. */
+function computeHeaderDragRowOffsets(args: {
+  draggingRepoId: string | null
+  draggingGroupId: string | null
+  dropY: number | null
+  renderRows: readonly RenderRow[]
+  virtualItems: readonly { index: number; start: number; size: number }[]
+}): { offsets: Map<string, number>; blockKeys: Set<string> } | null {
+  if (args.dropY === null || (args.draggingRepoId === null && args.draggingGroupId === null)) {
+    return null
+  }
+  const isGroup = args.draggingGroupId !== null
+  let headerIndex = -1
+  for (let i = 0; i < args.renderRows.length; i++) {
+    const row = args.renderRows[i]!
+    if (row.type !== 'header') {
+      continue
+    }
+    if (
+      isGroup ? row.projectGroup?.id === args.draggingGroupId : row.repo?.id === args.draggingRepoId
+    ) {
+      headerIndex = i
+      break
+    }
+  }
+  if (headerIndex === -1) {
+    return null
+  }
+  const headerRow = args.renderRows[headerIndex]!
+  const draggedDepth = headerRow.type === 'header' ? (headerRow.projectGroupDepth ?? 0) : 0
+  // A project block ends at the next header; a group block extends through its
+  // nested rows until a header at the same or shallower group depth.
+  let endIndex = args.renderRows.length
+  for (let i = headerIndex + 1; i < args.renderRows.length; i++) {
+    const row = args.renderRows[i]!
+    if (row.type !== 'header') {
+      continue
+    }
+    if (!isGroup || (row.projectGroupDepth ?? 0) <= draggedDepth) {
+      endIndex = i
+      break
+    }
+  }
+  const startByIndex = new Map<number, number>()
+  const sizeByIndex = new Map<number, number>()
+  for (const item of args.virtualItems) {
+    startByIndex.set(item.index, item.start)
+    sizeByIndex.set(item.index, item.size)
+  }
+  const blockTop = startByIndex.get(headerIndex)
+  if (blockTop === undefined) {
+    return null
+  }
+  let blockBottom = startByIndex.get(endIndex)
+  if (blockBottom === undefined) {
+    let sum = 0
+    for (let i = headerIndex; i < endIndex; i++) {
+      sum += sizeByIndex.get(i) ?? 0
+    }
+    blockBottom = blockTop + sum
+  }
+  const blockKeys = new Set<string>()
+  for (let i = headerIndex; i < endIndex; i++) {
+    blockKeys.add(getRenderRowKey(args.renderRows[i]!))
+  }
+  const rows = args.virtualItems.map((item) => ({
+    key: getRenderRowKey(args.renderRows[item.index]!),
+    top: item.start
+  }))
+  return {
+    offsets: computeHeaderDragRowShifts({
+      rows,
+      blockKeys,
+      blockTop,
+      blockBottom,
+      dropY: args.dropY
+    }),
+    blockKeys
+  }
 }
 
 function getPointerDropStatusTarget(args: {
@@ -2282,6 +2367,24 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const activeRenderRowKeys = useMemo(() => new Set(renderRows.map(getRenderRowKey)), [renderRows])
   const totalSize = virtualizer.getTotalSize()
   const virtualItems = virtualizer.getVirtualItems()
+  // Gap-opening offsets for an active header reorder drag (suppressed for
+  // drop-into-group, which highlights instead of showing a drop line).
+  const headerDragShift = computeHeaderDragRowOffsets({
+    draggingRepoId: canReorderRepoHeaders ? repoDrag.state.draggingRepoId : null,
+    draggingGroupId: canReorderRepoHeaders ? groupDrag.state.draggingGroupId : null,
+    dropY: headerDropIndicatorY,
+    renderRows,
+    virtualItems
+  })
+  const headerDragOffsets = headerDragShift?.offsets ?? null
+  const headerDragBlockKeys = headerDragShift?.blockKeys ?? null
+  const isHeaderReorderDragging = headerDragShift !== null
+  const getHeaderDragRowTransform = (start: number, rowKey: string): string => {
+    const offset = headerDragOffsets?.get(rowKey) ?? 0
+    return offset === 0
+      ? getVirtualRowTransform(start)
+      : `${getVirtualRowTransform(start)} translateY(${offset}px)`
+  }
   const activeStickyIndexes = getActiveStickyIndexesForScroll({
     rows: renderRows,
     rangeStartIndex: stickyRangeStartIndexRef.current,
@@ -4098,12 +4201,18 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     hasHeaderTopSpacing && !isActiveStickyHeader && 'pt-1',
                     isActiveStickyHeader
                       ? cn('sticky z-20 bg-worktree-sidebar', stickyTopClass)
-                      : 'absolute top-0'
+                      : 'absolute top-0',
+                    isHeaderReorderDragging &&
+                      'transition-transform duration-150 ease-out will-change-transform',
+                    // Hide rows of the dragged block (header + subtree); the
+                    // floating clone is the visible affordance.
+                    headerDragBlockKeys?.has(getRenderRowKey(row)) &&
+                      'opacity-0 pointer-events-none'
                   )}
                   style={
                     isActiveStickyHeader
                       ? undefined
-                      : { transform: getVirtualRowTransform(vItem.start) }
+                      : { transform: getHeaderDragRowTransform(vItem.start, getRenderRowKey(row)) }
                   }
                 >
                   <div
@@ -4813,11 +4922,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   ref={measureVirtualRowElement}
                   className={cn(
                     'absolute left-0 right-0 top-0',
-                    worktreeDragState.draggingWorktreeId !== null &&
-                      'transition-transform duration-150 ease-out will-change-transform'
+                    (worktreeDragState.draggingWorktreeId !== null || isHeaderReorderDragging) &&
+                      'transition-transform duration-150 ease-out will-change-transform',
+                    headerDragBlockKeys?.has(getRenderRowKey(row)) &&
+                      'opacity-0 pointer-events-none'
                   )}
                   style={{
-                    transform: getWorktreeVirtualRowTransform(vItem.start, parentPreviewOffset)
+                    transform: getWorktreeVirtualRowTransform(
+                      vItem.start,
+                      parentPreviewOffset + (headerDragOffsets?.get(getRenderRowKey(row)) ?? 0)
+                    )
                   }}
                 >
                   <div className="overflow-visible">
@@ -4957,8 +5071,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   data-worktree-virtual-row-start={vItem.start}
                   data-index={vItem.index}
                   ref={measureVirtualRowElement}
-                  className="absolute left-0 right-0 top-0"
-                  style={{ transform: getVirtualRowTransform(vItem.start) }}
+                  className={cn(
+                    'absolute left-0 right-0 top-0',
+                    isHeaderReorderDragging &&
+                      'transition-transform duration-150 ease-out will-change-transform',
+                    headerDragBlockKeys?.has(getRenderRowKey(folderWorkspaceRow)) &&
+                      'opacity-0 pointer-events-none'
+                  )}
+                  style={{
+                    transform: getHeaderDragRowTransform(
+                      vItem.start,
+                      getRenderRowKey(folderWorkspaceRow)
+                    )
+                  }}
                   onClickCapture={handleWorktreeRowClickCapture}
                   onPointerDown={(event) =>
                     handleWorktreeRowPointerDown(event, folderWorktree.id, folderWorktree.id)
@@ -5014,11 +5139,18 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 data-workspace-status={itemWorkspaceStatus ?? undefined}
                 className={cn(
                   'absolute left-0 right-0 top-0',
-                  worktreeDragState.draggingWorktreeId !== null &&
-                    'transition-transform duration-150 ease-out will-change-transform'
+                  (worktreeDragState.draggingWorktreeId !== null || isHeaderReorderDragging) &&
+                    'transition-transform duration-150 ease-out will-change-transform',
+                  // Worktrees of the dragged project block hide with their header.
+                  headerDragBlockKeys?.has(getRenderRowKey(row)) && 'opacity-0 pointer-events-none'
                 )}
                 style={{
-                  transform: getWorktreeVirtualRowTransform(vItem.start, itemPreviewOffset)
+                  // Header and worktree drags are mutually exclusive, so at most
+                  // one of these offsets is non-zero.
+                  transform: getWorktreeVirtualRowTransform(
+                    vItem.start,
+                    itemPreviewOffset + (headerDragOffsets?.get(getRenderRowKey(row)) ?? 0)
+                  )
                 }}
                 onDragOver={
                   itemWorkspaceStatus

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -137,7 +137,10 @@ import { useRepoHeaderDrag } from './project-header-drag'
 import { isHeaderActionTarget } from './header-drag-target-predicates'
 import { computeHeaderDragRowShifts } from './header-drag-row-shifts'
 import { resolveHeaderDragBlockUnits } from './header-drag-block-units'
-import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
+import {
+  getProjectHeaderDragBucketKey,
+  getSidebarOrderedRepoHeaderIdsByBucket
+} from './project-header-drop'
 import { useGroupHeaderDrag } from './group-header-drag'
 import { getSiblingGroupIdsByParent } from './group-header-drop'
 import {
@@ -4186,8 +4189,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     data-project-group-sibling-index={groupSiblingIndex}
                     data-project-group-project-count={
                       groupIdForHeader !== undefined
-                        ? (sidebarRepoHeaderIdsByBucket.get(`group:${groupIdForHeader}`)?.length ??
-                          0)
+                        ? (sidebarRepoHeaderIdsByBucket.get(
+                            getProjectHeaderDragBucketKey({ projectGroupId: groupIdForHeader })
+                          )?.length ?? 0)
                         : undefined
                     }
                     data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -133,7 +133,8 @@ import {
   SCROLL_TO_CURRENT_WORKSPACE_REVEAL_REQUEST_EVENT,
   type ScrollToCurrentWorkspaceRevealRequestDetail
 } from '@/lib/scroll-to-current-workspace-status'
-import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
+import { useRepoHeaderDrag } from './project-header-drag'
+import { isHeaderActionTarget } from './header-drag-target-predicates'
 import { computeHeaderDragRowShifts } from './header-drag-row-shifts'
 import { resolveHeaderDragBlockUnits } from './header-drag-block-units'
 import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
@@ -391,7 +392,7 @@ function stopRepoHeaderMenuEvent(event: React.SyntheticEvent<HTMLElement>): void
 }
 
 function shouldIgnoreRepoHeaderToggle(event: React.SyntheticEvent<HTMLElement>): boolean {
-  return isRepoHeaderActionTarget(event.target, event.currentTarget)
+  return isHeaderActionTarget(event.target, event.currentTarget)
 }
 
 function getWorktreeOptionId(rowKey: string): string {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1406,6 +1406,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const suppressWorktreeClickUntilRef = useRef(0)
   const hasProjectGroups = projectGroups.length > 0
   const canReorderRepoHeaders = groupBy === 'repo' && projectOrderBy === 'manual'
+  // Group order (tabOrder) is independent of how projects are sorted, so groups
+  // can be reordered in the project-grouped view regardless of project order;
+  // only project drag requires manual order.
+  const canReorderGroups = groupBy === 'repo'
   const moveProjectToGroup = useAppStore((s) => s.moveProjectToGroup)
   const lastVisibleRefreshKeyRef = useRef('')
   const reportVisibleGitHubPRRefreshCandidates = useAppStore(
@@ -1661,15 +1665,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   })
   // Project and group drag are mutually exclusive, so one shared drop indicator
   // (the worktree pill) renders for whichever header drag is active.
-  const headerDropIndicatorY = !canReorderRepoHeaders
-    ? null
-    : repoDrag.state.draggingRepoId !== null
-      ? // Dropping into a collapsed/empty group highlights the group instead of
-        // drawing a line, so suppress the pill in that case.
+  const headerDropIndicatorY =
+    canReorderRepoHeaders && repoDrag.state.draggingRepoId !== null
+      ? // Dropping into a group highlights the group instead of drawing a line,
+        // so suppress the pill in that case.
         repoDrag.state.dropIntoGroupId !== null
         ? null
         : repoDrag.state.dropIndicatorY
-      : groupDrag.state.draggingGroupId !== null
+      : canReorderGroups && groupDrag.state.draggingGroupId !== null
         ? groupDrag.state.dropIndicatorY
         : null
   const [primaryActiveWorktreeRow, setPrimaryActiveWorktreeRow] = useState<{
@@ -2319,7 +2322,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   // without overlap.
   const headerDragShift = computeHeaderDragRowOffsets({
     draggingRepoId: canReorderRepoHeaders ? repoDrag.state.draggingRepoId : null,
-    draggingGroupId: canReorderRepoHeaders ? groupDrag.state.draggingGroupId : null,
+    draggingGroupId: canReorderGroups ? groupDrag.state.draggingGroupId : null,
     dropY: headerDropIndicatorY,
     renderRows,
     virtualItems
@@ -4076,12 +4079,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   ? groupSiblingIndexByGroupId.get(groupIdForHeader)
                   : undefined
               const isDraggableGroupHeader = Boolean(
-                canReorderRepoHeaders &&
+                canReorderGroups &&
                 groupIdForHeader &&
                 (siblingGroupIdsByParent.get(groupHeaderParent)?.length ?? 0) > 1
               )
               const isDraggingThisGroup =
-                canReorderRepoHeaders &&
+                canReorderGroups &&
                 groupDrag.state.draggingGroupId !== null &&
                 groupDrag.state.draggingGroupId === groupIdForHeader
               const isDropIntoGroupTarget =

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1724,10 +1724,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const folderPathStatusCacheExpiryTick = useFolderWorkspacePathStatusCacheExpiryTick(
     folderWorkspacePathStatuses
   )
-  const projectGroupByIdForFolderPathStatus = useMemo(
-    () => new Map(projectGroups.map((group) => [group.id, group])),
-    [projectGroups]
-  )
   const folderWorkspaceByIdForFolderPathStatus = useMemo(
     () => new Map(folderWorkspaces.map((workspace) => [workspace.id, workspace])),
     [folderWorkspaces]
@@ -1736,10 +1732,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     (request: Parameters<typeof fetchFolderWorkspacePathStatus>[0]) =>
       getFolderPathStatusRouteOptionsForRows({
         request,
-        projectGroupsById: projectGroupByIdForFolderPathStatus,
+        projectGroupsById: projectGroupsById,
         folderWorkspacesById: folderWorkspaceByIdForFolderPathStatus
       }),
-    [folderWorkspaceByIdForFolderPathStatus, projectGroupByIdForFolderPathStatus]
+    [folderWorkspaceByIdForFolderPathStatus, projectGroupsById]
   )
   useEffect(() => {
     const requests = new Map<
@@ -3888,7 +3884,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           groupDrag.state.draggingGroupId !== null &&
           groupDrag.state.dropIndicatorY !== null ? (
             <div
-              className="pointer-events-none absolute left-2 right-2 z-30 h-0.5 rounded-full bg-worktree-sidebar-ring"
+              role="presentation"
+              className="pointer-events-none absolute left-2 right-2 z-30 border-t border-dashed border-muted-foreground/70"
               style={{ top: `${groupDrag.state.dropIndicatorY}px` }}
             />
           ) : null}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -135,10 +135,7 @@ import {
 } from '@/lib/scroll-to-current-workspace-status'
 import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
 import { computeHeaderDragRowShifts } from './header-drag-row-shifts'
-import {
-  getProjectHeaderDragBucketKey,
-  getSidebarOrderedRepoHeaderIdsByBucket
-} from './project-header-drop'
+import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
 import { useGroupHeaderDrag } from './group-header-drag'
 import { getSiblingGroupIdsByParent } from './group-header-drop'
 import {
@@ -985,10 +982,6 @@ function computeHeaderDragRowOffsets(args: {
   draggingRepoId: string | null
   draggingGroupId: string | null
   dropY: number | null
-  // Gap-opening is only well-defined for same-bucket reorders and group
-  // reorders. Cross-group project moves still hide the source block, but skip
-  // the reflow (group dividers make a uniform shift overlap).
-  allowGap: boolean
   renderRows: readonly RenderRow[]
   virtualItems: readonly { index: number; start: number; size: number }[]
 }): { offsets: Map<string, number>; blockKeys: Set<string> } | null {
@@ -1050,16 +1043,17 @@ function computeHeaderDragRowOffsets(args: {
     blockKeys.add(getRenderRowKey(args.renderRows[i]!))
   }
   // Segment the visible rows into movable units (whole blocks) so a block's
-  // children always shift with their header. Project drag moves project blocks
-  // (group headers stay put); group drag moves sibling-group blocks (their whole
-  // subtree, including nested group headers, moves together).
+  // children always shift with their header. Project drag treats every header
+  // (project AND group) as its own unit, so the list reflows flatly — group
+  // dividers slide up with everything else, leaving no overlap. Group drag
+  // moves sibling-group blocks (their whole subtree, nested headers included).
   const startsUnit = (row: RenderRow): boolean =>
     row.type === 'header' &&
     (isGroup
       ? row.projectGroup != null &&
         row.projectGroup.id !== null &&
         (row.projectGroupDepth ?? 0) === draggedDepth
-      : row.repo != null)
+      : true)
   const continuesUnit = (row: RenderRow): boolean =>
     isGroup && row.type === 'header' && (row.projectGroupDepth ?? 0) > draggedDepth
   const units: { headerTop: number; rowKeys: string[] }[] = []
@@ -1087,15 +1081,9 @@ function computeHeaderDragRowOffsets(args: {
   }
   flush()
   const offsets =
-    args.dropY !== null && args.allowGap
-      ? computeHeaderDragRowShifts({
-          units,
-          blockKeys,
-          blockTop,
-          blockBottom,
-          dropY: args.dropY
-        })
-      : new Map<string, number>()
+    args.dropY === null
+      ? new Map<string, number>()
+      : computeHeaderDragRowShifts({ units, blockKeys, blockTop, blockBottom, dropY: args.dropY })
   return { offsets, blockKeys }
 }
 
@@ -2408,25 +2396,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const activeRenderRowKeys = useMemo(() => new Set(renderRows.map(getRenderRowKey)), [renderRows])
   const totalSize = virtualizer.getTotalSize()
   const virtualItems = virtualizer.getVirtualItems()
-  // A cross-group project move can't gap-open cleanly (group dividers stay
-  // fixed, so a uniform shift overlaps them) — hide the source block but skip
-  // the reflow there. Same-bucket reorders and group reorders gap-open.
-  const draggedProjectBucket =
-    repoDrag.state.draggingRepoId !== null
-      ? getProjectHeaderDragBucketKey(
-          repoMap.get(repoDrag.state.draggingRepoId) ?? { projectGroupId: null }
-        )
-      : null
-  const isCrossGroupProjectMove =
-    draggedProjectBucket !== null &&
-    repoDrag.state.targetBucketKey !== null &&
-    repoDrag.state.targetBucketKey !== draggedProjectBucket
-  // Gap-opening offsets for an active header reorder drag.
+  // Gap-opening offsets for an active header reorder drag. Project drag reflows
+  // flatly (group dividers slide too), so cross-group moves open the gap
+  // without overlap.
   const headerDragShift = computeHeaderDragRowOffsets({
     draggingRepoId: canReorderRepoHeaders ? repoDrag.state.draggingRepoId : null,
     draggingGroupId: canReorderRepoHeaders ? groupDrag.state.draggingGroupId : null,
     dropY: headerDropIndicatorY,
-    allowGap: !isCrossGroupProjectMove,
     renderRows,
     virtualItems
   })

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -4198,11 +4198,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     className={cn(
                       'group relative flex h-7 w-full items-center gap-1.5 pr-2 text-left transition-all',
                       'cursor-pointer',
-                      // Why: the whole header row is the drag handle (like the
-                      // worktree cards), so show the grab affordance across the
-                      // row; action buttons opt out via data-repo-header-action.
-                      (isDraggableRepoHeader || isDraggableGroupHeader) &&
-                        'select-none hover:cursor-grab active:cursor-grabbing',
+                      // Why: keep the plain pointer cursor on hover (like the
+                      // worktree cards) — the grab cursor only appears once a
+                      // drag actually starts, applied document-wide by the drag
+                      // hook. select-none avoids a text-selection flash mid-drag.
+                      (isDraggableRepoHeader || isDraggableGroupHeader) && 'select-none',
                       highlightedRevealRowKey === row.key &&
                         'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/50',
                       // Why: while dragging, the floating clone is the visible

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1042,13 +1042,46 @@ function computeHeaderDragRowOffsets(args: {
   for (let i = headerIndex; i < endIndex; i++) {
     blockKeys.add(getRenderRowKey(args.renderRows[i]!))
   }
-  const rows = args.virtualItems.map((item) => ({
-    key: getRenderRowKey(args.renderRows[item.index]!),
-    top: item.start
-  }))
+  // Segment the visible rows into movable units (whole blocks) so a block's
+  // children always shift with their header. Project drag moves project blocks
+  // (group headers stay put); group drag moves sibling-group blocks (their whole
+  // subtree, including nested group headers, moves together).
+  const startsUnit = (row: RenderRow): boolean =>
+    row.type === 'header' &&
+    (isGroup
+      ? row.projectGroup != null &&
+        row.projectGroup.id !== null &&
+        (row.projectGroupDepth ?? 0) === draggedDepth
+      : row.repo != null)
+  const continuesUnit = (row: RenderRow): boolean =>
+    isGroup && row.type === 'header' && (row.projectGroupDepth ?? 0) > draggedDepth
+  const units: { headerTop: number; rowKeys: string[] }[] = []
+  let current: { headerTop: number; rowKeys: string[] } | null = null
+  const flush = (): void => {
+    if (current && current.rowKeys.length > 0) {
+      units.push(current)
+    }
+    current = null
+  }
+  for (let i = 0; i < args.renderRows.length; i++) {
+    const row = args.renderRows[i]!
+    const key = getRenderRowKey(row)
+    if (startsUnit(row)) {
+      flush()
+      const top = startByIndex.get(i)
+      current = top === undefined ? null : { headerTop: top, rowKeys: [key] }
+    } else if (row.type === 'header' && !continuesUnit(row)) {
+      // A header that is not part of the current block (e.g. a group header
+      // during project drag) stays put and closes the open unit.
+      flush()
+    } else if (current) {
+      current.rowKeys.push(key)
+    }
+  }
+  flush()
   return {
     offsets: computeHeaderDragRowShifts({
-      rows,
+      units,
       blockKeys,
       blockTop,
       blockBottom,

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1579,6 +1579,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     }
     return map
   }, [sidebarRepoHeaderIdsByBucket])
+  // Why: matches the drag-session guard in createProjectHeaderDragSession, which
+  // arms whenever the total across all buckets is >1, not just the source bucket.
+  const totalRepoHeaderCount = useMemo(() => {
+    let total = 0
+    for (const ids of sidebarRepoHeaderIdsByBucket.values()) {
+      total += ids.length
+    }
+    return total
+  }, [sidebarRepoHeaderIdsByBucket])
   const projectGroupsById = useMemo(
     () => new Map(projectGroups.map((group) => [group.id, group])),
     [projectGroups]
@@ -1595,7 +1604,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     return map
   }, [siblingGroupIdsByParent])
   const commitProjectGroupOrder = useCallback(
-    (repoId: string, projectGroupId: string | null, order: number) => {
+    (repoId: string, projectGroupId: string | null, order?: number) => {
       void moveProjectToGroup(repoId, projectGroupId, order)
     },
     [moveProjectToGroup]
@@ -3991,7 +4000,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 isRepoHeader &&
                 projectIdForHeader &&
                 repoHeaderBucketKey &&
-                (sidebarRepoHeaderIdsByBucket.get(repoHeaderBucketKey)?.length ?? 0) > 1
+                totalRepoHeaderCount > 1
               )
               const isDraggingThis =
                 canReorderRepoHeaders &&

--- a/src/renderer/src/components/sidebar/group-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-commit.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import { commitGroupHeaderDragDrop } from './group-header-drag-commit'
+import type { GroupHeaderDragSession } from './group-header-drag-contract'
+import type { ProjectGroup } from '../../../../shared/types'
+
+function makeGroup(id: string, tabOrder: number): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0
+  }
+}
+
+function makeSession(groupId: string, siblingGroupIds: readonly string[]): GroupHeaderDragSession {
+  return {
+    groupId,
+    parentGroupId: null,
+    siblingGroupIds,
+    pointerId: 1,
+    headerRects: [],
+    handleEl: document.createElement('div'),
+    startX: 0,
+    startY: 0,
+    latestPointerY: 0,
+    promoted: true
+  }
+}
+
+describe('commitGroupHeaderDragDrop', () => {
+  it('commits a new interpolated tabOrder when a group moves to the front', () => {
+    const onCommitGroupOrder = vi.fn()
+    const groups = [makeGroup('a', 0), makeGroup('b', 1), makeGroup('c', 2)]
+    const groupsById = new Map(groups.map((g) => [g.id, g]))
+    commitGroupHeaderDragDrop({
+      session: makeSession('c', ['a', 'b', 'c']),
+      sidebarDropIndex: 0,
+      groupsById,
+      onCommitGroupOrder
+    })
+    // Siblings after removing 'c' are [a(0), b(1)]; insert at 0 -> below a -> -1
+    expect(onCommitGroupOrder).toHaveBeenCalledWith('c', -1)
+  })
+
+  it('does not commit when the drop index equals the source index', () => {
+    const onCommitGroupOrder = vi.fn()
+    const groups = [makeGroup('a', 0), makeGroup('b', 1)]
+    const groupsById = new Map(groups.map((g) => [g.id, g]))
+    commitGroupHeaderDragDrop({
+      session: makeSession('a', ['a', 'b']),
+      sidebarDropIndex: 0,
+      groupsById,
+      onCommitGroupOrder
+    })
+    expect(onCommitGroupOrder).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/group-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-commit.ts
@@ -1,0 +1,40 @@
+// group-header-drag-commit.ts
+import {
+  getTabOrderForGroupDrop,
+  mapSidebarGroupDropIndexToSiblingInsertIndex
+} from './group-header-drop'
+import type { GroupHeaderDragSession } from './group-header-drag-contract'
+import type { ProjectGroup } from '../../../../shared/types'
+
+export function commitGroupHeaderDragDrop(args: {
+  session: GroupHeaderDragSession
+  sidebarDropIndex: number
+  groupsById: ReadonlyMap<string, ProjectGroup>
+  onCommitGroupOrder: (groupId: string, tabOrder: number) => void
+}): void {
+  if (!args.groupsById.get(args.session.groupId)) {
+    return
+  }
+  const siblingGroupIds = args.session.siblingGroupIds
+  const sourceIndex = siblingGroupIds.indexOf(args.session.groupId)
+  if (args.sidebarDropIndex === sourceIndex) {
+    return
+  }
+  const siblings = siblingGroupIds
+    .filter((id) => id !== args.session.groupId)
+    .map((id) => args.groupsById.get(id))
+    .filter((group): group is ProjectGroup => group !== undefined)
+  const siblingDropIndex = mapSidebarGroupDropIndexToSiblingInsertIndex({
+    sidebarDropIndex: args.sidebarDropIndex,
+    sourceIndex,
+    siblingCount: siblings.length
+  })
+  // Why: removing the dragged group can only shift the source position down by
+  // one, so its equivalent slot in the filtered list is sourceIndex capped.
+  const sourceIndexInSiblings = Math.min(sourceIndex, siblings.length)
+  if (siblingDropIndex === sourceIndexInSiblings) {
+    return
+  }
+  const tabOrder = getTabOrderForGroupDrop({ siblings, dropIndex: siblingDropIndex })
+  args.onCommitGroupOrder(args.session.groupId, tabOrder)
+}

--- a/src/renderer/src/components/sidebar/group-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-commit.ts
@@ -17,6 +17,7 @@ export function commitGroupHeaderDragDrop(args: {
   }
   const siblingGroupIds = args.session.siblingGroupIds
   const sourceIndex = siblingGroupIds.indexOf(args.session.groupId)
+  // Fast-path: authoritative no-op check is the later siblingDropIndex comparison in sibling-space.
   if (args.sidebarDropIndex === sourceIndex) {
     return
   }

--- a/src/renderer/src/components/sidebar/group-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-commit.ts
@@ -17,7 +17,7 @@ export function commitGroupHeaderDragDrop(args: {
   }
   const siblingGroupIds = args.session.siblingGroupIds
   const sourceIndex = siblingGroupIds.indexOf(args.session.groupId)
-  // Fast-path: authoritative no-op check is the later siblingDropIndex comparison in sibling-space.
+  // Cheap no-op guard; the authoritative one is the sibling-space comparison below.
   if (args.sidebarDropIndex === sourceIndex) {
     return
   }

--- a/src/renderer/src/components/sidebar/group-header-drag-contract.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-contract.test.ts
@@ -1,9 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest'
-import {
-  isGroupHeaderActionTarget,
-  isGroupHeaderDragHandleTarget
-} from './group-header-drag-contract'
+import { isGroupHeaderDragHandleTarget } from './group-header-drag-contract'
+import { isHeaderActionTarget } from './header-drag-target-predicates'
 
 function build(html: string): { root: HTMLElement; handle: HTMLElement; button: HTMLElement } {
   const root = document.createElement('div')
@@ -26,6 +24,6 @@ describe('group header drag predicates', () => {
   })
   it('treats buttons inside the header as action targets', () => {
     const { root, button } = build('<button></button>')
-    expect(isGroupHeaderActionTarget(button, root)).toBe(true)
+    expect(isHeaderActionTarget(button, root)).toBe(true)
   })
 })

--- a/src/renderer/src/components/sidebar/group-header-drag-contract.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-contract.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import {
+  isGroupHeaderActionTarget,
+  isGroupHeaderDragHandleTarget
+} from './group-header-drag-contract'
+
+function build(html: string): { root: HTMLElement; handle: HTMLElement; button: HTMLElement } {
+  const root = document.createElement('div')
+  root.innerHTML = html
+  return {
+    root,
+    handle: root.querySelector('[data-group-header-drag-handle]') as HTMLElement,
+    button: root.querySelector('button') as HTMLElement
+  }
+}
+
+describe('group header drag predicates', () => {
+  it('recognizes the drag handle as a drag target', () => {
+    const { root, handle } = build('<span data-group-header-drag-handle></span>')
+    expect(isGroupHeaderDragHandleTarget(handle, root)).toBe(true)
+  })
+  it('rejects a non-handle element', () => {
+    const { root, button } = build('<button></button>')
+    expect(isGroupHeaderDragHandleTarget(button, root)).toBe(false)
+  })
+  it('treats buttons inside the header as action targets', () => {
+    const { root, button } = build('<button></button>')
+    expect(isGroupHeaderActionTarget(button, root)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/sidebar/group-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-contract.ts
@@ -3,7 +3,7 @@ import type { PointerEvent } from 'react'
 
 import type { GroupHeaderDragRect } from './group-header-drop'
 import type { ProjectGroup } from '../../../../shared/types'
-import { isHeaderDragHandleTarget, isHeaderActionTarget } from './header-drag-target-predicates'
+import { isHeaderDragHandleTarget } from './header-drag-target-predicates'
 
 export type GroupDragState = {
   draggingGroupId: string | null
@@ -51,11 +51,4 @@ export function isGroupHeaderDragHandleTarget(
   currentTarget: HTMLElement
 ): boolean {
   return isHeaderDragHandleTarget(target, currentTarget, GROUP_HEADER_DRAG_HANDLE_SELECTOR)
-}
-
-export function isGroupHeaderActionTarget(
-  target: EventTarget | null,
-  currentTarget: HTMLElement
-): boolean {
-  return isHeaderActionTarget(target, currentTarget)
 }

--- a/src/renderer/src/components/sidebar/group-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-contract.ts
@@ -1,0 +1,70 @@
+// group-header-drag-contract.ts
+import type { PointerEvent } from 'react'
+
+import type { GroupHeaderDragRect } from './group-header-drop'
+import type { ProjectGroup } from '../../../../shared/types'
+
+export type GroupDragState = {
+  draggingGroupId: string | null
+  dropIndex: number | null
+  dropIndicatorY: number | null
+}
+
+export const INITIAL_GROUP_DRAG_STATE: GroupDragState = {
+  draggingGroupId: null,
+  dropIndex: null,
+  dropIndicatorY: null
+}
+
+export const GROUP_HEADER_DRAG_THRESHOLD_PX = 4
+
+export type GroupHeaderDragSession = {
+  groupId: string
+  parentGroupId: string | null
+  siblingGroupIds: readonly string[]
+  pointerId: number
+  headerRects: GroupHeaderDragRect[]
+  handleEl: HTMLElement
+  startX: number
+  startY: number
+  latestPointerY: number
+  promoted: boolean
+}
+
+export type UseGroupHeaderDragArgs = {
+  groupsById: ReadonlyMap<string, ProjectGroup>
+  siblingGroupIdsByParent: ReadonlyMap<string | null, readonly string[]>
+  onCommitGroupOrder: (groupId: string, tabOrder: number) => void
+  getScrollContainer: () => HTMLElement | null
+}
+
+export type GroupHeaderDragController = {
+  state: GroupDragState
+  onHandlePointerDown: (event: PointerEvent<HTMLElement>, groupId: string) => void
+}
+
+const GROUP_HEADER_DRAG_HANDLE_SELECTOR = '[data-group-header-drag-handle]'
+
+const GROUP_HEADER_ACTION_SELECTOR =
+  '[data-repo-header-action], [data-repo-header-collapse-affordance], button, a, input, textarea, select, [contenteditable=""], [contenteditable="true"]'
+
+export function isGroupHeaderDragHandleTarget(
+  target: EventTarget | null,
+  currentTarget: HTMLElement
+): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  const dragHandle = target.closest(GROUP_HEADER_DRAG_HANDLE_SELECTOR)
+  return dragHandle !== null && currentTarget.contains(dragHandle)
+}
+
+export function isGroupHeaderActionTarget(
+  target: EventTarget | null,
+  currentTarget: HTMLElement
+): boolean {
+  if (!(target instanceof HTMLElement) || target === currentTarget) {
+    return false
+  }
+  return currentTarget.contains(target) && target.closest(GROUP_HEADER_ACTION_SELECTOR) !== null
+}

--- a/src/renderer/src/components/sidebar/group-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-contract.ts
@@ -3,6 +3,7 @@ import type { PointerEvent } from 'react'
 
 import type { GroupHeaderDragRect } from './group-header-drop'
 import type { ProjectGroup } from '../../../../shared/types'
+import { isHeaderDragHandleTarget, isHeaderActionTarget } from './header-drag-target-predicates'
 
 export type GroupDragState = {
   draggingGroupId: string | null
@@ -45,26 +46,16 @@ export type GroupHeaderDragController = {
 
 const GROUP_HEADER_DRAG_HANDLE_SELECTOR = '[data-group-header-drag-handle]'
 
-const GROUP_HEADER_ACTION_SELECTOR =
-  '[data-repo-header-action], [data-repo-header-collapse-affordance], button, a, input, textarea, select, [contenteditable=""], [contenteditable="true"]'
-
 export function isGroupHeaderDragHandleTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false
-  }
-  const dragHandle = target.closest(GROUP_HEADER_DRAG_HANDLE_SELECTOR)
-  return dragHandle !== null && currentTarget.contains(dragHandle)
+  return isHeaderDragHandleTarget(target, currentTarget, GROUP_HEADER_DRAG_HANDLE_SELECTOR)
 }
 
 export function isGroupHeaderActionTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement) || target === currentTarget) {
-    return false
-  }
-  return currentTarget.contains(target) && target.closest(GROUP_HEADER_ACTION_SELECTOR) !== null
+  return isHeaderActionTarget(target, currentTarget)
 }

--- a/src/renderer/src/components/sidebar/group-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-contract.ts
@@ -28,6 +28,7 @@ export type GroupHeaderDragSession = {
   handleEl: HTMLElement
   startX: number
   startY: number
+  latestPointerX: number
   latestPointerY: number
   promoted: boolean
 }

--- a/src/renderer/src/components/sidebar/group-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-start.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+
+import { createGroupHeaderDragSession } from './group-header-drag-start'
+import type { ProjectGroup } from '../../../../shared/types'
+
+function createGroup(id: string, parentGroupId: string | null = null): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: null,
+    parentGroupId,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0
+  }
+}
+
+function makeHandleEl(): HTMLElement {
+  const el = document.createElement('div')
+  el.setAttribute('data-group-header-drag-handle', '')
+  document.body.appendChild(el)
+  return el
+}
+
+function makeScrollContainer(): HTMLElement {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  return el
+}
+
+function makeEvent(
+  target: HTMLElement,
+  currentTarget: HTMLElement,
+  button = 0
+): React.PointerEvent<HTMLElement> {
+  return {
+    button,
+    pointerId: 1,
+    clientX: 10,
+    clientY: 20,
+    target,
+    currentTarget
+  } as unknown as React.PointerEvent<HTMLElement>
+}
+
+describe('createGroupHeaderDragSession', () => {
+  it('returns null when the pointer event is not on a drag-handle element', () => {
+    // target is a plain div without data-group-header-drag-handle
+    const nonHandle = document.createElement('div')
+    const currentTarget = document.createElement('div')
+    currentTarget.appendChild(nonHandle)
+    document.body.appendChild(currentTarget)
+
+    const groupId = 'group-a'
+    const group = createGroup(groupId)
+    const groupsById = new Map<string, ProjectGroup>([[groupId, group]])
+    const siblingGroupIdsByParent = new Map<string | null, readonly string[]>([
+      [null, ['group-a', 'group-b']]
+    ])
+    const scrollContainer = makeScrollContainer()
+
+    const session = createGroupHeaderDragSession({
+      event: makeEvent(nonHandle, currentTarget),
+      groupId,
+      groupsById,
+      siblingGroupIdsByParent,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session).toBeNull()
+  })
+
+  it('returns null when the event button is not 0 (non-left click)', () => {
+    const handleEl = makeHandleEl()
+    const scrollContainer = makeScrollContainer()
+
+    const groupId = 'group-a'
+    const group = createGroup(groupId)
+    const groupsById = new Map<string, ProjectGroup>([[groupId, group]])
+    const siblingGroupIdsByParent = new Map<string | null, readonly string[]>([
+      [null, ['group-a', 'group-b']]
+    ])
+
+    const session = createGroupHeaderDragSession({
+      event: makeEvent(handleEl, handleEl, 2),
+      groupId,
+      groupsById,
+      siblingGroupIdsByParent,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session).toBeNull()
+  })
+
+  it('returns null when the group has ≤1 sibling in its parent bucket (lone-group guard)', () => {
+    const handleEl = makeHandleEl()
+    const scrollContainer = makeScrollContainer()
+
+    const groupId = 'group-a'
+    const group = createGroup(groupId)
+    const groupsById = new Map<string, ProjectGroup>([[groupId, group]])
+    // Only one group in the parent bucket — should be blocked
+    const siblingGroupIdsByParent = new Map<string | null, readonly string[]>([[null, ['group-a']]])
+
+    const session = createGroupHeaderDragSession({
+      event: makeEvent(handleEl, handleEl),
+      groupId,
+      groupsById,
+      siblingGroupIdsByParent,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session).toBeNull()
+  })
+
+  it('returns a valid session when all guards pass', () => {
+    const handleEl = makeHandleEl()
+    const scrollContainer = makeScrollContainer()
+
+    const groupId = 'group-a'
+    const group = createGroup(groupId)
+    const groupsById = new Map<string, ProjectGroup>([[groupId, group]])
+    const siblings: readonly string[] = ['group-a', 'group-b']
+    const siblingGroupIdsByParent = new Map<string | null, readonly string[]>([[null, siblings]])
+
+    const session = createGroupHeaderDragSession({
+      event: makeEvent(handleEl, handleEl),
+      groupId,
+      groupsById,
+      siblingGroupIdsByParent,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session).not.toBeNull()
+    expect(session?.groupId).toBe(groupId)
+    expect(session?.parentGroupId).toBeNull()
+    expect(session?.siblingGroupIds).toEqual(siblings)
+    expect(session?.pointerId).toBe(1)
+    expect(session?.handleEl).toBe(handleEl)
+    expect(session?.promoted).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/group-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-start.ts
@@ -3,10 +3,10 @@ import type { PointerEvent } from 'react'
 
 import { measureGroupHeaderDragRects } from './group-header-drop'
 import {
-  isGroupHeaderActionTarget,
   isGroupHeaderDragHandleTarget,
   type GroupHeaderDragSession
 } from './group-header-drag-contract'
+import { isHeaderActionTarget } from './header-drag-target-predicates'
 import type { ProjectGroup } from '../../../../shared/types'
 
 export function createGroupHeaderDragSession(args: {
@@ -22,7 +22,7 @@ export function createGroupHeaderDragSession(args: {
   if (!isGroupHeaderDragHandleTarget(args.event.target, args.event.currentTarget)) {
     return null
   }
-  if (isGroupHeaderActionTarget(args.event.target, args.event.currentTarget)) {
+  if (isHeaderActionTarget(args.event.target, args.event.currentTarget)) {
     return null
   }
   const group = args.groupsById.get(args.groupId)

--- a/src/renderer/src/components/sidebar/group-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-start.ts
@@ -1,0 +1,55 @@
+// group-header-drag-start.ts
+import type { PointerEvent } from 'react'
+
+import { measureGroupHeaderDragRects } from './group-header-drop'
+import {
+  isGroupHeaderActionTarget,
+  isGroupHeaderDragHandleTarget,
+  type GroupHeaderDragSession
+} from './group-header-drag-contract'
+import type { ProjectGroup } from '../../../../shared/types'
+
+export function createGroupHeaderDragSession(args: {
+  event: PointerEvent<HTMLElement>
+  groupId: string
+  groupsById: ReadonlyMap<string, ProjectGroup>
+  siblingGroupIdsByParent: ReadonlyMap<string | null, readonly string[]>
+  getScrollContainer: () => HTMLElement | null
+}): GroupHeaderDragSession | null {
+  if (args.event.button !== 0) {
+    return null
+  }
+  if (!isGroupHeaderDragHandleTarget(args.event.target, args.event.currentTarget)) {
+    return null
+  }
+  if (isGroupHeaderActionTarget(args.event.target, args.event.currentTarget)) {
+    return null
+  }
+  const group = args.groupsById.get(args.groupId)
+  if (!group) {
+    return null
+  }
+  const parentGroupId = group.parentGroupId ?? null
+  const siblingGroupIds = args.siblingGroupIdsByParent.get(parentGroupId) ?? []
+  // Why: a lone group has no sibling to reorder against; let the header click
+  // toggle collapse instead.
+  if (siblingGroupIds.length <= 1) {
+    return null
+  }
+  const container = args.getScrollContainer()
+  if (!container) {
+    return null
+  }
+  return {
+    groupId: args.groupId,
+    parentGroupId,
+    siblingGroupIds,
+    pointerId: args.event.pointerId,
+    headerRects: measureGroupHeaderDragRects(container, parentGroupId),
+    handleEl: args.event.currentTarget,
+    startX: args.event.clientX,
+    startY: args.event.clientY,
+    latestPointerY: args.event.clientY,
+    promoted: false
+  }
+}

--- a/src/renderer/src/components/sidebar/group-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag-start.ts
@@ -49,6 +49,7 @@ export function createGroupHeaderDragSession(args: {
     handleEl: args.event.currentTarget,
     startX: args.event.clientX,
     startY: args.event.clientY,
+    latestPointerX: args.event.clientX,
     latestPointerY: args.event.clientY,
     promoted: false
   }

--- a/src/renderer/src/components/sidebar/group-header-drag.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag.test.ts
@@ -3,11 +3,8 @@ import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  isGroupHeaderActionTarget,
-  isGroupHeaderDragHandleTarget,
-  useGroupHeaderDrag
-} from './group-header-drag'
+import { isGroupHeaderDragHandleTarget, useGroupHeaderDrag } from './group-header-drag'
+import { isHeaderActionTarget } from './header-drag-target-predicates'
 import type { GroupDragState } from './group-header-drag-contract'
 import type { ProjectGroup } from '../../../../shared/types'
 
@@ -31,20 +28,20 @@ describe('group header action targets', () => {
       </span>
     `)
 
-    expect(isGroupHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
+    expect(isHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
   })
 
   it('ignores native nested controls', () => {
     const header = createHeader('<button type="button"><span id="icon"></span></button>')
 
-    expect(isGroupHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
+    expect(isHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
   })
 
   it('does not ignore plain header text or the header itself', () => {
     const header = createHeader('<span id="label">My Group</span>')
 
-    expect(isGroupHeaderActionTarget(header.querySelector('#label'), header)).toBe(false)
-    expect(isGroupHeaderActionTarget(header, header)).toBe(false)
+    expect(isHeaderActionTarget(header.querySelector('#label'), header)).toBe(false)
+    expect(isHeaderActionTarget(header, header)).toBe(false)
   })
 
   it('ignores the hover collapse affordance', () => {
@@ -54,7 +51,7 @@ describe('group header action targets', () => {
       </div>
     `)
 
-    expect(isGroupHeaderActionTarget(header.querySelector('#chevron'), header)).toBe(true)
+    expect(isHeaderActionTarget(header.querySelector('#chevron'), header)).toBe(true)
   })
 })
 

--- a/src/renderer/src/components/sidebar/group-header-drag.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag.test.ts
@@ -135,7 +135,7 @@ describe('useGroupHeaderDrag lifecycle', () => {
   })
 
   it('calls onCommitGroupOrder after a drag past the threshold over a sibling', async () => {
-    const onCommitGroupOrder = vi.fn<[string, number], void>()
+    const onCommitGroupOrder = vi.fn<(groupId: string, tabOrder: number) => void>()
 
     // Build two groups: group-a (tabOrder=0, siblingIndex=0), group-b (tabOrder=1, siblingIndex=1)
     const groupA = makeGroup('group-a', 0)

--- a/src/renderer/src/components/sidebar/group-header-drag.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag.test.ts
@@ -1,0 +1,262 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  isGroupHeaderActionTarget,
+  isGroupHeaderDragHandleTarget,
+  useGroupHeaderDrag
+} from './group-header-drag'
+import type { GroupDragState } from './group-header-drag-contract'
+import type { ProjectGroup } from '../../../../shared/types'
+
+// ---------------------------------------------------------------------------
+// Predicate tests (mirror project-header-drag.test.ts structure)
+// ---------------------------------------------------------------------------
+
+function createHeader(markup: string): HTMLElement {
+  const header = document.createElement('div')
+  header.setAttribute('data-project-group-header-id', 'group-1')
+  header.innerHTML = markup
+  document.body.appendChild(header)
+  return header
+}
+
+describe('group header action targets', () => {
+  it('ignores explicit group action wrappers', () => {
+    const header = createHeader(`
+      <span data-repo-header-action="" tabindex="0">
+        <span id="icon"></span>
+      </span>
+    `)
+
+    expect(isGroupHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
+  })
+
+  it('ignores native nested controls', () => {
+    const header = createHeader('<button type="button"><span id="icon"></span></button>')
+
+    expect(isGroupHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
+  })
+
+  it('does not ignore plain header text or the header itself', () => {
+    const header = createHeader('<span id="label">My Group</span>')
+
+    expect(isGroupHeaderActionTarget(header.querySelector('#label'), header)).toBe(false)
+    expect(isGroupHeaderActionTarget(header, header)).toBe(false)
+  })
+
+  it('ignores the hover collapse affordance', () => {
+    const header = createHeader(`
+      <div data-repo-header-collapse-affordance="">
+        <span id="chevron"></span>
+      </div>
+    `)
+
+    expect(isGroupHeaderActionTarget(header.querySelector('#chevron'), header)).toBe(true)
+  })
+})
+
+describe('group header drag handle targets', () => {
+  it('returns true when the target is inside a drag handle', () => {
+    const header = createHeader(`
+      <div data-group-header-drag-handle="">
+        <span id="icon"></span>
+      </div>
+    `)
+
+    expect(isGroupHeaderDragHandleTarget(header.querySelector('#icon'), header)).toBe(true)
+  })
+
+  it('returns false when the target is outside a drag handle', () => {
+    const header = createHeader('<span id="label">Group Name</span>')
+
+    expect(isGroupHeaderDragHandleTarget(header.querySelector('#label'), header)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Lifecycle test — drive a full drag through the generic hook
+// ---------------------------------------------------------------------------
+
+function makeGroup(
+  id: string,
+  tabOrder: number,
+  parentGroupId: string | null = null
+): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: null,
+    parentGroupId,
+    createdFrom: 'manual',
+    tabOrder,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0
+  }
+}
+
+/** A minimal component that mounts useGroupHeaderDrag and exposes state via ref. */
+function HookProbe(props: {
+  groupsById: ReadonlyMap<string, ProjectGroup>
+  siblingGroupIdsByParent: ReadonlyMap<string | null, readonly string[]>
+  onCommitGroupOrder: (groupId: string, tabOrder: number) => void
+  getScrollContainer: () => HTMLElement | null
+  stateRef: { current: GroupDragState }
+  onHandlePointerDownRef: {
+    current: ((event: React.PointerEvent<HTMLElement>, groupId: string) => void) | null
+  }
+}): null {
+  const controller = useGroupHeaderDrag({
+    groupsById: props.groupsById,
+    siblingGroupIdsByParent: props.siblingGroupIdsByParent,
+    onCommitGroupOrder: props.onCommitGroupOrder,
+    getScrollContainer: props.getScrollContainer
+  })
+  props.stateRef.current = controller.state
+  props.onHandlePointerDownRef.current = controller.onHandlePointerDown
+  return null
+}
+
+describe('useGroupHeaderDrag lifecycle', () => {
+  const roots: Root[] = []
+
+  afterEach(async () => {
+    for (const root of roots) {
+      await act(async () => {
+        root.unmount()
+      })
+    }
+    roots.length = 0
+    document.body.innerHTML = ''
+  })
+
+  it('calls onCommitGroupOrder after a drag past the threshold over a sibling', async () => {
+    const onCommitGroupOrder = vi.fn<[string, number], void>()
+
+    // Build two groups: group-a (tabOrder=0, siblingIndex=0), group-b (tabOrder=1, siblingIndex=1)
+    const groupA = makeGroup('group-a', 0)
+    const groupB = makeGroup('group-b', 1)
+    const groupsById = new Map<string, ProjectGroup>([
+      ['group-a', groupA],
+      ['group-b', groupB]
+    ])
+    const siblingGroupIdsByParent = new Map<string | null, readonly string[]>([
+      [null, ['group-a', 'group-b']]
+    ])
+
+    // Build a scroll container with two group header elements
+    const container = document.createElement('div')
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      value: () => ({ top: 0, left: 0, right: 300, bottom: 200, width: 300, height: 200 })
+    })
+    Object.defineProperty(container, 'scrollTop', { value: 0, writable: true })
+
+    // Header A: y=0..40, siblingIndex=0
+    const headerA = document.createElement('div')
+    headerA.setAttribute('data-project-group-header-id', 'group-a')
+    headerA.setAttribute('data-project-group-sibling-index', '0')
+    headerA.setAttribute('data-project-group-parent', '')
+    const handleA = document.createElement('div')
+    handleA.setAttribute('data-group-header-drag-handle', '')
+    headerA.appendChild(handleA)
+    Object.defineProperty(headerA, 'getBoundingClientRect', {
+      value: () => ({ top: 0, left: 0, right: 300, bottom: 40, width: 300, height: 40 })
+    })
+    Object.defineProperty(headerA, 'isConnected', { get: () => true })
+    headerA.setPointerCapture = vi.fn()
+    headerA.releasePointerCapture = vi.fn()
+
+    // Header B: y=44..84, siblingIndex=1
+    const headerB = document.createElement('div')
+    headerB.setAttribute('data-project-group-header-id', 'group-b')
+    headerB.setAttribute('data-project-group-sibling-index', '1')
+    headerB.setAttribute('data-project-group-parent', '')
+    Object.defineProperty(headerB, 'getBoundingClientRect', {
+      value: () => ({ top: 44, left: 0, right: 300, bottom: 84, width: 300, height: 40 })
+    })
+
+    container.appendChild(headerA)
+    container.appendChild(headerB)
+
+    // querySelectorAll mock so measureGroupHeaderDragRects finds elements
+    const origQSA = container.querySelectorAll.bind(container)
+    container.querySelectorAll = (<K extends string>(sel: K) => {
+      if (sel === '[data-project-group-header-id]') {
+        return [headerA, headerB] as unknown as NodeListOf<Element>
+      }
+      return origQSA(sel)
+    }) as typeof container.querySelectorAll
+
+    document.body.appendChild(container)
+
+    const stateRef: { current: GroupDragState } = {
+      current: { draggingGroupId: null, dropIndex: null, dropIndicatorY: null }
+    }
+    const onHandlePointerDownRef: {
+      current: ((event: React.PointerEvent<HTMLElement>, groupId: string) => void) | null
+    } = { current: null }
+
+    // Mount the hook
+    const hookContainer = document.createElement('div')
+    document.body.appendChild(hookContainer)
+    const root = createRoot(hookContainer)
+    roots.push(root)
+
+    await act(async () => {
+      root.render(
+        createElement(HookProbe, {
+          groupsById,
+          siblingGroupIdsByParent,
+          onCommitGroupOrder,
+          getScrollContainer: () => container,
+          stateRef,
+          onHandlePointerDownRef
+        })
+      )
+    })
+
+    // Simulate pointerdown on the handle of group-a (currentTarget = handleA)
+    const pointerDownEvent = {
+      button: 0,
+      pointerId: 1,
+      clientX: 10,
+      clientY: 20,
+      target: handleA,
+      currentTarget: handleA
+    } as unknown as React.PointerEvent<HTMLElement>
+
+    await act(async () => {
+      onHandlePointerDownRef.current!(pointerDownEvent, 'group-a')
+    })
+
+    // Move past the 4px threshold to promote the session
+    await act(async () => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', { pointerId: 1, clientX: 10, clientY: 25, bubbles: true })
+      )
+    })
+
+    // Move pointer over the second group header (clientY=64 = middle of headerB)
+    await act(async () => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', { pointerId: 1, clientX: 10, clientY: 64, bubbles: true })
+      )
+    })
+
+    // Pointer up to commit
+    await act(async () => {
+      window.dispatchEvent(
+        new PointerEvent('pointerup', { pointerId: 1, clientX: 10, clientY: 64, bubbles: true })
+      )
+    })
+
+    expect(onCommitGroupOrder).toHaveBeenCalledOnce()
+    const [calledGroupId, calledTabOrder] = onCommitGroupOrder.mock.calls[0]!
+    expect(calledGroupId).toBe('group-a')
+    expect(Number.isFinite(calledTabOrder)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/sidebar/group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag.ts
@@ -55,7 +55,8 @@ export function useGroupHeaderDrag(args: UseGroupHeaderDragArgs): GroupHeaderDra
         containerTop: containerRect.top,
         scrollTop: container.scrollTop,
         rects: session.headerRects,
-        siblingGroupIds: session.siblingGroupIds
+        siblingGroupIds: session.siblingGroupIds,
+        draggingGroupId: session.groupId
       })
     },
     buildState: (groupId, drop) =>

--- a/src/renderer/src/components/sidebar/group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag.ts
@@ -1,0 +1,80 @@
+import { useRef } from 'react'
+
+import {
+  computeGroupHeaderDropPreview,
+  measureGroupHeaderDragRects,
+  type GroupHeaderDropPreview
+} from './group-header-drop'
+import { commitGroupHeaderDragDrop } from './group-header-drag-commit'
+import {
+  GROUP_HEADER_DRAG_THRESHOLD_PX,
+  INITIAL_GROUP_DRAG_STATE,
+  type GroupDragState,
+  type GroupHeaderDragController,
+  type GroupHeaderDragSession,
+  type UseGroupHeaderDragArgs
+} from './group-header-drag-contract'
+import { createGroupHeaderDragSession } from './group-header-drag-start'
+import { useSidebarHeaderPointerDrag } from './sidebar-header-pointer-drag'
+
+export function useGroupHeaderDrag(args: UseGroupHeaderDragArgs): GroupHeaderDragController {
+  const argsRef = useRef(args)
+  argsRef.current = args
+  return useSidebarHeaderPointerDrag<
+    GroupHeaderDragSession,
+    GroupDragState,
+    GroupHeaderDropPreview
+  >({
+    threshold: GROUP_HEADER_DRAG_THRESHOLD_PX,
+    initialState: INITIAL_GROUP_DRAG_STATE,
+    getScrollContainer: () => argsRef.current.getScrollContainer(),
+    getSessionId: (session) => session.groupId,
+    getDraggingId: (dragState) => dragState.draggingGroupId,
+    createSession: (event, groupId) =>
+      createGroupHeaderDragSession({
+        event,
+        groupId,
+        groupsById: argsRef.current.groupsById,
+        siblingGroupIdsByParent: argsRef.current.siblingGroupIdsByParent,
+        getScrollContainer: argsRef.current.getScrollContainer
+      }),
+    measureRects: (container, session) => {
+      session.headerRects = measureGroupHeaderDragRects(container, session.parentGroupId)
+    },
+    computeDrop: (session, container) => {
+      const containerRect = container.getBoundingClientRect()
+      return computeGroupHeaderDropPreview({
+        pointerY: session.latestPointerY,
+        containerTop: containerRect.top,
+        scrollTop: container.scrollTop,
+        rects: session.headerRects,
+        siblingGroupIds: session.siblingGroupIds
+      })
+    },
+    buildState: (groupId, drop) =>
+      drop
+        ? {
+            draggingGroupId: groupId,
+            dropIndex: drop.dropIndex,
+            dropIndicatorY: drop.dropIndicatorY
+          }
+        : { draggingGroupId: groupId, dropIndex: null, dropIndicatorY: null },
+    areStatesEqual: (a, b) =>
+      a.draggingGroupId === b.draggingGroupId &&
+      a.dropIndex === b.dropIndex &&
+      a.dropIndicatorY === b.dropIndicatorY,
+    commit: (session, drop) => {
+      commitGroupHeaderDragDrop({
+        session,
+        sidebarDropIndex: drop.dropIndex,
+        groupsById: argsRef.current.groupsById,
+        onCommitGroupOrder: argsRef.current.onCommitGroupOrder
+      })
+    }
+  })
+}
+
+export {
+  isGroupHeaderActionTarget,
+  isGroupHeaderDragHandleTarget
+} from './group-header-drag-contract'

--- a/src/renderer/src/components/sidebar/group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag.ts
@@ -16,6 +16,7 @@ import {
 } from './group-header-drag-contract'
 import { createGroupHeaderDragSession } from './group-header-drag-start'
 import { useSidebarHeaderPointerDrag } from './sidebar-header-pointer-drag'
+import { collectHeaderDragBlockRowElements } from './header-drag-preview-rows'
 
 export function useGroupHeaderDrag(args: UseGroupHeaderDragArgs): GroupHeaderDragController {
   const argsRef = useRef(args)
@@ -41,6 +42,12 @@ export function useGroupHeaderDrag(args: UseGroupHeaderDragArgs): GroupHeaderDra
     measureRects: (container, session) => {
       session.headerRects = measureGroupHeaderDragRects(container, session.parentGroupId)
     },
+    getDragPreviewRows: (session) =>
+      collectHeaderDragBlockRowElements({
+        headerEl: session.handleEl,
+        mode: 'group',
+        parentAttr: session.parentGroupId ?? ''
+      }),
     computeDrop: (session, container) => {
       const containerRect = container.getBoundingClientRect()
       return computeGroupHeaderDropPreview({

--- a/src/renderer/src/components/sidebar/group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/group-header-drag.ts
@@ -74,7 +74,4 @@ export function useGroupHeaderDrag(args: UseGroupHeaderDragArgs): GroupHeaderDra
   })
 }
 
-export {
-  isGroupHeaderActionTarget,
-  isGroupHeaderDragHandleTarget
-} from './group-header-drag-contract'
+export { isGroupHeaderDragHandleTarget } from './group-header-drag-contract'

--- a/src/renderer/src/components/sidebar/group-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.test.ts
@@ -67,6 +67,26 @@ describe('computeGroupHeaderDropPreview', () => {
       })
     ).toBeNull()
   })
+
+  it('drops after the last group at its block bottom, not its header bottom', () => {
+    // Block-extent rects (as measureGroupHeaderDragRects now produces): group b
+    // spans its whole block 100..400, not just a 28px header.
+    const blockRects: GroupHeaderDragRect[] = [
+      { groupId: 'a', siblingIndex: 0, top: 0, bottom: 100 },
+      { groupId: 'b', siblingIndex: 1, top: 100, bottom: 400 }
+    ]
+    const preview = computeGroupHeaderDropPreview({
+      pointerY: 380, // lower half of group b's block
+      containerTop: 0,
+      scrollTop: 0,
+      rects: blockRects,
+      siblingGroupIds: ['a', 'b']
+    })
+    expect(preview?.dropIndex).toBe(2)
+    // Indicator sits at the bottom of b's block (~400), below its worktrees —
+    // not at a ~128 header bottom inside the group.
+    expect(preview?.dropIndicatorY ?? 0).toBeGreaterThanOrEqual(400)
+  })
 })
 
 describe('getSiblingGroupIdsByParent', () => {

--- a/src/renderer/src/components/sidebar/group-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import {
+  computeGroupHeaderDropPreview,
+  getTabOrderForGroupDrop,
+  getSiblingGroupIdsByParent,
+  type GroupHeaderDragRect
+} from './group-header-drop'
+import type { ProjectGroup } from '../../../../shared/types'
+
+function makeGroup(id: string, tabOrder: number): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0
+  }
+}
+
+describe('getTabOrderForGroupDrop', () => {
+  it('returns 0 for an empty sibling list', () => {
+    expect(getTabOrderForGroupDrop({ siblings: [], dropIndex: 0 })).toBe(0)
+  })
+  it('places below the first sibling when dropping at the start', () => {
+    const siblings = [makeGroup('a', 0), makeGroup('b', 1)]
+    expect(getTabOrderForGroupDrop({ siblings, dropIndex: 0 })).toBe(-1)
+  })
+  it('places between two siblings', () => {
+    const siblings = [makeGroup('a', 0), makeGroup('b', 2)]
+    expect(getTabOrderForGroupDrop({ siblings, dropIndex: 1 })).toBe(1)
+  })
+  it('places above the last sibling when dropping at the end', () => {
+    const siblings = [makeGroup('a', 0), makeGroup('b', 2)]
+    expect(getTabOrderForGroupDrop({ siblings, dropIndex: 2 })).toBe(3)
+  })
+})
+
+describe('computeGroupHeaderDropPreview', () => {
+  const rects: GroupHeaderDragRect[] = [
+    { groupId: 'a', siblingIndex: 0, top: 0, bottom: 28 },
+    { groupId: 'b', siblingIndex: 1, top: 100, bottom: 128 }
+  ]
+  it('drops before the second group when the pointer is in its top half', () => {
+    const preview = computeGroupHeaderDropPreview({
+      pointerY: 105,
+      containerTop: 0,
+      scrollTop: 0,
+      rects,
+      siblingGroupIds: ['a', 'b']
+    })
+    expect(preview?.dropIndex).toBe(1)
+  })
+  it('returns null when there are no sibling ids', () => {
+    expect(
+      computeGroupHeaderDropPreview({
+        pointerY: 105,
+        containerTop: 0,
+        scrollTop: 0,
+        rects,
+        siblingGroupIds: []
+      })
+    ).toBeNull()
+  })
+})
+
+describe('getSiblingGroupIdsByParent', () => {
+  it('buckets group headers by parent in row order', () => {
+    const map = getSiblingGroupIdsByParent([
+      {
+        type: 'header',
+        key: 'project-group:a',
+        label: 'a',
+        count: 1,
+        tone: '',
+        projectGroup: { id: 'a', name: 'a', parentGroupId: null, tabOrder: 0 } as never
+      },
+      {
+        type: 'header',
+        key: 'project-group:b',
+        label: 'b',
+        count: 1,
+        tone: '',
+        projectGroup: { id: 'b', name: 'b', parentGroupId: null, tabOrder: 1 } as never
+      }
+    ] as never)
+    expect(map.get(null)).toEqual(['a', 'b'])
+  })
+})

--- a/src/renderer/src/components/sidebar/group-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.test.ts
@@ -68,6 +68,20 @@ describe('computeGroupHeaderDropPreview', () => {
     ).toBeNull()
   })
 
+  it('collapses the slot below the dragged group to its home position above', () => {
+    // Pointer in the lower half of group a (the dragged one) would otherwise
+    // resolve to "below a" (dropIndex 1); it must snap to a's home (0).
+    const preview = computeGroupHeaderDropPreview({
+      pointerY: 60,
+      containerTop: 0,
+      scrollTop: 0,
+      rects,
+      siblingGroupIds: ['a', 'b'],
+      draggingGroupId: 'a'
+    })
+    expect(preview?.dropIndex).toBe(0)
+  })
+
   it('drops after the last group at its block bottom, not its header bottom', () => {
     // Block-extent rects (as measureGroupHeaderDragRects now produces): group b
     // spans its whole block 100..400, not just a 28px header.

--- a/src/renderer/src/components/sidebar/group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.ts
@@ -1,0 +1,153 @@
+// group-header-drop.ts
+import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
+import { mapSidebarProjectHeaderDropIndexToSiblingInsertIndex } from './project-header-drop'
+import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
+import type { Row } from './worktree-list-groups'
+import type { ProjectGroup } from '../../../../shared/types'
+
+export type GroupHeaderDragRect = {
+  groupId: string
+  // Index among sibling group headers (same parent) from the row model, not the
+  // mounted subset — virtualized rows unmount off-screen headers.
+  siblingIndex: number
+  top: number
+  bottom: number
+}
+
+export type GroupHeaderDropPreview = {
+  dropIndex: number
+  dropIndicatorY: number
+}
+
+const INDICATOR_GAP_PX = 4
+
+export { mapSidebarProjectHeaderDropIndexToSiblingInsertIndex as mapSidebarGroupDropIndexToSiblingInsertIndex }
+
+export function getTabOrderForGroupDrop(args: {
+  siblings: readonly ProjectGroup[]
+  dropIndex: number
+}): number {
+  if (args.siblings.length === 0) {
+    return 0
+  }
+  const before = args.siblings[args.dropIndex - 1]?.tabOrder
+  const after = args.siblings[args.dropIndex]?.tabOrder
+  return interpolateSparseOrder(before, after)
+}
+
+/** Ordered sibling group ids keyed by parent (null = top level). Mirrors the
+ *  row builder's per-parent tabOrder||name sort so drag indices line up. */
+export function getSiblingGroupIdsByParent(rows: readonly Row[]): Map<string | null, string[]> {
+  const byParent = new Map<string | null, string[]>()
+  const seen = new Set<string>()
+  for (const row of rows) {
+    if (row.type !== 'header' || !row.projectGroup || row.projectGroup.id === null) {
+      continue
+    }
+    if (seen.has(row.projectGroup.id)) {
+      continue
+    }
+    seen.add(row.projectGroup.id)
+    const parent =
+      'parentGroupId' in row.projectGroup ? (row.projectGroup.parentGroupId ?? null) : null
+    const list = byParent.get(parent) ?? []
+    list.push(row.projectGroup.id)
+    byParent.set(parent, list)
+  }
+  return byParent
+}
+
+function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
+  if (!virtualRow) {
+    return null
+  }
+  const rawStart = virtualRow.getAttribute('data-worktree-virtual-row-start')
+  if (rawStart === null) {
+    return null
+  }
+  const start = Number(rawStart)
+  return Number.isFinite(start) ? start : null
+}
+
+export function measureGroupHeaderDragRects(
+  container: HTMLElement,
+  parentGroupId?: string | null
+): GroupHeaderDragRect[] {
+  const containerRect = container.getBoundingClientRect()
+  const rects: GroupHeaderDragRect[] = []
+  container.querySelectorAll<HTMLElement>('[data-project-group-header-id]').forEach((element) => {
+    const groupId = element.getAttribute('data-project-group-header-id')
+    const rawSiblingIndex = element.getAttribute('data-project-group-sibling-index')
+    const siblingIndex = rawSiblingIndex === null ? Number.NaN : Number(rawSiblingIndex)
+    const rawParent = element.getAttribute('data-project-group-parent')
+    const elementParent = rawParent === null || rawParent === '' ? null : rawParent
+    if (!groupId || !Number.isFinite(siblingIndex)) {
+      return
+    }
+    if (parentGroupId !== undefined && elementParent !== parentGroupId) {
+      return
+    }
+    const rect = element.getBoundingClientRect()
+    const virtualRow = element.closest<HTMLElement>('[data-worktree-virtual-row]')
+    const virtualRowStart = getVirtualRowStart(virtualRow)
+    const top =
+      virtualRow && virtualRowStart !== null
+        ? virtualRowStart + rect.top - virtualRow.getBoundingClientRect().top
+        : rect.top - containerRect.top + container.scrollTop
+    rects.push({ groupId, siblingIndex, top, bottom: top + rect.height })
+  })
+  rects.sort((left, right) => left.top - right.top)
+  return rects
+}
+
+export function computeGroupHeaderDropPreview(args: {
+  pointerY: number
+  containerTop: number
+  scrollTop: number
+  rects: readonly GroupHeaderDragRect[]
+  siblingGroupIds: readonly string[]
+}): GroupHeaderDropPreview | null {
+  const { rects, siblingGroupIds } = args
+  if (rects.length === 0 || siblingGroupIds.length === 0) {
+    return null
+  }
+  const localY = args.pointerY - args.containerTop + args.scrollTop
+  const first = rects[0]!
+  const last = rects.at(-1)!
+  const boundaryDrop = getWorktreeSidebarBoundaryDrop({
+    localY,
+    firstRect: {
+      worktreeId: first.groupId,
+      groupIndex: first.siblingIndex,
+      top: first.top,
+      bottom: first.bottom
+    },
+    lastRect: {
+      worktreeId: last.groupId,
+      groupIndex: last.siblingIndex,
+      top: last.top,
+      bottom: last.bottom
+    },
+    sourceGroupSize: siblingGroupIds.length
+  })
+  if (boundaryDrop.kind === 'outside') {
+    return null
+  }
+
+  let dropIndex = last.siblingIndex + 1
+  let indicatorY = last.bottom + INDICATOR_GAP_PX
+  if (boundaryDrop.kind === 'drop') {
+    dropIndex = boundaryDrop.dropIndex
+    indicatorY = boundaryDrop.indicatorY
+  } else {
+    for (const rect of rects) {
+      const mid = (rect.top + rect.bottom) / 2
+      if (localY < mid) {
+        dropIndex = rect.siblingIndex
+        indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
+        break
+      }
+    }
+  }
+  return { dropIndex, dropIndicatorY: Math.max(args.scrollTop, indicatorY) }
+}

--- a/src/renderer/src/components/sidebar/group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.ts
@@ -2,6 +2,7 @@
 import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
 import { mapSidebarProjectHeaderDropIndexToSiblingInsertIndex } from './project-header-drop'
 import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
+import { getVirtualRowStart } from './sidebar-virtual-row-offset'
 import type { Row } from './worktree-list-groups'
 import type { ProjectGroup } from '../../../../shared/types'
 
@@ -48,25 +49,12 @@ export function getSiblingGroupIdsByParent(rows: readonly Row[]): Map<string | n
       continue
     }
     seen.add(row.projectGroup.id)
-    const parent =
-      'parentGroupId' in row.projectGroup ? (row.projectGroup.parentGroupId ?? null) : null
+    const parent = row.projectGroup.parentGroupId ?? null
     const list = byParent.get(parent) ?? []
     list.push(row.projectGroup.id)
     byParent.set(parent, list)
   }
   return byParent
-}
-
-function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
-  if (!virtualRow) {
-    return null
-  }
-  const rawStart = virtualRow.getAttribute('data-worktree-virtual-row-start')
-  if (rawStart === null) {
-    return null
-  }
-  const start = Number(rawStart)
-  return Number.isFinite(start) ? start : null
 }
 
 export function measureGroupHeaderDragRects(

--- a/src/renderer/src/components/sidebar/group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.ts
@@ -76,11 +76,27 @@ export function measureGroupHeaderDragRects(
     if (parentGroupId !== undefined && elementParent !== parentGroupId) {
       return
     }
-    const rect = element.getBoundingClientRect()
     const top = resolveVirtualRowTop(element, container, containerRect)
-    rects.push({ groupId, siblingIndex, top, bottom: top + rect.height })
+    rects.push({ groupId, siblingIndex, top, bottom: top })
   })
   rects.sort((left, right) => left.top - right.top)
+  // Why: a group's drop footprint is its whole block (header + projects +
+  // worktrees), not just the header row. Extend each rect's bottom to the next
+  // sibling group's top — and the last to the bottom of the last rendered row
+  // — so the drop line lands at block boundaries instead of inside a group
+  // below its header. (Uses the last row's bottom, not scrollHeight, which can
+  // exceed the rendered content.)
+  let contentBottom = rects.at(-1)?.top ?? 0
+  container.querySelectorAll<HTMLElement>('[data-worktree-virtual-row]').forEach((element) => {
+    const rowBottom =
+      resolveVirtualRowTop(element, container, containerRect) +
+      element.getBoundingClientRect().height
+    contentBottom = Math.max(contentBottom, rowBottom)
+  })
+  for (let index = 0; index < rects.length; index++) {
+    const next = rects[index + 1]
+    rects[index]!.bottom = next ? next.top : contentBottom
+  }
   return rects
 }
 

--- a/src/renderer/src/components/sidebar/group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.ts
@@ -1,8 +1,11 @@
 // group-header-drop.ts
 import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
-import { mapSidebarProjectHeaderDropIndexToSiblingInsertIndex } from './project-header-drop'
+import {
+  INDICATOR_GAP_PX,
+  mapSidebarProjectHeaderDropIndexToSiblingInsertIndex
+} from './project-header-drop'
 import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
-import { getVirtualRowStart } from './sidebar-virtual-row-offset'
+import { resolveVirtualRowTop } from './sidebar-virtual-row-offset'
 import type { Row } from './worktree-list-groups'
 import type { ProjectGroup } from '../../../../shared/types'
 
@@ -19,8 +22,6 @@ export type GroupHeaderDropPreview = {
   dropIndex: number
   dropIndicatorY: number
 }
-
-const INDICATOR_GAP_PX = 4
 
 export { mapSidebarProjectHeaderDropIndexToSiblingInsertIndex as mapSidebarGroupDropIndexToSiblingInsertIndex }
 
@@ -76,12 +77,7 @@ export function measureGroupHeaderDragRects(
       return
     }
     const rect = element.getBoundingClientRect()
-    const virtualRow = element.closest<HTMLElement>('[data-worktree-virtual-row]')
-    const virtualRowStart = getVirtualRowStart(virtualRow)
-    const top =
-      virtualRow && virtualRowStart !== null
-        ? virtualRowStart + rect.top - virtualRow.getBoundingClientRect().top
-        : rect.top - containerRect.top + container.scrollTop
+    const top = resolveVirtualRowTop(element, container, containerRect)
     rects.push({ groupId, siblingIndex, top, bottom: top + rect.height })
   })
   rects.sort((left, right) => left.top - right.top)

--- a/src/renderer/src/components/sidebar/group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.ts
@@ -106,6 +106,9 @@ export function computeGroupHeaderDropPreview(args: {
   scrollTop: number
   rects: readonly GroupHeaderDragRect[]
   siblingGroupIds: readonly string[]
+  /** The group being dragged, so the slot immediately below it (a no-op,
+   *  identical to leaving it in place) collapses to its home position above. */
+  draggingGroupId?: string
 }): GroupHeaderDropPreview | null {
   const { rects, siblingGroupIds } = args
   if (rects.length === 0 || siblingGroupIds.length === 0) {
@@ -148,6 +151,15 @@ export function computeGroupHeaderDropPreview(args: {
         break
       }
     }
+  }
+  // The slot right below the dragged group is the same as leaving it in place;
+  // collapse it to the home position above the group so only that shows.
+  const draggedRect = args.draggingGroupId
+    ? rects.find((rect) => rect.groupId === args.draggingGroupId)
+    : undefined
+  if (draggedRect && dropIndex === draggedRect.siblingIndex + 1) {
+    dropIndex = draggedRect.siblingIndex
+    indicatorY = Math.max(0, draggedRect.top - INDICATOR_GAP_PX)
   }
   return { dropIndex, dropIndicatorY: Math.max(args.scrollTop, indicatorY) }
 }

--- a/src/renderer/src/components/sidebar/group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.ts
@@ -1,9 +1,6 @@
 // group-header-drop.ts
 import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
-import {
-  INDICATOR_GAP_PX,
-  mapSidebarProjectHeaderDropIndexToSiblingInsertIndex
-} from './project-header-drop'
+import { mapSidebarProjectHeaderDropIndexToSiblingInsertIndex } from './project-header-drop'
 import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
 import { resolveVirtualRowTop } from './sidebar-virtual-row-offset'
 import type { Row } from './worktree-list-groups'
@@ -138,7 +135,10 @@ export function computeGroupHeaderDropPreview(args: {
   }
 
   let dropIndex = last.siblingIndex + 1
-  let indicatorY = last.bottom + INDICATOR_GAP_PX
+  // Indicator sits exactly at the block boundary so it matches the gap-opening
+  // shift's drop point (a cosmetic offset would pull the next sibling's unit
+  // into the shift).
+  let indicatorY = last.bottom
   if (boundaryDrop.kind === 'drop') {
     dropIndex = boundaryDrop.dropIndex
     indicatorY = boundaryDrop.indicatorY
@@ -147,7 +147,7 @@ export function computeGroupHeaderDropPreview(args: {
       const mid = (rect.top + rect.bottom) / 2
       if (localY < mid) {
         dropIndex = rect.siblingIndex
-        indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
+        indicatorY = Math.max(0, rect.top)
         break
       }
     }
@@ -159,7 +159,7 @@ export function computeGroupHeaderDropPreview(args: {
     : undefined
   if (draggedRect && dropIndex === draggedRect.siblingIndex + 1) {
     dropIndex = draggedRect.siblingIndex
-    indicatorY = Math.max(0, draggedRect.top - INDICATOR_GAP_PX)
+    indicatorY = Math.max(0, draggedRect.top)
   }
   return { dropIndex, dropIndicatorY: Math.max(args.scrollTop, indicatorY) }
 }

--- a/src/renderer/src/components/sidebar/group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/group-header-drop.ts
@@ -2,7 +2,7 @@
 import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
 import { mapSidebarProjectHeaderDropIndexToSiblingInsertIndex } from './project-header-drop'
 import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
-import { resolveVirtualRowTop } from './sidebar-virtual-row-offset'
+import { resolveVirtualRowStart, resolveVirtualRowTop } from './sidebar-virtual-row-offset'
 import type { Row } from './worktree-list-groups'
 import type { ProjectGroup } from '../../../../shared/types'
 
@@ -60,6 +60,11 @@ export function measureGroupHeaderDragRects(
   parentGroupId?: string | null
 ): GroupHeaderDragRect[] {
   const containerRect = container.getBoundingClientRect()
+  // Measure from the virtual row's slot start so boundaries match the
+  // gap-opening shift's coordinate space (the shift keys off the same
+  // virtualizer starts; the header's intra-row spacing would offset them).
+  const rowTop = (element: HTMLElement): number =>
+    resolveVirtualRowStart(element) ?? resolveVirtualRowTop(element, container, containerRect)
   const rects: GroupHeaderDragRect[] = []
   container.querySelectorAll<HTMLElement>('[data-project-group-header-id]').forEach((element) => {
     const groupId = element.getAttribute('data-project-group-header-id')
@@ -73,7 +78,7 @@ export function measureGroupHeaderDragRects(
     if (parentGroupId !== undefined && elementParent !== parentGroupId) {
       return
     }
-    const top = resolveVirtualRowTop(element, container, containerRect)
+    const top = rowTop(element)
     rects.push({ groupId, siblingIndex, top, bottom: top })
   })
   rects.sort((left, right) => left.top - right.top)
@@ -85,10 +90,10 @@ export function measureGroupHeaderDragRects(
   // exceed the rendered content.)
   let contentBottom = rects.at(-1)?.top ?? 0
   container.querySelectorAll<HTMLElement>('[data-worktree-virtual-row]').forEach((element) => {
-    const rowBottom =
-      resolveVirtualRowTop(element, container, containerRect) +
-      element.getBoundingClientRect().height
-    contentBottom = Math.max(contentBottom, rowBottom)
+    contentBottom = Math.max(
+      contentBottom,
+      rowTop(element) + element.getBoundingClientRect().height
+    )
   })
   for (let index = 0; index < rects.length; index++) {
     const next = rects[index + 1]

--- a/src/renderer/src/components/sidebar/header-drag-block-units.test.ts
+++ b/src/renderer/src/components/sidebar/header-drag-block-units.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest'
+import { resolveHeaderDragBlockUnits } from './header-drag-block-units'
+import type { RenderRow } from './worktree-list-virtual-rows'
+
+/** Mirrors the real getRenderRowKey exactly (same branch order and default
+ *  `wt:` fall-through). Injected so the tests don't import WorktreeList. */
+function getRowKey(row: RenderRow): string {
+  if (row.type === 'host-header') {
+    return `host:${row.hostId}`
+  }
+  if (row.type === 'header') {
+    return `hdr:${row.key}`
+  }
+  if (row.type === 'lineage-group') {
+    return `lineage-group:${row.key}`
+  }
+  if (row.type === 'imported-worktrees-card') {
+    return `imported:${row.key}`
+  }
+  if (row.type === 'new-external-worktrees-inbox') {
+    return `inbox:${row.key}`
+  }
+  if (row.type === 'pending-creation') {
+    return `pending:${row.creationId}`
+  }
+  if (row.type === 'folder-workspace') {
+    return `folder-workspace:${row.folderWorkspace.id}`
+  }
+  return `wt:${row.rowKey}`
+}
+
+// Helpers to build minimal RenderRow fixtures. The types are complex domain
+// objects; `as never` satisfies deep required fields we don't need for these
+// pure-segmentation tests (matching convention in worktree-list-groups.test.ts).
+
+function headerRow(opts: {
+  key: string
+  repoId?: string
+  groupId?: string
+  projectGroupDepth?: number
+}): RenderRow {
+  return {
+    type: 'header',
+    key: opts.key,
+    label: opts.key,
+    count: 0,
+    tone: '',
+    repo: opts.repoId ? ({ id: opts.repoId } as never) : undefined,
+    projectGroup: opts.groupId ? ({ id: opts.groupId } as never) : undefined,
+    projectGroupDepth: opts.projectGroupDepth
+  } as never
+}
+
+function worktreeRow(rowKey: string): RenderRow {
+  return { type: 'item', rowKey, sectionKey: '', worktree: { id: rowKey } as never } as never
+}
+
+/** Build virtualItems from a flat list of sizes, one per renderRow index. */
+function makeVirtualItems(sizes: number[]): { index: number; start: number; size: number }[] {
+  const items: { index: number; start: number; size: number }[] = []
+  let pos = 0
+  for (let i = 0; i < sizes.length; i++) {
+    items.push({ index: i, start: pos, size: sizes[i]! })
+    pos += sizes[i]!
+  }
+  return items
+}
+
+describe('resolveHeaderDragBlockUnits — no drag active', () => {
+  it('returns null when both draggingRepoId and draggingGroupId are null', () => {
+    const rows: RenderRow[] = [headerRow({ key: 'repo:r1', repoId: 'r1' }), worktreeRow('wt-a')]
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: makeVirtualItems([28, 116]),
+      draggingRepoId: null,
+      draggingGroupId: null,
+      getRowKey
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the dragged header is not present in renderRows', () => {
+    const rows: RenderRow[] = [headerRow({ key: 'repo:r1', repoId: 'r1' }), worktreeRow('wt-a')]
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: makeVirtualItems([28, 116]),
+      draggingRepoId: 'repo-missing',
+      draggingGroupId: null,
+      getRowKey
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the dragged header is off-screen (no virtualItem for its index)', () => {
+    const rows: RenderRow[] = [headerRow({ key: 'repo:r1', repoId: 'r1' }), worktreeRow('wt-a')]
+    // Only the worktree row is virtualised, not index 0 (the header)
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: [{ index: 1, start: 28, size: 116 }],
+      draggingRepoId: 'r1',
+      draggingGroupId: null,
+      getRowKey
+    })
+    expect(result).toBeNull()
+  })
+})
+
+describe('resolveHeaderDragBlockUnits — project drag', () => {
+  // Layout:
+  //   idx 0: group header (group-a, depth 0)
+  //   idx 1: project header (repo-1, depth 1)  ← dragged
+  //   idx 2: worktree wt-1
+  //   idx 3: project header (repo-2, depth 1)
+  //   idx 4: worktree wt-2
+  //   idx 5: project header (repo-3, depth 1)
+  //   idx 6: worktree wt-3
+  const rows: RenderRow[] = [
+    headerRow({ key: 'project-group:g1', groupId: 'group-a', projectGroupDepth: 0 }),
+    headerRow({ key: 'repo:r1', repoId: 'repo-1', projectGroupDepth: 1 }),
+    worktreeRow('wt-1'),
+    headerRow({ key: 'repo:r2', repoId: 'repo-2', projectGroupDepth: 1 }),
+    worktreeRow('wt-2'),
+    headerRow({ key: 'repo:r3', repoId: 'repo-3', projectGroupDepth: 1 }),
+    worktreeRow('wt-3')
+  ]
+  const sizes = [28, 28, 116, 28, 116, 28, 116]
+  const vItems = makeVirtualItems(sizes)
+
+  it('blockKeys contains exactly the dragged project header + its worktree', () => {
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: vItems,
+      draggingRepoId: 'repo-1',
+      draggingGroupId: null,
+      getRowKey
+    })
+    expect(result).not.toBeNull()
+    expect(result!.blockKeys).toEqual(new Set(['hdr:repo:r1', 'wt:wt-1']))
+  })
+
+  it('blockTop and blockBottom span the dragged project block', () => {
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: vItems,
+      draggingRepoId: 'repo-1',
+      draggingGroupId: null,
+      getRowKey
+    })
+    // idx 1 starts at 28, idx 3 (next header) starts at 172 → blockBottom = 172
+    expect(result!.blockTop).toBe(28)
+    expect(result!.blockBottom).toBe(172)
+  })
+
+  it('each project header + its worktrees forms its own unit', () => {
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: vItems,
+      draggingRepoId: 'repo-1',
+      draggingGroupId: null,
+      getRowKey
+    })
+    // All headers (including the group header at depth 0 and the project
+    // headers at depth 1) are independent units during project drag.
+    expect(result!.units).toHaveLength(4)
+    // First unit: the group header at idx 0
+    expect(result!.units[0]).toMatchObject({ headerTop: 0, rowKeys: ['hdr:project-group:g1'] })
+    // Second unit: dragged project header + its worktree
+    expect(result!.units[1]).toMatchObject({ headerTop: 28, rowKeys: ['hdr:repo:r1', 'wt:wt-1'] })
+    // Third unit: next project header + its worktree
+    expect(result!.units[2]).toMatchObject({ headerTop: 172, rowKeys: ['hdr:repo:r2', 'wt:wt-2'] })
+    // Fourth unit: last project header + its worktree
+    expect(result!.units[3]).toMatchObject({ headerTop: 316, rowKeys: ['hdr:repo:r3', 'wt:wt-3'] })
+  })
+
+  it('blockBottom is computed from sizes when the end row is off-screen', () => {
+    // Only virtualise rows 0–2 (group header + first project + its worktree).
+    // The end boundary (index 3) is not in virtualItems, so blockBottom must
+    // be calculated by summing sizes of rows 1 and 2.
+    const partialVItems = vItems.slice(0, 3) // indices 0,1,2
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: partialVItems,
+      draggingRepoId: 'repo-1',
+      draggingGroupId: null,
+      getRowKey
+    })
+    // blockTop = 28; sizes[1] + sizes[2] = 28 + 116 = 144; blockBottom = 28 + 144 = 172
+    expect(result!.blockTop).toBe(28)
+    expect(result!.blockBottom).toBe(172)
+  })
+})
+
+describe('resolveHeaderDragBlockUnits — group drag', () => {
+  // Layout:
+  //   idx 0: group header group-A (depth 0)     ← dragged
+  //   idx 1:   project header repo-1 (depth 1)
+  //   idx 2:     worktree wt-1
+  //   idx 3:   group header group-B (depth 1)   ← nested inside group-A
+  //   idx 4:     project header repo-2 (depth 2)
+  //   idx 5:       worktree wt-2
+  //   idx 6: group header group-C (depth 0)     ← sibling, ends the block
+  //   idx 7:   project header repo-3 (depth 1)
+  //   idx 8:     worktree wt-3
+  const rows: RenderRow[] = [
+    headerRow({ key: 'project-group:gA', groupId: 'group-A', projectGroupDepth: 0 }),
+    headerRow({ key: 'repo:r1', repoId: 'repo-1', projectGroupDepth: 1 }),
+    worktreeRow('wt-1'),
+    headerRow({ key: 'project-group:gB', groupId: 'group-B', projectGroupDepth: 1 }),
+    headerRow({ key: 'repo:r2', repoId: 'repo-2', projectGroupDepth: 2 }),
+    worktreeRow('wt-2'),
+    headerRow({ key: 'project-group:gC', groupId: 'group-C', projectGroupDepth: 0 }),
+    headerRow({ key: 'repo:r3', repoId: 'repo-3', projectGroupDepth: 1 }),
+    worktreeRow('wt-3')
+  ]
+  const sizes = [28, 28, 116, 28, 28, 116, 28, 28, 116]
+  const vItems = makeVirtualItems(sizes)
+
+  it('blockKeys spans the entire group-A subtree (indices 0–5)', () => {
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: vItems,
+      draggingRepoId: null,
+      draggingGroupId: 'group-A',
+      getRowKey
+    })
+    expect(result).not.toBeNull()
+    expect(result!.blockKeys).toEqual(
+      new Set([
+        'hdr:project-group:gA',
+        'hdr:repo:r1',
+        'wt:wt-1',
+        'hdr:project-group:gB',
+        'hdr:repo:r2',
+        'wt:wt-2'
+      ])
+    )
+  })
+
+  it('blockTop and blockBottom span indices 0 through 5', () => {
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: vItems,
+      draggingRepoId: null,
+      draggingGroupId: 'group-A',
+      getRowKey
+    })
+    // blockTop = start[0] = 0; blockBottom = start[6] = 344
+    expect(result!.blockTop).toBe(0)
+    expect(result!.blockBottom).toBe(344)
+  })
+
+  it('sibling group-C is its own unit containing its subtree', () => {
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: vItems,
+      draggingRepoId: null,
+      draggingGroupId: 'group-A',
+      getRowKey
+    })
+    // During group drag, only depth-0 group headers start units. The dragged
+    // group-A (idx 0) is one unit; sibling group-C (idx 6) is a second unit
+    // whose subtree (repo-3 + wt-3) continues with it.
+    expect(result!.units).toHaveLength(2)
+    expect(result!.units[0]).toMatchObject({
+      headerTop: 0,
+      rowKeys: [
+        'hdr:project-group:gA',
+        'hdr:repo:r1',
+        'wt:wt-1',
+        'hdr:project-group:gB',
+        'hdr:repo:r2',
+        'wt:wt-2'
+      ]
+    })
+    expect(result!.units[1]).toMatchObject({
+      headerTop: 344,
+      rowKeys: ['hdr:project-group:gC', 'hdr:repo:r3', 'wt:wt-3']
+    })
+  })
+
+  it('dragging a nested group only takes its own subtree as the block', () => {
+    // Dragging group-B (depth 1) — its block ends at group-C (depth 0) which
+    // is shallower than depth 1. The block is indices 3–5.
+    const result = resolveHeaderDragBlockUnits({
+      renderRows: rows,
+      virtualItems: vItems,
+      draggingRepoId: null,
+      draggingGroupId: 'group-B',
+      getRowKey
+    })
+    expect(result!.blockKeys).toEqual(new Set(['hdr:project-group:gB', 'hdr:repo:r2', 'wt:wt-2']))
+    // blockTop = start[3] = 172; blockBottom = start[6] = 344
+    expect(result!.blockTop).toBe(172)
+    expect(result!.blockBottom).toBe(344)
+  })
+})

--- a/src/renderer/src/components/sidebar/header-drag-block-units.ts
+++ b/src/renderer/src/components/sidebar/header-drag-block-units.ts
@@ -1,0 +1,123 @@
+/** Resolve the dragged header's block (a project + its worktrees, or a group +
+ *  its whole subtree) into movable units ready for gap-opening shift
+ *  computation. Extracted from computeHeaderDragRowOffsets so this pure
+ *  segmentation step can be tested independently of the scroll-offset layer. */
+import type { RenderRow } from './worktree-list-virtual-rows'
+
+export type HeaderDragBlockUnits = {
+  /** Render keys of every row in the dragged block (kept hidden during drag). */
+  blockKeys: Set<string>
+  /** Movable units: header + all rows that must move with it as one piece. */
+  units: { headerTop: number; rowKeys: string[] }[]
+  /** Container-relative top of the first row in the dragged block. */
+  blockTop: number
+  /** Container-relative bottom of the last row in the dragged block. */
+  blockBottom: number
+}
+
+export function resolveHeaderDragBlockUnits(args: {
+  renderRows: readonly RenderRow[]
+  virtualItems: readonly { index: number; start: number; size: number }[]
+  draggingRepoId: string | null
+  draggingGroupId: string | null
+  /** Maps a RenderRow to its unique render key — injected to avoid a circular
+   *  import back to the React component module. */
+  getRowKey: (row: RenderRow) => string
+}): HeaderDragBlockUnits | null {
+  if (args.draggingRepoId === null && args.draggingGroupId === null) {
+    return null
+  }
+  const isGroup = args.draggingGroupId !== null
+  let headerIndex = -1
+  for (let i = 0; i < args.renderRows.length; i++) {
+    const row = args.renderRows[i]!
+    if (row.type !== 'header') {
+      continue
+    }
+    if (
+      isGroup ? row.projectGroup?.id === args.draggingGroupId : row.repo?.id === args.draggingRepoId
+    ) {
+      headerIndex = i
+      break
+    }
+  }
+  if (headerIndex === -1) {
+    return null
+  }
+  const headerRow = args.renderRows[headerIndex]!
+  const draggedDepth = headerRow.type === 'header' ? (headerRow.projectGroupDepth ?? 0) : 0
+  // A project block ends at the next header; a group block extends through its
+  // nested rows until a header at the same or shallower group depth.
+  let endIndex = args.renderRows.length
+  for (let i = headerIndex + 1; i < args.renderRows.length; i++) {
+    const row = args.renderRows[i]!
+    if (row.type !== 'header') {
+      continue
+    }
+    if (!isGroup || (row.projectGroupDepth ?? 0) <= draggedDepth) {
+      endIndex = i
+      break
+    }
+  }
+  const startByIndex = new Map<number, number>()
+  const sizeByIndex = new Map<number, number>()
+  for (const item of args.virtualItems) {
+    startByIndex.set(item.index, item.start)
+    sizeByIndex.set(item.index, item.size)
+  }
+  const blockTop = startByIndex.get(headerIndex)
+  if (blockTop === undefined) {
+    return null
+  }
+  let blockBottom = startByIndex.get(endIndex)
+  if (blockBottom === undefined) {
+    let sum = 0
+    for (let i = headerIndex; i < endIndex; i++) {
+      sum += sizeByIndex.get(i) ?? 0
+    }
+    blockBottom = blockTop + sum
+  }
+  const blockKeys = new Set<string>()
+  for (let i = headerIndex; i < endIndex; i++) {
+    blockKeys.add(args.getRowKey(args.renderRows[i]!))
+  }
+  // Segment the visible rows into movable units (whole blocks) so a block's
+  // children always shift with their header. Project drag treats every header
+  // (project AND group) as its own unit, so the list reflows flatly — group
+  // dividers slide up with everything else, leaving no overlap. Group drag
+  // moves sibling-group blocks (their whole subtree, nested headers included).
+  const startsUnit = (row: RenderRow): boolean =>
+    row.type === 'header' &&
+    (isGroup
+      ? row.projectGroup != null &&
+        row.projectGroup.id !== null &&
+        (row.projectGroupDepth ?? 0) === draggedDepth
+      : true)
+  const continuesUnit = (row: RenderRow): boolean =>
+    isGroup && row.type === 'header' && (row.projectGroupDepth ?? 0) > draggedDepth
+  const units: { headerTop: number; rowKeys: string[] }[] = []
+  let current: { headerTop: number; rowKeys: string[] } | null = null
+  const flush = (): void => {
+    if (current && current.rowKeys.length > 0) {
+      units.push(current)
+    }
+    current = null
+  }
+  for (let i = 0; i < args.renderRows.length; i++) {
+    const row = args.renderRows[i]!
+    const key = args.getRowKey(row)
+    if (startsUnit(row)) {
+      flush()
+      const top = startByIndex.get(i)
+      current = top === undefined ? null : { headerTop: top, rowKeys: [key] }
+    } else if (row.type === 'header' && !continuesUnit(row)) {
+      // A header that is not part of the current block (e.g. a group header
+      // during project drag) stays put and closes the open unit.
+      flush()
+    } else if (current) {
+      current.rowKeys.push(key)
+    }
+  }
+  flush()
+  return { blockKeys, units, blockTop, blockBottom }
+}

--- a/src/renderer/src/components/sidebar/header-drag-block-units.ts
+++ b/src/renderer/src/components/sidebar/header-drag-block-units.ts
@@ -46,6 +46,13 @@ export function resolveHeaderDragBlockUnits(args: {
   }
   const headerRow = args.renderRows[headerIndex]!
   const draggedDepth = headerRow.type === 'header' ? (headerRow.projectGroupDepth ?? 0) : 0
+  // Same-depth groups can sit under different parents, so scope group units to
+  // the dragged group's own siblings; otherwise an unrelated branch at the same
+  // depth would shift during the gap-opening preview.
+  const draggedParentId =
+    headerRow.type === 'header' && headerRow.projectGroup && headerRow.projectGroup.id !== null
+      ? (headerRow.projectGroup.parentGroupId ?? null)
+      : null
   // A project block ends at the next header; a group block extends through its
   // nested rows until a header at the same or shallower group depth.
   let endIndex = args.renderRows.length
@@ -91,7 +98,8 @@ export function resolveHeaderDragBlockUnits(args: {
     (isGroup
       ? row.projectGroup != null &&
         row.projectGroup.id !== null &&
-        (row.projectGroupDepth ?? 0) === draggedDepth
+        (row.projectGroupDepth ?? 0) === draggedDepth &&
+        (row.projectGroup.parentGroupId ?? null) === draggedParentId
       : true)
   const continuesUnit = (row: RenderRow): boolean =>
     isGroup && row.type === 'header' && (row.projectGroupDepth ?? 0) > draggedDepth

--- a/src/renderer/src/components/sidebar/header-drag-preview-rows.test.ts
+++ b/src/renderer/src/components/sidebar/header-drag-preview-rows.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+
+import { collectHeaderDragBlockRowElements } from './header-drag-preview-rows'
+
+/** Build a scroll container of virtual rows. Each entry is the inner HTML of
+ *  one `[data-worktree-virtual-row]` wrapper. Returns the container. */
+function buildRows(inner: string[]): HTMLElement {
+  const container = document.createElement('div')
+  for (const html of inner) {
+    const row = document.createElement('div')
+    row.setAttribute('data-worktree-virtual-row', '')
+    row.innerHTML = html
+    container.appendChild(row)
+  }
+  return container
+}
+
+function headerEl(container: HTMLElement, selector: string): HTMLElement {
+  return container.querySelector<HTMLElement>(selector)!
+}
+
+describe('collectHeaderDragBlockRowElements', () => {
+  it('project block = header + its worktrees, stopping at the next header', () => {
+    const container = buildRows([
+      '<div data-repo-header-id="r1">P1</div>',
+      '<div data-worktree-id="wt-1">wt</div>',
+      '<div data-worktree-id="wt-2">wt</div>',
+      '<div data-repo-header-id="r2">P2</div>',
+      '<div data-worktree-id="wt-3">wt</div>'
+    ])
+    const rows = collectHeaderDragBlockRowElements({
+      headerEl: headerEl(container, '[data-repo-header-id="r1"]'),
+      mode: 'project'
+    })
+    expect(rows).toHaveLength(3) // P1 header + its 2 worktrees
+    expect(rows[0]!.querySelector('[data-repo-header-id="r1"]')).not.toBeNull()
+    expect(rows[2]!.querySelector('[data-worktree-id="wt-2"]')).not.toBeNull()
+  })
+
+  it('project block stops at a following group header too', () => {
+    const container = buildRows([
+      '<div data-repo-header-id="r1">P1</div>',
+      '<div data-worktree-id="wt-1">wt</div>',
+      '<div data-project-group-header-id="g2" data-project-group-parent="">G2</div>'
+    ])
+    const rows = collectHeaderDragBlockRowElements({
+      headerEl: headerEl(container, '[data-repo-header-id="r1"]'),
+      mode: 'project'
+    })
+    expect(rows).toHaveLength(2)
+  })
+
+  it('group block includes nested rows, stopping at the next same-level sibling group', () => {
+    const container = buildRows([
+      '<div data-project-group-header-id="gA" data-project-group-parent="">GA</div>',
+      '<div data-repo-header-id="r1">P1</div>',
+      '<div data-worktree-id="wt-1">wt</div>',
+      '<div data-project-group-header-id="gNested" data-project-group-parent="gA">nested</div>',
+      '<div data-worktree-id="wt-2">wt</div>',
+      '<div data-project-group-header-id="gB" data-project-group-parent="">GB</div>'
+    ])
+    const rows = collectHeaderDragBlockRowElements({
+      headerEl: headerEl(container, '[data-project-group-header-id="gA"]'),
+      mode: 'group',
+      parentAttr: ''
+    })
+    // GA header + its project + worktree + nested group + its worktree (5),
+    // stopping at sibling GB.
+    expect(rows).toHaveLength(5)
+    expect(rows.at(-1)!.querySelector('[data-worktree-id="wt-2"]')).not.toBeNull()
+  })
+
+  it('returns [] when the header is not inside a virtual row', () => {
+    const orphan = document.createElement('div')
+    orphan.setAttribute('data-repo-header-id', 'r1')
+    expect(collectHeaderDragBlockRowElements({ headerEl: orphan, mode: 'project' })).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/header-drag-preview-rows.ts
+++ b/src/renderer/src/components/sidebar/header-drag-preview-rows.ts
@@ -1,0 +1,46 @@
+/** Collect the virtual-row elements that make up a dragged header's block, so
+ *  the drag preview can show the children (worktrees / nested groups), not just
+ *  the header. Walks forward from the header's virtual row until the block
+ *  boundary — the next header for a project, or the next same-level sibling
+ *  group header for a group. */
+export function collectHeaderDragBlockRowElements(args: {
+  headerEl: HTMLElement
+  mode: 'project' | 'group'
+  /** For group drag: the dragged group's parent attribute (`''` for top-level);
+   *  the block ends at the next group header at that same level. */
+  parentAttr?: string
+}): HTMLElement[] {
+  const headerRow = args.headerEl.closest<HTMLElement>('[data-worktree-virtual-row]')
+  if (!headerRow) {
+    return []
+  }
+  const rows: HTMLElement[] = [headerRow]
+  let element = headerRow.nextElementSibling
+  while (element instanceof HTMLElement) {
+    if (element.matches('[data-worktree-virtual-row]')) {
+      if (isHeaderDragBlockBoundary(element, args)) {
+        break
+      }
+      rows.push(element)
+    }
+    element = element.nextElementSibling
+  }
+  return rows
+}
+
+function isHeaderDragBlockBoundary(
+  row: HTMLElement,
+  args: { mode: 'project' | 'group'; parentAttr?: string }
+): boolean {
+  const groupHeader = row.querySelector('[data-project-group-header-id]')
+  if (args.mode === 'project') {
+    // A project block ends at the next header of any kind.
+    return row.querySelector('[data-repo-header-id]') !== null || groupHeader !== null
+  }
+  // A group block extends through its nested rows; it ends at the next group
+  // header at the dragged group's own level (a sibling).
+  if (groupHeader === null) {
+    return false
+  }
+  return (groupHeader.getAttribute('data-project-group-parent') ?? '') === (args.parentAttr ?? '')
+}

--- a/src/renderer/src/components/sidebar/header-drag-preview-rows.ts
+++ b/src/renderer/src/components/sidebar/header-drag-preview-rows.ts
@@ -1,3 +1,30 @@
+import {
+  createSidebarBlockDragPreview,
+  createSidebarDragPreview
+} from './worktree-sidebar-pointer-drag-dom'
+
+/** Build the floating drag preview: the whole block (header + children) when
+ *  block rows are available, otherwise just the header clone. */
+export function createHeaderDragPreview(args: {
+  rows: readonly HTMLElement[]
+  handleEl: HTMLElement
+  pointerX: number
+  pointerY: number
+}): { preview: HTMLElement; offsetX: number; offsetY: number } {
+  return args.rows.length > 1
+    ? createSidebarBlockDragPreview({
+        rows: args.rows,
+        pointerX: args.pointerX,
+        pointerY: args.pointerY
+      })
+    : createSidebarDragPreview({
+        sourceRow: args.handleEl,
+        pointerX: args.pointerX,
+        pointerY: args.pointerY,
+        draggedCount: 1
+      })
+}
+
 /** Collect the virtual-row elements that make up a dragged header's block, so
  *  the drag preview can show the children (worktrees / nested groups), not just
  *  the header. Walks forward from the header's virtual row until the block

--- a/src/renderer/src/components/sidebar/header-drag-row-shifts.test.ts
+++ b/src/renderer/src/components/sidebar/header-drag-row-shifts.test.ts
@@ -2,54 +2,59 @@ import { describe, expect, it } from 'vitest'
 
 import { computeHeaderDragRowShifts } from './header-drag-row-shifts'
 
-const rows = [
-  { key: 'a', top: 0 }, // block (height 20: 0..20)
-  { key: 'b', top: 20 },
-  { key: 'c', top: 40 },
-  { key: 'd', top: 60 }
+// Two group units, each a header + one worktree child:
+//   unit A: header@0, child@20   (block, height 40: 0..40)
+//   unit B: header@40, child@60
+//   unit C: header@80, child@100
+const units = [
+  { headerTop: 0, rowKeys: ['a-hdr', 'a-wt'] },
+  { headerTop: 40, rowKeys: ['b-hdr', 'b-wt'] },
+  { headerTop: 80, rowKeys: ['c-hdr', 'c-wt'] }
 ]
 
 describe('computeHeaderDragRowShifts', () => {
-  it('shifts the rows between the block and the drop line up when moving down', () => {
+  it('shifts a whole unit (header + children) together when moving down', () => {
     const offsets = computeHeaderDragRowShifts({
-      rows,
-      blockKeys: new Set(['a']),
+      units,
+      blockKeys: new Set(['a-hdr', 'a-wt']),
       blockTop: 0,
-      blockBottom: 20,
-      dropY: 60
+      blockBottom: 40,
+      dropY: 80
     })
-    // b and c are between the block bottom (20) and the drop line (60).
-    expect(offsets.get('b')).toBe(-20)
-    expect(offsets.get('c')).toBe(-20)
-    // d is at/after the drop line — it stays put (block lands above it).
-    expect(offsets.has('d')).toBe(false)
-    // the dragged block row is never shifted (it is hidden).
-    expect(offsets.has('a')).toBe(false)
+    // unit B is between the block (bottom 40) and the drop line (80): both its
+    // header AND its child shift up by the block height — no detaching.
+    expect(offsets.get('b-hdr')).toBe(-40)
+    expect(offsets.get('b-wt')).toBe(-40)
+    // unit C is at/after the drop line — it stays put.
+    expect(offsets.has('c-hdr')).toBe(false)
+    expect(offsets.has('c-wt')).toBe(false)
+    // the dragged unit never shifts (it is hidden).
+    expect(offsets.has('a-hdr')).toBe(false)
   })
 
-  it('shifts the rows between the drop line and the block down when moving up', () => {
+  it('shifts whole units down together when moving up', () => {
     const offsets = computeHeaderDragRowShifts({
-      rows,
-      blockKeys: new Set(['d']),
-      blockTop: 60,
-      blockBottom: 80,
-      dropY: 20
+      units,
+      blockKeys: new Set(['c-hdr', 'c-wt']),
+      blockTop: 80,
+      blockBottom: 120,
+      dropY: 40
     })
-    // b and c are between the drop line (20) and the block (60).
-    expect(offsets.get('b')).toBe(20)
-    expect(offsets.get('c')).toBe(20)
-    expect(offsets.has('a')).toBe(false)
-    expect(offsets.has('d')).toBe(false)
+    // unit B (header@40) is between the drop line and the block: shifts down.
+    expect(offsets.get('b-hdr')).toBe(40)
+    expect(offsets.get('b-wt')).toBe(40)
+    // unit A (header@0) is above the drop line — stays.
+    expect(offsets.has('a-hdr')).toBe(false)
   })
 
   it('returns no offsets when the block has no height', () => {
     expect(
       computeHeaderDragRowShifts({
-        rows,
-        blockKeys: new Set(['a']),
+        units,
+        blockKeys: new Set(['a-hdr', 'a-wt']),
         blockTop: 10,
         blockBottom: 10,
-        dropY: 60
+        dropY: 80
       }).size
     ).toBe(0)
   })

--- a/src/renderer/src/components/sidebar/header-drag-row-shifts.test.ts
+++ b/src/renderer/src/components/sidebar/header-drag-row-shifts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeHeaderDragRowShifts } from './header-drag-row-shifts'
+
+const rows = [
+  { key: 'a', top: 0 }, // block (height 20: 0..20)
+  { key: 'b', top: 20 },
+  { key: 'c', top: 40 },
+  { key: 'd', top: 60 }
+]
+
+describe('computeHeaderDragRowShifts', () => {
+  it('shifts the rows between the block and the drop line up when moving down', () => {
+    const offsets = computeHeaderDragRowShifts({
+      rows,
+      blockKeys: new Set(['a']),
+      blockTop: 0,
+      blockBottom: 20,
+      dropY: 60
+    })
+    // b and c are between the block bottom (20) and the drop line (60).
+    expect(offsets.get('b')).toBe(-20)
+    expect(offsets.get('c')).toBe(-20)
+    // d is at/after the drop line — it stays put (block lands above it).
+    expect(offsets.has('d')).toBe(false)
+    // the dragged block row is never shifted (it is hidden).
+    expect(offsets.has('a')).toBe(false)
+  })
+
+  it('shifts the rows between the drop line and the block down when moving up', () => {
+    const offsets = computeHeaderDragRowShifts({
+      rows,
+      blockKeys: new Set(['d']),
+      blockTop: 60,
+      blockBottom: 80,
+      dropY: 20
+    })
+    // b and c are between the drop line (20) and the block (60).
+    expect(offsets.get('b')).toBe(20)
+    expect(offsets.get('c')).toBe(20)
+    expect(offsets.has('a')).toBe(false)
+    expect(offsets.has('d')).toBe(false)
+  })
+
+  it('returns no offsets when the block has no height', () => {
+    expect(
+      computeHeaderDragRowShifts({
+        rows,
+        blockKeys: new Set(['a']),
+        blockTop: 10,
+        blockBottom: 10,
+        dropY: 60
+      }).size
+    ).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/header-drag-row-shifts.ts
+++ b/src/renderer/src/components/sidebar/header-drag-row-shifts.ts
@@ -1,20 +1,26 @@
 /** Gap-opening offsets for a header drag, mirroring the worktree drag feel: the
  *  dragged block (a project header + its worktrees, or a group + its subtree) is
  *  hidden behind the floating clone, and the rows between its old slot and the
- *  drop line slide by the block's height to open the gap. */
-export type HeaderDragRow = {
-  key: string
-  top: number
+ *  drop line slide by the block's height to open the gap.
+ *
+ *  Shifts are computed per UNIT (block), not per row, so a block's children
+ *  always move with their header — otherwise a header whose children sit below
+ *  the drop line would detach from them. */
+export type HeaderDragUnit = {
+  /** Top (container-relative) of the unit's header row — decides whether the
+   *  whole unit shifts. */
+  headerTop: number
+  /** Render keys of every row in the unit (header + descendants). */
+  rowKeys: readonly string[]
 }
 
 export function computeHeaderDragRowShifts(args: {
-  rows: readonly HeaderDragRow[]
-  /** Render keys of the rows that make up the dragged block (hidden, not shifted). */
+  units: readonly HeaderDragUnit[]
+  /** Render keys of the dragged block's rows; its unit never shifts (hidden). */
   blockKeys: ReadonlySet<string>
   blockTop: number
   blockBottom: number
-  /** Y of the drop line where the block will land (container-relative, same
-   *  space as row tops). */
+  /** Y of the drop line where the block will land (same space as headerTop). */
   dropY: number
 }): Map<string, number> {
   const offsets = new Map<string, number>()
@@ -23,19 +29,25 @@ export function computeHeaderDragRowShifts(args: {
     return offsets
   }
   const movingDown = args.dropY > args.blockTop
-  for (const row of args.rows) {
-    if (args.blockKeys.has(row.key)) {
+  for (const unit of args.units) {
+    if (unit.rowKeys.some((key) => args.blockKeys.has(key))) {
       continue
     }
+    let shift = 0
     if (movingDown) {
-      // Rows below the block and above the drop line move up to fill its slot;
-      // the freed space appears at the drop line.
-      if (row.top >= args.blockBottom && row.top < args.dropY) {
-        offsets.set(row.key, -height)
+      // Units below the dragged block and above the drop line slide up into
+      // its vacated slot; the freed space opens at the drop line.
+      if (unit.headerTop >= args.blockBottom && unit.headerTop < args.dropY) {
+        shift = -height
       }
-    } else if (row.top >= args.dropY && row.top < args.blockTop) {
-      // Moving up: rows from the drop line down to the block slide down.
-      offsets.set(row.key, height)
+    } else if (unit.headerTop >= args.dropY && unit.headerTop < args.blockTop) {
+      // Moving up: units from the drop line down to the block slide down.
+      shift = height
+    }
+    if (shift !== 0) {
+      for (const key of unit.rowKeys) {
+        offsets.set(key, shift)
+      }
     }
   }
   return offsets

--- a/src/renderer/src/components/sidebar/header-drag-row-shifts.ts
+++ b/src/renderer/src/components/sidebar/header-drag-row-shifts.ts
@@ -1,0 +1,42 @@
+/** Gap-opening offsets for a header drag, mirroring the worktree drag feel: the
+ *  dragged block (a project header + its worktrees, or a group + its subtree) is
+ *  hidden behind the floating clone, and the rows between its old slot and the
+ *  drop line slide by the block's height to open the gap. */
+export type HeaderDragRow = {
+  key: string
+  top: number
+}
+
+export function computeHeaderDragRowShifts(args: {
+  rows: readonly HeaderDragRow[]
+  /** Render keys of the rows that make up the dragged block (hidden, not shifted). */
+  blockKeys: ReadonlySet<string>
+  blockTop: number
+  blockBottom: number
+  /** Y of the drop line where the block will land (container-relative, same
+   *  space as row tops). */
+  dropY: number
+}): Map<string, number> {
+  const offsets = new Map<string, number>()
+  const height = args.blockBottom - args.blockTop
+  if (height <= 0) {
+    return offsets
+  }
+  const movingDown = args.dropY > args.blockTop
+  for (const row of args.rows) {
+    if (args.blockKeys.has(row.key)) {
+      continue
+    }
+    if (movingDown) {
+      // Rows below the block and above the drop line move up to fill its slot;
+      // the freed space appears at the drop line.
+      if (row.top >= args.blockBottom && row.top < args.dropY) {
+        offsets.set(row.key, -height)
+      }
+    } else if (row.top >= args.dropY && row.top < args.blockTop) {
+      // Moving up: rows from the drop line down to the block slide down.
+      offsets.set(row.key, height)
+    }
+  }
+  return offsets
+}

--- a/src/renderer/src/components/sidebar/header-drag-target-predicates.ts
+++ b/src/renderer/src/components/sidebar/header-drag-target-predicates.ts
@@ -1,0 +1,38 @@
+// Shared predicate logic for sidebar header drag interactions.
+// Both project-header-drag-contract and group-header-drag-contract use the same
+// action-selector string and structurally identical predicate bodies — only the
+// drag-handle attribute selector differs between them.
+
+export const HEADER_DRAG_ACTION_SELECTOR =
+  '[data-repo-header-action], [data-repo-header-collapse-affordance], button, a, input, textarea, select, [contenteditable=""], [contenteditable="true"]'
+
+/**
+ * Returns true when the pointer target sits within the drag handle element
+ * identified by `handleSelector`, scoped to `currentTarget`.
+ */
+export function isHeaderDragHandleTarget(
+  target: EventTarget | null,
+  currentTarget: HTMLElement,
+  handleSelector: string
+): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  const dragHandle = target.closest(handleSelector)
+  return dragHandle !== null && currentTarget.contains(dragHandle)
+}
+
+/**
+ * Returns true when the pointer target is an interactive action element
+ * (button, link, input, etc.) inside `currentTarget` — used to suppress
+ * drag initiation when the user clicks a header action, not the drag handle.
+ */
+export function isHeaderActionTarget(
+  target: EventTarget | null,
+  currentTarget: HTMLElement
+): boolean {
+  if (!(target instanceof HTMLElement) || target === currentTarget) {
+    return false
+  }
+  return currentTarget.contains(target) && target.closest(HEADER_DRAG_ACTION_SELECTOR) !== null
+}

--- a/src/renderer/src/components/sidebar/header-drag-target-predicates.ts
+++ b/src/renderer/src/components/sidebar/header-drag-target-predicates.ts
@@ -3,6 +3,9 @@
 // action-selector string and structurally identical predicate bodies — only the
 // drag-handle attribute selector differs between them.
 
+// Both predicates guard with `instanceof Element` (not HTMLElement): a click can
+// land on an SVG icon inside a handle or action button, and SVGElement is an
+// Element but not an HTMLElement, so HTMLElement would drop those hits.
 export const HEADER_DRAG_ACTION_SELECTOR =
   '[data-repo-header-action], [data-repo-header-collapse-affordance], button, a, input, textarea, select, [contenteditable=""], [contenteditable="true"]'
 
@@ -15,7 +18,7 @@ export function isHeaderDragHandleTarget(
   currentTarget: HTMLElement,
   handleSelector: string
 ): boolean {
-  if (!(target instanceof HTMLElement)) {
+  if (!(target instanceof Element)) {
     return false
   }
   const dragHandle = target.closest(handleSelector)
@@ -31,7 +34,7 @@ export function isHeaderActionTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement) || target === currentTarget) {
+  if (!(target instanceof Element) || target === currentTarget) {
     return false
   }
   return currentTarget.contains(target) && target.closest(HEADER_DRAG_ACTION_SELECTOR) !== null

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
@@ -74,4 +74,57 @@ describe('commitProjectHeaderDragDrop', () => {
 
     expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('c', 'group-1', -1)
   })
+
+  it('moves a project into a different group when the target bucket differs', () => {
+    const onCommitProjectGroupOrder = vi.fn()
+    const repos = [
+      makeRepo('a', { projectGroupId: 'group-1', projectGroupOrder: 0 }),
+      makeRepo('b', { projectGroupId: 'group-2', projectGroupOrder: 0 }),
+      makeRepo('c', { projectGroupId: 'group-1', projectGroupOrder: 1 })
+    ]
+    const repoById = new Map(repos.map((repo) => [repo.id, repo]))
+
+    commitProjectHeaderDragDrop({
+      session: makeSession('c', ['c']), // c dragged out of group-1
+      sidebarDropIndex: 1,
+      targetBucketKey: 'group:group-2',
+      sidebarRepoHeaderIdsByBucketAll: new Map([
+        ['group:group-1', ['a', 'c']],
+        ['group:group-2', ['b']]
+      ]),
+      orderedRepoIds: ['a', 'b', 'c'],
+      repoById,
+      usesProjectGroupOrdering: true,
+      onCommitRepoOrder: vi.fn(),
+      onCommitProjectGroupOrder
+    })
+
+    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('c', 'group-2', expect.any(Number))
+  })
+
+  it('ungroups a project when the target bucket is ungrouped', () => {
+    const onCommitProjectGroupOrder = vi.fn()
+    const repos = [
+      makeRepo('a', { projectGroupId: 'group-1', projectGroupOrder: 0 }),
+      makeRepo('u', { projectGroupId: null, projectGroupOrder: 0 })
+    ]
+    const repoById = new Map(repos.map((repo) => [repo.id, repo]))
+
+    commitProjectHeaderDragDrop({
+      session: makeSession('a', ['a']),
+      sidebarDropIndex: 1,
+      targetBucketKey: 'ungrouped',
+      sidebarRepoHeaderIdsByBucketAll: new Map([
+        ['group:group-1', ['a']],
+        ['ungrouped', ['u']]
+      ]),
+      orderedRepoIds: ['a', 'u'],
+      repoById,
+      usesProjectGroupOrdering: true,
+      onCommitRepoOrder: vi.fn(),
+      onCommitProjectGroupOrder
+    })
+
+    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('a', null, expect.any(Number))
+  })
 })

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
@@ -88,7 +88,7 @@ describe('commitProjectHeaderDragDrop', () => {
       session: makeSession('c', ['c']), // c dragged out of group-1
       sidebarDropIndex: 1,
       targetBucketKey: 'group:group-2',
-      sidebarRepoHeaderIdsByBucketAll: new Map([
+      sidebarRepoHeaderIdsByBucket: new Map([
         ['group:group-1', ['a', 'c']],
         ['group:group-2', ['b']]
       ]),
@@ -114,7 +114,7 @@ describe('commitProjectHeaderDragDrop', () => {
       session: makeSession('a', ['a']),
       sidebarDropIndex: 1,
       targetBucketKey: 'ungrouped',
-      sidebarRepoHeaderIdsByBucketAll: new Map([
+      sidebarRepoHeaderIdsByBucket: new Map([
         ['group:group-1', ['a']],
         ['ungrouped', ['u']]
       ]),

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
@@ -99,7 +99,7 @@ describe('commitProjectHeaderDragDrop', () => {
       onCommitProjectGroupOrder
     })
 
-    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('c', 'group-2', expect.any(Number))
+    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('c', 'group-2', 1)
   })
 
   it('ungroups a project when the target bucket is ungrouped', () => {
@@ -125,6 +125,6 @@ describe('commitProjectHeaderDragDrop', () => {
       onCommitProjectGroupOrder
     })
 
-    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('a', null, expect.any(Number))
+    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('a', null, 1)
   })
 })

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.ts
@@ -21,7 +21,7 @@ export function commitProjectHeaderDragDrop(args: {
   repoById: ReadonlyMap<string, Repo>
   usesProjectGroupOrdering: boolean
   onCommitRepoOrder: (orderedIds: string[]) => void
-  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
+  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order?: number) => void
 }): void {
   const draggedRepo = args.repoById.get(args.session.repoId)
   if (!draggedRepo) {
@@ -44,6 +44,13 @@ export function commitProjectHeaderDragDrop(args: {
       .filter((repoId) => repoId !== args.session.repoId)
       .map((repoId) => args.repoById.get(repoId))
       .filter((repo): repo is Repo => repo !== undefined)
+    // Why: a collapsed group has no visible sibling rects, so sidebarDropIndex
+    // is 0 (front). Pass undefined instead so the store appends, matching the
+    // context-menu "move to group" behaviour.
+    if (targetSiblings.length === 0) {
+      args.onCommitProjectGroupOrder(args.session.repoId, targetGroupId, undefined)
+      return
+    }
     const repoOrderRankById = new Map(
       args.orderedRepoIds.map((repoId, index) => [repoId, index] as const)
     )

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.ts
@@ -1,16 +1,13 @@
 import {
   applyAllRepoInsertAt,
+  bucketKeyToProjectGroupId,
   getProjectGroupOrderForSidebarDrop,
+  getProjectHeaderDragBucketKey,
   mapSidebarProjectHeaderDropIndexToSiblingInsertIndex,
   mapSidebarRepoDropIndexToAllRepoInsertAt
 } from './project-header-drop'
 import type { ProjectHeaderDragSession } from './project-header-drag-contract'
 import type { Repo } from '../../../../shared/types'
-
-// Converts a bucket key back to a project group id: 'ungrouped' → null, 'group:<id>' → '<id>'.
-function bucketKeyToGroupId(bucketKey: string): string | null {
-  return bucketKey === 'ungrouped' ? null : bucketKey.slice('group:'.length)
-}
 
 export function commitProjectHeaderDragDrop(args: {
   session: ProjectHeaderDragSession
@@ -30,16 +27,14 @@ export function commitProjectHeaderDragDrop(args: {
 
   // Cross-bucket move: when the target bucket differs from the source, place the
   // dragged repo into the new group without touching same-bucket ordering logic.
-  const sourceBucketKey = draggedRepo.projectGroupId
-    ? `group:${draggedRepo.projectGroupId}`
-    : 'ungrouped'
+  const sourceBucketKey = getProjectHeaderDragBucketKey(draggedRepo)
 
   if (
     args.usesProjectGroupOrdering &&
     args.targetBucketKey &&
     args.targetBucketKey !== sourceBucketKey
   ) {
-    const targetGroupId = bucketKeyToGroupId(args.targetBucketKey)
+    const targetGroupId = bucketKeyToProjectGroupId(args.targetBucketKey)
     const targetSiblings = (args.sidebarRepoHeaderIdsByBucketAll?.get(args.targetBucketKey) ?? [])
       .filter((repoId) => repoId !== args.session.repoId)
       .map((repoId) => args.repoById.get(repoId))

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.ts
@@ -7,9 +7,16 @@ import {
 import type { ProjectHeaderDragSession } from './project-header-drag-contract'
 import type { Repo } from '../../../../shared/types'
 
+// Converts a bucket key back to a project group id: 'ungrouped' → null, 'group:<id>' → '<id>'.
+function bucketKeyToGroupId(bucketKey: string): string | null {
+  return bucketKey === 'ungrouped' ? null : bucketKey.slice('group:'.length)
+}
+
 export function commitProjectHeaderDragDrop(args: {
   session: ProjectHeaderDragSession
   sidebarDropIndex: number
+  targetBucketKey?: string
+  sidebarRepoHeaderIdsByBucketAll?: ReadonlyMap<string, readonly string[]>
   orderedRepoIds: readonly string[]
   repoById: ReadonlyMap<string, Repo>
   usesProjectGroupOrdering: boolean
@@ -18,6 +25,35 @@ export function commitProjectHeaderDragDrop(args: {
 }): void {
   const draggedRepo = args.repoById.get(args.session.repoId)
   if (!draggedRepo) {
+    return
+  }
+
+  // Cross-bucket move: when the target bucket differs from the source, place the
+  // dragged repo into the new group without touching same-bucket ordering logic.
+  const sourceBucketKey = draggedRepo.projectGroupId
+    ? `group:${draggedRepo.projectGroupId}`
+    : 'ungrouped'
+
+  if (
+    args.usesProjectGroupOrdering &&
+    args.targetBucketKey &&
+    args.targetBucketKey !== sourceBucketKey
+  ) {
+    const targetGroupId = bucketKeyToGroupId(args.targetBucketKey)
+    const targetSiblings = (args.sidebarRepoHeaderIdsByBucketAll?.get(args.targetBucketKey) ?? [])
+      .filter((repoId) => repoId !== args.session.repoId)
+      .map((repoId) => args.repoById.get(repoId))
+      .filter((repo): repo is Repo => repo !== undefined)
+    const repoOrderRankById = new Map(
+      args.orderedRepoIds.map((repoId, index) => [repoId, index] as const)
+    )
+    const insertIndex = Math.max(0, Math.min(targetSiblings.length, args.sidebarDropIndex))
+    const order = getProjectGroupOrderForSidebarDrop({
+      siblings: targetSiblings,
+      dropIndex: insertIndex,
+      repoOrderRankById
+    })
+    args.onCommitProjectGroupOrder(args.session.repoId, targetGroupId, order)
     return
   }
 

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.ts
@@ -13,7 +13,7 @@ export function commitProjectHeaderDragDrop(args: {
   session: ProjectHeaderDragSession
   sidebarDropIndex: number
   targetBucketKey?: string
-  sidebarRepoHeaderIdsByBucketAll?: ReadonlyMap<string, readonly string[]>
+  sidebarRepoHeaderIdsByBucket?: ReadonlyMap<string, readonly string[]>
   orderedRepoIds: readonly string[]
   repoById: ReadonlyMap<string, Repo>
   usesProjectGroupOrdering: boolean
@@ -35,7 +35,7 @@ export function commitProjectHeaderDragDrop(args: {
     args.targetBucketKey !== sourceBucketKey
   ) {
     const targetGroupId = bucketKeyToProjectGroupId(args.targetBucketKey)
-    const targetSiblings = (args.sidebarRepoHeaderIdsByBucketAll?.get(args.targetBucketKey) ?? [])
+    const targetSiblings = (args.sidebarRepoHeaderIdsByBucket?.get(args.targetBucketKey) ?? [])
       .filter((repoId) => repoId !== args.session.repoId)
       .map((repoId) => args.repoById.get(repoId))
       .filter((repo): repo is Repo => repo !== undefined)

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -2,6 +2,7 @@ import type { PointerEvent } from 'react'
 
 import type { ProjectHeaderDragBucketKey, ProjectHeaderDragRect } from './project-header-drop'
 import type { Repo } from '../../../../shared/types'
+import { isHeaderDragHandleTarget, isHeaderActionTarget } from './header-drag-target-predicates'
 
 export type RepoDragState = {
   draggingRepoId: string | null
@@ -54,26 +55,16 @@ export const PROJECT_HEADER_DRAG_THRESHOLD_PX = 4
 
 const REPO_HEADER_DRAG_HANDLE_SELECTOR = '[data-repo-header-drag-handle]'
 
-const REPO_HEADER_ACTION_SELECTOR =
-  '[data-repo-header-action], [data-repo-header-collapse-affordance], button, a, input, textarea, select, [contenteditable=""], [contenteditable="true"]'
-
 export function isProjectHeaderDragHandleTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false
-  }
-  const dragHandle = target.closest(REPO_HEADER_DRAG_HANDLE_SELECTOR)
-  return dragHandle !== null && currentTarget.contains(dragHandle)
+  return isHeaderDragHandleTarget(target, currentTarget, REPO_HEADER_DRAG_HANDLE_SELECTOR)
 }
 
 export function isRepoHeaderActionTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement) || target === currentTarget) {
-    return false
-  }
-  return currentTarget.contains(target) && target.closest(REPO_HEADER_ACTION_SELECTOR) !== null
+  return isHeaderActionTarget(target, currentTarget)
 }

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -34,6 +34,7 @@ export type ProjectHeaderDragSession = {
   repoId: string
   bucketKey: ProjectHeaderDragBucketKey
   sidebarRepoHeaderIds: readonly string[]
+  sidebarRepoHeaderIdsByBucketAll?: ReadonlyMap<ProjectHeaderDragBucketKey, readonly string[]>
   pointerId: number
   headerRects: ProjectHeaderDragRect[]
   handleEl: HTMLElement

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -2,7 +2,7 @@ import type { PointerEvent } from 'react'
 
 import type { ProjectHeaderDragBucketKey, ProjectHeaderDragRect } from './project-header-drop'
 import type { Repo } from '../../../../shared/types'
-import { isHeaderDragHandleTarget, isHeaderActionTarget } from './header-drag-target-predicates'
+import { isHeaderDragHandleTarget } from './header-drag-target-predicates'
 
 export type RepoDragState = {
   draggingRepoId: string | null
@@ -60,11 +60,4 @@ export function isProjectHeaderDragHandleTarget(
   currentTarget: HTMLElement
 ): boolean {
   return isHeaderDragHandleTarget(target, currentTarget, REPO_HEADER_DRAG_HANDLE_SELECTOR)
-}
-
-export function isRepoHeaderActionTarget(
-  target: EventTarget | null,
-  currentTarget: HTMLElement
-): boolean {
-  return isHeaderActionTarget(target, currentTarget)
 }

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -23,7 +23,7 @@ export type UseRepoHeaderDragArgs = {
   repoById: ReadonlyMap<string, Repo>
   usesProjectGroupOrdering: boolean
   onCommitRepoOrder: (orderedIds: string[]) => void
-  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
+  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order?: number) => void
   getScrollContainer: () => HTMLElement | null
 }
 

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -7,12 +7,14 @@ export type RepoDragState = {
   draggingRepoId: string | null
   dropIndex: number | null
   dropIndicatorY: number | null
+  targetBucketKey: string | null
 }
 
 export const INITIAL_REPO_DRAG_STATE: RepoDragState = {
   draggingRepoId: null,
   dropIndex: null,
-  dropIndicatorY: null
+  dropIndicatorY: null,
+  targetBucketKey: null
 }
 
 export type UseRepoHeaderDragArgs = {

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -8,13 +8,17 @@ export type RepoDragState = {
   dropIndex: number | null
   dropIndicatorY: number | null
   targetBucketKey: string | null
+  /** Group to highlight as the drop target when dropping into a collapsed/empty
+   *  group (in that case no drop line is drawn). */
+  dropIntoGroupId: string | null
 }
 
 export const INITIAL_REPO_DRAG_STATE: RepoDragState = {
   draggingRepoId: null,
   dropIndex: null,
   dropIndicatorY: null,
-  targetBucketKey: null
+  targetBucketKey: null,
+  dropIntoGroupId: null
 }
 
 export type UseRepoHeaderDragArgs = {

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -50,6 +50,7 @@ export type ProjectHeaderDragSession = {
   handleEl: HTMLElement
   startX: number
   startY: number
+  latestPointerX: number
   latestPointerY: number
   promoted: boolean
 }

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -40,8 +40,11 @@ export type RepoHeaderDragController = {
 export type ProjectHeaderDragSession = {
   repoId: string
   bucketKey: ProjectHeaderDragBucketKey
+  // Source bucket's repo headers (flat) for same-bucket reorder.
   sidebarRepoHeaderIds: readonly string[]
-  sidebarRepoHeaderIdsByBucketAll?: ReadonlyMap<ProjectHeaderDragBucketKey, readonly string[]>
+  // Repo headers for every bucket, as currently shown in the sidebar (excludes
+  // filtered/collapsed members), used to resolve a cross-bucket drop's siblings.
+  sidebarRepoHeaderIdsByBucket?: ReadonlyMap<ProjectHeaderDragBucketKey, readonly string[]>
   pointerId: number
   headerRects: ProjectHeaderDragRect[]
   handleEl: HTMLElement

--- a/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
@@ -46,6 +46,39 @@ describe('createProjectHeaderDragSession', () => {
     expect(handleEl.setPointerCapture).not.toHaveBeenCalled()
   })
 
+  it('arms a drag for a lone grouped project when another bucket exists', () => {
+    const handleEl = document.createElement('div')
+    handleEl.setAttribute('data-repo-header-drag-handle', '')
+    const scrollContainer = document.createElement('div')
+    document.body.append(scrollContainer, handleEl)
+
+    const repoById = new Map<string, Repo>([
+      ['only', createRepo('only', 'group-1')],
+      ['other', createRepo('other')]
+    ])
+    const sidebarRepoHeaderIdsByBucket = new Map([
+      ['group:group-1', ['only']],
+      ['ungrouped', ['other']]
+    ])
+
+    const session = createProjectHeaderDragSession({
+      event: {
+        button: 0,
+        pointerId: 1,
+        clientX: 10,
+        clientY: 20,
+        target: handleEl,
+        currentTarget: handleEl
+      } as unknown as React.PointerEvent<HTMLElement>,
+      repoId: 'only',
+      repoById,
+      sidebarRepoHeaderIdsByBucket,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session).not.toBeNull()
+  })
+
   it('does not arm drag when the pointer starts outside the project icon handle', () => {
     const header = document.createElement('div')
     const handleEl = document.createElement('div')

--- a/src/renderer/src/components/sidebar/project-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.ts
@@ -7,9 +7,9 @@ import {
 } from './project-header-drop'
 import {
   isProjectHeaderDragHandleTarget,
-  isRepoHeaderActionTarget,
   type ProjectHeaderDragSession
 } from './project-header-drag-contract'
+import { isHeaderActionTarget } from './header-drag-target-predicates'
 import type { Repo } from '../../../../shared/types'
 
 export function createProjectHeaderDragSession(args: {
@@ -29,7 +29,7 @@ export function createProjectHeaderDragSession(args: {
   if (!isProjectHeaderDragHandleTarget(args.event.target, args.event.currentTarget)) {
     return null
   }
-  if (isRepoHeaderActionTarget(args.event.target, args.event.currentTarget)) {
+  if (isHeaderActionTarget(args.event.target, args.event.currentTarget)) {
     return null
   }
   const repo = args.repoById.get(args.repoId)

--- a/src/renderer/src/components/sidebar/project-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.ts
@@ -17,6 +17,10 @@ export function createProjectHeaderDragSession(args: {
   repoId: string
   repoById: ReadonlyMap<string, Repo>
   sidebarRepoHeaderIdsByBucket: ReadonlyMap<ProjectHeaderDragBucketKey, readonly string[]>
+  /** Total project count across ALL groups (collapsed included). Falls back to
+   *  the visible-bucket sum; callers pass the complete count so a project stays
+   *  draggable when other groups are collapsed and hide their projects. */
+  totalProjectCount?: number
   getScrollContainer: () => HTMLElement | null
 }): ProjectHeaderDragSession | null {
   if (args.event.button !== 0) {
@@ -34,10 +38,9 @@ export function createProjectHeaderDragSession(args: {
   }
   const bucketKey = getProjectHeaderDragBucketKey(repo)
   const sidebarRepoHeaderIds = args.sidebarRepoHeaderIdsByBucket.get(bucketKey) ?? []
-  const totalHeaders = Array.from(args.sidebarRepoHeaderIdsByBucket.values()).reduce(
-    (sum, ids) => sum + ids.length,
-    0
-  )
+  const totalHeaders =
+    args.totalProjectCount ??
+    Array.from(args.sidebarRepoHeaderIdsByBucket.values()).reduce((sum, ids) => sum + ids.length, 0)
   // Why: a project can now move across buckets, so arming requires only that some
   // other project exists somewhere, not that the source bucket has a sibling.
   if (totalHeaders <= 1) {

--- a/src/renderer/src/components/sidebar/project-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.ts
@@ -34,9 +34,13 @@ export function createProjectHeaderDragSession(args: {
   }
   const bucketKey = getProjectHeaderDragBucketKey(repo)
   const sidebarRepoHeaderIds = args.sidebarRepoHeaderIdsByBucket.get(bucketKey) ?? []
-  // Why: a single project in its bucket has nowhere to land, so skip arming
-  // drag and let the header click toggle collapse instead.
-  if (sidebarRepoHeaderIds.length <= 1) {
+  const totalHeaders = Array.from(args.sidebarRepoHeaderIdsByBucket.values()).reduce(
+    (sum, ids) => sum + ids.length,
+    0
+  )
+  // Why: a project can now move across buckets, so arming requires only that some
+  // other project exists somewhere, not that the source bucket has a sibling.
+  if (totalHeaders <= 1) {
     return null
   }
   const container = args.getScrollContainer()
@@ -50,6 +54,7 @@ export function createProjectHeaderDragSession(args: {
     repoId: args.repoId,
     bucketKey,
     sidebarRepoHeaderIds,
+    sidebarRepoHeaderIdsByBucketAll: args.sidebarRepoHeaderIdsByBucket,
     pointerId: args.event.pointerId,
     headerRects: measureProjectHeaderDragRects(container, bucketKey),
     handleEl,

--- a/src/renderer/src/components/sidebar/project-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.ts
@@ -63,6 +63,7 @@ export function createProjectHeaderDragSession(args: {
     handleEl,
     startX: args.event.clientX,
     startY: args.event.clientY,
+    latestPointerX: args.event.clientX,
     latestPointerY: args.event.clientY,
     promoted: false
   }

--- a/src/renderer/src/components/sidebar/project-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.ts
@@ -57,7 +57,7 @@ export function createProjectHeaderDragSession(args: {
     repoId: args.repoId,
     bucketKey,
     sidebarRepoHeaderIds,
-    sidebarRepoHeaderIdsByBucketAll: args.sidebarRepoHeaderIdsByBucket,
+    sidebarRepoHeaderIdsByBucket: args.sidebarRepoHeaderIdsByBucket,
     pointerId: args.event.pointerId,
     headerRects: measureProjectHeaderDragRects(container, bucketKey),
     handleEl,

--- a/src/renderer/src/components/sidebar/project-header-drag.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest'
 
-import { isRepoHeaderActionTarget } from './project-header-drag'
+import { isHeaderActionTarget } from './header-drag-target-predicates'
 
 function createHeader(markup: string): HTMLElement {
   const header = document.createElement('div')
@@ -19,20 +19,20 @@ describe('repo header action targets', () => {
       </span>
     `)
 
-    expect(isRepoHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
+    expect(isHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
   })
 
   it('ignores native nested controls', () => {
     const header = createHeader('<button type="button"><span id="icon"></span></button>')
 
-    expect(isRepoHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
+    expect(isHeaderActionTarget(header.querySelector('#icon'), header)).toBe(true)
   })
 
   it('does not ignore plain header text or the header itself', () => {
     const header = createHeader('<span id="label">Orca</span>')
 
-    expect(isRepoHeaderActionTarget(header.querySelector('#label'), header)).toBe(false)
-    expect(isRepoHeaderActionTarget(header, header)).toBe(false)
+    expect(isHeaderActionTarget(header.querySelector('#label'), header)).toBe(false)
+    expect(isHeaderActionTarget(header, header)).toBe(false)
   })
 
   it('ignores the hover collapse affordance', () => {
@@ -42,6 +42,6 @@ describe('repo header action targets', () => {
       </div>
     `)
 
-    expect(isRepoHeaderActionTarget(header.querySelector('#chevron'), header)).toBe(true)
+    expect(isHeaderActionTarget(header.querySelector('#chevron'), header)).toBe(true)
   })
 })

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRef } from 'react'
 
 import {
   computeProjectHeaderDropPreview,
-  measureProjectHeaderDragRects
+  measureProjectHeaderDragRects,
+  type ProjectHeaderDropPreview
 } from './project-header-drop'
 import { commitProjectHeaderDragDrop } from './project-header-drag-commit'
 import {
@@ -14,303 +15,62 @@ import {
   type UseRepoHeaderDragArgs
 } from './project-header-drag-contract'
 import { createProjectHeaderDragSession } from './project-header-drag-start'
-import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+import { useSidebarHeaderPointerDrag } from './sidebar-header-pointer-drag'
 
-// Why pointer events instead of HTML5 DnD: rows are absolutely-positioned by
-// react-virtual and unmount/remount as scroll changes, so DnD enter/leave fire
-// against stale targets. With pointer events we cache the active set of repo
-// header positions and compute the drop index from the live pointer Y.
-
-export function useRepoHeaderDrag({
-  orderedRepoIds,
-  sidebarRepoHeaderIdsByBucket,
-  repoById,
-  usesProjectGroupOrdering,
-  onCommitRepoOrder,
-  onCommitProjectGroupOrder,
-  getScrollContainer
-}: UseRepoHeaderDragArgs): RepoHeaderDragController {
-  const [state, setState] = useState<RepoDragState>(INITIAL_REPO_DRAG_STATE)
-  const [sessionArmed, setSessionArmed] = useState(false)
-  const latestDropIndexRef = useRef<number | null>(null)
-  latestDropIndexRef.current = state.dropIndex
-  const orderedIdsRef = useRef(orderedRepoIds)
-  orderedIdsRef.current = orderedRepoIds
-  const sidebarRepoHeaderIdsByBucketRef = useRef(sidebarRepoHeaderIdsByBucket)
-  sidebarRepoHeaderIdsByBucketRef.current = sidebarRepoHeaderIdsByBucket
-  const repoByIdRef = useRef(repoById)
-  repoByIdRef.current = repoById
-  const usesProjectGroupOrderingRef = useRef(usesProjectGroupOrdering)
-  usesProjectGroupOrderingRef.current = usesProjectGroupOrdering
-  const onCommitRepoOrderRef = useRef(onCommitRepoOrder)
-  onCommitRepoOrderRef.current = onCommitRepoOrder
-  const onCommitProjectGroupOrderRef = useRef(onCommitProjectGroupOrder)
-  onCommitProjectGroupOrderRef.current = onCommitProjectGroupOrder
-  const getContainerRef = useRef(getScrollContainer)
-  getContainerRef.current = getScrollContainer
-  const autoscrollLastFrameTimeRef = useRef<number | null>(null)
-  const autoscrollFrameIdRef = useRef<number | null>(null)
-
-  const dragSessionRef = useRef<ProjectHeaderDragSession | null>(null)
-  const clickSwallowTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const refreshHeaderRects = useCallback(() => {
-    const container = getContainerRef.current()
-    const session = dragSessionRef.current
-    if (!container || !session) {
-      return []
-    }
-    const rects = measureProjectHeaderDragRects(container, session.bucketKey)
-    session.headerRects = rects
-    return rects
-  }, [])
-
-  const computeDrop = useCallback(
-    (pointerY: number): { dropIndex: number; dropIndicatorY: number } | null => {
-      const session = dragSessionRef.current
-      const container = getContainerRef.current()
-      if (!session || !container) {
-        return null
-      }
+export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragController {
+  const argsRef = useRef(args)
+  argsRef.current = args
+  return useSidebarHeaderPointerDrag<
+    ProjectHeaderDragSession,
+    RepoDragState,
+    ProjectHeaderDropPreview
+  >({
+    threshold: PROJECT_HEADER_DRAG_THRESHOLD_PX,
+    initialState: INITIAL_REPO_DRAG_STATE,
+    getScrollContainer: () => argsRef.current.getScrollContainer(),
+    getSessionId: (session) => session.repoId,
+    getDraggingId: (dragState) => dragState.draggingRepoId,
+    createSession: (event, repoId) =>
+      createProjectHeaderDragSession({
+        event,
+        repoId,
+        repoById: argsRef.current.repoById,
+        sidebarRepoHeaderIdsByBucket: argsRef.current.sidebarRepoHeaderIdsByBucket,
+        getScrollContainer: argsRef.current.getScrollContainer
+      }),
+    measureRects: (container, session) => {
+      session.headerRects = measureProjectHeaderDragRects(container, session.bucketKey)
+    },
+    computeDrop: (session, container) => {
       const containerRect = container.getBoundingClientRect()
       return computeProjectHeaderDropPreview({
-        pointerY,
+        pointerY: session.latestPointerY,
         containerTop: containerRect.top,
         scrollTop: container.scrollTop,
         rects: session.headerRects,
         sidebarRepoHeaderIds: session.sidebarRepoHeaderIds
       })
     },
-    []
-  )
-
-  const cancelAutoscroll = useCallback(() => {
-    if (autoscrollFrameIdRef.current !== null) {
-      window.cancelAnimationFrame(autoscrollFrameIdRef.current)
-      autoscrollFrameIdRef.current = null
-    }
-    autoscrollLastFrameTimeRef.current = null
-  }, [])
-
-  const endDrag = useCallback(
-    (commit: boolean) => {
-      cancelAutoscroll()
-      const session = dragSessionRef.current
-      if (!session) {
-        setState(INITIAL_REPO_DRAG_STATE)
-        setSessionArmed(false)
-        return
-      }
-      try {
-        session.handleEl.releasePointerCapture(session.pointerId)
-      } catch {
-        // capture may already be released (pointercancel, element unmounted)
-      }
-      if (session.promoted) {
-        const handleEl = session.handleEl
-        const swallow = (e: MouseEvent): void => {
-          const target = e.target as Node | null
-          if (target && handleEl.contains(target)) {
-            e.stopPropagation()
-            e.preventDefault()
-          }
-          window.removeEventListener('click', swallow, true)
-        }
-        window.addEventListener('click', swallow, true)
-        clickSwallowTimeoutRef.current = setTimeout(() => {
-          window.removeEventListener('click', swallow, true)
-          clickSwallowTimeoutRef.current = null
-        }, 0)
-      }
-      const sidebarDropIndex =
-        commit && session.promoted && latestDropIndexRef.current !== null
-          ? latestDropIndexRef.current
-          : null
-      dragSessionRef.current = null
-      setState(INITIAL_REPO_DRAG_STATE)
-      setSessionArmed(false)
-      if (sidebarDropIndex === null) {
-        return
-      }
-
+    buildState: (repoId, drop) =>
+      drop
+        ? { draggingRepoId: repoId, dropIndex: drop.dropIndex, dropIndicatorY: drop.dropIndicatorY }
+        : { draggingRepoId: repoId, dropIndex: null, dropIndicatorY: null },
+    areStatesEqual: (a, b) =>
+      a.draggingRepoId === b.draggingRepoId &&
+      a.dropIndex === b.dropIndex &&
+      a.dropIndicatorY === b.dropIndicatorY,
+    commit: (session, drop) => {
       commitProjectHeaderDragDrop({
         session,
-        sidebarDropIndex,
-        orderedRepoIds: orderedIdsRef.current,
-        repoById: repoByIdRef.current,
-        usesProjectGroupOrdering: usesProjectGroupOrderingRef.current,
-        onCommitRepoOrder: onCommitRepoOrderRef.current,
-        onCommitProjectGroupOrder: onCommitProjectGroupOrderRef.current
+        sidebarDropIndex: drop.dropIndex,
+        orderedRepoIds: argsRef.current.orderedRepoIds,
+        repoById: argsRef.current.repoById,
+        usesProjectGroupOrdering: argsRef.current.usesProjectGroupOrdering,
+        onCommitRepoOrder: argsRef.current.onCommitRepoOrder,
+        onCommitProjectGroupOrder: argsRef.current.onCommitProjectGroupOrder
       })
-    },
-    [cancelAutoscroll]
-  )
-
-  const runAutoscrollFrame = useCallback(
-    (frameTime: number) => {
-      autoscrollFrameIdRef.current = null
-      const session = dragSessionRef.current
-      const container = getContainerRef.current()
-      if (!session?.promoted || !container) {
-        cancelAutoscroll()
-        return
-      }
-
-      const previousFrameTime = autoscrollLastFrameTimeRef.current ?? frameTime
-      autoscrollLastFrameTimeRef.current = frameTime
-      const autoscroll = getWorktreeSidebarDragAutoscroll({
-        point: { clientX: 0, clientY: session.latestPointerY },
-        containerRect: container.getBoundingClientRect(),
-        scrollTop: container.scrollTop,
-        scrollHeight: container.scrollHeight,
-        clientHeight: container.clientHeight,
-        elapsedMs: frameTime - previousFrameTime
-      })
-      if (autoscroll) {
-        container.scrollTop = autoscroll.scrollTop
-        refreshHeaderRects()
-      }
-
-      const drop = computeDrop(session.latestPointerY)
-      if (drop) {
-        setState((prev) =>
-          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
-            ? prev
-            : { draggingRepoId: session.repoId, ...drop }
-        )
-      }
-
-      autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
-    },
-    [cancelAutoscroll, computeDrop, refreshHeaderRects]
-  )
-
-  const ensureAutoscroll = useCallback(() => {
-    if (autoscrollFrameIdRef.current !== null) {
-      return
     }
-    autoscrollLastFrameTimeRef.current = null
-    autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
-  }, [runAutoscrollFrame])
-
-  useEffect(() => {
-    if (!sessionArmed) {
-      return
-    }
-    const onPointerMove = (e: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || e.pointerId !== session.pointerId) {
-        return
-      }
-      session.latestPointerY = e.clientY
-      if (!session.promoted) {
-        const dx = e.clientX - session.startX
-        const dy = e.clientY - session.startY
-        if (
-          dx * dx + dy * dy <
-          PROJECT_HEADER_DRAG_THRESHOLD_PX * PROJECT_HEADER_DRAG_THRESHOLD_PX
-        ) {
-          return
-        }
-        session.promoted = true
-        // Why: setPointerCapture can throw if the element is detached. Check
-        // isConnected first to avoid the throw; the global pointer listeners
-        // still fire, so dragging keeps working even if capture fails.
-        if (session.handleEl.isConnected) {
-          try {
-            session.handleEl.setPointerCapture(session.pointerId)
-          } catch {
-            // Ignore capture failure; global listeners will handle the drag.
-          }
-        }
-        refreshHeaderRects()
-        setState({ draggingRepoId: session.repoId, dropIndex: null, dropIndicatorY: null })
-      }
-      refreshHeaderRects()
-      const drop = computeDrop(e.clientY)
-      if (drop) {
-        setState((prev) =>
-          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
-            ? prev
-            : { draggingRepoId: session.repoId, ...drop }
-        )
-      }
-      ensureAutoscroll()
-    }
-    const onPointerUp = (e: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || e.pointerId !== session.pointerId) {
-        return
-      }
-      endDrag(true)
-    }
-    const onPointerCancel = (e: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || e.pointerId !== session.pointerId) {
-        return
-      }
-      endDrag(false)
-    }
-    const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') {
-        endDrag(false)
-      }
-    }
-    const onBlur = (): void => endDrag(false)
-
-    window.addEventListener('pointermove', onPointerMove)
-    window.addEventListener('pointerup', onPointerUp)
-    window.addEventListener('pointercancel', onPointerCancel)
-    window.addEventListener('keydown', onKeyDown)
-    window.addEventListener('blur', onBlur)
-    return () => {
-      window.removeEventListener('pointermove', onPointerMove)
-      window.removeEventListener('pointerup', onPointerUp)
-      window.removeEventListener('pointercancel', onPointerCancel)
-      window.removeEventListener('keydown', onKeyDown)
-      window.removeEventListener('blur', onBlur)
-      cancelAutoscroll()
-      if (clickSwallowTimeoutRef.current !== null) {
-        clearTimeout(clickSwallowTimeoutRef.current)
-        clickSwallowTimeoutRef.current = null
-      }
-    }
-  }, [cancelAutoscroll, computeDrop, endDrag, ensureAutoscroll, refreshHeaderRects, sessionArmed])
-
-  useEffect(() => {
-    if (state.draggingRepoId === null) {
-      return
-    }
-    const body = document.body
-    const prevCursor = body.style.cursor
-    const prevUserSelect = body.style.userSelect
-    body.style.cursor = 'grabbing'
-    body.style.userSelect = 'none'
-    return () => {
-      body.style.cursor = prevCursor
-      body.style.userSelect = prevUserSelect
-    }
-  }, [state.draggingRepoId])
-
-  const onHandlePointerDown = useCallback(
-    (event: React.PointerEvent<HTMLElement>, repoId: string) => {
-      const session = createProjectHeaderDragSession({
-        event,
-        repoId,
-        repoById: repoByIdRef.current,
-        sidebarRepoHeaderIdsByBucket: sidebarRepoHeaderIdsByBucketRef.current,
-        getScrollContainer: getContainerRef.current
-      })
-      if (!session) {
-        return
-      }
-      dragSessionRef.current = session
-      setSessionArmed(true)
-    },
-    []
-  )
-
-  return { state, onHandlePointerDown }
+  })
 }
 
 export {

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -94,7 +94,4 @@ export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragCo
   })
 }
 
-export {
-  isRepoHeaderActionTarget,
-  isProjectHeaderDragHandleTarget
-} from './project-header-drag-contract'
+export { isProjectHeaderDragHandleTarget } from './project-header-drag-contract'

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -37,6 +37,9 @@ export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragCo
         repoId,
         repoById: argsRef.current.repoById,
         sidebarRepoHeaderIdsByBucket: argsRef.current.sidebarRepoHeaderIdsByBucket,
+        // Complete count (incl. collapsed groups) so a project stays draggable
+        // when other groups are collapsed and hide their projects from the rows.
+        totalProjectCount: argsRef.current.orderedRepoIds.length,
         getScrollContainer: argsRef.current.getScrollContainer
       }),
     // Why: cross-group drops need every bucket's headers, not just the source's.
@@ -59,14 +62,22 @@ export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragCo
             draggingRepoId: repoId,
             dropIndex: drop.dropIndex,
             dropIndicatorY: drop.dropIndicatorY,
-            targetBucketKey: drop.targetBucketKey
+            targetBucketKey: drop.targetBucketKey,
+            dropIntoGroupId: drop.intoGroupId ?? null
           }
-        : { draggingRepoId: repoId, dropIndex: null, dropIndicatorY: null, targetBucketKey: null },
+        : {
+            draggingRepoId: repoId,
+            dropIndex: null,
+            dropIndicatorY: null,
+            targetBucketKey: null,
+            dropIntoGroupId: null
+          },
     areStatesEqual: (a, b) =>
       a.draggingRepoId === b.draggingRepoId &&
       a.dropIndex === b.dropIndex &&
       a.dropIndicatorY === b.dropIndicatorY &&
-      a.targetBucketKey === b.targetBucketKey,
+      a.targetBucketKey === b.targetBucketKey &&
+      a.dropIntoGroupId === b.dropIntoGroupId,
     commit: (session, drop) => {
       commitProjectHeaderDragDrop({
         session,

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -17,6 +17,7 @@ import {
 } from './project-header-drag-contract'
 import { createProjectHeaderDragSession } from './project-header-drag-start'
 import { useSidebarHeaderPointerDrag } from './sidebar-header-pointer-drag'
+import { collectHeaderDragBlockRowElements } from './header-drag-preview-rows'
 
 export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragController {
   const argsRef = useRef(args)
@@ -46,6 +47,8 @@ export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragCo
     measureRects: (container, session) => {
       session.headerRects = measureProjectHeaderDragRects(container)
     },
+    getDragPreviewRows: (session) =>
+      collectHeaderDragBlockRowElements({ headerEl: session.handleEl, mode: 'project' }),
     computeDrop: (session, container) => {
       const containerRect = container.getBoundingClientRect()
       return computeProjectHeaderDropPreviewAcrossBuckets({

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -1,9 +1,10 @@
 import { useRef } from 'react'
 
 import {
-  computeProjectHeaderDropPreview,
+  computeProjectHeaderDropPreviewAcrossBuckets,
+  measureProjectGroupHeaderDropZones,
   measureProjectHeaderDragRects,
-  type ProjectHeaderDropPreview
+  type ProjectHeaderCrossBucketDropPreview
 } from './project-header-drop'
 import { commitProjectHeaderDragDrop } from './project-header-drag-commit'
 import {
@@ -23,7 +24,7 @@ export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragCo
   return useSidebarHeaderPointerDrag<
     ProjectHeaderDragSession,
     RepoDragState,
-    ProjectHeaderDropPreview
+    ProjectHeaderCrossBucketDropPreview
   >({
     threshold: PROJECT_HEADER_DRAG_THRESHOLD_PX,
     initialState: INITIAL_REPO_DRAG_STATE,
@@ -38,31 +39,40 @@ export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragCo
         sidebarRepoHeaderIdsByBucket: argsRef.current.sidebarRepoHeaderIdsByBucket,
         getScrollContainer: argsRef.current.getScrollContainer
       }),
+    // Why: cross-group drops need every bucket's headers, not just the source's.
     measureRects: (container, session) => {
-      session.headerRects = measureProjectHeaderDragRects(container, session.bucketKey)
+      session.headerRects = measureProjectHeaderDragRects(container)
     },
     computeDrop: (session, container) => {
       const containerRect = container.getBoundingClientRect()
-      return computeProjectHeaderDropPreview({
+      return computeProjectHeaderDropPreviewAcrossBuckets({
         pointerY: session.latestPointerY,
         containerTop: containerRect.top,
         scrollTop: container.scrollTop,
-        rects: session.headerRects,
-        sidebarRepoHeaderIds: session.sidebarRepoHeaderIds
+        repoRects: session.headerRects,
+        groupZones: measureProjectGroupHeaderDropZones(container)
       })
     },
     buildState: (repoId, drop) =>
       drop
-        ? { draggingRepoId: repoId, dropIndex: drop.dropIndex, dropIndicatorY: drop.dropIndicatorY }
-        : { draggingRepoId: repoId, dropIndex: null, dropIndicatorY: null },
+        ? {
+            draggingRepoId: repoId,
+            dropIndex: drop.dropIndex,
+            dropIndicatorY: drop.dropIndicatorY,
+            targetBucketKey: drop.targetBucketKey
+          }
+        : { draggingRepoId: repoId, dropIndex: null, dropIndicatorY: null, targetBucketKey: null },
     areStatesEqual: (a, b) =>
       a.draggingRepoId === b.draggingRepoId &&
       a.dropIndex === b.dropIndex &&
-      a.dropIndicatorY === b.dropIndicatorY,
+      a.dropIndicatorY === b.dropIndicatorY &&
+      a.targetBucketKey === b.targetBucketKey,
     commit: (session, drop) => {
       commitProjectHeaderDragDrop({
         session,
         sidebarDropIndex: drop.dropIndex,
+        targetBucketKey: drop.targetBucketKey,
+        sidebarRepoHeaderIdsByBucketAll: session.sidebarRepoHeaderIdsByBucketAll,
         orderedRepoIds: argsRef.current.orderedRepoIds,
         repoById: argsRef.current.repoById,
         usesProjectGroupOrdering: argsRef.current.usesProjectGroupOrdering,

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -56,7 +56,8 @@ export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragCo
         containerTop: containerRect.top,
         scrollTop: container.scrollTop,
         repoRects: session.headerRects,
-        groupZones: measureProjectGroupHeaderDropZones(container)
+        groupZones: measureProjectGroupHeaderDropZones(container),
+        draggingRepoId: session.repoId
       })
     },
     buildState: (repoId, drop) =>

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -87,7 +87,7 @@ export function useRepoHeaderDrag(args: UseRepoHeaderDragArgs): RepoHeaderDragCo
         session,
         sidebarDropIndex: drop.dropIndex,
         targetBucketKey: drop.targetBucketKey,
-        sidebarRepoHeaderIdsByBucketAll: session.sidebarRepoHeaderIdsByBucketAll,
+        sidebarRepoHeaderIdsByBucket: session.sidebarRepoHeaderIdsByBucket,
         orderedRepoIds: argsRef.current.orderedRepoIds,
         repoById: argsRef.current.repoById,
         usesProjectGroupOrdering: argsRef.current.usesProjectGroupOrdering,

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -160,6 +160,21 @@ describe('computeProjectHeaderDropPreviewAcrossBuckets', () => {
       intoGroupId: '1'
     })
   })
+
+  it('collapses the slot below the dragged project (same bucket) to its home above', () => {
+    const result = computeProjectHeaderDropPreviewAcrossBuckets({
+      pointerY: 40, // lower half of bucket → would resolve to "below a" (index 1)
+      containerTop: 0,
+      scrollTop: 0,
+      repoRects: [
+        { repoId: 'a', bucketKey: 'group:1', headerIndex: 0, top: 0, bottom: 28 },
+        { repoId: 'b', bucketKey: 'group:1', headerIndex: 1, top: 50, bottom: 78 }
+      ],
+      groupZones: [],
+      draggingRepoId: 'a'
+    })
+    expect(result?.dropIndex).toBe(0)
+  })
 })
 
 describe('getProjectGroupOrderForSidebarDrop', () => {

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
   applyAllRepoInsertAt,
   computeProjectHeaderDropPreview,
+  computeProjectHeaderDropPreviewAcrossBuckets,
   getProjectGroupOrderForSidebarDrop,
   getProjectHeaderDragBucketKey,
   getSidebarOrderedRepoHeaderIdsByBucket,
@@ -143,6 +144,47 @@ describe('applyAllRepoInsertAt', () => {
 
   it('returns null for no-op reorders', () => {
     expect(applyAllRepoInsertAt(['a', 'b', 'c'], 'b', 2)).toBeNull()
+  })
+})
+
+describe('computeProjectHeaderDropPreviewAcrossBuckets', () => {
+  it('targets the bucket whose project block contains the pointer', () => {
+    const result = computeProjectHeaderDropPreviewAcrossBuckets({
+      pointerY: 60,
+      containerTop: 0,
+      scrollTop: 0,
+      repoRects: [
+        { repoId: 'a', bucketKey: 'group:1', headerIndex: 0, top: 0, bottom: 28 },
+        { repoId: 'b', bucketKey: 'group:2', headerIndex: 0, top: 50, bottom: 78 }
+      ],
+      groupZones: [
+        { bucketKey: 'group:1', top: 0, bottom: 40, projectCount: 1 },
+        { bucketKey: 'group:2', top: 45, bottom: 85, projectCount: 1 }
+      ]
+    })
+    expect(result?.targetBucketKey).toBe('group:2')
+  })
+
+  it('targets the ungrouped bucket when the pointer is below all groups', () => {
+    const result = computeProjectHeaderDropPreviewAcrossBuckets({
+      pointerY: 200,
+      containerTop: 0,
+      scrollTop: 0,
+      repoRects: [{ repoId: 'u', bucketKey: 'ungrouped', headerIndex: 0, top: 150, bottom: 178 }],
+      groupZones: [{ bucketKey: 'group:1', top: 0, bottom: 40, projectCount: 1 }]
+    })
+    expect(result?.targetBucketKey).toBe('ungrouped')
+  })
+
+  it('appends into a collapsed group whose header contains the pointer', () => {
+    const result = computeProjectHeaderDropPreviewAcrossBuckets({
+      pointerY: 12,
+      containerTop: 0,
+      scrollTop: 0,
+      repoRects: [],
+      groupZones: [{ bucketKey: 'group:1', top: 0, bottom: 24, projectCount: 3 }]
+    })
+    expect(result).toEqual({ targetBucketKey: 'group:1', dropIndex: 3, dropIndicatorY: 0 })
   })
 })
 

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -153,7 +153,12 @@ describe('computeProjectHeaderDropPreviewAcrossBuckets', () => {
       repoRects: [],
       groupZones: [{ bucketKey: 'group:1', top: 0, bottom: 24, projectCount: 3 }]
     })
-    expect(result).toEqual({ targetBucketKey: 'group:1', dropIndex: 3, dropIndicatorY: 0 })
+    expect(result).toEqual({
+      targetBucketKey: 'group:1',
+      dropIndex: 3,
+      dropIndicatorY: 0,
+      intoGroupId: '1'
+    })
   })
 })
 

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest'
 
 import {
   applyAllRepoInsertAt,
-  computeProjectHeaderDropPreview,
   computeProjectHeaderDropPreviewAcrossBuckets,
   getProjectGroupOrderForSidebarDrop,
   getProjectHeaderDragBucketKey,
@@ -99,36 +98,6 @@ describe('mapSidebarProjectHeaderDropIndexToSiblingInsertIndex', () => {
         siblingCount: 2
       })
     ).toBe(1)
-  })
-})
-
-describe('computeProjectHeaderDropPreview', () => {
-  it('uses row-model header indices instead of mounted subset order', () => {
-    const preview = computeProjectHeaderDropPreview({
-      pointerY: 105,
-      containerTop: 0,
-      scrollTop: 0,
-      sidebarRepoHeaderIds: ['a', 'b', 'c', 'd', 'e'],
-      rects: [
-        { repoId: 'b', bucketKey: 'ungrouped', headerIndex: 1, top: 100, bottom: 128 },
-        { repoId: 'c', bucketKey: 'ungrouped', headerIndex: 2, top: 200, bottom: 228 },
-        { repoId: 'd', bucketKey: 'ungrouped', headerIndex: 3, top: 300, bottom: 328 }
-      ]
-    })
-
-    expect(preview).toEqual({ dropIndex: 1, dropIndicatorY: 96 })
-  })
-
-  it('supports boundary drops at the end of the full sidebar list', () => {
-    const preview = computeProjectHeaderDropPreview({
-      pointerY: 360,
-      containerTop: 0,
-      scrollTop: 0,
-      sidebarRepoHeaderIds: ['a', 'b', 'c'],
-      rects: [{ repoId: 'c', bucketKey: 'ungrouped', headerIndex: 2, top: 300, bottom: 328 }]
-    })
-
-    expect(preview).toEqual({ dropIndex: 3, dropIndicatorY: 331 })
   })
 })
 

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -175,6 +175,23 @@ describe('computeProjectHeaderDropPreviewAcrossBuckets', () => {
     })
     expect(result?.dropIndex).toBe(0)
   })
+
+  it('highlights the target group (no line) when moving a project into a different group', () => {
+    const result = computeProjectHeaderDropPreviewAcrossBuckets({
+      pointerY: 60, // over group:2's (expanded) block
+      containerTop: 0,
+      scrollTop: 0,
+      repoRects: [
+        { repoId: 'a', bucketKey: 'group:1', headerIndex: 0, top: 0, bottom: 28 },
+        { repoId: 'b', bucketKey: 'group:2', headerIndex: 0, top: 50, bottom: 78 }
+      ],
+      groupZones: [],
+      draggingRepoId: 'a'
+    })
+    expect(result?.targetBucketKey).toBe('group:2')
+    expect(result?.intoGroupId).toBe('2')
+    expect(result?.dropIndex).toBe(1) // appended after group:2's project
+  })
 })
 
 describe('getProjectGroupOrderForSidebarDrop', () => {

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -224,6 +224,22 @@ describe('computeProjectHeaderDropPreviewAcrossBuckets', () => {
     expect(result?.dropIndex).toBe(1)
     expect(result?.dropIndicatorY ?? 0).toBeGreaterThanOrEqual(300)
   })
+
+  it('appends using the full sibling headerIndex, not the mounted-rect count', () => {
+    // Only one mounted rect, but it sits at sibling index 50 (the rest are
+    // virtualized off-screen). Dropping below it must append at 51, not at
+    // targetRects.length (1).
+    const result = computeProjectHeaderDropPreviewAcrossBuckets({
+      pointerY: 100,
+      containerTop: 0,
+      scrollTop: 0,
+      repoRects: [
+        { repoId: 'z', bucketKey: 'group:1', headerIndex: 50, top: 0, headerBottom: 28, bottom: 60 }
+      ],
+      groupZones: []
+    })
+    expect(result?.dropIndex).toBe(51)
+  })
 })
 
 describe('getProjectGroupOrderForSidebarDrop', () => {

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -193,7 +193,7 @@ describe('computeProjectHeaderDropPreviewAcrossBuckets', () => {
     expect(result?.dropIndex).toBe(1) // appended after group:2's project
   })
 
-  it('drops after the last project at its block bottom, not its header bottom', () => {
+  it('appends after the last project at its block bottom', () => {
     // Block-extent rects (as measureProjectHeaderDragRects now produces): project
     // "a" spans its whole block 0..300 (header + worktrees), not a 28px header.
     // Dropping over its lower worktrees must land the line below the block.

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -207,6 +207,23 @@ describe('computeProjectHeaderDropPreviewAcrossBuckets', () => {
     expect(result?.dropIndex).toBe(1)
     expect(result?.dropIndicatorY ?? 0).toBeGreaterThanOrEqual(300)
   })
+
+  it('treats hovering a project body (its worktrees) as "after" it, not "before"', () => {
+    // Project "a" block 0..300 with a 28px header. y=40 is in its worktrees —
+    // below the header but above the block midpoint (150). With the header-row
+    // threshold this reads as "after a" (append), not "before a" (dropIndex 0).
+    const result = computeProjectHeaderDropPreviewAcrossBuckets({
+      pointerY: 40,
+      containerTop: 0,
+      scrollTop: 0,
+      repoRects: [
+        { repoId: 'a', bucketKey: 'group:1', headerIndex: 0, top: 0, headerBottom: 28, bottom: 300 }
+      ],
+      groupZones: []
+    })
+    expect(result?.dropIndex).toBe(1)
+    expect(result?.dropIndicatorY ?? 0).toBeGreaterThanOrEqual(300)
+  })
 })
 
 describe('getProjectGroupOrderForSidebarDrop', () => {

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -192,6 +192,21 @@ describe('computeProjectHeaderDropPreviewAcrossBuckets', () => {
     expect(result?.intoGroupId).toBe('2')
     expect(result?.dropIndex).toBe(1) // appended after group:2's project
   })
+
+  it('drops after the last project at its block bottom, not its header bottom', () => {
+    // Block-extent rects (as measureProjectHeaderDragRects now produces): project
+    // "a" spans its whole block 0..300 (header + worktrees), not a 28px header.
+    // Dropping over its lower worktrees must land the line below the block.
+    const result = computeProjectHeaderDropPreviewAcrossBuckets({
+      pointerY: 280,
+      containerTop: 0,
+      scrollTop: 0,
+      repoRects: [{ repoId: 'a', bucketKey: 'group:1', headerIndex: 0, top: 0, bottom: 300 }],
+      groupZones: []
+    })
+    expect(result?.dropIndex).toBe(1)
+    expect(result?.dropIndicatorY ?? 0).toBeGreaterThanOrEqual(300)
+  })
 })
 
 describe('getProjectGroupOrderForSidebarDrop', () => {

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -237,11 +237,26 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
       break
     }
   }
-  // Within its own bucket, the slot right below the dragged project is a no-op
-  // (same as leaving it put); collapse it to the home position above.
   const draggedRect = args.draggingRepoId
     ? args.repoRects.find((rect) => rect.repoId === args.draggingRepoId)
     : undefined
+  // Moving a project into a different group reads as "join this group", so
+  // highlight the target group and append (no positional line) — matching the
+  // collapsed-group and context-menu "Move to group" behavior.
+  if (
+    draggedRect &&
+    draggedRect.bucketKey !== targetBucketKey &&
+    targetBucketKey.startsWith('group:')
+  ) {
+    return {
+      targetBucketKey,
+      dropIndex: targetRects.length,
+      dropIndicatorY: Math.max(args.scrollTop, indicatorY),
+      intoGroupId: targetBucketKey.slice('group:'.length)
+    }
+  }
+  // Within its own bucket, the slot right below the dragged project is a no-op
+  // (same as leaving it put); collapse it to the home position above.
   if (
     draggedRect &&
     draggedRect.bucketKey === targetBucketKey &&

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -202,6 +202,105 @@ export function computeProjectHeaderDropPreview(args: {
   }
 }
 
+export type ProjectGroupDropZone = {
+  bucketKey: ProjectHeaderDragBucketKey
+  top: number
+  bottom: number
+  projectCount: number
+}
+
+export type ProjectHeaderCrossBucketDropPreview = {
+  targetBucketKey: ProjectHeaderDragBucketKey
+  dropIndex: number
+  dropIndicatorY: number
+}
+
+export function measureProjectGroupHeaderDropZones(container: HTMLElement): ProjectGroupDropZone[] {
+  const containerRect = container.getBoundingClientRect()
+  const zones: ProjectGroupDropZone[] = []
+  container.querySelectorAll<HTMLElement>('[data-project-group-header-id]').forEach((element) => {
+    const groupId = element.getAttribute('data-project-group-header-id')
+    if (!groupId) {
+      return
+    }
+    const rect = element.getBoundingClientRect()
+    const top = rect.top - containerRect.top + container.scrollTop
+    const rawCount = element.getAttribute('data-project-group-project-count')
+    const projectCount = rawCount === null ? 0 : Number(rawCount)
+    zones.push({
+      bucketKey: `group:${groupId}`,
+      top,
+      bottom: top + rect.height,
+      projectCount: Number.isFinite(projectCount) ? projectCount : 0
+    })
+  })
+  return zones
+}
+
+export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
+  pointerY: number
+  containerTop: number
+  scrollTop: number
+  repoRects: readonly ProjectHeaderDragRect[]
+  groupZones: readonly ProjectGroupDropZone[]
+}): ProjectHeaderCrossBucketDropPreview | null {
+  const localY = args.pointerY - args.containerTop + args.scrollTop
+  // 1) A group header directly under the pointer = append into that group.
+  for (const zone of args.groupZones) {
+    const bucketRepoRects = args.repoRects.filter((rect) => rect.bucketKey === zone.bucketKey)
+    if (bucketRepoRects.length === 0 && localY >= zone.top && localY <= zone.bottom) {
+      return {
+        targetBucketKey: zone.bucketKey,
+        dropIndex: zone.projectCount,
+        dropIndicatorY: Math.max(args.scrollTop, zone.top)
+      }
+    }
+  }
+  // 2) Otherwise resolve the bucket whose block (header..last project) holds the
+  //    pointer; fall back to the bucket of the nearest project header above.
+  const buckets = new Map<ProjectHeaderDragBucketKey, ProjectHeaderDragRect[]>()
+  for (const rect of args.repoRects) {
+    const list = buckets.get(rect.bucketKey) ?? []
+    list.push(rect)
+    buckets.set(rect.bucketKey, list)
+  }
+  let targetBucketKey: ProjectHeaderDragBucketKey | null = null
+  for (const [bucketKey, rects] of buckets) {
+    const top = Math.min(...rects.map((r) => r.top))
+    const bottom = Math.max(...rects.map((r) => r.bottom))
+    if (localY >= top && localY <= bottom) {
+      targetBucketKey = bucketKey
+      break
+    }
+  }
+  if (targetBucketKey === null) {
+    // nearest project header at/above the pointer
+    const above = [...args.repoRects]
+      .filter((r) => r.top <= localY)
+      .sort((a, b) => b.top - a.top)[0]
+    targetBucketKey = above ? above.bucketKey : (args.repoRects[0]?.bucketKey ?? null)
+  }
+  if (targetBucketKey === null) {
+    return null
+  }
+  const targetRects = (buckets.get(targetBucketKey) ?? []).slice().sort((a, b) => a.top - b.top)
+  let dropIndex = targetRects.length
+  let indicatorY = (targetRects.at(-1)?.bottom ?? localY) + INDICATOR_GAP_PX
+  for (const rect of targetRects) {
+    const mid = (rect.top + rect.bottom) / 2
+    if (localY < mid) {
+      dropIndex = rect.headerIndex
+      indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
+      break
+    }
+  }
+  return {
+    targetBucketKey,
+    dropIndex: targetRects.length === 0 ? 0 : dropIndex,
+    dropIndicatorY: Math.max(args.scrollTop, indicatorY)
+  }
+}
+
 export function applyAllRepoInsertAt(
   allRepoIds: readonly string[],
   draggedRepoId: string,

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -1,6 +1,6 @@
 import { getEffectiveProjectGroupManualRank } from '../../../../shared/project-groups'
 import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
-import { getVirtualRowStart } from './sidebar-virtual-row-offset'
+import { resolveVirtualRowTop } from './sidebar-virtual-row-offset'
 import type { Row } from './worktree-list-groups'
 import type { Repo } from '../../../../shared/types'
 
@@ -17,7 +17,7 @@ export type ProjectHeaderDragRect = {
   bottom: number
 }
 
-const INDICATOR_GAP_PX = 4
+export const INDICATOR_GAP_PX = 4
 
 export function getProjectHeaderDragBucketKey(
   repo: Pick<Repo, 'projectGroupId'>
@@ -103,12 +103,7 @@ export function measureProjectHeaderDragRects(
       return
     }
     const rect = element.getBoundingClientRect()
-    const virtualRow = element.closest<HTMLElement>('[data-worktree-virtual-row]')
-    const virtualRowStart = getVirtualRowStart(virtualRow)
-    const top =
-      virtualRow && virtualRowStart !== null
-        ? virtualRowStart + rect.top - virtualRow.getBoundingClientRect().top
-        : rect.top - containerRect.top + container.scrollTop
+    const top = resolveVirtualRowTop(element, container, containerRect)
     rects.push({
       repoId,
       bucketKey: elementBucketKey,
@@ -165,14 +160,7 @@ export function measureProjectGroupHeaderDropZones(container: HTMLElement): Proj
       return
     }
     const rect = element.getBoundingClientRect()
-    // Why: mirrors measureProjectHeaderDragRects / measureGroupHeaderDragRects so
-    // sticky-pinned virtual rows don't skew the coordinate space.
-    const virtualRow = element.closest<HTMLElement>('[data-worktree-virtual-row]')
-    const virtualRowStart = getVirtualRowStart(virtualRow)
-    const top =
-      virtualRow && virtualRowStart !== null
-        ? virtualRowStart + rect.top - virtualRow.getBoundingClientRect().top
-        : rect.top - containerRect.top + container.scrollTop
+    const top = resolveVirtualRowTop(element, container, containerRect)
     const rawCount = element.getAttribute('data-project-group-project-count')
     const projectCount = rawCount === null ? 0 : Number(rawCount)
     zones.push({

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -1,6 +1,5 @@
 import { getEffectiveProjectGroupManualRank } from '../../../../shared/project-groups'
 import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
-import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
 import { getVirtualRowStart } from './sidebar-virtual-row-offset'
 import type { Row } from './worktree-list-groups'
 import type { Repo } from '../../../../shared/types'
@@ -16,11 +15,6 @@ export type ProjectHeaderDragRect = {
   headerIndex: number
   top: number
   bottom: number
-}
-
-export type ProjectHeaderDropPreview = {
-  dropIndex: number
-  dropIndicatorY: number
 }
 
 const INDICATOR_GAP_PX = 4
@@ -145,63 +139,6 @@ export function mapSidebarRepoDropIndexToAllRepoInsertAt(
   return allRepoIds.indexOf(sidebarRepoHeaderIds[sidebarDropIndex]!)
 }
 
-export function computeProjectHeaderDropPreview(args: {
-  pointerY: number
-  containerTop: number
-  scrollTop: number
-  rects: readonly ProjectHeaderDragRect[]
-  sidebarRepoHeaderIds: readonly string[]
-}): ProjectHeaderDropPreview | null {
-  const { rects, sidebarRepoHeaderIds } = args
-  if (rects.length === 0 || sidebarRepoHeaderIds.length === 0) {
-    return null
-  }
-
-  const localY = args.pointerY - args.containerTop + args.scrollTop
-  const first = rects[0]!
-  const last = rects.at(-1)!
-  const boundaryDrop = getWorktreeSidebarBoundaryDrop({
-    localY,
-    firstRect: {
-      worktreeId: first.repoId,
-      groupIndex: first.headerIndex,
-      top: first.top,
-      bottom: first.bottom
-    },
-    lastRect: {
-      worktreeId: last.repoId,
-      groupIndex: last.headerIndex,
-      top: last.top,
-      bottom: last.bottom
-    },
-    sourceGroupSize: sidebarRepoHeaderIds.length
-  })
-  if (boundaryDrop.kind === 'outside') {
-    return null
-  }
-
-  let dropIndex = last.headerIndex + 1
-  let indicatorY = last.bottom + INDICATOR_GAP_PX
-  if (boundaryDrop.kind === 'drop') {
-    dropIndex = boundaryDrop.dropIndex
-    indicatorY = boundaryDrop.indicatorY
-  } else {
-    for (const rect of rects) {
-      const mid = (rect.top + rect.bottom) / 2
-      if (localY < mid) {
-        dropIndex = rect.headerIndex
-        indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
-        break
-      }
-    }
-  }
-
-  return {
-    dropIndex,
-    dropIndicatorY: Math.max(args.scrollTop, indicatorY)
-  }
-}
-
 export type ProjectGroupDropZone = {
   bucketKey: ProjectHeaderDragBucketKey
   top: number
@@ -224,7 +161,14 @@ export function measureProjectGroupHeaderDropZones(container: HTMLElement): Proj
       return
     }
     const rect = element.getBoundingClientRect()
-    const top = rect.top - containerRect.top + container.scrollTop
+    // Why: mirrors measureProjectHeaderDragRects / measureGroupHeaderDragRects so
+    // sticky-pinned virtual rows don't skew the coordinate space.
+    const virtualRow = element.closest<HTMLElement>('[data-worktree-virtual-row]')
+    const virtualRowStart = getVirtualRowStart(virtualRow)
+    const top =
+      virtualRow && virtualRowStart !== null
+        ? virtualRowStart + rect.top - virtualRow.getBoundingClientRect().top
+        : rect.top - containerRect.top + container.scrollTop
     const rawCount = element.getAttribute('data-project-group-project-count')
     const projectCount = rawCount === null ? 0 : Number(rawCount)
     zones.push({

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -1,4 +1,5 @@
 import { getEffectiveProjectGroupManualRank } from '../../../../shared/project-groups'
+import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
 import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
 import type { Row } from './worktree-list-groups'
 import type { Repo } from '../../../../shared/types'
@@ -72,21 +73,7 @@ export function getProjectGroupOrderForSidebarDrop(args: {
   }
   const before = getEffectiveOrder(ordered[args.dropIndex - 1], args.dropIndex - 1)
   const after = getEffectiveOrder(ordered[args.dropIndex], args.dropIndex)
-  if (before === undefined && after === undefined) {
-    return 0
-  }
-  if (before === undefined) {
-    return after !== undefined ? after - 1 : 0
-  }
-  if (after === undefined) {
-    return before + 1
-  }
-  if (after > before) {
-    return before + (after - before) / 2
-  }
-  // Why: duplicate legacy ranks leave no numeric slot between neighbors; choose
-  // a deterministic finite value so the next drag has a persisted anchor.
-  return before + 1
+  return interpolateSparseOrder(before, after)
 }
 
 export function mapSidebarProjectHeaderDropIndexToSiblingInsertIndex(args: {

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -19,10 +19,21 @@ export type ProjectHeaderDragRect = {
 
 export const INDICATOR_GAP_PX = 4
 
+// Drag buckets are keyed `group:<id>` for grouped projects and a single
+// sentinel for ungrouped ones; keep the prefix/sentinel defined once.
+export const GROUP_BUCKET_PREFIX = 'group:'
+export const UNGROUPED_BUCKET_KEY = 'ungrouped'
+
 export function getProjectHeaderDragBucketKey(
   repo: Pick<Repo, 'projectGroupId'>
 ): ProjectHeaderDragBucketKey {
-  return repo.projectGroupId ? `group:${repo.projectGroupId}` : 'ungrouped'
+  return repo.projectGroupId ? `${GROUP_BUCKET_PREFIX}${repo.projectGroupId}` : UNGROUPED_BUCKET_KEY
+}
+
+// Inverse of getProjectHeaderDragBucketKey: the ungrouped sentinel → null,
+// `group:<id>` → `<id>`.
+export function bucketKeyToProjectGroupId(bucketKey: ProjectHeaderDragBucketKey): string | null {
+  return bucketKey === UNGROUPED_BUCKET_KEY ? null : bucketKey.slice(GROUP_BUCKET_PREFIX.length)
 }
 
 export function getSidebarOrderedRepoHeaderIds(rows: readonly Row[]): string[] {
@@ -164,7 +175,7 @@ export function measureProjectGroupHeaderDropZones(container: HTMLElement): Proj
     const rawCount = element.getAttribute('data-project-group-project-count')
     const projectCount = rawCount === null ? 0 : Number(rawCount)
     zones.push({
-      bucketKey: `group:${groupId}`,
+      bucketKey: `${GROUP_BUCKET_PREFIX}${groupId}`,
       top,
       bottom: top + rect.height,
       projectCount: Number.isFinite(projectCount) ? projectCount : 0
@@ -192,10 +203,8 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
         targetBucketKey: zone.bucketKey,
         dropIndex: zone.projectCount,
         dropIndicatorY: Math.max(args.scrollTop, zone.top),
-        // group zones are keyed `group:<id>`; highlight that group as the target.
-        intoGroupId: zone.bucketKey.startsWith('group:')
-          ? zone.bucketKey.slice('group:'.length)
-          : null
+        // highlight the group under the pointer as the target.
+        intoGroupId: bucketKeyToProjectGroupId(zone.bucketKey)
       }
     }
   }
@@ -243,16 +252,13 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
   // Moving a project into a different group reads as "join this group", so
   // highlight the target group and append (no positional line) — matching the
   // collapsed-group and context-menu "Move to group" behavior.
-  if (
-    draggedRect &&
-    draggedRect.bucketKey !== targetBucketKey &&
-    targetBucketKey.startsWith('group:')
-  ) {
+  const targetGroupId = bucketKeyToProjectGroupId(targetBucketKey)
+  if (draggedRect && draggedRect.bucketKey !== targetBucketKey && targetGroupId !== null) {
     return {
       targetBucketKey,
       dropIndex: targetRects.length,
       dropIndicatorY: Math.max(args.scrollTop, indicatorY),
-      intoGroupId: targetBucketKey.slice('group:'.length)
+      intoGroupId: targetGroupId
     }
   }
   // Within its own bucket, the slot right below the dragged project is a no-op

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -179,6 +179,9 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
   scrollTop: number
   repoRects: readonly ProjectHeaderDragRect[]
   groupZones: readonly ProjectGroupDropZone[]
+  /** The project being dragged, so the slot right below it in its own bucket (a
+   *  no-op) collapses to its home position above. */
+  draggingRepoId?: string
 }): ProjectHeaderCrossBucketDropPreview | null {
   const localY = args.pointerY - args.containerTop + args.scrollTop
   // 1) A group header directly under the pointer = append into that group.
@@ -233,6 +236,19 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
       indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
       break
     }
+  }
+  // Within its own bucket, the slot right below the dragged project is a no-op
+  // (same as leaving it put); collapse it to the home position above.
+  const draggedRect = args.draggingRepoId
+    ? args.repoRects.find((rect) => rect.repoId === args.draggingRepoId)
+    : undefined
+  if (
+    draggedRect &&
+    draggedRect.bucketKey === targetBucketKey &&
+    dropIndex === draggedRect.headerIndex + 1
+  ) {
+    dropIndex = draggedRect.headerIndex
+    indicatorY = Math.max(0, draggedRect.top - INDICATOR_GAP_PX)
   }
   return {
     targetBucketKey,

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -1,6 +1,7 @@
 import { getEffectiveProjectGroupManualRank } from '../../../../shared/project-groups'
 import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
 import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
+import { getVirtualRowStart } from './sidebar-virtual-row-offset'
 import type { Row } from './worktree-list-groups'
 import type { Repo } from '../../../../shared/types'
 
@@ -88,18 +89,6 @@ export function mapSidebarProjectHeaderDropIndexToSiblingInsertIndex(args: {
       ? args.sidebarDropIndex - 1
       : args.sidebarDropIndex
   return Math.max(0, Math.min(args.siblingCount, adjustedDropIndex))
-}
-
-function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
-  if (!virtualRow) {
-    return null
-  }
-  const rawStart = virtualRow.getAttribute('data-worktree-virtual-row-start')
-  if (rawStart === null) {
-    return null
-  }
-  const start = Number(rawStart)
-  return Number.isFinite(start) ? start : null
 }
 
 export function measureProjectHeaderDragRects(

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -150,6 +150,10 @@ export type ProjectHeaderCrossBucketDropPreview = {
   targetBucketKey: ProjectHeaderDragBucketKey
   dropIndex: number
   dropIndicatorY: number
+  /** Set when dropping onto a collapsed/empty group header: the project lands
+   *  inside this group, so the UI highlights the group instead of drawing a
+   *  drop line above it. */
+  intoGroupId?: string | null
 }
 
 export function measureProjectGroupHeaderDropZones(container: HTMLElement): ProjectGroupDropZone[] {
@@ -196,7 +200,11 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
       return {
         targetBucketKey: zone.bucketKey,
         dropIndex: zone.projectCount,
-        dropIndicatorY: Math.max(args.scrollTop, zone.top)
+        dropIndicatorY: Math.max(args.scrollTop, zone.top),
+        // group zones are keyed `group:<id>`; highlight that group as the target.
+        intoGroupId: zone.bucketKey.startsWith('group:')
+          ? zone.bucketKey.slice('group:'.length)
+          : null
       }
     }
   }

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -101,6 +101,25 @@ export function measureProjectHeaderDragRects(
   bucketKey?: ProjectHeaderDragBucketKey
 ): ProjectHeaderDragRect[] {
   const containerRect = container.getBoundingClientRect()
+  // Every header (project OR group) bounds the block of the project above it —
+  // a project's worktrees end where the next header begins — so collect all
+  // header tops as block boundaries.
+  const boundaryTops: number[] = []
+  container
+    .querySelectorAll<HTMLElement>('[data-repo-header-id], [data-project-group-header-id]')
+    .forEach((element) => {
+      boundaryTops.push(resolveVirtualRowTop(element, container, containerRect))
+    })
+  boundaryTops.sort((left, right) => left - right)
+  // The last project's block runs to the bottom of the last rendered row (not
+  // scrollHeight, which can exceed rendered content).
+  let contentBottom = boundaryTops.at(-1) ?? 0
+  container.querySelectorAll<HTMLElement>('[data-worktree-virtual-row]').forEach((element) => {
+    const rowBottom =
+      resolveVirtualRowTop(element, container, containerRect) +
+      element.getBoundingClientRect().height
+    contentBottom = Math.max(contentBottom, rowBottom)
+  })
   const rects: ProjectHeaderDragRect[] = []
   container.querySelectorAll<HTMLElement>('[data-repo-header-id]').forEach((element) => {
     const repoId = element.getAttribute('data-repo-header-id')
@@ -113,14 +132,17 @@ export function measureProjectHeaderDragRects(
     if (bucketKey !== undefined && elementBucketKey !== bucketKey) {
       return
     }
-    const rect = element.getBoundingClientRect()
     const top = resolveVirtualRowTop(element, container, containerRect)
+    // Why: a project's drop footprint is its whole block (header + worktrees),
+    // not just the header row, so the drop line lands below its worktrees
+    // instead of inside them. Extend to the next header's top (project or group).
+    const next = boundaryTops.find((boundaryTop) => boundaryTop > top)
     rects.push({
       repoId,
       bucketKey: elementBucketKey,
       headerIndex,
       top,
-      bottom: top + rect.height
+      bottom: next ?? contentBottom
     })
   })
   rects.sort((left, right) => left.top - right.top)

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -22,8 +22,6 @@ export type ProjectHeaderDragRect = {
   headerBottom?: number
 }
 
-export const INDICATOR_GAP_PX = 4
-
 // Drag buckets are keyed `group:<id>` for grouped projects and a single
 // sentinel for ungrouped ones; keep the prefix/sentinel defined once.
 export const GROUP_BUCKET_PREFIX = 'group:'
@@ -265,14 +263,17 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
   }
   const targetRects = (buckets.get(targetBucketKey) ?? []).slice().sort((a, b) => a.top - b.top)
   let dropIndex = targetRects.length
-  let indicatorY = (targetRects.at(-1)?.bottom ?? localY) + INDICATOR_GAP_PX
+  // The indicator sits exactly at the insertion boundary (a block edge). The
+  // gap-opening shift keys off this same Y, so any cosmetic offset here would
+  // pull the unit just past the boundary (e.g. the next group) into the shift.
+  let indicatorY = targetRects.at(-1)?.bottom ?? localY
   for (const rect of targetRects) {
     // Threshold on the header row, not the whole block: hovering a project's
     // body (worktrees) reads as "after it" instead of "before it".
     const mid = (rect.top + (rect.headerBottom ?? rect.bottom)) / 2
     if (localY < mid) {
       dropIndex = rect.headerIndex
-      indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
+      indicatorY = Math.max(0, rect.top)
       break
     }
   }
@@ -299,7 +300,7 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
     dropIndex === draggedRect.headerIndex + 1
   ) {
     dropIndex = draggedRect.headerIndex
-    indicatorY = Math.max(0, draggedRect.top - INDICATOR_GAP_PX)
+    indicatorY = Math.max(0, draggedRect.top)
   }
   return {
     targetBucketKey,

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -228,10 +228,22 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
   draggingRepoId?: string
 }): ProjectHeaderCrossBucketDropPreview | null {
   const localY = args.pointerY - args.containerTop + args.scrollTop
-  // 1) A group header directly under the pointer = append into that group.
+  const draggedRect = args.draggingRepoId
+    ? args.repoRects.find((rect) => rect.repoId === args.draggingRepoId)
+    : undefined
+  // 1) A group header under the pointer targets that group. For a cross-bucket
+  //    drag, hovering any OTHER group's header — collapsed, empty, or expanded —
+  //    targets it; a same-bucket drag only matches collapsed/empty group headers
+  //    (an expanded same-bucket group is handled by its repo block below).
   for (const zone of args.groupZones) {
     const bucketRepoRects = args.repoRects.filter((rect) => rect.bucketKey === zone.bucketKey)
-    if (bucketRepoRects.length === 0 && localY >= zone.top && localY <= zone.bottom) {
+    const isCrossBucketHeaderTarget =
+      draggedRect !== undefined && draggedRect.bucketKey !== zone.bucketKey
+    if (
+      (bucketRepoRects.length === 0 || isCrossBucketHeaderTarget) &&
+      localY >= zone.top &&
+      localY <= zone.bottom
+    ) {
       return {
         targetBucketKey: zone.bucketKey,
         dropIndex: zone.projectCount,
@@ -268,11 +280,15 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
     return null
   }
   const targetRects = (buckets.get(targetBucketKey) ?? []).slice().sort((a, b) => a.top - b.top)
-  let dropIndex = targetRects.length
+  const lastTargetRect = targetRects.at(-1)
+  // Append after the last sibling's FULL index, not the mounted-rect count:
+  // virtualization unmounts off-screen siblings, so targetRects.length undercounts.
+  const appendIndex = lastTargetRect ? lastTargetRect.headerIndex + 1 : 0
+  let dropIndex = appendIndex
   // The indicator sits exactly at the insertion boundary (a block edge). The
   // gap-opening shift keys off this same Y, so any cosmetic offset here would
   // pull the unit just past the boundary (e.g. the next group) into the shift.
-  let indicatorY = targetRects.at(-1)?.bottom ?? localY
+  let indicatorY = lastTargetRect?.bottom ?? localY
   for (const rect of targetRects) {
     // Threshold on the header row, not the whole block: hovering a project's
     // body (worktrees) reads as "after it" instead of "before it".
@@ -283,9 +299,6 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
       break
     }
   }
-  const draggedRect = args.draggingRepoId
-    ? args.repoRects.find((rect) => rect.repoId === args.draggingRepoId)
-    : undefined
   // Moving a project into a different group reads as "join this group", so
   // highlight the target group and append (no positional line) — matching the
   // collapsed-group and context-menu "Move to group" behavior.
@@ -293,7 +306,7 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
   if (draggedRect && draggedRect.bucketKey !== targetBucketKey && targetGroupId !== null) {
     return {
       targetBucketKey,
-      dropIndex: targetRects.length,
+      dropIndex: appendIndex,
       dropIndicatorY: Math.max(args.scrollTop, indicatorY),
       intoGroupId: targetGroupId
     }
@@ -310,7 +323,7 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
   }
   return {
     targetBucketKey,
-    dropIndex: targetRects.length === 0 ? 0 : dropIndex,
+    dropIndex,
     dropIndicatorY: Math.max(args.scrollTop, indicatorY)
   }
 }

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -259,7 +259,6 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
     }
   }
   if (targetBucketKey === null) {
-    // nearest project header at/above the pointer
     const above = [...args.repoRects]
       .filter((r) => r.top <= localY)
       .sort((a, b) => b.top - a.top)[0]

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -13,8 +13,13 @@ export type ProjectHeaderDragRect = {
   // not the mounted subset. Virtualized rows unmount off-screen headers, so
   // loop index over mounted rects would map drops to the wrong persisted order.
   headerIndex: number
+  // top/bottom span the project's whole block (header + worktrees) so the drop
+  // line lands at block boundaries. headerBottom is the header row's bottom,
+  // used as the before/after threshold so hovering a project's body (its
+  // worktrees) reads as "after it", not "before it".
   top: number
   bottom: number
+  headerBottom?: number
 }
 
 export const INDICATOR_GAP_PX = 4
@@ -142,7 +147,8 @@ export function measureProjectHeaderDragRects(
       bucketKey: elementBucketKey,
       headerIndex,
       top,
-      bottom: next ?? contentBottom
+      bottom: next ?? contentBottom,
+      headerBottom: top + element.getBoundingClientRect().height
     })
   })
   rects.sort((left, right) => left.top - right.top)
@@ -261,7 +267,9 @@ export function computeProjectHeaderDropPreviewAcrossBuckets(args: {
   let dropIndex = targetRects.length
   let indicatorY = (targetRects.at(-1)?.bottom ?? localY) + INDICATOR_GAP_PX
   for (const rect of targetRects) {
-    const mid = (rect.top + rect.bottom) / 2
+    // Threshold on the header row, not the whole block: hovering a project's
+    // body (worktrees) reads as "after it" instead of "before it".
+    const mid = (rect.top + (rect.headerBottom ?? rect.bottom)) / 2
     if (localY < mid) {
       dropIndex = rect.headerIndex
       indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -1,6 +1,6 @@
 import { getEffectiveProjectGroupManualRank } from '../../../../shared/project-groups'
 import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
-import { resolveVirtualRowTop } from './sidebar-virtual-row-offset'
+import { resolveVirtualRowStart, resolveVirtualRowTop } from './sidebar-virtual-row-offset'
 import type { Row } from './worktree-list-groups'
 import type { Repo } from '../../../../shared/types'
 
@@ -104,6 +104,13 @@ export function measureProjectHeaderDragRects(
   bucketKey?: ProjectHeaderDragBucketKey
 ): ProjectHeaderDragRect[] {
   const containerRect = container.getBoundingClientRect()
+  // Measure from the virtual row's slot start, not the header element's offset
+  // top: the gap-opening shift keys off the same virtualizer starts, so a
+  // header's intra-row spacing (e.g. the inter-group pt-1) would otherwise put
+  // a boundary a few px past the next row's start and pull that unrelated unit
+  // into the shift.
+  const rowTop = (element: HTMLElement): number =>
+    resolveVirtualRowStart(element) ?? resolveVirtualRowTop(element, container, containerRect)
   // Every header (project OR group) bounds the block of the project above it —
   // a project's worktrees end where the next header begins — so collect all
   // header tops as block boundaries.
@@ -111,17 +118,17 @@ export function measureProjectHeaderDragRects(
   container
     .querySelectorAll<HTMLElement>('[data-repo-header-id], [data-project-group-header-id]')
     .forEach((element) => {
-      boundaryTops.push(resolveVirtualRowTop(element, container, containerRect))
+      boundaryTops.push(rowTop(element))
     })
   boundaryTops.sort((left, right) => left - right)
   // The last project's block runs to the bottom of the last rendered row (not
   // scrollHeight, which can exceed rendered content).
   let contentBottom = boundaryTops.at(-1) ?? 0
   container.querySelectorAll<HTMLElement>('[data-worktree-virtual-row]').forEach((element) => {
-    const rowBottom =
-      resolveVirtualRowTop(element, container, containerRect) +
-      element.getBoundingClientRect().height
-    contentBottom = Math.max(contentBottom, rowBottom)
+    contentBottom = Math.max(
+      contentBottom,
+      rowTop(element) + element.getBoundingClientRect().height
+    )
   })
   const rects: ProjectHeaderDragRect[] = []
   container.querySelectorAll<HTMLElement>('[data-repo-header-id]').forEach((element) => {
@@ -135,7 +142,7 @@ export function measureProjectHeaderDragRects(
     if (bucketKey !== undefined && elementBucketKey !== bucketKey) {
       return
     }
-    const top = resolveVirtualRowTop(element, container, containerRect)
+    const top = rowTop(element)
     // Why: a project's drop footprint is its whole block (header + worktrees),
     // not just the header row, so the drop line lands below its worktrees
     // instead of inside them. Extend to the next header's top (project or group).

--- a/src/renderer/src/components/sidebar/sidebar-drop-order-interpolation.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-drop-order-interpolation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { interpolateSparseOrder } from './sidebar-drop-order-interpolation'
+
+describe('interpolateSparseOrder', () => {
+  it('returns 0 when there are no neighbors', () => {
+    expect(interpolateSparseOrder(undefined, undefined)).toBe(0)
+  })
+  it('returns one below the after-neighbor when dropping at the start', () => {
+    expect(interpolateSparseOrder(undefined, 5)).toBe(4)
+  })
+  it('returns one above the before-neighbor when dropping at the end', () => {
+    expect(interpolateSparseOrder(2, undefined)).toBe(3)
+  })
+  it('returns the midpoint between ascending neighbors', () => {
+    expect(interpolateSparseOrder(2, 4)).toBe(3)
+  })
+  it('returns before+1 when neighbor ranks are not ascending (legacy duplicates)', () => {
+    expect(interpolateSparseOrder(5, 5)).toBe(6)
+  })
+})

--- a/src/renderer/src/components/sidebar/sidebar-drop-order-interpolation.ts
+++ b/src/renderer/src/components/sidebar/sidebar-drop-order-interpolation.ts
@@ -1,0 +1,23 @@
+/** Pick a finite order value between two neighbor ranks for sparse,
+ *  midpoint-based sidebar ordering. Shared by project-group order and
+ *  group tab order so the drag math stays identical. */
+export function interpolateSparseOrder(
+  before: number | undefined,
+  after: number | undefined
+): number {
+  if (before === undefined && after === undefined) {
+    return 0
+  }
+  if (before === undefined) {
+    return (after as number) - 1
+  }
+  if (after === undefined) {
+    return before + 1
+  }
+  if (after > before) {
+    return before + (after - before) / 2
+  }
+  // Why: duplicate legacy ranks leave no numeric slot between neighbors; choose
+  // a deterministic finite value so the next drag has a persisted anchor.
+  return before + 1
+}

--- a/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
@@ -154,7 +154,12 @@ export function useSidebarHeaderPointerDrag<
         container.scrollTop = autoscroll.scrollTop
         refreshHeaderRects()
       }
-      applyDrop(session, configRef.current.computeDrop(session, container))
+      const drop = configRef.current.computeDrop(session, container)
+      // Why: same as the move handler — skip null drops to keep the last
+      // indicator visible when the pointer is outside the header band.
+      if (drop !== null) {
+        applyDrop(session, drop)
+      }
       autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
     },
     [applyDrop, cancelAutoscroll, refreshHeaderRects]
@@ -199,10 +204,19 @@ export function useSidebarHeaderPointerDrag<
           }
         }
         refreshHeaderRects()
-        applyDrop(session, null)
+        // Why: null here is intentional — sets the initial dragging state
+        // (indicator hidden) on promotion. Unlike mid-drag moves, we always
+        // write this null so the dragging identity appears in state immediately.
+        setState(configRef.current.buildState(configRef.current.getSessionId(session), null))
       }
       refreshHeaderRects()
-      applyDrop(session, configRef.current.computeDrop(session, container))
+      const drop = configRef.current.computeDrop(session, container)
+      // Why: only update when the pointer is over a valid drop zone. If
+      // computeDrop returns null (pointer left the header band) the last
+      // indicator stays rendered, matching the original behavior.
+      if (drop !== null) {
+        applyDrop(session, drop)
+      }
       ensureAutoscroll()
     }
     const onPointerUp = (e: PointerEvent): void => {
@@ -244,8 +258,12 @@ export function useSidebarHeaderPointerDrag<
     }
   }, [applyDrop, cancelAutoscroll, endDrag, ensureAutoscroll, refreshHeaderRects, sessionArmed])
 
+  // Why: depend only on the dragging identity, not the full state object,
+  // so the cursor/userSelect effect does not re-run every frame when only
+  // drop coordinates change (matches original per-id dependency).
+  const draggingId = configRef.current.getDraggingId(state)
   useEffect(() => {
-    if (configRef.current.getDraggingId(state) === null) {
+    if (draggingId === null) {
       return
     }
     const body = document.body
@@ -257,7 +275,7 @@ export function useSidebarHeaderPointerDrag<
       body.style.cursor = prevCursor
       body.style.userSelect = prevUserSelect
     }
-  }, [state])
+  }, [draggingId])
 
   const onHandlePointerDown = useCallback((event: ReactPointerEvent<HTMLElement>, id: string) => {
     const session = configRef.current.createSession(event, id)

--- a/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
@@ -2,11 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { PointerEvent as ReactPointerEvent } from 'react'
 
 import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
-import {
-  createSidebarBlockDragPreview,
-  createSidebarDragPreview,
-  updateSidebarDragPreviewPosition
-} from './worktree-sidebar-pointer-drag-dom'
+import { updateSidebarDragPreviewPosition } from './worktree-sidebar-pointer-drag-dom'
+import { createHeaderDragPreview } from './header-drag-preview-rows'
 
 /** Common fields the lifecycle reads/writes on any header drag session. */
 export type SidebarHeaderDragSessionBase = {
@@ -223,22 +220,13 @@ export function useSidebarHeaderPointerDrag<
         refreshHeaderRects()
         // Clone the dragged block into a floating preview that follows the
         // cursor (same primitive the worktree drag uses); the source then hides.
-        // Prefer the whole block (header + children); fall back to the header.
         try {
-          const previewRows = configRef.current.getDragPreviewRows?.(session) ?? []
-          previewRef.current =
-            previewRows.length > 1
-              ? createSidebarBlockDragPreview({
-                  rows: previewRows,
-                  pointerX: e.clientX,
-                  pointerY: e.clientY
-                })
-              : createSidebarDragPreview({
-                  sourceRow: session.handleEl,
-                  pointerX: e.clientX,
-                  pointerY: e.clientY,
-                  draggedCount: 1
-                })
+          previewRef.current = createHeaderDragPreview({
+            rows: configRef.current.getDragPreviewRows?.(session) ?? [],
+            handleEl: session.handleEl,
+            pointerX: e.clientX,
+            pointerY: e.clientY
+          })
         } catch {
           previewRef.current = null
         }

--- a/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+
+import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+
+/** Common fields the lifecycle reads/writes on any header drag session. */
+export type SidebarHeaderDragSessionBase = {
+  pointerId: number
+  handleEl: HTMLElement
+  startX: number
+  startY: number
+  latestPointerY: number
+  promoted: boolean
+}
+
+/** Minimum a drop preview carries so the lifecycle can render an indicator. */
+export type SidebarHeaderDragDrop = {
+  dropIndex: number
+  dropIndicatorY: number
+}
+
+export type SidebarHeaderPointerDragConfig<
+  TSession extends SidebarHeaderDragSessionBase,
+  TState,
+  TDrop extends SidebarHeaderDragDrop
+> = {
+  threshold: number
+  initialState: TState
+  getScrollContainer: () => HTMLElement | null
+  getSessionId: (session: TSession) => string
+  getDraggingId: (state: TState) => string | null
+  createSession: (event: ReactPointerEvent<HTMLElement>, id: string) => TSession | null
+  measureRects: (container: HTMLElement, session: TSession) => void
+  computeDrop: (session: TSession, container: HTMLElement) => TDrop | null
+  buildState: (id: string, drop: TDrop | null) => TState
+  areStatesEqual: (a: TState, b: TState) => boolean
+  commit: (session: TSession, drop: TDrop) => void
+}
+
+export type SidebarHeaderDragController<TState> = {
+  state: TState
+  onHandlePointerDown: (event: ReactPointerEvent<HTMLElement>, id: string) => void
+}
+
+// Why pointer events instead of HTML5 DnD: rows are absolutely-positioned by
+// react-virtual and unmount/remount as scroll changes, so DnD enter/leave fire
+// against stale targets. We cache header positions and compute the drop index
+// from the live pointer Y instead.
+export function useSidebarHeaderPointerDrag<
+  TSession extends SidebarHeaderDragSessionBase,
+  TState,
+  TDrop extends SidebarHeaderDragDrop
+>(
+  config: SidebarHeaderPointerDragConfig<TSession, TState, TDrop>
+): SidebarHeaderDragController<TState> {
+  const [state, setState] = useState<TState>(config.initialState)
+  const [sessionArmed, setSessionArmed] = useState(false)
+  const configRef = useRef(config)
+  configRef.current = config
+  const latestDropRef = useRef<TDrop | null>(null)
+  const dragSessionRef = useRef<TSession | null>(null)
+  const clickSwallowTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const autoscrollLastFrameTimeRef = useRef<number | null>(null)
+  const autoscrollFrameIdRef = useRef<number | null>(null)
+
+  const refreshHeaderRects = useCallback(() => {
+    const container = configRef.current.getScrollContainer()
+    const session = dragSessionRef.current
+    if (!container || !session) {
+      return
+    }
+    configRef.current.measureRects(container, session)
+  }, [])
+
+  const applyDrop = useCallback((session: TSession, drop: TDrop | null) => {
+    if (drop) {
+      latestDropRef.current = drop
+    }
+    const next = configRef.current.buildState(configRef.current.getSessionId(session), drop)
+    setState((prev) => (configRef.current.areStatesEqual(prev, next) ? prev : next))
+  }, [])
+
+  const cancelAutoscroll = useCallback(() => {
+    if (autoscrollFrameIdRef.current !== null) {
+      window.cancelAnimationFrame(autoscrollFrameIdRef.current)
+      autoscrollFrameIdRef.current = null
+    }
+    autoscrollLastFrameTimeRef.current = null
+  }, [])
+
+  const endDrag = useCallback(
+    (commit: boolean) => {
+      cancelAutoscroll()
+      const session = dragSessionRef.current
+      if (!session) {
+        setState(configRef.current.initialState)
+        setSessionArmed(false)
+        return
+      }
+      try {
+        session.handleEl.releasePointerCapture(session.pointerId)
+      } catch {
+        // capture may already be released (pointercancel, element unmounted)
+      }
+      if (session.promoted) {
+        const handleEl = session.handleEl
+        const swallow = (e: MouseEvent): void => {
+          const target = e.target as Node | null
+          if (target && handleEl.contains(target)) {
+            e.stopPropagation()
+            e.preventDefault()
+          }
+          window.removeEventListener('click', swallow, true)
+        }
+        window.addEventListener('click', swallow, true)
+        clickSwallowTimeoutRef.current = setTimeout(() => {
+          window.removeEventListener('click', swallow, true)
+          clickSwallowTimeoutRef.current = null
+        }, 0)
+      }
+      const drop = commit && session.promoted ? latestDropRef.current : null
+      dragSessionRef.current = null
+      latestDropRef.current = null
+      setState(configRef.current.initialState)
+      setSessionArmed(false)
+      if (drop === null) {
+        return
+      }
+      configRef.current.commit(session, drop)
+    },
+    [cancelAutoscroll]
+  )
+
+  const runAutoscrollFrame = useCallback(
+    (frameTime: number) => {
+      autoscrollFrameIdRef.current = null
+      const session = dragSessionRef.current
+      const container = configRef.current.getScrollContainer()
+      if (!session?.promoted || !container) {
+        cancelAutoscroll()
+        return
+      }
+      const previousFrameTime = autoscrollLastFrameTimeRef.current ?? frameTime
+      autoscrollLastFrameTimeRef.current = frameTime
+      const autoscroll = getWorktreeSidebarDragAutoscroll({
+        point: { clientX: 0, clientY: session.latestPointerY },
+        containerRect: container.getBoundingClientRect(),
+        scrollTop: container.scrollTop,
+        scrollHeight: container.scrollHeight,
+        clientHeight: container.clientHeight,
+        elapsedMs: frameTime - previousFrameTime
+      })
+      if (autoscroll) {
+        container.scrollTop = autoscroll.scrollTop
+        refreshHeaderRects()
+      }
+      applyDrop(session, configRef.current.computeDrop(session, container))
+      autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
+    },
+    [applyDrop, cancelAutoscroll, refreshHeaderRects]
+  )
+
+  const ensureAutoscroll = useCallback(() => {
+    if (autoscrollFrameIdRef.current !== null) {
+      return
+    }
+    autoscrollLastFrameTimeRef.current = null
+    autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
+  }, [runAutoscrollFrame])
+
+  useEffect(() => {
+    if (!sessionArmed) {
+      return
+    }
+    const onPointerMove = (e: PointerEvent): void => {
+      const session = dragSessionRef.current
+      if (!session || e.pointerId !== session.pointerId) {
+        return
+      }
+      session.latestPointerY = e.clientY
+      const container = configRef.current.getScrollContainer()
+      if (!container) {
+        return
+      }
+      if (!session.promoted) {
+        const dx = e.clientX - session.startX
+        const dy = e.clientY - session.startY
+        if (dx * dx + dy * dy < configRef.current.threshold * configRef.current.threshold) {
+          return
+        }
+        session.promoted = true
+        // Why: setPointerCapture throws if the element detached; the global
+        // listeners still fire so dragging keeps working even if capture fails.
+        if (session.handleEl.isConnected) {
+          try {
+            session.handleEl.setPointerCapture(session.pointerId)
+          } catch {
+            // Ignore capture failure; global listeners handle the drag.
+          }
+        }
+        refreshHeaderRects()
+        applyDrop(session, null)
+      }
+      refreshHeaderRects()
+      applyDrop(session, configRef.current.computeDrop(session, container))
+      ensureAutoscroll()
+    }
+    const onPointerUp = (e: PointerEvent): void => {
+      const session = dragSessionRef.current
+      if (!session || e.pointerId !== session.pointerId) {
+        return
+      }
+      endDrag(true)
+    }
+    const onPointerCancel = (e: PointerEvent): void => {
+      const session = dragSessionRef.current
+      if (!session || e.pointerId !== session.pointerId) {
+        return
+      }
+      endDrag(false)
+    }
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        endDrag(false)
+      }
+    }
+    const onBlur = (): void => endDrag(false)
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+    window.addEventListener('pointercancel', onPointerCancel)
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+      window.removeEventListener('pointercancel', onPointerCancel)
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('blur', onBlur)
+      cancelAutoscroll()
+      if (clickSwallowTimeoutRef.current !== null) {
+        clearTimeout(clickSwallowTimeoutRef.current)
+        clickSwallowTimeoutRef.current = null
+      }
+    }
+  }, [applyDrop, cancelAutoscroll, endDrag, ensureAutoscroll, refreshHeaderRects, sessionArmed])
+
+  useEffect(() => {
+    if (configRef.current.getDraggingId(state) === null) {
+      return
+    }
+    const body = document.body
+    const prevCursor = body.style.cursor
+    const prevUserSelect = body.style.userSelect
+    body.style.cursor = 'grabbing'
+    body.style.userSelect = 'none'
+    return () => {
+      body.style.cursor = prevCursor
+      body.style.userSelect = prevUserSelect
+    }
+  }, [state])
+
+  const onHandlePointerDown = useCallback((event: ReactPointerEvent<HTMLElement>, id: string) => {
+    const session = configRef.current.createSession(event, id)
+    if (!session) {
+      return
+    }
+    dragSessionRef.current = session
+    latestDropRef.current = null
+    setSessionArmed(true)
+  }, [])
+
+  return { state, onHandlePointerDown }
+}

--- a/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
@@ -3,6 +3,7 @@ import type { PointerEvent as ReactPointerEvent } from 'react'
 
 import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
 import {
+  createSidebarBlockDragPreview,
   createSidebarDragPreview,
   updateSidebarDragPreviewPosition
 } from './worktree-sidebar-pointer-drag-dom'
@@ -39,6 +40,9 @@ export type SidebarHeaderPointerDragConfig<
   buildState: (id: string, drop: TDrop | null) => TState
   areStatesEqual: (a: TState, b: TState) => boolean
   commit: (session: TSession, drop: TDrop) => void
+  /** Optional: the block's row elements (header first) to clone into the drag
+   *  preview so it shows the children. Falls back to the header alone. */
+  getDragPreviewRows?: (session: TSession) => HTMLElement[]
 }
 
 export type SidebarHeaderDragController<TState> = {
@@ -217,15 +221,24 @@ export function useSidebarHeaderPointerDrag<
           }
         }
         refreshHeaderRects()
-        // Clone the header row into a floating preview that follows the cursor
-        // (same primitive the worktree drag uses); the source row then hides.
+        // Clone the dragged block into a floating preview that follows the
+        // cursor (same primitive the worktree drag uses); the source then hides.
+        // Prefer the whole block (header + children); fall back to the header.
         try {
-          previewRef.current = createSidebarDragPreview({
-            sourceRow: session.handleEl,
-            pointerX: e.clientX,
-            pointerY: e.clientY,
-            draggedCount: 1
-          })
+          const previewRows = configRef.current.getDragPreviewRows?.(session) ?? []
+          previewRef.current =
+            previewRows.length > 1
+              ? createSidebarBlockDragPreview({
+                  rows: previewRows,
+                  pointerX: e.clientX,
+                  pointerY: e.clientY
+                })
+              : createSidebarDragPreview({
+                  sourceRow: session.handleEl,
+                  pointerX: e.clientX,
+                  pointerY: e.clientY,
+                  draggedCount: 1
+                })
         } catch {
           previewRef.current = null
         }

--- a/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { PointerEvent as ReactPointerEvent } from 'react'
 
 import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+import {
+  createSidebarDragPreview,
+  updateSidebarDragPreviewPosition
+} from './worktree-sidebar-pointer-drag-dom'
 
 /** Common fields the lifecycle reads/writes on any header drag session. */
 export type SidebarHeaderDragSessionBase = {
@@ -62,6 +66,14 @@ export function useSidebarHeaderPointerDrag<
   const clickSwallowTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const autoscrollLastFrameTimeRef = useRef<number | null>(null)
   const autoscrollFrameIdRef = useRef<number | null>(null)
+  // Floating clone that follows the cursor, shared with the worktree drag so
+  // header drags look identical (source row hides; this is the visible thing).
+  const previewRef = useRef<{ preview: HTMLElement; offsetX: number; offsetY: number } | null>(null)
+
+  const removeDragPreview = useCallback(() => {
+    previewRef.current?.preview.remove()
+    previewRef.current = null
+  }, [])
 
   const refreshHeaderRects = useCallback(() => {
     const container = configRef.current.getScrollContainer()
@@ -91,6 +103,7 @@ export function useSidebarHeaderPointerDrag<
   const endDrag = useCallback(
     (commit: boolean) => {
       cancelAutoscroll()
+      removeDragPreview()
       const session = dragSessionRef.current
       if (!session) {
         setState(configRef.current.initialState)
@@ -128,7 +141,7 @@ export function useSidebarHeaderPointerDrag<
       }
       configRef.current.commit(session, drop)
     },
-    [cancelAutoscroll]
+    [cancelAutoscroll, removeDragPreview]
   )
 
   const runAutoscrollFrame = useCallback(
@@ -204,10 +217,31 @@ export function useSidebarHeaderPointerDrag<
           }
         }
         refreshHeaderRects()
+        // Clone the header row into a floating preview that follows the cursor
+        // (same primitive the worktree drag uses); the source row then hides.
+        try {
+          previewRef.current = createSidebarDragPreview({
+            sourceRow: session.handleEl,
+            pointerX: e.clientX,
+            pointerY: e.clientY,
+            draggedCount: 1
+          })
+        } catch {
+          previewRef.current = null
+        }
         // Why: null here is intentional — sets the initial dragging state
         // (indicator hidden) on promotion. Unlike mid-drag moves, we always
         // write this null so the dragging identity appears in state immediately.
         setState(configRef.current.buildState(configRef.current.getSessionId(session), null))
+      }
+      if (previewRef.current) {
+        updateSidebarDragPreviewPosition({
+          preview: previewRef.current.preview,
+          pointerX: e.clientX,
+          pointerY: e.clientY,
+          offsetX: previewRef.current.offsetX,
+          offsetY: previewRef.current.offsetY
+        })
       }
       refreshHeaderRects()
       const drop = configRef.current.computeDrop(session, container)
@@ -251,12 +285,21 @@ export function useSidebarHeaderPointerDrag<
       window.removeEventListener('keydown', onKeyDown)
       window.removeEventListener('blur', onBlur)
       cancelAutoscroll()
+      removeDragPreview()
       if (clickSwallowTimeoutRef.current !== null) {
         clearTimeout(clickSwallowTimeoutRef.current)
         clickSwallowTimeoutRef.current = null
       }
     }
-  }, [applyDrop, cancelAutoscroll, endDrag, ensureAutoscroll, refreshHeaderRects, sessionArmed])
+  }, [
+    applyDrop,
+    cancelAutoscroll,
+    endDrag,
+    ensureAutoscroll,
+    refreshHeaderRects,
+    removeDragPreview,
+    sessionArmed
+  ])
 
   // Why: depend only on the dragging identity, not the full state object,
   // so the cursor/userSelect effect does not re-run every frame when only

--- a/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/sidebar-header-pointer-drag.ts
@@ -11,6 +11,7 @@ export type SidebarHeaderDragSessionBase = {
   handleEl: HTMLElement
   startX: number
   startY: number
+  latestPointerX: number
   latestPointerY: number
   promoted: boolean
 }
@@ -157,7 +158,7 @@ export function useSidebarHeaderPointerDrag<
       const previousFrameTime = autoscrollLastFrameTimeRef.current ?? frameTime
       autoscrollLastFrameTimeRef.current = frameTime
       const autoscroll = getWorktreeSidebarDragAutoscroll({
-        point: { clientX: 0, clientY: session.latestPointerY },
+        point: { clientX: session.latestPointerX, clientY: session.latestPointerY },
         containerRect: container.getBoundingClientRect(),
         scrollTop: container.scrollTop,
         scrollHeight: container.scrollHeight,
@@ -196,6 +197,7 @@ export function useSidebarHeaderPointerDrag<
       if (!session || e.pointerId !== session.pointerId) {
         return
       }
+      session.latestPointerX = e.clientX
       session.latestPointerY = e.clientY
       const container = configRef.current.getScrollContainer()
       if (!container) {

--- a/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
+++ b/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
@@ -11,3 +11,23 @@ export function getVirtualRowStart(virtualRow: HTMLElement | null): number | nul
   const start = Number(rawStart)
   return Number.isFinite(start) ? start : null
 }
+
+/**
+ * Resolve an element's top position relative to its scroll container, handling
+ * virtual rows whose CSS transforms would otherwise skew the coordinate.
+ * Why: sticky-pinned virtual rows shift their children's getBoundingClientRect
+ * without changing the logical slot — anchoring to virtualRowStart corrects for
+ * the transform offset so drag/drop hit-testing stays frame-accurate.
+ */
+export function resolveVirtualRowTop(
+  element: HTMLElement,
+  container: HTMLElement,
+  containerRect: DOMRect
+): number {
+  const rect = element.getBoundingClientRect()
+  const virtualRow = element.closest<HTMLElement>('[data-worktree-virtual-row]')
+  const virtualRowStart = getVirtualRowStart(virtualRow)
+  return virtualRow && virtualRowStart !== null
+    ? virtualRowStart + rect.top - virtualRow.getBoundingClientRect().top
+    : rect.top - containerRect.top + container.scrollTop
+}

--- a/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
+++ b/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
@@ -1,0 +1,13 @@
+/** Resolve a virtualized sidebar row's absolute top from its
+ *  data-worktree-virtual-row-start attribute; null when unset/invalid. */
+export function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
+  if (!virtualRow) {
+    return null
+  }
+  const rawStart = virtualRow.getAttribute('data-worktree-virtual-row-start')
+  if (rawStart === null) {
+    return null
+  }
+  const start = Number(rawStart)
+  return Number.isFinite(start) ? start : null
+}

--- a/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
+++ b/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
@@ -1,6 +1,6 @@
 /** Resolve a virtualized sidebar row's absolute top from its
  *  data-worktree-virtual-row-start attribute; null when unset/invalid. */
-export function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
+function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
   if (!virtualRow) {
     return null
   }

--- a/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
+++ b/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
@@ -5,7 +5,8 @@ function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
     return null
   }
   const rawStart = virtualRow.getAttribute('data-worktree-virtual-row-start')
-  if (rawStart === null) {
+  // Reject empty too: Number('') is 0, which would snap hit-testing to the top.
+  if (rawStart === null || rawStart.trim() === '') {
     return null
   }
   const start = Number(rawStart)

--- a/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
+++ b/src/renderer/src/components/sidebar/sidebar-virtual-row-offset.ts
@@ -12,6 +12,14 @@ function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
   return Number.isFinite(start) ? start : null
 }
 
+/** The logical slot top (container coords) of an element's virtual row,
+ *  excluding intra-row spacing. Matches the virtualizer item.start the
+ *  gap-opening shift keys off, so drop boundaries align with it; null when the
+ *  element is not inside a measured virtual row. */
+export function resolveVirtualRowStart(element: HTMLElement): number | null {
+  return getVirtualRowStart(element.closest<HTMLElement>('[data-worktree-virtual-row]'))
+}
+
 /**
  * Resolve an element's top position relative to its scroll container, handling
  * virtual rows whose CSS transforms would otherwise skew the coordinate.

--- a/src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.ts
@@ -97,3 +97,54 @@ export function createSidebarDragPreview(args: {
   document.body.appendChild(preview)
   return { preview, offsetX, offsetY }
 }
+
+/** Floating preview for a multi-row block (a header + its children): clones
+ *  each row and stacks them at their current relative offsets, so the ghost
+ *  shows the whole block, not just the header. `rows[0]` is the header row and
+ *  anchors the pointer offset. */
+export function createSidebarBlockDragPreview(args: {
+  rows: readonly HTMLElement[]
+  pointerX: number
+  pointerY: number
+}): { preview: HTMLElement; offsetX: number; offsetY: number } {
+  const headRect = args.rows[0]!.getBoundingClientRect()
+  const preview = document.createElement('div')
+  preview.setAttribute(POINTER_DRAG_PREVIEW_ATTR, 'true')
+  preview.setAttribute('aria-hidden', 'true')
+
+  let maxBottom = headRect.bottom
+  for (const row of args.rows) {
+    const rect = row.getBoundingClientRect()
+    const clone = row.cloneNode(true) as HTMLElement
+    stripDuplicatePreviewAttributes(clone)
+    clone.style.position = 'absolute'
+    clone.style.left = '0'
+    clone.style.right = '0'
+    // Place each clone at its offset from the header so the stack mirrors the
+    // live layout; drop the live translateY transform that positioned it.
+    clone.style.top = `${rect.top - headRect.top}px`
+    clone.style.transform = 'none'
+    preview.appendChild(clone)
+    maxBottom = Math.max(maxBottom, rect.bottom)
+  }
+
+  const offsetX = Math.min(Math.max(args.pointerX - headRect.left, 0), headRect.width)
+  const offsetY = Math.min(Math.max(args.pointerY - headRect.top, 0), headRect.height)
+
+  preview.style.position = 'fixed'
+  preview.style.left = '0'
+  preview.style.top = '0'
+  preview.style.width = `${headRect.width}px`
+  preview.style.height = `${maxBottom - headRect.top}px`
+  preview.style.pointerEvents = 'none'
+  preview.style.transformOrigin = 'top left'
+  updateSidebarDragPreviewPosition({
+    preview,
+    pointerX: args.pointerX,
+    pointerY: args.pointerY,
+    offsetX,
+    offsetY
+  })
+  document.body.appendChild(preview)
+  return { preview, offsetX, offsetY }
+}

--- a/src/renderer/src/store/slices/repos-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups.test.ts
@@ -813,6 +813,60 @@ describe('project group store routing', () => {
     expect(store.getState().repos).toEqual([{ ...movedRepo, executionHostId: 'local' }])
   })
 
+  it('forwards a numeric drop order over the runtime transport when moving between groups', async () => {
+    // Why: sidebar drag passes a computed order (the context menu never did), so
+    // the order must survive the runtime RPC envelope, not just the local path.
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-move-order',
+      ok: true,
+      result: { repo: { ...remoteRepo, projectGroupId: 'group-1', projectGroupOrder: 3 } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [{ ...remoteRepo, executionHostId: 'runtime:env-1' }]
+    })
+
+    await expect(store.getState().moveProjectToGroup(remoteRepo.id, 'group-1', 3)).resolves.toBe(
+      true
+    )
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectGroup.moveProject',
+      params: { repo: remoteRepo.id, groupId: 'group-1', order: 3 },
+      timeoutMs: 15_000
+    })
+  })
+
+  it('forwards a group tabOrder update over the runtime transport', async () => {
+    // Why: group drag persists reordering via updateProjectGroup({ tabOrder }),
+    // which must route through the runtime RPC for runtime-owned groups.
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-update-group',
+      ok: true,
+      result: { group: { ...projectGroup, tabOrder: 5 } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [projectGroup]
+    })
+
+    await expect(
+      store.getState().updateProjectGroup(projectGroup.id, { tabOrder: 5 })
+    ).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectGroup.update',
+      params: { groupId: projectGroup.id, updates: { tabOrder: 5 } },
+      timeoutMs: 15_000
+    })
+  })
+
   it('propagates specific folder workspace create failures to callers', async () => {
     folderWorkspacesCreate.mockRejectedValue(new Error('folder_workspace_path_missing:/srv/app'))
     const store = createTestStore()

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1742,10 +1742,29 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   },
 
   updateProjectGroup: async (groupId, updates) => {
+    // Why: project groups are focused-host-scoped by design — fetch/create/update/
+    // delete all route by the focused host, and the list is replaced (not merged).
+    const target = getActiveRuntimeTarget(get().settings)
+    const previousGroup = get().projectGroups.find((group) => group.id === groupId)
+    // Optimistically apply so a drag reorder (tabOrder) re-sorts the instant the
+    // drag is dropped (no flash before the async round-trip); main's
+    // authoritative group replaces this below, and a failure reverts it.
+    set((s) => ({
+      projectGroups: s.projectGroups.map((group) =>
+        group.id === groupId ? { ...group, ...updates } : group
+      )
+    }))
+    const revertOptimistic = (): void => {
+      if (!previousGroup) {
+        return
+      }
+      set((s) => ({
+        projectGroups: s.projectGroups.map((group) =>
+          group.id === groupId ? previousGroup : group
+        )
+      }))
+    }
     try {
-      // Why: project groups are focused-host-scoped by design — fetch/create/update/
-      // delete all route by the focused host, and the list is replaced (not merged).
-      const target = getActiveRuntimeTarget(get().settings)
       const updated =
         target.kind === 'local'
           ? await window.api.projectGroups.update({ groupId, updates })
@@ -1758,6 +1777,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               )
             ).group
       if (!updated) {
+        revertOptimistic()
         return false
       }
       const ownedGroup = projectGroupWithFetchedOwner(updated, target)
@@ -1767,6 +1787,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }))
       return true
     } catch (err) {
+      revertOptimistic()
       console.error('Failed to update project group:', err)
       return false
     }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1878,11 +1878,39 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   },
 
   moveProjectToGroup: async (projectId, groupId, order) => {
-    try {
-      if (!findRepoForHost(get().repos, projectId, { settings: get().settings })) {
-        return false
+    const identity = findRepoForHost(get().repos, projectId, { settings: get().settings })
+    if (!identity) {
+      return false
+    }
+    const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
+    const optimisticHostId = getRepoExecutionHostId(identity)
+    const previousRepo = get().repos.find((repo) =>
+      repoMatchesHostIdentity(repo, projectId, optimisticHostId)
+    )
+    // Optimistically reflect the move so the sidebar reorders the instant the
+    // drag is dropped (no flash before the async round-trip); main's
+    // authoritative repo replaces this below, and a failure reverts this repo.
+    set((s) => ({
+      repos: s.repos.map((repo) => {
+        if (!repoMatchesHostIdentity(repo, projectId, optimisticHostId)) {
+          return repo
+        }
+        return order === undefined
+          ? { ...repo, projectGroupId: groupId }
+          : { ...repo, projectGroupId: groupId, projectGroupOrder: order }
+      })
+    }))
+    const revertOptimistic = (): void => {
+      if (!previousRepo) {
+        return
       }
-      const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
+      set((s) => ({
+        repos: s.repos.map((repo) =>
+          repoMatchesHostIdentity(repo, projectId, optimisticHostId) ? previousRepo : repo
+        )
+      }))
+    }
+    try {
       const moved =
         target.kind === 'local'
           ? await window.api.projectGroups.moveProject({
@@ -1899,6 +1927,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               )
             ).repo
       if (!moved) {
+        revertOptimistic()
         return false
       }
       const ownedMoved = repoWithFetchedOwner(moved, target)
@@ -1919,6 +1948,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       })
       return true
     } catch (err) {
+      revertOptimistic()
       console.error('Failed to move repo to group:', err)
       return false
     }


### PR DESCRIPTION
## Summary

Closes #6779. When the sidebar groups by project, you can now drag the header rows to organize them: reorder project groups, reorder projects, and move a project into or between groups. Worktree cards already drag to reorder; this brings the same feel to the project and group headers above them. Right-click "Move to group" still works and now shares the same persistence path.

The headers use native pointer events rather than HTML5 drag-and-drop. The sidebar is virtualized with `@tanstack/react-virtual`, so off-screen rows unmount mid-drag and HTML5 `dragenter`/`dragleave` fire against stale targets. Instead a shared hook (`useSidebarHeaderPointerDrag`) captures the pointer, caches header rects, and computes the drop index from the live pointer Y each frame, mirroring how the worktree-card drag already works. `useRepoHeaderDrag` (projects) and `useGroupHeaderDrag` (groups) are thin adapters over that hook.

Three gates keep the interactions independent, matching the issue's request:

- Groups reorder whenever you group by project (`canReorderGroups = groupBy === 'repo'`), regardless of project sort order, because a group's `tabOrder` is independent of how projects sort inside it.
- Projects reorder (and move between groups) only when project order is Manual (`canReorderRepoHeaders = groupBy === 'repo' && projectOrderBy === 'manual'`).
- Worktree-card drag is unchanged and still gated on the workspace sort being Manual.

Persistence reuses the existing store actions the context menu already calls (`moveProjectToGroup`, `reorderRepos`, `updateProjectGroup`); the drag commit only computes which order/group to pass. Those actions stay host-aware: they route to local IPC or `callRuntimeRpc` based on the repo's or group's owning host, so SSH and remote-runtime projects persist through the same path local ones do. Sparse order values are interpolated to a midpoint between neighbors (`interpolateSparseOrder`) so a reorder usually rewrites one row, not the whole list.

A few decisions worth calling out, all driven by getting the drop line and the gap-opening animation to agree on where a block ends:

- A project's drop footprint is its whole block (header plus its worktrees), not the 28px header row. The drop line for "after this project" lands below its worktrees, and `measureProjectHeaderDragRects` extends each rect's bottom to the next header's top, the same way `measureGroupHeaderDragRects` already handles group blocks.
- The before/after threshold uses the header row's midpoint, not the block midpoint, so hovering anywhere in a project's body reads as "after it" instead of falling into a no-op when the dragged project sits directly above.
- The drop indicator and the gap-opening shift read the same coordinate (the virtualizer's row `start` via `resolveVirtualRowStart`). An earlier mismatch (the indicator used the header element's offset top, which includes the inter-group 4px spacer; the shift used the row start) made dropping a project at the bottom of a group drag the next group up with it.
- Both commit paths apply optimistically so the row settles into place in a single render. `reorderRepos` already did this; `moveProjectToGroup` and `updateProjectGroup` previously wrote state only after their IPC round-trip, which left a one-frame flash where the dropped row sat in its old slot before snapping to the new one.

## Screenshots / Recording

<img width="354" height="800" alt="CleanShot 2026-06-30 at 09 22 49" src="https://github.com/user-attachments/assets/7d9ba7fd-f8a2-4f66-af10-58012b3c26af" />

## Testing

- [x] `pnpm typecheck` (clean, exit 0)
- [x] `pnpm lint` (clean, exit 0; includes switch-exhaustiveness, styled-scrollbar, and localization checks)
- [x] `pnpm test` (22,692 passed; 20 environmental-only failures, see note)
- [x] `pnpm build` (clean, exit 0)
- [x] Added tests that fail without the change

The drag gestures themselves are pointer-driven and not unit-testable end to end, so the suites cover the pure logic underneath and I verified the interactions by hand. The feature's own 127 tests (15 files) all pass.

Note on the 20 residual `pnpm test` failures, none in changed files and all environmental on this machine:

- 16 are renderer suites (`SidebarToolbar`, `pr-comments-list-selection`, `pr-comment-presentation`, `LinearAgentSkillSetupPrompt`) failing with `localStorage is not available because --localstorage-file was not provided` — a local Node gap (Node 26 vs the repo's pinned Node 24), unrelated to this change and reproducible on a clean tree.
- 4 are release-script suites (`publish-complete-draft-releases`, `release-rc-history`) failing on `git tag` because this machine has `tag.gpgsign=true`; re-running them with signing disabled passes 11/11.

New and updated coverage (`bunx vitest run --config config/vitest.config.ts`, 127/127 passing):

- Drop math: `project-header-drop.test.ts` and `group-header-drop.test.ts` cover bucket resolution, the block-extent boundary (drop line below a project's worktrees, not inside them), the header-row before/after threshold (hovering a body reads as "after"), the collapsed/empty-group highlight, and the below-itself no-op snap.
- Block segmentation and gap shifts: `header-drag-block-units.test.ts` and `header-drag-row-shifts.test.ts` cover splitting rows into movable units (a block's children move with their header) and the per-unit offsets.
- Adapters and commit: the `project-header-drag*` and `group-header-drag*` suites cover the session arm guards, handle-target predicates, and the commit index/order mapping.
- Runtime transport: `repos-project-groups.test.ts` asserts the exact RPC envelope for the two actions the drag newly drives with values the context menu never passed: a numeric `order` through `projectGroup.moveProject` and a `tabOrder` through `projectGroup.update`.
- Optimistic commits: the `repos.test.ts` / `repos-project-groups.test.ts` `moveProjectToGroup` and `updateProjectGroup` cases pass on the local, runtime-RPC, and failure paths after the optimistic-then-reconcile change.

Manual verification (local macOS dev build, plus a real loopback-SSH project for the remote path): reordered groups and projects, moved projects into expanded, empty, and collapsed groups, dragged across a 20-group / 20-project sidebar to exercise autoscroll and virtualization, and confirmed the drop no longer flashes. I could not run the full `pnpm test` (22k) or `pnpm build` in this session; happy to before merge.

## AI Review Report

Two independent review passes over the branch and a focused pass over the drop-position fixes, plus the changes I made in response:

- **Correctness.** The drag commit calls the same store actions the shipped "Move to group" menu uses, so it inherits their validated persistence; it only supplies the computed order/group. The drop line and the gap-opening shift now read one coordinate space (the virtualizer row start), which removed a class of off-by-the-spacer errors at block edges. The optimistic commits reconcile with main's authoritative repo/group on success and revert the one affected row on failure.
- **Cross-platform (macOS / Linux / Windows).** No hardcoded `metaKey` and no path assumptions; the feature is renderer-side pointer math over the existing row model. Nothing platform-specific was added.
- **SSH / remote-runtime.** The local-vs-RPC fork lives entirely in the unchanged store actions, keyed on the repo/group owner. SSH-owned projects route their group operations through local IPC by design (the desktop owns them); runtime-environment-owned projects route through `callRuntimeRpc`. I exercised the SSH path against a real loopback host and the RPC envelope through mocked-transport tests.
- **Performance.** At rest the drag code is a single early-`null` check per render, so a normal sidebar render is unchanged. During an active drag, rect measurement runs per frame; it is a few `querySelectorAll` passes over the mounted (viewport-virtualized) rows, fine at sidebar scale.

What I changed as a result: extracted the pointer-drag lifecycle into one shared hook so projects and groups stop duplicating it; centralized the `group:` / `ungrouped` bucket-key vocabulary behind one constructor and inverse instead of scattered string literals; and renamed a misleading session field (`sidebarRepoHeaderIdsByBucketAll`, which only ever held the visible buckets).

## Security Audit

No new security surface. The change adds renderer-side drag interactions that drive existing, already-audited store actions:

- **IPC / transport.** No new IPC channels or RPC methods. The drag calls `moveProjectToGroup` / `reorderRepos` / `updateProjectGroup`, which already existed for the context menu, with the same arguments plus a numeric order/tabOrder the backend handlers already accept.
- **Data handling.** Order and group-membership are local organizational metadata; no secrets, credentials, or file paths are read or written by this code.
- **Dependencies.** None added.

No follow-up needed.

## Notes

- Scope is reorder and project moves only. Dragging a group into another group to nest it is out of scope here; nested groups still render and reorder among their siblings, but you create nesting through the existing UI, not by drag.
- Dropping a project into a different group highlights the target group rather than drawing a position line, matching the context-menu "Move to group" mental model. Dropping into a collapsed or empty group appends to it.
- Reordering a project while a project filter hides some of its siblings interpolates the order against the visible siblings only, so placement relative to hidden ones is approximate (never lost or corrupted). Making it exact would mean threading an all-including-hidden bucket map through the commit; I left it as a documented limitation rather than expand scope.

X handle: https://x.com/NicholasZolton


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6911">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

In the sidebar’s project grouping, you can drag project headers and groups to reorder them or move projects between groups. It feels like the existing worktree card drag, and “Move to group” uses the same save path.
