### PR TITLE
Keep sidebar agent rows stable during status updates

### DIFF
--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: this suite covers one row-building seam
-   shared by retention, stale decay, and orchestration lineage regressions. */
 import { describe, expect, it } from 'vitest'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
@@ -9,6 +7,7 @@ import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/typ
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { comparePaneKeysOrdinal } from './worktree-agent-row-order'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
 
 const ORPHAN_PANE_KEY = makePaneKey('tab-orphan', '11111111-1111-4111-8111-111111111111')
@@ -291,6 +290,78 @@ describe('buildWorktreeAgentRows', () => {
         worktreeId: 'wt-1'
       }
     })
+  })
+
+  it('keeps simultaneous worktree-attributed agents in a deterministic order', () => {
+    const first = makeEntry(PANE_KEY_1, 1000, {
+      state: 'working',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      prompt: 'omp worker'
+    })
+    const second = makeEntry(PANE_KEY_2, 1000, {
+      state: 'working',
+      worktreeId: 'wt-1',
+      tabId: 'tab-2',
+      prompt: 'omp worker'
+    })
+    const third = makeEntry(PANE_KEY_3, 1000, {
+      state: 'working',
+      worktreeId: 'wt-1',
+      tabId: 'tab-3',
+      prompt: 'omp worker'
+    })
+
+    const build = (entries: AgentStatusEntry[]) =>
+      buildWorktreeAgentRows({
+        tabs: [],
+        entries,
+        retained: [],
+        now: 2000
+      }).map((row) => row.paneKey)
+
+    // Why: OMP can send frequent same-state updates for several panes. When
+    // those workers are worktree-attributed before their tabs arrive, row order
+    // must not inherit a noisy status-map iteration order.
+    expect(build([third, first, second])).toEqual([PANE_KEY_1, PANE_KEY_2, PANE_KEY_3])
+    expect(build([{ ...second, updatedAt: 1500 }, third, first])).toEqual([
+      PANE_KEY_1,
+      PANE_KEY_2,
+      PANE_KEY_3
+    ])
+  })
+
+  it('keeps missing-tab row order stable after real state transitions', () => {
+    const first = makeEntry(PANE_KEY_1, 2000, {
+      state: 'done',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      stateHistory: [{ state: 'working', prompt: 'omp worker', startedAt: 1000 }]
+    })
+    const second = makeEntry(PANE_KEY_2, 1500, {
+      state: 'blocked',
+      worktreeId: 'wt-1',
+      tabId: 'tab-2',
+      stateHistory: [{ state: 'working', prompt: 'omp worker', startedAt: 1000 }]
+    })
+
+    const rows = buildWorktreeAgentRows({
+      tabs: [],
+      entries: [second, first],
+      retained: [],
+      now: 2500
+    })
+
+    // Why: both rows originally started together. A later working -> terminal
+    // transition must not make fallback tab createdAt outrank paneKey order.
+    expect(rows.map((row) => [row.paneKey, row.startedAt, row.tab.createdAt])).toEqual([
+      [PANE_KEY_1, 1000, 1000],
+      [PANE_KEY_2, 1000, 1000]
+    ])
+  })
+
+  it('uses ordinal pane-key comparison for final row ordering ties', () => {
+    expect(comparePaneKeysOrdinal('tab-\u00e4', 'tab-z')).toBeGreaterThan(0)
   })
 
   it('uses runtime orchestration metadata for hook-reported live rows', () => {

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -360,6 +360,39 @@ describe('buildWorktreeAgentRows', () => {
     ])
   })
 
