### PR TITLE
feat(notifications): add a macOS notification inbox

### DIFF
--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -15,7 +15,8 @@ const {
   notificationCtorMock,
   notificationIsSupportedMock,
   getAllWindowsMock,
-  shellOpenExternalMock
+  shellOpenExternalMock,
+  setBadgeMock
 } = vi.hoisted(() => {
   const removeHandlerMock = vi.fn()
   const handleMock = vi.fn()
@@ -36,6 +37,7 @@ const {
   const notificationIsSupportedMock = vi.fn(() => true)
   const getAllWindowsMock = vi.fn(() => [])
   const shellOpenExternalMock = vi.fn()
+  const setBadgeMock = vi.fn()
   return {
     removeHandlerMock,
     handleMock,
@@ -47,7 +49,8 @@ const {
     notificationCtorMock,
     notificationIsSupportedMock,
     getAllWindowsMock,
-    shellOpenExternalMock
+    shellOpenExternalMock,
+    setBadgeMock
   }
 })
 
@@ -63,7 +66,10 @@ vi.mock('electron', () => ({
     getAllWindows: getAllWindowsMock
   },
   app: {
-    focus: vi.fn()
+    focus: vi.fn(),
+    dock: {
+      setBadge: setBadgeMock
+    }
   },
   shell: {
     openExternal: shellOpenExternalMock
@@ -101,6 +107,7 @@ describe('registerNotificationHandlers', () => {
     getAllWindowsMock.mockReset()
     getAllWindowsMock.mockReturnValue([])
     shellOpenExternalMock.mockClear()
+    setBadgeMock.mockClear()
   })
 
   afterEach(() => {
@@ -121,6 +128,32 @@ describe('registerNotificationHandlers', () => {
       throw new Error('notifications:dismiss handler not registered')
     }
     return call[1] as (event: unknown, args: unknown) => unknown
+  }
+
+  function getInboxHandler(): (event: unknown) => unknown {
+    const call = handleMock.mock.calls.find((c: unknown[]) => c[0] === 'notifications:getInbox')
+    if (!call) {
+      throw new Error('notifications:getInbox handler not registered')
+    }
+    return call[1] as (event: unknown) => unknown
+  }
+
+  function getMarkInboxReadHandler(): (event: unknown) => unknown {
+    const call = handleMock.mock.calls.find(
+      (c: unknown[]) => c[0] === 'notifications:markInboxRead'
+    )
+    if (!call) {
+      throw new Error('notifications:markInboxRead handler not registered')
+    }
+    return call[1] as (event: unknown) => unknown
+  }
+
+  function getClearInboxHandler(): (event: unknown) => unknown {
+    const call = handleMock.mock.calls.find((c: unknown[]) => c[0] === 'notifications:clearInbox')
+    if (!call) {
+      throw new Error('notifications:clearInbox handler not registered')
+    }
+    return call[1] as (event: unknown) => unknown
   }
 
   function getOpenSystemSettingsHandler(): (event: unknown) => unknown {
@@ -310,6 +343,210 @@ describe('registerNotificationHandlers', () => {
       })
     )
     expect(notificationShowMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('records allowed non-test notifications in a bounded inbox', () => {
+    notificationIsSupportedMock.mockReturnValue(false)
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          terminalBell: true,
+          suppressWhenFocused: false
+        }
+      })
+    } as never)
+
+    const dispatchHandler = getDispatchHandler()
+    const inboxHandler = getInboxHandler()
+
+    for (let i = 0; i < 24; i++) {
+      vi.advanceTimersByTime(5001)
+      expect(
+        dispatchHandler(
+          {},
+          {
+            source: 'terminal-bell',
+            worktreeId: `repo::wt-${i}`,
+            worktreeLabel: `wt-${i}`,
+            repoLabel: 'orca'
+          }
+        )
+      ).toEqual({ delivered: false, reason: 'not-supported' })
+    }
+
+    vi.advanceTimersByTime(5001)
+    expect(
+      dispatchHandler(
+        {},
+        {
+          source: 'agent-task-complete',
+          notificationId: 'agent:latest',
+          worktreeId: 'repo::wt-latest',
+          paneKey: 'tab-1:11111111-1111-4111-8111-111111111111',
+          repoLabel: 'orca',
+          worktreeLabel: 'feat/notis',
+          agentType: 'codex',
+          agentState: 'done',
+          agentLastAssistantMessage: 'Updated the notification inbox.'
+        }
+      )
+    ).toEqual({ delivered: false, reason: 'not-supported' })
+
+    expect(inboxHandler({})).toMatchObject({
+      supported: true,
+      unreadCount: 20,
+      entries: expect.arrayContaining([
+        expect.objectContaining({
+          id: 'agent:latest',
+          notificationId: 'agent:latest',
+          source: 'agent-task-complete',
+          title: 'feat/notis - Codex finished',
+          body: 'Updated the notification inbox.',
+          worktreeId: 'repo::wt-latest',
+          paneKey: 'tab-1:11111111-1111-4111-8111-111111111111',
+          repoLabel: 'orca',
+          worktreeLabel: 'feat/notis',
+          unread: true
+        })
+      ])
+    })
+    expect((inboxHandler({}) as { entries: unknown[] }).entries).toHaveLength(20)
+    expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
+  it('does not record disabled, source-disabled, focused, or cooldown-suppressed dispatches', () => {
+    let notifications = {
+      enabled: false,
+      agentTaskComplete: true,
+      terminalBell: true,
+      suppressWhenFocused: false
+    }
+    registerNotificationHandlers({
+      getSettings: () => ({ notifications })
+    } as never)
+
+    const dispatchHandler = getDispatchHandler()
+    const inboxHandler = getInboxHandler()
+    expect(dispatchHandler({}, { source: 'agent-task-complete' })).toEqual({
+      delivered: false,
+      reason: 'disabled'
+    })
+
+    notifications = {
+      enabled: true,
+      agentTaskComplete: false,
+      terminalBell: true,
+      suppressWhenFocused: false
+    }
+    expect(dispatchHandler({}, { source: 'agent-task-complete' })).toEqual({
+      delivered: false,
+      reason: 'source-disabled'
+    })
+
+    notifications = {
+      enabled: true,
+      agentTaskComplete: true,
+      terminalBell: true,
+      suppressWhenFocused: true
+    }
+    getAllWindowsMock.mockReturnValue([
+      {
+        isDestroyed: () => false,
+        isFocused: () => true
+      } as never
+    ])
+    expect(
+      dispatchHandler(
+        {},
+        { source: 'agent-task-complete', worktreeId: 'repo::focused', isActiveWorktree: true }
+      )
+    ).toEqual({ delivered: false, reason: 'suppressed-focus' })
+
+    getAllWindowsMock.mockReturnValue([])
+    expect(dispatchHandler({}, { source: 'terminal-bell', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: true
+    })
+    expect(dispatchHandler({}, { source: 'terminal-bell', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: false,
+      reason: 'cooldown'
+    })
+
+    expect(inboxHandler({})).toMatchObject({
+      unreadCount: 1,
+      entries: [expect.objectContaining({ worktreeId: 'repo::wt1' })]
+    })
+  })
+
+  it('marks inbox entries read and clears the macOS badge without closing native notifications', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    try {
+      registerNotificationHandlers({
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never)
+
+      const dispatchHandler = getDispatchHandler()
+      const markReadHandler = getMarkInboxReadHandler()
+      const clearHandler = getClearInboxHandler()
+      expect(
+        dispatchHandler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })
+      ).toEqual({ delivered: true })
+      expect(setBadgeMock).toHaveBeenLastCalledWith('1')
+
+      expect(markReadHandler({})).toMatchObject({
+        unreadCount: 0,
+        entries: [expect.objectContaining({ unread: false })]
+      })
+      expect(setBadgeMock).toHaveBeenLastCalledWith('')
+      expect(notificationCloseMock).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(5001)
+      expect(dispatchHandler({}, { source: 'terminal-bell', worktreeId: 'repo::wt2' })).toEqual({
+        delivered: true
+      })
+      expect(setBadgeMock).toHaveBeenLastCalledWith('1')
+      expect(clearHandler({})).toEqual({ supported: true, entries: [], unreadCount: 0 })
+      expect(setBadgeMock).toHaveBeenLastCalledWith('')
+      expect(notificationCloseMock).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
+  })
+
+  it('does not touch the dock badge on non-macOS inbox mutations', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      registerNotificationHandlers({
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never)
+
+      const dispatchHandler = getDispatchHandler()
+      expect(
+        dispatchHandler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })
+      ).toEqual({ delivered: true })
+      expect(getMarkInboxReadHandler()({})).toMatchObject({ unreadCount: 0 })
+      expect(getClearInboxHandler()({})).toEqual({ supported: true, entries: [], unreadCount: 0 })
+      expect(setBadgeMock).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
   })
 
   it('uses the macOS default notification sound when no custom sound is configured', () => {
@@ -929,6 +1166,10 @@ describe('registerNotificationHandlers', () => {
     const dismissHandler = getDismissHandler()
     expect(dismissHandler({}, ['agent:one', 'agent:one', ''])).toEqual({ dismissed: 1 })
 
+    expect(getInboxHandler()({})).toMatchObject({
+      unreadCount: 1,
+      entries: [expect.objectContaining({ notificationId: 'agent:one' })]
+    })
     expect(notificationCloseMock).toHaveBeenCalledTimes(1)
     expect(notificationRemoveListenerMock).toHaveBeenCalledWith('close', expect.any(Function))
     expect(dismissMobileNotification).toHaveBeenCalledTimes(1)

--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -479,7 +479,7 @@ describe('registerNotificationHandlers', () => {
     })
   })
 
-  it('marks inbox entries read and clears the macOS badge without closing native notifications', () => {
+  it('marks inbox entries read without touching the macOS badge or closing native notifications', () => {
     const originalPlatform = process.platform
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
     try {
@@ -500,22 +500,22 @@ describe('registerNotificationHandlers', () => {
       expect(
         dispatchHandler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })
       ).toEqual({ delivered: true })
-      expect(setBadgeMock).toHaveBeenLastCalledWith('1')
+      expect(setBadgeMock).not.toHaveBeenCalled()
 
       expect(markReadHandler({})).toMatchObject({
         unreadCount: 0,
         entries: [expect.objectContaining({ unread: false })]
       })
-      expect(setBadgeMock).toHaveBeenLastCalledWith('')
+      expect(setBadgeMock).not.toHaveBeenCalled()
       expect(notificationCloseMock).not.toHaveBeenCalled()
 
       vi.advanceTimersByTime(5001)
       expect(dispatchHandler({}, { source: 'terminal-bell', worktreeId: 'repo::wt2' })).toEqual({
         delivered: true
       })
-      expect(setBadgeMock).toHaveBeenLastCalledWith('1')
+      expect(setBadgeMock).not.toHaveBeenCalled()
       expect(clearHandler({})).toEqual({ supported: true, entries: [], unreadCount: 0 })
-      expect(setBadgeMock).toHaveBeenLastCalledWith('')
+      expect(setBadgeMock).not.toHaveBeenCalled()
       expect(notificationCloseMock).not.toHaveBeenCalled()
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -16,6 +16,8 @@ import type {
   NotificationDispatchRequest,
   NotificationDispatchResult,
   NotificationDismissResult,
+  NotificationInboxEntry,
+  NotificationInboxResult,
   NotificationPermissionStatusResult,
   NotificationSettings,
   NotificationSoundDataResult
@@ -24,9 +26,11 @@ import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { buildNotificationOptions } from './notification-options'
 import { parsePaneKey } from '../../shared/stable-pane-id'
+import { setUnreadDockBadgeCount } from '../dock/unread-badge'
 
 const NOTIFICATION_COOLDOWN_MS = 5000
 const MAX_RECENT_NOTIFICATION_KEYS = 50
+const MAX_NOTIFICATION_INBOX_ENTRIES = 20
 const NOTIFICATION_DISPLAY_CONFIRMATION_TIMEOUT_MS = 2500
 const NOTIFICATION_RELEASE_FALLBACK_MS = 5 * 60 * 1000
 const MAX_NOTIFICATION_SOUND_BYTES = 10 * 1024 * 1024
@@ -201,12 +205,54 @@ function pruneRecentNotifications(recentNotifications: Map<string, number>, now:
   }
 }
 
+function getUnreadNotificationInboxCount(
+  notificationInbox: Map<string, NotificationInboxEntry>
+): number {
+  let unreadCount = 0
+  for (const entry of notificationInbox.values()) {
+    if (entry.unread) {
+      unreadCount += 1
+    }
+  }
+  return unreadCount
+}
+
+function getNotificationInboxSnapshot(
+  notificationInbox: Map<string, NotificationInboxEntry>
+): NotificationInboxResult {
+  const entries = Array.from(notificationInbox.values()).toReversed()
+  return {
+    supported: true,
+    entries,
+    unreadCount: getUnreadNotificationInboxCount(notificationInbox)
+  }
+}
+
+function syncNotificationInboxBadge(notificationInbox: Map<string, NotificationInboxEntry>): void {
+  setUnreadDockBadgeCount(getUnreadNotificationInboxCount(notificationInbox))
+}
+
+function pruneNotificationInbox(notificationInbox: Map<string, NotificationInboxEntry>): void {
+  while (notificationInbox.size > MAX_NOTIFICATION_INBOX_ENTRIES) {
+    const oldest = notificationInbox.keys().next()
+    if (oldest.done) {
+      return
+    }
+    notificationInbox.delete(oldest.value)
+  }
+}
+
 export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntimeService): void {
   const recentNotifications = new Map<string, number>()
+  const notificationInbox = new Map<string, NotificationInboxEntry>()
+  let generatedNotificationInboxId = 0
 
   ipcMain.removeHandler('notifications:openSystemSettings')
   ipcMain.removeHandler('notifications:getPermissionStatus')
   ipcMain.removeHandler('notifications:requestPermission')
+  ipcMain.removeHandler('notifications:getInbox')
+  ipcMain.removeHandler('notifications:markInboxRead')
+  ipcMain.removeHandler('notifications:clearInbox')
   ipcMain.handle('notifications:openSystemSettings', (): void => {
     openNotificationSystemSettings()
   })
@@ -228,6 +274,24 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
   ipcMain.handle('notifications:requestPermission', (): NotificationPermissionStatusResult => {
     triggerStartupNotificationRegistration(store)
     return getPermissionStatus()
+  })
+
+  ipcMain.handle('notifications:getInbox', (): NotificationInboxResult => {
+    return getNotificationInboxSnapshot(notificationInbox)
+  })
+
+  ipcMain.handle('notifications:markInboxRead', (): NotificationInboxResult => {
+    for (const entry of notificationInbox.values()) {
+      entry.unread = false
+    }
+    syncNotificationInboxBadge(notificationInbox)
+    return getNotificationInboxSnapshot(notificationInbox)
+  })
+
+  ipcMain.handle('notifications:clearInbox', (): NotificationInboxResult => {
+    notificationInbox.clear()
+    syncNotificationInboxBadge(notificationInbox)
+    return getNotificationInboxSnapshot(notificationInbox)
   })
 
   ipcMain.removeHandler('notifications:dismiss')
@@ -298,6 +362,28 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
       }
 
       const notificationOptions = buildNotificationOptions(args)
+
+      if (args.source !== 'test') {
+        const inboxId =
+          args.notificationId ??
+          `${args.source}:${args.worktreeId ?? 'global'}:${++generatedNotificationInboxId}`
+        notificationInbox.delete(inboxId)
+        notificationInbox.set(inboxId, {
+          id: inboxId,
+          source: args.source,
+          title: notificationOptions.title,
+          body: notificationOptions.body ?? '',
+          createdAt: Date.now(),
+          unread: true,
+          ...(args.notificationId ? { notificationId: args.notificationId } : {}),
+          ...(args.worktreeId ? { worktreeId: args.worktreeId } : {}),
+          ...(args.paneKey ? { paneKey: args.paneKey } : {}),
+          ...(args.repoLabel ? { repoLabel: args.repoLabel } : {}),
+          ...(args.worktreeLabel ? { worktreeLabel: args.worktreeLabel } : {})
+        })
+        pruneNotificationInbox(notificationInbox)
+        syncNotificationInboxBadge(notificationInbox)
+      }
 
       // Why: paired mobile clients should follow the same user-facing
       // notification gates as desktop delivery, while still working on hosts

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -357,6 +357,8 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
       const notificationOptions = buildNotificationOptions(args)
 
       if (args.source !== 'test') {
+        // Why: keep an in-app record even when native delivery is unsupported or deduped later.
+        // delete+set also moves fresh and notificationId-replaced entries to the newest slot.
         const inboxId =
           args.notificationId ??
           `${args.source}:${args.worktreeId ?? 'global'}:${++generatedNotificationInboxId}`

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -26,7 +26,6 @@ import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { buildNotificationOptions } from './notification-options'
 import { parsePaneKey } from '../../shared/stable-pane-id'
-import { setUnreadDockBadgeCount } from '../dock/unread-badge'
 
 const NOTIFICATION_COOLDOWN_MS = 5000
 const MAX_RECENT_NOTIFICATION_KEYS = 50
@@ -228,10 +227,6 @@ function getNotificationInboxSnapshot(
   }
 }
 
-function syncNotificationInboxBadge(notificationInbox: Map<string, NotificationInboxEntry>): void {
-  setUnreadDockBadgeCount(getUnreadNotificationInboxCount(notificationInbox))
-}
-
 function pruneNotificationInbox(notificationInbox: Map<string, NotificationInboxEntry>): void {
   while (notificationInbox.size > MAX_NOTIFICATION_INBOX_ENTRIES) {
     const oldest = notificationInbox.keys().next()
@@ -284,13 +279,11 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
     for (const entry of notificationInbox.values()) {
       entry.unread = false
     }
-    syncNotificationInboxBadge(notificationInbox)
     return getNotificationInboxSnapshot(notificationInbox)
   })
 
   ipcMain.handle('notifications:clearInbox', (): NotificationInboxResult => {
     notificationInbox.clear()
-    syncNotificationInboxBadge(notificationInbox)
     return getNotificationInboxSnapshot(notificationInbox)
   })
 
@@ -382,7 +375,6 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
           ...(args.worktreeLabel ? { worktreeLabel: args.worktreeLabel } : {})
         })
         pruneNotificationInbox(notificationInbox)
-        syncNotificationInboxBadge(notificationInbox)
       }
 
       // Why: paired mobile clients should follow the same user-facing

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -127,6 +127,7 @@ import type {
   NotificationDispatchRequest,
   NotificationDispatchResult,
   NotificationDismissResult,
+  NotificationInboxResult,
   NotificationPermissionStatusResult,
   NotificationSoundResult,
   OnboardingState,
@@ -1970,6 +1971,9 @@ export type PreloadApi = {
   notifications: {
     dispatch: (args: NotificationDispatchRequest) => Promise<NotificationDispatchResult>
     dismiss: (ids: string[]) => Promise<NotificationDismissResult>
+    getInbox: () => Promise<NotificationInboxResult>
+    markInboxRead: () => Promise<NotificationInboxResult>
+    clearInbox: () => Promise<NotificationInboxResult>
     openSystemSettings: () => Promise<void>
     getPermissionStatus: () => Promise<NotificationPermissionStatusResult>
     requestPermission: () => Promise<NotificationPermissionStatusResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -36,6 +36,7 @@ import type {
   MemorySnapshot,
   NotificationDismissResult,
   NotificationDispatchResult,
+  NotificationInboxResult,
   NotificationPermissionStatusResult,
   NotificationSoundDataResult,
   NotificationSoundPathResult,
@@ -1843,6 +1844,11 @@ const api = {
       ipcRenderer.invoke('notifications:dispatch', args),
     dismiss: (ids: string[]): Promise<NotificationDismissResult> =>
       ipcRenderer.invoke('notifications:dismiss', ids),
+    getInbox: (): Promise<NotificationInboxResult> => ipcRenderer.invoke('notifications:getInbox'),
+    markInboxRead: (): Promise<NotificationInboxResult> =>
+      ipcRenderer.invoke('notifications:markInboxRead'),
+    clearInbox: (): Promise<NotificationInboxResult> =>
+      ipcRenderer.invoke('notifications:clearInbox'),
     openSystemSettings: (): Promise<void> => ipcRenderer.invoke('notifications:openSystemSettings'),
     getPermissionStatus: (): Promise<NotificationPermissionStatusResult> =>
       ipcRenderer.invoke('notifications:getPermissionStatus'),

--- a/src/renderer/src/components/settings/NotificationsPane.test.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.test.tsx
@@ -9,9 +9,12 @@ import userEvent from '@testing-library/user-event'
 import type {
   GlobalSettings,
   NotificationDispatchRequest,
-  NotificationInboxResult
+  NotificationInboxResult,
+  TerminalTab,
+  Worktree
 } from '../../../../shared/types'
 import { getNotificationSoundOptions } from '@/components/notification-sound-options'
+import { useAppStore } from '@/store'
 import {
   createNotificationVolumeDraftState,
   NotificationsPane,
@@ -115,10 +118,12 @@ describe('NotificationsPane', () => {
     toastError.mockClear()
     toastMessage.mockClear()
     toastSuccess.mockClear()
+    useAppStore.setState(useAppStore.getInitialState(), true)
   })
 
   afterEach(() => {
     cleanup()
+    useAppStore.setState(useAppStore.getInitialState(), true)
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: undefined
@@ -158,6 +163,95 @@ describe('NotificationsPane', () => {
     expect(screen.getByText('3 unread')).toBeInTheDocument()
     expect(screen.getByText('Unread')).toBeInTheDocument()
     expect(screen.getByText(/Agent task - orca \/ feat\/notis -/)).toBeInTheDocument()
+  })
+
+  it('renders unread app badge contributors separately from the notification inbox', async () => {
+    stubNotificationsApi()
+    useAppStore.setState({
+      worktreesByRepo: {
+        orca: [
+          {
+            id: 'orca::wt-1',
+            repoId: 'orca',
+            displayName: 'feat/notis',
+            isUnread: true
+          } as Worktree,
+          {
+            id: 'orca::wt-2',
+            repoId: 'orca',
+            displayName: 'feat/tests',
+            isUnread: false
+          } as Worktree
+        ]
+      },
+      tabsByWorktree: {
+        'orca::wt-1': [{ id: 'tab-1', title: 'Terminal 1' } as TerminalTab],
+        'orca::wt-2': [{ id: 'tab-2', title: 'Tests' } as TerminalTab]
+      },
+      unreadTerminalTabs: {
+        'tab-1': true,
+        'tab-2': true
+      }
+    })
+
+    render(<NotificationsPane settings={createSettings()} updateSettings={vi.fn()} />)
+
+    expect(await screen.findByText('App Badge')).toBeInTheDocument()
+    expect(
+      screen.getByText('2 worktrees or tabs currently contribute to the app badge.')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Recent notifications below are separate from the app badge.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('feat/notis')).toBeInTheDocument()
+    expect(screen.getByText('Unread workspace; Unread tab: Terminal 1')).toBeInTheDocument()
+    expect(screen.getByText('feat/tests')).toBeInTheDocument()
+    expect(screen.getByText('Unread tab: Tests')).toBeInTheDocument()
+  })
+
+  it('opens and clears app badge contributors through existing store actions', async () => {
+    const setActiveWorktree = vi.fn()
+    const revealWorktreeInSidebar = vi.fn()
+    const setActiveTab = vi.fn()
+    const clearWorktreeUnread = vi.fn()
+    const clearTerminalTabUnread = vi.fn()
+    stubNotificationsApi()
+    useAppStore.setState({
+      worktreesByRepo: {
+        orca: [
+          {
+            id: 'orca::wt-1',
+            repoId: 'orca',
+            displayName: 'feat/notis',
+            isUnread: true
+          } as Worktree
+        ]
+      },
+      tabsByWorktree: {
+        'orca::wt-1': [{ id: 'tab-1', title: 'Terminal 1' } as TerminalTab]
+      },
+      unreadTerminalTabs: {
+        'tab-1': true
+      },
+      setActiveWorktree,
+      revealWorktreeInSidebar,
+      setActiveTab,
+      clearWorktreeUnread,
+      clearTerminalTabUnread
+    })
+    const user = userEvent.setup()
+
+    render(<NotificationsPane settings={createSettings()} updateSettings={vi.fn()} />)
+
+    await screen.findByText('feat/notis')
+    await user.click(screen.getByRole('button', { name: 'Open feat/notis' }))
+    await user.click(screen.getByRole('button', { name: 'Mark feat/notis read' }))
+
+    expect(setActiveWorktree).toHaveBeenCalledWith('orca::wt-1')
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith('orca::wt-1')
+    expect(setActiveTab).toHaveBeenCalledWith('tab-1')
+    expect(clearWorktreeUnread).toHaveBeenCalledWith('orca::wt-1')
+    expect(clearTerminalTabUnread).toHaveBeenCalledWith('tab-1')
   })
 
   it('marks the owner-backed inbox read and updates visible unread state', async () => {

--- a/src/renderer/src/components/settings/NotificationsPane.test.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.test.tsx
@@ -1,6 +1,16 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
-import type { GlobalSettings, NotificationDispatchRequest } from '../../../../shared/types'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type {
+  GlobalSettings,
+  NotificationDispatchRequest,
+  NotificationInboxResult
+} from '../../../../shared/types'
 import { getNotificationSoundOptions } from '@/components/notification-sound-options'
 import {
   createNotificationVolumeDraftState,
@@ -37,6 +47,69 @@ function createSettings(): GlobalSettings {
   } as GlobalSettings
 }
 
+function createNotificationsApi(inbox: NotificationInboxResult) {
+  return {
+    getPermissionStatus: vi.fn(async () => ({
+      supported: true,
+      platform: 'darwin' as NodeJS.Platform,
+      requested: true
+    })),
+    dispatch: vi.fn(async (_args: NotificationDispatchRequest) => ({ delivered: true })),
+    playSound: vi.fn(),
+    openSystemSettings: vi.fn(),
+    requestPermission: vi.fn(),
+    getInbox: vi.fn(async () => inbox),
+    markInboxRead: vi.fn(async () => ({
+      ...inbox,
+      unreadCount: 0,
+      entries: inbox.entries.map((entry) => ({ ...entry, unread: false }))
+    })),
+    clearInbox: vi.fn(async () => ({ supported: inbox.supported, entries: [], unreadCount: 0 }))
+  }
+}
+
+function stubNotificationsApi(notifications = createNotificationsApi(createEmptyInbox())) {
+  vi.stubGlobal('Notification', { permission: 'granted' })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      notifications,
+      shell: { pickAudio: vi.fn() }
+    }
+  })
+  return notifications
+}
+
+function createEmptyInbox(): NotificationInboxResult {
+  return {
+    supported: true,
+    entries: [],
+    unreadCount: 0
+  }
+}
+
+function createInbox(): NotificationInboxResult {
+  return {
+    supported: true,
+    unreadCount: 3,
+    entries: [
+      {
+        id: 'agent:one',
+        notificationId: 'agent:one',
+        source: 'agent-task-complete',
+        title: 'feat/notis - Codex finished',
+        body: 'Updated the notification inbox.',
+        createdAt: Date.parse('2026-03-28T16:00:00Z'),
+        unread: true,
+        worktreeId: 'repo::wt1',
+        paneKey: 'tab-1:11111111-1111-4111-8111-111111111111',
+        repoLabel: 'orca',
+        worktreeLabel: 'feat/notis'
+      }
+    ]
+  }
+}
+
 describe('NotificationsPane', () => {
   beforeEach(() => {
     toastError.mockClear()
@@ -45,6 +118,11 @@ describe('NotificationsPane', () => {
   })
 
   afterEach(() => {
+    cleanup()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: undefined
+    })
     vi.unstubAllGlobals()
   })
 
@@ -57,6 +135,56 @@ describe('NotificationsPane', () => {
     expect(getNotificationSoundOptions(null).map((option) => option.title)).toEqual(
       expect.arrayContaining(['System Default', 'Two Tone', 'Bong', 'Ding'])
     )
+  })
+
+  it('loads and renders the empty notification inbox state', async () => {
+    const notifications = stubNotificationsApi()
+
+    render(<NotificationsPane settings={createSettings()} updateSettings={vi.fn()} />)
+
+    expect(await screen.findByText('Notification Inbox')).toBeInTheDocument()
+    expect(await screen.findByText('No recent notifications')).toBeInTheDocument()
+    expect(screen.getByText('No unread notifications')).toBeInTheDocument()
+    expect(notifications.getInbox).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders owner-provided inbox entries and unread count', async () => {
+    stubNotificationsApi(createNotificationsApi(createInbox()))
+
+    render(<NotificationsPane settings={createSettings()} updateSettings={vi.fn()} />)
+
+    expect(await screen.findByText('feat/notis - Codex finished')).toBeInTheDocument()
+    expect(screen.getByText('Updated the notification inbox.')).toBeInTheDocument()
+    expect(screen.getByText('3 unread')).toBeInTheDocument()
+    expect(screen.getByText('Unread')).toBeInTheDocument()
+    expect(screen.getByText(/Agent task - orca \/ feat\/notis -/)).toBeInTheDocument()
+  })
+
+  it('marks the owner-backed inbox read and updates visible unread state', async () => {
+    const notifications = stubNotificationsApi(createNotificationsApi(createInbox()))
+    const user = userEvent.setup()
+
+    render(<NotificationsPane settings={createSettings()} updateSettings={vi.fn()} />)
+
+    expect(await screen.findByText('3 unread')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /mark read/i }))
+
+    await waitFor(() => expect(notifications.markInboxRead).toHaveBeenCalledTimes(1))
+    expect(screen.getByText('No unread notifications')).toBeInTheDocument()
+    expect(screen.queryByText('Unread')).not.toBeInTheDocument()
+  })
+
+  it('clears the owner-backed inbox and renders the empty state', async () => {
+    const notifications = stubNotificationsApi(createNotificationsApi(createInbox()))
+    const user = userEvent.setup()
+
+    render(<NotificationsPane settings={createSettings()} updateSettings={vi.fn()} />)
+
+    expect(await screen.findByText('feat/notis - Codex finished')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /clear/i }))
+
+    await waitFor(() => expect(notifications.clearInbox).toHaveBeenCalledTimes(1))
+    expect(screen.getByText('No recent notifications')).toBeInTheDocument()
   })
 
   it('resets the volume draft only when the persisted volume changes', () => {

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -10,6 +10,7 @@ import { BellRing, Bot, Inbox, MailCheck, Siren, Trash2 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { NotificationSettingToggle } from './NotificationSettingToggle'
 import { NotificationSoundSection } from './NotificationSoundSection'
+import { UnreadBadgeSection } from './UnreadBadgeSection'
 import {
   createNotificationVolumeDraftState,
   resolveNotificationVolumeDraftState,
@@ -287,6 +288,10 @@ export function NotificationsPane({
           )}
         </Button>
       </div>
+
+      <Separator />
+
+      <UnreadBadgeSection />
 
       <Separator />
 

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -366,7 +366,7 @@ export function NotificationsPane({
                     <div className="flex min-w-0 flex-wrap items-center gap-2">
                       <h4 className="truncate text-sm font-medium">{entry.title}</h4>
                       {entry.unread ? (
-                        <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-secondary-foreground">
+                        <span className="rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
                           {translate(
                             'auto.components.settings.NotificationsPane.bf95906231',
                             'Unread'
@@ -377,7 +377,7 @@ export function NotificationsPane({
                     {entry.body ? (
                       <p className="line-clamp-2 text-xs text-muted-foreground">{entry.body}</p>
                     ) : null}
-                    <p className="text-[11px] text-muted-foreground">
+                    <p className="text-xs text-muted-foreground">
                       {getNotificationEntryContext(entry)} -{' '}
                       {formatNotificationInboxTime(entry.createdAt)}
                     </p>

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
-import type { GlobalSettings } from '../../../../shared/types'
+import type {
+  GlobalSettings,
+  NotificationInboxEntry,
+  NotificationInboxResult
+} from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Separator } from '../ui/separator'
-import { BellRing, Bot, Siren } from 'lucide-react'
+import { BellRing, Bot, Inbox, MailCheck, Siren, Trash2 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { NotificationSettingToggle } from './NotificationSettingToggle'
 import { NotificationSoundSection } from './NotificationSoundSection'
@@ -24,12 +28,113 @@ type NotificationsPaneProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
 }
 
+function getNotificationSourceLabel(source: NotificationInboxEntry['source']): string {
+  switch (source) {
+    case 'agent-task-complete':
+      return translate('auto.components.settings.NotificationsPane.1cbe92dd41', 'Agent task')
+    case 'terminal-bell':
+      return translate('auto.components.settings.NotificationsPane.830de12dfc', 'Terminal bell')
+  }
+}
+
+function getNotificationEntryContext(entry: NotificationInboxEntry): string {
+  const sourceLabel = getNotificationSourceLabel(entry.source)
+  if (entry.repoLabel && entry.worktreeLabel) {
+    return `${sourceLabel} - ${entry.repoLabel} / ${entry.worktreeLabel}`
+  }
+  if (entry.worktreeLabel) {
+    return `${sourceLabel} - ${entry.worktreeLabel}`
+  }
+  if (entry.repoLabel) {
+    return `${sourceLabel} - ${entry.repoLabel}`
+  }
+  return sourceLabel
+}
+
+function formatNotificationInboxTime(createdAt: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(new Date(createdAt))
+}
+
 export function NotificationsPane({
   settings,
   updateSettings
 }: NotificationsPaneProps): React.JSX.Element {
   const notificationSettings = settings.notifications
   const notificationSettingsRef = useRef(notificationSettings)
+  const [inbox, setInbox] = useState<NotificationInboxResult | null>(null)
+  const [inboxLoading, setInboxLoading] = useState(false)
+  const [inboxMutating, setInboxMutating] = useState(false)
+  const [inboxError, setInboxError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadInbox(): Promise<void> {
+      setInboxLoading(true)
+      setInboxError(null)
+      try {
+        const result = await window.api.notifications.getInbox()
+        if (!cancelled) {
+          setInbox(result)
+        }
+      } catch {
+        if (!cancelled) {
+          setInboxError(
+            translate(
+              'auto.components.settings.NotificationsPane.a331f7a7a8',
+              'Could not load recent notifications.'
+            )
+          )
+        }
+      } finally {
+        if (!cancelled) {
+          setInboxLoading(false)
+        }
+      }
+    }
+    void loadInbox()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleMarkInboxRead = async (): Promise<void> => {
+    setInboxMutating(true)
+    setInboxError(null)
+    try {
+      setInbox(await window.api.notifications.markInboxRead())
+    } catch {
+      setInboxError(
+        translate(
+          'auto.components.settings.NotificationsPane.679b197b62',
+          'Could not mark notifications as read.'
+        )
+      )
+    } finally {
+      setInboxMutating(false)
+    }
+  }
+
+  const handleClearInbox = async (): Promise<void> => {
+    setInboxMutating(true)
+    setInboxError(null)
+    try {
+      setInbox(await window.api.notifications.clearInbox())
+    } catch {
+      setInboxError(
+        translate(
+          'auto.components.settings.NotificationsPane.1a2a47495a',
+          'Could not clear recent notifications.'
+        )
+      )
+    } finally {
+      setInboxMutating(false)
+    }
+  }
 
   const updateNotificationSettings = async (
     updates: Partial<GlobalSettings['notifications']>
@@ -182,6 +287,109 @@ export function NotificationsPane({
           )}
         </Button>
       </div>
+
+      <Separator />
+
+      <section className="space-y-3 pt-3" aria-labelledby="notification-inbox-heading">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Inbox className="size-4 text-muted-foreground" />
+            <div className="min-w-0">
+              <h3 id="notification-inbox-heading" className="text-sm font-medium">
+                {translate(
+                  'auto.components.settings.NotificationsPane.30e6463632',
+                  'Notification Inbox'
+                )}
+              </h3>
+              <p className="text-xs text-muted-foreground">
+                {inbox && inbox.unreadCount > 0
+                  ? translate(
+                      'auto.components.settings.NotificationsPane.1f01232dad',
+                      '{{count}} unread',
+                      { count: inbox.unreadCount }
+                    )
+                  : translate(
+                      'auto.components.settings.NotificationsPane.4b47bbd2bb',
+                      'No unread notifications'
+                    )}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="xs"
+              className="gap-1.5"
+              disabled={!inbox || inbox.unreadCount === 0 || inboxMutating}
+              onClick={() => void handleMarkInboxRead()}
+            >
+              <MailCheck className="size-3.5" />
+              {translate('auto.components.settings.NotificationsPane.b9375a63b5', 'Mark Read')}
+            </Button>
+            <Button
+              variant="outline"
+              size="xs"
+              className="gap-1.5"
+              disabled={!inbox || inbox.entries.length === 0 || inboxMutating}
+              onClick={() => void handleClearInbox()}
+            >
+              <Trash2 className="size-3.5" />
+              {translate('auto.components.settings.NotificationsPane.96b751e90c', 'Clear')}
+            </Button>
+          </div>
+        </div>
+
+        {inboxError ? <p className="text-xs text-destructive">{inboxError}</p> : null}
+
+        <div className="space-y-2">
+          {inboxLoading && !inbox ? (
+            <div className="rounded-md border border-border px-3 py-3 text-xs text-muted-foreground">
+              {translate(
+                'auto.components.settings.NotificationsPane.b6401b8f5f',
+                'Loading recent notifications...'
+              )}
+            </div>
+          ) : inbox && inbox.entries.length > 0 ? (
+            inbox.entries.map((entry) => (
+              <article
+                key={entry.id}
+                className="rounded-md border border-border bg-card px-3 py-2 text-card-foreground"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <h4 className="truncate text-sm font-medium">{entry.title}</h4>
+                      {entry.unread ? (
+                        <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-secondary-foreground">
+                          {translate(
+                            'auto.components.settings.NotificationsPane.bf95906231',
+                            'Unread'
+                          )}
+                        </span>
+                      ) : null}
+                    </div>
+                    {entry.body ? (
+                      <p className="line-clamp-2 text-xs text-muted-foreground">{entry.body}</p>
+                    ) : null}
+                    <p className="text-[11px] text-muted-foreground">
+                      {getNotificationEntryContext(entry)} -{' '}
+                      {formatNotificationInboxTime(entry.createdAt)}
+                    </p>
+                  </div>
+                </div>
+              </article>
+            ))
+          ) : (
+            <div className="rounded-md border border-dashed border-border px-3 py-4 text-center text-xs text-muted-foreground">
+              {translate(
+                'auto.components.settings.NotificationsPane.170f7a1a6a',
+                'No recent notifications'
+              )}
+            </div>
+          )}
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/UnreadBadgeSection.tsx
+++ b/src/renderer/src/components/settings/UnreadBadgeSection.tsx
@@ -7,6 +7,12 @@ import { useAppStore } from '@/store'
 import { Button } from '../ui/button'
 
 function getUnreadBadgeContributorTitle(contributor: UnreadBadgeContributor): string {
+  if (!contributor.worktreeId) {
+    return translate(
+      'auto.components.settings.UnreadBadgeSection.145d7f0eb9',
+      'Detached terminal tab'
+    )
+  }
   return contributor.worktreeLabel
 }
 
@@ -110,7 +116,7 @@ export function UnreadBadgeSection(): React.JSX.Element {
                   <div className="min-w-0 space-y-1">
                     <h4 className="truncate text-sm font-medium">{title}</h4>
                     {contributor.repoLabel ? (
-                      <p className="text-[11px] text-muted-foreground">{contributor.repoLabel}</p>
+                      <p className="text-xs text-muted-foreground">{contributor.repoLabel}</p>
                     ) : null}
                     <p className="text-xs text-muted-foreground">
                       {getUnreadBadgeContributorSummary(contributor)}

--- a/src/renderer/src/components/settings/UnreadBadgeSection.tsx
+++ b/src/renderer/src/components/settings/UnreadBadgeSection.tsx
@@ -1,0 +1,171 @@
+import { BellRing } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
+import type { UnreadBadgeContributor } from '@/lib/unread-badge-count'
+import { getUnreadBadgeModel } from '@/lib/unread-badge-count'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import { Button } from '../ui/button'
+
+function getUnreadBadgeContributorTitle(contributor: UnreadBadgeContributor): string {
+  return contributor.worktreeLabel
+}
+
+function getUnreadBadgeContributorSummary(contributor: UnreadBadgeContributor): string {
+  const parts: string[] = []
+  if (contributor.unreadWorktree) {
+    parts.push(
+      translate('auto.components.settings.UnreadBadgeSection.53e91d09bb', 'Unread workspace')
+    )
+  }
+  if (contributor.unreadTabTitles.length === 1) {
+    parts.push(
+      translate('auto.components.settings.UnreadBadgeSection.5a73ceaf0b', 'Unread tab: {{title}}', {
+        title: contributor.unreadTabTitles[0]
+      })
+    )
+  } else if (contributor.unreadTabTitles.length > 1) {
+    parts.push(
+      translate(
+        'auto.components.settings.UnreadBadgeSection.26989de033',
+        'Unread tabs: {{titles}}',
+        { titles: contributor.unreadTabTitles.join(', ') }
+      )
+    )
+  }
+  return parts.join('; ')
+}
+
+export function UnreadBadgeSection(): React.JSX.Element {
+  const unreadBadgeInputs = useAppStore(
+    useShallow((state) => ({
+      worktreesByRepo: state.worktreesByRepo,
+      tabsByWorktree: state.tabsByWorktree,
+      unreadTerminalTabs: state.unreadTerminalTabs
+    }))
+  )
+  const unreadBadgeModel = getUnreadBadgeModel(unreadBadgeInputs)
+
+  const handleOpenUnreadBadgeContributor = (contributor: UnreadBadgeContributor): void => {
+    if (!contributor.worktreeId) {
+      return
+    }
+    const store = useAppStore.getState()
+    store.setActiveWorktree(contributor.worktreeId)
+    store.revealWorktreeInSidebar(contributor.worktreeId)
+    const firstUnreadTabId = contributor.unreadTabIds[0]
+    if (firstUnreadTabId) {
+      store.setActiveTab(firstUnreadTabId)
+    }
+  }
+
+  const handleClearUnreadBadgeContributor = (contributor: UnreadBadgeContributor): void => {
+    const store = useAppStore.getState()
+    if (contributor.worktreeId && contributor.unreadWorktree) {
+      store.clearWorktreeUnread(contributor.worktreeId)
+    }
+    for (const tabId of contributor.unreadTabIds) {
+      store.clearTerminalTabUnread(tabId)
+    }
+  }
+
+  return (
+    <section className="space-y-3 pt-3" aria-labelledby="app-badge-heading">
+      <div className="flex min-w-0 items-center gap-2">
+        <BellRing className="size-4 text-muted-foreground" />
+        <div className="min-w-0">
+          <h3 id="app-badge-heading" className="text-sm font-medium">
+            {translate('auto.components.settings.UnreadBadgeSection.6fe9e761d4', 'App Badge')}
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            {unreadBadgeModel.count > 0
+              ? translate(
+                  'auto.components.settings.UnreadBadgeSection.5c03b21b7f',
+                  '{{count}} worktrees or tabs currently contribute to the app badge.',
+                  { count: unreadBadgeModel.count }
+                )
+              : translate(
+                  'auto.components.settings.UnreadBadgeSection.90303c42ae',
+                  'No worktrees or tabs currently contribute to the app badge.'
+                )}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.UnreadBadgeSection.10f410d6ba',
+              'Recent notifications below are separate from the app badge.'
+            )}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {unreadBadgeModel.contributors.length > 0 ? (
+          unreadBadgeModel.contributors.map((contributor) => {
+            const title = getUnreadBadgeContributorTitle(contributor)
+            return (
+              <article
+                key={contributor.id}
+                className="rounded-md border border-border bg-card px-3 py-2 text-card-foreground"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <h4 className="truncate text-sm font-medium">{title}</h4>
+                    {contributor.repoLabel ? (
+                      <p className="text-[11px] text-muted-foreground">{contributor.repoLabel}</p>
+                    ) : null}
+                    <p className="text-xs text-muted-foreground">
+                      {getUnreadBadgeContributorSummary(contributor)}
+                    </p>
+                  </div>
+
+                  <div className="flex shrink-0 flex-wrap items-center gap-2">
+                    {contributor.worktreeId ? (
+                      <Button
+                        variant="outline"
+                        size="xs"
+                        className="gap-1.5"
+                        aria-label={translate(
+                          'auto.components.settings.UnreadBadgeSection.4c9ec08e01',
+                          'Open {{title}}',
+                          { title }
+                        )}
+                        onClick={() => handleOpenUnreadBadgeContributor(contributor)}
+                      >
+                        {translate(
+                          'auto.components.settings.UnreadBadgeSection.76e749949a',
+                          'Open'
+                        )}
+                      </Button>
+                    ) : null}
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      className="gap-1.5"
+                      aria-label={translate(
+                        'auto.components.settings.UnreadBadgeSection.763de330f5',
+                        'Mark {{title}} read',
+                        { title }
+                      )}
+                      onClick={() => handleClearUnreadBadgeContributor(contributor)}
+                    >
+                      {translate(
+                        'auto.components.settings.UnreadBadgeSection.d34c17d177',
+                        'Mark Read'
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </article>
+            )
+          })
+        ) : (
+          <div className="rounded-md border border-dashed border-border px-3 py-4 text-center text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.UnreadBadgeSection.3c36cecbda',
+              'No unread worktrees or terminal tabs'
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/lib/unread-badge-count.test.ts
+++ b/src/renderer/src/lib/unread-badge-count.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { TerminalTab, Worktree } from '../../../shared/types'
-import { getUnreadBadgeCount } from './unread-badge-count'
+import { getUnreadBadgeCount, getUnreadBadgeModel } from './unread-badge-count'
 
 function worktree(id: string, isUnread: boolean): Worktree {
   return { id, isUnread } as Worktree
@@ -39,5 +39,77 @@ describe('getUnreadBadgeCount', () => {
         unreadTerminalTabs: { 'tab-1': true, 'tab-2': true }
       })
     ).toBe(2)
+  })
+
+  it('groups unread badge contributors by worktree', () => {
+    expect(
+      getUnreadBadgeModel({
+        worktreesByRepo: {
+          repo: [
+            { ...worktree('wt-1', true), displayName: 'Feature A', repoId: 'repo' },
+            { ...worktree('wt-2', false), displayName: 'Feature B', repoId: 'repo' }
+          ]
+        },
+        tabsByWorktree: {
+          'wt-1': [{ ...tab('tab-1'), title: 'Terminal 1' }],
+          'wt-2': [{ ...tab('tab-2'), title: 'Tests' }]
+        },
+        unreadTerminalTabs: { 'tab-1': true, 'tab-2': true }
+      })
+    ).toEqual({
+      count: 2,
+      contributors: [
+        {
+          id: 'wt-1',
+          repoLabel: 'repo',
+          worktreeId: 'wt-1',
+          worktreeLabel: 'Feature A',
+          unreadWorktree: true,
+          unreadTabIds: ['tab-1'],
+          unreadTabTitles: ['Terminal 1']
+        },
+        {
+          id: 'wt-2',
+          repoLabel: 'repo',
+          worktreeId: 'wt-2',
+          worktreeLabel: 'Feature B',
+          unreadWorktree: false,
+          unreadTabIds: ['tab-2'],
+          unreadTabTitles: ['Tests']
+        }
+      ]
+    })
+  })
+
+  it('keeps detached unread tabs as separate contributors', () => {
+    expect(
+      getUnreadBadgeModel({
+        worktreesByRepo: { repo: [worktree('wt-1', false)] },
+        tabsByWorktree: {},
+        unreadTerminalTabs: { 'tab-1': true, 'tab-2': true }
+      })
+    ).toEqual({
+      count: 2,
+      contributors: [
+        {
+          id: 'detached:tab-1',
+          repoLabel: null,
+          worktreeId: null,
+          worktreeLabel: 'Detached terminal tab',
+          unreadWorktree: false,
+          unreadTabIds: ['tab-1'],
+          unreadTabTitles: ['tab-1']
+        },
+        {
+          id: 'detached:tab-2',
+          repoLabel: null,
+          worktreeId: null,
+          worktreeLabel: 'Detached terminal tab',
+          unreadWorktree: false,
+          unreadTabIds: ['tab-2'],
+          unreadTabTitles: ['tab-2']
+        }
+      ]
+    })
   })
 })

--- a/src/renderer/src/lib/unread-badge-count.test.ts
+++ b/src/renderer/src/lib/unread-badge-count.test.ts
@@ -95,7 +95,7 @@ describe('getUnreadBadgeCount', () => {
           id: 'detached:tab-1',
           repoLabel: null,
           worktreeId: null,
-          worktreeLabel: 'Detached terminal tab',
+          worktreeLabel: '',
           unreadWorktree: false,
           unreadTabIds: ['tab-1'],
           unreadTabTitles: ['tab-1']
@@ -104,7 +104,7 @@ describe('getUnreadBadgeCount', () => {
           id: 'detached:tab-2',
           repoLabel: null,
           worktreeId: null,
-          worktreeLabel: 'Detached terminal tab',
+          worktreeLabel: '',
           unreadWorktree: false,
           unreadTabIds: ['tab-2'],
           unreadTabTitles: ['tab-2']

--- a/src/renderer/src/lib/unread-badge-count.ts
+++ b/src/renderer/src/lib/unread-badge-count.ts
@@ -22,7 +22,7 @@ export type UnreadBadgeModel = {
 }
 
 function getUnreadTabTitle(tab: TerminalTab): string {
-  return tab.customTitle ?? tab.title ?? tab.generatedTitle ?? tab.defaultTitle ?? tab.id
+  return tab.customTitle || tab.title || tab.generatedTitle || tab.defaultTitle || tab.id
 }
 
 export function getUnreadBadgeModel({
@@ -88,7 +88,7 @@ export function getUnreadBadgeModel({
       id: `detached:${tabId}`,
       repoLabel: null,
       worktreeId: null,
-      worktreeLabel: 'Detached terminal tab',
+      worktreeLabel: '',
       unreadWorktree: false,
       unreadTabIds: [tabId],
       unreadTabTitles: [tabId]

--- a/src/renderer/src/lib/unread-badge-count.ts
+++ b/src/renderer/src/lib/unread-badge-count.ts
@@ -1,39 +1,106 @@
 import type { TerminalTab, Worktree } from '../../../shared/types'
 
-export function getUnreadBadgeCount({
-  worktreesByRepo,
-  tabsByWorktree,
-  unreadTerminalTabs
-}: {
+type UnreadBadgeArgs = {
   worktreesByRepo: Record<string, Worktree[]>
   tabsByWorktree: Record<string, TerminalTab[]>
   unreadTerminalTabs: Record<string, true>
-}): number {
-  const unreadWorktreeIds = new Set<string>()
+}
+
+export type UnreadBadgeContributor = {
+  id: string
+  repoLabel: string | null
+  worktreeId: string | null
+  worktreeLabel: string
+  unreadWorktree: boolean
+  unreadTabIds: string[]
+  unreadTabTitles: string[]
+}
+
+export type UnreadBadgeModel = {
+  count: number
+  contributors: UnreadBadgeContributor[]
+}
+
+function getUnreadTabTitle(tab: TerminalTab): string {
+  return tab.customTitle ?? tab.title ?? tab.generatedTitle ?? tab.defaultTitle ?? tab.id
+}
+
+export function getUnreadBadgeModel({
+  worktreesByRepo,
+  tabsByWorktree,
+  unreadTerminalTabs
+}: UnreadBadgeArgs): UnreadBadgeModel {
+  const contributorsByWorktreeId = new Map<string, UnreadBadgeContributor>()
+  const worktreesById = new Map<string, Worktree>()
 
   for (const worktrees of Object.values(worktreesByRepo)) {
     for (const worktree of worktrees) {
+      worktreesById.set(worktree.id, worktree)
       if (worktree.isUnread) {
-        unreadWorktreeIds.add(worktree.id)
+        contributorsByWorktreeId.set(worktree.id, {
+          id: worktree.id,
+          repoLabel: worktree.repoId ?? null,
+          worktreeId: worktree.id,
+          worktreeLabel: worktree.displayName,
+          unreadWorktree: true,
+          unreadTabIds: [],
+          unreadTabTitles: []
+        })
       }
     }
   }
 
-  const unreadTabIds = new Set(Object.keys(unreadTerminalTabs))
-  if (unreadTabIds.size === 0) {
-    return unreadWorktreeIds.size
+  function ensureWorktreeContributor(worktreeId: string): UnreadBadgeContributor {
+    const existing = contributorsByWorktreeId.get(worktreeId)
+    if (existing) {
+      return existing
+    }
+
+    const worktree = worktreesById.get(worktreeId)
+    const contributor: UnreadBadgeContributor = {
+      id: worktreeId,
+      repoLabel: worktree?.repoId ?? null,
+      worktreeId,
+      worktreeLabel: worktree?.displayName ?? worktreeId,
+      unreadWorktree: false,
+      unreadTabIds: [],
+      unreadTabTitles: []
+    }
+    contributorsByWorktreeId.set(worktreeId, contributor)
+    return contributor
   }
 
+  const unreadTabIds = new Set(Object.keys(unreadTerminalTabs))
   for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
     for (const tab of tabs) {
       if (!unreadTabIds.delete(tab.id)) {
         continue
       }
-      unreadWorktreeIds.add(worktreeId)
+      const contributor = ensureWorktreeContributor(worktreeId)
+      contributor.unreadTabIds.push(tab.id)
+      contributor.unreadTabTitles.push(getUnreadTabTitle(tab))
     }
   }
 
-  // Why: tab unread state should normally map to a live worktree, but counting
-  // unmatched entries keeps the Dock badge honest during hydration races.
-  return unreadWorktreeIds.size + unreadTabIds.size
+  const contributors = Array.from(contributorsByWorktreeId.values())
+  for (const tabId of unreadTabIds) {
+    contributors.push({
+      id: `detached:${tabId}`,
+      repoLabel: null,
+      worktreeId: null,
+      worktreeLabel: 'Detached terminal tab',
+      unreadWorktree: false,
+      unreadTabIds: [tabId],
+      unreadTabTitles: [tabId]
+    })
+  }
+
+  return {
+    count: contributors.length,
+    contributors
+  }
+}
+
+export function getUnreadBadgeCount(args: UnreadBadgeArgs): number {
+  return getUnreadBadgeModel(args).count
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2432,17 +2432,17 @@ function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
 }
 
 function createNotificationsApi(): NonNullable<Partial<PreloadApi>['notifications']> {
-  const emptyInbox = {
+  const createEmptyInbox = () => ({
     supported: false,
     entries: [],
     unreadCount: 0
-  }
+  })
   return {
     dispatch: () => Promise.resolve({ delivered: false, reason: 'not-supported' }),
     dismiss: () => Promise.resolve({ dismissed: 0 }),
-    getInbox: () => Promise.resolve(emptyInbox),
-    markInboxRead: () => Promise.resolve(emptyInbox),
-    clearInbox: () => Promise.resolve(emptyInbox),
+    getInbox: () => Promise.resolve(createEmptyInbox()),
+    markInboxRead: () => Promise.resolve(createEmptyInbox()),
+    clearInbox: () => Promise.resolve(createEmptyInbox()),
     openSystemSettings: () => Promise.resolve(),
     getPermissionStatus: () =>
       Promise.resolve({ supported: false, platform: getBrowserPlatform(), requested: false }),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2432,9 +2432,17 @@ function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
 }
 
 function createNotificationsApi(): NonNullable<Partial<PreloadApi>['notifications']> {
+  const emptyInbox = {
+    supported: false,
+    entries: [],
+    unreadCount: 0
+  }
   return {
     dispatch: () => Promise.resolve({ delivered: false, reason: 'not-supported' }),
     dismiss: () => Promise.resolve({ dismissed: 0 }),
+    getInbox: () => Promise.resolve(emptyInbox),
+    markInboxRead: () => Promise.resolve(emptyInbox),
+    clearInbox: () => Promise.resolve(emptyInbox),
     openSystemSettings: () => Promise.resolve(),
     getPermissionStatus: () =>
       Promise.resolve({ supported: false, platform: getBrowserPlatform(), requested: false }),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2993,6 +2993,26 @@ export type NotificationDismissResult = {
   dismissed: number
 }
 
+export type NotificationInboxEntry = {
+  id: string
+  source: Exclude<NotificationEventSource, 'test'>
+  title: string
+  body: string
+  createdAt: number
+  unread: boolean
+  notificationId?: string
+  worktreeId?: string
+  paneKey?: string
+  repoLabel?: string
+  worktreeLabel?: string
+}
+
+export type NotificationInboxResult = {
+  supported: boolean
+  entries: NotificationInboxEntry[]
+  unreadCount: number
+}
+
 export type NotificationSoundResult = {
   played: boolean
   reason?:


### PR DESCRIPTION
## Summary

- Adds an App Badge section to Notifications settings that lists the actual unread worktrees and terminal tabs contributing to the badge, with direct Open and Mark Read actions.
- Adds a recent notification inbox to the same settings pane, backed by main-process IPC for empty, unread, and clear/read states.
- Records non-test notifications after settings gates and before native delivery, and keeps the inbox separate from the app badge so recent notifications do not become a second badge owner.

Closes #5256.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec oxlint src/main/ipc/notifications.ts src/main/ipc/notifications.test.ts src/renderer/src/components/settings/NotificationsPane.tsx src/renderer/src/components/settings/NotificationsPane.test.tsx src/renderer/src/components/settings/UnreadBadgeSection.tsx src/renderer/src/lib/unread-badge-count.ts src/renderer/src/lib/unread-badge-count.test.ts` - passed.
- `pnpm exec oxfmt --check src/main/ipc/notifications.ts src/main/ipc/notifications.test.ts src/renderer/src/components/settings/NotificationsPane.tsx src/renderer/src/components/settings/NotificationsPane.test.tsx src/renderer/src/components/settings/UnreadBadgeSection.tsx src/renderer/src/lib/unread-badge-count.ts src/renderer/src/lib/unread-badge-count.test.ts` - passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/notifications.test.ts src/renderer/src/components/settings/NotificationsPane.test.tsx src/renderer/src/lib/unread-badge-count.test.ts` - passed, 65 tests.
- `pnpm run typecheck:node` - passed.
- `pnpm run typecheck:web` - passed.

## AI Review Report

- macOS: the app badge stays owned by existing unread worktree and terminal-tab state, and the settings pane now exposes and clears those exact contributors instead of letting the inbox write the badge directly.
- Linux/Windows: the inbox API remains usable, and the new contributor section only reads existing renderer unread state; no platform-specific badge calls were added.
- SSH/remote/local: notification dispatch metadata is already serialized through main IPC; this change keeps entries in memory and does not add subprocesses, filesystem access, or host-specific assumptions.
- Provider neutrality: renderer reads inbox state from `window.api.notifications` and badge contributors from existing app-store unread state, without GitHub-only or provider-specific review concepts.
- UI quality: the settings pane keeps the existing shadcn button treatment and compact row layout while separating badge contributors from recent notifications.

## Security Audit

- Inbox entries are bounded in memory to 20 records and are not persisted.
- The IPC surface adds read, mark-read, and clear operations only; it does not accept arbitrary entry mutation payloads.
- Notification bodies are the same user-facing strings already delivered to native and mobile notification paths.
- App badge resolution reuses existing store actions for unread worktrees and terminal tabs, so it does not introduce a second persistence or badge-mutation channel.
- Existing native dismiss behavior remains scoped to active native notification ids and mobile dismissal forwarding; dismissing does not erase inbox history.

## Notes

- Out of scope: notification permission onboarding, mobile push behavior, sound settings, and per-entry deletion.
- No screenshot artifact is attached.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6953">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Settings gets a notification inbox and a clearer badge list. You can see which worktrees or terminals made the app badge light up, open them, mark them read, and browse recent notifications in one place.
