### PR TITLE
Move per-workspace environments to Experimental settings

### DIFF
--- a/src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx
@@ -1,11 +1,22 @@
+import type { GlobalSettings } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 import { Label } from '../ui/label'
 import { EphemeralVmsPane } from './EphemeralVmsPane'
 import { getExperimentalSearchEntry } from './experimental-search'
 import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitch } from './SettingsFormControls'
 
-export function EphemeralVmsExperimentalSetting(): React.JSX.Element {
+type EphemeralVmsExperimentalSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function EphemeralVmsExperimentalSetting({
+  settings,
+  updateSettings
+}: EphemeralVmsExperimentalSettingProps): React.JSX.Element {
   const entry = getExperimentalSearchEntry().ephemeralVms
+  const enabled = settings.experimentalEphemeralVms === true
 
   return (
     <SearchableSetting
@@ -15,21 +26,31 @@ export function EphemeralVmsExperimentalSetting(): React.JSX.Element {
       className="max-w-none space-y-4 py-2"
       id="ephemeral-vms"
     >
-      <div className="space-y-1.5">
-        <Label>
-          {translate(
-            'auto.components.settings.ephemeralVms.search.title',
-            'Per-Workspace Environments'
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 shrink space-y-0.5">
+          <Label>
+            {translate(
+              'auto.components.settings.ephemeralVms.search.title',
+              'Per-Workspace Environments'
+            )}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.ephemeralVmsExperimentalSetting.description',
+              'Shows setup controls and workspace run targets for repo-owned, on-demand environments.'
+            )}
+          </p>
+        </div>
+        <SettingsSwitch
+          checked={enabled}
+          ariaLabel={translate(
+            'auto.components.settings.ephemeralVmsExperimentalSetting.toggleLabel',
+            'Toggle per-workspace environments'
           )}
-        </Label>
-        <p className="text-xs text-muted-foreground">
-          {translate(
-            'auto.components.settings.ephemeralVms.search.description',
-            'Learn how repo-owned recipes give each workspace its own on-demand, disposable environment.'
-          )}
-        </p>
+          onChange={() => updateSettings({ experimentalEphemeralVms: !enabled })}
+        />
       </div>
-      <EphemeralVmsPane />
+      {enabled ? <EphemeralVmsPane /> : null}
     </SearchableSetting>
   )
 }

--- a/src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx
@@ -1,0 +1,35 @@
+import { translate } from '@/i18n/i18n'
+import { Label } from '../ui/label'
+import { EphemeralVmsPane } from './EphemeralVmsPane'
+import { getExperimentalSearchEntry } from './experimental-search'
+import { SearchableSetting } from './SearchableSetting'
+
+export function EphemeralVmsExperimentalSetting(): React.JSX.Element {
+  const entry = getExperimentalSearchEntry().ephemeralVms
+
+  return (
+    <SearchableSetting
+      title={entry.title}
+      description={entry.description}
+      keywords={entry.keywords}
+      className="max-w-none space-y-4 py-2"
+      id="ephemeral-vms"
+    >
+      <div className="space-y-1.5">
+        <Label>
+          {translate(
+            'auto.components.settings.ephemeralVms.search.title',
+            'Per-Workspace Environments'
+          )}
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.ephemeralVms.search.description',
+            'Learn how repo-owned recipes give each workspace its own on-demand, disposable environment.'
+          )}
+        </p>
+      </div>
+      <EphemeralVmsPane />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -134,17 +134,51 @@ describe('ExperimentalPane', () => {
     )
   })
 
-  it('renders per-workspace environments as an experimental subsection', () => {
+  it('renders per-workspace environments as an off-by-default experimental subsection', () => {
+    const settings = getDefaultSettings('/tmp')
     const markup = renderToStaticMarkup(
-      <ExperimentalPane settings={getDefaultSettings('/tmp')} updateSettings={vi.fn()} />
+      <ExperimentalPane settings={settings} updateSettings={vi.fn()} />
     )
     const entry = getExperimentalPaneSearchEntries().find(
       (searchEntry) => searchEntry.title === 'Per-Workspace Environments'
     )
 
+    expect(settings.experimentalEphemeralVms).toBe(false)
     expect(markup).toContain('Per-Workspace Environments')
-    expect(markup).toContain('Per-Workspace Environments pane')
+    expect(markup).toContain('aria-checked="false"')
+    expect(markup).not.toContain('Per-Workspace Environments pane')
     expect(entry?.targetSectionId).toBe('ephemeral-vms')
+  })
+
+  it('enables per-workspace environments through the experimental switch', async () => {
+    const updateSettings = vi.fn()
+    const { root, container } = await renderExperimentalPane({ updateSettings })
+
+    const switchButton = container.querySelector<HTMLButtonElement>(
+      '#ephemeral-vms button[role="switch"]'
+    )
+    if (!switchButton) {
+      throw new Error('Per-workspace environments switch was not rendered')
+    }
+
+    await act(async () => {
+      switchButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ experimentalEphemeralVms: true })
+    root.unmount()
+  })
+
+  it('shows per-workspace environment setup controls when enabled', () => {
+    const markup = renderToStaticMarkup(
+      <ExperimentalPane
+        settings={{ ...getDefaultSettings('/tmp'), experimentalEphemeralVms: true }}
+        updateSettings={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('Per-Workspace Environments pane')
+    expect(markup).toContain('aria-checked="true"')
   })
 
   it('shows native chat default-mode as a child setting only when native chat is enabled', async () => {

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -14,6 +14,12 @@ vi.mock('../../store', () => ({
     selector({ settingsSearchQuery: '' })
 }))
 
+vi.mock('./EphemeralVmsPane', () => ({
+  EphemeralVmsPane: () => (
+    <div data-testid="ephemeral-vms-pane">Per-Workspace Environments pane</div>
+  )
+}))
+
 vi.mock('../ui/select', async () => {
   const React = await import('react')
 
@@ -126,6 +132,19 @@ describe('ExperimentalPane', () => {
     expect(getExperimentalPaneSearchEntries().map((entry) => entry.title)).toContain(
       'New card style'
     )
+  })
+
+  it('renders per-workspace environments as an experimental subsection', () => {
+    const markup = renderToStaticMarkup(
+      <ExperimentalPane settings={getDefaultSettings('/tmp')} updateSettings={vi.fn()} />
+    )
+    const entry = getExperimentalPaneSearchEntries().find(
+      (searchEntry) => searchEntry.title === 'Per-Workspace Environments'
+    )
+
+    expect(markup).toContain('Per-Workspace Environments')
+    expect(markup).toContain('Per-Workspace Environments pane')
+    expect(entry?.targetSectionId).toBe('ephemeral-vms')
   })
 
   it('shows native chat default-mode as a child setting only when native chat is enabled', async () => {

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -373,7 +373,7 @@ export function ExperimentalPane({
         </SearchableSetting>
       ) : null}
 
-      <EphemeralVmsExperimentalSetting />
+      <EphemeralVmsExperimentalSetting settings={settings} updateSettings={updateSettings} />
 
       {hiddenExperimentalUnlocked ? <HiddenExperimentalGroup /> : null}
     </div>

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -8,6 +8,7 @@ import { HiddenExperimentalGroup } from './HiddenExperimentalGroup'
 import { NumberField, SettingsSwitch } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 import { NativeChatExperimentalSetting } from './NativeChatExperimentalSetting'
+import { EphemeralVmsExperimentalSetting } from './EphemeralVmsExperimentalSetting'
 import {
   MAX_AGENT_HIBERNATION_IDLE_MS,
   MIN_AGENT_HIBERNATION_IDLE_MS,
@@ -371,6 +372,8 @@ export function ExperimentalPane({
           </div>
         </SearchableSetting>
       ) : null}
+
+      <EphemeralVmsExperimentalSetting />
 
       {hiddenExperimentalUnlocked ? <HiddenExperimentalGroup /> : null}
     </div>

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -55,7 +55,6 @@ import { ComputerUsePane } from './ComputerUsePane'
 import { MobileSettingsPane } from './MobileSettingsPane'
 import { MobileEmulatorSettingsPane } from './MobileEmulatorSettingsPane'
 import { RuntimeEnvironmentsPane } from './RuntimeEnvironmentsPane'
-import { EphemeralVmsPane } from './EphemeralVmsPane'
 import { PrivacyPane } from './PrivacyPane'
 import { AdvancedPane } from './AdvancedPane'
 import { SettingsSidebar } from './SettingsSidebar'
@@ -628,8 +627,6 @@ function Settings(): React.JSX.Element {
       ]
     ])
     if (showDesktopOnlySettings) {
-      // Why: Per-Workspace Environments shows a 'Beta' badge in the sidebar (from nav
-      // metadata) rather than skill install status — skill status lives inside the pane.
       next.set(
         'computer-use',
         getSkillNavInstallStatus({
@@ -1514,22 +1511,6 @@ function Settings(): React.JSX.Element {
                       allowLocalRuntime={!isWebClient}
                     />
                   ) : null}
-                </SettingsSection>
-
-                <SettingsSection
-                  id="ephemeral-vms"
-                  title={translate(
-                    'auto.components.settings.Settings.ephemeralVms',
-                    'Per-Workspace Environments'
-                  )}
-                  badge="Beta"
-                  description={translate(
-                    'auto.components.settings.Settings.ephemeralVmsDescription',
-                    'Give each workspace its own disposable environment on any provider, over an Orca server or SSH.'
-                  )}
-                  searchEntries={getSectionSearchEntries('ephemeral-vms')}
-                >
-                  {isSectionMounted('ephemeral-vms') ? <EphemeralVmsPane /> : null}
                 </SettingsSection>
 
                 {showDesktopOnlySettings ? (

--- a/src/renderer/src/components/settings/ephemeral-vms-search.ts
+++ b/src/renderer/src/components/settings/ephemeral-vms-search.ts
@@ -14,6 +14,10 @@ export const getEphemeralVmsSearchEntry = createLocalizedCatalog(
       'Learn how repo-owned recipes give each workspace its own on-demand, disposable environment.'
     ),
     keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.0d24759f14',
+        'experimental'
+      ),
       ...translateSearchKeyword('auto.components.settings.ephemeralVms.search.keywordVm', 'vm'),
       ...translateSearchKeyword(
         'auto.components.settings.ephemeralVms.search.keywordSandbox',
@@ -31,6 +35,7 @@ export const getEphemeralVmsSearchEntry = createLocalizedCatalog(
         'auto.components.settings.ephemeralVms.search.keywordEphemeral',
         'ephemeral'
       )
-    ]
+    ],
+    targetSectionId: 'ephemeral-vms'
   })
 )

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -4,6 +4,7 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getNewWorktreeCardStyleSearchEntry } from './new-worktree-card-style-search-entry'
 import { getNativeChatExperimentalSearchEntry } from './native-chat-experimental-search-entry'
+import { getEphemeralVmsSearchEntry } from './ephemeral-vms-search'
 
 export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
@@ -232,7 +233,8 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
           'node_modules'
         )
       ]
-    }
+    },
+    getEphemeralVmsSearchEntry()
   ]
 )
 
@@ -276,6 +278,9 @@ export function getExperimentalSearchEntry() {
         'auto.components.settings.experimental.search.78c2a8dc74',
         'Shared paths on worktrees'
       )
+    ),
+    ephemeralVms: findEntry(
+      translate('auto.components.settings.ephemeralVms.search.title', 'Per-Workspace Environments')
     )
   } as const
 }

