### PR TITLE
Cut fseventsd load: fix macOS exclusion cap, drop wide always-on FSEvents streams

### DIFF
--- a/src/main/emulator/serve-sim-state-watcher.test.ts
+++ b/src/main/emulator/serve-sim-state-watcher.test.ts
@@ -34,7 +34,7 @@ describe('ServeSimStateWatcher', () => {
     const parentDir = await mkdtemp(join(tmpdir(), 'orca-serve-sim-watch-'))
     cleanupPaths.push(parentDir)
     const stateDir = join(parentDir, 'serve-sim')
-    const watcher = new ServeSimStateWatcher({ parentDir, stateDir })
+    const watcher = new ServeSimStateWatcher({ stateDir })
     const events: ServeSimStateDetectedEvent[] = []
 
     watcher.bindPty('pty-1', 'worktree-1')

--- a/src/main/emulator/serve-sim-state-watcher.ts
+++ b/src/main/emulator/serve-sim-state-watcher.ts
@@ -68,19 +68,16 @@ function helperInstanceKey(info: ServeSimHelperInfo): string {
 
 export class ServeSimStateWatcher {
   private readonly stateDir: string
-  private readonly parentDir: string
   private readonly ptyToWorktree = new Map<string, string>()
   private readonly ptyBuffers = new Map<string, string>()
   private readonly seenExternalKeys = new Set<string>()
   private readonly orcaManagedHelperKeys = new Set<string>()
   private readonly listeners = new Set<(event: ServeSimStateDetectedEvent) => void>()
-  private parentWatcher: FSWatcher | null = null
   private stateWatcher: FSWatcher | null = null
   private stateDirPoll: ReturnType<typeof setInterval> | null = null
 
-  constructor(options: { stateDir?: string; parentDir?: string } = {}) {
+  constructor(options: { stateDir?: string } = {}) {
     this.stateDir = options.stateDir ?? DEFAULT_STATE_DIR
-    this.parentDir = options.parentDir ?? tmpdir()
   }
 
   onDetected(listener: (event: ServeSimStateDetectedEvent) => void): () => void {
@@ -156,25 +153,20 @@ export class ServeSimStateWatcher {
   }
 
   start(): void {
-    if (this.parentWatcher || this.stateWatcher) {
+    if (this.stateDirPoll || this.stateWatcher) {
       return
     }
     try {
       // Why: $TMPDIR/serve-sim/ may not exist until the first terminal `serve-sim --detach`.
-      // Watch the parent tmpdir and attach to serve-sim/ when it appears (or watch it directly if present).
+      // Poll for it instead of fs.watch on the parent tmpdir: watching $TMPDIR
+      // registers a permanent FSEvents client on the system's highest-churn
+      // directory, while an existence poll costs the daemon nothing.
       this.attachStateDirWatch()
       if (this.stateWatcher) {
         this.scanExistingStateFiles()
         return
       }
 
-      this.parentWatcher = watch(this.parentDir, (_event, filename) => {
-        if (!filename || String(filename) !== 'serve-sim') {
-          return
-        }
-        this.attachStateDirWatch()
-        this.scanExistingStateFiles()
-      })
       this.stateDirPoll = setInterval(() => {
         this.attachStateDirWatch()
         this.scanExistingStateFiles()
@@ -186,12 +178,10 @@ export class ServeSimStateWatcher {
   }
 
   stop(): void {
-    this.parentWatcher?.close()
     this.stateWatcher?.close()
     if (this.stateDirPoll) {
       clearInterval(this.stateDirPoll)
     }
-    this.parentWatcher = null
     this.stateWatcher = null
     this.stateDirPoll = null
     this.ptyToWorktree.clear()

--- a/src/main/ipc/filesystem-watcher-ignore.test.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT,
+  WATCHER_IGNORE_DIRS,
+  buildParcelWatcherIgnoreOption
+} from './filesystem-watcher-ignore'
+
+const realPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform })
+}
+
+describe('buildParcelWatcherIgnoreOption', () => {
+  afterEach(() => {
+    setPlatform(realPlatform)
+  })
+
+  it('keeps at most 8 plain paths on macOS so FSEventStreamSetExclusionPaths succeeds', () => {
+    setPlatform('darwin')
+    const option = buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS)
+    // @parcel/watcher passes non-glob entries to FSEventStreamSetExclusionPaths,
+    // which rejects the WHOLE set past 8 paths — silently disabling daemon-side
+    // exclusion of node_modules/.git churn.
+    const plainPaths = option.filter((entry) => !entry.includes('*'))
+    expect(plainPaths.length).toBeLessThanOrEqual(MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
+    // Every ignore dir must still be covered, as a path or as a glob.
+    for (const dir of WATCHER_IGNORE_DIRS) {
+      expect(
+        option.some((entry) => entry === dir || entry === `**/${dir}` || entry === `**/${dir}/**`)
+      ).toBe(true)
+    }
+  })
+
+  it('passes the plain list through on other platforms', () => {
+    setPlatform('linux')
+    expect(buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS)).toEqual(WATCHER_IGNORE_DIRS)
+  })
+})

--- a/src/main/ipc/filesystem-watcher-ignore.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.ts
@@ -1,0 +1,36 @@
+// Canonical ignore list for recursive worktree watchers (mirrors VS Code's
+// predefined recursive-watch excludes). Shared by the explorer watcher and the
+// runtime file-watcher host so every @parcel/watcher subscription gets the
+// same high-churn exclusions.
+export const WATCHER_IGNORE_DIRS: string[] = [
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.cache',
+  'target',
+  '.venv',
+  '__pycache__'
+]
+
+// Why: macOS FSEventStreamSetExclusionPaths accepts at most 8 paths and fails
+// closed — one entry over the cap and @parcel/watcher silently loses ALL
+// daemon-side exclusions, so fseventsd delivers every node_modules/.git event
+// to this process (measured ~29x client CPU plus daemon-side delivery load).
+// Keep the 8 highest-churn dirs as plain paths (daemon-excluded) and demote
+// the rest to globs (userspace-filtered). Ordering of WATCHER_IGNORE_DIRS is
+// therefore meaningful: the first 8 get true daemon-side exclusion on macOS.
+export const MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT = 8
+
+export function buildParcelWatcherIgnoreOption(ignoreDirs: readonly string[]): string[] {
+  if (process.platform !== 'darwin') {
+    return [...ignoreDirs]
+  }
+  return [
+    ...ignoreDirs.slice(0, MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT),
+    ...ignoreDirs
+      .slice(MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
+      .flatMap((dir) => [`**/${dir}`, `**/${dir}/**`])
+  ]
+}

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -13,24 +13,11 @@ import { createWslWatcher } from './filesystem-watcher-wsl'
 import type { WatchedRoot } from './filesystem-watcher-wsl'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { MAX_BATCHED_WATCHER_EVENTS, queueWatcherEvents } from './filesystem-watcher-event-batch'
-
-// ── Ignore patterns ──────────────────────────────────────────────────
-// Why: high-churn directories are suppressed at the native watcher level
-// so events never leave the OS kernel. This list is separate from the
-// File Explorer display filter (which only hides rows). Directories like
-// `dist` and `build` remain visible in the tree but will not auto-refresh.
-
-const WATCHER_IGNORE_DIRS: string[] = [
-  '.git',
-  'node_modules',
-  'dist',
-  'build',
-  '.next',
-  '.cache',
-  '__pycache__',
-  'target',
-  '.venv'
-]
+// Why: high-churn directories are suppressed at the native watcher level so
+// events never leave the OS/daemon. This list is separate from the File
+// Explorer display filter (which only hides rows). Directories like `dist`
+// and `build` remain visible in the tree but will not auto-refresh.
+import { WATCHER_IGNORE_DIRS, buildParcelWatcherIgnoreOption } from './filesystem-watcher-ignore'
 
 // ── Debounce helpers ─────────────────────────────────────────────────
 
@@ -309,7 +296,7 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
     let errorCleanedUp = false
 
     const watcherOptions = {
-      ignore: WATCHER_IGNORE_DIRS,
+      ignore: buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS),
       // Why: Parcel checks Watchman before the native Windows backend by
       // default, and Windows prints a shell-level "watchman not recognized"
       // error for that probe. Pinning the backend keeps local watches quiet.

--- a/src/main/ipc/worktree-base-directory-poller.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  startWorktreeBaseDirectoryPoller,
+  type WorktreeBasePollEvent
+} from './worktree-base-directory-poller'
+import type {
+  WorktreeBaseRepoWatchConfig,
+  WorktreeBaseWatchTarget
+} from './worktree-base-directory-event-filter'
+
+const POLL_MS = 25
+
+function makeTarget(
+  kind: 'base' | 'git-common',
+  path: string,
+  config: Partial<WorktreeBaseRepoWatchConfig> = {}
+): WorktreeBaseWatchTarget {
+  const repoConfig: WorktreeBaseRepoWatchConfig = {
+    repoId: 'repo-1',
+    repoName: 'project',
+    nestWorkspaces: false,
+    ...config
+  }
+  return {
+    key: `${kind}:local:${path}`,
+    kind,
+    path,
+    repos: new Map([[repoConfig.repoId, repoConfig]])
+  }
+}
+
+async function waitForEvents(
+  events: WorktreeBasePollEvent[][],
+  predicate: (flat: WorktreeBasePollEvent[]) => boolean
+): Promise<WorktreeBasePollEvent[]> {
+  await vi.waitFor(
+    () => {
+      if (!predicate(events.flat())) {
+        throw new Error('expected poll events not observed yet')
+      }
+    },
+    { timeout: 5_000, interval: 20 }
+  )
+  return events.flat()
+}
+
+describe('worktree base directory poller', () => {
+  const cleanups: (() => Promise<void>)[] = []
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+  })
+
+  async function makeRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-base-poller-'))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    return root
+  }
+
+  it('emits a .git marker create and a worktree delete for flat layouts', async () => {
+    const root = await makeRoot()
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('base', root)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      POLL_MS
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    const worktree = join(root, 'external-1')
+    await mkdir(worktree)
+    await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+
+    const afterCreate = await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === join(worktree, '.git'))
+    )
+    expect(
+      afterCreate.filter((event) => event.type === 'create' && event.path.endsWith('.git'))
+    ).toHaveLength(1)
+
+    await rm(worktree, { recursive: true })
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'delete' && event.path === worktree)
+    )
+  })
+
+  it('emits the marker only after it appears for slow checkouts', async () => {
+    const root = await makeRoot()
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('base', root)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      POLL_MS
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    const worktree = join(root, 'external-2')
+    await mkdir(worktree)
+    // Give the poller time to observe the marker-less dir first.
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 3))
+    expect(received.flat()).toHaveLength(0)
+
+    await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === join(worktree, '.git'))
+    )
+  })
+
+  it('scans nested repo containers for nested layouts', async () => {
+    const root = await makeRoot()
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('base', root, { nestWorkspaces: true })
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      POLL_MS
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    const worktree = join(root, 'project', 'external-3')
+    await mkdir(worktree, { recursive: true })
+    await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === join(worktree, '.git'))
+    )
+  })
+
+  it('reports git-common worktrees metadata adds, updates, and removals', async () => {
+    const commonDir = await makeRoot()
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('git-common', commonDir)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      POLL_MS
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    const entry = join(commonDir, 'worktrees', 'external-4')
+    await mkdir(entry, { recursive: true })
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === entry)
+    )
+
+    // HEAD/gitdir metadata writes land as new files in the entry dir, which
+    // bumps the entry dir mtime the poller compares.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'update' && event.path === entry)
+    )
+
+    await rm(entry, { recursive: true })
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'delete' && event.path === entry)
+    )
+  })
+
+  it('emits deletes for all known worktrees when the root vanishes', async () => {
+    const root = await makeRoot()
+    const worktree = join(root, 'external-5')
+    await mkdir(worktree)
+    await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('base', root)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      POLL_MS
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    await rm(root, { recursive: true, force: true })
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'delete' && event.path === worktree)
+    )
+  })
+})

