### PR TITLE
fix(emulator): recycle iOS simulators that wedge-boot without a display framebuffer

### DIFF
--- a/src/cli/handlers/emulator.test.ts
+++ b/src/cli/handlers/emulator.test.ts
@@ -73,6 +73,24 @@ describe('orca emulator CLI handlers', () => {
     })
   })
 
+  it('uses a wider client timeout for emulator attach recovery', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_attach', {
+        attached: true,
+        info: { deviceUdid: 'device-1', streamUrl: 'http://127.0.0.1:3102/stream.mjpeg' }
+      })
+    )
+
+    await main(['emulator', 'attach', 'device-1', '--worktree', 'all'], '/repo/project')
+
+    expect(callMock).toHaveBeenCalledWith(
+      'emulator.attach',
+      { device: 'device-1', worktree: undefined, focus: false },
+      { timeoutMs: 180_000 }
+    )
+  })
+
   it('rejects relative APK paths for remote runtimes', async () => {
     remoteMock.mockReturnValue(true)
 

--- a/src/cli/handlers/emulator.ts
+++ b/src/cli/handlers/emulator.ts
@@ -128,7 +128,13 @@ export const EMULATOR_HANDLERS: Record<string, CommandHandler> = {
     const target = await getEmulatorCommandTarget(flags, cwd, client)
     const device = getOptionalStringFlag(flags, 'device')
     const focus = flags.get('focus') === true
-    const res = await client.call('emulator.attach', { device, worktree: target.worktree, focus })
+    // Why: attach may cold-boot or recycle a wedged simulator (shutdown + boot +
+    // helper restart), which can legitimately exceed the 60s default budget.
+    const res = await client.call(
+      'emulator.attach',
+      { device, worktree: target.worktree, focus },
+      { timeoutMs: 180_000 }
+    )
     printResult(res, json, (r: unknown) => {
       const result = r as EmulatorAttachResult
       const info = result.info ?? result

--- a/src/main/emulator/backends/ios-emulator-backend.test.ts
+++ b/src/main/emulator/backends/ios-emulator-backend.test.ts
@@ -3,6 +3,7 @@ import type { SimulatorDevice } from '../simctl-simulator-devices'
 import type { ServeSimHelperProcess } from '../serve-sim-helper-processes'
 
 const {
+  ensureSimulatorBootedMock,
   execServeSimCommandMock,
   hideNativeSimulatorAppMock,
   killServeSimHelperProcessesForDeviceMock,
@@ -12,6 +13,7 @@ const {
   sendEmulatorGestureSequenceMock,
   parseServeSimDetachedSessionMock
 } = vi.hoisted(() => ({
+  ensureSimulatorBootedMock: vi.fn(async () => {}),
   execServeSimCommandMock: vi.fn(async () => ({})),
   hideNativeSimulatorAppMock: vi.fn(async () => {}),
   killServeSimHelperProcessesForDeviceMock: vi.fn(async () => {}),
@@ -30,7 +32,7 @@ vi.mock('../serve-sim-execution', () => ({
 }))
 
 vi.mock('../simctl-simulator-devices', () => ({
-  ensureSimulatorBooted: vi.fn(async () => {}),
+  ensureSimulatorBooted: ensureSimulatorBootedMock,
   listSimulatorDevices: listSimulatorDevicesMock,
   resolveSimulatorUdid: vi.fn(async (device: string) => device),
   shutdownSimulatorDevice: shutdownSimulatorDeviceMock
@@ -53,12 +55,15 @@ vi.mock('../serve-sim-detached-session', () => ({
   parseServeSimDetachedSession: parseServeSimDetachedSessionMock
 }))
 
+import { EmulatorError } from '../emulator-errors'
 import { IosEmulatorBackend } from './ios-emulator-backend'
 
 const EXECUTABLE = { command: '/serve-sim', env: {} }
 
 describe('IosEmulatorBackend', () => {
   beforeEach(() => {
+    ensureSimulatorBootedMock.mockReset()
+    ensureSimulatorBootedMock.mockImplementation(async () => {})
     execServeSimCommandMock.mockReset()
     execServeSimCommandMock.mockImplementation(async () => ({}))
     listSimulatorDevicesMock.mockReset()
@@ -184,6 +189,79 @@ describe('IosEmulatorBackend', () => {
     expect(info.deviceUdid).toBe('device-1')
     expect(info.streamCodec).toBe('mjpeg')
     expect(hideNativeSimulatorAppMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('recycles the device and retries when the helper finds no framebuffer', async () => {
+    // The real-world failure: simctl reports Booted but the display IO ports
+    // never came up, so serve-sim --detach dies with the framebuffer error.
+    execServeSimCommandMock
+      .mockRejectedValueOnce(
+        new EmulatorError(
+          'emulator_error',
+          'Helper failed:\n[main] Starting serve-sim-bin\n[main] Failed to start capture: No framebuffer display descriptor found'
+        )
+      )
+      .mockResolvedValueOnce({})
+    parseServeSimDetachedSessionMock.mockReturnValue({
+      deviceUdid: 'device-1',
+      streamUrl: 'http://127.0.0.1:3102/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3102',
+      helperPid: 1234
+    })
+    const backend = new IosEmulatorBackend({ waitForEndpointReady: async () => true })
+    const info = await backend.startSession('device-1')
+    expect(info.deviceUdid).toBe('device-1')
+    expect(shutdownSimulatorDeviceMock).toHaveBeenCalledWith('device-1')
+    // Booted once up front, again after the recycle shutdown.
+    expect(ensureSimulatorBootedMock).toHaveBeenCalledTimes(2)
+    expect(execServeSimCommandMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not recycle the device for unrelated helper start failures', async () => {
+    execServeSimCommandMock.mockRejectedValueOnce(
+      new EmulatorError('emulator_error', 'Helper failed:\n[main] Port 3100 already in use')
+    )
+    const backend = new IosEmulatorBackend({ waitForEndpointReady: async () => true })
+    await expect(backend.startSession('device-1')).rejects.toMatchObject({
+      message: expect.stringContaining('Port 3100 already in use')
+    })
+    expect(shutdownSimulatorDeviceMock).not.toHaveBeenCalled()
+    expect(execServeSimCommandMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates mid-recycle failures instead of masking them', async () => {
+    execServeSimCommandMock.mockRejectedValue(
+      new EmulatorError(
+        'emulator_error',
+        'Helper failed:\n[main] Failed to start capture: No framebuffer display descriptor found'
+      )
+    )
+    shutdownSimulatorDeviceMock.mockRejectedValueOnce(
+      new EmulatorError('emulator_error', 'xcrun simctl shutdown timed out')
+    )
+    const backend = new IosEmulatorBackend({ waitForEndpointReady: async () => true })
+    await expect(backend.startSession('device-1')).rejects.toMatchObject({
+      message: expect.stringContaining('timed out')
+    })
+    expect(execServeSimCommandMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces an actionable error when the display stays wedged after one recycle', async () => {
+    execServeSimCommandMock.mockRejectedValue(
+      new EmulatorError(
+        'emulator_error',
+        'Helper failed:\n[main] Failed to start capture: No framebuffer display descriptor found'
+      )
+    )
+    const backend = new IosEmulatorBackend({ waitForEndpointReady: async () => true })
+    await expect(backend.startSession('device-1')).rejects.toMatchObject({
+      code: 'emulator_helper_failed',
+      // Actionable headline plus the raw helper log for diagnosis.
+      message: expect.stringMatching(/simctl erase[\s\S]*No framebuffer display descriptor found/)
+    })
+    // Exactly one recycle attempt — no shutdown/boot loop against a broken device.
+    expect(shutdownSimulatorDeviceMock).toHaveBeenCalledTimes(1)
+    expect(execServeSimCommandMock).toHaveBeenCalledTimes(2)
   })
 
   it('stops a helper via serve-sim kill plus the orphan sweep', async () => {

--- a/src/main/emulator/backends/ios-emulator-backend.test.ts
+++ b/src/main/emulator/backends/ios-emulator-backend.test.ts
@@ -14,7 +14,7 @@ const {
   parseServeSimDetachedSessionMock
 } = vi.hoisted(() => ({
   ensureSimulatorBootedMock: vi.fn(async () => {}),
-  execServeSimCommandMock: vi.fn(async () => ({})),
+  execServeSimCommandMock: vi.fn(async (_executable?: unknown, _args?: string[]) => ({})),
   hideNativeSimulatorAppMock: vi.fn(async () => {}),
   killServeSimHelperProcessesForDeviceMock: vi.fn(async () => {}),
   listSimulatorDevicesMock: vi.fn(async (): Promise<SimulatorDevice[]> => []),
@@ -259,9 +259,43 @@ describe('IosEmulatorBackend', () => {
       // Actionable headline plus the raw helper log for diagnosis.
       message: expect.stringMatching(/simctl erase[\s\S]*No framebuffer display descriptor found/)
     })
-    // Exactly one recycle attempt — no shutdown/boot loop against a broken device.
+    // Exactly one recycle attempt; no shutdown/boot loop against a broken device.
     expect(shutdownSimulatorDeviceMock).toHaveBeenCalledTimes(1)
     expect(execServeSimCommandMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not recycle more than once during one start attempt', async () => {
+    let detachCalls = 0
+    execServeSimCommandMock.mockImplementation(
+      async (_executable?: unknown, args: string[] = []) => {
+        if (args[0] !== '--detach') {
+          return {}
+        }
+        detachCalls += 1
+        if (detachCalls === 2) {
+          return {}
+        }
+        throw new EmulatorError(
+          'emulator_error',
+          'Helper failed:\n[main] Failed to start capture: No framebuffer display descriptor found'
+        )
+      }
+    )
+    parseServeSimDetachedSessionMock.mockReturnValue({
+      deviceUdid: 'device-1',
+      streamUrl: 'http://127.0.0.1:3102/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3102',
+      helperPid: 1234
+    })
+    const backend = new IosEmulatorBackend({ waitForEndpointReady: async () => false })
+
+    await expect(backend.startSession('device-1')).rejects.toMatchObject({
+      code: 'emulator_helper_failed',
+      message: expect.stringContaining('even after a reboot')
+    })
+    expect(detachCalls).toBe(3)
+    expect(shutdownSimulatorDeviceMock).toHaveBeenCalledTimes(1)
+    expect(ensureSimulatorBootedMock).toHaveBeenCalledTimes(2)
   })
 
   it('stops a helper via serve-sim kill plus the orphan sweep', async () => {

--- a/src/main/emulator/backends/ios-emulator-backend.ts
+++ b/src/main/emulator/backends/ios-emulator-backend.ts
@@ -190,9 +190,34 @@ export class IosEmulatorBackend implements EmulatorBackend {
       return false
     }
 
-    let info = await startDetachedHelper()
+    // Why: CoreSimulator can report "Booted" with the display IO ports down
+    // (HID alive, no framebuffer); a shutdown/boot recycle is the only recovery.
+    const startHelperRecyclingWedgedBoot = async (): Promise<EmulatorSessionInfo> => {
+      try {
+        return await startDetachedHelper()
+      } catch (error) {
+        if (!isMissingFramebufferError(error)) {
+          throw error
+        }
+        await shutdownSimulatorDevice(udid)
+        await ensureSimulatorBooted(udid)
+        try {
+          return await startDetachedHelper()
+        } catch (retryError) {
+          if (!isMissingFramebufferError(retryError)) {
+            throw retryError
+          }
+          throw new EmulatorError(
+            'emulator_helper_failed',
+            `Simulator ${udid} keeps booting without a working display (no framebuffer descriptor), even after a reboot. Erase it with \`xcrun simctl erase ${udid}\` or recreate it in Xcode > Window > Devices and Simulators.\n\n${retryError.message}`
+          )
+        }
+      }
+    }
+
+    let info = await startHelperRecyclingWedgedBoot()
     if (!(await waitForReadyOrKill(info))) {
-      info = await startDetachedHelper()
+      info = await startHelperRecyclingWedgedBoot()
       if (!(await waitForReadyOrKill(info))) {
         throw new EmulatorError(
           'emulator_helper_failed',
@@ -240,6 +265,18 @@ export class IosEmulatorBackend implements EmulatorBackend {
   ): Promise<unknown> {
     return execServeSimCommand(this.serveSimExecutable, args, options)
   }
+}
+
+// Why: serve-sim's capture helper prints exactly this when a booted device has
+// no com.apple.framebuffer.display IO port — the signature of a wedged boot.
+const MISSING_FRAMEBUFFER_RE = /No framebuffer display descriptor found/i
+
+function isMissingFramebufferError(error: unknown): error is EmulatorError {
+  return (
+    error instanceof EmulatorError &&
+    error.code === 'emulator_error' &&
+    MISSING_FRAMEBUFFER_RE.test(error.message)
+  )
 }
 
 function toEmulatorDevice(device: SimulatorDevice): EmulatorDevice {

--- a/src/main/emulator/backends/ios-emulator-backend.ts
+++ b/src/main/emulator/backends/ios-emulator-backend.ts
@@ -190,8 +190,16 @@ export class IosEmulatorBackend implements EmulatorBackend {
       return false
     }
 
+    const throwPersistentMissingFramebuffer = (error: EmulatorError): never => {
+      throw new EmulatorError(
+        'emulator_helper_failed',
+        `Simulator ${udid} keeps booting without a working display (no framebuffer descriptor), even after a reboot. Erase it with \`xcrun simctl erase ${udid}\` or recreate it in Xcode > Window > Devices and Simulators.\n\n${error.message}`
+      )
+    }
+
     // Why: CoreSimulator can report "Booted" with the display IO ports down
     // (HID alive, no framebuffer); a shutdown/boot recycle is the only recovery.
+    let didRecycleWedgedBoot = false
     const startHelperRecyclingWedgedBoot = async (): Promise<EmulatorSessionInfo> => {
       try {
         return await startDetachedHelper()
@@ -199,6 +207,10 @@ export class IosEmulatorBackend implements EmulatorBackend {
         if (!isMissingFramebufferError(error)) {
           throw error
         }
+        if (didRecycleWedgedBoot) {
+          return throwPersistentMissingFramebuffer(error)
+        }
+        didRecycleWedgedBoot = true
         await shutdownSimulatorDevice(udid)
         await ensureSimulatorBooted(udid)
         try {
@@ -207,10 +219,7 @@ export class IosEmulatorBackend implements EmulatorBackend {
           if (!isMissingFramebufferError(retryError)) {
             throw retryError
           }
-          throw new EmulatorError(
-            'emulator_helper_failed',
-            `Simulator ${udid} keeps booting without a working display (no framebuffer descriptor), even after a reboot. Erase it with \`xcrun simctl erase ${udid}\` or recreate it in Xcode > Window > Devices and Simulators.\n\n${retryError.message}`
-          )
+          return throwPersistentMissingFramebuffer(retryError)
         }
       }
     }
@@ -268,7 +277,7 @@ export class IosEmulatorBackend implements EmulatorBackend {
 }
 
 // Why: serve-sim's capture helper prints exactly this when a booted device has
-// no com.apple.framebuffer.display IO port — the signature of a wedged boot.
+// no com.apple.framebuffer.display IO port: the signature of a wedged boot.
 const MISSING_FRAMEBUFFER_RE = /No framebuffer display descriptor found/i
 
 function isMissingFramebufferError(error: unknown): error is EmulatorError {

--- a/src/main/emulator/simctl-simulator-devices.test.ts
+++ b/src/main/emulator/simctl-simulator-devices.test.ts
@@ -106,9 +106,7 @@ describe('shutdownSimulatorDevice', () => {
     execFileMock.mockImplementation((_command, _args, _options, callback) => {
       callback(
         Object.assign(
-          new Error(
-            'Command failed: xcrun simctl shutdown AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE\nUnable to shutdown device in current state: Shutdown'
-          ),
+          new Error('Command failed: xcrun simctl shutdown AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE'),
           { code: 164 }
         ),
         '',
@@ -123,7 +121,7 @@ describe('shutdownSimulatorDevice', () => {
 
   it('propagates real shutdown failures instead of swallowing them', async () => {
     // execFile's message echoes the command line, which always contains
-    // "shutdown" — a hung device (timeout kill) must still reject.
+    // "shutdown"; a hung device (timeout kill) must still reject.
     execFileMock.mockImplementation((_command, _args, _options, callback) => {
       callback(
         Object.assign(
@@ -132,6 +130,23 @@ describe('shutdownSimulatorDevice', () => {
         ),
         '',
         ''
+      )
+    })
+
+    await expect(
+      shutdownSimulatorDevice('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE')
+    ).rejects.toMatchObject({ code: 'emulator_error' })
+  })
+
+  it('rejects current-state failures that are not already shut down', async () => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(
+        Object.assign(
+          new Error('Command failed: xcrun simctl shutdown AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE'),
+          { code: 164 }
+        ),
+        '',
+        'Unable to shutdown device in current state: Booting'
       )
     })
 

--- a/src/main/emulator/simctl-simulator-devices.test.ts
+++ b/src/main/emulator/simctl-simulator-devices.test.ts
@@ -22,7 +22,7 @@ vi.mock('./serve-sim-execution', () => ({
   execServeSimCommand: vi.fn()
 }))
 
-import { listSimulatorDevices } from './simctl-simulator-devices'
+import { listSimulatorDevices, shutdownSimulatorDevice } from './simctl-simulator-devices'
 
 describe('listSimulatorDevices', () => {
   beforeEach(() => {
@@ -92,5 +92,51 @@ describe('listSimulatorDevices', () => {
     })
     expect(error).toBeInstanceOf(Error)
     expect((error as Error).message).not.toContain('Command failed')
+  })
+})
+
+describe('shutdownSimulatorDevice', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    platformMock.mockReset()
+    platformMock.mockReturnValue('darwin')
+  })
+
+  it('treats an already-shut-down device as success', async () => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(
+        Object.assign(
+          new Error(
+            'Command failed: xcrun simctl shutdown AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE\nUnable to shutdown device in current state: Shutdown'
+          ),
+          { code: 164 }
+        ),
+        '',
+        'Unable to shutdown device in current state: Shutdown'
+      )
+    })
+
+    await expect(
+      shutdownSimulatorDevice('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE')
+    ).resolves.toBeUndefined()
+  })
+
+  it('propagates real shutdown failures instead of swallowing them', async () => {
+    // execFile's message echoes the command line, which always contains
+    // "shutdown" — a hung device (timeout kill) must still reject.
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(
+        Object.assign(
+          new Error('Command failed: xcrun simctl shutdown AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE'),
+          { killed: true, signal: 'SIGTERM' }
+        ),
+        '',
+        ''
+      )
+    })
+
+    await expect(
+      shutdownSimulatorDevice('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE')
+    ).rejects.toMatchObject({ code: 'emulator_error' })
   })
 })

--- a/src/main/emulator/simctl-simulator-devices.ts
+++ b/src/main/emulator/simctl-simulator-devices.ts
@@ -191,8 +191,10 @@ export async function shutdownSimulatorDevice(udid: string): Promise<void> {
           resolve()
           return
         }
+        // Why: execFile's message echoes the command line, so it always contains
+        // "shutdown"; only "current state" reliably means the device was already off.
         const message = error.message.toLowerCase()
-        if (message.includes('shutdown') || message.includes('current state')) {
+        if (message.includes('current state')) {
           resolve()
           return
         }

--- a/src/main/emulator/simctl-simulator-devices.ts
+++ b/src/main/emulator/simctl-simulator-devices.ts
@@ -191,10 +191,10 @@ export async function shutdownSimulatorDevice(udid: string): Promise<void> {
           resolve()
           return
         }
-        // Why: execFile's message echoes the command line, so it always contains
-        // "shutdown"; only "current state" reliably means the device was already off.
-        const message = error.message.toLowerCase()
-        if (message.includes('current state')) {
+        // Why: execFile's message echoes the command line, so only the actual
+        // already-off state is idempotent; other current states are real failures.
+        const message = `${error.message}\n${stderr?.toString() ?? ''}`.toLowerCase()
+        if (/\bcurrent state:\s*shutdown\b/.test(message)) {
           resolve()
           return
         }


### PR DESCRIPTION
## Summary

Fixes #7062.

When a CoreSimulator device wedge-boots — `simctl` reports `Booted` and HID works, but the display IO ports never come up so there is no `com.apple.framebuffer.display` port — the Mobile Emulator pane fails with the raw `Helper failed: … Failed to start capture: No framebuffer display descriptor found` dump, and **Connect can never recover**: `ensureSimulatorBooted` early-returns on the `Booted` state string, so every retry re-targets the same broken device. The only remedy is a manual `simctl shutdown` + `boot` (verified on a live wedged device; serve-sim's own CI works around the same phenomenon with a reboot-and-retry wrapper, EvanBacon/serve-sim#118).

User-visible change: `startSession` now recognizes that specific helper-failure signature, recycles the device once (shutdown + boot), and retries the helper start. If the display still doesn't come up, the pane shows an actionable erase/recreate message (with the helper log appended for diagnosis) instead of the raw log dump.

Supporting fixes surfaced by review:

- `shutdownSimulatorDevice` treated **every** `simctl shutdown` failure as "already shut down" because Node's `execFile` error message echoes the command line, which always contains the word "shutdown". Real failures (e.g. a 30s timeout on a wedged device) were silently swallowed — which would have made the recycle a no-op and the "even after a reboot" message a lie. The match is now the intended `current state` idempotency check only, so genuine failures propagate.
- The CLI's `emulator attach` now passes a wider client-side RPC timeout: a successful recovery (shutdown + boot + second helper start) can legitimately exceed the 60s default, and previously would have been misreported as a client timeout while the server finished attaching.

## Screenshots

No visual change (main-process behavior fix). Before/after error text is in #7062.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — every suite covering the changed files passes (targeted run of the emulator backends, simctl devices, and CLI projects: 376/376). The full suite on my machine fails a shifting set of process-heavy tests (pty / git-relay / subprocess) on **both** this branch (9) and clean `origin/main` (18) — machine flakes with no overlap with this diff; notably `serve-sim-state-watcher`'s dedupe-key test fails identically on clean `main`
- [x] `pnpm build` — `build:desktop` and the native Swift build complete; the final codesign step fails on this machine due to a duplicated "Apple Development" identity in the local keychain (environment issue, present on `main` too, unrelated to this change)
- [x] Added high-quality regression tests:
  - recycles the device and retries when the helper reports the missing-framebuffer signature (asserts shutdown + re-boot + second start)
  - does **not** recycle for unrelated helper failures (asserts single start, no shutdown)
  - surfaces the actionable `emulator_helper_failed` error when the display stays wedged after exactly one recycle (no shutdown/boot loop)
  - propagates mid-recycle failures (e.g. `simctl shutdown` failing) instead of masking them with the canned message
  - new `shutdownSimulatorDevice` suite: resolves on the `current state` (already-shutdown) idempotency case, rejects on real failures — pinning the swallow-bug fix

Also reproduced end-to-end on the affected machine: a genuinely wedged device (`simctl io enumerate` showing no display ports) recovered fully after shutdown+boot and the pane connected.

## AI Review Report

Three independent adversarial review passes (correctness/failure-modes, project-conventions, security) were run on the diff; all findings were either fixed or consciously scoped out:

- **Fixed from review:** the CLI attach timeout (above); the `shutdownSimulatorDevice` swallow bug (above); the framebuffer predicate narrowed to `EmulatorError` with code `emulator_error` so a wrapped or non-helper error can't trigger a spurious recycle; both helper-start sites (initial start and the endpoint-readiness restart) now go through the same guarded closure so the recovery isn't asymmetric; the final actionable error preserves the helper's raw log.
- **Cross-platform (macOS/Linux/Windows):** all behavior changes live in the darwin-only iOS backend (`IosEmulatorBackend`, gated by `isSupportedOnHost`/`platform() !== 'darwin'` throws in the simctl helpers) plus a timeout constant in the CLI handler; no new platform-dependent paths, shortcuts, labels, or path handling.
- **SSH/remote:** the change is main-process + a client-side timeout; no assumption that files/processes are local beyond what the iOS backend already requires (simctl on the runtime host).
- **Agents/integrations/git providers:** untouched.
- **Performance:** the recovery work only runs after a failed helper start matching the wedge signature; the happy path is unchanged. Recycle is bounded to one per `startSession` call — no loops.

## Security Audit

- The error-string match only gates *whether* to recycle; it never contributes arguments to any command. All process spawns remain `execFile` with array argv (no shell).
- The `udid` embedded in the copy-pasteable `simctl erase` suggestion is provably a simctl-reported device UDID: `ensureSimulatorBooted` throws `emulator_device_not_found` for anything not in `simctl list` before the new path can run. (Defense-in-depth option noted for a follow-up: assert UDID shape before embedding.)
- DoS angle reviewed: the recycle is bounded to one per user-initiated attach; a hostile app inside the simulator cannot trigger repeated shutdown/boot cycles.
- No new IPC surface, input handling, secrets, or dependency changes.

## Notes

- Behavior change beyond the pane: with the swallow-bug fix, the toolbar power button now surfaces real `simctl shutdown` failures instead of silently succeeding — previously they were indistinguishable from success.
- Known bounded edge (consciously left out): if the wedge signature appears while a *different* Orca window holds a live session on the same device, the recycle shuts that session's device down; sessions are per-device registered and the registry re-attaches, and this mirrors what a user fixing the device manually would do.
- X handle: @micko_solac

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/7065">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->