--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -567,4 +567,31 @@ describe('useComposerState host-context boundaries', () => {
     expect(quickSubmit).toContain('agent === null || !quickDraftPrompt')
     expect(quickSubmit).toContain('startupPlan.draftPrompt = quickDraftPrompt')
   })
+
+  it('gates per-workspace environment recipe discovery behind the experimental setting', () => {
+    const recipeLoadSection = sourceBetween(
+      HOOK_SOURCE,
+      'const ephemeralVmsEnabled',
+      'const selectedRepoConnectionId'
+    )
+    expect(recipeLoadSection).toContain('settings?.experimentalEphemeralVms === true')
+    expect(recipeLoadSection).toContain('!ephemeralVmsEnabled')
+    expect(recipeLoadSection).toContain('window.api.ephemeralVm')
+
+    const submitSection = sourceBetween(
+      HOOK_SOURCE,
+      'let ephemeralVmRecipe',
+      'const request: WorktreeCreationRequest'
+    )
+    expect(submitSection).toContain(
+      'const activeEphemeralVmRecipeId = ephemeralVmsEnabled ? selectedEphemeralVmRecipeId : null'
+    )
+    expect(submitSection).toContain('recipeId: activeEphemeralVmRecipeId')
+
+    const cardPropsSection = sourceBetween(HOOK_SOURCE, 'const cardProps', 'return {')
+    expect(cardPropsSection).toContain('ephemeralVmRecipes:')
+    expect(cardPropsSection).toContain('!ephemeralVmsEnabled')
+    expect(cardPropsSection).toContain('selectedEphemeralVmRecipeId:')
+    expect(cardPropsSection).toContain('ephemeralVmRecipeError:')
+  })
 })

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -710,9 +710,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   )
   const selectedRepo = eligibleRepos.find((repo) => repo.id === repoId)
   const selectedRepoIsGit = selectedRepo ? isGitRepoKind(selectedRepo) : false
