### PR TITLE
Harden divider resize cancellation

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-divider-drag.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider-drag.ts
@@ -158,7 +158,7 @@ export function attachDividerDrag(
     if (shouldRefit && nextEl) {
       callbacks.refitPanesUnder(nextEl)
     }
-    if (shouldRefit) {
+    if (commitLayout && shouldRefit) {
       releasePtyResizeHold?.flush()
     } else {
       releasePtyResizeHold?.cancel()
@@ -179,6 +179,21 @@ export function attachDividerDrag(
     e.preventDefault()
     flexScheduler.cancel()
     finishActiveDrag(false)
+    const previousPane = divider.previousElementSibling as HTMLElement | null
+    const nextPane = divider.nextElementSibling as HTMLElement | null
+    if (!previousPane || !nextPane) {
+      return
+    }
+
+    const prevRect = previousPane.getBoundingClientRect()
+    const nextRect = nextPane.getBoundingClientRect()
+    const prevSize = isVertical ? prevRect.width : prevRect.height
+    const nextSize = isVertical ? nextRect.width : nextRect.height
+    const measuredTotalSize = prevSize + nextSize
+    if (!Number.isFinite(measuredTotalSize) || measuredTotalSize <= 0) {
+      return
+    }
+
     divider.setPointerCapture(e.pointerId)
     activePointerId = e.pointerId
     divider.classList.add('is-dragging')
@@ -188,12 +203,8 @@ export function attachDividerDrag(
     addWindowListeners()
 
     startPos = isVertical ? e.clientX : e.clientY
-    prevEl = divider.previousElementSibling as HTMLElement | null
-    nextEl = divider.nextElementSibling as HTMLElement | null
-
-    if (!prevEl || !nextEl) {
-      return
-    }
+    prevEl = previousPane
+    nextEl = nextPane
     prevInitialFlex = prevEl.style.flex
     nextInitialFlex = nextEl.style.flex
 
@@ -201,11 +212,7 @@ export function attachDividerDrag(
     // we still fit xterm locally, but forward only the final PTY size on drop.
     releasePtyResizeHold = holdPtyResizesForPaneSubtrees([prevEl, nextEl])
 
-    const prevRect = prevEl.getBoundingClientRect()
-    const nextRect = nextEl.getBoundingClientRect()
-    const prevSize = isVertical ? prevRect.width : prevRect.height
-    const nextSize = isVertical ? nextRect.width : nextRect.height
-    totalSize = prevSize + nextSize
+    totalSize = measuredTotalSize
     prevFlex = prevSize
   }
 

--- a/src/renderer/src/lib/pane-manager/pane-divider.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createDivider, createDividerFlexFrameScheduler, disposeDivider } from './pane-divider'
+import { queuePanePtyResizeIfHeld } from './pane-pty-resize-hold'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -47,6 +48,94 @@ describe('createDividerFlexFrameScheduler', () => {
 })
 
 describe('disposeDivider', () => {
+  it('does not start divider drag state without resizeable pane siblings', () => {
+    const dividerListeners = new Map<string, EventListener>()
+    const onDragActiveChange = vi.fn()
+    const preventDefault = vi.fn()
+    const divider = {
+      style: {
+        setProperty: vi.fn()
+      },
+      classList: {
+        add: vi.fn(),
+        remove: vi.fn()
+      },
+      addEventListener: vi.fn((event: string, listener: EventListener) => {
+        dividerListeners.set(event, listener)
+      }),
+      removeEventListener: vi.fn(),
+      setPointerCapture: vi.fn(),
+      hasPointerCapture: vi.fn(() => false),
+      releasePointerCapture: vi.fn(),
+      previousElementSibling: null,
+      nextElementSibling: null
+    } as unknown as HTMLElement
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => divider)
+    })
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+    vi.stubGlobal('requestAnimationFrame', vi.fn())
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    createDivider(true, {}, { refitPanesUnder: vi.fn(), onDragActiveChange })
+    dividerListeners.get('pointerdown')?.(
+      createPointerEvent({ pointerId: 7, clientX: 10, preventDefault })
+    )
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(divider.setPointerCapture).not.toHaveBeenCalled()
+    expect(divider.classList.add).not.toHaveBeenCalled()
+    expect(onDragActiveChange).not.toHaveBeenCalled()
+    expect(window.addEventListener).not.toHaveBeenCalled()
+  })
+
+  it('does not start divider drag state when sibling panes have no measurable size', () => {
+    const dividerListeners = new Map<string, EventListener>()
+    const onDragActiveChange = vi.fn()
+    const previousPane = createSizedPaneElement({ width: 0, height: 200 })
+    const nextPane = createSizedPaneElement({ width: 0, height: 200 })
+    const divider = {
+      style: {
+        setProperty: vi.fn()
+      },
+      classList: {
+        add: vi.fn(),
+        remove: vi.fn()
+      },
+      addEventListener: vi.fn((event: string, listener: EventListener) => {
+        dividerListeners.set(event, listener)
+      }),
+      removeEventListener: vi.fn(),
+      setPointerCapture: vi.fn(),
+      hasPointerCapture: vi.fn(() => false),
+      releasePointerCapture: vi.fn(),
+      previousElementSibling: previousPane,
+      nextElementSibling: nextPane
+    } as unknown as HTMLElement
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => divider)
+    })
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+    vi.stubGlobal('requestAnimationFrame', vi.fn())
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    createDivider(true, {}, { refitPanesUnder: vi.fn(), onDragActiveChange })
+    dividerListeners.get('pointerdown')?.(createPointerEvent({ pointerId: 7, clientX: 10 }))
+
+    expect(divider.setPointerCapture).not.toHaveBeenCalled()
+    expect(divider.classList.add).not.toHaveBeenCalled()
+    expect(onDragActiveChange).not.toHaveBeenCalled()
+    expect(window.addEventListener).not.toHaveBeenCalled()
+    expect(previousPane.style.flex).toBeUndefined()
+    expect(nextPane.style.flex).toBeUndefined()
+  })
+
   it('finishes an active resize from a window-level pointerup', () => {
     const dividerListeners = new Map<string, EventListener>()
     const windowListeners = new Map<string, EventListener>()
@@ -251,8 +340,75 @@ describe('disposeDivider', () => {
     expect(onLayoutChanged).not.toHaveBeenCalled()
   })
 
+  it('drops held PTY resize updates when an active resize is cancelled', () => {
+    const dividerListeners = new Map<string, EventListener>()
+    const windowListeners = new Map<string, EventListener>()
+    const capturedPointerIds = new Set<number>()
+    const previousPane = createSizedPaneElement(
+      { width: 100, height: 200 },
+      { classNames: ['pane'] }
+    )
+    const nextPane = createSizedPaneElement({ width: 300, height: 200 }, { classNames: ['pane'] })
+    const divider = {
+      style: {
+        setProperty: vi.fn()
+      },
+      classList: {
+        add: vi.fn(),
+        remove: vi.fn()
+      },
+      addEventListener: vi.fn((event: string, listener: EventListener) => {
+        dividerListeners.set(event, listener)
+      }),
+      removeEventListener: vi.fn(),
+      setPointerCapture: vi.fn((pointerId: number) => {
+        capturedPointerIds.add(pointerId)
+      }),
+      hasPointerCapture: vi.fn((pointerId: number) => capturedPointerIds.has(pointerId)),
+      releasePointerCapture: vi.fn((pointerId: number) => {
+        capturedPointerIds.delete(pointerId)
+      }),
+      previousElementSibling: previousPane,
+      nextElementSibling: nextPane
+    } as unknown as HTMLElement
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => divider)
+    })
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn((event: string, listener: EventListener) => {
+        windowListeners.set(event, listener)
+      }),
+      removeEventListener: vi.fn()
+    })
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 7)
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    createDivider(true, {}, { refitPanesUnder: vi.fn(), onLayoutChanged: vi.fn() })
+    dividerListeners.get('pointerdown')?.(
+      createPointerEvent({ pointerId: 9, clientX: 100, clientY: 0 })
+    )
+
+    expect(queuePanePtyResizeIfHeld(previousPane, 140, 30)).toBe(true)
+    expect(queuePanePtyResizeIfHeld(nextPane, 80, 30)).toBe(true)
+
+    windowListeners.get('pointermove')?.(
+      createPointerEvent({ pointerId: 9, clientX: 180, clientY: 0 })
+    )
+    windowListeners.get('pointercancel')?.(createPointerEvent({ pointerId: 9 }))
+
+    expect(previousPane.dispatchEvent).not.toHaveBeenCalled()
+    expect(nextPane.dispatchEvent).not.toHaveBeenCalled()
+    expect(queuePanePtyResizeIfHeld(previousPane, 140, 30)).toBe(false)
+    expect(queuePanePtyResizeIfHeld(nextPane, 80, 30)).toBe(false)
+  })
+
   it('removes divider-local drag listeners and releases active pointer capture', () => {
     const listeners = new Map<string, EventListener>()
+    const previousPane = createSizedPaneElement({ width: 100, height: 200 })
+    const nextPane = createSizedPaneElement({ width: 300, height: 200 })
     const divider = {
       style: {
         setProperty: vi.fn()
@@ -272,8 +428,8 @@ describe('disposeDivider', () => {
       setPointerCapture: vi.fn(),
       hasPointerCapture: vi.fn(() => true),
       releasePointerCapture: vi.fn(),
-      previousElementSibling: null,
-      nextElementSibling: null
+      previousElementSibling: previousPane,
+      nextElementSibling: nextPane
     } as unknown as HTMLElement
     vi.stubGlobal('document', {
       createElement: vi.fn(() => divider)
@@ -311,15 +467,25 @@ function createPointerEvent(args: Partial<PointerEvent>): PointerEvent {
   } as unknown as PointerEvent
 }
 
-function createSizedPaneElement(rect: {
-  width: number
-  height: number
-}): HTMLElement & { style: Record<string, string> } {
+function createSizedPaneElement(
+  rect: {
+    width: number
+    height: number
+  },
+  options?: {
+    classNames?: string[]
+  }
+): HTMLElement & {
+  dispatchEvent: ReturnType<typeof vi.fn>
+  style: Record<string, string>
+} {
+  const classNames = new Set(options?.classNames ?? [])
   return {
     style: {},
     classList: {
-      contains: vi.fn(() => false)
+      contains: vi.fn((className: string) => classNames.has(className))
     },
+    dispatchEvent: vi.fn(() => true),
     getBoundingClientRect: vi.fn(() => ({
       left: 0,
       top: 0,
@@ -329,5 +495,8 @@ function createSizedPaneElement(rect: {
       height: rect.height
     })),
     querySelectorAll: vi.fn(() => [])
-  } as unknown as HTMLElement & { style: Record<string, string> }
+  } as unknown as HTMLElement & {
+    dispatchEvent: ReturnType<typeof vi.fn>
+    style: Record<string, string>
+  }
 }


### PR DESCRIPTION
## Summary
- avoid starting divider resize state when divider panes are missing or have no measurable size
- cancel held PTY resize updates on aborted divider drags instead of flushing stale sizes
- add regression coverage for invalid divider starts and PTY resize hold cancellation

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-divider.test.ts src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts src/renderer/src/lib/pane-manager/pane-tree-reparent-frame.test.ts src/renderer/src/lib/pane-manager/pane-pty-resize-hold.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "queues re-asserted resizes while pane resize holds are active"
- pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-divider-drag.ts src/renderer/src/lib/pane-manager/pane-divider.ts src/renderer/src/lib/pane-manager/pane-divider.test.ts src/renderer/src/lib/pane-manager/pane-drag-pointer.ts src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts src/renderer/src/lib/pane-manager/pane-tree-ops.ts src/renderer/src/lib/pane-manager/pane-tree-reparent-frame.test.ts
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->