### PR TITLE
Notarize serve-sim camera dylibs in macOS releases

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -1,6 +1,7 @@
-const { chmodSync, existsSync, readdirSync } = require('node:fs')
+const { chmodSync, existsSync, mkdtempSync, readdirSync, rmSync } = require('node:fs')
 const { execFileSync } = require('node:child_process')
-const { join, resolve } = require('node:path')
+const { basename, dirname, join, resolve } = require('node:path')
+const { tmpdir } = require('node:os')
 const electronBuilderNativeRebuild = require('./scripts/electron-builder-native-rebuild.cjs')
 const {
   createPackagedRuntimeNodeModuleResources,
@@ -143,6 +144,9 @@ module.exports = {
     if (context.electronPlatformName === 'darwin') {
       await signMacComputerUseHelper(join(resourcesDir, 'Orca Computer Use.app'), context.packager)
     }
+  },
+  afterSign: async (context) => {
+    await notarizeMacServeSimCameraDylibs(context)
   },
   win: {
     executableName: 'Orca',
@@ -371,6 +375,178 @@ function chmodMacServeSimHelpers(resourcesDir, electronPlatformName) {
   }
 }
 
+async function notarizeMacServeSimCameraDylibs(context) {
+  await notarizeMacServeSimCameraDylibsWithHost(context, macNotarizationHost)
+}
+
+async function notarizeMacServeSimCameraDylibsWithHost(context, host) {
+  if (!isMacRelease || context.electronPlatformName !== 'darwin') {
+    return
+  }
+  const resourcesDir = join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`,
+    'Contents',
+    'Resources'
+  )
+  const requiredDylibPaths = [
+    join(resourcesDir, 'serve-sim', 'dist', 'simcam', 'libSimCameraInjector.dylib'),
+    join(resourcesDir, 'node_modules', 'serve-sim', 'dist', 'simcam', 'libSimCameraInjector.dylib')
+  ]
+  const optionalDylibPaths = [
+    join(
+      resourcesDir,
+      'app.asar.unpacked',
+      'node_modules',
+      'serve-sim',
+      'dist',
+      'simcam',
+      'libSimCameraInjector.dylib'
+    )
+  ]
+  for (const dylibPath of requiredDylibPaths) {
+    if (!host.existsSync(dylibPath)) {
+      throw new Error(`Missing serve-sim camera dylib for notarization: ${dylibPath}`)
+    }
+  }
+  const dylibPaths = [
+    ...requiredDylibPaths,
+    ...optionalDylibPaths.filter((dylibPath) => host.existsSync(dylibPath))
+  ]
+  // Why: stapler cannot attach tickets to bare dylibs; submitting each signed
+  // dylib zip registers its cdhash for direct Gatekeeper assessment.
+  for (const dylibPath of dylibPaths) {
+    notarizeMacStandaloneBinary(dylibPath, host)
+  }
+}
+
+let macNotarizationHost = {
+  existsSync,
+  execFileSync,
+  mkdtempSync,
+  rmSync
+}
+
+async function withMacNotarizationHost(host, callback) {
+  const previousHost = macNotarizationHost
+  macNotarizationHost = host
+  try {
+    return await callback()
+  } finally {
+    macNotarizationHost = previousHost
+  }
+}
+
+function notarizeMacStandaloneBinary(binaryPath, host) {
+  const archiveDir = host.mkdtempSync(join(tmpdir(), 'orca-mac-standalone-notary-'))
+  const archivePath = join(archiveDir, `${basename(binaryPath)}.zip`)
+  try {
+    host.execFileSync(
+      'ditto',
+      ['-c', '-k', '--sequesterRsrc', '--keepParent', basename(binaryPath), archivePath],
+      {
+        cwd: dirname(binaryPath),
+        stdio: 'inherit'
+      }
+    )
+    const credentialArgs = macNotarytoolCredentialArgs()
+    const output = execFileSyncWithRedactedError(
+      host,
+      'xcrun',
+      ['notarytool', 'submit', archivePath, ...credentialArgs, '--wait', '--output-format', 'json'],
+      {
+        encoding: 'utf8'
+      },
+      credentialArgs,
+      binaryPath
+    )
+    const result = JSON.parse(output)
+    if (result.status !== 'Accepted') {
+      throw new Error(`Standalone binary notarization failed for ${binaryPath}: ${output}`)
+    }
+  } finally {
+    host.rmSync(archiveDir, { recursive: true, force: true })
+  }
+}
+
+const macNotarytoolCredentialFlags = new Set([
+  '--apple-id',
+  '--password',
+  '--team-id',
+  '--key',
+  '--key-id',
+  '--issuer',
+  '--keychain',
+  '--keychain-profile'
+])
+
+function execFileSyncWithRedactedError(host, command, args, options, credentialArgs, binaryPath) {
+  try {
+    return host.execFileSync(command, args, options)
+  } catch (error) {
+    throw new Error(
+      `Standalone binary notarization subprocess failed for ${binaryPath}: ${redactCredentialValues(
+        error instanceof Error ? error.message : String(error),
+        credentialArgs
+      )}`
+    )
+  }
+}
+
+function redactCredentialValues(message, credentialArgs) {
+  let redacted = message
+  for (let index = 0; index < credentialArgs.length - 1; index += 2) {
+    const value = credentialArgs[index + 1]
+    if (macNotarytoolCredentialFlags.has(credentialArgs[index]) && value) {
+      redacted = redacted.split(value).join('[REDACTED]')
+    }
+  }
+  return redacted
+}
+
+function macNotarytoolCredentialArgs() {
+  if (process.env.APPLE_ID || process.env.APPLE_APP_SPECIFIC_PASSWORD) {
+    if (!process.env.APPLE_ID) {
+      throw new Error('APPLE_ID env var needs to be set')
+    }
+    if (!process.env.APPLE_APP_SPECIFIC_PASSWORD) {
+      throw new Error('APPLE_APP_SPECIFIC_PASSWORD env var needs to be set')
+    }
+    if (!process.env.APPLE_TEAM_ID) {
+      throw new Error('APPLE_TEAM_ID env var needs to be set')
+    }
+    return [
+      '--apple-id',
+      process.env.APPLE_ID,
+      '--password',
+      process.env.APPLE_APP_SPECIFIC_PASSWORD,
+      '--team-id',
+      process.env.APPLE_TEAM_ID
+    ]
+  }
+  if (process.env.APPLE_API_KEY && process.env.APPLE_API_KEY_ID && process.env.APPLE_API_ISSUER) {
+    return [
+      '--key',
+      process.env.APPLE_API_KEY,
+      '--key-id',
+      process.env.APPLE_API_KEY_ID,
+      '--issuer',
+      process.env.APPLE_API_ISSUER
+    ]
+  }
+  if (process.env.APPLE_KEYCHAIN_PROFILE) {
+    return [
+      ...(process.env.APPLE_KEYCHAIN ? ['--keychain', process.env.APPLE_KEYCHAIN] : []),
+      '--keychain-profile',
+      process.env.APPLE_KEYCHAIN_PROFILE
+    ]
+  }
+  if (process.env.APPLE_API_KEY || process.env.APPLE_API_KEY_ID || process.env.APPLE_API_ISSUER) {
+    throw new Error('Env vars APPLE_API_KEY, APPLE_API_KEY_ID and APPLE_API_ISSUER need to be set')
+  }
+  throw new Error('Missing notarization credentials for serve-sim camera dylibs')
+}
+
 async function signMacComputerUseHelper(helperAppPath, packager) {
   if (!existsSync(helperAppPath)) {
     if (isMacRelease) {
@@ -434,3 +610,12 @@ function findInstalledMacSigningIdentity(keychainFile) {
   } catch {}
   return null
 }
+
+Object.defineProperty(module.exports, '__test', {
+  enumerable: false,
+  value: {
+    macNotarytoolCredentialArgs,
+    notarizeMacServeSimCameraDylibsWithHost,
+    withMacNotarizationHost
+  }
+})

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -446,7 +446,8 @@ function notarizeMacStandaloneBinary(binaryPath, host) {
       ['-c', '-k', '--sequesterRsrc', '--keepParent', basename(binaryPath), archivePath],
       {
         cwd: dirname(binaryPath),
-        stdio: 'inherit'
+        stdio: 'inherit',
+        timeout: macDylibArchiveTimeoutMs
       }
     )
     const credentialArgs = macNotarytoolCredentialArgs()
@@ -455,7 +456,8 @@ function notarizeMacStandaloneBinary(binaryPath, host) {
       'xcrun',
       ['notarytool', 'submit', archivePath, ...credentialArgs, '--wait', '--output-format', 'json'],
       {
-        encoding: 'utf8'
+        encoding: 'utf8',
+        timeout: macDylibNotarytoolTimeoutMs
       },
       credentialArgs,
       binaryPath
@@ -468,6 +470,10 @@ function notarizeMacStandaloneBinary(binaryPath, host) {
     host.rmSync(archiveDir, { recursive: true, force: true })
   }
 }
+
+const macDylibArchiveTimeoutMs = 2 * 60 * 1000
+// Why: release jobs should fail loudly instead of hanging on a stuck submission.
+const macDylibNotarytoolTimeoutMs = 45 * 60 * 1000
 
 const macNotarytoolCredentialFlags = new Set([
   '--apple-id',

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -617,11 +617,13 @@ function findInstalledMacSigningIdentity(keychainFile) {
   return null
 }
 
-Object.defineProperty(module.exports, '__test', {
-  enumerable: false,
-  value: {
-    macNotarytoolCredentialArgs,
-    notarizeMacServeSimCameraDylibsWithHost,
-    withMacNotarizationHost
-  }
-})
+if (process.env.VITEST || process.env.VITEST_WORKER_ID) {
+  Object.defineProperty(module.exports, '__test', {
+    enumerable: false,
+    value: {
+      macNotarytoolCredentialArgs,
+      notarizeMacServeSimCameraDylibsWithHost,
+      withMacNotarizationHost
+    }
+  })
+}

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -1,8 +1,8 @@
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { dirname, join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const electronBuilderConfig = require('../electron-builder.config.cjs')
@@ -17,6 +17,128 @@ const {
   prunePackagedZodSources,
   verifyPackagedMainRuntimeDeps
 } = require('../packaged-runtime-node-modules.cjs')
+
+const electronBuilderConfigPath = require.resolve('../electron-builder.config.cjs')
+const macNotaryEnvKeys = [
+  'APPLE_ID',
+  'APPLE_APP_SPECIFIC_PASSWORD',
+  'APPLE_TEAM_ID',
+  'APPLE_API_KEY',
+  'APPLE_API_KEY_ID',
+  'APPLE_API_ISSUER',
+  'APPLE_KEYCHAIN_PROFILE',
+  'APPLE_KEYCHAIN',
+  'ORCA_MAC_RELEASE'
+]
+const appleIdMacReleaseEnv = {
+  APPLE_APP_SPECIFIC_PASSWORD: 'app-password',
+  APPLE_ID: 'release@example.com',
+  APPLE_TEAM_ID: 'TEAMID',
+  ORCA_MAC_RELEASE: '1'
+}
+
+async function withElectronBuilderConfigEnv(env, callback) {
+  const previous = new Map(macNotaryEnvKeys.map((key) => [key, process.env[key]]))
+  try {
+    for (const key of macNotaryEnvKeys) {
+      delete process.env[key]
+    }
+    Object.assign(process.env, env)
+    delete require.cache[electronBuilderConfigPath]
+    return await callback(require('../electron-builder.config.cjs'))
+  } finally {
+    for (const key of macNotaryEnvKeys) {
+      const value = previous.get(key)
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+    delete require.cache[electronBuilderConfigPath]
+  }
+}
+
+function createMacNotarizationContext(appOutDir) {
+  return {
+    appOutDir,
+    electronPlatformName: 'darwin',
+    packager: {
+      appInfo: {
+        productFilename: 'Orca'
+      }
+    }
+  }
+}
+
+function requiredMacServeSimDylibPaths(appOutDir) {
+  const resourcesDir = join(appOutDir, 'Orca.app', 'Contents', 'Resources')
+  return [
+    join(resourcesDir, 'serve-sim', 'dist', 'simcam', 'libSimCameraInjector.dylib'),
+    join(resourcesDir, 'node_modules', 'serve-sim', 'dist', 'simcam', 'libSimCameraInjector.dylib')
+  ]
+}
+
+function optionalMacServeSimDylibPaths(appOutDir) {
+  const resourcesDir = join(appOutDir, 'Orca.app', 'Contents', 'Resources')
+  return [
+    join(
+      resourcesDir,
+      'app.asar.unpacked',
+      'node_modules',
+      'serve-sim',
+      'dist',
+      'simcam',
+      'libSimCameraInjector.dylib'
+    )
+  ]
+}
+
+function macServeSimDylibPaths(appOutDir) {
+  return [...requiredMacServeSimDylibPaths(appOutDir), ...optionalMacServeSimDylibPaths(appOutDir)]
+}
+
+function createMacNotarizationHost({ existingPaths, output = { status: 'Accepted' } }) {
+  const calls = []
+  let temporaryDirectoryIndex = 0
+  const host = {
+    calls,
+    execFileSync: vi.fn((command, args, options = {}) => {
+      calls.push({ args, command, options })
+      if (command === 'xcrun') {
+        return typeof output === 'string' ? output : JSON.stringify(output)
+      }
+      return ''
+    }),
+    existsSync: vi.fn((targetPath) => existingPaths.has(targetPath)),
+    mkdtempSync: vi.fn((prefix) => `${prefix}${++temporaryDirectoryIndex}`),
+    rmSync: vi.fn()
+  }
+  return host
+}
+
+async function runMacAfterSignWithHost(config, appOutDir, host) {
+  return await config.__test.withMacNotarizationHost(host, async () => {
+    await config.afterSign(createMacNotarizationContext(appOutDir))
+  })
+}
+
+function expectNotaryCredentials(calls, credentials, expectedCallCount = 3) {
+  const notaryCalls = calls.filter(({ command }) => command === 'xcrun')
+  expect(notaryCalls).toHaveLength(expectedCallCount)
+  for (const notaryCall of notaryCalls) {
+    expect(notaryCall.args).toEqual(
+      expect.arrayContaining([
+        'notarytool',
+        'submit',
+        ...credentials,
+        '--wait',
+        '--output-format',
+        'json'
+      ])
+    )
+  }
+}
 
 describe('electron-builder config', () => {
   it('excludes repo-only source trees from app.asar', () => {
@@ -61,6 +183,206 @@ describe('electron-builder config', () => {
         })
       ])
     )
+  })
+
+  it('keeps the macOS afterSign hook inert outside macOS release builds', async () => {
+    for (const { context, env } of [
+      { context: { electronPlatformName: 'darwin' }, env: {} },
+      { context: { electronPlatformName: 'linux' }, env: { ORCA_MAC_RELEASE: '1' } }
+    ]) {
+      await withElectronBuilderConfigEnv(env, async (config) => {
+        const host = createMacNotarizationHost({ existingPaths: new Set() })
+
+        await expect(
+          config.__test.withMacNotarizationHost(host, async () => {
+            await config.afterSign(context)
+          })
+        ).resolves.toBeUndefined()
+        expect(host.execFileSync).not.toHaveBeenCalled()
+      })
+    }
+  })
+
+  it('submits all packaged serve-sim camera dylib copies in macOS releases', async () => {
+    await withElectronBuilderConfigEnv(appleIdMacReleaseEnv, async (config) => {
+      const appOutDir = join(tmpdir(), 'orca-electron-builder-test')
+      const dylibPaths = macServeSimDylibPaths(appOutDir)
+      const host = createMacNotarizationHost({ existingPaths: new Set(dylibPaths) })
+
+      await runMacAfterSignWithHost(config, appOutDir, host)
+
+      const dittoCalls = host.calls.filter(({ command }) => command === 'ditto')
+      const notaryCalls = host.calls.filter(({ command }) => command === 'xcrun')
+      expect(dittoCalls).toHaveLength(dylibPaths.length)
+      expect(notaryCalls).toHaveLength(dylibPaths.length)
+      expect(dittoCalls.map(({ options }) => options.cwd)).toEqual(
+        dylibPaths.map((dylibPath) => dirname(dylibPath))
+      )
+      expect(dittoCalls.map(({ args }) => args.at(-1))).toEqual(
+        notaryCalls.map(({ args }) => args[2])
+      )
+      expectNotaryCredentials(host.calls, [
+        '--apple-id',
+        'release@example.com',
+        '--password',
+        'app-password',
+        '--team-id',
+        'TEAMID'
+      ])
+      expect(host.rmSync).toHaveBeenCalledTimes(dylibPaths.length)
+    })
+  })
+
+  it('does not require optional app.asar.unpacked serve-sim dylibs in macOS releases', async () => {
+    await withElectronBuilderConfigEnv(appleIdMacReleaseEnv, async (config) => {
+      const appOutDir = join(tmpdir(), 'orca-electron-builder-test')
+      const dylibPaths = requiredMacServeSimDylibPaths(appOutDir)
+      const host = createMacNotarizationHost({ existingPaths: new Set(dylibPaths) })
+
+      await runMacAfterSignWithHost(config, appOutDir, host)
+
+      const dittoCalls = host.calls.filter(({ command }) => command === 'ditto')
+      expect(dittoCalls).toHaveLength(dylibPaths.length)
+      expect(dittoCalls.map(({ options }) => options.cwd)).toEqual(
+        dylibPaths.map((dylibPath) => dirname(dylibPath))
+      )
+      expectNotaryCredentials(
+        host.calls,
+        ['--apple-id', 'release@example.com', '--password', 'app-password', '--team-id', 'TEAMID'],
+        dylibPaths.length
+      )
+      expect(host.rmSync).toHaveBeenCalledTimes(dylibPaths.length)
+    })
+  })
+
+  it('fails before notarization when a packaged serve-sim camera dylib is missing', async () => {
+    await withElectronBuilderConfigEnv({ ORCA_MAC_RELEASE: '1' }, async (config) => {
+      const appOutDir = join(tmpdir(), 'orca-electron-builder-test')
+      const [firstDylibPath] = macServeSimDylibPaths(appOutDir)
+      const host = createMacNotarizationHost({ existingPaths: new Set([firstDylibPath]) })
+
+      await expect(
+        config.__test.notarizeMacServeSimCameraDylibsWithHost(
+          createMacNotarizationContext(appOutDir),
+          host
+        )
+      ).rejects.toThrow('Missing serve-sim camera dylib for notarization')
+
+      expect(host.execFileSync).not.toHaveBeenCalled()
+    })
+  })
+
+  it('maps supported macOS notarization credential families to notarytool flags', async () => {
+    const cases = [
+      {
+        credentials: ['--key', '/tmp/AuthKey.p8', '--key-id', 'KEYID', '--issuer', 'issuer'],
+        env: {
+          APPLE_API_ISSUER: 'issuer',
+          APPLE_API_KEY: '/tmp/AuthKey.p8',
+          APPLE_API_KEY_ID: 'KEYID',
+          ORCA_MAC_RELEASE: '1'
+        }
+      },
+      {
+        credentials: [
+          '--apple-id',
+          'release@example.com',
+          '--password',
+          'app-password',
+          '--team-id',
+          'TEAMID'
+        ],
+        env: {
+          APPLE_API_ISSUER: 'issuer',
+          APPLE_API_KEY: '/tmp/AuthKey.p8',
+          APPLE_API_KEY_ID: 'KEYID',
+          ...appleIdMacReleaseEnv
+        }
+      },
+      {
+        credentials: ['--keychain', '/tmp/login.keychain-db', '--keychain-profile', 'orca-release'],
+        env: {
+          APPLE_KEYCHAIN: '/tmp/login.keychain-db',
+          APPLE_KEYCHAIN_PROFILE: 'orca-release',
+          ORCA_MAC_RELEASE: '1'
+        }
+      }
+    ]
+
+    for (const { credentials, env } of cases) {
+      await withElectronBuilderConfigEnv(env, async (config) => {
+        const appOutDir = join(tmpdir(), 'orca-electron-builder-test')
+        const dylibPaths = macServeSimDylibPaths(appOutDir)
+        const host = createMacNotarizationHost({ existingPaths: new Set(dylibPaths) })
+
+        await runMacAfterSignWithHost(config, appOutDir, host)
+        expectNotaryCredentials(host.calls, credentials)
+      })
+    }
+  })
+
+  it('fails macOS standalone notarization on partial credentials and bad notary output', async () => {
+    for (const { env, message } of [
+      {
+        env: { APPLE_ID: 'release@example.com', ORCA_MAC_RELEASE: '1' },
+        message: 'APPLE_APP_SPECIFIC_PASSWORD env var needs to be set'
+      },
+      {
+        env: { APPLE_API_KEY: '/tmp/AuthKey.p8', APPLE_API_KEY_ID: 'KEYID', ORCA_MAC_RELEASE: '1' },
+        message: 'Env vars APPLE_API_KEY, APPLE_API_KEY_ID and APPLE_API_ISSUER need to be set'
+      }
+    ]) {
+      await withElectronBuilderConfigEnv(env, async (config) => {
+        expect(() => config.__test.macNotarytoolCredentialArgs()).toThrow(message)
+      })
+    }
+
+    for (const { output, message } of [
+      { message: 'Standalone binary notarization failed', output: { status: 'Invalid' } },
+      { message: '', output: '{not-json' }
+    ]) {
+      await withElectronBuilderConfigEnv(appleIdMacReleaseEnv, async (config) => {
+        const appOutDir = join(tmpdir(), 'orca-electron-builder-test')
+        const dylibPaths = macServeSimDylibPaths(appOutDir)
+        const host = createMacNotarizationHost({ existingPaths: new Set(dylibPaths), output })
+
+        const expectation = expect(
+          config.__test.notarizeMacServeSimCameraDylibsWithHost(
+            createMacNotarizationContext(appOutDir),
+            host
+          )
+        ).rejects
+        await (message ? expectation.toThrow(message) : expectation.toThrow())
+      })
+    }
+  })
+
+  it('surfaces macOS standalone notarization subprocess failures without secrets', async () => {
+    await withElectronBuilderConfigEnv(appleIdMacReleaseEnv, async (config) => {
+      const appOutDir = join(tmpdir(), 'orca-electron-builder-test')
+      const dylibPaths = macServeSimDylibPaths(appOutDir)
+      const host = createMacNotarizationHost({ existingPaths: new Set(dylibPaths) })
+      host.execFileSync.mockImplementation((command, args, options = {}) => {
+        host.calls.push({ args, command, options })
+        if (command === 'xcrun') {
+          throw new Error(`Command failed: xcrun ${args.join(' ')}`)
+        }
+        return ''
+      })
+
+      try {
+        await config.__test.notarizeMacServeSimCameraDylibsWithHost(
+          createMacNotarizationContext(appOutDir),
+          host
+        )
+        throw new Error('Expected notarization to fail')
+      } catch (error) {
+        expect(error.message).toContain('Standalone binary notarization subprocess failed')
+        expect(error.message).not.toContain('app-password')
+        expect(error.message).toContain('[REDACTED]')
+      }
+      expect(host.rmSync).toHaveBeenCalled()
+    })
   })
 
   it('unpacks the compiled CommonJS boundary with CLI runtime files', () => {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -218,6 +218,8 @@ describe('electron-builder config', () => {
       expect(dittoCalls.map(({ options }) => options.cwd)).toEqual(
         dylibPaths.map((dylibPath) => dirname(dylibPath))
       )
+      expect(dittoCalls.every(({ options }) => options.timeout === 2 * 60 * 1000)).toBe(true)
+      expect(notaryCalls.every(({ options }) => options.timeout === 45 * 60 * 1000)).toBe(true)
       expect(dittoCalls.map(({ args }) => args.at(-1))).toEqual(
         notaryCalls.map(({ args }) => args[2])
       )
@@ -378,7 +380,7 @@ describe('electron-builder config', () => {
         throw new Error('Expected notarization to fail')
       } catch (error) {
         expect(error.message).toContain('Standalone binary notarization subprocess failed')
-        expect(error.message).not.toContain('app-password')
+        expect(error.message).not.toMatch(/release@example\.com|app-password|TEAMID/)
         expect(error.message).toContain('[REDACTED]')
       }
       expect(host.rmSync).toHaveBeenCalled()


### PR DESCRIPTION
## Summary

Fixes #6877.

This adds a macOS release-only `afterSign` step that submits the packaged standalone `serve-sim` `libSimCameraInjector.dylib` copies to Apple notarization via zipped `xcrun notarytool submit --wait` archives. The outer app notarization path is unchanged; this closes the gap where nested camera injector dylibs could be signed but not directly accepted by Gatekeeper assessment.

Important boundary: local validation cannot prove the final Apple Gatekeeper result without release credentials and a produced signed macOS artifact. Before release, run the macOS release pipeline and assess the shipped app plus nested dylib copies with `spctl`/`codesign`.

## Design Approach

The smallest scoped change is in `config/electron-builder.config.cjs`: keep existing macOS app signing/notarization behavior, then add a release-gated hook for the nested standalone dylibs that `stapler` cannot ticket directly. The hook requires the two packaged resource copies currently declared by the build and notarizes the `app.asar.unpacked` copy only when present.

## Design Review Outcome

Design review completed clean after tightening the test plan around behavior rather than source-string checks, and after explicitly treating release artifact `spctl` validation as a credentialed release gate.

## Implementation

- Added `afterSign` notarization for packaged `serve-sim` camera injector dylibs when `ORCA_MAC_RELEASE=1` and `electronPlatformName === 'darwin'`.
- Supports Apple ID/app password/team, App Store Connect API key, and keychain profile credential families.
- Redacts credential values from wrapped subprocess failures.
- Bounds `ditto` and `notarytool --wait` subprocesses so release jobs fail instead of hanging indefinitely.
- Leaves non-release and non-macOS packaging inert.
- Added focused tests for release gating, path coverage, credential mapping, missing files, bad notary responses, subprocess failure redaction, subprocess timeouts, and temp cleanup.

No UI was touched, so `docs/STYLEGUIDE.md` is not applicable.

## Completeness

Completeness verification passed against the requested macOS release-packaging scope. The headline behavior is implemented locally, with the live signed-artifact Gatekeeper assessment remaining as the release-validation gap.

## Consistency

Source-of-truth behavior is the macOS release packaging/notarization path in electron-builder. Neighboring surfaces are Windows/Linux packaging and local development packaging; those remain unchanged because the new hook exits outside macOS release builds.

## Risks And Non-Goals

- This does not attempt to staple bare dylibs; Apple stapler does not support that artifact shape.
- This does not change `serve-sim` packaging layout beyond requiring the declared release dylib copies to be present.
- This does not prove Apple acceptance for a future release artifact until CI or a credentialed macOS machine runs the live release pipeline and `spctl` checks.

## Performance

Performance audit found no runtime hot path. The new work is bounded to macOS release packaging and runs two required, plus one optional, `ditto`/`notarytool` submissions.

## Code Review

The code-review loop completed with a fresh final round of two reviewers. Both returned clean. An earlier actionable finding was fixed by making the `app.asar.unpacked` dylib optional instead of hard-required.

## Merge-Confidence Validation

Result: land after release-artifact validation, or land now only if the live Apple artifact gap is explicitly accepted.

Passed locally:

- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/electron-builder-config.test.mjs` — 26 passed
- `pnpm exec oxfmt --check config/electron-builder.config.cjs config/scripts/electron-builder-config.test.mjs` — passed
- `pnpm exec oxlint config/electron-builder.config.cjs config/scripts/electron-builder-config.test.mjs` — passed
- `git diff --check` — passed
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed with existing unrelated warnings
- `pnpm build:unpack` — passed locally; runner output was truncated because the build is noisy, but the command exited 0 and passed electron-builder packaging/config validation
- Config import probe confirmed normal electron-builder imports do not expose the Vitest-only `__test` seam

Not applicable:

- UI/Electron/demo-project screenshots, mobile, SSH, and agent/provider validation. This PR only touches macOS release packaging.

Release gate still needed:

- Run a credentialed macOS release build.
- Validate the shipped artifact and nested dylib copies with `spctl -a -vvv` and `codesign --verify`.

## Post-PR Stabilization

- CodeRabbit latest review: no actionable comments. Earlier timeout finding was addressed in commit `65a81fd`.
- PR checks: passing (`verify`, Ubuntu native smoke, Windows native smoke); other platform jobs are skipped by workflow rules.
- Pushed-state verification: local branch matched upstream after the last push.

Made with [Orca](https://github.com/stablyai/orca) 🐋
