### PR TITLE
ci: pin Windows release runner to VS 2022

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -718,7 +718,9 @@ jobs:
             eb_cache_path: |
               ~/Library/Caches/electron
               ~/Library/Caches/electron-builder
-          - os: windows-latest
+          # Why: windows-latest moved to the Windows 2025 / VS 2026 image before
+          # node-gyp could detect VS 18, breaking native dependency install.
+          - os: windows-2022
             platform: win
             release_command: 'node config/scripts/ensure-native-runtime.mjs --runtime=electron; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; pnpm exec electron-builder --config config/electron-builder.config.cjs --win --publish never'
             eb_cache_path: |

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -85,6 +85,17 @@ describe('Electron runtime package contract', () => {
     )
   })
 
+  it('pins the Windows release builder to the VS 2022 runner image', () => {
+    const releaseWorkflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
+    )
+    const windowsReleaseEntry = releaseWorkflow.jobs.build.strategy.matrix.include.find(
+      ({ platform }) => platform === 'win'
+    )
+
+    expect(windowsReleaseEntry.os).toBe('windows-2022')
+  })
+
   it('preflights SignPath module install before Windows signing side effects', () => {
     const releaseWorkflow = readFileSync(
       join(projectDir, '.github/workflows/release-cut.yml'),


### PR DESCRIPTION
## Summary
- pin the Windows release build matrix entry to `windows-2022`
- add a release workflow contract test so the Windows builder does not drift back to `windows-latest`

## Why
Run https://github.com/stablyai/orca/actions/runs/28470516462 cut `v1.4.111-rc.0`, but the blocking Windows build failed during `pnpm install`: GitHub moved `windows-latest` to the Windows 2025 / VS 2026 image, and node-gyp could not detect the VS 18 installation while building `cpu-features`. The draft has macOS/Linux assets but no Windows assets, so the next RC needs this fix first.

## Test
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6932">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->