### PR TITLE
Fix AppImage env leakage into Linux terminal shells

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, realpathSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { delimiter, join } from 'node:path'
 import type * as LocalPtyUtils from '../providers/local-pty-utils'
 
 const {
@@ -756,6 +756,55 @@ describe('createPtySubprocess', () => {
 
     const env = spawnMock.mock.calls.at(-1)?.[2].env
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined()
+  })
+
+  it('does not inherit AppImage runtime env into daemon PTY shells', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    const saved = {
+      APPIMAGE: process.env.APPIMAGE,
+      APPDIR: process.env.APPDIR,
+      ARGV0: process.env.ARGV0,
+      OWD: process.env.OWD,
+      APPIMAGE_LIBRARY_PATH: process.env.APPIMAGE_LIBRARY_PATH,
+      PATH: process.env.PATH,
+      LD_LIBRARY_PATH: process.env.LD_LIBRARY_PATH
+    }
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    process.env.APPIMAGE = '/data/apps/orca.appimage'
+    process.env.APPDIR = '/tmp/.mount_orca123'
+    process.env.ARGV0 = '/data/apps/orca.appimage'
+    process.env.OWD = '/home/user/project'
+    process.env.APPIMAGE_LIBRARY_PATH = '/tmp/.mount_orca123/usr/lib'
+    process.env.PATH = ['/tmp/.mount_orca123', '/tmp/.mount_orca123/usr/sbin', '/usr/bin'].join(
+      delimiter
+    )
+    process.env.LD_LIBRARY_PATH = ['/tmp/.mount_orca123/usr/lib', '/opt/audio/lib'].join(delimiter)
+
+    try {
+      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+
+    const env = spawnMock.mock.calls.at(-1)?.[2].env
+    expect(env.APPIMAGE).toBeUndefined()
+    expect(env.APPDIR).toBeUndefined()
+    expect(env.ARGV0).toBeUndefined()
+    expect(env.OWD).toBeUndefined()
+    expect(env.APPIMAGE_LIBRARY_PATH).toBeUndefined()
+    expect(env.PATH).toBe('/usr/bin')
+    expect(env.LD_LIBRARY_PATH).toBe('/opt/audio/lib')
   })
 
   it('does not inherit parent agent hook endpoint for development hook env', () => {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -29,6 +29,7 @@ import {
 import { isPwshAvailable } from '../pwsh'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
+import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { parseWslPath } from '../wsl'
 import { addWslEnvKeys } from '../wsl-env'
 import { getWslContextFromSessionId } from './wsl-session-context'
@@ -559,6 +560,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   removeUnspecifiedPaneIdentityEnv(env, opts.env)
   removeInheritedDevAgentHookEndpoint(env, opts.env)
   removeInheritedElectronRunAsNode(env)
+  removeAppImageRuntimeEnv(env)
   removeInheritedNoColor(env)
 
   env.LANG ??= 'en_US.UTF-8'

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { delimiter } from 'node:path'
 
 const {
   existsSyncMock,
@@ -363,6 +364,50 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.PATH.split(':')[0]).toBe('/tmp/orca-agent-teams-bin')
       expect(spawnCall[2].env.TERM_PROGRAM).toBeUndefined()
       expect(spawnCall[2].env.ORCA_ATTRIBUTION_SHIM_DIR).toBeUndefined()
+    })
+
+    it('does not inherit AppImage runtime env into Linux PTY shells', async () => {
+      const saved = {
+        APPIMAGE: process.env.APPIMAGE,
+        APPDIR: process.env.APPDIR,
+        ARGV0: process.env.ARGV0,
+        OWD: process.env.OWD,
+        APPIMAGE_LIBRARY_PATH: process.env.APPIMAGE_LIBRARY_PATH,
+        PATH: process.env.PATH,
+        LD_LIBRARY_PATH: process.env.LD_LIBRARY_PATH
+      }
+      process.env.APPIMAGE = '/data/apps/orca.appimage'
+      process.env.APPDIR = '/tmp/.mount_orca123'
+      process.env.ARGV0 = '/data/apps/orca.appimage'
+      process.env.OWD = '/home/user/project'
+      process.env.APPIMAGE_LIBRARY_PATH = '/tmp/.mount_orca123/usr/lib'
+      process.env.PATH = ['/tmp/.mount_orca123', '/tmp/.mount_orca123/usr/sbin', '/usr/bin'].join(
+        delimiter
+      )
+      process.env.LD_LIBRARY_PATH = ['/tmp/.mount_orca123/usr/lib', '/opt/audio/lib'].join(
+        delimiter
+      )
+
+      try {
+        await provider.spawn({ cols: 80, rows: 24 })
+      } finally {
+        for (const [key, value] of Object.entries(saved)) {
+          if (value === undefined) {
+            delete process.env[key]
+          } else {
+            process.env[key] = value
+          }
+        }
+      }
+
+      const env = spawnMock.mock.calls.at(-1)?.[2].env
+      expect(env.APPIMAGE).toBeUndefined()
+      expect(env.APPDIR).toBeUndefined()
+      expect(env.ARGV0).toBeUndefined()
+      expect(env.OWD).toBeUndefined()
+      expect(env.APPIMAGE_LIBRARY_PATH).toBeUndefined()
+      expect(env.PATH).toBe('/usr/bin')
+      expect(env.LD_LIBRARY_PATH).toBe('/opt/audio/lib')
     })
 
     it('uses shell wrapper when MiMo home must survive shell startup', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -38,6 +38,7 @@ import {
 } from './local-pty-shell-ready'
 import type { ShellReadySignal } from './local-pty-shell-ready'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
+import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { addWslEnvKeys } from '../wsl-env'
 import {
@@ -484,6 +485,7 @@ export class LocalPtyProvider implements IPtyProvider {
     // Why: Orca can be launched from an Orca terminal while developing. Pane
     // identity belongs to the child PTY, not the parent shell that spawned app.
     removeUnspecifiedPaneIdentityEnv(spawnEnv, args.env)
+    removeAppImageRuntimeEnv(spawnEnv)
     removeInheritedNoColor(spawnEnv)
     for (const key of args.envToDelete ?? []) {
       delete spawnEnv[key]

--- a/src/main/pty/appimage-terminal-env.test.ts
+++ b/src/main/pty/appimage-terminal-env.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { delimiter } from 'node:path'
+import { removeAppImageRuntimeEnv } from './appimage-terminal-env'
+
+describe('removeAppImageRuntimeEnv', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('removes AppImage runtime identity and mount paths from Linux terminal env', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+
+    const env = {
+      APPIMAGE: '/data/apps/orca.appimage',
+      APPDIR: '/tmp/.mount_orca123',
+      ARGV0: '/data/apps/orca.appimage',
+      OWD: '/home/user',
+      APPIMAGE_LIBRARY_PATH: '/tmp/.mount_orca123/usr/lib',
+      PATH: ['/tmp/.mount_orca123', '/tmp/.mount_orca123/usr/sbin', '/usr/bin'].join(delimiter),
+      LD_LIBRARY_PATH: ['/tmp/.mount_orca123/usr/lib', '/opt/audio/lib'].join(delimiter),
+      HOME: '/home/user'
+    }
+
+    removeAppImageRuntimeEnv(env)
+
+    expect(env).toEqual({
+      PATH: '/usr/bin',
+      LD_LIBRARY_PATH: '/opt/audio/lib',
+      HOME: '/home/user'
+    })
+  })
+
+  it('leaves non-AppImage environments untouched', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    const env = {
+      PATH: ['/opt/tools', '/usr/bin'].join(delimiter),
+      LD_LIBRARY_PATH: '/opt/audio/lib'
+    }
+
+    removeAppImageRuntimeEnv(env)
+
+    expect(env).toEqual({
+      PATH: ['/opt/tools', '/usr/bin'].join(delimiter),
+      LD_LIBRARY_PATH: '/opt/audio/lib'
+    })
+  })
+
+  it('removes AppImage ARGV0 even without a mounted APPDIR', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    const env = {
+      ARGV0: '/data/apps/orca.appimage',
+      PATH: ['/usr/local/bin', '/usr/bin'].join(delimiter)
+    }
+
+    removeAppImageRuntimeEnv(env)
+
+    expect(env).toEqual({
+      PATH: ['/usr/local/bin', '/usr/bin'].join(delimiter)
+    })
+  })
+
+  it('leaves AppImage-looking env untouched outside Linux', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const env = {
+      APPIMAGE: '/data/apps/orca.appimage',
+      APPDIR: '/tmp/.mount_orca123',
+      ARGV0: '/data/apps/orca.appimage',
+      PATH: ['/tmp/.mount_orca123/usr/bin', '/usr/bin'].join(delimiter)
+    }
+
+    removeAppImageRuntimeEnv(env)
+
+    expect(env).toEqual({
+      APPIMAGE: '/data/apps/orca.appimage',
+      APPDIR: '/tmp/.mount_orca123',
+      ARGV0: '/data/apps/orca.appimage',
+      PATH: ['/tmp/.mount_orca123/usr/bin', '/usr/bin'].join(delimiter)
+    })
+  })
+})

--- a/src/main/pty/appimage-terminal-env.ts
+++ b/src/main/pty/appimage-terminal-env.ts
@@ -1,0 +1,56 @@
+import { delimiter } from 'node:path'
+
+const APPIMAGE_RUNTIME_ENV_KEYS = [
+  'APPIMAGE',
+  'APPDIR',
+  'ARGV0',
+  'OWD',
+  'APPIMAGE_LIBRARY_PATH'
+] as const
+
+function normalizeAppDir(value: string | undefined): string | null {
+  const trimmed = value?.trim().replace(/\/+$/, '') ?? ''
+  return trimmed.startsWith('/') ? trimmed : null
+}
+
+function isInsideAppDir(entry: string, appDir: string): boolean {
+  const normalized = entry.replace(/\/+$/, '')
+  return normalized === appDir || normalized.startsWith(`${appDir}/`)
+}
+
+function removeAppDirPathEntries(value: string | undefined, appDir: string): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  const cleaned = value
+    .split(delimiter)
+    .filter((entry) => !isInsideAppDir(entry, appDir))
+    .join(delimiter)
+  return cleaned.length > 0 ? cleaned : undefined
+}
+
+export function removeAppImageRuntimeEnv(env: Record<string, string>): void {
+  if (process.platform !== 'linux' || (!env.APPIMAGE && !env.APPDIR && !env.ARGV0)) {
+    return
+  }
+
+  // Why: zsh treats exported ARGV0 as argv[0] for external commands, so an
+  // AppImage launch can make host commands think they were invoked as Orca.
+  const appDir = normalizeAppDir(env.APPDIR)
+  if (appDir) {
+    // Why: AppImage mount paths are for Orca's own loader; user shells should
+    // resolve commands and shared libraries from the host environment.
+    for (const key of ['PATH', 'LD_LIBRARY_PATH'] as const) {
+      const cleaned = removeAppDirPathEntries(env[key], appDir)
+      if (cleaned === undefined) {
+        delete env[key]
+      } else {
+        env[key] = cleaned
+      }
+    }
+  }
+
+  for (const key of APPIMAGE_RUNTIME_ENV_KEYS) {
+    delete env[key]
+  }
+}


