### PR TITLE
Update Spanish, Japanese, Korean, and Chinese translations

### DIFF
--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -234,7 +234,7 @@
           "runtimeScopeForbiddenDescription": "Los espacios de trabajo no están disponibles con un emparejamiento de acceso móvil. Vuelve a conectarte con el enlace del navegador desde Ajustes → Servidores remotos de Orca → Comparte este servidor Orca."
         },
         "repos": {
-          "2975400634": "Update Orca server to open non-Git folders on this runtime.",
+          "2975400634": "Actualice el servidor Orca para abrir carpetas que no sean Git en este tiempo de ejecución.",
           "b7e14472ae": "No se pudo agregar la carpeta",
           "e649269645": "Utilice una ruta de servidor para agregar proyectos desde un tiempo de ejecución remoto.",
           "c6e022ddfc": "No se pudo agregar el proyecto",
@@ -242,8 +242,8 @@
           "8bb3ad7935": "Proyecto agregado",
           "a8e4b3af5b": "Proyecto ya agregado",
           "6d3318e813": "No se pudieron importar repositorios",
-          "3be0f7df04": "Cannot open folder on selected runtime",
-          "15cf5319ec": "{{path}} was checked on {{hostName}}, but that host did not report a usable folder."
+          "3be0f7df04": "No se puede abrir la carpeta en el tiempo de ejecución seleccionado",
+          "15cf5319ec": "{{path}} fue verificado en {{hostName}}, pero ese host no informó una carpeta utilizable."
         },
         "settings": {
           "e12dab333b": "No se pudo cambiar de servidor",
@@ -363,7 +363,7 @@
         "worktree": {
           "background": {
             "terminals": {
-              "setupTitle": "Setup"
+              "setupTitle": "Configuración"
             }
           }
         },
@@ -403,7 +403,7 @@
         "mobile": {
           "emulator": {
             "tab": {
-              "bf4f2a8a72": "Could not start the emulator. Check iOS or Android emulator setup and try another device."
+              "bf4f2a8a72": "No se pudo iniciar el emulador. Verifique la configuración del emulador de iOS o Android y pruebe con otro dispositivo."
             }
           }
         }
@@ -1162,15 +1162,15 @@
         "reuseExistingBranch": "Reutilizar rama",
         "reuseExistingBranchHint": "Hacer checkout de la rama existente en lugar de crear una nueva a partir de ella.",
         "createMultiple": "Crear más",
-        "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
-        "destroyDisabled": "destroy disabled",
-        "destroyConfigured": "destroy configured",
-        "noDestroyConfigured": "no destroy",
-        "ephemeralVm": "Per-Workspace Environment",
-        "chooseRunTarget": "Choose target",
-        "noRunTargets": "No run targets are ready for this project.",
-        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
+        "waitForSetupBeforeAgent": "Espere a que se complete la configuración antes de iniciar el agent",
+        "waitForSetupBeforeAgentHelp": "Active esto cuando el programa de instalación instale dependencias, servidores MCP o archivos de configuración que el agent necesite durante el inicio.",
+        "destroyDisabled": "destruir discapacitados",
+        "destroyConfigured": "destruir configurado",
+        "noDestroyConfigured": "no destruir",
+        "ephemeralVm": "Entorno por espacio de trabajo",
+        "chooseRunTarget": "Elige objetivo",
+        "noRunTargets": "No hay objetivos de ejecución listos para este proyecto.",
+        "perWorkspaceEnvHint": "Proporcione un entorno bajo demanda a partir de una receta"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Crear árbol de trabajo",
@@ -2222,9 +2222,9 @@
             "a3346fc6ed": "Cancelar la creación del árbol de trabajo",
             "532aea14ce": "Cancelar",
             "767951265d": "Algo salió mal al crear el árbol de trabajo.",
-            "vmProvisioningTitle": "Provisioning VM",
-            "cancelProvisioning": "Cancel",
-            "vmProvisioningLogEmpty": "Waiting for recipe output…"
+            "vmProvisioningTitle": "Aprovisionamiento de máquina virtual",
+            "cancelProvisioning": "Cancelar",
+            "vmProvisioningLogEmpty": "Esperando la salida de la receta..."
           }
         }
       },
@@ -2289,24 +2289,24 @@
             "ee81adfcef": "Vista",
             "4d0b72481c": "Ignorar",
             "9cc26c019d": "Eliminar",
-            "0e2d235c63": "Inactive workspace scan ready",
-            "4a35c08764": "Review",
-            "47123d0108": "Scanning inactive workspaces. You can close this and come back.",
-            "9a3be9f2df": "Scanning inactive workspaces. New rows appear here as they finish. You can close this and come back.",
-            "3d957ff117": "No workspaces match these filters.",
-            "e94b1f8bb4": "Clear filters",
-            "efb3843e75": "Filter and sort workspaces",
-            "93b7381d50": "Filters",
-            "a615e24679": "Sort",
-            "4cc5b73efe": "Finding inactive workspaces...",
-            "5bf2e88480": "{{value0}}/{{value1}} {{value2}} scanned",
-            "searchPlaceholder": "Search workspaces",
-            "ageFilter": "Age",
-            "reviewFilter": "Review",
+            "0e2d235c63": "Escaneo del espacio de trabajo inactivo listo",
+            "4a35c08764": "Revisar",
+            "47123d0108": "Escaneando espacios de trabajo inactivos. Puedes cerrar esto y volver.",
+            "9a3be9f2df": "Escaneando espacios de trabajo inactivos. Aquí aparecen nuevas filas a medida que terminan. Puedes cerrar esto y volver.",
+            "3d957ff117": "Ningún espacio de trabajo coincide con estos filtros.",
+            "e94b1f8bb4": "Limpiar filtros",
+            "efb3843e75": "Filtrar y ordenar espacios de trabajo",
+            "93b7381d50": "Filtros",
+            "a615e24679": "Clasificar",
+            "4cc5b73efe": "Encontrar espacios de trabajo inactivos...",
+            "5bf2e88480": "{{value0}}/{{value1}} {{value2}} escaneado",
+            "searchPlaceholder": "Buscar espacios de trabajo",
+            "ageFilter": "Edad",
+            "reviewFilter": "Revisar",
             "gitFilter": "Git",
-            "contextFilter": "Context",
-            "sortBy": "Sort by",
-            "sortDirection": "Direction"
+            "contextFilter": "Contexto",
+            "sortBy": "Ordenar por",
+            "sortDirection": "Dirección"
           }
         }
       },
@@ -3623,9 +3623,9 @@
           "05b33a17a9": "Cancelar",
           "8fba4b8cbb": "Esta carpeta no es un repositorio de Git. Tendrás el editor, la terminal y la búsqueda, pero las funciones basadas en Git no estarán disponibles.",
           "c49fb13492": "No se pudo agregar la carpeta remota",
-          "9a766f33ac": "This path was checked on the SSH host.",
-          "79fd02cf5f": "This path was checked on {{hostName}}.",
-          "8851b77327": "This path was checked locally."
+          "9a766f33ac": "Esta ruta se verificó en el host SSH.",
+          "79fd02cf5f": "Esta ruta fue verificada el {{hostName}}.",
+          "8851b77327": "Esta ruta fue verificada localmente."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "Ejecutar ganchos",
@@ -4350,15 +4350,15 @@
           "local": "Local",
           "runtime": "Server",
           "ssh": "SSH",
-          "connecting": "Connecting",
-          "connect": "Connect",
-          "addSshHost": "Add SSH host",
-          "addRemoteServer": "Add remote server",
-          "addRemoteHost": "Add remote host",
-          "addRemoteHostTooltip": "Choose SSH for a machine you can log into, or remote server for an Orca server.",
-          "addSshHostDetail": "Use an existing machine over SSH.",
-          "addRemoteServerDetail": "Pair with Orca running on another computer.",
-          "addRemoteHostDetail": "SSH host or Orca server"
+          "connecting": "Conectando",
+          "connect": "Conectar",
+          "addSshHost": "Agregar host SSH",
+          "addRemoteServer": "Agregar servidor remoto",
+          "addRemoteHost": "Agregar host remoto",
+          "addRemoteHostTooltip": "Elija SSH para una máquina en la que pueda iniciar sesión o servidor remoto para un servidor Orca.",
+          "addSshHostDetail": "Utilice una máquina existente a través de SSH.",
+          "addRemoteServerDetail": "Emparéjelo con Orca ejecutándose en otra computadora.",
+          "addRemoteHostDetail": "Host SSH o servidor Orca"
         },
         "sidebarHostOptions": {
           "3e102f111c": "All hosts",
@@ -4449,46 +4449,46 @@
           "3b7e4a1c96": "Ocultar árboles de trabajo externos"
         },
         "useAddRepoHostSelection": {
-          "connectionFailed": "SSH connection failed."
+          "connectionFailed": "La conexión SSH falló."
         },
         "AddRemoteHostDialog": {
-          "sshHostRequired": "Host or SSH config alias is required.",
-          "sshPortInvalid": "Port must be between 1 and 65535.",
-          "sshRelayGraceInvalid": "Terminal timeout must be between 60 and {{value0}} seconds.",
-          "sshSaved": "SSH host added.",
-          "sshSaveFailed": "Failed to add SSH host.",
-          "serverFieldsRequired": "Server name and pairing code are required.",
-          "serverSaved": "Remote server added.",
-          "serverSaveFailed": "Failed to add remote server.",
-          "serverTitle": "Add remote server",
-          "sshTitle": "Add SSH host",
-          "serverDescription": "Pair with Orca running on another computer.",
-          "sshDescription": "Add a persistent machine you can log into over SSH.",
-          "cancel": "Cancel",
-          "saving": "Saving...",
-          "save": "Save",
-          "label": "Label",
+          "sshHostRequired": "Se requiere un alias de configuración de host o SSH.",
+          "sshPortInvalid": "El puerto debe estar entre 1 y 65535.",
+          "sshRelayGraceInvalid": "El tiempo de espera del terminal debe estar entre 60 y {{value0}} segundos.",
+          "sshSaved": "Se agregó el host SSH.",
+          "sshSaveFailed": "No se pudo agregar el host SSH.",
+          "serverFieldsRequired": "Se requieren el nombre del servidor y el código de emparejamiento.",
+          "serverSaved": "Se agregó servidor remoto.",
+          "serverSaveFailed": "No se pudo agregar el servidor remoto.",
+          "serverTitle": "Agregar servidor remoto",
+          "sshTitle": "Agregar host SSH",
+          "serverDescription": "Emparéjelo con Orca ejecutándose en otra computadora.",
+          "sshDescription": "Agregue una máquina persistente en la que pueda iniciar sesión a través de SSH.",
+          "cancel": "Cancelar",
+          "saving": "Ahorro...",
+          "save": "Ahorrar",
+          "label": "Etiqueta",
           "sshLabelPlaceholder": "Dev box",
-          "sshHost": "Host or alias",
+          "sshHost": "Anfitrión o alias",
           "sshHostPlaceholder": "deploy@server:22",
-          "username": "Username",
+          "username": "Nombre de usuario",
           "usernamePlaceholder": "deploy",
-          "port": "Port",
-          "identityFile": "Identity file",
-          "identityFilePlaceholder": "~/.ssh/id_ed25519 (optional)",
-          "serverName": "Server name",
+          "port": "Puerto",
+          "identityFile": "Archivo de identidad",
+          "identityFilePlaceholder": "~/.ssh/id_ed25519 (opcional)",
+          "serverName": "Nombre del servidor",
           "serverNamePlaceholder": "Dev box",
-          "pairingCode": "Pairing code",
+          "pairingCode": "código de emparejamiento",
           "pairingCodePlaceholder": "orca://pair?code=...",
-          "pairingHelpPrefix": "Run",
+          "pairingHelpPrefix": "Ejecuta",
           "pairingCommand": "orca serve --pairing-address <host>",
-          "pairingHelpSuffix": "on the server and paste the printed pairing URL.",
-          "sshImportAlreadySynced": "~/.ssh/config already in sync.",
-          "sshImportSynced": "Synced {{value0}} host{{value1}}.",
-          "sshImportFailed": "Failed to import SSH config.",
-          "importing": "Importing...",
-          "importSshConfig": "Import ~/.ssh/config",
-          "sshPersistenceDefault": "Remote terminals on this host stay alive until you end them or reset the relay."
+          "pairingHelpSuffix": "en el servidor y pega la URL de emparejamiento impresa.",
+          "sshImportAlreadySynced": "~/.ssh/config ya está sincronizado.",
+          "sshImportSynced": "Sincronizado {{value0}} host{{value1}}.",
+          "sshImportFailed": "No se pudo importar la configuración SSH.",
+          "importing": "Importador...",
+          "importSshConfig": "Importar ~/.ssh/config",
+          "sshPersistenceDefault": "Los terminales remotos de este host seguirán activos hasta que los cierres o restablezcas el relé."
         }
       },
       "shared": {
@@ -5086,15 +5086,15 @@
             "toggleLabel": "Alternar nuevo estilo de tarjeta"
           },
           "nativeChat": {
-            "title": "Native chat",
-            "description": "Preview the desktop chat surface for Claude and Codex terminal sessions.",
-            "copy": "Adds a native chat view you can switch to from supported Claude and Codex terminal panes. Experimental while we tune transcript fidelity, streaming, and terminal parity.",
-            "toggleLabel": "Toggle native chat",
-            "defaultTitle": "Default view",
-            "defaultCopy": "Choose how new Claude and Codex terminal tabs open.",
-            "defaultViewLabel": "Default native chat view",
-            "defaultViewTerminal": "Terminal chat",
-            "defaultViewNative": "Native chat"
+            "title": "chat nativo",
+            "description": "Obtenga una vista previa de la superficie de chat del escritorio para las sesiones de terminal de Claude y Codex.",
+            "copy": "Agrega una vista de chat nativa a la que puede cambiar desde los paneles de terminal compatibles de Claude y Codex. Experimental mientras ajustamos la fidelidad de la transcripción, la transmisión y la paridad terminal.",
+            "toggleLabel": "Alternar chat nativo",
+            "defaultTitle": "Vista predeterminada",
+            "defaultCopy": "Elija cómo se abren las nuevas pestañas de terminal de Claude y Codex.",
+            "defaultViewLabel": "Vista de chat nativa predeterminada",
+            "defaultViewTerminal": "charla terminal",
+            "defaultViewNative": "chat nativo"
           }
         },
         "FloatingWorkspacePane": {
@@ -5145,10 +5145,10 @@
           "0df2e4fd12": "Guardar archivos automáticamente",
           "d21136d9ef": "Configure cómo Orca persiste en las ediciones de archivos.",
           "45c6e85c4d": "Editor",
-          "8f1afdfbd8": "Diff Word Wrap",
-          "4aa4d9fb73": "Wrap long lines in diff editors instead of requiring horizontal scrolling.",
-          "bf16ef0af2": "Off",
-          "3f6892f307": "On"
+          "8f1afdfbd8": "Ajuste de palabras diferencial",
+          "4aa4d9fb73": "Ajuste líneas largas en editores de diferencias en lugar de requerir desplazamiento horizontal.",
+          "bf16ef0af2": "Apagado",
+          "3f6892f307": "En"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "host local, 127.0.0.1, *.interno",
@@ -5490,11 +5490,11 @@
           "b5e2d93e01": "De cheques...",
           "c6f3ea4f12": "Listo",
           "d704fb5023": "Necesita configuración",
-          "06b06429c6": "Checking Android SDK and iOS Simulator support.",
-          "6d1483d4a0": "1 emulator device detected.",
-          "0a452d4d3b": "{{value0}} emulator devices detected.",
-          "f62a1bb759": "Orca will auto-select an emulator device after devices are detected.",
-          "b2fd62ea75": "Default device for new emulator tabs and agent attach commands. Auto-select prefers an already running device."
+          "06b06429c6": "Comprobando la compatibilidad con el SDK de Android y el simulador de iOS.",
+          "6d1483d4a0": "1 dispositivo emulador detectado.",
+          "0a452d4d3b": "{{value0}} dispositivos emuladores detectados.",
+          "f62a1bb759": "Orca seleccionará automáticamente un dispositivo emulador después de que se detecten los dispositivos.",
+          "b2fd62ea75": "Dispositivo predeterminado para nuevas pestañas del emulador y comandos de conexión de agents. La selección automática prefiere un dispositivo que ya esté en ejecución."
         },
         "MobileNetworkInterfaceSection": {
           "63d5e4ae1e": "Regenera el código QR y escanéalo desde la aplicación móvil de Orca.",
@@ -5542,9 +5542,9 @@
           "c8491c17ef": "Controla Orca desde tu teléfono escaneando un código QR. Beta/vista previa anticipada: espere errores y cambios importantes. Obtenga la aplicación para iOS desde",
           "e7a3ae8c4e": "Móvil",
           "174f4a3c6d": "Controla terminales y agents desde tu teléfono.",
-          "1de96ec8a6": "Show Orca Mobile Button",
-          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
-          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
+          "1de96ec8a6": "Mostrar botón de Orca Mobile",
+          "682293cadf": "Mostrar el botón de Orca Mobile en la parte superior de la barra lateral izquierda.",
+          "d4f2b65f30": "Mostrar el acceso directo de Orca Mobile en la barra lateral."
         },
         "NotificationsPane": {
           "906b4afebf": "Enviar notificación de prueba",
@@ -5795,8 +5795,8 @@
           "81057d5f71": "Ahorro...",
           "da37d6f10e": "Copiar",
           "3149964b66": "copiado",
-          "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-          "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+          "waitForSetupBeforeAgent": "Espere a que se complete la configuración antes de iniciar el agent",
+          "waitForSetupBeforeAgentHelp": "Active esto cuando el programa de instalación instale dependencias, servidores MCP o archivos de configuración que el agent necesite durante el inicio."
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "Utilice el color del repo {{value0}}",
@@ -6277,7 +6277,7 @@
           "2227ce47b6": "No se pudo guardar el objetivo",
           "f602009125": "Objetivo agregado",
           "b4ba0ce33d": "Objetivo actualizado",
-          "3879cbaa52": "Terminal timeout must be between 60 and {{value0}} seconds, or keep terminals alive until reset.",
+          "3879cbaa52": "El tiempo de espera del terminal debe estar entre 60 y {{value0}} segundos, o mantener los terminales activos hasta que se reinicien.",
           "4db9afce1c": "El puerto debe estar entre 1 y 65535",
           "0e5aa04161": "Se requiere un alias de configuración de host o SSH",
           "f1fc50dad2": "No se pudieron cargar destinos SSH",
@@ -6313,8 +6313,8 @@
           "18968ede9e": "Error",
           "f0871e6bfb": "conectar",
           "47e94bd6ba": "conectado",
-          "a883f5a00f": "terminal timeout: {{value0}}",
-          "8ce71262f4": "terminals until reset"
+          "a883f5a00f": "tiempo de espera del terminal: {{value0}}",
+          "8ce71262f4": "terminales hasta el reinicio"
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "Esto detendrá las sesiones de terminal activas en este destino SSH. Volver a conectarlos no los restaurará.",
@@ -6326,11 +6326,11 @@
         },
         "SshTargetForm": {
           "fea9cb402e": "Cancelar",
-          "1b19b00e93": "Bounded timeouts must be between 60 seconds and 7 days.",
-          "137e88ce8d": "Remote terminals keep running after Orca disconnects from this host.",
-          "b574994adc": "Use End Remote Terminals or Reset Relay when you want to stop them.",
-          "71fc546097": "Keep terminals alive until reset",
-          "92f80edbfd": "Remote Terminal Persistence",
+          "1b19b00e93": "Los tiempos de espera acotados deben estar entre 60 segundos y 7 días.",
+          "137e88ce8d": "Los terminales remotos siguen ejecutándose después de que Orca se desconecta de este host.",
+          "b574994adc": "Usa Finalizar terminales remotos o Restablecer relé cuando quieras detenerlos.",
+          "71fc546097": "Mantener los terminales activos hasta restablecer",
+          "92f80edbfd": "Persistencia de terminales remotos",
           "feae1d1e69": "Opcional. Equivalente a ProxyJump/ssh -J.",
           "11bcb4507a": "bastion.ejemplo.com",
           "b2ab248ded": "Anfitrión de salto",
@@ -6351,8 +6351,8 @@
           "a62b4cb39a": "Guardar cambios",
           "29af933cd5": "Nuevo destino SSH",
           "f2331ce599": "Editar destino SSH",
-          "7c13f58c91": "Until reset",
-          "55c56cf2c7": "Timeout after disconnect (seconds)"
+          "7c13f58c91": "Hasta restablecer",
+          "55c56cf2c7": "Tiempo de espera tras desconectar (segundos)"
         },
         "TasksPane": {
           "3a72b9745e": "Elija qué proveedores de tareas aparecen en la página Tareas y en los accesos directos de la barra lateral.",
@@ -6817,8 +6817,8 @@
             "afbf35be68": "sesión estable",
             "agentPermissions": "Agent Permissions",
             "agentPermissionsDescription": "Switch agent permission defaults between Yolo and Manual.",
-            "agentRuntime": "Agent Runtime",
-            "agentRuntimeDescription": "Choose whether agents are detected and launched on Windows or in WSL by default."
+            "agentRuntime": "Tiempo de ejecución del Agent",
+            "agentRuntimeDescription": "Elija si los agents se detectan y ejecutan en Windows o en WSL de forma predeterminada."
           }
         },
         "appearance": {
@@ -7027,8 +7027,8 @@
             "291f480a5e": "hogar",
             "a942905148": "URL abierta al crear una nueva pestaña del navegador. Déjelo vacío para abrir una pestaña en blanco.",
             "c3903322d2": "Página de inicio predeterminada",
-            "19ea5607cf": "Localhost Worktree Labels",
-            "4e0fdf0a3f": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+            "19ea5607cf": "Etiquetas del árbol de trabajo de localhost",
+            "4e0fdf0a3f": "Abra los puertos del espacio de trabajo como URL de host local de Orca específicas del árbol de trabajo para que las pestañas del navegador sean más fáciles de distinguir."
           },
           "use": {
             "search": {
@@ -7232,8 +7232,8 @@
               "worktrees": "worktrees"
             },
             "nativeChat": {
-              "title": "Native chat",
-              "description": "Preview the desktop chat surface for Claude and Codex terminal sessions."
+              "title": "chat nativo",
+              "description": "Obtenga una vista previa de la superficie de chat del escritorio para las sesiones de terminal de Claude y Codex."
             }
           }
         },