--- a/src/main/ipc/worktree-base-directory-poller.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -57,7 +57,10 @@ describe('worktree base directory poller', () => {
   async function makeRoot(): Promise<string> {
     const root = await mkdtemp(join(tmpdir(), 'orca-base-poller-'))
     cleanups.push(() => rm(root, { recursive: true, force: true }))
-    return root
+    // Why: macOS tmpdir lives behind the /var -> /private/var symlink and
+    // native watcher events report resolved paths; production targets are
+    // realpath'd the same way (canonicalizeExistingPath).
+    return realpath(root)
   }
 
   it('emits a .git marker create and a worktree delete for flat layouts', async () => {
@@ -68,7 +71,7 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      POLL_MS
+      { pollIntervalMs: POLL_MS }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -97,7 +100,7 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      POLL_MS
+      { pollIntervalMs: POLL_MS }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -121,7 +124,7 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      POLL_MS
+      { pollIntervalMs: POLL_MS }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -134,7 +137,41 @@ describe('worktree base directory poller', () => {
     )
   })
 
-  it('reports git-common worktrees metadata adds, updates, and removals', async () => {
+  it('skips full scans while the gate dirs are untouched', async () => {
+    const root = await makeRoot()
+    const worktree = join(root, 'external-idle')
+    await mkdir(worktree)
+    await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans: number[] = []
+    const target = makeTarget('base', root)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      { pollIntervalMs: POLL_MS, onFullScan: () => fullScans.push(Date.now()) }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    // ~8 idle ticks: under the backstop cadence, so the gate should skip
+    // every full scan (each tick is just gate-dir stats).
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 8))
+    expect(fullScans).toHaveLength(0)
+    expect(received.flat()).toHaveLength(0)
+
+    // Touching the root (new entry) flips the gate and triggers a scan.
+    await mkdir(join(root, 'external-new'))
+    await writeFile(join(root, 'external-new', '.git'), 'gitdir: elsewhere')
+    await waitForEvents(received, (flat) =>
+      flat.some(
+        (event) => event.type === 'create' && event.path === join(root, 'external-new', '.git')
+      )
+    )
+    expect(fullScans.length).toBeGreaterThan(0)
+  })
+
+  it('reports git-common worktrees metadata adds, updates, and removals via polling', async () => {
     const commonDir = await makeRoot()
     const received: WorktreeBasePollEvent[][] = []
     const target = makeTarget('git-common', commonDir)
@@ -142,7 +179,8 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      POLL_MS
+      // Force the non-darwin poll path so this test is deterministic on all CI.
+      { pollIntervalMs: POLL_MS, platform: 'linux' }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -178,7 +216,7 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      POLL_MS
+      { pollIntervalMs: POLL_MS }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -186,5 +224,89 @@ describe('worktree base directory poller', () => {
     await waitForEvents(received, (flat) =>
       flat.some((event) => event.type === 'delete' && event.path === worktree)
     )
+  })
+
+  describe.runIf(process.platform === 'darwin')('macOS narrow git-common stream', () => {
+    it('delivers instant add/update/remove without polling', async () => {
+      const commonDir = await makeRoot()
+      await mkdir(join(commonDir, 'worktrees'))
+      const received: WorktreeBasePollEvent[][] = []
+      const target = makeTarget('git-common', commonDir)
+      const poller = await startWorktreeBaseDirectoryPoller(
+        target,
+        () => target.repos,
+        (events) => received.push(events),
+        { pollIntervalMs: POLL_MS, platform: 'darwin' }
+      )
+      cleanups.push(() => poller.unsubscribe())
+
+      const entry = join(commonDir, 'worktrees', 'wt-a')
+      await mkdir(entry)
+      await waitForEvents(received, (flat) => flat.some((event) => event.path === entry))
+
+      await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
+      await waitForEvents(received, (flat) =>
+        flat.some((event) => event.path === join(entry, 'HEAD'))
+      )
+
+      await rm(entry, { recursive: true })
+      await waitForEvents(received, (flat) =>
+        flat.some((event) => event.type === 'delete' && event.path === entry)
+      )
+    })
+
+    it('arms via existence polling when the worktrees dir appears later', async () => {
+      const commonDir = await makeRoot()
+      const received: WorktreeBasePollEvent[][] = []
+      const target = makeTarget('git-common', commonDir)
+      const poller = await startWorktreeBaseDirectoryPoller(
+        target,
+        () => target.repos,
+        (events) => received.push(events),
+        { pollIntervalMs: POLL_MS, platform: 'darwin' }
+      )
+      cleanups.push(() => poller.unsubscribe())
+
+      const worktreesDir = join(commonDir, 'worktrees')
+      await mkdir(worktreesDir)
+      // The dir appearing is itself surfaced (a first worktree was added).
+      await waitForEvents(received, (flat) =>
+        flat.some((event) => event.type === 'create' && event.path === worktreesDir)
+      )
+
+      // And the narrow stream is live afterwards: entry adds are seen.
+      const entry = join(worktreesDir, 'wt-b')
+      await mkdir(entry)
+      await waitForEvents(received, (flat) => flat.some((event) => event.path === entry))
+    })
+
+    it('keeps watching across worktrees dir delete and recreate', async () => {
+      const commonDir = await makeRoot()
+      await mkdir(join(commonDir, 'worktrees'))
+      const received: WorktreeBasePollEvent[][] = []
+      const target = makeTarget('git-common', commonDir)
+      const poller = await startWorktreeBaseDirectoryPoller(
+        target,
+        () => target.repos,
+        (events) => received.push(events),
+        { pollIntervalMs: POLL_MS, platform: 'darwin' }
+      )
+      cleanups.push(() => poller.unsubscribe())
+
+      // Simulate `git worktree prune` removing the empty dir, then a new add
+      // recreating it. The stream re-arms via the existence poll; the repo
+      // gets notified on recreate, and subsequent entries are seen live.
+      const worktreesDir = join(commonDir, 'worktrees')
+      await rm(worktreesDir, { recursive: true })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      await mkdir(join(worktreesDir, 'wt-c'), { recursive: true })
+      await waitForEvents(received, (flat) =>
+        flat.some((event) => event.type === 'create' && event.path === worktreesDir)
+      )
+
+      const laterEntry = join(worktreesDir, 'wt-d')
+      await mkdir(laterEntry)
+      await waitForEvents(received, (flat) => flat.some((event) => event.path === laterEntry))
+    })
   })
 })

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -1,0 +1,207 @@
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import type {
+  WorktreeBaseRepoWatchConfig,
+  WorktreeBaseWatchTarget
+} from './worktree-base-directory-event-filter'
+
+export type WorktreeBasePollEvent = { type: 'create' | 'update' | 'delete'; path: string }
+
+// Why: these targets used to be recursive FSEvents subscriptions spanning the
+// entire workspace root (every worktree's full tree) and the repo's whole
+// common .git (objects included), forcing fseventsd to deliver all of that
+// churn to Orca just to observe a handful of shallow paths. A readdir/stat
+// poll observes exactly those paths with zero fseventsd clients. 2s is fast
+// enough for external `git worktree add/remove`; Orca's own worktree
+// operations notify the renderer directly and don't rely on this signal.
+export const WORKTREE_BASE_POLL_INTERVAL_MS = 2_000
+
+type BaseSnapshot = { kind: 'base'; markers: Map<string, boolean> }
+type GitCommonSnapshot = { kind: 'git-common'; mtimes: Map<string, number> }
+type PollSnapshot = BaseSnapshot | GitCommonSnapshot
+
+async function hasGitMarker(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, '.git'))
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Depth-1 worktree dirs (flat layout), plus depth-2 dirs under each nested
+// repo's container, mirroring what worktree-base-directory-event-filter
+// matches: `<wt>/.git` completion markers and `<wt>` deletions.
+async function snapshotBase(
+  rootPath: string,
+  repos: ReadonlyMap<string, WorktreeBaseRepoWatchConfig>
+): Promise<BaseSnapshot> {
+  const markers = new Map<string, boolean>()
+  const configs = [...repos.values()]
+  const includeFlat = configs.some((config) => !config.nestWorkspaces)
+  const nestedRepoNames = new Set(
+    configs
+      .filter((config) => config.nestWorkspaces)
+      .map((config) => normalizeRuntimePathForComparison(config.repoName))
+  )
+
+  let rootEntries
+  try {
+    rootEntries = await readdir(rootPath, { withFileTypes: true })
+  } catch {
+    // Root vanished: an empty snapshot diffs into delete events for every
+    // previously-known worktree dir, matching the old watcher's error path.
+    return { kind: 'base', markers }
+  }
+
+  const candidates: string[] = []
+  for (const entry of rootEntries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue
+    }
+    const entryPath = join(rootPath, entry.name)
+    if (includeFlat) {
+      candidates.push(entryPath)
+    }
+    if (nestedRepoNames.has(normalizeRuntimePathForComparison(entry.name))) {
+      let subEntries
+      try {
+        subEntries = await readdir(entryPath, { withFileTypes: true })
+      } catch {
+        subEntries = []
+      }
+      for (const sub of subEntries) {
+        if (sub.isDirectory() || sub.isSymbolicLink()) {
+          candidates.push(join(entryPath, sub.name))
+        }
+      }
+    }
+  }
+
+  for (const dir of candidates) {
+    markers.set(dir, await hasGitMarker(dir))
+  }
+  return { kind: 'base', markers }
+}
+
+function diffBase(prev: BaseSnapshot, next: BaseSnapshot): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  for (const [dir, marker] of next.markers) {
+    if (marker && prev.markers.get(dir) !== true) {
+      events.push({ type: 'create', path: join(dir, '.git') })
+    }
+  }
+  for (const dir of prev.markers.keys()) {
+    if (!next.markers.has(dir)) {
+      events.push({ type: 'delete', path: dir })
+    }
+  }
+  return events
+}
+
+// `<common>/worktrees/<name>` entries. Entry-dir mtime covers the metadata
+// writes the old recursive watcher reacted to (HEAD/gitdir/locked are written
+// via rename into the entry dir, which bumps its mtime).
+async function snapshotGitCommon(commonDirPath: string): Promise<GitCommonSnapshot> {
+  const mtimes = new Map<string, number>()
+  const worktreesDir = join(commonDirPath, 'worktrees')
+  let entries
+  try {
+    entries = await readdir(worktreesDir, { withFileTypes: true })
+  } catch {
+    // Missing worktrees dir is normal for repos without linked worktrees.
+    return { kind: 'git-common', mtimes }
+  }
+  for (const entry of entries) {
+    const entryPath = join(worktreesDir, entry.name)
+    try {
+      mtimes.set(entryPath, (await stat(entryPath)).mtimeMs)
+    } catch {
+      // Entry removed between readdir and stat.
+    }
+  }
+  return { kind: 'git-common', mtimes }
+}
+
+function diffGitCommon(prev: GitCommonSnapshot, next: GitCommonSnapshot): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  for (const [entryPath, mtime] of next.mtimes) {
+    const prevMtime = prev.mtimes.get(entryPath)
+    if (prevMtime === undefined) {
+      events.push({ type: 'create', path: entryPath })
+    } else if (prevMtime !== mtime) {
+      events.push({ type: 'update', path: entryPath })
+    }
+  }
+  for (const entryPath of prev.mtimes.keys()) {
+    if (!next.mtimes.has(entryPath)) {
+      events.push({ type: 'delete', path: entryPath })
+    }
+  }
+  return events
+}
+
+async function takeSnapshot(
+  target: WorktreeBaseWatchTarget,
+  getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>
+): Promise<PollSnapshot> {
+  return target.kind === 'git-common'
+    ? snapshotGitCommon(target.path)
+    : snapshotBase(target.path, getRepos())
+}
+
+function diffSnapshots(prev: PollSnapshot, next: PollSnapshot): WorktreeBasePollEvent[] {
+  if (prev.kind === 'git-common' && next.kind === 'git-common') {
+    return diffGitCommon(prev, next)
+  }
+  if (prev.kind === 'base' && next.kind === 'base') {
+    return diffBase(prev, next)
+  }
+  return []
+}
+
+/** Polls the shallow paths a worktree base target cares about and synthesizes
+ *  watcher-shaped events. Resolves once the baseline snapshot is taken. */
+export async function startWorktreeBaseDirectoryPoller(
+  target: WorktreeBaseWatchTarget,
+  getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>,
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  pollIntervalMs: number = WORKTREE_BASE_POLL_INTERVAL_MS
+): Promise<{ unsubscribe: () => Promise<void> }> {
+  let disposed = false
+  let ticking = false
+  let snapshot = await takeSnapshot(target, getRepos)
+
+  const timer = setInterval(() => {
+    if (disposed || ticking) {
+      return
+    }
+    ticking = true
+    void takeSnapshot(target, getRepos)
+      .then((next) => {
+        if (disposed) {
+          return
+        }
+        const events = diffSnapshots(snapshot, next)
+        snapshot = next
+        if (events.length > 0) {
+          onEvents(events)
+        }
+      })
+      .catch(() => {
+        // Transient fs error: keep the previous snapshot and retry next tick.
+      })
+      .finally(() => {
+        ticking = false
+      })
+  }, pollIntervalMs)
+  timer.unref?.()
+
+  return {
+    unsubscribe: async () => {
+      disposed = true
+      clearInterval(timer)
+    }
+  }
+}

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -5,21 +5,51 @@ import type {
   WorktreeBaseRepoWatchConfig,
   WorktreeBaseWatchTarget
 } from './worktree-base-directory-event-filter'