### PR DESCRIPTION
## Description

Fixes the Linux AppImage terminal bug where commands like `arecord -L` / `aplay` can fail inside Orca with:

```text
/data/apps/orca.appimage: main:558: command should be named either arecord or aplay
```

Root cause: AppImage launch metadata was leaking into user PTY shell environments. In particular, `ARGV0=/data/apps/orca.appimage` is meaningful to `zsh`: when exported, zsh uses it as `argv[0]` for external commands. That makes host binaries like `arecord` think they were invoked as Orca's AppImage path instead of as `arecord` / `aplay`.

This PR adds a Linux-only PTY env sanitizer that:

- removes AppImage runtime identity keys from terminal shell env: `APPIMAGE`, `APPDIR`, `ARGV0`, `OWD`, `APPIMAGE_LIBRARY_PATH`
- removes `APPDIR`-scoped entries from `PATH` and `LD_LIBRARY_PATH`
- applies the cleanup to both local PTY and daemon-backed PTY shell launch paths
- adds regression coverage for the sanitizer and both spawn paths

## Evidence

Original failure minimized on `openclaw`:

```text
normal arecord first lines:
null
    Discard all samples (playback) or generate zero samples (capture)
lavrate
    Rate Converter Plugin Using Libav/FFmpeg Library
samplerate
    Rate Converter Plugin Using Samplerate Library

poisoned argv0 first lines:
/data/apps/orca.appimage: main:558: command should be named either arecord or aplay
```

