### PR TITLE
Expand provider session replay ownership gate

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -82,11 +82,14 @@
         "https://github.com/stablyai/orca/pull/6833"
       ],
       "invariant": "Workspace activation, launch, restore, sleep, hibernate, dedupe, clearing, and reconnect code must not replay or resume a provider session id already owned, queued, pending, or live in that workspace.",
-      "oracle": "Provider-session claim keys are owned by preserved active tabs, inactive split leaves, visible non-focused split groups, live records, quit records, and worktree-sleep records; duplicates clear without launching a second resume command.",
+      "oracle": "Provider-session claim keys are owned by preserved active tabs, inactive split leaves, visible non-focused split groups, live hook records, queued startup commands, pending launch-config registrations, quit records, and worktree-sleep records; display-only or replay-looking evidence without provider-session identity cannot claim ownership, and duplicates clear without launching a second resume command.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts src/renderer/src/lib/resume-sleeping-agent-session-provider-claims.test.ts"
       ],
-      "testFiles": ["src/renderer/src/lib/resume-sleeping-agent-session.test.ts"],
+      "testFiles": [
+        "src/renderer/src/lib/resume-sleeping-agent-session.test.ts",
+        "src/renderer/src/lib/resume-sleeping-agent-session-provider-claims.test.ts"
+      ],
       "runtimeBudget": {
         "p95Seconds": 15,
         "scope": "local renderer state test"
@@ -97,20 +100,19 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Tests encode provider-session dedupe and ownership claims across active/inactive/visible split records. Needs saved red/green artifact for the class-level replay invariant."
+        "evidence": "Tests encode provider-session dedupe and ownership claims across active/inactive/visible split records, queued/pending resume commands, live hook records, and wrong-session/display-only non-claims. Red case: removing the queued/pending claim scan or provider identity threading allows a second resume tab for an already staged provider session."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Current state tests are cheap. PRs adding ownership scans must show bounded work over records and no hidden-pane wake loop before blocking promotion."
+        "evidence": "Ownership checks scan bounded renderer maps once per activation: sleeping records for the target workspace, pendingStartupByTabId, agentLaunchConfigByPaneKey, and agentStatusByPaneKey. There is no provider polling or hidden-pane wake loop."
       },
       "promotionCriteria": [
         "Run in soak for at least 100 consecutive passes or 14 days across required CI platforms.",
-        "Add explicit pending/queued ownership cases for resume commands already staged but not yet connected.",
-        "Attach red/green evidence that display/replay evidence alone cannot claim ownership."
+        "Attach saved CI red/green evidence for queued/pending ownership and display-only non-claim variants.",
+        "Add a focused activation-level repeat-wake fixture if a future state harness can model the full Terminal mount cycle without broad Electron coverage."
       ],
       "knownGaps": [
-        "Current command does not yet model delayed hooks, wrong-session hooks, or pending connection claims explicitly.",
-        "Current command does not run a real workspace activation loop repeatedly through Electron."
+        "Current command proves repeat-replay prevention at renderer state level; it does not run a real workspace activation loop repeatedly through Electron."
       ],
       "demotionRule": "Demote or quarantine if failures are non-actionable or if a duplicate resume escape occurs outside the modeled matrix."
     },

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -5,7 +5,10 @@ import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TerminalColorSchemeMode } from '../../../../shared/terminal-color-scheme-protocol'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
 import type { TuiAgent } from '../../../../shared/types'
-import type { SleepingAgentLaunchConfig } from '../../../../shared/agent-session-resume'
+import type {
+  AgentProviderSessionMetadata,
+  SleepingAgentLaunchConfig
+} from '../../../../shared/agent-session-resume'
 
 export type PtyConnectionDeps = {
   tabId: string
@@ -21,6 +24,7 @@ export type PtyConnectionDeps = {
     launchConfig?: SleepingAgentLaunchConfig
     launchToken?: string
     launchAgent?: TuiAgent
+    providerSession?: AgentProviderSessionMetadata
     /** Telemetry payload for `agent_started`. Forwarded to `pty:spawn`
      *  so main fires the event only after the spawn succeeds. */
     telemetry?: EventProps<'agent_started'>

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3255,6 +3255,57 @@ describe('connectPanePty', () => {
     expect(mockStoreState.dropAgentStatus).not.toHaveBeenCalled()
   })
 
+  it('keeps provider session identity when spawn returns an effective launch config', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const initialLaunchConfig = {
+      agentArgs: '--resume-from-startup',
+      agentEnv: {}
+    }
+    const effectiveLaunchConfig = {
+      agentCommand: 'codex',
+      agentArgs: '--effective',
+      agentEnv: {}
+    }
+    const providerSession = { key: 'session_id', id: 'codex-session-1' }
+    transport.connect.mockResolvedValue({
+      id: 'pty-local-1',
+      launchConfig: effectiveLaunchConfig
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({
+        startup: {
+          command: "codex 'resume' 'codex-session-1'",
+          launchConfig: initialLaunchConfig,
+          launchToken: 'launch-token-1',
+          launchAgent: 'codex',
+          providerSession
+        }
+      }) as never
+    )
+    await flushAsyncTicks(20)
+
+    expect(mockStoreState.registerAgentLaunchConfig).toHaveBeenCalledWith(
+      paneKey,
+      initialLaunchConfig,
+      expect.objectContaining({ providerSession })
+    )
+    expect(mockStoreState.registerAgentLaunchConfig).toHaveBeenLastCalledWith(
+      paneKey,
+      effectiveLaunchConfig,
+      expect.objectContaining({
+        agentType: 'codex',
+        launchToken: 'launch-token-1',
+        providerSession
+      })
+    )
+  })
+
   it('flushes pending interrupt inference before dropping an exited foreground agent command', async () => {
     const { connectPanePty } = await import('./pty-connection')
 
@@ -4372,7 +4423,8 @@ describe('connectPanePty', () => {
       agentType: 'codex',
       launchToken: expect.stringMatching(new RegExp(`^${UUID_RE}$`)),
       tabId: 'tab-1',
-      leafId: LEAF_1
+      leafId: LEAF_1,
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
     })
   })
 
@@ -4537,7 +4589,8 @@ describe('connectPanePty', () => {
       agentType: 'codex',
       launchToken: expect.stringMatching(new RegExp(`^${UUID_RE}$`)),
       tabId: 'tab-1',
-      leafId: LEAF_1
+      leafId: LEAF_1,
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
     })
     expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalled()
   })