+  it('anchors missing-tab row order to the oldest state history entry', () => {
+    const first = makeEntry(PANE_KEY_1, 2400, {
+      state: 'done',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      stateHistory: [
+        { state: 'working', prompt: 'omp worker', startedAt: 1000 },
+        { state: 'blocked', prompt: 'omp worker', startedAt: 1800 }
+      ]
+    })
+    const second = makeEntry(PANE_KEY_2, 1600, {
+      state: 'waiting',
+      worktreeId: 'wt-1',
+      tabId: 'tab-2',
+      stateHistory: [
+        { state: 'working', prompt: 'omp worker', startedAt: 1000 },
+        { state: 'blocked', prompt: 'omp worker', startedAt: 1200 }
+      ]
+    })
+
+    const rows = buildWorktreeAgentRows({
+      tabs: [],
+      entries: [second, first],
+      retained: [],
+      now: 2500
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.startedAt, row.tab.createdAt])).toEqual([
+      [PANE_KEY_1, 1000, 1000],
+      [PANE_KEY_2, 1000, 1000]
+    ])
+  })
+
   it('uses ordinal pane-key comparison for final row ordering ties', () => {
     expect(comparePaneKeysOrdinal('tab-\u00e4', 'tab-z')).toBeGreaterThan(0)
   })