`zsh` `ARGV0` propagation verified:

```text
zsh ARGV0 propagation:
/data/apps/orca.appimage

zsh without ARGV0:
node
```

Exact AppRun shape from the v1.4.114 Linux AppImage was inspected: it prepends AppImage mount paths to `PATH` / `LD_LIBRARY_PATH`, and the AppImage runtime supplies the identity env this PR now removes before starting user shells.

## Verification

Triple verification on the rebased PR branch:

1. Linux repro / causality check:

```bash
ssh openclaw 'arecord -L 2>&1 | sed -n "1,6p"'
ssh openclaw 'bash -lc "exec -a /data/apps/orca.appimage /usr/bin/arecord -L" 2>&1 | sed -n "1,3p"'
env ARGV0=/data/apps/orca.appimage zsh -fc 'node -e "console.log(process.argv0)"'
env -u ARGV0 zsh -fc 'node -e "console.log(process.argv0)"'
```

2. Focused regression tests:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/pty/appimage-terminal-env.test.ts \
  src/main/providers/local-pty-provider.test.ts \
  src/main/daemon/pty-subprocess.test.ts
```

Result: `3 passed (3)`, `138 passed (138)`.

3. Static checks:

```bash
pnpm exec tsgo --noEmit -p config/tsconfig.node.json --pretty false
pnpm exec oxlint \
  src/main/pty/appimage-terminal-env.ts \
  src/main/pty/appimage-terminal-env.test.ts \
  src/main/providers/local-pty-provider.ts \
  src/main/providers/local-pty-provider.test.ts \
  src/main/daemon/pty-subprocess.ts \
  src/main/daemon/pty-subprocess.test.ts
