### PR TITLE
fix: proxy skill discovery and preflight checks to remote runtime when connected

### DIFF
--- a/src/main/ipc/preflight-remote-runtime.ts
+++ b/src/main/ipc/preflight-remote-runtime.ts
@@ -1,0 +1,89 @@
+import { app } from 'electron'
+import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
+import type { PreflightStatus, RefreshAgentsResult } from './preflight'
+
+const REMOTE_RUNTIME_TIMEOUT_MS = 15_000
+
+// Why: mirrors the web client's fallback so a transient remote failure surfaces
+// "no agents" rather than an error — the agent picker treats an empty list as
+// "nothing installed yet", which is the correct degraded state while remote.
+const REMOTE_AGENT_REFRESH_FALLBACK: RefreshAgentsResult = {
+  agents: [],
+  addedPathSegments: [],
+  shellHydrationOk: false,
+  pathSource: 'sync_seed_only',
+  pathFailureReason: 'spawn_error'
+}
+
+// Why: when connected to a remote Orca runtime, git/gh/glab are installed on the
+// server, not the local client. Proxy to the server's preflight RPC so the check
+// runs against the correct filesystem and shell. Fail loud on error rather than
+// falling back to the local scan, which would surface misleading local status
+// while remote — mirrors the web client.
+export async function checkPreflightViaRemoteRuntime(
+  environmentId: string,
+  force: boolean | undefined
+): Promise<PreflightStatus> {
+  const response = await callRuntimeEnvironment(
+    app.getPath('userData'),
+    environmentId,
+    'preflight.check',
+    { force },
+    REMOTE_RUNTIME_TIMEOUT_MS
+  ).catch((error: unknown) => {
+    // Why: an unreachable host rejects rather than resolving ok:false.
+    console.warn('[preflight] remote check unavailable:', error)
+    throw error
+  })
+  if (response.ok) {
+    return response.result as PreflightStatus
+  }
+  console.warn('[preflight] remote check failed:', response.error.message)
+  throw new Error(response.error.message)
+}
+
+// Why: while a remote runtime is active the AI CLIs are installed on the server,
+// not the local client. Proxy detection to the server's RPC; on any failure
+// surface the empty fallback rather than the local list (which would mislabel
+// the remote) — mirrors the web client's preflight.detectAgents behavior.
+export async function detectAgentsViaRemoteRuntime(environmentId: string): Promise<string[]> {
+  try {
+    const response = await callRuntimeEnvironment(
+      app.getPath('userData'),
+      environmentId,
+      'preflight.detectAgents',
+      undefined,
+      REMOTE_RUNTIME_TIMEOUT_MS
+    )
+    if (response.ok) {
+      return response.result as string[]
+    }
+    console.warn('[preflight] remote agent detection failed:', response.error.message)
+  } catch (error) {
+    // Why: an unreachable host rejects rather than resolving ok:false.
+    console.warn('[preflight] remote agent detection unavailable:', error)
+  }
+  return []
+}
+
+export async function refreshAgentsViaRemoteRuntime(
+  environmentId: string
+): Promise<RefreshAgentsResult> {
+  try {
+    const response = await callRuntimeEnvironment(
+      app.getPath('userData'),
+      environmentId,
+      'preflight.refreshAgents',
+      undefined,
+      REMOTE_RUNTIME_TIMEOUT_MS
+    )
+    if (response.ok) {
+      return response.result as RefreshAgentsResult
+    }
+    console.warn('[preflight] remote agent refresh failed:', response.error.message)
+  } catch (error) {
+    // Why: an unreachable host rejects rather than resolving ok:false.
+    console.warn('[preflight] remote agent refresh unavailable:', error)
+  }
+  return REMOTE_AGENT_REFRESH_FALLBACK
+}

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -255,6 +255,110 @@ describe('preflight', () => {
     })
   })
 
