### PR TITLE
Test arm64 ConPTY payload packaging

### DIFF
--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -174,27 +174,36 @@ describe('electron-builder config', () => {
   })
 
   it('copies the Windows node-pty ConPTY runtime beside the rebuilt addon', async () => {
-    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-node-pty-conpty-runtime-'))
-    try {
-      const nodePtyDir = join(resourcesDir, 'node_modules', 'node-pty')
-      const releaseDir = join(nodePtyDir, 'build', 'Release')
-      const sourceDir = join(nodePtyDir, 'third_party', 'conpty', '0.1.0', 'win10-x64')
-      await mkdir(releaseDir, { recursive: true })
-      await mkdir(sourceDir, { recursive: true })
-      await writeFile(join(releaseDir, 'conpty.node'), 'native addon placeholder', 'utf8')
-      await writeFile(join(sourceDir, 'conpty.dll'), 'dll payload', 'utf8')
-      await writeFile(join(sourceDir, 'OpenConsole.exe'), 'console payload', 'utf8')
+    for (const arch of ['x64', 'arm64']) {
+      const resourcesDir = await mkdtemp(join(tmpdir(), `orca-node-pty-conpty-${arch}-`))
+      try {
+        const nodePtyDir = join(resourcesDir, 'node_modules', 'node-pty')
+        const releaseDir = join(nodePtyDir, 'build', 'Release')
+        const conptyRoot = join(nodePtyDir, 'third_party', 'conpty', '0.1.0')
+        await mkdir(releaseDir, { recursive: true })
+        await writeFile(join(releaseDir, 'conpty.node'), 'native addon placeholder', 'utf8')
+        for (const sourceArch of ['x64', 'arm64']) {
+          const sourceDir = join(conptyRoot, `win10-${sourceArch}`)
+          await mkdir(sourceDir, { recursive: true })
+          await writeFile(join(sourceDir, 'conpty.dll'), `dll payload ${sourceArch}`, 'utf8')
+          await writeFile(
+            join(sourceDir, 'OpenConsole.exe'),
+            `console payload ${sourceArch}`,
+            'utf8'
+          )
+        }
 
-      prunePackagedNodePty(resourcesDir, 'win32', 'x64')
+        prunePackagedNodePty(resourcesDir, 'win32', arch)
 
-      await expect(readFile(join(releaseDir, 'conpty', 'conpty.dll'), 'utf8')).resolves.toBe(
-        'dll payload'
-      )
-      await expect(readFile(join(releaseDir, 'conpty', 'OpenConsole.exe'), 'utf8')).resolves.toBe(
-        'console payload'
-      )
-    } finally {
-      await rm(resourcesDir, { recursive: true, force: true })
+        await expect(readFile(join(releaseDir, 'conpty', 'conpty.dll'), 'utf8')).resolves.toBe(
+          `dll payload ${arch}`
+        )
+        await expect(readFile(join(releaseDir, 'conpty', 'OpenConsole.exe'), 'utf8')).resolves.toBe(
+          `console payload ${arch}`
+        )
+      } finally {
+        await rm(resourcesDir, { recursive: true, force: true })
+      }
     }
   })
 


### PR DESCRIPTION
## Summary
- extend the Windows node-pty ConPTY packaging test to cover both x64 and arm64 payload selection
- use distinct fixture payload contents so the test proves the target arch is selected

## Context
Follow-up to #6968 addressing CodeRabbit's nitpick about missing arm64 coverage for the architecture-specific ConPTY payload path.

## Tests
- `pnpm exec vitest run config/scripts/electron-builder-config.test.mjs`
- `pnpm exec oxlint config/scripts/electron-builder-config.test.mjs`
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6970">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->