### PR TITLE
Show Git-created worktrees in external discovery

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1402,13 +1402,9 @@ export function registerWorktreeHandlers(
         if (!registeredWorktree) {
           const fsProvider = repo.connectionId ? getSshFilesystemProvider(repo.connectionId) : null
           let canCleanOrphanedDirectory = false
-          const knownOrcaLayouts = buildKnownOrcaWorkspaceLayouts(store.getSettings(), repo)
           if (
             canCleanupUnregisteredOrcaWorktreeDirectory({
-              meta: removedMeta,
-              worktreePath,
-              repo,
-              knownOrcaLayouts
+              meta: removedMeta
             })
           ) {
             if (repo.connectionId) {
@@ -1481,7 +1477,6 @@ export function registerWorktreeHandlers(
                 runtimeWorktreePath,
                 repo,
                 runtimeRepoPath: toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
-                knownOrcaLayouts,
                 registeredWorktrees,
                 statPath: access.statPath,
                 isGitRepository: (path) => isLocalGitRepository(path, localWorktreeGitOptions)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -14713,13 +14713,9 @@ export class OrcaRuntimeService {
       )
       if (!registeredWorktree) {
         let canCleanOrphanedDirectory = false
-        const knownOrcaLayouts = buildKnownOrcaWorkspaceLayouts(store.getSettings(), repo)
         if (
           canCleanupUnregisteredOrcaWorktreeDirectory({
-            meta: removedMeta,
-            worktreePath: removalTarget.path,
-            repo,
-            knownOrcaLayouts
+            meta: removedMeta
           })
         ) {
           if (repo.connectionId) {
@@ -14792,7 +14788,6 @@ export class OrcaRuntimeService {
               runtimeWorktreePath,
               repo,
               runtimeRepoPath: toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
-              knownOrcaLayouts,
               registeredWorktrees,
               statPath: access.statPath,
               isGitRepository: (path) => isLocalRuntimeGitRepository(path, localWorktreeGitOptions)

--- a/src/main/worktree-removal-authority.test.ts
+++ b/src/main/worktree-removal-authority.test.ts
@@ -4,6 +4,7 @@ import {
   isWorktreePathMissing,
   stripOrcaProvenanceMetaUpdates
 } from './worktree-removal-safety'
+import type { WorktreeMeta } from '../shared/types'
 
 describe('isWorktreePathMissing', () => {
   it('recognizes missing-path errors from local and remote stat providers', async () => {
@@ -33,10 +34,7 @@ describe('canCleanupUnregisteredOrcaWorktreeDirectory', () => {
   it('does not treat orcaCreatedAt alone as cleanup authority', () => {
     expect(
       canCleanupUnregisteredOrcaWorktreeDirectory({
-        meta: { orcaCreatedAt: Date.now() },
-        worktreePath: '/outside/orphan',
-        repo: { path: '/repo' },
-        knownOrcaLayouts: []
+        meta: { orcaCreatedAt: Date.now() }
       })
     ).toBe(false)
     expect(
@@ -44,10 +42,7 @@ describe('canCleanupUnregisteredOrcaWorktreeDirectory', () => {
         meta: {
           orcaCreatedAt: Date.now(),
           orcaCreationSource: 'runtime'
-        },
-        worktreePath: '/outside/orphan',
-        repo: { path: '/repo' },
-        knownOrcaLayouts: []
+        }
       })
     ).toBe(true)
   })
@@ -55,32 +50,48 @@ describe('canCleanupUnregisteredOrcaWorktreeDirectory', () => {
   it('accepts legacy Orca-created metadata before explicit provenance existed', () => {
     expect(
       canCleanupUnregisteredOrcaWorktreeDirectory({
-        meta: { createdAt: Date.now() },
-        worktreePath: '/outside/orphan',
-        repo: { path: '/repo' },
-        knownOrcaLayouts: []
+        meta: { createdAt: Date.now() }
       })
     ).toBe(true)
   })
 
-  it('accepts legacy repo-nested Orca workspace paths without metadata provenance', () => {
+  it('does not treat creation layout metadata alone as cleanup authority', () => {
+    const layoutOnlyMeta: WorktreeMeta = {
+      displayName: '',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      linkedGitLabMR: null,
+      linkedGitLabIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0,
+      workspaceStatus: 'todo',
+      orcaCreationWorkspaceLayout: { path: '/orca/workspaces', nestWorkspaces: true }
+    }
+
     expect(
       canCleanupUnregisteredOrcaWorktreeDirectory({
-        meta: undefined,
-        worktreePath: '/orca/workspaces/app/legacy-orphan',
-        repo: { path: '/repos/app' },
-        knownOrcaLayouts: [{ path: '/orca/workspaces', nestWorkspaces: true }]
+        meta: layoutOnlyMeta
       })
-    ).toBe(true)
+    ).toBe(false)
+  })
+
+  it('does not trust nested workspace paths without legacy metadata', () => {
+    expect(
+      canCleanupUnregisteredOrcaWorktreeDirectory({
+        meta: undefined
+      })
+    ).toBe(false)
   })
 
   it('does not trust flat workspace-root paths without legacy metadata', () => {
     expect(
       canCleanupUnregisteredOrcaWorktreeDirectory({
-        meta: undefined,
-        worktreePath: '/orca/workspaces/legacy-orphan',
-        repo: { path: '/repos/app' },
-        knownOrcaLayouts: [{ path: '/orca/workspaces', nestWorkspaces: false }]
+        meta: undefined
       })
     ).toBe(false)
   })

--- a/src/main/worktree-removal-authority.test.ts
+++ b/src/main/worktree-removal-authority.test.ts
@@ -80,15 +80,7 @@ describe('canCleanupUnregisteredOrcaWorktreeDirectory', () => {
     ).toBe(false)
   })
 
-  it('does not trust nested workspace paths without legacy metadata', () => {
-    expect(
-      canCleanupUnregisteredOrcaWorktreeDirectory({
-        meta: undefined
-      })
-    ).toBe(false)
-  })
-
-  it('does not trust flat workspace-root paths without legacy metadata', () => {
+  it('does not trust paths without provenance or legacy metadata', () => {
     expect(
       canCleanupUnregisteredOrcaWorktreeDirectory({
         meta: undefined

--- a/src/main/worktree-removal-safety.test.ts
+++ b/src/main/worktree-removal-safety.test.ts
@@ -325,7 +325,6 @@ describe('canCleanupUnregisteredOrcaLeftoverDirectory', () => {
     runtimeWorktreePath: '/workspaces/orca-owned',
     repo,
     runtimeRepoPath: repo.path,
-    knownOrcaLayouts: [],
     registeredWorktrees: [makeGitWorktree(repo.path, true)]
   }
 
@@ -376,7 +375,6 @@ describe('canCleanupUnregisteredOrcaLeftoverDirectory', () => {
       canCleanupUnregisteredOrcaLeftoverDirectory({
         ...baseArgs,
         meta: undefined,
-        knownOrcaLayouts: [{ path: '/workspaces', nestWorkspaces: false }],
         statPath: makeStatPath([], ['/workspaces/orca-owned']),
         isGitRepository
       })

--- a/src/main/worktree-removal-safety.ts
+++ b/src/main/worktree-removal-safety.ts
@@ -2,8 +2,7 @@ import { lstat, readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { posix, win32 } from 'node:path'
 import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
-import type { GitWorktreeInfo, OrcaWorkspaceLayout, Repo, WorktreeMeta } from '../shared/types'
-import { matchesStrongOrcaCreatePath } from '../shared/worktree-ownership'
+import type { GitWorktreeInfo, Repo, WorktreeMeta } from '../shared/types'
 import { areWorktreePathsEqual } from './ipc/worktree-logic'
 import {
   gitFileProvesOrphanedWorktreeDirectory,
@@ -172,9 +171,6 @@ export async function canSafelyRemoveOrphanedWorktreeDirectory(
 
 export function canCleanupUnregisteredOrcaWorktreeDirectory(args: {
   meta: UnregisteredOrcaCleanupMeta | null | undefined
-  worktreePath: string
-  repo: Pick<Repo, 'path'>
-  knownOrcaLayouts: readonly OrcaWorkspaceLayout[]
 }): boolean {
   if (hasCurrentOrcaCreationProvenance(args.meta)) {
     return true
@@ -184,9 +180,9 @@ export function canCleanupUnregisteredOrcaWorktreeDirectory(args: {
     return true
   }
 
-  // Why: profiles created before explicit provenance can still contain Orca
-  // workspaces at the repo-specific workspaceDir/<repo>/<name> path shape.
-  return matchesStrongOrcaCreatePath(args.worktreePath, args.knownOrcaLayouts, args.repo)
+  // Why: path shape alone is not authority; users can create plain Git
+  // worktrees inside Orca's workspace directory too.
+  return false
 }
 
 export async function canCleanupUnregisteredOrcaLeftoverDirectory(args: {
@@ -195,7 +191,6 @@ export async function canCleanupUnregisteredOrcaLeftoverDirectory(args: {
   runtimeWorktreePath: string
   repo: Pick<Repo, 'path'>
   runtimeRepoPath: string
-  knownOrcaLayouts: readonly OrcaWorkspaceLayout[]
   registeredWorktrees: readonly GitWorktreeInfo[]
   statPath: StatPath
   isGitRepository: (runtimeWorktreePath: string) => Promise<boolean>

--- a/src/shared/external-worktree-inbox.test.ts
+++ b/src/shared/external-worktree-inbox.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from 'vitest'
 
-import type { DetectedWorktree, DetectedWorktreeListResult, Repo } from './types'
+import type {
+  DetectedWorktree,
+  DetectedWorktreeListResult,
+  GlobalSettings,
+  Repo,
+  Worktree
+} from './types'
 import {
   getHiddenExternalWorktrees,
   getNewExternalWorktreeInboxWorktrees,
   mergeExternalWorktreeInboxPaths,
   shouldOfferNewExternalWorktreeInbox
 } from './external-worktree-inbox'
-import { EXTERNAL_WORKTREE_VISIBILITY_ROLLOUT_AT } from './worktree-ownership'
+import {
+  buildKnownOrcaWorkspaceLayouts,
+  EXTERNAL_WORKTREE_VISIBILITY_ROLLOUT_AT,
+  toDetectedWorktree
+} from './worktree-ownership'
 
 const repo: Repo = {
   id: 'repo-1',
@@ -51,6 +61,55 @@ function detectedResult(worktrees: DetectedWorktree[]): DetectedWorktreeListResu
     authoritative: true,
     source: 'git',
     worktrees
+  }
+}
+
+function makeSettings(): GlobalSettings {
+  return {
+    workspaceDir: '/orca/workspaces',
+    nestWorkspaces: true,
+    workspaceDirHistory: [],
+    refreshLocalBaseRefOnWorktreeCreate: false,
+    localBaseRefSuggestionDismissed: false,
+    branchPrefix: 'none',
+    branchPrefixCustom: '',
+    enableGitHubAttribution: false,
+    theme: 'system',
+    appFontFamily: 'Geist',
+    editorAutoSave: false,
+    editorAutoSaveDelayMs: 1000,
+    editorMinimapEnabled: false,
+    markdownReviewToolsEnabled: true,
+    terminalFontSize: 14,
+    terminalFontFamily: 'monospace',
+    terminalFontWeight: 400,
+    terminalLineHeight: 1.2
+  } as unknown as GlobalSettings
+}
+
+function makeGitWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: `repo-1::${overrides.path ?? '/repo'}`,
+    repoId: repo.id,
+    path: '/repo',
+    displayName: 'repo',
+    branch: 'refs/heads/main',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: true,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    workspaceStatus: 'todo',
+    ...overrides
   }
 }
 
@@ -101,6 +160,25 @@ describe('external worktree inbox', () => {
         externalWorktreeInboxBaselinePaths: ['/scratch/old-one']
       })
     ).toEqual([hidden])
+  })
+
+  it('offers metadata-free nested Orca workspace worktrees through the inbox', () => {
+    const settings = makeSettings()
+    const manual = toDetectedWorktree({
+      repo,
+      settings,
+      worktree: makeGitWorktree({
+        path: '/orca/workspaces/orca/manual-from-git',
+        displayName: 'manual-from-git',
+        branch: 'refs/heads/manual-from-git',
+        isMainWorktree: false
+      }),
+      knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+    })
+
+    expect(manual.ownership).toBe('external')
+    expect(manual.visible).toBe(false)
+    expect(getNewExternalWorktreeInboxWorktrees(detectedResult([manual]), repo)).toEqual([manual])
   })
 
   it('suppresses non-authoritative detected results', () => {

--- a/src/shared/worktree-ownership-worktree-base-path.test.ts
+++ b/src/shared/worktree-ownership-worktree-base-path.test.ts
@@ -48,7 +48,7 @@ describe('repo-specific worktree ownership layouts', () => {
         worktree: makeWorktree('/projects/a/worktrees/repo/feature'),
         knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repoA)
       })
-    ).toBe('orca-managed')
+    ).toBe('external')
     expect(
       classifyWorktreeOwnership({
         repo: repoB,
@@ -73,7 +73,7 @@ describe('repo-specific worktree ownership layouts', () => {
         worktree: makeWorktree('C:\\projects\\App\\worktrees\\repo\\Feature'),
         knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
       })
-    ).toBe('orca-managed')
+    ).toBe('external')
   })
 
   it('includes relative global layouts for SSH repos without applying absolute desktop paths', () => {

--- a/src/shared/worktree-ownership.test.ts
+++ b/src/shared/worktree-ownership.test.ts
@@ -108,7 +108,7 @@ describe('worktree ownership classification', () => {
     ).toBe('orca-managed')
   })
 
-  it('requires the nested repo-specific path shape for path-only ownership', () => {
+  it('treats nested Orca workspace paths without metadata as external', () => {
     const repo = makeRepo()
     const settings = makeSettings()
     const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
@@ -119,7 +119,7 @@ describe('worktree ownership classification', () => {
         worktree: makeWorktree({ path: '/orca/workspaces/app/feature' }),
         knownOrcaLayouts: layouts
       })
-    ).toBe('orca-managed')
+    ).toBe('external')
     expect(
       classifyWorktreeOwnership({
         repo,
@@ -128,6 +128,94 @@ describe('worktree ownership classification', () => {
         knownOrcaLayouts: layouts
       })
     ).toBe('external')
+  })
+
+  it('treats explicit Orca creation layout metadata as managed', () => {
+    const repo = makeRepo()
+    const settings = makeSettings()
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree({ path: '/orca/workspaces/app/feature' }),
+        meta: makeMeta({
+          orcaCreationWorkspaceLayout: { path: '/orca/workspaces', nestWorkspaces: true }
+        }),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+      })
+    ).toBe('orca-managed')
+  })
+
+  it('does not treat metadata-free nested workspace paths as Orca-managed for new repos', () => {
+    const repo = makeRepo({ externalWorktreeVisibility: 'hide' })
+    const settings = makeSettings()
+    const detected = toDetectedWorktree({
+      repo,
+      settings,
+      worktree: makeWorktree({
+        path: '/orca/workspaces/app/manual-git-worktree',
+        isMainWorktree: false
+      }),
+      knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+    })
+
+    expect(detected.ownership).toBe('external')
+    expect(detected.visible).toBe(false)
+  })
+
+  it('does not treat generic discovery metadata on nested workspace paths as Orca-managed', () => {
+    const repo = makeRepo({ externalWorktreeVisibility: 'hide' })
+    const settings = makeSettings()
+    const detected = toDetectedWorktree({
+      repo,
+      settings,
+      worktree: makeWorktree({
+        path: '/orca/workspaces/app/manual-git-worktree',
+        isMainWorktree: false
+      }),
+      meta: makeMeta({ displayName: 'manual-git-worktree' }),
+      knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+    })
+
+    expect(detected.ownership).toBe('external')
+    expect(detected.visible).toBe(false)
+  })
+
+  it('keeps nested workspace paths visible for legacy repos without explicit visibility', () => {
+    const repo = makeRepo()
+    const settings = makeSettings()
+    const detected = toDetectedWorktree({
+      repo,
+      settings,
+      worktree: makeWorktree({
+        path: '/orca/workspaces/app/manual-git-worktree',
+        isMainWorktree: false
+      }),
+      knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+    })
+
+    expect(detected.ownership).toBe('external')
+    expect(detected.visible).toBe(true)
+  })
+
+  it('hides metadata-free nested workspace paths for legacy repos that hide external worktrees', () => {
+    const repo = makeRepo({
+      externalWorktreeVisibility: 'hide',
+      externalWorktreeVisibilityLegacy: true
+    })
+    const settings = makeSettings()
+    const detected = toDetectedWorktree({
+      repo,
+      settings,
+      worktree: makeWorktree({
+        path: '/orca/workspaces/app/manual-git-worktree',
+        isMainWorktree: false
+      }),
+      knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+    })
+
+    expect(detected.ownership).toBe('external')
+    expect(detected.visible).toBe(false)
   })
 
   it('treats flat workspace-root descendants as unknown legacy without strong metadata', () => {
@@ -172,7 +260,7 @@ describe('worktree ownership classification', () => {
         worktree: makeWorktree({ path: '/old/workspaces/app/feature' }),
         knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
       })
-    ).toBe('orca-managed')
+    ).toBe('external')
   })
 
   it('builds known layouts from large workspace history lists', () => {
@@ -214,7 +302,7 @@ describe('worktree ownership classification', () => {
         }),
         knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
       })
-    ).toBe('orca-managed')
+    ).toBe('external')
   })
 
   it('keeps selected linked checkouts visible without trusting Git main-worktree', () => {

--- a/src/shared/worktree-ownership.ts
+++ b/src/shared/worktree-ownership.ts
@@ -1,5 +1,4 @@
 import {
-  getRuntimePathBasename,
   isRuntimePathAbsolute,
   isWindowsAbsolutePathLike,
   normalizeRuntimePathForComparison,
@@ -160,15 +159,13 @@ export function classifyWorktreeOwnership(args: {
     return 'orca-managed'
   }
 
-  if (matchesStrongOrcaCreatePath(args.worktree.path, args.knownOrcaLayouts, args.repo)) {
-    return 'orca-managed'
-  }
-
   if (isUnderFlatOrUntrustedOrcaRoot(args.worktree.path, args.knownOrcaLayouts)) {
     return 'unknown-legacy'
   }
 
   if (canClassifyAsExternal(args.worktree.path, args.knownOrcaLayouts)) {
+    // Why: a plain `git worktree add` can target Orca's nested workspace
+    // folder. Only metadata proves Orca created it.
     return 'external'
   }
 
@@ -240,6 +237,7 @@ export function areRuntimePathsEqual(leftPath: string, rightPath: string): boole
 function hasStrongOrcaMetadata(meta: WorktreeMeta | undefined): boolean {
   return Boolean(
     meta?.orcaCreatedAt ||
+    meta?.orcaCreationWorkspaceLayout ||
     meta?.createdAt ||
     meta?.createdWithAgent ||
     meta?.pushTarget ||
@@ -247,38 +245,6 @@ function hasStrongOrcaMetadata(meta: WorktreeMeta | undefined): boolean {
     meta?.sparsePresetId ||
     meta?.preserveBranchOnDelete
   )
-}
-
-export function matchesStrongOrcaCreatePath(
-  worktreePath: string,
-  knownOrcaLayouts: readonly OrcaWorkspaceLayout[],
-  repo: Pick<Repo, 'path'>
-): boolean {
-  const repoName = getRuntimePathBasename(repo.path).replace(/\.git$/i, '')
-  if (!repoName) {
-    return false
-  }
-  for (const layout of knownOrcaLayouts) {
-    if (!layout.nestWorkspaces) {
-      continue
-    }
-    const relative = relativePathInsideRoot(layout.path, worktreePath)
-    if (relative === null) {
-      continue
-    }
-    const segments = splitNormalizedPath(relative)
-    const caseInsensitive =
-      isWindowsAbsolutePathLike(layout.path) || isWindowsAbsolutePathLike(worktreePath)
-    if (
-      segments.length === 2 &&
-      normalizePathSegment(segments[0], caseInsensitive) ===
-        normalizePathSegment(repoName, caseInsensitive) &&
-      segments[1].length > 0
-    ) {
-      return true
-    }
-  }
-  return false
 }
 
 function isUnderFlatOrUntrustedOrcaRoot(
@@ -312,13 +278,4 @@ function canClassifyAsExternal(
     return layout.nestWorkspaces
   }
   return true
-}
-
-function splitNormalizedPath(value: string): string[] {
-  return normalizeRuntimePathSeparators(value).split('/').filter(Boolean)
-}
-
-function normalizePathSegment(value: string, caseInsensitive: boolean): string {
-  const normalized = normalizeRuntimePathSeparators(value)
-  return caseInsensitive ? normalized.toLowerCase() : normalized
 }


### PR DESCRIPTION
## Summary

Plain Git worktrees created inside Orca's nested workspace directory are now treated as external unless Orca metadata proves they were created by Orca. This lets Git-created worktrees flow into the existing `New externally-created worktrees` inbox, which is the UI that surfaces worktrees users made outside Orca because those worktrees are not automatically added to Orca's normal worktree list.

The cleanup path is intentionally more conservative too: unregistered directories are no longer considered safe for recursive cleanup from path shape alone.

## ELI5

If you make a worktree yourself with `git worktree add`, Orca does not automatically add it to your normal Orca worktree list. That is why the `New externally-created worktrees` inbox exists: it is the place Orca says, "I found a worktree you made outside Orca; do you want to import or keep it hidden?"

The bug was that if a Git-created worktree happened to live in a folder shaped like Orca's own workspace folders, Orca guessed, "I must have made this." Because of that wrong ownership guess, the worktree was skipped by the external-worktree inbox instead of being offered there.

This PR changes the rule: folder shape is not enough. Orca only treats a worktree as Orca-made when Orca metadata proves it. Plain Git-created worktrees go to the external-worktree inbox. That same rule also makes deletion safer, because Orca will not clean up a folder just because it looks like an Orca folder.

Design approach:
- Use Git as the source of truth for which worktrees exist.
- Use Orca metadata, not path shape, as the source of truth for Orca-managed ownership.
- Preserve managed ownership for rows with explicit or legacy Orca provenance metadata.
- Keep flat/untrusted workspace-root descendants in the existing `unknown-legacy` bucket.
- Keep the existing inbox UI, copy, placement, actions, and visibility gates unchanged.

Headline behavior status: implemented. Existing inbox gates still apply: the repo must hide external worktrees, the initial prompt must be dismissed, discovery must not be suppressed, and the path must not already be baselined.

## Reported symptom and root cause

Original product problem: users can create worktrees with plain Git, and those worktrees are not automatically added to Orca's normal worktree list. The `New externally-created worktrees` inbox exists to discover those outside-Orca worktrees and let users import them or keep them hidden.

Reported symptom for this PR: some Git-created worktrees were still not showing in that top inbox.

Root cause: for nested paths that looked like Orca's own workspace layout, Orca was using the folder shape as proof that Orca created the worktree. That made a plain `git worktree add` worktree classify as `orca-managed`, so the external-worktree inbox skipped it.

This PR addresses that reported behavior by requiring Orca provenance metadata for Orca-managed ownership. Plain Git-created worktrees now classify as external and flow into the new-external-worktree inbox when the existing inbox gates allow it.

## Screenshots

- Full-window Electron validation screenshot captured outside the repo: `/var/folders/nk/tt6kt56s3hn9rv32dj7kymv00000gn/T/orca-external-wt-1782974259/evidence/external-worktree-inbox-full-window.png`
- The screenshot shows `demo-project`, the `New externally-created worktrees` row with count `1`, and only `main` in the normal worktree list.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — PR `verify` check passed after rerunning one unrelated terminal-pane timer flake; the exact failed test also passed locally in isolation.
- [x] `pnpm build` equivalent for touched remote surface: `pnpm build:relay`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation:
- `git diff --check`
- `pnpm vitest run --config config/vitest.config.ts src/shared/worktree-ownership.test.ts src/shared/worktree-ownership-worktree-base-path.test.ts src/shared/external-worktree-inbox.test.ts src/main/worktree-removal-safety.test.ts src/main/worktree-removal-authority.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/main/worktree-removal-authority.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts --testNamePattern "drops pending foreground overflow when a stalled hidden restore falls back"`
- Pre-commit hook: `oxlint`, React-doctor oxlint config, and `oxfmt --write` on staged files

Dev/product validation:
- Reproduced the pre-fix issue in a dev Electron instance with a real plain `git worktree add` nested under `workspaceDir/<repo>/manual-from-git`: before the fix it was classified `orca-managed` and skipped the top external-worktree inbox.
- Rebuilt the dev app with the fix and reran the same repro: the worktree was classified `external`, hidden from normal rows, and the `New externally-created worktrees` inbox row rendered.
- Product validation launched this exact PR worktree in Electron and verified identity:
  - `devRepoRoot: /Users/thebr/orca/workspaces/orca/ningyo`
  - `devBranch: brennanb2025/external-worktree-detection`
- Local backing state proof on disposable `demo-project`:
  - Real plain Git worktree created at nested Orca workspace path.
  - `window.api.worktrees.listDetected` returned `ownership: "external"`, `visible: false`, `selectedCheckout: false`.
  - `window.api.worktrees.list` did not include the manual worktree, matching the product model that outside-Orca worktrees are not automatically added to the normal list.
  - Sidebar showed `New externally-created worktrees` with count `1`; normal list showed only `main`.
- Live SSH/runtime validation:
  - Built relay for linux/darwin/win targets.
  - Used a throwaway Linux Docker SSH target and bundled disposable `demo-project` repo.
  - Remote `git worktree list --porcelain` showed main plus manual remote worktree.
  - Remote `window.api.worktrees.listDetected` and direct `runtime.call({ method: "worktree.detectedList" })` both returned the manual worktree as `ownership: "external"`, `visible: false`.
  - Remote visible worktree list did not include the manual worktree.

## AI Review Report

Brennan's PR process was followed with delegated review stages:
- Design review: clean after review iterations; no P0/P1 design blockers remained. One reviewer backend was unavailable because `CODEX_LB_API_KEY` was missing, so the loop used the available reviewer plus local validation.
- Implementation verification: complete; no blockers and no deviations from the reviewed design.
- Broad app consistency: compared local detected-list IPC, runtime detected-list RPC, sidebar inbox grouping, imported-worktree candidates, command/jump hidden-row behavior, and cleanup/delete safety. The PR fixes the ownership mismatch and preserves existing UI/action behavior.
- Performance audit: no actionable findings. The classifier gets cheaper by removing the path-shape matcher; no new polling, subprocess, filesystem, provider fanout, or render loop was added.
- Code review loop: 4 rounds; final two reviewers returned clean. Fixed bridge coverage, legacy visibility coverage, stale cleanup API parameters, and a CodeRabbit follow-up test cleanup.

Cross-platform compatibility reviewed:
- macOS/Linux/Windows path behavior uses existing runtime path normalization and Windows-style regression coverage.
- SSH/runtime behavior was validated live through a throwaway Linux SSH target and direct runtime RPC.
- No shortcut labels, keyboard handling, shell startup behavior, or Electron platform UI branches were changed.

## Security Audit

Reviewed risks:
- Path handling: path shape is no longer trusted for ownership or recursive cleanup authority.
- Destructive actions: cleanup now requires persisted Orca provenance or legacy metadata; metadata-free directories return false.
- IPC/runtime: local IPC and runtime call sites were updated to use the stricter metadata-only cleanup API.
- Command execution/subprocesses: no new Git commands, shell commands, polling, or provider fanout were introduced.
- Auth/secrets/dependencies: no auth, secret, dependency, or external-provider credential behavior changed.

Residual security note: legacy metadata fields still represent historical cleanup authority. This PR does not broaden who can set those fields; a future hardening PR could further restrict user metadata updates for legacy cleanup-authority keys.

## Notes

- This does not change inbox copy, placement, or actions.
- This does not make external discovery instant after every external Git command; existing refresh behavior remains.
- This does not change a user's show/hide visibility preference.
- Old path-only Orca-created worktrees without persisted metadata can no longer be safely distinguished from plain Git-created worktrees. Re-trusting path shape would reintroduce the reported bug.
- Recursive cleanup may leave some old path-only leftovers for manual cleanup; this is intentional to avoid deleting user-created worktrees.
- Post-PR stabilization: CodeRabbit's actionable test-maintainability nit was fixed and pushed. CodeRabbit's refreshed summary reports no actionable comments, the description check passes, and PR checks pass.


