### PR TITLE
ci: keep release workflow GitHub-hosted for SignPath

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1102,9 +1102,9 @@ jobs:
       - cut
       - create-release
     if: needs.cut.outputs.should_release == 'true'
-    # Why: SignPath validates all jobs that can influence its artifact. Keep
-    # the non-GitHub-hosted Blacksmith macOS build out of the Windows matrix.
-    runs-on: blacksmith-6vcpu-macos-15
+    # Why: SignPath validates the release workflow provenance before signing
+    # Windows. Keep every release-producing job on GitHub-hosted runners.
+    runs-on: macos-15
     permissions:
       actions: read
       contents: write

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -99,16 +99,21 @@ describe('Electron runtime package contract', () => {
     expect(windowsReleaseEntry.os).toBe('windows-2022')
   })
 
-  it('keeps the Blacksmith macOS release build out of the SignPath Windows matrix', () => {
+  it('keeps release-cut signing provenance on GitHub-hosted runners', () => {
     const releaseWorkflow = parse(
       readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
     )
     const buildMatrixRunners = releaseWorkflow.jobs.build.strategy.matrix.include.map(
       ({ os }) => os
     )
+    const releaseWorkflowText = readFileSync(
+      join(projectDir, '.github/workflows/release-cut.yml'),
+      'utf8'
+    )
 
+    expect(releaseWorkflowText).not.toContain('blacksmith-')
+    expect(releaseWorkflow.jobs['build-mac']['runs-on']).toBe('macos-15')
     expect(buildMatrixRunners).not.toContain('blacksmith-6vcpu-macos-15')
-    expect(releaseWorkflow.jobs['build-mac']['runs-on']).toBe('blacksmith-6vcpu-macos-15')
     expect(releaseWorkflow.jobs['publish-release'].needs).toContain('build')
     expect(releaseWorkflow.jobs['publish-release'].needs).toContain('build-mac')
   })


### PR DESCRIPTION
## Summary
- move the macOS release build job in `release-cut.yml` back to GitHub-hosted `macos-15`
- keep `build-mac` as a separate release dependency, but remove Blacksmith from the SignPath-participating workflow
- update the workflow contract test to reject Blacksmith runners anywhere in `release-cut.yml`

## Why
Run https://github.com/stablyai/orca/actions/runs/28475284997 proved that isolating Blacksmith into a separate `build-mac` job is not enough. SignPath still rejected the Windows artifact because a non-GitHub-hosted runner existed in the release workflow provenance:

> At least one job that had an impact on the artifact creation was executed on a non-github-hosted runner but only GitHub hosted runners are allowed

For the release workflow that submits Windows signing requests, keep every release-producing job on GitHub-hosted runners.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec oxfmt --check config/scripts/package-electron-runtime-contract.test.mjs`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->