### PR TITLE
Fix WSL OMP live status env injection

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4988,7 +4988,16 @@ describe('registerPtyHandlers', () => {
     const env = spawnCall[2].env as Record<string, string>
     expect(spawnCall[0]).toBe('wsl.exe')
     expect(env.ORCA_TERMINAL_HANDLE).toBe('term_wsl')
-    expect(env.WSLENV).toBe('ORCA_TERMINAL_HANDLE/u:POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD')
+    expect(env.WSLENV?.split(':')).toEqual(
+      expect.arrayContaining([
+        'ORCA_TERMINAL_HANDLE/u',
+        'ORCA_AGENT_HOOK_PORT/u',
+        'ORCA_AGENT_HOOK_TOKEN/u',
+        'ORCA_OMP_SOURCE_AGENT_DIR/p',
+        'ORCA_OMP_STATUS_EXTENSION/p',
+        'POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD'
+      ])
+    )
   })
 
   describe('Windows UTF-8 code page', () => {

--- a/src/main/pi/titlebar-extension-service.test.ts
+++ b/src/main/pi/titlebar-extension-service.test.ts
@@ -82,6 +82,7 @@ describe('PiTitlebarExtensionService', () => {
     rmSync(piHome, { recursive: true, force: true })
     rmSync(join(userDataDir, 'pi-agent-overlays'), { recursive: true, force: true })
     rmSync(join(userDataDir, 'omp-agent-overlays'), { recursive: true, force: true })
+    rmSync(join(userDataDir, 'omp-managed-status-extension'), { recursive: true, force: true })
   })
 
   function expectPiHomeIntact(): void {
@@ -229,6 +230,25 @@ describe('PiTitlebarExtensionService', () => {
       userStatusExtension
     )
     expectPiHomeIntact()
+  })
+
+  it('uses an Orca-owned OMP status extension when a same-named user file exists', () => {
+    const userStatusExtension = 'user-owned status extension'
+    const userStatusPath = join(piHome, 'extensions', 'orca-agent-status.ts')
+    writeFileSync(userStatusPath, userStatusExtension, 'utf-8')
+
+    const svc = new PiTitlebarExtensionService()
+    const env = svc.buildPtyEnv('pty-omp-user-status-extension', piHome, 'omp')
+
+    const fallbackStatusPath = join(
+      userDataDir,
+      'omp-managed-status-extension',
+      'orca-agent-status.ts'
+    )
+    expect(readFileSync(userStatusPath, 'utf-8')).toBe(userStatusExtension)
+    expect(env.ORCA_OMP_STATUS_EXTENSION).toBe(fallbackStatusPath)
+    expect(readFileSync(fallbackStatusPath, 'utf-8')).toContain('@orca-managed-pi-extension')
+    expect(readFileSync(fallbackStatusPath, 'utf-8')).toContain('/hook/omp')
   })
 
   it.skipIf(process.platform === 'win32')(

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -27,6 +27,7 @@ export const isSafeDescendCandidate = sharedIsSafeDescendCandidate
 
 const PI_AGENT_SUBDIR = 'agent'
 const ORCA_MANAGED_EXTENSION_MARKER = '@orca-managed-pi-extension'
+const OMP_MANAGED_STATUS_EXTENSION_DIR = 'omp-managed-status-extension'
 
 type ManagedExtensionWriteResult = 'written' | 'skipped-user-owned' | 'failed'
 
@@ -111,6 +112,18 @@ export class PiTitlebarExtensionService {
     }
   }
 
+  private writeOmpFallbackStatusExtension(source: string): string | undefined {
+    const fallbackDir = join(app.getPath('userData'), OMP_MANAGED_STATUS_EXTENSION_DIR)
+    try {
+      mkdirSync(fallbackDir, { recursive: true })
+    } catch {
+      return undefined
+    }
+
+    const fallbackPath = join(fallbackDir, ORCA_PI_AGENT_STATUS_EXTENSION_FILE)
+    return this.writeManagedExtension(fallbackPath, source) === 'written' ? fallbackPath : undefined
+  }
+
   private installManagedExtensions(
     sourceAgentDir: string,
     kind: PiAgentKind
@@ -131,15 +144,18 @@ export class PiTitlebarExtensionService {
       withOrcaManagedExtensionMarker(getPiPrefillExtensionSource(kind))
     )
     const statusExtensionPath = join(extensionsDir, ORCA_PI_AGENT_STATUS_EXTENSION_FILE)
-    const statusResult = this.writeManagedExtension(
-      statusExtensionPath,
-      withOrcaManagedExtensionMarker(getPiAgentStatusExtensionSource(kind))
-    )
+    const statusSource = withOrcaManagedExtensionMarker(getPiAgentStatusExtensionSource(kind))
+    const statusResult = this.writeManagedExtension(statusExtensionPath, statusSource)
 
     return {
       extensionDir: extensionsDir,
       sourceAgentDir,
-      statusExtensionPath: statusResult === 'written' ? statusExtensionPath : undefined
+      statusExtensionPath:
+        statusResult === 'written'
+          ? statusExtensionPath
+          : kind === 'omp'
+            ? this.writeOmpFallbackStatusExtension(statusSource)
+            : undefined
     }
   }
 

--- a/src/main/pty/wsl-orca-env.test.ts
+++ b/src/main/pty/wsl-orca-env.test.ts
@@ -19,4 +19,30 @@ describe('addOrcaWslInteropEnv', () => {
 
     expect(env.WSLENV).toBe('FOO/u:ORCA_TERMINAL_HANDLE/u:BAR/p')
   })
+
+  it('marks OMP status and hook env for Windows to WSL import', () => {
+    const env: Record<string, string> = {
+      ORCA_TERMINAL_HANDLE: 'term_wsl',
+      ORCA_OMP_STATUS_EXTENSION: 'C:\\Users\\jin\\.omp\\agent\\extensions\\orca-agent-status.ts',
+      ORCA_PANE_KEY: 'tab-1:leaf-1',
+      ORCA_TAB_ID: 'tab-1',
+      ORCA_WORKTREE_ID: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo',
+      ORCA_AGENT_HOOK_PORT: '4567',
+      ORCA_AGENT_HOOK_TOKEN: 'token',
+      ORCA_AGENT_HOOK_ENV: 'dev',
+      ORCA_AGENT_HOOK_VERSION: '1'
+    }
+
+    addOrcaWslInteropEnv(env)
+
+    expect(env.WSLENV).toContain('ORCA_TERMINAL_HANDLE/u')
+    expect(env.WSLENV).toContain('ORCA_OMP_STATUS_EXTENSION/p')
+    expect(env.WSLENV).toContain('ORCA_PANE_KEY/u')
+    expect(env.WSLENV).toContain('ORCA_TAB_ID/u')
+    expect(env.WSLENV).toContain('ORCA_WORKTREE_ID/u')
+    expect(env.WSLENV).toContain('ORCA_AGENT_HOOK_PORT/u')
+    expect(env.WSLENV).toContain('ORCA_AGENT_HOOK_TOKEN/u')
+    expect(env.WSLENV).toContain('ORCA_AGENT_HOOK_ENV/u')
+    expect(env.WSLENV).toContain('ORCA_AGENT_HOOK_VERSION/u')
+  })
 })

