### PR TITLE
Fix rename inputs committing on CJK IME Enter confirmation (#6980)

### DIFF
--- a/src/renderer/src/components/settings/WorkspaceDirectorySetting.tsx
+++ b/src/renderer/src/components/settings/WorkspaceDirectorySetting.tsx
@@ -198,6 +198,8 @@ export function WorkspaceDirectorySetting({
           }}
           onBlur={handleBlur}
           onKeyDown={(e) => {
+            // Why: an Enter that only confirms a CJK IME candidate must not
+            // commit the rename; wait for a non-composition Enter.
             if (isImeCompositionKeyDown(e)) {
               return
             }

--- a/src/renderer/src/components/settings/WorkspaceDirectorySetting.tsx
+++ b/src/renderer/src/components/settings/WorkspaceDirectorySetting.tsx
@@ -14,6 +14,7 @@ import { Label } from '../ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { SearchableSetting } from './SearchableSetting'
 import { useSidebarHostScopeOptions } from '../sidebar/use-sidebar-host-scope-options'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import {
   buildHostScopeChoices,
   CLIENT_DEFAULT_SCOPE,
@@ -197,7 +198,7 @@ export function WorkspaceDirectorySetting({
           }}
           onBlur={handleBlur}
           onKeyDown={(e) => {
-            if (isComposingKeyboardEvent(e)) {
+            if (isImeCompositionKeyDown(e)) {
               return
             }
             if (e.key === 'Enter') {
@@ -269,9 +270,4 @@ export function WorkspaceDirectorySetting({
       )}
     </SearchableSetting>
   )
-}
-
-function isComposingKeyboardEvent(event: React.KeyboardEvent<HTMLInputElement>): boolean {
-  const nativeEvent = event.nativeEvent
-  return nativeEvent.isComposing || nativeEvent.keyCode === 229
 }

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.begin-editing.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.begin-editing.test.tsx
@@ -68,6 +68,7 @@ async function renderTitleRename(props: {
   beginEditing: boolean
   disabled?: boolean
   onBeginEditingConsumed: () => void
+  onRename?: (displayName: string) => Promise<void> | void
 }): Promise<unknown> {
   reactHookRuntime.index = 0
   const module = await import('./WorktreeTitleInlineRename')
@@ -120,6 +121,27 @@ function findElementsByType(node: unknown, typeName: string): ReactElementLike[]
   return results
 }
 
+function pressInputKey(
+  input: ReactElementLike,
+  key: string,
+  options?: { isComposing?: boolean; keyCode?: number }
+): {
+  preventDefault: ReturnType<typeof vi.fn>
+  stopPropagation: ReturnType<typeof vi.fn>
+} {
+  const event = {
+    key,
+    nativeEvent: {
+      isComposing: options?.isComposing ?? false,
+      keyCode: options?.keyCode ?? 13
+    },
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn()
+  }
+  ;(input.props.onKeyDown as (nextEvent: typeof event) => void)(event)
+  return event
+}
+
 describe('WorktreeTitleInlineRename beginEditing', () => {
   beforeEach(() => {
     reactHookRuntime.states = []
@@ -151,5 +173,33 @@ describe('WorktreeTitleInlineRename beginEditing', () => {
 
     expect(onBeginEditingConsumed).toHaveBeenCalledTimes(1)
     expect(findElementsByType(rerender, 'input')).toHaveLength(0)
+  })
+
+  it('ignores IME composition Enter before committing the edited title', async () => {
+    const onBeginEditingConsumed = vi.fn()
+    const onRename = vi.fn()
+
+    await renderTitleRename({ beginEditing: true, onBeginEditingConsumed, onRename })
+    let rerender = expandNode(
+      await renderTitleRename({ beginEditing: false, onBeginEditingConsumed, onRename })
+    )
+    let input = findElementsByType(rerender, 'input')[0]
+    ;(input.props.onChange as (event: { target: { value: string } }) => void)({
+      target: { value: '日本語 workspace' }
+    })
+    rerender = expandNode(
+      await renderTitleRename({ beginEditing: false, onBeginEditingConsumed, onRename })
+    )
+    input = findElementsByType(rerender, 'input')[0]
+
+    const composingEvent = pressInputKey(input, 'Enter', { isComposing: true })
+
+    expect(composingEvent.preventDefault).not.toHaveBeenCalled()
+    expect(onRename).not.toHaveBeenCalled()
+
+    pressInputKey(input, 'Enter')
+    await Promise.resolve()
+
+    expect(onRename).toHaveBeenCalledWith('日本語 workspace')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { translate } from '@/i18n/i18n'
 
 export type WorktreeTitleRenameCommit = { kind: 'cancel' } | { kind: 'save'; displayName: string }
@@ -211,6 +212,11 @@ export function WorktreeTitleInlineRename({
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       event.stopPropagation()
+      // Why: an Enter that only confirms a CJK IME candidate must not commit the
+      // rename; wait for a non-composition Enter.
+      if (isImeCompositionKeyDown(event)) {
+        return
+      }
       if (event.key === 'Enter') {
         event.preventDefault()
         void commitRename()

--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -19,6 +19,8 @@ const appStoreMocks = vi.hoisted(() => ({
   }))
 }))
 
+const renameFileOnDiskMock = vi.hoisted(() => vi.fn())
+
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
   return {
@@ -147,7 +149,7 @@ vi.mock('@/components/editor/editor-labels', () => ({
 }))
 
 vi.mock('@/lib/rename-file', () => ({
-  renameFileOnDisk: vi.fn()
+  renameFileOnDisk: renameFileOnDiskMock
 }))
 
 vi.mock('@/lib/file-type-icons', () => ({
@@ -326,6 +328,27 @@ function findSpanByText(node: unknown, label: string): ReactElementLike {
   return span
 }
 
+function pressInputKey(
+  input: ReactElementLike,
+  key: string,
+  options?: { isComposing?: boolean; keyCode?: number }
+): {
+  preventDefault: ReturnType<typeof vi.fn>
+  stopPropagation: ReturnType<typeof vi.fn>
+} {
+  const event = {
+    key,
+    nativeEvent: {
+      isComposing: options?.isComposing ?? false,
+      keyCode: options?.keyCode ?? 13
+    },
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn()
+  }
+  ;(input.props.onKeyDown as (nextEvent: typeof event) => void)(event)
+  return event
+}
+
 describe('EditorFileTab rename menu', () => {
   beforeEach(() => {
     reactHookRuntime.states = []
@@ -369,6 +392,38 @@ describe('EditorFileTab rename menu', () => {
     expect(focus).toHaveBeenCalledTimes(1)
     expect(setSelectionRange).toHaveBeenCalledWith(0, 'untitled-5'.length)
     expect(select).not.toHaveBeenCalled()
+  })
+
+  it('ignores IME composition Enter before renaming the editor file tab', async () => {
+    const file = baseFile()
+    const firstRender = expandNode((await renderEditorFileTab(file)).element)
+    const renameItem = findMenuItemByText(firstRender, 'Rename')
+
+    ;(renameItem.props.onSelect as () => void)()
+
+    const secondRender = expandNode((await renderEditorFileTab(file)).element)
+    const input = findElementsByType(secondRender, 'input')[0]
+    const setInputRef = input.props.ref as (input: HTMLInputElement | null) => void
+    setInputRef({
+      focus: vi.fn(),
+      select: vi.fn(),
+      setSelectionRange: vi.fn(),
+      value: '日本語.md'
+    } as unknown as HTMLInputElement)
+
+    const composingEvent = pressInputKey(input, 'Enter', { isComposing: true })
+
+    expect(composingEvent.preventDefault).not.toHaveBeenCalled()
+    expect(renameFileOnDiskMock).not.toHaveBeenCalled()
+
+    pressInputKey(input, 'Enter')
+
+    expect(renameFileOnDiskMock).toHaveBeenCalledWith({
+      oldPath: '/repo/untitled-5.md',
+      newName: '日本語.md',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo'
+    })
   })
 
   it('disables Rename for diff tabs that do not map to one writable file', async () => {

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { basename, normalizeRelativePath } from '@/lib/path'
 import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
 import { renameFileOnDisk } from '@/lib/rename-file'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { detectLanguage } from '@/lib/language-detect'
 import { getFileTypeIcon } from '@/lib/file-type-icons'
 import { useRepoById, useWorktreeById } from '@/store/selectors'
@@ -281,6 +282,11 @@ export default function EditorFileTab({
             onClick={(e) => e.stopPropagation()}
             onDoubleClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => {
+              // Why: an Enter that only confirms a CJK IME candidate must not
+              // commit the rename; wait for a non-composition Enter.
+              if (isImeCompositionKeyDown(e)) {
+                return
+              }
               if (e.key === 'Enter') {
                 e.preventDefault()
                 e.stopPropagation()

--- a/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
@@ -208,7 +208,11 @@ function makeTerminalTab() {
   }
 }
 
-async function renderSortableTab(): Promise<unknown> {
+async function renderSortableTab({
+  onSetCustomTitle = vi.fn()
+}: {
+  onSetCustomTitle?: (tabId: string, title: string | null) => void
+} = {}): Promise<unknown> {
   reactHookRuntime.index = 0
   const module = await import('./SortableTab')
   return module.default({
@@ -224,7 +228,7 @@ async function renderSortableTab(): Promise<unknown> {
     onClose: vi.fn(),
     onCloseOthers: vi.fn(),
     onCloseToRight: vi.fn(),
-    onSetCustomTitle: vi.fn(),
+    onSetCustomTitle,
     onSetTabColor: vi.fn(),
     onTogglePin: vi.fn(),
     onToggleExpand: vi.fn(),
@@ -282,6 +286,25 @@ function findElementsByType(node: unknown, typeName: string): ReactElementLike[]
   return results
 }
 
+function pressInputKey(
+  input: ReactElementLike,
+  key: string,
+  options?: { isComposing?: boolean; keyCode?: number }
+): {
+  preventDefault: ReturnType<typeof vi.fn>
+} {
+  const event = {
+    key,
+    nativeEvent: {
+      isComposing: options?.isComposing ?? false,
+      keyCode: options?.keyCode ?? 13
+    },
+    preventDefault: vi.fn()
+  }
+  ;(input.props.onKeyDown as (nextEvent: typeof event) => void)(event)
+  return event
+}
+
 describe('SortableTab rename shortcut signal', () => {
   beforeEach(() => {
     reactHookRuntime.states = []
@@ -311,5 +334,27 @@ describe('SortableTab rename shortcut signal', () => {
     expect(inputs).toHaveLength(1)
     expect(inputs[0].props.value).toBe('Runtime terminal title')
     expect(inputs[0].props['data-tab-rename-input']).toBe('true')
+  })
+
+  it('ignores IME composition Enter before committing the custom tab title', async () => {
+    const onSetCustomTitle = vi.fn()
+
+    await renderSortableTab({ onSetCustomTitle })
+    let rerender = expandNode(await renderSortableTab({ onSetCustomTitle }))
+    let input = findElementsByType(rerender, 'input')[0]
+    ;(input.props.onChange as (event: { target: { value: string } }) => void)({
+      target: { value: '日本語 terminal' }
+    })
+    rerender = expandNode(await renderSortableTab({ onSetCustomTitle }))
+    input = findElementsByType(rerender, 'input')[0]
+
+    const composingEvent = pressInputKey(input, 'Enter', { isComposing: true })
+
+    expect(composingEvent.preventDefault).not.toHaveBeenCalled()
+    expect(onSetCustomTitle).not.toHaveBeenCalled()
+
+    pressInputKey(input, 'Enter')
+
+    expect(onSetCustomTitle).toHaveBeenCalledWith('terminal-tab-1', '日本語 terminal')
   })
 })

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -5,6 +5,7 @@ import { ShellIcon } from './shell-icons'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { stripLeadingAgentTitleDecoration } from '../../../../shared/agent-title-decoration'
 import { useTabAgent } from '@/lib/use-tab-agent'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
@@ -333,6 +334,11 @@ export default function SortableTab({
           onChange={(event) => setRenameValue(event.target.value)}
           onBlur={commitRename}
           onKeyDown={(event) => {
+            // Why: an Enter that only confirms a CJK IME candidate must not
+            // commit the rename; wait for a non-composition Enter.
+            if (isImeCompositionKeyDown(event)) {
+              return
+            }
             if (event.key === 'Enter') {
               event.preventDefault()
               commitRename()

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
@@ -45,17 +45,24 @@ function renderOverlay({
   paneCount = 2,
   showAlwaysOnHeaders = true,
   onClosePane = vi.fn(),
-  onRemoveTitle = vi.fn()
+  onRemoveTitle = vi.fn(),
+  onRenameSubmit = vi.fn(),
+  renameValue = '',
+  renamingPaneId = null
 }: {
   paneTitles: Record<number, string>
   paneCount?: number
   showAlwaysOnHeaders?: boolean
   onClosePane?: ReturnType<typeof vi.fn>
   onRemoveTitle?: ReturnType<typeof vi.fn>
+  onRenameSubmit?: ReturnType<typeof vi.fn>
+  renameValue?: string
+  renamingPaneId?: number | null
 }): {
   container: HTMLDivElement
   onClosePane: ReturnType<typeof vi.fn>
   onRemoveTitle: ReturnType<typeof vi.fn>
+  onRenameSubmit: ReturnType<typeof vi.fn>
 } {
   const panes = [makePane(1), makePane(2)]
   const container = document.createElement('div')
@@ -76,8 +83,8 @@ function renderOverlay({
           1: { left: 0, top: 0, width: 200 },
           2: { left: 220, top: 0, width: 200 }
         }}
-        renamingPaneId={null}
-        renameValue=""
+        renamingPaneId={renamingPaneId}
+        renameValue={renameValue}
         renameInputRef={createRef<HTMLInputElement>()}
         titleUsesLightSurface={false}
         paneTitleBackground="transparent"
@@ -93,14 +100,31 @@ function renderOverlay({
         onRemoveTitle={onRemoveTitle as (paneId: number) => void}
         onClosePane={onClosePane as (paneId: number) => void}
         onRenameValueChange={vi.fn()}
-        onRenameSubmit={vi.fn()}
+        onRenameSubmit={onRenameSubmit as () => void}
         onRenameCancel={vi.fn()}
         onRenameBlur={vi.fn()}
       />
     )
   })
   mounted.push({ container, root })
-  return { container, onClosePane, onRemoveTitle }
+  return { container, onClosePane, onRemoveTitle, onRenameSubmit }
+}
+
+function pressInputKey(
+  input: HTMLInputElement,
+  key: string,
+  options?: { isComposing?: boolean; keyCode?: number }
+): void {
+  act(() => {
+    const event = new KeyboardEvent('keydown', { key, bubbles: true })
+    if (options?.isComposing !== undefined) {
+      Object.defineProperty(event, 'isComposing', { value: options.isComposing })
+    }
+    if (options?.keyCode !== undefined) {
+      Object.defineProperty(event, 'keyCode', { value: options.keyCode })
+    }
+    input.dispatchEvent(event)
+  })
 }
 
 afterEach(() => {
@@ -141,5 +165,24 @@ describe('TerminalPaneHeaderOverlay', () => {
 
     expect(onClosePane).toHaveBeenCalledWith(1)
     expect(onRemoveTitle).not.toHaveBeenCalled()
+  })
+
+  it('ignores IME composition Enter before submitting a pane title rename', () => {
+    const { container, onRenameSubmit } = renderOverlay({
+      paneTitles: { 1: 'server', 2: '' },
+      renamingPaneId: 1,
+      renameValue: '日本語 pane'
+    })
+    const input = container.querySelector<HTMLInputElement>('.pane-title-input')
+
+    expect(input).not.toBeNull()
+
+    pressInputKey(input as HTMLInputElement, 'Enter', { isComposing: true })
+
+    expect(onRenameSubmit).not.toHaveBeenCalled()
+
+    pressInputKey(input as HTMLInputElement, 'Enter')
+
+    expect(onRenameSubmit).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import { WORKSPACE_FILE_PATH_MIME, WORKSPACE_FILE_PATHS_MIME } from '@/lib/workspace-file-drag'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import type { PtyTransport } from './pty-transport'
 import { handleInternalTerminalFileDrop } from './terminal-drop-handler'
 
@@ -183,6 +184,11 @@ export default function TerminalPaneHeaderOverlay({
                 value={renameValue}
                 onChange={(event) => onRenameValueChange(event.target.value)}
                 onKeyDown={(event) => {
+                  // Why: an Enter that only confirms a CJK IME candidate must
+                  // not commit the rename; wait for a non-composition Enter.
+                  if (isImeCompositionKeyDown(event)) {
+                    return
+                  }
                   if (event.key === 'Enter') {
                     onRenameSubmit()
                   } else if (event.key === 'Escape') {

--- a/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { isImeCompositionKeyDown } from './ime-composition-keyboard-event'
+
+function keyEvent(nativeEvent: { isComposing?: boolean; keyCode?: number }): ReactKeyboardEvent {
+  return {
+    nativeEvent: {
+      isComposing: nativeEvent.isComposing ?? false,
+      keyCode: nativeEvent.keyCode ?? 13
+    }
+  } as unknown as ReactKeyboardEvent
+}
+
+describe('isImeCompositionKeyDown', () => {
+  it('is true while the IME is composing', () => {
+    expect(isImeCompositionKeyDown(keyEvent({ isComposing: true }))).toBe(true)
+  })
+
+  it('is true for the keyCode 229 fallback when isComposing is not set', () => {
+    expect(isImeCompositionKeyDown(keyEvent({ isComposing: false, keyCode: 229 }))).toBe(true)
+  })
+
+  it('is false for a plain Enter outside of composition', () => {
+    expect(isImeCompositionKeyDown(keyEvent({ isComposing: false, keyCode: 13 }))).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/ime-composition-keyboard-event.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.ts
@@ -1,0 +1,13 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+
+/**
+ * Why: CJK IMEs (Japanese/Chinese/Korean) fire a keydown for the Enter that
+ * only confirms a conversion candidate. Rename/title inputs that commit on
+ * `Enter` must ignore that keydown, otherwise they submit mid-composition with a
+ * half-converted value. `isComposing` covers most browsers; `keyCode === 229` is
+ * a defensive fallback for IMEs that don't set `isComposing` on keydown.
+ */
+export function isImeCompositionKeyDown(event: ReactKeyboardEvent): boolean {
+  const nativeEvent = event.nativeEvent
+  return nativeEvent.isComposing || nativeEvent.keyCode === 229
+}


### PR DESCRIPTION
## Summary

Fixes #6980.

Worktree/workspace inline rename, tab rename, editor file-tab rename, and terminal pane title rename all committed whenever `event.key === 'Enter'`, without guarding IME composition state. Pressing Enter to confirm a CJK (Japanese/Chinese/Korean) conversion candidate therefore submitted the rename mid-composition with a half-converted value — the same class of bug as #742, but on rename surfaces the earlier fixes didn't cover.

## Changes

- Extract the existing local `isComposing || keyCode === 229` guard (previously private to `WorkspaceDirectorySetting`) into a shared, reusable helper `src/renderer/src/lib/ime-composition-keyboard-event.ts` (`isImeCompositionKeyDown`), with a unit test.
- Apply the guard to every rename `Enter` handler that lacked it:
  - `WorktreeTitleInlineRename.tsx` — worktree card inline rename **and** workspace rename (⌘⇧R, which opens this same editor)
  - `SortableTab.tsx` — tab rename (⌘R)
  - `TerminalPaneHeaderOverlay.tsx` — terminal pane title rename
  - `EditorFileTab.tsx` — editor file-tab rename
- Refactor `WorkspaceDirectorySetting.tsx` to consume the shared helper (removes the duplicated local copy).

The `keyCode === 229` fallback is kept for IMEs/browsers that don't set `isComposing` on keydown, matching the reference in the issue.

## Behavior

- Enter while IME composition is active → only confirms the conversion candidate; the rename input stays open and nothing is committed.
- A subsequent, non-composition Enter → commits the rename as before.
- Non-CJK / non-composition input is unchanged.

## Testing

- `vitest` — new `ime-composition-keyboard-event.test.ts` plus existing `WorkspaceDirectorySetting`, `WorktreeTitleInlineRename`, and `SortableTab` rename tests pass.
- `oxlint` (incl. react-doctor) and web `tsgo` typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)