### PR TITLE
fix(markdown): restore TOC navigation for h4 and h5

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -10,6 +10,7 @@ import { useEditorScrollRestore } from './useEditorScrollRestore'
 import { useModifierHeldClass } from './useModifierHeldClass'
 import { registerPendingEditorFlush } from './editor-pending-flush'
 import type { MarkdownTocItem } from './markdown-table-of-contents'
+import { findRichMarkdownTocHeadingTarget } from './rich-markdown-toc-heading-target'
 import { selectMarkdownTableOfContents } from './markdown-toc-visibility-gate'
 import { RichMarkdownEditorSurface } from './RichMarkdownEditorSurface'
 import { useRichMarkdownEditorInstance } from './useRichMarkdownEditorInstance'
@@ -331,18 +332,11 @@ export default function RichMarkdownEditor({
 
   const navigateToTableOfContentsItem = useCallback(
     (id: string): void => {
-      const target = flatTableOfContentsItems.find((item) => item.id === id)
       const container = scrollContainerRef.current
-      if (!target || !container) {
+      if (!container) {
         return
       }
-      const sameTitleIndex = flatTableOfContentsItems
-        .filter((item) => item.title === target.title)
-        .findIndex((item) => item.id === target.id)
-      const matchingHeadings = Array.from(
-        container.querySelectorAll<HTMLElement>('h1, h2, h3')
-      ).filter((candidate) => candidate.textContent?.trim() === target.title)
-      const heading = matchingHeadings.at(Math.max(0, sameTitleIndex))
+      const heading = findRichMarkdownTocHeadingTarget(container, flatTableOfContentsItems, id)
       heading?.scrollIntoView({ block: 'center' })
     },
     [flatTableOfContentsItems]

--- a/src/renderer/src/components/editor/rich-markdown-toc-heading-target.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-toc-heading-target.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import type { MarkdownTocItem } from './markdown-table-of-contents'
+import { findRichMarkdownTocHeadingTarget } from './rich-markdown-toc-heading-target'
+
+function makeTocItem(
+  id: string,
+  level: MarkdownTocItem['level'],
+  title: string,
+  children: MarkdownTocItem[] = []
+): MarkdownTocItem {
+  return { id, level, title, children }
+}
+
+describe('findRichMarkdownTocHeadingTarget', () => {
+  it('finds deep headings that the table of contents exposes', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <h1>Intro</h1>
+      <h4>Configure</h4>
+      <h5>Options</h5>
+    `
+    const headings = container.querySelectorAll<HTMLElement>('h1, h4, h5')
+    const items = [
+      makeTocItem('intro', 1, 'Intro'),
+      makeTocItem('configure', 4, 'Configure'),
+      makeTocItem('options', 5, 'Options')
+    ]
+
+    expect(findRichMarkdownTocHeadingTarget(container, items, 'configure')).toBe(headings[1])
+    expect(findRichMarkdownTocHeadingTarget(container, items, 'options')).toBe(headings[2])
+  })
+
+  it('keeps duplicate heading navigation aligned with TOC slug order', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <h4>Repeat</h4>
+      <h5>Repeat</h5>
+    `
+    const headings = container.querySelectorAll<HTMLElement>('h4, h5')
+    const items = [makeTocItem('repeat', 4, 'Repeat'), makeTocItem('repeat-1', 5, 'Repeat')]
+
+    expect(findRichMarkdownTocHeadingTarget(container, items, 'repeat')).toBe(headings[0])
+    expect(findRichMarkdownTocHeadingTarget(container, items, 'repeat-1')).toBe(headings[1])
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-toc-heading-target.ts
+++ b/src/renderer/src/components/editor/rich-markdown-toc-heading-target.ts
@@ -1,5 +1,8 @@
 import type { MarkdownTocItem } from './markdown-table-of-contents'
 
+// Why: must cover every level the TOC exposes (MarkdownTocLevel = 1-5). The
+// original bug was this selector stopping at h3 while the TOC listed h4/h5, so
+// those rows rendered but never resolved a heading to scroll to.
 const RICH_MARKDOWN_TOC_HEADING_SELECTOR = 'h1, h2, h3, h4, h5'
 
 export function findRichMarkdownTocHeadingTarget(

--- a/src/renderer/src/components/editor/rich-markdown-toc-heading-target.ts
+++ b/src/renderer/src/components/editor/rich-markdown-toc-heading-target.ts
@@ -1,0 +1,23 @@
+import type { MarkdownTocItem } from './markdown-table-of-contents'
+
+const RICH_MARKDOWN_TOC_HEADING_SELECTOR = 'h1, h2, h3, h4, h5'
+
+export function findRichMarkdownTocHeadingTarget(
+  container: ParentNode,
+  items: readonly MarkdownTocItem[],
+  id: string
+): HTMLElement | undefined {
+  const target = items.find((item) => item.id === id)
+  if (!target) {
+    return undefined
+  }
+
+  const sameTitleIndex = items
+    .filter((item) => item.title === target.title)
+    .findIndex((item) => item.id === target.id)
+  const matchingHeadings = Array.from(
+    container.querySelectorAll<HTMLElement>(RICH_MARKDOWN_TOC_HEADING_SELECTOR)
+  ).filter((candidate) => candidate.textContent?.trim() === target.title)
+
+  return matchingHeadings.at(Math.max(0, sameTitleIndex))
+}


### PR DESCRIPTION
## Summary

Fixes rich Markdown table-of-contents navigation for `H4` and `H5` headings. The TOC already showed those entries, but click navigation in the rich editor only searched rendered `h1`-`h3` nodes, so deeper headings never resolved.

Fixes #7057

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
- `node .\\node_modules\\vitest\\vitest.mjs run src/renderer/src/components/editor/markdown-table-of-contents.test.ts src/renderer/src/components/editor/rich-markdown-toc-heading-target.test.ts`
- `node_modules\\.bin\\oxlint.cmd src/renderer/src/components/editor/RichMarkdownEditor.tsx src/renderer/src/components/editor/rich-markdown-toc-heading-target.ts src/renderer/src/components/editor/rich-markdown-toc-heading-target.test.ts`
- Commit hook also ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` on the staged files.

## AI Review Report

Reviewed the change with an AI coding agent for cross-platform compatibility, SSH/remote/local behavior, supported agent/integration neutrality, performance risk, UI quality, and basic security risk.

The main finding was the root cause fixed here: rich Markdown TOC navigation only searched `h1`-`h3`, so `H4`/`H5` rows could render but never scroll into view. The final change extracts the heading lookup into a focused helper, expands the selector to `h1`-`h5`, and adds regression tests for both deep headings and duplicate-title ordering.

Cross-platform risk is low because this is renderer-only DOM lookup logic with no platform-specific shortcuts, path handling, shell behavior, or Electron process changes. SSH/remote/local behavior is unchanged because the navigation happens entirely inside the local rendered Markdown surface. Supported agent, integration, and git-provider behavior are unchanged because no agent orchestration, provider routing, or review APIs were touched. Performance risk is low because the same TOC navigation path still does one scoped DOM query per click, only across the heading levels the TOC already exposes. UI quality risk is low and there is no visual change.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependency, and IPC risk. This change is low risk: it only adjusts which heading tags are queried in the rich Markdown editor and does not add any new command execution, path parsing, network access, auth handling, IPC surface, or dependency changes. The new tests use static in-memory DOM fixtures only.

## Notes

- X handle: not provided.
- Local limitation: full-repo `pnpm` commands were not reliable in this environment because dependency install hit ignored-build / Electron package-binary issues, so validation used targeted Vitest coverage plus file-scoped `oxlint` and the repository's commit hook.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7063">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->