### PR TITLE
Fix cursor agent ime anchor

### DIFF
--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -59,25 +59,24 @@ export const POST_REPLAY_LIVE_SNAPSHOT_RESET = `${RESET_TERMINAL_CURSOR_STYLE}\x
 
 // Why: daemon snapshot restore reattaches to a live session, so we avoid the
 // full POST_REPLAY_MODE_RESET bundle there — a still-running TUI may still
-// rely on mouse or bracketed-paste modes. Four exceptions are safe to reset:
+// rely on mouse, bracketed-paste, focus, or cursor-visibility modes. Only the
+// two always-safe renderer-owned bits are reset unconditionally here:
 //
 //   0 q  — DECSCUSR cursor style/blink reset: raw replay can contain a stale
 //          steady cursor override, while SerializeAddon does not preserve an
 //          authoritative current cursor style. Reset to the user's configured
 //          xterm cursor; the post-reattach SIGWINCH lets live TUIs repaint if
 //          they need a different cursor.
-//   25   — DECTCEM cursor visibility: SerializeAddon bakes `?25l` into the
-//          snapshot when the cursor was hidden at capture time. Without `?25h`
-//          here the cursor stays invisible after reattach. If a TUI is still
-//          running and wants the cursor hidden, the SIGWINCH sent immediately
-//          after restore triggers a repaint that re-hides it — a brief flash
-//          that is far less harmful than a permanently invisible cursor.
-//   1004 — focus event reporting: preserving `?1004h` makes restored shells
-//          ring BEL on pane focus/blur (shells like zsh treat `\e[I`/`\e[O`
-//          as unbound key input).
 //   <99u/=0u — Kitty keyboard mode is renderer-side xterm state; stale copies
 //              can make the next Ctrl+C encode as CSI-u after reattach.
-export const POST_REPLAY_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h\x1b[?1004l`
+//
+// Focus reporting (?1004) and cursor visibility (?25) are NOT reset here: a
+// still-running TUI legitimately owns them, and resetting ?1004h re-parks a
+// live agent's cursor away from its input caret (the IME-offset bug). Instead,
+// pty-connection.ts injects a single focus-in after reattach for the focused,
+// focus-reporting pane, nudging the live agent (e.g. cursor-agent) to move the
+// real cursor back onto its caret so the IME anchors correctly.
+export const POST_REPLAY_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`
 
 // Cross-platform monospace fallback chain ensures the terminal always has a
 // usable font regardless of OS.  macOS-only fonts like SF Mono and Menlo are

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -58,25 +58,29 @@ export const POST_REPLAY_MODE_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KIT
 export const POST_REPLAY_LIVE_SNAPSHOT_RESET = `${RESET_TERMINAL_CURSOR_STYLE}\x1b[?25h\x1b[?1004l`
 
 // Why: daemon snapshot restore reattaches to a live session, so we avoid the
-// full POST_REPLAY_MODE_RESET bundle there — a still-running TUI may still
-// rely on mouse, bracketed-paste, focus, or cursor-visibility modes. Only the
-// two always-safe renderer-owned bits are reset unconditionally here:
+// full POST_REPLAY_MODE_RESET bundle there. The default still clears the two
+// stale mode bits most harmful to a plain shell after a TUI exits badly:
 //
 //   0 q  — DECSCUSR cursor style/blink reset: raw replay can contain a stale
 //          steady cursor override, while SerializeAddon does not preserve an
 //          authoritative current cursor style. Reset to the user's configured
 //          xterm cursor; the post-reattach SIGWINCH lets live TUIs repaint if
 //          they need a different cursor.
+//   25   — DECTCEM cursor visibility: snapshots can preserve hidden cursor
+//          state from a no-longer-running TUI; reset by default so shells do
+//          not inherit a permanently invisible cursor.
+//   1004 — focus event reporting: snapshots can preserve focus reporting from
+//          a no-longer-running TUI; reset by default so shells do not receive
+//          stray focus-in/focus-out bytes.
 //   <99u/=0u — Kitty keyboard mode is renderer-side xterm state; stale copies
 //              can make the next Ctrl+C encode as CSI-u after reattach.
-//
-// Focus reporting (?1004) and cursor visibility (?25) are NOT reset here: a
-// still-running TUI legitimately owns them, and resetting ?1004h re-parks a
-// live agent's cursor away from its input caret (the IME-offset bug). Instead,
-// pty-connection.ts injects a single focus-in after reattach for the focused,
-// focus-reporting pane, nudging the live agent (e.g. cursor-agent) to move the
-// real cursor back onto its caret so the IME anchors correctly.
-export const POST_REPLAY_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`
+export const POST_REPLAY_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h\x1b[?1004l`
+
+// Why: a live agent TUI legitimately owns focus reporting and cursor
+// visibility. Resetting those modes during reattach can leave the agent's real
+// cursor parked away from its input caret, which anchors IME composition to the
+// wrong cell until the agent receives focus-in.
+export const POST_REPLAY_LIVE_AGENT_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`
 
 // Cross-platform monospace fallback chain ensures the terminal always has a
 // usable font regardless of OS.  macOS-only fonts like SF Mono and Menlo are

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -76,11 +76,13 @@ export const POST_REPLAY_LIVE_SNAPSHOT_RESET = `${RESET_TERMINAL_CURSOR_STYLE}\x
 //              can make the next Ctrl+C encode as CSI-u after reattach.
 export const POST_REPLAY_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h\x1b[?1004l`
 
-// Why: a live agent TUI legitimately owns focus reporting and cursor
-// visibility. Resetting those modes during reattach can leave the agent's real
-// cursor parked away from its input caret, which anchors IME composition to the
-// wrong cell until the agent receives focus-in.
-export const POST_REPLAY_LIVE_AGENT_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`
+// Why: a live agent TUI legitimately owns focus reporting; resetting `?1004h`
+// would suppress the post-reattach focus-in the agent needs to move its real
+// cursor back to the input caret (the IME anchor). Cursor visibility is still
+// reset: agent detection can false-positive on a dead TUI's leftovers, and a
+// permanently invisible shell cursor is far worse than the brief flash a live
+// agent re-hides on its post-reattach SIGWINCH repaint.
+export const POST_REPLAY_LIVE_AGENT_REATTACH_RESET = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?25h`
 
 // Cross-platform monospace fallback chain ensures the terminal always has a
 // usable font regardless of OS.  macOS-only fonts like SF Mono and Menlo are

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8594,8 +8594,9 @@ describe('connectPanePty', () => {
     setReattachPaneTitle('renamed shell')
 
     const pane = createPane(1)
-    // Why: an inspectable buffer whose cursor sits mid-prompt models a shell
-    // foreground after a dead cursor-agent run left its screen in scrollback.
+    // Why: an inspectable buffer whose visible rows carry no Cursor Agent
+    // screen models a shell foreground after a dead run left its screen in
+    // scrollback.
     Object.assign(pane.terminal.buffer.active, {
       cursorX: 2,
       getLine: () => undefined

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4223,6 +4223,45 @@ describe('connectPanePty', () => {
     })
   })
 
+  it('does not treat an agent-name token in a shell title as a live agent reattach', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return { id: sessionId, snapshot: '\x1b[?1004h\x1b[?25lstale shell snapshot' }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    // Why: broad token matching would classify this ordinary ssh title as an
+    // agent and preserve stale modes / inject focus-in into a bare shell.
+    setReattachPaneTitle('ssh devin@host')
+
+    const pane = createPane(1)
+    const textarea = {} as HTMLTextAreaElement
+    configureTerminalFocusMode(pane, textarea)
+    await withMockedDocumentActiveElement(textarea, async () => {
+      const manager = createManager(1)
+      const deps = createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+      })
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(20)
+
+      expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[I')
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        POST_REPLAY_REATTACH_RESET,
+        expect.any(Function)
+      )
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
+        expect.any(Function)
+      )
+    })
+  })
+
   it('does not treat ordinary shell scrollback mentioning Cursor Agent as a live agent reattach', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8579,6 +8579,45 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('downgrades a scrollback-only Cursor Agent signal when the parsed viewport shows a shell', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    enableActiveRuntimeEnvironment()
+    const transport = createMockTransport('remote:env-1@@terminal-1')
+    const capturedReplayCallback: {
+      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedReplayCallback.current = callbacks.onReplayData ?? null
+      return { id: 'remote:env-1@@terminal-1', replay: '' }
+    })
+    transportFactoryQueue.push(transport)
+    setReattachPaneTitle('renamed shell')
+
+    const pane = createPane(1)
+    // Why: an inspectable buffer whose cursor sits mid-prompt models a shell
+    // foreground after a dead cursor-agent run left its screen in scrollback.
+    Object.assign(pane.terminal.buffer.active, {
+      cursorX: 2,
+      getLine: () => undefined
+    })
+    const textarea = {} as HTMLTextAreaElement
+    configureTerminalFocusMode(pane, textarea)
+    const manager = createManager(1)
+    const deps = createDeps()
+    const disposable = await withMockedDocumentActiveElement(textarea, async () => {
+      const connection = connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(6)
+
+      capturedReplayCallback.current?.(ANSI_POSITIONED_CURSOR_AGENT_REATTACH_SCREEN)
+      await flushAsyncTicks(12)
+
+      expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[?1004l', expect.any(Function))
+      expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[I')
+      return connection
+    })
+    disposable.dispose()
+  })
+
   it('does not clear restored scrollback when eager metadata replay opts out', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -451,6 +451,52 @@ function createDeps(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function setReattachPaneTitle(title: string): void {
+  mockStoreState = {
+    ...mockStoreState,
+    tabsByWorktree: {
+      'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', title }]
+    },
+    runtimePaneTitlesByTabId: {
+      'tab-1': { 1: title }
+    }
+  } as StoreState
+}
+
+async function withMockedDocumentActiveElement<T>(
+  activeElement: unknown,
+  run: () => Promise<T>
+): Promise<T> {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: { activeElement }
+  })
+  try {
+    return await run()
+  } finally {
+    if (originalDocument) {
+      Object.defineProperty(globalThis, 'document', originalDocument)
+    } else {
+      Reflect.deleteProperty(globalThis, 'document')
+    }
+  }
+}
+
+function configureTerminalFocusMode(
+  pane: ReturnType<typeof createPane>,
+  textarea: HTMLTextAreaElement
+): void {
+  Object.assign(pane.terminal, { textarea })
+  Object.assign(pane.terminal.modes, { sendFocusMode: true })
+  pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+    callback?.()
+  })
+}
+
+const ANSI_POSITIONED_CURSOR_AGENT_REATTACH_SCREEN =
+  '\x1b[4;3HCursor Agent\x1b[5;3Hv2026.06.29\x1b[9;3H→ Plan, search, build anything'
+
 // Why: setting activeRuntimeEnvironmentId in mockStoreState exercises the
 // remote-runtime path where the renderer still owns OSC 9999 status.
 function enableActiveRuntimeEnvironment(environmentId = 'env-1'): void {
@@ -4080,31 +4126,14 @@ describe('connectPanePty', () => {
       return null
     })
     transportFactoryQueue.push(transport)
-    mockStoreState = {
-      ...mockStoreState,
-      tabsByWorktree: {
-        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', title: 'Cursor Agent' }]
-      },
-      runtimePaneTitlesByTabId: {
-        'tab-1': { 1: 'Cursor Agent' }
-      }
-    } as StoreState
+    setReattachPaneTitle('Cursor Agent')
 
     const pane = createPane(1)
     const textarea = {} as HTMLTextAreaElement
     // Why: public xterm modes plus an agent title are the stable signal for a
     // live focus-driven TUI; avoid private `_core` field probes.
-    Object.assign(pane.terminal, { textarea })
-    Object.assign(pane.terminal.modes, { sendFocusMode: true })
-    pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
-      callback?.()
-    })
-    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
-    Object.defineProperty(globalThis, 'document', {
-      configurable: true,
-      value: { activeElement: textarea }
-    })
-    try {
+    configureTerminalFocusMode(pane, textarea)
+    await withMockedDocumentActiveElement(textarea, async () => {
       const manager = createManager(1)
       const deps = createDeps({
         restoredLeafId: LEAF_1,
@@ -4119,13 +4148,7 @@ describe('connectPanePty', () => {
         POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
         expect.any(Function)
       )
-    } finally {
-      if (originalDocument) {
-        Object.defineProperty(globalThis, 'document', originalDocument)
-      } else {
-        Reflect.deleteProperty(globalThis, 'document')
-      }
-    }
+    })
   })
 
   it('does not inject focus-in after reattach when the terminal does not own DOM focus', async () => {
@@ -4138,31 +4161,14 @@ describe('connectPanePty', () => {
       return null
     })
     transportFactoryQueue.push(transport)
-    mockStoreState = {
-      ...mockStoreState,
-      tabsByWorktree: {
-        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', title: 'Cursor Agent' }]
-      },
-      runtimePaneTitlesByTabId: {
-        'tab-1': { 1: 'Cursor Agent' }
-      }
-    } as StoreState
+    setReattachPaneTitle('Cursor Agent')
 
     const pane = createPane(1)
     const textarea = {} as HTMLTextAreaElement
-    Object.assign(pane.terminal, { textarea })
-    Object.assign(pane.terminal.modes, { sendFocusMode: true })
-    pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
-      callback?.()
-    })
-    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
+    configureTerminalFocusMode(pane, textarea)
     // Why: a different element owns focus, so the reattach must not send a stray
     // focus-in to a background pane.
-    Object.defineProperty(globalThis, 'document', {
-      configurable: true,
-      value: { activeElement: {} }
-    })
-    try {
+    await withMockedDocumentActiveElement({}, async () => {
       const manager = createManager(1)
       const deps = createDeps({
         restoredLeafId: LEAF_1,
@@ -4177,13 +4183,7 @@ describe('connectPanePty', () => {
         POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
         expect.any(Function)
       )
-    } finally {
-      if (originalDocument) {
-        Object.defineProperty(globalThis, 'document', originalDocument)
-      } else {
-        Reflect.deleteProperty(globalThis, 'document')
-      }
-    }
+    })
   })
 
   it('resets stale focus and cursor modes for a focused non-agent shell reattach', async () => {
@@ -4196,29 +4196,12 @@ describe('connectPanePty', () => {
       return null
     })
     transportFactoryQueue.push(transport)
-    mockStoreState = {
-      ...mockStoreState,
-      tabsByWorktree: {
-        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', title: 'zsh' }]
-      },
-      runtimePaneTitlesByTabId: {
-        'tab-1': { 1: 'zsh' }
-      }
-    } as StoreState
+    setReattachPaneTitle('zsh')
 
     const pane = createPane(1)
     const textarea = {} as HTMLTextAreaElement
-    Object.assign(pane.terminal, { textarea })
-    Object.assign(pane.terminal.modes, { sendFocusMode: true })
-    pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
-      callback?.()
-    })
-    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
-    Object.defineProperty(globalThis, 'document', {
-      configurable: true,
-      value: { activeElement: textarea }
-    })
-    try {
+    configureTerminalFocusMode(pane, textarea)
+    await withMockedDocumentActiveElement(textarea, async () => {
       const manager = createManager(1)
       const deps = createDeps({
         restoredLeafId: LEAF_1,
@@ -4237,13 +4220,48 @@ describe('connectPanePty', () => {
         POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
         expect.any(Function)
       )
-    } finally {
-      if (originalDocument) {
-        Object.defineProperty(globalThis, 'document', originalDocument)
-      } else {
-        Reflect.deleteProperty(globalThis, 'document')
+    })
+  })
+
+  it('does not treat ordinary shell scrollback mentioning Cursor Agent as a live agent reattach', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return {
+          id: sessionId,
+          snapshot:
+            '\x1b[?1004h\x1b[?25l$ grep -R "Cursor Agent" docs\r\nCursor Agent IME notes\r\n'
+        }
       }
-    }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    setReattachPaneTitle('zsh')
+
+    const pane = createPane(1)
+    const textarea = {} as HTMLTextAreaElement
+    configureTerminalFocusMode(pane, textarea)
+    await withMockedDocumentActiveElement(textarea, async () => {
+      const manager = createManager(1)
+      const deps = createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+      })
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(20)
+
+      expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[I')
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        POST_REPLAY_REATTACH_RESET,
+        expect.any(Function)
+      )
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
+        expect.any(Function)
+      )
+    })
   })
 
   it('resets an already-idle agent cursor again after reattach SIGWINCH repaint', async () => {
@@ -8435,6 +8453,42 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledWith('remote prompt\r\n$ ', expect.any(Function))
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
     expect(manager.rebuildPaneWebgl).toHaveBeenCalledWith(1)
+    disposable.dispose()
+  })
+
+  it('preserves live agent modes when queued replay data carries the Cursor Agent screen', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    enableActiveRuntimeEnvironment()
+    const transport = createMockTransport('remote:env-1@@terminal-1')
+    const capturedReplayCallback: {
+      current: ((data: string, meta?: { clearBeforeReplay?: boolean }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedReplayCallback.current = callbacks.onReplayData ?? null
+      return { id: 'remote:env-1@@terminal-1', replay: '' }
+    })
+    transportFactoryQueue.push(transport)
+    setReattachPaneTitle('renamed shell')
+
+    const pane = createPane(1)
+    const textarea = {} as HTMLTextAreaElement
+    configureTerminalFocusMode(pane, textarea)
+    const manager = createManager(1)
+    const deps = createDeps()
+    const disposable = await withMockedDocumentActiveElement(textarea, async () => {
+      const connection = connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(6)
+
+      capturedReplayCallback.current?.(ANSI_POSITIONED_CURSOR_AGENT_REATTACH_SCREEN)
+      await flushAsyncTicks(12)
+
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
+        expect.any(Function)
+      )
+      expect(transport.sendInput).toHaveBeenCalledWith('\x1b[I')
+      return connection
+    })
     disposable.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -757,7 +757,10 @@ describe('connectPanePty', () => {
         agentStatus: {
           inferInterrupt: vi.fn().mockResolvedValue(false)
         }
-      }
+      },
+      dispatchEvent: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
     }
     globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
       callback(0)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4223,6 +4223,54 @@ describe('connectPanePty', () => {
     })
   })
 
