### PR TITLE
Fix mobile Source Control primary action styling

### DIFF
--- a/mobile/src/source-control/MobileSourceControlContent.tsx
+++ b/mobile/src/source-control/MobileSourceControlContent.tsx
@@ -51,7 +51,8 @@ export function MobileSourceControlContent({ state }: Props) {
   } = state
   const ioBusy = busyAction !== null || openingPath !== null || openingBranchPath !== null
   const shouldShowGenerateButton = stagedCount > 0 || generatingMessage
-  const createPrHeroActive = createPrAction.visible && !createPrAction.disabled
+  const createPrHeroActive =
+    createPrAction.visible && !createPrAction.disabled && !createPrAction.pushFirst
 
   return (
     <>

--- a/mobile/src/source-control/MobileSourceControlCreatePrEntry.tsx
+++ b/mobile/src/source-control/MobileSourceControlCreatePrEntry.tsx
@@ -28,14 +28,11 @@ export function MobileSourceControlCreatePrEntry({ action }: Props) {
         accessibilityHint={action.hint}
       >
         {action.loading ? (
-          <ActivityIndicator
-            size="small"
-            color={enabled ? colors.onAccentBlue : colors.textSecondary}
-          />
+          <ActivityIndicator size="small" color={enabled ? colors.bgBase : colors.textSecondary} />
         ) : (
           <GitPullRequestArrow
             size={16}
-            color={enabled ? colors.onAccentBlue : colors.textSecondary}
+            color={enabled ? colors.bgBase : colors.textSecondary}
             strokeWidth={2.2}
           />
         )}

--- a/mobile/src/source-control/mobile-source-control-styles.ts
+++ b/mobile/src/source-control/mobile-source-control-styles.ts
@@ -180,7 +180,7 @@ const baseStyles = StyleSheet.create({
   createPrButton: {
     minHeight: 42,
     borderRadius: radii.button,
-    backgroundColor: colors.accentBlueCta,
+    backgroundColor: colors.textPrimary,
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
@@ -196,7 +196,7 @@ const baseStyles = StyleSheet.create({
     opacity: 0.78
   },
   createPrButtonText: {
-    color: colors.onAccentBlue,
+    color: colors.bgBase,
     fontSize: typography.bodySize,
     fontWeight: '700'
   },

--- a/mobile/src/theme/mobile-theme.ts
+++ b/mobile/src/theme/mobile-theme.ts
@@ -18,11 +18,6 @@ export const colors = {
   surfaceBright: '#f5f5f5',
 
   accentBlue: '#3b82f6',
-  // Primary-CTA fill (darker than accentBlue) so white on-fill text/icons clear
-  // WCAG AA 4.5:1; accentBlue itself is ~3.7:1 on white and stays a link/accent tint.
-  accentBlueCta: '#2563eb',
-  // On-fill text/icon color for the primary-CTA button.
-  onAccentBlue: '#ffffff',
 
   statusGreen: '#22c55e',
   statusAmber: '#f59e0b',


### PR DESCRIPTION
## Summary
- Switch the mobile Source Control Create PR CTA back to the neutral monochrome treatment.
- Keep the bottom Push action primary when Create PR requires pushing first.
- Remove the unused blue CTA mobile theme tokens.

## Verification
- pnpm --dir mobile lint
- pnpm exec tsc --noEmit -p mobile/tsconfig.json
- pnpm --dir mobile test mobile-create-pr-action.test.ts mobile-review-route.test.ts use-mobile-hosted-review-eligibility.test.ts mobile-diff-review-positioning.test.ts opened-mobile-session-tab.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6918">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->