### PR TITLE
Fix Codex skill preview terminal artifacts

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -4,7 +4,7 @@ import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinat
 import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TerminalColorSchemeMode } from '../../../../shared/terminal-color-scheme-protocol'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
-import type { TuiAgent } from '../../../../shared/types'
+import type { SetupSplitDirection, TuiAgent } from '../../../../shared/types'
 import type { SleepingAgentLaunchConfig } from '../../../../shared/agent-session-resume'
 
 export type PtyConnectionDeps = {
@@ -28,6 +28,8 @@ export type PtyConnectionDeps = {
     initialAgentStatus?: { agent: TuiAgent; prompt: string }
     /** Show the restored-session banner when this startup command mounts. */
     showSessionRestoredBanner?: boolean
+    /** Initial startup may be paired with a setup split that changes its grid. */
+    waitForSetupSplitDirection?: SetupSplitDirection
   } | null
   restoredLeafId?: string | null
   restoredPtyIdByLeafId?: Record<string, string>

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -492,6 +492,52 @@ function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void
   return { promise, resolve: resolveDeferred }
 }
 
+function createRect(width: number, height: number, left = 0, top = 0): DOMRect {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({})
+  } as DOMRect
+}
+
+function stubElementRect(element: HTMLElement, readRect: () => DOMRect): void {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: vi.fn(readRect)
+  })
+}
+
+function createMeasuredElement(args: {
+  className?: () => string
+  parentElement?: () => HTMLElement | null
+  rect: () => DOMRect
+}): HTMLElement {
+  const element = new EventTarget() as HTMLElement
+  Object.defineProperty(element, 'dataset', {
+    configurable: true,
+    value: {}
+  })
+  Object.defineProperty(element, 'classList', {
+    configurable: true,
+    value: {
+      contains: (className: string): boolean =>
+        (args.className?.() ?? '').split(/\s+/).includes(className)
+    }
+  })
+  Object.defineProperty(element, 'parentElement', {
+    configurable: true,
+    get: () => args.parentElement?.() ?? null
+  })
+  stubElementRect(element, args.rect)
+  return element
+}
+
 function temporarilySetNavigatorUserAgent(userAgent: string): () => void {
   const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
   const platform = userAgent.includes('Windows')
@@ -2289,6 +2335,91 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('waits for setup-split geometry before spawning the initial startup command', async () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    const runNextFrame = (): void => {
+      const callback = frameCallbacks.shift()
+      if (!callback) {
+        throw new Error('expected a queued animation frame')
+      }
+      callback(0)
+    }
+
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    }
+
+    const pane = createPane(1)
+    const siblingPane = createPane(2)
+    let panes = [pane]
+    let proposedGrid = { cols: 240, rows: 50 }
+    let splitMounted = false
+    const root = createMeasuredElement({ rect: () => createRect(1200, 800) })
+    const split = createMeasuredElement({
+      className: () => (splitMounted ? 'pane-split is-vertical' : ''),
+      rect: () => createRect(1200, 800)
+    })
+    const mainContainer = createMeasuredElement({
+      parentElement: () => (splitMounted ? split : root),
+      rect: () => (splitMounted ? createRect(600, 800) : createRect(1200, 800))
+    })
+    const setupContainer = createMeasuredElement({
+      parentElement: () => (splitMounted ? split : null),
+      rect: () => createRect(599, 800, 601, 0)
+    })
+    pane.container = mainContainer
+    siblingPane.container = setupContainer
+    ;(
+      pane.fitAddon as unknown as {
+        proposeDimensions: () => { cols: number; rows: number }
+      }
+    ).proposeDimensions = vi.fn(() => proposedGrid)
+    pane.fitAddon.fit = vi.fn(() => {
+      pane.terminal.cols = proposedGrid.cols
+      pane.terminal.rows = proposedGrid.rows
+    })
+
+    const manager = createManager(1)
+    manager.getPanes = vi.fn(() => panes)
+    connectPanePty(
+      pane as never,
+      manager as never,
+      createDeps({
+        startup: { command: 'codex', waitForSetupSplitDirection: 'vertical' }
+      }) as never
+    )
+
+    runNextFrame()
+    for (let i = 0; i < 8; i++) {
+      runNextFrame()
+    }
+    expect(transport.connect).not.toHaveBeenCalled()
+
+    splitMounted = true
+    panes = [pane, siblingPane]
+    proposedGrid = { cols: 120, rows: 50 }
+    let postSplitFrames = 0
+    while (frameCallbacks.length > 0 && transport.connect.mock.calls.length === 0) {
+      if (postSplitFrames >= 12) {
+        throw new Error('startup did not connect after setup split became ready')
+      }
+      postSplitFrames += 1
+      runNextFrame()
+    }
+
+    expect(createdTransportOptions[0]?.command).toBe('codex')
+    expect(transport.connect).toHaveBeenCalledWith(expect.objectContaining({ cols: 120, rows: 50 }))
+  })
+
   it('does not reuse a sibling split pane pending spawn after remount', async () => {
     const { connectPanePty } = await import('./pty-connection')
 
@@ -3432,6 +3563,49 @@ describe('connectPanePty', () => {
     expect(transport.attach).not.toHaveBeenCalled()
     await Promise.resolve()
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'leaf-pty-2')
+  })
+
+  it('resizes a reattached PTY to the current grid when the pane narrows before reattach resolves', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const reattach = createDeferred<void>()
+    let currentPtyId: string | null = null
+    const transport = createMockTransport()
+    transport.getPtyId.mockImplementation(() => currentPtyId)
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      currentPtyId = sessionId ?? null
+      await reattach.promise
+      return sessionId ? { id: sessionId } : null
+    })
+    transportFactoryQueue.push(transport)
+    const pane = createPane(2)
+    pane.terminal.cols = 133
+    pane.terminal.rows = 63
+    let proposedGrid = { cols: 133, rows: 63 }
+    ;(
+      pane.fitAddon as unknown as {
+        proposeDimensions: () => { cols: number; rows: number }
+      }
+    ).proposeDimensions = vi.fn(() => proposedGrid)
+    pane.fitAddon.fit = vi.fn(() => {
+      pane.terminal.cols = proposedGrid.cols
+      pane.terminal.rows = proposedGrid.rows
+    })
+    const deps = createDeps({
+      restoredLeafId: LEAF_2,
+      restoredPtyIdByLeafId: { [LEAF_2]: 'leaf-pty-2' }
+    })
+
+    connectPanePty(pane as never, createManager(2) as never, deps as never)
+
+    expect(transport.connect).toHaveBeenCalledWith(
+      expect.objectContaining({ cols: 133, rows: 63, sessionId: 'leaf-pty-2' })
+    )
+
+    proposedGrid = { cols: 65, rows: 63 }
+    reattach.resolve()
+    await flushAsyncTicks()
+
+    expect(transport.resize).toHaveBeenLastCalledWith(65, 63)
   })
 
   it('adopts a still-live background PTY via attach instead of reattaching when an eager buffer exists', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -143,7 +143,7 @@ import {
   normalizeCompatibleAgentTitleForOwner,
   resolveCompatibleAgentTypeForOwner
 } from '../../../../shared/agent-title-owner'
-import type { TuiAgent } from '../../../../shared/types'
+import type { SetupSplitDirection, TuiAgent } from '../../../../shared/types'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
@@ -813,6 +813,79 @@ function containsCursorRestore(data: string): boolean {
   const hideIndex = data.indexOf(CURSOR_HIDE_SEQUENCE)
   const showIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE)
   return hideIndex !== -1 && showIndex > hideIndex && containsCursorPositionSequence(data)
+}
+
+const SPLIT_GEOMETRY_EPSILON_PX = 1
+
+function readElementRect(element: HTMLElement | null | undefined): DOMRect | null {
+  try {
+    return element?.getBoundingClientRect?.() ?? null
+  } catch {
+    return null
+  }
+}
+
+function hasVisibleRect(rect: DOMRect | null): rect is DOMRect {
+  return Boolean(
+    rect && rect.width > SPLIT_GEOMETRY_EPSILON_PX && rect.height > SPLIT_GEOMETRY_EPSILON_PX
+  )
+}
+
+function readProposedPaneGrid(pane: ManagedPane): { cols: number; rows: number } | null {
+  try {
+    const dimensions = pane.fitAddon.proposeDimensions()
+    if (!dimensions || dimensions.cols <= 0 || dimensions.rows <= 0) {
+      return null
+    }
+    return dimensions
+  } catch {
+    return null
+  }
+}
+
+function isPaneGridAlignedWithFit(pane: ManagedPane): boolean {
+  const proposed = readProposedPaneGrid(pane)
+  return Boolean(
+    proposed && pane.terminal.cols === proposed.cols && pane.terminal.rows === proposed.rows
+  )
+}
+
+function isSetupSplitGeometryReady(
+  pane: ManagedPane,
+  manager: PaneManager,
+  direction: SetupSplitDirection
+): boolean {
+  const splitElement = pane.container.parentElement
+  const directionClass = direction === 'vertical' ? 'is-vertical' : 'is-horizontal'
+  if (
+    !splitElement?.classList?.contains('pane-split') ||
+    !splitElement.classList.contains(directionClass)
+  ) {
+    return false
+  }
+
+  const sibling = manager
+    .getPanes()
+    .find(
+      (candidate) => candidate.id !== pane.id && candidate.container.parentElement === splitElement
+    )
+  const splitRect = readElementRect(splitElement)
+  const paneRect = readElementRect(pane.container)
+  const siblingRect = readElementRect(sibling?.container)
+  if (!hasVisibleRect(splitRect) || !hasVisibleRect(paneRect) || !hasVisibleRect(siblingRect)) {
+    return false
+  }
+
+  const splitAxis = direction === 'vertical' ? splitRect.width : splitRect.height
+  const paneAxis = direction === 'vertical' ? paneRect.width : paneRect.height
+  const siblingAxis = direction === 'vertical' ? siblingRect.width : siblingRect.height
+  return (
+    paneAxis > SPLIT_GEOMETRY_EPSILON_PX &&
+    siblingAxis > SPLIT_GEOMETRY_EPSILON_PX &&
+    splitAxis - paneAxis > SPLIT_GEOMETRY_EPSILON_PX &&
+    splitAxis - siblingAxis > SPLIT_GEOMETRY_EPSILON_PX &&
+    isPaneGridAlignedWithFit(pane)
+  )
 }
 
 /**
@@ -2420,6 +2493,15 @@ export function connectPanePty(
     deps.isVisibleRef.current &&
     !connectionId &&
     runtimeEnvironmentId === null
+  const isStartupGridReadyForConnect = (): boolean => {
+    const setupSplitDirection = paneStartup?.waitForSetupSplitDirection
+    if (!setupSplitDirection) {
+      return true
+    }
+    // Why: the setup split reparents the main pane before its xterm grid
+    // necessarily reflects the new flex geometry; wait for both to agree.
+    return isSetupSplitGeometryReady(pane, manager, setupSplitDirection)
+  }
   const settleStartupGridBeforeConnect = (connect: () => void): void => {
     startupGridSettleHandle?.cancel()
     let settledSynchronously = false
@@ -2427,6 +2509,9 @@ export function connectPanePty(
     // has settled; spawn from a briefly stable grid so the TUI paints cleanly.
     const handle = waitForStableStartupGrid({
       isAlive: () => !disposed,
+      isReadyToSettle: paneStartup?.waitForSetupSplitDirection
+        ? isStartupGridReadyForConnect
+        : undefined,
       measure: measureStartupGrid,
       onSettled: () => {
         settledSynchronously = true
@@ -4119,7 +4204,12 @@ export function connectPanePty(
       // to the PTY — the PTY is already at phone dimensions and must stay there.
       const reattachPtyId = transport.getPtyId()
       if (!reattachPtyId || !getFitOverrideForPty(reattachPtyId)) {
-        transport.resize(cols, rows)
+        safeFit(pane)
+        const reattachCols = pane.terminal.cols
+        const reattachRows = pane.terminal.rows
+        if (reattachCols > 0 && reattachRows > 0) {
+          transport.resize(reattachCols, reattachRows)
+        }
       }
       // Why: POSIX only delivers SIGWINCH when terminal dimensions actually
       // change. Sending it explicitly guarantees restored TUIs repaint at

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -101,6 +101,10 @@ import {
   observeTerminalBracketedPasteModeOutput
 } from './terminal-bracketed-paste'
 import { executeTerminalStartupCommandPaste } from './terminal-startup-command-paste'
+import {
+  waitForStableStartupGrid,
+  type TerminalStartupGridSettleHandle
+} from './terminal-startup-grid-settle'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { isKnownTuiAgentTerminalStartupCommand } from './terminal-startup-command-classifier'
@@ -824,6 +828,8 @@ export function connectPanePty(
   let disposed = false
   let connectFrame: number | null = null
   let connectFallbackTimer: ReturnType<typeof setTimeout> | null = null
+  let startupGridSettleHandle: TerminalStartupGridSettleHandle | null = null
+  let startupGridSettledForConnect = false
   let connectStarted = false
   let unregisterBacklogRecovery: (() => void) | null = null
   let unregisterDocumentVisibilityRecovery: (() => void) | null = null
@@ -2403,8 +2409,55 @@ export function connectPanePty(
       connectFrame = null
     }
   }
+  const measureStartupGrid = (): { cols: number; rows: number } | null => {
+    safeFit(pane)
+    const cols = pane.terminal.cols
+    const rows = pane.terminal.rows
+    return cols > 0 && rows > 0 ? { cols, rows } : null
+  }
+  const shouldSettleStartupGridBeforeConnect = (): boolean =>
+    Boolean(paneStartup?.command) &&
+    deps.isVisibleRef.current &&
+    !connectionId &&
+    runtimeEnvironmentId === null
+  const settleStartupGridBeforeConnect = (connect: () => void): void => {
+    startupGridSettleHandle?.cancel()
+    let settledSynchronously = false
+    // Why: local startup commands can launch a TUI before the split-pane grid
+    // has settled; spawn from a briefly stable grid so the TUI paints cleanly.
+    const handle = waitForStableStartupGrid({
+      isAlive: () => !disposed,
+      measure: measureStartupGrid,
+      onSettled: () => {
+        settledSynchronously = true
+        startupGridSettleHandle = null
+        connect()
+      },
+      requestFrame: (callback) => requestAnimationFrame(callback),
+      cancelFrame: (handle) => {
+        if (typeof cancelAnimationFrame === 'function') {
+          cancelAnimationFrame(handle)
+        }
+      }
+    })
+    if (!settledSynchronously) {
+      startupGridSettleHandle = handle
+    }
+  }
   const runDeferredConnect = (): void => {
     if (connectStarted) {
+      return
+    }
+    if (!startupGridSettledForConnect && shouldSettleStartupGridBeforeConnect()) {
+      cancelScheduledConnectFrame()
+      if (connectFallbackTimer !== null) {
+        clearTimeout(connectFallbackTimer)
+        connectFallbackTimer = null
+      }
+      settleStartupGridBeforeConnect(() => {
+        startupGridSettledForConnect = true
+        runDeferredConnect()
+      })
       return
     }
     connectStarted = true
@@ -4705,6 +4758,8 @@ export function connectPanePty(
       // rAF so a torn-down pane cannot keep fitting/resizing after disposal.
       ptySizeReconcileHandle?.cancel()
       ptySizeReconcileHandle = null
+      startupGridSettleHandle?.cancel()
+      startupGridSettleHandle = null
       if (terminalKeyTargetSupportsEvents) {
         terminalKeyTarget.removeEventListener('keydown', onTerminalKeyDown, { capture: true })
       }

--- a/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.test.ts
@@ -88,6 +88,33 @@ describe('waitForStableStartupGrid', () => {
     expect(onSettled).toHaveBeenCalledWith({ cols: 88, rows: 50 })
   })
 
+  it('ignores pre-ready stable grids until an external split gate opens', () => {
+    const scheduler = createFrameScheduler()
+    const onSettled = vi.fn()
+    let ready = false
+    const measure = vi.fn(() => (ready ? { cols: 88, rows: 50 } : { cols: 180, rows: 50 }))
+
+    waitForStableStartupGrid({
+      isAlive: () => true,
+      isReadyToSettle: () => ready,
+      measure,
+      onSettled,
+      requestFrame: scheduler.requestFrame,
+      cancelFrame: scheduler.cancelFrame,
+      minFrames: 3,
+      stableFrames: 2,
+      maxFrames: 4
+    })
+
+    scheduler.run(8)
+    expect(onSettled).not.toHaveBeenCalled()
+
+    ready = true
+    scheduler.run()
+
+    expect(onSettled).toHaveBeenCalledWith({ cols: 88, rows: 50 })
+  })
+
   it('uses the latest usable grid at the frame cap when dimensions keep changing', () => {
     const scheduler = createFrameScheduler()
     const onSettled = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  waitForStableStartupGrid,
+  type TerminalStartupGridDimensions
+} from './terminal-startup-grid-settle'
+
+function createFrameScheduler() {
+  const queue = new Map<number, () => void>()
+  let nextHandle = 1
+  return {
+    requestFrame: (callback: () => void): number => {
+      const handle = nextHandle
+      nextHandle += 1
+      queue.set(handle, callback)
+      return handle
+    },
+    cancelFrame: (handle: number): void => {
+      queue.delete(handle)
+    },
+    run(maxFrames = 100): number {
+      let ran = 0
+      while (queue.size > 0 && ran < maxFrames) {
+        const [handle, callback] = queue.entries().next().value as [number, () => void]
+        queue.delete(handle)
+        callback()
+        ran += 1
+      }
+      return ran
+    },
+    pending: (): number => queue.size
+  }
+}
+
+function createTimelineMeasure(timeline: (frame: number) => TerminalStartupGridDimensions | null) {
+  let frame = 0
+  return vi.fn((): TerminalStartupGridDimensions | null => {
+    const dimensions = timeline(frame)
+    frame += 1
+    return dimensions
+  })
+}
+
+describe('waitForStableStartupGrid', () => {
+  it('holds until the cap when the first measured grid stays stable', () => {
+    const scheduler = createFrameScheduler()
+    const onSettled = vi.fn()
+    const measure = createTimelineMeasure(() => ({ cols: 120, rows: 40 }))
+
+    waitForStableStartupGrid({
+      isAlive: () => true,
+      measure,
+      onSettled,
+      requestFrame: scheduler.requestFrame,
+      cancelFrame: scheduler.cancelFrame,
+      minFrames: 4,
+      stableFrames: 2,
+      maxFrames: 8
+    })
+
+    scheduler.run(7)
+    expect(onSettled).not.toHaveBeenCalled()
+
+    scheduler.run()
+    expect(onSettled).toHaveBeenCalledWith({ cols: 120, rows: 40 })
+    expect(measure).toHaveBeenCalledTimes(8)
+  })
+
+  it('settles on the later split grid instead of the early wide grid', () => {
+    const scheduler = createFrameScheduler()
+    const onSettled = vi.fn()
+    const measure = createTimelineMeasure((frame) =>
+      frame < 5 ? { cols: 180, rows: 50 } : { cols: 88, rows: 50 }
+    )
+
+    waitForStableStartupGrid({
+      isAlive: () => true,
+      measure,
+      onSettled,
+      requestFrame: scheduler.requestFrame,
+      cancelFrame: scheduler.cancelFrame,
+      minFrames: 4,
+      stableFrames: 2,
+      maxFrames: 12
+    })
+
+    scheduler.run()
+
+    expect(onSettled).toHaveBeenCalledWith({ cols: 88, rows: 50 })
+  })
+
+  it('uses the latest usable grid at the frame cap when dimensions keep changing', () => {
+    const scheduler = createFrameScheduler()
+    const onSettled = vi.fn()
+    const measure = createTimelineMeasure((frame) => ({ cols: 100 + frame, rows: 30 }))
+
+    waitForStableStartupGrid({
+      isAlive: () => true,
+      measure,
+      onSettled,
+      requestFrame: scheduler.requestFrame,
+      cancelFrame: scheduler.cancelFrame,
+      minFrames: 2,
+      stableFrames: 2,
+      maxFrames: 5
+    })
+
+    scheduler.run()
+
+    expect(onSettled).toHaveBeenCalledWith({ cols: 104, rows: 30 })
+  })
+
+  it('settles with null when the pane never becomes measurable', () => {
+    const scheduler = createFrameScheduler()
+    const onSettled = vi.fn()
+
+    waitForStableStartupGrid({
+      isAlive: () => true,
+      measure: vi.fn(() => null),
+      onSettled,
+      requestFrame: scheduler.requestFrame,
+      cancelFrame: scheduler.cancelFrame,
+      minFrames: 2,
+      stableFrames: 2,
+      maxFrames: 4
+    })
+
+    scheduler.run()
+
+    expect(onSettled).toHaveBeenCalledWith(null)
+  })
+
+  it('cancels the pending frame without calling the settle callback', () => {
+    const scheduler = createFrameScheduler()
+    const onSettled = vi.fn()
+    const handle = waitForStableStartupGrid({
+      isAlive: () => true,
+      measure: vi.fn(() => ({ cols: 120, rows: 40 })),
+      onSettled,
+      requestFrame: scheduler.requestFrame,
+      cancelFrame: scheduler.cancelFrame
+    })
+
+    handle.cancel()
+    scheduler.run()
+
+    expect(scheduler.pending()).toBe(0)
+    expect(onSettled).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.ts
@@ -5,6 +5,7 @@ export type TerminalStartupGridDimensions = {
 
 export type TerminalStartupGridSettleOptions = {
   isAlive: () => boolean
+  isReadyToSettle?: () => boolean
   measure: () => TerminalStartupGridDimensions | null
   onSettled: (dimensions: TerminalStartupGridDimensions | null) => void
   requestFrame: (callback: () => void) => number
@@ -48,6 +49,8 @@ export function waitForStableStartupGrid(
   let observedGridChange = false
   let pendingFrame: number | null = null
   let cancelled = false
+  let readyFrame = 0
+  const usesReadinessGate = options.isReadyToSettle !== undefined
 
   const settle = (dimensions: TerminalStartupGridDimensions | null): void => {
     if (cancelled) {
@@ -68,6 +71,16 @@ export function waitForStableStartupGrid(
 
     frame += 1
     const measured = options.measure()
+    const readyToSettle = options.isReadyToSettle?.() ?? true
+    if (!readyToSettle) {
+      previous = null
+      stableFrameCount = 0
+      observedGridChange = false
+      pendingFrame = options.requestFrame(tick)
+      return
+    }
+
+    readyFrame += 1
     if (usableDimensions(measured)) {
       latestUsable = measured
       if (dimensionsEqual(previous, measured)) {
@@ -81,10 +94,13 @@ export function waitForStableStartupGrid(
       stableFrameCount = 0
     }
 
-    const heldMinimumWindow = frame >= minFrames
+    const settleFrame = usesReadinessGate ? readyFrame : frame
+    const heldMinimumWindow = settleFrame >= minFrames
     const stableAfterChange =
-      observedGridChange && heldMinimumWindow && stableFrameCount >= stableFrames
-    if ((latestUsable && stableAfterChange) || frame >= maxFrames) {
+      (observedGridChange || usesReadinessGate) &&
+      heldMinimumWindow &&
+      stableFrameCount >= stableFrames
+    if ((latestUsable && stableAfterChange) || settleFrame >= maxFrames) {
       settle(latestUsable)
       return
     }

--- a/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.ts
@@ -1,0 +1,106 @@
+export type TerminalStartupGridDimensions = {
+  cols: number
+  rows: number
+}
+
+export type TerminalStartupGridSettleOptions = {
+  isAlive: () => boolean
+  measure: () => TerminalStartupGridDimensions | null
+  onSettled: (dimensions: TerminalStartupGridDimensions | null) => void
+  requestFrame: (callback: () => void) => number
+  cancelFrame: (handle: number) => void
+  minFrames?: number
+  stableFrames?: number
+  maxFrames?: number
+}
+
+export type TerminalStartupGridSettleHandle = {
+  cancel: () => void
+}
+
+const DEFAULT_MIN_FRAMES = 6
+const DEFAULT_STABLE_FRAMES = 2
+const DEFAULT_MAX_FRAMES = 12
+
+function usableDimensions(
+  dimensions: TerminalStartupGridDimensions | null
+): dimensions is TerminalStartupGridDimensions {
+  return Boolean(dimensions && dimensions.cols > 0 && dimensions.rows > 0)
+}
+
+function dimensionsEqual(
+  a: TerminalStartupGridDimensions | null,
+  b: TerminalStartupGridDimensions | null
+): boolean {
+  return a?.cols === b?.cols && a?.rows === b?.rows
+}
+
+export function waitForStableStartupGrid(
+  options: TerminalStartupGridSettleOptions
+): TerminalStartupGridSettleHandle {
+  const minFrames = Math.max(1, options.minFrames ?? DEFAULT_MIN_FRAMES)
+  const stableFrames = Math.max(1, options.stableFrames ?? DEFAULT_STABLE_FRAMES)
+  const maxFrames = Math.max(minFrames, options.maxFrames ?? DEFAULT_MAX_FRAMES)
+  let frame = 0
+  let stableFrameCount = 0
+  let previous: TerminalStartupGridDimensions | null = null
+  let latestUsable: TerminalStartupGridDimensions | null = null
+  let observedGridChange = false
+  let pendingFrame: number | null = null
+  let cancelled = false
+
+  const settle = (dimensions: TerminalStartupGridDimensions | null): void => {
+    if (cancelled) {
+      return
+    }
+    cancelled = true
+    pendingFrame = null
+    if (options.isAlive()) {
+      options.onSettled(dimensions)
+    }
+  }
+
+  const tick = (): void => {
+    pendingFrame = null
+    if (cancelled || !options.isAlive()) {
+      return
+    }
+
+    frame += 1
+    const measured = options.measure()
+    if (usableDimensions(measured)) {
+      latestUsable = measured
+      if (dimensionsEqual(previous, measured)) {
+        stableFrameCount += 1
+      } else {
+        observedGridChange = previous !== null
+        previous = measured
+        stableFrameCount = 1
+      }
+    } else {
+      stableFrameCount = 0
+    }
+
+    const heldMinimumWindow = frame >= minFrames
+    const stableAfterChange =
+      observedGridChange && heldMinimumWindow && stableFrameCount >= stableFrames
+    if ((latestUsable && stableAfterChange) || frame >= maxFrames) {
+      settle(latestUsable)
+      return
+    }
+
+    pendingFrame = options.requestFrame(tick)
+  }
+
+  pendingFrame = options.requestFrame(tick)
+
+  return {
+    cancel: () => {
+      cancelled = true
+      if (pendingFrame !== null) {
+        options.cancelFrame(pendingFrame)
+        pendingFrame = null
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -178,6 +178,8 @@ type UseTerminalPaneLifecycleDeps = {
     telemetry?: EventProps<'agent_started'>
     /** Show the restored-session banner when this startup command mounts. */
     showSessionRestoredBanner?: boolean
