### PR TITLE
Fix Windows ConPTY OSC color reply leak

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -58,7 +58,13 @@ type StoreState = {
   activeWorktreeId: string | null
   tabsByWorktree: Record<
     string,
-    { id: string; ptyId: string | null; title?: string; launchAgent?: string }[]
+    {
+      id: string
+      ptyId: string | null
+      title?: string
+      launchAgent?: string
+      shellOverride?: string
+    }[]
   >
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
@@ -87,7 +93,18 @@ type StoreState = {
       | { kind: 'windows-host' }
       | { kind: 'wsl'; distro: string }
   }[]
-  sshConnectionStates: Map<string, { status: string }>
+  folderWorkspaces?: {
+    id: string
+    projectGroupId: string
+    folderPath: string
+    connectionId?: string | null
+  }[]
+  projectGroups?: {
+    id: string
+    connectionId?: string | null
+    executionHostId?: string | null
+  }[]
+  sshConnectionStates: Map<string, { status: string; remotePlatform?: NodeJS.Platform }>
   cacheTimerByKey: Record<string, number | null>
   settings: {
     theme?: 'system' | 'dark' | 'light'
@@ -576,6 +593,23 @@ function sendTerminalInputThroughPane(pane: ReturnType<typeof createPane>, data:
   terminalInputHandler?.(data)
 }
 
+type TerminalOscHandler = (data: string) => boolean | void
+type TerminalReplyScenario = {
+  name: string
+  arrange: () => { cwd: string; worktreeId?: string }
+}
+
+function captureTerminalOscHandlers(
+  pane: ReturnType<typeof createPane>
+): Map<number, TerminalOscHandler> {
+  const handlers = new Map<number, TerminalOscHandler>()
+  pane.terminal.parser.registerOscHandler = vi.fn((id: number, cb: TerminalOscHandler) => {
+    handlers.set(id, cb)
+    return { dispose: vi.fn() }
+  }) as typeof pane.terminal.parser.registerOscHandler
+  return handlers
+}
+
 describe('connectPanePty', () => {
   const originalRequestAnimationFrame = globalThis.requestAnimationFrame
   const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
@@ -850,6 +884,443 @@ describe('connectPanePty', () => {
       await flushAsyncTicks()
 
       expect(createdTransportOptions[0]).not.toHaveProperty('terminalColorQueryReplies')
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('uses project Windows-host runtime when deciding whether ConPTY startup OSC replies are safe', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+      mockStoreState = {
+        ...mockStoreState,
+        tabsByWorktree: {
+          'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', shellOverride: 'wsl.exe' }]
+        },
+        projects: [{ id: 'repo1', localWindowsRuntimePreference: { kind: 'windows-host' } }],
+        worktreesByRepo: {
+          repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+        }
+      }
+
+      connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        createDeps({ cwd }) as never
+      )
+      await flushAsyncTicks()
+
+      expect(createdTransportOptions[0]).toMatchObject({
+        projectRuntime: expect.objectContaining({
+          runtime: expect.objectContaining({ kind: 'windows-host' })
+        })
+      })
+      expect(createdTransportOptions[0]).not.toHaveProperty('terminalColorQueryReplies')
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it.each([
+    {
+      name: 'WSL UNC cwd',
+      arrange: () => {
+        const cwd = '\\\\wsl.localhost\\Ubuntu\\home\\neil\\orca\\seafan'
+        mockStoreState = {
+          ...mockStoreState,
+          worktreesByRepo: {
+            repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+          }
+        }
+        return { cwd }
+      }
+    },
+    {
+      name: 'project WSL runtime',
+      arrange: () => {
+        const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+        mockStoreState = {
+          ...mockStoreState,
+          projects: [
+            { id: 'repo1', localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' } }
+          ],
+          worktreesByRepo: {
+            repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+          }
+        }
+        return { cwd }
+      }
+    },
+    {
+      name: 'global WSL runtime default',
+      arrange: () => {
+        const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+        mockStoreState = {
+          ...mockStoreState,
+          settings: {
+            ...mockStoreState.settings,
+            localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+          },
+          worktreesByRepo: {
+            repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+          }
+        }
+        return { cwd }
+      }
+    },
+    {
+      name: 'legacy WSL terminal shell',
+      arrange: () => {
+        const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+        mockStoreState = {
+          ...mockStoreState,
+          settings: {
+            ...mockStoreState.settings,
+            terminalWindowsShell: 'wsl.exe',
+            terminalWindowsWslDistro: 'Ubuntu'
+          },
+          worktreesByRepo: {
+            repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+          }
+        }
+        return { cwd }
+      }
+    },
+    {
+      name: 'Linux SSH pane',
+      arrange: () => {
+        const cwd = '/home/neil/orca/seafan'
+        mockStoreState = {
+          ...mockStoreState,
+          repos: [{ id: 'repo1', connectionId: 'ssh-conn-1', displayName: 'orca' }],
+          sshConnectionStates: new Map([
+            ['ssh-conn-1', { status: 'connected', remotePlatform: 'linux' }]
+          ]),
+          worktreesByRepo: {
+            repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+          }
+        }
+        return { cwd }
+      }
+    },
+    {
+      name: 'remote runtime pane with stale Windows SSH metadata',
+      arrange: () => {
+        const cwd = '/workspaces/orca/seafan'
+        const worktreeId = 'folder:folder-1'
+        mockStoreState = {
+          ...mockStoreState,
+          repos: [],
+          folderWorkspaces: [
+            {
+              id: 'folder-1',
+              projectGroupId: 'group-1',
+              folderPath: cwd,
+              connectionId: 'ssh-conn-1'
+            }
+          ],
+          projectGroups: [
+            {
+              id: 'group-1',
+              connectionId: 'ssh-conn-1',
+              executionHostId: 'runtime:runtime-env-1'
+            }
+          ],
+          sshConnectionStates: new Map([
+            ['ssh-conn-1', { status: 'connected', remotePlatform: 'win32' }]
+          ]),
+          tabsByWorktree: {
+            [worktreeId]: [{ id: 'tab-1', ptyId: 'tab-pty' }]
+          }
+        }
+        return { cwd, worktreeId }
+      }
+    }
+  ] satisfies TerminalReplyScenario[])(
+    'passes startup OSC color replies for $name on Windows clients',
+    async ({ arrange }: TerminalReplyScenario) => {
+      const restoreNavigator = temporarilySetNavigatorUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+      )
+      try {
+        const { cwd, worktreeId } = arrange()
+        const { connectPanePty } = await import('./pty-connection')
+        const transport = createMockTransport()
+        transportFactoryQueue.push(transport)
+
+        connectPanePty(
+          createPane(1) as never,
+          createManager(1) as never,
+          createDeps({ cwd, ...(worktreeId ? { worktreeId } : {}) }) as never
+        )
+        await flushAsyncTicks()
+
+        expect(createdTransportOptions[0]?.terminalColorQueryReplies).toEqual({
+          foreground: '#eeeeee',
+          background: '#111111'
+        })
+      } finally {
+        restoreNavigator()
+      }
+    }
+  )
+
+  it('does not pass startup OSC color replies to known Windows SSH ConPTY spawns', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+      mockStoreState = {
+        ...mockStoreState,
+        repos: [{ id: 'repo1', connectionId: 'ssh-conn-1', displayName: 'orca' }],
+        sshConnectionStates: new Map([
+          ['ssh-conn-1', { status: 'connected', remotePlatform: 'win32' }]
+        ]),
+        worktreesByRepo: {
+          repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+        }
+      }
+
+      connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        createDeps({ cwd }) as never
+      )
+      await flushAsyncTicks()
+
+      expect(createdTransportOptions[0]).not.toHaveProperty('terminalColorQueryReplies')
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('passes startup OSC color replies to Windows SSH panes that explicitly launch WSL', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+      mockStoreState = {
+        ...mockStoreState,
+        repos: [{ id: 'repo1', connectionId: 'ssh-conn-1', displayName: 'orca' }],
+        sshConnectionStates: new Map([
+          ['ssh-conn-1', { status: 'connected', remotePlatform: 'win32' }]
+        ]),
+        tabsByWorktree: {
+          'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', shellOverride: 'wsl.exe' }]
+        },
+        worktreesByRepo: {
+          repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+        }
+      }
+
+      connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        createDeps({ cwd }) as never
+      )
+      await flushAsyncTicks()
+
+      expect(createdTransportOptions[0]?.terminalColorQueryReplies).toEqual({
+        foreground: '#eeeeee',
+        background: '#111111'
+      })
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('consumes visible OSC color queries without replying on native Windows ConPTY', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      transportFactoryQueue.push(transport)
+      mockStoreState = {
+        ...mockStoreState,
+        worktreesByRepo: {
+          repo1: [
+            {
+              id: 'wt-1',
+              repoId: 'repo1',
+              path: 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan',
+              displayName: 'feat/notis'
+            }
+          ]
+        }
+      }
+      const pane = createPane(1)
+      const oscHandlers = captureTerminalOscHandlers(pane)
+
+      connectPanePty(
+        pane as never,
+        createManager(1) as never,
+        createDeps({ cwd: 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan' }) as never
+      )
+      await flushAsyncTicks()
+
+      expect(oscHandlers.get(10)?.('?')).toBe(true)
+      expect(transport.sendInput).not.toHaveBeenCalled()
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it.each([
+    {
+      name: 'project WSL runtime',
+      arrange: () => {
+        const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+        mockStoreState = {
+          ...mockStoreState,
+          projects: [
+            { id: 'repo1', localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' } }
+          ],
+          worktreesByRepo: {
+            repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+          }
+        }
+        return { cwd }
+      }
+    },
+    {
+      name: 'Linux SSH pane',
+      arrange: () => {
+        const cwd = '/home/neil/orca/seafan'
+        mockStoreState = {
+          ...mockStoreState,
+          repos: [{ id: 'repo1', connectionId: 'ssh-conn-1', displayName: 'orca' }],
+          sshConnectionStates: new Map([
+            ['ssh-conn-1', { status: 'connected', remotePlatform: 'linux' }]
+          ]),
+          worktreesByRepo: {
+            repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+          }
+        }
+        return { cwd }
+      }
+    },
+    {
+      name: 'remote runtime pane',
+      arrange: () => {
+        const cwd = '/workspaces/orca/seafan'
+        mockStoreState = {
+          ...mockStoreState,
+          settings: {
+            ...mockStoreState.settings,
+            activeRuntimeEnvironmentId: 'runtime-env-1'
+          },
+          worktreesByRepo: {
+            repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+          }
+        }
+        return { cwd }
+      }
+    },
+    {
+      name: 'remote runtime pane with stale Windows SSH metadata',
+      arrange: () => {
+        const cwd = '/workspaces/orca/seafan'
+        const worktreeId = 'folder:folder-1'
+        mockStoreState = {
+          ...mockStoreState,
+          repos: [],
+          folderWorkspaces: [
+            {
+              id: 'folder-1',
+              projectGroupId: 'group-1',
+              folderPath: cwd,
+              connectionId: 'ssh-conn-1'
+            }
+          ],
+          projectGroups: [
+            {
+              id: 'group-1',
+              connectionId: 'ssh-conn-1',
+              executionHostId: 'runtime:runtime-env-1'
+            }
+          ],
+          sshConnectionStates: new Map([
+            ['ssh-conn-1', { status: 'connected', remotePlatform: 'win32' }]
+          ]),
+          tabsByWorktree: {
+            [worktreeId]: [{ id: 'tab-1', ptyId: 'tab-pty' }]
+          }
+        }
+        return { cwd, worktreeId }
+      }
+    }
+  ] satisfies TerminalReplyScenario[])(
+    'answers visible OSC color queries for $name on Windows clients',
+    async ({ arrange }: TerminalReplyScenario) => {
+      const restoreNavigator = temporarilySetNavigatorUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+      )
+      try {
+        const { cwd, worktreeId } = arrange()
+        const { connectPanePty } = await import('./pty-connection')
+        const transport = createMockTransport('pty-id')
+        transportFactoryQueue.push(transport)
+        const pane = createPane(1)
+        const oscHandlers = captureTerminalOscHandlers(pane)
+
+        connectPanePty(
+          pane as never,
+          createManager(1) as never,
+          createDeps({ cwd, ...(worktreeId ? { worktreeId } : {}) }) as never
+        )
+        await flushAsyncTicks()
+
+        expect(oscHandlers.get(10)?.('?')).toBe(true)
+        expect(transport.sendInput).toHaveBeenCalledWith('\x1b]10;rgb:eeee/eeee/eeee\x1b\\')
+      } finally {
+        restoreNavigator()
+      }
+    }
+  )
+
+  it('consumes visible OSC color queries without replying on known Windows SSH ConPTY panes', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      transportFactoryQueue.push(transport)
+      const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+      mockStoreState = {
+        ...mockStoreState,
+        repos: [{ id: 'repo1', connectionId: 'ssh-conn-1', displayName: 'orca' }],
+        sshConnectionStates: new Map([
+          ['ssh-conn-1', { status: 'connected', remotePlatform: 'win32' }]
+        ]),
+        worktreesByRepo: {
+          repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+        }
+      }
+      const pane = createPane(1)
+      const oscHandlers = captureTerminalOscHandlers(pane)
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps({ cwd }) as never)
+      await flushAsyncTicks()
+
+      expect(oscHandlers.get(10)?.('?')).toBe(true)
+      expect(transport.sendInput).not.toHaveBeenCalled()
     } finally {
       restoreNavigator()
     }
@@ -6051,6 +6522,115 @@ describe('connectPanePty', () => {
       expect(pane.terminal.write).not.toHaveBeenCalledWith(queries, expect.any(Function))
       expect(pane.terminal.write).not.toHaveBeenCalledWith(
         `${queries}startup frame\r\n`,
+        expect.any(Function)
+      )
+
+      binding.dispose()
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('does not answer hidden Codex OSC color queries through known Windows SSH ConPTY', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+      mockStoreState = {
+        ...mockStoreState,
+        repos: [{ id: 'repo1', connectionId: 'ssh-conn-1', displayName: 'orca' }],
+        sshConnectionStates: new Map([
+          ['ssh-conn-1', { status: 'connected', remotePlatform: 'win32' }]
+        ]),
+        worktreesByRepo: {
+          repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+        }
+      }
+
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const binding = connectPanePty(
+        pane as never,
+        manager as never,
+        createDeps({
+          cwd,
+          isVisibleRef: { current: false },
+          startup: { command: 'codex' }
+        }) as never
+      )
+      await flushAsyncTicks(6)
+
+      const queries = '\x1b]10;?\x1b\\\x1b]11;?\x1b\\'
+      capturedDataCallback.current?.(`${queries}startup frame\r\n`)
+
+      expect(transport.sendInput).not.toHaveBeenCalled()
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(queries, expect.any(Function))
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        `${queries}startup frame\r\n`,
+        expect.any(Function)
+      )
+
+      binding.dispose()
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('answers hidden Codex OSC color queries for project WSL runtime on Windows cwd', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const cwd = 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan'
+      mockStoreState = {
+        ...mockStoreState,
+        projects: [
+          { id: 'repo1', localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' } }
+        ],
+        worktreesByRepo: {
+          repo1: [{ id: 'wt-1', repoId: 'repo1', path: cwd, displayName: 'feat/notis' }]
+        }
+      }
+
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const binding = connectPanePty(
+        pane as never,
+        manager as never,
+        createDeps({
+          cwd,
+          isVisibleRef: { current: false },
+          startup: { command: 'codex' }
+        }) as never
+      )
+      await flushAsyncTicks(6)
+
+      capturedDataCallback.current?.('\x1b]10;?\x1b\\startup frame\r\n')
+
+      expect(transport.sendInput).toHaveBeenCalledWith('\x1b]10;rgb:eeee/eeee/eeee\x1b\\')
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        '\x1b]10;?\x1b\\startup frame\r\n',
         expect.any(Function)
       )
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -810,6 +810,51 @@ describe('connectPanePty', () => {
     })
   })
 
+  it('does not pass startup OSC color replies to native Windows ConPTY spawns', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      mockStoreState = {
+        ...mockStoreState,
+        worktreesByRepo: {
+          repo1: [
+            {
+              id: 'wt-1',
+              repoId: 'repo1',
+              path: 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan',
+              displayName: 'feat/notis'
+            }
+          ]
+        }
+      }
+
+      connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        createDeps({
+          cwd: 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan',
+          startup: {
+            command: 'codex',
+            telemetry: {
+              agent_kind: 'codex',
+              launch_source: 'tab_bar_quick_launch',
+              request_kind: 'new'
+            }
+          }
+        }) as never
+      )
+      await flushAsyncTicks()
+
+      expect(createdTransportOptions[0]).not.toHaveProperty('terminalColorQueryReplies')
+    } finally {
+      restoreNavigator()
+    }
+  })
+
   it('observes live terminal GitHub PR URLs before agent completion', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
@@ -5955,6 +6000,64 @@ describe('connectPanePty', () => {
     )
 
     binding.dispose()
+  })
+
+  it('does not answer hidden Codex OSC color queries through native Windows ConPTY', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      mockStoreState = {
+        ...mockStoreState,
+        worktreesByRepo: {
+          repo1: [
+            {
+              id: 'wt-1',
+              repoId: 'repo1',
+              path: 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan',
+              displayName: 'feat/notis'
+            }
+          ]
+        }
+      }
+
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const binding = connectPanePty(
+        pane as never,
+        manager as never,
+        createDeps({
+          cwd: 'C:\\Users\\neil\\orca\\workspaces\\orca\\seafan',
+          isVisibleRef: { current: false },
+          startup: { command: 'codex' }
+        }) as never
+      )
+      await flushAsyncTicks(6)
+
+      const queries = '\x1b]10;?\x1b\\\x1b]11;?\x1b\\'
+      capturedDataCallback.current?.(`${queries}startup frame\r\n`)
+
+      expect(transport.sendInput).not.toHaveBeenCalled()
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(queries, expect.any(Function))
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        `${queries}startup frame\r\n`,
+        expect.any(Function)
+      )
+
+      binding.dispose()
+    } finally {
+      restoreNavigator()
+    }
   })
 
   it('keeps split hidden Codex terminal queries on the live xterm path', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2112,9 +2112,13 @@ export function connectPanePty(
     recordAcceptedTerminalInputForHibernation()
   }
   const terminalTheme = pane.terminal.options.theme
-  const terminalColorQueryReplies = terminalTheme
-    ? { foreground: terminalTheme.foreground, background: terminalTheme.background }
-    : undefined
+  // Why: ConPTY can turn OSC color replies written as PTY input into visible
+  // prompt text by swallowing ESC and echoing the printable remainder.
+  const shouldSendOscColorQueryReplies = !isNativeWindowsConpty
+  const terminalColorQueryReplies =
+    shouldSendOscColorQueryReplies && terminalTheme
+      ? { foreground: terminalTheme.foreground, background: terminalTheme.background }
+      : undefined
   const transportOptions = {
     cwd: deps.cwd,
     env: paneEnv,
@@ -2220,6 +2224,7 @@ export function connectPanePty(
     parser: pane.terminal.parser,
     sendInput: (data) => transport.sendInput(data),
     isReplaying: () => isPaneReplaying(deps.replayingPanesRef, pane.id),
+    disableOscColorReplies: !shouldSendOscColorQueryReplies,
     ...(isNativeWindowsConpty ? { da1Response: CONPTY_DA1_RESPONSE } : {})
   })
   const respondToTerminalPixelSizeQueries = createTerminalPixelSizeQueryResponder(
@@ -3608,7 +3613,7 @@ export function connectPanePty(
         hiddenStartupRendererQueryPending
       )
       hiddenStartupRendererQueryPending = extracted.pending
-      if (extracted.oscColorQueryData) {
+      if (extracted.oscColorQueryData && shouldSendOscColorQueryReplies) {
         // Why: Codex's startup palette probe has a 100 ms budget. Answer
         // hidden color queries directly so renderer scheduling cannot miss it.
         sendTerminalOscColorQueryReplies(extracted.oscColorQueryData, pane.terminal, (reply) =>
@@ -4241,7 +4246,7 @@ export function connectPanePty(
           hiddenStartupRendererQuery: true
         })
       }
-      if (pendingForegroundQuery?.oscColorQueryData) {
+      if (pendingForegroundQuery?.oscColorQueryData && shouldSendOscColorQueryReplies) {
         sendTerminalOscColorQueryReplies(
           pendingForegroundQuery.oscColorQueryData,
           pane.terminal,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -11,6 +11,10 @@ import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import {
+  isWslShellName,
+  resolveLocalWindowsTerminalShellOverrideForTab
+} from '../../../../shared/local-windows-terminal-runtime'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
 import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-color-reply'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
@@ -2059,23 +2063,6 @@ export function connectPanePty(
   const connectionId = getConnectionId(deps.worktreeId) ?? null
   const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find((t) => t.id === deps.tabId)
   const shellOverride = tab?.shellOverride
-  // Why: a serve/remote-runtime pane has no SSH connectionId and a Linux cwd, so
-  // the native-Windows ConPTY heuristic misfires on a Windows client and wrongly
-  // enables ConPTY synchronized-output protection, which strips an agent's
-  // transient cursor-show (?25h) and leaves the cursor invisible. The execution
-  // host is the authoritative signal: only a 'local' host is a local native PTY.
-  const executionHostId = getExecutionHostIdForWorktree(state, deps.worktreeId)
-  const isNativeWindowsConpty = isLocalNativeWindowsConpty({
-    userAgent: navigator.userAgent,
-    connectionId,
-    cwd: deps.cwd,
-    shellOverride,
-    executionHostId
-  })
-  const shouldApplyNativeWindowsRewriteRefresh = isNativeWindowsConpty
-  const shouldApplyWindowsRendererUnicodeRefresh = CLIENT_PLATFORM === 'win32'
-  const shouldProtectNativeWindowsSynchronizedOutput = isNativeWindowsConpty
-
   const restoredPtyIdForTransport =
     deps.restoredLeafId && deps.restoredPtyIdByLeafId
       ? (deps.restoredPtyIdByLeafId[deps.restoredLeafId] ?? null)
@@ -2096,6 +2083,40 @@ export function connectPanePty(
           availableWslDistros: localWindowsTerminalCapabilities?.wslDistros ?? null
         })
       : undefined
+  const isWslWorktree = isWslUncPath(deps.cwd ?? '') || isWslUncPath(worktree?.path ?? '')
+  // Why: spawn may enter WSL through an explicit shell or project/global runtime
+  // settings even when the renderer cwd is a Windows path.
+  const effectiveWindowsShellOverride = resolveLocalWindowsTerminalShellOverrideForTab({
+    explicitShellOverride: shellOverride,
+    defaultWindowsShell: state.settings?.terminalWindowsShell,
+    isWslWorktree,
+    projectRuntime
+  })
+  // Why: a serve/remote-runtime pane has no SSH connectionId and a Linux cwd, so
+  // the native-Windows ConPTY heuristic misfires on a Windows client and wrongly
+  // enables ConPTY synchronized-output protection, which strips an agent's
+  // transient cursor-show (?25h) and leaves the cursor invisible. The execution
+  // host is the authoritative signal: only a 'local' host is a local native PTY.
+  const executionHostId = getExecutionHostIdForWorktree(state, deps.worktreeId)
+  const isNativeWindowsConpty = isLocalNativeWindowsConpty({
+    userAgent: navigator.userAgent,
+    connectionId,
+    cwd: deps.cwd,
+    shellOverride: effectiveWindowsShellOverride,
+    executionHostId
+  })
+  const sshRemotePlatform = connectionId
+    ? (state.sshConnectionStates.get(connectionId)?.remotePlatform ?? null)
+    : null
+  // Why: SSH relay panes run node-pty on the remote host. A known Windows
+  // remote has the same ConPTY input-reply hazard, but runtime-owned panes use
+  // the runtime transport even if stale SSH metadata is still present.
+  const isSshWindowsConpty =
+    runtimeEnvironmentId === null && sshRemotePlatform === 'win32' && !isWslShellName(shellOverride)
+  const shouldApplyNativeWindowsRewriteRefresh = isNativeWindowsConpty
+  const shouldApplyWindowsRendererUnicodeRefresh = CLIENT_PLATFORM === 'win32'
+  const shouldProtectNativeWindowsSynchronizedOutput = isNativeWindowsConpty
+
   const shouldOwnAgentStatusInRenderer = runtimeEnvironmentId !== null
   const shouldDeliverStartupViaTerminalPaste = paneStartup?.delivery === 'terminal-paste'
   const hadExistingPaneTransportAtConnect = deps.paneTransportsRef.current.size > 0
@@ -2114,7 +2135,7 @@ export function connectPanePty(
   const terminalTheme = pane.terminal.options.theme
   // Why: ConPTY can turn OSC color replies written as PTY input into visible
   // prompt text by swallowing ESC and echoing the printable remainder.
-  const shouldSendOscColorQueryReplies = !isNativeWindowsConpty
+  const shouldSendOscColorQueryReplies = !isNativeWindowsConpty && !isSshWindowsConpty
   const terminalColorQueryReplies =
     shouldSendOscColorQueryReplies && terminalTheme
       ? { foreground: terminalTheme.foreground, background: terminalTheme.background }

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
@@ -88,6 +88,42 @@ describe('installTerminalCapabilityReplyHandlers', () => {
     }
   })
 
+  it('leaves OSC color queries to other handlers when color replies are disabled', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    term.options.theme = {
+      foreground: '#2e3434',
+      background: '#ffffff'
+    }
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const returnValues: boolean[] = []
+    const disposable = installTerminalCapabilityReplyHandlers({
+      terminal: term as never,
+      parser: {
+        registerCsiHandler: (id, cb) =>
+          term.parser.registerCsiHandler(id, (params) => cb(params) === true),
+        registerOscHandler: (id, cb) =>
+          term.parser.registerOscHandler(id, (data) => {
+            const value = cb(data) === true
+            returnValues.push(value)
+            return value
+          })
+      },
+      sendInput,
+      isReplaying: () => false,
+      disableOscColorReplies: true
+    })
+
+    try {
+      await writeTerminal(term, '\x1b]10;?\x1b\\\x1b]11;?\x1b\\')
+
+      expect(sendInput).not.toHaveBeenCalled()
+      expect(returnValues).toEqual([false, false])
+    } finally {
+      disposable.dispose()
+      term.dispose()
+    }
+  })
+
   it('answers OSC color queries for active rgba and modern rgb theme colors', async () => {
     const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
     term.options.theme = {

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
@@ -88,7 +88,7 @@ describe('installTerminalCapabilityReplyHandlers', () => {
     }
   })
 
-  it('leaves OSC color queries to other handlers when color replies are disabled', async () => {
+  it('consumes recognized OSC color queries without replying when color replies are disabled', async () => {
     const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
     term.options.theme = {
       foreground: '#2e3434',
@@ -114,10 +114,49 @@ describe('installTerminalCapabilityReplyHandlers', () => {
     })
 
     try {
-      await writeTerminal(term, '\x1b]10;?\x1b\\\x1b]11;?\x1b\\')
+      await writeTerminal(term, '\x1b]10;?\x1b\\\x1b]11;?\x1b\\\x1b]10;?;?\x1b\\')
 
       expect(sendInput).not.toHaveBeenCalled()
-      expect(returnValues).toEqual([false, false])
+      expect(returnValues).toEqual([true, true, true])
+    } finally {
+      disposable.dispose()
+      term.dispose()
+    }
+  })
+
+  it('leaves disabled OSC color commands and malformed queries to other handlers', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    term.options.theme = {
+      foreground: '#2e3434',
+      background: '#ffffff'
+    }
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const returnValues: boolean[] = []
+    const disposable = installTerminalCapabilityReplyHandlers({
+      terminal: term as never,
+      parser: {
+        registerCsiHandler: (id, cb) =>
+          term.parser.registerCsiHandler(id, (params) => cb(params) === true),
+        registerOscHandler: (id, cb) =>
+          term.parser.registerOscHandler(id, (data) => {
+            const value = cb(data) === true
+            returnValues.push(value)
+            return value
+          })
+      },
+      sendInput,
+      isReplaying: () => false,
+      disableOscColorReplies: true
+    })
+
+    try {
+      await writeTerminal(
+        term,
+        '\x1b]10;#123456\x1b\\\x1b]11;?still-not-a-query\x1b\\\x1b]10;?;?;?\x1b\\'
+      )
+
+      expect(sendInput).not.toHaveBeenCalled()
+      expect(returnValues).toEqual([false, false, false])
     } finally {
       disposable.dispose()
       term.dispose()

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
@@ -15,6 +15,7 @@ type TerminalCapabilityRepliesDeps = {
   sendInput: (data: string) => boolean | void
   isReplaying: () => boolean
   da1Response?: string
+  disableOscColorReplies?: boolean
 }
 
 function isPrimaryDeviceAttributesQuery(params: (number | number[])[]): boolean {
@@ -130,6 +131,9 @@ export function installTerminalCapabilityReplyHandlers(
       return true
     }),
     deps.parser.registerOscHandler(10, (data) => {
+      if (deps.disableOscColorReplies) {
+        return false
+      }
       const slots = terminalOscColorQuerySlotsForBody(10, data.trim())
       if (!slots) {
         return false
@@ -140,6 +144,9 @@ export function installTerminalCapabilityReplyHandlers(
       return sendTerminalOscColorQueryRepliesForSlots(slots, deps.terminal, deps.sendInput)
     }),
     deps.parser.registerOscHandler(11, (data) => {
+      if (deps.disableOscColorReplies) {
+        return false
+      }
       const slots = terminalOscColorQuerySlotsForBody(11, data.trim())
       if (!slots) {
         return false

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
@@ -76,6 +76,21 @@ function sendTerminalOscColorQueryRepliesForSlots(
   return true
 }
 
+function handleTerminalOscColorQuery(
+  slot: TerminalOscColorQuerySlot,
+  data: string,
+  deps: TerminalCapabilityRepliesDeps
+): boolean {
+  const slots = terminalOscColorQuerySlotsForBody(slot, data.trim())
+  if (!slots) {
+    return false
+  }
+  if (deps.disableOscColorReplies || deps.isReplaying()) {
+    return true
+  }
+  return sendTerminalOscColorQueryRepliesForSlots(slots, deps.terminal, deps.sendInput)
+}
+
 export function createTerminalPixelSizeQueryResponder(
   terminal: Pick<Terminal, 'cols' | 'rows' | 'element'>,
   sendInput: (data: string) => boolean | void
@@ -131,30 +146,10 @@ export function installTerminalCapabilityReplyHandlers(
       return true
     }),
     deps.parser.registerOscHandler(10, (data) => {
-      if (deps.disableOscColorReplies) {
-        return false
-      }
-      const slots = terminalOscColorQuerySlotsForBody(10, data.trim())
-      if (!slots) {
-        return false
-      }
-      if (deps.isReplaying()) {
-        return true
-      }
-      return sendTerminalOscColorQueryRepliesForSlots(slots, deps.terminal, deps.sendInput)
+      return handleTerminalOscColorQuery(10, data, deps)
     }),
     deps.parser.registerOscHandler(11, (data) => {
-      if (deps.disableOscColorReplies) {
-        return false
-      }
-      const slots = terminalOscColorQuerySlotsForBody(11, data.trim())
-      if (!slots) {
-        return false
-      }
-      if (deps.isReplaying()) {
-        return true
-      }
-      return sendTerminalOscColorQueryRepliesForSlots(slots, deps.terminal, deps.sendInput)
+      return handleTerminalOscColorQuery(11, data, deps)
     })
   ]
 


### PR DESCRIPTION
## Summary\n- suppress OSC 10/11 color-query replies for local native Windows ConPTY panes\n- keep OSC color replies enabled for POSIX-like paths such as WSL, SSH, and remote runtimes\n- add regression coverage for startup spawn metadata and hidden Codex startup output on Windows ConPTY\n\n## Root Cause\nThe startup color-query work added replies that are written back as PTY input. Native Windows ConPTY can treat those bytes like keyboard input, swallowing ESC and echoing the printable remainder into Codex's prompt (for example, `]10;rgb:...`).\n\n## Tests\n- pnpm test src/renderer/src/components/terminal-pane/pty-connection.test.ts\n- pnpm test src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts\n- pnpm run typecheck:web

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6975">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->