@@ -4800,7 +4853,8 @@ describe('connectPanePty', () => {
         agentType: 'codex',
         launchToken: expect.stringMatching(new RegExp(`^${UUID_RE}$`)),
         tabId: 'tab-1',
-        leafId: LEAF_2
+        leafId: LEAF_2,
+        providerSession: { key: 'session_id', id: 'codex-session-1' }
       }
     )
     expect(deps.onShowSessionRestoredBanner).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -225,6 +225,7 @@ type PendingStartupCommand = {
 
 type ColdRestoreAgentResumeStartup = PendingStartupCommand & {
   agent: ResumableTuiAgent
+  providerSession: AgentProviderSessionMetadata
   launchConfig: NonNullable<ReturnType<typeof buildAgentResumeStartupPlan>>['launchConfig']
   launchToken: string
   useLiveEntry: boolean
@@ -961,7 +962,11 @@ export function connectPanePty(
   }
   const registerEffectiveLaunchConfig = (
     effectiveLaunchConfig: PtyConnectResult['launchConfig'] | undefined,
-    metadata?: { launchToken?: string; launchAgent?: TuiAgent }
+    metadata?: {
+      launchToken?: string
+      launchAgent?: TuiAgent
+      providerSession?: AgentProviderSessionMetadata
+    }
   ): void => {
     if (!effectiveLaunchConfig) {
       return
@@ -973,7 +978,10 @@ export function connectPanePty(
         ? { launchToken: metadata?.launchToken ?? launchToken }
         : {}),
       tabId: deps.tabId,
-      leafId: pane.leafId
+      leafId: pane.leafId,
+      ...((metadata?.providerSession ?? paneStartup?.providerSession)
+        ? { providerSession: metadata?.providerSession ?? paneStartup?.providerSession }
+        : {})
     })
   }
   const clearRegisteredStartupLaunchConfig = (): void => {
@@ -2611,6 +2619,7 @@ export function connectPanePty(
           ...startupPlan.env,
           ORCA_AGENT_LAUNCH_TOKEN: coldRestoreLaunchToken
         },
+        providerSession,
         launchConfig: startupPlan.launchConfig,
         launchToken: coldRestoreLaunchToken,
         useLiveEntry: Boolean(useLiveEntry),
@@ -2629,7 +2638,8 @@ export function connectPanePty(
         agentType: startup.agent,
         launchToken: startup.launchToken,
         tabId: deps.tabId,
-        leafId: pane.leafId
+        leafId: pane.leafId,
+        providerSession: startup.providerSession
       })
       return true
     }
