### PR TITLE
Fix Resource Manager session polling lag

### DIFF
--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SOURCE_PATH = resolve(__dirname, 'ResourceUsageStatusSegment.tsx')
+
+describe('ResourceUsageStatusSegment session polling', () => {
+  it('does not poll global terminal sessions while the popover is closed', () => {
+    const source = readFileSync(SOURCE_PATH, 'utf8')
+
+    expect(source).not.toContain('installWindowVisibilityInterval')
+    expect(source).not.toContain('SESSIONS_POLL_MS')
+    expect(source.match(/window\.api\.pty\.listSessions\(\)/g) ?? []).toHaveLength(1)
+
+    const openEffectIndex = source.indexOf('if (!open || runtimeEnvironmentActive)')
+    const refreshIndex = source.indexOf('void refreshSessions()', openEffectIndex)
+
+    // Why: pty.listSessions() is a global daemon inventory and can pause input
+    // with large preserved-session sets. Keep it on explicit Resource Manager use.
+    expect(openEffectIndex).toBeGreaterThanOrEqual(0)
+    expect(refreshIndex).toBeGreaterThan(openEffectIndex)
+  })
+})

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -977,8 +977,8 @@ export function ResourceUsageStatusSegment({
     ]
   )
 
-  // Why: orphanCount drives the trigger badge (always visible in the status
-  // bar, popover open or not) so it must compute outside the open-gate.
+  // Why: orphan detection needs daemon inventory. Keep it open-only so the
+  // closed badge never reintroduces a background global session scan.
   const orphanCount = useMemo(() => {
     if (!open || !workspaceSessionReady || runtimeEnvironmentActive) {
       return 0
@@ -992,7 +992,11 @@ export function ResourceUsageStatusSegment({
     }
     return buildResourceSessionBindingIndex(resourceSessionBindings).boundPtyIds.size
   }, [resourceSessionBindings, workspaceSessionReady, runtimeEnvironmentActive])
-  const triggerSessionCount = open ? sessions.length : closedSessionCount
+  const triggerSessionCount = runtimeEnvironmentActive
+    ? 0
+    : open
+      ? sessions.length
+      : closedSessionCount
 
   const { totalMemory, totalCpu, hostShare, memBadgeLabel } = useMemo(() => {
     const memory = resourceSnapshot?.totalMemory ?? 0
@@ -1007,10 +1011,8 @@ export function ResourceUsageStatusSegment({
   }, [resourceSnapshot])
 
   // Why: memorySnapshotError is null both for "last fetch succeeded" and
-  // "never fetched". When the segment is mounted but the popover hasn't
-  // been opened, fetchMemorySnapshot has never run, so a sessions IPC
-  // failure on the always-on poll would otherwise be silent. Treat the
-  // absence of any snapshot plus a sessions error as unreachable too.
+  // "never fetched". If session refresh fails before a memory snapshot exists,
+  // treat that as daemon-unreachable too.
   const daemonUnreachable =
     !runtimeEnvironmentActive &&
     sessionsError &&

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -31,7 +31,6 @@ import { cn } from '@/lib/utils'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
-import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { useAppStore } from '../../store'
 import { useWorktreeMap } from '../../store/selectors'
 import { runWorktreeDelete } from '../sidebar/delete-worktree-flow'
@@ -76,7 +75,6 @@ import {
 import { translate } from '@/i18n/i18n'
 
 const POLL_MS = 2_000
-const SESSIONS_POLL_MS = 10_000
 
 type SortOption = 'memory' | 'cpu' | 'name'
 
@@ -877,19 +875,19 @@ export function ResourceUsageStatusSegment({
   }
   const spaceScanReady = nextSpaceScanSnapshot.ready
 
-  // Poll memory + sessions when popover is open. Sessions also poll in the
-  // background at a slower rate so the badge count stays reasonably fresh
-  // without keeping the Memory IPC hot.
+  // Poll memory when popover is open. Sessions are refreshed on open and after
+  // session actions; a closed status-bar badge must not globally inventory
+  // daemon PTYs because large preserved-session sets make that visible while
+  // typing.
   useEffect(() => {
     if (!open || runtimeEnvironmentActive) {
       return
     }
     void fetchSnapshot()
     void refreshSessions()
-    // Why: sessions already have an always-on poll in the effect below; only
-    // the memory snapshot is gated on the popover being open. Stacking a
-    // second sessions interval here doubled IPC traffic while the popover
-    // was open.
+    // Why: only the memory snapshot keeps an interval while the popover is
+    // open. Session inventory is explicit-on-open/action because it can be
+    // expensive with many daemon-preserved terminals.
     const memTimer = window.setInterval(() => {
       void fetchSnapshot()
     }, POLL_MS)
@@ -902,16 +900,8 @@ export function ResourceUsageStatusSegment({
     if (runtimeEnvironmentActive) {
       setSessions([])
       setSessionsError(false)
-      return
     }
-    // Why: the closed-popover badge is informational. Polling daemon sessions
-    // while the whole window is hidden keeps IPC and daemon list calls hot for
-    // no visible UI; visibility refreshes catch the badge up immediately.
-    return installWindowVisibilityInterval({
-      run: () => void refreshSessions(),
-      intervalMs: SESSIONS_POLL_MS
-    })
-  }, [runtimeEnvironmentActive, refreshSessions])
+  }, [runtimeEnvironmentActive])
 
   const repoDisplayNameById = useMemo(() => {
     const map = new Map<string, string>()
@@ -990,11 +980,19 @@ export function ResourceUsageStatusSegment({
   // Why: orphanCount drives the trigger badge (always visible in the status
   // bar, popover open or not) so it must compute outside the open-gate.
   const orphanCount = useMemo(() => {
-    if (!workspaceSessionReady || runtimeEnvironmentActive) {
+    if (!open || !workspaceSessionReady || runtimeEnvironmentActive) {
       return 0
     }
     return countUnboundDaemonSessions(sessions, resourceSessionBindings)
-  }, [sessions, resourceSessionBindings, workspaceSessionReady, runtimeEnvironmentActive])
+  }, [open, sessions, resourceSessionBindings, workspaceSessionReady, runtimeEnvironmentActive])
+
+  const closedSessionCount = useMemo(() => {
+    if (!workspaceSessionReady || runtimeEnvironmentActive) {
+      return 0
+    }
+    return buildResourceSessionBindingIndex(resourceSessionBindings).boundPtyIds.size
+  }, [resourceSessionBindings, workspaceSessionReady, runtimeEnvironmentActive])
+  const triggerSessionCount = open ? sessions.length : closedSessionCount
 
   const { totalMemory, totalCpu, hostShare, memBadgeLabel } = useMemo(() => {
     const memory = resourceSnapshot?.totalMemory ?? 0
@@ -1026,12 +1024,12 @@ export function ResourceUsageStatusSegment({
     !runtimeEnvironmentActive && sessionsError && memorySnapshotError === null
   const resourceManagerTooltipLines = getResourceManagerTooltipLines({
     memoryLabel: memBadgeLabel,
-    sessionCount: sessions.length,
+    sessionCount: triggerSessionCount,
     runtimeEnvironmentActive,
     spaceScanReady
   })
   const resourceManagerAriaLabel = getResourceManagerAriaLabel({
-    sessionCount: sessions.length,
+    sessionCount: triggerSessionCount,
     runtimeEnvironmentActive,
     spaceScanReady
   })
@@ -1132,8 +1130,8 @@ export function ResourceUsageStatusSegment({
     if (orphans.length === 0) {
       return
     }
-    // Why: optimistic removal so the rows disappear immediately rather than
-    // lingering up to SESSIONS_POLL_MS while the daemon-side list reconciles.
+    // Why: optimistic removal so rows disappear immediately instead of waiting
+    // for the next explicit daemon-side list refresh.
     const orphanIds = new Set(orphans.map((s) => s.id))
     setSessions((prev) => prev.filter((s) => !orphanIds.has(s.id)))
     await Promise.allSettled(orphans.map((s) => window.api.pty.kill(s.id)))
@@ -1148,7 +1146,7 @@ export function ResourceUsageStatusSegment({
     setKilling(true)
     // Why: optimistic removal — the kill X was on the row that's about to be
     // unmounted, so updating local state immediately avoids a flash where the
-    // dialog closes but the killed row stays for up to 10s.
+    // dialog closes but the killed row waits for the next list refresh.
     setSessions((prev) => prev.filter((s) => s.id !== target.sessionId))
     try {
       await window.api.pty.kill(target.sessionId)
@@ -1220,16 +1218,16 @@ export function ResourceUsageStatusSegment({
                   <span className="text-muted-foreground/50">·</span>
                   <Terminal className="size-3 text-muted-foreground" />
                   <span className="text-[11px] tabular-nums text-muted-foreground">
-                    {sessions.length}
+                    {triggerSessionCount}
                     {orphanCount > 0 && (
                       <span className="text-yellow-500 ml-0.5">({orphanCount})</span>
                     )}
                   </span>
                 </>
               )}
-              {iconOnly && sessions.length > 0 && (
+              {iconOnly && triggerSessionCount > 0 && (
                 <span className="text-[11px] tabular-nums text-muted-foreground">
-                  {sessions.length}
+                  {triggerSessionCount}
                 </span>
               )}
               {daemonUnreachable && (


### PR DESCRIPTION
## Summary
- Stop Resource Manager from polling global daemon terminal sessions every 10s while the popover is closed.
- Keep session inventory refreshes on explicit Resource Manager use: open, kill, restart, and kill-orphan actions.
- Use renderer-owned PTY bindings for the closed status-bar terminal count so typing does not pay for daemon-wide inventory.

## Measurement
- On Jinwoo's main Orca profile, daemon-v18 owned ~146 sessions.
- Passive monitor showed ~10s-periodic daemon ping stalls while typing, with spikes around 516-1039ms.
- The timing matched the closed Resource Manager session poll interval.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts src/renderer/src/components/status-bar/resource-session-bindings.test.ts`
- `pnpm exec oxlint src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.json`
- Temporary E2E probe confirmed `window.api.pty.listSessions()` stayed at 0 calls for 12.5s while Resource Manager was closed.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->