--- a/src/renderer/src/components/sidebar/worktree-agent-row-fallback-tab.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-fallback-tab.ts
@@ -1,0 +1,29 @@
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
+
+export function effectiveWorktreeAgentRowStartedAt(entry: AgentStatusEntry): number {
+  return entry.stateHistory[0]?.startedAt ?? entry.stateStartedAt
+}
+
+export function tabFromWorktreeAttributedStatusEntry(
+  entry: AgentStatusEntry,
+  effectiveStartedAt: number
+): TerminalTab | null {
+  const parsed = parsePaneKey(entry.paneKey)
+  if (!parsed || !entry.worktreeId) {
+    return null
+  }
+  return {
+    id: parsed.tabId,
+    ptyId: null,
+    worktreeId: entry.worktreeId,
+    title: entry.terminalTitle ?? 'Agent',
+    customTitle: null,
+    color: null,
+    sortOrder: Number.MAX_SAFE_INTEGER,
+    // Why: missing-tab rows must keep their original clock through real state
+    // transitions; current stateStartedAt is a status timestamp, not tab order.
+    createdAt: effectiveStartedAt
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-agent-row-order.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-order.ts
@@ -1,0 +1,24 @@
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+
+function comparableNumber(value: number | undefined, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+export function comparePaneKeysOrdinal(a: string, b: string): number {
+  if (a < b) {
+    return -1
+  }
+  if (a > b) {
+    return 1
+  }
+  return 0
+}
+
+export function compareWorktreeAgentRows(a: DashboardAgentRow, b: DashboardAgentRow): number {
+  return (
+    comparableNumber(a.startedAt) - comparableNumber(b.startedAt) ||
+    comparableNumber(a.tab.sortOrder) - comparableNumber(b.tab.sortOrder) ||
+    comparableNumber(a.tab.createdAt) - comparableNumber(b.tab.createdAt) ||
+    comparePaneKeysOrdinal(a.paneKey, b.paneKey)
+  )
+}

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -23,23 +23,11 @@ import {
   resolveAgentTypeFromTerminalTitle
 } from './worktree-title-derived-agent-rows'
 import { resolveCompatibleAgentTypeForOwner } from '../../../../shared/agent-title-owner'
-
-function tabFromAttributedStatusEntry(entry: AgentStatusEntry): TerminalTab | null {
-  const parsed = parsePaneKey(entry.paneKey)
-  if (!parsed || !entry.worktreeId) {
-    return null
-  }
-  return {
-    id: parsed.tabId,
-    ptyId: null,
-    worktreeId: entry.worktreeId,
-    title: entry.terminalTitle ?? 'Agent',
-    customTitle: null,
-    color: null,
-    sortOrder: Number.MAX_SAFE_INTEGER,
-    createdAt: entry.stateStartedAt
-  }
-}
+import { compareWorktreeAgentRows } from './worktree-agent-row-order'
+import {
+  effectiveWorktreeAgentRowStartedAt,
+  tabFromWorktreeAttributedStatusEntry
+} from './worktree-agent-row-fallback-tab'
 
 /**
  * Resolves the sidebar row agent type, prioritizing launch agent configuration
@@ -250,6 +238,7 @@ export function buildWorktreeAgentRows(args: {
         (rowEntry.state === 'working' ||
           rowEntry.state === 'blocked' ||
           rowEntry.state === 'waiting')
+      const startedAt = effectiveWorktreeAgentRowStartedAt(rowEntry)
       rows.push({
         paneKey: rowEntry.paneKey,
         entry: rowEntry,
@@ -257,7 +246,7 @@ export function buildWorktreeAgentRows(args: {
         agentType: resolveRowAgentType(rowEntry, tab),
         rowSource: 'live',
         state: shouldDecay ? 'idle' : rowEntry.state,
-        startedAt: rowEntry.stateHistory[0]?.startedAt ?? rowEntry.stateStartedAt
+        startedAt
       })
       seenPaneKeys.add(rowEntry.paneKey)
     }
@@ -282,7 +271,8 @@ export function buildWorktreeAgentRows(args: {
       continue
     }
     const rowEntry = entryWithRuntimeOrchestration(entry, args.runtimeAgentOrchestrationByPaneKey)
-    const tab = tabFromAttributedStatusEntry(rowEntry)
+    const startedAt = effectiveWorktreeAgentRowStartedAt(rowEntry)
+    const tab = tabFromWorktreeAttributedStatusEntry(rowEntry, startedAt)
     if (!tab) {
       continue
     }
@@ -297,7 +287,7 @@ export function buildWorktreeAgentRows(args: {
       agentType: resolveRowAgentType(rowEntry, tab),
       rowSource: 'live',
       state: shouldDecay ? 'idle' : rowEntry.state,
-      startedAt: rowEntry.stateHistory[0]?.startedAt ?? rowEntry.stateStartedAt
+      startedAt
     })
     seenPaneKeys.add(rowEntry.paneKey)
   }
@@ -330,6 +320,8 @@ export function buildWorktreeAgentRows(args: {
     })
   }
 
-  rows.sort((a, b) => a.startedAt - b.startedAt)
+  // Why: hook pings can rebuild the live entry list in a different iteration
+  // order. Equal-start agents still need a deterministic sidebar order.
+  rows.sort(compareWorktreeAgentRows)
   return rows
 }


### PR DESCRIPTION
This keeps inline sidebar agent rows stable when multiple agents in the same worktree report frequent status updates.

The change does not throttle OMP/Pi hooks. Hook pings may still refresh row text, tool state, and completion state; they just no longer get to rotate equal-start sibling rows through incidental status-map iteration order.

## ELI5
The sidebar had a few agents that looked like they started at the same time. Orca sorted them by start time, then had no clear rule for which tied row came first. OMP sends lots of normal status updates, and each update could hand Orca the same tied rows in a slightly different order, so the sidebar kept shuffling them. This PR gives tied rows a stable backup order, so updates can change the row content without making the rows trade places.

## Summary
- Added a deterministic WorktreeCard agent-row comparator: effective row start, tab sort order, tab creation time, then ordinal pane key.
- Moved missing-tab fallback tab construction into a focused module and made it use the row's effective original start time, so `working -> done/blocked/waiting` transitions do not become ordering inputs.
- Added regressions for simultaneous OMP-like missing-tab rows, same-state noisy update order changes, state transitions with `stateHistory`, and ordinal pane-key comparison.

## Design Approach
The source-of-truth behavior is the WorktreeCard inline agent list: rows should represent current/retained sessions and should only move when a meaningful ordering input changes. The design kept the existing oldest-first ordering but made ties deterministic rather than inherited from live status-entry iteration order.

## Design Review Outcome
Brennan's PR process ran the design-review loop against the scratch design doc. It ended clean with no P0/P1 blockers. Review tightened two requirements that are reflected in the implementation: use ordinal pane-key comparison instead of locale comparison, and keep missing-tab fallback rows on the row's effective original start across state transitions.

## Implementation And Deviations
Implemented as designed in:
- `src/renderer/src/components/sidebar/worktree-agent-rows.ts`
- `src/renderer/src/components/sidebar/worktree-agent-row-order.ts`
- `src/renderer/src/components/sidebar/worktree-agent-row-fallback-tab.ts`
- `src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts`

No material behavior deviations. The only implementation-shape addition was a focused fallback-tab module to satisfy max-lines without adding a lint disable.

## Completeness Verification
Independent completeness verification found the headline behavior implemented and no blockers. It confirmed:
- Comparator order is total and deterministic.
- Pane-key comparison is ordinal, not locale-sensitive.
- Missing-tab fallback `createdAt` uses effective original row start.
- Existing neighboring behavior for lineage, send-target mode, cache timers, title-derived rows, terminal activation, and worktree sorting is preserved.

## Headline Behavior Status
Implemented. Multiple same-start OMP/worktree-attributed sidebar agent rows no longer reorder because of same-state status pings or noisy incoming status-entry order.

## Broad App Consistency
Compared the affected desktop WorktreeCard compact and detailed inline agent rows with neighboring agent-row behavior, lineage grouping, terminal row activation, send-target mode, cache timers, dashboard row shape, and worktree smart/recent sort.

The PR fixes the unstable inline row ordering and intentionally preserves all neighboring actions and labels. No mobile, review/checks, settings, command palette, header/footer, or git-provider UI behavior changes.

## Risks, Ambiguities, And Non-Goals
- Non-goal: reducing or throttling OMP/Pi hook frequency.
- Non-goal: changing compact row layout, labels, timestamps, summaries, send-target mode, cache timers, lineage UI, or worktree sorting.
- Risk: pane-key tie-break is stable but not semantically meaningful; it only applies after start time and tab metadata tie.
- Accepted validation gap: live OMP multi-agent repro was not completed because `omp` is not available on PATH in this environment. Product validation used the real WorktreeCard surface with deterministic noisy status-map churn instead.

## Perf Audit
Perf audit found no actionable blockers. Touched hot path is `buildWorktreeAgentRows`, which still sorts once per worktree row set. The comparator adds constant-time numeric comparisons and only reaches ordinal string comparison on ties. No widened subscriptions, timers, subprocesses, polling, persistence, or cache lifecycle changes.

## Code Review Loop
Round 1 ran two independent code reviewers in parallel. Both returned clean. No fixes were required.

## Brennan Test Changes Result
Verdict: land.

Electron was launched from this exact worktree and identity was verified:
- `devBranch: brennanb2025/sidebar-order-thrash`
- `devRepoRoot: /Users/thebr/orca/workspaces/orca/pencilfish`
- `devWorktreeName: pencilfish`

Product validation used `demo-project` and rendered the real sidebar `WorktreeCardAgents` surface with three worktree-attributed missing-tab OMP rows sharing the same start time. The backing status map was deliberately reordered across initial, same-state noisy update, and terminal transition states. Visible row order stayed stable:
- `ORDER-A Alpha`
- `ORDER-B Beta`
- `ORDER-C Gamma`

Screenshot evidence:
- `/tmp/orca-sidebar-row-order-evidence-20260630/sidebar-agent-row-order-stable.png`

Console/log review found no sidebar/order-related failures.

## Static Checks And Focused Tests
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts`
- `pnpm exec oxlint src/renderer/src/components/sidebar/worktree-agent-rows.ts src/renderer/src/components/sidebar/worktree-agent-row-order.ts src/renderer/src/components/sidebar/worktree-agent-row-fallback-tab.ts src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts`

## Post-PR Stabilization
Complete.

- Initial CodeRabbit review found one actionable test nit: add a multi-transition `stateHistory` case. Fixed in commit `84e4750ab Cover multi-transition sidebar row ordering`.
- Refreshed CodeRabbit review reported no actionable comments.
- PR check `verify` passed.
- Merge state is `CLEAN`.
