### PR TITLE
Add persisted session upgrade fixture gate

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -214,31 +214,41 @@
         "https://github.com/stablyai/orca/pull/5240"
       ],
       "invariant": "Startup and restore fixes must preserve or explicitly recover sessions from the last affected production persisted-state schema, not only from state written by current code.",
-      "oracle": "Boot current Orca against immutable copied user-data fixtures from affected versions and reject blank replacement panes, duplicate resume tabs, silent session loss, or works-only-after-current-write behavior.",
-      "commands": [],
-      "testFiles": [],
+      "oracle": "Parse and restore immutable old-version session fixtures through the current hydration contract, rejecting blank replacement panes, duplicate tabs, silent PTY/session evidence loss, eager startup spawns, or works-only-after-current-write behavior.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/persisted-session-upgrade-fixture.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/store/slices/persisted-session-upgrade-fixture.test.ts",
+        "src/shared/workspace-session-upgrade-fixtures/orca-1.4.65-legacy-pty-wake.json",
+        "src/shared/workspace-session-upgrade-fixtures/README.md"
+      ],
       "runtimeBudget": {
-        "p95Seconds": 120,
-        "scope": "focused Electron upgrade fixture"
+        "p95Seconds": 15,
+        "scope": "focused renderer-state upgrade fixture"
       },
       "flakeHistory": {
-        "status": "not-started",
-        "evidence": "Fixture corpus not implemented."
+        "status": "unknown",
+        "evidence": "First deterministic lower-layer fixture command registered; needs soak history before any promotion."
       },
       "redGreenEvidence": {
-        "status": "missing",
-        "evidence": "Needs immutable pre-fix persisted-state fixture."
+        "status": "partial",
+        "evidence": "Immutable 1.4.65-shaped fixture fails if the schema rejects old session JSON or hydration drops legacy PTY wake hints; needs saved intentional-break evidence and full Electron boot coverage."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Startup fixture must record startup latency and avoid adding blocking migration scans."
+        "evidence": "Current fixture command reads one small text JSON file in Vitest and adds no startup migration scan, user-data copy, Electron boot, IPC round trip, or binary fixture overhead."
       },
       "promotionCriteria": [
         "Land immutable old-version fixture with documented source version.",
         "Run second restart after current code writes upgraded state.",
         "Record startup timing and failure artifact."
       ],
-      "knownGaps": ["No fixture corpus or command yet."],
+      "knownGaps": [
+        "Current command proves schema parse plus renderer restore behavior, not a full Electron boot against copied user-data.",
+        "Current fixture covers local/daemon and floating-terminal legacy PTY wake hints; SSH, WSL, explicit unrecoverable marking, and second restart after current write still need coverage.",
+        "Needs saved red/green evidence from intentionally breaking the old-shape hydration contract."
+      ],
       "demotionRule": "Cannot promote without old production fixture provenance."
     }
   ]