-  const [ephemeralVmRecipes, setEphemeralVmRecipes] = useState<NonNullable<OrcaHooks['environmentRecipes']>>(
-    []
-  )
+  const [ephemeralVmRecipes, setEphemeralVmRecipes] = useState<
+    NonNullable<OrcaHooks['environmentRecipes']>
+  >([])
   const [selectedEphemeralVmRecipeId, setSelectedEphemeralVmRecipeId] = useState<string | null>(
     null
   )
@@ -807,12 +807,16 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // reset the user's manually-chosen recipe via setSelectedEphemeralVmRecipeId(null).
   const selectedRecipeRepoId = selectedRepo?.id ?? null
   const selectedRecipeRepoConnectionId = selectedRepo?.connectionId ?? null
+  // Why: the experimental toggle must hide the composer target and avoid probing
+  // repo recipes, since recipe discovery can surface setup errors for a hidden feature.
+  const ephemeralVmsEnabled = settings?.experimentalEphemeralVms === true
   useEffect(() => {
     let cancelled = false
     setEphemeralVmRecipes([])
     setSelectedEphemeralVmRecipeId(null)
     setEphemeralVmRecipeError(null)
     if (
+      !ephemeralVmsEnabled ||
       !selectedRecipeRepoId ||
       !selectedRepoIsGit ||
       selectedRecipeRepoConnectionId ||
@@ -857,6 +861,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       cancelled = true
     }
   }, [
+    ephemeralVmsEnabled,
     initialEphemeralVmRecipeId,
     isProjectGroupTarget,
     selectedRecipeRepoConnectionId,
@@ -3966,7 +3971,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
               }
             : null
         let ephemeralVmRecipe: WorktreeCreationRequest['ephemeralVmRecipe']
-        if (selectedEphemeralVmRecipeId && selectedWorkspaceTarget.status === 'ready') {
+        const activeEphemeralVmRecipeId = ephemeralVmsEnabled ? selectedEphemeralVmRecipeId : null
+        if (activeEphemeralVmRecipeId && selectedWorkspaceTarget.status === 'ready') {
           const vmRecipeTrustDecision = await ensureHooksConfirmed(
             useAppStore.getState(),
             repoId,
@@ -3977,7 +3983,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           }
           ephemeralVmRecipe = {
             sourceRepoId: repoId,
-            recipeId: selectedEphemeralVmRecipeId,
+            recipeId: activeEphemeralVmRecipeId,
             projectId: selectedWorkspaceTarget.target.projectId
           }
         }
@@ -3986,7 +3992,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           repoId,
           ...(ephemeralVmRecipe ? { ephemeralVmRecipe } : {}),
           worktreeCreateProgressMode:
-            selectedEphemeralVmRecipeId ||
+            activeEphemeralVmRecipeId ||
             getActiveRuntimeTarget(selectedRepoSettings).kind !== 'local'
               ? 'indeterminate'
               : 'stepped',
@@ -4095,6 +4101,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       selectedRepoRequiresConnection,
       selectedWorkspaceTarget,
       selectedEphemeralVmRecipeId,
+      ephemeralVmsEnabled,
       showProjectRequiredError,
       settings?.agentCmdOverrides,
       settings?.agentDefaultArgs,
@@ -4146,10 +4153,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     projectHostSetupOptions: isProjectGroupTarget ? [] : projectHostSetupOptions,
     selectedProjectHostSetupId: isProjectGroupTarget ? null : selectedProjectHostSetupId,
     onProjectHostSetupChange: handleProjectHostSetupChange,
-    ephemeralVmRecipes: isProjectGroupTarget ? [] : ephemeralVmRecipes,
-    selectedEphemeralVmRecipeId: isProjectGroupTarget ? null : selectedEphemeralVmRecipeId,
+    ephemeralVmRecipes: isProjectGroupTarget || !ephemeralVmsEnabled ? [] : ephemeralVmRecipes,
+    selectedEphemeralVmRecipeId:
+      isProjectGroupTarget || !ephemeralVmsEnabled ? null : selectedEphemeralVmRecipeId,
     onEphemeralVmRecipeChange: setSelectedEphemeralVmRecipeId,
-    ephemeralVmRecipeError: isProjectGroupTarget ? null : ephemeralVmRecipeError,
+    ephemeralVmRecipeError:
+      isProjectGroupTarget || !ephemeralVmsEnabled ? null : ephemeralVmRecipeError,
     repoBackedSearchRepos: isProjectGroupTarget ? folderSourceRepos : undefined,
     repoBackedSourcesDisabled: isProjectGroupTarget ? folderSourceRepos.length === 0 : false,
     allowSmartNameAddProject: !isProjectGroupTarget,

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -88,6 +88,23 @@ describe('settings navigation metadata', () => {
     expect(sections.find((section) => section.id === 'voice')?.badge).toBeUndefined()
   })
 
+  it('places per-workspace environments under Experimental instead of as a beta sidebar item', () => {
+    const sections = buildSettingsNavigationMetadata({
+      isMac: false,
+      isWindows: false,
+      isWebClient: false,
+      repos: [repo]
+    })
+    const experimental = sections.find((section) => section.id === 'experimental')
+    const entry = experimental?.searchEntries.find(
+      (searchEntry) => searchEntry.title === 'Per-Workspace Environments'
+    )
+
+    expect(sections.map((section) => section.id)).not.toContain('ephemeral-vms')
+    expect(experimental?.group).toBe('experimental')
+    expect(entry?.targetSectionId).toBe('ephemeral-vms')
+  })
+
   it('omits Windows project runtime search entries when the active host is unsupported', () => {
     const sections = buildSettingsNavigationMetadata({
       isMac: false,

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -59,7 +59,6 @@ import {
   getRuntimeEnvironmentsSearchEntry,
   getWebRuntimeEnvironmentsSearchEntry
 } from '@/components/settings/runtime-environments-search'
-import { getEphemeralVmsSearchEntry } from '@/components/settings/ephemeral-vms-search'
 import { getSshPaneSearchEntries } from '@/components/settings/ssh-search'
 import { getMobileSettingsPaneSearchEntries } from '@/components/settings/mobile-settings-search'
 import { getMobileEmulatorSearchEntries } from '@/components/settings/mobile-emulator-search'
@@ -457,21 +456,6 @@ export function buildSettingsNavigationMetadata({
         : 'Pair remote Orca runtimes for persistent sessions, richer remote state, and web or mobile handoff.',
       icon: Server,
       searchEntries: [runtimeEnvironmentsSearchEntry],
-      group: 'remote',
-      badge: translate('auto.hooks.useSettingsNavigationMetadata.40d80bad8a', 'Beta')
-    },
-    {
-      id: 'ephemeral-vms',
-      title: translate(
-        'auto.hooks.useSettingsNavigationMetadata.ephemeralVms',
-        'Per-Workspace Environments'
-      ),
-      description: translate(
-        'auto.hooks.useSettingsNavigationMetadata.ephemeralVmsDescription',
-        'Give each workspace its own on-demand, disposable environment on any provider, connected over an Orca server or SSH.'
-      ),
-      icon: Server,
-      searchEntries: [getEphemeralVmsSearchEntry()],
       group: 'remote',
       badge: translate('auto.hooks.useSettingsNavigationMetadata.40d80bad8a', 'Beta')
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8674,6 +8674,10 @@
           "refresh": "Refresh ephemeral VM recipes",
           "checking": "Checking recipes...",
           "none": "No recipes found yet."
+        },
+        "ephemeralVmsExperimentalSetting": {
+          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
+          "toggleLabel": "Toggle per-workspace environments"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -535,6 +535,12 @@
         "distroRequired": "Select a WSL distro for this project before installing this skill.",
         "distroMissing": "The selected WSL distro is unavailable. Choose an available distro or switch this project to Windows.",
         "wslDefault": "WSL default"
+      },
+      "sidebarWorktreeActivation": {
+        "wakeEphemeralVmFailed": "Failed to wake ephemeral VM workspace"
+      },
+      "ephemeralVmWorkspaceTarget": {
+        "projectRootRegistrationFailed": "Failed to register the recipe-created project root on the runtime."
       }
     },
     "hooks": {
@@ -1157,7 +1163,14 @@
         "notConnected": "Not connected",
         "notePasteTooLarge": "Paste is too large for the note field.",
         "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
+        "destroyDisabled": "destroy disabled",
+        "destroyConfigured": "destroy configured",
+        "noDestroyConfigured": "no destroy",
+        "ephemeralVm": "Per-Workspace Environment",
+        "chooseRunTarget": "Choose target",
+        "noRunTargets": "No run targets are ready for this project.",
+        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Create worktree",
@@ -2208,7 +2221,10 @@
             "ed2a664f8b": "Couldn’t create worktree",
             "a3346fc6ed": "Cancel worktree creation",
             "532aea14ce": "Cancel",
-            "767951265d": "Something went wrong while creating the worktree."
+            "767951265d": "Something went wrong while creating the worktree.",
+            "vmProvisioningTitle": "Provisioning VM",
+            "cancelProvisioning": "Cancel",
+            "vmProvisioningLogEmpty": "Waiting for recipe output…"
           }
         }
       },
@@ -8609,6 +8625,55 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
+        },
+        "EphemeralVmRecipeRow": {
+          "useInWorkspace": "Use in workspace"
+        },
+        "EphemeralVmRuntimesSection": {
+          "cleanupFailed": "Cleanup failed",
+          "cleanupRunning": "Cleanup running",
+          "cleanupDisabled": "Cleanup disabled",
+          "running": "Running",
+          "failed": "Failed",
+          "loadFailed": "Couldn’t load temporary VM runtimes.",
+          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
+          "markedCleaned": "Marked temporary VM runtime as cleaned.",
+          "cleaned": "Cleaned up temporary VM runtime.",
+          "copiedCleanupCommand": "Copied cleanup command.",
+          "copiedCleanupPayload": "Copied cleanup payload.",
+          "copyCleanupFailed": "Couldn’t copy cleanup command.",
+          "title": "Temporary VM runtimes",
+          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
+          "refresh": "Refresh temporary VM runtimes",
+          "loading": "Checking temporary VM runtimes…",
+          "empty": "No temporary VM runtimes need cleanup.",
+          "copyCleanup": "Copy command",
+          "retry": "Retry cleanup",
+          "cleanup": "Cleanup"
+        },
+        "ephemeralVms": {
+          "search": {
+            "title": "Per-Workspace Environments",
+            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+          }
+        },
+        "EphemeralVmsPane": {
+          "loadError": "Could not load recipes.",
+          "copyError": "Could not copy the prompt.",
+          "skillTitle": "Per-Workspace Environments skill",
+          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
+          "whatTitle": "What the skill does, with you",
+          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
+          "whatBuild": "Builds a reusable base image and signs your agent in.",
+          "whatValidate": "Validates it so you can create a workspace on it.",
+          "promptHint": "In any workspace, ask your agent:",
+          "copy": "Copy",
+          "copied": "Copied",
+          "recipes": "Recipes",
+          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
+          "refresh": "Refresh ephemeral VM recipes",
+          "checking": "Checking recipes...",
+          "none": "No recipes found yet."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -535,6 +535,12 @@
         "distroRequired": "Selecciona una distribución WSL para este proyecto antes de instalar esta habilidad.",
         "distroMissing": "La distribución WSL seleccionada no está disponible. Elige una disponible o cambia este proyecto a Windows.",
         "wslDefault": "Predeterminado de WSL"
+      },
+      "sidebarWorktreeActivation": {
+        "wakeEphemeralVmFailed": "Failed to wake ephemeral VM workspace"
+      },
+      "ephemeralVmWorkspaceTarget": {
+        "projectRootRegistrationFailed": "Failed to register the recipe-created project root on the runtime."
       }
     },
     "hooks": {
@@ -1157,7 +1163,14 @@
         "reuseExistingBranchHint": "Hacer checkout de la rama existente en lugar de crear una nueva a partir de ella.",
         "createMultiple": "Crear más",
         "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
+        "destroyDisabled": "destroy disabled",
+        "destroyConfigured": "destroy configured",
+        "noDestroyConfigured": "no destroy",
+        "ephemeralVm": "Per-Workspace Environment",
+        "chooseRunTarget": "Choose target",
+        "noRunTargets": "No run targets are ready for this project.",
+        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Crear árbol de trabajo",
@@ -2208,7 +2221,10 @@
             "ed2a664f8b": "No se pudo crear el árbol de trabajo",
             "a3346fc6ed": "Cancelar la creación del árbol de trabajo",
             "532aea14ce": "Cancelar",
-            "767951265d": "Algo salió mal al crear el árbol de trabajo."
+            "767951265d": "Algo salió mal al crear el árbol de trabajo.",
+            "vmProvisioningTitle": "Provisioning VM",
+            "cancelProvisioning": "Cancel",
+            "vmProvisioningLogEmpty": "Waiting for recipe output…"
           }
         }
       },
