### PR TITLE
Fix project group move and management actions

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -49,11 +49,14 @@ import { WorktreeParentPickerPopover } from './WorktreeParentPickerPopover'
 import { getEligibleWorktreeParents } from './worktree-parent-candidates'
 import { isEventTargetInsideCurrentTarget } from './worktree-card-dom-events'
 import { translate } from '@/i18n/i18n'
+import { ProjectGroupDeleteDialog } from './ProjectGroupDeleteDialog'
+import { selectProjectGroupRemovalTargets } from '@/store/slices/project-group-removal-targets'
 import {
   folderWorkspaceKey,
   parseWorkspaceKey,
   worktreeWorkspaceKey
 } from '../../../../shared/workspace-scope'
+import { getProjectGroupMoveTargets } from '../../../../shared/project-group-move-targets'
 
 type Props = {
   worktree: Worktree
@@ -82,6 +85,16 @@ const EMPTY_BROWSER_TABS_BY_WORKTREE: AppState['browserTabsByWorktree'] = {}
 const EMPTY_DELETE_STATE_BY_WORKTREE_ID: AppState['deleteStateByWorktreeId'] = {}
 const EMPTY_WORKTREE_LINEAGE_BY_ID: AppState['worktreeLineageById'] = {}
 const EMPTY_WORKSPACE_LINEAGE_BY_CHILD_KEY: AppState['workspaceLineageByChildKey'] = {}
+
+type ProjectGroupNameDialogState =
+  | { type: 'create-from-repo' }
+  | { type: 'rename'; groupId: string; currentName: string }
+
+type ProjectGroupDeleteDialogState = {
+  groupId: string
+  groupName: string
+  removeContainedProjects: boolean
+}
 
 // Why: the gating decision for the menu-only store subscriptions. When the menu is
 // closed we MUST return the same `empty` reference every render so Zustand's Object.is
@@ -278,17 +291,32 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const openModal = useAppStore((s) => s.openModal)
   const projectGroups = useAppStore((s) => s.projectGroups)
   const createProjectGroup = useAppStore((s) => s.createProjectGroup)
+  const updateProjectGroup = useAppStore((s) => s.updateProjectGroup)
+  const deleteProjectGroupWithContainedProjects = useAppStore(
+    (s) => s.deleteProjectGroupWithContainedProjects
+  )
   const moveProjectToGroup = useAppStore((s) => s.moveProjectToGroup)
   const deleteFolderWorkspace = useAppStore((s) => s.deleteFolderWorkspace)
   const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
   const repo = useRepoById(worktree.repoId)
+  const projectGroupMoveTargets = useMemo(
+    () => getProjectGroupMoveTargets(repo, projectGroups),
+    [projectGroups, repo]
+  )
+  const currentProjectGroup = useMemo(
+    () => projectGroups.find((group) => group.id === repo?.projectGroupId) ?? null,
+    [projectGroups, repo?.projectGroupId]
+  )
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
   const [contextWorktrees, setContextWorktrees] = useState<readonly Worktree[]>(
     effectiveSelectedWorktrees
   )
-  const [createGroupDialogOpen, setCreateGroupDialogOpen] = useState(false)
+  const [projectGroupNameDialog, setProjectGroupNameDialog] =
+    useState<ProjectGroupNameDialogState | null>(null)
+  const [projectGroupDeleteDialog, setProjectGroupDeleteDialog] =
+    useState<ProjectGroupDeleteDialogState | null>(null)
   const [parentPicker, setParentPicker] = useState<{
     childWorktreeId: string
     anchorElement: HTMLElement
@@ -440,21 +468,84 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     if (!repo) {
       return
     }
-    setCreateGroupDialogOpen(true)
+    setProjectGroupNameDialog({ type: 'create-from-repo' })
   }, [repo])
 