+    /** Initial startup may be paired with a setup split that changes its grid. */
+    waitForSetupSplitDirection?: SetupSplitDirection
   } | null
   /** When present, the initial pane boots clean and a split pane is created
    *  (vertical or horizontal per the user setting) to run the setup command —
@@ -707,11 +709,15 @@ export function useTerminalPaneLifecycle({
       initialLayoutRef.current = hydratedInitialScrollback.layout
     }
     let shouldPersistLayout = false
+    const startupWithSetupSplitWait =
+      startup && setupSplit
+        ? { ...startup, waitForSetupSplitDirection: setupSplit.direction }
+        : startup
     const ptyDeps = {
       tabId,
       worktreeId,
       cwd: startupCwd,
-      startup,
+      startup: startupWithSetupSplitWait,
       paneTransportsRef,
       paneMode2031Ref,
       paneLastThemeModeRef,

--- a/tests/e2e/terminal-codex-skill-preview-artifact-repro.spec.ts
+++ b/tests/e2e/terminal-codex-skill-preview-artifact-repro.spec.ts
@@ -1,0 +1,625 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { realpathSync } from 'node:fs'
+import path from 'node:path'
+import type { ElectronApplication, Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { removeWorktreeViaStore } from './helpers/dead-terminal'
+import {
+  ensureTerminalVisible,
+  getActiveWorktreeId,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  sendToTerminal,
+  waitForActiveTerminalManager,
+  waitForPaneCount,
+  waitForPaneIdentitySnapshot
+} from './helpers/terminal'
+import { compareTerminalScreenshots } from './terminal-screenshot-diff'
+
+const RUN_REPRO = process.env.ORCA_E2E_CODEX_SKILL_PREVIEW_REPRO === '1'
+const EXPECT_NO_ARTIFACTS = process.env.ORCA_E2E_EXPECT_NO_CODEX_SKILL_PREVIEW_ARTIFACTS === '1'
+const FULLSCREEN_MIN_SIZE = { width: 1200, height: 760 }
+const MIN_REPRO_DIFF_RATIO = 0.006
+const MAX_CLEAN_DIFF_RATIO = 0.0015
+const ORCA_REPO_PATH = realpathSync(process.cwd())
+const ARTIFACT_DIR = path.join(process.cwd(), '.tmp', 'codex-skill-preview-real-flow')
+
+const CODEX_READY_RE = /Ask Codex|OpenAI Codex/i
+const CODEX_TRUST_PROMPT_RE =
+  /Do you trust|trust this folder|Trust this|Working with untrusted contents/i
+const CODEX_UPDATE_PROMPT_RE = /update available|install update|Skip for now|Skip until next/i
+const CODEX_SKILL_PREVIEW_RE = /Press enter to insert|esc to close|electron|orca-cli|orca-emulator/i
+const SETUP_PANE_ACTIVITY_RE = /install-orca-skills|pnpm|Progress:|Packages:|Lockfile/i
+const CLEAN_SKILL_ROW_RE = /^  [A-Za-z][A-Za-z0-9 -]{1,32}\s+\[Skill\]\s/
+const CODEX_READY_SETTLE_MS = 3_500
+const SETUP_CHANGES_AFTER_PREVIEW = 3
+
+type PaneDescriptor = {
+  tabId: string
+  paneId: number
+  leafId: string
+  ptyId: string
+  rect: { x: number; y: number; width: number; height: number }
+  cols: number
+  rows: number
+  hasWebgl: boolean
+}
+
+type ArtifactCapture = {
+  diffRatio: number
+  changedPixels: number
+  totalPixels: number
+  leftPane: PaneDescriptor
+  beforeContent: string
+  afterContent: string
+}
+
+async function setStableFullscreenWindow(
+  electronApp: ElectronApplication,
+  page: Page
+): Promise<void> {
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0]
+    if (!window) {
+      throw new Error('No BrowserWindow available')
+    }
+    if (window.isMinimized()) {
+      window.restore()
+    }
+    window.show()
+    window.focus()
+    window.setFullScreen(true)
+  })
+  await expect
+    .poll(
+      async () => {
+        const [fullscreen, size] = await Promise.all([
+          electronApp.evaluate(({ BrowserWindow }) => {
+            const window = BrowserWindow.getAllWindows()[0]
+            return window?.isFullScreen() ?? false
+          }),
+          page.evaluate(() => ({
+            width: window.innerWidth,
+            height: window.innerHeight
+          }))
+        ])
+        return (
+          fullscreen &&
+          size.width >= FULLSCREEN_MIN_SIZE.width &&
+          size.height >= FULLSCREEN_MIN_SIZE.height
+        )
+      },
+      {
+        timeout: 15_000,
+        message: 'Electron window did not enter fullscreen for the repro'
+      }
+    )
+    .toBe(true)
+  await page.waitForTimeout(1_200)
+}
+
+async function addRealOrcaRepo(page: Page, repoPath: string): Promise<string> {
+  return page.evaluate(async (repoPath) => {
+    await window.api.repos.add({ path: repoPath }).catch((error: unknown) => {
+      if (!/already|exists|duplicate/i.test(String(error))) {
+        throw error
+      }
+    })
+
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store unavailable')
+    }
+    const state = store.getState()
+    await state.fetchRepos()
+    const repo = store.getState().repos.find((candidate) => candidate.path === repoPath)
+    if (!repo) {
+      throw new Error(`Real Orca repo did not load: ${repoPath}`)
+    }
+
+    await store.getState().updateRepo(repo.id, {
+      externalWorktreeVisibility: 'show',
+      hookSettings: {
+        ...repo.hookSettings,
+        setupRunPolicy: 'run-by-default',
+        setupAgentStartupPolicy: 'start-immediately'
+      }
+    })
+    await store.getState().fetchWorktrees(repo.id)
+
+    const nextState = store.getState()
+    const worktree = (nextState.worktreesByRepo[repo.id] ?? []).find(
+      (candidate) => candidate.path === repoPath
+    )
+    if (!worktree) {
+      throw new Error(`Real Orca worktree did not load: ${repoPath}`)
+    }
+
+    nextState.updateSettings({
+      defaultTuiAgent: 'codex',
+      disabledTuiAgents: [],
+      setupScriptLaunchMode: 'split-vertical',
+      terminalGpuAcceleration: 'on',
+      theme: 'dark'
+    })
+    nextState.setActiveRepo(repo.id)
+    nextState.setActiveView('terminal')
+    nextState.setActiveWorktree(worktree.id)
+    nextState.setRightSidebarOpen(false)
+    nextState.setSidebarOpen(true)
+    return repo.id
+  }, repoPath)
+}
+
+async function createWorkspaceThroughComposer(page: Page, workspaceName: string): Promise<string> {
+  const previousWorktreeId = await getActiveWorktreeId(page)
+  await page.getByRole('button', { name: 'New workspace', exact: true }).click()
+  const dialog = page.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+  await expect(dialog).toBeVisible({ timeout: 10_000 })
+  await expect(dialog.locator('[data-workspace-name-input="true"]')).toBeVisible({
+    timeout: 10_000
+  })
+
+  const agentCombobox = dialog.locator('[data-agent-combobox-root="true"][role="combobox"]').first()
+  await expect(agentCombobox).toContainText(/Codex/i, { timeout: 10_000 })
+
+  const nameInput = dialog.getByPlaceholder(/Type a name/i)
+  await nameInput.fill(workspaceName)
+
+  const createButton = dialog.getByRole('button', { name: /Create (Workspace|Worktree)/i })
+  await expect(createButton).toBeEnabled({ timeout: 10_000 })
+  await createButton.click()
+
+  await page
+    .getByRole('button', { name: 'Run hooks' })
+    .click({ timeout: 5_000 })
+    .catch(() => undefined)
+
+  await expect(dialog).toBeHidden({ timeout: 60_000 })
+  await expect
+    .poll(
+      async () =>
+        page.evaluate((workspaceName) => {
+          const state = window.__store?.getState()
+          const worktree = Object.values(state?.worktreesByRepo ?? {})
+            .flat()
+            .find(
+              (candidate) =>
+                candidate.displayName === workspaceName || candidate.path.endsWith(workspaceName)
+            )
+          return worktree?.id ?? null
+        }, workspaceName),
+      {
+        timeout: 60_000,
+        message: `Workspace ${workspaceName} did not appear in the real Orca repo`
+      }
+    )
+    .not.toBeNull()
+
+  const createdId = await page.evaluate((workspaceName) => {
+    const state = window.__store?.getState()
+    const worktree = Object.values(state?.worktreesByRepo ?? {})
+      .flat()
+      .find(
+        (candidate) =>
+          candidate.displayName === workspaceName || candidate.path.endsWith(workspaceName)
+      )
+    return worktree?.id ?? null
+  }, workspaceName)
+  if (!createdId) {
+    throw new Error(`Workspace ${workspaceName} disappeared after creation`)
+  }
+  await expect
+    .poll(() => getActiveWorktreeId(page), {
+      timeout: 30_000,
+      message: 'Created real Orca workspace did not become active'
+    })
+    .toBe(createdId)
+  expect(createdId).not.toBe(previousWorktreeId)
+  return createdId
+}
+
+async function forceTerminalWebgl(page: Page): Promise<boolean> {
+  await page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    if (!tabId) {
+      throw new Error('No active terminal tab')
+    }
+    window.__paneManagers?.get(tabId)?.setTerminalGpuAcceleration?.('on')
+  })
+
+  return page
+    .waitForFunction(
+      () => {
+        const state = window.__store?.getState()
+        const worktreeId = state?.activeWorktreeId
+        const tabId =
+          state?.activeTabType === 'terminal'
+            ? state.activeTabId
+            : worktreeId
+              ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+              : null
+        const diagnostics = window.__paneManagers?.get(tabId ?? '')?.getRenderingDiagnostics?.()
+        return (diagnostics ?? []).filter((diagnostic) => diagnostic.hasWebgl).length >= 2
+      },
+      undefined,
+      { timeout: 10_000 }
+    )
+    .then(() => true)
+    .catch(() => false)
+}
+
+async function describeActiveTerminalPanes(page: Page): Promise<PaneDescriptor[]> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const panes = manager?.getPanes?.() ?? []
+    if (!tabId || !manager || panes.length < 2) {
+      throw new Error('Expected a split terminal tab with at least two panes')
+    }
+    const diagnostics = manager.getRenderingDiagnostics?.() ?? []
+    return [...panes]
+      .sort((a, b) => {
+        const aRect = a.container.getBoundingClientRect()
+        const bRect = b.container.getBoundingClientRect()
+        return aRect.x - bRect.x || aRect.y - bRect.y
+      })
+      .map((pane) => {
+        if (!pane.container.dataset.ptyId) {
+          throw new Error(`Terminal pane ${pane.id} has no PTY binding`)
+        }
+        const rect = pane.container.getBoundingClientRect()
+        const rendering = diagnostics.find((diagnostic) => diagnostic.paneId === pane.id)
+        return {
+          tabId,
+          paneId: pane.id,
+          leafId: pane.leafId,
+          ptyId: pane.container.dataset.ptyId,
+          rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+          cols: pane.terminal.cols,
+          rows: pane.terminal.rows,
+          hasWebgl: rendering?.hasWebgl ?? false
+        }
+      })
+  })
+}
+
+async function focusTerminalPane(page: Page, pane: PaneDescriptor): Promise<void> {
+  await page.evaluate(({ tabId, ptyId }) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager
+      ?.getPanes?.()
+      .find((candidate) => candidate.container.dataset.ptyId === ptyId)
+    if (!pane) {
+      throw new Error('Terminal pane disappeared before focus')
+    }
+    manager?.setActivePane(pane.id, { focus: true })
+    pane.terminal.options.cursorBlink = false
+    pane.terminal.options.cursorStyle = 'block'
+    pane.terminal.focus()
+    pane.container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')?.focus()
+  }, pane)
+}
+
+async function focusLeftTerminalPane(page: Page): Promise<PaneDescriptor> {
+  const [leftPane] = await describeActiveTerminalPanes(page)
+  if (!leftPane) {
+    throw new Error('Left terminal pane is unavailable')
+  }
+  await focusTerminalPane(page, leftPane)
+  return leftPane
+}
+
+async function getRightTerminalPane(page: Page): Promise<PaneDescriptor> {
+  const panes = await describeActiveTerminalPanes(page)
+  const rightPane = panes.at(-1)
+  if (!rightPane) {
+    throw new Error('Right setup terminal pane is unavailable')
+  }
+  return rightPane
+}
+
+async function readPaneContent(
+  page: Page,
+  tabId: string,
+  ptyId: string,
+  charLimit = 8_000
+): Promise<string> {
+  return page.evaluate(
+    ({ tabId, ptyId, charLimit }) => {
+      const manager = window.__paneManagers?.get(tabId)
+      const pane = manager
+        ?.getPanes?.()
+        .find((candidate) => candidate.container.dataset.ptyId === ptyId)
+      const content = pane?.serializeAddon?.serialize?.() ?? ''
+      return content.slice(-charLimit)
+    },
+    { tabId, ptyId, charLimit }
+  )
+}
+
+async function readPaneVisibleContent(page: Page, tabId: string, ptyId: string): Promise<string> {
+  return page.evaluate(
+    ({ tabId, ptyId }) => {
+      const manager = window.__paneManagers?.get(tabId)
+      const pane = manager
+        ?.getPanes?.()
+        .find((candidate) => candidate.container.dataset.ptyId === ptyId)
+      if (!pane) {
+        return ''
+      }
+      const terminal = pane.terminal
+      const viewportY = terminal.buffer.active.viewportY
+      const lines: string[] = []
+      for (let row = 0; row < terminal.rows; row += 1) {
+        lines.push(terminal.buffer.active.getLine(viewportY + row)?.translateToString(true) ?? '')
+      }
+      return lines.join('\n')
+    },
+    { tabId, ptyId }
+  )
+}
+
+async function readPaneObservableContent(
+  page: Page,
+  tabId: string,
+  ptyId: string
+): Promise<string> {
+  const [serialized, visible] = await Promise.all([
+    readPaneContent(page, tabId, ptyId, 12_000),
+    readPaneVisibleContent(page, tabId, ptyId)
+  ])
+  return `${serialized}\n${visible}`
+}
+
+async function waitForPaneContent(
+  page: Page,
+  tabId: string,
+  ptyId: string,
+  pattern: RegExp,
+  timeoutMs: number
+): Promise<void> {
+  await expect
+    .poll(async () => pattern.test(await readPaneObservableContent(page, tabId, ptyId)), {
+      timeout: timeoutMs,
+      message: `Terminal pane did not match ${pattern}`
+    })
+    .toBe(true)
+}
+
+async function waitForPaneVisibleContentChanges(
+  page: Page,
+  pane: PaneDescriptor,
+  expectedChanges: number,
+  timeoutMs: number
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  let changes = 0
+  let previous = await readPaneVisibleContent(page, pane.tabId, pane.ptyId)
+  while (Date.now() < deadline && changes < expectedChanges) {
+    await page.waitForTimeout(450)
+    const next = await readPaneVisibleContent(page, pane.tabId, pane.ptyId)
+    if (next !== previous) {
+      changes += 1
+      previous = next
+    }
+  }
+  return changes
+}
+
+async function dismissCodexPromptsIfPresent(page: Page, pane: PaneDescriptor): Promise<void> {
+  const deadline = Date.now() + 25_000
+  while (Date.now() < deadline) {
+    const content = await readPaneObservableContent(page, pane.tabId, pane.ptyId)
+    if (CODEX_READY_RE.test(content) && !CODEX_TRUST_PROMPT_RE.test(content)) {
+      return
+    }
+    if (CODEX_TRUST_PROMPT_RE.test(content)) {
+      await sendToTerminal(page, pane.ptyId, '1\r')
+      await page.waitForTimeout(400)
+      continue
+    }
+    if (CODEX_UPDATE_PROMPT_RE.test(content)) {
+      await sendToTerminal(page, pane.ptyId, '3\r')
+      await page.waitForTimeout(400)
+      continue
+    }
+    await page.waitForTimeout(250)
+  }
+}
+
+async function clickPaneAfterEvidenceCapture(page: Page, pane: PaneDescriptor): Promise<void> {
+  await page.mouse.click(
+    pane.rect.x + Math.min(120, Math.max(24, pane.rect.width / 2)),
+    pane.rect.y + Math.min(80, Math.max(24, pane.rect.height / 4))
+  )
+}
+
+async function screenshotPane(page: Page, ptyId: string): Promise<Buffer> {
+  const screen = page.locator(`[data-pty-id="${ptyId}"] .xterm-screen`).first()
+  await expect(screen).toBeVisible({ timeout: 10_000 })
+  return Buffer.from(await screen.screenshot({ animations: 'disabled' }))
+}
+
+function persistEvidenceFile(name: string, body: Buffer | string): string {
+  mkdirSync(ARTIFACT_DIR, { recursive: true })
+  const filePath = path.join(ARTIFACT_DIR, name)
+  writeFileSync(filePath, body)
+  return filePath
+}
+
+function getOverpaintedSkillRows(content: string): string[] {
+  return content
+    .split('\n')
+    .filter((line) => line.includes('[Skill]'))
+    .filter((line) => !CLEAN_SKILL_ROW_RE.test(line))
+}
+
+async function captureClickEvidence(
+  page: Page,
+  pane: PaneDescriptor,
+  testInfo: TestInfo
+): Promise<ArtifactCapture> {
+  await page.waitForTimeout(250)
+  const beforeContent = await readPaneVisibleContent(page, pane.tabId, pane.ptyId)
+  const beforeFullPage = Buffer.from(await page.screenshot({ fullPage: true }))
+  const beforePane = await screenshotPane(page, pane.ptyId)
+  await clickPaneAfterEvidenceCapture(page, pane)
+  await page.waitForTimeout(250)
+  const afterContent = await readPaneVisibleContent(page, pane.tabId, pane.ptyId)
+  const afterPane = await screenshotPane(page, pane.ptyId)
+  const diff = compareTerminalScreenshots(beforePane, afterPane)
+
+  const beforePanePath = persistEvidenceFile('left-pane-before-click.png', beforePane)
+  const beforeWindowPath = persistEvidenceFile('full-window-before-click.png', beforeFullPage)
+  const afterPanePath = persistEvidenceFile('left-pane-after-click.png', afterPane)
+  const bufferPath = persistEvidenceFile('left-pane-buffer.txt', beforeContent)
+
+  await testInfo.attach('codex-skill-preview-left-pane-before-click', {
+    body: beforePane,
+    contentType: 'image/png'
+  })
+  await testInfo.attach('codex-skill-preview-full-window-before-click', {
+    body: beforeFullPage,
+    contentType: 'image/png'
+  })
+  await testInfo.attach('codex-skill-preview-left-pane-after-click', {
+    body: afterPane,
+    contentType: 'image/png'
+  })
+  await testInfo.attach('codex-skill-preview-left-pane-buffer.txt', {
+    body: beforeContent,
+    contentType: 'text/plain'
+  })
+  testInfo.annotations.push({
+    type: 'codex-skill-preview-evidence-files',
+    description: JSON.stringify({ beforePanePath, beforeWindowPath, afterPanePath, bufferPath })
+  })
+
+  return {
+    ...diff,
+    leftPane: pane,
+    beforeContent,
+    afterContent
+  }
+}
+
+test.describe('Codex skill preview terminal artifact repro @headful', () => {
+  test.use({ seedTestRepo: false })
+
+  const createdWorktreeIds: string[] = []
+
+  test.skip(!RUN_REPRO, 'Set ORCA_E2E_CODEX_SKILL_PREVIEW_REPRO=1 to run this repro.')
+
+  test.afterEach(async ({ orcaPage }) => {
+    for (const id of createdWorktreeIds) {
+      await removeWorktreeViaStore(orcaPage, id)
+    }
+    createdWorktreeIds.length = 0
+  })
+
+  test('captures the real Orca repo setup-split Codex skill preview overpaint before any click', async ({
+    electronApp,
+    orcaPage
+  }, testInfo) => {
+    test.setTimeout(240_000)
+    test.skip(process.platform === 'win32', 'Codex skill preview repro uses POSIX shell commands')
+
+    await setStableFullscreenWindow(electronApp, orcaPage)
+    await waitForSessionReady(orcaPage)
+    await addRealOrcaRepo(orcaPage, ORCA_REPO_PATH)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const workspaceName = `codex-skill-preview-${Date.now()}`
+    const worktreeId = await createWorkspaceThroughComposer(orcaPage, workspaceName)
+    createdWorktreeIds.push(worktreeId)
+
+    await ensureTerminalVisible(orcaPage, 30_000)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await waitForPaneCount(orcaPage, 2, 60_000)
+    await waitForPaneIdentitySnapshot(orcaPage, 2)
+    const webglActive = await forceTerminalWebgl(orcaPage)
+    test.skip(!webglActive, 'Codex skill preview artifact repro needs WebGL rendering')
+
+    const leftPane = await focusLeftTerminalPane(orcaPage)
+    const rightPane = await getRightTerminalPane(orcaPage)
+    expect(leftPane.hasWebgl).toBe(true)
+    expect(rightPane.hasWebgl).toBe(true)
+    await waitForPaneContent(
+      orcaPage,
+      rightPane.tabId,
+      rightPane.ptyId,
+      SETUP_PANE_ACTIVITY_RE,
+      60_000
+    )
+    await dismissCodexPromptsIfPresent(orcaPage, leftPane)
+    await waitForPaneContent(orcaPage, leftPane.tabId, leftPane.ptyId, CODEX_READY_RE, 60_000)
+    await waitForPaneContent(
+      orcaPage,
+      leftPane.tabId,
+      leftPane.ptyId,
+      /usage limit reset|YOLO mode|permissions/i,
+      15_000
+    )
+    await orcaPage.waitForTimeout(CODEX_READY_SETTLE_MS)
+    await waitForPaneVisibleContentChanges(orcaPage, rightPane, 1, 8_000)
+
+    await focusLeftTerminalPane(orcaPage)
+    await orcaPage.keyboard.type('test $e', { delay: 70 })
+    await waitForPaneContent(
+      orcaPage,
+      leftPane.tabId,
+      leftPane.ptyId,
+      CODEX_SKILL_PREVIEW_RE,
+      30_000
+    )
+    const setupChangesAfterPreview = await waitForPaneVisibleContentChanges(
+      orcaPage,
+      rightPane,
+      SETUP_CHANGES_AFTER_PREVIEW,
+      12_000
+    )
+
+    const evidence = await captureClickEvidence(orcaPage, leftPane, testInfo)
+    const overpaintedSkillRows = getOverpaintedSkillRows(evidence.beforeContent)
+    const detectedArtifact =
+      overpaintedSkillRows.length >= 2 || evidence.diffRatio >= MIN_REPRO_DIFF_RATIO
+    testInfo.annotations.push({
+      type: 'codex-skill-preview-click-diff',
+      description: JSON.stringify({
+        diffRatio: evidence.diffRatio,
+        changedPixels: evidence.changedPixels,
+        totalPixels: evidence.totalPixels,
+        leftPane: evidence.leftPane,
+        setupChangesAfterPreview,
+        overpaintedSkillRows,
+        repoPath: ORCA_REPO_PATH
+      })
+    })
+
+    if (EXPECT_NO_ARTIFACTS) {
+      expect(overpaintedSkillRows).toHaveLength(0)
+      expect(evidence.diffRatio).toBeLessThanOrEqual(MAX_CLEAN_DIFF_RATIO)
+    } else {
+      expect(detectedArtifact).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- wait for visible local startup-command terminal panes to report a stable grid before spawning the PTY/TUI
- add a frame-driven startup grid settle helper with focused unit coverage
- add a real workspace setup-split Codex skill preview repro harness

## Tests
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.ts src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.test.ts tests/e2e/terminal-codex-skill-preview-artifact-repro.spec.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/pty-size-reconcile.test.ts src/renderer/src/components/terminal-pane/split-right-white-screen.test.ts src/renderer/src/components/terminal-pane/terminal-startup-grid-settle.test.ts`
- `pnpm exec electron-vite build --mode e2e`
- `SKIP_BUILD=1 ORCA_E2E_CODEX_SKILL_PREVIEW_REPRO=1 ORCA_E2E_EXPECT_NO_CODEX_SKILL_PREVIEW_ARTIFACTS=1 pnpm run test:e2e:headful -- tests/e2e/terminal-codex-skill-preview-artifact-repro.spec.ts --grep "real Orca repo setup-split"`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6940">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->