@@ -7647,8 +7647,8 @@
               "f213400800": "móvil",
               "671eb4173c": "Controla terminales y agents desde tu teléfono.",
               "ffd52a96e4": "Móvil",
-              "1de96ec8a6": "Show Orca Mobile Button",
-              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
+              "1de96ec8a6": "Mostrar botón de Orca Mobile",
+              "682293cadf": "Mostrar el botón de Orca Mobile en la parte superior de la barra lateral izquierda."
             }
           }
         },
@@ -8566,37 +8566,37 @@
           "f5ed5dcbf6": "Press keys…"
         },
         "ShortcutRemoveButton": {
-          "9e29aff18b": "Remove {{value0}} shortcut {{value1}}",
+          "9e29aff18b": "Eliminar {{value0}} acceso directo {{value1}}",
           "2a9588b1c2": "Remove this binding"
         },
         "BrowserLocalhostWorktreeLabelsSetting": {
-          "8ac8c3ad19": "Localhost Worktree Labels",
-          "1db3c8b983": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+          "8ac8c3ad19": "Etiquetas del árbol de trabajo de localhost",
+          "1db3c8b983": "Abra los puertos del espacio de trabajo como URL de host local de Orca específicas del árbol de trabajo para que las pestañas del navegador sean más fáciles de distinguir."
         },
         "AgentRuntimeSetting": {
-          "label": "Agent runtime",
+          "label": "Tiempo de ejecución del Agent",
           "wsl": "WSL",
-          "loadingWsl": "Loading WSL",
-          "selectDistro": "Select distro",
-          "windowsDescription": "Detect and launch agents on Windows for projects that do not override their runtime.",
-          "wslUnavailable": "WSL is not available on this machine.",
-          "distroRequired": "Choose a WSL distro before projects can inherit WSL.",
-          "wslDescription": "Detect and launch agents in {{value0}} via WSL for projects that do not override their runtime."
+          "loadingWsl": "Cargando WSL",
+          "selectDistro": "Seleccionar distribución",
+          "windowsDescription": "Detecte e inicie agents en Windows para proyectos que no anulan su tiempo de ejecución.",
+          "wslUnavailable": "WSL no está disponible en esta máquina.",
+          "distroRequired": "Elija una distribución WSL antes de que los proyectos puedan heredar WSL.",
+          "wslDescription": "Detecta y lanza agents en {{value0}} a través de WSL para proyectos que no anulan su tiempo de ejecución."
         },
         "MobileEmulatorSdkStatus": {
-          "536026130e": "Emulator SDKs",
-          "dde0ec1cd8": "Toolchains Orca uses to run emulators. Android works on any OS via the Android SDK; iOS Simulators need Xcode on macOS.",
+          "536026130e": "SDK de emulador",
+          "dde0ec1cd8": "Cadenas de herramientas que Orca utiliza para ejecutar emuladores. Android funciona en cualquier sistema operativo a través del SDK de Android; Los simuladores de iOS necesitan Xcode en macOS.",
           "027cbf668a": "Android SDK",
-          "f6d080d128": "Using configured path",
-          "7fe4bd5907": "Detected at",
-          "2784f0b22d": "Not found. Install Android Studio, then create a Virtual Device.",
-          "b94ff260e6": "Download Android Studio",
-          "18925b082d": "Locate SDK folder",
-          "8c52684db8": "Clear",
+          "f6d080d128": "Usando la ruta configurada",
+          "7fe4bd5907": "Detectado en",
+          "2784f0b22d": "Extraviado. Instale Android Studio, luego cree un dispositivo virtual.",
+          "b94ff260e6": "Descargar Android Studio",
+          "18925b082d": "Localizar la carpeta SDK",
+          "8c52684db8": "Claro",
           "76eb88b88e": "iOS Simulator (Xcode)",
-          "c6f3ea4f12": "Ready",
-          "e4f14b50d7": "Install Xcode and add an iOS Simulator runtime.",
-          "63fe73a1ea": "Could not update Android SDK folder."
+          "c6f3ea4f12": "Listo",
+          "e4f14b50d7": "Instale Xcode y agregue un tiempo de ejecución del simulador de iOS.",
+          "63fe73a1ea": "No se pudo actualizar la carpeta SDK de Android."
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "Avanzado"
@@ -8632,57 +8632,57 @@
           "devOnly": "Dev only"
         },
         "EphemeralVmRecipeRow": {
-          "useInWorkspace": "Use in workspace"
+          "useInWorkspace": "Uso en el espacio de trabajo"
         },
         "EphemeralVmRuntimesSection": {
-          "cleanupFailed": "Cleanup failed",
-          "cleanupRunning": "Cleanup running",
-          "cleanupDisabled": "Cleanup disabled",
-          "running": "Running",
-          "failed": "Failed",
-          "loadFailed": "Couldn’t load temporary VM runtimes.",
-          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
-          "markedCleaned": "Marked temporary VM runtime as cleaned.",
-          "cleaned": "Cleaned up temporary VM runtime.",
-          "copiedCleanupCommand": "Copied cleanup command.",
-          "copiedCleanupPayload": "Copied cleanup payload.",
-          "copyCleanupFailed": "Couldn’t copy cleanup command.",
-          "title": "Temporary VM runtimes",
-          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
-          "refresh": "Refresh temporary VM runtimes",
-          "loading": "Checking temporary VM runtimes…",
-          "empty": "No temporary VM runtimes need cleanup.",
-          "copyCleanup": "Copy command",
-          "retry": "Retry cleanup",
-          "cleanup": "Cleanup"
+          "cleanupFailed": "Error de limpieza",
+          "cleanupRunning": "limpieza en ejecución",
+          "cleanupDisabled": "Limpieza deshabilitada",
+          "running": "Correr",
+          "failed": "Fallido",
+          "loadFailed": "No se pudieron cargar tiempos de ejecución de VM temporales.",
+          "cleanupFailedToast": "No se pudo limpiar el tiempo de ejecución temporal de la VM.",
+          "markedCleaned": "Tiempo de ejecución de VM temporal marcado como limpio.",
+          "cleaned": "Se limpió el tiempo de ejecución temporal de la VM.",
+          "copiedCleanupCommand": "Comando de limpieza copiado.",
+          "copiedCleanupPayload": "Carga útil de limpieza copiada.",
+          "copyCleanupFailed": "No se pudo copiar el comando de limpieza.",
+          "title": "Tiempos de ejecución temporales de VM",
+          "description": "Los tiempos de ejecución creados por recetas son propiedad del espacio de trabajo. Limpie las entradas obsoletas después de fallas, creaciones fallidas o recuperación manual.",
+          "refresh": "Actualizar tiempos de ejecución de VM temporales",
+          "loading": "Comprobando tiempos de ejecución de VM temporales...",
+          "empty": "No es necesario limpiar tiempos de ejecución de VM temporales.",
+          "copyCleanup": "comando copiar",
+          "retry": "Reintentar la limpieza",
+          "cleanup": "Limpieza"
         },
         "ephemeralVms": {
           "search": {
-            "title": "Per-Workspace Environments",
-            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+            "title": "Entornos por espacio de trabajo",
+            "description": "Descubra cómo las recetas propiedad del repo brindan a cada espacio de trabajo su propio entorno desechable bajo demanda."
           }
         },
         "EphemeralVmsPane": {
-          "loadError": "Could not load recipes.",
-          "copyError": "Could not copy the prompt.",
-          "skillTitle": "Per-Workspace Environments skill",
-          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
-          "whatTitle": "What the skill does, with you",
-          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
-          "whatBuild": "Builds a reusable base image and signs your agent in.",
-          "whatValidate": "Validates it so you can create a workspace on it.",
-          "promptHint": "In any workspace, ask your agent:",
-          "copy": "Copy",
-          "copied": "Copied",
-          "recipes": "Recipes",
-          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
-          "refresh": "Refresh ephemeral VM recipes",
-          "checking": "Checking recipes...",
-          "none": "No recipes found yet."
+          "loadError": "No se pudieron cargar recetas.",
+          "copyError": "No se pudo copiar el mensaje.",
+          "skillTitle": "Habilidad Entornos por espacio de trabajo",
+          "skillDescription": "Configura, crea, autentica y valida recetas de entornos propiedad del repo.",
+          "whatTitle": "Qué hace la habilidad contigo",
+          "whatScaffold": "Escribe la receta y los scripts para su proveedor, conectados a través de un servidor Orca o SSH.",
+          "whatBuild": "Crea una imagen base reutilizable e inicia la sesión de su agent.",
+          "whatValidate": "Lo valida para que puedas crear un espacio de trabajo en él.",
+          "promptHint": "En cualquier espacio de trabajo, pregúntale a tu agent:",
+          "copy": "Copiar",
+          "copied": "copiado",
+          "recipes": "Recetas",
+          "recipesHelp": "Las recetas que su agent agrega a orca.yaml aparecen aquí, listas para iniciar un espacio de trabajo.",
+          "refresh": "Actualizar recetas de VM efímeras",
+          "checking": "Comprobando recetas...",
+          "none": "Aún no se han encontrado recetas."
         },
         "ephemeralVmsExperimentalSetting": {
-          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
-          "toggleLabel": "Toggle per-workspace environments"
+          "description": "Muestra controles de configuración y objetivos de ejecución del espacio de trabajo para entornos bajo demanda de propiedad de repos.",
+          "toggleLabel": "Alternar entornos por espacio de trabajo"
         }
       },
       "right": {
@@ -10912,8 +10912,8 @@
           "8f68ad9ca9": "Mostrar {{value0}} AI {{value1}}",
           "724a13568d": "en {{value0}}",
           "6094135eec": "frente a {{value0}}",
-          "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "a4420ca1f7": "Envolver",
+          "dde325ddfe": "Envolver"
         },
         "ConflictComponents": {
           "f338288514": "Cargando contenidos conflictivos...",
@@ -11002,7 +11002,7 @@
           "561251019a": "Más acciones",
           "8c8b7f5ff5": "Mostrar portada",
           "10c39d58c1": "Ocultar materia preliminar",
-          "1eef809708": "Word Wrap"
+          "1eef809708": "Ajuste de palabras"
         },
         "EditorPanelShell": {
           "e2c4dec350": "Cargando editor..."
@@ -11244,11 +11244,11 @@
           "d34a2021c8": "Título 2",
           "abb5100a3d": "Título 1",
           "b462641ed2": "Texto del cuerpo",
-          "91a843fb43": "More blocks",
-          "2cd9e0bbb3": "Headings",
-          "b05e14620d": "Heading 4",
-          "6bbf827ef5": "Heading 5",
-          "d1bbf9a835": "Collapsible section"
+          "91a843fb43": "Más bloques",
+          "2cd9e0bbb3": "Encabezamientos",
+          "b05e14620d": "Título 4",
+          "6bbf827ef5": "Título 5",
+          "d1bbf9a835": "Sección plegable"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "Ahorrar",
@@ -11327,10 +11327,10 @@
                 "41482b15ce": "Alternar título 1",
                 "570611864e": "Encabezado de sección grande.",
                 "e66e7f04c6": "Título 1",
-                "5f9a0ed7c4": "Heading 4",
-                "01a71dbbdd": "Nested section heading.",
-                "8440fa4acf": "Heading 5",
-                "b287b93c66": "Deep section heading."
+                "5f9a0ed7c4": "Título 4",
+                "01a71dbbdd": "Encabezado de sección anidada.",
+                "8440fa4acf": "Título 5",
+                "b287b93c66": "Encabezado de sección profunda."
               }
             }
           }
@@ -11391,8 +11391,8 @@
           "d5a8c2f1b9": "Iniciar el agente de IA predeterminado para corregir esta comprobación",
           "e2b4d7c8a1": "Elige un agente para esta comprobación",
           "f1c9e3a6d4": "Elige un agente para corregir la comprobación",
-          "5e2a9c3f88": "Open file at this line",
-          "actionRequired": "Action required"
+          "5e2a9c3f88": "Abrir archivo en esta línea",
+          "actionRequired": "Acción requerida"
         },
         "check": {
           "run": {
@@ -11415,10 +11415,10 @@
           "tooLarge": "El contenido pegado es demasiado grande."
         },
         "CheckRunJobs": {
-          "1c0a4d7e02": "succeeded",
-          "2d3b8f1a55": "skipped",
-          "3e6c9a2b71": "pending",
-          "4f7d0c3e88": "steps failed",
+          "1c0a4d7e02": "tuvo éxito",
+          "2d3b8f1a55": "saltado",
+          "3e6c9a2b71": "pendiente",
+          "4f7d0c3e88": "pasos fallidos",
           "5a8e1d4f23": " · "
         }
       },
@@ -12267,7 +12267,7 @@
       },
       "nativeChat": {
         "contextMenu": {
-          "copy": "Copy"
+          "copy": "Copiar"
         }
       }
     },
@@ -12289,84 +12289,84 @@
   "components": {
     "native-chat": {
       "composer": {
-        "imageUnsupported": "Image paste is not supported for this agent.",
-        "send": "Send",
-        "noPty": "No live terminal — toggle back to reconnect.",
-        "locked": "Input is held by another device.",
-        "placeholder": "Send a message…",
-        "mentionHint": "Referencing file:",
-        "attach": "Attach file",
-        "startDictation": "Start dictation",
-        "stopDictation": "Stop dictation",
-        "noSkills": "No matching skills",
-        "localAttachmentUnsupported": "Local attachments are not available for remote sessions.",
-        "removeAttachment": "Remove attachment",
-        "pastedImageLabel": "Pasted image"
+        "imageUnsupported": "Este agente no admite pegar imágenes.",
+        "send": "Enviar",
+        "noPty": "No hay terminal activa: vuelva a alternar para volver a conectarse.",
+        "locked": "La entrada está retenida por otro dispositivo.",
+        "placeholder": "Enviar un mensaje…",
+        "mentionHint": "Archivo de referencia:",
+        "attach": "Adjuntar archivo",
+        "startDictation": "Iniciar dictado",
+        "stopDictation": "Detener dictado",
+        "noSkills": "Sin habilidades coincidentes",
+        "localAttachmentUnsupported": "Los archivos adjuntos locales no están disponibles para sesiones remotas.",
+        "removeAttachment": "Quitar archivo adjunto",
+        "pastedImageLabel": "Imagen pegada"
       },
       "tool": {
-        "running": "Running…",
-        "result": "Result"
+        "running": "Ejecutando…",
+        "result": "Resultado"
       },
       "status": {
-        "responding": "Agent is responding"
+        "responding": "El agente está respondiendo"
       },
-      "jumpToLatest": "Jump to latest",
+      "jumpToLatest": "Saltar a lo último",
       "toggle": {
-        "showTerminal": "Show terminal",
-        "showChat": "Show chat view"
+        "showTerminal": "Mostrar terminal",
+        "showChat": "Mostrar vista de chat"
       },
       "state": {
         "loading": {
-          "title": "Loading conversation…",
-          "subtitle": "Reading the agent transcript."
+          "title": "Cargando conversación…",
+          "subtitle": "Leyendo la transcripción del agente."
         },
         "error": {
-          "title": "Could not load conversation",
-          "subtitle": "The transcript could not be read. Toggle back to the terminal to keep working."
+          "title": "No se pudo cargar la conversación",
+          "subtitle": "No se pudo leer la transcripción. Vuelva a la terminal para seguir trabajando."
         },
         "notAgent": {
-          "title": "No conversation here",
-          "subtitle": "This terminal is not running a recognized coding agent."
+          "title": "No hay conversación aquí",
+          "subtitle": "Este terminal no está ejecutando un agente de código reconocido."
         },
         "empty": {
-          "title": "Start a chat with {{value0}}",
-          "subtitle": "Ask {{value0}} to inspect code, explain output, or make a change."
+          "title": "Iniciar un chat con {{value0}}",
+          "subtitle": "Pídale a {{value0}} que inspeccione el código, explique el resultado o realice un cambio."
         }
       },
-      "stop": "Stop the agent",
+      "stop": "Detener el agente",
       "copyMessage": {
-        "copied": "Copied",
-        "copy": "Copy message"
+        "copied": "Copiado",
+        "copy": "Copiar mensaje"
       },
-      "scrollMessageToTop": "Scroll this message to top",
-      "loadingEarlier": "Loading…",
-      "loadEarlier": "Load earlier messages",
+      "scrollMessageToTop": "Desplazar este mensaje hacia arriba",
+      "loadingEarlier": "Cargando…",
+      "loadEarlier": "Cargar mensajes anteriores",
       "question": {
-        "step": "Step {{value0}}",
-        "other": "Other…",
-        "otherPlaceholder": "Type your answer",
-        "cancel": "Cancel",
-        "send": "Send answer",
-        "next": "Next"
+        "step": "Paso {{value0}}",
+        "other": "Otro…",
+        "otherPlaceholder": "Escribe tu respuesta",
+        "cancel": "Cancelar",
+        "send": "Enviar respuesta",
+        "next": "Siguiente"
       },
       "approval": {
-        "title": "Allow {{value0}}?",
-        "allow": "Allow",
-        "deny": "Deny"
+        "title": "¿Permitir {{value0}}?",
+        "allow": "Permitir",
+        "deny": "Denegar"
       }
     },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {
-          "switchToTerminalView": "Switch to terminal view",
-          "switchToChatView": "Switch to chat view"
+          "switchToTerminalView": "Cambiar a la vista de terminal",
+          "switchToChatView": "Cambiar a vista de chat"
         }
       }
     },
     "workspace": {
       "cleanup": {
         "presentationFixtures": {
-          "reviewAlphaCleanup": "Review alpha cleanup"
+          "reviewAlphaCleanup": "Revisar la limpieza alfa"
         },
         "presentation": {
           "gitlabMergeRequestNumber": "MR #{{value0}}",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -234,7 +234,7 @@
           "runtimeScopeForbiddenDescription": "モバイル範囲のペアリングではワークスペースを使用できません。設定 → リモート Orca サーバー → この Orca サーバーを共有する からブラウザー用リンクで再接続してください。"
         },
         "repos": {
-          "2975400634": "Update Orca server to open non-Git folders on this runtime.",
+          "2975400634": "Orca サーバーを更新して、このランタイムで Git 以外のフォルダーを開くようにします。",
           "b7e14472ae": "フォルダーの追加に失敗しました",
           "e649269645": "サーバー パスを使用して、リモート ランタイムからプロジェクトを追加します。",
           "c6e022ddfc": "プロジェクトの追加に失敗しました",
@@ -242,8 +242,8 @@
           "8bb3ad7935": "プロジェクトを追加しました",
           "a8e4b3af5b": "プロジェクトはすでに追加されています",
           "6d3318e813": "repos のインポートに失敗しました",
-          "3be0f7df04": "Cannot open folder on selected runtime",
-          "15cf5319ec": "{{path}} was checked on {{hostName}}, but that host did not report a usable folder."
+          "3be0f7df04": "選択したランタイムでフォルダーを開けません",
+          "15cf5319ec": "{{path}} は {{hostName}} でチェックされましたが、そのホストは使用可能なフォルダーを報告しませんでした。"
         },
         "settings": {
           "e12dab333b": "サーバーの切り替えに失敗しました",
@@ -363,7 +363,7 @@
         "worktree": {
           "background": {
             "terminals": {
-              "setupTitle": "Setup"
+              "setupTitle": "設定"
             }
           }
         },
@@ -403,7 +403,7 @@
         "mobile": {
           "emulator": {
             "tab": {
-              "bf4f2a8a72": "Could not start the emulator. Check iOS or Android emulator setup and try another device."
+              "bf4f2a8a72": "エミュレータを起動できませんでした。 iOS または Android エミュレータの設定を確認し、別のデバイスを試す。"
             }
           }
         }
@@ -1162,15 +1162,15 @@
         "reuseExistingBranch": "ブランチを再利用",
         "reuseExistingBranchHint": "既存のブランチから新しいブランチを作成せず、そのブランチをチェックアウトします。",
         "createMultiple": "さらに作成",
-        "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
-        "destroyDisabled": "destroy disabled",
-        "destroyConfigured": "destroy configured",
-        "noDestroyConfigured": "no destroy",
-        "ephemeralVm": "Per-Workspace Environment",
-        "chooseRunTarget": "Choose target",
-        "noRunTargets": "No run targets are ready for this project.",
-        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
+        "waitForSetupBeforeAgent": "セットアップが完了するまで待ってから agent を開始してください",
+        "waitForSetupBeforeAgentHelp": "セットアップによって、起動時に agent に必要な依存関係、MCP サーバー、または構成ファイルがインストールされるときに、これをオンにします。",
+        "destroyDisabled": "破壊は無効です",
+        "destroyConfigured": "設定されたものを破棄する",
+        "noDestroyConfigured": "破壊しない",
+        "ephemeralVm": "ワークスペースごとの環境",
+        "chooseRunTarget": "ターゲットを選択",
+        "noRunTargets": "このプロジェクトには実行ターゲットが準備されていません。",
+        "perWorkspaceEnvHint": "レシピからオンデマンド環境をプロビジョニングする"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "ワークツリーを作成する",
@@ -2222,9 +2222,9 @@
             "a3346fc6ed": "ワークツリーの作成をキャンセルする",
             "532aea14ce": "キャンセル",
             "767951265d": "ワークツリーの作成中に問題が発生しました。",
-            "vmProvisioningTitle": "Provisioning VM",
-            "cancelProvisioning": "Cancel",
-            "vmProvisioningLogEmpty": "Waiting for recipe output…"
+            "vmProvisioningTitle": "VMのプロビジョニング",
+            "cancelProvisioning": "キャンセル",
+            "vmProvisioningLogEmpty": "レシピの出力を待っています…"
           }
         }
       },
