### PR TITLE
Fix delayed TUI mouse wheel reports

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -62,7 +62,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalLineHeight: 1,
     terminalScrollSensitivity: 1.15,
     terminalFastScrollSensitivity: 5,
-    terminalTuiScrollSensitivity: 3,
+    terminalTuiScrollSensitivity: 1,
     terminalGpuAcceleration: 'auto',
     terminalLigatures: 'auto',
     terminalCursorStyle: 'block',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -66,7 +66,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalLineHeight: 1,
     terminalScrollSensitivity: 1.15,
     terminalFastScrollSensitivity: 5,
-    terminalTuiScrollSensitivity: 3,
+    terminalTuiScrollSensitivity: 1,
     terminalGpuAcceleration: 'auto',
     terminalLigatures: 'auto',
     terminalCursorStyle: 'block',

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -492,7 +492,8 @@ describe('Store', () => {
     expect(settings.terminalFontWeight).toBe(500)
     expect(settings.terminalScrollSensitivity).toBe(1.15)
     expect(settings.terminalFastScrollSensitivity).toBe(5)
-    expect(settings.terminalTuiScrollSensitivity).toBe(3)
+    expect(settings.terminalTuiScrollSensitivity).toBe(1)
+    expect(settings.terminalTuiScrollSensitivityDefaultedToOne).toBe(true)
     expect(settings.terminalUseSeparateLightTheme).toBe(true)
     expect(settings.rightSidebarOpenByDefault).toBe(true)
     expect(settings.showTasksButton).toBe(true)
@@ -1936,6 +1937,57 @@ describe('Store', () => {
     const updated = store.updateSettings({ autoRenameBranchFromWorkDefaultedOn: false })
 
     expect(updated.autoRenameBranchFromWorkDefaultedOn).toBe(true)
+  })
+
+  it('migrates inherited TUI scroll sensitivity defaults to one report on first load', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalTuiScrollSensitivity: 3 },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().terminalTuiScrollSensitivity).toBe(1)
+    expect(store.getSettings().terminalTuiScrollSensitivityDefaultedToOne).toBe(true)
+    store.flush()
+    expect((readDataFile() as PersistedState).settings.terminalTuiScrollSensitivity).toBe(1)
+  })
+
+  it('preserves TUI scroll sensitivity choices after the one-report migration', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        terminalTuiScrollSensitivity: 3,
+        terminalTuiScrollSensitivityDefaultedToOne: true
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().terminalTuiScrollSensitivity).toBe(3)
+    expect(store.getSettings().terminalTuiScrollSensitivityDefaultedToOne).toBe(true)
+  })
+
+  it('stamps the TUI scroll sensitivity migration guard on future updates', async () => {
+    const store = await createStore()
+
+    const updated = store.updateSettings({
+      terminalTuiScrollSensitivity: 3,
+      terminalTuiScrollSensitivityDefaultedToOne: false
+    })
+
+    expect(updated.terminalTuiScrollSensitivity).toBe(3)
+    expect(updated.terminalTuiScrollSensitivityDefaultedToOne).toBe(true)
   })
 
   it('merges rollback commit-message AI writes into existing source-control AI on load', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -474,6 +474,8 @@ type LegacyTerminalScrollbackSettings = {
   terminalScrollbackBytes?: unknown
 }
 
+const LEGACY_TERMINAL_TUI_SCROLL_SENSITIVITY_DEFAULT = 3
+
 function readLegacyTerminalScrollbackSettings(settings: unknown): LegacyTerminalScrollbackSettings {
   return settings && typeof settings === 'object'
     ? (settings as LegacyTerminalScrollbackSettings)
@@ -506,6 +508,29 @@ function migrateTerminalScrollbackRows(settings: unknown): {
   return {
     rows,
     needsSave: !hasRows || hasLegacyBytes || legacySettings.terminalScrollbackRows !== rows
+  }
+}
+
+function migrateTerminalTuiScrollSensitivityDefault(settings: GlobalSettings | undefined): {
+  settings: Pick<
+    GlobalSettings,
+    'terminalTuiScrollSensitivity' | 'terminalTuiScrollSensitivityDefaultedToOne'
+  >
+  needsSave: boolean
+} {
+  const alreadyDefaultedToOne = settings?.terminalTuiScrollSensitivityDefaultedToOne === true
+  const current = settings?.terminalTuiScrollSensitivity
+  const shouldMoveInheritedDefault =
+    !alreadyDefaultedToOne &&
+    (current === undefined || current === LEGACY_TERMINAL_TUI_SCROLL_SENSITIVITY_DEFAULT)
+  const terminalTuiScrollSensitivity = shouldMoveInheritedDefault ? 1 : (current ?? 1)
+
+  return {
+    settings: {
+      terminalTuiScrollSensitivity,
+      terminalTuiScrollSensitivityDefaultedToOne: true
+    },
+    needsSave: !alreadyDefaultedToOne || current === undefined
   }
 }
 
@@ -2672,6 +2697,12 @@ export class Store {
         if (migratedTerminalScrollback.needsSave) {
           this.loadNeedsSave = true
         }
+        const migratedTerminalTuiScrollSensitivity = migrateTerminalTuiScrollSensitivityDefault(
+          parsed.settings
+        )
+        if (migratedTerminalTuiScrollSensitivity.needsSave) {
+          this.loadNeedsSave = true
+        }
         const rawSourceControlAi = parsed.settings?.sourceControlAi
         const rawSourceControlAiMissing = rawSourceControlAi === undefined
         const rawSourceControlAiActionsMissing =
@@ -2913,6 +2944,7 @@ export class Store {
               primarySelectionDefaultedForTerminalDefaults || stampPrimarySelectionTerminalDefaults,
             ...migratedAutoRenameBranchFromWork,
             ...migratedTerminalCursorStyle,
+            ...migratedTerminalTuiScrollSensitivity.settings,
             experimentalActivity: migratedExperimentalActivity,
             experimentalActivityDefaultedOffForAllUsers: true,
             // Why: open first-run onboarding is the local fresh-install signal;
@@ -4815,6 +4847,12 @@ export class Store {
       sanitizedUpdates.terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(
         updates.terminalScrollbackRows
       )
+    }
+    if (
+      'terminalTuiScrollSensitivity' in updates ||
+      'terminalTuiScrollSensitivityDefaultedToOne' in updates
+    ) {
+      sanitizedUpdates.terminalTuiScrollSensitivityDefaultedToOne = true
     }
     if ('visibleTaskProviders' in updates || 'defaultTaskSource' in updates) {
       const taskProviderSettings = normalizeTaskProviderSettings({

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -1,12 +1,58 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER,
+  attachTerminalMouseWheelMultiplier,
   normalizeTerminalTuiMouseWheelMultiplier,
   shouldMultiplyTerminalMouseWheel
 } from './pane-terminal-mouse-wheel'
 
 const DOM_DELTA_PIXEL = 0
 const DOM_DELTA_LINE = 1
+
+class TestWheelEvent extends Event {
+  static readonly DOM_DELTA_PIXEL = DOM_DELTA_PIXEL
+  static readonly DOM_DELTA_LINE = DOM_DELTA_LINE
+  static readonly DOM_DELTA_PAGE = 2
+
+  readonly altKey: boolean
+  readonly button: number
+  readonly buttons: number
+  readonly clientX: number
+  readonly clientY: number
+  readonly ctrlKey: boolean
+  readonly deltaMode: number
+  readonly deltaX: number
+  readonly deltaY: number
+  readonly deltaZ: number
+  readonly detail: number
+  readonly metaKey: boolean
+  readonly relatedTarget: EventTarget | null
+  readonly screenX: number
+  readonly screenY: number
+  readonly shiftKey: boolean
+  readonly view: Window | null
+
+  constructor(type: string, init: WheelEventInit = {}) {
+    super(type, init)
+    this.altKey = init.altKey ?? false
+    this.button = init.button ?? 0
+    this.buttons = init.buttons ?? 0
+    this.clientX = init.clientX ?? 0
+    this.clientY = init.clientY ?? 0
+    this.ctrlKey = init.ctrlKey ?? false
+    this.deltaMode = init.deltaMode ?? DOM_DELTA_PIXEL
+    this.deltaX = init.deltaX ?? 0
+    this.deltaY = init.deltaY ?? 0
+    this.deltaZ = init.deltaZ ?? 0
+    this.detail = init.detail ?? 0
+    this.metaKey = init.metaKey ?? false
+    this.relatedTarget = init.relatedTarget ?? null
+    this.screenX = init.screenX ?? 0
+    this.screenY = init.screenY ?? 0
+    this.shiftKey = init.shiftKey ?? false
+    this.view = init.view ?? null
+  }
+}
 
 function terminalElement(mouseReporting = true): HTMLElement {
   return {
@@ -16,7 +62,9 @@ function terminalElement(mouseReporting = true): HTMLElement {
   } as HTMLElement
 }
 
-function wheelEvent(init: Partial<WheelEventInit> = {}): WheelEvent {
+function wheelEvent(
+  init: Partial<WheelEventInit> & { wheelDelta?: number; wheelDeltaY?: number } = {}
+): WheelEvent {
   return {
     deltaY: 100,
     deltaMode: DOM_DELTA_PIXEL,
@@ -25,12 +73,16 @@ function wheelEvent(init: Partial<WheelEventInit> = {}): WheelEvent {
 }
 
 describe('terminal mouse wheel multiplier', () => {
-  it('uses a three-report multiplier for TUI mouse wheel scrolling', () => {
-    expect(TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER).toBe(3)
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses a one-report multiplier for TUI mouse wheel scrolling', () => {
+    expect(TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER).toBe(1)
   })
 
   it('normalizes TUI wheel multipliers to the supported report range', () => {
-    expect(normalizeTerminalTuiMouseWheelMultiplier(undefined)).toBe(3)
+    expect(normalizeTerminalTuiMouseWheelMultiplier(undefined)).toBe(1)
     expect(normalizeTerminalTuiMouseWheelMultiplier(0)).toBe(1)
     expect(normalizeTerminalTuiMouseWheelMultiplier(4.4)).toBe(4)
     expect(normalizeTerminalTuiMouseWheelMultiplier(20)).toBe(10)
@@ -56,6 +108,19 @@ describe('terminal mouse wheel multiplier', () => {
     ).toBe(false)
   })
 
+  it('multiplies notched mouse wheel ticks even when Chromium exposes a small pixel delta', () => {
+    expect(
+      shouldMultiplyTerminalMouseWheel(
+        wheelEvent({
+          deltaY: 12,
+          deltaMode: DOM_DELTA_PIXEL,
+          wheelDeltaY: -120
+        }),
+        terminalElement()
+      )
+    ).toBe(true)
+  })
+
   it('multiplies non-pixel wheel deltas as discrete input', () => {
     expect(
       shouldMultiplyTerminalMouseWheel(
@@ -77,5 +142,45 @@ describe('terminal mouse wheel multiplier', () => {
         terminalElement()
       )
     ).toBe(false)
+  })
+
+  it('replays discrete TUI wheel ticks as line-mode reports', async () => {
+    vi.stubGlobal('WheelEvent', TestWheelEvent)
+    const handlers: ((event: WheelEvent) => boolean)[] = []
+    const target = Object.assign(new EventTarget(), {
+      classList: {
+        contains: (className: string) => className === 'enable-mouse-events'
+      }
+    }) as unknown as EventTarget & HTMLElement
+    const dispatched: WheelEvent[] = []
+    target.addEventListener('wheel', (event) => dispatched.push(event as WheelEvent))
+    attachTerminalMouseWheelMultiplier(
+      {
+        attachCustomWheelEventHandler: (handler) => {
+          handlers.push(handler)
+        },
+        element: target
+      },
+      { getTuiMouseWheelMultiplier: () => 1 }
+    )
+    const event = new TestWheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaMode: DOM_DELTA_PIXEL,
+      deltaY: 12
+    }) as WheelEvent
+    Object.defineProperty(event, 'wheelDeltaY', {
+      configurable: true,
+      value: -120
+    })
+
+    expect(handlers).toHaveLength(1)
+    expect(handlers[0]?.(event)).toBe(false)
+    await Promise.resolve()
+
+    expect(dispatched).toHaveLength(1)
+    expect(dispatched.map((entry) => entry.deltaMode)).toEqual([DOM_DELTA_LINE])
+    expect(dispatched.map((entry) => entry.deltaY)).toEqual([1])
+    expect(shouldMultiplyTerminalMouseWheel(dispatched[0]!, target)).toBe(false)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
@@ -3,8 +3,11 @@ import type { Terminal } from '@xterm/xterm'
 const XTERM_MOUSE_REPORTING_CLASS = 'enable-mouse-events'
 const REPLAYED_WHEEL_EVENT_PROPERTY = '__orcaReplayedTerminalWheelEvent'
 const DOM_DELTA_PIXEL = 0
+const DOM_DELTA_LINE = 1
+const DISCRETE_PIXEL_WHEEL_DELTA_MIN = 50
+const LEGACY_MOUSE_WHEEL_DELTA_MIN = 100
 
-export const TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER = 3
+export const TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER = 1
 export const TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER_MIN = 1
 export const TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER_MAX = 10
 
@@ -18,6 +21,11 @@ type ReplayedWheelEvent = WheelEvent & {
   [REPLAYED_WHEEL_EVENT_PROPERTY]?: boolean
 }
 
+type WheelEventWithLegacyDelta = WheelEvent & {
+  wheelDelta?: number
+  wheelDeltaY?: number
+}
+
 function isReplayedWheelEvent(event: WheelEvent): boolean {
   return (event as ReplayedWheelEvent)[REPLAYED_WHEEL_EVENT_PROPERTY] === true
 }
@@ -29,32 +37,31 @@ function markReplayedWheelEvent(event: WheelEvent): void {
   })
 }
 
+function legacyVerticalWheelDelta(event: WheelEvent): number | null {
+  const wheelEvent = event as WheelEventWithLegacyDelta
+  if (typeof wheelEvent.wheelDeltaY === 'number' && Number.isFinite(wheelEvent.wheelDeltaY)) {
+    return wheelEvent.wheelDeltaY
+  }
+  if (typeof wheelEvent.wheelDelta === 'number' && Number.isFinite(wheelEvent.wheelDelta)) {
+    return wheelEvent.wheelDelta
+  }
+  return null
+}
+
 function isDiscreteWheelEvent(event: WheelEvent): boolean {
   if (event.deltaMode !== DOM_DELTA_PIXEL) {
     return true
   }
 
-  return Math.abs(event.deltaY) >= 50
-}
-
-export function shouldMultiplyTerminalMouseWheel(
-  event: WheelEvent,
-  terminalElement: HTMLElement | null | undefined
-): boolean {
-  if (
-    isReplayedWheelEvent(event) ||
-    !terminalElement?.classList.contains(XTERM_MOUSE_REPORTING_CLASS) ||
-    event.deltaY === 0 ||
-    event.shiftKey ||
-    !isDiscreteWheelEvent(event)
-  ) {
-    return false
+  if (Math.abs(event.deltaY) >= DISCRETE_PIXEL_WHEEL_DELTA_MIN) {
+    return true
   }
 
-  return true
+  const legacyDelta = legacyVerticalWheelDelta(event)
+  return legacyDelta !== null && Math.abs(legacyDelta) >= LEGACY_MOUSE_WHEEL_DELTA_MIN
 }
 
-function cloneWheelEvent(event: WheelEvent): WheelEvent {
+function cloneWheelReportEvent(event: WheelEvent): WheelEvent {
   const clone = new WheelEvent(event.type, {
     bubbles: event.bubbles,
     cancelable: event.cancelable,
@@ -72,13 +79,30 @@ function cloneWheelEvent(event: WheelEvent): WheelEvent {
     button: event.button,
     buttons: event.buttons,
     relatedTarget: event.relatedTarget,
-    deltaX: event.deltaX,
-    deltaY: event.deltaY,
-    deltaZ: event.deltaZ,
-    deltaMode: event.deltaMode
+    deltaX: 0,
+    deltaY: event.deltaY < 0 ? -1 : 1,
+    deltaZ: 0,
+    deltaMode: DOM_DELTA_LINE
   })
   markReplayedWheelEvent(clone)
   return clone
+}
+
+export function shouldMultiplyTerminalMouseWheel(
+  event: WheelEvent,
+  terminalElement: HTMLElement | null | undefined
+): boolean {
+  if (
+    isReplayedWheelEvent(event) ||
+    !terminalElement?.classList.contains(XTERM_MOUSE_REPORTING_CLASS) ||
+    event.deltaY === 0 ||
+    event.shiftKey ||
+    !isDiscreteWheelEvent(event)
+  ) {
+    return false
+  }
+
+  return true
 }
 
 export function normalizeTerminalTuiMouseWheelMultiplier(value: number | undefined): number {
@@ -108,17 +132,17 @@ export function attachTerminalMouseWheelMultiplier(
       return true
     }
 
-    // Why: mouse-reporting TUIs receive wheel input as reports, not viewport
-    // scrollback, so normal xterm scrollSensitivity cannot tune their speed.
+    // Why: xterm dampens small pixel deltas before emitting mouse reports;
+    // line-mode replays make each notched wheel tick produce immediate reports.
     queueMicrotask(() => {
       const multiplier = normalizeTerminalTuiMouseWheelMultiplier(
         options.getTuiMouseWheelMultiplier?.()
       )
-      for (let i = 1; i < multiplier; i++) {
-        target.dispatchEvent(cloneWheelEvent(event))
+      for (let i = 0; i < multiplier; i++) {
+        target.dispatchEvent(cloneWheelReportEvent(event))
       }
     })
 
-    return true
+    return false
   })
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -215,7 +215,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalLineHeight: 1,
     terminalScrollSensitivity: 1.15,
     terminalFastScrollSensitivity: 5,
-    terminalTuiScrollSensitivity: 3,
+    terminalTuiScrollSensitivity: 1,
+    terminalTuiScrollSensitivityDefaultedToOne: true,
     // Why: "auto" should use WebGL when supported while keeping DOM fallback
     // for renderer failures and Linux software/unknown GPU renderers.
     terminalGpuAcceleration: 'auto',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2488,6 +2488,8 @@ export type GlobalSettings = {
   terminalScrollSensitivity: number
   terminalFastScrollSensitivity: number
   terminalTuiScrollSensitivity: number
+  /** One-shot migration guard for moving inherited TUI wheel reports from 3 to 1. */
+  terminalTuiScrollSensitivityDefaultedToOne?: boolean
   /** Terminal renderer policy.
    *  - 'auto': try xterm WebGL and fall back to DOM when unsupported or risky.
    *  - 'on': always try xterm WebGL.

--- a/tests/e2e/terminal-tui-wheel-reports.spec.ts
+++ b/tests/e2e/terminal-tui-wheel-reports.spec.ts
@@ -1,0 +1,114 @@
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActiveTerminalManager } from './helpers/terminal'
+
+type WheelReportSample = {
+  reportCount: number
+  reportDelta: number
+  reports: string[]
+}
+
+const PHYSICAL_MOUSE_WHEEL_DELTA = -120
+
+async function probeSmallMouseWheelReports(
+  page: Page,
+  ticks: number
+): Promise<WheelReportSample[]> {
+  return page.evaluate(
+    async ({ tickCount, physicalMouseWheelDelta }) => {
+      const state = window.__store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      const tabId =
+        state?.activeTabType === 'terminal'
+          ? state.activeTabId
+          : worktreeId
+            ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const manager = tabId ? window.__paneManagers?.get(tabId) : null
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      if (!pane?.terminal.element) {
+        throw new Error('Active terminal pane unavailable')
+      }
+
+      const reports: string[] = []
+      const disposable = pane.terminal.onData((data) => reports.push(data))
+      try {
+        await new Promise<void>((resolve) => pane.terminal.write('\x1b[?1003h\x1b[?1006h', resolve))
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)))
+        if (!pane.terminal.element.classList.contains('enable-mouse-events')) {
+          throw new Error('Mouse reporting mode did not activate')
+        }
+
+        const screen = pane.terminal.element.querySelector<HTMLElement>('.xterm-screen')
+        if (!screen) {
+          throw new Error('Active terminal screen unavailable')
+        }
+
+        const rect = screen.getBoundingClientRect()
+        const cellHeight =
+          pane.terminal._core?._renderService?.dimensions?.css?.cell?.height ??
+          rect.height / pane.terminal.rows
+        const scrollSensitivity = Number(pane.terminal.options.scrollSensitivity ?? 1)
+        // Why: this is a notched mouse wheel event that Chromium can surface as a
+        // small pixel delta; xterm's <50px damping accumulates it for four ticks.
+        const deltaY = (cellHeight * 0.28) / (scrollSensitivity * 0.3)
+        const samples: WheelReportSample[] = []
+
+        for (let i = 0; i < tickCount; i += 1) {
+          const before = reports.length
+          const event = new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + Math.min(rect.height - 1, cellHeight * 4),
+            deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+            deltaY
+          })
+          Object.defineProperty(event, 'wheelDeltaY', {
+            configurable: true,
+            value: physicalMouseWheelDelta
+          })
+          Object.defineProperty(event, 'wheelDelta', {
+            configurable: true,
+            value: physicalMouseWheelDelta
+          })
+          pane.terminal.element.dispatchEvent(event)
+          await new Promise((resolve) => setTimeout(resolve, 0))
+          samples.push({
+            reportCount: reports.length,
+            reportDelta: reports.length - before,
+            reports: [...reports]
+          })
+        }
+
+        return samples
+      } finally {
+        disposable.dispose()
+      }
+    },
+    { tickCount: ticks, physicalMouseWheelDelta: PHYSICAL_MOUSE_WHEEL_DELTA }
+  )
+}
+
+test.describe('terminal TUI wheel reports', () => {
+  test('notched mouse wheel ticks produce immediate mouse-reporting TUI scroll reports', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await orcaPage.evaluate(() =>
+      window.__store?.getState().updateSettings({ terminalTuiScrollSensitivity: 1 })
+    )
+
+    const samples = await probeSmallMouseWheelReports(orcaPage, 4)
+
+    expect(
+      samples.map((sample) => sample.reportDelta),
+      `per-tick SGR mouse reports: ${JSON.stringify(samples)}`
+    ).toEqual([1, 1, 1, 1])
+    expect(samples.at(-1)?.reports.join('')).toContain('\x1b[<65;')
+  })
+})


### PR DESCRIPTION
## Summary
- Add an Electron E2E harness that enables xterm mouse reporting and counts exact SGR wheel reports from notched wheel ticks.
- Fix mouse-reporting TUI wheel input by detecting discrete wheel ticks with legacy wheel deltas and replaying one line-mode event per notch so xterm emits a report immediately.
- Change the default TUI scroll sensitivity from 3 to 1 and migrate inherited old-default profiles once while preserving later explicit choices.

## Evidence
- Pre-fix repro from the harness matched the report: per-tick report deltas were `[0, 0, 0, 1]`.
- Post-fix harness asserts `[1, 1, 1, 1]`, so each notch produces exactly one SGR mouse report immediately.

## Verification
- `pnpm exec oxlint src/shared/types.ts src/shared/constants.ts src/main/persistence.ts src/main/persistence.test.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/codex-accounts/service.test.ts src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts tests/e2e/terminal-tui-wheel-reports.spec.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts src/main/persistence.test.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/codex-accounts/service.test.ts`
- `pnpm exec playwright test tests/e2e/terminal-tui-wheel-reports.spec.ts --config tests/playwright.config.ts --project electron-headless`
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7060">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->