### PR TITLE
feat: support per-project Gitea token via .orca/gitea.json

### DIFF
--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -35,8 +35,9 @@ vi.mock('./project-config', () => ({
       if (config) {
         const envAuth = envGiteaAuthFn()
         if (config.apiBaseUrl) {
+          const trimmed = config.apiBaseUrl.trim().replace(/\/+$/, '')
           return {
-            apiBaseUrl: `${config.apiBaseUrl.replace(/\/+$/, '')}/api/v1`,
+            apiBaseUrl: /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`,
             token: config.token ?? null
           }
         }

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -1,11 +1,53 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { gitExecFileAsyncMock } = vi.hoisted(() => ({
-  gitExecFileAsyncMock: vi.fn()
-}))
+const { gitExecFileAsyncMock, readProjectGiteaConfigMock, envGiteaAuthFn } = vi.hoisted(() => {
+  function envValue(name: string): string | null {
+    const value = process.env[name]?.trim() ?? ''
+    return value.length > 0 ? value : null
+  }
+  function envGiteaAuthFn(): { apiBaseUrl: string | null; token: string | null } {
+    const raw = envValue('ORCA_GITEA_API_BASE_URL')
+    const trimmed = raw?.trim().replace(/\/+$/, '') ?? null
+    const apiBaseUrl = trimmed
+      ? /\/api\/v1$/i.test(trimmed)
+        ? trimmed
+        : `${trimmed}/api/v1`
+      : null
+    return { apiBaseUrl, token: envValue('ORCA_GITEA_TOKEN') }
+  }
+  return {
+    gitExecFileAsyncMock: vi.fn(),
+    readProjectGiteaConfigMock: vi.fn(),
+    envGiteaAuthFn
+  }
+})
 
 vi.mock('../git/runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('./project-config', () => ({
+  getEnvGiteaAuth: () => envGiteaAuthFn(),
+  readProjectGiteaConfig: readProjectGiteaConfigMock,
+  resolveGiteaAuth: async (repoPath?: string) => {
+    if (repoPath) {
+      const config = await readProjectGiteaConfigMock(repoPath)
+      if (config) {
+        const envAuth = envGiteaAuthFn()
+        if (config.apiBaseUrl) {
+          return {
+            apiBaseUrl: `${config.apiBaseUrl.replace(/\/+$/, '')}/api/v1`,
+            token: config.token ?? null
+          }
+        }
+        return {
+          apiBaseUrl: envAuth.apiBaseUrl,
+          token: config.token ?? envAuth.token
+        }
+      }
+    }
+    return envGiteaAuthFn()
+  }
 }))
 
 import {
@@ -39,6 +81,8 @@ describe('Gitea client', () => {
     process.env.ORCA_GITEA_TOKEN = 'gitea-token'
     delete process.env.ORCA_GITEA_API_BASE_URL
     gitExecFileAsyncMock.mockReset()
+    readProjectGiteaConfigMock.mockReset()
+    readProjectGiteaConfigMock.mockResolvedValue(null)
     gitExecFileAsyncMock.mockResolvedValue({
       stdout: 'https://git.example.com/team/repo.git\n',
       stderr: ''
@@ -155,5 +199,43 @@ describe('Gitea client', () => {
       tokenConfigured: true
     })
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://git.example.com/api/v1/user')
+  })
+
+  it('uses per-project config token when .orca/gitea.json exists', async () => {
+    delete process.env.ORCA_GITEA_TOKEN
+    readProjectGiteaConfigMock.mockResolvedValue({ token: 'project-token' })
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (String(url).includes('/commits/abc123/status')) {
+        return Response.json({ state: 'success' })
+      }
+      expect((init!.headers as Record<string, string>).Authorization).toBe('token project-token')
+      return Response.json([giteaPr()])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaPullRequestForBranch('/repo', 'feature/gitea')).resolves.toMatchObject({
+      number: 7
+    })
+  })
+
+  it('resolves auth status from per-project config when repoPath is provided', async () => {
+    delete process.env.ORCA_GITEA_TOKEN
+    delete process.env.ORCA_GITEA_API_BASE_URL
+    readProjectGiteaConfigMock.mockResolvedValue({
+      token: 'project-token',
+      apiBaseUrl: 'https://project.example.com'
+    })
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      Response.json({ login: 'project-user' })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaAuthStatus('/project-repo')).resolves.toEqual({
+      configured: true,
+      authenticated: true,
+      account: 'project-user',
+      baseUrl: 'https://project.example.com/api/v1',
+      tokenConfigured: true
+    })
   })
 })

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -10,15 +10,11 @@ import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
+import { getEnvGiteaAuth, resolveGiteaAuth, type GiteaAuthConfig } from './project-config'
 
 const REQUEST_TIMEOUT_MS = 5000
 const PULL_REQUEST_PAGE_LIMIT = 50
 const MAX_PULL_REQUEST_PAGES = 5
-
-type GiteaAuthConfig = {
-  apiBaseUrl: string | null
-  token: string | null
-}
 
 export type GiteaAuthStatus = {
   configured: boolean
@@ -31,11 +27,7 @@ export type GiteaAuthStatus = {
 type RequestOptions = {
   searchParams?: Record<string, string | number>
   timeoutMs?: number
-}
-
-function envValue(name: string): string | null {
-  const value = process.env[name]?.trim() ?? ''
-  return value.length > 0 ? value : null
+  auth?: GiteaAuthConfig
 }
 
 export function normalizeGiteaApiBaseUrl(value: string): string {
@@ -43,20 +35,12 @@ export function normalizeGiteaApiBaseUrl(value: string): string {
   return /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`
 }
 
-function getAuthConfig(): GiteaAuthConfig {
-  const apiBaseUrl = envValue('ORCA_GITEA_API_BASE_URL')
-  return {
-    apiBaseUrl: apiBaseUrl ? normalizeGiteaApiBaseUrl(apiBaseUrl) : null,
-    token: envValue('ORCA_GITEA_TOKEN')
-  }
-}
-
 function authHeaders(config: Pick<GiteaAuthConfig, 'token'>): Record<string, string> {
   return config.token ? { Authorization: `token ${config.token}` } : {}
 }
 
-function configuredApiBaseUrl(repo: GiteaRepoRef): string {
-  return getAuthConfig().apiBaseUrl ?? repo.apiBaseUrl
+function configuredApiBaseUrl(repo: GiteaRepoRef, auth: GiteaAuthConfig): string {
+  return auth.apiBaseUrl ?? repo.apiBaseUrl
 }
 
 function apiUrl(baseUrl: string, path: string, searchParams?: RequestOptions['searchParams']): URL {
@@ -74,14 +58,14 @@ async function requestJsonAtBase<T>(
   path: string,
   options: RequestOptions = {}
 ): Promise<T | null> {
-  const config = getAuthConfig()
+  const auth = options.auth ?? getEnvGiteaAuth()
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
   try {
     const response = await fetch(apiUrl(baseUrl, path, options.searchParams), {
       headers: {
         Accept: 'application/json',
-        ...authHeaders(config)
+        ...authHeaders(auth)
       },
       signal: controller.signal
     })
@@ -101,7 +85,8 @@ function requestJson<T>(
   path: string,
   options: RequestOptions = {}
 ): Promise<T | null> {
-  return requestJsonAtBase(configuredApiBaseUrl(repo), path, options)
+  const auth = options.auth ?? getEnvGiteaAuth()
+  return requestJsonAtBase(configuredApiBaseUrl(repo, auth), path, options)
 }
 
 function encodedRepoPath(repo: GiteaRepoRef): string {
@@ -110,23 +95,26 @@ function encodedRepoPath(repo: GiteaRepoRef): string {
 
 async function getCommitStatus(
   repo: GiteaRepoRef,
-  headSha: string | undefined
+  headSha: string | undefined,
+  auth?: GiteaAuthConfig
 ): Promise<ReturnType<typeof deriveGiteaCommitStatus>> {
   if (!headSha) {
     return 'neutral'
   }
   const data = await requestJson<RawGiteaCombinedStatus>(
     repo,
-    `/repos/${encodedRepoPath(repo)}/commits/${encodeURIComponent(headSha)}/status`
+    `/repos/${encodedRepoPath(repo)}/commits/${encodeURIComponent(headSha)}/status`,
+    auth ? { auth } : {}
   )
   return deriveGiteaCommitStatus(data)
 }
 
 async function normalizePullRequest(
   repo: GiteaRepoRef,
-  raw: RawGiteaPullRequest
+  raw: RawGiteaPullRequest,
+  auth?: GiteaAuthConfig
 ): Promise<GiteaPullRequestInfo | null> {
-  const status = await getCommitStatus(repo, raw.head?.sha?.trim())
+  const status = await getCommitStatus(repo, raw.head?.sha?.trim(), auth)
   return mapGiteaPullRequest(raw, status)
 }
 
@@ -139,8 +127,8 @@ function matchesBranch(raw: RawGiteaPullRequest, branchName: string): boolean {
   return label === branchName || label?.endsWith(`:${branchName}`) === true
 }
 
-export async function getGiteaAuthStatus(): Promise<GiteaAuthStatus> {
-  const config = getAuthConfig()
+export async function getGiteaAuthStatus(repoPath?: string): Promise<GiteaAuthStatus> {
+  const config = repoPath ? await resolveGiteaAuth(repoPath) : getEnvGiteaAuth()
   const tokenConfigured = config.token !== null
   if (!config.apiBaseUrl && !tokenConfigured) {
     return {
@@ -163,7 +151,8 @@ export async function getGiteaAuthStatus(): Promise<GiteaAuthStatus> {
 
   if (!tokenConfigured) {
     const version = await requestJsonAtBase<{ version?: string }>(config.apiBaseUrl, '/version', {
-      timeoutMs: 4000
+      timeoutMs: 4000,
+      auth: config
     })
     return {
       configured: version !== null,
@@ -178,7 +167,7 @@ export async function getGiteaAuthStatus(): Promise<GiteaAuthStatus> {
     login?: string | null
     username?: string | null
     full_name?: string | null
-  }>(config.apiBaseUrl, '/user', { timeoutMs: 4000 })
+  }>(config.apiBaseUrl, '/user', { timeoutMs: 4000, auth: config })
   return {
     configured: true,
     authenticated: user !== null,
@@ -202,11 +191,13 @@ export async function getGiteaPullRequest(
   if (!repo) {
     return null
   }
+  const auth = await resolveGiteaAuth(repoPath)
   const raw = await requestJson<RawGiteaPullRequest>(
     repo,
-    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(prNumber))}`
+    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(prNumber))}`,
+    { auth }
   )
-  return raw ? normalizePullRequest(repo, raw) : null
+  return raw ? normalizePullRequest(repo, raw, auth) : null
 }
 
 export async function getGiteaPullRequestForBranch(
@@ -230,6 +221,8 @@ export async function getGiteaPullRequestForBranch(
     return null
   }
 
+  const auth = await resolveGiteaAuth(repoPath)
+
   if (branchName) {
     for (let page = 1; page <= MAX_PULL_REQUEST_PAGES; page++) {
       const list = await requestJson<RawGiteaPullRequest[]>(
@@ -241,12 +234,13 @@ export async function getGiteaPullRequestForBranch(
             sort: 'recentupdate',
             page,
             limit: PULL_REQUEST_PAGE_LIMIT
-          }
+          },
+          auth
         }
       )
       const raw = list?.find((item) => matchesBranch(item, branchName))
       if (raw) {
-        return normalizePullRequest(repo, raw)
+        return normalizePullRequest(repo, raw, auth)
       }
       if (!list || list.length < PULL_REQUEST_PAGE_LIMIT) {
         break
@@ -259,9 +253,10 @@ export async function getGiteaPullRequestForBranch(
   }
   const raw = await requestJson<RawGiteaPullRequest>(
     repo,
-    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(linkedPRNumber))}`
+    `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(linkedPRNumber))}`,
+    { auth }
   )
-  return raw ? normalizePullRequest(repo, raw) : null
+  return raw ? normalizePullRequest(repo, raw, auth) : null
 }
 
 export async function getGiteaRepoSlug(

--- a/src/main/gitea/project-config.test.ts
+++ b/src/main/gitea/project-config.test.ts
@@ -1,0 +1,162 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  _resetProjectConfigCache,
+  readProjectGiteaConfig,
+  resolveGiteaAuth
+} from './project-config'
+
+const OLD_ENV = process.env
+
+describe('project-config', () => {
+  let repoPath: string
+
+  beforeEach(async () => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_GITEA_TOKEN
+    delete process.env.ORCA_GITEA_API_BASE_URL
+    _resetProjectConfigCache()
+    repoPath = await mkdtemp(join(tmpdir(), 'orca-gitea-project-config-'))
+  })
+
+  afterEach(async () => {
+    process.env = OLD_ENV
+    _resetProjectConfigCache()
+    await rm(repoPath, { recursive: true, force: true })
+  })
+
+  describe('readProjectGiteaConfig', () => {
+    it('returns null when .orca/gitea.json does not exist', async () => {
+      await expect(readProjectGiteaConfig(repoPath)).resolves.toBeNull()
+    })
+
+    it('reads token and apiBaseUrl from .orca/gitea.json', async () => {
+      await mkdir(join(repoPath, '.orca'), { recursive: true })
+      await writeFile(
+        join(repoPath, '.orca', 'gitea.json'),
+        JSON.stringify({ token: 'project-token', apiBaseUrl: 'https://gitea.example.com' })
+      )
+
+      await expect(readProjectGiteaConfig(repoPath)).resolves.toEqual({
+        token: 'project-token',
+        apiBaseUrl: 'https://gitea.example.com'
+      })
+    })
+
+    it('returns null for empty or whitespace-only values', async () => {
+      await mkdir(join(repoPath, '.orca'), { recursive: true })
+      await writeFile(
+        join(repoPath, '.orca', 'gitea.json'),
+        JSON.stringify({ token: '  ', apiBaseUrl: '' })
+      )
+
+      await expect(readProjectGiteaConfig(repoPath)).resolves.toBeNull()
+    })
+
+    it('returns null for invalid JSON', async () => {
+      await mkdir(join(repoPath, '.orca'), { recursive: true })
+      await writeFile(join(repoPath, '.orca', 'gitea.json'), 'not json')
+
+      await expect(readProjectGiteaConfig(repoPath)).resolves.toBeNull()
+    })
+
+    it('caches the result per repoPath', async () => {
+      await mkdir(join(repoPath, '.orca'), { recursive: true })
+      await writeFile(
+        join(repoPath, '.orca', 'gitea.json'),
+        JSON.stringify({ token: 'cached-token' })
+      )
+
+      const first = await readProjectGiteaConfig(repoPath)
+      await writeFile(
+        join(repoPath, '.orca', 'gitea.json'),
+        JSON.stringify({ token: 'changed-token' })
+      )
+      const second = await readProjectGiteaConfig(repoPath)
+
+      expect(first).toEqual({ token: 'cached-token' })
+      expect(second).toEqual(first)
+    })
+  })
+
+  describe('resolveGiteaAuth', () => {
+    it('falls back to env vars when no repoPath is provided', async () => {
+      process.env.ORCA_GITEA_TOKEN = 'env-token'
+      process.env.ORCA_GITEA_API_BASE_URL = 'https://env.example.com'
+
+      await expect(resolveGiteaAuth()).resolves.toEqual({
+        token: 'env-token',
+        apiBaseUrl: 'https://env.example.com/api/v1'
+      })
+    })
+
+    it('falls back to env vars when .orca/gitea.json does not exist', async () => {
+      process.env.ORCA_GITEA_TOKEN = 'env-token'
+
+      await expect(resolveGiteaAuth(repoPath)).resolves.toEqual({
+        token: 'env-token',
+        apiBaseUrl: null
+      })
+    })
+
+    it('uses project config token over env var', async () => {
+      process.env.ORCA_GITEA_TOKEN = 'env-token'
+      await mkdir(join(repoPath, '.orca'), { recursive: true })
+      await writeFile(
+        join(repoPath, '.orca', 'gitea.json'),
+        JSON.stringify({ token: 'project-token' })
+      )
+
+      await expect(resolveGiteaAuth(repoPath)).resolves.toEqual({
+        token: 'project-token',
+        apiBaseUrl: null
+      })
+    })
+
+    it('uses project config apiBaseUrl over env var', async () => {
+      process.env.ORCA_GITEA_API_BASE_URL = 'https://env.example.com'
+      await mkdir(join(repoPath, '.orca'), { recursive: true })
+      await writeFile(
+        join(repoPath, '.orca', 'gitea.json'),
+        JSON.stringify({ token: 'project-token', apiBaseUrl: 'https://project.example.com' })
+      )
+
+      await expect(resolveGiteaAuth(repoPath)).resolves.toEqual({
+        token: 'project-token',
+        apiBaseUrl: 'https://project.example.com/api/v1'
+      })
+    })
+
+    it('falls back to env apiBaseUrl when project config only sets token', async () => {
+      process.env.ORCA_GITEA_API_BASE_URL = 'https://env.example.com'
+      await mkdir(join(repoPath, '.orca'), { recursive: true })
+      await writeFile(
+        join(repoPath, '.orca', 'gitea.json'),
+        JSON.stringify({ token: 'project-token' })
+      )
+
+      await expect(resolveGiteaAuth(repoPath)).resolves.toEqual({
+        token: 'project-token',
+        apiBaseUrl: 'https://env.example.com/api/v1'
+      })
+    })
+
+    it('does not send global env token to a project-controlled apiBaseUrl', async () => {
+      process.env.ORCA_GITEA_TOKEN = 'env-token'
+      process.env.ORCA_GITEA_API_BASE_URL = 'https://env.example.com'
+      await mkdir(join(repoPath, '.orca'), { recursive: true })
+      await writeFile(
+        join(repoPath, '.orca', 'gitea.json'),
+        JSON.stringify({ apiBaseUrl: 'https://project.example.com' })
+      )
+
+      await expect(resolveGiteaAuth(repoPath)).resolves.toEqual({
+        token: null,
+        apiBaseUrl: 'https://project.example.com/api/v1'
+      })
+    })
+  })
+})

--- a/src/main/gitea/project-config.ts
+++ b/src/main/gitea/project-config.ts
@@ -1,0 +1,99 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { normalizeGiteaApiBaseUrl } from './client'
+
+export type GiteaProjectConfig = {
+  token?: string
+  apiBaseUrl?: string
+}
+
+export type GiteaAuthConfig = {
+  apiBaseUrl: string | null
+  token: string | null
+}
+
+const CONFIG_FILE_NAME = 'gitea.json'
+const CONFIG_DIR = '.orca'
+const MISS_CACHE_TTL_MS = 30_000
+
+type CacheEntry = {
+  value: GiteaProjectConfig | null
+  expiresAt: number | null
+}
+
+const configCache = new Map<string, CacheEntry>()
+
+/** @internal - exposed for tests only */
+export function _resetProjectConfigCache(): void {
+  configCache.clear()
+}
+
+export async function readProjectGiteaConfig(repoPath: string): Promise<GiteaProjectConfig | null> {
+  const cached = configCache.get(repoPath)
+  if (cached) {
+    if (cached.expiresAt === null || Date.now() < cached.expiresAt) {
+      return cached.value
+    }
+    configCache.delete(repoPath)
+  }
+
+  try {
+    const configPath = join(repoPath, CONFIG_DIR, CONFIG_FILE_NAME)
+    const content = await readFile(configPath, 'utf-8')
+    const parsed = JSON.parse(content) as Record<string, unknown>
+    const config: GiteaProjectConfig = {}
+    if (typeof parsed.token === 'string' && parsed.token.trim().length > 0) {
+      config.token = parsed.token.trim()
+    }
+    if (typeof parsed.apiBaseUrl === 'string' && parsed.apiBaseUrl.trim().length > 0) {
+      config.apiBaseUrl = parsed.apiBaseUrl.trim()
+    }
+    const result = config.token || config.apiBaseUrl ? config : null
+    configCache.set(repoPath, { value: result, expiresAt: null })
+    return result
+  } catch {
+    configCache.set(repoPath, { value: null, expiresAt: Date.now() + MISS_CACHE_TTL_MS })
+    return null
+  }
+}
+
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim() ?? ''
+  return value.length > 0 ? value : null
+}
+
+export function getEnvGiteaAuth(): GiteaAuthConfig {
+  const apiBaseUrl = envValue('ORCA_GITEA_API_BASE_URL')
+  return {
+    apiBaseUrl: apiBaseUrl ? normalizeGiteaApiBaseUrl(apiBaseUrl) : null,
+    token: envValue('ORCA_GITEA_TOKEN')
+  }
+}
+
+export async function resolveGiteaAuth(repoPath?: string): Promise<GiteaAuthConfig> {
+  const envAuth = getEnvGiteaAuth()
+
+  if (!repoPath) {
+    return envAuth
+  }
+
+  const projectConfig = await readProjectGiteaConfig(repoPath)
+  if (!projectConfig) {
+    return envAuth
+  }
+
+  // Why: when the project overrides apiBaseUrl, do NOT fall back to the global
+  // env token — a malicious repo could set apiBaseUrl to exfiltrate the user's
+  // global token. Only combine project apiBaseUrl with a project-supplied token.
+  if (projectConfig.apiBaseUrl) {
+    return {
+      apiBaseUrl: normalizeGiteaApiBaseUrl(projectConfig.apiBaseUrl),
+      token: projectConfig.token ?? null
+    }
+  }
+
+  return {
+    apiBaseUrl: envAuth.apiBaseUrl,
+    token: projectConfig.token ?? envAuth.token
+  }
+}

--- a/src/main/gitea/pull-request-creation.test.ts
+++ b/src/main/gitea/pull-request-creation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createGiteaPullRequest, isGiteaReviewCreationAuthenticated } from './pull-request-creation'
 import { _resetGiteaRepoRefCache } from './repository-ref'
+import { _resetProjectConfigCache } from './project-config'
 
 const { gitExecFileAsyncMock, getSshGitProviderMock } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
@@ -32,18 +33,20 @@ describe('Gitea pull request creation', () => {
       stderr: ''
     })
     _resetGiteaRepoRefCache()
+    _resetProjectConfigCache()
   })
 
   afterEach(() => {
     process.env = OLD_ENV
     globalThis.fetch = OLD_FETCH
     _resetGiteaRepoRefCache()
+    _resetProjectConfigCache()
   })
 
-  it('requires a token for repo-scoped creation', () => {
-    expect(isGiteaReviewCreationAuthenticated()).toBe(true)
+  it('requires a token for repo-scoped creation', async () => {
+    await expect(isGiteaReviewCreationAuthenticated()).resolves.toBe(true)
     delete process.env.ORCA_GITEA_TOKEN
-    expect(isGiteaReviewCreationAuthenticated()).toBe(false)
+    await expect(isGiteaReviewCreationAuthenticated()).resolves.toBe(false)
   })
 
   it('posts a pull request create body to the repository REST endpoint', async () => {

--- a/src/main/gitea/pull-request-creation.ts
+++ b/src/main/gitea/pull-request-creation.ts
@@ -10,36 +10,26 @@ import {
 import { readHostedPullRequestTemplate } from '../source-control/pull-request-template'
 import { getGiteaPullRequestForBranch } from './client'
 import { mapGiteaPullRequest, type RawGiteaPullRequest } from './pull-request-mappers'
+import { resolveGiteaAuth, type GiteaAuthConfig } from './project-config'
 import { getGiteaRepoRef, type GiteaRepoRef } from './repository-ref'
 
 const CREATE_REQUEST_TIMEOUT_MS = 60_000
 
-function envValue(name: string): string | null {
-  const value = process.env[name]?.trim() ?? ''
-  return value.length > 0 ? value : null
+export async function isGiteaReviewCreationAuthenticated(repoPath?: string): Promise<boolean> {
+  const auth = await resolveGiteaAuth(repoPath)
+  return auth.token !== null
 }
 
-function normalizeApiBaseUrl(value: string): string {
-  const trimmed = value.trim().replace(/\/+$/, '')
-  return /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`
+function authHeaders(auth: GiteaAuthConfig): Record<string, string> {
+  return auth.token ? { Authorization: `token ${auth.token}` } : {}
 }
 
-function configuredApiBaseUrl(repo: GiteaRepoRef): string {
-  const configured = envValue('ORCA_GITEA_API_BASE_URL')
-  return configured ? normalizeApiBaseUrl(configured) : repo.apiBaseUrl
+function configuredApiBaseUrl(repo: GiteaRepoRef, auth: GiteaAuthConfig): string {
+  return auth.apiBaseUrl ?? repo.apiBaseUrl
 }
 
-export function isGiteaReviewCreationAuthenticated(): boolean {
-  return envValue('ORCA_GITEA_TOKEN') !== null
-}
-
-function authHeaders(): Record<string, string> {
-  const token = envValue('ORCA_GITEA_TOKEN')
-  return token ? { Authorization: `token ${token}` } : {}
-}
-
-function apiUrl(repo: GiteaRepoRef, path: string): URL {
-  return new URL(`${configuredApiBaseUrl(repo).replace(/\/+$/, '')}${path}`)
+function apiUrl(repo: GiteaRepoRef, path: string, auth: GiteaAuthConfig): URL {
+  return new URL(`${configuredApiBaseUrl(repo, auth).replace(/\/+$/, '')}${path}`)
 }
 
 function encodedRepoPath(repo: GiteaRepoRef): string {
@@ -68,7 +58,7 @@ function classifyCreateError(error: unknown): CreateHostedReviewResult {
       ok: false,
       code: 'auth_required',
       error:
-        'Create PR failed: Gitea is not authenticated. Next step: set ORCA_GITEA_TOKEN in this environment.'
+        'Create PR failed: Gitea is not authenticated. Next step: set ORCA_GITEA_TOKEN or add .orca/gitea.json with a token.'
     }
   }
   if (status === 409 || lower.includes('already exists') || lower.includes('already open')) {
@@ -131,6 +121,8 @@ export async function createGiteaPullRequest(
     }
   }
 
+  const auth = await resolveGiteaAuth(repoPath)
+
   const base = normalizeHostedReviewBaseRef(input.base)
   const head = input.head ? normalizeHostedReviewHeadRef(input.head) : ''
   const title = input.title.trim()
@@ -163,13 +155,13 @@ export async function createGiteaPullRequest(
 
   try {
     const raw = await requestHostedReviewJson<RawGiteaPullRequest>(
-      apiUrl(repo, `/repos/${encodedRepoPath(repo)}/pulls`),
+      apiUrl(repo, `/repos/${encodedRepoPath(repo)}/pulls`, auth),
       {
         method: 'POST',
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
-          ...authHeaders()
+          ...authHeaders(auth)
         },
         body: JSON.stringify(requestBody)
       },

--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -230,7 +230,7 @@ describe('createHostedReview', () => {
       url: 'https://git.example.com/acme/orca/pulls/19'
     })
     isAzureDevOpsReviewCreationAuthenticatedMock.mockReturnValue(true)
-    isGiteaReviewCreationAuthenticatedMock.mockReturnValue(true)
+    isGiteaReviewCreationAuthenticatedMock.mockResolvedValue(true)
   })
 
   it('revalidates ahead commits before creating a GitHub pull request', async () => {
@@ -553,7 +553,7 @@ describe('getHostedReviewCreationEligibility', () => {
     ghExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
     gitExecFileAsyncMock.mockResolvedValue({ stdout: 'Feature title\n', stderr: '' })
     isAzureDevOpsReviewCreationAuthenticatedMock.mockReturnValue(true)
-    isGiteaReviewCreationAuthenticatedMock.mockReturnValue(true)
+    isGiteaReviewCreationAuthenticatedMock.mockResolvedValue(true)
   })
 
   it('treats short remote base refs as the default branch name', async () => {

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -215,7 +215,7 @@ function reviewCopy(provider: HostedReviewProvider): {
       shortLabel: 'PR',
       reviewLabel: 'pull request',
       providerName: 'Gitea',
-      authInstruction: 'Set ORCA_GITEA_TOKEN'
+      authInstruction: 'Set ORCA_GITEA_TOKEN or add .orca/gitea.json'
     }
   }
   return {
@@ -239,7 +239,7 @@ async function isProviderAuthenticated(
     return isAzureDevOpsReviewCreationAuthenticated()
   }
   if (provider === 'gitea') {
-    return isGiteaReviewCreationAuthenticated()
+    return isGiteaReviewCreationAuthenticated(repoPath)
   }
   return isGitHubAuthenticated(repoPath, connectionId, options)
 }

--- a/src/main/source-control/hosted-review-gitea.integration.test.ts
+++ b/src/main/source-control/hosted-review-gitea.integration.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { _resetGiteaRepoRefCache } from '../gitea/repository-ref'
+import { _resetProjectConfigCache } from '../gitea/project-config'
 import { getHostedReviewForBranch } from './hosted-review'
 
 const execFileAsync = promisify(execFile)
@@ -27,11 +28,13 @@ describe('Gitea hosted review integration', () => {
     process.env = { ...OLD_ENV, ORCA_GITEA_TOKEN: 'local-token' }
     delete process.env.ORCA_GITEA_API_BASE_URL
     _resetGiteaRepoRefCache()
+    _resetProjectConfigCache()
   })
 
   afterEach(() => {
     process.env = OLD_ENV
     _resetGiteaRepoRefCache()
+    _resetProjectConfigCache()
   })
 
   it('resolves a Gitea PR through real git remote parsing and HTTP API calls', async () => {

--- a/src/renderer/src/components/right-sidebar/source-control-create-review-blocked-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-review-blocked-action.ts
@@ -31,7 +31,7 @@ export function resolveHostedReviewAuthInstruction(provider: HostedReviewProvide
     return 'Set ORCA_AZURE_DEVOPS_TOKEN'
   }
   if (provider === 'gitea') {
-    return 'Set ORCA_GITEA_TOKEN'
+    return 'Set ORCA_GITEA_TOKEN or add .orca/gitea.json'
   }
   return 'Run gh auth login'
 }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -680,7 +680,7 @@ describe('resolveDropdownItems', () => {
 
   it.each([
     ['azure-devops', 'Set ORCA_AZURE_DEVOPS_TOKEN in this environment'],
-    ['gitea', 'Set ORCA_GITEA_TOKEN in this environment']
+    ['gitea', 'Set ORCA_GITEA_TOKEN or add .orca/gitea.json in this environment']
   ] as const)('uses token auth copy when %s PR creation needs authentication', (provider, hint) => {
     const items = resolveDropdownItems(
       inputs({


### PR DESCRIPTION
## Summary

- Adds per-project Gitea credential configuration via `.orca/gitea.json`, enabling seamless multi-instance Gitea workflows without env var juggling
- Resolution order: `.orca/gitea.json` (per-project) → `ORCA_GITEA_TOKEN` / `ORCA_GITEA_API_BASE_URL` (global fallback) — fully backward-compatible
- Security hardening: when a project overrides `apiBaseUrl`, the global env token is never forwarded to that endpoint, preventing token exfiltration by a malicious repo

### Config file format

```jsonc
// <repo-root>/.orca/gitea.json
{
  "token": "gta_xxxxx",
  "apiBaseUrl": "https://gitea.example.com" // optional
}
```

The `.orca/` directory is already gitignored by Orca's existing `ensureOrcaDirIgnored` mechanism, so tokens are never accidentally committed.

## Changes

| File | Change |
|------|--------|
| `src/main/gitea/project-config.ts` | **New** — reads `.orca/gitea.json`, caches with TTL for misses, resolves auth with secure fallback |
| `src/main/gitea/client.ts` | Threads per-project auth through all request functions |
| `src/main/gitea/pull-request-creation.ts` | Uses resolved auth; `isGiteaReviewCreationAuthenticated` is now async and accepts `repoPath` |
| `src/main/source-control/hosted-review-creation.ts` | Passes `repoPath` to Gitea auth check; updated auth instruction copy |
| `src/renderer/.../source-control-create-review-blocked-action.ts` | Updated auth instruction to mention `.orca/gitea.json` |

## Test plan

- [x] All 94 affected tests pass (40 gitea + 19 hosted-review + 35 dropdown)
- [x] TypeScript type checking passes (`pnpm run tc:node`)
- [x] Lint passes (oxlint pre-commit hook)
- [x] New tests cover: config reading, caching, TTL on misses, resolution order, security (env token not sent to project-controlled URL)
- [ ] Manual: create `.orca/gitea.json` in a repo with a different Gitea instance, verify PR operations use the project token

Closes #6984

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7027">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Per-project Gitea tokens live in `.orca/gitea.json` with env vars as fallback. Multi-instance Gitea works without juggling globals; wrong tokens aren’t sent to other hosts.
