### PR TITLE
Fix WSL UI project branch discovery

### DIFF
--- a/src/main/git/repo-detection.test.ts
+++ b/src/main/git/repo-detection.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { getGitRepoRoot, isGitRepo } from './repo'
+import { getGitRepoRoot, isGitRepo, normalizeGitRepoRootForInputPath } from './repo'
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
@@ -46,6 +46,15 @@ describe('isGitRepo', () => {
     // the /var tmpdir symlink to /private/var) across all platforms.
     const expectedRoot = git(repoRoot, ['rev-parse', '--show-toplevel']).trim().replace(/\\/g, '/')
     expect(getGitRepoRoot(nestedDir)).toBe(expectedRoot)
+  })
+
+  it('keeps WSL UNC identity when git reports a Linux worktree root', () => {
+    expect(
+      normalizeGitRepoRootForInputPath(
+        String.raw`\\wsl.localhost\Ubuntu\home\alice\repo\packages\web`,
+        '/home/alice/repo'
+      )
+    ).toBe(String.raw`\\wsl.localhost\Ubuntu\home\alice\repo`)
   })
 
   it('preserves bare repository paths when no worktree root exists', () => {

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -6,6 +6,8 @@ import { gitExecFileSync, gitExecFileAsync } from './runner'
 import type { BaseRefSearchResult } from '../../shared/types'
 import { parseGitRevListAheadBehindCounts } from '../../shared/git-rev-list-output'
 import { normalizeRuntimePathSeparators } from '../../shared/cross-platform-path'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import { toWindowsWslPath } from '../wsl'
 import {
   buildHostedRemoteCommitUrl,
   buildHostedRemoteFileUrl,
@@ -99,16 +101,25 @@ export function getGitRepoRoot(path: string): string {
       cwd: path
     }).trim()
     if (insideWorkTree === 'true') {
-      return normalizeRuntimePathSeparators(
-        gitExecFileSync(['rev-parse', '--show-toplevel'], {
-          cwd: path
-        }).trim()
-      )
+      const root = gitExecFileSync(['rev-parse', '--show-toplevel'], {
+        cwd: path
+      }).trim()
+      return normalizeGitRepoRootForInputPath(path, root)
     }
   } catch {
     // Fall through to preserving the original path.
   }
   return path
+}
+
+export function normalizeGitRepoRootForInputPath(inputPath: string, rootPath: string): string {
+  const inputWsl = parseWslUncPath(inputPath)
+  if (inputWsl && rootPath.startsWith('/')) {
+    // Why: WSL git reports Linux-native roots; Orca must persist the UNC path so
+    // later local git calls keep routing through the WSL-aware runner.
+    return toWindowsWslPath(rootPath, inputWsl.distro)
+  }
+  return normalizeRuntimePathSeparators(rootPath)
 }
 
 /**


### PR DESCRIPTION
﻿## Summary
- Preserve WSL UNC repo identity when resolving Git worktree roots from UI-added projects.
- Convert WSL `git rev-parse --show-toplevel` Linux output back to `\\wsl.localhost\<Distro>\...` so later local Git calls route through the WSL-aware runner.
- Add regression coverage for WSL UNC input plus Linux root output.

## Repro / Evidence
- Fetched Linear context with `node out/cli/index.js linear issue STA-1094 --full --json`.
- Created disposable WSL repo at `/home/jinwoo/tmp/sta1094manual` with `feature/local-only`, `feature/remote-backed`, and `origin/feature/remote-backed`.
- Before fix, Electron UI add path stored `/home/jinwoo/tmp/sta1094manual` and `searchBaseRefs("feature")` returned `[]`; visible Create Worktree branch search only offered “Create new branch feature”.
- Same repo added via repo-local CLI stored `\\wsl.localhost\Ubuntu\home\jinwoo\tmp\sta1094manual` and returned all expected refs.
- After fix, the Electron UI add path stored the UNC path and visible Branch search showed `feature/local-only`, `feature/remote-backed`, and `origin/feature/remote-backed`.

## Tests
- [x] `pnpm vitest run --config config/vitest.config.ts src/main/git/repo-detection.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] Electron/CDP WSL repro: failing UI path before fix, passing UI path after fix

Notes: lint passed with pre-existing unrelated warnings. Commands emitted the local Node 25 vs repo Node 24 engine warning.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6973">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->