-  const handleSubmitNewProjectGroup = useCallback(
+  const handleSubmitProjectGroupName = useCallback(
     async (name: string) => {
       if (!repo) {
         return
       }
-      const group = await createProjectGroup(name)
-      if (group) {
-        await moveProjectToGroup(repo.id, group.id)
+      if (projectGroupNameDialog?.type === 'create-from-repo') {
+        const group = await createProjectGroup(name)
+        if (group) {
+          await moveProjectToGroup(repo.id, group.id)
+        }
+        return
+      }
+      if (projectGroupNameDialog?.type === 'rename') {
+        await updateProjectGroup(projectGroupNameDialog.groupId, { name })
       }
     },
-    [createProjectGroup, moveProjectToGroup, repo]
+    [createProjectGroup, moveProjectToGroup, projectGroupNameDialog, repo, updateProjectGroup]
   )
+
+  const handleRenameCurrentProjectGroup = useCallback(() => {
+    if (!currentProjectGroup) {
+      return
+    }
+    setProjectGroupNameDialog({
+      type: 'rename',
+      groupId: currentProjectGroup.id,
+      currentName: currentProjectGroup.name
+    })
+  }, [currentProjectGroup])
+
+  const handleDeleteCurrentProjectGroup = useCallback(() => {
+    if (!currentProjectGroup) {
+      return
+    }
+    setProjectGroupDeleteDialog({
+      groupId: currentProjectGroup.id,
+      groupName: currentProjectGroup.name,
+      removeContainedProjects: false
+    })
+  }, [currentProjectGroup])
+
+  const projectGroupDeleteTargets = useMemo(() => {
+    if (!projectGroupDeleteDialog) {
+      return null
+    }
+    return selectProjectGroupRemovalTargets(
+      projectGroups,
+      [...repoMap.values()],
+      projectGroupDeleteDialog.groupId
+    )
+  }, [projectGroupDeleteDialog, projectGroups, repoMap])
+  const projectGroupDeleteProjectCount = projectGroupDeleteTargets?.projectIds.length ?? 0
+  const projectGroupDeleteProjectNames = useMemo(
+    () =>
+      (projectGroupDeleteTargets?.projectIds ?? []).map(
+        (projectId) => repoMap.get(projectId)?.displayName ?? projectId
+      ),
+    [projectGroupDeleteTargets, repoMap]
+  )
+  const projectGroupRemoveContainedProjects =
+    projectGroupDeleteProjectCount > 0 && projectGroupDeleteDialog?.removeContainedProjects === true
+
+  const handleConfirmDeleteProjectGroup = useCallback(async () => {
+    if (!projectGroupDeleteDialog) {
+      return
+    }
+    await deleteProjectGroupWithContainedProjects(projectGroupDeleteDialog.groupId, {
+      removeContainedProjects: projectGroupRemoveContainedProjects
+    })
+    setProjectGroupDeleteDialog(null)
+  }, [
+    deleteProjectGroupWithContainedProjects,
+    projectGroupDeleteDialog,
+    projectGroupRemoveContainedProjects
+  ])
 
   const handleMoveProjectToGroup = useCallback(
     (groupId: string) => {
@@ -773,7 +864,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                       'New group from project'
                     )}
                   </DropdownMenuItem>
-                  {projectGroups.length > 0 ? (
+                  {projectGroupMoveTargets.length > 0 ? (
                     <DropdownMenuSub>
                       <DropdownMenuSubTrigger disabled={isDeleting}>
                         <FolderInput className="size-3.5" />
@@ -783,7 +874,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                         )}
                       </DropdownMenuSubTrigger>
                       <DropdownMenuSubContent>
-                        {projectGroups.map((group) => (
+                        {projectGroupMoveTargets.map((group) => (
                           <DropdownMenuItem
                             key={group.id}
                             disabled={repo.projectGroupId === group.id}
@@ -803,6 +894,31 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                         'Remove from group'
                       )}
                     </DropdownMenuItem>
+                  ) : null}
+                  {currentProjectGroup ? (
+                    <>
+                      <DropdownMenuItem
+                        onSelect={handleRenameCurrentProjectGroup}
+                        disabled={isDeleting}
+                      >
+                        <Pencil className="size-3.5" />
+                        {translate(
+                          'auto.components.sidebar.WorktreeContextMenu.renameCurrentGroup',
+                          'Rename current group'
+                        )}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onSelect={handleDeleteCurrentProjectGroup}
+                        disabled={isDeleting}
+                      >
+                        <Trash2 className="size-3.5" />
+                        {translate(
+                          'auto.components.sidebar.WorktreeContextMenu.deleteCurrentGroup',
+                          'Delete current group'
+                        )}
+                      </DropdownMenuItem>
+                    </>
                   ) : null}
                 </>
               ) : null}
@@ -939,19 +1055,61 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
         </DropdownMenuContent>
       </DropdownMenu>
       <ProjectGroupNameDialog
-        open={createGroupDialogOpen}
-        title={translate(
-          'auto.components.sidebar.WorktreeContextMenu.6664418e98',
-          'New Project Group'
-        )}
-        description={translate(
-          'auto.components.sidebar.WorktreeContextMenu.c39c37676a',
-          'Create a group and move this project into it.'
-        )}
-        initialName={repo ? `${repo.displayName} group` : ''}
-        confirmLabel="Create"
-        onOpenChange={setCreateGroupDialogOpen}
-        onSubmit={handleSubmitNewProjectGroup}
+        open={projectGroupNameDialog !== null}
+        title={
+          projectGroupNameDialog?.type === 'rename'
+            ? translate(
+                'auto.components.sidebar.WorktreeContextMenu.renameProjectGroupTitle',
+                'Rename Project Group'
+              )
+            : translate(
+                'auto.components.sidebar.WorktreeContextMenu.6664418e98',
+                'New Project Group'
+              )
+        }
+        description={
+          projectGroupNameDialog?.type === 'rename'
+            ? translate(
+                'auto.components.sidebar.WorktreeContextMenu.renameProjectGroupDescription',
+                'Update the group name shown in the sidebar.'
+              )
+            : translate(
+                'auto.components.sidebar.WorktreeContextMenu.c39c37676a',
+                'Create a group and move this project into it.'
+              )
+        }
+        initialName={
+          projectGroupNameDialog?.type === 'rename'
+            ? projectGroupNameDialog.currentName
+            : repo
+              ? `${repo.displayName} group`
+              : ''
+        }
+        confirmLabel={projectGroupNameDialog?.type === 'rename' ? 'Rename' : 'Create'}
+        onOpenChange={(open) => {
+          if (!open) {
+            setProjectGroupNameDialog(null)
+          }
+        }}
+        onSubmit={handleSubmitProjectGroupName}
+      />
+      <ProjectGroupDeleteDialog
+        open={projectGroupDeleteDialog !== null}
+        groupName={projectGroupDeleteDialog?.groupName ?? ''}
+        projectCount={projectGroupDeleteProjectCount}
+        projectNames={projectGroupDeleteProjectNames}
+        removeContainedProjects={projectGroupRemoveContainedProjects}
+        onRemoveContainedProjectsChange={(removeContainedProjects) => {
+          setProjectGroupDeleteDialog((current) =>
+            current ? { ...current, removeContainedProjects } : current
+          )
+        }}
+        onOpenChange={(open) => {
+          if (!open) {
+            setProjectGroupDeleteDialog(null)
+          }
+        }}
+        onConfirm={handleConfirmDeleteProjectGroup}
       />
       <WorktreeParentPickerPopover
         open={parentPicker !== null}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -63,6 +63,7 @@ import type {
   WorkspaceStatusDefinition
 } from '../../../../shared/types'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
+import { getProjectGroupMoveTargets } from '../../../../shared/project-group-move-targets'
 import { buildWorktreeComparator } from './smart-sort'
 import {
   buildAttentionByWorktree,
@@ -4375,7 +4376,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                                 'New group from project'
                               )}
                             </DropdownMenuItem>
-                            {projectGroups.length > 0 ? (
+                            {getProjectGroupMoveTargets(row.repo, projectGroups).length > 0 ? (
                               <DropdownMenuSub>
                                 <DropdownMenuSubTrigger>
                                   <FolderInput className="size-3.5" />
@@ -4385,19 +4386,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                                   )}
                                 </DropdownMenuSubTrigger>
                                 <DropdownMenuSubContent>
-                                  {projectGroups.map((group) => (
-                                    <DropdownMenuItem
-                                      key={group.id}
-                                      disabled={row.repo?.projectGroupId === group.id}
-                                      onSelect={() => {
-                                        if (row.repo) {
-                                          handleMoveProjectToGroup(row.repo, group.id)
-                                        }
-                                      }}
-                                    >
-                                      <span className="max-w-48 truncate">{group.name}</span>
-                                    </DropdownMenuItem>
-                                  ))}
+                                  {getProjectGroupMoveTargets(row.repo, projectGroups).map(
+                                    (group) => (
+                                      <DropdownMenuItem
+                                        key={group.id}
+                                        disabled={row.repo?.projectGroupId === group.id}
+                                        onSelect={() => {
+                                          if (row.repo) {
+                                            handleMoveProjectToGroup(row.repo, group.id)
+                                          }
+                                        }}
+                                      >
+                                        <span className="max-w-48 truncate">{group.name}</span>
+                                      </DropdownMenuItem>
+                                    )
+                                  )}
                                 </DropdownMenuSubContent>
                               </DropdownMenuSub>
                             ) : null}

--- a/src/renderer/src/store/slices/repos-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups.test.ts
@@ -813,6 +813,23 @@ describe('project group store routing', () => {
     expect(store.getState().repos).toEqual([{ ...movedRepo, executionHostId: 'local' }])
   })
 
+  it('does not send local repo moves to groups owned by another host', async () => {
+    const runtimeGroup: ProjectGroup = {
+      ...projectGroup,
+      id: 'runtime-group',
+      executionHostId: 'runtime:env-1'
+    }
+    const store = createTestStore()
+    store.setState({ repos: [remoteRepo], projectGroups: [runtimeGroup] })
+
+    await expect(store.getState().moveProjectToGroup(remoteRepo.id, runtimeGroup.id)).resolves.toBe(
+      false
+    )
+
+    expect(projectGroupsMoveProject).not.toHaveBeenCalled()
+    expect(store.getState().repos).toEqual([remoteRepo])
+  })
+
   it('propagates specific folder workspace create failures to callers', async () => {
     folderWorkspacesCreate.mockRejectedValue(new Error('folder_workspace_path_missing:/srv/app'))
     const store = createTestStore()

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -44,6 +44,10 @@ import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { sanitizeRepoIcon } from '../../../../shared/repo-icon'
 import { normalizeRepoBadgeColor } from '../../../../shared/repo-badge-color'
 import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
+import {
+  canMoveProjectToGroup,
+  getProjectGroupExecutionHostId
+} from '../../../../shared/project-group-move-targets'
 import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
@@ -788,13 +792,6 @@ function mergeProjectCompatibilityForHostRepoChange({
   })
 }
 
-function getProjectGroupHostId(group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>) {
-  if (group.executionHostId) {
-    return group.executionHostId
-  }
-  return group.connectionId ? toSshExecutionHostId(group.connectionId) : LOCAL_EXECUTION_HOST_ID
-}
-
 function mergeFetchedProjectGroupsForHost(
   previous: readonly ProjectGroup[],
   fetched: ProjectGroup[],
@@ -802,7 +799,7 @@ function mergeFetchedProjectGroupsForHost(
 ): ProjectGroup[] {
   const fetchedIds = new Set(fetched.map((group) => group.id))
   const preserved = previous.filter((group) => {
-    const existingHostId = getProjectGroupHostId(group)
+    const existingHostId = getProjectGroupExecutionHostId(group)
     return existingHostId !== hostId || fetchedIds.has(group.id)
   })
   return mergeById(preserved, fetched)
@@ -821,7 +818,7 @@ function mergeFetchedFolderWorkspacesForHost({
 }): FolderWorkspace[] {
   const fetchedIds = new Set(fetched.map((workspace) => workspace.id))
   const projectGroupHostIds = new Map(
-    projectGroups.map((group) => [group.id, getProjectGroupHostId(group)])
+    projectGroups.map((group) => [group.id, getProjectGroupExecutionHostId(group)])
   )
   const preserved = previous.filter((workspace) => {
     const existingHostId = projectGroupHostIds.get(workspace.projectGroupId)
@@ -1916,7 +1913,18 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   moveProjectToGroup: async (projectId, groupId, order) => {
     try {
-      if (!findRepoForHost(get().repos, projectId, { settings: get().settings })) {
+      const repo = findRepoForHost(get().repos, projectId, { settings: get().settings })
+      if (!repo) {
+        return false
+      }
+      const group =
+        groupId === null
+          ? null
+          : get().projectGroups.find((projectGroup) => projectGroup.id === groupId)
+      if (groupId !== null && (!group || !canMoveProjectToGroup(repo, group))) {
+        // Why: project-group membership is persisted by the project's owning
+        // host. Sending a group from another host makes that backend drop the
+        // membership as unknown, which looks like a failed move.
         return false
       }
       const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))

--- a/src/shared/project-group-move-targets.test.ts
+++ b/src/shared/project-group-move-targets.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectGroup, Repo } from './types'
+import { canMoveProjectToGroup, getProjectGroupMoveTargets } from './project-group-move-targets'
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#111',
+    addedAt: 1,
+    ...overrides
+  }
+}
+
+function makeGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Group',
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('project group move targets', () => {
+  it('allows local projects to move into local groups', () => {
+    expect(canMoveProjectToGroup(makeRepo(), makeGroup())).toBe(true)
+  })
+
+  it('filters out groups from another execution host', () => {
+    const localGroup = makeGroup({ id: 'local-group' })
+    const remoteGroup = makeGroup({ id: 'remote-group', executionHostId: 'runtime:env-1' })
+
+    expect(getProjectGroupMoveTargets(makeRepo(), [localGroup, remoteGroup])).toEqual([localGroup])
+  })
+})

--- a/src/shared/project-group-move-targets.ts
+++ b/src/shared/project-group-move-targets.ts
@@ -1,0 +1,35 @@
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  toSshExecutionHostId
+} from './execution-host'
+import type { ProjectGroup, Repo } from './types'
+
+export function getProjectGroupExecutionHostId(
+  group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
+): string {
+  if (group.executionHostId) {
+    return group.executionHostId
+  }
+  return group.connectionId ? toSshExecutionHostId(group.connectionId) : LOCAL_EXECUTION_HOST_ID
+}
+
+export function canMoveProjectToGroup(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>,
+  group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
+): boolean {
+  return getRepoExecutionHostId(repo) === getProjectGroupExecutionHostId(group)
+}
+
+export function getProjectGroupMoveTargets<
+  TGroup extends Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
+>(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'> | null | undefined,
+  groups: readonly TGroup[]
+): TGroup[] {
+  if (!repo) {
+    return []
+  }
+  const repoHostId = getRepoExecutionHostId(repo)
+  return groups.filter((group) => getProjectGroupExecutionHostId(group) === repoHostId)
+}


### PR DESCRIPTION
## Summary

- Filter project-group move targets to groups owned by the same execution host as the project.
- Reject incompatible project/group moves in the repo store before they reach local or runtime persistence.
- Add current-group rename/delete actions to the workspace context menu so groups remain manageable when Group by is set to None.

## Root Cause

The sidebar listed every project group as a move target, but project-group membership is persisted by the project's owning host. When a group belonged to another local/SSH/runtime host, that backend did not recognize the group id and normalized the project back to ungrouped. Group edit/delete actions were also only attached to rendered project-group headers, which disappear outside Project grouping.

## Validation

- pnpm exec vitest run --config config/vitest.config.ts src/shared/project-group-move-targets.test.ts src/renderer/src/store/slices/repos-project-groups.test.ts
- pnpm run typecheck:web


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7023">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Moving a project into a group on another host could break persistence. Only same-host groups are offered, and rename/delete work even when Group by is None.
