### PR TITLE
Fix startup draft paste race for Codex

### DIFF
--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -233,6 +233,7 @@ export async function submitFolderWorkspaceCreate({
           launchConfig: startupPlan.launchConfig,
           ...(startupPlan.launchToken ? { launchToken: startupPlan.launchToken } : {}),
           launchAgent: quickAgent,
+          ...(startupPlan.draftPrompt ? { draftPrompt: startupPlan.draftPrompt } : {}),
           ...(startupPlan.startupCommandDelivery
             ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
             : {}),

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -21,6 +21,7 @@ export type PtyConnectionDeps = {
     launchConfig?: SleepingAgentLaunchConfig
     launchToken?: string
     launchAgent?: TuiAgent
+    draftPrompt?: string
     /** Telemetry payload for `agent_started`. Forwarded to `pty:spawn`
      *  so main fires the event only after the spawn succeeds. */
     telemetry?: EventProps<'agent_started'>

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -614,6 +614,8 @@ describe('connectPanePty', () => {
           getMainBufferSnapshot: vi.fn().mockResolvedValue(null),
           getForegroundProcess: vi.fn().mockResolvedValue(null),
           hasChildProcesses: vi.fn().mockResolvedValue(false),
+          write: vi.fn(),
+          writeAccepted: vi.fn().mockResolvedValue(true),
           ackColdRestore: vi.fn(),
           onClearBufferRequest: vi.fn(() => vi.fn()),
           onSerializeBufferRequest: vi.fn(() => vi.fn()),
@@ -2953,6 +2955,48 @@ describe('connectPanePty', () => {
     } finally {
       globalThis.setTimeout = originalSetTimeout
     }
+  })
+
+  it('pastes a startup draft when Codex renders its composer in the first observed output', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    const transport = createMockTransport('pty-codex')
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-codex'
+    })
+    transportFactoryQueue.push(transport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      startup: {
+        command: 'codex',
+        launchAgent: 'codex',
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        launchToken: 'launch-token-1',
+        draftPrompt: 'https://github.com/stablyai/orca/issues/42'
+      }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks()
+    expect(capturedDataCallback.current).not.toBeNull()
+
+    capturedDataCallback.current?.('\x1b[?2004h\x1b[2K› ')
+    await flushAsyncTicks()
+
+    expect(window.api.pty.writeAccepted).toHaveBeenCalledWith(
+      'pty-codex',
+      '\x1b[200~https://github.com/stablyai/orca/issues/42\x1b[201~'
+    )
   })
 
   it('falls back for SSH shell-ready startup commands when no marker arrives', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -13,6 +13,10 @@ import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 import { YOLO_TUI_AGENT_ARGS } from '../../../../shared/tui-agent-permissions'
 import { SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV } from '../../../../shared/setup-agent-sequencing'
+import {
+  beginAgentStartupDeliveryAttempt,
+  resetAgentStartupDelayedDeliveryForTests
+} from '@/lib/agent-startup-delayed-delivery'
 
 // Repro command:
 //   pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "OpenTUI-style small ANSI redraw"
@@ -666,6 +670,7 @@ describe('connectPanePty', () => {
     }
     delete (globalThis as unknown as { window?: unknown }).window
     delete (globalThis as Record<string, unknown>).__ptyConnectDiag
+    resetAgentStartupDelayedDeliveryForTests()
   })
 
   it('does not retain PTY connect diagnostics unless e2e debug state is enabled', async () => {
@@ -2997,6 +3002,44 @@ describe('connectPanePty', () => {
       'pty-codex',
       '\x1b[200~https://github.com/stablyai/orca/issues/42\x1b[201~'
     )
+  })
+
+  it('does not consume startup draft delivery before deferred connect starts', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    globalThis.requestAnimationFrame = vi.fn(() => 1)
+    const transport = createMockTransport('pty-codex')
+    transportFactoryQueue.push(transport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+
+    const binding = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({
+        startup: {
+          command: 'codex',
+          launchAgent: 'codex',
+          launchConfig: { agentArgs: '', agentEnv: {} },
+          launchToken: 'launch-token-1',
+          draftPrompt: 'https://github.com/stablyai/orca/issues/42'
+        }
+      }) as never
+    )
+
+    binding.dispose()
+
+    expect(transport.connect).not.toHaveBeenCalled()
+    expect(
+      beginAgentStartupDeliveryAttempt({
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        launchToken: 'launch-token-1'
+      })
+    ).toBe(true)
   })
 
   it('falls back for SSH shell-ready startup commands when no marker arrives', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -120,6 +120,7 @@ import {
 } from './hidden-output-restore-scheduler'
 import {
   getExecutionHostIdForWorktree,
+  getSettingsForWorktreeRuntimeOwner,
   getRuntimeEnvironmentIdForWorktree
 } from '@/lib/worktree-runtime-owner'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
@@ -141,6 +142,11 @@ import {
 } from '../../../../shared/agent-title-owner'
 import type { TuiAgent } from '../../../../shared/types'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
+import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
+import { createDraftPasteReadyScanner } from '../../../../shared/draft-paste-ready-scanner'
+import { sendAgentDraftPasteContent } from '@/lib/agent-draft-paste-content'
+import { beginAgentStartupDeliveryAttempt } from '@/lib/agent-startup-delayed-delivery'
+import { isExpectedAgentProcess } from '../../../../shared/agent-process-recognition'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -151,6 +157,8 @@ const AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS = 1500
 const AGENT_TASK_COMPLETE_NOTIFICATION_DETAIL_MAX_AGE_MS = 10_000
 const COMMAND_CODE_OUTPUT_DONE_SETTLE_MS = 1500
 const SSH_SHELL_READY_STARTUP_FALLBACK_MS = 1500
+const STARTUP_DRAFT_PASTE_QUIET_MS = 1500
+const STARTUP_DRAFT_PASTE_TIMEOUT_MS = 8000
 const HIDDEN_OUTPUT_RESTORE_SCROLLBACK_ROWS = 5000
 const HIDDEN_OUTPUT_RESTORE_PENDING_CHARS = 512 * 1024
 const HIDDEN_OUTPUT_RESTORE_DEFERRED_RETRY_MS = 50
@@ -829,6 +837,7 @@ export function connectPanePty(
   let unregisterDocumentVisibilityRecovery: (() => void) | null = null
   let cleanupHiddenOutputRestoreDeferredRetry = (): void => {}
   let cleanupHiddenOutputRestoreForegroundDeadline = (): void => {}
+  let cleanupStartupDraftPasteTimers = (): void => {}
   let unregisterE2ePtyDataInjection = (): void => {}
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
   let sshShellReadyFallbackTimer: ReturnType<typeof setTimeout> | null = null
@@ -948,6 +957,26 @@ export function connectPanePty(
   const launchToken = paneStartup?.launchConfig
     ? (paneStartup.launchToken ?? createBrowserUuid())
     : undefined
+  const startupDraftAgent = paneStartup?.launchAgent ?? paneStartup?.initialAgentStatus?.agent
+  const startupDraftAgentConfig = startupDraftAgent ? TUI_AGENT_CONFIG[startupDraftAgent] : null
+  const startupDraftPrompt =
+    typeof paneStartup?.draftPrompt === 'string' && paneStartup.draftPrompt.trim()
+      ? paneStartup.draftPrompt
+      : null
+  const startupDraftPromptNeedsPaste =
+    startupDraftPrompt !== null &&
+    !startupDraftAgentConfig?.draftPromptFlag &&
+    !startupDraftAgentConfig?.draftPromptEnvVar
+  const ownsStartupDraftPaste =
+    startupDraftPromptNeedsPaste &&
+    launchToken !== undefined &&
+    // Why: reserve the launch before the PTY exists so delayed delivery cannot
+    // attach a late sidecar subscription and miss Codex's first composer frame.
+    beginAgentStartupDeliveryAttempt({
+      worktreeId: deps.worktreeId,
+      tabId: deps.tabId,
+      launchToken
+    })
   if (paneStartup?.launchConfig) {
     useAppStore.getState().registerAgentLaunchConfig(cacheKey, paneStartup.launchConfig, {
       agentType: paneStartup.launchAgent ?? paneStartup.initialAgentStatus?.agent,
@@ -2531,6 +2560,128 @@ export function connectPanePty(
       }
       schedulePendingStartupCommandDelivery()
     }
+    const startupDraftReadyScanner = ownsStartupDraftPaste
+      ? createDraftPasteReadyScanner(
+          startupDraftAgentConfig?.draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'
+        )
+      : null
+    let startupDraftReadinessArmed = false
+    let startupDraftPasteSettled = !ownsStartupDraftPaste
+    let startupDraftPasteInFlight = false
+    let startupDraftQuietTimer: ReturnType<typeof setTimeout> | null = null
+    let startupDraftHardTimer: ReturnType<typeof setTimeout> | null = null
+    const clearStartupDraftPasteTimers = (): void => {
+      if (startupDraftQuietTimer !== null) {
+        clearTimeout(startupDraftQuietTimer)
+        startupDraftQuietTimer = null
+      }
+      if (startupDraftHardTimer !== null) {
+        clearTimeout(startupDraftHardTimer)
+        startupDraftHardTimer = null
+      }
+    }
+    cleanupStartupDraftPasteTimers = clearStartupDraftPasteTimers
+    const getStartupDraftPtyId = (): string | null => {
+      const ptyId = transport.getPtyId()
+      if (
+        !ptyId ||
+        disposed ||
+        deps.paneTransportsRef.current.get(pane.id) !== transport ||
+        transport.getPtyId() !== ptyId
+      ) {
+        return null
+      }
+      return ptyId
+    }
+    const sendStartupDraftPaste = (): void => {
+      if (
+        !startupDraftPrompt ||
+        startupDraftPasteSettled ||
+        startupDraftPasteInFlight ||
+        !startupDraftReadinessArmed
+      ) {
+        return
+      }
+      const ptyId = getStartupDraftPtyId()
+      if (!ptyId) {
+        return
+      }
+      startupDraftPasteInFlight = true
+      startupDraftPasteSettled = true
+      cleanupStartupDraftPasteTimers()
+      const settings = getSettingsForWorktreeRuntimeOwner(useAppStore.getState(), deps.worktreeId)
+      void sendAgentDraftPasteContent(settings, ptyId, startupDraftPrompt)
+        .catch(() => false)
+        .finally(() => {
+          startupDraftPasteInFlight = false
+        })
+    }
+    const deliverStartupDraftIfAgentOwnsPty = async (): Promise<void> => {
+      if (!startupDraftAgentConfig || startupDraftPasteSettled) {
+        return
+      }
+      const ptyId = getStartupDraftPtyId()
+      if (!ptyId) {
+        return
+      }
+      const settings = getSettingsForWorktreeRuntimeOwner(useAppStore.getState(), deps.worktreeId)
+      try {
+        const process = await inspectRuntimeTerminalProcess(settings, ptyId)
+        const foreground = process.foregroundProcess?.toLowerCase() ?? ''
+        if (
+          getStartupDraftPtyId() === ptyId &&
+          isExpectedAgentProcess(foreground, startupDraftAgentConfig.expectedProcess)
+        ) {
+          sendStartupDraftPaste()
+        }
+      } catch {
+        // Best-effort fallback; the primary path is the PTY readiness marker.
+      }
+    }
+    const armStartupDraftHardTimer = (): void => {
+      if (!startupDraftReadyScanner || startupDraftPasteSettled || startupDraftHardTimer !== null) {
+        return
+      }
+      startupDraftHardTimer = setTimeout(() => {
+        startupDraftHardTimer = null
+        void deliverStartupDraftIfAgentOwnsPty()
+      }, STARTUP_DRAFT_PASTE_TIMEOUT_MS)
+    }
+    const armStartupDraftQuietTimer = (): void => {
+      if (!startupDraftReadyScanner || startupDraftPasteSettled) {
+        return
+      }
+      if (startupDraftQuietTimer !== null) {
+        clearTimeout(startupDraftQuietTimer)
+      }
+      startupDraftQuietTimer = setTimeout(() => {
+        startupDraftQuietTimer = null
+        sendStartupDraftPaste()
+      }, STARTUP_DRAFT_PASTE_QUIET_MS)
+    }
+    const armStartupDraftReadinessObservation = (): void => {
+      if (!startupDraftReadyScanner || startupDraftReadinessArmed) {
+        return
+      }
+      startupDraftReadinessArmed = true
+      armStartupDraftHardTimer()
+    }
+    const observeStartupDraftPasteReadiness = (data: string): void => {
+      if (!startupDraftReadyScanner || !startupDraftReadinessArmed || startupDraftPasteSettled) {
+        return
+      }
+      const scanned = startupDraftReadyScanner.observe(data)
+      if (scanned.ready) {
+        sendStartupDraftPaste()
+        return
+      }
+      if (scanned.armQuietTimer) {
+        armStartupDraftQuietTimer()
+      }
+    }
+    if (ownsStartupDraftPaste && !connectionId && !shouldDeliverStartupViaTerminalPaste) {
+      armStartupDraftReadinessObservation()
+    }
     let sessionRestoredBannerShown = false
     const showSessionRestoredBanner = (): void => {
       if (sessionRestoredBannerShown) {
@@ -2716,10 +2867,11 @@ export function connectPanePty(
             return
           }
           const command = startup.command
-          if (shouldDeliverStartupViaTerminalPaste) {
-            await runTerminalPasteStartupCommand(command)
-          } else {
-            transport.sendInput(`${command}\r`)
+          const submitted = shouldDeliverStartupViaTerminalPaste
+            ? await runTerminalPasteStartupCommand(command)
+            : transport.sendInput(`${command}\r`)
+          if (submitted) {
+            armStartupDraftReadinessObservation()
           }
           pendingStartupCommand = null
         })()
@@ -3859,6 +4011,7 @@ export function connectPanePty(
         }
         data = scanned.output
       }
+      observeStartupDraftPasteReadiness(data)
       resetHiddenOutputRestoreIfPtyChanged()
       respondToTerminalPixelSizeQueries(data)
       observeTerminalBracketedPasteModeOutput(pane.terminal, data)
@@ -4728,6 +4881,7 @@ export function connectPanePty(
         clearTimeout(sshShellReadyFallbackTimer)
         sshShellReadyFallbackTimer = null
       }
+      cleanupStartupDraftPasteTimers()
       clearPendingAgentTaskCompleteNotification()
       pendingTerminalBellNotification = false
       clearTerminalBellNotificationTimer()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -145,7 +145,10 @@ import { isWslUncPath } from '../../../../shared/wsl-paths'
 import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import { createDraftPasteReadyScanner } from '../../../../shared/draft-paste-ready-scanner'
 import { sendAgentDraftPasteContent } from '@/lib/agent-draft-paste-content'
-import { beginAgentStartupDeliveryAttempt } from '@/lib/agent-startup-delayed-delivery'
+import {
+  beginAgentStartupDeliveryAttempt,
+  releaseAgentStartupDeliveryAttempt
+} from '@/lib/agent-startup-delayed-delivery'
 import { isExpectedAgentProcess } from '../../../../shared/agent-process-recognition'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
@@ -967,16 +970,36 @@ export function connectPanePty(
     startupDraftPrompt !== null &&
     !startupDraftAgentConfig?.draftPromptFlag &&
     !startupDraftAgentConfig?.draftPromptEnvVar
-  const ownsStartupDraftPaste =
-    startupDraftPromptNeedsPaste &&
-    launchToken !== undefined &&
-    // Why: reserve the launch before the PTY exists so delayed delivery cannot
-    // attach a late sidecar subscription and miss Codex's first composer frame.
-    beginAgentStartupDeliveryAttempt({
+  let startupDraftDeliveryClaimed = false
+  let startupDraftPasteAttempted = false
+  const claimStartupDraftPasteDelivery = (): boolean => {
+    if (!startupDraftPromptNeedsPaste || launchToken === undefined) {
+      return false
+    }
+    if (startupDraftDeliveryClaimed) {
+      return true
+    }
+    // Why: launch-bound draft paste needs a launch token; all current
+    // draftPrompt startup callers pair it with launchConfig so this can safely
+    // fence off delayed sidecar delivery before Codex's first composer frame.
+    startupDraftDeliveryClaimed = beginAgentStartupDeliveryAttempt({
       worktreeId: deps.worktreeId,
       tabId: deps.tabId,
       launchToken
     })
+    return startupDraftDeliveryClaimed
+  }
+  const releaseUnattemptedStartupDraftPasteDelivery = (): void => {
+    if (!startupDraftDeliveryClaimed || startupDraftPasteAttempted || launchToken === undefined) {
+      return
+    }
+    releaseAgentStartupDeliveryAttempt({
+      worktreeId: deps.worktreeId,
+      tabId: deps.tabId,
+      launchToken
+    })
+    startupDraftDeliveryClaimed = false
+  }
   if (paneStartup?.launchConfig) {
     useAppStore.getState().registerAgentLaunchConfig(cacheKey, paneStartup.launchConfig, {
       agentType: paneStartup.launchAgent ?? paneStartup.initialAgentStatus?.agent,
@@ -2560,6 +2583,7 @@ export function connectPanePty(
       }
       schedulePendingStartupCommandDelivery()
     }
+    const ownsStartupDraftPaste = claimStartupDraftPasteDelivery()
     const startupDraftReadyScanner = ownsStartupDraftPaste
       ? createDraftPasteReadyScanner(
           startupDraftAgentConfig?.draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'
@@ -2608,6 +2632,7 @@ export function connectPanePty(
       }
       startupDraftPasteInFlight = true
       startupDraftPasteSettled = true
+      startupDraftPasteAttempted = true
       cleanupStartupDraftPasteTimers()
       const settings = getSettingsForWorktreeRuntimeOwner(useAppStore.getState(), deps.worktreeId)
       void sendAgentDraftPasteContent(settings, ptyId, startupDraftPrompt)
@@ -2872,6 +2897,8 @@ export function connectPanePty(
             : transport.sendInput(`${command}\r`)
           if (submitted) {
             armStartupDraftReadinessObservation()
+          } else {
+            releaseUnattemptedStartupDraftPasteDelivery()
           }
           pendingStartupCommand = null
         })()
@@ -4882,6 +4909,7 @@ export function connectPanePty(
         sshShellReadyFallbackTimer = null
       }
       cleanupStartupDraftPasteTimers()
+      releaseUnattemptedStartupDraftPasteDelivery()
       clearPendingAgentTaskCompleteNotification()
       pendingTerminalBellNotification = false
       clearTerminalBellNotificationTimer()

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -32,11 +32,13 @@ import type {
   GlobalSettings,
   SetupSplitDirection,
   TerminalTab,
-  TerminalLayoutSnapshot
+  TerminalLayoutSnapshot,
+  TuiAgent
 } from '../../../../shared/types'
 import type { TerminalPaneSplitSource } from '../../../../shared/feature-education-telemetry'
 import type { EventProps } from '../../../../shared/telemetry-events'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
+import type { SleepingAgentLaunchConfig } from '../../../../shared/agent-session-resume'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import {
   buildFontFamily,
@@ -173,6 +175,12 @@ type UseTerminalPaneLifecycleDeps = {
     delivery?: 'terminal-paste'
     startupCommandDelivery?: StartupCommandDelivery
     env?: Record<string, string>
+    launchConfig?: SleepingAgentLaunchConfig
+    launchToken?: string
+    launchAgent?: TuiAgent
+    draftPrompt?: string
+    /** Initial prompt-start status for agents that lack native prompt hooks. */
+    initialAgentStatus?: { agent: TuiAgent; prompt: string }
     /** Telemetry payload for `agent_started`. Forwarded to `pty:spawn`
      *  so main fires the event only after the spawn succeeds. */
     telemetry?: EventProps<'agent_started'>

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -710,9 +710,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   )
   const selectedRepo = eligibleRepos.find((repo) => repo.id === repoId)
   const selectedRepoIsGit = selectedRepo ? isGitRepoKind(selectedRepo) : false
-  const [ephemeralVmRecipes, setEphemeralVmRecipes] = useState<NonNullable<OrcaHooks['environmentRecipes']>>(
-    []
-  )
+  const [ephemeralVmRecipes, setEphemeralVmRecipes] = useState<
+    NonNullable<OrcaHooks['environmentRecipes']>
+  >([])
   const [selectedEphemeralVmRecipeId, setSelectedEphemeralVmRecipeId] = useState<string | null>(
     null
   )
@@ -3576,6 +3576,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 launchConfig: startupPlan.launchConfig,
                 ...(startupPlan.launchToken ? { launchToken: startupPlan.launchToken } : {}),
                 launchAgent: tuiAgent,
+                ...(startupPlan.draftPrompt ? { draftPrompt: startupPlan.draftPrompt } : {}),
                 ...(startupPlan.startupCommandDelivery
                   ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
                   : {}),

--- a/src/renderer/src/lib/agent-startup-delayed-delivery.ts
+++ b/src/renderer/src/lib/agent-startup-delayed-delivery.ts
@@ -133,6 +133,14 @@ export function beginAgentStartupDeliveryAttempt(args: {
   return true
 }
 
+export function releaseAgentStartupDeliveryAttempt(args: {
+  worktreeId: string
+  tabId: string
+  launchToken: string
+}): void {
+  consumedAgentStartupDeliveries.delete(deliveryKey(args))
+}
+
 function deliveryKey(
   delivery: Pick<PendingAgentStartupDelivery, 'worktreeId' | 'tabId' | 'launchToken'>
 ): string {

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -89,6 +89,9 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
     agentEnv: effectiveAgentEnv,
     allowEmptyPromptLaunch: true
   })
+  if (startupPlan && args.promptDelivery === 'draft') {
+    startupPlan.draftPrompt = args.draftContent
+  }
   return {
     startupPlan,
     draftLaunchedNatively: false,
@@ -106,6 +109,7 @@ export function buildDirectWorkItemStartupOpts(
     env?: Record<string, string>
     launchConfig?: SleepingAgentLaunchConfig
     launchAgent?: TuiAgent
+    draftPrompt?: string
     startupCommandDelivery?: StartupCommandDelivery
     telemetry?: AgentStartedTelemetry
   }
@@ -123,6 +127,7 @@ export function buildDirectWorkItemStartupOpts(
       ...(plan.env ? { env: plan.env } : {}),
       launchConfig: plan.launchConfig,
       ...(agent ? { launchAgent: agent } : {}),
+      ...(plan.draftPrompt ? { draftPrompt: plan.draftPrompt } : {}),
       ...(plan.startupCommandDelivery
         ? { startupCommandDelivery: plan.startupCommandDelivery }
         : {}),

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -489,14 +489,15 @@ describe('launchWorkItemDirect', () => {
       isRemote: true,
       allowEmptyPromptLaunch: true
     })
-    expect(pasteDraftWhenAgentReady).toHaveBeenCalledWith({
-      tabId: 'tab-1',
-      content: 'https://github.com/acme/repo/issues/77',
-      agent: 'cursor',
-      submit: false,
-      forcePaste: false,
-      onTimeout: expect.any(Function)
-    })
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(
+      'wt-ssh',
+      expect.objectContaining({
+        startup: expect.objectContaining({
+          draftPrompt: 'https://github.com/acme/repo/issues/77'
+        })
+      })
+    )
+    expect(pasteDraftWhenAgentReady).not.toHaveBeenCalled()
   })
 
   it('does not launch a disabled saved agent even when another agent is available', async () => {

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -304,6 +304,11 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
   if (!primaryTabId || !startupPlan || draftLaunchedNatively) {
     return true
   }
+  if (promptDelivery === 'draft' && startupPlan.draftPrompt) {
+    // Why: startup-owned draft paste observes the first PTY frames; the older
+    // delayed sidecar path can attach too late and miss Codex's ready marker.
+    return true
+  }
 
   void pasteDirectWorkItemDraftWhenAgentReady({
     primaryTabId,

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -72,6 +72,7 @@ export type WorktreeStartupPayload = {
   launchConfig?: SleepingAgentLaunchConfig
   launchToken?: string
   launchAgent?: TuiAgent
+  draftPrompt?: string
   startupCommandDelivery?: StartupCommandDelivery
   initialAgentStatus?: { agent: TuiAgent; prompt: string }
   telemetry?: AgentStartedTelemetry
@@ -118,6 +119,7 @@ type WorktreeActivationStore = Partial<WorktreeRuntimeOwnerState> & {
       launchConfig?: SleepingAgentLaunchConfig
       launchToken?: string
       launchAgent?: TuiAgent
+      draftPrompt?: string
       initialAgentStatus?: { agent: TuiAgent; prompt: string }
       showSessionRestoredBanner?: boolean
       telemetry?: AgentStartedTelemetry

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -46,6 +46,7 @@ function buildStartupOpt(
     launchConfig: plan.launchConfig,
     ...(plan.launchToken ? { launchToken: plan.launchToken } : {}),
     ...(request.agent ? { launchAgent: request.agent } : {}),
+    ...(plan.draftPrompt ? { draftPrompt: plan.draftPrompt } : {}),
     ...(plan.startupCommandDelivery ? { startupCommandDelivery: plan.startupCommandDelivery } : {}),
     // Why: command-code shows its prompt in the tab status before the first
     // hook fires, so the prompt is threaded through here.

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -339,6 +339,7 @@ export type TerminalSlice = {
       launchConfig?: SleepingAgentLaunchConfig
       launchToken?: string
       launchAgent?: TuiAgent
+      draftPrompt?: string
       /** Initial prompt-start status for agents that lack native prompt hooks. */
       initialAgentStatus?: { agent: TuiAgent; prompt: string }
       /** Show the restored-session banner when this startup command mounts. */
@@ -500,6 +501,7 @@ export type TerminalSlice = {
       launchConfig?: SleepingAgentLaunchConfig
       launchToken?: string
       launchAgent?: TuiAgent
+      draftPrompt?: string
       initialAgentStatus?: { agent: TuiAgent; prompt: string }
       showSessionRestoredBanner?: boolean
       telemetry?: AgentStartedTelemetry
@@ -515,6 +517,7 @@ export type TerminalSlice = {
     launchConfig?: SleepingAgentLaunchConfig
     launchToken?: string
     launchAgent?: TuiAgent
+    draftPrompt?: string
     initialAgentStatus?: { agent: TuiAgent; prompt: string }
     showSessionRestoredBanner?: boolean
     telemetry?: AgentStartedTelemetry


### PR DESCRIPTION
## Summary
- Move review-draft paste ownership into `pty-connection` startup so it observes the first PTY output frames from Codex.
- Reserve the launch token before spawn to prevent the older delayed sidecar delivery from racing or double-pasting.
- Thread `draftPrompt` through workspace/task/folder startup payloads and skip the older delayed direct-work-item paste when startup owns the draft.

## Repro / Regression
- Added a regression test where Codex emits `\x1b[?2004h` plus the `›` composer prompt in the first observed PTY output chunk.
- That captures the timing hole: the old delayed sidecar delivery could attach after this first ready frame, so the GitHub/Linear draft never pasted. The startup-owned observer now sees that first chunk and pastes via the existing bracketed-paste path.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/agent-paste-draft.test.ts src/shared/draft-paste-ready-scanner.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts src/renderer/src/lib/launch-work-item-direct-agent.test.ts src/renderer/src/lib/new-workspace.test.ts` — 7 files, 342 tests passed
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 248 tests passed after pre-commit lint cleanup
- `pnpm run typecheck:web` — passed; local shell is Node 26 while package wants Node 24, so pnpm prints the existing engine warning
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6936">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->