@@ -2289,24 +2289,24 @@
             "ee81adfcef": "表示",
             "4d0b72481c": "無視",
             "9cc26c019d": "削除",
-            "0e2d235c63": "Inactive workspace scan ready",
-            "4a35c08764": "Review",
-            "47123d0108": "Scanning inactive workspaces. You can close this and come back.",
-            "9a3be9f2df": "Scanning inactive workspaces. New rows appear here as they finish. You can close this and come back.",
-            "3d957ff117": "No workspaces match these filters.",
-            "e94b1f8bb4": "Clear filters",
-            "efb3843e75": "Filter and sort workspaces",
-            "93b7381d50": "Filters",
-            "a615e24679": "Sort",
-            "4cc5b73efe": "Finding inactive workspaces...",
-            "5bf2e88480": "{{value0}}/{{value1}} {{value2}} scanned",
-            "searchPlaceholder": "Search workspaces",
-            "ageFilter": "Age",
-            "reviewFilter": "Review",
+            "0e2d235c63": "非アクティブなワークスペースのスキャン準備完了",
+            "4a35c08764": "レビュー",
+            "47123d0108": "非アクティブなワークスペースをスキャンしています。これを閉じて戻ってきても構いません。",
+            "9a3be9f2df": "非アクティブなワークスペースをスキャンしています。新規行が終了すると、ここに表示されます。これを閉じて戻ってきても構いません。",
+            "3d957ff117": "これらのフィルターに一致するワークスペースはありません。",
+            "e94b1f8bb4": "フィルターをクリアする",
+            "efb3843e75": "ワークスペースのフィルターと並べ替え",
+            "93b7381d50": "フィルター",
+            "a615e24679": "選別",
+            "4cc5b73efe": "非アクティブなワークスペースを検索しています...",
+            "5bf2e88480": "{{value0}}/{{value1}} {{value2}} をスキャンしました",
+            "searchPlaceholder": "ワークスペースの検索",
+            "ageFilter": "年",
+            "reviewFilter": "レビュー",
             "gitFilter": "Git",
-            "contextFilter": "Context",
-            "sortBy": "Sort by",
-            "sortDirection": "Direction"
+            "contextFilter": "コンテクスト",
+            "sortBy": "並べ替え",
+            "sortDirection": "方向"
           }
         }
       },
@@ -3604,9 +3604,9 @@
           "05b33a17a9": "キャンセル",
           "8fba4b8cbb": "このフォルダーは Git repos ではありません。エディター、terminal、検索は利用できますが、Git ベースの機能は利用できません。",
           "c49fb13492": "リモートフォルダーの追加に失敗しました",
-          "9a766f33ac": "This path was checked on the SSH host.",
-          "79fd02cf5f": "This path was checked on {{hostName}}.",
-          "8851b77327": "This path was checked locally."
+          "9a766f33ac": "このパスは SSH ホストでチェックされました。",
+          "79fd02cf5f": "このパスは {{hostName}} でチェックされました。",
+          "8851b77327": "このパスはローカルでチェックされました。"
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "フックを実行する",
@@ -4350,15 +4350,15 @@
           "local": "ローカル",
           "runtime": "Server",
           "ssh": "SSH",
-          "connecting": "Connecting",
-          "connect": "Connect",
-          "addSshHost": "Add SSH host",
-          "addRemoteServer": "Add remote server",
-          "addRemoteHost": "Add remote host",
-          "addRemoteHostTooltip": "Choose SSH for a machine you can log into, or remote server for an Orca server.",
-          "addSshHostDetail": "Use an existing machine over SSH.",
-          "addRemoteServerDetail": "Pair with Orca running on another computer.",
-          "addRemoteHostDetail": "SSH host or Orca server"
+          "connecting": "接続中",
+          "connect": "接続",
+          "addSshHost": "SSH ホストの追加",
+          "addRemoteServer": "リモートサーバーを追加する",
+          "addRemoteHost": "リモートホストの追加",
+          "addRemoteHostTooltip": "ログインできるマシンには SSH を選択し、Orca サーバーにはリモート サーバーを選択します。",
+          "addSshHostDetail": "SSH 経由で既存のマシンを使用します。",
+          "addRemoteServerDetail": "別のコンピューターで実行されている Orca とペアリングします。",
+          "addRemoteHostDetail": "SSH ホストまたは Orca サーバー"
         },
         "sidebarHostOptions": {
           "3e102f111c": "All hosts",
@@ -4449,46 +4449,46 @@
           "3b7e4a1c96": "外部ワークツリーを非表示"
         },
         "useAddRepoHostSelection": {
-          "connectionFailed": "SSH connection failed."
+          "connectionFailed": "SSH 接続に失敗しました。"
         },
         "AddRemoteHostDialog": {
-          "sshHostRequired": "Host or SSH config alias is required.",
-          "sshPortInvalid": "Port must be between 1 and 65535.",
-          "sshRelayGraceInvalid": "Terminal timeout must be between 60 and {{value0}} seconds.",
-          "sshSaved": "SSH host added.",
-          "sshSaveFailed": "Failed to add SSH host.",
-          "serverFieldsRequired": "Server name and pairing code are required.",
-          "serverSaved": "Remote server added.",
-          "serverSaveFailed": "Failed to add remote server.",
-          "serverTitle": "Add remote server",
-          "sshTitle": "Add SSH host",
-          "serverDescription": "Pair with Orca running on another computer.",
-          "sshDescription": "Add a persistent machine you can log into over SSH.",
-          "cancel": "Cancel",
-          "saving": "Saving...",
-          "save": "Save",
-          "label": "Label",
+          "sshHostRequired": "ホストまたは SSH 構成エイリアスが必要です。",
+          "sshPortInvalid": "ポートは 1 ～ 65535 でなければなりません。",
+          "sshRelayGraceInvalid": "Terminal のタイムアウトは 60 秒から {{value0}} 秒の間である必要があります。",
+          "sshSaved": "SSH ホストが追加されました。",
+          "sshSaveFailed": "SSH ホストの追加に失敗しました。",
+          "serverFieldsRequired": "サーバー名とペアリングコードは必須です。",
+          "serverSaved": "リモートサーバーが追加されました。",
+          "serverSaveFailed": "リモートサーバーの追加に失敗しました。",
+          "serverTitle": "リモートサーバーを追加する",
+          "sshTitle": "SSH ホストの追加",
+          "serverDescription": "別のコンピューターで実行されている Orca とペアリングします。",
+          "sshDescription": "SSH 経由でログインできる永続マシンを追加します。",
+          "cancel": "キャンセル",
+          "saving": "保存中...",
+          "save": "保存",
+          "label": "ラベル",
           "sshLabelPlaceholder": "Dev box",
-          "sshHost": "Host or alias",
+          "sshHost": "ホストまたはエイリアス",
           "sshHostPlaceholder": "deploy@server:22",
-          "username": "Username",
+          "username": "ユーザー名",
           "usernamePlaceholder": "deploy",
-          "port": "Port",
-          "identityFile": "Identity file",
-          "identityFilePlaceholder": "~/.ssh/id_ed25519 (optional)",
-          "serverName": "Server name",
+          "port": "ポート",
+          "identityFile": "アイデンティティファイル",
+          "identityFilePlaceholder": "~/.ssh/id_ed25519 (オプション)",
+          "serverName": "サーバー名",
           "serverNamePlaceholder": "Dev box",
-          "pairingCode": "Pairing code",
+          "pairingCode": "ペアリングコード",
           "pairingCodePlaceholder": "orca://pair?code=...",
-          "pairingHelpPrefix": "Run",
+          "pairingHelpPrefix": "サーバーで実行",
           "pairingCommand": "orca serve --pairing-address <host>",
-          "pairingHelpSuffix": "on the server and paste the printed pairing URL.",
-          "sshImportAlreadySynced": "~/.ssh/config already in sync.",
-          "sshImportSynced": "Synced {{value0}} host{{value1}}.",
-          "sshImportFailed": "Failed to import SSH config.",
-          "importing": "Importing...",
-          "importSshConfig": "Import ~/.ssh/config",
-          "sshPersistenceDefault": "Remote terminals on this host stay alive until you end them or reset the relay."
+          "pairingHelpSuffix": "し、表示されたペアリング URL を貼り付けます。",
+          "sshImportAlreadySynced": "~/.ssh/config はすでに同期されています。",
+          "sshImportSynced": "{{value0}} ホスト{{value1}} を同期しました。",
+          "sshImportFailed": "SSH 構成のインポートに失敗しました。",
+          "importing": "インポート中...",
+          "importSshConfig": "~/.ssh/config をインポートします",
+          "sshPersistenceDefault": "このホスト上のリモートターミナルは、終了するかリレーをリセットするまで動作し続けます。"
         }
       },
       "shared": {
@@ -5071,15 +5071,15 @@
             "toggleLabel": "新しいカードスタイルを切り替え"
           },
           "nativeChat": {
-            "title": "Native chat",
-            "description": "Preview the desktop chat surface for Claude and Codex terminal sessions.",
-            "copy": "Adds a native chat view you can switch to from supported Claude and Codex terminal panes. Experimental while we tune transcript fidelity, streaming, and terminal parity.",
-            "toggleLabel": "Toggle native chat",
-            "defaultTitle": "Default view",
-            "defaultCopy": "Choose how new Claude and Codex terminal tabs open.",
-            "defaultViewLabel": "Default native chat view",
-            "defaultViewTerminal": "Terminal chat",
-            "defaultViewNative": "Native chat"
+            "title": "ネイティブチャット",
+            "description": "Claude と Codex の terminal セッションのデスクトップ チャット サーフェスをプレビューします。",
+            "copy": "サポートされている Claude および Codex の terminal ペインから切り替えることができるネイティブ チャット ビューを追加します。トランスクリプトの忠実度、ストリーミング、ターミナルのパリティを調整するための実験です。",
+            "toggleLabel": "ネイティブチャットの切り替え",
+            "defaultTitle": "デフォルトのビュー",
+            "defaultCopy": "新規 Claude および Codex の terminal タブを開く方法を選択します。",
+            "defaultViewLabel": "デフォルトのネイティブ チャット ビュー",
+            "defaultViewTerminal": "Terminal チャット",
+            "defaultViewNative": "ネイティブチャット"
           }
         },
         "FloatingWorkspacePane": {
@@ -5130,10 +5130,10 @@
           "0df2e4fd12": "ファイルの自動保存",
           "d21136d9ef": "Orca がファイル編集を保持する方法を構成します。",
           "45c6e85c4d": "エディタ",
-          "8f1afdfbd8": "Diff Word Wrap",
-          "4aa4d9fb73": "Wrap long lines in diff editors instead of requiring horizontal scrolling.",
-          "bf16ef0af2": "Off",
-          "3f6892f307": "On"
+          "8f1afdfbd8": "差分ワードラップ",
+          "4aa4d9fb73": "水平スクロールを必要とせずに、差分エディターで長い行を折り返します。",
+          "bf16ef0af2": "オフ",
+          "3f6892f307": "オン"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "ローカルホスト、127.0.0.1、*.internal",
@@ -5512,11 +5512,11 @@
           "b5e2d93e01": "確認中...",
           "c6f3ea4f12": "準備完了",
           "d704fb5023": "設定が必要",
-          "06b06429c6": "Checking Android SDK and iOS Simulator support.",
-          "6d1483d4a0": "1 emulator device detected.",
-          "0a452d4d3b": "{{value0}} emulator devices detected.",
-          "f62a1bb759": "Orca will auto-select an emulator device after devices are detected.",
-          "b2fd62ea75": "Default device for new emulator tabs and agent attach commands. Auto-select prefers an already running device."
+          "06b06429c6": "Android SDK と iOS シミュレーターのサポートを確認しています。",
+          "6d1483d4a0": "1 つのエミュレータ デバイスが検出されました。",
+          "0a452d4d3b": "{{value0}} エミュレータ デバイスが検出されました。",
+          "f62a1bb759": "Orca は、デバイスが検出された後、エミュレータ デバイスを自動選択します。",
+          "b2fd62ea75": "新規エミュレータ タブと agent 接続コマンドのデフォルト デバイス。自動選択では、すでに実行中のデバイスが優先されます。"
         },
         "MobileNetworkInterfaceSection": {
           "63d5e4ae1e": "QR コードを再生成し、Orca モバイル アプリからスキャンします。",
@@ -5564,9 +5564,9 @@
           "c8491c17ef": "QR コードをスキャンしてスマートフォンから Orca を制御します。ベータ/早期プレビュー - バグや重大な変更が予想されます。 iOS アプリを次の場所から入手します。",
           "e7a3ae8c4e": "モバイル",
           "174f4a3c6d": "スマートフォンから terminals と agents を操作",
-          "1de96ec8a6": "Show Orca Mobile Button",
-          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
-          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
+          "1de96ec8a6": "Orca Mobile ボタンを表示",
+          "682293cadf": "左サイドバー上部に Orca Mobile ボタンを表示します。",
+          "d4f2b65f30": "サイドバーに Orca Mobile ショートカットを表示します。"
         },
         "NotificationsPane": {
           "906b4afebf": "テスト通知を送信する",
@@ -5817,8 +5817,8 @@
           "81057d5f71": "保存中...",
           "da37d6f10e": "コピー",
           "3149964b66": "コピーされました",
-          "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-          "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+          "waitForSetupBeforeAgent": "セットアップが完了するまで待ってから agent を開始してください",
+          "waitForSetupBeforeAgentHelp": "セットアップによって、起動時に agent に必要な依存関係、MCP サーバー、または構成ファイルがインストールされるときに、これをオンにします。"
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "{{value0}} repo カラーを使用する",
@@ -6299,7 +6299,7 @@
           "2227ce47b6": "ターゲットの保存に失敗しました",
           "f602009125": "ターゲットが追加されました",
           "b4ba0ce33d": "ターゲットが更新されました",
-          "3879cbaa52": "Terminal timeout must be between 60 and {{value0}} seconds, or keep terminals alive until reset.",
+          "3879cbaa52": "terminals のタイムアウトは 60 ～ {{value0}} 秒にする必要があります。そうでない場合は、リセットされるまで terminals をアクティブにしておく必要があります。",
           "4db9afce1c": "ポートは 1 ～ 65535 でなければなりません",
           "0e5aa04161": "ホストまたは SSH 構成エイリアスが必要です",
           "f1fc50dad2": "SSH ターゲットのロードに失敗しました",
@@ -6335,8 +6335,8 @@
           "18968ede9e": "エラー",
           "f0871e6bfb": "接続",
           "47e94bd6ba": "接続されています",
-          "a883f5a00f": "terminal timeout: {{value0}}",
-          "8ce71262f4": "terminals until reset"
+          "a883f5a00f": "terminal タイムアウト: {{value0}}",
+          "8ce71262f4": "リセットまでの terminals"
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "これにより、この SSH ターゲット上のアクティブな terminal セッションが停止されます。再接続しても復元されません。",
@@ -6348,11 +6348,11 @@
         },
         "SshTargetForm": {
           "fea9cb402e": "キャンセル",
-          "1b19b00e93": "Bounded timeouts must be between 60 seconds and 7 days.",
-          "137e88ce8d": "Remote terminals keep running after Orca disconnects from this host.",
-          "b574994adc": "Use End Remote Terminals or Reset Relay when you want to stop them.",
-          "71fc546097": "Keep terminals alive until reset",
-          "92f80edbfd": "Remote Terminal Persistence",
+          "1b19b00e93": "制限付きタイムアウトは 60 秒から 7 日間にする必要があります。",
+          "137e88ce8d": "Orca がこのホストから切断された後も、リモートターミナルは実行を続けます。",
+          "b574994adc": "停止したい場合は「リモートターミナルを終了」または「リレーをリセット」を使用してください。",
+          "71fc546097": "リセットするまでターミナルを維持",
+          "92f80edbfd": "リモートターミナルの永続化",
           "feae1d1e69": "オプション。 ProxyJump / ssh -J と同等。",
           "11bcb4507a": "バスティオン.example.com",
           "b2ab248ded": "ジャンプホスト",
@@ -6373,8 +6373,8 @@
           "a62b4cb39a": "変更を保存",
           "29af933cd5": "新規 SSH ターゲット",
           "f2331ce599": "SSH ターゲットの編集",
-          "7c13f58c91": "Until reset",
-          "55c56cf2c7": "Timeout after disconnect (seconds)"
+          "7c13f58c91": "リセットまで",
+          "55c56cf2c7": "切断後のタイムアウト（秒）"
         },
         "TasksPane": {
           "3a72b9745e": "[タスク] ページとサイドバーのショートカットに表示するタスク プロバイダーを選択します。",
@@ -6839,8 +6839,8 @@
             "afbf35be68": "安定したセッション",
             "agentPermissions": "Agent Permissions",
             "agentPermissionsDescription": "Switch agent permission defaults between Yolo and Manual.",
-            "agentRuntime": "Agent Runtime",
-            "agentRuntimeDescription": "Choose whether agents are detected and launched on Windows or in WSL by default."
+            "agentRuntime": "Agent のランタイム",
+            "agentRuntimeDescription": "デフォルトで agents を Windows または WSL のどちらで検出および起動するかを選択します。"
           }
         },
         "appearance": {
@@ -7049,8 +7049,8 @@
             "291f480a5e": "家",
             "a942905148": "新規ブラウザ タブを作成するときに開かれる URL。空白のタブを開くには、空白のままにします。",
             "c3903322d2": "デフォルトのホームページ",
-            "19ea5607cf": "Localhost Worktree Labels",
-            "4e0fdf0a3f": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+            "19ea5607cf": "ローカルホストのワークツリーのラベル",
+            "4e0fdf0a3f": "ワークスペース ポートをワークツリー固有の Orca localhost URL として開くと、ブラウザーのタブを区別しやすくなります。"
           },
           "use": {
             "search": {
@@ -7254,8 +7254,8 @@
               "worktrees": "worktrees"
             },
             "nativeChat": {
-              "title": "Native chat",
-              "description": "Preview the desktop chat surface for Claude and Codex terminal sessions."
+              "title": "ネイティブチャット",
+              "description": "Claude と Codex の terminal セッションのデスクトップ チャット サーフェスをプレビューします。"
             }
           }
         },