git diff --check
```

Result: passed.

Pre-commit also ran and passed `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` for staged files.

## ELI5

Orca's Linux AppImage starts with a few sticky notes that say "I am this Orca AppImage, and my bundled files live over here." Those notes are useful while launching Orca, but they should not be handed to the user's terminal.

One sticky note is named `ARGV0`. `zsh` treats that note specially and tells every command, "your name is `/data/apps/orca.appimage`." `arecord` checks its own name and only accepts `arecord` or `aplay`, so it crashes with the weird Orca AppImage error.

This fix removes those AppImage-only sticky notes before starting terminal shells, so normal Linux commands see their real names again.

## Trade-offs / User Impact

- Intended improvement: Linux AppImage terminal commands no longer inherit Orca's AppImage identity or bundled library/search paths.
- macOS and Windows behavior is unchanged; the sanitizer is Linux-only.
- SSH remote terminals are not changed by this sanitizer.
- Host `PATH` / `LD_LIBRARY_PATH` entries are preserved; only entries inside the AppImage mount (`APPDIR`) are removed.
- A user intentionally depending on `APPIMAGE`, `APPDIR`, `ARGV0`, `OWD`, or `APPIMAGE_LIBRARY_PATH` inside Orca's integrated terminal will no longer see those AppImage runtime internals. That is the only plausible degradation, and it is the intended isolation boundary for user shells.
- No UI changes.
