### PR TITLE
Show collapse affordance on status sidebar headers

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -10,6 +10,7 @@ import type {
   WorktreeLineage
 } from '../../../../shared/types'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import { cloneDefaultWorkspaceStatuses } from '../../../../shared/workspace-statuses'
 
 const mockStore = vi.hoisted(() => ({
   state: {} as Record<string, unknown>
@@ -508,7 +509,7 @@ function setPinnedDuplicateFixtureState(): void {
 }
 
 function setLineageFixtureState(
-  groupBy: 'none' | 'repo' = 'none',
+  groupBy: 'none' | 'repo' | 'workspace-status' = 'none',
   options: {
     childWorktreeOverrides?: Partial<Worktree>
     deletingWorktreeIds?: string[]
@@ -631,7 +632,7 @@ function setLineageFixtureState(
     // Why: multi-host added a host scope filter; 'all' (the store default)
     // bypasses it so the fixture's worktrees aren't dropped before rendering.
     workspaceHostScope: 'all',
-    workspaceStatuses: [],
+    workspaceStatuses: groupBy === 'workspace-status' ? cloneDefaultWorkspaceStatuses() : [],
     worktreeCardProperties: ['status', 'inline-agents'],
     worktreeLineageById: {
       [child.id]: makeLineage(child, parent),
@@ -882,6 +883,16 @@ describe('WorktreeList lineage child card renderer', () => {
     const markup = await renderWorktreeListMarkup()
 
     expect(markup).not.toContain('data-repo-header-collapse-affordance=""')
+  })
+
+  it('renders a collapse chevron on status group headers with worktrees', async () => {
+    setLineageFixtureState('workspace-status')
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('In progress')
+    expect(markup).toContain('data-workspace-status-drop-target=""')
+    expect(markup).toContain('data-repo-header-collapse-affordance=""')
+    expect(markup).toContain('aria-expanded="true"')
   })
 
   it('renders a collapse chevron on grouped repo headers with worktrees', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -3997,10 +3997,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   projectGroupPathStatus.reason === 'ambiguous-connection')
               const projectGroupDepth = row.projectGroupDepth ?? 0
               const isHeaderCollapsed = collapsedGroups.has(row.key)
-              // Why: repo/project headers already reveal actions on hover; tuck
-              // the collapse chevron into that cluster instead of a new surface.
+              // Why: repo/project and status headers use the same compact
+              // section chrome; flat "All" stays a simple label.
               const showHeaderCollapseAffordance =
-                row.count > 0 && (isRepoHeader || isProjectGroupHeader)
+                row.count > 0 &&
+                (isRepoHeader || isProjectGroupHeader || headerWorkspaceStatus !== null)
               // Why: non-project section headers like "All" are labels for the
               // flat list, so they should not reserve project hierarchy indent.
               const headerPaddingLeft =


### PR DESCRIPTION
## Summary

Status-grouped workspace sections now get the same compact collapsible header affordance as repo/project grouping. The root cause was render-layer gating: `buildRows` already emitted status groups as headers, but `WorktreeList` only showed the collapse chevron for repo/project headers.

## Screenshots

Status grouping with `Todo` expanded and the status header hover affordance visible:

![Status grouping expanded header](https://gist.githubusercontent.com/nwparker/bc462a2102507dab5a04cbce4f955eef/raw/4d0d5ccef7737b5a23de80e16efb9fcf67115951/status-header-expanded-hover-sidebar.svg)

After collapsing `Todo`, with `In progress` promoted below it:

![Status grouping collapsed header](https://gist.githubusercontent.com/nwparker/bc462a2102507dab5a04cbce4f955eef/raw/dc0668ffd18aab7f9a2f5f759d8b0c5f9d224f71/status-header-collapsed-sidebar.svg)

## Testing

- [ ] `pnpm lint` (not run fully)
- [ ] `pnpm typecheck` (not run fully)
- [ ] `pnpm test` (not run fully)
- [ ] `pnpm build` (not run)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Ran:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts -t "status group headers"` (failed before fix, passed after)
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts`
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts`
- `pnpm run typecheck:web`
- pre-commit hooks: `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --write`
- Electron verification on dev instance `Orca: nwparker/sections-headers`: status headers had `aria-expanded` and `data-repo-header-collapse-affordance`; screenshots above captured expanded/hovered and collapsed states.

## AI Review Report

Checked the row-builder/render split and confirmed the grouping model was already correct: status grouping emitted `header` rows with the right status label, icon, tone, and count. The regression was in `WorktreeList` render gating, where only repo/project headers opted into the compact collapse affordance. The fix broadens that specific affordance to workspace-status headers and leaves repo-only menus, project actions, drag handling, and flat `All` headers unchanged.

Cross-platform review: this change does not touch keyboard shortcut handling, labels, filesystem paths, shell behavior, IPC contracts, provider-specific git logic, or Electron main/preload platform branches. It is renderer-only markup/class gating and should behave the same on macOS, Linux, Windows, local, and SSH-backed workspaces.

## Security Audit

No new input handling, command execution, auth, secrets, dependency, path, network, IPC, or provider-specific behavior. The new test fixture uses default workspace status definitions only. Evidence screenshots are hosted outside the repo and are not committed.

## Notes

Gemini image review was attempted but unavailable: headless Gemini required `GEMINI_API_KEY`, and the local Orca CLI route was not built in this worktree (`out/cli/index.js` missing). Visual verification was performed directly through Playwright screenshots plus DOM checks.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7051">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->