+import { startGitCommonWatch } from './worktree-git-common-watch'
 
 export type WorktreeBasePollEvent = { type: 'create' | 'update' | 'delete'; path: string }
+
+export type WorktreeBaseSubscription = { unsubscribe: () => Promise<void> }
+
+export type WorktreeBasePollerOptions = {
+  pollIntervalMs?: number
+  platform?: NodeJS.Platform
+  /** Test hook: called whenever a full snapshot scan runs (vs. a gated skip). */
+  onFullScan?: () => void
+}
 
 // Why: these targets used to be recursive FSEvents subscriptions spanning the
 // entire workspace root (every worktree's full tree) and the repo's whole
 // common .git (objects included), forcing fseventsd to deliver all of that
-// churn to Orca just to observe a handful of shallow paths. A readdir/stat
-// poll observes exactly those paths with zero fseventsd clients. 2s is fast
-// enough for external `git worktree add/remove`; Orca's own worktree
-// operations notify the renderer directly and don't rely on this signal.
+// churn to Orca just to observe a handful of shallow paths. The replacements
+// register at most one tiny-scope native stream (macOS git-common) and
+// otherwise poll with a dir-mtime gate, so idle cost is a couple of stat
+// calls per tick. 2s is fast enough for external `git worktree add/remove`;
+// Orca's own worktree operations notify the renderer directly.
 export const WORKTREE_BASE_POLL_INTERVAL_MS = 2_000
 