+  it('does not treat persisted tab launchAgent metadata as a live agent reattach', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return { id: sessionId, snapshot: '\x1b[?1004h\x1b[?25lstale shell snapshot' }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    // Why: launchAgent is launch ownership metadata that never decays after
+    // the agent exits; it must not preserve stale modes for the shell left
+    // behind after an unclean agent death.
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', title: 'zsh', launchAgent: 'claude' }]
+      },
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'zsh' }
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const textarea = {} as HTMLTextAreaElement
+    configureTerminalFocusMode(pane, textarea)
+    await withMockedDocumentActiveElement(textarea, async () => {
+      const manager = createManager(1)
+      const deps = createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+      })
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(20)
+
+      expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[I')
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        POST_REPLAY_REATTACH_RESET,
+        expect.any(Function)
+      )
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
+        expect.any(Function)
+      )
+    })
+  })
+
   it('does not treat an agent-name token in a shell title as a live agent reattach', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4023,7 +4023,7 @@ describe('connectPanePty', () => {
     expect(transport.connect).toHaveBeenCalledTimes(1)
   })
 
-  it('resets reattach cursor/focus state after daemon snapshot replay without applying the full mode reset', async () => {
+  it('resets reattach renderer state after daemon snapshot replay without applying the full mode reset', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -4066,6 +4066,124 @@ describe('connectPanePty', () => {
       POST_REPLAY_MODE_RESET,
       expect.any(Function)
     )
+  })
+
+  it('injects focus-in after reattach when focus reporting is enabled and the terminal owns focus', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return { id: sessionId, snapshot: '\x1b[?1004h\x1b[?25lrestored cursor snapshot' }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const textarea = {} as HTMLTextAreaElement
+    // Why: focus reporting on + the pane owning DOM focus is the observable
+    // signal of a live focus-driven TUI (e.g. cursor-agent) — no agent identity.
+    Object.assign(pane.terminal, {
+      textarea,
+      _core: {
+        coreService: {
+          decPrivateModes: {
+            sendFocus: true
+          }
+        }
+      }
+    })
+    pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: { activeElement: textarea }
+    })
+    try {
+      const manager = createManager(1)
+      const deps = createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+      })
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(20)
+
+      expect(transport.sendInput).toHaveBeenCalledWith('\x1b[I')
+    } finally {
+      if (originalDocument) {
+        Object.defineProperty(globalThis, 'document', originalDocument)
+      } else {
+        Reflect.deleteProperty(globalThis, 'document')
+      }
+    }
+  })
+
+  it('does not inject focus-in after reattach when the terminal does not own DOM focus', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return { id: sessionId, snapshot: '\x1b[?1004h\x1b[?25lrestored cursor snapshot' }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const textarea = {} as HTMLTextAreaElement
+    Object.assign(pane.terminal, {
+      textarea,
+      _core: {
+        coreService: {
+          decPrivateModes: {
+            sendFocus: true
+          }
+        }
+      }
+    })
+    pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
+    // Why: a different element owns focus, so the reattach must not send a stray
+    // focus-in to a background pane.
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: { activeElement: {} }
+    })
+    try {
+      const manager = createManager(1)
+      const deps = createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+      })
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(20)
+
+      expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[I')
+    } finally {
+      if (originalDocument) {
+        Object.defineProperty(globalThis, 'document', originalDocument)
+      } else {
+        Reflect.deleteProperty(globalThis, 'document')
+      }
+    }
   })
 
   it('resets an already-idle agent cursor again after reattach SIGWINCH repaint', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2,6 +2,7 @@
 import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
   RESET_KITTY_KEYBOARD_PROTOCOL,
@@ -330,7 +331,8 @@ function createPane(paneId: number) {
         active: activeBuffer
       },
       modes: {
-        bracketedPasteMode: false
+        bracketedPasteMode: false,
+        sendFocusMode: false
       },
       options: {
         ignoreBracketedPasteMode: false,
@@ -4068,7 +4070,7 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('injects focus-in after reattach when focus reporting is enabled and the terminal owns focus', async () => {
+  it('preserves live modes and injects focus-in after focused agent reattach', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -4081,24 +4083,19 @@ describe('connectPanePty', () => {
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: {
-        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', title: 'Cursor Agent' }]
+      },
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'Cursor Agent' }
       }
     } as StoreState
 
     const pane = createPane(1)
     const textarea = {} as HTMLTextAreaElement
-    // Why: focus reporting on + the pane owning DOM focus is the observable
-    // signal of a live focus-driven TUI (e.g. cursor-agent) — no agent identity.
-    Object.assign(pane.terminal, {
-      textarea,
-      _core: {
-        coreService: {
-          decPrivateModes: {
-            sendFocus: true
-          }
-        }
-      }
-    })
+    // Why: public xterm modes plus an agent title are the stable signal for a
+    // live focus-driven TUI; avoid private `_core` field probes.
+    Object.assign(pane.terminal, { textarea })
+    Object.assign(pane.terminal.modes, { sendFocusMode: true })
     pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
       callback?.()
     })
@@ -4118,6 +4115,10 @@ describe('connectPanePty', () => {
       await flushAsyncTicks(20)
 
       expect(transport.sendInput).toHaveBeenCalledWith('\x1b[I')
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
+        expect.any(Function)
+      )
     } finally {
       if (originalDocument) {
         Object.defineProperty(globalThis, 'document', originalDocument)
@@ -4140,22 +4141,17 @@ describe('connectPanePty', () => {
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: {
-        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', title: 'Cursor Agent' }]
+      },
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'Cursor Agent' }
       }
     } as StoreState
 
     const pane = createPane(1)
     const textarea = {} as HTMLTextAreaElement
-    Object.assign(pane.terminal, {
-      textarea,
-      _core: {
-        coreService: {
-          decPrivateModes: {
-            sendFocus: true
-          }
-        }
-      }
-    })
+    Object.assign(pane.terminal, { textarea })
+    Object.assign(pane.terminal.modes, { sendFocusMode: true })
     pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
       callback?.()
     })
@@ -4177,6 +4173,70 @@ describe('connectPanePty', () => {
       await flushAsyncTicks(20)
 
       expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[I')
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
+        expect.any(Function)
+      )
+    } finally {
+      if (originalDocument) {
+        Object.defineProperty(globalThis, 'document', originalDocument)
+      } else {
+        Reflect.deleteProperty(globalThis, 'document')
+      }
+    }
+  })
+
+  it('resets stale focus and cursor modes for a focused non-agent shell reattach', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return { id: sessionId, snapshot: '\x1b[?1004h\x1b[?25lstale shell snapshot' }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty', title: 'zsh' }]
+      },
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'zsh' }
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const textarea = {} as HTMLTextAreaElement
+    Object.assign(pane.terminal, { textarea })
+    Object.assign(pane.terminal.modes, { sendFocusMode: true })
+    pane.terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: { activeElement: textarea }
+    })
+    try {
+      const manager = createManager(1)
+      const deps = createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+      })
+
+      connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(20)
+
+      expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[I')
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        POST_REPLAY_REATTACH_RESET,
+        expect.any(Function)
+      )
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
+        expect.any(Function)
+      )
     } finally {
       if (originalDocument) {
         Object.defineProperty(globalThis, 'document', originalDocument)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1,7 +1,8 @@
 /* oxlint-disable max-lines */
 import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
 import type { ManagedPaneInternal } from '@/lib/pane-manager/pane-manager-types'
-import type { IDisposable } from '@xterm/xterm'
+import type { IBuffer, IDisposable } from '@xterm/xterm'
+import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
 import {
   detectAgentStatusFromTitle,
   isGeminiTerminalTitle,
@@ -188,6 +189,7 @@ const SYNCHRONIZED_OUTPUT_MARKER_TAIL_CHARS = SYNCHRONIZED_OUTPUT_START_SEQUENCE
 const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
 const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
 const TERMINAL_FOCUS_IN_SEQUENCE = '\x1b[I'
+const FOCUS_REPORTING_DISABLE_SEQUENCE = '\x1b[?1004l'
 const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
 const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 128 * 1024
@@ -218,6 +220,41 @@ type TerminalWithFocusMode = {
   modes?: {
     sendFocusMode?: boolean
   }
+}
+
+type TerminalWithInspectableBuffer = {
+  cols: number
+  rows: number
+  buffer?: {
+    active?: IBuffer
+  }
+}
+
+// Why: replay bytes can carry a dead run's screen in scrollback; once xterm
+// has parsed the replay, the visible screen is the ground truth for whether a
+// cursor-agent UI is actually foreground. Returns null when the buffer is not
+// inspectable (e.g. test doubles) so callers can skip the check.
+function parsedViewportShowsCursorAgentScreen(
+  terminal: TerminalWithInspectableBuffer
+): boolean | null {
+  const buffer = terminal.buffer?.active
+  if (
+    !buffer ||
+    typeof buffer.getLine !== 'function' ||
+    typeof buffer.cursorX !== 'number' ||
+    typeof buffer.cursorY !== 'number'
+  ) {
+    return null
+  }
+  return (
+    resolveCursorAgentImeAnchor({
+      buffer,
+      rows: terminal.rows,
+      cols: terminal.cols,
+      cursorX: buffer.cursorX,
+      cursorY: buffer.cursorY
+    }) !== null
+  )
 }
 
 function terminalHasFocusReportingEnabled(terminal: TerminalWithFocusMode): boolean {
@@ -1305,7 +1342,7 @@ export function connectPanePty(
   const isCursorAgentNativeTitle = (title: string): boolean => {
     return title.trim().toLowerCase() === CURSOR_AGENT_REATTACH_HEADER.toLowerCase()
   }
-  const hasLiveAgentReattachSignal = (): boolean => {
+  const hasLiveAgentReattachStatusOrTitleSignal = (): boolean => {
     // Why: launch ownership (tab.launchAgent) never decays after the agent
     // exits, so it must not count as liveness here — only live status, live
     // titles, and the replayed screen shape do.
@@ -1316,11 +1353,10 @@ export function connectPanePty(
     // Why: broad token matching (getAgentLabel) fires on titles like
     // "ssh devin@host"; that surface is too loose to gate mode preservation
     // and PTY byte injection, so only exact/status titles count here.
-    return (
-      detectAgentStatusFromTitle(title) !== null ||
-      isCursorAgentNativeTitle(title) ||
-      reattachReplayPayloadHasCursorAgentSignal
-    )
+    return detectAgentStatusFromTitle(title) !== null || isCursorAgentNativeTitle(title)
+  }
+  const hasLiveAgentReattachSignal = (): boolean => {
+    return hasLiveAgentReattachStatusOrTitleSignal() || reattachReplayPayloadHasCursorAgentSignal
   }
   const shouldPreserveAgentReattachModes = (): boolean => {
     // Why: ordinary shells can inherit stale ?25l/?1004h from replay bytes.
@@ -3468,6 +3504,20 @@ export function connectPanePty(
       void waitForTerminalOutputParsed(pane.terminal).then(() => {
         if (disposed) {
           return
+        }
+        // Why: the replay-byte signal also matches a dead run's screen sitting
+        // in scrollback. The parsed viewport is the ground truth; when it shows
+        // no cursor-agent screen and no status/title corroborates, downgrade to
+        // the plain-shell behavior (drop focus reporting, skip focus-in).
+        if (
+          !hasLiveAgentReattachStatusOrTitleSignal() &&
+          reattachReplayPayloadHasCursorAgentSignal
+        ) {
+          if (parsedViewportShowsCursorAgentScreen(pane.terminal) === false) {
+            reattachReplayPayloadHasCursorAgentSignal = false
+            writeReplayData(FOCUS_REPORTING_DISABLE_SEQUENCE)
+            return
+          }
         }
         // Why: a live TUI such as cursor-agent parks the real terminal cursor off
         // its own input caret and moves it back only on a focus-in. Reattach

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1306,7 +1306,10 @@ export function connectPanePty(
     return title.trim().toLowerCase() === CURSOR_AGENT_REATTACH_HEADER.toLowerCase()
   }
   const hasLiveAgentReattachSignal = (): boolean => {
-    if (useAppStore.getState().agentStatusByPaneKey[cacheKey] || getAuthoritativePaneAgent()) {
+    // Why: launch ownership (tab.launchAgent) never decays after the agent
+    // exits, so it must not count as liveness here — only live status, live
+    // titles, and the replayed screen shape do.
+    if (useAppStore.getState().agentStatusByPaneKey[cacheKey]) {
       return true
     }
     const title = getCurrentTerminalTitle() ?? ''
@@ -3498,7 +3501,9 @@ export function connectPanePty(
         if (clearBeforeReplay) {
           await writeReplayDataAsync('\x1b[2J\x1b[3J\x1b[H')
         }
-        if (data.length > 0) {
+        if (clearBeforeReplay || data.length > 0) {
+          // Why: an empty clearing frame is still an authoritative repaint and
+          // must clear a stale agent signal from an earlier payload.
           rememberReattachPayloadAgentSignal(data, { fullScreenReplay: clearBeforeReplay })
         }
         await writeReplayDataAsync(data)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4,6 +4,7 @@ import type { ManagedPaneInternal } from '@/lib/pane-manager/pane-manager-types'
 import type { IDisposable } from '@xterm/xterm'
 import {
   detectAgentStatusFromTitle,
+  getAgentLabel,
   isGeminiTerminalTitle,
   isClaudeAgent
 } from '@/lib/agent-status'
@@ -49,6 +50,7 @@ import {
   type PanePtyResizeHoldFlushDetail
 } from '@/lib/pane-manager/pane-pty-resize-hold'
 import {
+  POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
   POST_REPLAY_LIVE_SNAPSHOT_RESET,
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
@@ -214,25 +216,13 @@ type E2eTerminalPtyDataInjectionApi = {
 
 type TerminalWithFocusMode = {
   textarea?: HTMLTextAreaElement | null
-  _core?: {
-    coreService?: {
-      decPrivateModes?: {
-        sendFocus?: boolean
-      }
-    }
-    _coreService?: {
-      decPrivateModes?: {
-        sendFocus?: boolean
-      }
-    }
+  modes?: {
+    sendFocusMode?: boolean
   }
 }
 
 function terminalHasFocusReportingEnabled(terminal: TerminalWithFocusMode): boolean {
-  const core = terminal._core
-  return Boolean(
-    core?.coreService?.decPrivateModes?.sendFocus ?? core?._coreService?.decPrivateModes?.sendFocus
-  )
+  return terminal.modes?.sendFocusMode === true
 }
 
 function terminalOwnsDomFocus(terminal: TerminalWithFocusMode): boolean {
@@ -240,6 +230,27 @@ function terminalOwnsDomFocus(terminal: TerminalWithFocusMode): boolean {
     return false
   }
   return document.activeElement === terminal.textarea
+}
+
+function stripAnsiCsiSequences(data: string): string {
+  let normalized = ''
+  let index = 0
+  while (index < data.length) {
+    if (data.charCodeAt(index) === 0x1b && data[index + 1] === '[') {
+      index += 2
+      while (index < data.length) {
+        const code = data.charCodeAt(index)
+        index += 1
+        if (code >= 0x40 && code <= 0x7e) {
+          break
+        }
+      }
+      continue
+    }
+    normalized += data[index]
+    index += 1
+  }
+  return normalized
 }
 
 type E2eTerminalPtyDataInjectionWindow = Window & {
@@ -1257,6 +1268,30 @@ export function connectPanePty(
       (entry) => entry.id === deps.tabId
     )?.title
     return runtimeTitle ?? tabTitle ?? null
+  }
+  let reattachReplayPayloadAgentLabel: string | null = null
+  const rememberReattachPayloadAgentSignal = (data: string): void => {
+    const normalized = stripAnsiCsiSequences(data)
+    reattachReplayPayloadAgentLabel = getAgentLabel(normalized)
+  }
+  const hasLiveAgentReattachSignal = (): boolean => {
+    if (useAppStore.getState().agentStatusByPaneKey[cacheKey] || getAuthoritativePaneAgent()) {
+      return true
+    }
+    const title = getCurrentTerminalTitle() ?? ''
+    return (
+      detectAgentStatusFromTitle(title) !== null ||
+      getAgentLabel(title) !== null ||
+      reattachReplayPayloadAgentLabel !== null
+    )
+  }
+  const shouldPreserveAgentReattachModes = (): boolean => {
+    // Why: ordinary shells can inherit stale ?25l/?1004h from replay bytes.
+    // Preserve those modes only when reattach still looks agent-owned.
+    return hasLiveAgentReattachSignal()
+  }
+  const shouldSendFocusedAgentReattachFocusIn = (): boolean => {
+    return terminalOwnsDomFocus(pane.terminal) && shouldPreserveAgentReattachModes()
   }
   const scheduleReattachIdleAgentCursorReset = (): void => {
     const status = detectAgentStatusFromTitle(getCurrentTerminalTitle() ?? '')
@@ -3386,6 +3421,12 @@ export function connectPanePty(
       return replayIntoTerminalAsync(pane, deps.replayingPanesRef, data)
     }
 
+    const reattachReplayResetSequence = (): string => {
+      return shouldPreserveAgentReattachModes()
+        ? POST_REPLAY_LIVE_AGENT_REATTACH_RESET
+        : POST_REPLAY_REATTACH_RESET
+    }
+
     const sendFocusedReattachFocusInAfterReplay = (): void => {
       void waitForTerminalOutputParsed(pane.terminal).then(() => {
         if (disposed) {
@@ -3397,10 +3438,8 @@ export function connectPanePty(
         // focus, so xterm never emits the focus-in the agent needs and the parked
         // cursor anchors the IME/caret to the wrong cell. Gated on ?1004h so a
         // bare shell never receives a stray \x1b[I.
-        if (
-          !terminalHasFocusReportingEnabled(pane.terminal) ||
-          !terminalOwnsDomFocus(pane.terminal)
-        ) {
+        const sendFocusMode = terminalHasFocusReportingEnabled(pane.terminal)
+        if (!shouldSendFocusedAgentReattachFocusIn() || !sendFocusMode) {
           return
         }
         transport.sendInput(TERMINAL_FOCUS_IN_SEQUENCE)
@@ -3427,7 +3466,7 @@ export function connectPanePty(
         }
         await writeReplayDataAsync(data)
         if (clearBeforeReplay || data.length > 0) {
-          await writeReplayDataAsync(POST_REPLAY_REATTACH_RESET)
+          await writeReplayDataAsync(reattachReplayResetSequence())
           sendFocusedReattachFocusInAfterReplay()
         }
         if (disposed) {
@@ -4606,12 +4645,13 @@ export function connectPanePty(
       // the daemon and relay are by definition tracking the same session
       // and only the freshest source belongs on screen.
       if (connectResult?.snapshot) {
+        rememberReattachPayloadAgentSignal(connectResult.snapshot)
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.snapshot)
         // Snapshot reattach keeps a live session, so avoid the broader mode
         // reset. We only drop renderer-owned state that should not leak from
         // replay bytes into the restored renderer terminal.
-        writeReplayData(POST_REPLAY_REATTACH_RESET)
+        writeReplayData(reattachReplayResetSequence())
         sendFocusedReattachFocusInAfterReplay()
         if (connectResult.coldRestore) {
           // Snapshot superseded the cold-restore payload — ack it so the
@@ -4621,13 +4661,14 @@ export function connectPanePty(
           }
         }
       } else if (connectResult?.replay) {
+        rememberReattachPayloadAgentSignal(connectResult.replay)
         // Relay replay holds the last 100 KB of raw output. The xterm may
         // already hold pre-disconnect content; clear first to avoid
         // duplication. The reattach reset clears renderer-owned state without
         // tearing down the still-running TUI's live modes.
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.replay)
-        writeReplayData(POST_REPLAY_REATTACH_RESET)
+        writeReplayData(reattachReplayResetSequence())
         sendFocusedReattachFocusInAfterReplay()
         if (connectResult.coldRestore) {
           if (!isRemoteRuntimePtyId(ptyId)) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -186,6 +186,7 @@ const SYNCHRONIZED_OUTPUT_END_SEQUENCE = '\x1b[?2026l'
 const SYNCHRONIZED_OUTPUT_MARKER_TAIL_CHARS = SYNCHRONIZED_OUTPUT_START_SEQUENCE.length - 1
 const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
 const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
+const TERMINAL_FOCUS_IN_SEQUENCE = '\x1b[I'
 const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
 const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 128 * 1024
@@ -209,6 +210,36 @@ const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
 type E2eTerminalPtyDataInjectionApi = {
   inject: (paneKey: string, data: string, meta?: PtyDataMeta) => boolean
   keys: () => string[]
+}
+
+type TerminalWithFocusMode = {
+  textarea?: HTMLTextAreaElement | null
+  _core?: {
+    coreService?: {
+      decPrivateModes?: {
+        sendFocus?: boolean
+      }
+    }
+    _coreService?: {
+      decPrivateModes?: {
+        sendFocus?: boolean
+      }
+    }
+  }
+}
+
+function terminalHasFocusReportingEnabled(terminal: TerminalWithFocusMode): boolean {
+  const core = terminal._core
+  return Boolean(
+    core?.coreService?.decPrivateModes?.sendFocus ?? core?._coreService?.decPrivateModes?.sendFocus
+  )
+}
+
+function terminalOwnsDomFocus(terminal: TerminalWithFocusMode): boolean {
+  if (typeof document === 'undefined' || !terminal.textarea) {
+    return false
+  }
+  return document.activeElement === terminal.textarea
 }
 
 type E2eTerminalPtyDataInjectionWindow = Window & {
@@ -3355,6 +3386,27 @@ export function connectPanePty(
       return replayIntoTerminalAsync(pane, deps.replayingPanesRef, data)
     }
 
+    const sendFocusedReattachFocusInAfterReplay = (): void => {
+      void waitForTerminalOutputParsed(pane.terminal).then(() => {
+        if (disposed) {
+          return
+        }
+        // Why: a live TUI such as cursor-agent parks the real terminal cursor off
+        // its own input caret and moves it back only on a focus-in. Reattach
+        // reuses the same live PTY and the xterm textarea already holds DOM
+        // focus, so xterm never emits the focus-in the agent needs and the parked
+        // cursor anchors the IME/caret to the wrong cell. Gated on ?1004h so a
+        // bare shell never receives a stray \x1b[I.
+        if (
+          !terminalHasFocusReportingEnabled(pane.terminal) ||
+          !terminalOwnsDomFocus(pane.terminal)
+        ) {
+          return
+        }
+        transport.sendInput(TERMINAL_FOCUS_IN_SEQUENCE)
+      })
+    }
+
     let replayWriteQueue = Promise.resolve()
     type PendingReplayData = {
       data: string
@@ -3376,6 +3428,7 @@ export function connectPanePty(
         await writeReplayDataAsync(data)
         if (clearBeforeReplay || data.length > 0) {
           await writeReplayDataAsync(POST_REPLAY_REATTACH_RESET)
+          sendFocusedReattachFocusInAfterReplay()
         }
         if (disposed) {
           pendingReplayData = null
@@ -4556,9 +4609,10 @@ export function connectPanePty(
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.snapshot)
         // Snapshot reattach keeps a live session, so avoid the broader mode
-        // reset. We only drop stale cursor/focus state that should not leak
-        // from replay bytes into the restored renderer terminal.
+        // reset. We only drop renderer-owned state that should not leak from
+        // replay bytes into the restored renderer terminal.
         writeReplayData(POST_REPLAY_REATTACH_RESET)
+        sendFocusedReattachFocusInAfterReplay()
         if (connectResult.coldRestore) {
           // Snapshot superseded the cold-restore payload — ack it so the
           // daemon does not redeliver it on the next reattach.
@@ -4569,11 +4623,12 @@ export function connectPanePty(
       } else if (connectResult?.replay) {
         // Relay replay holds the last 100 KB of raw output. The xterm may
         // already hold pre-disconnect content; clear first to avoid
-        // duplication. The reattach reset prevents stale cursor/focus mode
-        // bits in the replayed data from leaking into the restored terminal.
+        // duplication. The reattach reset clears renderer-owned state without
+        // tearing down the still-running TUI's live modes.
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.replay)
         writeReplayData(POST_REPLAY_REATTACH_RESET)
+        sendFocusedReattachFocusInAfterReplay()
         if (connectResult.coldRestore) {
           if (!isRemoteRuntimePtyId(ptyId)) {
             window.api.pty.ackColdRestore(ptyId)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -253,6 +253,23 @@ function stripAnsiCsiSequences(data: string): string {
   return normalized
 }
 
+const CURSOR_AGENT_REATTACH_HEADER = 'Cursor Agent'
+const CURSOR_AGENT_REATTACH_INPUT_MARKER = '→'
+const CURSOR_AGENT_REATTACH_SCREEN_SIGNAL_MAX_CHARS = 5000
+
+function hasCursorAgentReattachPayloadScreenSignal(data: string): boolean {
+  const normalized = stripAnsiCsiSequences(data)
+  const headerIndex = normalized.indexOf(CURSOR_AGENT_REATTACH_HEADER)
+  if (headerIndex === -1) {
+    return false
+  }
+  const screenTail = normalized.slice(
+    headerIndex + CURSOR_AGENT_REATTACH_HEADER.length,
+    headerIndex + CURSOR_AGENT_REATTACH_SCREEN_SIGNAL_MAX_CHARS
+  )
+  return screenTail.includes(`${CURSOR_AGENT_REATTACH_INPUT_MARKER} `)
+}
+
 type E2eTerminalPtyDataInjectionWindow = Window & {
   __terminalPtyDataInjection?: E2eTerminalPtyDataInjectionApi
   __terminalHiddenSnapshotOverride?: E2eTerminalHiddenSnapshotOverrideApi
@@ -1269,10 +1286,11 @@ export function connectPanePty(
     )?.title
     return runtimeTitle ?? tabTitle ?? null
   }
-  let reattachReplayPayloadAgentLabel: string | null = null
+  let reattachReplayPayloadHasCursorAgentSignal = false
   const rememberReattachPayloadAgentSignal = (data: string): void => {
-    const normalized = stripAnsiCsiSequences(data)
-    reattachReplayPayloadAgentLabel = getAgentLabel(normalized)
+    // Why: ordinary scrollback can mention agent names. Treat replay bytes as
+    // a live Cursor Agent signal only when they look like its restored screen.
+    reattachReplayPayloadHasCursorAgentSignal = hasCursorAgentReattachPayloadScreenSignal(data)
   }
   const hasLiveAgentReattachSignal = (): boolean => {
     if (useAppStore.getState().agentStatusByPaneKey[cacheKey] || getAuthoritativePaneAgent()) {
@@ -1282,7 +1300,7 @@ export function connectPanePty(
     return (
       detectAgentStatusFromTitle(title) !== null ||
       getAgentLabel(title) !== null ||
-      reattachReplayPayloadAgentLabel !== null
+      reattachReplayPayloadHasCursorAgentSignal
     )
   }
   const shouldPreserveAgentReattachModes = (): boolean => {
@@ -3463,6 +3481,9 @@ export function connectPanePty(
         // can keep restored scrollback while still using the replay guard.
         if (clearBeforeReplay) {
           await writeReplayDataAsync('\x1b[2J\x1b[3J\x1b[H')
+        }
+        if (data.length > 0) {
+          rememberReattachPayloadAgentSignal(data)
         }
         await writeReplayDataAsync(data)
         if (clearBeforeReplay || data.length > 0) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2,7 +2,7 @@
 import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
 import type { ManagedPaneInternal } from '@/lib/pane-manager/pane-manager-types'
 import type { IBuffer, IDisposable } from '@xterm/xterm'
-import { viewportShowsCursorAgentScreen } from '@/lib/pane-manager/terminal-ime-anchor'
+import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
 import {
   detectAgentStatusFromTitle,
   isGeminiTerminalTitle,
@@ -230,23 +230,35 @@ type TerminalWithInspectableBuffer = {
   }
 }
 
-// Why: replay bytes can carry a dead run's screen in scrollback; once xterm
-// has parsed the replay, the visible screen is the ground truth for whether a
-// cursor-agent UI is actually foreground. Shape-only (header + input row) so a
-// live agent whose cursor happens to sit at the caret is not misjudged.
-// Returns null when the buffer is not inspectable (e.g. test doubles).
-function parsedViewportShowsCursorAgentScreen(
+// Why: replay bytes can carry a dead run's screen in scrollback — or still
+// painted in the viewport with a shell prompt below it — so once xterm has
+// parsed the replay the confirmation needs both the cursor-agent screen shape
+// AND the parked cursor. A dead screen leaves the shell cursor after its
+// prompt; a live agent that needs the focus-in is by definition parked, and a
+// live agent that is not parked only loses focus reporting the way the
+// pre-fix reattach always did. Returns null when the buffer is not
+// inspectable (e.g. test doubles).
+function parsedViewportShowsParkedCursorAgentScreen(
   terminal: TerminalWithInspectableBuffer
 ): boolean | null {
   const buffer = terminal.buffer?.active
-  if (!buffer || typeof buffer.getLine !== 'function') {
+  if (
+    !buffer ||
+    typeof buffer.getLine !== 'function' ||
+    typeof buffer.cursorX !== 'number' ||
+    typeof buffer.cursorY !== 'number'
+  ) {
     return null
   }
-  return viewportShowsCursorAgentScreen({
-    buffer,
-    rows: terminal.rows,
-    cols: terminal.cols
-  })
+  return (
+    resolveCursorAgentImeAnchor({
+      buffer,
+      rows: terminal.rows,
+      cols: terminal.cols,
+      cursorX: buffer.cursorX,
+      cursorY: buffer.cursorY
+    }) !== null
+  )
 }
 
 function terminalHasFocusReportingEnabled(terminal: TerminalWithFocusMode): boolean {
@@ -3507,15 +3519,16 @@ export function connectPanePty(
         if (scheduledGeneration !== reattachReplayPayloadSignalGeneration) {
           return
         }
-        // Why: the replay-byte signal also matches a dead run's screen sitting
-        // in scrollback. The parsed viewport is the ground truth; when it shows
-        // no cursor-agent screen and no status/title corroborates, downgrade to
+        // Why: the replay-byte signal also matches a dead run's screen — in
+        // scrollback or still painted above a fresh shell prompt. The parsed
+        // viewport is the ground truth; unless it shows a parked-cursor
+        // cursor-agent screen and no status/title corroborates, downgrade to
         // the plain-shell behavior (drop focus reporting, skip focus-in).
         if (
           !hasLiveAgentReattachStatusOrTitleSignal() &&
           reattachReplayPayloadHasCursorAgentSignal
         ) {
-          if (parsedViewportShowsCursorAgentScreen(pane.terminal) === false) {
+          if (parsedViewportShowsParkedCursorAgentScreen(pane.terminal) === false) {
             reattachReplayPayloadHasCursorAgentSignal = false
             writeReplayData(FOCUS_REPORTING_DISABLE_SEQUENCE)
             return

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4,7 +4,6 @@ import type { ManagedPaneInternal } from '@/lib/pane-manager/pane-manager-types'
 import type { IDisposable } from '@xterm/xterm'
 import {
   detectAgentStatusFromTitle,
-  getAgentLabel,
   isGeminiTerminalTitle,
   isClaudeAgent
 } from '@/lib/agent-status'
@@ -259,7 +258,9 @@ const CURSOR_AGENT_REATTACH_SCREEN_SIGNAL_MAX_CHARS = 5000
 
 function hasCursorAgentReattachPayloadScreenSignal(data: string): boolean {
   const normalized = stripAnsiCsiSequences(data)
-  const headerIndex = normalized.indexOf(CURSOR_AGENT_REATTACH_HEADER)
+  // Why: anchor on the LAST header occurrence — replay buffers keep scrollback,
+  // and an earlier finished run must not classify the current screen.
+  const headerIndex = normalized.lastIndexOf(CURSOR_AGENT_REATTACH_HEADER)
   if (headerIndex === -1) {
     return false
   }
@@ -1287,19 +1288,34 @@ export function connectPanePty(
     return runtimeTitle ?? tabTitle ?? null
   }
   let reattachReplayPayloadHasCursorAgentSignal = false
-  const rememberReattachPayloadAgentSignal = (data: string): void => {
+  const rememberReattachPayloadAgentSignal = (
+    data: string,
+    opts: { fullScreenReplay: boolean }
+  ): void => {
     // Why: ordinary scrollback can mention agent names. Treat replay bytes as
     // a live Cursor Agent signal only when they look like its restored screen.
-    reattachReplayPayloadHasCursorAgentSignal = hasCursorAgentReattachPayloadScreenSignal(data)
+    const signal = hasCursorAgentReattachPayloadScreenSignal(data)
+    // Why: incremental (non-clearing) replay frames repaint only part of the
+    // screen, so their bytes can only add evidence — a full-screen replay is
+    // the authoritative repaint that may clear the flag.
+    reattachReplayPayloadHasCursorAgentSignal = opts.fullScreenReplay
+      ? signal
+      : reattachReplayPayloadHasCursorAgentSignal || signal
+  }
+  const isCursorAgentNativeTitle = (title: string): boolean => {
+    return title.trim().toLowerCase() === CURSOR_AGENT_REATTACH_HEADER.toLowerCase()
   }
   const hasLiveAgentReattachSignal = (): boolean => {
     if (useAppStore.getState().agentStatusByPaneKey[cacheKey] || getAuthoritativePaneAgent()) {
       return true
     }
     const title = getCurrentTerminalTitle() ?? ''
+    // Why: broad token matching (getAgentLabel) fires on titles like
+    // "ssh devin@host"; that surface is too loose to gate mode preservation
+    // and PTY byte injection, so only exact/status titles count here.
     return (
       detectAgentStatusFromTitle(title) !== null ||
-      getAgentLabel(title) !== null ||
+      isCursorAgentNativeTitle(title) ||
       reattachReplayPayloadHasCursorAgentSignal
     )
   }
@@ -3483,7 +3499,7 @@ export function connectPanePty(
           await writeReplayDataAsync('\x1b[2J\x1b[3J\x1b[H')
         }
         if (data.length > 0) {
-          rememberReattachPayloadAgentSignal(data)
+          rememberReattachPayloadAgentSignal(data, { fullScreenReplay: clearBeforeReplay })
         }
         await writeReplayDataAsync(data)
         if (clearBeforeReplay || data.length > 0) {
@@ -4666,7 +4682,7 @@ export function connectPanePty(
       // the daemon and relay are by definition tracking the same session
       // and only the freshest source belongs on screen.
       if (connectResult?.snapshot) {
-        rememberReattachPayloadAgentSignal(connectResult.snapshot)
+        rememberReattachPayloadAgentSignal(connectResult.snapshot, { fullScreenReplay: true })
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.snapshot)
         // Snapshot reattach keeps a live session, so avoid the broader mode
@@ -4682,7 +4698,7 @@ export function connectPanePty(
           }
         }
       } else if (connectResult?.replay) {
-        rememberReattachPayloadAgentSignal(connectResult.replay)
+        rememberReattachPayloadAgentSignal(connectResult.replay, { fullScreenReplay: true })
         // Relay replay holds the last 100 KB of raw output. The xterm may
         // already hold pre-disconnect content; clear first to avoid
         // duplication. The reattach reset clears renderer-owned state without

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2,7 +2,7 @@
 import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
 import type { ManagedPaneInternal } from '@/lib/pane-manager/pane-manager-types'
 import type { IBuffer, IDisposable } from '@xterm/xterm'
-import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
+import { viewportShowsCursorAgentScreen } from '@/lib/pane-manager/terminal-ime-anchor'
 import {
   detectAgentStatusFromTitle,
   isGeminiTerminalTitle,
@@ -232,29 +232,21 @@ type TerminalWithInspectableBuffer = {
 
 // Why: replay bytes can carry a dead run's screen in scrollback; once xterm
 // has parsed the replay, the visible screen is the ground truth for whether a
-// cursor-agent UI is actually foreground. Returns null when the buffer is not
-// inspectable (e.g. test doubles) so callers can skip the check.
+// cursor-agent UI is actually foreground. Shape-only (header + input row) so a
+// live agent whose cursor happens to sit at the caret is not misjudged.
+// Returns null when the buffer is not inspectable (e.g. test doubles).
 function parsedViewportShowsCursorAgentScreen(
   terminal: TerminalWithInspectableBuffer
 ): boolean | null {
   const buffer = terminal.buffer?.active
-  if (
-    !buffer ||
-    typeof buffer.getLine !== 'function' ||
-    typeof buffer.cursorX !== 'number' ||
-    typeof buffer.cursorY !== 'number'
-  ) {
+  if (!buffer || typeof buffer.getLine !== 'function') {
     return null
   }
-  return (
-    resolveCursorAgentImeAnchor({
-      buffer,
-      rows: terminal.rows,
-      cols: terminal.cols,
-      cursorX: buffer.cursorX,
-      cursorY: buffer.cursorY
-    }) !== null
-  )
+  return viewportShowsCursorAgentScreen({
+    buffer,
+    rows: terminal.rows,
+    cols: terminal.cols
+  })
 }
 
 function terminalHasFocusReportingEnabled(terminal: TerminalWithFocusMode): boolean {
@@ -1325,10 +1317,14 @@ export function connectPanePty(
     return runtimeTitle ?? tabTitle ?? null
   }
   let reattachReplayPayloadHasCursorAgentSignal = false
+  // Why: post-parse veto callbacks must only judge the latest replay frame; a
+  // newer frame bumps the generation so a stale callback stands down.
+  let reattachReplayPayloadSignalGeneration = 0
   const rememberReattachPayloadAgentSignal = (
     data: string,
     opts: { fullScreenReplay: boolean }
   ): void => {
+    reattachReplayPayloadSignalGeneration += 1
     // Why: ordinary scrollback can mention agent names. Treat replay bytes as
     // a live Cursor Agent signal only when they look like its restored screen.
     const signal = hasCursorAgentReattachPayloadScreenSignal(data)
@@ -3501,8 +3497,14 @@ export function connectPanePty(
     }
 
     const sendFocusedReattachFocusInAfterReplay = (): void => {
+      const scheduledGeneration = reattachReplayPayloadSignalGeneration
       void waitForTerminalOutputParsed(pane.terminal).then(() => {
         if (disposed) {
+          return
+        }
+        // Why: a newer replay frame owns the judgment; its own post-parse
+        // callback will re-evaluate against its own viewport.
+        if (scheduledGeneration !== reattachReplayPayloadSignalGeneration) {
           return
         }
         // Why: the replay-byte signal also matches a dead run's screen sitting

--- a/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
@@ -13,6 +13,7 @@ const OLD_REATTACH_RESET_WITHOUT_CURSOR_STYLE = '\x1b[?25h\x1b[?1004l'
 type DecPrivateCursorState = {
   cursorStyle?: string
   cursorBlink?: boolean
+  sendFocus?: boolean
 }
 
 type KittyKeyboardState = {
@@ -28,10 +29,12 @@ type XtermWithCoreService = Terminal & {
     coreService?: {
       decPrivateModes?: DecPrivateCursorState
       kittyKeyboard?: KittyKeyboardState
+      isCursorHidden?: boolean
     }
     _coreService?: {
       decPrivateModes?: DecPrivateCursorState
       kittyKeyboard?: KittyKeyboardState
+      isCursorHidden?: boolean
     }
   }
 }
@@ -40,6 +43,15 @@ function readDecPrivateCursorState(term: Terminal): DecPrivateCursorState {
   const core = (term as XtermWithCoreService)._core
   const cursorState = core?.coreService?.decPrivateModes ?? core?._coreService?.decPrivateModes
   return cursorState ? { ...cursorState } : {}
+}
+
+function readCursorHidden(term: Terminal): boolean | undefined {
+  const core = (term as XtermWithCoreService)._core
+  return core?.coreService?.isCursorHidden ?? core?._coreService?.isCursorHidden
+}
+
+function readSendFocus(term: Terminal): boolean | undefined {
+  return readDecPrivateCursorState(term).sendFocus
 }
 
 function readKittyKeyboardState(term: Terminal): KittyKeyboardState | null {
@@ -175,6 +187,66 @@ describe('terminal replay state reset', () => {
         mainFlags: 0,
         mainStack: []
       })
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('preserves hidden cursor visibility after live reattach replay', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      allowProposedApi: true
+    })
+
+    try {
+      await writeTerminal(term, '\x1b[?25l')
+      expect(readCursorHidden(term)).toBe(true)
+
+      await writeTerminal(term, POST_REPLAY_REATTACH_RESET)
+
+      // Why: live agent TUIs often park the real terminal cursor off-input and
+      // hide it while drawing their own input caret. Reattach must not reveal it.
+      expect(readCursorHidden(term)).toBe(true)
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('preserves live focus reporting after live reattach replay', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      allowProposedApi: true
+    })
+    try {
+      await writeTerminal(term, '\x1b[?1004h')
+      expect(readSendFocus(term)).toBe(true)
+
+      await writeTerminal(term, POST_REPLAY_REATTACH_RESET)
+
+      // Why: live TUIs such as cursor-agent can rely on focus events to repaint
+      // their own hidden-cursor input caret after renderer reattach.
+      expect(readSendFocus(term)).toBe(true)
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('shows the cursor after cold-restore replay reset', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      allowProposedApi: true
+    })
+
+    try {
+      await writeTerminal(term, '\x1b[?25l')
+      expect(readCursorHidden(term)).toBe(true)
+
+      await writeTerminal(term, POST_REPLAY_MODE_RESET)
+
+      expect(readCursorHidden(term)).toBe(false)
     } finally {
       term.dispose()
     }

--- a/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { Terminal } from '@xterm/headless'
 import {
+  POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
   POST_REPLAY_LIVE_SNAPSHOT_RESET,
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
@@ -192,7 +193,7 @@ describe('terminal replay state reset', () => {
     }
   })
 
-  it('preserves hidden cursor visibility after live reattach replay', async () => {
+  it('resets hidden cursor visibility after ordinary reattach replay', async () => {
     const term = new Terminal({
       cols: 80,
       rows: 24,
@@ -205,15 +206,13 @@ describe('terminal replay state reset', () => {
 
       await writeTerminal(term, POST_REPLAY_REATTACH_RESET)
 
-      // Why: live agent TUIs often park the real terminal cursor off-input and
-      // hide it while drawing their own input caret. Reattach must not reveal it.
-      expect(readCursorHidden(term)).toBe(true)
+      expect(readCursorHidden(term)).toBe(false)
     } finally {
       term.dispose()
     }
   })
 
-  it('preserves live focus reporting after live reattach replay', async () => {
+  it('resets focus reporting after ordinary reattach replay', async () => {
     const term = new Terminal({
       cols: 80,
       rows: 24,
@@ -224,6 +223,45 @@ describe('terminal replay state reset', () => {
       expect(readSendFocus(term)).toBe(true)
 
       await writeTerminal(term, POST_REPLAY_REATTACH_RESET)
+
+      expect(readSendFocus(term)).toBe(false)
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('preserves hidden cursor visibility after live agent reattach replay', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      allowProposedApi: true
+    })
+
+    try {
+      await writeTerminal(term, '\x1b[?25l')
+      expect(readCursorHidden(term)).toBe(true)
+
+      await writeTerminal(term, POST_REPLAY_LIVE_AGENT_REATTACH_RESET)
+
+      // Why: live agent TUIs often park the real terminal cursor off-input and
+      // hide it while drawing their own input caret. Reattach must not reveal it.
+      expect(readCursorHidden(term)).toBe(true)
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('preserves live focus reporting after live agent reattach replay', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      allowProposedApi: true
+    })
+    try {
+      await writeTerminal(term, '\x1b[?1004h')
+      expect(readSendFocus(term)).toBe(true)
+
+      await writeTerminal(term, POST_REPLAY_LIVE_AGENT_REATTACH_RESET)
 
       // Why: live TUIs such as cursor-agent can rely on focus events to repaint
       // their own hidden-cursor input caret after renderer reattach.

--- a/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
@@ -230,7 +230,7 @@ describe('terminal replay state reset', () => {
     }
   })
 
-  it('preserves hidden cursor visibility after live agent reattach replay', async () => {
+  it('resets hidden cursor visibility after live agent reattach replay', async () => {
     const term = new Terminal({
       cols: 80,
       rows: 24,
@@ -243,9 +243,10 @@ describe('terminal replay state reset', () => {
 
       await writeTerminal(term, POST_REPLAY_LIVE_AGENT_REATTACH_RESET)
 
-      // Why: live agent TUIs often park the real terminal cursor off-input and
-      // hide it while drawing their own input caret. Reattach must not reveal it.
-      expect(readCursorHidden(term)).toBe(true)
+      // Why: agent detection can false-positive on a dead TUI's leftovers, so
+      // even the live-agent reset must not leave a shell cursor permanently
+      // invisible; a live agent re-hides it on the post-reattach repaint.
+      expect(readCursorHidden(term)).toBe(false)
     } finally {
       term.dispose()
     }

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -17,6 +17,7 @@ import { attachTerminalMouseWheelMultiplier } from './pane-terminal-mouse-wheel'
 import { attachTerminalScrollIntentTracking } from './terminal-scroll-intent'
 import { attachDomRendererFocusClassSync } from './pane-dom-focus-class-sync'
 import { attachWebgl, cancelPendingWebglRefresh, disposeWebgl } from './pane-webgl-renderer'
+import { resolveCursorAgentImeAnchor } from './terminal-ime-anchor'
 
 // ---------------------------------------------------------------------------
 // Pane creation, terminal open/close, addon management
@@ -70,11 +71,10 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   activateOrcaTerminalUnicodeProvider(terminal)
 
   // Why: the OS reads the focused textarea's screen rect at compositionstart to
-  // decide where to display the IME candidate window. xterm.js only repositions
-  // the textarea on compositionupdate (via updateCompositionElements), not on
-  // compositionstart, so the window can appear at a stale cursor position. We
-  // force-sync the textarea position in a capture-phase listener so the OS sees
-  // the correct location before it opens the candidate window.
+  // decide where to display the IME candidate window. xterm positions that
+  // textarea from its own cursor, which can be stale or intentionally hidden by
+  // TUIs. We force-sync after xterm's own composition handlers so the OS sees
+  // the corrected location before it opens the candidate window.
   //
   // Cell dimensions are derived from the public .xterm-screen element's bounds
   // (xterm sizes that element to cols*cellWidth × rows*cellHeight) rather than
@@ -94,11 +94,34 @@ export function openTerminal(pane: ManagedPaneInternal): void {
         return
       }
       const buf = terminal.buffer.active
-      const x = Math.min(buf.cursorX, terminal.cols - 1)
-      textarea.style.top = `${buf.cursorY * cellHeight}px`
-      textarea.style.left = `${x * cellWidth}px`
+      // Why: Cursor Agent draws its prompt UI while leaving xterm's public cursor
+      // on a blank row, so the OS IME anchor needs the rendered prompt row instead.
+      const cursorAgentAnchor = resolveCursorAgentImeAnchor({
+        buffer: buf,
+        rows: terminal.rows,
+        cols: terminal.cols,
+        cursorX: buf.cursorX,
+        cursorY: buf.cursorY
+      })
+      const anchor = cursorAgentAnchor ?? {
+        row: buf.cursorY,
+        column: Math.min(buf.cursorX, terminal.cols - 1)
+      }
+      const applyAnchor = (): void => {
+        textarea.style.top = `${anchor.row * cellHeight}px`
+        textarea.style.left = `${anchor.column * cellWidth}px`
+      }
+      applyAnchor()
+      if (cursorAgentAnchor) {
+        window.setTimeout(() => {
+          if (textarea.isConnected) {
+            applyAnchor()
+          }
+        }, 0)
+      }
     }
-    terminal.element.addEventListener('compositionstart', handler, true)
+    terminal.element.addEventListener('compositionstart', handler)
+    terminal.element.addEventListener('compositionupdate', handler)
     // Store so disposePane() can remove it and avoid a memory leak.
     pane.compositionHandler = handler
   }
@@ -200,7 +223,8 @@ export function disposePane(
   pane.terminalScrollIntentDisposable?.dispose()
   pane.terminalScrollIntentDisposable = null
   if (pane.compositionHandler) {
-    pane.terminal.element?.removeEventListener('compositionstart', pane.compositionHandler, true)
+    pane.terminal.element?.removeEventListener('compositionstart', pane.compositionHandler)
+    pane.terminal.element?.removeEventListener('compositionupdate', pane.compositionHandler)
     pane.compositionHandler = null
   }
   try {

--- a/src/renderer/src/lib/pane-manager/terminal-ime-anchor.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-anchor.test.ts
@@ -118,6 +118,28 @@ describe('resolveCursorAgentImeAnchor', () => {
     ).toBeNull()
   })
 
+  it('anchors the input row, not a transcript line containing an arrow', () => {
+    const buffer = makeBuffer([
+      '',
+      '  Cursor Agent',
+      '',
+      '  Renamed a.ts → b.ts',
+      '',
+      '  → Plan, search, build anything',
+      ''
+    ])
+
+    expect(
+      resolveCursorAgentImeAnchor({
+        buffer,
+        rows: 7,
+        cols: 80,
+        cursorX: 0,
+        cursorY: 6
+      })
+    ).toEqual({ row: 5, column: 4 })
+  })
+
   it('uses cell width when anchoring after typed Cursor Agent input', () => {
     const buffer = makeBuffer(['', '  Cursor Agent', '', '  → hi你', ''])
 

--- a/src/renderer/src/lib/pane-manager/terminal-ime-anchor.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-anchor.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import type { IBuffer, IBufferCell, IBufferLine } from '@xterm/xterm'
+import { resolveCursorAgentImeAnchor } from './terminal-ime-anchor'
+
+type FakeCell = {
+  chars: string
+  width: number
+}
+
+function makeCell(cell: FakeCell): IBufferCell {
+  return {
+    getWidth: () => cell.width,
+    getChars: () => cell.chars
+  } as IBufferCell
+}
+
+function makeLine(text: string, cols = 80): IBufferLine {
+  const cells: FakeCell[] = []
+  for (const char of Array.from(text)) {
+    const width = char === '你' ? 2 : 1
+    cells.push({ chars: char, width })
+    if (width === 2) {
+      cells.push({ chars: '', width: 0 })
+    }
+  }
+  while (cells.length < cols) {
+    cells.push({ chars: '', width: 1 })
+  }
+
+  return {
+    isWrapped: false,
+    length: cells.length,
+    getCell: (column: number) => {
+      const cell = cells[column]
+      return cell ? makeCell(cell) : undefined
+    },
+    translateToString: (trimRight = false, startColumn = 0, endColumn = cells.length) => {
+      let result = ''
+      for (let column = startColumn; column < endColumn; column++) {
+        const cell = cells[column]
+        if (!cell || cell.width === 0) {
+          continue
+        }
+        result += cell.chars || ' '
+      }
+      return trimRight ? result.replace(/\s+$/, '') : result
+    }
+  } as IBufferLine
+}
+
+function makeBuffer(lines: string[], cols = 80): IBuffer {
+  const bufferLines = lines.map((line) => makeLine(line, cols))
+  return {
+    baseY: 0,
+    cursorX: 0,
+    cursorY: 0,
+    length: bufferLines.length,
+    getLine: (row: number) => bufferLines[row],
+    getNullCell: () => makeCell({ chars: '', width: 1 })
+  } as IBuffer
+}
+
+describe('resolveCursorAgentImeAnchor', () => {
+  it('anchors an empty Cursor Agent prompt at the visible prompt caret', () => {
+    const buffer = makeBuffer([
+      '',
+      '  Cursor Agent',
+      '  v2026.06.29-2ad2186',
+      '  Tip: Use /config to customize Cursor settings and behavior.',
+      '',
+      '',
+      '',
+      '',
+      '  → Plan, search, build anything',
+      '',
+      '',
+      '  Composer 2.5',
+      '  ~/development/code/xinyue/app_android · develop/app6.5.1',
+      ''
+    ])
+
+    expect(
+      resolveCursorAgentImeAnchor({
+        buffer,
+        rows: 14,
+        cols: 80,
+        cursorX: 0,
+        cursorY: 13
+      })
+    ).toEqual({ row: 8, column: 4 })
+  })
+
+  it('does not override normal terminal cursor positioning', () => {
+    const buffer = makeBuffer(['', '  → Plan, search, build anything', '', ''])
+
+    expect(
+      resolveCursorAgentImeAnchor({
+        buffer,
+        rows: 4,
+        cols: 80,
+        cursorX: 0,
+        cursorY: 3
+      })
+    ).toBeNull()
+  })
+
+  it('does not override when xterm already exposes a non-stale cursor position', () => {
+    const buffer = makeBuffer(['', '  Cursor Agent', '', '  → Plan, search, build anything'])
+
+    expect(
+      resolveCursorAgentImeAnchor({
+        buffer,
+        rows: 4,
+        cols: 80,
+        cursorX: 4,
+        cursorY: 3
+      })
+    ).toBeNull()
+  })
+
+  it('uses cell width when anchoring after typed Cursor Agent input', () => {
+    const buffer = makeBuffer(['', '  Cursor Agent', '', '  → hi你', ''])
+
+    expect(
+      resolveCursorAgentImeAnchor({
+        buffer,
+        rows: 5,
+        cols: 80,
+        cursorX: 0,
+        cursorY: 4
+      })
+    ).toEqual({ row: 3, column: 8 })
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
@@ -25,7 +25,9 @@ export function resolveCursorAgentImeAnchor(args: {
     return null
   }
 
-  for (let row = 0; row < args.rows; row++) {
+  // Why: the input box sits below the transcript, so scan bottom-up — a
+  // transcript line containing "→ " (e.g. a rename diff) must not win.
+  for (let row = args.rows - 1; row >= 0; row--) {
     const line = getVisibleLine(args.buffer, row)
     if (!line) {
       continue

--- a/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
@@ -21,6 +21,26 @@ export function resolveCursorAgentImeAnchor(args: {
   if (args.cursorX !== 0 || !isBlankLine(cursorLine)) {
     return null
   }
+  return findCursorAgentScreenInputAnchor(args)
+}
+
+/**
+ * Whether the visible screen has the Cursor Agent shape (header near the top
+ * plus an input row), independent of where the cursor currently sits.
+ */
+export function viewportShowsCursorAgentScreen(args: {
+  buffer: IBuffer
+  rows: number
+  cols: number
+}): boolean {
+  return findCursorAgentScreenInputAnchor(args) !== null
+}
+
+function findCursorAgentScreenInputAnchor(args: {
+  buffer: IBuffer
+  rows: number
+  cols: number
+}): TerminalImeAnchor | null {
   if (!hasCursorAgentHeader(args.buffer, args.rows)) {
     return null
   }

--- a/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
@@ -1,0 +1,112 @@
+import type { IBuffer, IBufferCell, IBufferLine } from '@xterm/xterm'
+
+export type TerminalImeAnchor = {
+  row: number
+  column: number
+}
+
+const CURSOR_AGENT_HEADER = 'Cursor Agent'
+const CURSOR_AGENT_INPUT_MARKER = '→'
+const CURSOR_AGENT_EMPTY_PROMPT = 'Plan, search, build anything'
+const CURSOR_AGENT_HEADER_SCAN_ROWS = 6
+
+export function resolveCursorAgentImeAnchor(args: {
+  buffer: IBuffer
+  rows: number
+  cols: number
+  cursorX: number
+  cursorY: number
+}): TerminalImeAnchor | null {
+  const cursorLine = getVisibleLine(args.buffer, args.cursorY)
+  if (args.cursorX !== 0 || !isBlankLine(cursorLine)) {
+    return null
+  }
+  if (!hasCursorAgentHeader(args.buffer, args.rows)) {
+    return null
+  }
+
+  for (let row = 0; row < args.rows; row++) {
+    const line = getVisibleLine(args.buffer, row)
+    if (!line) {
+      continue
+    }
+    const column = resolveCursorAgentInputColumn(line, args.cols)
+    if (column !== null) {
+      return { row, column: Math.min(column, Math.max(args.cols - 1, 0)) }
+    }
+  }
+
+  return null
+}
+
+function getVisibleLine(buffer: IBuffer, row: number): IBufferLine | undefined {
+  return buffer.getLine(buffer.baseY + row)
+}
+
+function hasCursorAgentHeader(buffer: IBuffer, rows: number): boolean {
+  const scanRows = Math.min(rows, CURSOR_AGENT_HEADER_SCAN_ROWS)
+  for (let row = 0; row < scanRows; row++) {
+    if (getVisibleLine(buffer, row)?.translateToString(true).trim() === CURSOR_AGENT_HEADER) {
+      return true
+    }
+  }
+  return false
+}
+
+function resolveCursorAgentInputColumn(line: IBufferLine, cols: number): number | null {
+  const inputColumn = findCursorAgentInputStartColumn(line, cols)
+  if (inputColumn === null) {
+    return null
+  }
+
+  const inputText = line.translateToString(true, inputColumn, cols)
+  if (!inputText.trim() || inputText.startsWith(CURSOR_AGENT_EMPTY_PROMPT)) {
+    return inputColumn
+  }
+
+  return findLineContentEndColumn(line, inputColumn, cols) ?? inputColumn
+}
+
+function findCursorAgentInputStartColumn(line: IBufferLine, cols: number): number | null {
+  const maxColumn = Math.min(line.length, cols)
+  for (let column = 0; column < maxColumn - 1; column++) {
+    const markerCell = line.getCell(column)
+    if (!isCellChar(markerCell, CURSOR_AGENT_INPUT_MARKER)) {
+      continue
+    }
+
+    const nextColumn = column + Math.max(markerCell.getWidth(), 1)
+    if (nextColumn < maxColumn && isCellChar(line.getCell(nextColumn), ' ')) {
+      return nextColumn + 1
+    }
+  }
+  return null
+}
+
+function findLineContentEndColumn(
+  line: IBufferLine,
+  startColumn: number,
+  cols: number
+): number | null {
+  const maxColumn = Math.min(line.length, cols)
+  for (let column = maxColumn - 1; column >= startColumn; column--) {
+    const cell = line.getCell(column)
+    if (!cell || cell.getWidth() === 0 || getCellChars(cell) === ' ') {
+      continue
+    }
+    return column + Math.max(cell.getWidth(), 1)
+  }
+  return null
+}
+
+function isBlankLine(line: IBufferLine | undefined): boolean {
+  return !line || line.translateToString(true).trim() === ''
+}
+
+function isCellChar(cell: IBufferCell | undefined, expected: string): cell is IBufferCell {
+  return !!cell && cell.getWidth() > 0 && getCellChars(cell) === expected
+}
+
+function getCellChars(cell: IBufferCell): string {
+  return cell.getChars() || ' '
+}

--- a/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
@@ -24,18 +24,6 @@ export function resolveCursorAgentImeAnchor(args: {
   return findCursorAgentScreenInputAnchor(args)
 }
 
-/**
- * Whether the visible screen has the Cursor Agent shape (header near the top
- * plus an input row), independent of where the cursor currently sits.
- */
-export function viewportShowsCursorAgentScreen(args: {
-  buffer: IBuffer
-  rows: number
-  cols: number
-}): boolean {
-  return findCursorAgentScreenInputAnchor(args) !== null
-}
-
 function findCursorAgentScreenInputAnchor(args: {
   buffer: IBuffer
   rows: number


### PR DESCRIPTION
## Summary

  Fixes Cursor Agent IME candidate-window positioning after terminal reattach.

  The change keeps ordinary reattach cleanup safe for shells by resetting stale cursor visibility and focus-reporting modes, while preserving those modes
  for detected live agent reattach. It also adds a narrow Cursor Agent IME anchor fallback that uses xterm public buffer/cell APIs to place the hidden
  helper textarea on the agent’s rendered input prompt instead of xterm’s stale real cursor row.

  ## Screenshots

  Behavior was verified locally by CDP coordinate checks: the xterm helper textarea moved from the stale cursor position `(285, 248)` to the Cursor Agent
  prompt position `(317, 168)` and stayed there through `compositionstart` / `compositionupdate`.
 - before:
<img width="707" height="191" alt="image" src="https://github.com/user-attachments/assets/d32ebc83-01f3-4756-bf2a-9f955fd7a98e" />

 - after:
<img width="680" height="261" alt="image" src="https://github.com/user-attachments/assets/33dffa79-7b39-4a8b-bf04-93cce61bf74e" />


  ## Testing

  - [ ] `pnpm lint`
  - [ ] `pnpm typecheck`
  - [ ] `pnpm test`
  - [ ] `pnpm build`
  - [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

  Additional targeted validation run:

  - `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts src/renderer/src/
  lib/pane-manager/terminal-ime-anchor.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts`
  - `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "focused agent reattach|
  terminal does not own DOM focus|focused non-agent shell reattach|resets reattach renderer state"`
  - `pnpm exec oxlint ...` on touched files
  - `pnpm run typecheck:web`
  - `git diff --check`
  - Local `pnpm dev` verification after restart

  ## AI Review Report

  AI review focused on code style consistency, performance, macOS/Linux/Windows compatibility, local/remote/SSH behavior, multiple agent providers, staged/
  unstaged state, empty and ordinary-shell reattach states, live agent reattach, focus reporting, hidden cursor state, and retry/reattach ordering.

  Main finding: the original focus-in/reset path was not the root cause. Logs showed Cursor Agent renders its own input caret while xterm’s public cursor
  remains on a blank row. The IME helper textarea was therefore anchored to xterm’s stale cursor. The fix was changed to use a narrow Cursor Agent buffer-
  based anchor fallback and to apply it after xterm’s own composition handlers.

  Cross-platform review:
  - macOS/Linux/Windows: no platform-specific shortcuts, labels, paths, or shell assumptions were added.
  - Electron: change stays in renderer/xterm behavior and does not add IPC or main-process coupling.
  - SSH/remote/local: anchor calculation uses renderer-local xterm buffer state, so it does not depend on local process inspection or shell paths.
  - Agent providers: fallback is intentionally scoped to Cursor Agent screen shape; other shells/TUIs keep normal xterm cursor anchoring.
  - Performance: buffer scan runs only on composition events and scans visible rows only.

  ## Security Audit

  No new command execution, auth handling, secrets handling, file path handling, dependency changes, or IPC surface was introduced.

  Reviewed risks:
  - Input handling: composition event handling only moves xterm’s helper textarea; it does not alter committed text or PTY input bytes.
  - Command execution: none added.
  - Path handling: none added.
  - IPC: none added.
  - Dependency risk: none added.
  - Provider-specific parsing: Cursor Agent detection is limited to visible terminal buffer text and fails closed to existing behavior.

  No security follow-up required.

  ## Notes

  The Cursor Agent fallback depends on the visible `Cursor Agent` header and `→ ` prompt marker. If Cursor Agent changes its TUI layout, the fallback
  should safely no-op, but IME anchoring for that new layout may need another provider-specific resolver.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7061">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->