--- a/src/renderer/src/store/slices/persisted-session-upgrade-fixture.test.ts
+++ b/src/renderer/src/store/slices/persisted-session-upgrade-fixture.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { parseWorkspaceSession } from '../../../../shared/workspace-session-schema'
+import type { WorkspaceSessionState } from '../../../../shared/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { createTestStore, makeWorktree, seedStore } from './store-test-helpers'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync: vi.fn()
+}))
+vi.mock('@/components/terminal-pane/pty-transport', () => ({
+  registerEagerPtyBuffer: vi.fn().mockReturnValue({ flush: () => '', dispose: () => {} }),
+  ensurePtyDispatcher: vi.fn()
+}))
+
+const mockApi = {
+  worktrees: {
+    list: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockResolvedValue({}),
+    remove: vi.fn().mockResolvedValue(undefined),
+    updateMeta: vi.fn().mockResolvedValue({})
+  },
+  repos: {
+    list: vi.fn().mockResolvedValue([]),
+    add: vi.fn().mockResolvedValue({}),
+    remove: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue({}),
+    pickFolder: vi.fn().mockResolvedValue(null)
+  },
+  pty: {
+    kill: vi.fn().mockResolvedValue(undefined),
+    spawn: vi.fn().mockResolvedValue({ id: 'unexpected-spawn' })
+  },
+  gh: {
+    prForBranch: vi.fn().mockResolvedValue(null),
+    issue: vi.fn().mockResolvedValue(null)
+  },
+  settings: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined)
+  },
+  cache: {
+    getGitHub: vi.fn().mockResolvedValue(null),
+    setGitHub: vi.fn().mockResolvedValue(undefined)
+  },
+  claudeUsage: usageApi(),
+  codexUsage: usageApi(),
+  openCodeUsage: usageApi()
+}
+
+// @ts-expect-error -- mocked browser preload API
+globalThis.window = { api: mockApi }
+
+function usageApi() {
+  return {
+    getScanState: vi.fn().mockResolvedValue({
+      enabled: false,
+      isScanning: false,
+      lastScanStartedAt: null,
+      lastScanCompletedAt: null,
+      lastScanError: null,
+      hasAnyClaudeData: false,
+      hasAnyCodexData: false,
+      hasAnyOpenCodeData: false
+    }),
+    setEnabled: vi.fn().mockResolvedValue({}),
+    refresh: vi.fn().mockResolvedValue({}),
+    getSummary: vi.fn().mockResolvedValue(null),
+    getDaily: vi.fn().mockResolvedValue([]),
+    getBreakdown: vi.fn().mockResolvedValue([]),
+    getRecentSessions: vi.fn().mockResolvedValue([])
+  }
+}
+
+function loadFixture(): unknown {
+  return JSON.parse(
+    readFileSync(
+      join(
+        process.cwd(),
+        'src/shared/workspace-session-upgrade-fixtures/orca-1.4.65-legacy-pty-wake.json'
+      ),
+      'utf8'
+    )
+  )
+}
+
+function parseFixture(): WorkspaceSessionState {
+  const parsed = parseWorkspaceSession(loadFixture())
+  expect(parsed.ok).toBe(true)
+  if (!parsed.ok) {
+    throw new Error(parsed.error)
+  }
+  return parsed.value
+}
+
+describe('persisted session upgrade fixture', () => {
+  it('restores legacy PTY wake hints without blanking or eager spawning', async () => {
+    vi.clearAllMocks()
+    const session = parseFixture()
+    const rawFixture = loadFixture() as Record<string, unknown>
+    const worktreeId = session.activeWorktreeId ?? ''
+    const store = createTestStore()
+
+    // Why: this fixture represents the pre-sleeping-agent corpus; the older
+    // tab/layout PTY evidence is the only recovery source on first launch.
+    expect(rawFixture.sleepingAgentSessionsByPaneKey).toBeUndefined()
+    seedStore(store, {
+      repos: [
+        {
+          id: 'repo-upgrade',
+          path: 'C:\\Users\\user\\orca\\repo',
+          displayName: 'Upgrade Repo',
+          badgeColor: '#000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: {
+        'repo-upgrade': [
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-upgrade',
+            path: 'C:\\Users\\user\\orca\\upgrade-worktree'
+          })
+        ]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession(session)
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([
+      worktreeId,
+      FLOATING_TERMINAL_WORKTREE_ID
+    ])
+    expect(store.getState().tabsByWorktree[worktreeId]).toHaveLength(2)
+    expect(store.getState().tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID]).toHaveLength(1)
+
+    await store.getState().reconnectPersistedTerminals()
+
+    const state = store.getState()
+    expect(state.workspaceSessionReady).toBe(true)
+    expect(mockApi.pty.spawn).not.toHaveBeenCalled()
+    expect(state.sleepingAgentSessionsByPaneKey).toEqual({})
+    expect(state.tabsByWorktree[worktreeId].map((tab) => tab.id)).toEqual([
+      'agent-tab',
+      'shell-tab'
+    ])
+    expect(state.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID].map((tab) => tab.id)).toEqual([
+      'floating-shell-tab'
+    ])
+    expect(state.tabsByWorktree[worktreeId][0]).toMatchObject({
+      id: 'agent-tab',
+      ptyId: 'daemon-session-agent-legacy',
+      title: 'Agent working',
+      launchAgent: 'codex'
+    })
+    expect(state.tabsByWorktree[worktreeId][1]?.ptyId).toBe('daemon-session-shell-legacy')
+    expect(state.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID][0]?.ptyId).toBe(
+      'daemon-session-floating-legacy'
+    )
+    expect(state.ptyIdsByTabId).toMatchObject({
+      'agent-tab': ['daemon-session-agent-legacy', 'daemon-session-agent-sidecar'],
+      'shell-tab': ['daemon-session-shell-legacy'],
+      'floating-shell-tab': ['daemon-session-floating-legacy']
+    })
+    expect(Object.values(state.terminalLayoutsByTabId['agent-tab']?.ptyIdsByLeafId ?? {})).toEqual([
+      'daemon-session-agent-legacy',
+      'daemon-session-agent-sidecar'
+    ])
+  })
+})