@@ -7669,8 +7669,8 @@
               "f213400800": "モバイル",
               "671eb4173c": "スマートフォンから terminals と agents を操作",
               "ffd52a96e4": "モバイル",
-              "1de96ec8a6": "Show Orca Mobile Button",
-              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
+              "1de96ec8a6": "Orca Mobile ボタンを表示",
+              "682293cadf": "左サイドバー上部に Orca Mobile ボタンを表示します。"
             }
           }
         },
@@ -8566,37 +8566,37 @@
           "f5ed5dcbf6": "Press keys…"
         },
         "ShortcutRemoveButton": {
-          "9e29aff18b": "Remove {{value0}} shortcut {{value1}}",
+          "9e29aff18b": "{{value0}} ショートカット {{value1}} を削除",
           "2a9588b1c2": "Remove this binding"
         },
         "BrowserLocalhostWorktreeLabelsSetting": {
-          "8ac8c3ad19": "Localhost Worktree Labels",
-          "1db3c8b983": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+          "8ac8c3ad19": "ローカルホストのワークツリーのラベル",
+          "1db3c8b983": "ワークスペース ポートをワークツリー固有の Orca localhost URL として開くと、ブラウザーのタブを区別しやすくなります。"
         },
         "AgentRuntimeSetting": {
-          "label": "Agent runtime",
+          "label": "Agent のランタイム",
           "wsl": "WSL",
-          "loadingWsl": "Loading WSL",
-          "selectDistro": "Select distro",
-          "windowsDescription": "Detect and launch agents on Windows for projects that do not override their runtime.",
-          "wslUnavailable": "WSL is not available on this machine.",
-          "distroRequired": "Choose a WSL distro before projects can inherit WSL.",
-          "wslDescription": "Detect and launch agents in {{value0}} via WSL for projects that do not override their runtime."
+          "loadingWsl": "WSL の読み込み中",
+          "selectDistro": "ディストリビューションの選択",
+          "windowsDescription": "ランタイムをオーバーライドしないプロジェクトの agents を Windows 上で検出して起動します。",
+          "wslUnavailable": "このマシンでは WSL を利用できません。",
+          "distroRequired": "プロジェクトが WSL を継承できるようにする前に、WSL ディストリビューションを選択。",
+          "wslDescription": "ランタイムをオーバーライドしないプロジェクトの WSL 経由で {{value0}} 内の agents を検出して起動します。"
         },
         "MobileEmulatorSdkStatus": {
-          "536026130e": "Emulator SDKs",
-          "dde0ec1cd8": "Toolchains Orca uses to run emulators. Android works on any OS via the Android SDK; iOS Simulators need Xcode on macOS.",
+          "536026130e": "エミュレータ SDK",
+          "dde0ec1cd8": "Orca がエミュレータを実行するために使用するツールチェーン。 Android は、Android SDK を介してあらゆる OS 上で動作します。 iOS シミュレーターには macOS 上の Xcode が必要です。",
           "027cbf668a": "Android SDK",
-          "f6d080d128": "Using configured path",
-          "7fe4bd5907": "Detected at",
-          "2784f0b22d": "Not found. Install Android Studio, then create a Virtual Device.",
-          "b94ff260e6": "Download Android Studio",
-          "18925b082d": "Locate SDK folder",
-          "8c52684db8": "Clear",
+          "f6d080d128": "設定されたパスの使用",
+          "7fe4bd5907": "で検出されました",
+          "2784f0b22d": "見つかりません。 Android Studioをインストールし、仮想デバイスを作成します。",
+          "b94ff260e6": "Android Studioをダウンロード",
+          "18925b082d": "SDKフォルダーを見つけます",
+          "8c52684db8": "クリア",
           "76eb88b88e": "iOS Simulator (Xcode)",
-          "c6f3ea4f12": "Ready",
-          "e4f14b50d7": "Install Xcode and add an iOS Simulator runtime.",
-          "63fe73a1ea": "Could not update Android SDK folder."
+          "c6f3ea4f12": "準備完了",
+          "e4f14b50d7": "Xcode をインストールし、iOS シミュレーター ランタイムを追加します。",
+          "63fe73a1ea": "Android SDK フォルダーを更新できませんでした。"
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "詳細設定"
@@ -8632,57 +8632,57 @@
           "devOnly": "Dev only"
         },
         "EphemeralVmRecipeRow": {
-          "useInWorkspace": "Use in workspace"
+          "useInWorkspace": "ワークスペースでの使用"
         },
         "EphemeralVmRuntimesSection": {
-          "cleanupFailed": "Cleanup failed",
-          "cleanupRunning": "Cleanup running",
-          "cleanupDisabled": "Cleanup disabled",
-          "running": "Running",
-          "failed": "Failed",
-          "loadFailed": "Couldn’t load temporary VM runtimes.",
-          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
-          "markedCleaned": "Marked temporary VM runtime as cleaned.",
-          "cleaned": "Cleaned up temporary VM runtime.",
-          "copiedCleanupCommand": "Copied cleanup command.",
-          "copiedCleanupPayload": "Copied cleanup payload.",
-          "copyCleanupFailed": "Couldn’t copy cleanup command.",
-          "title": "Temporary VM runtimes",
-          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
-          "refresh": "Refresh temporary VM runtimes",
-          "loading": "Checking temporary VM runtimes…",
-          "empty": "No temporary VM runtimes need cleanup.",
-          "copyCleanup": "Copy command",
-          "retry": "Retry cleanup",
-          "cleanup": "Cleanup"
+          "cleanupFailed": "クリーンアップに失敗しました",
+          "cleanupRunning": "クリーンアップ実行中",
+          "cleanupDisabled": "クリーンアップが無効になっています",
+          "running": "ランニング",
+          "failed": "失敗した",
+          "loadFailed": "一時的な VM ランタイムを読み込めませんでした。",
+          "cleanupFailedToast": "一時的な VM ランタイムをクリーンアップできませんでした。",
+          "markedCleaned": "一時的な VM ランタイムをクリーン済みとしてマークしました。",
+          "cleaned": "一時的な VM ランタイムをクリーンアップしました。",
+          "copiedCleanupCommand": "クリーンアップコマンドをコピーしました。",
+          "copiedCleanupPayload": "コピーされたクリーンアップ ペイロード。",
+          "copyCleanupFailed": "クリーンアップ コマンドをコピーできませんでした。",
+          "title": "一時的な VM ランタイム",
+          "description": "レシピで作成されたランタイムはワークスペースに所有されます。クラッシュ、作成の失敗、または手動リカバリの後に、古いエントリをクリーンアップします。",
+          "refresh": "一時的な VM ランタイムを更新する",
+          "loading": "一時的な VM ランタイムを確認しています…",
+          "empty": "一時的な VM ランタイムにはクリーンアップが必要ありません。",
+          "copyCleanup": "コピーコマンド",
+          "retry": "クリーンアップを再試行します",
+          "cleanup": "掃除"
         },
         "ephemeralVms": {
           "search": {
-            "title": "Per-Workspace Environments",
-            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+            "title": "ワークスペースごとの環境",
+            "description": "repo 所有のレシピが各ワークスペースに独自のオンデマンドの使い捨て環境を与える方法を学びましょう。"
           }
         },
         "EphemeralVmsPane": {
-          "loadError": "Could not load recipes.",
-          "copyError": "Could not copy the prompt.",
-          "skillTitle": "Per-Workspace Environments skill",
-          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
-          "whatTitle": "What the skill does, with you",
-          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
-          "whatBuild": "Builds a reusable base image and signs your agent in.",
-          "whatValidate": "Validates it so you can create a workspace on it.",
-          "promptHint": "In any workspace, ask your agent:",
-          "copy": "Copy",
-          "copied": "Copied",
-          "recipes": "Recipes",
-          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
-          "refresh": "Refresh ephemeral VM recipes",
-          "checking": "Checking recipes...",
-          "none": "No recipes found yet."
+          "loadError": "レシピを読み込めませんでした。",
+          "copyError": "プロンプトをコピーできませんでした。",
+          "skillTitle": "ワークスペースごとの環境スキル",
+          "skillDescription": "repo が所有する環境レシピをセットアップ、構築、認証、および検証します。",
+          "whatTitle": "スキルが何をするのか、あなたと一緒に",
+          "whatScaffold": "Orca サーバーまたは SSH 経由で接続されているプロバイダーのレシピとスクリプトを作成します。",
+          "whatBuild": "再利用可能な基本イメージを構築し、agent をサインインします。",
+          "whatValidate": "ワークスペースを作成できるようにそれを検証します。",
+          "promptHint": "どのワークスペースでも、agent に次のように尋ねます。",
+          "copy": "コピー",
+          "copied": "コピーされました",
+          "recipes": "レシピ",
+          "recipesHelp": "agent が orca.yaml に追加したレシピがここに表示され、ワー​​クスペースを起動できるようになります。",
+          "refresh": "一時的な VM レシピを更新する",
+          "checking": "レシピを確認中...",
+          "none": "レシピはまだ見つかりません。"
         },
         "ephemeralVmsExperimentalSetting": {
-          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
-          "toggleLabel": "Toggle per-workspace environments"
+          "description": "repo が所有するオンデマンド環境のセットアップ コントロールとワークスペース実行ターゲットを示します。",
+          "toggleLabel": "ワークスペースごとの環境を切り替える"
         }
       },
       "right": {
@@ -10912,8 +10912,8 @@
           "8f68ad9ca9": "{{value0}} AI {{value1}} を表示",
           "724a13568d": "{{value0}} に",
           "6094135eec": "vs {{value0}}",
-          "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "a4420ca1f7": "ラップオン",
+          "dde325ddfe": "ラップオフ"
         },
         "ConflictComponents": {
           "f338288514": "競合するコンテンツを読み込んでいます...",
@@ -11002,7 +11002,7 @@
           "561251019a": "その他の操作",
           "8c8b7f5ff5": "前付を表示",
           "10c39d58c1": "前付を隠す",
-          "1eef809708": "Word Wrap"
+          "1eef809708": "ワードラップ"
         },
         "EditorPanelShell": {
           "e2c4dec350": "エディターを読み込み中..."
@@ -11244,11 +11244,11 @@
           "d34a2021c8": "見出し2",
           "abb5100a3d": "見出し1",
           "b462641ed2": "本文",
-          "91a843fb43": "More blocks",
-          "2cd9e0bbb3": "Headings",
-          "b05e14620d": "Heading 4",
-          "6bbf827ef5": "Heading 5",
-          "d1bbf9a835": "Collapsible section"
+          "91a843fb43": "より多くのブロック",
+          "2cd9e0bbb3": "見出し",
+          "b05e14620d": "見出し 4",
+          "6bbf827ef5": "見出し 5",
+          "d1bbf9a835": "折りたたみ可能なセクション"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "保存",
@@ -11327,10 +11327,10 @@
                 "41482b15ce": "見出し 1 を切り替えます",
                 "570611864e": "大きなセクション見出し。",
                 "e66e7f04c6": "見出し1",
-                "5f9a0ed7c4": "Heading 4",
-                "01a71dbbdd": "Nested section heading.",
-                "8440fa4acf": "Heading 5",
-                "b287b93c66": "Deep section heading."
+                "5f9a0ed7c4": "見出し 4",
+                "01a71dbbdd": "ネストされたセクション見出し。",
+                "8440fa4acf": "見出し 5",
+                "b287b93c66": "深いセクションの見出し。"
               }
             }
           }
@@ -11391,8 +11391,8 @@
           "d5a8c2f1b9": "既定の AI エージェントでこのチェックを修正",
           "e2b4d7c8a1": "このチェックのエージェントを選択",
           "f1c9e3a6d4": "チェックを修正するエージェントを選択",
-          "5e2a9c3f88": "Open file at this line",
-          "actionRequired": "Action required"
+          "5e2a9c3f88": "この行でファイルを開く",
+          "actionRequired": "操作が必要です"
         },
         "check": {
           "run": {
@@ -11415,10 +11415,10 @@
           "tooLarge": "貼り付け内容が大きすぎます。"
         },
         "CheckRunJobs": {
-          "1c0a4d7e02": "succeeded",
-          "2d3b8f1a55": "skipped",
-          "3e6c9a2b71": "pending",
-          "4f7d0c3e88": "steps failed",
+          "1c0a4d7e02": "成功しました",
+          "2d3b8f1a55": "スキップしました",
+          "3e6c9a2b71": "保留中",
+          "4f7d0c3e88": "失敗したステップ",
           "5a8e1d4f23": " · "
         }
       },
@@ -12267,7 +12267,7 @@
       },
       "nativeChat": {
         "contextMenu": {
-          "copy": "Copy"
+          "copy": "コピー"
         }
       }
     },
@@ -12289,84 +12289,84 @@
   "components": {
     "native-chat": {
       "composer": {
-        "imageUnsupported": "Image paste is not supported for this agent.",
-        "send": "Send",
-        "noPty": "No live terminal — toggle back to reconnect.",
-        "locked": "Input is held by another device.",
-        "placeholder": "Send a message…",
-        "mentionHint": "Referencing file:",
-        "attach": "Attach file",
-        "startDictation": "Start dictation",
-        "stopDictation": "Stop dictation",
-        "noSkills": "No matching skills",
-        "localAttachmentUnsupported": "Local attachments are not available for remote sessions.",
-        "removeAttachment": "Remove attachment",
-        "pastedImageLabel": "Pasted image"
+        "imageUnsupported": "この agent では画像の貼り付けはサポートされていません。",
+        "send": "送信",
+        "noPty": "ライブ terminal がありません - 再接続するには元に切り替えてください。",
+        "locked": "入力は別のデバイスによって保持されます。",
+        "placeholder": "メッセージを送信してください…",
+        "mentionHint": "参照ファイル:",
+        "attach": "ファイルを添付する",
+        "startDictation": "ディクテーションを開始する",
+        "stopDictation": "ディクテーションを停止する",
+        "noSkills": "一致するスキルがありません",
+        "localAttachmentUnsupported": "ローカル添付ファイルはリモート セッションでは使用できません。",
+        "removeAttachment": "添付ファイルを削除する",
+        "pastedImageLabel": "貼り付けた画像"
       },
       "tool": {
-        "running": "Running…",
-        "result": "Result"
+        "running": "実行中…",
+        "result": "結果"
       },
       "status": {
-        "responding": "Agent is responding"
+        "responding": "Agent が応答中です"
       },
-      "jumpToLatest": "Jump to latest",
+      "jumpToLatest": "最新にジャンプ",
       "toggle": {
-        "showTerminal": "Show terminal",
-        "showChat": "Show chat view"
+        "showTerminal": "terminal を表示",
+        "showChat": "チャットビューを表示"
       },
       "state": {
         "loading": {
-          "title": "Loading conversation…",
-          "subtitle": "Reading the agent transcript."
+          "title": "会話を読み込んでいます…",
+          "subtitle": "agent の記録を読んでいます。"
         },
         "error": {
-          "title": "Could not load conversation",
-          "subtitle": "The transcript could not be read. Toggle back to the terminal to keep working."
+          "title": "会話を読み込めませんでした",
+          "subtitle": "トランスクリプトを読み取ることができませんでした。作業を続けるには、terminal に切り替えてください。"
         },
         "notAgent": {
-          "title": "No conversation here",
-          "subtitle": "This terminal is not running a recognized coding agent."
+          "title": "ここでは会話はありません",
+          "subtitle": "この terminal は認識されたコーディング agent を実行していません。"
         },
         "empty": {
-          "title": "Start a chat with {{value0}}",
-          "subtitle": "Ask {{value0}} to inspect code, explain output, or make a change."
+          "title": "{{value0}} とチャットを開始する",
+          "subtitle": "{{value0}} にコードの検査、出力の説明、または変更を依頼してください。"
         }
       },
-      "stop": "Stop the agent",
+      "stop": "エージェントを停止",
       "copyMessage": {
-        "copied": "Copied",
-        "copy": "Copy message"
+        "copied": "コピーされました",
+        "copy": "メッセージをコピーする"
       },
-      "scrollMessageToTop": "Scroll this message to top",
-      "loadingEarlier": "Loading…",
-      "loadEarlier": "Load earlier messages",
+      "scrollMessageToTop": "このメッセージを一番上までスクロールします",
+      "loadingEarlier": "読み込み中…",
+      "loadEarlier": "以前のメッセージをロードする",
       "question": {
-        "step": "Step {{value0}}",
-        "other": "Other…",
-        "otherPlaceholder": "Type your answer",
-        "cancel": "Cancel",
-        "send": "Send answer",
-        "next": "Next"
+        "step": "ステップ {{value0}}",
+        "other": "他の…",
+        "otherPlaceholder": "答えを入力してください",
+        "cancel": "キャンセル",
+        "send": "回答を送信する",
+        "next": "次へ"
       },
       "approval": {
-        "title": "Allow {{value0}}?",
-        "allow": "Allow",
-        "deny": "Deny"
+        "title": "{{value0}} を許可しますか?",
+        "allow": "許可する",
+        "deny": "拒否"
       }
     },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {
-          "switchToTerminalView": "Switch to terminal view",
-          "switchToChatView": "Switch to chat view"
+          "switchToTerminalView": "terminal ビューに切り替える",
+          "switchToChatView": "チャットビューに切り替える"
         }
       }
     },
     "workspace": {
       "cleanup": {
         "presentationFixtures": {
-          "reviewAlphaCleanup": "Review alpha cleanup"
+          "reviewAlphaCleanup": "アルファクリーンアップを確認する"
         },
         "presentation": {
           "gitlabMergeRequestNumber": "MR #{{value0}}",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -234,7 +234,7 @@
           "runtimeScopeForbiddenDescription": "모바일 범위 페어링에서는 워크스페이스를 사용할 수 없습니다. 설정 → 원격 Orca 서버 → 이 Orca 서버 공유에서 브라우저 액세스 링크로 다시 연결하세요."
         },
         "repos": {
-          "2975400634": "Update Orca server to open non-Git folders on this runtime.",
+          "2975400634": "이 런타임에서 Git이 아닌 폴더를 열려면 Orca 서버를 업데이트하세요.",
           "b7e14472ae": "폴더를 추가하지 못했습니다.",
           "e649269645": "선택한 호스트에 경로를 입력하려면 프로젝트 추가를 사용하세요.",
           "c6e022ddfc": "프로젝트를 추가하지 못했습니다.",
@@ -242,8 +242,8 @@
           "8bb3ad7935": "프로젝트가 추가됨",
           "a8e4b3af5b": "프로젝트가 이미 추가되었습니다.",
           "6d3318e813": "repos를 가져오지 못했습니다.",
-          "3be0f7df04": "Cannot open folder on selected runtime",
-          "15cf5319ec": "{{path}} was checked on {{hostName}}, but that host did not report a usable folder."
+          "3be0f7df04": "선택한 런타임에서 폴더를 열 수 없습니다.",
+          "15cf5319ec": "{{path}}이(가) {{hostName}}에서 확인되었지만 해당 호스트가 사용 가능한 폴더를 보고하지 않았습니다."
         },
         "settings": {
           "e12dab333b": "서버를 전환하지 못했습니다.",
@@ -363,7 +363,7 @@
         "worktree": {
           "background": {
             "terminals": {
-              "setupTitle": "Setup"
+              "setupTitle": "설정"
             }
           }
         },
@@ -403,7 +403,7 @@
         "mobile": {
           "emulator": {
             "tab": {
-              "bf4f2a8a72": "Could not start the emulator. Check iOS or Android emulator setup and try another device."
+              "bf4f2a8a72": "에뮬레이터를 시작할 수 없습니다. iOS 또는 Android 에뮬레이터 설정을 확인하고 다른 기기를 사용해 보세요."
             }
           }
         }
@@ -1162,15 +1162,15 @@
         "reuseExistingBranch": "브랜치 재사용",
         "reuseExistingBranchHint": "기존 브랜치에서 새 브랜치를 만들지 않고 해당 브랜치를 체크아웃합니다.",
         "createMultiple": "더 만들기",
-        "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
-        "destroyDisabled": "destroy disabled",
-        "destroyConfigured": "destroy configured",
-        "noDestroyConfigured": "no destroy",
-        "ephemeralVm": "Per-Workspace Environment",
-        "chooseRunTarget": "Choose target",
-        "noRunTargets": "No run targets are ready for this project.",
-        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
+        "waitForSetupBeforeAgent": "agent를 시작하기 전에 설정이 완료될 때까지 기다리세요.",
+        "waitForSetupBeforeAgentHelp": "설치 프로그램이 시작 중에 agent에 필요한 종속성, MCP 서버 또는 구성 파일을 설치할 때 이 기능을 켜십시오.",
+        "destroyDisabled": "비활성화된 파괴",
+        "destroyConfigured": "구성된 파괴",
+        "noDestroyConfigured": "파괴하지 마세요",
+        "ephemeralVm": "워크스페이스별 환경",
+        "chooseRunTarget": "대상 선택",
+        "noRunTargets": "이 프로젝트에는 실행 대상이 준비되어 있지 않습니다.",
+        "perWorkspaceEnvHint": "레시피에서 온디맨드 환경 프로비저닝"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "작업 트리 만들기",
@@ -2222,9 +2222,9 @@
             "a3346fc6ed": "작업 트리 생성 취소",
             "532aea14ce": "취소",
             "767951265d": "작업 트리를 만드는 중에 문제가 발생했습니다.",
-            "vmProvisioningTitle": "Provisioning VM",
-            "cancelProvisioning": "Cancel",
-            "vmProvisioningLogEmpty": "Waiting for recipe output…"
+            "vmProvisioningTitle": "VM 프로비저닝",
+            "cancelProvisioning": "취소",
+            "vmProvisioningLogEmpty": "레시피 출력을 기다리는 중…"
           }
         }
       },