@@ -8609,6 +8625,55 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
+        },
+        "EphemeralVmRecipeRow": {
+          "useInWorkspace": "Use in workspace"
+        },
+        "EphemeralVmRuntimesSection": {
+          "cleanupFailed": "Cleanup failed",
+          "cleanupRunning": "Cleanup running",
+          "cleanupDisabled": "Cleanup disabled",
+          "running": "Running",
+          "failed": "Failed",
+          "loadFailed": "Couldn’t load temporary VM runtimes.",
+          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
+          "markedCleaned": "Marked temporary VM runtime as cleaned.",
+          "cleaned": "Cleaned up temporary VM runtime.",
+          "copiedCleanupCommand": "Copied cleanup command.",
+          "copiedCleanupPayload": "Copied cleanup payload.",
+          "copyCleanupFailed": "Couldn’t copy cleanup command.",
+          "title": "Temporary VM runtimes",
+          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
+          "refresh": "Refresh temporary VM runtimes",
+          "loading": "Checking temporary VM runtimes…",
+          "empty": "No temporary VM runtimes need cleanup.",
+          "copyCleanup": "Copy command",
+          "retry": "Retry cleanup",
+          "cleanup": "Cleanup"
+        },
+        "ephemeralVms": {
+          "search": {
+            "title": "Per-Workspace Environments",
+            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+          }
+        },
+        "EphemeralVmsPane": {
+          "loadError": "Could not load recipes.",
+          "copyError": "Could not copy the prompt.",
+          "skillTitle": "Per-Workspace Environments skill",
+          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
+          "whatTitle": "What the skill does, with you",
+          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
+          "whatBuild": "Builds a reusable base image and signs your agent in.",
+          "whatValidate": "Validates it so you can create a workspace on it.",
+          "promptHint": "In any workspace, ask your agent:",
+          "copy": "Copy",
+          "copied": "Copied",
+          "recipes": "Recipes",
+          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
+          "refresh": "Refresh ephemeral VM recipes",
+          "checking": "Checking recipes...",
+          "none": "No recipes found yet."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8674,6 +8674,10 @@
           "refresh": "Refresh ephemeral VM recipes",
           "checking": "Checking recipes...",
           "none": "No recipes found yet."
+        },
+        "ephemeralVmsExperimentalSetting": {
+          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
+          "toggleLabel": "Toggle per-workspace environments"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -535,6 +535,12 @@
         "distroRequired": "このスキルをインストールする前に、このプロジェクトの WSL ディストリビューションを選択してください。",
         "distroMissing": "選択した WSL ディストリビューションは利用できません。利用可能なものを選ぶか、このプロジェクトを Windows に切り替えてください。",
         "wslDefault": "WSL 既定"
+      },
+      "sidebarWorktreeActivation": {
+        "wakeEphemeralVmFailed": "Failed to wake ephemeral VM workspace"
+      },
+      "ephemeralVmWorkspaceTarget": {
+        "projectRootRegistrationFailed": "Failed to register the recipe-created project root on the runtime."
       }
     },
     "hooks": {
@@ -1157,7 +1163,14 @@
         "reuseExistingBranchHint": "既存のブランチから新しいブランチを作成せず、そのブランチをチェックアウトします。",
         "createMultiple": "さらに作成",
         "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
+        "destroyDisabled": "destroy disabled",
+        "destroyConfigured": "destroy configured",
+        "noDestroyConfigured": "no destroy",
+        "ephemeralVm": "Per-Workspace Environment",
+        "chooseRunTarget": "Choose target",
+        "noRunTargets": "No run targets are ready for this project.",
+        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "ワークツリーを作成する",
@@ -2208,7 +2221,10 @@
             "ed2a664f8b": "ワークツリーを作成できませんでした",
             "a3346fc6ed": "ワークツリーの作成をキャンセルする",
             "532aea14ce": "キャンセル",
-            "767951265d": "ワークツリーの作成中に問題が発生しました。"
+            "767951265d": "ワークツリーの作成中に問題が発生しました。",
+            "vmProvisioningTitle": "Provisioning VM",
+            "cancelProvisioning": "Cancel",
+            "vmProvisioningLogEmpty": "Waiting for recipe output…"
           }
         }
       },
