### PR TITLE
Folder card icons + non-destructive workspace archive

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -166,6 +166,7 @@ const UiUpdate = z
     showActiveOnly: z.boolean().optional(),
     hideSleepingWorkspaces: z.boolean().optional(),
     showSleepingWorkspaces: z.boolean().optional(),
+    showArchivedWorkspaces: z.boolean().optional(),
     showInactiveWorkspaces: z.boolean().optional(),
     workspaceHostScope: z.string().optional(),
     visibleWorkspaceHostIds: z.array(z.string()).nullable().optional(),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -603,6 +603,7 @@ function App(): React.JSX.Element {
   const sortBy = useAppStore((s) => s.sortBy)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
+  const showArchivedWorkspaces = useAppStore((s) => s.showArchivedWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const hideAutomationGeneratedWorkspaces = useAppStore((s) => s.hideAutomationGeneratedWorkspaces)
   const showDotfilesByWorktree = useAppStore((s) => s.showDotfilesByWorktree)
@@ -1324,6 +1325,7 @@ function App(): React.JSX.Element {
         showActiveOnly: false,
         hideSleepingWorkspaces: !showSleepingWorkspaces,
         showSleepingWorkspaces,
+        showArchivedWorkspaces,
         hideDefaultBranchWorkspace,
         hideAutomationGeneratedWorkspaces,
         showDotfilesByWorktree,
@@ -1350,6 +1352,7 @@ function App(): React.JSX.Element {
     sortBy,
     projectOrderBy,
     showSleepingWorkspaces,
+    showArchivedWorkspaces,
     hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces,
     showDotfilesByWorktree,

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { GitBranch, Moon, Workflow } from 'lucide-react'
+import { Archive, GitBranch, Moon, Workflow } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
@@ -13,6 +13,8 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
   const setHideAutomationGeneratedWorkspaces = useAppStore(
     (s) => s.setHideAutomationGeneratedWorkspaces
   )
+  const showArchivedWorkspaces = useAppStore((s) => s.showArchivedWorkspaces)
+  const setShowArchivedWorkspaces = useAppStore((s) => s.setShowArchivedWorkspaces)
 
   return (
     <>
@@ -47,6 +49,15 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
         )}
         checked={hideAutomationGeneratedWorkspaces}
         onChange={setHideAutomationGeneratedWorkspaces}
+      />
+      <FilterToggleRow
+        icon={<Archive className="size-3.5" />}
+        label={translate(
+          'auto.components.sidebar.SidebarWorkspaceFilterSection.showArchived',
+          'Show archived'
+        )}
+        checked={showArchivedWorkspaces}
+        onChange={setShowArchivedWorkspaces}
       />
     </>
   )

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1180,6 +1180,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
     showRepoIdentityInTitle && !!repo && !hideRepoBadge && !isFolder && !showPinnedRepoIcon
   const showRepoBadgeInMetaRow =
     !showRepoIdentityInTitle && !!repo && !hideRepoBadge && !showPinnedRepoIcon
+  // Why: folder cards otherwise render no leading glyph (only pinned cards did),
+  // leaving the status dot as the row's only marker; show the folder icon inline.
+  const showInlineFolderIcon = isFolder && !hideRepoBadge && !showPinnedRepoIcon
   const showHostContextBadge = !compactCards && !!hostContextLabel
   const showDetachedHeadInMetaRow = !compactCards && !isFolder && detachedHeadDisplay !== null
   const showBranch =
@@ -1482,6 +1485,23 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 />
               </RepoIdentityChip>
             )}
+
+            {showInlineFolderIcon &&
+              (repo ? (
+                <RepoIdentityChip repo={repo}>
+                  <RepoIconGlyph
+                    repoIcon={repo.repoIcon}
+                    color={resolveRepoHeaderColor(repo.badgeColor)}
+                    className="size-full"
+                    iconClassName="size-3"
+                  />
+                </RepoIdentityChip>
+              ) : (
+                // Folder workspaces carry no repo; fall back to the default glyph.
+                <span className="inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-worktree-sidebar-border bg-worktree-sidebar-accent/55">
+                  <RepoIconGlyph repoIcon={null} className="size-full" iconClassName="size-3" />
+                </span>
+              ))}
 
             {/* Why: unread alert lives in the left status lane; weight plus dimmed
                  read titles carry scan contrast in the title row. */}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1889,7 +1889,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
         ],
         titleRenaming && '!border-transparent !bg-transparent !shadow-none !ring-0',
         isDeleting && 'opacity-50 grayscale cursor-not-allowed',