--- a/src/main/pty/wsl-orca-env.ts
+++ b/src/main/pty/wsl-orca-env.ts
@@ -4,16 +4,39 @@ function parseWslenvEntries(value: string | undefined): string[] {
   return value ? value.split(WSLENV_ENTRY_SEPARATOR).filter(Boolean) : []
 }
 
-function hasWslenvVariable(entries: readonly string[], variableName: string): boolean {
-  return entries.some((entry) => entry.split('/')[0] === variableName)
+function upsertWslenvEntry(entries: string[], entry: string): void {
+  const variableName = entry.split('/')[0]
+  const existingIndex = entries.findIndex((value) => value.split('/')[0] === variableName)
+  if (existingIndex === -1) {
+    entries.push(entry)
+    return
+  }
+  entries[existingIndex] = entry
 }
 
 export function addOrcaWslInteropEnv(env: Record<string, string>): void {
   const entries = parseWslenvEntries(env.WSLENV)
-  if (!hasWslenvVariable(entries, 'ORCA_TERMINAL_HANDLE')) {
-    // Why: WSL only imports selected Windows env vars. The terminal handle is
-    // the trusted orchestration identity, so managed WSL shells must opt it in.
-    entries.push('ORCA_TERMINAL_HANDLE/u')
+  // Why: wsl.exe only imports selected Windows env vars. Agent status in WSL
+  // needs both the pane identity and the hook/OMP coordinates at process start.
+  const passthroughEntries = [
+    'ORCA_TERMINAL_HANDLE/u',
+    'ORCA_PANE_KEY/u',
+    'ORCA_TAB_ID/u',
+    'ORCA_WORKTREE_ID/u',
+    'ORCA_AGENT_LAUNCH_TOKEN/u',
+    'ORCA_AGENT_HOOK_PORT/u',
+    'ORCA_AGENT_HOOK_TOKEN/u',
+    'ORCA_AGENT_HOOK_ENV/u',
+    'ORCA_AGENT_HOOK_VERSION/u',
+    'ORCA_AGENT_HOOK_ENDPOINT/p',
+    'ORCA_OMP_SOURCE_AGENT_DIR/p',
+    'ORCA_OMP_STATUS_EXTENSION/p'
+  ]
+  for (const entry of passthroughEntries) {
+    const variableName = entry.split('/')[0]
+    if (env[variableName]) {
+      upsertWslenvEntry(entries, entry)
+    }
   }
   env.WSLENV = entries.join(WSLENV_ENTRY_SEPARATOR)
 }


### PR DESCRIPTION
## Summary
- Forward Orca agent status env through `WSLENV` for WSL-backed PTYs, including OMP status extension, pane identity, and hook coordinates.
- Keep user-owned `~/.omp/agent/extensions/orca-agent-status.ts` untouched, but provide OMP an Orca-owned fallback status extension under app `userData` so `ORCA_OMP_STATUS_EXTENSION` is still valid.
- Add regression coverage for both WSL env import and the user-owned OMP status-extension collision.

## Repro / evidence
- Fetched full Linear context with `node out\cli\index.js linear issue STA-1102 --full --json`.
- Confirmed the failing shape before the fix: WSL `WSLENV` only imported `ORCA_TERMINAL_HANDLE/u`, so live OMP processes lacked `ORCA_OMP_STATUS_EXTENSION`, `ORCA_PANE_KEY`, and `ORCA_AGENT_HOOK_PORT`.
- Also reproduced a second local blocker from live state: `C:\Users\jinwo\.omp\agent\extensions\orca-agent-status.ts` existed as a zero-byte user-owned file, so Orca refused to overwrite it and omitted `ORCA_OMP_STATUS_EXTENSION`.
- After the fix, launched a fresh dev Electron Orca via CDP from this worktree and verified identity: `Orca: Jinwoo-H/sta-1102-wsl-omp-live-agent-status`, runtime `e5743b05-8d52-42ac-adbf-eea2d698ebc7`.
- Real WSL `worktree create --agent omp` produced a live process whose terminal and `/proc/<pid>/environ` included:
  - `ORCA_OMP_STATUS_EXTENSION=/mnt/c/Users/jinwo/AppData/Local/Temp/.../omp-managed-status-extension/orca-agent-status.ts`
  - `ORCA_PANE_KEY=0c11fb44-...:eed30741-...`
  - `ORCA_AGENT_HOOK_PORT=56675`
  - `WSLENV=...:ORCA_AGENT_HOOK_ENDPOINT/p:ORCA_OMP_SOURCE_AGENT_DIR/p:ORCA_OMP_STATUS_EXTENSION/p:...`

## Tests
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/pi/titlebar-extension-service.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/pty/wsl-orca-env.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`

Notes: local warnings only: Node engine wanted 24 while local node is 25.9.0, `.npmrc` could not expand `${GITHUB_TOKEN}`, and lint printed existing warnings outside this diff.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6974">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->