-type BaseSnapshot = { kind: 'base'; markers: Map<string, boolean> }
-type GitCommonSnapshot = { kind: 'git-common'; mtimes: Map<string, number> }
-type PollSnapshot = BaseSnapshot | GitCommonSnapshot
+// Why: the mtime gate is an optimization, not a correctness boundary — some
+// filesystems have coarse dir timestamps, and pending `.git` markers expire.
+// A periodic ungated scan guarantees eventual convergence.
+export const WORKTREE_BASE_BACKSTOP_TICKS = 15
+
+// Why: a `.git` completion marker lands within moments of its worktree dir
+// (git writes it before populating the checkout). Dirs that never get one are
+// not worktrees; stop re-statting them after this many ticks and let the
+// backstop scan cover the pathological case.
+const PENDING_MARKER_MAX_TICKS = 300
+
+function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
+  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
+}
+
+async function dirSignature(path: string): Promise<string> {
+  try {
+    return statSignature(await stat(path))
+  } catch {
+    return 'missing'
+  }
+}
 
 async function hasGitMarker(dir: string): Promise<boolean> {
   try {
@@ -30,6 +60,14 @@ async function hasGitMarker(dir: string): Promise<boolean> {
   }
 }
 
+type BaseSnapshot = {
+  // worktree-candidate dir → whether its `.git` completion marker exists
+  markers: Map<string, boolean>
+  // dirs whose listing determines the candidate set: the root plus any
+  // nested repo containers. Their stat signatures gate the next full scan.
+  gateDirs: string[]
+}
+
 // Depth-1 worktree dirs (flat layout), plus depth-2 dirs under each nested
 // repo's container, mirroring what worktree-base-directory-event-filter
 // matches: `<wt>/.git` completion markers and `<wt>` deletions.
@@ -38,6 +76,7 @@ async function snapshotBase(
   repos: ReadonlyMap<string, WorktreeBaseRepoWatchConfig>
 ): Promise<BaseSnapshot> {
   const markers = new Map<string, boolean>()
+  const gateDirs = [rootPath]
   const configs = [...repos.values()]
   const includeFlat = configs.some((config) => !config.nestWorkspaces)
   const nestedRepoNames = new Set(
@@ -52,7 +91,7 @@ async function snapshotBase(
   } catch {
     // Root vanished: an empty snapshot diffs into delete events for every
     // previously-known worktree dir, matching the old watcher's error path.
-    return { kind: 'base', markers }
+    return { markers, gateDirs }
   }
 
   const candidates: string[] = []
@@ -65,6 +104,7 @@ async function snapshotBase(
       candidates.push(entryPath)
     }
     if (nestedRepoNames.has(normalizeRuntimePathForComparison(entry.name))) {
+      gateDirs.push(entryPath)
       let subEntries
       try {
         subEntries = await readdir(entryPath, { withFileTypes: true })
@@ -82,7 +122,7 @@ async function snapshotBase(
   for (const dir of candidates) {
     markers.set(dir, await hasGitMarker(dir))
   }
-  return { kind: 'base', markers }
+  return { markers, gateDirs }
 }
 
 function diffBase(prev: BaseSnapshot, next: BaseSnapshot): WorktreeBasePollEvent[] {
@@ -100,95 +140,94 @@ function diffBase(prev: BaseSnapshot, next: BaseSnapshot): WorktreeBasePollEvent
   return events
 }
 
-// `<common>/worktrees/<name>` entries. Entry-dir mtime covers the metadata
-// writes the old recursive watcher reacted to (HEAD/gitdir/locked are written
-// via rename into the entry dir, which bumps its mtime).
-async function snapshotGitCommon(commonDirPath: string): Promise<GitCommonSnapshot> {
-  const mtimes = new Map<string, number>()
-  const worktreesDir = join(commonDirPath, 'worktrees')
-  let entries
-  try {
-    entries = await readdir(worktreesDir, { withFileTypes: true })
-  } catch {
-    // Missing worktrees dir is normal for repos without linked worktrees.
-    return { kind: 'git-common', mtimes }
-  }
-  for (const entry of entries) {
-    const entryPath = join(worktreesDir, entry.name)
-    try {
-      mtimes.set(entryPath, (await stat(entryPath)).mtimeMs)
-    } catch {
-      // Entry removed between readdir and stat.
-    }
-  }
-  return { kind: 'git-common', mtimes }
-}
-
-function diffGitCommon(prev: GitCommonSnapshot, next: GitCommonSnapshot): WorktreeBasePollEvent[] {
-  const events: WorktreeBasePollEvent[] = []
-  for (const [entryPath, mtime] of next.mtimes) {
-    const prevMtime = prev.mtimes.get(entryPath)
-    if (prevMtime === undefined) {
-      events.push({ type: 'create', path: entryPath })
-    } else if (prevMtime !== mtime) {
-      events.push({ type: 'update', path: entryPath })
-    }
-  }
-  for (const entryPath of prev.mtimes.keys()) {
-    if (!next.mtimes.has(entryPath)) {
-      events.push({ type: 'delete', path: entryPath })
-    }
-  }
-  return events
-}
-
-async function takeSnapshot(
-  target: WorktreeBaseWatchTarget,
-  getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>
-): Promise<PollSnapshot> {
-  return target.kind === 'git-common'
-    ? snapshotGitCommon(target.path)
-    : snapshotBase(target.path, getRepos())
-}
-
-function diffSnapshots(prev: PollSnapshot, next: PollSnapshot): WorktreeBasePollEvent[] {
-  if (prev.kind === 'git-common' && next.kind === 'git-common') {
-    return diffGitCommon(prev, next)
-  }
-  if (prev.kind === 'base' && next.kind === 'base') {
-    return diffBase(prev, next)
-  }
-  return []
-}
-
-/** Polls the shallow paths a worktree base target cares about and synthesizes
- *  watcher-shaped events. Resolves once the baseline snapshot is taken. */
-export async function startWorktreeBaseDirectoryPoller(
+async function startBasePoller(
   target: WorktreeBaseWatchTarget,
   getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
-  pollIntervalMs: number = WORKTREE_BASE_POLL_INTERVAL_MS
-): Promise<{ unsubscribe: () => Promise<void> }> {
+  pollIntervalMs: number,
+  onFullScan?: () => void
+): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
-  let snapshot = await takeSnapshot(target, getRepos)
+  let tickCount = 0
+  let snapshot = await snapshotBase(target.path, getRepos())
+  let gateSignatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
+  // dir → tick when first seen without a `.git` marker
+  const pendingMarkers = new Map<string, number>()
+  for (const [dir, marker] of snapshot.markers) {
+    if (!marker) {
+      pendingMarkers.set(dir, 0)
+    }
+  }
+
+  const fullScan = async (): Promise<void> => {
+    onFullScan?.()
+    const next = await snapshotBase(target.path, getRepos())
+    const nextSignatures = await Promise.all(next.gateDirs.map(dirSignature))
+    if (disposed) {
+      return
+    }
+    const events = diffBase(snapshot, next)
+    for (const [dir, marker] of next.markers) {
+      if (marker) {
+        pendingMarkers.delete(dir)
+      } else if (!pendingMarkers.has(dir)) {
+        pendingMarkers.set(dir, tickCount)
+      }
+    }
+    for (const [dir, firstSeenTick] of pendingMarkers) {
+      if (!next.markers.has(dir) || tickCount - firstSeenTick > PENDING_MARKER_MAX_TICKS) {
+        pendingMarkers.delete(dir)
+      }
+    }
+    snapshot = next
+    gateSignatures = nextSignatures
+    if (events.length > 0) {
+      onEvents(events)
+    }
+  }
+
+  const checkPendingMarkers = async (): Promise<void> => {
+    const events: WorktreeBasePollEvent[] = []
+    for (const dir of pendingMarkers.keys()) {
+      if (await hasGitMarker(dir)) {
+        pendingMarkers.delete(dir)
+        snapshot.markers.set(dir, true)
+        events.push({ type: 'create', path: join(dir, '.git') })
+      }
+    }
+    if (!disposed && events.length > 0) {
+      onEvents(events)
+    }
+  }
+
+  const tick = async (): Promise<void> => {
+    tickCount++
+    if (tickCount % WORKTREE_BASE_BACKSTOP_TICKS === 0) {
+      await fullScan()
+      return
+    }
+    // Idle fast path: when the dirs whose listings define the candidate set
+    // are untouched, skip the readdir + per-candidate stat fan-out entirely.
+    const signatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
+    const gateChanged =
+      signatures.length !== gateSignatures.length ||
+      signatures.some((sig, index) => sig !== gateSignatures[index])
+    if (gateChanged) {
+      await fullScan()
+      return
+    }
+    if (pendingMarkers.size > 0) {
+      await checkPendingMarkers()
+    }
+  }
 
   const timer = setInterval(() => {
     if (disposed || ticking) {
       return
     }
     ticking = true
-    void takeSnapshot(target, getRepos)
-      .then((next) => {
-        if (disposed) {
-          return
-        }
-        const events = diffSnapshots(snapshot, next)
-        snapshot = next
-        if (events.length > 0) {
-          onEvents(events)
-        }
-      })
+    void tick()
       .catch(() => {
         // Transient fs error: keep the previous snapshot and retry next tick.
       })
@@ -204,4 +243,21 @@ export async function startWorktreeBaseDirectoryPoller(
       clearInterval(timer)
     }
   }
+}
+
+/** Watches the shallow paths a worktree base target cares about and emits
+ *  watcher-shaped events. Resolves once the baseline (snapshot or narrow
+ *  native subscription) is established. */
+export async function startWorktreeBaseDirectoryPoller(
+  target: WorktreeBaseWatchTarget,
+  getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>,
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  options: WorktreeBasePollerOptions = {}
+): Promise<WorktreeBaseSubscription> {
+  const pollIntervalMs = options.pollIntervalMs ?? WORKTREE_BASE_POLL_INTERVAL_MS
+  const platform = options.platform ?? process.platform
+  if (target.kind === 'git-common') {
+    return startGitCommonWatch(target, onEvents, pollIntervalMs, platform, options.onFullScan)
+  }
+  return startBasePoller(target, getRepos, onEvents, pollIntervalMs, options.onFullScan)
 }

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { join, sep } from 'node:path'
-import type { Event as WatcherEvent, SubscribeCallback } from '@parcel/watcher'
 import type { GlobalSettings, Repo } from '../../shared/types'
+import type { WorktreeBasePollEvent } from './worktree-base-directory-poller'
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(async () => ''),
@@ -9,8 +9,8 @@ vi.mock('fs/promises', () => ({
   stat: vi.fn(async () => ({ isDirectory: () => true }))
 }))
 
-vi.mock('@parcel/watcher', () => ({
-  subscribe: vi.fn()
+vi.mock('./worktree-base-directory-poller', () => ({
+  startWorktreeBaseDirectoryPoller: vi.fn()
 }))
 
 vi.mock('./worktree-remote', () => ({
@@ -21,18 +21,18 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   getSshFilesystemProvider: vi.fn()
 }))
 
-import { subscribe } from '@parcel/watcher'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { notifyWorktreesChanged } from './worktree-remote'
+import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
 import {
   disposeWorktreeBaseDirectoryWatchers,
   syncWorktreeBaseDirectoryWatchers
 } from './worktree-base-directory-watcher'
 import { matchingWorktreeBaseRepoIds } from './worktree-base-directory-event-filter'
 
-type WatcherCallback = SubscribeCallback
+type PollerCallback = (events: WorktreeBasePollEvent[]) => void
 
-const watcherCallbacks = new Map<string, WatcherCallback>()
+const watcherCallbacks = new Map<string, PollerCallback>()
 const unsubscribeMocks = new Map<string, ReturnType<typeof vi.fn>>()
 const absolutePath = (...parts: string[]): string => join(sep, ...parts)
 const WORKTREE_ROOT = absolutePath('workspace', 'worktrees')
@@ -69,12 +69,12 @@ function makeWindow(options: { destroyed?: () => boolean } = {}) {
   }
 }
 
-function emit(root: string, events: WatcherEvent[]): void {
+function emit(root: string, events: WorktreeBasePollEvent[]): void {
   const callback = watcherCallbacks.get(root)
   if (!callback) {
-    throw new Error(`No watcher callback for ${root}`)
+    throw new Error(`No poller callback for ${root}`)
   }
-  callback(null, events)
+  callback(events)
 }
 
 describe('worktree base directory watcher', () => {
@@ -83,12 +83,14 @@ describe('worktree base directory watcher', () => {
     watcherCallbacks.clear()
     unsubscribeMocks.clear()
     vi.mocked(getSshFilesystemProvider).mockReturnValue(undefined)
-    vi.mocked(subscribe).mockImplementation(async (root, callback) => {
-      const unsubscribe = vi.fn(async () => {})
-      watcherCallbacks.set(root, callback)
-      unsubscribeMocks.set(root, unsubscribe)
-      return { unsubscribe }
-    })
+    vi.mocked(startWorktreeBaseDirectoryPoller).mockImplementation(
+      async (target, _getRepos, onEvents) => {
+        const unsubscribe = vi.fn(async () => {})
+        watcherCallbacks.set(target.path, onEvents)
+        unsubscribeMocks.set(target.path, unsubscribe)
+        return { unsubscribe }
+      }
+    )
   })
 
   afterEach(async () => {
@@ -103,7 +105,7 @@ describe('worktree base directory watcher', () => {
     emit(WORKTREE_ROOT, [
       { type: 'create', path: join(WORKTREE_ROOT, 'project', 'external-5104') },
       { type: 'create', path: join(WORKTREE_ROOT, 'project', 'external-5104', '.git') }
-    ] as WatcherEvent[])
+    ])
 
     await vi.advanceTimersByTimeAsync(300)
 
@@ -120,7 +122,7 @@ describe('worktree base directory watcher', () => {
 
     emit(WORKTREE_ROOT, [
       { type: 'create', path: join(WORKTREE_ROOT, 'project', 'external-5104', '.git') }
-    ] as WatcherEvent[])
+    ])
     destroyed = true
     await vi.advanceTimersByTimeAsync(300)
 
@@ -132,7 +134,7 @@ describe('worktree base directory watcher', () => {
 
     emit(WORKTREE_ROOT, [
       { type: 'update', path: join(WORKTREE_ROOT, 'project', 'existing', 'src', 'file.ts') }
-    ] as WatcherEvent[])
+    ])
     await vi.advanceTimersByTimeAsync(300)
 
     expect(notifyWorktreesChanged).not.toHaveBeenCalled()
@@ -143,7 +145,7 @@ describe('worktree base directory watcher', () => {
 
     emit(PROJECT_GIT_COMMON_DIR, [
       { type: 'create', path: join(PROJECT_GIT_COMMON_DIR, 'worktrees', 'external-5104', 'gitdir') }
-    ] as WatcherEvent[])
+    ])
     await vi.advanceTimersByTimeAsync(300)
 
     expect(notifyWorktreesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1')
@@ -158,7 +160,7 @@ describe('worktree base directory watcher', () => {
       makeWindow() as never
     )
 
-    expect(subscribe).not.toHaveBeenCalled()
+    expect(startWorktreeBaseDirectoryPoller).not.toHaveBeenCalled()
   })
 
   it('uses the remote sibling root for default SSH worktree roots', async () => {
@@ -180,7 +182,7 @@ describe('worktree base directory watcher', () => {
       makeWindow() as never
     )
 
-    expect(subscribe).not.toHaveBeenCalled()
+    expect(startWorktreeBaseDirectoryPoller).not.toHaveBeenCalled()
     expect(remoteWatch).toHaveBeenCalledWith('/home/alice', expect.any(Function))
     remoteCallbacks.get('/home/alice')?.([
       {
@@ -209,12 +211,12 @@ describe('worktree base directory watcher', () => {
   })
 
   it('unsubscribes a watcher that finishes installing after disposal starts', async () => {
-    let resolveSubscribe: (subscription: { unsubscribe: () => Promise<void> }) => void = () => {}
+    let resolveInstall: (subscription: { unsubscribe: () => Promise<void> }) => void = () => {}
     const unsubscribe = vi.fn(async () => {})
-    vi.mocked(subscribe).mockImplementationOnce(
+    vi.mocked(startWorktreeBaseDirectoryPoller).mockImplementationOnce(
       async () =>
         new Promise((resolve) => {
-          resolveSubscribe = resolve
+          resolveInstall = resolve
         })
     )
 
@@ -222,9 +224,9 @@ describe('worktree base directory watcher', () => {
       makeStore([makeRepo()]) as never,
       makeWindow() as never
     )
-    await vi.waitFor(() => expect(subscribe).toHaveBeenCalled())
+    await vi.waitFor(() => expect(startWorktreeBaseDirectoryPoller).toHaveBeenCalled())
     const disposePromise = disposeWorktreeBaseDirectoryWatchers()
-    resolveSubscribe({ unsubscribe })
+    resolveInstall({ unsubscribe })
     await syncPromise
     await disposePromise
 
@@ -243,13 +245,13 @@ describe('worktree base directory watcher', () => {
       matchingWorktreeBaseRepoIds(target, {
         type: 'create',
         path: join(WORKTREE_ROOT, 'external-5104', '.git')
-      } as WatcherEvent)
+      })
     ).toEqual(['repo-1'])
     expect(
       matchingWorktreeBaseRepoIds(target, {
         type: 'update',
         path: join(WORKTREE_ROOT, 'external-5104', 'src', 'file.ts')
-      } as WatcherEvent)
+      })
     ).toEqual([])
   })
 })

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -1,5 +1,4 @@
 import type { BrowserWindow } from 'electron'
-import type { AsyncSubscription } from '@parcel/watcher'
 import type { FsChangeEvent } from '../../shared/types'
 import type { Store } from '../persistence'
 import { notifyWorktreesChanged } from './worktree-remote'
@@ -12,10 +11,11 @@ import {
   buildWorktreeBaseDirectoryWatchTargets,
   clearWorktreeBaseDirectoryWatchTargetWarnings
 } from './worktree-base-directory-watch-targets'
+import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
 
 type ActiveWatch = WorktreeBaseWatchTarget & {
   mainWindow: BrowserWindow
-  subscription: Pick<AsyncSubscription, 'unsubscribe'>
+  subscription: { unsubscribe: () => Promise<void> }
   notifyTimer: ReturnType<typeof setTimeout> | null
   pendingRepoIds: Set<string>
   disposed: boolean
@@ -137,19 +137,19 @@ async function subscribeTarget(
     return activeWatch
   }
 
-  const watcher = await import('@parcel/watcher')
-  const subscription = await watcher.subscribe(
-    target.path,
-    (error, events) => {
+  // Why: a recursive native watcher here forced fseventsd to deliver every
+  // event under the whole workspace root (all worktrees) / whole common .git
+  // (objects included) just to observe a few shallow paths. The poller reads
+  // exactly those paths and registers zero fseventsd clients.
+  const subscription = await startWorktreeBaseDirectoryPoller(
+    target,
+    () => (activeWatches.get(target.key) ?? activeWatch)?.repos ?? target.repos,
+    (events) => {
       const currentWatch = activeWatches.get(target.key) ?? activeWatch
       if (!currentWatch || currentWatch.disposed) {
         return
       }
-      handleLocalWatchEvents(currentWatch, error, events)
-    },
-    {
-      ignore: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/.next/**', '**/.cache/**'],
-      ...(process.platform === 'win32' ? { backend: 'windows' as const } : {})
+      handleLocalWatchEvents(currentWatch, null, events)
     }
   )
   activeWatch = {

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -1,0 +1,233 @@
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import type {
+  WorktreeBasePollEvent,
+  WorktreeBaseSubscription
+} from './worktree-base-directory-poller'
+
+// Watches a repo's `<common>/.git/worktrees` metadata — the only subtree the
+// git-common event filter consumes.
+// macOS: a narrow native stream rooted there — a tiny, rare-churn tree —
+// gives instant detection with zero idle cost and zero wide-scope fseventsd
+// delivery. Other platforms: dir-listing poll (no fseventsd to protect, and
+// on Windows an open directory handle on `worktrees/` could interfere with
+// `git worktree prune` removing it).
+
+async function snapshotGitCommon(commonDirPath: string): Promise<Map<string, number>> {
+  const mtimes = new Map<string, number>()
+  const worktreesDir = join(commonDirPath, 'worktrees')
+  let entries
+  try {
+    entries = await readdir(worktreesDir, { withFileTypes: true })
+  } catch {
+    // Missing worktrees dir is normal for repos without linked worktrees.
+    return mtimes
+  }
+  for (const entry of entries) {
+    const entryPath = join(worktreesDir, entry.name)
+    try {
+      // Entry-dir mtime covers the metadata writes the old recursive watcher
+      // reacted to (HEAD/gitdir/locked are written via rename into the entry
+      // dir, which bumps its mtime).
+      mtimes.set(entryPath, (await stat(entryPath)).mtimeMs)
+    } catch {
+      // Entry removed between readdir and stat.
+    }
+  }
+  return mtimes
+}
+
+function diffGitCommon(
+  prev: Map<string, number>,
+  next: Map<string, number>
+): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  for (const [entryPath, mtime] of next) {
+    const prevMtime = prev.get(entryPath)
+    if (prevMtime === undefined) {
+      events.push({ type: 'create', path: entryPath })
+    } else if (prevMtime !== mtime) {
+      events.push({ type: 'update', path: entryPath })
+    }
+  }
+  for (const entryPath of prev.keys()) {
+    if (!next.has(entryPath)) {
+      events.push({ type: 'delete', path: entryPath })
+    }
+  }
+  return events
+}
+
+async function startGitCommonPoller(
+  target: WorktreeBaseWatchTarget,
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  pollIntervalMs: number,
+  onFullScan?: () => void
+): Promise<WorktreeBaseSubscription> {
+  let disposed = false
+  let ticking = false
+  let snapshot = await snapshotGitCommon(target.path)
+
+  const timer = setInterval(() => {
+    if (disposed || ticking) {
+      return
+    }
+    ticking = true
+    onFullScan?.()
+    void snapshotGitCommon(target.path)
+      .then((next) => {
+        if (disposed) {
+          return
+        }
+        const events = diffGitCommon(snapshot, next)
+        snapshot = next
+        if (events.length > 0) {
+          onEvents(events)
+        }
+      })
+      .catch(() => {
+        // Transient fs error: keep the previous snapshot and retry next tick.
+      })
+      .finally(() => {
+        ticking = false
+      })
+  }, pollIntervalMs)
+  timer.unref?.()
+
+  return {
+    unsubscribe: async () => {
+      disposed = true
+      clearInterval(timer)
+    }
+  }
+}
+
+async function startGitCommonNarrowWatch(
+  target: WorktreeBaseWatchTarget,
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  pollIntervalMs: number
+): Promise<WorktreeBaseSubscription> {
+  const worktreesDir = join(target.path, 'worktrees')
+  let disposed = false
+  let subscription: WorktreeBaseSubscription | null = null
+  let existenceTimer: ReturnType<typeof setInterval> | null = null
+  let subscribing = false
+
+  const stopExistencePoll = (): void => {
+    if (existenceTimer) {
+      clearInterval(existenceTimer)
+      existenceTimer = null
+    }
+  }
+
+  const armExistencePoll = (): void => {
+    if (disposed || existenceTimer) {
+      return
+    }
+    existenceTimer = setInterval(() => {
+      if (disposed || subscribing || subscription) {
+        return
+      }
+      subscribing = true
+      void trySubscribe()
+        .then((installed) => {
+          if (installed && !disposed) {
+            stopExistencePoll()
+            // The dir appearing means a first linked worktree was just
+            // registered; surface it so the repo's worktree list refreshes.
+            onEvents([{ type: 'create', path: worktreesDir }])
+          }
+        })
+        .finally(() => {
+          subscribing = false
+        })
+    }, pollIntervalMs)
+    existenceTimer.unref?.()
+  }
+
+  const trySubscribe = async (): Promise<boolean> => {
+    try {
+      const s = await stat(worktreesDir)
+      if (!s.isDirectory()) {
+        return false
+      }
+    } catch {
+      return false
+    }
+    let errored = false
+    // Why: parcel tears its native stream down when the watched root is
+    // deleted (e.g. `git worktree prune` removing an empty worktrees dir) —
+    // sometimes surfaced as an error, sometimes as a delete event for the
+    // root. Either way: notify, drop the dead stream, and let the existence
+    // poll re-arm when a future worktree add recreates the dir.
+    const teardownAndRearm = (): void => {
+      errored = true
+      const current = subscription
+      subscription = null
+      if (current) {
+        void current.unsubscribe().catch(() => {})
+      }
+      armExistencePoll()
+    }
+    try {
+      const watcher = await import('@parcel/watcher')
+      const sub = await watcher.subscribe(worktreesDir, (error, events) => {
+        if (disposed) {
+          return
+        }
+        if (error) {
+          onEvents([{ type: 'update', path: worktreesDir }])
+          teardownAndRearm()
+          return
+        }
+        if (events.length > 0) {
+          const rootGone = events.some(
+            (event) => event.type === 'delete' && event.path === worktreesDir
+          )
+          onEvents(events.map((event) => ({ type: event.type, path: event.path })))
+          if (rootGone) {
+            teardownAndRearm()
+          }
+        }
+      })
+      if (disposed || errored) {
+        void sub.unsubscribe().catch(() => {})
+        return !errored
+      }
+      subscription = { unsubscribe: () => sub.unsubscribe() }
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  if (!(await trySubscribe())) {
+    armExistencePoll()
+  }
+
+  return {
+    unsubscribe: async () => {
+      disposed = true
+      stopExistencePoll()
+      const current = subscription
+      subscription = null
+      if (current) {
+        await current.unsubscribe().catch(() => {})
+      }
+    }
+  }
+}
+
+export async function startGitCommonWatch(
+  target: WorktreeBaseWatchTarget,
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  pollIntervalMs: number,
+  platform: NodeJS.Platform,
+  onFullScan?: () => void
+): Promise<WorktreeBaseSubscription> {
+  if (platform === 'darwin') {
+    return startGitCommonNarrowWatch(target, onEvents, pollIntervalMs)
+  }
+  return startGitCommonPoller(target, onEvents, pollIntervalMs, onFullScan)
+}

--- a/src/main/runtime/file-watcher-host.ts
+++ b/src/main/runtime/file-watcher-host.ts
@@ -8,20 +8,15 @@ import { join } from 'node:path'
 import { app } from 'electron'
 import type { FsChangeEvent } from '../../shared/types'
 import type { FileWatcherHostMessage, FileWatcherWorkerMessage } from './file-watcher-worker'
+// Why: shares the explorer watcher's canonical ignore list, pre-shaped so the
+// macOS daemon-side exclusion-path cap (8) is respected — over the cap ALL
+// exclusions silently fail and fseventsd delivers full node_modules churn.
+import {
+  WATCHER_IGNORE_DIRS,
+  buildParcelWatcherIgnoreOption
+} from '../ipc/filesystem-watcher-ignore'
 
-// Mirrors VS Code's predefined recursive-watch excludes: skip churny generated
-// trees at crawl time so the watcher never traverses them.
-const RUNTIME_FILE_WATCH_IGNORE = [
-  '.git',
-  'node_modules',
-  'dist',
-  'build',
-  '.next',
-  '.cache',
-  '__pycache__',
-  'target',
-  '.venv'
-]
+const RUNTIME_FILE_WATCH_IGNORE = buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS)
 
 // Why: clean teardown is async (the worker awaits subscription.unsubscribe()
 // before closing its port and exiting). Wait this long for the worker to exit on


### PR DESCRIPTION
## Problem

macOS `fseventsd` ballooned to **95GB RSS** on a machine running Orca with ~146 worktrees and multiple agents. fseventsd memory/CPU scales with **event volume × registered client streams × delivery work** (documented multi-GB blowups exist from a single over-broad client: [colima#1569](https://github.com/abiosoft/colima/issues/1569)), and macOS 26.x additionally has a widely-reported system memory-leak regression that compounds under heavy delivery. There is also a **system-wide 1024 FSEvents client cap** past which watching silently fails.

Orca was making fseventsd do dramatically more delivery work than needed, three ways:

## Root causes fixed

### 1. macOS exclusion-path cap silently disabled all daemon-side exclusions
`@parcel/watcher` passes plain-path `ignore` entries to `FSEventStreamSetExclusionPaths` (true daemon-side filtering), but macOS caps that at **8 paths per stream and fails closed** — and parcel never checks the return value. Orca passed **9** entries, so every per-worktree explorer stream (one per worktree with an open editor tab, persisted across restarts) received full per-file `node_modules`/`.git` delivery and discarded it in userspace.

Fixed by capping plain paths at 8 (extras demoted to userspace globs) in a shared `filesystem-watcher-ignore` module, used by both the explorer watcher and the runtime file-watcher host — which also unifies the two ignore lists, so parcel's native per-`(root, ignore)` dedup now shares one stream when both watch the same root.

### 2. Always-on recursive streams over entire workspace roots and whole `.git` dirs
`worktree-base-directory-watcher` subscribed a recursive FSEvents stream per repo over the **entire workspace root** (all worktrees, e.g. `~/orca/workspaces/orca` with 146 of them) plus another over the repo's **whole common `.git`** (objects included) — with glob-only ignores, i.e. **zero** daemon-side exclusion — just to observe `<wt>/.git` completion markers, `<wt>` deletions, and `.git/worktrees/*` metadata. Every agent write, build, fetch, and pnpm install in any worktree was delivered to Orca (and buffered per-stream inside fseventsd) to be thrown away by a JS filter.

Replaced with a two-part scheme sized to what the event filter actually consumes:

- **Worktree metadata (`git-common`), macOS:** one *narrow* native stream rooted at `<common>/.git/worktrees` — a tiny, rare-churn tree. Zero idle cost, zero wide-scope delivery, and **instant** detection: `git worktree add/remove` always writes here, so external add/remove/HEAD changes surface sub-second. If the dir doesn't exist yet (no linked worktrees) a 1-stat existence poll arms the stream when it appears; if `git worktree prune` deletes it, the watcher re-arms the same way. On Windows/Linux this stays a listing poll (no fseventsd to protect; on Windows an open directory handle could interfere with `prune` removing the dir).
- **Workspace roots (`base`), all platforms:** a 2s poll whose tick is **mtime-gated** — one `stat` of the root (plus nested repo containers); the readdir + per-worktree `.git`-marker fan-out only runs when a gate dir actually changed, with a 30s ungated full-scan backstop and a bounded recheck list for worktrees whose `.git` marker lands after the dir. Registers zero fseventsd clients.

### 3. App-lifetime `fs.watch` on `$TMPDIR`
The serve-sim state watcher held a permanent FSEvents client on the system's highest-churn directory, even though a 250ms existence poll already ran alongside it. Dropped the parent watch; the poll alone attaches the narrow `$TMPDIR/serve-sim/` watcher when the dir appears.

## Evidence (reproduced before fixing)

Identical 30k-op `node_modules` churn burst; metric is watching-process CPU including the native FSEvents drain thread, proportional to what fseventsd had to enqueue + deliver:

| configuration | CPU | events delivered to JS |
|---|---|---|
| explorer stream, old 9-entry ignore (exclusions **silently off**) | 82ms | 0 (filtered in userspace) |
| explorer stream, new capped ignore (exclusions **on**) | **5ms (16×)** | 0 (never delivered) |
| base stream at workspace root, old glob-only ignore | 354ms | n/a |
| new shallow watcher/poller | **5ms (70×)**, 0 wide fseventsd clients | n/a |

Idle cost of the replacement, simulated at 146 worktrees:

| idle tick | cost |
|---|---|
| ungated scan (readdir + per-dir stat fan-out) | 600µs |
| mtime-gated tick (shipped) | **1.1µs (~545×)** |
| macOS worktree-metadata watching | **0 syscalls** (narrow event stream) |

Control experiments on the affected machine showed fseventsd RSS is insensitive to raw churn (~0.14MB per 80k events), suspended clients (bounded queue, then drops), and 100 idle clients (~6KB each) — the damage comes from sustained wide-scope delivery, which is exactly what these changes eliminate. At 15 repos + 50 open worktrees this removes ~30 always-on whole-tree streams (replaced by ~15 tiny `.git/worktrees` streams + gated polls) and restores daemon-side exclusion on the ~50 per-worktree streams.

## E2E verification (dev build, CDP)

- App boots cleanly with the new watchers; identity `Orca: nwparker/fseventsd`.
- External `git worktree add` from a terminal → sidebar store updated in **728ms**.
- External `git worktree remove` → detected in **2.4s** (pre-narrow-stream build; now event-driven on macOS).
- Explorer watch on a worktree: visible file create delivered; 50-file `node_modules` churn delivered **zero** events.
- Unit: 35 tests pass across the touched suites, including real-fs poller tests, macOS narrow-stream tests (add/update/remove, late arming, prune + recreate re-arming), an idle-gate test, and an 8-cap regression test; `pnpm typecheck` clean.

## ELI5

macOS has one built-in "post office" for file changes (`fseventsd`). Any app can subscribe: *"deliver me a note whenever anything changes under this folder."* The post office does real work for every note — sorting, packaging, delivering a copy to each subscriber — and on macOS 26 it also has a hoarding problem: under heavy load it never quite gives back the memory it used. That's the 95GB.

Orca was the post office's worst customer, three ways:

1. **It subscribed to gigantic folders.** To notice "a worktree appeared/disappeared", Orca subscribed to the folder containing *all* your worktrees — so every file an agent wrote, every `pnpm install`, every build in any of 146 worktrees got packaged and delivered to Orca... which read the address and threw it away. Now Orca subscribes only to git's tiny worktree-bookkeeping folder (a few entries, changes only when worktrees actually change) and otherwise just checks a timestamp — one glance every 2 seconds, escalating to a real look only when the timestamp moved.
2. **Its "no junk mail" sticker was invalid.** For the per-worktree file-explorer subscriptions, Orca attached a list of 9 noisy folders to skip (`node_modules`, `.git`, ...). macOS only accepts stickers with **8 or fewer** entries — one over, and it silently ignores the whole sticker. So the post office delivered *all* the junk mail anyway. Now the sticker has 8 entries and actually works: junk is discarded at the post office, never delivered.
3. **It watched the town dump.** Orca kept a lifetime subscription on the system temp folder (the churniest place on disk) to notice one rare thing, even though it already had a cheap periodic check for the same thing. The subscription is gone.

Orca can't fix the post office's hoarding bug (that's Apple's), but it can stop sending it 100× more work than needed — which is what feeds the hoarding.

## User-visible trade-offs

Honest list of what changes, and by how much:

| area | before | after | felt impact |
|---|---|---|---|
| Worktree created/removed **outside Orca** via git (`git worktree add/remove` in a terminal, scripts) | ~0.3–0.5s | macOS: **sub-second** (event-driven via the worktree-metadata stream). Win/Linux: ≤2s poll tick. | None on macOS; a beat later elsewhere. Worktrees managed **through Orca** (UI, agents, orca-cli) are unaffected — those notify directly. |
| External branch/HEAD changes reflected in the worktree list | near-instant | macOS: near-instant. Win/Linux: ≤2s. | None on macOS. |
| Worktree dir deleted **without git** (`rm -rf`) | near-instant | ≤2s (mtime-gated tick; the deletion itself bumps the root dir timestamp, so it's caught on the next tick) | A beat later; git metadata cleanup (`prune`) is still instant on macOS. |
| External `serve-sim --detach` pickup | instant | ≤250ms | Imperceptible. |
| Idle background cost | zero when disk idle (event-driven) | **~1µs per 2s tick per workspace root** (one `stat`; measured at 146 worktrees), 0 syscalls for macOS worktree metadata, plus a 30s full-scan backstop | Nothing measurable; strictly cheaper than the FSEvents delivery it replaced whenever anything on disk is active. |
| `__pycache__` churn (the demoted 9th ignore entry) | delivered + discarded in-process (exclusions were broken for *all* dirs) | still delivered + discarded in-process, but the other 8 dirs are now excluded daemon-side | Strictly better than before; just not daemon-side-free like the top 8. |

Explicitly **unchanged**: file-explorer auto-refresh behavior and its ignore semantics (dirs like `dist`/`node_modules` never auto-refreshed by design), SSH/remote worktree watching (still `provider.watch`), WSL watching (still the snapshot subprocess with the same plain-name list), and all Orca-initiated worktree flows.

## Not fixed here (follow-ups)

- Terminal-history checkpoint cadence (5s per dirty PTY, multi-MB rewrites) is Orca's dominant *write* churn — separate perf PR with its own repro.
- `persistence.ts` 300ms full-state rewrites, unthrottled conflict-summary `git fetch`/`merge-tree` — same.
- The macOS 26.x (Tahoe) system memory-leak regression is an OS bug we can only starve, not fix; if fseventsd balloons again, `ps -o rss= -p $(pgrep -x fseventsd)` trend + `log show --predicate 'process == "fseventsd"'` will attribute it.