-        (isSshDisconnected || isRuntimeDisconnected) && !isDeleting && 'opacity-60'
+        (isSshDisconnected || isRuntimeDisconnected) && !isDeleting && 'opacity-60',
+        // Why: archived rows only appear under the "Show archived" filter; dim
+        // them so they read as put-away without hiding their content.
+        worktree.isArchived && !isDeleting && 'opacity-60'
       )}
       data-worktree-card-surface="true"
       data-worktree-card-active={isActiveSurface ? activeSurfaceVariant : undefined}

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -16,6 +16,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   Copy,
+  Archive,
+  ArchiveRestore,
   Bell,
   BellOff,
   CircleX,
@@ -487,6 +489,24 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     [activeContextWorktrees, setMenuOpenState, updateWorktreeMeta, workspaceStatuses]
   )
 
+  // Why: archive is non-destructive removal — it hides the row (surfaced again
+  // via the sidebar "Show archived" filter) instead of deleting anything.
+  const allContextArchived =
+    activeContextWorktrees.length > 0 &&
+    activeContextWorktrees.every((item) => item.isArchived === true)
+
+  const handleToggleArchive = useCallback(() => {
+    const nextArchived = !allContextArchived
+    setMenuOpenState(false)
+    void Promise.all(
+      activeContextWorktrees.map((item) =>
+        item.isArchived === nextArchived
+          ? Promise.resolve()
+          : updateWorktreeMeta(item.id, { isArchived: nextArchived })
+      )
+    )
+  }, [activeContextWorktrees, allContextArchived, setMenuOpenState, updateWorktreeMeta])
+
   const handleRename = useCallback(() => {
     openModal('edit-meta', {
       worktreeId: worktree.id,
@@ -852,6 +872,25 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
             </>
           ) : null}
 
+          <DropdownMenuItem
+            onSelect={handleToggleArchive}
+            disabled={deletingContext || activeContextWorktrees.length === 0}
+          >
+            {allContextArchived ? (
+              <ArchiveRestore className="size-3.5" />
+            ) : (
+              <Archive className="size-3.5" />
+            )}
+            {allContextArchived
+              ? translate(
+                  'auto.components.sidebar.WorktreeContextMenu.unarchiveWorkspace',
+                  'Unarchive'
+                )
+              : translate(
+                  'auto.components.sidebar.WorktreeContextMenu.archiveWorkspace',
+                  'Archive'
+                )}
+          </DropdownMenuItem>
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuItem

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -4992,6 +4992,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const setSortBy = useAppStore((s) => s.setSortBy)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
+  const showArchivedWorkspaces = useAppStore((s) => s.showArchivedWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const hideAutomationGeneratedWorkspaces = useAppStore((s) => s.hideAutomationGeneratedWorkspaces)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
@@ -5169,9 +5170,11 @@ const WorktreeList = React.memo(function WorktreeList({
 
   const sortedIds = useMemo(() => {
     const state = useAppStore.getState()
-    const nonArchivedWorktrees = getAllWorktreesFromState(state).filter(
-      (worktree) => !worktree.isArchived
-    )
+    // Why: when "Show archived" is on, archived rows must earn a sort position
+    // here so they render inline rather than piling unsorted at the bottom.
+    const nonArchivedWorktrees = showArchivedWorkspaces
+      ? getAllWorktreesFromState(state)
+      : getAllWorktreesFromState(state).filter((worktree) => !worktree.isArchived)
 
     // Why cold-start detection: smart-class resolution depends on the
     // agent-status snapshot (agentStatusByPaneKey) hydrating from the hook
@@ -5225,7 +5228,7 @@ const WorktreeList = React.memo(function WorktreeList({
     // memo, but its change signals that the sort order should be recomputed.
     // The debounce prevents jarring mid-interaction position shifts.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedSortEpoch, repoMap, sortBy])
+  }, [debouncedSortEpoch, repoMap, sortBy, showArchivedWorkspaces])
 
   // Why a ref of prior class per worktree: smart_sort_class_1_promotion must
   // fire only on transitions INTO Class 1, not on every recompute that keeps
@@ -5349,6 +5352,7 @@ const WorktreeList = React.memo(function WorktreeList({
     const ids = computeVisibleWorktreeIds(worktreesByRepo, sortedIds, {
       filterRepoIds,
       showSleepingWorkspaces,
+      showArchivedWorkspaces,
       tabsByWorktree,
       ptyIdsByTabId,
       browserTabsByWorktree,
@@ -5375,6 +5379,7 @@ const WorktreeList = React.memo(function WorktreeList({
     agentSendTargetWorktreeId,
     filterRepoIds,
     showSleepingWorkspaces,
+    showArchivedWorkspaces,
     hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces,
     workspaceHostScope,
@@ -5491,11 +5496,16 @@ const WorktreeList = React.memo(function WorktreeList({
     })
   }, [defaultHostId, projectGroups, visibleHostIdSet])
   const visibleFolderWorkspacesForRows = useMemo(() => {
+    // Why: archived folder workspaces have no other filter site, so hide them
+    // here unless the "Show archived" view is on.
+    const base = showArchivedWorkspaces
+      ? folderWorkspaces
+      : folderWorkspaces.filter((folderWorkspace) => !folderWorkspace.isArchived)
     if (!visibleHostIdSet) {
-      return folderWorkspaces
+      return base
     }
     const projectGroupById = new Map(projectGroups.map((group) => [group.id, group]))
-    return folderWorkspaces.filter((folderWorkspace) => {
+    return base.filter((folderWorkspace) => {
       const hostId = getFolderWorkspaceExecutionHostIdForRows({
         folderWorkspace,
         projectGroup: projectGroupById.get(folderWorkspace.projectGroupId),
@@ -5503,7 +5513,7 @@ const WorktreeList = React.memo(function WorktreeList({
       })
       return visibleHostIdSet.has(hostId)
     })
-  }, [defaultHostId, folderWorkspaces, projectGroups, visibleHostIdSet])
+  }, [defaultHostId, folderWorkspaces, projectGroups, visibleHostIdSet, showArchivedWorkspaces])
   const repoOrder = useMemo(() => {
     const map = new Map<string, number>()
     repos.forEach((r, i) => map.set(r.id, i))

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -163,6 +163,32 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([manual.id])
   })
 
+  it('hides archived worktrees by default', () => {
+    const active = makeWorktree('active')
+    const archived = { ...makeWorktree('archived'), isArchived: true }
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [active, archived] },
+      [active.id, archived.id],
+      visibleOptions()
+    )
+
+    expect(result).toEqual([active.id])
+  })
+
+  it('shows archived worktrees when show archived is on', () => {
+    const active = makeWorktree('active')
+    const archived = { ...makeWorktree('archived'), isArchived: true }
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [active, archived] },
+      [active.id, archived.id],
+      visibleOptions({ showArchivedWorkspaces: true })
+    )
+
+    expect(result).toEqual([active.id, archived.id])
+  })
+
   it('does not treat slept wake-hint tabs as live surfaces', () => {
     const wt = makeWorktree('wt-slept')
 

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -107,6 +107,10 @@ export function computeVisibleWorktreeIds(
   opts: {
     filterRepoIds: string[]
     showSleepingWorkspaces: boolean
+    // Why optional: omitting it keeps the safe default (archived hidden). Only
+    // the sidebar "Show archived" path opts in, so no caller can accidentally
+    // surface archived rows by forgetting to pass it.
+    showArchivedWorkspaces?: boolean
     tabsByWorktree: Record<string, Pick<TerminalTab, 'id'>[]> | null
     ptyIdsByTabId: Record<string, string[]> | null
     browserTabsByWorktree?: Record<string, { id: string }[]> | null
@@ -125,8 +129,10 @@ export function computeVisibleWorktreeIds(
 ): string[] {
   let all: Worktree[] = getAllWorktreesFromState({ worktreesByRepo })
 
-  // Filter archived
-  all = all.filter((w) => !w.isArchived)
+  // Filter archived unless the "Show archived" view is on.
+  if (!opts.showArchivedWorkspaces) {
+    all = all.filter((w) => !w.isArchived)
+  }
 
   // Why: sidebar lineage is structural. Archived workspaces stay hidden, but
   // every other valid ancestor can bypass filters so children never orphan.
@@ -272,7 +278,9 @@ export function getVisibleWorktreeIds(): string[] {
 
   // Fallback: live recomputation for the window before WorktreeList renders.
   const state = useAppStore.getState()
-  const allWorktrees = getAllWorktreesFromState(state).filter((w) => !w.isArchived)
+  const allWorktrees = state.showArchivedWorkspaces
+    ? getAllWorktreesFromState(state)
+    : getAllWorktreesFromState(state).filter((w) => !w.isArchived)
 
   // Hoist repoMap so it's built once and reused across all branches below.
   const repoMap = getRepoMapFromState(state)
@@ -302,6 +310,7 @@ export function getVisibleWorktreeIds(): string[] {
   return computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
     filterRepoIds: state.filterRepoIds,
     showSleepingWorkspaces: state.showSleepingWorkspaces,
+    showArchivedWorkspaces: state.showArchivedWorkspaces,
     tabsByWorktree: state.tabsByWorktree,
     ptyIdsByTabId: state.ptyIdsByTabId,
     browserTabsByWorktree: state.browserTabsByWorktree,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3841,7 +3841,8 @@
           "c3fa13dc2e": "Hide default branch",
           "ed1611b65b": "Hide sleeping",
           "82594419ba": "Filters",
-          "automationCreated": "Hide automation-created"
+          "automationCreated": "Hide automation-created",
+          "showArchived": "Show archived"
         },
         "sidebarHostOptions": {
           "3e102f111c": "All hosts",
@@ -4072,7 +4073,9 @@
           "setParentWorkspace": "Set Parent Worktree...",
           "workspaceSection": "Workspace",
           "primaryDeleteDisabled": "Primary worktree — can't be deleted. Remove the project instead.",
-          "deleteWorktree": "Delete Worktree"
+          "deleteWorktree": "Delete Worktree",
+          "unarchiveWorkspace": "Unarchive",
+          "archiveWorkspace": "Archive"
         },
         "WorktreeList": {
           "7a8b9c0d1e": "Update required",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3826,7 +3826,8 @@
           "c3fa13dc2e": "Ocultar rama predeterminada",
           "ed1611b65b": "Ocultar durmiendo",
           "82594419ba": "Filtros",
-          "automationCreated": "Ocultar creados por automatizaciones"
+          "automationCreated": "Ocultar creados por automatizaciones",
+          "showArchived": "Show archived"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "Diseño de actividad del Agent",
@@ -4049,7 +4050,9 @@
           "setParentWorkspace": "Establecer árbol de trabajo padre...",
           "workspaceSection": "Espacio de trabajo",
           "primaryDeleteDisabled": "El árbol de trabajo principal no se puede eliminar. Elimina el proyecto en su lugar.",
-          "deleteWorktree": "Eliminar árbol de trabajo"
+          "deleteWorktree": "Eliminar árbol de trabajo",
+          "unarchiveWorkspace": "Unarchive",
+          "archiveWorkspace": "Archive"
         },
         "WorktreeList": {
           "d880ea0744": "Crea un grupo y mueve este proyecto a él.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3807,7 +3807,8 @@
           "c3fa13dc2e": "デフォルトのブランチを非表示にする",
           "ed1611b65b": "スリープ中を非表示",
           "82594419ba": "フィルター",
-          "automationCreated": "自動化で作成されたワークスペースを非表示"
+          "automationCreated": "自動化で作成されたワークスペースを非表示",
+          "showArchived": "Show archived"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "Agent アクティビティのレイアウト",
@@ -4030,7 +4031,9 @@
           "setParentWorkspace": "親ワークツリーを設定...",
           "workspaceSection": "ワークスペース",
           "primaryDeleteDisabled": "プライマリワークツリーは削除できません。代わりにプロジェクトを削除してください。",
-          "deleteWorktree": "ワークツリーを削除"
+          "deleteWorktree": "ワークツリーを削除",
+          "unarchiveWorkspace": "Unarchive",
+          "archiveWorkspace": "Archive"
         },
         "WorktreeList": {
           "d880ea0744": "グループを作成し、このプロジェクトをそのグループに移動します。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3807,7 +3807,8 @@
           "c3fa13dc2e": "기본 브랜치 숨기기",
           "ed1611b65b": "슬립 중인 항목 숨기기",
           "82594419ba": "필터",
-          "automationCreated": "자동화로 생성된 워크스페이스 숨기기"
+          "automationCreated": "자동화로 생성된 워크스페이스 숨기기",
+          "showArchived": "Show archived"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "Agent 활동 레이아웃",
@@ -4030,7 +4031,9 @@
           "setParentWorkspace": "상위 워크트리 설정...",
           "workspaceSection": "워크스페이스",
           "primaryDeleteDisabled": "기본 작업 트리는 삭제할 수 없습니다. 대신 프로젝트를 제거하세요.",
-          "deleteWorktree": "작업 트리 삭제"
+          "deleteWorktree": "작업 트리 삭제",
+          "unarchiveWorkspace": "Unarchive",
+          "archiveWorkspace": "Archive"
         },
         "WorktreeList": {
           "d880ea0744": "그룹을 만들고 이 프로젝트를 그룹으로 이동하세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3807,7 +3807,8 @@
           "c3fa13dc2e": "隐藏默认分支",
           "ed1611b65b": "隐藏休眠项",
           "82594419ba": "搜索器",
-          "automationCreated": "隐藏自动化创建的工作区"
+          "automationCreated": "隐藏自动化创建的工作区",
+          "showArchived": "Show archived"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "智能体活动布局",
@@ -4030,7 +4031,9 @@
           "setParentWorkspace": "设置父工作树...",
           "workspaceSection": "工作区",
           "primaryDeleteDisabled": "主要工作树无法删除，请改为删除项目。",
-          "deleteWorktree": "删除工作树"
+          "deleteWorktree": "删除工作树",
+          "unarchiveWorkspace": "Unarchive",
+          "archiveWorkspace": "Archive"
         },
         "WorktreeList": {
           "d880ea0744": "创建一个组并将该项目移入其中。",

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_HIDE_SLEEPING_WORKSPACES,
+  DEFAULT_SHOW_ARCHIVED_WORKSPACES,
   DEFAULT_SHOW_SLEEPING_WORKSPACES,
   DEFAULT_STATUS_BAR_ITEMS,
   DEFAULT_WORKTREE_CARD_PROPERTIES
@@ -46,6 +47,7 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     showActiveOnly: false,
     hideSleepingWorkspaces: DEFAULT_HIDE_SLEEPING_WORKSPACES,
     showSleepingWorkspaces: DEFAULT_SHOW_SLEEPING_WORKSPACES,
+    showArchivedWorkspaces: DEFAULT_SHOW_ARCHIVED_WORKSPACES,
     hideDefaultBranchWorkspace: false,
     hideAutomationGeneratedWorkspaces: false,
     filterRepoIds: [],

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -59,6 +59,7 @@ import {
   DEFAULT_HIDE_SLEEPING_WORKSPACES,
   DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE,
   DEFAULT_SHOW_SLEEPING_WORKSPACES,
+  DEFAULT_SHOW_ARCHIVED_WORKSPACES,
   DEFAULT_STATUS_BAR_ITEMS,
   DEFAULT_WORKTREE_CARD_PROPERTIES,
   getWorktreeCardModeUpdates,
@@ -792,6 +793,8 @@ export type UISlice = {
   setShowActiveOnly: (v: boolean) => void
   showSleepingWorkspaces: boolean
   setShowSleepingWorkspaces: (v: boolean) => void
+  showArchivedWorkspaces: boolean
+  setShowArchivedWorkspaces: (v: boolean) => void
   workspaceHostScope: WorkspaceHostScope
   setWorkspaceHostScope: (scope: WorkspaceHostScope) => void
   visibleWorkspaceHostIds: VisibleWorkspaceHostIds
@@ -1899,6 +1902,9 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   showSleepingWorkspaces: DEFAULT_SHOW_SLEEPING_WORKSPACES,
   setShowSleepingWorkspaces: (v) => set({ showSleepingWorkspaces: v }),
 
+  showArchivedWorkspaces: DEFAULT_SHOW_ARCHIVED_WORKSPACES,
+  setShowArchivedWorkspaces: (v) => set({ showArchivedWorkspaces: v }),
+
   workspaceHostScope: 'all',
   // Why (multi-host design): host scope is presentation/filtering only — it must
   // never trigger resource teardown (terminals, browser pages, etc.).
@@ -2269,6 +2275,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         // Older positive-form keys are intentionally ignored so old profiles
         // start from the new default: sleeping workspaces visible.
         showSleepingWorkspaces: !(ui.hideSleepingWorkspaces ?? DEFAULT_HIDE_SLEEPING_WORKSPACES),
+        showArchivedWorkspaces: ui.showArchivedWorkspaces === true,
         workspaceHostScope: normalizeExecutionHostScope(ui.workspaceHostScope),
         visibleWorkspaceHostIds: normalizeHydratedVisibleWorkspaceHostIds(ui),
         workspaceHostOrder: normalizeExecutionHostOrder(ui.workspaceHostOrder),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -47,6 +47,9 @@ export const SCHEMA_VERSION = 1
 export const DEFAULT_APP_FONT_FAMILY = 'Geist'
 export const DEFAULT_SHOW_SLEEPING_WORKSPACES = true
 export const DEFAULT_HIDE_SLEEPING_WORKSPACES = false
+// Why: archived workspaces are hidden by default; the sidebar "Show archived"
+// filter opts back in so they can be reviewed and unarchived.
+export const DEFAULT_SHOW_ARCHIVED_WORKSPACES = false
 export const DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE: AgentActivityDisplayMode = 'compact'
 
 export function normalizeAgentActivityDisplayMode(value: unknown): AgentActivityDisplayMode {
@@ -461,6 +464,7 @@ export function getDefaultUIState(): PersistedUIState {
     visibleWorkspaceHostIds: null,
     workspaceHostOrder: [],
     showSleepingWorkspaces: DEFAULT_SHOW_SLEEPING_WORKSPACES,
+    showArchivedWorkspaces: DEFAULT_SHOW_ARCHIVED_WORKSPACES,
     hideDefaultBranchWorkspace: false,
     hideAutomationGeneratedWorkspaces: false,
     showDotfilesByWorktree: {},

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3151,6 +3151,8 @@ export type PersistedUIState = {
   showActiveOnly: boolean
   /** Hide sleeping/inactive workspaces from workspace navigation. Off by default. */
   hideSleepingWorkspaces?: boolean
+  /** Show archived workspaces in the sidebar so they can be unarchived. Off by default. */
+  showArchivedWorkspaces?: boolean
   /** Which execution hosts the workspace sidebar shows. `all` keeps the mixed
    *  command-center view; specific host IDs focus the sidebar without tearing
    *  down sessions owned by other hosts. */


### PR DESCRIPTION
## Summary

Two small, independent sidebar improvements for folder-backed projects and non-destructive workspace management.

### 1. Show the folder icon on sidebar folder cards
Adding a raw (non-git) folder creates a `Repo` with `kind: 'folder'`, so `isFolder` is true on its card. Every inline-icon render site was gated to skip folders (`showInlineRepoBadge` excludes `!isFolder`; `showPinnedRepoIcon` only fires when pinned), so a normal folder card rendered **no leading glyph** — only the activity status dot. This renders the folder/repo icon inline in the title row across all card styles (honoring a custom icon/badge color when set, defaulting to the `Folder` glyph), including repo-less folder workspaces.

### 2. Archive workspaces (non-destructive) + "Show archived" filter
`isArchived` already existed in the data model and was honored by the jump palette and dashboard, but there was no way to set it or an archived-aware sidebar. This adds:
- **Archive / Unarchive** in the workspace context menu (works for git worktrees *and* folder workspaces, and for multi-select), routed through the existing `updateWorktreeMeta`.
- A persisted **"Show archived"** filter in the sidebar Filters menu (off by default). When on, archived rows appear **dimmed** and can be unarchived.
- Archived-aware filtering threaded through the sort order, the visible-worktree pipeline, and the folder-workspace row path (which had no archived filter before).

Archiving hides a workspace from the sidebar while keeping it on disk and fully recoverable — a non-destructive alternative to Delete.

## Testing
- `typecheck` (web) clean; `oxlint` clean; localization catalog synced across all 5 locales.
- Unit tests pass, including 2 new `computeVisibleWorktreeIds` cases (archived hidden by default; shown when the filter is on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7015">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Folder-backed projects show a folder icon on sidebar cards, and workspaces can be archived non-destructively. Folders no longer look blank, and archive is safer than hard delete.