@@ -2289,24 +2289,24 @@
             "ee81adfcef": "보기",
             "4d0b72481c": "무시",
             "9cc26c019d": "제거",
-            "0e2d235c63": "Inactive workspace scan ready",
-            "4a35c08764": "Review",
-            "47123d0108": "Scanning inactive workspaces. You can close this and come back.",
-            "9a3be9f2df": "Scanning inactive workspaces. New rows appear here as they finish. You can close this and come back.",
-            "3d957ff117": "No workspaces match these filters.",
-            "e94b1f8bb4": "Clear filters",
-            "efb3843e75": "Filter and sort workspaces",
-            "93b7381d50": "Filters",
-            "a615e24679": "Sort",
-            "4cc5b73efe": "Finding inactive workspaces...",
-            "5bf2e88480": "{{value0}}/{{value1}} {{value2}} scanned",
-            "searchPlaceholder": "Search workspaces",
-            "ageFilter": "Age",
-            "reviewFilter": "Review",
+            "0e2d235c63": "비활성 워크스페이스 스캔 준비됨",
+            "4a35c08764": "리뷰",
+            "47123d0108": "비활성 워크스페이스를 검색 중입니다. 이것을 닫고 다시 오시면 됩니다.",
+            "9a3be9f2df": "비활성 워크스페이스를 검색 중입니다. 완료되면 여기에 새 행이 나타납니다. 이것을 닫고 다시 오시면 됩니다.",
+            "3d957ff117": "이 필터와 일치하는 워크스페이스가 없습니다.",
+            "e94b1f8bb4": "필터 지우기",
+            "efb3843e75": "워크스페이스 필터링 및 정렬",
+            "93b7381d50": "필터",
+            "a615e24679": "종류",
+            "4cc5b73efe": "비활성 워크스페이스를 찾는 중...",
+            "5bf2e88480": "{{value0}}/{{value1}} {{value2}} 스캔됨",
+            "searchPlaceholder": "워크스페이스 검색",
+            "ageFilter": "나이",
+            "reviewFilter": "리뷰",
             "gitFilter": "Git",
-            "contextFilter": "Context",
-            "sortBy": "Sort by",
-            "sortDirection": "Direction"
+            "contextFilter": "문맥",
+            "sortBy": "정렬 기준",
+            "sortDirection": "방향"
           }
         }
       },
@@ -3604,9 +3604,9 @@
           "05b33a17a9": "취소",
           "8fba4b8cbb": "이 폴더는 Git repos가 아닙니다. 편집기, terminal, 검색 기능은 제공되지만 Git 기반 기능은 사용할 수 없습니다.",
           "c49fb13492": "이 호스트에 폴더를 추가하지 못했습니다.",
-          "9a766f33ac": "This path was checked on the SSH host.",
-          "79fd02cf5f": "This path was checked on {{hostName}}.",
-          "8851b77327": "This path was checked locally."
+          "9a766f33ac": "이 경로는 SSH 호스트에서 확인되었습니다.",
+          "79fd02cf5f": "이 경로는 {{hostName}}에서 확인되었습니다.",
+          "8851b77327": "이 경로는 로컬에서 확인되었습니다."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "후크 실행",
@@ -4350,15 +4350,15 @@
           "local": "로컬",
           "runtime": "서버",
           "ssh": "SSH",
-          "connecting": "Connecting",
-          "connect": "Connect",
-          "addSshHost": "Add SSH host",
-          "addRemoteServer": "Add remote server",
-          "addRemoteHost": "Add remote host",
-          "addRemoteHostTooltip": "Choose SSH for a machine you can log into, or remote server for an Orca server.",
-          "addSshHostDetail": "Use an existing machine over SSH.",
-          "addRemoteServerDetail": "Pair with Orca running on another computer.",
-          "addRemoteHostDetail": "SSH host or Orca server"
+          "connecting": "연결 중",
+          "connect": "연결",
+          "addSshHost": "SSH 호스트 추가",
+          "addRemoteServer": "원격 서버 추가",
+          "addRemoteHost": "원격 호스트 추가",
+          "addRemoteHostTooltip": "로그인할 수 있는 시스템의 경우 SSH를 선택하고 Orca 서버의 경우 원격 서버를 선택합니다.",
+          "addSshHostDetail": "SSH를 통해 기존 머신을 사용합니다.",
+          "addRemoteServerDetail": "다른 컴퓨터에서 실행 중인 Orca와 페어링합니다.",
+          "addRemoteHostDetail": "SSH 호스트 또는 Orca 서버"
         },
         "sidebarHostOptions": {
           "3e102f111c": "모든 호스트",
@@ -4449,46 +4449,46 @@
           "3b7e4a1c96": "외부 워크트리 숨기기"
         },
         "useAddRepoHostSelection": {
-          "connectionFailed": "SSH connection failed."
+          "connectionFailed": "SSH 연결에 실패했습니다."
         },
         "AddRemoteHostDialog": {
-          "sshHostRequired": "Host or SSH config alias is required.",
-          "sshPortInvalid": "Port must be between 1 and 65535.",
-          "sshRelayGraceInvalid": "Terminal timeout must be between 60 and {{value0}} seconds.",
-          "sshSaved": "SSH host added.",
-          "sshSaveFailed": "Failed to add SSH host.",
-          "serverFieldsRequired": "Server name and pairing code are required.",
-          "serverSaved": "Remote server added.",
-          "serverSaveFailed": "Failed to add remote server.",
-          "serverTitle": "Add remote server",
-          "sshTitle": "Add SSH host",
-          "serverDescription": "Pair with Orca running on another computer.",
-          "sshDescription": "Add a persistent machine you can log into over SSH.",
-          "cancel": "Cancel",
-          "saving": "Saving...",
-          "save": "Save",
-          "label": "Label",
+          "sshHostRequired": "호스트 또는 SSH 구성 별칭이 필요합니다.",
+          "sshPortInvalid": "포트는 1에서 65535 사이여야 합니다.",
+          "sshRelayGraceInvalid": "Terminal 시간 초과는 60~{{value0}}초 사이여야 합니다.",
+          "sshSaved": "SSH 호스트가 추가되었습니다.",
+          "sshSaveFailed": "SSH 호스트를 추가하지 못했습니다.",
+          "serverFieldsRequired": "서버 이름과 페어링 코드가 필요합니다.",
+          "serverSaved": "원격 서버가 추가되었습니다.",
+          "serverSaveFailed": "원격 서버를 추가하지 못했습니다.",
+          "serverTitle": "원격 서버 추가",
+          "sshTitle": "SSH 호스트 추가",
+          "serverDescription": "다른 컴퓨터에서 실행 중인 Orca와 페어링합니다.",
+          "sshDescription": "SSH를 통해 로그인할 수 있는 영구 머신을 추가합니다.",
+          "cancel": "취소",
+          "saving": "저장 중...",
+          "save": "저장",
+          "label": "레이블",
           "sshLabelPlaceholder": "Dev box",
-          "sshHost": "Host or alias",
+          "sshHost": "호스트 또는 별칭",
           "sshHostPlaceholder": "deploy@server:22",
-          "username": "Username",
+          "username": "사용자 이름",
           "usernamePlaceholder": "deploy",
-          "port": "Port",
-          "identityFile": "Identity file",
-          "identityFilePlaceholder": "~/.ssh/id_ed25519 (optional)",
-          "serverName": "Server name",
+          "port": "포트",
+          "identityFile": "신원 파일",
+          "identityFilePlaceholder": "~/.ssh/id_ed25519 (선택 사항)",
+          "serverName": "서버 이름",
           "serverNamePlaceholder": "Dev box",
-          "pairingCode": "Pairing code",
+          "pairingCode": "페어링 코드",
           "pairingCodePlaceholder": "orca://pair?code=...",
-          "pairingHelpPrefix": "Run",
+          "pairingHelpPrefix": "서버에서 실행",
           "pairingCommand": "orca serve --pairing-address <host>",
-          "pairingHelpSuffix": "on the server and paste the printed pairing URL.",
-          "sshImportAlreadySynced": "~/.ssh/config already in sync.",
-          "sshImportSynced": "Synced {{value0}} host{{value1}}.",
-          "sshImportFailed": "Failed to import SSH config.",
-          "importing": "Importing...",
-          "importSshConfig": "Import ~/.ssh/config",
-          "sshPersistenceDefault": "Remote terminals on this host stay alive until you end them or reset the relay."
+          "pairingHelpSuffix": "한 다음 출력된 페어링 URL을 붙여넣으세요.",
+          "sshImportAlreadySynced": "~/.ssh/config가 이미 동기화되어 있습니다.",
+          "sshImportSynced": "{{value0}} 호스트{{value1}}을(를) 동기화했습니다.",
+          "sshImportFailed": "SSH 구성을 가져오지 못했습니다.",
+          "importing": "가져오는 중...",
+          "importSshConfig": "~/.ssh/config 가져오기",
+          "sshPersistenceDefault": "이 호스트의 원격 터미널은 종료하거나 릴레이를 재설정할 때까지 계속 실행됩니다."
         }
       },
       "shared": {
@@ -5071,15 +5071,15 @@
             "toggleLabel": "새 카드 스타일 전환"
           },
           "nativeChat": {
-            "title": "Native chat",
-            "description": "Preview the desktop chat surface for Claude and Codex terminal sessions.",
-            "copy": "Adds a native chat view you can switch to from supported Claude and Codex terminal panes. Experimental while we tune transcript fidelity, streaming, and terminal parity.",
-            "toggleLabel": "Toggle native chat",
-            "defaultTitle": "Default view",
-            "defaultCopy": "Choose how new Claude and Codex terminal tabs open.",
-            "defaultViewLabel": "Default native chat view",
-            "defaultViewTerminal": "Terminal chat",
-            "defaultViewNative": "Native chat"
+            "title": "네이티브 채팅",
+            "description": "Claude 및 Codex terminal 세션에 대한 데스크톱 채팅 화면을 미리 봅니다.",
+            "copy": "지원되는 Claude 및 Codex terminal 창에서 전환할 수 있는 기본 채팅 보기를 추가합니다. 성적표 충실도, 스트리밍 및 terminal 패리티를 조정하는 동안 실험적입니다.",
+            "toggleLabel": "기본 채팅 전환",
+            "defaultTitle": "기본 보기",
+            "defaultCopy": "새로운 Claude 및 Codex terminal 탭이 열리는 방식을 선택하세요.",
+            "defaultViewLabel": "기본 기본 채팅 보기",
+            "defaultViewTerminal": "Terminal 채팅",
+            "defaultViewNative": "네이티브 채팅"
           }
         },
         "FloatingWorkspacePane": {
@@ -5130,10 +5130,10 @@
           "0df2e4fd12": "자동 저장 파일",
           "d21136d9ef": "Orca가 파일 편집을 유지하는 방법을 구성합니다.",
           "45c6e85c4d": "편집기",
-          "8f1afdfbd8": "Diff Word Wrap",
-          "4aa4d9fb73": "Wrap long lines in diff editors instead of requiring horizontal scrolling.",
-          "bf16ef0af2": "Off",
-          "3f6892f307": "On"
+          "8f1afdfbd8": "차이점 단어 줄 바꿈",
+          "4aa4d9fb73": "가로 스크롤을 요구하는 대신 diff 편집기에서 긴 줄을 줄 바꿈합니다.",
+          "bf16ef0af2": "끄다",
+          "3f6892f307": "~에"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "로컬호스트, 127.0.0.1, *.internal",
@@ -5475,11 +5475,11 @@
           "b5e2d93e01": "확인 중...",
           "c6f3ea4f12": "준비됨",
           "d704fb5023": "설정 필요",
-          "06b06429c6": "Checking Android SDK and iOS Simulator support.",
-          "6d1483d4a0": "1 emulator device detected.",
-          "0a452d4d3b": "{{value0}} emulator devices detected.",
-          "f62a1bb759": "Orca will auto-select an emulator device after devices are detected.",
-          "b2fd62ea75": "Default device for new emulator tabs and agent attach commands. Auto-select prefers an already running device."
+          "06b06429c6": "Android SDK 및 iOS 시뮬레이터 지원을 확인 중입니다.",
+          "6d1483d4a0": "1개의 에뮬레이터 장치가 감지되었습니다.",
+          "0a452d4d3b": "{{value0}} 에뮬레이터 장치가 감지되었습니다.",
+          "f62a1bb759": "Orca는 장치가 감지된 후 에뮬레이터 장치를 자동으로 선택합니다.",
+          "b2fd62ea75": "새 에뮬레이터 탭 및 agent 연결 명령을 위한 기본 장치입니다. 자동 선택은 이미 실행 중인 장치를 선호합니다."
         },
         "MobileNetworkInterfaceSection": {
           "63d5e4ae1e": "QR 코드를 재생성하고 Orca 모바일 앱에서 스캔하세요.",
@@ -5527,9 +5527,9 @@
           "c8491c17ef": "QR 코드를 스캔하여 휴대폰에서 Orca를 제어하세요. 베타/초기 미리보기 - 버그 및 주요 변경 사항이 예상됩니다. 다음에서 iOS 앱을 받으세요.",
           "e7a3ae8c4e": "모바일",
           "174f4a3c6d": "휴대폰에서 terminals과 agents를 제어하세요.",
-          "1de96ec8a6": "Show Orca Mobile Button",
-          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
-          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
+          "1de96ec8a6": "Orca Mobile 버튼 표시",
+          "682293cadf": "왼쪽 사이드바 상단에 Orca Mobile 버튼을 표시합니다.",
+          "d4f2b65f30": "사이드바에 Orca Mobile 바로가기를 표시합니다."
         },
         "NotificationsPane": {
           "906b4afebf": "테스트 알림 보내기",
@@ -5780,8 +5780,8 @@
           "81057d5f71": "저장 중...",
           "da37d6f10e": "복사",
           "3149964b66": "복사됨",
-          "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-          "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+          "waitForSetupBeforeAgent": "agent를 시작하기 전에 설정이 완료될 때까지 기다리세요.",
+          "waitForSetupBeforeAgentHelp": "설치 프로그램이 시작 중에 agent에 필요한 종속성, MCP 서버 또는 구성 파일을 설치할 때 이 기능을 켜십시오."
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "{{value0}} repo 색상 사용",
@@ -6262,7 +6262,7 @@
           "2227ce47b6": "대상을 저장하지 못했습니다.",
           "f602009125": "대상이 추가됨",
           "b4ba0ce33d": "타겟이 업데이트되었습니다.",
-          "3879cbaa52": "Terminal timeout must be between 60 and {{value0}} seconds, or keep terminals alive until reset.",
+          "3879cbaa52": "terminals 시간 제한은 60~{{value0}}초 사이여야 하며, 그렇지 않으면 재설정될 때까지 terminals을 활성 상태로 유지해야 합니다.",
           "4db9afce1c": "포트는 1에서 65535 사이여야 합니다.",
           "0e5aa04161": "호스트 또는 SSH 구성 별칭이 필요합니다.",
           "f1fc50dad2": "SSH 대상을 로드하지 못했습니다.",
@@ -6298,8 +6298,8 @@
           "18968ede9e": "오류",
           "f0871e6bfb": "연결",
           "47e94bd6ba": "연결됨",
-          "a883f5a00f": "terminal timeout: {{value0}}",
-          "8ce71262f4": "terminals until reset"
+          "a883f5a00f": "terminal 시간 초과: {{value0}}",
+          "8ce71262f4": "재설정될 때까지 terminals"
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "그러면 이 SSH 대상에서 활성 terminal 세션이 중지됩니다. 다시 연결해도 복원되지 않습니다.",
@@ -6311,11 +6311,11 @@
         },
         "SshTargetForm": {
           "fea9cb402e": "취소",
-          "1b19b00e93": "Bounded timeouts must be between 60 seconds and 7 days.",
-          "137e88ce8d": "Remote terminals keep running after Orca disconnects from this host.",
-          "b574994adc": "Use End Remote Terminals or Reset Relay when you want to stop them.",
-          "71fc546097": "Keep terminals alive until reset",
-          "92f80edbfd": "Remote Terminal Persistence",
+          "1b19b00e93": "제한된 시간 초과는 60초에서 7일 사이여야 합니다.",
+          "137e88ce8d": "Orca가 이 호스트에서 연결 해제된 뒤에도 원격 터미널은 계속 실행됩니다.",
+          "b574994adc": "중지하려면 원격 터미널 종료 또는 릴레이 재설정을 사용하세요.",
+          "71fc546097": "재설정할 때까지 터미널 유지",
+          "92f80edbfd": "원격 터미널 지속성",
           "feae1d1e69": "선택 사항. ProxyJump / ssh -J와 동일합니다.",
           "11bcb4507a": "bastion.example.com",
           "b2ab248ded": "점프 호스트",
@@ -6336,8 +6336,8 @@
           "a62b4cb39a": "변경 사항 저장",
           "29af933cd5": "새로운 SSH 대상",
           "f2331ce599": "SSH 대상 편집",
-          "7c13f58c91": "Until reset",
-          "55c56cf2c7": "Timeout after disconnect (seconds)"
+          "7c13f58c91": "재설정할 때까지",
+          "55c56cf2c7": "연결 해제 후 시간 제한(초)"
         },
         "TasksPane": {
           "3a72b9745e": "작업 페이지와 사이드바 바로가기에 표시할 작업 제공자를 선택합니다.",
@@ -6802,8 +6802,8 @@
             "afbf35be68": "안정적인 세션",
             "agentPermissions": "Agent 권한",
             "agentPermissionsDescription": "agent 권한 기본값을 Yolo와 수동 사이에서 전환합니다.",
-            "agentRuntime": "Agent Runtime",
-            "agentRuntimeDescription": "Choose whether agents are detected and launched on Windows or in WSL by default."
+            "agentRuntime": "Agent 런타임",
+            "agentRuntimeDescription": "기본적으로 Windows 또는 WSL에서 agents를 감지하고 시작할지 선택합니다."
           }
         },
         "appearance": {
@@ -7012,8 +7012,8 @@
             "291f480a5e": "홈",
             "a942905148": "새 브라우저 탭을 만들 때 열리는 URL입니다. 빈 탭을 열려면 비워 두세요.",
             "c3903322d2": "기본 홈 페이지",
-            "19ea5607cf": "Localhost Worktree Labels",
-            "4e0fdf0a3f": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+            "19ea5607cf": "로컬호스트 작업 트리 레이블",
+            "4e0fdf0a3f": "브라우저 탭을 더 쉽게 구분할 수 있도록 작업 트리별 Orca 로컬 호스트 URL로 워크스페이스 포트를 엽니다."
           },
           "use": {
             "search": {
@@ -7217,8 +7217,8 @@
               "worktrees": "worktrees"
             },
             "nativeChat": {
-              "title": "Native chat",
-              "description": "Preview the desktop chat surface for Claude and Codex terminal sessions."
+              "title": "네이티브 채팅",
+              "description": "Claude 및 Codex terminal 세션에 대한 데스크톱 채팅 화면을 미리 봅니다."
             }
           }
         },
@@ -7632,8 +7632,8 @@
               "f213400800": "모바일",
               "671eb4173c": "휴대폰에서 terminals과 agents를 제어하세요.",
               "ffd52a96e4": "모바일",
-              "1de96ec8a6": "Show Orca Mobile Button",
-              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
+              "1de96ec8a6": "Orca Mobile 버튼 표시",
+              "682293cadf": "왼쪽 사이드바 상단에 Orca Mobile 버튼을 표시합니다."
             }
           }
         },
