### PR TITLE
Fix runtime GitHub PR actions from sidebar

### DIFF
--- a/src/renderer/src/components/right-sidebar/hosted-review-github-actions.ts
+++ b/src/renderer/src/components/right-sidebar/hosted-review-github-actions.ts
@@ -1,0 +1,101 @@
+import type { GitHubPRMergeMethod, PRInfo, Repo } from '../../../../shared/types'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../../../shared/execution-host'
+import { callRuntimeRpc, type RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
+
+type GitHubPRRepo = PRInfo['prRepo']
+
+// Why: runtime-host projects mirror server paths into the desktop store, but
+// desktop gh IPC only trusts local/SSH repo registrations.
+function getGitHubActionTarget(repo: Repo): RuntimeClientTarget {
+  const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+  return host?.kind === 'runtime'
+    ? { kind: 'environment', environmentId: host.environmentId }
+    : { kind: 'local' }
+}
+
+export async function mergeGitHubHostedReview(args: {
+  repo: Repo
+  prNumber: number
+  method: GitHubPRMergeMethod
+  prRepo?: GitHubPRRepo | null
+}): Promise<Awaited<ReturnType<typeof window.api.gh.mergePR>>> {
+  const target = getGitHubActionTarget(args.repo)
+  if (target.kind === 'environment') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.mergePR>>>(
+      target,
+      'github.mergePR',
+      {
+        repo: args.repo.id,
+        prNumber: args.prNumber,
+        method: args.method,
+        prRepo: args.prRepo ?? null
+      },
+      { timeoutMs: 30_000 }
+    )
+  }
+  return window.api.gh.mergePR({
+    repoPath: args.repo.path,
+    repoId: args.repo.id,
+    prNumber: args.prNumber,
+    method: args.method,
+    prRepo: args.prRepo ?? null
+  })
+}
+
+export async function setGitHubHostedReviewAutoMerge(args: {
+  repo: Repo
+  prNumber: number
+  enabled: boolean
+  method?: GitHubPRMergeMethod
+  prRepo?: GitHubPRRepo | null
+}): Promise<Awaited<ReturnType<typeof window.api.gh.setPRAutoMerge>>> {
+  const target = getGitHubActionTarget(args.repo)
+  if (target.kind === 'environment') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.setPRAutoMerge>>>(
+      target,
+      'github.setPRAutoMerge',
+      {
+        repo: args.repo.id,
+        prNumber: args.prNumber,
+        enabled: args.enabled,
+        method: args.method,
+        prRepo: args.prRepo ?? null
+      },
+      { timeoutMs: 30_000 }
+    )
+  }
+  return window.api.gh.setPRAutoMerge({
+    repoPath: args.repo.path,
+    repoId: args.repo.id,
+    prNumber: args.prNumber,
+    enabled: args.enabled,
+    method: args.method,
+    prRepo: args.prRepo ?? null
+  })
+}
+
+export async function updateGitHubHostedReviewState(args: {
+  repo: Repo
+  prNumber: number
+  nextState: 'open' | 'closed'
+}): Promise<Awaited<ReturnType<typeof window.api.gh.updatePRState>>> {
+  const target = getGitHubActionTarget(args.repo)
+  if (target.kind === 'environment') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
+      target,
+      'github.updatePRState',
+      {
+        repo: args.repo.id,
+        prNumber: args.prNumber,
+        updates: { state: args.nextState }
+      },
+      { timeoutMs: 30_000 }
+    )
+  }
+  return window.api.gh.updatePRState({
+    repoPath: args.repo.path,
+    repoId: args.repo.id,
+    prNumber: args.prNumber,
+    updates: { state: args.nextState }
+  })
+}

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PRInfo, Repo } from '../../../../shared/types'
+import { useHostedReviewActions, type HostedReviewActionInfo } from './use-hosted-review-actions'
+
+const confirmationMocks = vi.hoisted(() => ({
+  confirm: vi.fn()
+}))
+
+const runtimeRpcMocks = vi.hoisted(() => ({
+  callRuntimeRpc: vi.fn()
+}))
+
+vi.mock('@/components/confirmation-dialog', () => ({
+  useConfirmationDialog: () => confirmationMocks.confirm
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  callRuntimeRpc: runtimeRpcMocks.callRuntimeRpc
+}))
+
+const prRepo = { host: 'github.com', owner: 'stablyai', repo: 'orca-sta1015-sandbox' }
+const review: HostedReviewActionInfo = {
+  provider: 'github',
+  number: 1015,
+  state: 'open',
+  status: 'success',
+  mergeable: 'MERGEABLE'
+}
+const githubPR = { prRepo } as unknown as PRInfo
+
+let root: Root | null = null
+let latest: ReturnType<typeof useHostedReviewActions> | null = null
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'repo',
+    kind: 'git',
+    connectionId: null,
+    ...overrides
+  } as Repo
+}
+
+function HookProbe(props: { repo: Repo; onRefreshReview: () => Promise<void> }): null {
+  latest = useHostedReviewActions({
+    review,
+    githubPR,
+    repo: props.repo,
+    isGitLab: false,
+    shortLabel: 'PR',
+    reviewLabel: 'pull request',
+    defaultMergeMethod: 'squash',
+    autoMergeAction: null,
+    onRefreshReview: props.onRefreshReview
+  })
+  return null
+}
+
+async function renderHook(repo: Repo, onRefreshReview = vi.fn().mockResolvedValue(undefined)) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(createElement(HookProbe, { repo, onRefreshReview }))
+  })
+  return { onRefreshReview }
+}
+
+describe('useHostedReviewActions', () => {
+  beforeEach(() => {
+    confirmationMocks.confirm.mockReset().mockResolvedValue(true)
+    runtimeRpcMocks.callRuntimeRpc.mockReset().mockResolvedValue({ ok: true })
+    latest = null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window.api shim
+    ;(window as any).api = {
+      gh: {
+        mergePR: vi.fn().mockResolvedValue({ ok: true }),
+        setPRAutoMerge: vi.fn().mockResolvedValue({ ok: true }),
+        updatePRState: vi.fn().mockResolvedValue({ ok: true })
+      },
+      gl: {
+        mergeMR: vi.fn().mockResolvedValue({ ok: true }),
+        closeMR: vi.fn().mockResolvedValue({ ok: true }),
+        reopenMR: vi.fn().mockResolvedValue({ ok: true })
+      }
+    }
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+      root = null
+    }
+    document.body.replaceChildren()
+  })
+
+  it('routes runtime-owned GitHub PR merges through the runtime host', async () => {
+    const { onRefreshReview } = await renderHook(makeRepo({ executionHostId: 'runtime:env-1' }))
+
+    await act(async () => {
+      await latest?.handleMerge('squash')
+    })
+
+    expect(runtimeRpcMocks.callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'github.mergePR',
+      {
+        repo: 'repo-1',
+        prNumber: 1015,
+        method: 'squash',
+        prRepo
+      },
+      { timeoutMs: 30_000 }
+    )
+    expect(window.api.gh.mergePR).not.toHaveBeenCalled()
+    expect(onRefreshReview).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps non-runtime GitHub PR merges on desktop IPC', async () => {
+    const { onRefreshReview } = await renderHook(
+      makeRepo({ connectionId: 'ssh-target', executionHostId: 'ssh:ssh-target' })
+    )
+
+    await act(async () => {
+      await latest?.handleMerge('merge')
+    })
+
+    expect(window.api.gh.mergePR).toHaveBeenCalledWith({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      prNumber: 1015,
+      method: 'merge',
+      prRepo
+    })
+    expect(runtimeRpcMocks.callRuntimeRpc).not.toHaveBeenCalled()
+    expect(onRefreshReview).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -5,6 +5,11 @@ import type { GitHubPRAutoMergeAction } from '@/components/github-pr-merge-state
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { PRInfo, Repo } from '../../../../shared/types'
 import type { GitHubPRMergeMethod } from '../../../../shared/types'
+import {
+  mergeGitHubHostedReview,
+  setGitHubHostedReviewAutoMerge,
+  updateGitHubHostedReviewState
+} from './hosted-review-github-actions'
 import { translate } from '@/i18n/i18n'
 
 export type HostedReviewActionInfo = Pick<
@@ -68,9 +73,8 @@ export function useHostedReviewActions({
               iid: review.number,
               method
             })
-          : await window.api.gh.mergePR({
-              repoPath: repo.path,
-              repoId: repo.id,
+          : await mergeGitHubHostedReview({
+              repo,
               prNumber: review.number,
               method,
               prRepo: githubPR?.prRepo ?? null
@@ -86,15 +90,7 @@ export function useHostedReviewActions({
         setMerging(false)
       }
     },
-    [
-      githubPR?.prRepo,
-      isGitLab,
-      defaultMergeMethod,
-      onRefreshReview,
-      repo.id,
-      repo.path,
-      review.number
-    ]
+    [githubPR?.prRepo, isGitLab, defaultMergeMethod, onRefreshReview, repo, review.number]
   )
 
   const handleAutoMerge = useCallback(async () => {
@@ -105,9 +101,8 @@ export function useHostedReviewActions({
     setMerging(true)
     setActionError(null)
     try {
-      const result = await window.api.gh.setPRAutoMerge({
-        repoPath: repo.path,
-        repoId: repo.id,
+      const result = await setGitHubHostedReviewAutoMerge({
+        repo,
         prNumber: review.number,
         enabled,
         method: enabled ? defaultMergeMethod : undefined,
@@ -129,8 +124,7 @@ export function useHostedReviewActions({
     autoMergeAction,
     defaultMergeMethod,
     onRefreshReview,
-    repo.id,
-    repo.path,
+    repo,
     review.number
   ])
 
@@ -175,11 +169,10 @@ export function useHostedReviewActions({
                 repoId: repo.id,
                 iid: review.number
               })
-          : await window.api.gh.updatePRState({
-              repoPath: repo.path,
-              repoId: repo.id,
+          : await updateGitHubHostedReviewState({
+              repo,
               prNumber: review.number,
-              updates: { state: nextState }
+              nextState
             })
         if (!result.ok) {
           setActionError(result.error)
@@ -213,8 +206,7 @@ export function useHostedReviewActions({
       confirm,
       isGitLab,
       onRefreshReview,
-      repo.id,
-      repo.path,
+      repo,
       review.number,
       reviewLabel,
       shortLabel,


### PR DESCRIPTION
## Summary

Fixes STA-1015 by routing right-sidebar GitHub hosted-review actions through the owning runtime environment when the repo is runtime-hosted.

The sidebar previously sent GitHub merge actions to desktop `gh:*` IPC with the runtime server's repo path. Desktop IPC only trusts local/SSH repo registrations, so remote runtime repos failed with `Access denied: unknown repository path`.

## Testing

- [x] `pnpm exec oxlint src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts src/renderer/src/components/right-sidebar/hosted-review-github-actions.ts src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx src/main/runtime/rpc/methods/github.test.ts src/main/runtime/runtime-rpc.test.ts src/main/runtime/mobile-rpc-allowlist.test.ts`
- [x] `pnpm run typecheck:web`
- [x] `git diff --check`

Manual repro/validation:

- Launched an Orca dev app with CDP and drove the visible Electron UI.
- Built a local desktop-to-runtime setup using a local Orca runtime server and a controlled sandbox PR fixture.
- Reproduced the exact visible failure before the fix: `Error invoking remote method 'gh:mergePR': Error: Access denied: unknown repository path`.
- Validated after the fix that the visible merge action no longer hits desktop access-denied validation and instead reaches runtime-side GitHub handling.
- Did not merge any production PR; the live path used a sandbox/fake PR target.

## Notes

This keeps GitLab behavior unchanged and keeps local/SSH GitHub actions on the existing desktop IPC path.

Made with [Orca](https://github.com/stablyai/orca) 🐋
