### PR TITLE
Fix Windows bundled ConPTY packaging

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -868,6 +868,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify Windows node-pty ConPTY runtime
+        if: matrix.platform == 'win'
+        shell: pwsh
+        run: |
+          $runtimeDir = 'dist/win-unpacked/resources/node_modules/node-pty/build/Release'
+          $requiredFiles = @(
+            "$runtimeDir/conpty.node",
+            "$runtimeDir/conpty/conpty.dll",
+            "$runtimeDir/conpty/OpenConsole.exe"
+          )
+          foreach ($file in $requiredFiles) {
+            if (-not (Test-Path -LiteralPath $file -PathType Leaf)) {
+              throw "Missing Windows node-pty runtime file: $file"
+            }
+            Get-Item -LiteralPath $file
+          }
+
       - name: Install SignPath PowerShell module
         if: matrix.platform == 'win'
         shell: pwsh

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -127,7 +127,7 @@ module.exports = {
     if (!existsSync(resourcesDir)) {
       return
     }
-    prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName)
+    prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName, context.arch)
     verifyPackagedMainRuntimeDeps(resourcesDir)
     chmodUnixCliLaunchers(resourcesDir, context.electronPlatformName)
     chmodMacServeSimHelpers(resourcesDir, context.electronPlatformName)

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -1,4 +1,12 @@
-const { existsSync, readFileSync, readdirSync, realpathSync, rmSync } = require('node:fs')
+const {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync
+} = require('node:fs')
 const { dirname, join, resolve } = require('node:path')
 const { builtinModules, createRequire } = require('node:module')
 
@@ -29,6 +37,7 @@ const NODE_PTY_PREBUILD_PREFIX_BY_PLATFORM = {
   linux: 'linux-',
   win32: 'win32-'
 }
+const NODE_PTY_CONPTY_RUNTIME_FILES = ['conpty.dll', 'OpenConsole.exe']
 const PARCEL_WATCHER_PLATFORM_PREFIX_BY_PLATFORM = {
   darwin: 'watcher-darwin',
   linux: 'watcher-linux',
@@ -230,7 +239,62 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
   }
 }
 