@@ -8566,37 +8566,37 @@
           "f5ed5dcbf6": "Press keys…"
         },
         "ShortcutRemoveButton": {
-          "9e29aff18b": "Remove {{value0}} shortcut {{value1}}",
+          "9e29aff18b": "{{value0}} 바로가기 {{value1}} 제거",
           "2a9588b1c2": "Remove this binding"
         },
         "BrowserLocalhostWorktreeLabelsSetting": {
-          "8ac8c3ad19": "Localhost Worktree Labels",
-          "1db3c8b983": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+          "8ac8c3ad19": "로컬호스트 작업 트리 레이블",
+          "1db3c8b983": "브라우저 탭을 더 쉽게 구분할 수 있도록 작업 트리별 Orca 로컬 호스트 URL로 워크스페이스 포트를 엽니다."
         },
         "AgentRuntimeSetting": {
-          "label": "Agent runtime",
+          "label": "Agent 런타임",
           "wsl": "WSL",
-          "loadingWsl": "Loading WSL",
-          "selectDistro": "Select distro",
-          "windowsDescription": "Detect and launch agents on Windows for projects that do not override their runtime.",
-          "wslUnavailable": "WSL is not available on this machine.",
-          "distroRequired": "Choose a WSL distro before projects can inherit WSL.",
-          "wslDescription": "Detect and launch agents in {{value0}} via WSL for projects that do not override their runtime."
+          "loadingWsl": "WSL 로드 중",
+          "selectDistro": "배포판 선택",
+          "windowsDescription": "런타임을 재정의하지 않는 프로젝트에 대해 Windows에서 agents를 감지하고 시작합니다.",
+          "wslUnavailable": "이 컴퓨터에서는 WSL을 사용할 수 없습니다.",
+          "distroRequired": "프로젝트가 WSL을 상속하려면 먼저 WSL 배포판을 선택하세요.",
+          "wslDescription": "런타임을 재정의하지 않는 프로젝트에 대해 WSL을 통해 {{value0}}에서 agents를 감지하고 시작합니다."
         },
         "MobileEmulatorSdkStatus": {
-          "536026130e": "Emulator SDKs",
-          "dde0ec1cd8": "Toolchains Orca uses to run emulators. Android works on any OS via the Android SDK; iOS Simulators need Xcode on macOS.",
+          "536026130e": "에뮬레이터 SDK",
+          "dde0ec1cd8": "Orca가 에뮬레이터를 실행하는 데 사용하는 도구 체인입니다. Android는 Android SDK를 통해 모든 OS에서 작동합니다. iOS 시뮬레이터에는 macOS에서 Xcode가 필요합니다.",
           "027cbf668a": "Android SDK",
-          "f6d080d128": "Using configured path",
-          "7fe4bd5907": "Detected at",
-          "2784f0b22d": "Not found. Install Android Studio, then create a Virtual Device.",
-          "b94ff260e6": "Download Android Studio",
-          "18925b082d": "Locate SDK folder",
-          "8c52684db8": "Clear",
+          "f6d080d128": "구성된 경로 사용",
+          "7fe4bd5907": "다음에서 감지됨",
+          "2784f0b22d": "찾을 수 없습니다. Android Studio를 설치한 다음 가상 장치를 만듭니다.",
+          "b94ff260e6": "안드로이드 스튜디오 다운로드",
+          "18925b082d": "SDK 폴더 찾기",
+          "8c52684db8": "지우기",
           "76eb88b88e": "iOS Simulator (Xcode)",
-          "c6f3ea4f12": "Ready",
-          "e4f14b50d7": "Install Xcode and add an iOS Simulator runtime.",
-          "63fe73a1ea": "Could not update Android SDK folder."
+          "c6f3ea4f12": "준비됨",
+          "e4f14b50d7": "Xcode를 설치하고 iOS 시뮬레이터 런타임을 추가하세요.",
+          "63fe73a1ea": "Android SDK 폴더를 업데이트할 수 없습니다."
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "고급"
@@ -8632,57 +8632,57 @@
           "devOnly": "Dev only"
         },
         "EphemeralVmRecipeRow": {
-          "useInWorkspace": "Use in workspace"
+          "useInWorkspace": "워크스페이스에서 사용"
         },
         "EphemeralVmRuntimesSection": {
-          "cleanupFailed": "Cleanup failed",
-          "cleanupRunning": "Cleanup running",
-          "cleanupDisabled": "Cleanup disabled",
-          "running": "Running",
-          "failed": "Failed",
-          "loadFailed": "Couldn’t load temporary VM runtimes.",
-          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
-          "markedCleaned": "Marked temporary VM runtime as cleaned.",
-          "cleaned": "Cleaned up temporary VM runtime.",
-          "copiedCleanupCommand": "Copied cleanup command.",
-          "copiedCleanupPayload": "Copied cleanup payload.",
-          "copyCleanupFailed": "Couldn’t copy cleanup command.",
-          "title": "Temporary VM runtimes",
-          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
-          "refresh": "Refresh temporary VM runtimes",
-          "loading": "Checking temporary VM runtimes…",
-          "empty": "No temporary VM runtimes need cleanup.",
-          "copyCleanup": "Copy command",
-          "retry": "Retry cleanup",
-          "cleanup": "Cleanup"
+          "cleanupFailed": "정리 실패",
+          "cleanupRunning": "정리 실행 중",
+          "cleanupDisabled": "정리가 비활성화되었습니다.",
+          "running": "달리기",
+          "failed": "실패한",
+          "loadFailed": "임시 VM 런타임을 로드할 수 없습니다.",
+          "cleanupFailedToast": "임시 VM 런타임을 정리할 수 없습니다.",
+          "markedCleaned": "임시 VM 런타임을 정리된 것으로 표시했습니다.",
+          "cleaned": "임시 VM 런타임을 정리했습니다.",
+          "copiedCleanupCommand": "정리 명령을 복사했습니다.",
+          "copiedCleanupPayload": "정리 페이로드를 복사했습니다.",
+          "copyCleanupFailed": "정리 명령을 복사할 수 없습니다.",
+          "title": "임시 VM 런타임",
+          "description": "레시피로 생성된 런타임은 워크스페이스를 소유합니다. 충돌, 생성 실패 또는 수동 복구 후 오래된 항목을 정리합니다.",
+          "refresh": "임시 VM 런타임 새로 고침",
+          "loading": "임시 VM 런타임 확인 중…",
+          "empty": "임시 VM 런타임은 정리가 필요하지 않습니다.",
+          "copyCleanup": "복사 명령",
+          "retry": "정리 다시 시도",
+          "cleanup": "대청소"
         },
         "ephemeralVms": {
           "search": {
-            "title": "Per-Workspace Environments",
-            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+            "title": "워크스페이스별 환경",
+            "description": "repo 소유 레시피가 각 워크스페이스에 고유한 주문형 일회용 환경을 제공하는 방법을 알아보세요."
           }
         },
         "EphemeralVmsPane": {
-          "loadError": "Could not load recipes.",
-          "copyError": "Could not copy the prompt.",
-          "skillTitle": "Per-Workspace Environments skill",
-          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
-          "whatTitle": "What the skill does, with you",
-          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
-          "whatBuild": "Builds a reusable base image and signs your agent in.",
-          "whatValidate": "Validates it so you can create a workspace on it.",
-          "promptHint": "In any workspace, ask your agent:",
-          "copy": "Copy",
-          "copied": "Copied",
-          "recipes": "Recipes",
-          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
-          "refresh": "Refresh ephemeral VM recipes",
-          "checking": "Checking recipes...",
-          "none": "No recipes found yet."
+          "loadError": "레시피를 로드할 수 없습니다.",
+          "copyError": "프롬프트를 복사할 수 없습니다.",
+          "skillTitle": "워크스페이스별 환경 기술",
+          "skillDescription": "repo 소유 환경 레시피를 설정, 빌드, 인증 및 검증합니다.",
+          "whatTitle": "당신과 함께 기술이 하는 일",
+          "whatScaffold": "Orca 서버 또는 SSH를 통해 연결된 공급자를 위한 레시피 및 스크립트를 작성합니다.",
+          "whatBuild": "재사용 가능한 기본 이미지를 구축하고 agent에 로그인합니다.",
+          "whatValidate": "워크스페이스를 생성할 수 있도록 유효성을 검사합니다.",
+          "promptHint": "어떤 워크스페이스에서든 agent에게 다음과 같이 질문하세요.",
+          "copy": "복사",
+          "copied": "복사됨",
+          "recipes": "조리법",
+          "recipesHelp": "agent가 orca.yaml에 추가하는 레시피가 여기에 표시되어 워크스페이스를 시작할 준비가 됩니다.",
+          "refresh": "임시 VM 레시피 새로 고침",
+          "checking": "레시피 확인 중...",
+          "none": "아직 레시피를 찾을 수 없습니다."
         },
         "ephemeralVmsExperimentalSetting": {
-          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
-          "toggleLabel": "Toggle per-workspace environments"
+          "description": "repo 소유 온디맨드 환경에 대한 설정 제어 및 워크스페이스 실행 대상을 표시합니다.",
+          "toggleLabel": "워크스페이스별 환경 전환"
         }
       },
       "right": {
@@ -10912,8 +10912,8 @@
           "8f68ad9ca9": "{{value0}} AI {{value1}} 표시",
           "724a13568d": "{{value0}}에서",
           "6094135eec": "대 {{value0}}",
-          "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "a4420ca1f7": "랩 온",
+          "dde325ddfe": "마무리"
         },
         "ConflictComponents": {
           "f338288514": "충돌 콘텐츠 로드 중...",
@@ -11002,7 +11002,7 @@
           "561251019a": "추가 작업",
           "8c8b7f5ff5": "머리말 표시",
           "10c39d58c1": "머리말 숨기기",
-          "1eef809708": "Word Wrap"
+          "1eef809708": "단어 줄 바꿈"
         },
         "EditorPanelShell": {
           "e2c4dec350": "편집기 로드 중..."
@@ -11244,11 +11244,11 @@
           "d34a2021c8": "제목 2",
           "abb5100a3d": "제목 1",
           "b462641ed2": "본문 텍스트",
-          "91a843fb43": "More blocks",
-          "2cd9e0bbb3": "Headings",
-          "b05e14620d": "Heading 4",
-          "6bbf827ef5": "Heading 5",
-          "d1bbf9a835": "Collapsible section"
+          "91a843fb43": "더 많은 블록",
+          "2cd9e0bbb3": "제목",
+          "b05e14620d": "제목 4",
+          "6bbf827ef5": "제목 5",
+          "d1bbf9a835": "접을 수 있는 섹션"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "저장",
@@ -11327,10 +11327,10 @@
                 "41482b15ce": "토글 제목 1",
                 "570611864e": "큰 섹션 제목.",
                 "e66e7f04c6": "제목 1",
-                "5f9a0ed7c4": "Heading 4",
-                "01a71dbbdd": "Nested section heading.",
-                "8440fa4acf": "Heading 5",
-                "b287b93c66": "Deep section heading."
+                "5f9a0ed7c4": "제목 4",
+                "01a71dbbdd": "중첩된 섹션 제목.",
+                "8440fa4acf": "제목 5",
+                "b287b93c66": "깊은 섹션 제목."
               }
             }
           }
@@ -11391,8 +11391,8 @@
           "d5a8c2f1b9": "이 체크를 수정할 기본 AI agent 시작",
           "e2b4d7c8a1": "이 체크를 처리할 agent 선택",
           "f1c9e3a6d4": "체크를 수정할 agent 선택",
-          "5e2a9c3f88": "Open file at this line",
-          "actionRequired": "Action required"
+          "5e2a9c3f88": "이 줄에서 파일 열기",
+          "actionRequired": "조치 필요"
         },
         "check": {
           "run": {
@@ -11415,10 +11415,10 @@
           "tooLarge": "붙여넣기 내용이 너무 큽니다."
         },
         "CheckRunJobs": {
-          "1c0a4d7e02": "succeeded",
-          "2d3b8f1a55": "skipped",
-          "3e6c9a2b71": "pending",
-          "4f7d0c3e88": "steps failed",
+          "1c0a4d7e02": "성공했다",
+          "2d3b8f1a55": "건너뛰었습니다",
+          "3e6c9a2b71": "보류 중",
+          "4f7d0c3e88": "단계 실패",
           "5a8e1d4f23": " · "
         }
       },
@@ -12267,7 +12267,7 @@
       },
       "nativeChat": {
         "contextMenu": {
-          "copy": "Copy"
+          "copy": "복사"
         }
       }
     },
@@ -12289,84 +12289,84 @@
   "components": {
     "native-chat": {
       "composer": {
-        "imageUnsupported": "Image paste is not supported for this agent.",
-        "send": "Send",
-        "noPty": "No live terminal — toggle back to reconnect.",
-        "locked": "Input is held by another device.",
-        "placeholder": "Send a message…",
-        "mentionHint": "Referencing file:",
-        "attach": "Attach file",
-        "startDictation": "Start dictation",
-        "stopDictation": "Stop dictation",
-        "noSkills": "No matching skills",
-        "localAttachmentUnsupported": "Local attachments are not available for remote sessions.",
-        "removeAttachment": "Remove attachment",
-        "pastedImageLabel": "Pasted image"
+        "imageUnsupported": "이 에이전트는 이미지 붙여넣기를 지원하지 않습니다.",
+        "send": "보내기",
+        "noPty": "라이브 terminal이 없습니다. 다시 연결하려면 다시 전환하세요.",
+        "locked": "입력이 다른 장치에 의해 보류됩니다.",
+        "placeholder": "메시지 보내기…",
+        "mentionHint": "참조 파일:",
+        "attach": "파일첨부",
+        "startDictation": "받아쓰기 시작",
+        "stopDictation": "받아쓰기 중지",
+        "noSkills": "어울리는 스킬 없음",
+        "localAttachmentUnsupported": "원격 세션에는 로컬 첨부 파일을 사용할 수 없습니다.",
+        "removeAttachment": "첨부파일 삭제",
+        "pastedImageLabel": "붙여넣은 이미지"
       },
       "tool": {
-        "running": "Running…",
-        "result": "Result"
+        "running": "실행 중…",
+        "result": "결과"
       },
       "status": {
-        "responding": "Agent is responding"
+        "responding": "Agent이 응답 중입니다."
       },
-      "jumpToLatest": "Jump to latest",
+      "jumpToLatest": "최신으로 이동",
       "toggle": {
-        "showTerminal": "Show terminal",
-        "showChat": "Show chat view"
+        "showTerminal": "terminal 표시",
+        "showChat": "채팅 보기 표시"
       },
       "state": {
         "loading": {
-          "title": "Loading conversation…",
-          "subtitle": "Reading the agent transcript."
+          "title": "대화 로드 중…",
+          "subtitle": "agent 기록을 읽는 중입니다."
         },
         "error": {
-          "title": "Could not load conversation",
-          "subtitle": "The transcript could not be read. Toggle back to the terminal to keep working."
+          "title": "대화를 로드할 수 없습니다.",
+          "subtitle": "스크립트를 읽을 수 없습니다. 계속 작업하려면 terminal로 다시 전환하세요."
         },
         "notAgent": {
-          "title": "No conversation here",
-          "subtitle": "This terminal is not running a recognized coding agent."
+          "title": "여기에는 대화가 없습니다.",
+          "subtitle": "이 terminal은 인식된 코딩 agent를 실행하고 있지 않습니다."
         },
         "empty": {
-          "title": "Start a chat with {{value0}}",
-          "subtitle": "Ask {{value0}} to inspect code, explain output, or make a change."
+          "title": "{{value0}}님과 채팅을 시작하세요",
+          "subtitle": "{{value0}}에게 코드 검사, 출력 설명 또는 변경을 요청하세요."
         }
       },
-      "stop": "Stop the agent",
+      "stop": "에이전트 중지",
       "copyMessage": {
-        "copied": "Copied",
-        "copy": "Copy message"
+        "copied": "복사됨",
+        "copy": "메시지 복사"
       },
-      "scrollMessageToTop": "Scroll this message to top",
-      "loadingEarlier": "Loading…",
-      "loadEarlier": "Load earlier messages",
+      "scrollMessageToTop": "이 메시지를 맨 위로 스크롤",
+      "loadingEarlier": "로드 중…",
+      "loadEarlier": "이전 메시지 로드",
       "question": {
-        "step": "Step {{value0}}",
-        "other": "Other…",
-        "otherPlaceholder": "Type your answer",
-        "cancel": "Cancel",
-        "send": "Send answer",
-        "next": "Next"
+        "step": "{{value0}} 단계",
+        "other": "다른…",
+        "otherPlaceholder": "답변을 입력하세요",
+        "cancel": "취소",
+        "send": "답변 보내기",
+        "next": "다음"
       },
       "approval": {
-        "title": "Allow {{value0}}?",
-        "allow": "Allow",
-        "deny": "Deny"
+        "title": "{{value0}}을(를) 허용하시겠습니까?",
+        "allow": "허용하다",
+        "deny": "부인하다"
       }
     },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {
-          "switchToTerminalView": "Switch to terminal view",
-          "switchToChatView": "Switch to chat view"
+          "switchToTerminalView": "terminal 보기로 전환",
+          "switchToChatView": "채팅 보기로 전환"
         }
       }
     },
     "workspace": {
       "cleanup": {
         "presentationFixtures": {
-          "reviewAlphaCleanup": "Review alpha cleanup"
+          "reviewAlphaCleanup": "알파 정리 검토"
         },
         "presentation": {
           "gitlabMergeRequestNumber": "MR #{{value0}}",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -46,7 +46,7 @@
     "showStatusBar": "显示状态栏",
     "showTasksButton": "显示任务按钮",
     "showAutomationsButton": "显示自动化按钮",
-    "showMobileButton": "显示 Orca Mobile 按钮",
+    "showMobileButton": "显示 Orca手机端 按钮",
     "showTitlebarAppName": "显示标题栏应用名称",
     "view": "查看",
     "reload": "重新加载",
@@ -234,7 +234,7 @@
           "runtimeScopeForbiddenDescription": "移动端范围的配对无法使用工作区。请通过设置 → 远程 Orca 服务器 → 分享此 Orca 服务器中的浏览器访问链接重新连接。"
         },
         "repos": {
-          "2975400634": "Update Orca server to open non-Git folders on this runtime.",
+          "2975400634": "请更新 Orca 服务器，以便在此运行时打开非 Git 文件夹。",
           "b7e14472ae": "添加文件夹失败",
           "e649269645": "使用\"添加项目\"在所选主机上输入路径。",
           "c6e022ddfc": "添加项目失败",
@@ -242,8 +242,8 @@
           "8bb3ad7935": "项目已添加",
           "a8e4b3af5b": "项目已添加过了",
           "6d3318e813": "导入存储库失败",
-          "3be0f7df04": "Cannot open folder on selected runtime",
-          "15cf5319ec": "{{path}} was checked on {{hostName}}, but that host did not report a usable folder."
+          "3be0f7df04": "无法在所选运行时打开文件夹",
+          "15cf5319ec": "已在 {{hostName}} 上检查 {{path}}，但该主机未报告可用文件夹。"
         },
         "settings": {
           "e12dab333b": "切换服务器失败",
@@ -363,7 +363,7 @@
         "worktree": {
           "background": {
             "terminals": {
-              "setupTitle": "Setup"
+              "setupTitle": "设置"
             }
           }
         },
@@ -403,7 +403,7 @@
         "mobile": {
           "emulator": {
             "tab": {
-              "bf4f2a8a72": "Could not start the emulator. Check iOS or Android emulator setup and try another device."
+              "bf4f2a8a72": "无法启动模拟器。请检查 iOS 或 Android 模拟器设置，然后尝试其他设备。"
             }
           }
         }
@@ -1106,7 +1106,7 @@
       },
       "NewWorkspaceComposerCard": {
         "cbb47ee0dc": "仅适用于本地 Git 项目。",
-        "d861de981b": "Sparse checkout",
+        "d861de981b": "稀疏检出",
         "090cfedeb4": "写备注",
         "f8728aa4f9": "备注",
         "0ee17638fe": "工作区名称",
@@ -1162,15 +1162,15 @@
         "reuseExistingBranch": "复用分支",
         "reuseExistingBranchHint": "检出已有分支，而不是从它创建新分支。",
         "createMultiple": "创建更多",
-        "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-        "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
-        "destroyDisabled": "destroy disabled",
-        "destroyConfigured": "destroy configured",
-        "noDestroyConfigured": "no destroy",
-        "ephemeralVm": "Per-Workspace Environment",
-        "chooseRunTarget": "Choose target",
-        "noRunTargets": "No run targets are ready for this project.",
-        "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe"
+        "waitForSetupBeforeAgent": "等待设置完成后再启动智能体",
+        "waitForSetupBeforeAgentHelp": "如果设置会安装依赖、MCP 服务器或智能体启动时需要的配置文件，请开启此选项。",
+        "destroyDisabled": "已禁用销毁",
+        "destroyConfigured": "已配置销毁",
+        "noDestroyConfigured": "未配置销毁",
+        "ephemeralVm": "工作区专属环境",
+        "chooseRunTarget": "选择目标",
+        "noRunTargets": "此项目还没有可用的运行目标。",
+        "perWorkspaceEnvHint": "根据配方按需创建环境"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "创建工作树",
@@ -2222,9 +2222,9 @@
             "a3346fc6ed": "取消工作树创建",
             "532aea14ce": "取消",
             "767951265d": "创建工作树时出现问题。",
-            "vmProvisioningTitle": "Provisioning VM",
-            "cancelProvisioning": "Cancel",
-            "vmProvisioningLogEmpty": "Waiting for recipe output…"
+            "vmProvisioningTitle": "正在预配虚拟机",
+            "cancelProvisioning": "取消",
+            "vmProvisioningLogEmpty": "正在等待配方输出…"
           }
         }
       },