@@ -8609,6 +8625,55 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
+        },
+        "EphemeralVmRecipeRow": {
+          "useInWorkspace": "Use in workspace"
+        },
+        "EphemeralVmRuntimesSection": {
+          "cleanupFailed": "Cleanup failed",
+          "cleanupRunning": "Cleanup running",
+          "cleanupDisabled": "Cleanup disabled",
+          "running": "Running",
+          "failed": "Failed",
+          "loadFailed": "Couldn’t load temporary VM runtimes.",
+          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
+          "markedCleaned": "Marked temporary VM runtime as cleaned.",
+          "cleaned": "Cleaned up temporary VM runtime.",
+          "copiedCleanupCommand": "Copied cleanup command.",
+          "copiedCleanupPayload": "Copied cleanup payload.",
+          "copyCleanupFailed": "Couldn’t copy cleanup command.",
+          "title": "Temporary VM runtimes",
+          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
+          "refresh": "Refresh temporary VM runtimes",
+          "loading": "Checking temporary VM runtimes…",
+          "empty": "No temporary VM runtimes need cleanup.",
+          "copyCleanup": "Copy command",
+          "retry": "Retry cleanup",
+          "cleanup": "Cleanup"
+        },
+        "ephemeralVms": {
+          "search": {
+            "title": "Per-Workspace Environments",
+            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+          }
+        },
+        "EphemeralVmsPane": {
+          "loadError": "Could not load recipes.",
+          "copyError": "Could not copy the prompt.",
+          "skillTitle": "Per-Workspace Environments skill",
+          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
+          "whatTitle": "What the skill does, with you",
+          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
+          "whatBuild": "Builds a reusable base image and signs your agent in.",
+          "whatValidate": "Validates it so you can create a workspace on it.",
+          "promptHint": "In any workspace, ask your agent:",
+          "copy": "Copy",
+          "copied": "Copied",
+          "recipes": "Recipes",
+          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
+          "refresh": "Refresh ephemeral VM recipes",
+          "checking": "Checking recipes...",
+          "none": "No recipes found yet."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8674,6 +8674,10 @@
           "refresh": "Refresh ephemeral VM recipes",
           "checking": "Checking recipes...",
           "none": "No recipes found yet."
+        },
+        "ephemeralVmsExperimentalSetting": {
+          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
+          "toggleLabel": "Toggle per-workspace environments"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8674,6 +8674,10 @@
           "refresh": "Refresh ephemeral VM recipes",
           "checking": "Checking recipes...",
           "none": "No recipes found yet."
+        },
+        "ephemeralVmsExperimentalSetting": {
+          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
+          "toggleLabel": "Toggle per-workspace environments"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -535,6 +535,12 @@
         "distroRequired": "이 스킬을 설치하기 전에 프로젝트의 WSL 배포판을 선택하세요.",
         "distroMissing": "선택한 WSL 배포판을 사용할 수 없습니다. 사용 가능한 배포판을 선택하거나 이 프로젝트를 Windows로 전환하세요.",
         "wslDefault": "WSL 기본값"
+      },
+      "sidebarWorktreeActivation": {
+        "wakeEphemeralVmFailed": "Failed to wake ephemeral VM workspace"
+      },
+      "ephemeralVmWorkspaceTarget": {
+        "projectRootRegistrationFailed": "Failed to register the recipe-created project root on the runtime."
       }
     },
     "hooks": {
@@ -1157,7 +1163,14 @@
         "reuseExistingBranchHint": "기존 브랜치에서 새 브랜치를 만들지 않고 해당 브랜치를 체크아웃합니다.",
         "createMultiple": "더 만들기",
         "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
+        "destroyDisabled": "destroy disabled",
+        "destroyConfigured": "destroy configured",
+        "noDestroyConfigured": "no destroy",
+        "ephemeralVm": "Per-Workspace Environment",
+        "chooseRunTarget": "Choose target",
+        "noRunTargets": "No run targets are ready for this project.",
+        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "작업 트리 만들기",
@@ -2208,7 +2221,10 @@
             "ed2a664f8b": "작업 트리를 만들 수 없습니다.",
             "a3346fc6ed": "작업 트리 생성 취소",
             "532aea14ce": "취소",
-            "767951265d": "작업 트리를 만드는 중에 문제가 발생했습니다."
+            "767951265d": "작업 트리를 만드는 중에 문제가 발생했습니다.",
+            "vmProvisioningTitle": "Provisioning VM",
+            "cancelProvisioning": "Cancel",
+            "vmProvisioningLogEmpty": "Waiting for recipe output…"
           }
         }
       },
