### PR TITLE
Keep Claude hooks scoped to selected config dirs

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -278,6 +278,23 @@ describe('writeManagedScript', () => {
       expect(statSync(scriptPath).mode & 0o111).not.toBe(0)
     }
   )
+
+  it.skipIf(process.platform === 'win32')(
+    'does not rewrite or chmod an unchanged executable script',
+    () => {
+      const scriptPath = join(tmpDir, 'agent-hooks', 'claude-hook.sh')
+
+      writeManagedScript(scriptPath, '#!/bin/sh\nexit 0\n')
+      const before = statSync(scriptPath)
+
+      writeManagedScript(scriptPath, '#!/bin/sh\nexit 0\n')
+      const after = statSync(scriptPath)
+
+      expect(after.mtimeMs).toBe(before.mtimeMs)
+      expect(after.ctimeMs).toBe(before.ctimeMs)
+      expect(after.mode & 0o111).not.toBe(0)
+    }
+  )
 })
 
 describe('wrapPosixHookCommand', () => {

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -1,8 +1,9 @@
 import {
+  accessSync,
+  constants,
   existsSync,
   mkdirSync,
   readFileSync,
-  statSync,
   writeFileSync,
   chmodSync,
   copyFileSync,
@@ -269,8 +270,12 @@ export function writeManagedScript(scriptPath: string, content: string): void {
   if (existsSync(scriptPath)) {
     try {
       if (readFileSync(scriptPath, 'utf-8') === content) {
-        if (process.platform !== 'win32' && (statSync(scriptPath).mode & 0o111) === 0) {
-          chmodSync(scriptPath, 0o755)
+        if (process.platform !== 'win32') {
+          try {
+            accessSync(scriptPath, constants.X_OK)
+          } catch {
+            chmodSync(scriptPath, 0o755)
+          }
         }
         return
       }

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -271,6 +271,8 @@ export function writeManagedScript(scriptPath: string, content: string): void {
     try {
       if (readFileSync(scriptPath, 'utf-8') === content) {
         if (process.platform !== 'win32') {
+          // Why: POSIX [ -x ] checks the running user's execute access, not
+          // whether any owner/group/other execute bit happens to be set.
           try {
             accessSync(scriptPath, constants.X_OK)
           } catch {

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -2,6 +2,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
   chmodSync,
   copyFileSync,
@@ -268,7 +269,7 @@ export function writeManagedScript(scriptPath: string, content: string): void {
   if (existsSync(scriptPath)) {
     try {
       if (readFileSync(scriptPath, 'utf-8') === content) {
-        if (process.platform !== 'win32') {
+        if (process.platform !== 'win32' && (statSync(scriptPath).mode & 0o111) === 0) {
           chmodSync(scriptPath, 0o755)
         }
         return

--- a/src/main/agent-hooks/managed-agent-hook-controls.test.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.test.ts
@@ -16,6 +16,7 @@ const hookMocks = vi.hoisted(() => {
     getStatus: vi.fn(() => status(agent))
   })
   return {
+    status,
     getDefaultWslDistroMock: vi.fn(() => 'Ubuntu'),
     getWslHomeMock: vi.fn((distro: string): string | null =>
       distro === 'Ubuntu' ? '\\\\wsl.localhost\\Ubuntu\\home\\jin' : null
@@ -86,9 +87,14 @@ function managedClaudeAccount(overrides: {
 
 describe('applyAgentStatusHooksEnabled', () => {
   beforeEach(() => {
-    for (const service of Object.values(hookMocks.services)) {
+    const agentByServiceKey: Record<string, string> = {
+      commandCode: 'command-code',
+      openClaude: 'openclaude'
+    }
+    for (const [serviceKey, service] of Object.entries(hookMocks.services)) {
+      const agent = agentByServiceKey[serviceKey] ?? serviceKey
       service.install.mockClear()
-      service.remove.mockClear()
+      service.remove.mockReset().mockImplementation(() => hookMocks.status(agent))
       service.getStatus.mockClear()
     }
     hookMocks.getDefaultWslDistroMock.mockReset().mockReturnValue('Ubuntu')

--- a/src/main/agent-hooks/managed-agent-hook-controls.test.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const hookMocks = vi.hoisted(() => {
+  const status = (agent: string) => ({
+    agent,
+    state: 'not_installed',
+    configPath: '',
+    managedHooksPresent: false,
+    detail: null
+  })
+  const makeService = (agent: string) => ({
+    install: vi.fn(),
+    remove: vi.fn(() => status(agent)),
+    getStatus: vi.fn(() => status(agent))
+  })
+  return {
+    getDefaultWslDistroMock: vi.fn(() => 'Ubuntu'),
+    getWslHomeMock: vi.fn((distro: string): string | null =>
+      distro === 'Ubuntu' ? '\\\\wsl.localhost\\Ubuntu\\home\\jin' : null
+    ),
+    services: {
+      amp: makeService('amp'),
+      antigravity: makeService('antigravity'),
+      claude: makeService('claude'),
+      codex: makeService('codex'),
+      copilot: makeService('copilot'),
+      cursor: makeService('cursor'),
+      droid: makeService('droid'),
+      commandCode: makeService('command-code'),
+      devin: makeService('devin'),
+      gemini: makeService('gemini'),
+      grok: makeService('grok'),
+      hermes: makeService('hermes'),
+      kimi: makeService('kimi'),
+      openClaude: makeService('openclaude')
+    }
+  }
+})
+
+vi.mock('../amp/hook-service', () => ({ ampHookService: hookMocks.services.amp }))
+vi.mock('../antigravity/hook-service', () => ({
+  antigravityHookService: hookMocks.services.antigravity
+}))
+vi.mock('../claude/hook-service', () => ({ claudeHookService: hookMocks.services.claude }))
+vi.mock('../codex/hook-service', () => ({ codexHookService: hookMocks.services.codex }))
+vi.mock('../copilot/hook-service', () => ({ copilotHookService: hookMocks.services.copilot }))
+vi.mock('../cursor/hook-service', () => ({ cursorHookService: hookMocks.services.cursor }))
+vi.mock('../droid/hook-service', () => ({ droidHookService: hookMocks.services.droid }))
+vi.mock('../command-code/hook-service', () => ({
+  commandCodeHookService: hookMocks.services.commandCode
+}))
+vi.mock('../devin/hook-service', () => ({ devinHookService: hookMocks.services.devin }))
+vi.mock('../gemini/hook-service', () => ({ geminiHookService: hookMocks.services.gemini }))
+vi.mock('../grok/hook-service', () => ({ grokHookService: hookMocks.services.grok }))
+vi.mock('../hermes/hook-service', () => ({ hermesHookService: hookMocks.services.hermes }))
+vi.mock('../kimi/hook-service', () => ({ kimiHookService: hookMocks.services.kimi }))
+vi.mock('../openclaude/hook-service', () => ({
+  openClaudeHookService: hookMocks.services.openClaude
+}))
+
+import {
+  applyAgentStatusHooksEnabled,
+  clearRecordedClaudeWslSystemDefaultHookTargetsForTests,
+  removeManagedAgentHooks,
+  recordClaudeWslSystemDefaultHookTarget,
+  setWslSystemDefaultHookTargetResolver
+} from './managed-agent-hook-controls'
+
+function managedClaudeAccount(overrides: {
+  id: string
+  managedAuthPath: string
+  managedAuthRuntime?: 'host' | 'wsl'
+  wslLinuxAuthPath?: string | null
+}) {
+  return {
+    email: `${overrides.id}@example.com`,
+    authMethod: 'subscription-oauth',
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('applyAgentStatusHooksEnabled', () => {
+  beforeEach(() => {
+    for (const service of Object.values(hookMocks.services)) {
+      service.install.mockClear()
+      service.remove.mockClear()
+      service.getStatus.mockClear()
+    }
+    hookMocks.getDefaultWslDistroMock.mockReset().mockReturnValue('Ubuntu')
+    hookMocks.getWslHomeMock
+      .mockReset()
+      .mockImplementation((distro: string) =>
+        distro === 'Ubuntu' || distro === 'Debian'
+          ? `\\\\wsl.localhost\\${distro}\\home\\jin`
+          : null
+      )
+    setWslSystemDefaultHookTargetResolver({
+      getDefaultWslDistro: hookMocks.getDefaultWslDistroMock,
+      getWslHome: hookMocks.getWslHomeMock
+    })
+    clearRecordedClaudeWslSystemDefaultHookTargetsForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    setWslSystemDefaultHookTargetResolver(null)
+  })
+
+  it('removes Claude hooks from default, ambient, and saved account config dirs when disabled', () => {
+    vi.stubEnv('CLAUDE_CONFIG_DIR', '/tmp/ambient-claude')
+
+    applyAgentStatusHooksEnabled(false, {
+      claudeManagedAccounts: [
+        managedClaudeAccount({
+          id: 'host-account',
+          managedAuthPath: '/tmp/orca/claude-host'
+        }),
+        managedClaudeAccount({
+          id: 'wsl-account',
+          managedAuthPath: '\\\\wsl.localhost\\Ubuntu\\home\\me\\.orca\\claude',
+          managedAuthRuntime: 'wsl',
+          wslLinuxAuthPath: '/home/me/.orca/claude'
+        }),
+        managedClaudeAccount({
+          id: 'incomplete-wsl-account',
+          managedAuthPath: '\\\\wsl.localhost\\Debian\\home\\me\\.orca\\claude',
+          managedAuthRuntime: 'wsl',
+          wslLinuxAuthPath: null
+        })
+      ]
+    } as never)
+
+    expect(hookMocks.services.claude.remove).toHaveBeenNthCalledWith(1)
+    expect(hookMocks.services.claude.remove).toHaveBeenNthCalledWith(2, {
+      configDir: '/tmp/ambient-claude'
+    })
+    expect(hookMocks.services.claude.remove).toHaveBeenNthCalledWith(3, {
+      configDir: '/tmp/orca/claude-host'
+    })
+    expect(hookMocks.services.claude.remove).toHaveBeenNthCalledWith(4, {
+      configDir: '\\\\wsl.localhost\\Ubuntu\\home\\me\\.orca\\claude',
+      runtime: 'wsl',
+      wslLinuxConfigDir: '/home/me/.orca/claude'
+    })
+    expect(hookMocks.services.claude.remove).toHaveBeenCalledWith({
+      configDir: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.claude',
+      runtime: 'wsl',
+      wslLinuxConfigDir: '/home/jin/.claude'
+    })
+    expect(hookMocks.services.claude.remove).toHaveBeenCalledTimes(5)
+    expect(hookMocks.services.openClaude.remove).toHaveBeenCalledTimes(1)
+  })
+
+  it('dedupes repeated Claude config dirs before removing account-scoped hooks', () => {
+    const defaultClaudeConfigDir = join(homedir(), '.claude')
+    vi.stubEnv('CLAUDE_CONFIG_DIR', defaultClaudeConfigDir)
+
+    applyAgentStatusHooksEnabled(false, {
+      claudeManagedAccounts: [
+        managedClaudeAccount({
+          id: 'host-account-1',
+          managedAuthPath: defaultClaudeConfigDir
+        }),
+        managedClaudeAccount({
+          id: 'host-account-2',
+          managedAuthPath: defaultClaudeConfigDir
+        })
+      ]
+    } as never)
+
+    expect(hookMocks.services.claude.remove).toHaveBeenNthCalledWith(1)
+    expect(hookMocks.services.claude.remove).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues removing saved Claude account hooks when one config dir fails', () => {
+    vi.stubEnv('CLAUDE_CONFIG_DIR', '/tmp/ambient-claude')
+    hookMocks.services.claude.remove.mockImplementation((target?: { configDir?: string }) => {
+      if (target?.configDir === '/tmp/ambient-claude') {
+        throw new Error('permission denied')
+      }
+      return {
+        agent: 'claude',
+        state: 'not_installed',
+        configPath: target?.configDir ? `${target.configDir}/settings.json` : '',
+        managedHooksPresent: false,
+        detail: null
+      }
+    })
+
+    const statuses = applyAgentStatusHooksEnabled(false, {
+      claudeManagedAccounts: [
+        managedClaudeAccount({
+          id: 'host-account',
+          managedAuthPath: '/tmp/orca/claude-host'
+        })
+      ]
+    } as never)
+
+    expect(hookMocks.services.claude.remove).toHaveBeenNthCalledWith(1)
+    expect(hookMocks.services.claude.remove).toHaveBeenNthCalledWith(2, {
+      configDir: '/tmp/ambient-claude'
+    })
+    expect(hookMocks.services.claude.remove).toHaveBeenNthCalledWith(3, {
+      configDir: '/tmp/orca/claude-host'
+    })
+    expect(statuses).toContainEqual(
+      expect.objectContaining({
+        agent: 'claude',
+        state: 'error',
+        detail: 'permission denied'
+      })
+    )
+  })
+
+  it('removes Claude hooks from WSL system-default config dirs when disabled', () => {
+    applyAgentStatusHooksEnabled(false, {
+      activeClaudeManagedAccountIdsByRuntime: {
+        host: null,
+        wsl: { Ubuntu: null, Debian: 'saved-wsl-account' }
+      },
+      claudeManagedAccounts: [
+        managedClaudeAccount({
+          id: 'saved-wsl-account',
+          managedAuthPath: '\\\\wsl.localhost\\Debian\\home\\jin\\.orca\\claude',
+          managedAuthRuntime: 'wsl',
+          wslLinuxAuthPath: '/home/jin/.orca/claude'
+        })
+      ]
+    } as never)
+
+    expect(hookMocks.services.claude.remove).toHaveBeenCalledWith({
+      configDir: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.claude',
+      runtime: 'wsl',
+      wslLinuxConfigDir: '/home/jin/.claude'
+    })
+    expect(hookMocks.services.claude.remove).toHaveBeenCalledWith({
+      configDir: '\\\\wsl.localhost\\Debian\\home\\jin\\.claude',
+      runtime: 'wsl',
+      wslLinuxConfigDir: '/home/jin/.claude'
+    })
+    expect(hookMocks.getWslHomeMock).toHaveBeenCalledWith('Ubuntu')
+    expect(hookMocks.getWslHomeMock).toHaveBeenCalledWith('Debian')
+  })
+
+  it('removes recorded WSL system-default config dirs when settings have no WSL selection', () => {
+    recordClaudeWslSystemDefaultHookTarget({
+      configDir: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.claude',
+      runtime: 'wsl',
+      wslLinuxConfigDir: '/home/jin/.claude'
+    })
+
+    applyAgentStatusHooksEnabled(false, {
+      activeClaudeManagedAccountIdsByRuntime: { host: null, wsl: {} },
+      claudeManagedAccounts: []
+    } as never)
+
+    expect(hookMocks.services.claude.remove).toHaveBeenCalledWith({
+      configDir: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.claude',
+      runtime: 'wsl',
+      wslLinuxConfigDir: '/home/jin/.claude'
+    })
+  })
+
+  it('removes WSL system-default config dirs from persisted WSL runtime settings', () => {
+    applyAgentStatusHooksEnabled(false, {
+      localAccountRuntime: 'wsl',
+      localAccountWslDistro: 'Ubuntu',
+      activeClaudeManagedAccountIdsByRuntime: { host: null, wsl: {} },
+      claudeManagedAccounts: []
+    } as never)
+
+    expect(hookMocks.services.claude.remove).toHaveBeenCalledWith({
+      configDir: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.claude',
+      runtime: 'wsl',
+      wslLinuxConfigDir: '/home/jin/.claude'
+    })
+  })
+
+  it('can skip WSL system-default discovery during startup cleanup', () => {
+    removeManagedAgentHooks(
+      {
+        localAccountRuntime: 'wsl',
+        localAccountWslDistro: 'Ubuntu',
+        activeClaudeManagedAccountIdsByRuntime: { host: null, wsl: { Debian: null } },
+        claudeManagedAccounts: []
+      } as never,
+      { includeWslSystemDefaultDiscovery: false }
+    )
+
+    expect(hookMocks.getWslHomeMock).not.toHaveBeenCalled()
+    expect(hookMocks.getDefaultWslDistroMock).not.toHaveBeenCalled()
+    expect(hookMocks.services.claude.remove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -1,6 +1,7 @@
 import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import type { HookInstallAgent } from '../../shared/telemetry-events'
 import type { ClaudeManagedAccount, GlobalSettings } from '../../shared/types'
+import { posix as pathPosix, win32 as pathWin32 } from 'node:path'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { ampHookService } from '../amp/hook-service'
 import { antigravityHookService } from '../antigravity/hook-service'
@@ -150,9 +151,9 @@ function getWslSystemDefaultClaudeHookTargets(
     }
     return [
       {
-        configDir: `${wslHome.replace(/[\\/]+$/, '')}\\.claude`,
+        configDir: pathWin32.join(wslHome, '.claude'),
         runtime: 'wsl' as const,
-        wslLinuxConfigDir: `${wslHomeInfo.linuxPath.replace(/\/+$/, '')}/.claude`
+        wslLinuxConfigDir: pathPosix.join(wslHomeInfo.linuxPath, '.claude')
       }
     ]
   })
@@ -182,7 +183,7 @@ function removeClaudeHooksFromKnownConfigDirs(
     try {
       statuses.push(removeClaudeHooksFromTarget(target))
     } catch (error) {
-      statuses.push(errorStatus('claude', error))
+      statuses.push(errorStatus('claude', error, getConfigPath(CLAUDE_HOOK_SETTINGS, target)))
     }
   }
   return statuses
@@ -253,11 +254,15 @@ export function installManagedAgentHooks(): void {
   }
 }
 
-function errorStatus(agent: HookInstallAgent, error: unknown): AgentHookInstallStatus {
+function errorStatus(
+  agent: HookInstallAgent,
+  error: unknown,
+  configPath = ''
+): AgentHookInstallStatus {
   return {
     agent,
     state: 'error',
-    configPath: '',
+    configPath,
     managedHooksPresent: false,
     detail: error instanceof Error ? error.message : String(error)
   }

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -1,9 +1,11 @@
 import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import type { HookInstallAgent } from '../../shared/telemetry-events'
-import type { GlobalSettings } from '../../shared/types'
+import type { ClaudeManagedAccount, GlobalSettings } from '../../shared/types'
+import { parseWslUncPath } from '../../shared/wsl-paths'
 import { ampHookService } from '../amp/hook-service'
 import { antigravityHookService } from '../antigravity/hook-service'
-import { claudeHookService } from '../claude/hook-service'
+import { claudeHookService, type ClaudeLocalHookTarget } from '../claude/hook-service'
+import { CLAUDE_HOOK_SETTINGS, getConfigPath } from '../claude/hook-settings'
 import { codexHookService } from '../codex/hook-service'
 import { copilotHookService } from '../copilot/hook-service'
 import { cursorHookService } from '../cursor/hook-service'
@@ -17,8 +19,31 @@ import { kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 export type ManagedAgentHookInstaller = readonly [HookInstallAgent, () => void]
-type ManagedHookRemover = readonly [HookInstallAgent, () => AgentHookInstallStatus]
+type ManagedHookRemover = readonly [
+  HookInstallAgent,
+  (settings?: ManagedHookSettings) => AgentHookInstallStatus | AgentHookInstallStatus[]
+]
 type ManagedHookStatusReader = readonly [HookInstallAgent, () => AgentHookInstallStatus]
+type ManagedHookSettings = Partial<
+  Pick<
+    GlobalSettings,
+    | 'agentStatusHooksEnabled'
+    | 'claudeManagedAccounts'
+    | 'activeClaudeManagedAccountIdsByRuntime'
+    | 'localAccountRuntime'
+    | 'localAccountWslDistro'
+  >
+>
+type ManagedHookRemovalOptions = {
+  includeWslSystemDefaultDiscovery?: boolean
+}
+type WslSystemDefaultHookTargetResolver = {
+  getDefaultWslDistro(): string | null
+  getWslHome(distro: string): string | null
+}
+
+const recordedClaudeWslSystemDefaultHookTargets: ClaudeLocalHookTarget[] = []
+let wslSystemDefaultHookTargetResolver: WslSystemDefaultHookTargetResolver | null = null
 
 export const MANAGED_AGENT_HOOK_INSTALLERS: readonly ManagedAgentHookInstaller[] = [
   ['claude', () => claudeHookService.install()],
@@ -38,7 +63,7 @@ export const MANAGED_AGENT_HOOK_INSTALLERS: readonly ManagedAgentHookInstaller[]
 ]
 
 const LOCAL_MANAGED_HOOK_REMOVERS: readonly ManagedHookRemover[] = [
-  ['claude', () => claudeHookService.remove()],
+  ['claude', (settings) => removeClaudeHooksFromKnownConfigDirs(settings)],
   ['openclaude', () => openClaudeHookService.remove()],
   ['codex', () => codexHookService.remove()],
   ['gemini', () => geminiHookService.remove()],
@@ -53,6 +78,147 @@ const LOCAL_MANAGED_HOOK_REMOVERS: readonly ManagedHookRemover[] = [
   ['devin', () => devinHookService.remove()],
   ['kimi', () => kimiHookService.remove()]
 ]
+
+function getClaudeHookRemovalTargets(
+  settings: ManagedHookSettings | undefined,
+  options: ManagedHookRemovalOptions = {}
+): ClaudeLocalHookTarget[] {
+  const targets: ClaudeLocalHookTarget[] = [{}]
+  const ambientConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim()
+  if (ambientConfigDir) {
+    targets.push({ configDir: ambientConfigDir })
+  }
+  for (const account of settings?.claudeManagedAccounts ?? []) {
+    const target = getClaudeManagedAccountHookTarget(account)
+    if (target) {
+      targets.push(target)
+    }
+  }
+  targets.push(...recordedClaudeWslSystemDefaultHookTargets)
+  if (options.includeWslSystemDefaultDiscovery !== false) {
+    targets.push(...getWslSystemDefaultClaudeHookTargets(settings))
+  }
+  return dedupeClaudeHookTargets(targets)
+}
+
+function getClaudeManagedAccountHookTarget(
+  account: ClaudeManagedAccount
+): ClaudeLocalHookTarget | null {
+  if (account.managedAuthRuntime === 'wsl') {
+    if (!account.wslLinuxAuthPath) {
+      return null
+    }
+    return {
+      configDir: account.managedAuthPath,
+      runtime: 'wsl',
+      wslLinuxConfigDir: account.wslLinuxAuthPath
+    }
+  }
+  return { configDir: account.managedAuthPath }
+}
+
+function getWslSystemDefaultClaudeHookTargets(
+  settings: ManagedHookSettings | undefined
+): ClaudeLocalHookTarget[] {
+  const distroKeys = new Set(
+    Object.keys(settings?.activeClaudeManagedAccountIdsByRuntime?.wsl ?? {})
+  )
+  for (const account of settings?.claudeManagedAccounts ?? []) {
+    if (account.managedAuthRuntime === 'wsl') {
+      distroKeys.add(account.wslDistro?.trim() || '__default__')
+    }
+  }
+  if (settings?.localAccountRuntime === 'wsl') {
+    distroKeys.add(settings.localAccountWslDistro?.trim() || '__default__')
+  }
+
+  return Array.from(distroKeys).flatMap((distroKey) => {
+    if (!wslSystemDefaultHookTargetResolver) {
+      return []
+    }
+    const distro =
+      distroKey === '__default__'
+        ? wslSystemDefaultHookTargetResolver.getDefaultWslDistro()
+        : distroKey
+    if (!distro) {
+      return []
+    }
+    const wslHome = wslSystemDefaultHookTargetResolver.getWslHome(distro)
+    const wslHomeInfo = wslHome ? parseWslUncPath(wslHome) : null
+    if (!wslHome || !wslHomeInfo) {
+      return []
+    }
+    return [
+      {
+        configDir: `${wslHome.replace(/[\\/]+$/, '')}\\.claude`,
+        runtime: 'wsl' as const,
+        wslLinuxConfigDir: `${wslHomeInfo.linuxPath.replace(/\/+$/, '')}/.claude`
+      }
+    ]
+  })
+}
+
+function dedupeClaudeHookTargets(targets: ClaudeLocalHookTarget[]): ClaudeLocalHookTarget[] {
+  const seen = new Set<string>()
+  return targets.filter((target) => {
+    const key = getConfigPath(CLAUDE_HOOK_SETTINGS, target)
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
+}
+
+function removeClaudeHooksFromKnownConfigDirs(
+  settings: ManagedHookSettings | undefined,
+  options: ManagedHookRemovalOptions = {}
+): AgentHookInstallStatus[] {
+  const statuses: AgentHookInstallStatus[] = []
+  // Why: launch-time repair may have written hooks into selected Claude
+  // account config dirs; the global off switch must not leave those known
+  // namespaces armed, but it also must not crawl or delete unrelated dirs.
+  for (const target of getClaudeHookRemovalTargets(settings, options)) {
+    try {
+      statuses.push(removeClaudeHooksFromTarget(target))
+    } catch (error) {
+      statuses.push(errorStatus('claude', error))
+    }
+  }
+  return statuses
+}
+
+function removeClaudeHooksFromTarget(target: ClaudeLocalHookTarget): AgentHookInstallStatus {
+  return Object.keys(target).length === 0
+    ? claudeHookService.remove()
+    : claudeHookService.remove(target)
+}
+
+export function recordClaudeWslSystemDefaultHookTarget(target: ClaudeLocalHookTarget): void {
+  if (target.runtime !== 'wsl' || !target.configDir || !target.wslLinuxConfigDir) {
+    return
+  }
+  if (
+    recordedClaudeWslSystemDefaultHookTargets.some(
+      (recorded) =>
+        getConfigPath(CLAUDE_HOOK_SETTINGS, recorded) ===
+        getConfigPath(CLAUDE_HOOK_SETTINGS, target)
+    )
+  ) {
+    return
+  }
+  recordedClaudeWslSystemDefaultHookTargets.push(target)
+}
+
+export function clearRecordedClaudeWslSystemDefaultHookTargetsForTests(): void {
+  recordedClaudeWslSystemDefaultHookTargets.length = 0
+}
+
+export function setWslSystemDefaultHookTargetResolver(
+  resolver: WslSystemDefaultHookTargetResolver | null
+): void {
+  wslSystemDefaultHookTargetResolver = resolver
+}
 
 const LOCAL_MANAGED_HOOK_STATUS_READERS: readonly ManagedHookStatusReader[] = [
   ['claude', () => claudeHookService.getStatus()],
@@ -97,10 +263,16 @@ function errorStatus(agent: HookInstallAgent, error: unknown): AgentHookInstallS
   }
 }
 
-export function removeManagedAgentHooks(): AgentHookInstallStatus[] {
-  return LOCAL_MANAGED_HOOK_REMOVERS.map(([agent, remove]) => {
+export function removeManagedAgentHooks(
+  settings?: ManagedHookSettings,
+  options: ManagedHookRemovalOptions = {}
+): AgentHookInstallStatus[] {
+  return LOCAL_MANAGED_HOOK_REMOVERS.flatMap(([agent, remove]) => {
     try {
-      return remove()
+      if (agent === 'claude') {
+        return removeClaudeHooksFromKnownConfigDirs(settings, options)
+      }
+      return remove(settings)
     } catch (error) {
       return errorStatus(agent, error)
     }
@@ -117,10 +289,14 @@ export function getManagedAgentHookStatuses(): AgentHookInstallStatus[] {
   })
 }
 
-export function applyAgentStatusHooksEnabled(enabled: boolean): AgentHookInstallStatus[] {
+export function applyAgentStatusHooksEnabled(
+  enabled: boolean,
+  settings?: ManagedHookSettings,
+  options: ManagedHookRemovalOptions = {}
+): AgentHookInstallStatus[] {
   if (enabled) {
     installManagedAgentHooks()
     return getManagedAgentHookStatuses()
   }
-  return removeManagedAgentHooks()
+  return removeManagedAgentHooks(settings, options)
 }

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -5419,6 +5419,29 @@ describe('Endpoint file lifecycle', () => {
     }
   })
 
+  it('writes a POSIX endpoint file alongside the Windows native endpoint file', async () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const server = new AgentHookServer()
+    try {
+      await server.start({ env: 'development', userDataPath })
+      const nativePath = server.endpointFilePath
+      const posixPath = server.posixEndpointFilePath
+      expect(nativePath).toBeTruthy()
+      expect(posixPath).toBeTruthy()
+      expect(nativePath).toContain('endpoint.cmd')
+      expect(posixPath).toContain('endpoint.env')
+      expect(readFileSync(nativePath!, 'utf8')).toContain('set ORCA_AGENT_HOOK_PORT=')
+      expect(readFileSync(posixPath!, 'utf8')).toContain('ORCA_AGENT_HOOK_PORT=')
+      expect(readFileSync(posixPath!, 'utf8')).not.toContain('set ORCA_AGENT_HOOK_PORT=')
+    } finally {
+      server.stop()
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('writes the endpoint file with owner-only permissions on POSIX', async () => {
     if (process.platform === 'win32') {
       return

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -436,7 +436,9 @@ export class AgentHookServer {
   // (keeps it mockable in the vitest node environment).
   private endpointDir: string | null = null
   private endpointFilePathCache: string | null = null
+  private posixEndpointFilePathCache: string | null = null
   private endpointFileWritten = false
+  private posixEndpointFileWritten = false
   // Why: per-instance caches (warn-once Sets, lastPrompt/lastTool/lastStatus
   // by paneKey). Held on the instance instead of as module-level Maps so
   // tests can spin up multiple servers without state cross-contamination.
@@ -1165,10 +1167,12 @@ export class AgentHookServer {
         ? join(options.userDataPath, 'agent-hooks', options.endpointNamespace)
         : join(options.userDataPath, 'agent-hooks')
       this.endpointFilePathCache = join(this.endpointDir, getEndpointFileName())
+      this.posixEndpointFilePathCache = join(this.endpointDir, getEndpointFileName('posix'))
       this.lastStatusFilePath = join(this.endpointDir, LAST_STATUS_FILE_NAME)
     }
     this.token = randomUUID()
     this.endpointFileWritten = false
+    this.posixEndpointFileWritten = false
     this.lastWrittenJson = null
     // Why: hydrate before binding the HTTP listener so any new hook POST
     // (which goes through state.lastStatusByPaneKey.set) runs against an
@@ -1273,7 +1277,9 @@ export class AgentHookServer {
     // would introduce a TOCTOU race vs. a concurrent Orca instance.
     this.endpointDir = null
     this.endpointFilePathCache = null
+    this.posixEndpointFilePathCache = null
     this.endpointFileWritten = false
+    this.posixEndpointFileWritten = false
     this.lastStatusFilePath = null
     this.lastWrittenJson = null
     this.runtimeObservedStatusPaneKeys.clear()
@@ -1432,6 +1438,10 @@ export class AgentHookServer {
     return this.endpointFilePathCache
   }
 
+  get posixEndpointFilePath(): string | null {
+    return this.posixEndpointFileWritten ? this.posixEndpointFilePathCache : null
+  }
+
   /** Test/diagnostic accessor for the on-disk last-status file path. */
   get lastStatusPath(): string | null {
     return this.lastStatusFilePath
@@ -1442,13 +1452,29 @@ export class AgentHookServer {
       return
     }
     this.endpointFileWritten = false
+    this.posixEndpointFileWritten = false
     const ok = writeEndpointFile(this.endpointDir, this.endpointFilePathCache, {
       port: this.port,
       token: this.token,
       env: this.env,
       version: ORCA_HOOK_PROTOCOL_VERSION
     })
+    const posixOk =
+      !this.posixEndpointFilePathCache ||
+      this.posixEndpointFilePathCache === this.endpointFilePathCache ||
+      writeEndpointFile(
+        this.endpointDir,
+        this.posixEndpointFilePathCache,
+        {
+          port: this.port,
+          token: this.token,
+          env: this.env,
+          version: ORCA_HOOK_PROTOCOL_VERSION
+        },
+        { shell: 'posix' }
+      )
     this.endpointFileWritten = ok
+    this.posixEndpointFileWritten = Boolean(posixOk)
   }
 
   private hydrateLastStatusFromDisk(): void {

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -188,6 +188,115 @@ describe('ClaudeHookService.install', () => {
     }
   })
 
+  it('installs, reports, and removes managed hooks in an explicit Claude config dir', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-target-hooks-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      const defaultSettings = join(tmpHome, '.claude', 'settings.json')
+      const targetConfigDir = join(tmpHome, 'accounts', 'personal')
+      const targetSettings = join(targetConfigDir, 'settings.json')
+      mkdirSync(join(tmpHome, '.claude'), { recursive: true })
+      mkdirSync(targetConfigDir, { recursive: true })
+      writeFileSync(defaultSettings, JSON.stringify({ hooks: {} }))
+      writeFileSync(
+        targetSettings,
+        JSON.stringify({
+          hooks: {
+            Stop: [{ hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] }]
+          }
+        })
+      )
+
+      const service = new ClaudeHookService()
+      const installStatus = service.install({ configDir: targetConfigDir })
+      const target = JSON.parse(readFileSync(targetSettings, 'utf-8'))
+      const defaultConfig = JSON.parse(readFileSync(defaultSettings, 'utf-8'))
+
+      expect(installStatus).toMatchObject({ state: 'installed', configPath: targetSettings })
+      expect(service.getStatus({ configDir: targetConfigDir }).state).toBe('installed')
+      expect(defaultConfig.hooks).toEqual({})
+      const managedCommand = target.hooks.UserPromptSubmit[0].hooks[0].command as string
+      if (process.platform !== 'win32') {
+        expect(managedCommand).toContain(join(targetConfigDir, '.orca', 'agent-hooks'))
+        expect(managedCommand).not.toContain(join(tmpHome, '.orca', 'agent-hooks'))
+      }
+      expect(
+        readFileSync(
+          join(targetConfigDir, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME),
+          'utf-8'
+        )
+      ).toContain(process.platform === 'win32' ? '@echo off' : '#!/bin/sh')
+      expect(
+        target.hooks.Stop.flatMap((definition: { hooks: { command: string }[] }) =>
+          definition.hooks.map((hook) => hook.command)
+        )
+      ).toContain('/usr/local/bin/user-hook')
+
+      const removeStatus = service.remove({ configDir: targetConfigDir })
+      const removed = JSON.parse(readFileSync(targetSettings, 'utf-8'))
+      expect(removeStatus).toMatchObject({ state: 'not_installed', configPath: targetSettings })
+      expect(removed.hooks.Stop[0].hooks[0].command).toBe('/usr/local/bin/user-hook')
+      expect(JSON.parse(readFileSync(defaultSettings, 'utf-8')).hooks).toEqual({})
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
+  it('writes WSL Claude settings with a Linux hook command and Windows-accessible script', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-wsl-hooks-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      const hostConfigDir = join(tmpHome, 'host-user-data', 'claude-account')
+      const settingsPath = join(hostConfigDir, 'settings.json')
+      mkdirSync(hostConfigDir, { recursive: true })
+
+      const status = new ClaudeHookService().install({
+        configDir: hostConfigDir,
+        runtime: 'wsl',
+        wslLinuxConfigDir: '/home/dev/.local/share/orca/claude-account'
+      })
+
+      expect(status).toMatchObject({ state: 'installed', configPath: settingsPath })
+      const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      const command = parsed.hooks.Stop[0].hooks[0].command as string
+      expect(command).toContain(
+        '/home/dev/.local/share/orca/claude-account/.orca/agent-hooks/claude-hook.sh'
+      )
+      expect(command).toMatch(/^if \[ -f /)
+      expect(command).not.toContain('.cmd')
+      expect(command).not.toContain('\\\\wsl')
+      expect(command).not.toContain('host-user-data')
+      expect(command).not.toContain(tmpHome)
+      expect(
+        readFileSync(join(hostConfigDir, '.orca', 'agent-hooks', 'claude-hook.sh'), 'utf-8')
+      ).toContain('#!/bin/sh')
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects WSL hook targets without a Linux config dir instead of writing host commands', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-wsl-missing-linux-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      const hostConfigDir = join(tmpHome, 'host-user-data', 'claude-account')
+      mkdirSync(hostConfigDir, { recursive: true })
+
+      expect(() =>
+        new ClaudeHookService().install({ configDir: hostConfigDir, runtime: 'wsl' })
+      ).toThrow(/host and Linux config dirs/)
+      expect(existsSync(join(hostConfigDir, 'settings.json'))).toBe(false)
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
   // Why: #6078 — Claude Code runs hooks through Git Bash, and an unquoted path
   // with a space (e.g. `C:/Users/Jane Doe`) splits at the space. The managed
   // command must use an encoded launcher so Git Bash/cmd.exe never splits or

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -1,4 +1,5 @@
 import type { SFTPWrapper } from 'ssh2'
+import { join } from 'node:path'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import {
   buildWindowsAgentHookCurlPostCommand,
@@ -15,6 +16,7 @@ import {
   applyManagedHooks,
   CLAUDE_EVENTS,
   CLAUDE_HOOK_SETTINGS,
+  type ClaudeHookConfigTarget,
   getManagedScriptFileName,
   getConfigPath,
   getManagedCommand,
@@ -22,9 +24,19 @@ import {
   getPosixManagedScriptFileName,
   getRemoteConfigPath,
   getRemoteManagedCommand,
+  getWslManagedCommand,
   removeManagedHooks,
   type ClaudeCompatibleHookSettings
 } from './hook-settings'
+
+export type ClaudeLocalHookTarget = ClaudeHookConfigTarget & {
+  runtime?: 'host' | 'wsl'
+  wslLinuxConfigDir?: string | null
+}
+
+export type ClaudeHookInstallOptions = {
+  verifyStatus?: boolean
+}
 
 type ClaudeHookServiceOptions = {
   agent: AgentHookInstallStatus['agent']
@@ -129,6 +141,54 @@ function getManagedScript(
   ].join('\n')
 }
 
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '')
+}
+
+function getLocalHookPaths(
+  settings: ClaudeCompatibleHookSettings,
+  target: ClaudeLocalHookTarget = {}
+): {
+  configPath: string
+  scriptPath: string
+  scriptFileName: string
+  scriptTarget: 'local' | 'posix'
+  command: string
+} {
+  const hostConfigDir = target.configDir
+  const wslLinuxConfigDir = target.wslLinuxConfigDir
+  if (target.runtime === 'wsl' && (!hostConfigDir || !wslLinuxConfigDir)) {
+    throw new Error('Cannot install WSL Claude hooks without host and Linux config dirs')
+  }
+  if (target.runtime === 'wsl') {
+    const scriptFileName = getPosixManagedScriptFileName(settings)
+    const commandScriptPath = [
+      trimTrailingSlash(wslLinuxConfigDir!),
+      '.orca/agent-hooks',
+      scriptFileName
+    ].join('/')
+    return {
+      configPath: getConfigPath(settings, target),
+      scriptPath: join(hostConfigDir!, '.orca', 'agent-hooks', scriptFileName),
+      scriptFileName,
+      scriptTarget: 'posix',
+      command: getWslManagedCommand(commandScriptPath)
+    }
+  }
+
+  const scriptFileName = getManagedScriptFileName(settings)
+  const scriptPath = hostConfigDir
+    ? join(hostConfigDir, '.orca', 'agent-hooks', scriptFileName)
+    : getManagedScriptPath(settings)
+  return {
+    configPath: getConfigPath(settings, target),
+    scriptPath,
+    scriptFileName,
+    scriptTarget: 'local',
+    command: getManagedCommand(scriptPath)
+  }
+}
+
 export class ClaudeHookService {
   private readonly options: ClaudeHookServiceOptions
 
@@ -136,9 +196,8 @@ export class ClaudeHookService {
     this.options = options
   }
 
-  getStatus(): AgentHookInstallStatus {
-    const configPath = getConfigPath(this.options.settings)
-    const scriptPath = getManagedScriptPath(this.options.settings)
+  getStatus(target: ClaudeLocalHookTarget = {}): AgentHookInstallStatus {
+    const { configPath, command } = getLocalHookPaths(this.options.settings, target)
     const config = readHooksJson(configPath)
     if (!config) {
       return {
@@ -154,7 +213,6 @@ export class ClaudeHookService {
     // sidebar surfaces a degraded install rather than a false-positive
     // `installed`. Each CLAUDE_EVENTS entry must contain the managed command for
     // the integration to function end-to-end.
-    const command = getManagedCommand(scriptPath)
     const missing: string[] = []
     let presentCount = 0
     for (const event of CLAUDE_EVENTS) {
@@ -186,9 +244,14 @@ export class ClaudeHookService {
     return { agent: this.options.agent, state, configPath, managedHooksPresent, detail }
   }
 
-  install(): AgentHookInstallStatus {
-    const configPath = getConfigPath(this.options.settings)
-    const scriptPath = getManagedScriptPath(this.options.settings)
+  install(
+    target: ClaudeLocalHookTarget = {},
+    options: ClaudeHookInstallOptions = {}
+  ): AgentHookInstallStatus {
+    const { configPath, scriptPath, scriptFileName, scriptTarget, command } = getLocalHookPaths(
+      this.options.settings,
+      target
+    )
     const config = readHooksJson(configPath)
     if (!config) {
       return {
@@ -200,18 +263,24 @@ export class ClaudeHookService {
       }
     }
 
-    const command = getManagedCommand(scriptPath)
-    const nextConfig = applyManagedHooks(
-      config,
-      command,
-      getManagedScriptFileName(this.options.settings)
-    )
+    const nextConfig = applyManagedHooks(config, command, scriptFileName)
     writeManagedScript(
       scriptPath,
-      getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
+      getManagedScript(scriptTarget, {
+        skipWhenDevinImportsClaude: this.options.agent === 'claude'
+      })
     )
     writeHooksJson(configPath, nextConfig)
-    return this.getStatus()
+    if (options.verifyStatus === false) {
+      return {
+        agent: this.options.agent,
+        state: 'installed',
+        configPath,
+        managedHooksPresent: true,
+        detail: null
+      }
+    }
+    return this.getStatus(target)
   }
 
   // Why: install Orca's Claude hook settings on the remote box rather than the
@@ -282,8 +351,8 @@ export class ClaudeHookService {
     }
   }
 
-  remove(): AgentHookInstallStatus {
-    const configPath = getConfigPath(this.options.settings)
+  remove(target: ClaudeLocalHookTarget = {}): AgentHookInstallStatus {
+    const { configPath, scriptFileName } = getLocalHookPaths(this.options.settings, target)
     const config = readHooksJson(configPath)
     if (!config) {
       return {
@@ -294,14 +363,11 @@ export class ClaudeHookService {
         detail: `Could not parse ${this.options.displayName} settings.json`
       }
     }
-    const { config: nextConfig, changed } = removeManagedHooks(
-      config,
-      getManagedScriptFileName(this.options.settings)
-    )
+    const { config: nextConfig, changed } = removeManagedHooks(config, scriptFileName)
     if (changed) {
       writeHooksJson(configPath, nextConfig)
     }
-    return this.getStatus()
+    return this.getStatus(target)
   }
 }
 

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -16,6 +16,10 @@ export type ClaudeCompatibleHookSettings = {
   scriptBaseName: 'claude-hook' | 'openclaude-hook'
 }
 
+export type ClaudeHookConfigTarget = {
+  configDir?: string
+}
+
 export const CLAUDE_HOOK_SETTINGS: ClaudeCompatibleHookSettings = {
   configDirName: '.claude',
   scriptBaseName: 'claude-hook'
@@ -52,8 +56,13 @@ export const CLAUDE_EVENTS = [
   }
 ] as const
 
-export function getConfigPath(settings = CLAUDE_HOOK_SETTINGS): string {
-  return join(homedir(), settings.configDirName, 'settings.json')
+export function getConfigPath(
+  settings = CLAUDE_HOOK_SETTINGS,
+  target: ClaudeHookConfigTarget = {}
+): string {
+  return target.configDir
+    ? join(target.configDir, 'settings.json')
+    : join(homedir(), settings.configDirName, 'settings.json')
 }
 
 export function getManagedScriptFileName(settings = CLAUDE_HOOK_SETTINGS): string {
@@ -87,6 +96,13 @@ export function getManagedCommand(scriptPath: string): string {
 
 export function getRemoteManagedCommand(scriptPath: string): string {
   return wrapPosixHookCommand(scriptPath)
+}
+
+export function getWslManagedCommand(scriptPath: string): string {
+  const quoted = `'${scriptPath.replaceAll("'", "'\\''")}'`
+  // Why: WSL hook scripts are written through Windows and may not carry POSIX
+  // executable bits; Claude only needs /bin/sh to be able to read them.
+  return `if [ -f ${quoted} ]; then /bin/sh ${quoted}; fi`
 }
 
 export function applyManagedHooks(

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1997,6 +1997,7 @@ describe('createPtySubprocess', () => {
         rows: 24,
         cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo',
         env: {
+          WSLENV: 'KEEP/u:CLAUDE_CONFIG_DIR/u:ORCA_AGENT_HOOK_ENDPOINT/u',
           ORCA_AGENT_HOOK_PORT: '5678',
           ORCA_AGENT_HOOK_TOKEN: 'token',
           ORCA_AGENT_HOOK_ENV: 'test',
@@ -2081,6 +2082,7 @@ describe('createPtySubprocess', () => {
         rows: 24,
         cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo',
         env: {
+          WSLENV: 'KEEP/u',
           ORCA_AGENT_HOOK_PORT: '5678',
           ORCA_AGENT_HOOK_TOKEN: 'token',
           ORCA_PANE_KEY: 'tab:leaf',

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1983,6 +1983,120 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('imports Claude hook receiver env into daemon WSL terminals without explicit Claude config dirs', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo',
+        env: {
+          ORCA_AGENT_HOOK_PORT: '5678',
+          ORCA_AGENT_HOOK_TOKEN: 'token',
+          ORCA_AGENT_HOOK_ENV: 'test',
+          ORCA_AGENT_HOOK_VERSION: '1',
+          ORCA_PANE_KEY: 'tab:leaf',
+          ORCA_TAB_ID: 'tab',
+          ORCA_WORKTREE_ID: 'wt',
+          ORCA_AGENT_LAUNCH_TOKEN: 'launch',
+          ORCA_AGENT_HOOK_ENDPOINT: 'C:\\Users\\jin\\AppData\\Roaming\\endpoint.cmd'
+        }
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    const spawnCall = spawnMock.mock.calls.at(-1)!
+    const wslEnv = spawnCall[2].env.WSLENV as string
+    for (const key of [
+      'ORCA_AGENT_HOOK_PORT',
+      'ORCA_AGENT_HOOK_TOKEN',
+      'ORCA_AGENT_HOOK_ENV',
+      'ORCA_AGENT_HOOK_VERSION',
+      'ORCA_PANE_KEY',
+      'ORCA_TAB_ID',
+      'ORCA_WORKTREE_ID',
+      'ORCA_AGENT_LAUNCH_TOKEN'
+    ]) {
+      expect(wslEnv).toContain(key)
+    }
+    expect(wslEnv).not.toContain('CLAUDE_CONFIG_DIR')
+    expect(wslEnv).not.toContain('ORCA_AGENT_HOOK_ENDPOINT')
+  })
+
+  it('removes inherited Claude config dir WSL imports when the launch deletes the config dir', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo',
+        envToDelete: ['CLAUDE_CONFIG_DIR'],
+        env: {
+          WSLENV: 'FOO/u:CLAUDE_CONFIG_DIR/u',
+          ORCA_AGENT_HOOK_PORT: '5678',
+          ORCA_AGENT_HOOK_TOKEN: 'token',
+          ORCA_PANE_KEY: 'tab:leaf'
+        }
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    const spawnCall = spawnMock.mock.calls.at(-1)!
+    const env = spawnCall[2].env
+    expect(env.CLAUDE_CONFIG_DIR).toBeUndefined()
+    expect(env.WSLENV).toContain('FOO/u')
+    expect(env.WSLENV).not.toContain('CLAUDE_CONFIG_DIR')
+    expect(env.WSLENV).toContain('ORCA_AGENT_HOOK_PORT')
+  })
+
+  it('imports Linux-shaped Claude hook endpoint paths into daemon WSL terminals', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo',
+        env: {
+          ORCA_AGENT_HOOK_PORT: '5678',
+          ORCA_AGENT_HOOK_TOKEN: 'token',
+          ORCA_PANE_KEY: 'tab:leaf',
+          ORCA_AGENT_HOOK_ENDPOINT: '/mnt/c/Users/jin/AppData/Roaming/Orca/endpoint.env'
+        }
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    const spawnCall = spawnMock.mock.calls.at(-1)!
+    expect(spawnCall[2].env.WSLENV).toContain('ORCA_AGENT_HOOK_ENDPOINT')
+  })
+
   it('does not mark deleted Powerlevel10k wizard env for daemon WSL import', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -713,6 +713,9 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         addWslEnvKeys(env, WSL_AGENT_HOOK_ENV_KEYS)
         if (env.ORCA_AGENT_HOOK_ENDPOINT?.startsWith('/')) {
           addWslEnvKeys(env, ['ORCA_AGENT_HOOK_ENDPOINT'])
+        } else {
+          delete env.ORCA_AGENT_HOOK_ENDPOINT
+          removeWslEnvKeys(env, ['ORCA_AGENT_HOOK_ENDPOINT'])
         }
       }
     } else if (codexHomeWslInfo || isWslCodexHomeForHost(env.CODEX_HOME)) {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -30,7 +30,7 @@ import { isPwshAvailable } from '../pwsh'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { parseWslPath } from '../wsl'
-import { addWslEnvKeys } from '../wsl-env'
+import { addWslEnvKeys, removeWslEnvKeys, WSL_AGENT_HOOK_ENV_KEYS } from '../wsl-env'
 import { getWslContextFromSessionId } from './wsl-session-context'
 import { addOrcaWslInteropEnv } from '../pty/wsl-orca-env'
 import {
@@ -701,6 +701,19 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         // Why: managed WSL Claude accounts pass a Linux CLAUDE_CONFIG_DIR
         // through Windows wsl.exe; non-default env vars need WSLENV import.
         addWslEnvKeys(env, ['CLAUDE_CONFIG_DIR'])
+      } else {
+        // Why: inherited host-side Claude config dirs are not valid inside WSL;
+        // system-default WSL Claude must read its Linux ~/.claude namespace.
+        removeWslEnvKeys(env, ['CLAUDE_CONFIG_DIR'])
+      }
+      if (env.ORCA_PANE_KEY && env.ORCA_AGENT_HOOK_PORT && env.ORCA_AGENT_HOOK_TOKEN) {
+        // Why: WSL system-default Claude can use ~/.claude without
+        // CLAUDE_CONFIG_DIR, but its status hooks still need these
+        // non-default env vars imported through wsl.exe.
+        addWslEnvKeys(env, WSL_AGENT_HOOK_ENV_KEYS)
+        if (env.ORCA_AGENT_HOOK_ENDPOINT?.startsWith('/')) {
+          addWslEnvKeys(env, ['ORCA_AGENT_HOOK_ENDPOINT'])
+        }
       }
     } else if (codexHomeWslInfo || isWslCodexHomeForHost(env.CODEX_HOME)) {
       // Why: WSL-managed Codex homes are Linux paths. Windows Codex cannot use

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,8 +32,10 @@ import { runManagedHookInstallers } from './agent-hooks/install-telemetry'
 import {
   isAgentStatusHooksEnabled,
   MANAGED_AGENT_HOOK_INSTALLERS,
-  removeManagedAgentHooks
+  removeManagedAgentHooks,
+  setWslSystemDefaultHookTargetResolver
 } from './agent-hooks/managed-agent-hook-controls'
+import { getDefaultWslDistro, getWslHome } from './wsl'
 import { initCohortClassifier } from './telemetry/cohort-classifier'
 import { initOnboardingCohortClassifier } from './telemetry/onboarding-cohort-classifier'
 import { resolveConsent } from './telemetry/consent'
@@ -1737,13 +1739,14 @@ app.whenReady().then(async () => {
     runtimeService.notifyEmulatorAutoAttachFromWatcher(worktreeId, info)
   })
   nativeTheme.themeSource = store.getSettings().theme ?? 'system'
+  setWslSystemDefaultHookTargetResolver({ getDefaultWslDistro, getWslHome })
   if (shouldInstallManagedHooks(is.dev)) {
     // Why: the persisted off switch must run before any auto-install path so
     // users who removed Orca-managed hooks do not see them silently reappear on launch.
     if (isAgentStatusHooksEnabled(store.getSettings())) {
       runManagedHookInstallers(MANAGED_AGENT_HOOK_INSTALLERS)
     } else {
-      removeManagedAgentHooks()
+      removeManagedAgentHooks(store.getSettings(), { includeWslSystemDefaultDiscovery: false })
     }
   }
 

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -715,6 +715,9 @@ describe('registerPtyHandlers', () => {
         }),
         { verifyStatus: false }
       )
+      expect(claudeHookInstallMock.mock.invocationCallOrder[0]).toBeLessThan(
+        spawnMock.mock.invocationCallOrder[0]
+      )
       expect(spawnMock).toHaveBeenCalled()
       await handlers.get('pty:kill')!(null, { id: result.id })
     })
@@ -894,6 +897,9 @@ describe('registerPtyHandlers', () => {
       expect(claudeHookInstallMock).toHaveBeenCalledWith(
         expect.objectContaining({ configDir: '/tmp/claude-runtime' }),
         { verifyStatus: false }
+      )
+      expect(claudeHookInstallMock.mock.invocationCallOrder[0]).toBeLessThan(
+        spawnMock.mock.invocationCallOrder[0]
       )
       clearProviderPtyState(result.id)
     })
@@ -1826,6 +1832,28 @@ describe('registerPtyHandlers', () => {
           expect(spawnOptions.env.ORCA_AGENT_HOOK_ENDPOINT).toBe(
             '/mnt/c/Users/test/AppData/Roaming/Orca/agent-hooks/endpoint.env'
           )
+        })
+      })
+
+      it('clears the native endpoint file path when WSL has no POSIX endpoint file', async () => {
+        await withWin32Platform(async () => {
+          buildAgentHookEnvMock.mockReturnValueOnce({
+            ORCA_AGENT_HOOK_PORT: '5678',
+            ORCA_AGENT_HOOK_TOKEN: 'agent-token',
+            ORCA_AGENT_HOOK_ENDPOINT:
+              'C:\\Users\\test\\AppData\\Roaming\\Orca\\agent-hooks\\endpoint.cmd'
+          })
+          agentHookPosixEndpointFilePathMock.mockReturnValue(null)
+
+          const spawnOptions = await daemonSpawnAndGetOptions(
+            {},
+            undefined,
+            () => ({ agentStatusHooksEnabled: true }),
+            undefined,
+            { shellOverride: 'wsl.exe' }
+          )
+
+          expect(spawnOptions.env.ORCA_AGENT_HOOK_ENDPOINT).toBeUndefined()
         })
       })
 

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -8,6 +8,7 @@ import {
   TERMINAL_INPUT_MAX_BYTES
 } from '../../shared/terminal-input'
 import { CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS } from '../../shared/clipboard-text'
+import type * as ClaudeHookServiceModule from '../claude/hook-service'
 
 const isWindowsHost = process.platform === 'win32'
 const posixOnlyIt = isWindowsHost ? it.skip : it
@@ -38,8 +39,10 @@ const {
   spawnMock,
   openCodeBuildPtyEnvMock,
   openCodeClearPtyMock,
+  claudeHookInstallMock,
   mimoCodeBuildPtyEnvMock,
   buildAgentHookEnvMock,
+  agentHookPosixEndpointFilePathMock,
   clearAgentHookPaneStateMock,
   registerPaneKeyAliasMock,
   piBuildPtyEnvMock,
@@ -69,9 +72,11 @@ const {
   spawnMock: vi.fn(),
   openCodeBuildPtyEnvMock: vi.fn(),
   mimoCodeBuildPtyEnvMock: vi.fn(),
+  claudeHookInstallMock: vi.fn(),
   isPwshAvailableMock: vi.fn(),
   openCodeClearPtyMock: vi.fn(),
   buildAgentHookEnvMock: vi.fn(),
+  agentHookPosixEndpointFilePathMock: vi.fn(),
   clearAgentHookPaneStateMock: vi.fn(),
   registerPaneKeyAliasMock: vi.fn(),
   piBuildPtyEnvMock: vi.fn(),
@@ -126,6 +131,16 @@ vi.mock('../opencode/hook-service', () => ({
   }
 }))
 
+vi.mock('../claude/hook-service', async (importOriginal) => {
+  const actual = await importOriginal<typeof ClaudeHookServiceModule>()
+  return {
+    ...actual,
+    claudeHookService: {
+      install: claudeHookInstallMock
+    }
+  }
+})
+
 vi.mock('../mimo/hook-service', () => ({
   mimoCodeHookService: {
     buildPtyEnv: mimoCodeBuildPtyEnvMock
@@ -135,6 +150,9 @@ vi.mock('../mimo/hook-service', () => ({
 vi.mock('../agent-hooks/server', () => ({
   agentHookServer: {
     buildPtyEnv: buildAgentHookEnvMock,
+    get posixEndpointFilePath() {
+      return agentHookPosixEndpointFilePathMock()
+    },
     clearPaneState: clearAgentHookPaneStateMock,
     registerPaneKeyAlias: registerPaneKeyAliasMock,
     clearPaneKeyAliasesForPty: clearPaneKeyAliasesForPtyMock
@@ -286,9 +304,11 @@ describe('registerPtyHandlers', () => {
     getPathMock.mockReset()
     spawnMock.mockReset()
     openCodeBuildPtyEnvMock.mockReset()
+    claudeHookInstallMock.mockReset()
     mimoCodeBuildPtyEnvMock.mockReset()
     openCodeClearPtyMock.mockReset()
     buildAgentHookEnvMock.mockReset()
+    agentHookPosixEndpointFilePathMock.mockReset()
     clearAgentHookPaneStateMock.mockReset()
     registerPaneKeyAliasMock.mockReset()
     piBuildPtyEnvMock.mockReset()
@@ -329,6 +349,13 @@ describe('registerPtyHandlers', () => {
         ? '/tmp/orca-opencode-overlay'
         : '/tmp/orca-opencode-config'
     }))
+    claudeHookInstallMock.mockReturnValue({
+      agent: 'claude',
+      state: 'installed',
+      configPath: '/tmp/claude/settings.json',
+      managedHooksPresent: true,
+      detail: null
+    })
     mimoCodeBuildPtyEnvMock.mockImplementation((_ptyId: string, existingHome?: string) => ({
       MIMOCODE_HOME: existingHome ? '/tmp/orca-mimocode-overlay' : '/tmp/orca-mimocode-shared'
     }))
@@ -336,6 +363,9 @@ describe('registerPtyHandlers', () => {
       ORCA_AGENT_HOOK_PORT: '5678',
       ORCA_AGENT_HOOK_TOKEN: 'agent-token'
     })
+    agentHookPosixEndpointFilePathMock.mockReturnValue(
+      '/tmp/orca-user-data/agent-hooks/endpoint.env'
+    )
     piBuildPtyEnvMock.mockImplementation(
       (_ptyId: string, existingAgentDir?: string, kind?: string) =>
         kind === 'omp'
@@ -654,6 +684,218 @@ describe('registerPtyHandlers', () => {
       await handlers.get('pty:kill')!(null, { id: spawnResult.id })
 
       expect(hasLiveClaudePtys()).toBe(false)
+    })
+
+    it('repairs Claude hooks in the prepared config dir before pty:spawn launches Claude', async () => {
+      const prepareClaudeAuth = vi.fn(async () => ({
+        configDir: '/tmp/claude-personal',
+        runtime: 'host' as const,
+        envPatch: { CLAUDE_CONFIG_DIR: '/tmp/claude-personal' },
+        stripAuthEnv: false,
+        provenance: 'managed:personal'
+      }))
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        (() => ({ agentStatusHooksEnabled: true })) as never,
+        prepareClaudeAuth
+      )
+
+      const result = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        command: 'claude'
+      })) as { id: string }
+
+      expect(claudeHookInstallMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configDir: '/tmp/claude-personal',
+          runtime: 'host'
+        }),
+        { verifyStatus: false }
+      )
+      expect(spawnMock).toHaveBeenCalled()
+      await handlers.get('pty:kill')!(null, { id: result.id })
+    })
+
+    it('continues Claude pty:spawn when prepared hook repair fails', async () => {
+      claudeHookInstallMock.mockImplementation(() => {
+        throw new Error('settings locked')
+      })
+      const prepareClaudeAuth = vi.fn(async () => ({
+        configDir: '/tmp/claude-locked',
+        envPatch: { CLAUDE_CONFIG_DIR: '/tmp/claude-locked' },
+        stripAuthEnv: false,
+        provenance: 'managed:locked'
+      }))
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        (() => ({ agentStatusHooksEnabled: true })) as never,
+        prepareClaudeAuth
+      )
+
+      const result = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        command: 'claude'
+      })) as { id: string }
+      expect(spawnMock).toHaveBeenCalled()
+      await handlers.get('pty:kill')!(null, { id: result.id })
+    })
+
+    it('does not repair Claude hooks when agent status hooks are disabled', async () => {
+      const prepareClaudeAuth = vi.fn(async () => ({
+        configDir: '/tmp/claude-disabled',
+        envPatch: { CLAUDE_CONFIG_DIR: '/tmp/claude-disabled' },
+        stripAuthEnv: false,
+        provenance: 'managed:disabled'
+      }))
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        (() => ({ agentStatusHooksEnabled: false })) as never,
+        prepareClaudeAuth
+      )
+
+      const result = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        command: 'claude'
+      })) as { id: string }
+
+      expect(claudeHookInstallMock).not.toHaveBeenCalled()
+      await handlers.get('pty:kill')!(null, { id: result.id })
+    })
+
+    it('does not run local Claude hook repair for SSH launches', async () => {
+      const sshSpawn = vi.fn(async () => ({ id: 'ssh-pty' }))
+      registerSshPtyProvider('ssh-1', {
+        spawn: sshSpawn,
+        write: vi.fn(),
+        resize: vi.fn(),
+        shutdown: vi.fn(),
+        sendSignal: vi.fn(),
+        getCwd: vi.fn(),
+        getInitialCwd: vi.fn(),
+        clearBuffer: vi.fn(),
+        acknowledgeDataEvent: vi.fn(),
+        hasChildProcesses: vi.fn(),
+        getForegroundProcess: vi.fn(),
+        serialize: vi.fn(),
+        revive: vi.fn(),
+        onData: vi.fn(() => () => {}),
+        onReplay: vi.fn(() => () => {}),
+        onExit: vi.fn(() => () => {}),
+        listProcesses: vi.fn(async () => []),
+        attach: vi.fn(),
+        getDefaultShell: vi.fn(),
+        getProfiles: vi.fn()
+      } as never)
+      const prepareClaudeAuth = vi.fn(async () => ({
+        configDir: '/tmp/claude-ssh',
+        envPatch: { CLAUDE_CONFIG_DIR: '/tmp/claude-ssh' },
+        stripAuthEnv: false,
+        provenance: 'managed:ssh'
+      }))
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        (() => ({ agentStatusHooksEnabled: true })) as never,
+        prepareClaudeAuth
+      )
+
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        command: 'claude',
+        connectionId: 'ssh-1'
+      })
+
+      expect(prepareClaudeAuth).not.toHaveBeenCalled()
+      expect(claudeHookInstallMock).not.toHaveBeenCalled()
+      expect(sshSpawn).toHaveBeenCalled()
+    })
+
+    it('passes WSL Claude config dirs to hook repair without host-path settings commands', async () => {
+      const prepareClaudeAuth = vi.fn(async () => ({
+        configDir: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.claude-managed',
+        runtime: 'wsl' as const,
+        wslDistro: 'Ubuntu',
+        wslLinuxConfigDir: '/home/dev/.claude-managed',
+        envPatch: { CLAUDE_CONFIG_DIR: '/home/dev/.claude-managed' },
+        stripAuthEnv: false,
+        provenance: 'managed:wsl'
+      }))
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        (() => ({ agentStatusHooksEnabled: true })) as never,
+        prepareClaudeAuth
+      )
+
+      const result = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        command: 'claude',
+        shellOverride: 'wsl.exe'
+      })) as { id: string }
+
+      expect(claudeHookInstallMock).toHaveBeenCalledWith(
+        {
+          configDir: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.claude-managed',
+          runtime: 'wsl',
+          wslLinuxConfigDir: '/home/dev/.claude-managed'
+        },
+        { verifyStatus: false }
+      )
+      await handlers.get('pty:kill')!(null, { id: result.id })
+    })
+
+    it('repairs Claude hooks before runtime-controller spawned Claude launches', async () => {
+      type RuntimeSpawnController = {
+        spawn(args: {
+          cols: number
+          rows: number
+          worktreeId?: string
+          command?: string
+          env?: Record<string, string>
+        }): Promise<{ id: string }>
+      }
+      const runtime = {
+        setPtyController: vi.fn(),
+        preAllocateHandleForPty: vi.fn(() => 'term_runtime'),
+        onPtySpawned: vi.fn(),
+        onPtyExit: vi.fn(),
+        onPtyData: vi.fn()
+      }
+      const prepareClaudeAuth = vi.fn(async () => ({
+        configDir: '/tmp/claude-runtime',
+        envPatch: { CLAUDE_CONFIG_DIR: '/tmp/claude-runtime' },
+        stripAuthEnv: false,
+        provenance: 'managed:runtime'
+      }))
+      registerPtyHandlers(
+        mainWindow as never,
+        runtime as never,
+        undefined,
+        (() => ({ agentStatusHooksEnabled: true })) as never,
+        prepareClaudeAuth
+      )
+      const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+      const result = await controller.spawn({ cols: 80, rows: 24, command: 'claude', env: {} })
+
+      expect(claudeHookInstallMock).toHaveBeenCalledWith(
+        expect.objectContaining({ configDir: '/tmp/claude-runtime' }),
+        { verifyStatus: false }
+      )
+      clearProviderPtyState(result.id)
     })
 
     it('clears Claude live-PTY tracking from shared provider teardown', () => {
@@ -1247,6 +1489,7 @@ describe('registerPtyHandlers', () => {
         argsEnv?: Record<string, string>,
         getSelectedCodexHomePath?: () => string | null,
         getSettings?: () => {
+          agentStatusHooksEnabled?: boolean
           enableGitHubAttribution?: boolean
           httpProxyUrl?: string
           httpProxyBypassRules?: string
@@ -1303,6 +1546,7 @@ describe('registerPtyHandlers', () => {
         argsEnv?: Record<string, string>,
         getSelectedCodexHomePath?: () => string | null,
         getSettings?: () => {
+          agentStatusHooksEnabled?: boolean
           enableGitHubAttribution?: boolean
           httpProxyUrl?: string
           httpProxyBypassRules?: string
@@ -1493,6 +1737,96 @@ describe('registerPtyHandlers', () => {
             value: originalPlatform
           })
         }
+      })
+
+      it('deletes inherited Claude config dirs for WSL system-default Claude launches', async () => {
+        await withWin32Platform(async () => {
+          const daemonSpawn = setupDaemonAdapter()
+          const prepareClaudeAuth = vi.fn(async () => ({
+            configDir: '\\\\wsl.localhost\\Ubuntu\\home\\test\\.claude',
+            runtime: 'wsl' as const,
+            wslDistro: 'Ubuntu',
+            wslLinuxConfigDir: '/home/test/.claude',
+            envPatch: {},
+            stripAuthEnv: true,
+            provenance: 'wsl:Ubuntu:system'
+          }))
+          handlers.clear()
+          registerPtyHandlers(
+            mainWindow as never,
+            undefined,
+            undefined,
+            (() => ({ agentStatusHooksEnabled: true })) as never,
+            prepareClaudeAuth
+          )
+
+          await handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            command: 'claude',
+            shellOverride: 'wsl.exe',
+            env: {
+              CLAUDE_CONFIG_DIR: 'C:\\Users\\test\\.claude-host'
+            }
+          })
+
+          const spawnOptions = daemonSpawn.mock.calls.at(-1)?.[0] as DaemonSpawnCall
+          expect(spawnOptions.env.CLAUDE_CONFIG_DIR).toBeUndefined()
+          expect(spawnOptions.envToDelete).toEqual(expect.arrayContaining(['CLAUDE_CONFIG_DIR']))
+        })
+      })
+
+      it('keeps explicit managed WSL Claude config dirs for WSL Claude launches', async () => {
+        await withWin32Platform(async () => {
+          const daemonSpawn = setupDaemonAdapter()
+          const prepareClaudeAuth = vi.fn(async () => ({
+            configDir: '\\\\wsl.localhost\\Ubuntu\\home\\test\\.claude-managed',
+            runtime: 'wsl' as const,
+            wslDistro: 'Ubuntu',
+            wslLinuxConfigDir: '/home/test/.claude-managed',
+            envPatch: { CLAUDE_CONFIG_DIR: '/home/test/.claude-managed' },
+            stripAuthEnv: true,
+            provenance: 'managed:wsl'
+          }))
+          handlers.clear()
+          registerPtyHandlers(
+            mainWindow as never,
+            undefined,
+            undefined,
+            (() => ({ agentStatusHooksEnabled: true })) as never,
+            prepareClaudeAuth
+          )
+
+          await handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            command: 'claude',
+            shellOverride: 'wsl.exe'
+          })
+
+          const spawnOptions = daemonSpawn.mock.calls.at(-1)?.[0] as DaemonSpawnCall
+          expect(spawnOptions.env.CLAUDE_CONFIG_DIR).toBe('/home/test/.claude-managed')
+          expect(spawnOptions.envToDelete ?? []).not.toContain('CLAUDE_CONFIG_DIR')
+        })
+      })
+
+      it('uses the POSIX endpoint file path for WSL daemon hook env', async () => {
+        await withWin32Platform(async () => {
+          agentHookPosixEndpointFilePathMock.mockReturnValue(
+            'C:\\Users\\test\\AppData\\Roaming\\Orca\\agent-hooks\\endpoint.env'
+          )
+          const spawnOptions = await daemonSpawnAndGetOptions(
+            {},
+            undefined,
+            () => ({ agentStatusHooksEnabled: true }),
+            undefined,
+            { shellOverride: 'wsl.exe' }
+          )
+
+          expect(spawnOptions.env.ORCA_AGENT_HOOK_ENDPOINT).toBe(
+            '/mnt/c/Users/test/AppData/Roaming/Orca/agent-hooks/endpoint.env'
+          )
+        })
       })
 
       it('injects the agent-hook receiver env on the daemon path', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -889,11 +889,15 @@ export function buildPtyHostEnv(
   }
   if (opts.agentStatusHooksEnabled) {
     Object.assign(baseEnv, agentHookServer.buildPtyEnv())
-    if (opts.isWsl && agentHookServer.posixEndpointFilePath) {
-      // Why: WSL hook scripts source POSIX shell, not Windows cmd.exe.
-      // Point them at the stable endpoint.env path through DrvFs so
-      // long-lived WSL PTYs can refresh hook coords after Orca restarts.
-      baseEnv.ORCA_AGENT_HOOK_ENDPOINT = toLinuxPath(agentHookServer.posixEndpointFilePath)
+    if (opts.isWsl) {
+      if (agentHookServer.posixEndpointFilePath) {
+        // Why: WSL hook scripts source POSIX shell, not Windows cmd.exe.
+        // Point them at the stable endpoint.env path through DrvFs so
+        // long-lived WSL PTYs can refresh hook coords after Orca restarts.
+        baseEnv.ORCA_AGENT_HOOK_ENDPOINT = toLinuxPath(agentHookServer.posixEndpointFilePath)
+      } else {
+        delete baseEnv.ORCA_AGENT_HOOK_ENDPOINT
+      }
     }
   }
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -23,6 +23,7 @@ import {
   isWslShellName,
   resolveLocalWindowsTerminalRuntimeOptions
 } from '../../shared/local-windows-terminal-runtime'
+import { claudeHookService, type ClaudeLocalHookTarget } from '../claude/hook-service'
 import { openCodeHookService } from '../opencode/hook-service'
 import { mimoCodeHookService } from '../mimo/hook-service'
 import {
@@ -30,7 +31,10 @@ import {
   getFirstCommandToken
 } from '../../shared/command-token-scanner'
 import { agentHookServer } from '../agent-hooks/server'
-import { isAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
+import {
+  isAgentStatusHooksEnabled,
+  recordClaudeWslSystemDefaultHookTarget
+} from '../agent-hooks/managed-agent-hook-controls'
 import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 import { detectPiAgentKindFromCommand, type PiAgentKind } from '../../shared/pi-agent-kind'
 import { isPwshAvailable } from '../pwsh'
@@ -80,7 +84,7 @@ import {
   clearMigrationUnsupportedPty,
   clearMigrationUnsupportedPtysForPaneKey
 } from '../agent-hooks/migration-unsupported-pty-state'
-import { parseWslPath } from '../wsl'
+import { parseWslPath, toLinuxPath } from '../wsl'
 import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
 import { addOrcaWslInteropEnv } from '../pty/wsl-orca-env'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
@@ -550,6 +554,35 @@ type PrepareClaudeAuth = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
 
+function installClaudeHooksForPreparedLaunch(
+  claudeAuth: ClaudeRuntimeAuthPreparation | null,
+  agentStatusHooksEnabled: boolean
+): void {
+  if (!claudeAuth || !agentStatusHooksEnabled) {
+    return
+  }
+  if (claudeAuth.runtime === 'wsl' && !claudeAuth.wslLinuxConfigDir) {
+    console.warn('[claude-hooks] Skipping WSL hook install: missing Linux Claude config dir')
+    return
+  }
+
+  try {
+    const target: ClaudeLocalHookTarget = {
+      configDir: claudeAuth.configDir,
+      ...(claudeAuth.runtime ? { runtime: claudeAuth.runtime } : {}),
+      ...(claudeAuth.wslLinuxConfigDir ? { wslLinuxConfigDir: claudeAuth.wslLinuxConfigDir } : {})
+    }
+    const status = claudeHookService.install(target, { verifyStatus: false })
+    if (status.state === 'error') {
+      console.warn('[claude-hooks] Failed to install Claude hooks:', status.detail)
+    } else if (claudeAuth.runtime === 'wsl' && !claudeAuth.envPatch.CLAUDE_CONFIG_DIR) {
+      recordClaudeWslSystemDefaultHookTarget(target)
+    }
+  } catch (error) {
+    console.warn('[claude-hooks] Failed to install Claude hooks:', error)
+  }
+}
+
 function getCodexSelectionTargetForPty(
   shellPath: string | undefined,
   cwd: string | undefined,
@@ -669,6 +702,14 @@ function mergePtyEnvDeletions(
     return undefined
   }
   return Array.from(new Set([...(existingKeys ?? []), ...additionalKeys]))
+}
+
+function getWslClaudeConfigDirEnvKeysToDelete(
+  claudeAuth: ClaudeRuntimeAuthPreparation | null
+): string[] {
+  return claudeAuth?.runtime === 'wsl' && !claudeAuth.envPatch.CLAUDE_CONFIG_DIR
+    ? ['CLAUDE_CONFIG_DIR']
+    : []
 }
 
 function getInheritedAgentHookEnvKeysToDelete(
@@ -848,6 +889,12 @@ export function buildPtyHostEnv(
   }
   if (opts.agentStatusHooksEnabled) {
     Object.assign(baseEnv, agentHookServer.buildPtyEnv())
+    if (opts.isWsl && agentHookServer.posixEndpointFilePath) {
+      // Why: WSL hook scripts source POSIX shell, not Windows cmd.exe.
+      // Point them at the stable endpoint.env path through DrvFs so
+      // long-lived WSL PTYs can refresh hook coords after Orca restarts.
+      baseEnv.ORCA_AGENT_HOOK_ENDPOINT = toLinuxPath(agentHookServer.posixEndpointFilePath)
+    }
   }
 
   // Why: PI_CODING_AGENT_DIR owns Pi's / OMP's full config/session root. Keep
@@ -1825,6 +1872,8 @@ export function registerPtyHandlers(
           'This Claude launch defines explicit Anthropic auth environment variables. Remove those overrides before using a managed Claude account.'
         )
       }
+      const agentStatusHooksEnabled = isAgentStatusHooksEnabled(getSettings?.())
+      installClaudeHooksForPreparedLaunch(claudeAuth, agentStatusHooksEnabled)
 
       const isDaemonHostSpawn =
         !args.connectionId &&
@@ -1895,7 +1944,7 @@ export function registerPtyHandlers(
           launchCommand: args.command,
           shellPath: daemonShellOverride ?? process.env.COMSPEC,
           isWsl: shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, args.cwd),
-          agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
+          agentStatusHooksEnabled,
           networkProxySettings: getSettings?.()
         })
         promoteAgentTeamsShimPath(env, requestedAgentTeamsPath)
@@ -1912,7 +1961,10 @@ export function registerPtyHandlers(
         ...(isMintedSessionId ? { isNewSession: true } : {})
       }
       spawnOptions.envToDelete = mergePtyEnvDeletions(
-        mergePtyEnvDeletions(authEnvToDelete, args.envToDelete ?? []),
+        mergePtyEnvDeletions(
+          mergePtyEnvDeletions(authEnvToDelete, args.envToDelete ?? []),
+          getWslClaudeConfigDirEnvKeysToDelete(claudeAuth)
+        ),
         isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(env) : []
       )
       if (skipCodexHomeEnv) {
@@ -2374,6 +2426,8 @@ export function registerPtyHandlers(
           'This Claude launch defines explicit Anthropic auth environment variables. Remove those overrides before using a managed Claude account.'
         )
       }
+      const agentStatusHooksEnabled = isAgentStatusHooksEnabled(getSettings?.())
+      installClaudeHooksForPreparedLaunch(claudeAuth, agentStatusHooksEnabled)
       // Why: the daemon-backed provider replaces LocalPtyProvider and therefore
       // never runs its buildSpawnEnv closure. We must assemble the same
       // host-local env (OpenCode plugin, agent-hook server, Pi/OMP managed
@@ -2572,7 +2626,7 @@ export function registerPtyHandlers(
             launchCommand: args.command,
             shellPath: effectiveShellOverride ?? process.env.COMSPEC,
             isWsl: shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, args.cwd),
-            agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
+            agentStatusHooksEnabled,
             networkProxySettings: getSettings?.()
           })
           promoteAgentTeamsShimPath(env, requestedAgentTeamsPath)
@@ -2600,7 +2654,10 @@ export function registerPtyHandlers(
       const combinedEnvToDelete = mergePtyEnvDeletions(
         mergePtyEnvDeletions(
           mergePtyEnvDeletions(
-            mergePtyEnvDeletions(envToDelete, args.envToDelete ?? []),
+            mergePtyEnvDeletions(
+              mergePtyEnvDeletions(envToDelete, args.envToDelete ?? []),
+              getWslClaudeConfigDirEnvKeysToDelete(claudeAuth)
+            ),
             agentTeamsEnvToDelete ?? []
           ),
           isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(spawnEnv) : []

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -118,7 +118,7 @@ export function registerSettingsHandlers(
       before.agentStatusHooksEnabled !== result.agentStatusHooksEnabled
     ) {
       try {
-        applyAgentStatusHooksEnabled(result.agentStatusHooksEnabled)
+        applyAgentStatusHooksEnabled(result.agentStatusHooksEnabled, result)
       } catch (error) {
         console.warn('[settings] failed to apply agentStatusHooksEnabled:', error)
       }

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -452,6 +452,7 @@ describe('LocalPtyProvider', () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
       provider.configure({
         buildSpawnEnv: (_id, env) => {
+          env.WSLENV = 'KEEP/u:CLAUDE_CONFIG_DIR/u:ORCA_AGENT_HOOK_ENDPOINT/u'
           env.ORCA_AGENT_HOOK_PORT = '5678'
           env.ORCA_AGENT_HOOK_TOKEN = 'token'
           env.ORCA_AGENT_HOOK_ENV = 'test'
@@ -519,6 +520,7 @@ describe('LocalPtyProvider', () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
       provider.configure({
         buildSpawnEnv: (_id, env) => {
+          env.WSLENV = 'KEEP/u'
           env.ORCA_AGENT_HOOK_PORT = '5678'
           env.ORCA_AGENT_HOOK_TOKEN = 'token'
           env.ORCA_PANE_KEY = 'tab:leaf'

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -448,6 +448,95 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.WSLENV).toContain('CODEX_HOME')
     })
 
+    it('imports Claude hook receiver env into WSL terminals without explicit Claude config dirs', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      provider.configure({
+        buildSpawnEnv: (_id, env) => {
+          env.ORCA_AGENT_HOOK_PORT = '5678'
+          env.ORCA_AGENT_HOOK_TOKEN = 'token'
+          env.ORCA_AGENT_HOOK_ENV = 'test'
+          env.ORCA_AGENT_HOOK_VERSION = '1'
+          env.ORCA_PANE_KEY = 'tab:leaf'
+          env.ORCA_TAB_ID = 'tab'
+          env.ORCA_WORKTREE_ID = 'wt'
+          env.ORCA_AGENT_LAUNCH_TOKEN = 'launch'
+          env.ORCA_AGENT_HOOK_ENDPOINT = 'C:\\Users\\jin\\AppData\\Roaming\\endpoint.cmd'
+          return env
+        }
+      })
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo'
+      })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      const wslEnv = spawnCall[2].env.WSLENV as string
+      for (const key of [
+        'ORCA_AGENT_HOOK_PORT',
+        'ORCA_AGENT_HOOK_TOKEN',
+        'ORCA_AGENT_HOOK_ENV',
+        'ORCA_AGENT_HOOK_VERSION',
+        'ORCA_PANE_KEY',
+        'ORCA_TAB_ID',
+        'ORCA_WORKTREE_ID',
+        'ORCA_AGENT_LAUNCH_TOKEN'
+      ]) {
+        expect(wslEnv).toContain(key)
+      }
+      expect(wslEnv).not.toContain('CLAUDE_CONFIG_DIR')
+      expect(wslEnv).not.toContain('ORCA_AGENT_HOOK_ENDPOINT')
+    })
+
+    it('removes inherited Claude config dir WSL imports when the launch deletes the config dir', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      provider.configure({
+        buildSpawnEnv: (_id, env) => {
+          env.WSLENV = 'FOO/u:CLAUDE_CONFIG_DIR/u'
+          env.ORCA_AGENT_HOOK_PORT = '5678'
+          env.ORCA_AGENT_HOOK_TOKEN = 'token'
+          env.ORCA_PANE_KEY = 'tab:leaf'
+          return env
+        }
+      })
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo',
+        envToDelete: ['CLAUDE_CONFIG_DIR']
+      })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[2].env.CLAUDE_CONFIG_DIR).toBeUndefined()
+      expect(spawnCall[2].env.WSLENV).toContain('FOO/u')
+      expect(spawnCall[2].env.WSLENV).not.toContain('CLAUDE_CONFIG_DIR')
+      expect(spawnCall[2].env.WSLENV).toContain('ORCA_AGENT_HOOK_PORT')
+    })
+
+    it('imports Linux-shaped Claude hook endpoint paths into WSL terminals', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      provider.configure({
+        buildSpawnEnv: (_id, env) => {
+          env.ORCA_AGENT_HOOK_PORT = '5678'
+          env.ORCA_AGENT_HOOK_TOKEN = 'token'
+          env.ORCA_PANE_KEY = 'tab:leaf'
+          env.ORCA_AGENT_HOOK_ENDPOINT = '/mnt/c/Users/jin/AppData/Roaming/Orca/endpoint.env'
+          return env
+        }
+      })
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo'
+      })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[2].env.WSLENV).toContain('ORCA_AGENT_HOOK_ENDPOINT')
+    })
+
     it('translates a WSL managed Codex home before launching a WSL terminal', async () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
       provider.configure({

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -579,6 +579,9 @@ export class LocalPtyProvider implements IPtyProvider {
           addWslEnvKeys(finalEnv, WSL_AGENT_HOOK_ENV_KEYS)
           if (finalEnv.ORCA_AGENT_HOOK_ENDPOINT?.startsWith('/')) {
             addWslEnvKeys(finalEnv, ['ORCA_AGENT_HOOK_ENDPOINT'])
+          } else {
+            delete finalEnv.ORCA_AGENT_HOOK_ENDPOINT
+            removeWslEnvKeys(finalEnv, ['ORCA_AGENT_HOOK_ENDPOINT'])
           }
         }
       } else if (codexHomeWslInfo || isWslCodexHomeForHost(finalEnv.CODEX_HOME)) {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -39,7 +39,7 @@ import {
 import type { ShellReadySignal } from './local-pty-shell-ready'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
-import { addWslEnvKeys } from '../wsl-env'
+import { addWslEnvKeys, removeWslEnvKeys, WSL_AGENT_HOOK_ENV_KEYS } from '../wsl-env'
 import {
   POWERLEVEL10K_WIZARD_DISABLE_ENV,
   seedPowerlevel10kWizardEnv
@@ -563,6 +563,23 @@ export class LocalPtyProvider implements IPtyProvider {
           // Why: managed WSL Claude accounts pass a Linux CLAUDE_CONFIG_DIR
           // through Windows wsl.exe; non-default env vars need WSLENV import.
           addWslEnvKeys(finalEnv, ['CLAUDE_CONFIG_DIR'])
+        } else {
+          // Why: Orca or the daemon can inherit a host-side CLAUDE_CONFIG_DIR.
+          // WSL system-default Claude must use its Linux ~/.claude instead.
+          removeWslEnvKeys(finalEnv, ['CLAUDE_CONFIG_DIR'])
+        }
+        if (
+          finalEnv.ORCA_PANE_KEY &&
+          finalEnv.ORCA_AGENT_HOOK_PORT &&
+          finalEnv.ORCA_AGENT_HOOK_TOKEN
+        ) {
+          // Why: WSL system-default Claude can use ~/.claude without
+          // CLAUDE_CONFIG_DIR, but its status hooks still need these
+          // non-default env vars imported through wsl.exe.
+          addWslEnvKeys(finalEnv, WSL_AGENT_HOOK_ENV_KEYS)
+          if (finalEnv.ORCA_AGENT_HOOK_ENDPOINT?.startsWith('/')) {
+            addWslEnvKeys(finalEnv, ['ORCA_AGENT_HOOK_ENDPOINT'])
+          }
         }
       } else if (codexHomeWslInfo || isWslCodexHomeForHost(finalEnv.CODEX_HOME)) {
         // Why: WSL-managed Codex homes are Linux paths. Windows Codex cannot use

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2335,7 +2335,7 @@ export class OrcaRuntimeService {
       typeof updates.agentStatusHooksEnabled === 'boolean' &&
       before !== updates.agentStatusHooksEnabled
     ) {
-      applyAgentStatusHooksEnabled(updates.agentStatusHooksEnabled)
+      applyAgentStatusHooksEnabled(updates.agentStatusHooksEnabled, this.store.getSettings())
     }
     return this.getClientSettings()
   }

--- a/src/main/wsl-env.ts
+++ b/src/main/wsl-env.ts
@@ -1,3 +1,14 @@
+export const WSL_AGENT_HOOK_ENV_KEYS = [
+  'ORCA_AGENT_HOOK_PORT',
+  'ORCA_AGENT_HOOK_TOKEN',
+  'ORCA_AGENT_HOOK_ENV',
+  'ORCA_AGENT_HOOK_VERSION',
+  'ORCA_PANE_KEY',
+  'ORCA_TAB_ID',
+  'ORCA_WORKTREE_ID',
+  'ORCA_AGENT_LAUNCH_TOKEN'
+] as const
+
 export function addWslEnvKeys(
   env: Record<string, string | undefined>,
   keys: readonly string[]
@@ -12,6 +23,20 @@ export function addWslEnvKeys(
       tokenNames.add(key)
     }
   }
+
+  env.WSLENV = tokens.join(':')
+}
+
+export function removeWslEnvKeys(
+  env: Record<string, string | undefined>,
+  keys: readonly string[]
+): void {
+  const existing = env.WSLENV ?? process.env.WSLENV ?? ''
+  const keySet = new Set(keys)
+  const tokens = existing
+    .split(':')
+    .filter(Boolean)
+    .filter((token) => !keySet.has(token.split('/')[0]))
 
   env.WSLENV = tokens.join(':')
 }

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -3359,11 +3359,13 @@ export function resolveHookSource(pathname: string): AgentHookSource | null {
 
 // ─── Endpoint-file writing ──────────────────────────────────────────
 
-export function getEndpointFileName(): string {
+export type EndpointFileShell = 'native' | 'posix'
+
+export function getEndpointFileName(shell: EndpointFileShell = 'native'): string {
   // Why: per-platform extension lets hook scripts source the file natively
   // (`. "$file"` POSIX, `call "%file%"` Windows). The OpenCode plugin's regex
   // accepts both shapes already.
-  return process.platform === 'win32' ? 'endpoint.cmd' : 'endpoint.env'
+  return shell === 'native' && process.platform === 'win32' ? 'endpoint.cmd' : 'endpoint.env'
 }
 
 export function isShellSafeEndpointValue(value: string): boolean {
@@ -3387,10 +3389,12 @@ export type EndpointFileFields = {
 export function writeEndpointFile(
   endpointDir: string,
   finalPath: string,
-  fields: EndpointFileFields
+  fields: EndpointFileFields,
+  options: { shell?: EndpointFileShell } = {}
 ): boolean {
   const tmpPath = join(endpointDir, `.endpoint-${process.pid}-${randomUUID()}.tmp`)
-  const prefix = process.platform === 'win32' ? 'set ' : ''
+  const isWindowsShell = (options.shell ?? 'native') === 'native' && process.platform === 'win32'
+  const prefix = isWindowsShell ? 'set ' : ''
   const valuesToWrite: [string, string][] = [
     ['ORCA_AGENT_HOOK_PORT', String(fields.port)],
     ['ORCA_AGENT_HOOK_TOKEN', fields.token],
@@ -3442,7 +3446,7 @@ export function writeEndpointFile(
     } catch {
       // readdirSync can fail on exotic filesystems
     }
-    const separator = process.platform === 'win32' ? '\r\n' : '\n'
+    const separator = isWindowsShell ? '\r\n' : '\n'
     writeFileSync(tmpPath, lines.join(separator), { mode: 0o600 })
     tmpWritten = true
     renameSync(tmpPath, finalPath)


### PR DESCRIPTION
## Summary

Keeps Orca-managed Claude hooks in the same Claude config namespace that launch prep selects for the active runtime/account. When Orca launches Claude with a resolved `CLAUDE_CONFIG_DIR` or WSL config dir, hook settings and scripts are repaired in that same namespace instead of defaulting to `~/.claude`.

Boundaries: this does not add a multi-account UI, does not use Claude enterprise managed settings, and does not crawl arbitrary old config dirs. Disable cleanup removes default, ambient, saved-account, recorded WSL system-default, and known persisted WSL default targets only.

## Design Approach

- Parameterized Claude hook settings paths so local hook install/status/remove can target an explicit Claude config dir.
- Runs account-scoped hook repair after Claude auth prep and before local Claude spawn on both PTY spawn paths.
- Supports WSL by writing settings through the Windows-accessible config dir while storing Linux-shaped hook commands and importing hook env through `WSLENV`.
- Writes a POSIX endpoint file alongside the native endpoint file so long-lived WSL hook scripts can refresh live hook coordinates after an Orca restart.
- Preserves default no-target hook behavior for settings/status surfaces and OpenClaude.

## Review And Verification

- Design review: completed; confirmed current Claude Code supports config-dir-scoped state and that this should follow the selected runtime config dir rather than introducing a synthetic shared home.
- Completeness verification: final pass reported implemented with no blockers.
- Headline behavior status: implemented.
- Broad app consistency: launch prep remains source of truth; settings/status remain provider-level for default installs; global disable now cleans up known account/runtime namespaces to avoid leaving launch-repaired hooks armed.
- Perf audit: fixed unnecessary steady-state chmod, avoided the final launch repair status reread, deduped disable cleanup targets, and avoided synchronous WSL discovery during startup cleanup.
- Code review loop: multiple rounds; final two reviewers returned clean after fixes for WSL inherited env, cleanup lifecycle, endpoint handling, and CLI typecheck boundaries.
- Merge-confidence validation: final verdict `land`; Electron launched from this worktree with identity verified, no renderer console errors observed.

## Tests

- `pnpm run typecheck`
- `pnpm run tc:node`
- `pnpm run typecheck:cli`
- `pnpm run lint`
- `pnpm exec oxlint src/shared/agent-hook-listener.ts src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts src/main/agent-hooks/installer-utils.ts src/main/agent-hooks/installer-utils.test.ts src/main/agent-hooks/managed-agent-hook-controls.ts src/main/agent-hooks/managed-agent-hook-controls.test.ts src/main/claude/hook-settings.ts src/main/claude/hook-service.ts src/main/claude/hook-service.test.ts src/main/ipc/pty.ts src/main/ipc/pty.test.ts src/main/providers/local-pty-provider.ts src/main/providers/local-pty-provider.test.ts src/main/daemon/pty-subprocess.ts src/main/daemon/pty-subprocess.test.ts src/main/wsl-env.ts src/main/index.ts src/main/ipc/settings.ts src/main/runtime/orca-runtime.ts`
- `pnpm vitest run src/main/agent-hooks/server.test.ts src/main/agent-hooks/installer-utils.test.ts src/main/agent-hooks/managed-agent-hook-controls.test.ts src/main/claude/hook-service.test.ts src/main/ipc/pty.test.ts src/main/providers/local-pty-provider.test.ts src/main/daemon/pty-subprocess.test.ts src/cli/handlers/agent-hooks.test.ts --config config/vitest.config.ts`
- `git diff --check`

## Remaining Gaps

- No real WSL live-path test was possible on this macOS host.
- No real Claude account/auth mutation was performed; tests cover the launch prep, settings, script, and env plumbing without touching production Claude accounts.
- Older Claude builds that ignore `CLAUDE_CONFIG_DIR` may still degrade; current Claude Code supports this config-dir state model.

## Post-PR Stabilization

Completed. CI `verify` passed on the latest commit. CodeRabbit posted 8 actionable comments on the first pass and 1 actionable follow-up on the second pass; both sets were fixed and the latest CodeRabbit review reports no actionable comments. CodeRabbit still shows a non-blocking repo-wide docstring-coverage warning in its pre-merge summary, but GitHub checks are passing and that warning is unrelated to this PR.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6956">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