+  describe('agent detection remote runtime proxying', () => {
+    const remoteAgents = ['openclaude', 'cursor']
+    const remoteRefresh = {
+      agents: remoteAgents,
+      addedPathSegments: ['/srv/bin'],
+      shellHydrationOk: true,
+      pathSource: 'shell_hydrated',
+      pathFailureReason: 'none'
+    }
+
+    it('proxies preflight:detectAgents to the active remote runtime', async () => {
+      callRuntimeEnvironmentMock.mockResolvedValue({
+        id: 'preflight.detectAgents',
+        ok: true,
+        result: remoteAgents,
+        _meta: { runtimeId: 'runtime-1' }
+      })
+
+      registerPreflightHandlers(storeWithActiveEnvironment('env-1'))
+
+      await expect(handlers['preflight:detectAgents']()).resolves.toEqual(remoteAgents)
+      expect(callRuntimeEnvironmentMock).toHaveBeenCalledWith(
+        '/mock/userData',
+        'env-1',
+        'preflight.detectAgents',
+        undefined,
+        15_000
+      )
+      // Why: while a remote runtime is active the local probe must not run.
+      expect(execFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('returns an empty agent list (never a local scan) when detection fails', async () => {
+      callRuntimeEnvironmentMock.mockResolvedValue({
+        id: 'preflight.detectAgents',
+        ok: false,
+        error: { code: 'runtime_unavailable', message: 'remote refused' },
+        _meta: { runtimeId: null }
+      })
+
+      registerPreflightHandlers(storeWithActiveEnvironment('env-1'))
+
+      await expect(handlers['preflight:detectAgents']()).resolves.toEqual([])
+      expect(execFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('returns an empty agent list when the remote host is unreachable', async () => {
+      callRuntimeEnvironmentMock.mockRejectedValue(new Error('connect ETIMEDOUT'))
+
+      registerPreflightHandlers(storeWithActiveEnvironment('env-1'))
+
+      await expect(handlers['preflight:detectAgents']()).resolves.toEqual([])
+      expect(execFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('proxies preflight:refreshAgents to the active remote runtime', async () => {
+      callRuntimeEnvironmentMock.mockResolvedValue({
+        id: 'preflight.refreshAgents',
+        ok: true,
+        result: remoteRefresh,
+        _meta: { runtimeId: 'runtime-1' }
+      })
+
+      registerPreflightHandlers(storeWithActiveEnvironment('env-1'))
+
+      await expect(handlers['preflight:refreshAgents']()).resolves.toEqual(remoteRefresh)
+      expect(callRuntimeEnvironmentMock).toHaveBeenCalledWith(
+        '/mock/userData',
+        'env-1',
+        'preflight.refreshAgents',
+        undefined,
+        15_000
+      )
+      expect(execFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('returns the empty-refresh fallback when the remote refresh fails', async () => {
+      callRuntimeEnvironmentMock.mockRejectedValue(new Error('connect ETIMEDOUT'))
+
+      registerPreflightHandlers(storeWithActiveEnvironment('env-1'))
+
+      await expect(handlers['preflight:refreshAgents']()).resolves.toEqual({
+        agents: [],
+        addedPathSegments: [],
+        shellHydrationOk: false,
+        pathSource: 'sync_seed_only',
+        pathFailureReason: 'spawn_error'
+      })
+      expect(execFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('runs local detection (no proxy) when no remote runtime is active', async () => {
+      hydrateShellPathMock.mockResolvedValue({ segments: [], ok: true, failureReason: 'none' })
+      execFileAsyncMock.mockRejectedValue(new Error('not found'))
+
+      registerPreflightHandlers(mockStore)
+
+      await handlers['preflight:detectAgents']()
+      await handlers['preflight:refreshAgents']()
+
+      expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
+    })
+  })
+
   // Why: every preflight run probes (in order) `git --version`, `gh --version`,
   // `glab --version`, then in parallel `gh auth status` + `glab auth status` —
   // five execFile calls per cycle. Tests below provide values for all five.

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -34,6 +34,9 @@ const {
 vi.mock('electron', () => ({
   ipcMain: {
     handle: handleMock
+  },
+  app: {
+    getPath: () => '/mock/userData'
   }
 }))
 
@@ -94,10 +97,15 @@ import {
   registerPreflightHandlers,
   runPreflightCheck
 } from './preflight'
+import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
+
+const callRuntimeEnvironmentMock = vi.mocked(callRuntimeEnvironment)
 
 type HandlerMap = Record<string, (_event?: unknown, args?: unknown) => Promise<unknown>>
 
 const mockStore = { getSettings: () => ({ activeRuntimeEnvironmentId: null }) } as never
+const storeWithActiveEnvironment = (environmentId: string) =>
+  ({ getSettings: () => ({ activeRuntimeEnvironmentId: environmentId }) }) as never
 
 describe('preflight', () => {
   const originalPlatform = process.platform
@@ -129,6 +137,7 @@ describe('preflight', () => {
     getAzureDevOpsAuthStatusMock.mockReset()
     getGiteaAuthStatusMock.mockReset()
     mergePersistedWindowsPathMock.mockReset()
+    callRuntimeEnvironmentMock.mockReset()
     // Why: existing tests should keep treating `which` as the only source
     // unless a case explicitly exercises the install-dir fallback.
     resolveCliCommandsMock.mockReset()
@@ -173,6 +182,76 @@ describe('preflight', () => {
     Object.defineProperty(process, 'platform', {
       configurable: true,
       value: originalPlatform
+    })
+  })
+
+  describe('preflight:check remote runtime proxying', () => {
+    const remoteStatus = {
+      git: { installed: true },
+      gh: { installed: true, authenticated: true },
+      glab: { installed: false, authenticated: false }
+    }
+
+    it('proxies to the active remote runtime and returns its status', async () => {
+      callRuntimeEnvironmentMock.mockResolvedValue({
+        id: 'preflight.check',
+        ok: true,
+        result: remoteStatus,
+        _meta: { runtimeId: 'runtime-1' }
+      })
+
+      registerPreflightHandlers(storeWithActiveEnvironment('env-1'))
+
+      await expect(handlers['preflight:check'](null, { force: true })).resolves.toEqual(
+        remoteStatus
+      )
+      expect(callRuntimeEnvironmentMock).toHaveBeenCalledWith(
+        '/mock/userData',
+        'env-1',
+        'preflight.check',
+        { force: true },
+        15_000
+      )
+      // Why: while a remote runtime is active the local probe must not run.
+      expect(execFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('fails loud on ok:false and never falls back to the local scan', async () => {
+      callRuntimeEnvironmentMock.mockResolvedValue({
+        id: 'preflight.check',
+        ok: false,
+        error: { code: 'runtime_unavailable', message: 'remote refused' },
+        _meta: { runtimeId: null }
+      })
+
+      registerPreflightHandlers(storeWithActiveEnvironment('env-1'))
+
+      await expect(handlers['preflight:check']()).rejects.toThrow('remote refused')
+      expect(execFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('propagates the rejection when the remote host is unreachable', async () => {
+      callRuntimeEnvironmentMock.mockRejectedValue(new Error('connect ETIMEDOUT'))
+
+      registerPreflightHandlers(storeWithActiveEnvironment('env-1'))
+
+      await expect(handlers['preflight:check']()).rejects.toThrow('connect ETIMEDOUT')
+      expect(execFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('runs the local scan when no remote runtime is active', async () => {
+      execFileAsyncMock
+        .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+        .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+        .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+        .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+        .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
+
+      registerPreflightHandlers(mockStore)
+
+      const status = (await handlers['preflight:check']()) as { gh: { installed: boolean } }
+      expect(status.gh.installed).toBe(true)
+      expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -83,6 +83,10 @@ vi.mock('../gitea/client', () => ({
   getGiteaAuthStatus: getGiteaAuthStatusMock
 }))
 
+vi.mock('./runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: vi.fn()
+}))
+
 import {
   _resetPreflightCache,
   detectInstalledAgents,
@@ -92,6 +96,8 @@ import {
 } from './preflight'
 
 type HandlerMap = Record<string, (_event?: unknown, args?: unknown) => Promise<unknown>>
+
+const mockStore = { getSettings: () => ({ activeRuntimeEnvironmentId: null }) } as never
 
 describe('preflight', () => {
   const originalPlatform = process.platform
@@ -446,7 +452,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'github.com\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     const status = await handlers['preflight:check']()
 
@@ -473,7 +479,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     const firstStatus = await handlers['preflight:check']()
     const refreshedStatus = await handlers['preflight:check'](null, { force: true })
@@ -650,7 +656,7 @@ describe('preflight', () => {
       throw new Error('not found')
     })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     await expect(handlers['preflight:detectAgents']()).resolves.toEqual(['openclaude', 'cursor'])
   })
@@ -769,7 +775,7 @@ describe('preflight', () => {
       request
     })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     await expect(
       handlers['preflight:detectRemoteAgents'](undefined, { connectionId: 'ssh-1' })
@@ -786,7 +792,7 @@ describe('preflight', () => {
   it('returns no remote agents when the SSH connection is unavailable', async () => {
     getActiveMultiplexerMock.mockReturnValue(null)
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     await expect(
       handlers['preflight:detectRemoteAgents'](undefined, { connectionId: 'ssh-1' })
@@ -800,7 +806,7 @@ describe('preflight', () => {
       request
     })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     await expect(
       handlers['preflight:detectRemoteAgents'](undefined, { connectionId: 'ssh-1' })
@@ -821,7 +827,7 @@ describe('preflight', () => {
       request
     })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     await expect(
       handlers['preflight:detectRemoteWindowsTerminalCapabilities'](undefined, {
@@ -945,7 +951,7 @@ describe('preflight', () => {
       throw new Error('not found')
     })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     const result = (await handlers['preflight:refreshAgents'](undefined, {
       projectRuntime: {
@@ -998,7 +1004,7 @@ describe('preflight', () => {
       throw new Error('not found')
     })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     const result = (await handlers['preflight:refreshAgents']()) as {
       agents: string[]
@@ -1034,7 +1040,7 @@ describe('preflight', () => {
       throw new Error('not found')
     })
 
-    registerPreflightHandlers()
+    registerPreflightHandlers(mockStore)
 
     const result = (await handlers['preflight:refreshAgents']()) as {
       agents: string[]
@@ -1063,7 +1069,7 @@ describe('preflight', () => {
       hydrateShellPathMock.mockResolvedValueOnce({ segments: [], ok: false, failureReason })
       execFileAsyncMock.mockRejectedValue(new Error('not found'))
 
-      registerPreflightHandlers()
+      registerPreflightHandlers(mockStore)
 
       const result = (await handlers['preflight:refreshAgents']()) as {
         pathSource: string

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -1,4 +1,6 @@
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
 import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
@@ -273,13 +275,29 @@ export async function runPreflightCheck(
   return result
 }
 
-export function registerPreflightHandlers(): void {
+export function registerPreflightHandlers(store: Store): void {
   ipcMain.handle(
     'preflight:check',
     async (
       _event,
       args?: PreflightRuntimeContext & { force?: boolean }
     ): Promise<PreflightStatus> => {
+      // Why: when connected to a remote Orca runtime, git/gh/glab are installed
+      // on the server, not the local client. Proxy to the server's preflight RPC
+      // so the check runs against the correct filesystem and shell.
+      const environmentId = store.getSettings().activeRuntimeEnvironmentId?.trim()
+      if (environmentId) {
+        const response = await callRuntimeEnvironment(
+          app.getPath('userData'),
+          environmentId,
+          'preflight.check',
+          { force: args?.force },
+          15_000
+        )
+        if (response.ok) {
+          return response.result as PreflightStatus
+        }
+      }
       return runPreflightCheck(args?.force, args)
     }
   )

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -284,7 +284,9 @@ export function registerPreflightHandlers(store: Store): void {
     ): Promise<PreflightStatus> => {
       // Why: when connected to a remote Orca runtime, git/gh/glab are installed
       // on the server, not the local client. Proxy to the server's preflight RPC
-      // so the check runs against the correct filesystem and shell.
+      // so the check runs against the correct filesystem and shell. Fail loud on
+      // error rather than falling back to the local scan, which would surface
+      // misleading local status while remote — mirrors the web client.
       const environmentId = store.getSettings().activeRuntimeEnvironmentId?.trim()
       if (environmentId) {
         const response = await callRuntimeEnvironment(
@@ -293,10 +295,16 @@ export function registerPreflightHandlers(store: Store): void {
           'preflight.check',
           { force: args?.force },
           15_000
-        )
+        ).catch((error: unknown) => {
+          // Why: an unreachable host rejects rather than resolving ok:false.
+          console.warn('[preflight] remote check unavailable:', error)
+          throw error
+        })
         if (response.ok) {
           return response.result as PreflightStatus
         }
+        console.warn('[preflight] remote check failed:', response.error.message)
+        throw new Error(response.error.message)
       }
       return runPreflightCheck(args?.force, args)
     }

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -1,6 +1,10 @@
-import { app, ipcMain } from 'electron'
+import { ipcMain } from 'electron'
 import type { Store } from '../persistence'
-import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
+import {
+  checkPreflightViaRemoteRuntime,
+  detectAgentsViaRemoteRuntime,
+  refreshAgentsViaRemoteRuntime
+} from './preflight-remote-runtime'
 import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
@@ -282,39 +286,27 @@ export function registerPreflightHandlers(store: Store): void {
       _event,
       args?: PreflightRuntimeContext & { force?: boolean }
     ): Promise<PreflightStatus> => {
-      // Why: when connected to a remote Orca runtime, git/gh/glab are installed
-      // on the server, not the local client. Proxy to the server's preflight RPC
-      // so the check runs against the correct filesystem and shell. Fail loud on
-      // error rather than falling back to the local scan, which would surface
-      // misleading local status while remote — mirrors the web client.
       const environmentId = store.getSettings().activeRuntimeEnvironmentId?.trim()
       if (environmentId) {
-        const response = await callRuntimeEnvironment(
-          app.getPath('userData'),
-          environmentId,
-          'preflight.check',
-          { force: args?.force },
-          15_000
-        ).catch((error: unknown) => {
-          // Why: an unreachable host rejects rather than resolving ok:false.
-          console.warn('[preflight] remote check unavailable:', error)
-          throw error
-        })
-        if (response.ok) {
-          return response.result as PreflightStatus
-        }
-        console.warn('[preflight] remote check failed:', response.error.message)
-        throw new Error(response.error.message)
+        return checkPreflightViaRemoteRuntime(environmentId, args?.force)
       }
       return runPreflightCheck(args?.force, args)
     }
   )
 
-  ipcMain.handle('preflight:detectAgents', async (_event, args?: PreflightRuntimeContext) =>
-    detectInstalledAgentsWithShellPathHydration(args)
-  )
+  ipcMain.handle('preflight:detectAgents', async (_event, args?: PreflightRuntimeContext) => {
+    const environmentId = store.getSettings().activeRuntimeEnvironmentId?.trim()
+    if (environmentId) {
+      return detectAgentsViaRemoteRuntime(environmentId)
+    }
+    return detectInstalledAgentsWithShellPathHydration(args)
+  })
 
   ipcMain.handle('preflight:refreshAgents', async (_event, args?: PreflightRuntimeContext) => {
+    const environmentId = store.getSettings().activeRuntimeEnvironmentId?.trim()
+    if (environmentId) {
+      return refreshAgentsViaRemoteRuntime(environmentId)
+    }
     return refreshShellPathAndDetectAgents(args)
   })
 

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -121,7 +121,7 @@ export function registerCoreHandlers(
 
   registerAppHandlers(store, { onBeforeRelaunch: lifecycleOptions.onBeforeRelaunch })
   registerCliHandlers()
-  registerPreflightHandlers()
+  registerPreflightHandlers(store)
   registerClaudeUsageHandlers(claudeUsage)
   registerCodexUsageHandlers(codexUsage)
   registerOpenCodeUsageHandlers(openCodeUsage)

--- a/src/main/ipc/skills.test.ts
+++ b/src/main/ipc/skills.test.ts
@@ -7,7 +7,8 @@ const {
   inventorySkillFreshnessMock,
   getDefaultWslDistroMock,
   getWslHomeMock,
-  parseWslPathMock
+  parseWslPathMock,
+  callRuntimeEnvironmentMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   discoverSkillsMock: vi.fn(),
@@ -15,12 +16,14 @@ const {
   inventorySkillFreshnessMock: vi.fn(),
   getDefaultWslDistroMock: vi.fn(),
   getWslHomeMock: vi.fn(),
-  parseWslPathMock: vi.fn()
+  parseWslPathMock: vi.fn(),
+  callRuntimeEnvironmentMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
   app: {
-    getVersion: () => '9.9.9-test'
+    getVersion: () => '9.9.9-test',
+    getPath: () => '/mock/userData'
   },
   ipcMain: {
     handle: handleMock
@@ -54,13 +57,18 @@ vi.mock('../wsl', () => ({
   }
 }))
 
+vi.mock('./runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: callRuntimeEnvironmentMock
+}))
+
 import { registerSkillsHandlers } from './skills'
 
 describe('registerSkillsHandlers', () => {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
   const repos = [{ id: 'repo-1', path: 'C:\\Users\\alice\\repo' }]
   const store = {
-    getRepos: vi.fn(() => repos)
+    getRepos: vi.fn(() => repos),
+    getSettings: vi.fn(() => ({ activeRuntimeEnvironmentId: null as string | null }))
   }
 
   beforeEach(() => {
@@ -71,6 +79,8 @@ describe('registerSkillsHandlers', () => {
     getWslHomeMock.mockReset()
     parseWslPathMock.mockReset()
     parseWslPathMock.mockReturnValue(null)
+    callRuntimeEnvironmentMock.mockReset()
+    store.getSettings.mockReturnValue({ activeRuntimeEnvironmentId: null })
     discoverSkillsMock.mockResolvedValue({ skills: [], sources: [], scannedAt: 1 })
     discoverSkillsInWslMock.mockResolvedValue({ skills: [], sources: [], scannedAt: 1 })
     inventorySkillFreshnessMock.mockResolvedValue({
@@ -223,5 +233,73 @@ describe('registerSkillsHandlers', () => {
       repos
     })
     expect(getWslHomeMock).not.toHaveBeenCalled()
+  })
+
+  describe('remote runtime proxying', () => {
+    const remoteResult = {
+      skills: [{ id: 'orchestration' }],
+      sources: [{ kind: 'user' }],
+      scannedAt: 42
+    }
+
+    beforeEach(() => {
+      store.getSettings.mockReturnValue({ activeRuntimeEnvironmentId: 'env-1' })
+    })
+
+    it('proxies discovery to the active remote runtime and returns its result', async () => {
+      callRuntimeEnvironmentMock.mockResolvedValue({
+        id: 'skills.discover',
+        ok: true,
+        result: remoteResult,
+        _meta: { runtimeId: 'runtime-1' }
+      })
+      const handler = getDiscoverHandler()
+
+      await expect(handler(null, { cwd: '/srv/repo' })).resolves.toEqual(remoteResult)
+      expect(callRuntimeEnvironmentMock).toHaveBeenCalledWith(
+        '/mock/userData',
+        'env-1',
+        'skills.discover',
+        { cwd: '/srv/repo' },
+        15_000
+      )
+      // Why: while a remote runtime is active the local scan must not run.
+      expect(discoverSkillsMock).not.toHaveBeenCalled()
+    })
+
+    it('returns an empty result (never a local scan) when the remote returns ok:false', async () => {
+      callRuntimeEnvironmentMock.mockResolvedValue({
+        id: 'skills.discover',
+        ok: false,
+        error: { code: 'runtime_unavailable', message: 'remote refused' },
+        _meta: { runtimeId: null }
+      })
+      const handler = getDiscoverHandler()
+
+      const result = (await handler(null)) as { skills: unknown[]; sources: unknown[] }
+      expect(result.skills).toEqual([])
+      expect(result.sources).toEqual([])
+      expect(discoverSkillsMock).not.toHaveBeenCalled()
+    })
+
+    it('returns an empty result when the remote host is unreachable', async () => {
+      callRuntimeEnvironmentMock.mockRejectedValue(new Error('connect ETIMEDOUT'))
+      const handler = getDiscoverHandler()
+
+      const result = (await handler(null)) as { skills: unknown[]; sources: unknown[] }
+      expect(result.skills).toEqual([])
+      expect(result.sources).toEqual([])
+      expect(discoverSkillsMock).not.toHaveBeenCalled()
+    })
+
+    it('runs the local scan when no remote runtime is active', async () => {
+      store.getSettings.mockReturnValue({ activeRuntimeEnvironmentId: null })
+      const handler = getDiscoverHandler()
+
+      await handler(null, { cwd: '/repo/worktree' })
+
+      expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
+      expect(discoverSkillsMock).toHaveBeenCalledWith({ repos: [], cwd: '/repo/worktree' })
+    })
   })
 })

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -11,12 +11,32 @@ import {
   discoverSkillsOnTarget,
   resolveSkillDiscoveryTarget
 } from '../skills/skill-discovery-target'
+import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
 
 export function registerSkillsHandlers(store: Store): void {
   ipcMain.handle(
     'skills:discover',
     async (_event, target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> => {
       const parsedTarget = target ? SkillDiscoveryTargetSchema.parse(target) : undefined
+      // Why: when connected to a remote Orca runtime the skill files live on
+      // the server, not on the local host. Proxy to the server's RPC method so
+      // discovery scans the correct filesystem. Prefer an explicit environmentId
+      // from the caller, then fall back to the persisted active environment.
+      const environmentId =
+        target?.environmentId?.trim() || store.getSettings().activeRuntimeEnvironmentId?.trim()
+      if (environmentId) {
+        const response = await callRuntimeEnvironment(
+          app.getPath('userData'),
+          environmentId,
+          'skills.discover',
+          parsedTarget,
+          15_000
+        )
+        if (response.ok) {
+          return response.result as SkillDiscoveryResult
+        }
+        return { skills: [], sources: [], scannedAt: Date.now() }
+      }
       return discoverSkillsOnTarget(resolveSkillDiscoveryTarget(parsedTarget), store.getRepos())
     }
   )

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -20,20 +20,26 @@ export function registerSkillsHandlers(store: Store): void {
       const parsedTarget = target ? SkillDiscoveryTargetSchema.parse(target) : undefined
       // Why: when connected to a remote Orca runtime the skill files live on
       // the server, not on the local host. Proxy to the server's RPC method so
-      // discovery scans the correct filesystem. Prefer an explicit environmentId
-      // from the caller, then fall back to the persisted active environment.
-      const environmentId =
-        target?.environmentId?.trim() || store.getSettings().activeRuntimeEnvironmentId?.trim()
+      // discovery scans the correct filesystem. On any failure surface no skills
+      // rather than falling back to a local scan (which would mislabel the
+      // remote) — mirrors the web client's skills.discover behavior.
+      const environmentId = store.getSettings().activeRuntimeEnvironmentId?.trim()
       if (environmentId) {
-        const response = await callRuntimeEnvironment(
-          app.getPath('userData'),
-          environmentId,
-          'skills.discover',
-          parsedTarget,
-          15_000
-        )
-        if (response.ok) {
-          return response.result as SkillDiscoveryResult
+        try {
+          const response = await callRuntimeEnvironment(
+            app.getPath('userData'),
+            environmentId,
+            'skills.discover',
+            parsedTarget,
+            15_000
+          )
+          if (response.ok) {
+            return response.result as SkillDiscoveryResult
+          }
+          console.warn('[skills] remote discovery failed:', response.error.message)
+        } catch (error) {
+          // Why: an unreachable host rejects rather than resolving ok:false.
+          console.warn('[skills] remote discovery unavailable:', error)
         }
         return { skills: [], sources: [], scannedAt: Date.now() }
       }

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -17,7 +17,8 @@ import { translate } from '@/i18n/i18n'
 import {
   getLandingPreflightIssues,
   hasGitHubBackedProject,
-  type PreflightIssue
+  type PreflightIssue,
+  type LandingPreflightStatus
 } from './landing-preflight-issues'
 
 type ShortcutItem = {
@@ -27,6 +28,16 @@ type ShortcutItem = {
 }
 
 const ORCA_STARGAZERS_URL = 'https://github.com/stablyai/orca/stargazers'
+
+async function checkLandingPreflight(force = false): Promise<LandingPreflightStatus | null> {
+  try {
+    return await window.api.preflight.check(force ? { force: true } : undefined)
+  } catch (error) {
+    // Why: an offline remote runtime should retain the last-known banner state.
+    console.warn('[Landing] preflight check unavailable:', error)
+    return null
+  }
+}
 
 type StarState = 'loading' | 'starred' | 'not-starred' | 'web-fallback' | 'hidden'
 
@@ -242,19 +253,14 @@ export default function Landing(): React.JSX.Element {
   useEffect(() => {
     let cancelled = false
     const refreshPreflight = (force = false): void => {
-      // Why: a remote-runtime preflight rejects when the server is unreachable;
-      // keep the last-known issues instead of surfacing an unhandled rejection.
-      window.api.preflight
-        .check(force ? { force: true } : undefined)
-        .then((status) => {
-          if (cancelled) {
-            return
-          }
-          setPreflightIssues(
-            getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
-          )
-        })
-        .catch(() => {})
+      void checkLandingPreflight(force).then((status) => {
+        if (cancelled || !status) {
+          return
+        }
+        setPreflightIssues(
+          getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
+        )
+      })
     }
 
     // oxlint-disable-next-line react-doctor/no-initialize-state -- Why: preflight status is read from an external IPC probe on mount and focus.
@@ -287,19 +293,14 @@ export default function Landing(): React.JSX.Element {
     // Why: some users complete `gh auth login` without ever leaving the Orca
     // window. Poll only while a warning is visible so the banner self-clears.
     const intervalId = window.setInterval(() => {
-      // Why: a remote-runtime preflight rejects when the server is unreachable;
-      // keep the last-known issues instead of surfacing an unhandled rejection.
-      window.api.preflight
-        .check({ force: true })
-        .then((status) => {
-          if (cancelled) {
-            return
-          }
-          setPreflightIssues(
-            getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
-          )
-        })
-        .catch(() => {})
+      void checkLandingPreflight(true).then((status) => {
+        if (cancelled || !status) {
+          return
+        }
+        setPreflightIssues(
+          getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
+        )
+      })
     }, 30000)
 
     return () => {

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -242,14 +242,19 @@ export default function Landing(): React.JSX.Element {
   useEffect(() => {
     let cancelled = false
     const refreshPreflight = (force = false): void => {
-      void window.api.preflight.check(force ? { force: true } : undefined).then((status) => {
-        if (cancelled) {
-          return
-        }
-        setPreflightIssues(
-          getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
-        )
-      })
+      // Why: a remote-runtime preflight rejects when the server is unreachable;
+      // keep the last-known issues instead of surfacing an unhandled rejection.
+      window.api.preflight
+        .check(force ? { force: true } : undefined)
+        .then((status) => {
+          if (cancelled) {
+            return
+          }
+          setPreflightIssues(
+            getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
+          )
+        })
+        .catch(() => {})
     }
 
     // oxlint-disable-next-line react-doctor/no-initialize-state -- Why: preflight status is read from an external IPC probe on mount and focus.
@@ -282,14 +287,19 @@ export default function Landing(): React.JSX.Element {
     // Why: some users complete `gh auth login` without ever leaving the Orca
     // window. Poll only while a warning is visible so the banner self-clears.
     const intervalId = window.setInterval(() => {
-      void window.api.preflight.check({ force: true }).then((status) => {
-        if (cancelled) {
-          return
-        }
-        setPreflightIssues(
-          getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
-        )
-      })
+      // Why: a remote-runtime preflight rejects when the server is unreachable;
+      // keep the last-known issues instead of surfacing an unhandled rejection.
+      window.api.preflight
+        .check({ force: true })
+        .then((status) => {
+          if (cancelled) {
+            return
+          }
+          setPreflightIssues(
+            getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
+          )
+        })
+        .catch(() => {})
     }, 30000)
 
     return () => {

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -51,6 +51,9 @@ export type SkillDiscoveryTarget = {
    *  when the caller (e.g. a remote client) cannot supply `projectRuntime`. */
   worktreeId?: string | null
   projectRuntime?: ProjectExecutionRuntimeResolution
+  // Why: when connected to a remote Orca runtime, discovery must scan the
+  // server's filesystem via the remote RPC rather than the local host.
+  environmentId?: string | null
 }
 
 const ResolvedProjectRuntimeSchema = z.object({

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -51,9 +51,6 @@ export type SkillDiscoveryTarget = {
    *  when the caller (e.g. a remote client) cannot supply `projectRuntime`. */
   worktreeId?: string | null
   projectRuntime?: ProjectExecutionRuntimeResolution
-  // Why: when connected to a remote Orca runtime, discovery must scan the
-  // server's filesystem via the remote RPC rather than the local host.
-  environmentId?: string | null
 }
 
 const ResolvedProjectRuntimeSchema = z.object({


### PR DESCRIPTION
## Summary

When a client is connected to a remote Orca server via `orca serve`, two key checks always ran against the **local client's filesystem** instead of the server — making installed skills and tools (gh, git, glab) appear as \"Not installed\" regardless of what's on the server.

**Root cause.** Both the `skills:discover` and `preflight:check` IPC handlers are registered on the client's main process and call local functions (`discoverSkills`, `runPreflightCheck`). When a remote runtime is active, the relevant files live on the server, not on the client. Neither handler had any awareness of `activeRuntimeEnvironmentId`.

**Fix.** In both handlers, read `activeRuntimeEnvironmentId` from the persisted settings. When set, forward the call to the server's corresponding RPC method (`skills.discover` / `preflight.check`) via `callRuntimeEnvironment` instead of running locally. The existing server-side RPC methods already handle these checks correctly on the server's filesystem — they just weren't being called.

Also adds an optional `environmentId` field to `SkillDiscoveryTarget` for callers that want to explicitly target a specific environment.

## Changes

- `src/main/ipc/skills.ts` — proxy `skills:discover` to remote when `activeRuntimeEnvironmentId` is set
- `src/main/ipc/preflight.ts` — proxy `preflight:check` to remote when `activeRuntimeEnvironmentId` is set; accepts `store` parameter
- `src/main/ipc/register-core-handlers.ts` — pass `store` to `registerPreflightHandlers`
- `src/shared/skills.ts` — add optional `environmentId` to `SkillDiscoveryTarget`
- `src/main/ipc/preflight.test.ts` — update tests for new `store` parameter

## Testing

- `pnpm run typecheck` — passes clean
- `pnpm run build:electron-vite` — builds successfully on v1.4.110 source base

**Skills fix — validated end-to-end** against a remote `orca serve` instance on Ubuntu 22.04 (Tailscale): skills installed on the server (`orchestration`, `computer-use`) correctly show as **Installed** in Settings after patching `out/main/index.js`.

**Preflight fix — not end-to-end validated.** Electron's asar integrity checks (SHA256 per-file hashes in the header) prevented us from patching a live client to test the `gh` CLI detection fix. The fix follows the identical pattern as the validated skills fix and targets the same `activeRuntimeEnvironmentId` → `callRuntimeEnvironment` path, but reviewer validation against a live remote connection would be appreciated.

Fixes #6789 (partial — the `selector_not_found` path was fixed in #6816; this addresses the remaining "Not installed" status issue after successful installation)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6938">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

When you use a remote Orca server, skill and tool checks were still looking at your local machine. This routes those checks to the remote server so installed skills and tools show up correctly.