--- a/src/shared/workspace-session-upgrade-fixtures/README.md
+++ b/src/shared/workspace-session-upgrade-fixtures/README.md
@@ -1,0 +1,12 @@
+# Workspace Session Upgrade Fixtures
+
+This directory holds minimized, text-only persisted session fixtures for `startup-upgrade.persisted-session-corpus`.
+
+## `orca-1.4.65-legacy-pty-wake.json`
+
+- Provenance: representative production `orca-data.json.workspaceSession` shape from the 1.4.65 upgrade window that motivated issue #5356 and PRs #5234/#5240.
+- Scope: minimized and anonymized by hand to keep only fields the restore path consumes.
+- Compatibility target: sessions written before `sleepingAgentSessionsByPaneKey` existed, while terminal tabs still carried legacy tab-level PTY wake hints.
+- Startup/perf note: the gate reads one small JSON file in a focused Vitest process; it does not introduce any startup migration scan, Electron user-data copy, or binary fixture overhead.
+
+The fixture intentionally omits `sleepingAgentSessionsByPaneKey`. Current code must still preserve the old terminal/session evidence instead of replacing the session with blank tabs.

--- a/src/shared/workspace-session-upgrade-fixtures/orca-1.4.65-legacy-pty-wake.json
+++ b/src/shared/workspace-session-upgrade-fixtures/orca-1.4.65-legacy-pty-wake.json
@@ -1,0 +1,82 @@
+{
+  "_fixtureProvenance": {
+    "sourceVersion": "1.4.65 production persisted workspaceSession shape",
+    "minimizedAt": "2026-07-01",
+    "notes": [
+      "Pre-current fixture intentionally omits sleepingAgentSessionsByPaneKey.",
+      "Tab-level ptyId values are the legacy wake hints consumed after startup restore."
+    ]
+  },
+  "activeRepoId": "repo-upgrade",
+  "activeWorktreeId": "repo-upgrade::C:\\Users\\user\\orca\\upgrade-worktree",
+  "activeTabId": "agent-tab",
+  "tabsByWorktree": {
+    "repo-upgrade::C:\\Users\\user\\orca\\upgrade-worktree": [
+      {
+        "id": "agent-tab",
+        "ptyId": "daemon-session-agent-legacy",
+        "worktreeId": "repo-upgrade::C:\\Users\\user\\orca\\upgrade-worktree",
+        "title": "Agent working",
+        "defaultTitle": "Terminal 1",
+        "generatedTitle": "Agent working",
+        "customTitle": null,
+        "color": null,
+        "sortOrder": 0,
+        "createdAt": 1717444800000,
+        "launchAgent": "codex"
+      },
+      {
+        "id": "shell-tab",
+        "ptyId": "daemon-session-shell-legacy",
+        "worktreeId": "repo-upgrade::C:\\Users\\user\\orca\\upgrade-worktree",
+        "title": "pwsh",
+        "customTitle": null,
+        "color": null,
+        "sortOrder": 1,
+        "createdAt": 1717444860000
+      }
+    ],
+    "global-floating-terminal": [
+      {
+        "id": "floating-shell-tab",
+        "ptyId": "daemon-session-floating-legacy",
+        "worktreeId": "global-floating-terminal",
+        "title": "PowerShell",
+        "customTitle": null,
+        "color": null,
+        "sortOrder": 0,
+        "createdAt": 1717444920000
+      }
+    ]
+  },
+  "terminalLayoutsByTabId": {
+    "agent-tab": {
+      "root": {
+        "type": "split",
+        "direction": "horizontal",
+        "first": { "type": "leaf", "leafId": "pane:agent" },
+        "second": { "type": "leaf", "leafId": "pane:shell" }
+      },
+      "activeLeafId": "pane:agent",
+      "expandedLeafId": null,
+      "ptyIdsByLeafId": {
+        "pane:agent": "daemon-session-agent-legacy",
+        "pane:shell": "daemon-session-agent-sidecar"
+      },
+      "titlesByLeafId": {
+        "pane:agent": "Agent working",
+        "pane:shell": "Shell"
+      }
+    },
+    "shell-tab": {
+      "root": { "type": "leaf", "leafId": "pane:shell-tab" },
+      "activeLeafId": "pane:shell-tab",
+      "expandedLeafId": null
+    },
+    "floating-shell-tab": {
+      "root": { "type": "leaf", "leafId": "pane:floating" },
+      "activeLeafId": "pane:floating",
+      "expandedLeafId": null
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a small text-based 1.4.65-shaped `workspaceSession` fixture with documented provenance for the persisted-session upgrade corpus.
- Add a focused renderer-state gate that parses the fixture through the shared schema, hydrates/reconnects the store, and rejects blank replacement tabs, duplicate tabs, lost legacy PTY wake hints, or eager startup spawning.
- Register the `startup-upgrade.persisted-session-corpus` command in `config/reliability-gates.jsonc` with updated performance evidence and known gaps; maturity remains `experimental`.

## ELI5
Older versions of Orca saved workspace/session data in slightly different shapes. When a newer Orca opens that old data, it should restore the real tabs and sessions instead of making blank tabs, duplicates, or launching things too early. This PR adds an old saved-session fixture and a test that proves the upgrade path still restores it safely.

## Why We Need This
This covers the startup/upgrade persisted-session class. Users can open Orca with workspace/session data saved by older versions, and that data must not produce blank replacement tabs, duplicate tabs, lost PTY wake hints, or eager startup spawning.

## Product Code vs Gate Coverage
This PR is fixture/gate coverage, not a runtime upgrade-path change. It adds a legacy saved-session fixture and focused hydration tests against the current schema/store path. The manifest keeps full Electron boot, second restart, SSH, and WSL upgrade coverage as explicit follow-up gaps.

## Merge Order
Requires #7001 first because this PR updates the reliability gate manifest introduced there.

After #7001 lands, this PR can merge independently of #7004, #7005, #7006, and #7008. No other child PR must merge before this one. Later child PRs may need a normal manifest rebase if this one lands first.

## Validation

- `pnpm run check:reliability-gates`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/persisted-session-upgrade-fixture.test.ts src/shared/workspace-session-schema.test.ts`
- `pnpm exec oxlint src/renderer/src/store/slices/persisted-session-upgrade-fixture.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

## Residual Risks

- This is the first lower-layer fixture gate, not a full Electron boot against copied user-data.
- Second restart after current-write, explicit unrecoverable marking, SSH, and WSL fixture coverage remain listed as manifest gaps.
- Red/green evidence is still partial until an intentional-break artifact is saved.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Post-PR Stabilization
- CI checks pass after the post-PR wait.
- PR comments and review-comment surfaces were checked; no actionable automated review comments remain.

