### PR TITLE
Raise WebGL terminal context budget and recover from context loss

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -297,6 +297,17 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('enable-unsafe-webgpu')
   })
 
+  it('raises the WebGL context budget above the 16-context Blink default', async () => {
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    delete process.env.ORCA_E2E_USER_DATA_DIR
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    enableMainProcessGpuFeatures()
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('max-active-webgl-contexts', '128')
+  })
+
   it('disables the GPU sandbox on Linux Wayland without disabling acceleration', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')
@@ -445,6 +456,10 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('disable-gpu')
     expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith(
       'enable-features',
+      expect.any(String)
+    )
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith(
+      'max-active-webgl-contexts',
       expect.any(String)
     )
   })

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -307,6 +307,12 @@ export function enableMainProcessGpuFeatures(): void {
     return
   }
 
+  // Why: Blink force-loses the oldest WebGL context past 16 per renderer, and
+  // each attached terminal pane holds one — a busy worktree (tabs × splits)
+  // can exceed that, silently downgrading evicted panes to the DOM renderer.
+  // 128 covers real layouts while keeping a bound so context leaks surface.
+  app.commandLine.appendSwitch('max-active-webgl-contexts', '128')
+
   const ozonePlatform = (app.commandLine.getSwitchValue('ozone-platform') ?? '').toLowerCase()
   const ozonePlatformHint = (process.env.ELECTRON_OZONE_PLATFORM_HINT ?? '').toLowerCase()
   const isLinuxX11Override =

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -2,6 +2,7 @@ import type { ManagedPaneInternal } from './pane-manager-types'
 import { safeFit } from './pane-tree-ops'
 import {
   attachWebgl,
+  clearTerminalWebglAttachBackoff,
   disposeWebgl,
   markComplexScriptOutput,
   resetWebglTextureAtlas
@@ -49,8 +50,13 @@ export function suspendPaneRendering(panes: Iterable<ManagedPaneInternal>): void
 }
 
 export function resumePaneRendering(panes: Iterable<ManagedPaneInternal>): void {
+  // Why: resume (worktree foreground, window wake) is the WebGL retry
+  // boundary — Chromium may have restored the GPU process since a context
+  // loss, and bounding retries to resume events cannot loop on live loss.
+  clearTerminalWebglAttachBackoff()
   for (const pane of panes) {
     pane.webglAttachmentDeferred = false
+    pane.webglDisabledAfterContextLoss = false
     reattachWebglIfNeeded(pane)
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
@@ -77,6 +77,30 @@ describe('applyTerminalGpuAcceleration', () => {
     expect(pane.fitAddon.fit).not.toHaveBeenCalled()
   })
 
+  it('clears context-loss latches when the acceleration mode changes', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)'
+    })
+    const pane = createPane()
+    pane.webglDisabledAfterContextLoss = true
+    const options: PaneManagerOptions = { terminalGpuAcceleration: 'auto' }
+
+    applyTerminalGpuAcceleration([pane], options, 'on')
+
+    expect(pane.webglDisabledAfterContextLoss).toBe(false)
+  })
+
+  it('keeps context-loss latches when the acceleration mode is unchanged', () => {
+    const pane = createPane()
+    pane.webglDisabledAfterContextLoss = true
+    const options: PaneManagerOptions = { terminalGpuAcceleration: 'on' }
+
+    applyTerminalGpuAcceleration([pane], options, 'on')
+
+    expect(pane.webglDisabledAfterContextLoss).toBe(true)
+  })
+
   it('returns Linux panes to DOM when switching from forced WebGL back to auto without a safe renderer', () => {
     vi.stubGlobal('navigator', {
       platform: 'Linux x86_64',

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
@@ -14,12 +14,18 @@ export function applyTerminalGpuAcceleration(
 ): void {
   const nextMode = mode ?? 'auto'
   const previousMode = options.terminalGpuAcceleration ?? 'auto'
+  const modeChanged = previousMode !== nextMode
   options.terminalGpuAcceleration = nextMode
-  if (previousMode !== nextMode) {
+  if (modeChanged) {
     resetTerminalWebglSuggestion()
   }
   for (const pane of panes) {
     pane.terminalGpuAcceleration = nextMode
+    if (modeChanged) {
+      // Why: an explicit setting change is user intent to re-evaluate the
+      // renderer; context-loss latches from the old mode should not pin DOM.
+      pane.webglDisabledAfterContextLoss = false
+    }
     if (!shouldUseTerminalWebgl(pane)) {
       disposeWebgl(pane, { refreshDimensions: true })
       continue

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { resumePaneRendering } from './pane-rendering-control'
+import { attachWebgl, resetTerminalWebglSuggestion } from './pane-webgl-renderer'
+
+function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneInternal {
+  const leafId = '11111111-1111-4111-8111-111111111111' as never
+  return {
+    id: 1,
+    leafId,
+    stablePaneId: leafId,
+    terminal: {
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn(),
+      loadAddon: vi.fn(options.loadAddon)
+    } as never,
+    container: {} as never,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'on',
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    webglAddon: null,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    pendingWebglRefreshRafId: null,
+    fitAddon: {
+      proposeDimensions: vi.fn(() => ({ cols: 80, rows: 23 })),
+      fit: vi.fn()
+    } as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+function throwWebglUnavailable(): never {
+  // Mirrors the addon's activate() throw when getContext('webgl2') returns null.
+  throw new Error('WebGL2 not supported null')
+}
+
+function fireContextLoss(pane: ManagedPaneInternal): void {
+  // Fire the addon's real context-loss emitter so the loss -> latch -> resume
+  // cycle runs through the production onContextLoss handler.
+  const addon = pane.webglAddon as unknown as { _onContextLoss: { fire: () => void } }
+  addon._onContextLoss.fire()
+}
+
+describe('terminal WebGL context recovery', () => {
+  beforeEach(() => {
+    resetTerminalWebglSuggestion()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('backs off after a failed attach instead of retrying on every call', () => {
+    const pane = createPane({ loadAddon: throwWebglUnavailable })
+
+    attachWebgl(pane)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+    expect(pane.webglAddon).toBeNull()
+
+    // Title changes re-enter attach via setPaneGpuRendering; while WebGL is
+    // blocked these must not construct new addons or log again.
+    attachWebgl(pane)
+    attachWebgl(pane)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a backed-off attach on the next rendering resume', () => {
+    const pane = createPane({ loadAddon: throwWebglUnavailable })
+
+    attachWebgl(pane)
+    attachWebgl(pane)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+
+    resumePaneRendering([pane])
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers a context-lost pane on the next rendering resume', () => {
+    const pane = createPane()
+
+    attachWebgl(pane)
+    expect(pane.webglAddon).not.toBeNull()
+
+    fireContextLoss(pane)
+    expect(pane.webglDisabledAfterContextLoss).toBe(true)
+    expect(pane.webglAddon).toBeNull()
+
+    resumePaneRendering([pane])
+    expect(pane.webglDisabledAfterContextLoss).toBe(false)
+    expect(pane.webglAddon).not.toBeNull()
+  })
+
+  it('re-latches when the retried context is lost again', () => {
+    const pane = createPane()
+
+    attachWebgl(pane)
+    fireContextLoss(pane)
+    resumePaneRendering([pane])
+    expect(pane.webglAddon).not.toBeNull()
+
+    fireContextLoss(pane)
+    expect(pane.webglDisabledAfterContextLoss).toBe(true)
+    expect(pane.webglAddon).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-webgl-reattach.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-reattach.ts
@@ -1,5 +1,5 @@
 import type { ManagedPaneInternal } from './pane-manager-types'
-import { attachWebgl, disposeWebgl } from './pane-webgl-renderer'
+import { attachWebgl, clearTerminalWebglAttachBackoff, disposeWebgl } from './pane-webgl-renderer'
 
 export function reattachWebglIfNeeded(pane: ManagedPaneInternal): void {
   if (pane.gpuRenderingEnabled && !pane.webglAddon && !pane.webglDisabledAfterContextLoss) {
@@ -12,5 +12,8 @@ export function rebuildAttachedWebgl(pane: ManagedPaneInternal): void {
     return
   }
   disposeWebgl(pane)
+  // Why: the live addon just proved context creation works, so a stale attach
+  // backoff from an earlier failure must not downgrade this pane to DOM.
+  clearTerminalWebglAttachBackoff()
   attachWebgl(pane)
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -7,12 +7,23 @@ import {
 
 export const ENABLE_WEBGL_RENDERER = true
 let suggestedRendererType: 'dom' | undefined
+// Why: while Chromium refuses WebGL context creation (GPU process crashed or
+// WebGL blocked after repeated resets), every attach attempt burns a canvas +
+// failed getContext and logs a full-stack warning — and title changes retrigger
+// attach constantly in "on" mode. Latch the first failure and skip attempts
+// until the next recovery boundary (rendering resume or GPU-setting change).
+let webglAttachFailedSinceRecovery = false
 
 export function resetTerminalWebglSuggestion(): void {
   // Why: toggling GPU settings should let "auto" retry WebGL after an earlier
   // attach failure suggested DOM rendering for this app session.
   suggestedRendererType = undefined
+  webglAttachFailedSinceRecovery = false
   resetTerminalWebglAutoDecision()
+}
+
+export function clearTerminalWebglAttachBackoff(): void {
+  webglAttachFailedSinceRecovery = false
 }
 
 export function shouldUseTerminalWebgl(pane: ManagedPaneInternal): boolean {
@@ -96,7 +107,8 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
     !pane.gpuRenderingEnabled ||
     !shouldUseTerminalWebgl(pane) ||
     pane.webglAttachmentDeferred ||
-    pane.webglDisabledAfterContextLoss
+    pane.webglDisabledAfterContextLoss ||
+    webglAttachFailedSinceRecovery
   ) {
     pane.webglAddon = null
     return
@@ -111,7 +123,8 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       )
       // Why: Chromium starts reclaiming terminal contexts under pressure.
       // Recreating WebGL for this pane can loop context loss and leave xterm
-      // visually blank, so keep the pane on the DOM renderer until remount.
+      // visually blank, so keep the pane on the DOM renderer until the next
+      // rendering resume (worktree foreground / window wake) retries it.
       pane.webglDisabledAfterContextLoss = true
       disposeWebgl(pane, { refreshDimensions: true })
     })
@@ -124,6 +137,7 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       // enough signal to keep new auto panes on DOM until the setting changes.
       suggestedRendererType = 'dom'
     }
+    webglAttachFailedSinceRecovery = true
     // WebGL not available — default DOM renderer is fine, but log it for debugging
     console.warn('[terminal] WebGL unavailable for pane', pane.id, '— using DOM renderer:', err)
     pane.webglAddon = null


### PR DESCRIPTION
## Summary

Two related fixes for terminal GPU rendering falling back to the slow DOM renderer.

**1. Raise Blink's active-WebGL-context cap to 128.** Terminals use xterm's WebGL renderer, but Blink caps active WebGL contexts at 16 per renderer process and force-loses the oldest context beyond that. Each attached terminal pane holds one context, and background terminal tabs within the active worktree intentionally keep theirs for fast tab switching — so heavy tab × split layouts can exceed 16 and evict panes. Raised via Chromium's `max-active-webgl-contexts` switch in `enableMainProcessGpuFeatures()` before `app.whenReady()`. 128 covers realistic layouts (active worktree tabs × splits + floating terminal + transient overlap during worktree switches) while staying bounded, so a context leak still surfaces as visible eviction instead of unbounded GPU memory growth. The switch is inert wherever GPU rendering is already off (Linux E2E path, GPU-fallback launches, Wayland/software-renderer auto-policy).

**2. Recover WebGL after context loss instead of latching panes to the DOM renderer.** Context loss previously latched `webglDisabledAfterContextLoss` until pane remount, so one GPU process reset (sleep/wake, driver crash) silently downgraded every affected terminal for the rest of the worktree's life — even after Chromium restored the GPU. Rendering resume (worktree foreground, window wake) and explicit GPU-setting changes now clear the latch and retry. Retries only happen at these discrete recovery boundaries, so loss cannot loop the way immediate re-creation could (the reason the latch was originally permanent).

**3. Back off failed attach attempts.** While Chromium refuses context creation entirely (GPU process down / WebGL blocked after repeated resets), forced-`on` mode constructed a new `WebglAddon` on every terminal title change — agent TUIs retitle constantly, flooding the console with full-stack `WebGL2 not supported` warnings (observed 51× in one session). The first failure now suppresses further attempts until the next recovery boundary, giving at most one attempt per resume instead of one per title change. `rebuildAttachedWebgl` clears the backoff before reattaching: its guard proves a live addon existed, so a stale backoff must not downgrade a healthy pane during font/settings rebuilds.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — targeted: all 144 test files / 1728 tests under `src/renderer/src/lib/pane-manager` + `src/renderer/src/components/terminal-pane`, plus `src/main/startup/configure-process.test.ts` (23); full suite left to CI
- [ ] `pnpm build` — not run locally; left to CI
- [x] New tests: `pane-webgl-context-recovery.test.ts` drives the production `onContextLoss` handler via the real addon's context-loss emitter — full loss → latch → resume → recovery cycle, re-latch on repeated loss, attach backoff and its resume-boundary reset. `pane-terminal-gpu-acceleration.test.ts` covers latch clearing on mode change (and preservation when mode is unchanged). `configure-process.test.ts` covers the switch on the default path and its absence on the disabled-GPU path.

## AI Review Report

Reviewed: (1) loop safety — the original permanent latch existed to prevent context-loss recreation loops; retries are now bound to discrete resume/wake/setting events and each failure re-latches, so a persistent outage costs one attempt per event, never a loop. (2) Backoff staleness — a global backoff could wrongly skip reattach for panes whose contexts provably work; the rebuild path clears it (live-addon evidence), the split-restore path intentionally honors it (a concurrent failure there means creation is failing right now). (3) One-attempt-per-resume — resume clears the backoff before iterating panes, so the first failing pane re-latches it and remaining panes skip construction. (4) `auto`-mode semantics unchanged: the session-permanent DOM suggestion after a failed attach still applies; recovery-boundary retries affect forced-`on` and context-loss latches only. Cross-platform: no shortcuts, labels, paths, or shell behavior; the switch and renderer logic are platform-independent, and Linux Wayland/software paths keep terminal WebGL off via the existing auto-policy. SSH/headless unaffected (rendering is renderer-local; headless disables GPU).

## Security Audit

Main-process change appends one hardcoded Chromium switch; renderer changes are internal rendering state with no user, config, network, or IPC input. No auth, secrets, path handling, or command execution. Resource bound: a renderer may hold more live WebGL contexts before eviction — deliberately capped at 128.

## Notes

- Recovery boundaries are worktree foregrounding and window wake. A pane that loses its context while visible rejoins WebGL on the next such event rather than instantly — deliberate, to keep retries loop-proof. macOS sleep/wake GPU resets recover automatically via the existing window-wake path.
- The context-loss → DOM fallback flow was validated with unit tests that fire the real xterm addon context-loss event through the production handler; a genuine GPU process crash was not reproduced end-to-end locally.