### PR TITLE
fix: persist CLI install/remove errors inline in Settings

### DIFF
--- a/src/renderer/src/components/settings/CliRegistrationDialog.tsx
+++ b/src/renderer/src/components/settings/CliRegistrationDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { translate } from '@/i18n/i18n'
 
 type CliRegistrationDialogProps = {
+  actionError: string | null
   busyAction: 'install' | 'remove' | null
   commandName: string
   commandPath: string | null | undefined
@@ -22,6 +23,7 @@ type CliRegistrationDialogProps = {
 }
 
 export function CliRegistrationDialog({
+  actionError,
   busyAction,
   commandName,
   commandPath,
@@ -66,6 +68,11 @@ export function CliRegistrationDialog({
           <p className="text-xs text-muted-foreground">
             {translate('auto.components.settings.CliSection.a4aafe46e3', 'Target path:')}{' '}
             <code className="rounded bg-muted px-1 py-0.5 text-[11px]">{commandPath}</code>
+          </p>
+        ) : null}
+        {actionError ? (
+          <p role="alert" className="text-xs text-destructive">
+            {actionError}
           </p>
         ) : null}
         <DialogFooter>

--- a/src/renderer/src/components/settings/CliSection.install-error.test.tsx
+++ b/src/renderer/src/components/settings/CliSection.install-error.test.tsx
@@ -9,12 +9,29 @@ import { CliSection } from './CliSection'
 
 const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
+  toastMessage: vi.fn(),
   toastSuccess: vi.fn(),
-  dialog: { onInstall: null as null | (() => Promise<void>) }
+  toastWarning: vi.fn(),
+  ensurePrerequisite: vi.fn(),
+  dialog: { onInstall: null as null | (() => Promise<void>) },
+  panel: { onBeforeOpenTerminal: null as null | (() => Promise<void>) }
 }))
 
 vi.mock('sonner', () => ({
-  toast: { error: mocks.toastError, success: mocks.toastSuccess }
+  toast: {
+    error: mocks.toastError,
+    message: mocks.toastMessage,
+    success: mocks.toastSuccess,
+    warning: mocks.toastWarning
+  }
+}))
+
+vi.mock('@/lib/agent-skill-cli-prerequisite', () => ({
+  AGENT_SKILL_CLI_PREREQUISITE_NOTICE:
+    'Before opening setup, Orca may show a system prompt to register the Orca CLI command on PATH.',
+  ensureOrcaCliAvailableForAgentSkillTerminal: mocks.ensurePrerequisite,
+  isOrcaCliAvailableOnPath: (status: CliInstallStatus | null | undefined) =>
+    status?.state === 'installed' && status.pathConfigured
 }))
 
 vi.mock('@/hooks/useInstalledAgentSkills', () => ({
@@ -28,15 +45,26 @@ vi.mock('@/hooks/useInstalledAgentSkills', () => ({
 }))
 
 vi.mock('./AgentSkillSetupPanel', () => ({
-  AgentSkillSetupPanel: () => <div data-testid="agent-skill-setup-panel" />
+  AgentSkillSetupPanel: (props: { onBeforeOpenTerminal: () => Promise<void> }) => {
+    mocks.panel.onBeforeOpenTerminal = props.onBeforeOpenTerminal
+    return <div data-testid="agent-skill-setup-panel" />
+  }
 }))
 
 // Capture the dialog's install callback so the test can trigger the install
 // flow without driving the Radix dialog portal.
 vi.mock('./CliRegistrationDialog', () => ({
-  CliRegistrationDialog: (props: { onInstall: () => Promise<void> }) => {
+  CliRegistrationDialog: (props: {
+    actionError: string | null
+    onInstall: () => Promise<void>
+    open: boolean
+  }) => {
     mocks.dialog.onInstall = props.onInstall
-    return null
+    return props.open && props.actionError ? (
+      <p data-testid="registration-dialog-error" role="alert">
+        {props.actionError}
+      </p>
+    ) : null
   }
 }))
 
@@ -77,8 +105,12 @@ async function renderSection(): Promise<void> {
 describe('CliSection persistent install error', () => {
   beforeEach(() => {
     mocks.toastError.mockReset()
+    mocks.toastMessage.mockReset()
     mocks.toastSuccess.mockReset()
+    mocks.toastWarning.mockReset()
+    mocks.ensurePrerequisite.mockReset()
     mocks.dialog.onInstall = null
+    mocks.panel.onBeforeOpenTerminal = null
     getInstallStatus.mockReset()
     install.mockReset()
     getInstallStatus.mockResolvedValue(NOT_INSTALLED_STATUS)
@@ -102,7 +134,9 @@ describe('CliSection persistent install error', () => {
 
   it('persists a failed install reason inline and clears it on a successful refresh', async () => {
     install.mockRejectedValueOnce(
-      new Error('Directory /usr/local/bin does not exist on this system')
+      new Error(
+        "Error invoking remote method 'cli:install': Error: Directory /usr/local/bin does not exist on this system"
+      )
     )
     await renderSection()
 
@@ -129,6 +163,32 @@ describe('CliSection persistent install error', () => {
     await act(async () => {})
 
     expect(container?.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('keeps a persisted install error when refreshing status fails', async () => {
+    install.mockRejectedValueOnce(new Error('Failed to create /usr/local/bin'))
+    await renderSection()
+
+    await act(async () => {
+      await mocks.dialog.onInstall?.()
+    })
+    await act(async () => {})
+    expect(container?.querySelector('[role="alert"]')?.textContent).toBe(
+      'Failed to create /usr/local/bin'
+    )
+
+    getInstallStatus.mockRejectedValueOnce(new Error('Failed to load CLI status.'))
+    const refreshButton = Array.from(container?.querySelectorAll('button') ?? []).find(
+      (button) => button.getAttribute('aria-label') === 'Refresh CLI status'
+    )
+    await act(async () => {
+      refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {})
+
+    expect(container?.querySelector('[role="alert"]')?.textContent).toBe(
+      'Failed to create /usr/local/bin'
+    )
   })
 
   it('clears a persisted install error after a later install succeeds', async () => {
@@ -159,5 +219,54 @@ describe('CliSection persistent install error', () => {
 
     expect(container?.querySelector('[role="alert"]')).toBeNull()
     expect(mocks.toastSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a failed install reason visible while the registration dialog stays open', async () => {
+    install.mockRejectedValueOnce(new Error('Failed to create /usr/local/bin'))
+    await renderSection()
+
+    const cliSwitch = container?.querySelector<HTMLButtonElement>('button[role="switch"]')
+    expect(cliSwitch).toBeDefined()
+    await act(async () => {
+      cliSwitch?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {
+      await mocks.dialog.onInstall?.()
+    })
+    await act(async () => {})
+
+    expect(container?.querySelector('[data-testid="registration-dialog-error"]')?.textContent).toBe(
+      'Failed to create /usr/local/bin'
+    )
+  })
+
+  it('clears a persisted install error when agent skill setup registers the CLI', async () => {
+    install.mockRejectedValueOnce(new Error('Failed to create /usr/local/bin'))
+    mocks.ensurePrerequisite.mockImplementationOnce(
+      async ({ onStatusChange }: { onStatusChange?: (status: CliInstallStatus) => void }) => {
+        onStatusChange?.({
+          ...NOT_INSTALLED_STATUS,
+          state: 'installed',
+          pathConfigured: true,
+          detail: 'Registered /usr/local/bin/orca.'
+        })
+      }
+    )
+    await renderSection()
+
+    await act(async () => {
+      await mocks.dialog.onInstall?.()
+    })
+    await act(async () => {})
+    expect(container?.querySelector('[role="alert"]')?.textContent).toBe(
+      'Failed to create /usr/local/bin'
+    )
+
+    await act(async () => {
+      await mocks.panel.onBeforeOpenTerminal?.()
+    })
+    await act(async () => {})
+
+    expect(container?.querySelector('[role="alert"]')).toBeNull()
   })
 })

--- a/src/renderer/src/components/settings/CliSection.install-error.test.tsx
+++ b/src/renderer/src/components/settings/CliSection.install-error.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { CliSection } from './CliSection'
+
+const mocks = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  dialog: { onInstall: null as null | (() => Promise<void>) }
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess }
+}))
+
+vi.mock('@/hooks/useInstalledAgentSkills', () => ({
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS: ['global'],
+  useInstalledAgentSkill: () => ({
+    installed: false,
+    loading: false,
+    error: null,
+    refresh: vi.fn()
+  })
+}))
+
+vi.mock('./AgentSkillSetupPanel', () => ({
+  AgentSkillSetupPanel: () => <div data-testid="agent-skill-setup-panel" />
+}))
+
+// Capture the dialog's install callback so the test can trigger the install
+// flow without driving the Radix dialog portal.
+vi.mock('./CliRegistrationDialog', () => ({
+  CliRegistrationDialog: (props: { onInstall: () => Promise<void> }) => {
+    mocks.dialog.onInstall = props.onInstall
+    return null
+  }
+}))
+
+vi.mock('./WslCliRegistration', () => ({
+  WslCliRegistration: () => null
+}))
+
+const NOT_INSTALLED_STATUS: CliInstallStatus = {
+  platform: 'darwin',
+  commandName: 'orca',
+  commandPath: '/usr/local/bin/orca',
+  pathDirectory: '/usr/local/bin',
+  pathConfigured: false,
+  launcherPath: '/Applications/Orca.app/Contents/Resources/bin/orca',
+  installMethod: 'symlink',
+  supported: true,
+  state: 'not_installed',
+  currentTarget: null,
+  unsupportedReason: null,
+  detail: 'Register /usr/local/bin/orca to use Orca from the terminal.'
+}
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+const getInstallStatus = vi.fn()
+const install = vi.fn()
+
+async function renderSection(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<CliSection currentPlatform="darwin" settings={getDefaultSettings('/tmp')} />)
+  })
+  await act(async () => {})
+}
+
+describe('CliSection persistent install error', () => {
+  beforeEach(() => {
+    mocks.toastError.mockReset()
+    mocks.toastSuccess.mockReset()
+    mocks.dialog.onInstall = null
+    getInstallStatus.mockReset()
+    install.mockReset()
+    getInstallStatus.mockResolvedValue(NOT_INSTALLED_STATUS)
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        cli: { getInstallStatus, install, remove: vi.fn() },
+        shell: { openPath: vi.fn() }
+      }
+    })
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount()
+    })
+    container?.remove()
+    root = null
+    container = null
+  })
+
+  it('persists a failed install reason inline and clears it on a successful refresh', async () => {
+    install.mockRejectedValueOnce(
+      new Error('Directory /usr/local/bin does not exist on this system')
+    )
+    await renderSection()
+
+    await act(async () => {
+      await mocks.dialog.onInstall?.()
+    })
+    await act(async () => {})
+
+    const alert = container?.querySelector('[role="alert"]')
+    expect(alert?.textContent).toBe('Directory /usr/local/bin does not exist on this system')
+    expect(alert?.className).toContain('text-destructive')
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Directory /usr/local/bin does not exist on this system'
+    )
+
+    // Refreshing status clears the stale failure so it does not linger forever.
+    const refreshButton = Array.from(container?.querySelectorAll('button') ?? []).find(
+      (button) => button.getAttribute('aria-label') === 'Refresh CLI status'
+    )
+    expect(refreshButton).toBeDefined()
+    await act(async () => {
+      refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {})
+
+    expect(container?.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('clears a persisted install error after a later install succeeds', async () => {
+    install
+      .mockRejectedValueOnce(new Error('Failed to create /usr/local/bin'))
+      .mockResolvedValueOnce({
+        ...NOT_INSTALLED_STATUS,
+        state: 'installed',
+        pathConfigured: true,
+        detail: 'Registered /usr/local/bin/orca.'
+      })
+    await renderSection()
+
+    await act(async () => {
+      await mocks.dialog.onInstall?.()
+    })
+    await act(async () => {})
+    expect(container?.querySelector('[role="alert"]')?.textContent).toBe(
+      'Failed to create /usr/local/bin'
+    )
+
+    // A subsequent successful install must clear the stale failure, so the user
+    // can tell "install failed" apart from "now installed".
+    await act(async () => {
+      await mocks.dialog.onInstall?.()
+    })
+    await act(async () => {})
+
+    expect(container?.querySelector('[role="alert"]')).toBeNull()
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -8,6 +8,7 @@ import {
   ORCA_CLI_SKILL_NAME,
   ORCA_CLI_SKILL_UPDATE_COMMAND
 } from '@/lib/agent-feature-install-commands'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
   ensureOrcaCliAvailableForAgentSkillTerminal,
@@ -58,6 +59,7 @@ export function CliSection({
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
+  const [wslCliRefreshSignal, setWslCliRefreshSignal] = useState(0)
   // Why: toasts vanish, leaving an install failure indistinguishable from
   // "never attempted". Persist the last action error inline so the user can
   // still read and act on it (e.g. permission/missing-directory guidance).
@@ -106,6 +108,9 @@ export function CliSection({
     (nextStatus: CliInstallStatus): void => {
       if (mountedRef.current) {
         setStatus(nextStatus)
+        if (nextStatus.state === 'installed') {
+          setActionError(null)
+        }
       }
     },
     [mountedRef]
@@ -113,9 +118,11 @@ export function CliSection({
 
   const refreshStatus = useCallback(async (): Promise<void> => {
     setLoading(true)
-    setActionError(null)
     try {
       handleStatusChange(await window.api.cli.getInstallStatus())
+      if (mountedRef.current) {
+        setActionError(null)
+      }
     } catch (error) {
       if (mountedRef.current) {
         toast.error(
@@ -164,14 +171,14 @@ export function CliSection({
       }
     } catch (error) {
       if (mountedRef.current) {
-        const message =
-          error instanceof Error
-            ? error.message
-            : translate(
-                'auto.components.settings.CliSection.a2b13efa94',
-                'Failed to register `{{value0}}` in PATH.',
-                { value0: commandName }
-              )
+        const message = extractIpcErrorMessage(
+          error,
+          translate(
+            'auto.components.settings.CliSection.a2b13efa94',
+            'Failed to register `{{value0}}` in PATH.',
+            { value0: commandName }
+          )
+        )
         setActionError(message)
         toast.error(message)
       }
@@ -200,14 +207,14 @@ export function CliSection({
       }
     } catch (error) {
       if (mountedRef.current) {
-        const message =
-          error instanceof Error
-            ? error.message
-            : translate(
-                'auto.components.settings.CliSection.d77352f2df',
-                'Failed to remove `{{value0}}` from PATH.',
-                { value0: commandName }
-              )
+        const message = extractIpcErrorMessage(
+          error,
+          translate(
+            'auto.components.settings.CliSection.d77352f2df',
+            'Failed to remove `{{value0}}` from PATH.',
+            { value0: commandName }
+          )
+        )
         setActionError(message)
         toast.error(message)
       }
@@ -320,7 +327,7 @@ export function CliSection({
           <p className="text-xs text-muted-foreground">{status.detail}</p>
         ) : null}
 
-        {actionError ? (
+        {actionError && !dialogOpen ? (
           <p role="alert" className="text-xs text-destructive">
             {actionError}
           </p>
@@ -376,11 +383,16 @@ export function CliSection({
               getPrerequisiteStatus={getCliSkillPrerequisiteStatus}
               isPrerequisiteAvailable={isOrcaCliAvailableOnPath}
               onBeforeOpenTerminal={async () => {
-                await (agentRuntime.runtime === 'wsl'
-                  ? ensureWslCliAvailableForAgentSkillTerminal(agentRuntime)
-                  : ensureOrcaCliAvailableForAgentSkillTerminal({
-                      onStatusChange: handleStatusChange
-                    }))
+                if (agentRuntime.runtime === 'wsl') {
+                  const next = await ensureWslCliAvailableForAgentSkillTerminal(agentRuntime)
+                  if (next && isOrcaCliAvailableOnPath(next)) {
+                    setWslCliRefreshSignal((signal) => signal + 1)
+                  }
+                  return
+                }
+                await ensureOrcaCliAvailableForAgentSkillTerminal({
+                  onStatusChange: handleStatusChange
+                })
               }}
               onRecheck={refreshCliSkill}
             />
@@ -388,9 +400,10 @@ export function CliSection({
         ) : null}
       </div>
 
-      <WslCliRegistration currentPlatform={currentPlatform} />
+      <WslCliRegistration currentPlatform={currentPlatform} refreshSignal={wslCliRefreshSignal} />
 
       <CliRegistrationDialog
+        actionError={actionError}
         busyAction={busyAction}
         commandName={commandName}
         commandPath={status?.commandPath}

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -24,6 +24,11 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { CliRegistrationDialog } from './CliRegistrationDialog'
 import {
+  getFallbackCommandName,
+  getInstallDescription,
+  getRevealLabel
+} from './cli-section-platform-labels'
+import {
   buildSkillCommandForRuntime,
   ensureWslCliAvailableForAgentSkillTerminal,
   getAgentSkillTerminalShellOverride,
@@ -42,33 +47,6 @@ type CliSectionProps = {
   wslCapabilitiesLoading?: boolean
 }
 
-function getRevealLabel(platform: string): string {
-  if (platform === 'darwin') {
-    return 'Show in Finder'
-  }
-  if (platform === 'win32') {
-    return 'Show in Explorer'
-  }
-  return 'Show in File Manager'
-}
-
-function getInstallDescription(platform: string): string {
-  if (platform === 'darwin') {
-    return 'Register `orca` in /usr/local/bin.'
-  }
-  if (platform === 'linux') {
-    return 'Register `orca-ide` in ~/.local/bin.'
-  }
-  if (platform === 'win32') {
-    return 'Register `orca` in your user PATH.'
-  }
-  return 'CLI registration is not yet available on this platform.'
-}
-
-function getFallbackCommandName(platform: string): string {
-  return platform === 'linux' ? 'orca-ide' : 'orca'
-}
-
 export function CliSection({
   currentPlatform,
   settings,
@@ -80,6 +58,10 @@ export function CliSection({
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
+  // Why: toasts vanish, leaving an install failure indistinguishable from
+  // "never attempted". Persist the last action error inline so the user can
+  // still read and act on it (e.g. permission/missing-directory guidance).
+  const [actionError, setActionError] = useState<string | null>(null)
   const mountedRef = useMountedRef()
   const agentRuntime = useMemo(
     () =>
@@ -131,6 +113,7 @@ export function CliSection({
 
   const refreshStatus = useCallback(async (): Promise<void> => {
     setLoading(true)
+    setActionError(null)
     try {
       handleStatusChange(await window.api.cli.getInstallStatus())
     } catch (error) {
@@ -169,6 +152,7 @@ export function CliSection({
       const next = await window.api.cli.install()
       if (mountedRef.current) {
         setStatus(next)
+        setActionError(null)
         setDialogOpen(false)
         toast.success(
           translate(
@@ -180,7 +164,7 @@ export function CliSection({
       }
     } catch (error) {
       if (mountedRef.current) {
-        toast.error(
+        const message =
           error instanceof Error
             ? error.message
             : translate(
@@ -188,7 +172,8 @@ export function CliSection({
                 'Failed to register `{{value0}}` in PATH.',
                 { value0: commandName }
               )
-        )
+        setActionError(message)
+        toast.error(message)
       }
     } finally {
       if (mountedRef.current) {
@@ -203,6 +188,7 @@ export function CliSection({
       const next = await window.api.cli.remove()
       if (mountedRef.current) {
         setStatus(next)
+        setActionError(null)
         setDialogOpen(false)
         toast.success(
           translate(
@@ -214,7 +200,7 @@ export function CliSection({
       }
     } catch (error) {
       if (mountedRef.current) {
-        toast.error(
+        const message =
           error instanceof Error
             ? error.message
             : translate(
@@ -222,7 +208,8 @@ export function CliSection({
                 'Failed to remove `{{value0}}` from PATH.',
                 { value0: commandName }
               )
-        )
+        setActionError(message)
+        toast.error(message)
       }
     } finally {
       if (mountedRef.current) {
@@ -331,6 +318,12 @@ export function CliSection({
 
         {!loading && !isSupported && !isBrowserManaged && status?.detail ? (
           <p className="text-xs text-muted-foreground">{status.detail}</p>
+        ) : null}
+
+        {actionError ? (
+          <p role="alert" className="text-xs text-destructive">
+            {actionError}
+          </p>
         ) : null}
 
         <div className="flex items-center gap-2">

--- a/src/renderer/src/components/settings/WslCliRegistration.install-error.test.tsx
+++ b/src/renderer/src/components/settings/WslCliRegistration.install-error.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import { WslCliRegistration } from './WslCliRegistration'
+
+const mocks = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess
+  }
+}))
+
+vi.mock('@/lib/windows-terminal-capabilities', () => ({
+  useWindowsTerminalCapabilities: () => ({
+    gitBashAvailable: false,
+    hostPlatform: 'win32',
+    isLoading: false,
+    pwshAvailable: false,
+    wslAvailable: true,
+    wslDistros: ['Ubuntu']
+  })
+}))
+
+vi.mock('../ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>
+}))
+
+vi.mock('../ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+const NOT_INSTALLED_WSL_STATUS: CliInstallStatus = {
+  platform: 'linux',
+  commandName: 'orca-ide',
+  commandPath: '/home/user/.local/bin/orca-ide',
+  pathDirectory: '/home/user/.local/bin',
+  pathConfigured: false,
+  launcherPath: '/mnt/c/Users/user/AppData/Local/Programs/Orca/resources/bin/orca',
+  installMethod: 'symlink',
+  supported: true,
+  state: 'not_installed',
+  currentTarget: null,
+  unsupportedReason: null,
+  detail: 'Register orca-ide in WSL.'
+}
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+const getWslInstallStatus = vi.fn()
+const installWsl = vi.fn()
+const removeWsl = vi.fn()
+
+async function renderSection(refreshSignal = 0): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<WslCliRegistration currentPlatform="win32" refreshSignal={refreshSignal} />)
+  })
+  await act(async () => {})
+}
+
+async function rerenderSection(refreshSignal: number): Promise<void> {
+  await act(async () => {
+    root?.render(<WslCliRegistration currentPlatform="win32" refreshSignal={refreshSignal} />)
+  })
+  await act(async () => {})
+}
+
+describe('WslCliRegistration persistent install error', () => {
+  beforeEach(() => {
+    mocks.toastError.mockReset()
+    mocks.toastSuccess.mockReset()
+    getWslInstallStatus.mockReset()
+    installWsl.mockReset()
+    removeWsl.mockReset()
+    getWslInstallStatus.mockResolvedValue(NOT_INSTALLED_WSL_STATUS)
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        cli: {
+          getWslInstallStatus,
+          installWsl,
+          removeWsl
+        }
+      }
+    })
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount()
+    })
+    container?.remove()
+    root = null
+    container = null
+  })
+
+  it('persists a failed WSL install reason in the open dialog and inline after close', async () => {
+    installWsl.mockRejectedValueOnce(
+      new Error(
+        "Error invoking remote method 'cli:installWsl': Error: Failed to create /home/user/.local/bin"
+      )
+    )
+    await renderSection()
+
+    const cliSwitch = container?.querySelector<HTMLButtonElement>('button[role="switch"]')
+    expect(cliSwitch).toBeDefined()
+    await act(async () => {
+      cliSwitch?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const registerButton = Array.from(container?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent === 'Register'
+    )
+    expect(registerButton).toBeDefined()
+    await act(async () => {
+      registerButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {})
+
+    const alerts = Array.from(container?.querySelectorAll('[role="alert"]') ?? [])
+    expect(alerts.map((alert) => alert.textContent)).toEqual([
+      'Failed to create /home/user/.local/bin'
+    ])
+    expect(mocks.toastError).toHaveBeenCalledWith('Failed to create /home/user/.local/bin')
+
+    const cancelButton = Array.from(container?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent === 'Cancel'
+    )
+    await act(async () => {
+      cancelButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(
+      Array.from(container?.querySelectorAll('[role="alert"]') ?? []).map(
+        (alert) => alert.textContent
+      )
+    ).toEqual(['Failed to create /home/user/.local/bin'])
+  })
+
+  it('clears a persisted WSL install error after an external successful registration', async () => {
+    installWsl.mockRejectedValueOnce(new Error('Failed to create /home/user/.local/bin'))
+    await renderSection()
+
+    const cliSwitch = container?.querySelector<HTMLButtonElement>('button[role="switch"]')
+    await act(async () => {
+      cliSwitch?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const registerButton = Array.from(container?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent === 'Register'
+    )
+    await act(async () => {
+      registerButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {})
+
+    const cancelButton = Array.from(container?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent === 'Cancel'
+    )
+    await act(async () => {
+      cancelButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(container?.querySelector('[role="alert"]')?.textContent).toBe(
+      'Failed to create /home/user/.local/bin'
+    )
+
+    getWslInstallStatus.mockResolvedValueOnce({
+      ...NOT_INSTALLED_WSL_STATUS,
+      state: 'installed',
+      pathConfigured: true,
+      detail: 'Registered orca-ide in WSL.'
+    })
+    await rerenderSection(1)
+
+    expect(container?.querySelector('[role="alert"]')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/settings/WslCliRegistration.tsx
+++ b/src/renderer/src/components/settings/WslCliRegistration.tsx
@@ -31,6 +31,8 @@ export function WslCliRegistration({
   const [loading, setLoading] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
+  // Why: WSL registration can fail behind a transient toast too; keep the
+  // last action failure visible until the user refreshes or a later action works.
   const [actionError, setActionError] = useState<string | null>(null)
   const mountedRef = useMountedRef()
   const { wslAvailable } = useWindowsTerminalCapabilities(currentPlatform === 'win32')

--- a/src/renderer/src/components/settings/WslCliRegistration.tsx
+++ b/src/renderer/src/components/settings/WslCliRegistration.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { useWindowsTerminalCapabilities } from '@/lib/windows-terminal-capabilities'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { Button } from '../ui/button'
@@ -19,15 +20,18 @@ import { translate } from '@/i18n/i18n'
 
 type WslCliRegistrationProps = {
   currentPlatform: string
+  refreshSignal?: number
 }
 
 export function WslCliRegistration({
-  currentPlatform
+  currentPlatform,
+  refreshSignal = 0
 }: WslCliRegistrationProps): React.JSX.Element | null {
   const [status, setStatus] = useState<CliInstallStatus | null>(null)
   const [loading, setLoading] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
   const mountedRef = useMountedRef()
   const { wslAvailable } = useWindowsTerminalCapabilities(currentPlatform === 'win32')
   const showWslCli = currentPlatform === 'win32' && wslAvailable
@@ -38,6 +42,7 @@ export function WslCliRegistration({
       const next = await window.api.cli.getWslInstallStatus()
       if (mountedRef.current) {
         setStatus(next)
+        setActionError(null)
       }
     } catch (error) {
       if (mountedRef.current) {
@@ -61,7 +66,7 @@ export function WslCliRegistration({
     if (showWslCli) {
       void refreshStatus()
     }
-  }, [refreshStatus, showWslCli])
+  }, [refreshSignal, refreshStatus, showWslCli])
 
   if (!showWslCli) {
     return null
@@ -79,6 +84,7 @@ export function WslCliRegistration({
         return
       }
       setStatus(next)
+      setActionError(null)
       setDialogOpen(false)
       toast.success(
         translate(
@@ -89,15 +95,16 @@ export function WslCliRegistration({
       )
     } catch (error) {
       if (mountedRef.current) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : translate(
-                'auto.components.settings.WslCliRegistration.6f91ad1333',
-                'Failed to register `{{value0}}` in WSL.',
-                { value0: commandName }
-              )
+        const message = extractIpcErrorMessage(
+          error,
+          translate(
+            'auto.components.settings.WslCliRegistration.6f91ad1333',
+            'Failed to register `{{value0}}` in WSL.',
+            { value0: commandName }
+          )
         )
+        setActionError(message)
+        toast.error(message)
       }
     } finally {
       if (mountedRef.current) {
@@ -114,6 +121,7 @@ export function WslCliRegistration({
         return
       }
       setStatus(next)
+      setActionError(null)
       setDialogOpen(false)
       toast.success(
         translate(
@@ -124,15 +132,16 @@ export function WslCliRegistration({
       )
     } catch (error) {
       if (mountedRef.current) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : translate(
-                'auto.components.settings.WslCliRegistration.52d990420e',
-                'Failed to remove `{{value0}}` from WSL.',
-                { value0: commandName }
-              )
+        const message = extractIpcErrorMessage(
+          error,
+          translate(
+            'auto.components.settings.WslCliRegistration.52d990420e',
+            'Failed to remove `{{value0}}` from WSL.',
+            { value0: commandName }
+          )
         )
+        setActionError(message)
+        toast.error(message)
       }
     } finally {
       if (mountedRef.current) {
@@ -221,6 +230,12 @@ export function WslCliRegistration({
             <code>{status.currentTarget}</code>
           </p>
         ) : null}
+
+        {actionError && !dialogOpen ? (
+          <p role="alert" className="text-xs text-destructive">
+            {actionError}
+          </p>
+        ) : null}
       </div>
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
@@ -256,6 +271,11 @@ export function WslCliRegistration({
             <p className="text-xs text-muted-foreground">
               {translate('auto.components.settings.WslCliRegistration.119fef6cd2', 'Target path:')}{' '}
               <code className="rounded bg-muted px-1 py-0.5 text-[11px]">{status.commandPath}</code>
+            </p>
+          ) : null}
+          {actionError ? (
+            <p role="alert" className="text-xs text-destructive">
+              {actionError}
             </p>
           ) : null}
           <DialogFooter>

--- a/src/renderer/src/components/settings/cli-section-platform-labels.ts
+++ b/src/renderer/src/components/settings/cli-section-platform-labels.ts
@@ -1,7 +1,3 @@
-// Platform-specific copy for the CLI Settings section: reveal-in-file-manager
-// label, default install description, and the fallback command name shown
-// before install status resolves.
-
 export function getRevealLabel(platform: string): string {
   if (platform === 'darwin') {
     return 'Show in Finder'

--- a/src/renderer/src/components/settings/cli-section-platform-labels.ts
+++ b/src/renderer/src/components/settings/cli-section-platform-labels.ts
@@ -1,0 +1,30 @@
+// Platform-specific copy for the CLI Settings section: reveal-in-file-manager
+// label, default install description, and the fallback command name shown
+// before install status resolves.
+
+export function getRevealLabel(platform: string): string {
+  if (platform === 'darwin') {
+    return 'Show in Finder'
+  }
+  if (platform === 'win32') {
+    return 'Show in Explorer'
+  }
+  return 'Show in File Manager'
+}
+
+export function getInstallDescription(platform: string): string {
+  if (platform === 'darwin') {
+    return 'Register `orca` in /usr/local/bin.'
+  }
+  if (platform === 'linux') {
+    return 'Register `orca-ide` in ~/.local/bin.'
+  }
+  if (platform === 'win32') {
+    return 'Register `orca` in your user PATH.'
+  }
+  return 'CLI registration is not yet available on this platform.'
+}
+
+export function getFallbackCommandName(platform: string): string {
+  return platform === 'linux' ? 'orca-ide' : 'orca'
+}


### PR DESCRIPTION
## Summary

CLI install/removal failures in **Settings → CLI** were only surfaced via a transient toast. Once the toast vanished, a failed registration looked identical to "never attempted" — the user had no way to read, copy, or act on the reason (e.g. a missing directory or a permission error).

This persists the last install/remove error **inline** below the status, styled with the `text-destructive` token and `role="alert"`, per the STYLEGUIDE guidance to persist errors the user needs to retry, copy, or act on. The inline error clears on a successful install/remove and on a status refresh, so it never lingers stale.

## Changes

- `CliSection.tsx` — new `actionError` state; set on install/remove failure, cleared on success and refresh; rendered as an inline `role="alert"` paragraph.
- `cli-section-platform-labels.ts` (new) — extracted the three platform-copy helpers (`getRevealLabel`, `getInstallDescription`, `getFallbackCommandName`) so the file stays under the `max-lines` limit without a disable.
- `CliSection.install-error.test.tsx` (new) — covers persist-then-clear-on-refresh and clear-after-later-success.

## Testing

- Vitest: 3 tests green (`CliSection.install-error.test.tsx` + existing `CliSection.test.tsx`).
- Lint + typecheck + localization catalog: green.
- Manually validated in the real Electron app via a CLI conflict scenario: the persistent red error renders and survives dismissing the registration dialog.

## Note

The raw Electron IPC prefix (`Error invoking remote method 'cli:install': Error:`) can show through in the surfaced message. This is pre-existing behavior of the thrown error, not introduced here; happy to add a small sanitizer in a follow-up if desired.

Fixes #3952

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->