### PR TITLE
Recover stale coordinator runs

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-gates.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-gates.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrchestrationDb } from '../../orchestration/db'
+import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
+
+type MockCoordinatorInstance = {
+  resolveRun?: () => void
+  stopped: boolean
+}
+
+const coordinatorMock = vi.hoisted(() => {
+  const instances: MockCoordinatorInstance[] = []
+
+  class Coordinator {
+    resolveRun?: () => void
+    stopped = false
+
+    constructor() {
+      instances.push(this)
+    }
+
+    runFromExistingRun(): Promise<unknown> {
+      return new Promise((resolve) => {
+        this.resolveRun = () => {
+          resolve({})
+        }
+      })
+    }
+
+    stop(): void {
+      this.stopped = true
+      this.resolveRun?.()
+    }
+  }
+
+  return { Coordinator, instances }
+})
+
+vi.mock('../../orchestration/coordinator', () => ({
+  Coordinator: coordinatorMock.Coordinator
+}))
+
+describe('orchestration gate RPC lifecycle recovery', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(async () => {
+    for (const instance of coordinatorMock.instances) {
+      instance.resolveRun?.()
+    }
+    coordinatorMock.instances.length = 0
+    await Promise.resolve()
+    await Promise.resolve()
+    db?.close()
+    db = undefined
+  })
+
+  function findMethod(name: string) {
+    const method = ORCHESTRATION_GATE_METHODS.find((candidate) => candidate.name === name)
+    if (!method) {
+      throw new Error(`Method not found: ${name}`)
+    }
+    return method
+  }
+
+  async function call(name: string, params: Record<string, unknown>): Promise<unknown> {
+    const method = findMethod(name)
+    const parsed = method.params ? method.params.parse(params) : undefined
+    return method.handler(parsed, {
+      runtime: { getOrchestrationDb: () => db }
+    } as never)
+  }
+
+  it('marks a stale durable run failed when stop has no live coordinator', async () => {
+    db = new OrchestrationDb(':memory:')
+    const staleRun = db.createCoordinatorRun({
+      spec: 'old work',
+      coordinatorHandle: 'coordinator'
+    })
+
+    await expect(call('orchestration.runStop', {})).resolves.toEqual({
+      runId: staleRun.id,
+      stopped: true
+    })
+
+    expect(db.getCoordinatorRun(staleRun.id)?.status).toBe('failed')
+    expect(db.getActiveCoordinatorRun()).toBeUndefined()
+    expect(coordinatorMock.instances).toHaveLength(0)
+  })
+
+  it('fails a stale durable run before accepting a new coordinator run', async () => {
+    db = new OrchestrationDb(':memory:')
+    const staleRun = db.createCoordinatorRun({
+      spec: 'old work',
+      coordinatorHandle: 'coordinator'
+    })
+
+    const result = (await call('orchestration.run', { spec: 'new work' })) as {
+      runId: string
+      status: string
+    }
+
+    expect(result.status).toBe('running')
+    expect(result.runId).not.toBe(staleRun.id)
+    expect(db.getCoordinatorRun(staleRun.id)?.status).toBe('failed')
+    expect(db.getActiveCoordinatorRun()?.id).toBe(result.runId)
+    expect(coordinatorMock.instances).toHaveLength(1)
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-gates.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-gates.test.ts
@@ -47,6 +47,8 @@ describe('orchestration gate RPC lifecycle recovery', () => {
       instance.resolveRun?.()
     }
     coordinatorMock.instances.length = 0
+    // Why: flush microtasks so the handler's `.finally()` callback can clear
+    // the module-scoped active coordinator before the next test starts.
     await Promise.resolve()
     await Promise.resolve()
     db?.close()
@@ -101,6 +103,25 @@ describe('orchestration gate RPC lifecycle recovery', () => {
     expect(result.status).toBe('running')
     expect(result.runId).not.toBe(staleRun.id)
     expect(db.getCoordinatorRun(staleRun.id)?.status).toBe('failed')
+    expect(db.getActiveCoordinatorRun()?.id).toBe(result.runId)
+    expect(coordinatorMock.instances).toHaveLength(1)
+  })
+
+  it('rejects a new run while a live coordinator is active', async () => {
+    db = new OrchestrationDb(':memory:')
+
+    const result = (await call('orchestration.run', { spec: 'active work' })) as {
+      runId: string
+      status: string
+    }
+
+    expect(result.status).toBe('running')
+    expect(db.getActiveCoordinatorRun()?.id).toBe(result.runId)
+    expect(coordinatorMock.instances).toHaveLength(1)
+
+    await expect(call('orchestration.run', { spec: 'new work' })).rejects.toThrow(
+      `Coordinator already running: ${result.runId}`
+    )
     expect(db.getActiveCoordinatorRun()?.id).toBe(result.runId)
     expect(coordinatorMock.instances).toHaveLength(1)
   })

--- a/src/main/runtime/rpc/methods/orchestration-gates.ts
+++ b/src/main/runtime/rpc/methods/orchestration-gates.ts
@@ -1,13 +1,21 @@
 import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
-import type { GateStatus } from '../../orchestration/db'
+import type { CoordinatorRun, GateStatus, OrchestrationDb } from '../../orchestration/db'
 import { Coordinator } from '../../orchestration/coordinator'
 
 // Why: the coordinator instance is stored at module scope so orchestration.runStop
 // can signal it to halt. Only one coordinator can run at a time (enforced by
 // the DB's active-run check), so a single reference suffices.
 let activeCoordinator: Coordinator | null = null
+
+function markStaleCoordinatorRunFailed(db: OrchestrationDb, run: CoordinatorRun): void {
+  // Why: a process restart loses the module-scope coordinator handle but can
+  // leave the durable row marked running. Without a live handle, the row cannot
+  // make progress, so fail it before accepting or acknowledging new lifecycle
+  // commands.
+  db.updateCoordinatorRun(run.id, 'failed')
+}
 
 const RunParams = z.object({
   spec: requiredString('Missing --spec'),
@@ -48,7 +56,10 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
 
       const existing = db.getActiveCoordinatorRun()
       if (existing) {
-        throw new Error(`Coordinator already running: ${existing.id}`)
+        if (activeCoordinator) {
+          throw new Error(`Coordinator already running: ${existing.id}`)
+        }
+        markStaleCoordinatorRunFailed(db, existing)
       }
 
       const coordinatorHandle = params.from ?? 'coordinator'
@@ -93,7 +104,8 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
 
       if (activeCoordinator) {
         activeCoordinator.stop()
-        activeCoordinator = null
+      } else {
+        markStaleCoordinatorRunFailed(db, run)
       }
 
       return { runId: run.id, stopped: true }


### PR DESCRIPTION
## Summary

Reconcile coordinator lifecycle state when the durable DB row says a run is still `running` but the process-local coordinator handle is gone.

This changes the RPC boundary so:

- `orchestration.run` marks a stale durable `running` row as `failed` before accepting a new coordinator run.
- `orchestration.runStop` marks a stale durable `running` row as `failed` when there is no live coordinator to stop.
- Live stop requests keep the in-memory coordinator handle in place until the background loop finalizes, avoiding a same-process overlap window.

## Root cause / impact

Coordinator run status is persisted in SQLite, but the object that can advance or stop a run is process-local memory. If Orca exits while a run is active, the next process can see a durable `running` row without any live coordinator behind it. That stale row blocks new orchestration, and stop previously reported success without reconciling the row.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` - full suite ran with 23,148 passing tests and one unrelated timeout in `src/main/startup/run-electron-vite-dev.test.ts`; the failed test passed when reproduced standalone.
- [x] `pnpm build`
- [x] Added focused regression coverage for stale durable coordinator runs with no live handle.

Additional focused checks run:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration-gates.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/db.test.ts src/main/runtime/orchestration/coordinator.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/run-electron-vite-dev.test.ts -t 'rebuilds the copied Electron app when Chromium resources are missing'`
- [x] `pnpm exec oxfmt --check src/main/runtime/rpc/methods/orchestration-gates.ts src/main/runtime/rpc/methods/orchestration-gates.test.ts`
- [x] `pnpm exec oxlint --format github src/main/runtime/rpc/methods/orchestration-gates.ts src/main/runtime/rpc/methods/orchestration-gates.test.ts`
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec lint-staged`

## AI Review Report

Review checked macOS, Linux, and Windows compatibility; local, remote, and SSH workflows; supported agent and integration compatibility; performance risk; UI impact; and basic security risk. The change is DB-state reconciliation in the existing RPC lifecycle path, with no platform-specific paths, shell behavior, shortcuts, UI changes, or provider-specific behavior. Performance impact is limited to an existing active-run lookup plus a single status update only on lifecycle commands.

## Security Audit

No new command execution, path handling, auth, secrets, dependency, or user-input parsing surface is added. The SQL write uses the existing `updateCoordinatorRun` helper with the already-known run ID. The change only corrects stale lifecycle state for a run that no live coordinator can advance.

## Notes

Local build emitted existing/non-patch warnings: baseline oxlint warnings in unrelated files, Vite dynamic-import/chunk-size warnings, a local `/usr/local/bin/orca-dev` symlink permission warning, and a macOS `CGWindowListCreateImage` deprecation warning in native code. GitHub profile has no public X handle listed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6981">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Coordinator runs could stay “running” in the DB after the process handle was gone. Stale runs are marked failed on new start or stop so orchestration doesn’t hang forever.
