### PR TITLE
Bump mobile app version to 0.0.18

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump mobile/app.json expo.version to 0.0.18 so the repo matches the mobile RC/TestFlight version.
- Leave iOS buildNumber and Android versionCode unchanged for CI to manage.

## Verification
- node -e "const a=require('./mobile/app.json'); console.log(JSON.stringify({version:a.expo.version, iosBuildNumber:a.expo.ios?.buildNumber, androidVersionCode:a.expo.android?.versionCode}, null, 2))"
- git diff --check
- pushed-state verified: local HEAD matches upstream branch

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6941">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->