@@ -8609,6 +8625,55 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
+        },
+        "EphemeralVmRecipeRow": {
+          "useInWorkspace": "Use in workspace"
+        },
+        "EphemeralVmRuntimesSection": {
+          "cleanupFailed": "Cleanup failed",
+          "cleanupRunning": "Cleanup running",
+          "cleanupDisabled": "Cleanup disabled",
+          "running": "Running",
+          "failed": "Failed",
+          "loadFailed": "Couldn’t load temporary VM runtimes.",
+          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
+          "markedCleaned": "Marked temporary VM runtime as cleaned.",
+          "cleaned": "Cleaned up temporary VM runtime.",
+          "copiedCleanupCommand": "Copied cleanup command.",
+          "copiedCleanupPayload": "Copied cleanup payload.",
+          "copyCleanupFailed": "Couldn’t copy cleanup command.",
+          "title": "Temporary VM runtimes",
+          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
+          "refresh": "Refresh temporary VM runtimes",
+          "loading": "Checking temporary VM runtimes…",
+          "empty": "No temporary VM runtimes need cleanup.",
+          "copyCleanup": "Copy command",
+          "retry": "Retry cleanup",
+          "cleanup": "Cleanup"
+        },
+        "ephemeralVms": {
+          "search": {
+            "title": "Per-Workspace Environments",
+            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+          }
+        },
+        "EphemeralVmsPane": {
+          "loadError": "Could not load recipes.",
+          "copyError": "Could not copy the prompt.",
+          "skillTitle": "Per-Workspace Environments skill",
+          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
+          "whatTitle": "What the skill does, with you",
+          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
+          "whatBuild": "Builds a reusable base image and signs your agent in.",
+          "whatValidate": "Validates it so you can create a workspace on it.",
+          "promptHint": "In any workspace, ask your agent:",
+          "copy": "Copy",
+          "copied": "Copied",
+          "recipes": "Recipes",
+          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
+          "refresh": "Refresh ephemeral VM recipes",
+          "checking": "Checking recipes...",
+          "none": "No recipes found yet."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8674,6 +8674,10 @@
           "refresh": "Refresh ephemeral VM recipes",
           "checking": "Checking recipes...",
           "none": "No recipes found yet."
+        },
+        "ephemeralVmsExperimentalSetting": {
+          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
+          "toggleLabel": "Toggle per-workspace environments"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -535,6 +535,12 @@
         "distroRequired": "安装此技能前，请为此项目选择一个 WSL 发行版。",
         "distroMissing": "所选 WSL 发行版不可用。请选择可用发行版，或将此项目切换到 Windows。",
         "wslDefault": "WSL 默认"
+      },
+      "sidebarWorktreeActivation": {
+        "wakeEphemeralVmFailed": "Failed to wake ephemeral VM workspace"
+      },
+      "ephemeralVmWorkspaceTarget": {
+        "projectRootRegistrationFailed": "Failed to register the recipe-created project root on the runtime."
       }
     },
     "hooks": {
@@ -1157,7 +1163,14 @@
         "reuseExistingBranchHint": "检出已有分支，而不是从它创建新分支。",
         "createMultiple": "创建更多",
         "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
+        "destroyDisabled": "destroy disabled",
+        "destroyConfigured": "destroy configured",
+        "noDestroyConfigured": "no destroy",
+        "ephemeralVm": "Per-Workspace Environment",
+        "chooseRunTarget": "Choose target",
+        "noRunTargets": "No run targets are ready for this project.",
+        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "创建工作树",
@@ -2208,7 +2221,10 @@
             "ed2a664f8b": "无法创建工作树",
             "a3346fc6ed": "取消工作树创建",
             "532aea14ce": "取消",
-            "767951265d": "创建工作树时出现问题。"
+            "767951265d": "创建工作树时出现问题。",
+            "vmProvisioningTitle": "Provisioning VM",
+            "cancelProvisioning": "Cancel",
+            "vmProvisioningLogEmpty": "Waiting for recipe output…"
           }
         }
       },