@@ -2289,24 +2289,24 @@
             "ee81adfcef": "查看",
             "4d0b72481c": "忽略",
             "9cc26c019d": "移除",
-            "0e2d235c63": "Inactive workspace scan ready",
-            "4a35c08764": "Review",
-            "47123d0108": "Scanning inactive workspaces. You can close this and come back.",
-            "9a3be9f2df": "Scanning inactive workspaces. New rows appear here as they finish. You can close this and come back.",
-            "3d957ff117": "No workspaces match these filters.",
-            "e94b1f8bb4": "Clear filters",
-            "efb3843e75": "Filter and sort workspaces",
-            "93b7381d50": "Filters",
-            "a615e24679": "Sort",
-            "4cc5b73efe": "Finding inactive workspaces...",
-            "5bf2e88480": "{{value0}}/{{value1}} {{value2}} scanned",
-            "searchPlaceholder": "Search workspaces",
-            "ageFilter": "Age",
-            "reviewFilter": "Review",
+            "0e2d235c63": "非活动工作区扫描已就绪",
+            "4a35c08764": "查看",
+            "47123d0108": "正在扫描非活动工作区。你可以关闭此窗口，稍后再回来查看。",
+            "9a3be9f2df": "正在扫描非活动工作区。新结果会在完成时显示在这里。你可以关闭此窗口，稍后再回来查看。",
+            "3d957ff117": "没有工作区匹配这些筛选条件。",
+            "e94b1f8bb4": "清除筛选",
+            "efb3843e75": "筛选并排序工作区",
+            "93b7381d50": "筛选",
+            "a615e24679": "排序",
+            "4cc5b73efe": "正在查找非活动工作区...",
+            "5bf2e88480": "已扫描 {{value0}}/{{value1}} 个{{value2}}",
+            "searchPlaceholder": "搜索工作区",
+            "ageFilter": "时间",
+            "reviewFilter": "评审",
             "gitFilter": "Git",
-            "contextFilter": "Context",
-            "sortBy": "Sort by",
-            "sortDirection": "Direction"
+            "contextFilter": "上下文",
+            "sortBy": "排序依据",
+            "sortDirection": "方向"
           }
         }
       },
@@ -3604,9 +3604,9 @@
           "05b33a17a9": "取消",
           "8fba4b8cbb": "此文件夹不是 Git 存储库。您将拥有编辑器、终端和搜索，但基于 Git 的功能将不可用。",
           "c49fb13492": "添加远程文件夹失败",
-          "9a766f33ac": "This path was checked on the SSH host.",
-          "79fd02cf5f": "This path was checked on {{hostName}}.",
-          "8851b77327": "This path was checked locally."
+          "9a766f33ac": "已在 SSH 主机上检查此路径。",
+          "79fd02cf5f": "已在 {{hostName}} 上检查此路径。",
+          "8851b77327": "已在本机检查此路径。"
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "运行钩子",
@@ -3747,7 +3747,7 @@
           "80611a8b10": "搜索",
           "0c3395fd32": "搜索工作树和浏览器选项卡",
           "c86d83b5c3": "新建",
-          "1b5c41caee": "Orca Mobile",
+          "1b5c41caee": "Orca 手机端",
           "9c95e1ce91": "智能体",
           "f323383e9a": "自动化",
           "e7ad3c540d": "打开 Jira 任务",
@@ -4350,15 +4350,15 @@
           "local": "本地",
           "runtime": "服务器",
           "ssh": "SSH",
-          "connecting": "Connecting",
-          "connect": "Connect",
-          "addSshHost": "Add SSH host",
-          "addRemoteServer": "Add remote server",
-          "addRemoteHost": "Add remote host",
-          "addRemoteHostTooltip": "Choose SSH for a machine you can log into, or remote server for an Orca server.",
-          "addSshHostDetail": "Use an existing machine over SSH.",
-          "addRemoteServerDetail": "Pair with Orca running on another computer.",
-          "addRemoteHostDetail": "SSH host or Orca server"
+          "connecting": "正在连接",
+          "connect": "连接",
+          "addSshHost": "添加 SSH 主机",
+          "addRemoteServer": "添加远程服务器",
+          "addRemoteHost": "添加远程主机",
+          "addRemoteHostTooltip": "可选择能通过 SSH 登录的机器，也可选择运行 Orca 的远程服务器。",
+          "addSshHostDetail": "通过 SSH 使用现有机器。",
+          "addRemoteServerDetail": "与另一台电脑上运行的 Orca 配对。",
+          "addRemoteHostDetail": "SSH 主机或 Orca 服务器"
         },
         "sidebarHostOptions": {
           "3e102f111c": "所有主机",
@@ -4449,46 +4449,46 @@
           "3b7e4a1c96": "隐藏外部工作树"
         },
         "useAddRepoHostSelection": {
-          "connectionFailed": "SSH connection failed."
+          "connectionFailed": "SSH 连接失败。"
         },
         "AddRemoteHostDialog": {
-          "sshHostRequired": "Host or SSH config alias is required.",
-          "sshPortInvalid": "Port must be between 1 and 65535.",
-          "sshRelayGraceInvalid": "Terminal timeout must be between 60 and {{value0}} seconds.",
-          "sshSaved": "SSH host added.",
-          "sshSaveFailed": "Failed to add SSH host.",
-          "serverFieldsRequired": "Server name and pairing code are required.",
-          "serverSaved": "Remote server added.",
-          "serverSaveFailed": "Failed to add remote server.",
-          "serverTitle": "Add remote server",
-          "sshTitle": "Add SSH host",
-          "serverDescription": "Pair with Orca running on another computer.",
-          "sshDescription": "Add a persistent machine you can log into over SSH.",
-          "cancel": "Cancel",
-          "saving": "Saving...",
-          "save": "Save",
-          "label": "Label",
+          "sshHostRequired": "必须填写主机或 SSH 配置别名。",
+          "sshPortInvalid": "端口必须介于 1 到 65535 之间。",
+          "sshRelayGraceInvalid": "终端超时时间必须介于 60 到 {{value0}} 秒之间。",
+          "sshSaved": "已添加 SSH 主机。",
+          "sshSaveFailed": "添加 SSH 主机失败。",
+          "serverFieldsRequired": "必须填写服务器名称和配对码。",
+          "serverSaved": "已添加远程服务器。",
+          "serverSaveFailed": "添加远程服务器失败。",
+          "serverTitle": "添加远程服务器",
+          "sshTitle": "添加 SSH 主机",
+          "serverDescription": "与另一台电脑上运行的 Orca 配对。",
+          "sshDescription": "添加一台可通过 SSH 登录并持久保存的机器。",
+          "cancel": "取消",
+          "saving": "正在保存...",
+          "save": "保存",
+          "label": "标签",
           "sshLabelPlaceholder": "Dev box",
-          "sshHost": "Host or alias",
+          "sshHost": "主机或别名",
           "sshHostPlaceholder": "deploy@server:22",
-          "username": "Username",
+          "username": "用户名",
           "usernamePlaceholder": "deploy",
-          "port": "Port",
-          "identityFile": "Identity file",
-          "identityFilePlaceholder": "~/.ssh/id_ed25519 (optional)",
-          "serverName": "Server name",
+          "port": "端口",
+          "identityFile": "身份文件",
+          "identityFilePlaceholder": "~/.ssh/id_ed25519（可选）",
+          "serverName": "服务器名称",
           "serverNamePlaceholder": "Dev box",
-          "pairingCode": "Pairing code",
+          "pairingCode": "配对码",
           "pairingCodePlaceholder": "orca://pair?code=...",
-          "pairingHelpPrefix": "Run",
+          "pairingHelpPrefix": "在服务器上运行",
           "pairingCommand": "orca serve --pairing-address <host>",
-          "pairingHelpSuffix": "on the server and paste the printed pairing URL.",
-          "sshImportAlreadySynced": "~/.ssh/config already in sync.",
-          "sshImportSynced": "Synced {{value0}} host{{value1}}.",
-          "sshImportFailed": "Failed to import SSH config.",
-          "importing": "Importing...",
-          "importSshConfig": "Import ~/.ssh/config",
-          "sshPersistenceDefault": "Remote terminals on this host stay alive until you end them or reset the relay."
+          "pairingHelpSuffix": "，然后粘贴打印出的配对 URL。",
+          "sshImportAlreadySynced": "~/.ssh/config 已同步。",
+          "sshImportSynced": "已同步 {{value0}} 个主机{{value1}}。",
+          "sshImportFailed": "导入 SSH 配置失败。",
+          "importing": "正在导入...",
+          "importSshConfig": "导入 ~/.ssh/config",
+          "sshPersistenceDefault": "此主机上的远程终端会保持运行，直到你结束它们或重置中继。"
         }
       },
       "shared": {
@@ -4692,9 +4692,9 @@
           "3057983501": "未分配",
           "0cd9b8228f": "选择 Dock 和窗口切换器中显示的应用程序图标。",
           "ca1590d42f": "应用程序图标",
-          "61d842eca0": "在侧边栏中显示 Orca Mobile 快捷方式。它仍然可以从 Toolbox 中获取。",
-          "9da1020447": "显示 Orca Mobile 按钮",
-          "5db6ba961f": "在左侧边栏顶部显示 Orca Mobile 按钮。",
+          "61d842eca0": "在侧边栏中显示 Orca手机端 快捷方式。它仍然可以从 Toolbox 中获取。",
+          "9da1020447": "显示 Orca手机端 按钮",
+          "5db6ba961f": "在左侧边栏顶部显示 Orca手机端 按钮。",
           "fa882a3e6b": "在左侧边栏顶部显示“自动化”按钮。",
           "511f270ebb": "显示自动化按钮",
           "661942ab7f": "在左侧边栏顶部显示“任务”按钮。",
@@ -5071,15 +5071,15 @@
             "toggleLabel": "切换新卡片样式"
           },
           "nativeChat": {
-            "title": "Native chat",
-            "description": "Preview the desktop chat surface for Claude and Codex terminal sessions.",
-            "copy": "Adds a native chat view you can switch to from supported Claude and Codex terminal panes. Experimental while we tune transcript fidelity, streaming, and terminal parity.",
-            "toggleLabel": "Toggle native chat",
-            "defaultTitle": "Default view",
-            "defaultCopy": "Choose how new Claude and Codex terminal tabs open.",
-            "defaultViewLabel": "Default native chat view",
-            "defaultViewTerminal": "Terminal chat",
-            "defaultViewNative": "Native chat"
+            "title": "原生聊天",
+            "description": "预览 Claude 和 Codex 终端会话的桌面聊天界面。",
+            "copy": "添加一个原生聊天视图，可从受支持的 Claude 和 Codex 终端窗格切换进入。在我们调校记录保真度、流式输出和终端一致性期间，此功能仍为实验性。",
+            "toggleLabel": "切换原生聊天",
+            "defaultTitle": "默认视图",
+            "defaultCopy": "选择新的 Claude 和 Codex 终端标签页如何打开。",
+            "defaultViewLabel": "默认原生聊天视图",
+            "defaultViewTerminal": "终端聊天",
+            "defaultViewNative": "原生聊天"
           }
         },
         "FloatingWorkspacePane": {
@@ -5130,10 +5130,10 @@
           "0df2e4fd12": "自动保存文件",
           "d21136d9ef": "配置 Orca 如何保留文件编辑。",
           "45c6e85c4d": "编辑",
-          "8f1afdfbd8": "Diff Word Wrap",
-          "4aa4d9fb73": "Wrap long lines in diff editors instead of requiring horizontal scrolling.",
-          "bf16ef0af2": "Off",
-          "3f6892f307": "On"
+          "8f1afdfbd8": "差异自动换行",
+          "4aa4d9fb73": "在差异编辑器中换行显示长行，而不是要求水平滚动。",
+          "bf16ef0af2": "关闭",
+          "3f6892f307": "开启"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "本地主机，127.0.0.1，*.internal",
@@ -5475,11 +5475,11 @@
           "b5e2d93e01": "检查中...",
           "c6f3ea4f12": "就绪",
           "d704fb5023": "需要设置",
-          "06b06429c6": "Checking Android SDK and iOS Simulator support.",
-          "6d1483d4a0": "1 emulator device detected.",
-          "0a452d4d3b": "{{value0}} emulator devices detected.",
-          "f62a1bb759": "Orca will auto-select an emulator device after devices are detected.",
-          "b2fd62ea75": "Default device for new emulator tabs and agent attach commands. Auto-select prefers an already running device."
+          "06b06429c6": "正在检查 Android SDK 和 iOS 模拟器支持。",
+          "6d1483d4a0": "检测到 1 个模拟器设备。",
+          "0a452d4d3b": "检测到 {{value0}} 个模拟器设备。",
+          "f62a1bb759": "检测到设备后，Orca 会自动选择一个模拟器设备。",
+          "b2fd62ea75": "新模拟器标签页和智能体附加命令使用的默认设备。自动选择会优先使用已在运行的设备。"
         },
         "MobileNetworkInterfaceSection": {
           "63d5e4ae1e": "重新生成二维码并从 Orca 手机应用程序扫描。",
@@ -5488,7 +5488,7 @@
           "668016be7a": "在您的计算机和手机上。",
           "1dc87a7fbc": "Tailscale",
           "51d29927eb": "安装",
-          "9fc5d203ff": "Orca Mobile 直接连接到此计算机。要在远离同一本地网络的地方使用它，请将您的计算机和手机置于同一私有覆盖网络上，然后使用所选的网络地址生成二维码。",
+          "9fc5d203ff": "Orca手机端 直接连接到此计算机。要在远离同一本地网络的地方使用它，请将您的计算机和手机置于同一私有覆盖网络上，然后使用所选的网络地址生成二维码。",
           "39fad211d9": "使用尾网连接 Wi-Fi 外部",
           "a9db5d771d": "刷新网络接口",
           "b2c384cfd6": "没有找到接口",
@@ -5498,7 +5498,7 @@
           "1e64659126": "再生"
         },
         "MobilePane": {
-          "dd3cd78d04": "使用 Orca Mobile 扫描",
+          "dd3cd78d04": "使用 Orca手机端 扫描",
           "35100bca5d": "当您在手机上使用终端时，Orca 会将其缩小以适合您的手机屏幕。当您关闭应用程序或切换离开时，这可以控制它是保持手机大小（因此交互式 CLI 工具不会回流）还是将大小调整回桌面。您始终可以在横幅上使用“恢复此终端”或“恢复所有终端”来手动调整大小。",
           "ee56f1c7e4": "当您离开手机应用程序时",
           "3939fd062c": "撤销设备会立即断开连接。",
@@ -5527,9 +5527,9 @@
           "c8491c17ef": "通过扫描二维码从手机控制 Orca。 Beta/早期预览 - 预计会出现错误和重大更改。从以下位置获取 iOS 应用程序",
           "e7a3ae8c4e": "移动端",
           "174f4a3c6d": "通过手机控制终端和智能体。",
-          "1de96ec8a6": "Show Orca Mobile Button",
-          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
-          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
+          "1de96ec8a6": "显示 Orca手机端 按钮",
+          "682293cadf": "在左侧边栏顶部显示 Orca手机端 按钮。",
+          "d4f2b65f30": "在边栏中显示 Orca手机端 快捷入口。"
         },
         "NotificationsPane": {
           "906b4afebf": "发送测试通知",
@@ -5780,8 +5780,8 @@
           "81057d5f71": "保存中...",
           "da37d6f10e": "复制",
           "3149964b66": "已复制",
-          "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-          "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+          "waitForSetupBeforeAgent": "等待设置完成后再启动智能体",
+          "waitForSetupBeforeAgentHelp": "如果设置会安装依赖、MCP 服务器或智能体启动时需要的配置文件，请开启此选项。"
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "使用 {{value0}} 仓库颜色",
@@ -6262,7 +6262,7 @@
           "2227ce47b6": "保存目标失败",
           "f602009125": "目标已添加",
           "b4ba0ce33d": "目标已更新",
-          "3879cbaa52": "Terminal timeout must be between 60 and {{value0}} seconds, or keep terminals alive until reset.",
+          "3879cbaa52": "终端超时时间必须介于 60 到 {{value0}} 秒之间，或保持终端运行直到重置。",
           "4db9afce1c": "端口必须介于 1 和 65535 之间",
           "0e5aa04161": "需要主机或 SSH 配置别名",
           "f1fc50dad2": "无法加载 SSH 目标",
@@ -6298,8 +6298,8 @@
           "18968ede9e": "错误",
           "f0871e6bfb": "连接",
           "47e94bd6ba": "已连接",
-          "a883f5a00f": "terminal timeout: {{value0}}",
-          "8ce71262f4": "terminals until reset"
+          "a883f5a00f": "终端超时：{{value0}}",
+          "8ce71262f4": "终端保持运行直到重置"
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "这将停止此 SSH 目标上的活动终端会话。重新连接不会恢复它们。",
@@ -6311,11 +6311,11 @@
         },
         "SshTargetForm": {
           "fea9cb402e": "取消",
-          "1b19b00e93": "Bounded timeouts must be between 60 seconds and 7 days.",
-          "137e88ce8d": "Remote terminals keep running after Orca disconnects from this host.",
-          "b574994adc": "Use End Remote Terminals or Reset Relay when you want to stop them.",
-          "71fc546097": "Keep terminals alive until reset",
-          "92f80edbfd": "Remote Terminal Persistence",
+          "1b19b00e93": "有限超时时间必须介于 60 秒到 7 天之间。",
+          "137e88ce8d": "Orca 与此主机断开连接后，远程终端会继续运行。",
+          "b574994adc": "需要停止它们时，请使用“结束远程终端”或“重置中继”。",
+          "71fc546097": "保持终端运行直到重置",
+          "92f80edbfd": "远程终端持久化",
           "feae1d1e69": "可选。相当于 ProxyJump / ssh -J。",
           "11bcb4507a": "bastion.example.com",
           "b2ab248ded": "跳跃主机",
@@ -6336,8 +6336,8 @@
           "a62b4cb39a": "保存更改",
           "29af933cd5": "新的 SSH 目标",
           "f2331ce599": "编辑 SSH 目标",
-          "7c13f58c91": "Until reset",
-          "55c56cf2c7": "Timeout after disconnect (seconds)"
+          "7c13f58c91": "直到重置",
+          "55c56cf2c7": "断开连接后的超时时间（秒）"
         },
         "TasksPane": {
           "3a72b9745e": "选择要在“任务”页面和侧边栏快捷键中显示的任务提供商。",
@@ -6802,8 +6802,8 @@
             "afbf35be68": "稳定会话",
             "agentPermissions": "智能体权限",
             "agentPermissionsDescription": "在 Yolo 和手动之间切换智能体权限默认值。",
-            "agentRuntime": "Agent Runtime",
-            "agentRuntimeDescription": "Choose whether agents are detected and launched on Windows or in WSL by default."
+            "agentRuntime": "智能体运行时",
+            "agentRuntimeDescription": "选择默认在 Windows 还是 WSL 中检测并启动智能体。"
           }
         },
         "appearance": {
@@ -6824,8 +6824,8 @@
             "5bff6a2ef0": "侧边栏",
             "5e5b8878bf": "手机",
             "74618577c7": "移动端",
-            "682293cadf": "在左侧边栏顶部显示 Orca Mobile 按钮。",
-            "1de96ec8a6": "显示 Orca Mobile 按钮",
+            "682293cadf": "在左侧边栏顶部显示 Orca手机端 按钮。",
+            "1de96ec8a6": "显示 Orca手机端 按钮",
             "4c920ab2d1": "日程",
             "58f4e22fa2": "自动化",
             "b186f3cefb": "自动化",
@@ -7012,8 +7012,8 @@
             "291f480a5e": "家",
             "a942905148": "创建新浏览器选项卡时打开的 URL。留空以打开空白选项卡。",
             "c3903322d2": "默认主页",
-            "19ea5607cf": "Localhost Worktree Labels",
-            "4e0fdf0a3f": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+            "19ea5607cf": "本地主机工作区标签",
+            "4e0fdf0a3f": "将工作区端口打开为特定于工作区的 Orca localhost URL，便于区分浏览器标签页。"
           },
           "use": {
             "search": {
@@ -7217,8 +7217,8 @@
               "worktrees": "工作树"
             },
             "nativeChat": {
-              "title": "Native chat",
-              "description": "Preview the desktop chat surface for Claude and Codex terminal sessions."
+              "title": "原生聊天",
+              "description": "预览 Claude 和 Codex 终端会话的桌面聊天界面。"
             }
           }
         },