@@ -2779,7 +2789,10 @@ export function connectPanePty(
           if (spawnedPtyId && typeof spawnedPtyId === 'object' && 'id' in spawnedPtyId) {
             registerEffectiveLaunchConfig(spawnedPtyId.launchConfig, {
               ...(coldRestoreOverride ? { launchToken: coldRestoreOverride.launchToken } : {}),
-              ...(coldRestoreOverride ? { launchAgent: coldRestoreOverride.agent } : {})
+              ...(coldRestoreOverride ? { launchAgent: coldRestoreOverride.agent } : {}),
+              ...(coldRestoreOverride
+                ? { providerSession: coldRestoreOverride.providerSession }
+                : {})
             })
           }
           if (resolvedPtyId) {
@@ -3968,7 +3981,8 @@ export function connectPanePty(
       }
       registerEffectiveLaunchConfig(connectResult?.launchConfig, {
         ...(coldRestoreStartup ? { launchToken: coldRestoreStartup.launchToken } : {}),
-        ...(coldRestoreStartup ? { launchAgent: coldRestoreStartup.agent } : {})
+        ...(coldRestoreStartup ? { launchAgent: coldRestoreStartup.agent } : {}),
+        ...(coldRestoreStartup ? { providerSession: coldRestoreStartup.providerSession } : {})
       })
       if (connectResult?.sessionExpired) {
         if (staleSessionId) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -953,7 +953,8 @@ export function connectPanePty(
       agentType: paneStartup.launchAgent ?? paneStartup.initialAgentStatus?.agent,
       ...(launchToken ? { launchToken } : {}),
       tabId: deps.tabId,
-      leafId: pane.leafId
+      leafId: pane.leafId,
+      ...(paneStartup.providerSession ? { providerSession: paneStartup.providerSession } : {})
     })
   } else if (paneStartup) {
     useAppStore.getState().clearAgentLaunchConfig(cacheKey)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -132,6 +132,7 @@ import {
 import {
   isResumableTuiAgent,
   normalizeAgentProviderSession,
+  type AgentProviderSessionMetadata,
   type ResumableTuiAgent,
   type SleepingAgentSessionRecord
 } from '../../../../shared/agent-session-resume'

--- a/src/renderer/src/lib/resume-sleeping-agent-session-provider-claims.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-provider-claims.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
@@ -239,6 +240,30 @@ describe('resumeSleepingAgentSessionsForWorktree provider claims', () => {
     const state = useAppStore.getState()
     expect(launched).toBe(0)
     expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('does not let a stale orphan live status clear a resumable record', () => {
+    const paneKey = makePaneKey('missing-tab', LEAF_ID)
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [] },
+      agentStatusByPaneKey: {
+        [paneKey]: {
+          ...makeLiveAgentStatus(paneKey, 'sess-1'),
+          tabId: 'missing-tab',
+          updatedAt: Date.now() - AGENT_STATUS_STALE_AFTER_MS - 1
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
+    expect(launched).toBe(1)
+    expect(resumedTab?.launchAgent).toBe('claude')
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 

--- a/src/renderer/src/lib/resume-sleeping-agent-session-provider-claims.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-provider-claims.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import { useAppStore } from '@/store'
+import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+
+const initialAppStoreState = useAppStore.getState()
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function makeRecord(
+  overrides: Partial<SleepingAgentSessionRecord> = {}
+): SleepingAgentSessionRecord {
+  return {
+    paneKey: makePaneKey('stale-tab', OTHER_LEAF_ID),
+    tabId: 'stale-tab',
+    worktreeId: 'wt-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: 'sess-1' },
+    prompt: 'finish the task',
+    state: 'working',
+    capturedAt: 1,
+    updatedAt: 1,
+    origin: 'worktree-sleep',
+    ...overrides
+  }
+}
+
+function makeTerminalTab(id: string, worktreeId = 'wt-1'): Record<string, unknown> {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: 'shell',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function makeLiveAgentStatus(paneKey: string, providerSessionId: string): Record<string, unknown> {
+  return {
+    state: 'working',
+    prompt: 'still running',
+    updatedAt: 2,
+    stateStartedAt: 2,
+    agentType: 'claude',
+    paneKey,
+    worktreeId: 'wt-1',
+    tabId: 'tab-live',
+    stateHistory: [],
+    providerSession: { key: 'session_id', id: providerSessionId }
+  }
+}
+
+function makePendingLaunchConfigProviderClaim(): Record<string, unknown> {
+  return {
+    launchConfig: { agentArgs: '', agentEnv: {} },
+    registeredAt: 10,
+    identity: {
+      agentType: 'claude',
+      tabId: 'tab-pending',
+      leafId: LEAF_ID,
+      providerSession: { key: 'session_id', id: 'sess-1' }
+    }
+  }
+}
+
+describe('resumeSleepingAgentSessionsForWorktree provider claims', () => {
+  it('uses captured launch config instead of changed settings when resuming worktree sleep', () => {
+    const record = makeRecord({
+      agent: 'codex',
+      launchConfig: {
+        agentCommand: "codex --profile captured '--model' 'gpt-5' '--reasoning-effort' 'high'",
+        agentArgs: '--model gpt-5 --reasoning-effort high',
+        agentEnv: { CODEX_PROFILE: 'captured' }
+      }
+    })
+    useAppStore.setState({
+      settings: {
+        agentCmdOverrides: { codex: 'codex --profile changed' },
+        agentDefaultArgs: { codex: '--model changed' },
+        agentDefaultEnv: { codex: { CODEX_PROFILE: 'changed' } }
+      },
+      tabsByWorktree: { 'wt-1': [] },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(1)
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
+    const startup = state.pendingStartupByTabId[resumedTab!.id]
+    expect(startup?.command).toBe(
+      "codex --profile captured '--model' 'gpt-5' '--reasoning-effort' 'high' 'resume' 'sess-1'"
+    )
+    expect(startup?.env).toEqual({ CODEX_PROFILE: 'captured' })
+    expect(startup?.command).not.toContain('changed')
+    expect(startup?.launchConfig).toEqual(record.launchConfig)
+  })
+
+  it('launches once and clears skipped duplicates for the same provider session', () => {
+    const first = makeRecord({
+      paneKey: 'tab-1:leaf-1',
+      capturedAt: 1,
+      updatedAt: 1,
+      launchConfig: { agentArgs: '--older', agentEnv: {} }
+    })
+    const duplicate = makeRecord({
+      paneKey: 'tab-2:leaf-1',
+      capturedAt: 2,
+      updatedAt: 2,
+      launchConfig: { agentArgs: '--newer', agentEnv: {} }
+    })
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [] },
+      sleepingAgentSessionsByPaneKey: {
+        [first.paneKey]: first,
+        [duplicate.paneKey]: duplicate
+      }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(1)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.launchConfig).toMatchObject({
+      agentArgs: '--newer'
+    })
+    expect(state.sleepingAgentSessionsByPaneKey[first.paneKey]).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[duplicate.paneKey]).toBeUndefined()
+  })
+
+  it('dedupes sleeping records when a matching resume startup is already queued', () => {
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-queued')] },
+      pendingStartupByTabId: {
+        'tab-queued': {
+          command: "claude '--resume' 'sess-1'",
+          launchAgent: 'claude',
+          providerSession: { key: 'session_id', id: 'sess-1' },
+          launchConfig: { agentArgs: '', agentEnv: {} }
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.pendingStartupByTabId['tab-queued']).toBeDefined()
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('does not treat replay-looking queued startup without provider identity as ownership', () => {
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-queued')] },
+      pendingStartupByTabId: {
+        'tab-queued': {
+          command: "claude '--resume' 'sess-1'",
+          launchAgent: 'claude',
+          launchConfig: { agentArgs: '', agentEnv: {} }
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.find((tab) => tab.id !== 'tab-queued')
+    expect(launched).toBe(1)
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('dedupes sleeping records while a consumed resume startup is pending hooks', () => {
+    const paneKey = makePaneKey('tab-pending', LEAF_ID)
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-pending')] },
+      agentLaunchConfigByPaneKey: { [paneKey]: makePendingLaunchConfigProviderClaim() },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('keeps pending resume ownership when a delayed hook reports the wrong session', () => {
+    const paneKey = makePaneKey('tab-pending', LEAF_ID)
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-pending')] },
+      agentLaunchConfigByPaneKey: { [paneKey]: makePendingLaunchConfigProviderClaim() },
+      agentStatusByPaneKey: {
+        [paneKey]: {
+          ...makeLiveAgentStatus(paneKey, 'sess-other'),
+          tabId: 'tab-pending'
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('dedupes sleeping records when a matching live agent status already owns the session', () => {
+    const paneKey = makePaneKey('tab-live', LEAF_ID)
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-live')] },
+      agentStatusByPaneKey: { [paneKey]: makeLiveAgentStatus(paneKey, 'sess-1') },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('does not let a wrong live hook session block a different provider resume', () => {
+    const paneKey = makePaneKey('tab-live', LEAF_ID)
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-live')] },
+      agentStatusByPaneKey: { [paneKey]: makeLiveAgentStatus(paneKey, 'sess-other') },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.find((tab) => tab.id !== 'tab-live')
+    expect(launched).toBe(1)
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('uses WSL resume quoting for Windows-path projects forced to WSL', () => {
+    const record = makeRecord({
+      providerSession: { key: 'session_id', id: "sess-1's" }
+    })
+    useAppStore.setState({
+      activeRepoId: 'repo-1',
+      activeWorktreeId: 'wt-1',
+      repos: [{ id: 'repo-1', path: 'C:\\repo', displayName: 'repo', addedAt: 1 }],
+      projects: [
+        {
+          id: 'repo-1',
+          sourceRepoIds: ['repo-1'],
+          localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+        }
+      ],
+      settings: {
+        localWindowsRuntimeDefault: { kind: 'windows-host' },
+        agentCmdOverrides: {}
+      },
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'wt-1',
+            repoId: 'repo-1',
+            path: 'C:\\repo',
+            displayName: 'repo',
+            branch: 'main'
+          }
+        ]
+      },
+      tabsByWorktree: { 'wt-1': [] },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(1)
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.command).toContain(
+      "'--resume' 'sess-1'\\''s'"
+    )
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -512,74 +512,6 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 
-  it('uses captured launch config instead of changed settings when resuming worktree sleep', () => {
-    const record = makeRecord({
-      agent: 'codex',
-      origin: 'worktree-sleep',
-      launchConfig: {
-        agentCommand: "codex --profile captured '--model' 'gpt-5' '--reasoning-effort' 'high'",
-        agentArgs: '--model gpt-5 --reasoning-effort high',
-        agentEnv: { CODEX_PROFILE: 'captured' }
-      }
-    })
-    useAppStore.setState({
-      settings: {
-        agentCmdOverrides: { codex: 'codex --profile changed' },
-        agentDefaultArgs: { codex: '--model changed' },
-        agentDefaultEnv: { codex: { CODEX_PROFILE: 'changed' } }
-      },
-      tabsByWorktree: { 'wt-1': [] },
-      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
-    } as never)
-
-    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
-    expect(launched).toBe(1)
-    const state = useAppStore.getState()
-    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
-    const startup = state.pendingStartupByTabId[resumedTab!.id]
-    expect(startup?.command).toBe(
-      "codex --profile captured '--model' 'gpt-5' '--reasoning-effort' 'high' 'resume' 'sess-1'"
-    )
-    expect(startup?.env).toEqual({ CODEX_PROFILE: 'captured' })
-    expect(startup?.command).not.toContain('changed')
-    expect(startup?.launchConfig).toEqual(record.launchConfig)
-  })
-
-  it('launches once and clears skipped duplicates for the same provider session', () => {
-    const first = makeRecord({
-      paneKey: 'tab-1:leaf-1',
-      capturedAt: 1,
-      updatedAt: 1,
-      launchConfig: { agentArgs: '--older', agentEnv: {} }
-    })
-    const duplicate = makeRecord({
-      paneKey: 'tab-2:leaf-1',
-      capturedAt: 2,
-      updatedAt: 2,
-      launchConfig: { agentArgs: '--newer', agentEnv: {} }
-    })
-    useAppStore.setState({
-      tabsByWorktree: { 'wt-1': [] },
-      sleepingAgentSessionsByPaneKey: {
-        [first.paneKey]: first,
-        [duplicate.paneKey]: duplicate
-      }
-    } as never)
-
-    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
-    const state = useAppStore.getState()
-    expect(launched).toBe(1)
-    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
-    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
-    expect(state.pendingStartupByTabId[resumedTab!.id]?.launchConfig).toMatchObject({
-      agentArgs: '--newer'
-    })
-    expect(state.sleepingAgentSessionsByPaneKey[first.paneKey]).toBeUndefined()
-    expect(state.sleepingAgentSessionsByPaneKey[duplicate.paneKey]).toBeUndefined()
-  })
-
   it('lets a preserved pane claim its provider session and clears only stale duplicates', () => {
     const ownedPaneKey = makePaneKey('tab-1', LEAF_ID)
     const stalePaneKey = makePaneKey('missing-tab', OTHER_LEAF_ID)
@@ -838,51 +770,5 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(launched).toBe(0)
     expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
-  })
-
-  it('uses WSL resume quoting for Windows-path projects forced to WSL', () => {
-    const record = makeRecord({
-      providerSession: { key: 'session_id', id: "sess-1's" },
-      origin: 'worktree-sleep'
-    })
-    useAppStore.setState({
-      activeRepoId: 'repo-1',
-      activeWorktreeId: 'wt-1',
-      repos: [{ id: 'repo-1', path: 'C:\\repo', displayName: 'repo', addedAt: 1 }],
-      projects: [
-        {
-          id: 'repo-1',
-          sourceRepoIds: ['repo-1'],
-          localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
-        }
-      ],
-      settings: {
-        localWindowsRuntimeDefault: { kind: 'windows-host' },
-        agentCmdOverrides: {}
-      },
-      worktreesByRepo: {
-        'repo-1': [
-          {
-            id: 'wt-1',
-            repoId: 'repo-1',
-            path: 'C:\\repo',
-            displayName: 'repo',
-            branch: 'main'
-          }
-        ]
-      },
-      tabsByWorktree: { 'wt-1': [] },
-      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
-    } as never)
-
-    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
-    expect(launched).toBe(1)
-    const state = useAppStore.getState()
-    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
-    expect(resumedTab?.launchAgent).toBe('claude')
-    expect(state.pendingStartupByTabId[resumedTab!.id]?.command).toContain(
-      "'--resume' 'sess-1'\\''s'"
-    )
   })
 })

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -14,6 +14,7 @@ import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-r
 import { translate } from '@/i18n/i18n'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
 import {
+  getQueuedOrPendingProviderSessionClaimKeys,
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
   recordPaneIsOwnedByPreservedPane
@@ -90,6 +91,7 @@ function launchSleepingAgentSession(record: SleepingAgentSessionRecord): boolean
     ...(startupPlan.env ? { env: startupPlan.env } : {}),
     launchConfig: startupPlan.launchConfig,
     launchAgent: record.agent,
+    providerSession: record.providerSession,
     ...(startupPlan.startupCommandDelivery
       ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
       : {}),
@@ -184,6 +186,7 @@ export function resumeSleepingAgentSessionsForWorktree(worktreeId: string): numb
   const activeClaimKeys = new Set(activeWorktreeRecords.map(getProviderSessionClaimKey))
   const newestActiveRecordByClaimKey = getNewestActiveRecordsByClaimKey(activeWorktreeRecords)
   const freshlyLaunchedClaimKeys = new Set<string>()
+  const queuedOrPendingClaimKeys = getQueuedOrPendingProviderSessionClaimKeys(state, worktreeId)
 
   let launched = 0
   for (const record of worktreeRecords) {
@@ -200,9 +203,15 @@ export function resumeSleepingAgentSessionsForWorktree(worktreeId: string): numb
     if (isPassiveCompletedHibernationEvidence(record)) {
       // Why: completed-agent hibernation is passive history; activation should
       // only keep displayable evidence, never start new work from it.
-      if (!isPaneOwned || activeClaimKeys.has(claimKey)) {
+      if (!isPaneOwned || activeClaimKeys.has(claimKey) || queuedOrPendingClaimKeys.has(claimKey)) {
         state.clearSleepingAgentSession(record.paneKey)
       }
+      continue
+    }
+    if (queuedOrPendingClaimKeys.has(claimKey)) {
+      // Why: queued and registered resume startups are ownership claims until
+      // the agent hook proves a different provider session.
+      state.clearSleepingAgentSession(record.paneKey)
       continue
     }
     const paneOwnedClaimKeys = getCurrentPaneOwnedClaimKeys(activeWorktreeRecords)

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -1,5 +1,9 @@
 import type { useAppStore } from '@/store'
 import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../shared/agent-status-types'
+import {
   isResumableTuiAgent,
   type AgentProviderSessionMetadata,
   type ResumableTuiAgent,
@@ -47,6 +51,10 @@ function findTerminalTabWorktreeId(
 function getTabIdFromPaneKey(paneKey: string): string | undefined {
   const separator = paneKey.indexOf(':')
   return separator > 0 ? paneKey.slice(0, separator) : undefined
+}
+
+function isFreshProviderSessionClaim(entry: AgentStatusEntry): boolean {
+  return Date.now() - entry.updatedAt <= AGENT_STATUS_STALE_AFTER_MS
 }
 
 function addClaimKey(
@@ -105,10 +113,15 @@ export function getQueuedOrPendingProviderSessionClaimKeys(
     if (!entry.providerSession || !isResumableTuiAgent(entry.agentType) || entry.state === 'done') {
       continue
     }
-    const entryWorktreeId =
-      entry.worktreeId ??
-      findTerminalTabWorktreeId(state.tabsByWorktree, entry.tabId ?? getTabIdFromPaneKey(paneKey))
+    const tabWorktreeId = findTerminalTabWorktreeId(
+      state.tabsByWorktree,
+      entry.tabId ?? getTabIdFromPaneKey(paneKey)
+    )
+    const entryWorktreeId = tabWorktreeId ?? entry.worktreeId
     if (entryWorktreeId !== worktreeId) {
+      continue
+    }
+    if (!tabWorktreeId && !isFreshProviderSessionClaim(entry)) {
       continue
     }
     addClaimKey(keys, {

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -1,5 +1,10 @@
 import type { useAppStore } from '@/store'
-import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import {
+  isResumableTuiAgent,
+  type AgentProviderSessionMetadata,
+  type ResumableTuiAgent,
+  type SleepingAgentSessionRecord
+} from '../../../shared/agent-session-resume'
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
@@ -9,8 +14,111 @@ import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../shared/stable-
 
 type AppStoreState = ReturnType<typeof useAppStore.getState>
 
-export function getProviderSessionClaimKey(record: SleepingAgentSessionRecord): string {
-  return `${record.worktreeId}\0${record.agent}\0${record.providerSession.key}\0${record.providerSession.id}`
+type ProviderSessionClaim = Pick<
+  SleepingAgentSessionRecord,
+  'worktreeId' | 'agent' | 'providerSession'
+>
+
+type QueuedProviderSessionClaim = {
+  worktreeId: string
+  agent: ResumableTuiAgent
+  providerSession: AgentProviderSessionMetadata
+}
+
+export function getProviderSessionClaimKey(claim: ProviderSessionClaim): string {
+  return `${claim.worktreeId}\0${claim.agent}\0${claim.providerSession.key}\0${claim.providerSession.id}`
+}
+
+function findTerminalTabWorktreeId(
+  tabsByWorktree: AppStoreState['tabsByWorktree'],
+  tabId: string | undefined
+): string | null {
+  if (!tabId) {
+    return null
+  }
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    if (tabs.some((tab) => tab.id === tabId)) {
+      return worktreeId
+    }
+  }
+  return null
+}
+
+function getTabIdFromPaneKey(paneKey: string): string | undefined {
+  const separator = paneKey.indexOf(':')
+  return separator > 0 ? paneKey.slice(0, separator) : undefined
+}
+
+function addClaimKey(
+  keys: Set<string>,
+  claim: QueuedProviderSessionClaim | null | undefined
+): void {
+  if (!claim) {
+    return
+  }
+  keys.add(getProviderSessionClaimKey(claim))
+}
+
+export function getQueuedOrPendingProviderSessionClaimKeys(
+  state: AppStoreState,
+  worktreeId: string
+): Set<string> {
+  const keys = new Set<string>()
+
+  for (const [tabId, startup] of Object.entries(state.pendingStartupByTabId)) {
+    if (
+      !startup.providerSession ||
+      !startup.launchAgent ||
+      !isResumableTuiAgent(startup.launchAgent) ||
+      findTerminalTabWorktreeId(state.tabsByWorktree, tabId) !== worktreeId
+    ) {
+      continue
+    }
+    addClaimKey(keys, {
+      worktreeId,
+      agent: startup.launchAgent,
+      providerSession: startup.providerSession
+    })
+  }
+
+  for (const [paneKey, entry] of Object.entries(state.agentLaunchConfigByPaneKey)) {
+    const identity = entry.identity
+    if (
+      !identity.providerSession ||
+      !identity.agentType ||
+      !isResumableTuiAgent(identity.agentType)
+    ) {
+      continue
+    }
+    const tabId = identity.tabId ?? getTabIdFromPaneKey(paneKey)
+    if (findTerminalTabWorktreeId(state.tabsByWorktree, tabId) !== worktreeId) {
+      continue
+    }
+    addClaimKey(keys, {
+      worktreeId,
+      agent: identity.agentType,
+      providerSession: identity.providerSession
+    })
+  }
+
+  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
+    if (!entry.providerSession || !isResumableTuiAgent(entry.agentType) || entry.state === 'done') {
+      continue
+    }
+    const entryWorktreeId =
+      entry.worktreeId ??
+      findTerminalTabWorktreeId(state.tabsByWorktree, entry.tabId ?? getTabIdFromPaneKey(paneKey))
+    if (entryWorktreeId !== worktreeId) {
+      continue
+    }
+    addClaimKey(keys, {
+      worktreeId,
+      agent: entry.agentType,
+      providerSession: entry.providerSession
+    })
+  }
+
+  return keys
 }
 
 export function isPassiveCompletedHibernationEvidence(record: SleepingAgentSessionRecord): boolean {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -11,7 +11,10 @@ import type {
   WorkspaceKey,
   WorkspaceSessionState
 } from '../../../../shared/types'
-import type { SleepingAgentLaunchConfig } from '../../../../shared/agent-session-resume'
+import type {
+  AgentProviderSessionMetadata,
+  SleepingAgentLaunchConfig
+} from '../../../../shared/agent-session-resume'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import {
   folderWorkspaceKey,
@@ -339,6 +342,7 @@ export type TerminalSlice = {
       launchConfig?: SleepingAgentLaunchConfig
       launchToken?: string
       launchAgent?: TuiAgent
+      providerSession?: AgentProviderSessionMetadata
       /** Initial prompt-start status for agents that lack native prompt hooks. */
       initialAgentStatus?: { agent: TuiAgent; prompt: string }
       /** Show the restored-session banner when this startup command mounts. */
@@ -500,6 +504,7 @@ export type TerminalSlice = {
       launchConfig?: SleepingAgentLaunchConfig
       launchToken?: string
       launchAgent?: TuiAgent
+      providerSession?: AgentProviderSessionMetadata
       initialAgentStatus?: { agent: TuiAgent; prompt: string }
       showSessionRestoredBanner?: boolean
       telemetry?: AgentStartedTelemetry
@@ -515,6 +520,7 @@ export type TerminalSlice = {
     launchConfig?: SleepingAgentLaunchConfig
     launchToken?: string
     launchAgent?: TuiAgent
+    providerSession?: AgentProviderSessionMetadata
     initialAgentStatus?: { agent: TuiAgent; prompt: string }
     showSessionRestoredBanner?: boolean
     telemetry?: AgentStartedTelemetry


### PR DESCRIPTION
## Summary
- Thread provider-session identity through queued resume startup commands, pending launch-config registration, effective spawn launch configs, and cold-restore resume registration so staged resumes claim ownership until hooks confirm or correct them.
- Expand `agent-session.provider-ownership` coverage with queued startup, pending registration, delayed/wrong hook, live hook, display-only non-claim, duplicate selection, launch-config, and WSL quoting cases.
- Update the reliability gate oracle, command list, red/green note, and perf note while keeping maturity at `soak`.

## Stack Fit / Relationship to Other PRs
This PR is a child of #7001 and depends on the reliability-gate manifest and validator added there. It narrows in on the `agent-session.provider-ownership` gate: the parent PR creates the reliability proof process, while this PR strengthens the provider-session ownership invariant and its targeted renderer-state evidence.

It is parallel to #7004, #7005, #7006, and #7007. Those PRs cover other reliability surfaces; this one is only the provider-session replay ownership surface and should not broaden product scope beyond duplicate resume prevention.

## Anti-Regression Guarantees
This PR does not claim an absolute no-regression guarantee. The evidence-backed invariant is narrower: workspace activation, launch, restore, sleep, hibernate, dedupe, clearing, and reconnect code must not replay or resume a provider session id already owned, queued, pending, retained by a preserved pane, hidden/inactive but still owned by the workspace, or live in that workspace.

The targeted gate proves provider-session claim keys are owned by preserved active tabs, inactive split leaves, visible non-focused split groups, live hook records, queued startup commands, pending launch-config registrations, quit records, and worktree-sleep records. It also proves display-only or replay-looking evidence without provider-session identity does not claim ownership, and duplicates clear without launching a second resume command.

Red/green evidence is partial but targeted: removing the queued/pending claim scan or failing to thread provider-session identity through staged resumes allows a second resume tab for an already staged provider session. With this PR, queued, pending, retained/preserved, hidden-or-inactive owned, and live ownership evidence block replay, while wrong-session or display-only evidence does not.

## ELI5
An agent session is like a named conversation the provider already knows about. If Orca already has that conversation open, queued to open, or in the middle of opening, workspace activation should not start that same conversation a second time. This PR teaches the resume path to count those in-between states as ownership and adds tests so an already-owned provider session is not replayed.

## Performance Proof
Perf risk was reviewed separately from code review. The ruled-out risk is adding provider polling, remote filesystem probing, subprocess churn, hidden-pane wake loops, startup awaits, or repeated provider listing to answer ownership during activation.

The implementation stays state-driven and bounded: once per activation it scans the target worktree sleeping records plus the renderer maps `pendingStartupByTabId`, `agentLaunchConfigByPaneKey`, and `agentStatusByPaneKey`. It does not add provider I/O, background renderer output work, retry loops, fixed sleeps, or hidden-pane wakeups. The manifest keeps a performance budget on this gate so any future PR that adds ownership scans must keep proving bounded work before promotion.

## Usefulness / Material Impact
This reduces the escaped provider-session replay class where one provider session can be represented by an active tab, inactive tab, hidden split pane, queued startup, pending launch config, live status hook, quit record, or worktree-sleep record. Without recognizing those ownership states, workspace activation can create a duplicate resume tab for a session Orca already owns or is already staging.

The practical impact is fewer duplicate agent resumes after sleep, hibernate, activation, or reconnect, without treating title text, replay-looking command strings, or display-only evidence as authority.

## Validation
- PASS: `git fetch origin main`
- PASS: inspected current PR #7008 body, diff, and checks with `gh pr view 7008 --json ...`, `gh pr checks 7008`, `gh pr diff 7008 --name-only`, and `git diff origin/brennanb2025/fix-terminal-reliability..HEAD`
- PASS: PR checks are green: `verify` and `wayland terminal input`
- PASS: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts src/renderer/src/lib/resume-sleeping-agent-session-provider-claims.test.ts` (37 tests)
- PASS: `pnpm run check:reliability-gates`
- PASS: `pnpm exec oxlint config/reliability-gates.jsonc config/scripts/check-reliability-gates.mjs config/scripts/check-reliability-gates.test.mjs docs/reference/reliability-gates-implementation-plan.md src/renderer/src/components/terminal-pane/pty-connection-types.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/lib/resume-sleeping-agent-session-provider-claims.test.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts src/renderer/src/lib/resume-sleeping-agent-session.ts src/renderer/src/lib/sleeping-agent-pane-ownership.ts src/renderer/src/store/slices/terminals.ts`
- FAIL (unrelated): `pnpm run typecheck:tsc` stops at `src/renderer/src/components/terminal-pane/useSessionRestoredBannerDismiss.test.tsx:27` with `TS2740: Type Element is missing HTMLDivElement properties`.
- FAIL (unrelated): `pnpm run lint` reaches localization verification and reports missing ephemeral-VM localization keys in files outside this PR, including `src/renderer/src/components/NewWorkspaceComposerCard.tsx`, `src/renderer/src/components/settings/EphemeralVmRecipeRow.tsx`, `src/renderer/src/components/settings/EphemeralVmRuntimesSection.tsx`, `src/renderer/src/components/settings/EphemeralVmsPane.tsx`, `src/renderer/src/components/settings/Settings.tsx`, `src/renderer/src/components/settings/ephemeral-vms-search.ts`, `src/renderer/src/components/worktree-creation/WorktreeCreationPanel.tsx`, `src/renderer/src/hooks/useSettingsNavigationMetadata.ts`, and `src/renderer/src/lib/sidebar-worktree-activation.ts`.

## Residual Gaps
- The gate remains renderer-state coverage rather than a broad Electron repeat-activation loop; the manifest keeps that as a known gap.
- Red/green evidence is still `partial`, not complete saved CI red/green history.
- Manifest maturity did not change (`soak`), so this PR strengthens coverage but does not promote the gate to blocking.
- Live SSH, WSL, remote-runtime, mobile/relay, macOS, Linux, and Windows provider paths are covered here by state/identity contracts and WSL quoting tests, not by a live provider/platform matrix run.
- Local broad `typecheck:tsc` and `lint` still have unrelated repository blockers listed above, even though PR CI checks are passing.

## Merge Order
Requires #7001 first because this PR depends on the reliability gate manifest and validator added there.

After #7001 lands, this PR can merge independently of #7004, #7005, #7006, and #7007. No other child PR must merge before this one. Later child PRs may need a normal manifest rebase if this one lands first.

## Post-PR Stabilization
- CI checks pass for the current PR head after the post-PR wait.
- PR comments and review-comment surfaces were checked; no actionable automated review comments remain.

Made with [Orca](https://github.com/stablyai/orca)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7008">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