@@ -8609,6 +8625,55 @@
           "notificationPlayground": "Notification playground",
           "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
           "devOnly": "Dev only"
+        },
+        "EphemeralVmRecipeRow": {
+          "useInWorkspace": "Use in workspace"
+        },
+        "EphemeralVmRuntimesSection": {
+          "cleanupFailed": "Cleanup failed",
+          "cleanupRunning": "Cleanup running",
+          "cleanupDisabled": "Cleanup disabled",
+          "running": "Running",
+          "failed": "Failed",
+          "loadFailed": "Couldn’t load temporary VM runtimes.",
+          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
+          "markedCleaned": "Marked temporary VM runtime as cleaned.",
+          "cleaned": "Cleaned up temporary VM runtime.",
+          "copiedCleanupCommand": "Copied cleanup command.",
+          "copiedCleanupPayload": "Copied cleanup payload.",
+          "copyCleanupFailed": "Couldn’t copy cleanup command.",
+          "title": "Temporary VM runtimes",
+          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
+          "refresh": "Refresh temporary VM runtimes",
+          "loading": "Checking temporary VM runtimes…",
+          "empty": "No temporary VM runtimes need cleanup.",
+          "copyCleanup": "Copy command",
+          "retry": "Retry cleanup",
+          "cleanup": "Cleanup"
+        },
+        "ephemeralVms": {
+          "search": {
+            "title": "Per-Workspace Environments",
+            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+          }
+        },
+        "EphemeralVmsPane": {
+          "loadError": "Could not load recipes.",
+          "copyError": "Could not copy the prompt.",
+          "skillTitle": "Per-Workspace Environments skill",
+          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
+          "whatTitle": "What the skill does, with you",
+          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
+          "whatBuild": "Builds a reusable base image and signs your agent in.",
+          "whatValidate": "Validates it so you can create a workspace on it.",
+          "promptHint": "In any workspace, ask your agent:",
+          "copy": "Copy",
+          "copied": "Copied",
+          "recipes": "Recipes",
+          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
+          "refresh": "Refresh ephemeral VM recipes",
+          "checking": "Checking recipes...",
+          "none": "No recipes found yet."
         }
       },
       "right": {

--- a/src/renderer/src/lib/ephemeral-vm-workspace-target.ts
+++ b/src/renderer/src/lib/ephemeral-vm-workspace-target.ts
@@ -8,6 +8,7 @@ import {
   type EphemeralVmRecipeResultWarning
 } from '../../../shared/ephemeral-vm-recipes'
 import { PROJECT_HOST_SETUP_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import { translate } from '@/i18n/i18n'
 import { assertRuntimeEnvironmentCapability } from '@/runtime/runtime-rpc-client'
 
 export type PrepareEphemeralVmWorkspaceTargetArgs = {
@@ -92,7 +93,10 @@ export async function prepareEphemeralVmWorkspaceTarget(
     await cleanupProvisionedRuntime(provisioned.runtime.id)
     return {
       ok: false,
-      error: 'Failed to register the recipe-created project root on the runtime.',
+      error: translate(
+        'auto.lib.ephemeralVmWorkspaceTarget.projectRootRegistrationFailed',
+        'Failed to register the recipe-created project root on the runtime.'
+      ),
       stderr: provisioned.stderr
     }
   }

--- a/src/renderer/src/lib/settings-navigation-types.ts
+++ b/src/renderer/src/lib/settings-navigation-types.ts
@@ -31,7 +31,6 @@ export type SettingsNavTarget =
   | 'agents'
   | 'orchestration'
   | 'servers'
-  | 'ephemeral-vms'
   | 'mobile'
   | 'mobile-emulator'
   | 'repo'

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -73,6 +73,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').compactWorktreeCards).toBe(false)
   })
 
+  it('keeps per-workspace environments disabled by default', () => {
+    expect(getDefaultSettings('/tmp').experimentalEphemeralVms).toBe(false)
+  })
+
   it('defaults local Windows projects to the host runtime', () => {
     expect(getDefaultSettings('/tmp').localWindowsRuntimeDefault).toEqual({
       kind: 'windows-host'

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -353,6 +353,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     experimentalAgentHibernation: false,
     agentHibernationIdleMs: 30 * 60 * 1000,
     experimentalNewWorktreeCardStyle: false,
+    experimentalEphemeralVms: false,
     compactWorktreeCards: false,
     experimentalWorktreeSymlinks: false,
     // Why: local desktop remains the default server until the user explicitly

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -297,6 +297,7 @@ export const SETTINGS_CHANGED_WHITELIST = [
   'experimentalActivity',
   'experimentalTerminalAttention',
   'experimentalAgentHibernation',
+  'experimentalEphemeralVms',
   'experimentalWorktreeSymlinks',
   'geminiCliOAuthEnabled',
   'openAgentTabsInChatByDefault'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2832,6 +2832,8 @@ export type GlobalSettings = {
   agentHibernationIdleMs?: number
   /** Experimental: opt-in preview of the updated worktree-card layout and metadata behavior. */
   experimentalNewWorktreeCardStyle?: boolean
+  /** Experimental: per-workspace on-demand environment recipes and setup surface. */
+  experimentalEphemeralVms?: boolean
   /** Compact worktree cards by hiding a redundant metadata row when the title
    *  and branch already say the same thing. */
   compactWorktreeCards: boolean


### PR DESCRIPTION
## Summary
- Move Per-Workspace Environments out of the Remote Hosts beta sidebar entry and into Settings > Experimental.
- Add an off-by-default Experimental toggle that shows the setup/recipe UI only when enabled.
- Gate new-workspace recipe discovery/run targets behind the toggle so hidden per-workspace environments do not surface in the composer.
- Keep search/Cmd+J targeting for the per-workspace environments subsection.
- Sync missing locale catalog entries from the merged per-workspace environment surface and localize one renderer error string.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ExperimentalPane.test.tsx src/renderer/src/components/settings/EphemeralVmsPane.test.tsx src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts src/shared/constants.test.ts src/shared/telemetry-events.test.ts src/renderer/src/lib/ephemeral-vm-workspace-target.test.ts
- pnpm exec oxlint src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx src/renderer/src/components/settings/ExperimentalPane.tsx src/renderer/src/components/settings/ExperimentalPane.test.tsx src/renderer/src/hooks/useComposerState.ts src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts src/shared/constants.ts src/shared/constants.test.ts src/shared/types.ts src/shared/telemetry-events.ts src/shared/telemetry-events.test.ts
- pnpm run typecheck:web
- pnpm run verify:localization-catalog
- pnpm run verify:localization-coverage