### PR TITLE
Keep automations runnable after GitHub identity normalization

### DIFF
--- a/src/main/automations/run-target-resolution.ts
+++ b/src/main/automations/run-target-resolution.ts
@@ -2,6 +2,7 @@ import type { Store } from '../persistence'
 import type { Automation } from '../../shared/automations-types'
 import { getAutomationLegacyRepoId } from '../../shared/automation-run-identity'
 import { getRepoExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
+import { projectIdentityMatchesRunContext } from '../../shared/project-host-setup-projection'
 import type { ProjectHostSetup, Repo } from '../../shared/types'
 import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 
@@ -64,11 +65,7 @@ export function resolveAutomationRunTarget(
       error: `Project setup on the selected automation host is ${setup.setupState}.`
     }
   }
-  if (
-    setup.projectId !== context.projectId ||
-    setup.hostId !== context.hostId ||
-    setup.repoId !== context.repoId
-  ) {
+  if (setup.hostId !== context.hostId || setup.repoId !== context.repoId) {
     return {
       ok: false,
       error: 'Automation run target no longer matches the selected project host setup.'
@@ -80,6 +77,12 @@ export function resolveAutomationRunTarget(
     return {
       ok: false,
       error: 'Repository for the selected automation host is no longer available.'
+    }
+  }
+  if (!projectIdentityMatchesRunContext(context.projectId, setup.projectId, repo)) {
+    return {
+      ok: false,
+      error: 'Automation run target no longer matches the selected project host setup.'
     }
   }
   if (getRepoExecutionHostId(repo) !== context.hostId) {

--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -200,6 +200,164 @@ describe('AutomationService', () => {
     expect(send).not.toHaveBeenCalled()
   })
 
+  it('dispatches when only the saved project identity drifted after repo normalization', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:00:00Z'))
+    const store = await createStore()
+    store.addRepo(
+      makeRepo({
+        gitRemoteIdentity: {
+          canonicalKey: 'github.com/stablyai/orca',
+          remoteName: 'origin',
+          remoteUrl: 'https://github.com/stablyai/orca.git'
+        }
+      })
+    )
+    const setup = store.getProjectHostSetups()[0]!
+    const automation = store.createAutomation({
+      name: 'Manual check',
+      prompt: 'Check the repo',
+      agentId: 'claude',
+      projectId: 'r1',
+      runContext: {
+        kind: 'workspace-run',
+        projectId: 'git:github.com/stablyai/orca',
+        hostId: setup.hostId,
+        projectHostSetupId: setup.id,
+        repoId: setup.repoId,
+        path: setup.path
+      },
+      workspaceMode: 'new_per_run',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-14T00:00:00Z').getTime()
+    })
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({
+      isDestroyed: () => false,
+      send
+    } as never)
+    service.setRendererReady()
+
+    const run = await service.runNow(automation.id)
+
+    expect(setup.projectId).toBe('github:stablyai/orca')
+    expect(run.status).toBe('dispatching')
+    expect(send).toHaveBeenCalledWith(
+      'automations:dispatchRequested',
+      expect.objectContaining({
+        automation: expect.objectContaining({ id: automation.id }),
+        run: expect.objectContaining({ id: run.id, status: 'dispatching' })
+      })
+    )
+  })
+
+  it('skips dispatch when the saved project identity differs from the current repo identity', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:00:00Z'))
+    const store = await createStore()
+    store.addRepo(
+      makeRepo({
+        gitRemoteIdentity: {
+          canonicalKey: 'github.com/new-org/orca',
+          remoteName: 'origin',
+          remoteUrl: 'https://github.com/new-org/orca.git'
+        }
+      })
+    )
+    const setup = store.getProjectHostSetups()[0]!
+    const automation = store.createAutomation({
+      name: 'Manual check',
+      prompt: 'Check the repo',
+      agentId: 'claude',
+      projectId: 'r1',
+      runContext: {
+        kind: 'workspace-run',
+        projectId: 'git:github.com/stablyai/orca',
+        hostId: setup.hostId,
+        projectHostSetupId: setup.id,
+        repoId: setup.repoId,
+        path: setup.path
+      },
+      workspaceMode: 'new_per_run',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-14T00:00:00Z').getTime()
+    })
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({
+      isDestroyed: () => false,
+      send
+    } as never)
+    service.setRendererReady()
+
+    const run = await service.runNow(automation.id)
+
+    expect(setup.projectId).toBe('github:new-org/orca')
+    expect(run.status).toBe('skipped_unavailable')
+    expect(run.error).toBe(
+      'Automation run target no longer matches the selected project host setup.'
+    )
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('dispatches scheduled runs when only the saved project identity drifted', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:59:00'))
+    const store = await createStore()
+    store.addRepo(
+      makeRepo({
+        gitRemoteIdentity: {
+          canonicalKey: 'github.com/stablyai/orca',
+          remoteName: 'origin',
+          remoteUrl: 'https://github.com/stablyai/orca.git'
+        }
+      })
+    )
+    const setup = store.getProjectHostSetups()[0]!
+    const automation = store.createAutomation({
+      name: 'Morning check',
+      prompt: 'Check the repo',
+      agentId: 'claude',
+      projectId: 'r1',
+      runContext: {
+        kind: 'workspace-run',
+        projectId: 'git:github.com/stablyai/orca',
+        hostId: setup.hostId,
+        projectHostSetupId: setup.id,
+        repoId: setup.repoId,
+        path: setup.path
+      },
+      workspaceMode: 'new_per_run',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-12T00:00:00').getTime()
+    })
+
+    vi.setSystemTime(new Date('2026-05-13T09:01:00'))
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({
+      isDestroyed: () => false,
+      send
+    } as never)
+
+    service.start()
+    service.setRendererReady()
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith('automations:dispatchRequested', expect.any(Object))
+    )
+    service.stop()
+
+    const [, payload] = send.mock.calls[0]
+    expect(setup.projectId).toBe('github:stablyai/orca')
+    expect(payload.automation.id).toBe(automation.id)
+    expect(payload.run).toMatchObject({
+      scheduledFor: new Date('2026-05-13T09:00:00').getTime(),
+      status: 'dispatching'
+    })
+    expect(store.listAutomationRuns(automation.id)[0]?.status).toBe('dispatching')
+  })
+
   it('skips runtime-owned automations before desktop renderer dispatch', async () => {
     vi.setSystemTime(new Date('2026-05-13T08:00:00Z'))
     const store = await createStore()

--- a/src/renderer/src/components/automations/automation-target-availability.test.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.test.ts
@@ -140,6 +140,118 @@ describe('automation target availability', () => {
     ).toBe('host-mismatch')
   })
 
+  it('allows saved run contexts when only the project identity drifted', () => {
+    expect(
+      getAutomationTargetAvailability({
+        automation: makeAutomation({
+          runContext: {
+            kind: 'workspace-run',
+            projectId: 'git:github.com/stablyai/orca',
+            hostId: 'local',
+            projectHostSetupId: 'setup-1',
+            repoId: 'repo-1',
+            path: '/repo'
+          }
+        }),
+        repo: makeRepo({
+          gitRemoteIdentity: {
+            canonicalKey: 'github.com/stablyai/orca',
+            remoteName: 'origin',
+            remoteUrl: 'https://github.com/stablyai/orca.git'
+          }
+        }),
+        workspace: makeWorkspace(),
+        projectHostSetups: [makeProjectHostSetup({ projectId: 'github:stablyai/orca' })],
+        sshConnectionStates: new Map()
+      })
+    ).toEqual({ canRunNow: true, reason: 'available', message: null })
+  })
+
+  it('blocks saved run contexts when project identity changed beyond GitHub normalization', () => {
+    expect(
+      getAutomationTargetAvailability({
+        automation: makeAutomation({
+          runContext: {
+            kind: 'workspace-run',
+            projectId: 'git:github.com/stablyai/orca',
+            hostId: 'local',
+            projectHostSetupId: 'setup-1',
+            repoId: 'repo-1',
+            path: '/repo'
+          }
+        }),
+        repo: makeRepo({
+          gitRemoteIdentity: {
+            canonicalKey: 'github.com/new-org/orca',
+            remoteName: 'origin',
+            remoteUrl: 'https://github.com/new-org/orca.git'
+          }
+        }),
+        workspace: makeWorkspace(),
+        projectHostSetups: [makeProjectHostSetup({ projectId: 'github:new-org/orca' })],
+        sshConnectionStates: new Map()
+      }).reason
+    ).toBe('host-mismatch')
+  })
+
+  it('blocks saved run contexts with real setup, repo, host, or path mismatches', () => {
+    const automation = makeAutomation({
+      runContext: {
+        kind: 'workspace-run',
+        projectId: 'project-1',
+        hostId: 'local',
+        projectHostSetupId: 'setup-1',
+        repoId: 'repo-1',
+        path: '/repo'
+      }
+    })
+    const baseline = {
+      automation,
+      workspace: makeWorkspace(),
+      sshConnectionStates: new Map()
+    }
+
+    expect(
+      getAutomationTargetAvailability({
+        ...baseline,
+        repo: makeRepo(),
+        projectHostSetups: [makeProjectHostSetup({ repoId: 'repo-2' })]
+      }).reason
+    ).toBe('host-mismatch')
+
+    expect(
+      getAutomationTargetAvailability({
+        ...baseline,
+        repo: makeRepo(),
+        projectHostSetups: [makeProjectHostSetup({ path: '/other' })]
+      }).reason
+    ).toBe('host-mismatch')
+
+    expect(
+      getAutomationTargetAvailability({
+        ...baseline,
+        repo: makeRepo({ id: 'repo-2' }),
+        projectHostSetups: [makeProjectHostSetup()]
+      }).reason
+    ).toBe('host-mismatch')
+
+    expect(
+      getAutomationTargetAvailability({
+        ...baseline,
+        repo: makeRepo({ executionHostId: 'ssh:devbox' }),
+        projectHostSetups: [makeProjectHostSetup()]
+      }).reason
+    ).toBe('host-mismatch')
+
+    expect(
+      getAutomationTargetAvailability({
+        ...baseline,
+        repo: makeRepo({ path: '/other' }),
+        projectHostSetups: [makeProjectHostSetup()]
+      }).reason
+    ).toBe('host-mismatch')
+  })
+
   it('allows remote-listed SSH automations whose repo is projected through a runtime server', () => {
     expect(
       getAutomationTargetAvailability({

--- a/src/renderer/src/components/automations/automation-target-availability.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.ts
@@ -4,6 +4,7 @@ import {
   describeRuntimeCompatBlock,
   evaluateRuntimeCompat
 } from '../../../../shared/protocol-compat'
+import { projectIdentityMatchesRunContext } from '../../../../shared/project-host-setup-projection'
 import {
   MIN_COMPATIBLE_RUNTIME_SERVER_VERSION,
   RUNTIME_PROTOCOL_VERSION
@@ -97,7 +98,7 @@ export function getAutomationTargetAvailability({
       )
     }
     const setupMatchesContext =
-      setup.projectId === automation.runContext.projectId &&
+      projectIdentityMatchesRunContext(automation.runContext.projectId, setup.projectId, repo) &&
       setup.repoId === automation.runContext.repoId &&
       setup.path === automation.runContext.path &&
       setupHostMatchesRunContext(setup.hostId, automation.runContext.hostId, automationHostTarget)

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -59,6 +59,40 @@ function getProjectGitRemoteIdentity(
   return canonicalKey && remoteName && remoteUrl ? { canonicalKey, remoteName, remoteUrl } : null
 }
 
+function getGitHubProjectIdFromCanonicalGitKey(canonicalKey: string): string | null {
+  const [host, owner, repo, ...rest] = canonicalKey.trim().split('/')
+  if (host?.toLowerCase() !== 'github.com' || !owner?.trim() || !repo?.trim() || rest.length > 0) {
+    return null
+  }
+  return `github:${normalizeIdentityPart(owner)}/${normalizeIdentityPart(repo)}`
+}
+
+export function projectIdentityMatchesRunContext(
+  savedProjectId: string,
+  currentProjectId: string,
+  repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon' | 'gitRemoteIdentity'>
+): boolean {
+  if (savedProjectId === currentProjectId) {
+    return true
+  }
+
+  const gitRemoteIdentity = getProjectGitRemoteIdentity(repo)
+  if (!gitRemoteIdentity) {
+    return false
+  }
+  const normalizedGitHubProjectId = getGitHubProjectIdFromCanonicalGitKey(
+    gitRemoteIdentity.canonicalKey
+  )
+  // Why: only the repo-normalization upgrade from git:<github canonical key>
+  // to github:<owner>/<repo> is tolerated; real remote changes still block.
+  return (
+    normalizedGitHubProjectId !== null &&
+    savedProjectId === `git:${gitRemoteIdentity.canonicalKey}` &&
+    currentProjectId === normalizedGitHubProjectId &&
+    getProjectIdentityKey(repo) === normalizedGitHubProjectId
+  )
+}
+
 /** True when the repo resolves to a GitHub provider identity (via explicit
  *  upstream or a GitHub-sourced avatar icon). Used to scope GitHub-CLI setup
  *  prompts to users who actually have GitHub-backed projects. */


### PR DESCRIPTION
## Summary

Keeps existing automations runnable after Orca normalizes a GitHub-backed repo project id from the old `git:github.com/<owner>/<repo>` shape to the current `github:<owner>/<repo>` shape.

The compatibility is intentionally narrow: exact project ids still match as before, and the old GitHub `git:` id is accepted only when it is derived from the current repo's canonical GitHub identity. Real setup, repo, host, path, or incompatible project identity changes still block dispatch.

## Design approach

- Added a shared project identity compatibility helper in `project-host-setup-projection`.
- Updated main automation target resolution and renderer manual-run availability to use the same helper.
- Preserved strict execution-target checks for setup id, repo id, host id, execution host, and path.
- Did not add a migration or rewrite historical run/workspace provenance ids.

Design review outcome: clean after the design was narrowed to avoid accepting arbitrary project-id drift.

Implementation deviations: none from the final reviewed design. A code-review finding identified an overly broad first implementation; the final patch only accepts the known GitHub normalization mapping.

## Completeness

Completeness verification result: pass. The final implementation matches the requested bug fix: stale GitHub-normalized automation records dispatch again, while true target changes still skip.

Headline behavior status: implemented.

Broad app consistency result:

- Source of truth: an automation target remains runnable when the same setup, repo, host, and path are still available.
- Scheduler/manual service dispatch and renderer manual-run availability now share the same project identity compatibility semantics.
- CLI/manual run paths benefit through the shared resolver.
- Run history and provenance remain historical snapshots by design.

Risks and non-goals:

- Non-goal: broad migration of stored automation or run records.
- Non-goal: accepting non-GitHub or future unknown identity drift.
- Risk: records without `gitRemoteIdentity` cannot prove the old `git:` id maps to the current GitHub project id and will still skip.
- Operational caveat: the production catch-up used a live target re-save workaround so those runs prove recovery, not this source patch.

## Reliability and performance

Reliability invariant: persisted automation dispatch must not fail when the same ready setup, repo, host, and path remain valid and only the project grouping id changed across the known GitHub normalization upgrade.

Correctness evidence:

- Manual stale `git:` context dispatches against current `github:` setup.
- Scheduled stale `git:` context dispatches against current `github:` setup.
- True incompatible project identity drift still skips.
- Renderer manual-run availability allows the same known drift and blocks real setup/repo/host/path mismatches.

Provider/platform coverage:

- Local automation dispatch: covered by focused service tests.
- Renderer availability: covered by focused renderer tests.
- SSH/remote-runtime/mobile/WSL: unaffected; host/repo/path/runtime checks remain unchanged.
- macOS/Linux/Windows: no platform-specific path or process behavior changed.

Perf audit result: pass. The diff adds bounded string checks in existing resolver/availability paths and adds no polling, subprocesses, timers, listeners, IPC, startup awaits, cache invalidation, or unbounded scans.

## Review and validation

Design review: clean.

Implementation completeness verification: clean.

Performance review: clean.

Code-review loop: two-reviewer loop completed; first round found over-broad project-id drift tolerance, final round returned clean after narrowing the helper.

Brennan's test-changes result: land. Electron/manual screenshots were not required because this is a non-visual deterministic resolver and availability-predicate change; no production Orca project, issue, PR, or automation was mutated for source validation.

Tests and checks:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/automations/service.test.ts src/renderer/src/components/automations/automation-target-availability.test.ts src/shared/project-host-setup-projection.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/automations/service-precheck.test.ts src/main/automations/service.test.ts`
- `pnpm exec oxlint src/shared/project-host-setup-projection.ts src/main/automations/run-target-resolution.ts src/main/automations/service.test.ts src/renderer/src/components/automations/automation-target-availability.ts src/renderer/src/components/automations/automation-target-availability.test.ts`
- `pnpm run typecheck`
- `pnpm run lint` (passed; emitted existing unrelated warnings)
- `git diff --check`

## Operational catch-up evidence

The missed Discord automation was recovered before this source fix by re-saving the live target in installed Orca and running two sequential new-per-run catch-up invocations:

- Run 5: `c96d420b-c2fc-4d16-8909-0f4d47e4e988`, worktree `/Users/thebr/orca/workspaces/orca/auto-discord-feedback-triage-7am-3pm-pt-run-5-20260702T0439`, completed, Slack permalink `https://stablygroup.slack.com/archives/C0ASMDT6LQZ/p1782967613667469`.
- Run 6: `c191e21e-cef1-4eb3-bcd2-ae1482d2ae81`, worktree `/Users/thebr/orca/workspaces/orca/auto-discord-feedback-triage-7am-3pm-pt-run-6-20260702T0447`, completed, Slack permalink `https://stablygroup.slack.com/archives/C0ASMDT6LQZ/p1782967997910739`.

The automation prompt was not date-parameterized, so these were two missed scheduled sweep catch-ups rather than hard-coded July 1-only queries.

## Post-PR stabilization

Completed.

- Required quiet wait completed before the first feedback sweep.
- CodeRabbit reported no actionable comments.
- PR checks passed: `track-community-pr` and `verify`.
- No post-PR fixes or follow-up commits were needed.