@@ -7632,8 +7632,8 @@
               "f213400800": "移动端",
               "671eb4173c": "通过手机控制终端和智能体。",
               "ffd52a96e4": "移动端",
-              "1de96ec8a6": "Show Orca Mobile Button",
-              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
+              "1de96ec8a6": "显示 Orca Mobile 按钮",
+              "682293cadf": "在左侧边栏顶部显示 Orca Mobile 按钮。"
             }
           }
         },
@@ -8566,37 +8566,37 @@
           "f5ed5dcbf6": "按下按键…"
         },
         "ShortcutRemoveButton": {
-          "9e29aff18b": "Remove {{value0}} shortcut {{value1}}",
+          "9e29aff18b": "移除 {{value0}} 快捷键 {{value1}}",
           "2a9588b1c2": "移除此绑定"
         },
         "BrowserLocalhostWorktreeLabelsSetting": {
-          "8ac8c3ad19": "Localhost Worktree Labels",
-          "1db3c8b983": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+          "8ac8c3ad19": "本地主机工作区标签",
+          "1db3c8b983": "将工作区端口打开为特定于工作区的 Orca localhost URL，便于区分浏览器标签页。"
         },
         "AgentRuntimeSetting": {
-          "label": "Agent runtime",
+          "label": "智能体运行时",
           "wsl": "WSL",
-          "loadingWsl": "Loading WSL",
-          "selectDistro": "Select distro",
-          "windowsDescription": "Detect and launch agents on Windows for projects that do not override their runtime.",
-          "wslUnavailable": "WSL is not available on this machine.",
-          "distroRequired": "Choose a WSL distro before projects can inherit WSL.",
-          "wslDescription": "Detect and launch agents in {{value0}} via WSL for projects that do not override their runtime."
+          "loadingWsl": "正在加载 WSL",
+          "selectDistro": "选择发行版",
+          "windowsDescription": "对于未覆盖运行时的项目，在 Windows 上检测并启动智能体。",
+          "wslUnavailable": "此机器上不可用 WSL。",
+          "distroRequired": "项目继承 WSL 前，请先选择一个 WSL 发行版。",
+          "wslDescription": "对于未覆盖运行时的项目，通过 WSL 在 {{value0}} 中检测并启动智能体。"
         },
         "MobileEmulatorSdkStatus": {
-          "536026130e": "Emulator SDKs",
-          "dde0ec1cd8": "Toolchains Orca uses to run emulators. Android works on any OS via the Android SDK; iOS Simulators need Xcode on macOS.",
+          "536026130e": "模拟器 SDK",
+          "dde0ec1cd8": "Orca 用于运行模拟器的工具链。Android 可通过 Android SDK 在任何系统上运行；iOS 模拟器需要 macOS 上的 Xcode。",
           "027cbf668a": "Android SDK",
-          "f6d080d128": "Using configured path",
-          "7fe4bd5907": "Detected at",
-          "2784f0b22d": "Not found. Install Android Studio, then create a Virtual Device.",
-          "b94ff260e6": "Download Android Studio",
-          "18925b082d": "Locate SDK folder",
-          "8c52684db8": "Clear",
+          "f6d080d128": "正在使用配置的路径",
+          "7fe4bd5907": "检测位置",
+          "2784f0b22d": "未找到。请安装 Android Studio，然后创建虚拟设备。",
+          "b94ff260e6": "下载 Android Studio",
+          "18925b082d": "定位 SDK 文件夹",
+          "8c52684db8": "清除",
           "76eb88b88e": "iOS Simulator (Xcode)",
-          "c6f3ea4f12": "Ready",
-          "e4f14b50d7": "Install Xcode and add an iOS Simulator runtime.",
-          "63fe73a1ea": "Could not update Android SDK folder."
+          "c6f3ea4f12": "已就绪",
+          "e4f14b50d7": "请安装 Xcode 并添加 iOS 模拟器运行时。",
+          "63fe73a1ea": "无法更新 Android SDK 文件夹。"
         },
         "AppearanceAdvancedDisclosure": {
           "advanced": "高级"
@@ -8632,57 +8632,57 @@
           "devOnly": "Dev only"
         },
         "EphemeralVmRecipeRow": {
-          "useInWorkspace": "Use in workspace"
+          "useInWorkspace": "在工作区中使用"
         },
         "EphemeralVmRuntimesSection": {
-          "cleanupFailed": "Cleanup failed",
-          "cleanupRunning": "Cleanup running",
-          "cleanupDisabled": "Cleanup disabled",
-          "running": "Running",
-          "failed": "Failed",
-          "loadFailed": "Couldn’t load temporary VM runtimes.",
-          "cleanupFailedToast": "Couldn’t clean up temporary VM runtime.",
-          "markedCleaned": "Marked temporary VM runtime as cleaned.",
-          "cleaned": "Cleaned up temporary VM runtime.",
-          "copiedCleanupCommand": "Copied cleanup command.",
-          "copiedCleanupPayload": "Copied cleanup payload.",
-          "copyCleanupFailed": "Couldn’t copy cleanup command.",
-          "title": "Temporary VM runtimes",
-          "description": "Recipe-created runtimes are workspace-owned. Clean up stale entries after crashes, failed creates, or manual recovery.",
-          "refresh": "Refresh temporary VM runtimes",
-          "loading": "Checking temporary VM runtimes…",
-          "empty": "No temporary VM runtimes need cleanup.",
-          "copyCleanup": "Copy command",
-          "retry": "Retry cleanup",
-          "cleanup": "Cleanup"
+          "cleanupFailed": "清理失败",
+          "cleanupRunning": "正在清理",
+          "cleanupDisabled": "清理已禁用",
+          "running": "运行中",
+          "failed": "失败",
+          "loadFailed": "无法加载临时 VM 运行时。",
+          "cleanupFailedToast": "无法清理临时 VM 运行时。",
+          "markedCleaned": "已将临时 VM 运行时标记为已清理。",
+          "cleaned": "已清理临时 VM 运行时。",
+          "copiedCleanupCommand": "已复制清理命令。",
+          "copiedCleanupPayload": "已复制清理载荷。",
+          "copyCleanupFailed": "无法复制清理命令。",
+          "title": "临时 VM 运行时",
+          "description": "由配方创建的运行时归工作区所有。崩溃、创建失败或手动恢复后，请清理过期条目。",
+          "refresh": "刷新临时 VM 运行时",
+          "loading": "正在检查临时 VM 运行时…",
+          "empty": "没有需要清理的临时 VM 运行时。",
+          "copyCleanup": "复制命令",
+          "retry": "重试清理",
+          "cleanup": "清理"
         },
         "ephemeralVms": {
           "search": {
-            "title": "Per-Workspace Environments",
-            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+            "title": "工作区专属环境",
+            "description": "了解仓库自带的配方如何为每个工作区提供按需创建、可丢弃的独立环境。"
           }
         },
         "EphemeralVmsPane": {
-          "loadError": "Could not load recipes.",
-          "copyError": "Could not copy the prompt.",
-          "skillTitle": "Per-Workspace Environments skill",
-          "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
-          "whatTitle": "What the skill does, with you",
-          "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
-          "whatBuild": "Builds a reusable base image and signs your agent in.",
-          "whatValidate": "Validates it so you can create a workspace on it.",
-          "promptHint": "In any workspace, ask your agent:",
-          "copy": "Copy",
-          "copied": "Copied",
-          "recipes": "Recipes",
-          "recipesHelp": "Recipes your agent adds to orca.yaml show up here, ready to launch a workspace on.",
-          "refresh": "Refresh ephemeral VM recipes",
-          "checking": "Checking recipes...",
-          "none": "No recipes found yet."
+          "loadError": "无法加载配方。",
+          "copyError": "无法复制提示词。",
+          "skillTitle": "工作区专属环境技能",
+          "skillDescription": "设置、构建、认证并验证仓库自带的环境配方。",
+          "whatTitle": "此技能会与你一起完成",
+          "whatScaffold": "为你的提供商编写配方和脚本，可通过 Orca 服务器或 SSH 连接。",
+          "whatBuild": "构建可复用的基础镜像，并让智能体完成登录。",
+          "whatValidate": "验证环境，以便你可以在其上创建工作区。",
+          "promptHint": "在任意工作区中，可以这样询问智能体：",
+          "copy": "复制",
+          "copied": "已复制",
+          "recipes": "配方",
+          "recipesHelp": "智能体添加到 orca.yaml 的配方会显示在这里，可用于启动工作区。",
+          "refresh": "刷新临时 VM 配方",
+          "checking": "正在检查配方...",
+          "none": "还没有找到配方。"
         },
         "ephemeralVmsExperimentalSetting": {
-          "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
-          "toggleLabel": "Toggle per-workspace environments"
+          "description": "显示仓库自带按需环境的设置控件和工作区运行目标。",
+          "toggleLabel": "切换工作区专属环境"
         }
       },
       "right": {
@@ -10041,7 +10041,7 @@
           "dfd2aa9d5d": "网络",
           "2f077ef4eb": "，然后扫码。",
           "3aa7bb2d8b": "配对桌面",
-          "d1495e5e64": "打开 Orca Mobile，点击",
+          "d1495e5e64": "打开 Orca手机端，点击",
           "901c98bb93": "配对这个",
           "3960f5c339": "第 2 步（共 2 步）",
           "3241f3c26a": "安装二维码",
@@ -10049,15 +10049,15 @@
           "aa97420ba4": "复制安装链接",
           "ac1eb64952": "安卓",
           "711e6f4b47": "iOS系统",
-          "e75647ace0": "使用手机扫描二维码或打开安装链接以获取 Orca Mobile。",
+          "e75647ace0": "使用手机扫描二维码或打开安装链接以获取 Orca手机端。",
           "0d9b33299e": "获取应用程序。",
           "92ddfdfa1f": "第 1 步（共 2 步）",
           "ff48d9d520": "与另一台设备配对",
           "f9cbf4bb53": "撤销设备",
           "34f878d04f": "撤销 {{value0}}",
           "94829abdb1": "配对",
-          "266c18c105": "打开 Orca Mobile 从上次中断的地方继续，或配对其他设备。",
-          "5410d55d79": "Orca Mobile",
+          "266c18c105": "打开 Orca手机端 从上次中断的地方继续，或配对其他设备。",
+          "5410d55d79": "Orca手机端",
           "10d27b4cba": "开始使用",
           "da1d5e5ed0": "可用于",
           "ec0607bf66": "支持的手机平台",
@@ -10092,8 +10092,8 @@
           "fb5f28330e": "在侧边栏中显示",
           "c669abcf8f": "从侧边栏隐藏",
           "e1c7b4a92d": "Configure in Settings > Mobile.",
-          "a4f8c2d91e": "Remove Orca Mobile from left sidebar",
-          "b7e3d1c84a": "Show Orca Mobile in left sidebar",
+          "a4f8c2d91e": "Remove Orca手机端 from left sidebar",
+          "b7e3d1c84a": "Show Orca手机端 in left sidebar",
           "f3d8e5b71a": "Adds the shortcut back to the left sidebar."
         },
         "PhoneCarousel": {
@@ -10912,8 +10912,8 @@
           "8f68ad9ca9": "显示 {{value0}} AI {{value1}}",
           "724a13568d": "在 {{value0}}",
           "6094135eec": "与 {{value0}}",
-          "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "a4420ca1f7": "开启换行",
+          "dde325ddfe": "关闭换行"
         },
         "ConflictComponents": {
           "f338288514": "正在加载冲突内容...",
@@ -11002,7 +11002,7 @@
           "561251019a": "更多操作",
           "8c8b7f5ff5": "显示前面的内容",
           "10c39d58c1": "隐藏前面的内容",
-          "1eef809708": "Word Wrap"
+          "1eef809708": "自动换行"
         },
         "EditorPanelShell": {
           "e2c4dec350": "正在加载编辑器..."
@@ -11244,11 +11244,11 @@
           "d34a2021c8": "标题 2",
           "abb5100a3d": "标题 1",
           "b462641ed2": "正文",
-          "91a843fb43": "More blocks",
-          "2cd9e0bbb3": "Headings",
-          "b05e14620d": "Heading 4",
-          "6bbf827ef5": "Heading 5",
-          "d1bbf9a835": "Collapsible section"
+          "91a843fb43": "更多块",
+          "2cd9e0bbb3": "标题",
+          "b05e14620d": "标题 4",
+          "6bbf827ef5": "标题 5",
+          "d1bbf9a835": "可折叠小节"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "保存",
@@ -11327,10 +11327,10 @@
                 "41482b15ce": "切换标题 1",
                 "570611864e": "大节标题。",
                 "e66e7f04c6": "标题 1",
-                "5f9a0ed7c4": "Heading 4",
-                "01a71dbbdd": "Nested section heading.",
-                "8440fa4acf": "Heading 5",
-                "b287b93c66": "Deep section heading."
+                "5f9a0ed7c4": "标题 4",
+                "01a71dbbdd": "嵌套小节标题。",
+                "8440fa4acf": "标题 5",
+                "b287b93c66": "深层小节标题。"
               }
             }
           }
@@ -11391,8 +11391,8 @@
           "d5a8c2f1b9": "启动默认 AI 智能体来修复此检查",
           "e2b4d7c8a1": "为此检查选择智能体",
           "f1c9e3a6d4": "选择智能体修复检查",
-          "5e2a9c3f88": "Open file at this line",
-          "actionRequired": "Action required"
+          "5e2a9c3f88": "在此行打开文件",
+          "actionRequired": "需要操作"
         },
         "check": {
           "run": {
@@ -11415,10 +11415,10 @@
           "tooLarge": "粘贴内容过大。"
         },
         "CheckRunJobs": {
-          "1c0a4d7e02": "succeeded",
-          "2d3b8f1a55": "skipped",
-          "3e6c9a2b71": "pending",
-          "4f7d0c3e88": "steps failed",
+          "1c0a4d7e02": "已成功",
+          "2d3b8f1a55": "已跳过",
+          "3e6c9a2b71": "等待中",
+          "4f7d0c3e88": "步骤失败",
           "5a8e1d4f23": " · "
         }
       },
@@ -12267,7 +12267,7 @@
       },
       "nativeChat": {
         "contextMenu": {
-          "copy": "Copy"
+          "copy": "复制"
         }
       }
     },
@@ -12289,84 +12289,84 @@
   "components": {
     "native-chat": {
       "composer": {
-        "imageUnsupported": "Image paste is not supported for this agent.",
-        "send": "Send",
-        "noPty": "No live terminal — toggle back to reconnect.",
-        "locked": "Input is held by another device.",
-        "placeholder": "Send a message…",
-        "mentionHint": "Referencing file:",
-        "attach": "Attach file",
-        "startDictation": "Start dictation",
-        "stopDictation": "Stop dictation",
-        "noSkills": "No matching skills",
-        "localAttachmentUnsupported": "Local attachments are not available for remote sessions.",
-        "removeAttachment": "Remove attachment",
-        "pastedImageLabel": "Pasted image"
+        "imageUnsupported": "此智能体不支持粘贴图片。",
+        "send": "发送",
+        "noPty": "没有实时终端，请切回终端以重新连接。",
+        "locked": "输入正被另一台设备占用。",
+        "placeholder": "发送消息…",
+        "mentionHint": "引用文件：",
+        "attach": "附加文件",
+        "startDictation": "开始听写",
+        "stopDictation": "停止听写",
+        "noSkills": "没有匹配的技能",
+        "localAttachmentUnsupported": "远程会话不支持本地附件。",
+        "removeAttachment": "移除附件",
+        "pastedImageLabel": "粘贴的图片"
       },
       "tool": {
-        "running": "Running…",
-        "result": "Result"
+        "running": "正在运行…",
+        "result": "结果"
       },
       "status": {
-        "responding": "Agent is responding"
+        "responding": "智能体正在回复"
       },
-      "jumpToLatest": "Jump to latest",
+      "jumpToLatest": "跳到最新消息",
       "toggle": {
-        "showTerminal": "Show terminal",
-        "showChat": "Show chat view"
+        "showTerminal": "显示终端",
+        "showChat": "显示聊天视图"
       },
       "state": {
         "loading": {
-          "title": "Loading conversation…",
-          "subtitle": "Reading the agent transcript."
+          "title": "正在加载对话…",
+          "subtitle": "正在读取智能体记录。"
         },
         "error": {
-          "title": "Could not load conversation",
-          "subtitle": "The transcript could not be read. Toggle back to the terminal to keep working."
+          "title": "无法加载对话",
+          "subtitle": "无法读取记录。请切回终端继续工作。"
         },
         "notAgent": {
-          "title": "No conversation here",
-          "subtitle": "This terminal is not running a recognized coding agent."
+          "title": "这里没有对话",
+          "subtitle": "此终端未运行可识别的编码智能体。"
         },
         "empty": {
-          "title": "Start a chat with {{value0}}",
-          "subtitle": "Ask {{value0}} to inspect code, explain output, or make a change."
+          "title": "开始与 {{value0}} 聊天",
+          "subtitle": "让 {{value0}} 检查代码、解释输出或进行修改。"
         }
       },
-      "stop": "Stop the agent",
+      "stop": "停止智能体",
       "copyMessage": {
-        "copied": "Copied",
-        "copy": "Copy message"
+        "copied": "已复制",
+        "copy": "复制消息"
       },
-      "scrollMessageToTop": "Scroll this message to top",
-      "loadingEarlier": "Loading…",
-      "loadEarlier": "Load earlier messages",
+      "scrollMessageToTop": "将此消息滚动到顶部",
+      "loadingEarlier": "正在加载…",
+      "loadEarlier": "加载更早的消息",
       "question": {
-        "step": "Step {{value0}}",
-        "other": "Other…",
-        "otherPlaceholder": "Type your answer",
-        "cancel": "Cancel",
-        "send": "Send answer",
-        "next": "Next"
+        "step": "步骤 {{value0}}",
+        "other": "其他…",
+        "otherPlaceholder": "输入你的回答",
+        "cancel": "取消",
+        "send": "发送回答",
+        "next": "下一步"
       },
       "approval": {
-        "title": "Allow {{value0}}?",
-        "allow": "Allow",
-        "deny": "Deny"
+        "title": "允许 {{value0}}？",
+        "allow": "允许",
+        "deny": "拒绝"
       }
     },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {
-          "switchToTerminalView": "Switch to terminal view",
-          "switchToChatView": "Switch to chat view"
+          "switchToTerminalView": "切换到终端视图",
+          "switchToChatView": "切换到聊天视图"
         }
       }
     },
     "workspace": {
       "cleanup": {
         "presentationFixtures": {
-          "reviewAlphaCleanup": "Review alpha cleanup"
+          "reviewAlphaCleanup": "评审 Alpha 清理"
         },
         "presentation": {
           "gitlabMergeRequestNumber": "MR #{{value0}}",


### PR DESCRIPTION
## Summary

Updated Spanish, Japanese, Korean, and Chinese localization files to translate previously untranslated keys. Key areas updated include:
- Ephemeral VM / Per-Workspace Environment setup, provisioning, and recipe options
- SSH host, remote server, and relay timeout configurations
- Native chat/terminal session preview settings
- Mobile emulator, iOS/Android SDK detection status messages
- Localhost worktree labeling settings
- WSL / Agent runtime settings in Windows

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The code review verified the translation updates for accuracy and consistency across Spanish, Japanese, Korean, and Chinese locales. Verified that all dynamic string parameter placeholders (such as `{{value0}}`, `{{value1}}`, `{{path}}`, and `{{hostName}}`) remain fully intact and correct to prevent translation rendering breaks.
Cross-platform compatibility check: Reviewed shortcuts, labels, path translations, and platform-specific behavior descriptors (e.g., WSL vs Windows configurations, iOS Simulator Xcode references on macOS vs Android SDK references) to confirm descriptions are accurate across macOS, Linux, and Windows.

## Security Audit

A security review was conducted on the changed JSON translation files. These changes are strictly static user-interface translation strings and do not alter any input handling, shell command execution, path handling, auth mechanisms, credentials, or IPC endpoints.

## Notes

None. Translation updates have no platform-specific risks or functional behavior changes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->