### PR TITLE
Fix Windows ConPTY agent keyboard reset

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
+  RESET_KITTY_KEYBOARD_PROTOCOL,
   RESET_TERMINAL_CURSOR_STYLE
 } from './layout-serialization'
 import { TERMINAL_PASTE_DIRECT_MAX_BYTES } from './terminal-paste-coordinator'
@@ -10899,6 +10900,164 @@ describe('connectPanePty', () => {
       RESET_TERMINAL_CURSOR_STYLE,
       expect.any(Function)
     )
+  })
+
+  it('resets stale Kitty keyboard state when a native Windows agent becomes idle', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      connectPanePty(pane as never, manager as never, deps as never)
+
+      const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
+        | ((title: string) => void)
+        | undefined
+      if (!idleHandler) {
+        throw new Error('Expected onAgentBecameIdle to be registered')
+      }
+
+      idleHandler('* Codex done')
+
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
+        expect.any(Function)
+      )
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
+  it('keeps SSH agent idle reset cursor-only on Windows clients', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      mockStoreState = {
+        ...mockStoreState,
+        repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+        sshConnectionStates: new Map([['conn-1', { status: 'connected' }]])
+      } as StoreState
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      connectPanePty(pane as never, manager as never, deps as never)
+
+      const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
+        | ((title: string) => void)
+        | undefined
+      if (!idleHandler) {
+        throw new Error('Expected onAgentBecameIdle to be registered')
+      }
+
+      idleHandler('* Codex done')
+
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        RESET_TERMINAL_CURSOR_STYLE,
+        expect.any(Function)
+      )
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
+        expect.any(Function)
+      )
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
+  it('resets stale Kitty keyboard state when native Windows hook status reaches done', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      connectPanePty(pane as never, manager as never, deps as never)
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'working',
+        prompt: 'ship it',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'codex',
+        paneKey,
+        stateHistory: []
+      }
+      notifyStoreSubscribers()
+      expect(pane.terminal.write).not.toHaveBeenCalled()
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'done',
+        prompt: 'ship it',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'codex',
+        paneKey,
+        stateHistory: []
+      }
+      notifyStoreSubscribers()
+
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
+        expect.any(Function)
+      )
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
+  it('unsubscribes the native Windows done reset watcher on pane dispose', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      const binding = connectPanePty(pane as never, manager as never, deps as never)
+      binding.dispose()
+      pane.terminal.write.mockClear()
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'done',
+        prompt: 'ship it',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'codex',
+        paneKey,
+        stateHistory: []
+      }
+      notifyStoreSubscribers()
+
+      expect(pane.terminal.write).not.toHaveBeenCalled()
+    } finally {
+      restoreUserAgent()
+    }
   })
 
   it('queues the idle cursor reset behind hidden agent output', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -48,6 +48,7 @@ import {
   POST_REPLAY_LIVE_SNAPSHOT_RESET,
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
+  RESET_KITTY_KEYBOARD_PROTOCOL,
   RESET_TERMINAL_CURSOR_STYLE
 } from './layout-serialization'
 import { createShellReadyMarkerScanState, scanForShellReadyMarker } from './shell-ready-marker-scan'
@@ -948,11 +949,12 @@ export function connectPanePty(
   // Why: idle callbacks are registered before the deferred PTY output plumbing
   // exists. Start with the shared scheduler, then switch to the PTY writer
   // below so hidden-tab resets keep backlog-recovery callbacks and byte order.
-  let queueAgentIdleCursorReset = (): void => {
+  let idleAgentTerminalModeReset = RESET_TERMINAL_CURSOR_STYLE
+  let queueAgentIdleTerminalModeReset = (): void => {
     if (disposed) {
       return
     }
-    writeTerminalOutput(pane.terminal, RESET_TERMINAL_CURSOR_STYLE, {
+    writeTerminalOutput(pane.terminal, idleAgentTerminalModeReset, {
       foreground: shouldWritePtyOutputForeground(deps.isVisibleRef.current)
     })
   }
@@ -1235,7 +1237,7 @@ export function connectPanePty(
       // Why: restored idle agent TUIs can repaint after reattach SIGWINCH and
       // reapply DECSCUSR steady-bar; the normal working→idle reset will not
       // fire because the agent was already idle before Orca restarted.
-      queueAgentIdleCursorReset()
+      queueAgentIdleTerminalModeReset()
     }, REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS)
   }
   const interruptInference = createAgentInterruptInference({
@@ -2012,9 +2014,9 @@ export function connectPanePty(
     if (syncAgentTaskCompleteTrackingEnabled()) {
       agentCompletionCoordinator.observeClassifiedTitleCompletion(title)
     }
-    // Why: some agent TUIs leave xterm in DECSCUSR steady-cursor mode when
-    // they become idle. Reset to Orca's configured cursor once the turn ends.
-    queueAgentIdleCursorReset()
+    // Why: some agent TUIs leave xterm renderer modes active after a turn.
+    // Reset cursor everywhere, and Kitty keyboard state on native Windows.
+    queueAgentIdleTerminalModeReset()
   }
   const onAgentBecameWorking = (): void => {
     if (syncAgentTaskCompleteTrackingEnabled()) {
@@ -2085,9 +2087,25 @@ export function connectPanePty(
     shellOverride,
     executionHostId
   })
+  if (isNativeWindowsConpty) {
+    // Why: completed Windows ConPTY agent turns can leave xterm's renderer-side
+    // Kitty encoder enabled; clearing it restores plain Backspace/Enter input.
+    idleAgentTerminalModeReset = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`
+  }
   const shouldApplyNativeWindowsRewriteRefresh = isNativeWindowsConpty
   const shouldApplyWindowsRendererUnicodeRefresh = CLIENT_PLATFORM === 'win32'
   const shouldProtectNativeWindowsSynchronizedOutput = isNativeWindowsConpty
+  let lastAgentStatusState = state.agentStatusByPaneKey[cacheKey]?.state
+  let unsubscribeWindowsDoneTerminalModeReset: (() => void) | null = null
+  if (isNativeWindowsConpty) {
+    unsubscribeWindowsDoneTerminalModeReset = useAppStore.subscribe((nextState) => {
+      const nextAgentStatusState = nextState.agentStatusByPaneKey[cacheKey]?.state
+      if (lastAgentStatusState !== 'done' && nextAgentStatusState === 'done') {
+        queueAgentIdleTerminalModeReset()
+      }
+      lastAgentStatusState = nextAgentStatusState
+    })
+  }
 
   const restoredPtyIdForTransport =
     deps.restoredLeafId && deps.restoredPtyIdByLeafId
@@ -3577,12 +3595,12 @@ export function connectPanePty(
       })
     }
 
-    queueAgentIdleCursorReset = (): void => {
+    queueAgentIdleTerminalModeReset = (): void => {
       if (disposed) {
         return
       }
       writePtyOutputToXterm(
-        RESET_TERMINAL_CURSOR_STYLE,
+        idleAgentTerminalModeReset,
         shouldWritePtyOutputForeground(deps.isVisibleRef.current)
       )
     }
@@ -5171,6 +5189,10 @@ export function connectPanePty(
       if (agentTaskCompleteSettingsUnsubscribe !== null) {
         agentTaskCompleteSettingsUnsubscribe()
         agentTaskCompleteSettingsUnsubscribe = null
+      }
+      if (unsubscribeWindowsDoneTerminalModeReset !== null) {
+        unsubscribeWindowsDoneTerminalModeReset()
+        unsubscribeWindowsDoneTerminalModeReset = null
       }
       if (connectFrame !== null) {
         // Why: StrictMode and split-group remounts can dispose a pane binding

--- a/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
@@ -4,7 +4,8 @@ import {
   POST_REPLAY_LIVE_SNAPSHOT_RESET,
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
-  RESET_KITTY_KEYBOARD_PROTOCOL
+  RESET_KITTY_KEYBOARD_PROTOCOL,
+  RESET_TERMINAL_CURSOR_STYLE
 } from './layout-serialization'
 
 const OLD_REATTACH_RESET_WITHOUT_CURSOR_STYLE = '\x1b[?25h\x1b[?1004l'
@@ -141,6 +142,34 @@ describe('terminal replay state reset', () => {
       await writeTerminal(term, POST_REPLAY_REATTACH_RESET)
       // Why: after renderer reattach, the next Ctrl+C must not inherit a stale
       // Kitty CSI-u encoder state from the replayed TUI snapshot.
+      expect(readKittyKeyboardState(term)).toMatchObject({
+        flags: 0,
+        mainFlags: 0,
+        mainStack: []
+      })
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('clears active-buffer Kitty keyboard state with the idle-agent reset sequence', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      allowProposedApi: true,
+      vtExtensions: { kittyKeyboard: true }
+    })
+
+    try {
+      await writeTerminal(term, '\x1b[=31u\x1b[>15u')
+      expect(readKittyKeyboardState(term)).toMatchObject({
+        flags: 15,
+        mainStack: [31]
+      })
+
+      await writeTerminal(term, `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`)
+      // Why: this is the exact reset emitted when a native Windows agent turn
+      // completes, so the next Backspace/Enter must not inherit CSI-u encoding.
       expect(readKittyKeyboardState(term)).toMatchObject({
         flags: 0,
         mainFlags: 0,


### PR DESCRIPTION
## ELI5
On Windows, an agent TUI can finish a turn but leave xterm thinking it should still encode keys in a special "enhanced keyboard" mode. If that stale mode sticks around, ordinary keys can behave wrong afterward: Backspace may not delete normally and Enter may not submit normally.

This PR adds a small cleanup at the end of a local Windows ConPTY agent turn: when Orca sees the agent go idle/done, it resets xterm's cursor mode like before, and also clears xterm's Kitty keyboard mode for native Windows terminals. Think of it as putting the terminal keyboard back into normal mode before the next prompt/user input.

## Summary
- Extends the existing idle-agent terminal-mode reset to include `RESET_KITTY_KEYBOARD_PROTOCOL` for local native Windows ConPTY panes.
- Adds a Windows-only pane status watcher so hook/status-driven `done` transitions get the same reset even if the title idle path is delayed.
- Keeps SSH/remote panes cursor-only; enhanced keyboard reporting is preserved outside local Windows ConPTY.
- Adds direct headless-xterm evidence that the exact emitted reset sequence clears xterm's Kitty keyboard state.

## Why This Fix Should Work
The failure mode we saw was not Orca mapping Backspace to space. The stale session had already produced a final answer, but the Windows ConPTY/PowerShell/Codex process tree was still attached, and xterm/terminal modes could remain in an abnormal state.

Orca already had the reset bytes for stale Kitty keyboard mode in replay/reattach recovery. This PR applies the same reset at the end of local Windows agent turns, where the stuck-key symptom happens.

The strongest proof is the new headless xterm test:
1. Enable xterm Kitty keyboard support.
2. Put xterm into an active Kitty keyboard state with `\x1b[=31u\x1b[>15u`.
3. Write the exact sequence Orca now emits on Windows agent completion: `RESET_TERMINAL_CURSOR_STYLE + RESET_KITTY_KEYBOARD_PROTOCOL`.
4. Assert xterm's internal Kitty state returns to `flags: 0`, `mainFlags: 0`, and an empty `mainStack`.

That proves the reset is not cosmetic: it clears the encoder state that can make the next Backspace/Enter inherit CSI-u/enhanced-key behavior.

## Tradeoffs
- This is scoped to local native Windows ConPTY only. It deliberately does not reset Kitty keyboard state for macOS, Linux, SSH, or remote-runtime panes, because those environments may legitimately rely on enhanced keyboard reporting.
- It is a recovery/reset, not a process killer. Codex may remain alive after a turn, which is normal; this fix makes the terminal input mode sane without terminating reusable agent sessions.
- It adds a lightweight pane-local store subscription only for native Windows ConPTY panes. The watcher is disposed with the pane; there is a regression test proving a disposed pane no longer writes resets on later `done` status changes.
- It cannot prove every possible Windows console-mode corruption is gone, but it directly addresses the stale xterm Kitty keyboard state class that matches the observed Backspace/Enter symptoms and existing recovery comments.

## Evidence
Local validation:
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts`
  - Passed: 6/6
  - Includes the direct proof that the emitted idle-agent reset clears active Kitty keyboard state.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "stale Kitty keyboard state|resets renderer cursor style|SSH agent idle reset|unsubscribes the native Windows done reset watcher"`
  - Passed: 5/5 focused regression tests
  - Covers native Windows idle-title reset, native Windows hook/status `done`, SSH Windows-client non-reset, existing cursor reset, and disposal cleanup.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
  - Passed: 266/266
- `pnpm run typecheck:web`
  - Passed
- Pre-commit hook on staged PR files:
  - `oxlint`: passed
  - `oxlint --config config/oxlint-react-doctor.json`: passed
  - `oxfmt --write`: applied/passed

## Win/Linux Compat Review
- No new shell commands, path handling, native modules, keyboard shortcuts, or Electron accelerators.
- Windows-only behavior is gated through `isLocalNativeWindowsConpty`.
- SSH use case is explicitly covered by a Windows-client regression test that verifies SSH panes keep the cursor-only reset and do not receive the Kitty keyboard reset.