### PR TITLE
Fix pending worktree spinner alignment

### DIFF
--- a/src/renderer/src/components/sidebar/PendingWorktreeRow.tsx
+++ b/src/renderer/src/components/sidebar/PendingWorktreeRow.tsx
@@ -57,7 +57,7 @@ export function PendingWorktreeRow({
           {isError ? (
             <AlertTriangle className="size-3.5 text-destructive" />
           ) : (
-            <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+            <Loader2 className="size-4 animate-spin text-muted-foreground" />
           )}
         </span>
         <span className="min-w-0 flex-1">


### PR DESCRIPTION
Summary:
- Align the pending worktree row spinner with the canonical Loader2 size so its visual center stays fixed while rotating.

Tests:
- pnpm exec oxlint src/renderer/src/components/sidebar/PendingWorktreeRow.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/hover-reveal-touch-action-visibility.test.ts

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6948">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->