### PR TITLE
Fix trackpad scroll rubberband/jank in terminal panes

### DIFF
--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
@@ -223,6 +223,42 @@ describe('terminal scroll intent', () => {
     disposable.dispose()
   })
 
+  it('ignores a stale unguarded resync from an earlier jitter tick once a newer tick supersedes it', () => {
+    vi.stubGlobal('requestAnimationFrame', () => 0)
+    vi.useFakeTimers()
+    vi.stubGlobal('Element', TestElement)
+    const terminal = createTerminal({ viewportY: 40, baseY: 100 })
+    const host = new TestElement() as unknown as HTMLElement
+    const disposable = attachTerminalScrollIntentTracking(terminal, host)
+
+    // A trackpad reports a near-zero jitter tick mid-gesture. deltaY is not
+    // negative, so it skips the preservePinnedAtBottom guard and schedules an
+    // unguarded resync chase.
+    const jitter = new Event('wheel') as WheelEvent
+    Object.defineProperty(jitter, 'deltaY', { value: 0.1 })
+    host.dispatchEvent(jitter)
+
+    // 16ms later the gesture continues with a normal upward tick, which
+    // synchronously (re)pins the viewport.
+    vi.advanceTimersByTime(16)
+    const wheelUp = new Event('wheel') as WheelEvent
+    Object.defineProperty(wheelUp, 'deltaY', { value: -10 })
+    host.dispatchEvent(wheelUp)
+    expect(getTerminalScrollIntentKind(terminal)).toBe('pinnedViewport')
+
+    // At t=80 the jitter tick's stale 80ms timeout fires. Simulate a
+    // transient bounce toward the bottom right at that instant — without
+    // coalescing this used to be read as "settled at the bottom" and flip
+    // the intent back to followOutput even though the user is still
+    // actively scrolling away.
+    terminal.buffer.active.viewportY = 100
+    vi.advanceTimersByTime(64) // virtual t = 80
+
+    expect(getTerminalScrollIntentKind(terminal)).toBe('pinnedViewport')
+
+    disposable.dispose()
+  })
+
   it('keeps a pane-keyed pinned viewport across a remounted empty terminal', () => {
     vi.stubGlobal('Element', TestElement)
     const firstTerminal = createTerminal({ viewportY: 76, baseY: 100 })

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -41,6 +41,32 @@ const terminalScrollIntentKeyByTerminal = new WeakMap<
 >()
 const terminalScrollIntentByKey = new Map<TerminalScrollIntentKey, TerminalScrollIntent>()
 
+// Why: a continuous trackpad gesture fires many wheel events per second, and
+// each one used to schedule its own independent microtask + double-rAF +
+// 80ms-timeout resync chase with no coalescing. Most of those chases are
+// redundant (they all converge on the same answer), but a stale one left
+// over from an earlier tick can fire late — after a newer tick already wrote
+// the correct intent — and clobber it with a transient reading (e.g. a
+// momentary near-bottom viewportY mid-gesture), flipping intent back to
+// followOutput right before a live PTY write forces scrollToBottom(). That
+// produces the rubberband snap. Tagging each tick's chase with a generation
+// lets a newer tick supersede an older one's still-pending callbacks instead
+// of racing them.
+const terminalScrollIntentGenerationByTerminal = new WeakMap<TerminalScrollIntentTarget, number>()
+
+function nextScrollIntentGeneration(terminal: TerminalScrollIntentTarget): number {
+  const next = (terminalScrollIntentGenerationByTerminal.get(terminal) ?? 0) + 1
+  terminalScrollIntentGenerationByTerminal.set(terminal, next)
+  return next
+}
+
+function isCurrentScrollIntentGeneration(
+  terminal: TerminalScrollIntentTarget,
+  generation: number
+): boolean {
+  return terminalScrollIntentGenerationByTerminal.get(terminal) === generation
+}
+
 const BOTTOM_TOLERANCE_ROWS = 1
 
 function readBufferSnapshot(
@@ -160,7 +186,13 @@ export function syncTerminalScrollIntentSoon(
   terminal: TerminalScrollIntentTarget,
   options: { preservePinnedAtBottom?: boolean } = {}
 ): void {
-  const sync = (): void => syncTerminalScrollIntentFromViewport(terminal, options)
+  const generation = nextScrollIntentGeneration(terminal)
+  const sync = (): void => {
+    if (!isCurrentScrollIntentGeneration(terminal, generation)) {
+      return
+    }
+    syncTerminalScrollIntentFromViewport(terminal, options)
+  }
   queueMicrotask(sync)
   requestAnimationFrame(sync)
   requestAnimationFrame(() => requestAnimationFrame(sync))


### PR DESCRIPTION
## Summary

Terminal panes scroll smoothly with a mouse wheel, but on a trackpad scrolling is blocky/stuttery while dragging, and rubberbands (snaps back) mid-gesture — even mid-document, not just at scroll boundaries.

## Root cause

`syncTerminalScrollIntentSoon` in `terminal-scroll-intent.ts` schedules a 4-stage deferred recheck (microtask + 2 nested `requestAnimationFrame` + `setTimeout(80ms)`) on *every* wheel tick to decide whether a terminal pane should auto-follow new output (`followOutput`) or stay pinned where the user scrolled (`pinnedViewport`).

- `attachTerminalScrollIntentTracking`'s `onWheel` only protects clear upward ticks (`deltaY < 0`) with a `preservePinnedAtBottom` guard. A near-zero "jitter" tick (`deltaY >= 0` but tiny) — which trackpads emit constantly mid-gesture and a mouse wheel essentially never produces — skips that guard.
- None of these chases are coalesced across ticks. A continuous trackpad gesture fires far more wheel events than a mouse wheel, so dozens of overlapping chases pile up on the main thread (plausible source of the blocky rendering while dragging).
- If an unguarded jitter tick's deferred callback fires *late* — after a newer tick already wrote the correct intent — and happens to read the viewport transiently near the bottom, it incorrectly flips intent to `followOutput`. The next live PTY write then force-calls `scrollToBottom()`, producing the visible rubberband snap, even mid-document.

## Fix

Tag each wheel tick's resync chase with a per-terminal generation counter (`terminalScrollIntentGenerationByTerminal`). A newer tick supersedes an older tick's still-pending callbacks instead of racing it — stale callbacks become no-ops. No behavior change for a single isolated wheel tick (all 14 existing tests pass unmodified).

## Test plan

- [x] Added a regression test (`ignores a stale unguarded resync from an earlier jitter tick once a newer tick supersedes it`) that reproduces the exact race: jitter tick → real upward tick 16ms later → transient near-bottom reading exactly when the jitter tick's stale timeout fires.
  - Confirmed it **fails** on the pre-fix code (`'followOutput'` instead of `'pinnedViewport'`).
  - Confirmed it **passes** with the fix.
- [x] `terminal-scroll-intent.test.ts` full suite: 15/15 passing
- [x] `oxlint` clean on both changed files
- [x] `tsgo --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6924">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->