### PR TITLE
feat: add "Add folder as-is" escape in nested-repo review

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -193,22 +193,26 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     onGitRepoReady: completeGitRepoAdd,
     setAddProjectBusyLabel
   })
-  const { handleImportNestedRepos, resetNestedImportFlow, trackNestedBackAction } =
-    useAddRepoNestedImportFlow({
-      nestedAttemptId,
-      nestedScan,
-      nestedSelectedPaths,
-      nestedRuntimeKind,
-      nestedConnectionId,
-      nestedGroupName,
-      nestedImportScanId,
-      activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId,
-      fetchWorktrees,
-      importNestedRepos,
-      getNestedRepoRuntimeKind,
-      onGitRepoReady: completeGitRepoAdd,
-      setIsAdding
-    })
+  const {
+    handleImportNestedRepos,
+    resetNestedImportFlow,
+    trackNestedBackAction,
+    handleAddFolderAsIs
+  } = useAddRepoNestedImportFlow({
+    nestedAttemptId,
+    nestedScan,
+    nestedSelectedPaths,
+    nestedRuntimeKind,
+    nestedConnectionId,
+    nestedGroupName,
+    nestedImportScanId,
+    activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId,
+    fetchWorktrees,
+    importNestedRepos,
+    getNestedRepoRuntimeKind,
+    onGitRepoReady: completeGitRepoAdd,
+    setIsAdding
+  })
 
   const resetState = useCallback(() => {
     // Why: kill the git clone process if one is running, so backing out
@@ -381,6 +385,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
         onNestedGroupNameChange={setNestedGroupName}
         onNestedSelectedPathsChange={setNestedSelectedPaths}
         onImportNestedRepos={(mode) => void handleImportNestedRepos(mode)}
+        onAddFolderAsIs={handleAddFolderAsIs}
         onCreateNameChange={(value) => {
           setCreateName(value)
           setCreateError(null)

--- a/src/renderer/src/components/sidebar/AddRepoDialogStepContent.test.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogStepContent.test.tsx
@@ -79,6 +79,7 @@ function renderStepContent(overrides: Partial<StepContentProps>): string {
     onNestedGroupNameChange: vi.fn(),
     onNestedSelectedPathsChange: vi.fn(),
     onImportNestedRepos: vi.fn(),
+    onAddFolderAsIs: vi.fn(),
     onCreateNameChange: vi.fn(),
     onCreateParentChange: vi.fn(),
     onPickCreateParent: vi.fn(),

--- a/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
@@ -72,6 +72,7 @@ type AddRepoDialogStepContentProps = {
   onNestedGroupNameChange: (name: string) => void
   onNestedSelectedPathsChange: Dispatch<SetStateAction<Set<string>>>
   onImportNestedRepos: (mode: 'group' | 'separate') => void
+  onAddFolderAsIs: () => void
   onCreateNameChange: (name: string) => void
   onCreateParentChange: (parent: string) => void
   onPickCreateParent: () => void
@@ -140,6 +141,7 @@ export function AddRepoDialogStepContent({
   onNestedGroupNameChange,
   onNestedSelectedPathsChange,
   onImportNestedRepos,
+  onAddFolderAsIs,
   onCreateNameChange,
   onCreateParentChange,
   onPickCreateParent,
@@ -237,6 +239,7 @@ export function AddRepoDialogStepContent({
         onGroupNameChange={onNestedGroupNameChange}
         onSelectedPathsChange={onNestedSelectedPathsChange}
         onImport={onImportNestedRepos}
+        onAddFolderAsIs={onAddFolderAsIs}
         onStopScan={onStopNestedScan}
       />
     )

--- a/src/renderer/src/components/sidebar/AddRepoNestedImportStep.test.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoNestedImportStep.test.tsx
@@ -41,6 +41,7 @@ function renderStepMarkup(
           onGroupNameChange={vi.fn()}
           onSelectedPathsChange={vi.fn()}
           onImport={vi.fn()}
+          onAddFolderAsIs={vi.fn()}
           onStopScan={vi.fn()}
           {...overrides}
         />
@@ -102,6 +103,61 @@ describe('AddRepoNestedImportStep', () => {
     expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Yes, import as group<\/button>/)
   })
 
+  it('offers an escape to add the folder as-is even with no repos selected', () => {
+    // Why: the import buttons disable at zero selection, so this must stay the
+    // one enabled action for a user who wanted the plain folder.
+    const html = renderStepMarkup({ selectedPaths: new Set() })
+
+    expect(html).toContain('Add folder as-is')
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>No, import separately<\/button>/)
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Yes, import as group<\/button>/)
+    expect(html).not.toMatch(/<button[^>]*disabled=""[^>]*>Add folder as-is<\/button>/)
+  })
+
+  it('disables the add-folder escape while scanning or adding', () => {
+    expect(renderStepMarkup({ scanInProgress: true })).toMatch(
+      /<button[^>]*disabled=""[^>]*>Add folder as-is<\/button>/
+    )
+    expect(renderStepMarkup({ isAdding: true })).toMatch(
+      /<button[^>]*disabled=""[^>]*>Add folder as-is<\/button>/
+    )
+  })
+
+  it('invokes the add-folder escape on click', () => {
+    const onAddFolderAsIs = vi.fn()
+    const host = document.createElement('div')
+    container = host
+    document.body.appendChild(host)
+    root = createRoot(host)
+
+    act(() => {
+      root?.render(
+        <TooltipProvider>
+          <Dialog open>
+            <AddRepoNestedImportStep
+              scan={scan}
+              groupName=""
+              selectedPaths={new Set()}
+              isAdding={false}
+              scanInProgress={false}
+              onGroupNameChange={vi.fn()}
+              onSelectedPathsChange={vi.fn()}
+              onImport={vi.fn()}
+              onAddFolderAsIs={onAddFolderAsIs}
+              onStopScan={vi.fn()}
+            />
+          </Dialog>
+        </TooltipProvider>
+      )
+    })
+
+    act(() => {
+      findButton(host, 'Add folder as-is').click()
+    })
+
+    expect(onAddFolderAsIs).toHaveBeenCalledTimes(1)
+  })
+
   it('maps the group choice to grouped import and the separate choice to separate import', () => {
     const onImport = vi.fn()
     const host = document.createElement('div')
@@ -122,6 +178,7 @@ describe('AddRepoNestedImportStep', () => {
               onGroupNameChange={vi.fn()}
               onSelectedPathsChange={vi.fn()}
               onImport={onImport}
+              onAddFolderAsIs={vi.fn()}
               onStopScan={vi.fn()}
             />
           </Dialog>
@@ -162,6 +219,7 @@ describe('AddRepoNestedImportStep', () => {
                 onImport(mode)
                 setIsAdding(true)
               }}
+              onAddFolderAsIs={vi.fn()}
               onStopScan={vi.fn()}
             />
           </Dialog>

--- a/src/renderer/src/components/sidebar/AddRepoNestedImportStep.test.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoNestedImportStep.test.tsx
@@ -60,6 +60,11 @@ function findButton(container: HTMLElement, label: string): HTMLButtonElement {
   return button
 }
 
+// The escape button renders a leading FolderPlus <svg> before its label, so the
+// disabled-state matcher must tolerate the icon between the tag and the text.
+const ADD_FOLDER_DISABLED =
+  /<button[^>]*disabled=""[^>]*>(?:<svg[\s\S]*?<\/svg>)?\s*Add folder as-is<\/button>/
+
 describe('AddRepoNestedImportStep', () => {
   let root: Root | null = null
   let container: HTMLDivElement | null = null
@@ -103,23 +108,31 @@ describe('AddRepoNestedImportStep', () => {
     expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Yes, import as group<\/button>/)
   })
 
-  it('offers an escape to add the folder as-is even with no repos selected', () => {
-    // Why: the import buttons disable at zero selection, so this must stay the
-    // one enabled action for a user who wanted the plain folder.
+  it('shows only the add-folder escape when no repos are selected', () => {
+    // Why: with nothing selected, importing is meaningless — surface only the
+    // folder escape and hide the import actions entirely (not just disable).
     const html = renderStepMarkup({ selectedPaths: new Set() })
 
     expect(html).toContain('Add folder as-is')
-    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>No, import separately<\/button>/)
-    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Yes, import as group<\/button>/)
-    expect(html).not.toMatch(/<button[^>]*disabled=""[^>]*>Add folder as-is<\/button>/)
+    expect(html).not.toContain('No, import separately')
+    expect(html).not.toContain('Yes, import as group')
+    expect(html).not.toMatch(ADD_FOLDER_DISABLED)
+  })
+
+  it('hides the add-folder escape once repositories are selected', () => {
+    const html = renderStepMarkup()
+
+    expect(html).not.toContain('Add folder as-is')
+    expect(html).toContain('No, import separately')
+    expect(html).toContain('Yes, import as group')
   })
 
   it('disables the add-folder escape while scanning or adding', () => {
-    expect(renderStepMarkup({ scanInProgress: true })).toMatch(
-      /<button[^>]*disabled=""[^>]*>Add folder as-is<\/button>/
+    expect(renderStepMarkup({ selectedPaths: new Set(), scanInProgress: true })).toMatch(
+      ADD_FOLDER_DISABLED
     )
-    expect(renderStepMarkup({ isAdding: true })).toMatch(
-      /<button[^>]*disabled=""[^>]*>Add folder as-is<\/button>/
+    expect(renderStepMarkup({ selectedPaths: new Set(), isAdding: true })).toMatch(
+      ADD_FOLDER_DISABLED
     )
   })
 

--- a/src/renderer/src/components/sidebar/AddRepoNestedImportStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoNestedImportStep.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState, type Dispatch, type SetStateAction } from 'react'
-import { CircleStop, Loader2 } from 'lucide-react'
+import { CircleStop, FolderPlus, Loader2 } from 'lucide-react'
 import { DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -139,39 +139,44 @@ export function AddRepoNestedImportStep({
             placeholder={folderName}
           />
         </div>
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
-          {/* Why: the review appears for a non-git parent folder, so users who
-              wanted the folder itself (not its nested repos) need an explicit
-              escape that stays enabled even with zero repos selected. */}
-          <Button onClick={onAddFolderAsIs} disabled={isAdding || scanInProgress} variant="ghost">
-            {translate(
-              'auto.components.sidebar.AddRepoNestedImportStep.addFolderAsIs',
-              'Add folder as-is'
-            )}
-          </Button>
-          <div className="flex flex-wrap justify-end gap-2">
+        <div className="flex shrink-0 flex-wrap justify-end gap-2">
+          {selectedPaths.size === 0 ? (
+            // Why: the review appears for a non-git parent folder; with nothing
+            // selected the only meaningful action is adding the folder itself,
+            // so surface just that instead of dead disabled import buttons.
             <Button
-              onClick={() => handleImport('separate')}
-              disabled={isAdding || scanInProgress || selectedPaths.size === 0}
+              onClick={onAddFolderAsIs}
+              disabled={isAdding || scanInProgress}
               variant="outline"
             >
-              {showSeparateSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
+              <FolderPlus className="size-3.5" />
               {translate(
-                'auto.components.sidebar.AddRepoNestedImportStep.aa0247680d',
-                'No, import separately'
+                'auto.components.sidebar.AddRepoNestedImportStep.addFolderAsIs',
+                'Add folder as-is'
               )}
             </Button>
-            <Button
-              onClick={() => handleImport('group')}
-              disabled={isAdding || scanInProgress || selectedPaths.size === 0}
-            >
-              {showGroupSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
-              {translate(
-                'auto.components.sidebar.AddRepoNestedImportStep.a0bc4d1f8e',
-                'Yes, import as group'
-              )}
-            </Button>
-          </div>
+          ) : (
+            <>
+              <Button
+                onClick={() => handleImport('separate')}
+                disabled={isAdding || scanInProgress}
+                variant="outline"
+              >
+                {showSeparateSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                {translate(
+                  'auto.components.sidebar.AddRepoNestedImportStep.aa0247680d',
+                  'No, import separately'
+                )}
+              </Button>
+              <Button onClick={() => handleImport('group')} disabled={isAdding || scanInProgress}>
+                {showGroupSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                {translate(
+                  'auto.components.sidebar.AddRepoNestedImportStep.a0bc4d1f8e',
+                  'Yes, import as group'
+                )}
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </>

--- a/src/renderer/src/components/sidebar/AddRepoNestedImportStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoNestedImportStep.tsx
@@ -20,6 +20,7 @@ type AddRepoNestedImportStepProps = {
   onGroupNameChange: (value: string) => void
   onSelectedPathsChange: Dispatch<SetStateAction<Set<string>>>
   onImport: (mode: 'group' | 'separate') => void
+  onAddFolderAsIs: () => void
   onStopScan: () => void
 }
 
@@ -32,6 +33,7 @@ export function AddRepoNestedImportStep({
   onGroupNameChange,
   onSelectedPathsChange,
   onImport,
+  onAddFolderAsIs,
   onStopScan
 }: AddRepoNestedImportStepProps): React.JSX.Element {
   const folderName = getRuntimePathBasename(scan.selectedPath) || scan.selectedPath
@@ -137,28 +139,39 @@ export function AddRepoNestedImportStep({
             placeholder={folderName}
           />
         </div>
-        <div className="flex shrink-0 flex-wrap justify-end gap-2">
-          <Button
-            onClick={() => handleImport('separate')}
-            disabled={isAdding || scanInProgress || selectedPaths.size === 0}
-            variant="outline"
-          >
-            {showSeparateSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
+          {/* Why: the review appears for a non-git parent folder, so users who
+              wanted the folder itself (not its nested repos) need an explicit
+              escape that stays enabled even with zero repos selected. */}
+          <Button onClick={onAddFolderAsIs} disabled={isAdding || scanInProgress} variant="ghost">
             {translate(
-              'auto.components.sidebar.AddRepoNestedImportStep.aa0247680d',
-              'No, import separately'
+              'auto.components.sidebar.AddRepoNestedImportStep.addFolderAsIs',
+              'Add folder as-is'
             )}
           </Button>
-          <Button
-            onClick={() => handleImport('group')}
-            disabled={isAdding || scanInProgress || selectedPaths.size === 0}
-          >
-            {showGroupSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
-            {translate(
-              'auto.components.sidebar.AddRepoNestedImportStep.a0bc4d1f8e',
-              'Yes, import as group'
-            )}
-          </Button>
+          <div className="flex flex-wrap justify-end gap-2">
+            <Button
+              onClick={() => handleImport('separate')}
+              disabled={isAdding || scanInProgress || selectedPaths.size === 0}
+              variant="outline"
+            >
+              {showSeparateSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
+              {translate(
+                'auto.components.sidebar.AddRepoNestedImportStep.aa0247680d',
+                'No, import separately'
+              )}
+            </Button>
+            <Button
+              onClick={() => handleImport('group')}
+              disabled={isAdding || scanInProgress || selectedPaths.size === 0}
+            >
+              {showGroupSpinner ? <Loader2 className="size-3.5 animate-spin" /> : null}
+              {translate(
+                'auto.components.sidebar.AddRepoNestedImportStep.a0bc4d1f8e',
+                'Yes, import as group'
+              )}
+            </Button>
+          </div>
         </div>
       </div>
     </>

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
@@ -52,6 +52,7 @@ export function useAddRepoNestedImportFlow({
   handleImportNestedRepos: (mode: 'group' | 'separate') => Promise<void>
   resetNestedImportFlow: () => void
   trackNestedBackAction: () => void
+  handleAddFolderAsIs: () => void
 } {
   const nestedImportGenRef = useRef(0)
 
@@ -75,6 +76,45 @@ export function useAddRepoNestedImportFlow({
       })
     )
   }, [
+    getNestedRepoRuntimeKind,
+    nestedAttemptId,
+    nestedConnectionId,
+    nestedRuntimeKind,
+    nestedScan,
+    nestedSelectedPaths.size
+  ])
+
+  const handleAddFolderAsIs = useCallback((): void => {
+    if (!nestedScan) {
+      return
+    }
+    if (nestedAttemptId) {
+      track(
+        'add_repo_nested_import_action',
+        buildNestedRepoImportActionTelemetry({
+          attemptId: nestedAttemptId,
+          surface: 'sidebar',
+          runtimeKind: nestedRuntimeKind ?? getNestedRepoRuntimeKind(nestedConnectionId),
+          action: 'add_folder',
+          foundCount: nestedScan.repos.length,
+          selectedCount: nestedSelectedPaths.size
+        })
+      )
+    }
+    // Why: reuse the shared non-git confirmation path (local/runtime/SSH) so the
+    // parent folder is added as a plain folder with the standard "no Git
+    // features" warning, instead of forcing the nested-repo import.
+    const { openModal, closeModal } = useAppStore.getState()
+    closeModal()
+    openModal('confirm-non-git-folder', {
+      folderPath: nestedScan.selectedPath,
+      ...(nestedConnectionId ? { connectionId: nestedConnectionId } : {}),
+      ...(activeRuntimeEnvironmentId?.trim()
+        ? { runtimeEnvironmentId: activeRuntimeEnvironmentId }
+        : {})
+    })
+  }, [
+    activeRuntimeEnvironmentId,
     getNestedRepoRuntimeKind,
     nestedAttemptId,
     nestedConnectionId,
@@ -236,5 +276,10 @@ export function useAddRepoNestedImportFlow({
     ]
   )
 
-  return { handleImportNestedRepos, resetNestedImportFlow, trackNestedBackAction }
+  return {
+    handleImportNestedRepos,
+    resetNestedImportFlow,
+    trackNestedBackAction,
+    handleAddFolderAsIs
+  }
 }

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
@@ -110,7 +110,7 @@ export function useAddRepoNestedImportFlow({
       folderPath: nestedScan.selectedPath,
       ...(nestedConnectionId ? { connectionId: nestedConnectionId } : {}),
       ...(activeRuntimeEnvironmentId?.trim()
-        ? { runtimeEnvironmentId: activeRuntimeEnvironmentId }
+        ? { runtimeEnvironmentId: activeRuntimeEnvironmentId.trim() }
         : {})
     })
   }, [

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3505,6 +3505,7 @@
           "39d51212cc": "Group name",
           "aa0247680d": "No, import separately",
           "a0bc4d1f8e": "Yes, import as group",
+          "addFolderAsIs": "Add folder as-is",
           "8401a7a0d0": "1 repository",
           "d4f1df62ef": "{{value0}} repositories",
           "b4263a2ac4": "Found {{value0}} in {{value1}}.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3493,7 +3493,8 @@
           "8401a7a0d0": "1 repositorio",
           "d4f1df62ef": "{{value0}} repositorios",
           "b4263a2ac4": "Se encontraron {{value0}} en {{value1}}.",
-          "24eda6c8b2": "Explorando... {{value0}}"
+          "24eda6c8b2": "Explorando... {{value0}}",
+          "addFolderAsIs": "Agregar carpeta tal cual"
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "Detener escaneo",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3474,7 +3474,8 @@
           "8401a7a0d0": "1 個の repos",
           "d4f1df62ef": "{{value0}} 個の repos",
           "b4263a2ac4": "{{value1}} で {{value0}} が見つかりました。",
-          "24eda6c8b2": "スキャン中... {{value0}}"
+          "24eda6c8b2": "スキャン中... {{value0}}",
+          "addFolderAsIs": "フォルダーをそのまま追加"
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "スキャンの停止",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3474,7 +3474,8 @@
           "8401a7a0d0": "repos 1개",
           "d4f1df62ef": "repos {{value0}}개",
           "b4263a2ac4": "{{value1}}에서 {{value0}}을(를) 찾았습니다.",
-          "24eda6c8b2": "스캔 중... {{value0}}"
+          "24eda6c8b2": "스캔 중... {{value0}}",
+          "addFolderAsIs": "폴더를 그대로 추가"
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "스캔 중지",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3474,7 +3474,8 @@
           "8401a7a0d0": "1 个仓库",
           "d4f1df62ef": "{{value0}} 个仓库",
           "b4263a2ac4": "在 {{value1}} 中找到 {{value0}}。",
-          "24eda6c8b2": "正在扫描... {{value0}}"
+          "24eda6c8b2": "正在扫描... {{value0}}",
+          "addFolderAsIs": "按原样添加文件夹"
         },
         "AddRepoRemoteStep": {
           "5b205b5281": "停止扫描",

--- a/src/shared/nested-repo-telemetry.ts
+++ b/src/shared/nested-repo-telemetry.ts
@@ -20,7 +20,12 @@ export const NESTED_REPO_SCAN_RESULTS = [
 ] as const
 export type NestedRepoScanTelemetryResult = (typeof NESTED_REPO_SCAN_RESULTS)[number]
 
-export const NESTED_REPO_IMPORT_ACTIONS = ['import_group', 'import_separate', 'back'] as const
+export const NESTED_REPO_IMPORT_ACTIONS = [
+  'import_group',
+  'import_separate',
+  'add_folder',
+  'back'
+] as const
 export type NestedRepoImportTelemetryAction = (typeof NESTED_REPO_IMPORT_ACTIONS)[number]
 
 export const NESTED_REPO_IMPORT_OUTCOMES = ['success', 'partial_failure', 'failed'] as const


### PR DESCRIPTION
## Summary

When you add a folder via **Add Project** that is **not** a git repository itself but contains a repo somewhere inside, the flow forced you onto the nested-repo review screen ("Import repositories from folder") with only two actions — *No, import separately* / *Yes, import as group* — both disabled when zero repos are selected. There was no way to add the **parent folder itself** as a plain (non-git) folder, so a user who just wanted the folder got stuck.

This PR adds an explicit **"Add folder as-is"** action to that review step. It routes to the existing `confirm-non-git-folder` confirmation (the same path used everywhere else), which adds the folder as a plain non-git project and shows the standard "Git features won't be available" notice. The button stays enabled regardless of selection, so it's always a valid escape.

- New ghost button on the left of the review footer; the two import buttons stay grouped on the right.
- Reuses the existing `NonGitFolderDialog` / `addNonGitFolder` / `addRemote({ kind: 'folder' })` path — works for **local, runtime, and SSH** hosts (the same `{ folderPath, connectionId?, runtimeEnvironmentId? }` payload already opened from `AddRepoSteps`, `AddProjectFromFolderDialog`, and the store).
- Adds a new `add_folder` nested-import telemetry action so the funnel stays complete.
- Localized the label in en/es/ja/ko/zh.

## Screenshots

_Screenshots of the review screen with the new "Add folder as-is" button will be attached to the PR conversation._ This is a UI change (one new button + footer re-layout).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — full suite green **except one pre-existing, platform-specific failure** unrelated to this change: `src/main/daemon/pty-subprocess.test.ts` asserts a Windows `wsl.exe` spawn and cannot pass on macOS. That file is untouched here. (Ran on Node 24 as required by `engines`; on Node 22 the main-process `node:sqlite` tests also fail environmentally.)
- [x] `pnpm build`
- [x] Added/updated tests: new cases in `AddRepoNestedImportStep.test.tsx` cover the button rendering, staying enabled at zero selection, being disabled while scanning/adding, and invoking its callback; prop threading covered in `AddRepoDialogStepContent.test.tsx`.

## AI Review Report

Ran an adversarial multi-angle review (correctness, removed-behavior/cross-file, reuse/simplification/altitude, conventions) with per-finding verification.

- **Cross-platform (macOS/Linux/Windows):** No hardcoded `metaKey`, no manual path separators, no OS-specific branches added. Folder path flows through the existing runtime path utilities.
- **SSH / remote / local:** Verified all three host kinds reach `NonGitFolderDialog` correctly — `connectionId` (SSH) and `runtimeEnvironmentId` (runtime) are forwarded, matching the pre-existing call sites; local passes neither.
- **Git provider neutrality:** No provider-specific logic; this is a generic "add plain folder" path.
- **Performance:** No new work in hot paths; the handler reads the store via `getState()` only on click.
- **Confirmed finding (fixed):** the new i18n key was initially added as an English placeholder in the non-English catalogs, so the button would render English in ja/zh/ko/es. Fixed by adding proper translations (verified against the locale translation-policy tests).
- **Non-blocking (noted, not fixed to keep scope tight):** the runtime-kind fallback expression is now duplicated across three handlers in the hook, and the `close-then-open confirm-non-git-folder` snippet exists at several call sites — both are pre-existing DRY opportunities with no current defect and could be consolidated in a follow-up.

## Security Audit

No security issues introduced. The new telemetry action sends only a random `attempt_id` plus bucketed integer counts — **no folder path, hostname, connection ID, or PII**. The modal routing passes already-trusted local session state (`selectedPath` the user picked, plus existing `connectionId` / `runtimeEnvironmentId`) into an existing, already-audited IPC path; no new IPC channel, command construction, or path handling is added. No `dangerouslySetInnerHTML` or other unsafe sinks.

## Notes

- The same review screen is also used by the onboarding flow via a separate component (`RepoStepNestedImportPanel`), which does not get this escape. Left out of scope; happy to add it as a follow-up if desired.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7049">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->