-function prunePackagedNodePty(resourcesDir, electronPlatformName) {
+function normalizeNodePtyWindowsArch(electronArch) {
+  if (electronArch === 'x64' || electronArch === 1) {
+    return 'x64'
+  }
+  if (electronArch === 'arm64' || electronArch === 3) {
+    return 'arm64'
+  }
+  return process.arch === 'arm64' ? 'arm64' : 'x64'
+}
+
+function findNodePtyConptySourceDir(nodePtyDir, windowsArch) {
+  const conptyRoot = join(nodePtyDir, 'third_party', 'conpty')
+  if (!existsSync(conptyRoot)) {
+    throw new Error(`Packaged node-pty is missing ${conptyRoot}`)
+  }
+  for (const entry of readdirSync(conptyRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+    const sourceDir = join(conptyRoot, entry.name, `win10-${windowsArch}`)
+    if (existsSync(sourceDir)) {
+      return sourceDir
+    }
+  }
+  throw new Error(`Packaged node-pty has no ConPTY payload for win10-${windowsArch}`)
+}
+
+function ensurePackagedNodePtyConptyRuntime(nodePtyDir, electronArch) {
+  const releaseDir = join(nodePtyDir, 'build', 'Release')
+  if (!existsSync(join(releaseDir, 'conpty.node'))) {
+    return
+  }
+
+  const runtimeDir = join(releaseDir, 'conpty')
+  const missingRuntimeFiles = NODE_PTY_CONPTY_RUNTIME_FILES.filter(
+    (filename) => !existsSync(join(runtimeDir, filename))
+  )
+  if (missingRuntimeFiles.length === 0) {
+    return
+  }
+
+  const windowsArch = normalizeNodePtyWindowsArch(electronArch)
+  const sourceDir = findNodePtyConptySourceDir(nodePtyDir, windowsArch)
+  mkdirSync(runtimeDir, { recursive: true })
+  for (const filename of missingRuntimeFiles) {
+    const sourceFile = join(sourceDir, filename)
+    if (!existsSync(sourceFile)) {
+      throw new Error(`Packaged node-pty is missing ${sourceFile}`)
+    }
+    // Why: node-pty's Windows addon loads conpty.dll relative to conpty.node,
+    // but its install script can run before electron-builder gathers resources.
+    copyFileSync(sourceFile, join(runtimeDir, filename))
+  }
+}
+
+function prunePackagedNodePty(resourcesDir, electronPlatformName, electronArch) {
   const nodePtyDir = join(resourcesDir, 'node_modules', 'node-pty')
   if (!existsSync(nodePtyDir)) {
     return
@@ -248,7 +312,9 @@ function prunePackagedNodePty(resourcesDir, electronPlatformName) {
     }
   }
 
-  if (electronPlatformName !== 'win32') {
+  if (electronPlatformName === 'win32') {
+    ensurePackagedNodePtyConptyRuntime(nodePtyDir, electronArch)
+  } else {
     // Why: conpty is Windows-only and node-pty resolves runtime binaries from
     // build/Release or prebuilds/<platform>-<arch>, not third_party/conpty.
     rmSync(join(nodePtyDir, 'third_party', 'conpty'), { recursive: true, force: true })
@@ -322,8 +388,8 @@ function prunePackagedZodSources(resourcesDir) {
   rmSync(join(resourcesDir, 'node_modules', 'zod', 'src'), { recursive: true, force: true })
 }
 
-function prunePackagedRuntimeNodeModules(resourcesDir, electronPlatformName) {
-  prunePackagedNodePty(resourcesDir, electronPlatformName)
+function prunePackagedRuntimeNodeModules(resourcesDir, electronPlatformName, electronArch) {
+  prunePackagedNodePty(resourcesDir, electronPlatformName, electronArch)
   prunePackagedParcelWatcher(resourcesDir, electronPlatformName)
   prunePackagedRuntimeTypeDeclarations(resourcesDir)
   prunePackagedSherpaOnnx(resourcesDir, electronPlatformName)

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -168,6 +168,31 @@ describe('electron-builder config', () => {
       await expect(
         readdir(join(resourcesDir, 'node_modules', 'node-pty', 'deps'))
       ).resolves.toEqual([])
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('copies the Windows node-pty ConPTY runtime beside the rebuilt addon', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-node-pty-conpty-runtime-'))
+    try {
+      const nodePtyDir = join(resourcesDir, 'node_modules', 'node-pty')
+      const releaseDir = join(nodePtyDir, 'build', 'Release')
+      const sourceDir = join(nodePtyDir, 'third_party', 'conpty', '0.1.0', 'win10-x64')
+      await mkdir(releaseDir, { recursive: true })
+      await mkdir(sourceDir, { recursive: true })
+      await writeFile(join(releaseDir, 'conpty.node'), 'native addon placeholder', 'utf8')
+      await writeFile(join(sourceDir, 'conpty.dll'), 'dll payload', 'utf8')
+      await writeFile(join(sourceDir, 'OpenConsole.exe'), 'console payload', 'utf8')
+
+      prunePackagedNodePty(resourcesDir, 'win32', 'x64')
+
+      await expect(readFile(join(releaseDir, 'conpty', 'conpty.dll'), 'utf8')).resolves.toBe(
+        'dll payload'
+      )
+      await expect(readFile(join(releaseDir, 'conpty', 'OpenConsole.exe'), 'utf8')).resolves.toBe(
+        'console payload'
+      )
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -166,11 +166,18 @@ describe('Electron runtime package contract', () => {
       name === 'Install SignPath PowerShell module' ? [index] : []
     )
     const buildIndex = stepNames.indexOf('Build Windows release artifacts')
+    const verifyNodePtyIndex = stepNames.indexOf('Verify Windows node-pty ConPTY runtime')
     const uploadIndex = stepNames.indexOf('Upload unsigned Windows installer for SignPath')
     const downloadIndex = stepNames.indexOf('Download signed Windows installer from SignPath')
 
-    expect(installStepIndexes).toEqual([buildIndex + 1])
+    expect(verifyNodePtyIndex).toBe(buildIndex + 1)
+    expect(installStepIndexes).toEqual([verifyNodePtyIndex + 1])
     expect(installStepIndexes[0]).toBeLessThan(uploadIndex)
+
+    expect(steps[verifyNodePtyIndex].run).toContain(
+      'dist/win-unpacked/resources/node_modules/node-pty/build/Release'
+    )
+    expect(steps[verifyNodePtyIndex].run).toContain('conpty/conpty.dll')
 
     const uploadThroughDownloadScript = steps
       .slice(uploadIndex, downloadIndex + 1)


### PR DESCRIPTION
## Summary
- copy node-pty's bundled ConPTY runtime beside the rebuilt Windows addon during packaging
- pass the electron-builder target arch into runtime pruning so x64/arm64 select the right payload
- add a Windows release guard before SignPath/upload so missing ConPTY files block the release

## Regression
Windows daemon terminals now intentionally set `useConptyDll: true` for modern ConPTY wrap-marker behavior. Existing Windows installers lacked `resources/node_modules/node-pty/build/Release/conpty/conpty.dll`, so node-pty failed with `Cannot find conpty.dll` when spawning shells.

I verified the `v1.4.112` installer payload was missing `build/Release/conpty/conpty.dll`, then ran the patched packager against that extracted payload and confirmed it created both `conpty.dll` and `OpenConsole.exe`.

## Tests
- `pnpm exec vitest run config/scripts/electron-builder-config.test.mjs config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec vitest run src/main/daemon/pty-subprocess.test.ts`
- `pnpm exec oxlint config/packaged-runtime-node-modules.cjs config/electron-builder.config.cjs config/scripts/electron-builder-config.test.mjs config/scripts/package-electron-runtime-contract.test.mjs`
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6968">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->