### PR TITLE
Improve Windows terminal performance: retain WebGL contexts, warm first ConPTY

### DIFF
--- a/config/scripts/repro-windows-apphang-terminal-activation.mjs
+++ b/config/scripts/repro-windows-apphang-terminal-activation.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import {
+  createWslFixture,
+  listWslDistros,
+  removeWslFixture
+} from './windows-apphang-repro/wsl-workspace-fixture.mjs'
+import { runGpuMode } from './windows-apphang-repro/terminal-activation-scenario.mjs'
+import { summarizeResult } from './windows-apphang-repro/apphang-report-summary.mjs'
+
+const defaultCycles = 14
+const defaultOutputLines = 1_600
+
+function parseArgs() {
+  const args = {
+    cycles: defaultCycles,
+    distro: null,
+    expect: 'none',
+    gpuModes: ['on'],
+    keep: false,
+    outputLines: defaultOutputLines,
+    reportPath: null,
+    sourceControl: true,
+    deadPtyReactivate: true
+  }
+
+  for (const arg of process.argv.slice(2)) {
+    if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    }
+    if (arg === '--keep') {
+      args.keep = true
+      continue
+    }
+    if (arg === '--no-source-control') {
+      args.sourceControl = false
+      continue
+    }
+    if (arg === '--no-dead-pty-reactivate') {
+      args.deadPtyReactivate = false
+      continue
+    }
+    const [name, value] = arg.split('=', 2)
+    if (name === '--cycles') {
+      args.cycles = parsePositiveInt(name, value)
+      continue
+    }
+    if (name === '--distro') {
+      args.distro = value?.trim() || null
+      continue
+    }
+    if (name === '--expect') {
+      if (!['none', 'repro', 'pass'].includes(value)) {
+        throw new Error(`Unsupported --expect=${value}. Use none, repro, or pass.`)
+      }
+      args.expect = value
+      continue
+    }
+    if (name === '--gpu') {
+      const modes = (value ?? '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+      if (modes.length === 0 || modes.some((mode) => !['on', 'off', 'auto'].includes(mode))) {
+        throw new Error(`Unsupported --gpu=${value}. Use on, off, auto, or a comma-list.`)
+      }
+      args.gpuModes = modes
+      continue
+    }
+    if (name === '--output-lines') {
+      args.outputLines = parsePositiveInt(name, value)
+      continue
+    }
+    if (name === '--report') {
+      args.reportPath = value?.trim() || null
+      if (!args.reportPath) {
+        throw new Error('--report requires a file path.')
+      }
+      continue
+    }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  return args
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node config/scripts/repro-windows-apphang-terminal-activation.mjs [options]
+
+Options:
+  --expect=none|repro|pass       none prints measurements, repro exits 0 only when hang evidence is observed,
+                                 pass exits 1 if hang evidence is observed. Default: none.
+  --gpu=on|off|auto[,mode...]    Terminal GPU setting(s) to run. Default: on.
+  --cycles=N                     Activation/output cycles per GPU mode. Default: ${defaultCycles}.
+  --output-lines=N               Lines emitted by each terminal stress command. Default: ${defaultOutputLines}.
+  --report=PATH                  Write full JSON evidence to PATH and print a compact summary to stdout.
+  --distro=NAME                  WSL distro to use. Default: first non docker-desktop distro.
+  --no-source-control            Do not open Source Control during the stress loop.
+  --no-dead-pty-reactivate       Do not kill PTYs and revisit workspaces after initial activation.
+  --keep                         Keep disposable WSL/userData fixtures after the run.`)
+}
+
+function parsePositiveInt(name, value) {
+  const parsed = Number.parseInt(value ?? '', 10)
+  if (!Number.isInteger(parsed) || parsed <= 0 || String(parsed) !== value) {
+    throw new Error(`${name} requires a positive integer.`)
+  }
+  return parsed
+}
+
+async function main() {
+  if (process.platform !== 'win32') {
+    throw new Error('This repro harness is intentionally Windows-only.')
+  }
+  const args = parseArgs()
+  const distros = listWslDistros()
+  const distro = args.distro ?? distros[0]
+  if (!distro) {
+    throw new Error('No user WSL distro found. Install/enable WSL or pass --distro=NAME.')
+  }
+  console.log(
+    `[apphang-repro] issue=https://github.com/stablyai/orca/issues/6874 distro=${distro} gpuModes=${args.gpuModes.join(',')} cycles=${args.cycles}`
+  )
+  const fixture = createWslFixture(distro)
+  console.log(
+    `[apphang-repro] fixture repo=${fixture.repoUncPath} plain=${fixture.plainUncPath} base=${fixture.baseLinuxPath}`
+  )
+
+  const results = []
+  try {
+    for (const gpuMode of args.gpuModes) {
+      results.push(await runGpuMode(gpuMode, args, fixture))
+      if (args.expect === 'repro' && results.at(-1)?.reproduced) {
+        break
+      }
+    }
+  } finally {
+    if (!args.keep) {
+      removeWslFixture(fixture)
+    }
+  }
+
+  const payload = {
+    issue: 'https://github.com/stablyai/orca/issues/6874',
+    expect: args.expect,
+    distro,
+    fixture: args.keep ? fixture : { removed: true, baseLinuxPath: fixture.baseLinuxPath },
+    summary: results.map(summarizeResult),
+    results
+  }
+  if (args.reportPath) {
+    const reportPath = path.resolve(args.reportPath)
+    mkdirSync(path.dirname(reportPath), { recursive: true })
+    writeFileSync(reportPath, `${JSON.stringify(payload, null, 2)}\n`)
+    console.log(JSON.stringify({ reportPath, summary: payload.summary }, null, 2))
+  } else {
+    console.log(JSON.stringify(payload, null, 2))
+  }
+
+  const reproduced = results.some((result) => result.reproduced)
+  if (args.expect === 'repro' && !reproduced) {
+    console.error(
+      '[apphang-repro] Expected to reproduce the hang, but no hang evidence was observed.'
+    )
+    process.exit(1)
+  }
+  if (args.expect === 'pass' && reproduced) {
+    console.error('[apphang-repro] Expected a clean pass, but hang evidence was observed.')
+    process.exit(1)
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error))
+  process.exit(1)
+})

--- a/config/scripts/repro-windows-apphang-terminal-activation.mjs
+++ b/config/scripts/repro-windows-apphang-terminal-activation.mjs
@@ -162,6 +162,21 @@ async function main() {
     console.log(JSON.stringify(payload, null, 2))
   }
 
+  // Why: a broken harness run (CDP/setup/selector failure) proves nothing —
+  // it must fail both --expect=repro and --expect=pass rather than being
+  // miscounted as hang evidence or as a clean pass.
+  const harnessErrors = results.filter((result) => result.harnessError)
+  if (harnessErrors.length > 0) {
+    const harnessErrorLines = harnessErrors
+      .map((result) => `  gpu=${result.gpuMode}: ${result.harnessError}`)
+      .join('\n')
+    console.error(
+      `[apphang-repro] Harness failed in ${harnessErrors.length} run(s); result inconclusive:\n${harnessErrorLines}`
+    )
+    if (args.expect !== 'none') {
+      process.exit(1)
+    }
+  }
   const reproduced = results.some((result) => result.reproduced)
   if (args.expect === 'repro' && !reproduced) {
     console.error(

--- a/config/scripts/windows-apphang-repro/apphang-report-summary.mjs
+++ b/config/scripts/windows-apphang-repro/apphang-report-summary.mjs
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+export function summarizeTrace(userDataDir) {
+  const tracePath = path.join(userDataDir, 'logs', 'main.trace.ndjson')
+  if (!existsSync(tracePath)) {
+    return { tracePath, exists: false }
+  }
+  const lines = readFileSync(tracePath, 'utf8').trim().split(/\r?\n/).filter(Boolean)
+  const parsed = []
+  for (const line of lines.slice(-400)) {
+    try {
+      parsed.push(JSON.parse(line))
+    } catch {
+      parsed.push({ raw: line })
+    }
+  }
+  const interesting = parsed.filter((entry) => {
+    const name = String(entry.name ?? entry.event ?? entry.type ?? '')
+    const text = JSON.stringify(entry)
+    return (
+      name.includes('git.exec') ||
+      name.includes('renderer_memory') ||
+      name.includes('sidebar_worktree_activate') ||
+      text.includes('git.exec remote') ||
+      text.includes('git.exec worktree') ||
+      text.includes('sidebar_worktree_activate')
+    )
+  })
+  return {
+    tracePath,
+    exists: true,
+    totalLines: lines.length,
+    interestingTail: interesting.slice(-40)
+  }
+}
+
+export function summarizeAppLogs(logs) {
+  const webglContextWarnings = logs.filter((entry) =>
+    entry.line.includes('Too many active WebGL contexts')
+  )
+  const webglContextLosses = logs.filter((entry) =>
+    entry.line.toLowerCase().includes('webgl context lost')
+  )
+  const gpuProcessEvents = logs.filter((entry) => /gpu|d3d|angle/i.test(entry.line))
+  return {
+    lineCount: logs.length,
+    webglContextWarningCount: webglContextWarnings.length,
+    webglContextWarningsTail: webglContextWarnings.slice(-10),
+    webglContextLossCount: webglContextLosses.length,
+    webglContextLossesTail: webglContextLosses.slice(-10),
+    gpuProcessEventCount: gpuProcessEvents.length,
+    gpuProcessEventsTail: gpuProcessEvents.slice(-20)
+  }
+}
+
+export function summarizeResult(result) {
+  const samples = result.samples.filter((sample) => sample && typeof sample === 'object')
+  const maxActivationMs = Math.max(0, ...samples.map((sample) => sample.activationMs ?? 0))
+  const maxPtyWaitMs = Math.max(0, ...samples.map((sample) => sample.ptyWaitMs ?? 0))
+  const maxMainIpcMs = Math.max(0, ...samples.map((sample) => sample.mainIpcMs ?? 0))
+  const maxRendererDriftMs = Math.max(0, ...samples.map((sample) => sample.rendererMaxDriftMs ?? 0))
+  return {
+    gpuMode: result.gpuMode,
+    reproduced: result.reproduced,
+    reproductionReason: result.reproductionReason,
+    elapsedMs: result.elapsedMs,
+    sampleCount: samples.length,
+    maxActivationMs,
+    maxPtyWaitMs,
+    maxMainIpcMs,
+    maxRendererDriftMs,
+    finalWebglContextCounts: result.finalDiagnostics?.webglContextCounts ?? null,
+    appLogSummary: result.appLogSummary
+  }
+}

--- a/config/scripts/windows-apphang-repro/apphang-report-summary.mjs
+++ b/config/scripts/windows-apphang-repro/apphang-report-summary.mjs
@@ -64,6 +64,7 @@ export function summarizeResult(result) {
     gpuMode: result.gpuMode,
     reproduced: result.reproduced,
     reproductionReason: result.reproductionReason,
+    harnessError: result.harnessError ?? null,
     elapsedMs: result.elapsedMs,
     sampleCount: samples.length,
     maxActivationMs,

--- a/config/scripts/windows-apphang-repro/electron-dev-session.mjs
+++ b/config/scripts/windows-apphang-repro/electron-dev-session.mjs
@@ -60,12 +60,16 @@ export function launchDevApp({ cdpPort, userDataDir }) {
     REMOTE_DEBUGGING_PORT: String(cdpPort),
     VITE_EXPOSE_STORE: 'true'
   })
-  const child = spawn(process.execPath, ['config/scripts/run-electron-vite-dev.mjs'], {
-    cwd: rootDir,
-    env,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    windowsHide: true
-  })
+  const child = spawn(
+    process.execPath,
+    [path.join('config', 'scripts', 'run-electron-vite-dev.mjs')],
+    {
+      cwd: rootDir,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    }
+  )
   const logs = []
   const collect = (source) => (chunk) => {
     const text = chunk.toString()

--- a/config/scripts/windows-apphang-repro/electron-dev-session.mjs
+++ b/config/scripts/windows-apphang-repro/electron-dev-session.mjs
@@ -1,0 +1,327 @@
+import { chromium } from '@playwright/test'
+import { spawn } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import {
+  appShutdownTimeoutMs,
+  cdpPollTimeoutMs,
+  delay,
+  pollUntil,
+  rendererActionTimeoutMs,
+  runWithTimeout
+} from './repro-timing.mjs'
+import { createCompletedOnboardingProfile } from './wsl-workspace-fixture.mjs'
+
+const rootDir = path.resolve(fileURLToPath(new URL('../../..', import.meta.url)))
+
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => {
+      try {
+        server.close()
+      } catch {}
+      resolve(false)
+    })
+    server.once('listening', () => server.close(() => resolve(true)))
+    server.listen(port, '127.0.0.1')
+  })
+}
+
+export async function pickFreePort() {
+  for (let port = 9533; port < 9633; port += 1) {
+    if (await isPortFree(port)) {
+      return port
+    }
+  }
+  throw new Error('Could not find a free CDP port in 9533..9632.')
+}
+
+export function createGpuUserDataDirectory(gpuMode) {
+  const userDataDir = mkdtempSync(path.join(os.tmpdir(), `orca-apphang-${gpuMode}-userdata-`))
+  createCompletedOnboardingProfile(userDataDir)
+  return userDataDir
+}
+
+export function launchDevApp({ cdpPort, userDataDir }) {
+  const env = { ...process.env }
+  delete env.ELECTRON_RUN_AS_NODE
+  Object.assign(env, {
+    ELECTRON_ENABLE_LOGGING: '1',
+    ELECTRON_ENABLE_STACK_DUMPING: '1',
+    NODE_ENV: 'development',
+    ORCA_DEV_USER_DATA_PATH: userDataDir,
+    ORCA_SKIP_DEV_WEB_PREPARE: '1',
+    ORCA_STARTUP_DIAGNOSTICS: '1',
+    REMOTE_DEBUGGING_PORT: String(cdpPort),
+    VITE_EXPOSE_STORE: 'true'
+  })
+  const child = spawn(process.execPath, ['config/scripts/run-electron-vite-dev.mjs'], {
+    cwd: rootDir,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true
+  })
+  const logs = []
+  const collect = (source) => (chunk) => {
+    const text = chunk.toString()
+    for (const line of text.split(/\r?\n/).filter(Boolean)) {
+      logs.push({ source, line, at: Date.now() })
+      console.log(`[apphang-repro:${source}] ${line}`)
+    }
+  }
+  child.stdout?.on('data', collect('stdout'))
+  child.stderr?.on('data', collect('stderr'))
+  return { child, logs }
+}
+
+export async function stopDevApp(child) {
+  if (!child?.pid || child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+  await new Promise((resolve) => {
+    const timer = setTimeout(resolve, appShutdownTimeoutMs)
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+    if (process.platform === 'win32') {
+      const killer = spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true
+      })
+      killer.once('exit', () => undefined)
+      return
+    }
+    child.kill('SIGTERM')
+  })
+}
+
+async function waitForCdp(port) {
+  const url = `http://127.0.0.1:${port}/json`
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < cdpPollTimeoutMs) {
+    try {
+      const response = await fetch(url)
+      if (response.ok) {
+        const targets = await response.json()
+        if (Array.isArray(targets) && targets.some((target) => target.type)) {
+          return targets
+        }
+      }
+    } catch {}
+    await delay(500)
+  }
+  throw new Error(`Timed out waiting for CDP targets on ${url}`)
+}
+
+async function getMainPage(browser) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < cdpPollTimeoutMs) {
+    for (const context of browser.contexts()) {
+      const pages = context.pages()
+      const page =
+        pages.find((candidate) =>
+          /^https?:\/\/127\.0\.0\.1:|^https?:\/\/localhost:/.test(candidate.url())
+        ) ?? pages[0]
+      if (page) {
+        return page
+      }
+    }
+    await delay(250)
+  }
+  throw new Error('Timed out waiting for the Electron renderer page.')
+}
+
+export async function connectToApp(cdpPort) {
+  await waitForCdp(cdpPort)
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`)
+  const page = await getMainPage(browser)
+  await page.waitForLoadState('domcontentloaded', { timeout: 30_000 })
+  return { browser, page }
+}
+
+export async function installRendererProbe(page) {
+  await page.evaluate(() => {
+    if (globalThis.__orcaApphangProbe) {
+      return
+    }
+    const probe = {
+      intervalMs: 50,
+      last: performance.now(),
+      maxDriftMs: 0,
+      samples: 0,
+      startedAt: performance.now(),
+      lastTickAt: performance.now()
+    }
+    const timer = setInterval(() => {
+      const now = performance.now()
+      const drift = Math.max(0, now - probe.last - probe.intervalMs)
+      probe.maxDriftMs = Math.max(probe.maxDriftMs, drift)
+      probe.last = now
+      probe.lastTickAt = now
+      probe.samples += 1
+    }, probe.intervalMs)
+    globalThis.__orcaApphangProbe = { probe, timer }
+  })
+}
+
+export async function waitForStoreReady(page) {
+  await pollUntil(
+    'renderer store exposure',
+    () => page.evaluate(() => Boolean(window.__store && window.api)),
+    Boolean,
+    30_000
+  )
+  await pollUntil(
+    'workspace session hydration',
+    () =>
+      page.evaluate(() => {
+        const state = window.__store?.getState?.()
+        return Boolean(state?.workspaceSessionReady && state?.hydrationSucceeded)
+      }),
+    Boolean,
+    45_000
+  )
+}
+
+export async function collectRendererDiagnostics(page) {
+  if (!page) {
+    return null
+  }
+  try {
+    return await runWithTimeout(
+      'renderer diagnostics',
+      () =>
+        page.evaluate(async () => {
+          const timed = (label, promise) =>
+            Promise.race([
+              Promise.resolve(promise).then(
+                (value) => ({ value }),
+                (error) => ({ error: error instanceof Error ? error.message : String(error) })
+              ),
+              new Promise((resolve) =>
+                setTimeout(() => resolve({ error: `Timed out collecting ${label}` }), 1_000)
+              )
+            ])
+          const readWebglIdentity = () => {
+            const canvas = document.createElement('canvas')
+            let gl = null
+            try {
+              gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl')
+              if (!gl) {
+                return { available: false, vendor: null, renderer: null }
+              }
+              const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+              if (!debugInfo) {
+                return { available: true, vendor: null, renderer: null }
+              }
+              return {
+                available: true,
+                vendor: String(gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) ?? '') || null,
+                renderer: String(gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) ?? '') || null
+              }
+            } catch (error) {
+              return {
+                available: false,
+                error: error instanceof Error ? error.message : String(error)
+              }
+            } finally {
+              try {
+                gl?.getExtension('WEBGL_lose_context')?.loseContext()
+              } catch {}
+              canvas.width = 0
+              canvas.height = 0
+            }
+          }
+          const allPaneManagersDiagnostics = Array.from(
+            window.__paneManagers?.entries?.() ?? []
+          ).map(([managerTabId, paneManager]) => ({
+            tabId: managerTabId,
+            diagnostics: paneManager?.getRenderingDiagnostics?.() ?? []
+          }))
+          const webglContextCounts = allPaneManagersDiagnostics.reduce(
+            (acc, entry) => {
+              acc.managerCount += 1
+              acc.paneCount += entry.diagnostics.length
+              for (const diagnostic of entry.diagnostics) {
+                if (diagnostic.hasWebgl) {
+                  acc.attachedWebglCount += 1
+                }
+                if (diagnostic.webglAttachmentDeferred) {
+                  acc.deferredWebglCount += 1
+                }
+              }
+              return acc
+            },
+            { attachedWebglCount: 0, deferredWebglCount: 0, managerCount: 0, paneCount: 0 }
+          )
+          const state = window.__store?.getState?.()
+          const worktreeId = state?.activeWorktreeId ?? null
+          const tabId =
+            state?.activeTabType === 'terminal'
+              ? state.activeTabId
+              : worktreeId
+                ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+                : null
+          const manager = tabId ? window.__paneManagers?.get(tabId) : null
+          const activePane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+          const buffer = activePane?.terminal?.buffer?.active ?? null
+          return {
+            hasStore: Boolean(window.__store),
+            workspaceSessionReady: state?.workspaceSessionReady ?? null,
+            hydrationSucceeded: state?.hydrationSucceeded ?? null,
+            activeView: state?.activeView ?? null,
+            activeRepoId: state?.activeRepoId ?? null,
+            activeWorktreeId: worktreeId,
+            activeTabType: state?.activeTabType ?? null,
+            activeTabId: tabId,
+            terminalGpuAcceleration: state?.settings?.terminalGpuAcceleration ?? null,
+            repoCount: state?.repos?.length ?? null,
+            worktreeCountsByRepo: Object.fromEntries(
+              Object.entries(state?.worktreesByRepo ?? {}).map(([repoId, worktrees]) => [
+                repoId,
+                worktrees.length
+              ])
+            ),
+            ptyIdsByTabId: tabId ? (state?.ptyIdsByTabId?.[tabId] ?? []) : [],
+            paneManagerCount: window.__paneManagers?.size ?? null,
+            activePane: activePane
+              ? {
+                  id: activePane.id ?? null,
+                  leafId: activePane.leafId ?? null,
+                  ptyId: activePane.container?.dataset?.ptyId ?? null,
+                  cols: activePane.terminal?.cols ?? null,
+                  rows: activePane.terminal?.rows ?? null,
+                  buffer: buffer
+                    ? {
+                        baseY: buffer.baseY,
+                        viewportY: buffer.viewportY,
+                        cursorY: buffer.cursorY,
+                        length: buffer.length
+                      }
+                    : null
+                }
+              : null,
+            renderingDiagnostics: manager?.getRenderingDiagnostics?.() ?? null,
+            allPaneManagersDiagnostics,
+            webglContextCounts,
+            webglIdentity: readWebglIdentity(),
+            rendererProbe: globalThis.__orcaApphangProbe?.probe ?? null,
+            ptySessions: await timed('PTY sessions', window.api?.pty?.listSessions?.()),
+            rendererDeliveryDebug: await timed(
+              'renderer delivery debug',
+              window.api?.pty?.getRendererDeliveryDebugSnapshot?.()
+            )
+          }
+        }),
+      rendererActionTimeoutMs
+    )
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/config/scripts/windows-apphang-repro/repro-timing.mjs
+++ b/config/scripts/windows-apphang-repro/repro-timing.mjs
@@ -1,0 +1,47 @@
+export const cdpPollTimeoutMs = 90_000
+export const rendererActionTimeoutMs = 5_000
+export const activationTimeoutMs = 15_000
+export const ptyWaitTimeoutMs = 20_000
+export const terminalMarkerTimeoutMs = 45_000
+export const setupTimeoutMs = 90_000
+export const appShutdownTimeoutMs = 8_000
+export const severeRendererDriftMs = 2_000
+export const severeActivationMs = 5_000
+export const severeMainIpcMs = 2_000
+export const severePtyWaitMs = 10_000
+
+export function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function runWithTimeout(label, action, timeoutMs) {
+  const actionPromise = Promise.resolve().then(action)
+  actionPromise.catch(() => undefined)
+  const result = await Promise.race([
+    actionPromise.then(
+      (value) => ({ timedOut: false, value }),
+      (error) => ({ timedOut: false, error })
+    ),
+    delay(timeoutMs).then(() => ({ timedOut: true }))
+  ])
+  if (result.timedOut) {
+    throw new Error(`Timed out during ${label} after ${timeoutMs}ms.`)
+  }
+  if ('error' in result) {
+    throw result.error
+  }
+  return result.value
+}
+
+export async function pollUntil(label, read, predicate, timeoutMs, intervalMs = 100) {
+  const startedAt = Date.now()
+  let lastValue = null
+  while (Date.now() - startedAt < timeoutMs) {
+    lastValue = await runWithTimeout(label, read, rendererActionTimeoutMs)
+    if (predicate(lastValue)) {
+      return lastValue
+    }
+    await delay(intervalMs)
+  }
+  throw new Error(`Timed out waiting for ${label}; last value: ${JSON.stringify(lastValue)}`)
+}

--- a/config/scripts/windows-apphang-repro/terminal-activation-scenario.mjs
+++ b/config/scripts/windows-apphang-repro/terminal-activation-scenario.mjs
@@ -1,0 +1,460 @@
+import {
+  collectRendererDiagnostics,
+  connectToApp,
+  createGpuUserDataDirectory,
+  installRendererProbe,
+  launchDevApp,
+  pickFreePort,
+  stopDevApp,
+  waitForStoreReady
+} from './electron-dev-session.mjs'
+import { summarizeAppLogs, summarizeTrace } from './apphang-report-summary.mjs'
+import {
+  activationTimeoutMs,
+  pollUntil,
+  ptyWaitTimeoutMs,
+  rendererActionTimeoutMs,
+  runWithTimeout,
+  setupTimeoutMs,
+  severeActivationMs,
+  severeMainIpcMs,
+  severePtyWaitMs,
+  severeRendererDriftMs,
+  terminalMarkerTimeoutMs
+} from './repro-timing.mjs'
+import { safeRemoveLocalDirectory } from './wsl-workspace-fixture.mjs'
+
+class ReproductionObservedError extends Error {
+  constructor(message, evidence) {
+    super(message)
+    this.name = 'ReproductionObservedError'
+    this.evidence = evidence
+  }
+}
+
+async function setupAppFixture(page, fixture, gpuMode, sourceControl) {
+  return await runWithTimeout(
+    'fixture registration in Orca',
+    () =>
+      page.evaluate(
+        async ({ repoPath, plainPath, importedWorktreePaths, mode, openSourceControl }) => {
+          const store = window.__store
+          if (!store) {
+            throw new Error('window.__store is unavailable.')
+          }
+          const state = store.getState()
+          await state.fetchSettings?.()
+          await store.getState().updateSettings({ terminalGpuAcceleration: mode })
+
+          const addResult = await window.api.repos.add({ path: repoPath, kind: 'git' })
+          if ('error' in addResult) {
+            throw new Error(addResult.error)
+          }
+          await store.getState().fetchRepos()
+          let nextState = store.getState()
+          const repo =
+            nextState.repos.find((candidate) => candidate.path === repoPath) ?? addResult.repo
+          await nextState.updateRepo(repo.id, {
+            externalWorktreeVisibility: 'show',
+            externalWorktreeVisibilityPromptDismissedAt: Date.now(),
+            importedExternalWorktreePaths: importedWorktreePaths,
+            externalWorktreeInboxBaselinePaths: importedWorktreePaths
+          })
+          await store.getState().fetchWorktrees(repo.id, { requireAuthoritative: true })
+
+          const plainRepo = await store.getState().addNonGitFolder(plainPath)
+          if (!plainRepo) {
+            throw new Error('addNonGitFolder returned null.')
+          }
+          await store.getState().fetchWorktrees(plainRepo.id, { requireAuthoritative: true })
+
+          nextState = store.getState()
+          nextState.setSidebarOpen(true)
+          nextState.setGroupBy('none')
+          nextState.setSortBy('recent')
+          nextState.setShowActiveOnly(false)
+          nextState.setActiveView('terminal')
+          if (openSourceControl) {
+            nextState.setRightSidebarOpen(true)
+            nextState.setRightSidebarTab('source-control')
+          }
+
+          const gitWorktrees = nextState.worktreesByRepo[repo.id] ?? []
+          const plainWorktrees = nextState.worktreesByRepo[plainRepo.id] ?? []
+          return {
+            repoId: repo.id,
+            repoPath: repo.path,
+            plainRepoId: plainRepo.id,
+            gitWorktrees: gitWorktrees.map((worktree) => ({
+              id: worktree.id,
+              path: worktree.path,
+              displayName: worktree.displayName,
+              branch: worktree.branch,
+              isMainWorktree: worktree.isMainWorktree
+            })),
+            plainWorktrees: plainWorktrees.map((worktree) => ({
+              id: worktree.id,
+              path: worktree.path,
+              displayName: worktree.displayName,
+              branch: worktree.branch,
+              isMainWorktree: worktree.isMainWorktree
+            }))
+          }
+        },
+        {
+          repoPath: fixture.repoUncPath,
+          plainPath: fixture.plainUncPath,
+          importedWorktreePaths: fixture.worktreeUncPaths,
+          mode: gpuMode,
+          openSourceControl: sourceControl
+        }
+      ),
+    setupTimeoutMs
+  )
+}
+
+async function clickWorktreeCard(page, worktreeId) {
+  const rect = await runWithTimeout(
+    `locate worktree card ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const rows = Array.from(document.querySelectorAll('[data-worktree-id]'))
+        const row = rows.find((candidate) => candidate.getAttribute('data-worktree-id') === id)
+        if (!row) {
+          return null
+        }
+        row.scrollIntoView({ block: 'center', inline: 'nearest' })
+        const surface = row.querySelector('[data-worktree-card-surface="true"]') ?? row
+        const bounds = surface.getBoundingClientRect()
+        if (bounds.width <= 0 || bounds.height <= 0) {
+          return null
+        }
+        return {
+          x: bounds.left + bounds.width / 2,
+          y: bounds.top + bounds.height / 2,
+          width: bounds.width,
+          height: bounds.height
+        }
+      }, worktreeId),
+    rendererActionTimeoutMs
+  )
+  if (!rect) {
+    throw new Error(`Could not find rendered worktree card for ${worktreeId}`)
+  }
+  await runWithTimeout(
+    `click worktree card ${worktreeId}`,
+    () => page.mouse.click(rect.x, rect.y),
+    rendererActionTimeoutMs
+  )
+}
+
+async function waitForActiveWorktree(page, worktreeId) {
+  return await pollUntil(
+    `active worktree ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        return {
+          activeWorktreeId: state?.activeWorktreeId ?? null,
+          activeTabId: state?.activeTabId ?? null,
+          activeTabType: state?.activeTabType ?? null,
+          tabs: state?.tabsByWorktree?.[id]?.map((tab) => tab.id) ?? []
+        }
+      }, worktreeId),
+    (value) => value?.activeWorktreeId === worktreeId && value.activeTabType === 'terminal',
+    activationTimeoutMs
+  )
+}
+
+async function waitForActivePty(page, worktreeId) {
+  const startedAt = Date.now()
+  const value = await pollUntil(
+    `active PTY for ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        const tabId =
+          state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+            ? state.activeTabId
+            : (state?.activeTabIdByWorktree?.[id] ?? null)
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+        const ptyId = pane?.container?.dataset?.ptyId ?? null
+        return {
+          tabId,
+          ptyId,
+          hasManager: Boolean(manager),
+          paneCount: manager?.getPanes?.()?.length ?? 0,
+          ptyIdsByTab: tabId ? (state?.ptyIdsByTabId?.[tabId] ?? []) : []
+        }
+      }, worktreeId),
+    (value) => Boolean(value?.ptyId),
+    ptyWaitTimeoutMs
+  )
+  return { ...value, waitMs: Date.now() - startedAt }
+}
+
+function makeOutputCommand(marker, outputLines) {
+  const payload = 'x'.repeat(180)
+  return `printf '${marker}_START\\n'; i=1; while [ "$i" -le ${outputLines} ]; do printf '${marker}_%05d ${payload}\\n' "$i"; i=$((i+1)); done; printf '${marker}_DONE\\n'\r`
+}
+
+async function getTerminalContent(page, charLimit = 20_000) {
+  return await runWithTimeout(
+    'terminal content',
+    () =>
+      page.evaluate((limit) => {
+        const state = window.__store?.getState?.()
+        const worktreeId = state?.activeWorktreeId
+        const tabId =
+          state?.activeTabType === 'terminal'
+            ? state.activeTabId
+            : worktreeId
+              ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+              : null
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+        return (pane?.serializeAddon?.serialize?.() ?? '').slice(-limit)
+      }, charLimit),
+    rendererActionTimeoutMs
+  )
+}
+
+async function sendOutputStress(page, ptyId, marker, outputLines) {
+  await runWithTimeout(
+    `write terminal stress ${marker}`,
+    () =>
+      page.evaluate(
+        ({ id, command }) => {
+          window.api.pty.write(id, command)
+        },
+        { id: ptyId, command: makeOutputCommand(marker, outputLines) }
+      ),
+    rendererActionTimeoutMs
+  )
+  await pollUntil(
+    `terminal stress marker ${marker}`,
+    async () => (await getTerminalContent(page)).includes(`${marker}_DONE`),
+    Boolean,
+    terminalMarkerTimeoutMs,
+    200
+  )
+}
+
+async function pingMainIpc(page) {
+  const startedAt = Date.now()
+  await runWithTimeout(
+    'main IPC ping',
+    () => page.evaluate(() => window.api.pty.listSessions()),
+    rendererActionTimeoutMs
+  )
+  return Date.now() - startedAt
+}
+
+async function readRendererProbe(page) {
+  return await runWithTimeout(
+    'renderer probe read',
+    () => page.evaluate(() => globalThis.__orcaApphangProbe?.probe ?? null),
+    rendererActionTimeoutMs
+  )
+}
+
+async function killActivePty(page) {
+  return await runWithTimeout(
+    'kill active PTY',
+    () =>
+      page.evaluate(async () => {
+        const state = window.__store?.getState?.()
+        const tabId = state?.activeTabId ?? null
+        const ptyIds = tabId ? (state?.ptyIdsByTabId?.[tabId] ?? []) : []
+        const ptyId = ptyIds[0] ?? null
+        if (!ptyId) {
+          return null
+        }
+        await window.api.pty.kill(ptyId)
+        return ptyId
+      }),
+    rendererActionTimeoutMs
+  )
+}
+
+async function runActivationCycle(page, target, args) {
+  const marker = `ORCA_APPHANG_${target.index}_${Date.now()}`
+  const cycleStartedAt = Date.now()
+  const activationStartedAt = Date.now()
+  await clickWorktreeCard(page, target.id)
+  const activation = await waitForActiveWorktree(page, target.id)
+  const activationMs = Date.now() - activationStartedAt
+  const activePty = await waitForActivePty(page, target.id)
+  const diagnosticsBeforeOutput = await collectRendererDiagnostics(page)
+  const outputStartedAt = Date.now()
+  await sendOutputStress(page, activePty.ptyId, marker, args.outputLines)
+  const outputMs = Date.now() - outputStartedAt
+  const mainIpcMs = await pingMainIpc(page)
+  const rendererProbe = await readRendererProbe(page)
+  const diagnosticsAfterOutput = await collectRendererDiagnostics(page)
+  const elapsedMs = Date.now() - cycleStartedAt
+  const sample = {
+    index: target.index,
+    kind: target.kind,
+    worktreeId: target.id,
+    displayName: target.displayName,
+    elapsedMs,
+    activationMs,
+    outputMs,
+    activation,
+    ptyWaitMs: activePty.waitMs,
+    ptyId: activePty.ptyId,
+    tabId: activePty.tabId,
+    mainIpcMs,
+    rendererMaxDriftMs: rendererProbe?.maxDriftMs ?? null,
+    renderingDiagnostics: diagnosticsAfterOutput?.renderingDiagnostics ?? null,
+    webglIdentity: diagnosticsAfterOutput?.webglIdentity ?? null,
+    diagnosticsBeforeOutput,
+    diagnosticsAfterOutput
+  }
+
+  const reproducedReasons = []
+  if (activationMs > severeActivationMs) {
+    reproducedReasons.push(`worktree activation took ${activationMs}ms`)
+  }
+  if (activePty.waitMs > severePtyWaitMs) {
+    reproducedReasons.push(`PTY binding took ${activePty.waitMs}ms`)
+  }
+  if (mainIpcMs > severeMainIpcMs) {
+    reproducedReasons.push(`main IPC ping took ${mainIpcMs}ms`)
+  }
+  if ((rendererProbe?.maxDriftMs ?? 0) > severeRendererDriftMs) {
+    reproducedReasons.push(`renderer timer drift reached ${Math.round(rendererProbe.maxDriftMs)}ms`)
+  }
+  if (reproducedReasons.length > 0) {
+    throw new ReproductionObservedError(reproducedReasons.join('; '), sample)
+  }
+  return sample
+}
+
+async function runDeadPtyReactivation(page, targets, args) {
+  const samples = []
+  for (const target of targets) {
+    await clickWorktreeCard(page, target.id)
+    await waitForActiveWorktree(page, target.id)
+    await waitForActivePty(page, target.id)
+    const killedPtyId = await killActivePty(page)
+    samples.push({ worktreeId: target.id, killedPtyId })
+  }
+  for (const target of targets) {
+    samples.push(
+      await runActivationCycle(page, { ...target, kind: `${target.kind}:dead-pty` }, args)
+    )
+  }
+  return samples
+}
+
+function selectTargets(setupResult, cycles) {
+  const gitWorktrees = setupResult.gitWorktrees
+    .filter((worktree) => worktree.path)
+    .sort((a, b) => Number(b.isMainWorktree) - Number(a.isMainWorktree))
+    .slice(0, 5)
+    .map((worktree) => ({ ...worktree, kind: 'git-wsl' }))
+  const plainWorktrees = setupResult.plainWorktrees.map((worktree) => ({
+    ...worktree,
+    kind: 'plain-folder-wsl'
+  }))
+  const baseTargets = [...gitWorktrees, ...plainWorktrees]
+  if (baseTargets.length === 0) {
+    throw new Error('No worktrees were discovered for the repro fixture.')
+  }
+  return Array.from({ length: cycles }, (_, index) => ({
+    ...baseTargets[index % baseTargets.length],
+    index: index + 1
+  }))
+}
+
+export async function runGpuMode(gpuMode, args, fixture) {
+  const cdpPort = await pickFreePort()
+  const userDataDir = createGpuUserDataDirectory(gpuMode)
+  const launched = launchDevApp({ cdpPort, userDataDir })
+  let browser = null
+  let page = null
+  const startedAt = Date.now()
+  const result = {
+    gpuMode,
+    reproduced: false,
+    reproductionReason: null,
+    startedAt,
+    elapsedMs: null,
+    cdpPort,
+    userDataDir,
+    appPid: launched.child.pid ?? null,
+    setup: null,
+    samples: [],
+    finalDiagnostics: null,
+    trace: null,
+    appLogSummary: null,
+    appLogsTail: null,
+    cleanupErrors: []
+  }
+
+  try {
+    const connected = await connectToApp(cdpPort)
+    browser = connected.browser
+    page = connected.page
+    await waitForStoreReady(page)
+    await installRendererProbe(page)
+    const identity = await runWithTimeout(
+      'app identity',
+      () => page.evaluate(() => window.api.app.getIdentity?.()),
+      rendererActionTimeoutMs
+    ).catch(() => null)
+    console.log(
+      `[apphang-repro] connected gpu=${gpuMode} pid=${result.appPid} identity=${JSON.stringify(identity)}`
+    )
+    result.setup = await setupAppFixture(page, fixture, gpuMode, args.sourceControl)
+    const targets = selectTargets(result.setup, args.cycles)
+    console.log(
+      `[apphang-repro] targets gpu=${gpuMode}: ${targets
+        .map((target) => `${target.kind}:${target.displayName}`)
+        .join(', ')}`
+    )
+    for (const target of targets) {
+      console.log(`[apphang-repro] cycle=${target.index} gpu=${gpuMode} kind=${target.kind}`)
+      result.samples.push(await runActivationCycle(page, target, args))
+    }
+    if (args.deadPtyReactivate) {
+      const uniqueTargets = []
+      const seen = new Set()
+      for (const target of targets) {
+        if (!seen.has(target.id)) {
+          seen.add(target.id)
+          uniqueTargets.push(target)
+        }
+      }
+      console.log(`[apphang-repro] dead-pty-reactivation gpu=${gpuMode}`)
+      result.samples.push(...(await runDeadPtyReactivation(page, uniqueTargets, args)))
+    }
+  } catch (error) {
+    if (error instanceof ReproductionObservedError) {
+      result.reproduced = true
+      result.reproductionReason = error.message
+      result.samples.push(error.evidence)
+    } else {
+      result.reproduced = true
+      result.reproductionReason =
+        error instanceof Error ? error.stack || error.message : String(error)
+    }
+  } finally {
+    result.elapsedMs = Date.now() - startedAt
+    result.finalDiagnostics = await collectRendererDiagnostics(page)
+    result.trace = summarizeTrace(userDataDir)
+    result.appLogSummary = summarizeAppLogs(launched.logs)
+    result.appLogsTail = launched.logs.slice(-120)
+    if (browser) {
+      await browser.close().catch(() => undefined)
+    }
+    await stopDevApp(launched.child)
+    if (!args.keep) {
+      safeRemoveLocalDirectory(userDataDir, result.cleanupErrors)
+    }
+  }
+  return result
+}

--- a/config/scripts/windows-apphang-repro/terminal-activation-scenario.mjs
+++ b/config/scripts/windows-apphang-repro/terminal-activation-scenario.mjs
@@ -278,7 +278,31 @@ async function killActivePty(page) {
   )
 }
 
+async function resetRendererProbe(page) {
+  // Why: probe drift is cumulative since installation; without a per-cycle
+  // reset, one startup/setup stall gets re-reported as a hang in every
+  // later cycle's rendererMaxDriftMs check.
+  await runWithTimeout(
+    'renderer probe reset',
+    () =>
+      page.evaluate(() => {
+        const probe = globalThis.__orcaApphangProbe?.probe
+        if (!probe) {
+          return
+        }
+        const now = performance.now()
+        probe.last = now
+        probe.lastTickAt = now
+        probe.startedAt = now
+        probe.maxDriftMs = 0
+        probe.samples = 0
+      }),
+    rendererActionTimeoutMs
+  )
+}
+
 async function runActivationCycle(page, target, args) {
+  await resetRendererProbe(page)
   const marker = `ORCA_APPHANG_${target.index}_${Date.now()}`
   const cycleStartedAt = Date.now()
   const activationStartedAt = Date.now()
@@ -381,6 +405,7 @@ export async function runGpuMode(gpuMode, args, fixture) {
     gpuMode,
     reproduced: false,
     reproductionReason: null,
+    harnessError: null,
     startedAt,
     elapsedMs: null,
     cdpPort,
@@ -438,9 +463,10 @@ export async function runGpuMode(gpuMode, args, fixture) {
       result.reproductionReason = error.message
       result.samples.push(error.evidence)
     } else {
-      result.reproduced = true
-      result.reproductionReason =
-        error instanceof Error ? error.stack || error.message : String(error)
+      // Why: setup/CDP/selector failures are inconclusive, not hang evidence.
+      // Conflating them with `reproduced` lets --expect=repro pass on a broken
+      // harness; callers treat harnessError as a hard failure instead.
+      result.harnessError = error instanceof Error ? error.stack || error.message : String(error)
     }
   } finally {
     result.elapsedMs = Date.now() - startedAt

--- a/config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs
+++ b/config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs
@@ -95,7 +95,10 @@ export function createCompletedOnboardingProfile(userDataDir) {
   const profile = {
     settings: {
       telemetry: {
-        optedIn: true,
+        // Why: synthetic harness/benchmark activity must not send telemetry.
+        // Explicit false with existedBeforeTelemetryRelease=false also keeps
+        // the first-launch consent surface from blocking automation.
+        optedIn: false,
         installId: '00000000-0000-4000-8000-000000000000',
         existedBeforeTelemetryRelease: false
       }

--- a/config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs
+++ b/config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs
@@ -1,0 +1,132 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = path.resolve(fileURLToPath(new URL('../../..', import.meta.url)))
+
+function runWsl(distro, script, options = {}) {
+  return execFileSync('wsl.exe', ['-d', distro, '--', 'bash', '-se'], {
+    cwd: rootDir,
+    encoding: 'utf8',
+    input: script,
+    timeout: options.timeoutMs ?? 120_000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  })
+}
+
+export function listWslDistros() {
+  const output = execFileSync('wsl.exe', ['--list', '--quiet'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 10_000
+  })
+  return output
+    .replaceAll(String.fromCharCode(0), '')
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^\*\s*/, ''))
+    .filter((line) => line && !line.toLowerCase().startsWith('docker-desktop'))
+}
+
+function linuxPathToWslUnc(distro, linuxPath) {
+  if (!linuxPath.startsWith('/')) {
+    throw new Error(`Expected absolute Linux path, got ${linuxPath}`)
+  }
+  return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
+}
+
+export function createWslFixture(distro) {
+  const script = String.raw`
+set -euo pipefail
+base="$(mktemp -d /tmp/orca-apphang-repro.XXXXXX)"
+repo="$base/repo"
+mkdir -p "$repo"
+cd "$repo"
+git init -q
+git config user.email apphang-repro@test.local
+git config user.name "AppHang Repro"
+mkdir -p src docs
+printf '# Orca Windows AppHang repro\n' > README.md
+for n in $(seq 1 25); do
+  printf 'line %03d %s\n' "$n" "abcdefghijklmnopqrstuvwxyz0123456789" >> src/payload.txt
+done
+git add -A
+git commit -q -m "Initial repro fixture"
+for n in 1 2 3 4; do
+  git branch "repro-wt-$n"
+  git worktree add -q "$base/wt-$n" "repro-wt-$n"
+  mkdir -p "$base/wt-$n/docs"
+  printf 'worktree %s\n' "$n" > "$base/wt-$n/docs/wt.txt"
+done
+plain="$base/plain-folder"
+mkdir -p "$plain/subdir"
+printf 'plain folder for Orca AppHang repro\n' > "$plain/README.txt"
+printf '%s\n' "$base" "$repo" "$base/wt-1" "$base/wt-2" "$base/wt-3" "$base/wt-4" "$plain"
+`
+  const lines = runWsl(distro, script, { timeoutMs: 120_000 }).trim().split(/\r?\n/).filter(Boolean)
+  if (lines.length < 7) {
+    throw new Error(`WSL fixture creation returned unexpected output: ${JSON.stringify(lines)}`)
+  }
+  const [base, repo, ...rest] = lines
+  const plain = rest.at(-1)
+  const worktrees = rest.slice(0, -1)
+  return {
+    distro,
+    baseLinuxPath: base,
+    repoLinuxPath: repo,
+    plainLinuxPath: plain,
+    worktreeLinuxPaths: worktrees,
+    repoUncPath: linuxPathToWslUnc(distro, repo),
+    plainUncPath: linuxPathToWslUnc(distro, plain),
+    worktreeUncPaths: worktrees.map((entry) => linuxPathToWslUnc(distro, entry))
+  }
+}
+
+export function removeWslFixture(fixture) {
+  if (!fixture?.baseLinuxPath) {
+    return
+  }
+  const quoted = fixture.baseLinuxPath.replaceAll("'", "'\\''")
+  runWsl(fixture.distro, `rm -rf '${quoted}'`, { timeoutMs: 30_000 })
+}
+
+export function createCompletedOnboardingProfile(userDataDir) {
+  mkdirSync(userDataDir, { recursive: true })
+  const profile = {
+    settings: {
+      telemetry: {
+        optedIn: true,
+        installId: '00000000-0000-4000-8000-000000000000',
+        existedBeforeTelemetryRelease: false
+      }
+    },
+    onboarding: {
+      flowVersion: 4,
+      closedAt: 1,
+      outcome: 'completed',
+      lastCompletedStep: 5
+    },
+    ui: {
+      contextualToursAutoEligible: false,
+      contextualToursSeenIds: [
+        'workspace-board',
+        'browser',
+        'tasks',
+        'automations',
+        'workspace-creation'
+      ],
+      featureTipsSeenIds: [],
+      featureInteractions: {},
+      projectOrderManualDefaultNoticeDismissed: true
+    }
+  }
+  writeFileSync(path.join(userDataDir, 'orca-data.json'), `${JSON.stringify(profile, null, 2)}\n`)
+}
+
+export function safeRemoveLocalDirectory(dir, cleanupErrors) {
+  try {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+  } catch (error) {
+    cleanupErrors.push(error instanceof Error ? error.message : String(error))
+  }
+}

--- a/notes/windows-perf-progress.md
+++ b/notes/windows-perf-progress.md
@@ -38,10 +38,27 @@ Fixes on this branch (PR #7080 merged in — WebGL release on dispose + stale pt
 - F: daemon boots a throwaway `cmd.exe /c exit` ConPTY (windows-conpty-warmup.ts) so the
   first user terminal doesn't pay the ~2.7s first-ConPTY cost.
 
-Follow-ups (documented, not in this branch): gate/scope the light-tab-switch atlas burst
-(see #7058/#7073 history first); renderer-side tab-create cost (defer WebGL attach for
-brand-new panes?); cold-restore respawn fan-out concurrency cap; node-pty ≥1.2.0-beta
-deferred conpty connect (spawn returns pid=0 fast, stops daemon-loop serialization).
+Follow-ups (documented, not in this branch):
+- Gate/scope the light-tab-switch atlas burst (see #7058/#7073 history first). Residual
+  tab-switch cost besides the burst: debounced ResizeObserver re-fit can reflow scrollback
+  when column count changed while hidden.
+- Renderer-side tab-create cost (~400ms): mount chain runs new Terminal() + 5 eager addons
+  + synchronous attachWebgl (pane-lifecycle.ts:108) before the spawn IPC (deferred one rAF,
+  pty-connection.ts:5158). Candidate: defer WebGL attach for brand-new panes.
+- Cold-restore respawn fan-out: reconnectPersistedTerminals does NOT spawn; the fan-out is
+  Terminal.tsx mounting a TerminalPane per restored tab at once — each fires connectPanePty
+  → rAF-deferred spawn IPC (pty-connection.ts:5158) with no concurrency cap. Cap belongs at
+  that renderer connect layer, not in reconnectPersistedTerminals.
+- First terminal opened immediately after launch also waits on the one-time daemon-init
+  barrier (pty:spawn awaits getLocalPtyStartupPromise, ipc/pty.ts:2518; measured
+  preflight=0 in the bench because hydration had finished first, but an early Ctrl+T pays
+  it). In-daemon Windows shell resolution (pwsh -Version probe, PowerShell exe-chain
+  existsSync/statSync scan) is uncached per spawn; the conpty warm-up spawns cmd.exe so it
+  does not warm PowerShell resolution. Note the warm-up and an early first spawn serialize
+  on the daemon's single thread — the 1255ms post-fix first-spawn number is mostly queueing
+  behind the in-flight warm-up, not unwarmed cost.
+- node-pty ≥1.2.0-beta defers conpty connect (spawn returns pid=0 fast) — would stop spawn
+  storms serializing the daemon loop.
 
 Pre-existing Windows-only test failures (also on main, CI is ubuntu-only): 5 attribution-shim
 PATH assertions in src/main/ipc/pty.test.ts (path-separator artifacts).

--- a/notes/windows-perf-progress.md
+++ b/notes/windows-perf-progress.md
@@ -4,6 +4,48 @@ Goal: (1) significantly improve Windows startup time (~1 min cold start reported
 (2) fix OpenCode-driven UI freezes, (3) improve overall Windows performance.
 All changes must be proven with before/after benchmark numbers.
 
+## Phase 2 (2026-07-02, branch Jinwoo-H/windows-performance-improvement) — terminal interaction latency
+
+Complaints: slow workspace switching, slow tab create/switch (terminal-related), occasional crashes.
+Harness: `tools/benchmarks/terminal-perf-bench.mjs` (CDP-driven dev app, renderer-clock phase
+timings; scenarios tab-create / tab-switch / workspace-switch; local git fixture).
+Main-process spawn attribution: `ORCA_PTY_SPAWN_TIMING=1` → `[pty-spawn-timing]` lines
+(pty.ts handler phases: preflight/auth/host_env/options/provider_spawn).
+
+Findings (baseline, this machine):
+- Workspace switch: every hide disposed each pane's WebGL context; resume recreated it —
+  ~5ms macOS, 100-500ms/pane Windows ANGLE (the comment in terminal-visibility-resume.ts
+  admitted this). Premise (16-context budget) stale since #7064 raised budget to 128.
+- Tab create: ~550ms steady state; main handler only ~115ms (host_env≈50ms, daemon
+  provider_spawn≈68ms). Remainder is renderer-side (xterm open + WebGL context for the new
+  pane + React mount). First-ever spawn paid +2.7s inside provider_spawn = daemon's first
+  ConPTY (native module + conpty.dll + OpenConsole + Defender), lazily on the user's first terminal.
+- Tab switch: paint settle median 80-99ms; longtasks 64-151ms — every light tab resume runs
+  scheduleTerminalWebglAtlasRecovery: 3× (frame/120ms/500ms) global shared-atlas clear +
+  refresh of EVERY pane in EVERY manager. Parse-time recovery (pty-connection.ts
+  recoverWebglAtlasAfterParse / hiddenOutputNeedsAtlasRecoveryAfterParse) already covers
+  risky output including hidden. CAUTION: #7058 changed this area and was reverted (#7073) —
+  left as follow-up.
+- LocalPtyProvider spawned without useConptyDll while the daemon path used it (legacy system
+  ConPTY corruption + perf differences on degraded-mode/fresh-local spawns).
+
+Fixes on this branch (PR #7080 merged in — WebGL release on dispose + stale pty:exit synthesis):
+- A: WebGL context retention across hide/show (pane-webgl-context-retention.ts, LRU cap 16;
+  suspend keeps live contexts; resume repaints instead of recreating).
+- B: useConptyDll for LocalPtyProvider spawns (local-pty-utils.ts) — parity with daemon.
+- D: atlas recovery bursts skip suspended panes (scoped to visible); retained panes repaint
+  on resume (shared-atlas invariant preserved).
+- F: daemon boots a throwaway `cmd.exe /c exit` ConPTY (windows-conpty-warmup.ts) so the
+  first user terminal doesn't pay the ~2.7s first-ConPTY cost.
+
+Follow-ups (documented, not in this branch): gate/scope the light-tab-switch atlas burst
+(see #7058/#7073 history first); renderer-side tab-create cost (defer WebGL attach for
+brand-new panes?); cold-restore respawn fan-out concurrency cap; node-pty ≥1.2.0-beta
+deferred conpty connect (spawn returns pid=0 fast, stops daemon-loop serialization).
+
+Pre-existing Windows-only test failures (also on main, CI is ubuntu-only): 5 attribution-shim
+PATH assertions in src/main/ipc/pty.test.ts (path-separator artifacts).
+
 ## Status
 
 - [x] Benchmark harness for startup time (`tools/benchmarks/startup-time-bench.mjs`)

--- a/notes/windows-perf-progress.md
+++ b/notes/windows-perf-progress.md
@@ -30,10 +30,12 @@ Findings (baseline, this machine):
   ConPTY corruption + perf differences on degraded-mode/fresh-local spawns).
 
 Fixes on this branch (PR #7080 merged in — WebGL release on dispose + stale pty:exit synthesis):
-- A: WebGL context retention across hide/show (pane-webgl-context-retention.ts, LRU cap 16;
-  suspend keeps live contexts; resume repaints instead of recreating). Gated to Windows
-  (getRendererAppPlatform() === 'win32'): macOS/Linux context creation is cheap, so they
-  keep dispose-on-hide and pay no retention GPU-memory cost.
+- A: WebGL context retention across hide/show (pane-webgl-context-retention.ts, LRU cap 32 —
+  sized for ~10-16 worktrees × ~2 terminals hot sets; suspend keeps live contexts; resume
+  repaints instead of recreating). Gated to Windows (getRendererAppPlatform() === 'win32'):
+  macOS/Linux context creation is cheap, so they keep dispose-on-hide and pay no retention
+  GPU-memory cost. Peer note: at least one comparable product raises the context budget to
+  256 and retains unbounded with a session-wide DOM latch on loss; we bound + recover instead.
 - B: useConptyDll for LocalPtyProvider spawns (local-pty-utils.ts) — parity with daemon.
 - D: atlas recovery bursts skip suspended panes (scoped to visible); retained panes repaint
   on resume (shared-atlas invariant preserved).

--- a/notes/windows-perf-progress.md
+++ b/notes/windows-perf-progress.md
@@ -31,7 +31,9 @@ Findings (baseline, this machine):
 
 Fixes on this branch (PR #7080 merged in — WebGL release on dispose + stale pty:exit synthesis):
 - A: WebGL context retention across hide/show (pane-webgl-context-retention.ts, LRU cap 16;
-  suspend keeps live contexts; resume repaints instead of recreating).
+  suspend keeps live contexts; resume repaints instead of recreating). Gated to Windows
+  (getRendererAppPlatform() === 'win32'): macOS/Linux context creation is cheap, so they
+  keep dispose-on-hide and pay no retention GPU-memory cost.
 - B: useConptyDll for LocalPtyProvider spawns (local-pty-utils.ts) — parity with daemon.
 - D: atlas recovery bursts skip suspended panes (scoped to visible); retained panes repaint
   on resume (shared-atlas invariant preserved).

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -8,6 +8,7 @@
  */
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { createPtySubprocess } from './pty-subprocess'
+import { warmWindowsConptyOnce } from './windows-conpty-warmup'
 import { warmPwshAvailabilityCache } from '../pwsh'
 
 export function parseArgs(argv: string[]): { socketPath: string; tokenPath: string } {
@@ -84,6 +85,8 @@ async function main(): Promise<void> {
   if (process.send) {
     process.send({ type: 'ready' })
   }
+
+  warmWindowsConptyOnce()
 }
 
 // Only auto-run when executed directly (not imported for testing)

--- a/src/main/daemon/windows-conpty-warmup.test.ts
+++ b/src/main/daemon/windows-conpty-warmup.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as pty from 'node-pty'
+import { warmWindowsConptyOnce } from './windows-conpty-warmup'
+
+function setPlatform(platform: NodeJS.Platform): () => void {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  return () => Object.defineProperty(process, 'platform', { configurable: true, value: original })
+}
+
+function flushImmediates(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+let restorePlatform: (() => void) | null = null
+afterEach(() => {
+  restorePlatform?.()
+  restorePlatform = null
+  vi.restoreAllMocks()
+})
+
+function makeFakePty(): { proc: pty.IPty; fireExit: () => void } {
+  let exitListener: (() => void) | null = null
+  const proc = {
+    pid: 4321,
+    kill: vi.fn(),
+    onExit: vi.fn((listener: () => void) => {
+      exitListener = listener
+      return { dispose: () => undefined }
+    })
+  } as unknown as pty.IPty
+  return { proc, fireExit: () => exitListener?.() }
+}
+
+describe('warmWindowsConptyOnce', () => {
+  it('is a no-op off Windows', async () => {
+    restorePlatform = setPlatform('darwin')
+    const spawnPty = vi.fn() as unknown as typeof pty.spawn
+
+    warmWindowsConptyOnce(spawnPty)
+    await flushImmediates()
+
+    expect(spawnPty).not.toHaveBeenCalled()
+  })
+
+  it('spawns a short-lived cmd.exe with the bundled ConPTY on Windows', async () => {
+    restorePlatform = setPlatform('win32')
+    const { proc, fireExit } = makeFakePty()
+    const spawnPty = vi.fn(() => proc) as unknown as typeof pty.spawn
+
+    warmWindowsConptyOnce(spawnPty)
+    await flushImmediates()
+
+    expect(spawnPty).toHaveBeenCalledTimes(1)
+    const [file, args, options] = vi.mocked(spawnPty).mock.calls[0]
+    expect(String(file).toLowerCase()).toContain('cmd')
+    expect(args).toEqual(['/c', 'exit'])
+    expect(options).toMatchObject({ useConptyDll: true, cols: 2, rows: 1 })
+
+    // A clean exit must not leave the kill timer to fire later.
+    fireExit()
+    expect(proc.kill).not.toHaveBeenCalled()
+  })
+
+  it('kills the warm-up shell if it never exits', async () => {
+    restorePlatform = setPlatform('win32')
+    vi.useFakeTimers()
+    try {
+      const { proc } = makeFakePty()
+      const spawnPty = vi.fn(() => proc) as unknown as typeof pty.spawn
+
+      warmWindowsConptyOnce(spawnPty)
+      await vi.runOnlyPendingTimersAsync()
+      vi.advanceTimersByTime(10_000)
+
+      expect(proc.kill).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('swallows spawn failures', async () => {
+    restorePlatform = setPlatform('win32')
+    const spawnPty = vi.fn(() => {
+      throw new Error('conpty unavailable')
+    }) as unknown as typeof pty.spawn
+
+    expect(() => warmWindowsConptyOnce(spawnPty)).not.toThrow()
+    await flushImmediates()
+  })
+})

--- a/src/main/daemon/windows-conpty-warmup.ts
+++ b/src/main/daemon/windows-conpty-warmup.ts
@@ -1,0 +1,45 @@
+import os from 'node:os'
+import * as pty from 'node-pty'
+
+const WARMUP_KILL_TIMEOUT_MS = 10_000
+
+/**
+ * Pays the one-time cost of the first ConPTY spawn (conpty native module
+ * load, bundled conpty.dll + OpenConsole.exe first launch, Defender scans of
+ * those binaries) at daemon boot instead of on the user's first terminal.
+ * Measured ~2.7s on a Windows dev profile for the first spawn vs ~70ms after.
+ */
+export function warmWindowsConptyOnce(spawnPty: typeof pty.spawn = pty.spawn): void {
+  if (process.platform !== 'win32') {
+    return
+  }
+  // Why: setImmediate keeps the ready/handshake path ahead of the warm-up; a
+  // real spawn arriving first simply does the warming itself.
+  setImmediate(() => {
+    try {
+      const proc = spawnPty(process.env.COMSPEC || 'cmd.exe', ['/c', 'exit'], {
+        name: 'xterm-256color',
+        cols: 2,
+        rows: 1,
+        cwd: os.homedir(),
+        env: process.env as Record<string, string>,
+        // Match real terminal spawns so the bundled ConPTY binaries are the
+        // ones warmed, not the legacy system ConPTY.
+        useConptyDll: true
+      })
+      const killTimer = setTimeout(() => {
+        try {
+          proc.kill()
+        } catch {
+          /* best-effort cleanup of a stuck warm-up shell */
+        }
+      }, WARMUP_KILL_TIMEOUT_MS)
+      killTimer.unref?.()
+      proc.onExit(() => {
+        clearTimeout(killTimer)
+      })
+    } catch {
+      /* warm-up is best-effort; real spawns surface their own errors */
+    }
+  })
+}

--- a/src/main/ipc/pty-spawn-timing.ts
+++ b/src/main/ipc/pty-spawn-timing.ts
@@ -1,0 +1,40 @@
+// Why: pty:spawn latency has four very different suspects (startup barrier,
+// Claude auth prep, buildPtyHostEnv filesystem work, provider/daemon spawn).
+// A single opt-in log line per spawn lets benchmarks attribute the cost
+// without a tracing dependency. Enabled via ORCA_PTY_SPAWN_TIMING=1.
+
+export type PtySpawnTiming = {
+  mark(phase: string): void
+  log(id: string, extra?: Record<string, string | number | boolean>): void
+}
+
+const noopTiming: PtySpawnTiming = {
+  mark: () => undefined,
+  log: () => undefined
+}
+
+export function createPtySpawnTiming(): PtySpawnTiming {
+  if (!process.env.ORCA_PTY_SPAWN_TIMING) {
+    return noopTiming
+  }
+  const startedAt = Date.now()
+  let lastAt = startedAt
+  const phases: string[] = []
+  return {
+    mark(phase: string): void {
+      const now = Date.now()
+      phases.push(`${phase}=${now - lastAt}ms`)
+      lastAt = now
+    },
+    log(id: string, extra?: Record<string, string | number | boolean>): void {
+      const extras = extra
+        ? ` ${Object.entries(extra)
+            .map(([key, value]) => `${key}=${value}`)
+            .join(' ')}`
+        : ''
+      console.log(
+        `[pty-spawn-timing] id=${id} total=${Date.now() - startedAt}ms ${phases.join(' ')}${extras}`
+      )
+    }
+  }
+}

--- a/src/main/ipc/pty-spawn-timing.ts
+++ b/src/main/ipc/pty-spawn-timing.ts
@@ -14,7 +14,8 @@ const noopTiming: PtySpawnTiming = {
 }
 
 export function createPtySpawnTiming(): PtySpawnTiming {
-  if (!process.env.ORCA_PTY_SPAWN_TIMING) {
+  const flag = process.env.ORCA_PTY_SPAWN_TIMING
+  if (!flag || flag === '0' || flag.toLowerCase() === 'false') {
     return noopTiming
   }
   const startedAt = Date.now()

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2911,6 +2911,104 @@ describe('registerPtyHandlers', () => {
       keepHistory: true
     })
     expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', -1)
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
+      id: 'local-pty',
+      code: -1
+    })
+  })
+
+  it('does not synthesize a duplicate renderer exit when kill emits provider exit', async () => {
+    const exitListeners = new Set<(payload: { id: string; code: number }) => void>()
+    const shutdown = vi.fn(async (id: string) => {
+      for (const listener of exitListeners) {
+        listener({ id, code: 0 })
+      }
+    })
+    const runtime = {
+      setPtyController: vi.fn(),
+      onPtyExit: vi.fn()
+    }
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown,
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn((listener: (payload: { id: string; code: number }) => void) => {
+        exitListeners.add(listener)
+        return () => exitListeners.delete(listener)
+      }),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:kill')!(null, { id: 'local-pty' })
+
+    expect(runtime.onPtyExit).toHaveBeenCalledTimes(1)
+    expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0)
+    expect(mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')).toEqual(
+      [['pty:exit', { id: 'local-pty', code: 0 }]]
+    )
+  })
+
+  it('ignores a late provider exit after synthesizing kill exit', async () => {
+    const exitListeners = new Set<(payload: { id: string; code: number }) => void>()
+    const runtime = {
+      setPtyController: vi.fn(),
+      onPtyExit: vi.fn()
+    }
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn((listener: (payload: { id: string; code: number }) => void) => {
+        exitListeners.add(listener)
+        return () => exitListeners.delete(listener)
+      }),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:kill')!(null, { id: 'local-pty' })
+    for (const listener of exitListeners) {
+      listener({ id: 'local-pty', code: 0 })
+    }
+
+    expect(runtime.onPtyExit).toHaveBeenCalledTimes(1)
+    expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', -1)
+    expect(mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')).toEqual(
+      [['pty:exit', { id: 'local-pty', code: -1 }]]
+    )
   })
 
   it('waits for the desktop startup barrier before renderer local spawns resolve the provider', async () => {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2331,7 +2331,9 @@ describe('registerPtyHandlers', () => {
         }
 
         expect(controller.kill('remote-pty')).toBe(true)
-        await Promise.resolve()
+        // Why: kill's shutdown now runs through the exit-detection wrapper,
+        // which adds async hops; a single microtask flush is no longer enough.
+        await new Promise((resolve) => setImmediate(resolve))
 
         expect(shutdown).toHaveBeenCalledWith('remote-pty', { immediate: false })
         expect(store.markSshRemotePtyLease).toHaveBeenCalledWith(
@@ -2340,6 +2342,113 @@ describe('registerPtyHandlers', () => {
           'terminated'
         )
         expect(runtime.onPtyExit).toHaveBeenCalledWith('remote-pty', -1)
+      })
+
+      it('controller kill does not duplicate exits when the provider emits exit during shutdown', async () => {
+        const exitListeners = new Set<(payload: { id: string; code: number }) => void>()
+        const shutdown = vi.fn(async (id: string) => {
+          for (const listener of exitListeners) {
+            listener({ id, code: 0 })
+          }
+        })
+        const runtime = {
+          setPtyController: vi.fn(),
+          onPtyExit: vi.fn()
+        }
+        setLocalPtyProvider({
+          spawn: vi.fn(),
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown,
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn((listener: (payload: { id: string; code: number }) => void) => {
+            exitListeners.add(listener)
+            return () => exitListeners.delete(listener)
+          }),
+          listProcesses: vi.fn(async () => []),
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never)
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+          kill: (ptyId: string) => boolean
+        }
+
+        expect(controller.kill('local-pty')).toBe(true)
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(runtime.onPtyExit).toHaveBeenCalledTimes(1)
+        expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0)
+        expect(
+          mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')
+        ).toEqual([['pty:exit', { id: 'local-pty', code: 0 }]])
+      })
+
+      it('controller stopAndWait skips the synthetic exit when the provider emitted one', async () => {
+        vi.useFakeTimers()
+        const exitListeners = new Set<(payload: { id: string; code: number }) => void>()
+        const shutdown = vi.fn(async (id: string) => {
+          for (const listener of exitListeners) {
+            listener({ id, code: 0 })
+          }
+        })
+        const runtime = {
+          setPtyController: vi.fn(),
+          onPtyExit: vi.fn()
+        }
+        setLocalPtyProvider({
+          spawn: vi.fn(),
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown,
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn((listener: (payload: { id: string; code: number }) => void) => {
+            exitListeners.add(listener)
+            return () => exitListeners.delete(listener)
+          }),
+          listProcesses: vi.fn(async () => []),
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never)
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+          stopAndWait: (ptyId: string, opts?: { keepHistory?: boolean }) => Promise<boolean>
+        }
+
+        const stopPromise = controller.stopAndWait('local-pty')
+        await vi.advanceTimersByTimeAsync(1_200)
+        await expect(stopPromise).resolves.toBe(true)
+
+        expect(runtime.onPtyExit).toHaveBeenCalledTimes(1)
+        expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0)
+        expect(
+          mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')
+        ).toEqual([['pty:exit', { id: 'local-pty', code: 0 }]])
       })
 
       it('passes keepHistory through runtime controller stopAndWait', async () => {
@@ -2566,7 +2675,7 @@ describe('registerPtyHandlers', () => {
         }
 
         expect(controller.kill('ssh:ssh-1@@relay-pty')).toBe(true)
-        await Promise.resolve()
+        await new Promise((resolve) => setImmediate(resolve))
 
         expect(shutdown).toHaveBeenCalledWith('ssh:ssh-1@@relay-pty', { immediate: false })
         expect(localShutdown).not.toHaveBeenCalled()
@@ -2701,8 +2810,7 @@ describe('registerPtyHandlers', () => {
 
         try {
           expect(controller.kill('remote-pty')).toBe(true)
-          await Promise.resolve()
-          await Promise.resolve()
+          await new Promise((resolve) => setImmediate(resolve))
         } finally {
           warnSpy.mockRestore()
           deletePtyOwnership('remote-pty')

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -39,6 +39,7 @@ import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import { SSH_SESSION_EXPIRED_ERROR, isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
 import { parseAppSshPtyId, toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
+import { createPtySpawnTiming } from './pty-spawn-timing'
 import { mintPtySessionId, isSafePtySessionId } from '../daemon/pty-session-id'
 import { addNodePtyRecoveryHint } from '../daemon/node-pty-error-hints'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
@@ -2515,11 +2516,13 @@ export function registerPtyHandlers(
         }
       }
     ) => {
+      const spawnTiming = createPtySpawnTiming()
       const startupPromise = getLocalPtyStartupPromise(args.connectionId)
       if (startupPromise) {
         await startupPromise
       }
       await assertFolderWorkspacePtyPathUsable(args.worktreeId)
+      spawnTiming.mark('preflight')
       const provider = getProvider(args.connectionId)
       const isClaudeLaunch = !args.connectionId && isClaudeLaunchCommand(args.command)
       if (isClaudeLaunch && isClaudeAuthSwitchInProgress()) {
@@ -2542,6 +2545,7 @@ export function registerPtyHandlers(
       )
       const claudeAuth =
         isClaudeLaunch && prepareClaudeAuth ? await prepareClaudeAuth(initialSelectionTarget) : null
+      spawnTiming.mark('auth')
       if (isClaudeLaunch && isClaudeAuthSwitchInProgress()) {
         throw new Error('A Claude account switch is in progress. Try again after it finishes.')
       }
@@ -2767,6 +2771,7 @@ export function registerPtyHandlers(
           throw err
         }
       }
+      spawnTiming.mark('host_env')
       const spawnEnv = preAllocatedHandle
         ? { ...env, ORCA_TERMINAL_HANDLE: preAllocatedHandle }
         : env
@@ -2861,7 +2866,9 @@ export function registerPtyHandlers(
               startupTerminalColorQueryReplyColors
             )
           }
+          spawnTiming.mark('options')
           result = await provider.spawn(spawnOptions)
+          spawnTiming.mark('provider_spawn')
         } catch (err) {
           const rawMessage = err instanceof Error ? err.message : String(err)
           const spawnError = normalizeNodePtySpawnError(err)
@@ -2922,6 +2929,10 @@ export function registerPtyHandlers(
             trustedTerminalHandleEnv.delete(preAllocatedHandle)
           }
         }
+        spawnTiming.log(result.id, {
+          daemon: isDaemonHostSpawn,
+          reattach: result.isReattach ?? false
+        })
         ptyOwnership.set(result.id, args.connectionId ?? null)
         if (startupTerminalColorQueryReplyColors) {
           if (result.isReattach) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -111,6 +111,7 @@ type FreshLocalFallbackProvider = IPtyProvider & {
   routesFreshSpawnsToLocalProvider?: true
 }
 const sshProviders = new Map<string, IPtyProvider>()
+const SYNTHETIC_KILL_EXIT_DUPLICATE_WINDOW_MS = 30_000
 // Why: PTY IDs are assigned at spawn time with a connectionId, but subsequent
 // write/resize/kill calls only carry the PTY ID. This map lets us route
 // post-spawn operations to the correct provider without the renderer needing
@@ -1656,6 +1657,82 @@ export function registerPtyHandlers(
     flushTimer = null
   }
 
+  const syntheticKillExitPtyIds = new Map<string, NodeJS.Timeout>()
+
+  function rememberSyntheticKillExit(id: string): void {
+    const existing = syntheticKillExitPtyIds.get(id)
+    if (existing) {
+      clearTimeout(existing)
+    }
+    // Why: some providers can report the real exit after kill has already
+    // completed; skip only that late duplicate, not a future reused id forever.
+    const cleanupTimer = setTimeout(() => {
+      syntheticKillExitPtyIds.delete(id)
+    }, SYNTHETIC_KILL_EXIT_DUPLICATE_WINDOW_MS)
+    cleanupTimer.unref?.()
+    syntheticKillExitPtyIds.set(id, cleanupTimer)
+  }
+
+  function consumeSyntheticKillExit(id: string): boolean {
+    const cleanupTimer = syntheticKillExitPtyIds.get(id)
+    if (!cleanupTimer) {
+      return false
+    }
+    clearTimeout(cleanupTimer)
+    syntheticKillExitPtyIds.delete(id)
+    return true
+  }
+
+  function sendPtyExitToRenderer(payload: { id: string; code: number }): void {
+    if (mainWindow.isDestroyed()) {
+      return
+    }
+    // Why: flush any batched data for this PTY before sending the exit event,
+    // otherwise the last <=8ms of output is silently lost because the renderer
+    // tears down the terminal on pty:exit before the batch timer fires.
+    const remaining = pendingData.get(payload.id)
+    if (remaining) {
+      sendPtyDataToRenderer(
+        payload.id,
+        makePtyDataPayload(
+          payload.id,
+          remaining.data,
+          remaining.startSeq,
+          remaining.containsBackgroundOutput
+        )
+      )
+      pendingData.delete(payload.id)
+    }
+    lastInputAtByPty.delete(payload.id)
+    interactiveOutputCharsByPty.delete(payload.id)
+    rendererInFlightTotalChars = Math.max(
+      0,
+      rendererInFlightTotalChars - (rendererInFlightCharsByPty.get(payload.id) ?? 0)
+    )
+    rendererInFlightCharsByPty.delete(payload.id)
+    recordPtyRendererDeliveryPressure()
+    mainWindow.webContents.send('pty:exit', payload)
+  }
+
+  async function shutdownProviderAndDetectExit(
+    provider: IPtyProvider,
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean }
+  ): Promise<boolean> {
+    let providerExitObserved = false
+    const unsubscribe = provider.onExit((payload) => {
+      if (payload.id === id) {
+        providerExitObserved = true
+      }
+    })
+    try {
+      await provider.shutdown(id, opts)
+    } finally {
+      unsubscribe()
+    }
+    return providerExitObserved
+  }
+
   // Why: extracted so the "Restart daemon" flow can rebind against the fresh
   // adapter after replaceDaemonProvider runs. Both the startup registration
   // and the post-restart rebind go through the same code path — no risk of
@@ -1745,39 +1822,16 @@ export function registerPtyHandlers(
       }
     })
     localExitUnsub = localProvider.onExit((payload) => {
+      if (consumeSyntheticKillExit(payload.id)) {
+        return
+      }
       if (!isLocalProvider) {
         clearProviderPtyState(payload.id)
         ptyOwnership.delete(payload.id)
         markClaudePtyExited(payload.id)
         runtime?.onPtyExit(payload.id, payload.code)
       }
-      if (!mainWindow.isDestroyed()) {
-        // Why: flush any batched data for this PTY before sending the exit event,
-        // otherwise the last ≤8ms of output is silently lost because the renderer
-        // tears down the terminal on pty:exit before the batch timer fires.
-        const remaining = pendingData.get(payload.id)
-        if (remaining) {
-          sendPtyDataToRenderer(
-            payload.id,
-            makePtyDataPayload(
-              payload.id,
-              remaining.data,
-              remaining.startSeq,
-              remaining.containsBackgroundOutput
-            )
-          )
-          pendingData.delete(payload.id)
-        }
-        lastInputAtByPty.delete(payload.id)
-        interactiveOutputCharsByPty.delete(payload.id)
-        rendererInFlightTotalChars = Math.max(
-          0,
-          rendererInFlightTotalChars - (rendererInFlightCharsByPty.get(payload.id) ?? 0)
-        )
-        rendererInFlightCharsByPty.delete(payload.id)
-        recordPtyRendererDeliveryPressure()
-        mainWindow.webContents.send('pty:exit', payload)
-      }
+      sendPtyExitToRenderer(payload)
     })
   }
 
@@ -3396,10 +3450,14 @@ export function registerPtyHandlers(
       // before ownership is rebuilt. Tombstone instead of falling back local.
       finishPtyShutdown(args.id, connectionId, store)
       runtime?.onPtyExit(args.id, -1)
+      rememberSyntheticKillExit(args.id)
+      sendPtyExitToRenderer({ id: args.id, code: -1 })
       return
     }
+    const shutdownProvider = provider ?? getProviderForPty(args.id)
+    let providerExitObserved = false
     try {
-      await (provider ?? getProviderForPty(args.id)).shutdown(args.id, {
+      providerExitObserved = await shutdownProviderAndDetectExit(shutdownProvider, args.id, {
         immediate: true,
         keepHistory: args.keepHistory ?? false
       })
@@ -3412,11 +3470,14 @@ export function registerPtyHandlers(
       }
       /* session already dead — cleanup below handles the rest */
     }
-    // Why: onExit clears provider state for LocalPtyProvider, but remote SSH
-    // and daemon shutdown paths do not emit onExit through the local provider's
-    // listener. Explicit cleanup is idempotent and covers already-dead PTYs.
+    // Why: some shutdown paths do not emit onExit through the provider listener.
+    // Explicit cleanup is idempotent and covers already-dead PTYs.
     finishPtyShutdown(args.id, connectionId, store)
-    runtime?.onPtyExit(args.id, -1)
+    if (!providerExitObserved) {
+      runtime?.onPtyExit(args.id, -1)
+      rememberSyntheticKillExit(args.id)
+      sendPtyExitToRenderer({ id: args.id, code: -1 })
+    }
   })
 
   ipcMain.handle(

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2295,6 +2295,8 @@ export function registerPtyHandlers(
           // not revive a terminal the user explicitly closed.
           finishPtyShutdown(ptyId, connectionId, store)
           runtime?.onPtyExit(ptyId, -1)
+          rememberSyntheticKillExit(ptyId)
+          sendPtyExitToRenderer({ id: ptyId, code: -1 })
           return true
         }
         return false
@@ -2302,16 +2304,25 @@ export function registerPtyHandlers(
       // Why: shutdown() is async but the PtyController interface is sync. Defer
       // cleanup until shutdown resolves so transient SSH/daemon failures don't
       // hide a still-running remote process or local daemon session.
-      void provider
-        .shutdown(ptyId, { immediate: false })
-        .then(() => {
+      //
+      // Same synthetic-exit contract as the renderer pty:kill handler: when the
+      // provider emitted its own exit during shutdown, the exit listener already
+      // delivered runtime + renderer exits — synthesizing again would double-fire.
+      void shutdownProviderAndDetectExit(provider, ptyId, { immediate: false })
+        .then((providerExitObserved) => {
           finishPtyShutdown(ptyId, connectionId, store)
-          runtime?.onPtyExit(ptyId, -1)
+          if (!providerExitObserved) {
+            runtime?.onPtyExit(ptyId, -1)
+            rememberSyntheticKillExit(ptyId)
+            sendPtyExitToRenderer({ id: ptyId, code: -1 })
+          }
         })
         .catch((err) => {
           if (isPtyAlreadyGoneError(err)) {
             finishPtyShutdown(ptyId, connectionId, store)
             runtime?.onPtyExit(ptyId, -1)
+            rememberSyntheticKillExit(ptyId)
+            sendPtyExitToRenderer({ id: ptyId, code: -1 })
             return
           }
           console.warn(
@@ -2338,12 +2349,15 @@ export function registerPtyHandlers(
           // await, but the relay lease must still be tombstoned.
           finishPtyShutdown(ptyId, connectionId, store)
           runtime?.onPtyExit(ptyId, -1)
+          rememberSyntheticKillExit(ptyId)
+          sendPtyExitToRenderer({ id: ptyId, code: -1 })
           return true
         }
         return false
       }
+      let providerExitObserved = false
       try {
-        await provider.shutdown(ptyId, {
+        providerExitObserved = await shutdownProviderAndDetectExit(provider, ptyId, {
           immediate: true,
           keepHistory: opts?.keepHistory ?? false
         })
@@ -2368,7 +2382,11 @@ export function registerPtyHandlers(
         return false
       }
       finishPtyShutdown(ptyId, connectionId, store)
-      runtime?.onPtyExit(ptyId, -1)
+      if (!providerExitObserved) {
+        runtime?.onPtyExit(ptyId, -1)
+        rememberSyntheticKillExit(ptyId)
+        sendPtyExitToRenderer({ id: ptyId, code: -1 })
+      }
       return true
     },
     getForegroundProcess: async (ptyId) => {

--- a/src/main/providers/local-pty-utils-windows-fallback.test.ts
+++ b/src/main/providers/local-pty-utils-windows-fallback.test.ts
@@ -76,13 +76,13 @@ describe('spawnShellWithFallback on Windows', () => {
       1,
       PWSH7,
       attempts[0].shellArgs,
-      expect.objectContaining({ cwd: 'C:\\repo' })
+      expect.objectContaining({ cwd: 'C:\\repo', useConptyDll: true })
     )
     expect(ptySpawn).toHaveBeenNthCalledWith(
       2,
       WINDOWS_POWERSHELL,
       attempts[1].shellArgs,
-      expect.objectContaining({ cwd: 'C:\\repo' })
+      expect.objectContaining({ cwd: 'C:\\repo', useConptyDll: true })
     )
   })
 

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -160,6 +160,14 @@ export type ShellSpawnResult = {
  * executables with per-shell args, so when the primary fails we retry with the
  * next safe shell instead of leaving the user with no terminal.
  */
+// Why: match the daemon spawn path (pty-subprocess.ts) — the bundled ConPTY
+// has the modern wrap-marker behavior xterm expects; legacy system ConPTY can
+// corrupt full-width TUI rows in scrollback. Without this, degraded-mode and
+// fresh-local spawns silently behave differently from daemon terminals.
+function windowsConptyDllOptions(): { useConptyDll: true } | Record<string, never> {
+  return process.platform === 'win32' ? { useConptyDll: true } : {}
+}
+
 function spawnWindowsFallbackChain(
   params: ShellSpawnParams,
   primaryError: string
@@ -174,7 +182,8 @@ function spawnWindowsFallbackChain(
         cols,
         rows,
         cwd: attempt.effectiveCwd,
-        env
+        env,
+        ...windowsConptyDllOptions()
       })
       console.warn(
         `[pty] Primary shell "${params.shellPath}" failed (${primaryError}), fell back to "${attempt.shellPath}"`
@@ -217,7 +226,14 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
   if (!primaryError) {
     try {
       return {
-        process: ptySpawn(shellPath, shellArgs, { name: termName, cols, rows, cwd, env }),
+        process: ptySpawn(shellPath, shellArgs, {
+          name: termName,
+          cols,
+          rows,
+          cwd,
+          env,
+          ...windowsConptyDllOptions()
+        }),
         shellPath
       }
     } catch (err) {

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -237,11 +237,7 @@ export function disposePane(
   } catch {
     /* ignore */
   }
-  try {
-    pane.webglAddon?.dispose()
-  } catch {
-    /* ignore */
-  }
+  disposeWebgl(pane)
   try {
     pane.searchAddon.dispose()
   } catch {

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -168,6 +168,11 @@ export class PaneManager {
 
   refreshAllPanes(): void {
     for (const pane of this.panes.values()) {
+      // Why: suspended panes are invisible and repaint on rendering resume;
+      // recovery repaints must not scale with hidden-workspace pane count.
+      if (pane.webglAttachmentDeferred) {
+        continue
+      }
       try {
         if (pane.terminal.rows > 0) {
           pane.terminal.refresh(0, pane.terminal.rows - 1)

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -7,6 +7,7 @@ import {
   markComplexScriptOutput,
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
+import { retainSuspendedWebglPane, unretainWebglPane } from './pane-webgl-context-retention'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
 
 export function setPaneGpuRenderingState(
@@ -44,8 +45,14 @@ export function markPaneComplexScriptOutput(
 
 export function suspendPaneRendering(panes: Iterable<ManagedPaneInternal>): void {
   for (const pane of panes) {
+    // Why: deferred blocks NEW context creation while hidden; live contexts
+    // are retained (not disposed) so the return switch repaints instantly
+    // instead of paying ANGLE context re-creation. The LRU cap bounds how
+    // many hidden panes may keep one.
     pane.webglAttachmentDeferred = true
-    disposeWebgl(pane)
+    for (const evicted of retainSuspendedWebglPane(pane)) {
+      disposeWebgl(evicted)
+    }
   }
 }
 
@@ -55,8 +62,23 @@ export function resumePaneRendering(panes: Iterable<ManagedPaneInternal>): void 
   // loss, and bounding retries to resume events cannot loop on live loss.
   clearTerminalWebglAttachBackoff()
   for (const pane of panes) {
+    unretainWebglPane(pane)
     pane.webglAttachmentDeferred = false
     pane.webglDisabledAfterContextLoss = false
+    if (pane.webglAddon) {
+      // Why: recovery bursts skip suspended panes, so the shared glyph atlas
+      // may have been cleared/rebuilt while this pane sat hidden with its
+      // retained context. Repaint from the buffer so stale glyph coordinates
+      // never reach the screen.
+      try {
+        if (pane.terminal.rows > 0) {
+          pane.terminal.refresh(0, pane.terminal.rows - 1)
+        }
+      } catch {
+        /* ignore — pane may be tearing down during resume */
+      }
+      continue
+    }
     reattachWebglIfNeeded(pane)
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -7,7 +7,11 @@ import {
   markComplexScriptOutput,
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
-import { retainSuspendedWebglPane, unretainWebglPane } from './pane-webgl-context-retention'
+import {
+  retainSuspendedWebglPane,
+  shouldRetainSuspendedWebglContexts,
+  unretainWebglPane
+} from './pane-webgl-context-retention'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
 
 export function setPaneGpuRenderingState(
@@ -44,12 +48,17 @@ export function markPaneComplexScriptOutput(
 }
 
 export function suspendPaneRendering(panes: Iterable<ManagedPaneInternal>): void {
+  const retainContexts = shouldRetainSuspendedWebglContexts()
   for (const pane of panes) {
-    // Why: deferred blocks NEW context creation while hidden; live contexts
-    // are retained (not disposed) so the return switch repaints instantly
-    // instead of paying ANGLE context re-creation. The LRU cap bounds how
-    // many hidden panes may keep one.
+    // Why: deferred blocks NEW context creation while hidden; on Windows,
+    // live contexts are retained (not disposed) so the return switch repaints
+    // instantly instead of paying ANGLE context re-creation. The LRU cap
+    // bounds how many hidden panes may keep one.
     pane.webglAttachmentDeferred = true
+    if (!retainContexts) {
+      disposeWebgl(pane)
+      continue
+    }
     for (const evicted of retainSuspendedWebglPane(pane)) {
       disposeWebgl(evicted)
     }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import {
+  clearRetainedWebglPanes,
+  RETAINED_WEBGL_PANE_CAP,
+  retainedWebglPaneCount
+} from './pane-webgl-context-retention'
+import { resumePaneRendering, suspendPaneRendering } from './pane-rendering-control'
+import {
+  attachWebgl,
+  disposeWebgl,
+  resetTerminalWebglSuggestion,
+  resetWebglTextureAtlas
+} from './pane-webgl-renderer'
+
+let nextPaneId = 1
+
+function createPane(): ManagedPaneInternal {
+  const leafId = '11111111-1111-4111-8111-111111111111' as never
+  return {
+    id: nextPaneId++,
+    leafId,
+    stablePaneId: leafId,
+    terminal: {
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn(),
+      loadAddon: vi.fn()
+    } as never,
+    container: {} as never,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'on',
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    webglAddon: null,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    pendingWebglRefreshRafId: null,
+    fitAddon: {
+      proposeDimensions: vi.fn(() => ({ cols: 80, rows: 23 })),
+      fit: vi.fn()
+    } as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+function createAttachedPane(): ManagedPaneInternal {
+  const pane = createPane()
+  attachWebgl(pane)
+  expect(pane.webglAddon).not.toBeNull()
+  return pane
+}
+
+function fireContextLoss(pane: ManagedPaneInternal): void {
+  const addon = pane.webglAddon as unknown as { _onContextLoss: { fire: () => void } }
+  addon._onContextLoss.fire()
+}
+
+describe('terminal WebGL context retention across hide/show', () => {
+  beforeEach(() => {
+    resetTerminalWebglSuggestion()
+    clearRetainedWebglPanes()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    clearRetainedWebglPanes()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the live WebGL addon when rendering is suspended', () => {
+    const pane = createAttachedPane()
+    const addon = pane.webglAddon
+
+    suspendPaneRendering([pane])
+
+    expect(pane.webglAttachmentDeferred).toBe(true)
+    expect(pane.webglAddon).toBe(addon)
+    expect(retainedWebglPaneCount()).toBe(1)
+  })
+
+  it('does not create a new context when resuming a retained pane', () => {
+    const pane = createAttachedPane()
+    const addon = pane.webglAddon
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+
+    suspendPaneRendering([pane])
+    resumePaneRendering([pane])
+
+    expect(pane.webglAddon).toBe(addon)
+    expect(pane.webglAttachmentDeferred).toBe(false)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+    expect(retainedWebglPaneCount()).toBe(0)
+  })
+
+  it('still blocks new context creation while suspended', () => {
+    const pane = createPane()
+
+    suspendPaneRendering([pane])
+    attachWebgl(pane)
+
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+  })
+
+  it('evicts and disposes the least-recently-suspended pane past the cap', () => {
+    const panes = Array.from({ length: RETAINED_WEBGL_PANE_CAP + 2 }, () => createAttachedPane())
+
+    suspendPaneRendering(panes)
+
+    expect(retainedWebglPaneCount()).toBe(RETAINED_WEBGL_PANE_CAP)
+    expect(panes[0].webglAddon).toBeNull()
+    expect(panes[1].webglAddon).toBeNull()
+    expect(panes[2].webglAddon).not.toBeNull()
+    expect(panes.at(-1)?.webglAddon).not.toBeNull()
+  })
+
+  it('re-attaches an evicted pane on resume', () => {
+    const panes = Array.from({ length: RETAINED_WEBGL_PANE_CAP + 1 }, () => createAttachedPane())
+    suspendPaneRendering(panes)
+    expect(panes[0].webglAddon).toBeNull()
+
+    resumePaneRendering([panes[0]])
+
+    expect(panes[0].webglAddon).not.toBeNull()
+    expect(panes[0].terminal.loadAddon).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops the retention entry when a suspended pane is disposed', () => {
+    const pane = createAttachedPane()
+    suspendPaneRendering([pane])
+    expect(retainedWebglPaneCount()).toBe(1)
+
+    disposeWebgl(pane)
+
+    expect(retainedWebglPaneCount()).toBe(0)
+    expect(pane.webglAddon).toBeNull()
+  })
+
+  it('repaints a retained pane on resume so a cleared shared atlas cannot leave stale glyphs', () => {
+    const pane = createAttachedPane()
+    suspendPaneRendering([pane])
+    vi.mocked(pane.terminal.refresh).mockClear()
+
+    resumePaneRendering([pane])
+
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, pane.terminal.rows - 1)
+  })
+
+  it('skips suspended panes during atlas recovery resets', () => {
+    const pane = createAttachedPane()
+    const clearTextureAtlas = vi.fn()
+    ;(pane.webglAddon as unknown as { clearTextureAtlas: () => void }).clearTextureAtlas =
+      clearTextureAtlas
+    suspendPaneRendering([pane])
+    vi.mocked(pane.terminal.refresh).mockClear()
+
+    resetWebglTextureAtlas(pane)
+
+    expect(clearTextureAtlas).not.toHaveBeenCalled()
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+  })
+
+  it('drops the retention entry on context loss while hidden and recovers on resume', () => {
+    const pane = createAttachedPane()
+    suspendPaneRendering([pane])
+
+    fireContextLoss(pane)
+
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.webglDisabledAfterContextLoss).toBe(true)
+    expect(retainedWebglPaneCount()).toBe(0)
+
+    resumePaneRendering([pane])
+
+    expect(pane.webglDisabledAfterContextLoss).toBe(false)
+    expect(pane.webglAddon).not.toBeNull()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.test.ts
@@ -66,16 +66,21 @@ function fireContextLoss(pane: ManagedPaneInternal): void {
   addon._onContextLoss.fire()
 }
 
-describe('terminal WebGL context retention across hide/show', () => {
+function stubCommonGlobals(userAgent: string): void {
+  vi.stubGlobal('navigator', { userAgent })
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(16)
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+}
+
+describe('terminal WebGL context retention across hide/show (Windows)', () => {
   beforeEach(() => {
     resetTerminalWebglSuggestion()
     clearRetainedWebglPanes()
     vi.spyOn(console, 'warn').mockImplementation(() => {})
-    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-      callback(16)
-      return 1
-    })
-    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    stubCommonGlobals('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
   })
 
   afterEach(() => {
@@ -191,5 +196,40 @@ describe('terminal WebGL context retention across hide/show', () => {
 
     expect(pane.webglDisabledAfterContextLoss).toBe(false)
     expect(pane.webglAddon).not.toBeNull()
+  })
+})
+
+describe('terminal WebGL context retention is Windows-only', () => {
+  beforeEach(() => {
+    resetTerminalWebglSuggestion()
+    clearRetainedWebglPanes()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    stubCommonGlobals('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+  })
+
+  afterEach(() => {
+    clearRetainedWebglPanes()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the dispose-on-hide behavior off Windows', () => {
+    const pane = createAttachedPane()
+
+    suspendPaneRendering([pane])
+
+    expect(pane.webglAttachmentDeferred).toBe(true)
+    expect(pane.webglAddon).toBeNull()
+    expect(retainedWebglPaneCount()).toBe(0)
+  })
+
+  it('re-attaches on resume off Windows as before', () => {
+    const pane = createAttachedPane()
+    suspendPaneRendering([pane])
+
+    resumePaneRendering([pane])
+
+    expect(pane.webglAddon).not.toBeNull()
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.ts
@@ -5,8 +5,9 @@ import type { ManagedPaneInternal } from './pane-manager-types'
 // and recreate it on return — ~5ms on macOS but 100-500ms per pane on Windows
 // (ANGLE → D3D11), paid synchronously on the switch path. With the app-level
 // context budget raised to 128 (#7064), hidden panes can keep their contexts;
-// this LRU cap only bounds hidden-pane GPU memory.
-export const RETAINED_WEBGL_PANE_CAP = 16
+// this LRU cap only bounds hidden-pane GPU memory. Sized for the reported hot
+// set (~10-16 worktrees × ~2 terminals) while staying far under the budget.
+export const RETAINED_WEBGL_PANE_CAP = 32
 
 /** Windows-only: context re-creation is cheap on macOS/Linux GL, so hidden
  *  panes there keep the long-proven dispose-on-hide behavior instead of

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.ts
@@ -1,0 +1,47 @@
+import type { ManagedPaneInternal } from './pane-manager-types'
+
+// Why: workspace switches used to dispose every hidden pane's WebGL context
+// and recreate it on return — ~5ms on macOS but 100-500ms per pane on Windows
+// (ANGLE → D3D11), paid synchronously on the switch path. With the app-level
+// context budget raised to 128 (#7064), hidden panes can keep their contexts;
+// this LRU cap only bounds hidden-pane GPU memory.
+export const RETAINED_WEBGL_PANE_CAP = 16
+
+// Insertion order doubles as LRU order: re-retaining deletes + re-adds.
+const retainedPanes = new Set<ManagedPaneInternal>()
+
+/**
+ * Registers a suspended pane's live WebGL context for retention across
+ * hide/show. Returns panes evicted by the cap — the caller disposes them
+ * (dependency points that way to avoid a cycle with pane-webgl-renderer).
+ */
+export function retainSuspendedWebglPane(pane: ManagedPaneInternal): ManagedPaneInternal[] {
+  if (!pane.webglAddon) {
+    return []
+  }
+  retainedPanes.delete(pane)
+  retainedPanes.add(pane)
+  const evicted: ManagedPaneInternal[] = []
+  while (retainedPanes.size > RETAINED_WEBGL_PANE_CAP) {
+    const oldest = retainedPanes.values().next().value
+    if (!oldest) {
+      break
+    }
+    retainedPanes.delete(oldest)
+    evicted.push(oldest)
+  }
+  return evicted
+}
+
+export function unretainWebglPane(pane: ManagedPaneInternal): void {
+  retainedPanes.delete(pane)
+}
+
+export function retainedWebglPaneCount(): number {
+  return retainedPanes.size
+}
+
+/** Drops all retention entries without disposing anything (test isolation). */
+export function clearRetainedWebglPanes(): void {
+  retainedPanes.clear()
+}

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-retention.ts
@@ -1,3 +1,4 @@
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import type { ManagedPaneInternal } from './pane-manager-types'
 
 // Why: workspace switches used to dispose every hidden pane's WebGL context
@@ -6,6 +7,13 @@ import type { ManagedPaneInternal } from './pane-manager-types'
 // context budget raised to 128 (#7064), hidden panes can keep their contexts;
 // this LRU cap only bounds hidden-pane GPU memory.
 export const RETAINED_WEBGL_PANE_CAP = 16
+
+/** Windows-only: context re-creation is cheap on macOS/Linux GL, so hidden
+ *  panes there keep the long-proven dispose-on-hide behavior instead of
+ *  paying retention's GPU-memory cost for no perceptible switch latency win. */
+export function shouldRetainSuspendedWebglContexts(): boolean {
+  return getRendererAppPlatform() === 'win32'
+}
 
 // Insertion order doubles as LRU order: re-retaining deletes + re-adds.
 const retainedPanes = new Set<ManagedPaneInternal>()

--- a/src/renderer/src/lib/pane-manager/pane-webgl-refresh-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-refresh-lifecycle.test.ts
@@ -65,6 +65,30 @@ describe('pane WebGL refresh lifecycle', () => {
     expect(pane.pendingWebglRefreshRafId).toBe(29)
   })
 
+  it('actively releases the xterm WebGL context before disposing the addon', () => {
+    const loseContext = vi.fn()
+    const canvas = { width: 120, height: 40 }
+    const dispose = vi.fn()
+    const pane = createPane({
+      webglAddon: {
+        dispose,
+        _renderer: {
+          _gl: {
+            getExtension: vi.fn(() => ({ loseContext }))
+          },
+          _canvas: canvas
+        }
+      } as never
+    })
+
+    disposeWebgl(pane)
+
+    expect(loseContext).toHaveBeenCalledTimes(1)
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(canvas).toEqual({ width: 0, height: 0 })
+    expect(pane.webglAddon).toBeNull()
+  })
+
   it('cancels a pending WebGL refresh when the pane is disposed', () => {
     const cancelAnimationFrame = vi.fn()
     vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -1,5 +1,6 @@
 import { WebglAddon } from '@xterm/addon-webgl'
 import type { ManagedPaneInternal } from './pane-manager-types'
+import { unretainWebglPane } from './pane-webgl-context-retention'
 import {
   getTerminalWebglAutoDecision,
   resetTerminalWebglAutoDecision
@@ -72,6 +73,10 @@ export function disposeWebgl(
   options?: { refreshDimensions?: boolean }
 ): void {
   cancelPendingWebglRefresh(pane)
+  // Why: every dispose path (pane close, context loss, GPU-setting off) must
+  // drop the retention entry, or the LRU would later evict-dispose a pane
+  // whose addon was already gone.
+  unretainWebglPane(pane)
   if (!pane.webglAddon) {
     return
   }
@@ -118,7 +123,11 @@ export function markComplexScriptOutput(pane: ManagedPaneInternal): void {
 }
 
 export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
-  if (pane.webglDisabledAfterContextLoss) {
+  // Why: suspended panes keep retained contexts but are invisible; their
+  // rebuild is deferred to resumePaneRendering. Clearing + repainting them
+  // here would make every recovery burst scale with total pane count across
+  // all workspaces instead of visible panes.
+  if (pane.webglDisabledAfterContextLoss || pane.webglAttachmentDeferred) {
     return
   }
   try {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -14,6 +14,17 @@ let suggestedRendererType: 'dom' | undefined
 // until the next recovery boundary (rendering resume or GPU-setting change).
 let webglAttachFailedSinceRecovery = false
 
+type ReleasableWebglContext = {
+  getExtension(name: 'WEBGL_lose_context'): WEBGL_lose_context | null
+}
+
+type XtermWebglAddonInternals = {
+  _renderer?: {
+    _gl?: ReleasableWebglContext
+    _canvas?: HTMLCanvasElement
+  }
+}
+
 export function resetTerminalWebglSuggestion(): void {
   // Why: toggling GPU settings should let "auto" retry WebGL after an earlier
   // attach failure suggested DOM rendering for this app session.
@@ -64,6 +75,7 @@ export function disposeWebgl(
   if (!pane.webglAddon) {
     return
   }
+  releaseXtermWebglContext(pane.webglAddon)
   try {
     pane.webglAddon.dispose()
   } catch {
@@ -82,6 +94,22 @@ export function disposeWebgl(
         /* ignore — pane may have been disposed in the meantime */
       }
     })
+  }
+}
+
+function releaseXtermWebglContext(webglAddon: ManagedPaneInternal['webglAddon']): void {
+  try {
+    // Why: xterm removes the canvas on dispose, but Windows/ANGLE can keep the
+    // driver context alive long enough for rapid terminal activation to hit
+    // Chromium's active WebGL context budget (#6874).
+    const renderer = (webglAddon as unknown as XtermWebglAddonInternals | null)?._renderer
+    renderer?._gl?.getExtension('WEBGL_lose_context')?.loseContext()
+    if (renderer?._canvas) {
+      renderer._canvas.width = 0
+      renderer._canvas.height = 0
+    }
+  } catch {
+    /* ignore - WebGL teardown must not block fallback to the DOM renderer */
   }
 }
 

--- a/tools/benchmarks/results/terminal-perf-baseline-2026-07-02T07-23-46-933Z.json
+++ b/tools/benchmarks/results/terminal-perf-baseline-2026-07-02T07-23-46-933Z.json
@@ -1,0 +1,1041 @@
+{
+  "label": "baseline",
+  "startedAt": "2026-07-02T07:23:46.933Z",
+  "platform": "win32 10.0.26200",
+  "shell": "default",
+  "args": {
+    "iterations": 8,
+    "switches": 24,
+    "cycles": 12
+  },
+  "scenarios": {
+    "tab-create": {
+      "samples": [
+        {
+          "index": 0,
+          "storeCreateMs": 2.700000047683716,
+          "ptyBindMs": 5853.5,
+          "firstOutputMs": 5875.900000035763,
+          "paintSettleMs": 5878.100000023842,
+          "timedOut": false
+        },
+        {
+          "index": 1,
+          "storeCreateMs": 1.9000000357627869,
+          "ptyBindMs": 476.9000000357628,
+          "firstOutputMs": 489.10000002384186,
+          "paintSettleMs": 493.10000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 2,
+          "storeCreateMs": 1.9000000357627869,
+          "ptyBindMs": 381.60000002384186,
+          "firstOutputMs": 401,
+          "paintSettleMs": 404.10000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 3,
+          "storeCreateMs": 1.300000011920929,
+          "ptyBindMs": 391.10000002384186,
+          "firstOutputMs": 405.80000001192093,
+          "paintSettleMs": 408.10000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 4,
+          "storeCreateMs": 1.5,
+          "ptyBindMs": 454,
+          "firstOutputMs": 467.80000001192093,
+          "paintSettleMs": 474,
+          "timedOut": false
+        },
+        {
+          "index": 5,
+          "storeCreateMs": 2,
+          "ptyBindMs": 527.6999999880791,
+          "firstOutputMs": 544.5,
+          "paintSettleMs": 551.3999999761581,
+          "timedOut": false
+        },
+        {
+          "index": 6,
+          "storeCreateMs": 1.9000000357627869,
+          "ptyBindMs": 483.60000002384186,
+          "firstOutputMs": 498.5,
+          "paintSettleMs": 501.10000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 7,
+          "storeCreateMs": 1.600000023841858,
+          "ptyBindMs": 492.89999997615814,
+          "firstOutputMs": 509.19999998807907,
+          "paintSettleMs": 517,
+          "timedOut": false
+        }
+      ],
+      "longtasks": [
+        411, 65, 184, 124, 191, 163, 141, 183, 59, 158, 217, 61, 61, 253, 89, 70, 248, 152, 73, 170,
+        184, 160, 178, 176, 151
+      ]
+    },
+    "tab-switch": {
+      "samples": [
+        {
+          "index": 0,
+          "targetTabId": "3db20953-661a-4e65-8e4c-ca6a6f9d0538",
+          "storeMs": 1.100000023841858,
+          "paneVisibleMs": 1.100000023841858,
+          "paintSettleMs": 109,
+          "timedOut": false
+        },
+        {
+          "index": 1,
+          "targetTabId": "f4dca755-e41c-4f03-aa25-ed67526ca90e",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 114.5,
+          "timedOut": false
+        },
+        {
+          "index": 2,
+          "targetTabId": "8f40ca49-476c-4959-ae9f-f976293e0b62",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 138.5,
+          "timedOut": false
+        },
+        {
+          "index": 3,
+          "targetTabId": "d7adfbbb-a7eb-48ed-876b-440835e7174f",
+          "storeMs": 1.100000023841858,
+          "paneVisibleMs": 1.100000023841858,
+          "paintSettleMs": 73,
+          "timedOut": false
+        },
+        {
+          "index": 4,
+          "targetTabId": "3db20953-661a-4e65-8e4c-ca6a6f9d0538",
+          "storeMs": 1.800000011920929,
+          "paneVisibleMs": 1.800000011920929,
+          "paintSettleMs": 79.60000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 5,
+          "targetTabId": "f4dca755-e41c-4f03-aa25-ed67526ca90e",
+          "storeMs": 2,
+          "paneVisibleMs": 2,
+          "paintSettleMs": 43.80000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 6,
+          "targetTabId": "8f40ca49-476c-4959-ae9f-f976293e0b62",
+          "storeMs": 2.5,
+          "paneVisibleMs": 2.5,
+          "paintSettleMs": 125.89999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 7,
+          "targetTabId": "d7adfbbb-a7eb-48ed-876b-440835e7174f",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 116.5,
+          "timedOut": false
+        },
+        {
+          "index": 8,
+          "targetTabId": "3db20953-661a-4e65-8e4c-ca6a6f9d0538",
+          "storeMs": 1.399999976158142,
+          "paneVisibleMs": 1.399999976158142,
+          "paintSettleMs": 51.80000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 9,
+          "targetTabId": "f4dca755-e41c-4f03-aa25-ed67526ca90e",
+          "storeMs": 1,
+          "paneVisibleMs": 1,
+          "paintSettleMs": 45.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 10,
+          "targetTabId": "8f40ca49-476c-4959-ae9f-f976293e0b62",
+          "storeMs": 1.600000023841858,
+          "paneVisibleMs": 1.600000023841858,
+          "paintSettleMs": 50.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 11,
+          "targetTabId": "d7adfbbb-a7eb-48ed-876b-440835e7174f",
+          "storeMs": 1.399999976158142,
+          "paneVisibleMs": 1.399999976158142,
+          "paintSettleMs": 97.89999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 12,
+          "targetTabId": "3db20953-661a-4e65-8e4c-ca6a6f9d0538",
+          "storeMs": 1.0999999642372131,
+          "paneVisibleMs": 1.0999999642372131,
+          "paintSettleMs": 112.5,
+          "timedOut": false
+        },
+        {
+          "index": 13,
+          "targetTabId": "f4dca755-e41c-4f03-aa25-ed67526ca90e",
+          "storeMs": 2.100000023841858,
+          "paneVisibleMs": 2.100000023841858,
+          "paintSettleMs": 48.69999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 14,
+          "targetTabId": "8f40ca49-476c-4959-ae9f-f976293e0b62",
+          "storeMs": 1.399999976158142,
+          "paneVisibleMs": 1.5,
+          "paintSettleMs": 35.09999996423721,
+          "timedOut": false
+        },
+        {
+          "index": 15,
+          "targetTabId": "d7adfbbb-a7eb-48ed-876b-440835e7174f",
+          "storeMs": 1,
+          "paneVisibleMs": 1,
+          "paintSettleMs": 28.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 16,
+          "targetTabId": "3db20953-661a-4e65-8e4c-ca6a6f9d0538",
+          "storeMs": 0.8999999761581421,
+          "paneVisibleMs": 0.8999999761581421,
+          "paintSettleMs": 35.09999996423721,
+          "timedOut": false
+        },
+        {
+          "index": 17,
+          "targetTabId": "f4dca755-e41c-4f03-aa25-ed67526ca90e",
+          "storeMs": 1.300000011920929,
+          "paneVisibleMs": 1.300000011920929,
+          "paintSettleMs": 150.70000004768372,
+          "timedOut": false
+        },
+        {
+          "index": 18,
+          "targetTabId": "8f40ca49-476c-4959-ae9f-f976293e0b62",
+          "storeMs": 1.9000000357627869,
+          "paneVisibleMs": 1.9000000357627869,
+          "paintSettleMs": 95.60000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 19,
+          "targetTabId": "d7adfbbb-a7eb-48ed-876b-440835e7174f",
+          "storeMs": 2.099999964237213,
+          "paneVisibleMs": 2.099999964237213,
+          "paintSettleMs": 75.79999995231628,
+          "timedOut": false
+        },
+        {
+          "index": 20,
+          "targetTabId": "3db20953-661a-4e65-8e4c-ca6a6f9d0538",
+          "storeMs": 1.2000000476837158,
+          "paneVisibleMs": 1.2000000476837158,
+          "paintSettleMs": 40.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 21,
+          "targetTabId": "f4dca755-e41c-4f03-aa25-ed67526ca90e",
+          "storeMs": 1.5999999642372131,
+          "paneVisibleMs": 1.5999999642372131,
+          "paintSettleMs": 30.099999964237213,
+          "timedOut": false
+        },
+        {
+          "index": 22,
+          "targetTabId": "8f40ca49-476c-4959-ae9f-f976293e0b62",
+          "storeMs": 1.399999976158142,
+          "paneVisibleMs": 1.399999976158142,
+          "paintSettleMs": 86.89999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 23,
+          "targetTabId": "d7adfbbb-a7eb-48ed-876b-440835e7174f",
+          "storeMs": 1.300000011920929,
+          "paneVisibleMs": 1.300000011920929,
+          "paintSettleMs": 133,
+          "timedOut": false
+        }
+      ],
+      "longtasks": [98, 109, 130, 66, 71, 117, 110, 94, 100, 144, 91, 64, 82, 122]
+    },
+    "workspace-switch": {
+      "samples": [
+        {
+          "index": 0,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo@@f226ee15",
+          "activationMs": 202,
+          "ptyBindMs": 204,
+          "paintSettleMs": 211
+        },
+        {
+          "index": 1,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one@@d00bc639",
+          "activationMs": 406,
+          "ptyBindMs": 550,
+          "paintSettleMs": 563
+        },
+        {
+          "index": 2,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two@@e12f992a",
+          "activationMs": 373,
+          "ptyBindMs": 476,
+          "paintSettleMs": 488
+        },
+        {
+          "index": 3,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo@@f226ee15",
+          "activationMs": 205,
+          "ptyBindMs": 251,
+          "paintSettleMs": 258
+        },
+        {
+          "index": 4,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one@@d00bc639",
+          "activationMs": 345,
+          "ptyBindMs": 369,
+          "paintSettleMs": 379
+        },
+        {
+          "index": 5,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two@@e12f992a",
+          "activationMs": 149,
+          "ptyBindMs": 177,
+          "paintSettleMs": 184
+        },
+        {
+          "index": 6,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo@@f226ee15",
+          "activationMs": 147,
+          "ptyBindMs": 162,
+          "paintSettleMs": 170
+        },
+        {
+          "index": 7,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one@@d00bc639",
+          "activationMs": 178,
+          "ptyBindMs": 202,
+          "paintSettleMs": 208
+        },
+        {
+          "index": 8,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two@@e12f992a",
+          "activationMs": 336,
+          "ptyBindMs": 366,
+          "paintSettleMs": 375
+        },
+        {
+          "index": 9,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo@@f226ee15",
+          "activationMs": 157,
+          "ptyBindMs": 192,
+          "paintSettleMs": 200
+        },
+        {
+          "index": 10,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one@@d00bc639",
+          "activationMs": 140,
+          "ptyBindMs": 164,
+          "paintSettleMs": 173
+        },
+        {
+          "index": 11,
+          "worktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two",
+          "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two@@e12f992a",
+          "activationMs": 159,
+          "ptyBindMs": 188,
+          "paintSettleMs": 199
+        }
+      ]
+    }
+  },
+  "summaries": [
+    {
+      "name": "tab-create",
+      "samples": 8,
+      "timedOut": 0,
+      "fields": {
+        "storeCreateMs": {
+          "count": 8,
+          "median": 2,
+          "p95": 3,
+          "max": 3
+        },
+        "ptyBindMs": {
+          "count": 8,
+          "median": 484,
+          "p95": 5854,
+          "max": 5854
+        },
+        "firstOutputMs": {
+          "count": 8,
+          "median": 499,
+          "p95": 5876,
+          "max": 5876
+        },
+        "paintSettleMs": {
+          "count": 8,
+          "median": 501,
+          "p95": 5878,
+          "max": 5878
+        }
+      },
+      "longtaskCount": 25,
+      "longtaskMaxMs": 411
+    },
+    {
+      "name": "tab-switch",
+      "samples": 24,
+      "timedOut": 0,
+      "fields": {
+        "storeMs": {
+          "count": 24,
+          "median": 1,
+          "p95": 2,
+          "max": 3
+        },
+        "paneVisibleMs": {
+          "count": 24,
+          "median": 2,
+          "p95": 2,
+          "max": 3
+        },
+        "paintSettleMs": {
+          "count": 24,
+          "median": 80,
+          "p95": 139,
+          "max": 151
+        }
+      },
+      "longtaskCount": 14,
+      "longtaskMaxMs": 144
+    },
+    {
+      "name": "workspace-switch",
+      "samples": 12,
+      "timedOut": 0,
+      "fields": {
+        "activationMs": {
+          "count": 12,
+          "median": 202,
+          "p95": 373,
+          "max": 406
+        },
+        "ptyBindMs": {
+          "count": 12,
+          "median": 204,
+          "p95": 476,
+          "max": 550
+        },
+        "paintSettleMs": {
+          "count": 12,
+          "median": 211,
+          "p95": 488,
+          "max": 563
+        }
+      },
+      "longtaskCount": 0,
+      "longtaskMaxMs": 0
+    }
+  ],
+  "finalDiagnostics": {
+    "hasStore": true,
+    "workspaceSessionReady": true,
+    "hydrationSucceeded": true,
+    "activeView": "terminal",
+    "activeRepoId": "f93c43c3-57ef-4811-8edc-73d924918ed8",
+    "activeWorktreeId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two",
+    "activeTabType": "terminal",
+    "activeTabId": "2a067075-6acf-4aca-a0a6-bc88c1e6abc7",
+    "terminalGpuAcceleration": "auto",
+    "repoCount": 1,
+    "worktreeCountsByRepo": {
+      "f93c43c3-57ef-4811-8edc-73d924918ed8": 3
+    },
+    "ptyIdsByTabId": [
+      "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two@@e12f992a"
+    ],
+    "paneManagerCount": 3,
+    "activePane": {
+      "id": 1,
+      "leafId": "6a3ca793-864f-4182-bec5-5b044a884b9b",
+      "ptyId": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two@@e12f992a",
+      "cols": 175,
+      "rows": 73,
+      "buffer": {
+        "baseY": 0,
+        "viewportY": 0,
+        "cursorY": 0,
+        "length": 73
+      }
+    },
+    "renderingDiagnostics": [
+      {
+        "paneId": 1,
+        "terminalGpuAcceleration": "auto",
+        "gpuRenderingEnabled": true,
+        "webglAttachmentDeferred": false,
+        "webglDisabledAfterContextLoss": false,
+        "hasComplexScriptOutput": false,
+        "terminalWebglAutoDecision": {
+          "allowWebgl": true,
+          "reason": "non-linux",
+          "renderer": null,
+          "vendor": null
+        },
+        "hasWebgl": true
+      }
+    ],
+    "allPaneManagersDiagnostics": [
+      {
+        "tabId": "ab3a14da-e087-4677-9fa8-df990c149951",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": true,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": false
+          }
+        ]
+      },
+      {
+        "tabId": "afdd9731-982a-4255-8c0e-b4360453f433",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": true,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": false
+          }
+        ]
+      },
+      {
+        "tabId": "2a067075-6acf-4aca-a0a6-bc88c1e6abc7",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": false,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      }
+    ],
+    "webglContextCounts": {
+      "attachedWebglCount": 1,
+      "deferredWebglCount": 2,
+      "managerCount": 3,
+      "paneCount": 3
+    },
+    "webglIdentity": {
+      "available": true,
+      "vendor": "Google Inc. (Intel)",
+      "renderer": "ANGLE (Intel, Intel(R) Arc(TM) Graphics (0x00007D55) Direct3D11 vs_5_0 ps_5_0, D3D11)"
+    },
+    "rendererProbe": {
+      "intervalMs": 50,
+      "last": 50268.60000002384,
+      "maxDriftMs": 440.10000002384186,
+      "samples": 335,
+      "startedAt": 25060.600000023842,
+      "lastTickAt": 50268.60000002384
+    },
+    "ptySessions": {
+      "value": [
+        {
+          "id": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/repo@@f226ee15",
+          "cwd": "",
+          "title": "shell"
+        },
+        {
+          "id": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-one@@d00bc639",
+          "cwd": "",
+          "title": "shell"
+        },
+        {
+          "id": "f93c43c3-57ef-4811-8edc-73d924918ed8::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-uLA6Xx/wt-two@@e12f992a",
+          "cwd": "",
+          "title": "shell"
+        }
+      ]
+    },
+    "rendererDeliveryDebug": {
+      "value": {
+        "pendingPtyCount": 0,
+        "pendingChars": 0,
+        "maxPendingCharsByPty": 0,
+        "rendererInFlightPtyCount": 0,
+        "rendererInFlightChars": 0,
+        "maxRendererInFlightCharsByPty": 0,
+        "activeRendererPtyCount": 1,
+        "flushScheduled": false,
+        "peakPendingChars": 82,
+        "peakMaxPendingCharsByPty": 82,
+        "peakRendererInFlightChars": 82,
+        "peakMaxRendererInFlightCharsByPty": 82,
+        "ackGatedFlushSkipCount": 0
+      }
+    }
+  },
+  "cleanupErrors": [],
+  "elapsedMs": 71875,
+  "appLogsTail": [
+    {
+      "source": "stderr",
+      "line": "https://electronjs.org/docs/tutorial/security.",
+      "at": 1782977071571
+    },
+    {
+      "source": "stderr",
+      "line": "This warning will not show up",
+      "at": 1782977071571
+    },
+    {
+      "source": "stderr",
+      "line": "once the app is packaged.\", source: node:electron/js2c/sandbox_bundle (2)",
+      "at": 1782977071571
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-settings-done t=30952 rendererT=23288 durationMs=454",
+      "at": 1782977071792
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-settings-done t=31069 rendererT=23405 durationMs=533",
+      "at": 1782977071909
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032432.013:INFO:CONSOLE:1078] \"%cReact Grab v0.1.34%c",
+      "at": 1782977072013
+    },
+    {
+      "source": "stderr",
+      "line": "https://react-grab.com background: #330039; color: #ffffff; border: 1px solid #d75fcb; padding: 4px 4px 4px 24px; border-radius: 4px; background-image: url(\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyOTQgMjk0Ij48cGF0aCBmaWxsPSIjZmY0MGUwIiBkPSJNMTQ1IDQ3YzI1LTIwIDUwLTI3IDY3LTE3IDE2IDkgMjMgMzAgMjAgNjAgMCAyLTEgNS0xIDdsLTIgMTNoLTFsLTEyLTRjLTgtMy0xNy01LTI1LTZsLTE3LTNjLTEwLTEtMjAtMS0yOS0xLTEwIDAtMjAgMC0yOSAxLTYgOC0xMSAxNi0xNiAyNC01IDktOSAxNy0xMyAyNiA0IDkgOCAxOCAxMyAyNnMxMCAxNiAxNiAyNGwxMSAxNGM1IDcgMTEgMTMgMTggMTlsMTAgOHMtMSAwIDAgMGwtMTEgOWMtMTcgMTQtMzUgMjItNDkgMjItNiAwLTEzLTItMTgtNS0xNi05LTIzLTMwLTIwLTU5IDEtMyAxLTUgMS04LTMwLTEyLTQ4LTI5LTQ4LTUwIDAtMTggMTQtMzUgNDEtNDcgMi0xIDUtMiA3LTMgMC0yIDAtNS0xLTctMy0zMCA0LTUxIDIwLTYwIDE4LTEwIDQyLTMgNjggMTdNNzEgMjAxYy0xIDItMSA0LTEgNS0yIDI0IDMgNDEgMTMgNDdoMWMxMSA3IDMwIDEgNTEtMTUtMTAtOS0xOC0xOC0yNi0yOS0xMy0xLTI2LTQtMzgtOG05LTM4Yy0zIDktNSAxNy03IDI2IDggMiAxNyA0IDI1IDYtMy01LTYtMTAtOS0xNi0zLTUtNi0xMC05LTE2bS0xOS01M2MtMiAxLTMgMS01IDItMjEgMTAtMzQgMjMtMzQgMzUgMCAxMyAxNCAyNyAzOSAzNyAzLTEyIDctMjUgMTItMzctNS0xMi05LTI0LTEyLTM3bTM3LTEwYy04IDEtMTcgMy0yNSA2IDIgOCA0IDE2IDcgMjUgMy01IDYtMTEgOS0xNnptLTMtNjFjLTQtMS04IDAtMTIgMi0xMCA3LTE1IDI0LTEzIDQ3IDAgMiAwIDMgMSA1IDEyLTQgMjUtNiAzOC04IDgtMTAgMTYtMjAgMjYtMjktMTUtMTEtMjktMTctNDAtMTdtMTExIDJjLTQtMi04LTMtMTItMi0xMSAwLTI1IDUtNDAgMTcgMTAgOSAxOSAxOSAyNiAyOSAxMyAyIDI2IDQgMzkgOHYtNWMzLTIzLTItNDAtMTMtNDdtLTYxIDIzYy03IDYtMTMgMTMtMTkgMTloMzdjLTYtNi0xMi0xMy0xOC0xOSIvPjxtYXNrIGlkPSJhIj48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMjM1IDg1LTEzMyAyNyAyOCAxMzMgMTMzLTI3WiIvPjwvbWFzaz48cGF0aCBmaWxsPSIjZmY0MGUwIiBkPSJtMTM3IDEzMCA3NiAxMWM4IDEgOSAxMSAzIDE1bC0yOCAxNi00IDMyYy0xIDgtMTAgMTAtMTQgNGwtNDEtNjZjLTMtNiAxLTEzIDgtMTIiIG1hc2s9InVybCgjYSkiLz48L3N2Zz4=\"); background-size: 16px 16px; background-repeat: no-repeat; background-position: 4px center; display: inline-block; margin-bottom: 4px; \", source: http://localhost:5173/@fs/C:/Users/jinwo/orca/workspaces/orca/windows-performance-improvement/node_modules/.vite/deps/react-grab.js?v=e74fde05 (1078)",
+      "at": 1782977072013
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=31229 maxGapMs=223",
+      "at": 1782977072070
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-repos-done t=31330 rendererT=23666 durationMs=378",
+      "at": 1782977072171
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-repos-done t=31330 rendererT=23667 durationMs=262",
+      "at": 1782977072171
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-project-groups-done t=31425 rendererT=23762 durationMs=95",
+      "at": 1782977072266
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-project-groups-done t=31426 rendererT=23762 durationMs=96",
+      "at": 1782977072266
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032432.274:INFO:CONSOLE:1080] \"[React Grab] v0.1.34 is outdated (latest: v0.1.47). Run `npx grab@latest upgrade` to upgrade.\", source: http://localhost:5173/@fs/C:/Users/jinwo/orca/workspaces/orca/windows-performance-improvement/node_modules/.vite/deps/react-grab.js?v=e74fde05 (1080)",
+      "at": 1782977072274
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-folder-workspaces-done t=31469 rendererT=23805 durationMs=43",
+      "at": 1782977072309
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktrees-done t=31469 rendererT=23806 durationMs=1",
+      "at": 1782977072310
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-folder-workspaces-done t=31470 rendererT=23807 durationMs=44",
+      "at": 1782977072311
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktrees-done t=31470 rendererT=23807 durationMs=0",
+      "at": 1782977072311
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktree-lineage-done t=31486 rendererT=23823 durationMs=16",
+      "at": 1782977072327
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktree-lineage-done t=31490 rendererT=23827 durationMs=20",
+      "at": 1782977072331
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ui-get-done t=31511 rendererT=23848 durationMs=25",
+      "at": 1782977072352
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-persisted-ui-done t=31511 rendererT=23848 durationMs=0",
+      "at": 1782977072352
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ui-get-done t=31512 rendererT=23848 durationMs=22",
+      "at": 1782977072353
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-persisted-ui-done t=31515 rendererT=23851 durationMs=3",
+      "at": 1782977072355
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032432.892:INFO:CONSOLE:397] \"Tooltip is changing from uncontrolled to controlled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.\", source: http://localhost:5173/@fs/C:/Users/jinwo/orca/workspaces/orca/windows-performance-improvement/node_modules/.vite/deps/chunk-22L5D3A7.js?v=33341407 (397)",
+      "at": 1782977072892
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-session-get-done t=32052 rendererT=24110 durationMs=262",
+      "at": 1782977072893
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-session-get-done t=32054 rendererT=24149 durationMs=298",
+      "at": 1782977072894
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-keybindings-done t=32142 rendererT=24479 durationMs=368",
+      "at": 1782977072983
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-keybindings-done t=32218 rendererT=24554 durationMs=405",
+      "at": 1782977073059
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-session-stores-done t=32222 rendererT=24559 durationMs=5",
+      "at": 1782977073063
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-visit-timestamp-prune-done t=32225 rendererT=24560 durationMs=1",
+      "at": 1782977073066
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-browser-session-profiles-done t=32574 rendererT=24606 durationMs=46",
+      "at": 1782977073415
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-onboarding-get-done t=32587 rendererT=24924 durationMs=318",
+      "at": 1782977073428
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ssh-reconnect-skipped t=32588 rendererT=24924 connectionIds=0",
+      "at": 1782977073428
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-first-window-services-await-done t=32628 rendererT=24965 durationMs=41",
+      "at": 1782977073472
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-reconnect-terminals-done t=32675 rendererT=25011 durationMs=46",
+      "at": 1782977073515
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-startup-hydration-done t=32677 rendererT=25013 durationMs=2142",
+      "at": 1782977073517
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=33422 maxGapMs=401",
+      "at": 1782977074262
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=35433 maxGapMs=309",
+      "at": 1782977076274
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=37456 maxGapMs=10",
+      "at": 1782977078296
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032438.587:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=ab3a14da-e087-4677-9fa8-df990c149951 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=ab3a14da-e087-4677-9fa8-df990c149951:4f90bd45-a941-4d4f-b132-614d700c43c8\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977078587
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032438.587:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977078587
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032438.636:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=0d6b052e-77c8-463f-afc9-d8f151d2cdeb restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=0d6b052e-77c8-463f-afc9-d8f151d2cdeb:69c12565-c05a-493d-8de2-11ff97619d51\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977078637
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032438.636:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977078637
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=39469 maxGapMs=57",
+      "at": 1782977080309
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032441.957:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=c9f77dc6-cd6f-4965-809c-c09127a40a03 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=c9f77dc6-cd6f-4965-809c-c09127a40a03:f1346d6f-965f-41fb-924b-764c7e3fc305\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977081957
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032441.957:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977081957
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=41474 maxGapMs=48",
+      "at": 1782977082314
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032442.858:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=cfb07cef-9bf1-4c78-996b-849186b593a4 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=cfb07cef-9bf1-4c78-996b-849186b593a4:de8f4a47-b5c9-4bf7-a650-1689aba5a8a8\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977082858
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032442.858:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977082858
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032443.702:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=3a994118-6004-4225-9c79-b7f00e7d72f1 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=3a994118-6004-4225-9c79-b7f00e7d72f1:89f847c7-b204-4b3a-b4cf-06f5c8c513bd\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977083702
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032443.702:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977083702
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=43486 maxGapMs=53",
+      "at": 1782977084327
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032444.556:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=8fc5cf91-915a-4244-a4da-1724f3682004 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=8fc5cf91-915a-4244-a4da-1724f3682004:805fa077-9c84-409e-95c0-d6974394f92a\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977084556
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032444.556:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977084556
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032444.635:INFO:CONSOLE:397] \"Tooltip is changing from controlled to uncontrolled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.\", source: http://localhost:5173/@fs/C:/Users/jinwo/orca/workspaces/orca/windows-performance-improvement/node_modules/.vite/deps/chunk-22L5D3A7.js?v=33341407 (397)",
+      "at": 1782977084635
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032445.429:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=9fa0c94f-508a-44a0-b8ba-5c24ac4ee536 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=9fa0c94f-508a-44a0-b8ba-5c24ac4ee536:89760fac-065f-4c31-a88a-3d57536749a6\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977085430
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032445.429:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977085430
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032446.318:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=be158070-c785-4cea-aca9-a94e71675335 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=be158070-c785-4cea-aca9-a94e71675335:8f686ee6-1816-4b55-8368-0cf249d9ca92\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977086318
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032446.318:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977086319
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=45527 maxGapMs=50",
+      "at": 1782977086368
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032447.232:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=257d758c-e00a-45f4-9543-41bb82652d68 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=257d758c-e00a-45f4-9543-41bb82652d68:d3e9824c-9691-4f5d-8bfa-8e7099c095a3\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977087232
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032447.232:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977087233
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032448.177:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=3db20953-661a-4e65-8e4c-ca6a6f9d0538 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=3db20953-661a-4e65-8e4c-ca6a6f9d0538:621eeeff-c3b9-4558-bb55-fe3470e05025\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977088177
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032448.177:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977088178
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=47556 maxGapMs=42",
+      "at": 1782977088397
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032448.612:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=f4dca755-e41c-4f03-aa25-ed67526ca90e restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=f4dca755-e41c-4f03-aa25-ed67526ca90e:edcb7b76-70ec-4c21-b6c1-be29e795657d\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977088612
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032448.612:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977088612
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032449.077:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=8f40ca49-476c-4959-ae9f-f976293e0b62 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=8f40ca49-476c-4959-ae9f-f976293e0b62:f690ab96-e8c7-416a-a8e2-26cc38e11325\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977089078
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032449.078:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977089078
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032449.492:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=d7adfbbb-a7eb-48ed-876b-440835e7174f restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=d7adfbbb-a7eb-48ed-876b-440835e7174f:dee0c9f1-8ff4-4c92-894b-178d9a23b3a0\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977089493
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032449.493:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977089494
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=49559 maxGapMs=57",
+      "at": 1782977090400
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=51588 maxGapMs=12",
+      "at": 1782977092429
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=53613 maxGapMs=12",
+      "at": 1782977094454
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032455.950:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=afdd9731-982a-4255-8c0e-b4360453f433 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=afdd9731-982a-4255-8c0e-b4360453f433:e6721533-a824-4847-98d2-b2c9f073a233\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977095950
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032455.950:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977095951
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=55626 maxGapMs=26",
+      "at": 1782977096467
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032456.469:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=2a067075-6acf-4aca-a0a6-bc88c1e6abc7 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=2a067075-6acf-4aca-a0a6-bc88c1e6abc7:6a3ca793-864f-4182-bec5-5b044a884b9b\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977096469
+    },
+    {
+      "source": "stderr",
+      "line": "[50192:0702/032456.469:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782977096469
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=57642 maxGapMs=30",
+      "at": 1782977098483
+    }
+  ]
+}

--- a/tools/benchmarks/results/terminal-perf-fix-a-b-2026-07-02T07-46-58-178Z.json
+++ b/tools/benchmarks/results/terminal-perf-fix-a-b-2026-07-02T07-46-58-178Z.json
@@ -1,0 +1,1058 @@
+{
+  "label": "fix-a-b",
+  "startedAt": "2026-07-02T07:46:58.178Z",
+  "platform": "win32 10.0.26200",
+  "shell": "default",
+  "args": {
+    "iterations": 8,
+    "switches": 24,
+    "cycles": 12
+  },
+  "scenarios": {
+    "tab-create": {
+      "samples": [
+        {
+          "index": 0,
+          "storeCreateMs": 3.099999964237213,
+          "ptyBindMs": 5504,
+          "firstOutputMs": 5550.799999952316,
+          "paintSettleMs": 5553.099999964237,
+          "timedOut": false
+        },
+        {
+          "index": 1,
+          "storeCreateMs": 1.9000000357627869,
+          "ptyBindMs": 518.2000000476837,
+          "firstOutputMs": 535.7000000476837,
+          "paintSettleMs": 544.7000000476837,
+          "timedOut": false
+        },
+        {
+          "index": 2,
+          "storeCreateMs": 2.399999976158142,
+          "ptyBindMs": 412.5999999642372,
+          "firstOutputMs": 432.89999997615814,
+          "paintSettleMs": 434.7999999523163,
+          "timedOut": false
+        },
+        {
+          "index": 3,
+          "storeCreateMs": 1.5,
+          "ptyBindMs": 388.9000000357628,
+          "firstOutputMs": 401.10000002384186,
+          "paintSettleMs": 408.60000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 4,
+          "storeCreateMs": 2.800000011920929,
+          "ptyBindMs": 469,
+          "firstOutputMs": 482.5999999642372,
+          "paintSettleMs": 485.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 5,
+          "storeCreateMs": 1.899999976158142,
+          "ptyBindMs": 499.60000002384186,
+          "firstOutputMs": 511.60000002384186,
+          "paintSettleMs": 519,
+          "timedOut": false
+        },
+        {
+          "index": 6,
+          "storeCreateMs": 2,
+          "ptyBindMs": 441.10000002384186,
+          "firstOutputMs": 455.60000002384186,
+          "paintSettleMs": 456.39999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 7,
+          "storeCreateMs": 2.300000011920929,
+          "ptyBindMs": 312.80000001192093,
+          "firstOutputMs": 326.69999998807907,
+          "paintSettleMs": 334.19999998807907,
+          "timedOut": false
+        }
+      ],
+      "longtasks": [
+        404, 60, 184, 142, 208, 169, 148, 194, 87, 159, 211, 62, 67, 258, 95, 55, 226, 151, 53, 149,
+        172, 142, 144, 56, 64
+      ]
+    },
+    "tab-switch": {
+      "samples": [
+        {
+          "index": 0,
+          "targetTabId": "8d57a052-276e-4882-ade4-dcc5278b822c",
+          "storeMs": 1.7000000476837158,
+          "paneVisibleMs": 1.7000000476837158,
+          "paintSettleMs": 95.5,
+          "timedOut": false
+        },
+        {
+          "index": 1,
+          "targetTabId": "d0231601-75d6-4b5e-b6f9-edae135f3beb",
+          "storeMs": 1.100000023841858,
+          "paneVisibleMs": 1.100000023841858,
+          "paintSettleMs": 40.5,
+          "timedOut": false
+        },
+        {
+          "index": 2,
+          "targetTabId": "37b9b3da-9361-47ea-b14e-eb9bc33fd17a",
+          "storeMs": 2,
+          "paneVisibleMs": 2,
+          "paintSettleMs": 129.5999999642372,
+          "timedOut": false
+        },
+        {
+          "index": 3,
+          "targetTabId": "ac3abf8a-ed89-4c51-83ae-5fca5e395ed5",
+          "storeMs": 1.899999976158142,
+          "paneVisibleMs": 1.899999976158142,
+          "paintSettleMs": 118.39999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 4,
+          "targetTabId": "8d57a052-276e-4882-ade4-dcc5278b822c",
+          "storeMs": 1.9000000357627869,
+          "paneVisibleMs": 1.9000000357627869,
+          "paintSettleMs": 86.60000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 5,
+          "targetTabId": "d0231601-75d6-4b5e-b6f9-edae135f3beb",
+          "storeMs": 1.600000023841858,
+          "paneVisibleMs": 1.600000023841858,
+          "paintSettleMs": 34.80000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 6,
+          "targetTabId": "37b9b3da-9361-47ea-b14e-eb9bc33fd17a",
+          "storeMs": 1,
+          "paneVisibleMs": 1,
+          "paintSettleMs": 43.59999996423721,
+          "timedOut": false
+        },
+        {
+          "index": 7,
+          "targetTabId": "ac3abf8a-ed89-4c51-83ae-5fca5e395ed5",
+          "storeMs": 1.7999999523162842,
+          "paneVisibleMs": 1.7999999523162842,
+          "paintSettleMs": 128.89999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 8,
+          "targetTabId": "8d57a052-276e-4882-ade4-dcc5278b822c",
+          "storeMs": 1.100000023841858,
+          "paneVisibleMs": 1.100000023841858,
+          "paintSettleMs": 95.5,
+          "timedOut": false
+        },
+        {
+          "index": 9,
+          "targetTabId": "d0231601-75d6-4b5e-b6f9-edae135f3beb",
+          "storeMs": 1.399999976158142,
+          "paneVisibleMs": 1.399999976158142,
+          "paintSettleMs": 94.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 10,
+          "targetTabId": "37b9b3da-9361-47ea-b14e-eb9bc33fd17a",
+          "storeMs": 1.5,
+          "paneVisibleMs": 1.5,
+          "paintSettleMs": 29.100000023841858,
+          "timedOut": false
+        },
+        {
+          "index": 11,
+          "targetTabId": "ac3abf8a-ed89-4c51-83ae-5fca5e395ed5",
+          "storeMs": 1.199999988079071,
+          "paneVisibleMs": 1.199999988079071,
+          "paintSettleMs": 35,
+          "timedOut": false
+        },
+        {
+          "index": 12,
+          "targetTabId": "8d57a052-276e-4882-ade4-dcc5278b822c",
+          "storeMs": 1.800000011920929,
+          "paneVisibleMs": 1.800000011920929,
+          "paintSettleMs": 167.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 13,
+          "targetTabId": "d0231601-75d6-4b5e-b6f9-edae135f3beb",
+          "storeMs": 2.900000035762787,
+          "paneVisibleMs": 2.900000035762787,
+          "paintSettleMs": 141.9000000357628,
+          "timedOut": false
+        },
+        {
+          "index": 14,
+          "targetTabId": "37b9b3da-9361-47ea-b14e-eb9bc33fd17a",
+          "storeMs": 1,
+          "paneVisibleMs": 1,
+          "paintSettleMs": 57.69999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 15,
+          "targetTabId": "ac3abf8a-ed89-4c51-83ae-5fca5e395ed5",
+          "storeMs": 1.7000000476837158,
+          "paneVisibleMs": 1.7000000476837158,
+          "paintSettleMs": 42.90000003576279,
+          "timedOut": false
+        },
+        {
+          "index": 16,
+          "targetTabId": "8d57a052-276e-4882-ade4-dcc5278b822c",
+          "storeMs": 2.399999976158142,
+          "paneVisibleMs": 2.399999976158142,
+          "paintSettleMs": 49.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 17,
+          "targetTabId": "d0231601-75d6-4b5e-b6f9-edae135f3beb",
+          "storeMs": 1.2000000476837158,
+          "paneVisibleMs": 1.2000000476837158,
+          "paintSettleMs": 126.40000003576279,
+          "timedOut": false
+        },
+        {
+          "index": 18,
+          "targetTabId": "37b9b3da-9361-47ea-b14e-eb9bc33fd17a",
+          "storeMs": 1.399999976158142,
+          "paneVisibleMs": 1.399999976158142,
+          "paintSettleMs": 134.89999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 19,
+          "targetTabId": "ac3abf8a-ed89-4c51-83ae-5fca5e395ed5",
+          "storeMs": 2.100000023841858,
+          "paneVisibleMs": 2.100000023841858,
+          "paintSettleMs": 75.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 20,
+          "targetTabId": "8d57a052-276e-4882-ade4-dcc5278b822c",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 40.69999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 21,
+          "targetTabId": "d0231601-75d6-4b5e-b6f9-edae135f3beb",
+          "storeMs": 1.0999999642372131,
+          "paneVisibleMs": 1.0999999642372131,
+          "paintSettleMs": 40.80000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 22,
+          "targetTabId": "37b9b3da-9361-47ea-b14e-eb9bc33fd17a",
+          "storeMs": 2.099999964237213,
+          "paneVisibleMs": 2.099999964237213,
+          "paintSettleMs": 131.89999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 23,
+          "targetTabId": "ac3abf8a-ed89-4c51-83ae-5fca5e395ed5",
+          "storeMs": 2.100000023841858,
+          "paneVisibleMs": 2.100000023841858,
+          "paintSettleMs": 146.9000000357628,
+          "timedOut": false
+        }
+      ],
+      "longtasks": [86, 123, 111, 73, 122, 90, 84, 108, 127, 52, 121, 129, 64, 124, 134]
+    },
+    "workspace-switch": {
+      "samples": [
+        {
+          "index": 0,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@588e69ce",
+          "activationMs": 240,
+          "ptyBindMs": 247,
+          "paintSettleMs": 254
+        },
+        {
+          "index": 1,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one@@407494c8",
+          "activationMs": 423,
+          "ptyBindMs": 573,
+          "paintSettleMs": 584
+        },
+        {
+          "index": 2,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07",
+          "activationMs": 355,
+          "ptyBindMs": 441,
+          "paintSettleMs": 464
+        },
+        {
+          "index": 3,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@588e69ce",
+          "activationMs": 152,
+          "ptyBindMs": 177,
+          "paintSettleMs": 182
+        },
+        {
+          "index": 4,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one@@407494c8",
+          "activationMs": 294,
+          "ptyBindMs": 330,
+          "paintSettleMs": 341
+        },
+        {
+          "index": 5,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07",
+          "activationMs": 167,
+          "ptyBindMs": 192,
+          "paintSettleMs": 200
+        },
+        {
+          "index": 6,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@588e69ce",
+          "activationMs": 141,
+          "ptyBindMs": 158,
+          "paintSettleMs": 164
+        },
+        {
+          "index": 7,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one@@407494c8",
+          "activationMs": 115,
+          "ptyBindMs": 139,
+          "paintSettleMs": 145
+        },
+        {
+          "index": 8,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07",
+          "activationMs": 123,
+          "ptyBindMs": 147,
+          "paintSettleMs": 154
+        },
+        {
+          "index": 9,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@588e69ce",
+          "activationMs": 258,
+          "ptyBindMs": 284,
+          "paintSettleMs": 294
+        },
+        {
+          "index": 10,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one@@407494c8",
+          "activationMs": 153,
+          "ptyBindMs": 176,
+          "paintSettleMs": 185
+        },
+        {
+          "index": 11,
+          "worktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two",
+          "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07",
+          "activationMs": 123,
+          "ptyBindMs": 151,
+          "paintSettleMs": 158
+        }
+      ]
+    }
+  },
+  "summaries": [
+    {
+      "name": "tab-create",
+      "samples": 8,
+      "timedOut": 0,
+      "fields": {
+        "storeCreateMs": {
+          "count": 8,
+          "median": 2,
+          "p95": 3,
+          "max": 3
+        },
+        "ptyBindMs": {
+          "count": 8,
+          "median": 469,
+          "p95": 5504,
+          "max": 5504
+        },
+        "firstOutputMs": {
+          "count": 8,
+          "median": 483,
+          "p95": 5551,
+          "max": 5551
+        },
+        "paintSettleMs": {
+          "count": 8,
+          "median": 485,
+          "p95": 5553,
+          "max": 5553
+        }
+      },
+      "longtaskCount": 25,
+      "longtaskMaxMs": 404
+    },
+    {
+      "name": "tab-switch",
+      "samples": 24,
+      "timedOut": 0,
+      "fields": {
+        "storeMs": {
+          "count": 24,
+          "median": 2,
+          "p95": 2,
+          "max": 3
+        },
+        "paneVisibleMs": {
+          "count": 24,
+          "median": 2,
+          "p95": 2,
+          "max": 3
+        },
+        "paintSettleMs": {
+          "count": 24,
+          "median": 94,
+          "p95": 147,
+          "max": 167
+        }
+      },
+      "longtaskCount": 15,
+      "longtaskMaxMs": 134
+    },
+    {
+      "name": "workspace-switch",
+      "samples": 12,
+      "timedOut": 0,
+      "fields": {
+        "activationMs": {
+          "count": 12,
+          "median": 167,
+          "p95": 355,
+          "max": 423
+        },
+        "ptyBindMs": {
+          "count": 12,
+          "median": 192,
+          "p95": 441,
+          "max": 573
+        },
+        "paintSettleMs": {
+          "count": 12,
+          "median": 200,
+          "p95": 464,
+          "max": 584
+        }
+      },
+      "longtaskCount": 0,
+      "longtaskMaxMs": 0
+    }
+  ],
+  "finalDiagnostics": {
+    "hasStore": true,
+    "workspaceSessionReady": true,
+    "hydrationSucceeded": true,
+    "activeView": "terminal",
+    "activeRepoId": "62e7f2fd-6fb6-446e-bded-2866c26a968e",
+    "activeWorktreeId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two",
+    "activeTabType": "terminal",
+    "activeTabId": "5cf37be5-4f5e-4e6f-a00c-5116e3f6127e",
+    "terminalGpuAcceleration": "auto",
+    "repoCount": 1,
+    "worktreeCountsByRepo": {
+      "62e7f2fd-6fb6-446e-bded-2866c26a968e": 3
+    },
+    "ptyIdsByTabId": [
+      "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07"
+    ],
+    "paneManagerCount": 3,
+    "activePane": {
+      "id": 1,
+      "leafId": "74365402-0e1f-4d28-b14b-212e48cb4584",
+      "ptyId": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07",
+      "cols": 175,
+      "rows": 73,
+      "buffer": {
+        "baseY": 0,
+        "viewportY": 0,
+        "cursorY": 0,
+        "length": 73
+      }
+    },
+    "renderingDiagnostics": [
+      {
+        "paneId": 1,
+        "terminalGpuAcceleration": "auto",
+        "gpuRenderingEnabled": true,
+        "webglAttachmentDeferred": false,
+        "webglDisabledAfterContextLoss": false,
+        "hasComplexScriptOutput": false,
+        "terminalWebglAutoDecision": {
+          "allowWebgl": true,
+          "reason": "non-linux",
+          "renderer": null,
+          "vendor": null
+        },
+        "hasWebgl": true
+      }
+    ],
+    "allPaneManagersDiagnostics": [
+      {
+        "tabId": "5ae16ac3-2ecb-4d5b-bdc2-3751e9b5c6a8",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": true,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      },
+      {
+        "tabId": "212a99f7-8de7-4b20-9a0b-c8caba7656e4",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": true,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      },
+      {
+        "tabId": "5cf37be5-4f5e-4e6f-a00c-5116e3f6127e",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": false,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      }
+    ],
+    "webglContextCounts": {
+      "attachedWebglCount": 3,
+      "deferredWebglCount": 2,
+      "managerCount": 3,
+      "paneCount": 3
+    },
+    "webglIdentity": {
+      "available": true,
+      "vendor": "Google Inc. (Intel)",
+      "renderer": "ANGLE (Intel, Intel(R) Arc(TM) Graphics (0x00007D55) Direct3D11 vs_5_0 ps_5_0, D3D11)"
+    },
+    "rendererProbe": {
+      "intervalMs": 50,
+      "last": 36550,
+      "maxDriftMs": 436.4000000357628,
+      "samples": 329,
+      "startedAt": 12199.699999988079,
+      "lastTickAt": 36550
+    },
+    "ptySessions": {
+      "value": [
+        {
+          "id": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@588e69ce",
+          "cwd": "",
+          "title": "shell"
+        },
+        {
+          "id": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one@@407494c8",
+          "cwd": "",
+          "title": "shell"
+        },
+        {
+          "id": "62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07",
+          "cwd": "",
+          "title": "shell"
+        }
+      ]
+    },
+    "rendererDeliveryDebug": {
+      "value": {
+        "pendingPtyCount": 0,
+        "pendingChars": 0,
+        "maxPendingCharsByPty": 0,
+        "rendererInFlightPtyCount": 0,
+        "rendererInFlightChars": 0,
+        "maxRendererInFlightCharsByPty": 0,
+        "activeRendererPtyCount": 1,
+        "flushScheduled": false,
+        "peakPendingChars": 82,
+        "peakMaxPendingCharsByPty": 82,
+        "peakRendererInFlightChars": 82,
+        "peakMaxRendererInFlightCharsByPty": 82,
+        "ackGatedFlushSkipCount": 0
+      }
+    }
+  },
+  "cleanupErrors": [],
+  "elapsedMs": 50260,
+  "appLogsTail": [
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-folder-workspaces-done t=13843 rendererT=11282 durationMs=40",
+      "at": 1782978443148
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktrees-done t=13844 rendererT=11282 durationMs=0",
+      "at": 1782978443148
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktree-lineage-done t=13858 rendererT=11297 durationMs=16",
+      "at": 1782978443163
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktree-lineage-done t=13860 rendererT=11299 durationMs=17",
+      "at": 1782978443165
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ui-get-done t=13873 rendererT=11312 durationMs=15",
+      "at": 1782978443178
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-persisted-ui-done t=13873 rendererT=11312 durationMs=0",
+      "at": 1782978443178
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ui-get-done t=13875 rendererT=11314 durationMs=15",
+      "at": 1782978443180
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-persisted-ui-done t=13875 rendererT=11314 durationMs=0",
+      "at": 1782978443180
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-session-get-done t=13891 rendererT=11330 durationMs=18",
+      "at": 1782978443196
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-session-get-done t=13893 rendererT=11332 durationMs=17",
+      "at": 1782978443198
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034723.201:INFO:CONSOLE:1080] \"[React Grab] v0.1.34 is outdated (latest: v0.1.47). Run `npx grab@latest upgrade` to upgrade.\", source: http://localhost:5173/@fs/C:/Users/jinwo/orca/workspaces/orca/windows-performance-improvement/node_modules/.vite/deps/react-grab.js?v=43681c89 (1080)",
+      "at": 1782978443201
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-keybindings-done t=14296 rendererT=11390 durationMs=59",
+      "at": 1782978443601
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-keybindings-done t=14297 rendererT=11429 durationMs=97",
+      "at": 1782978443602
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-session-stores-done t=14297 rendererT=11434 durationMs=5",
+      "at": 1782978443602
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-visit-timestamp-prune-done t=14297 rendererT=11436 durationMs=1",
+      "at": 1782978443602
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-browser-session-profiles-done t=14305 rendererT=11744 durationMs=308",
+      "at": 1782978443610
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-onboarding-get-done t=14306 rendererT=11745 durationMs=1",
+      "at": 1782978443611
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ssh-reconnect-skipped t=14306 rendererT=11745 connectionIds=0",
+      "at": 1782978443611
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-first-window-services-await-done t=14338 rendererT=11777 durationMs=32",
+      "at": 1782978443643
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=14736 maxGapMs=360",
+      "at": 1782978444041
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-reconnect-terminals-done t=14736 rendererT=11817 durationMs=41",
+      "at": 1782978444041
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-startup-hydration-done t=14737 rendererT=11818 durationMs=1577",
+      "at": 1782978444042
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=16763 maxGapMs=352",
+      "at": 1782978446068
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=18790 maxGapMs=8",
+      "at": 1782978448094
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034728.941:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=5ae16ac3-2ecb-4d5b-bdc2-3751e9b5c6a8 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=5ae16ac3-2ecb-4d5b-bdc2-3751e9b5c6a8:36d54ebb-a041-4133-b5da-c7d36f570603\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978448941
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034728.941:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978448941
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034728.994:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=d13ff0ea-ef9b-4cc0-bc75-de82d29e4c7e restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=d13ff0ea-ef9b-4cc0-bc75-de82d29e4c7e:375f8b17-83a7-4b05-9794-8c7e6daaad79\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978448994
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034728.994:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978448994
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=20813 maxGapMs=95",
+      "at": 1782978450118
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@588e69ce total=1879ms preflight=0ms auth=0ms host_env=50ms options=0ms provider_spawn=1829ms daemon=true reattach=false",
+      "at": 1782978450823
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@15f1dbf7 total=1880ms preflight=0ms auth=0ms host_env=55ms options=0ms provider_spawn=1825ms daemon=true reattach=false",
+      "at": 1782978450875
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034731.745:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=2b742216-def2-45d8-a554-afa8b63a7efc restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=2b742216-def2-45d8-a554-afa8b63a7efc:6328b254-57e8-479e-bf53-220dd8fbefed\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978451746
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034731.745:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978451746
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@1ee97184 total=118ms preflight=0ms auth=0ms host_env=53ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+      "at": 1782978451864
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=22815 maxGapMs=57",
+      "at": 1782978452120
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034732.691:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=a669eb6f-24a3-4e93-9b9d-230b1734818a restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=a669eb6f-24a3-4e93-9b9d-230b1734818a:97eecd6f-f5df-41f6-8d16-0052bd0dd085\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978452692
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034732.691:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978452692
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@04171bdd total=113ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=65ms daemon=true reattach=false",
+      "at": 1782978452806
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034733.549:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=a7f4f0da-28f3-4938-b412-0b5c7d389a1a restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=a7f4f0da-28f3-4938-b412-0b5c7d389a1a:0e97486f-93f7-4de1-a921-d7883bf6742d\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978453549
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034733.550:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978453549
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@46952210 total=97ms preflight=0ms auth=0ms host_env=46ms options=0ms provider_spawn=51ms daemon=true reattach=false",
+      "at": 1782978453647
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=24819 maxGapMs=45",
+      "at": 1782978454124
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034734.418:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=33f0654c-45be-4686-9f91-934dbd838341 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=33f0654c-45be-4686-9f91-934dbd838341:aa40fd80-39ca-4647-833f-081ff4315faf\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978454418
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034734.418:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978454419
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034734.488:INFO:CONSOLE:397] \"Tooltip is changing from controlled to uncontrolled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.\", source: http://localhost:5173/@fs/C:/Users/jinwo/orca/workspaces/orca/windows-performance-improvement/node_modules/.vite/deps/chunk-22L5D3A7.js?v=43681c89 (397)",
+      "at": 1782978454488
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@c7cc0a5b total=98ms preflight=0ms auth=0ms host_env=45ms options=0ms provider_spawn=53ms daemon=true reattach=false",
+      "at": 1782978454518
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034735.279:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=acf961b2-58e1-4700-8246-8fbd13aec1e9 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=acf961b2-58e1-4700-8246-8fbd13aec1e9:d19e1bbf-4575-4b3c-b09e-b674244b0126\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978455279
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034735.279:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978455279
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@07c16de2 total=110ms preflight=0ms auth=0ms host_env=46ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+      "at": 1782978455389
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=26824 maxGapMs=40",
+      "at": 1782978456129
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034736.131:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=6c82b2e6-a836-47cc-9450-d81aab89a3ca restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=6c82b2e6-a836-47cc-9450-d81aab89a3ca:fa45ccbe-b10e-4260-850c-350edc40a8f5\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978456131
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034736.131:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978456131
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@316fcc20 total=96ms preflight=0ms auth=0ms host_env=44ms options=0ms provider_spawn=52ms daemon=true reattach=false",
+      "at": 1782978456228
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034736.986:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=cc574a5e-9ee8-416a-acb3-9042ca35caf1 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=cc574a5e-9ee8-416a-acb3-9042ca35caf1:5e19c1dc-6360-4032-99f6-cb0345e5d7e5\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978456986
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034736.987:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978456987
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@6993e5e7 total=95ms preflight=0ms auth=0ms host_env=39ms options=0ms provider_spawn=56ms daemon=true reattach=false",
+      "at": 1782978457082
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034737.848:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=8d57a052-276e-4882-ade4-dcc5278b822c restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=8d57a052-276e-4882-ade4-dcc5278b822c:e39bef7b-f078-40f5-b29e-83468097b694\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978457848
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034737.848:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978457848
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@56d1407f total=114ms preflight=0ms auth=0ms host_env=47ms options=1ms provider_spawn=66ms daemon=true reattach=false",
+      "at": 1782978457962
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=28852 maxGapMs=58",
+      "at": 1782978458157
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034738.252:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=d0231601-75d6-4b5e-b6f9-edae135f3beb restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=d0231601-75d6-4b5e-b6f9-edae135f3beb:0ce6efc9-3d20-49df-a9cc-8ee9dec16cc3\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978458252
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034738.252:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978458252
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@d077bcb8 total=106ms preflight=0ms auth=0ms host_env=43ms options=0ms provider_spawn=63ms daemon=true reattach=false",
+      "at": 1782978458358
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034738.803:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=37b9b3da-9361-47ea-b14e-eb9bc33fd17a restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=37b9b3da-9361-47ea-b14e-eb9bc33fd17a:ea9a8021-01d2-440f-a587-809680c60baf\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978458803
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034738.803:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978458804
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@f465a9a7 total=118ms preflight=1ms auth=0ms host_env=48ms options=0ms provider_spawn=69ms daemon=true reattach=false",
+      "at": 1782978458921
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034739.203:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=ac3abf8a-ed89-4c51-83ae-5fca5e395ed5 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=ac3abf8a-ed89-4c51-83ae-5fca5e395ed5:d46a8d0d-69a8-4f14-8186-6f094f152d36\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978459203
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034739.203:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978459203
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@2223d5a6 total=113ms preflight=0ms auth=0ms host_env=54ms options=0ms provider_spawn=59ms daemon=true reattach=false",
+      "at": 1782978459316
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=30878 maxGapMs=43",
+      "at": 1782978460183
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=32902 maxGapMs=12",
+      "at": 1782978462207
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=34905 maxGapMs=14",
+      "at": 1782978464210
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034745.917:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=212a99f7-8de7-4b20-9a0b-c8caba7656e4 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=212a99f7-8de7-4b20-9a0b-c8caba7656e4:dcbaade8-8868-4626-b685-37a662d40aa0\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978465917
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034745.917:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978465917
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one@@407494c8 total=108ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=60ms daemon=true reattach=false",
+      "at": 1782978466025
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=36929 maxGapMs=46",
+      "at": 1782978466234
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034746.426:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=5cf37be5-4f5e-4e6f-a00c-5116e3f6127e restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=5cf37be5-4f5e-4e6f-a00c-5116e3f6127e:74365402-0e1f-4d28-b14b-212e48cb4584\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978466425
+    },
+    {
+      "source": "stderr",
+      "line": "[55788:0702/034746.426:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978466426
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07 total=109ms preflight=0ms auth=0ms host_env=52ms options=0ms provider_spawn=57ms daemon=true reattach=false",
+      "at": 1782978466535
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=38934 maxGapMs=40",
+      "at": 1782978468239
+    }
+  ],
+  "ptySpawnTimings": [
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@588e69ce total=1879ms preflight=0ms auth=0ms host_env=50ms options=0ms provider_spawn=1829ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@15f1dbf7 total=1880ms preflight=0ms auth=0ms host_env=55ms options=0ms provider_spawn=1825ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@1ee97184 total=118ms preflight=0ms auth=0ms host_env=53ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@04171bdd total=113ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=65ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@46952210 total=97ms preflight=0ms auth=0ms host_env=46ms options=0ms provider_spawn=51ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@c7cc0a5b total=98ms preflight=0ms auth=0ms host_env=45ms options=0ms provider_spawn=53ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@07c16de2 total=110ms preflight=0ms auth=0ms host_env=46ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@316fcc20 total=96ms preflight=0ms auth=0ms host_env=44ms options=0ms provider_spawn=52ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@6993e5e7 total=95ms preflight=0ms auth=0ms host_env=39ms options=0ms provider_spawn=56ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@56d1407f total=114ms preflight=0ms auth=0ms host_env=47ms options=1ms provider_spawn=66ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@d077bcb8 total=106ms preflight=0ms auth=0ms host_env=43ms options=0ms provider_spawn=63ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@f465a9a7 total=118ms preflight=1ms auth=0ms host_env=48ms options=0ms provider_spawn=69ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/repo@@2223d5a6 total=113ms preflight=0ms auth=0ms host_env=54ms options=0ms provider_spawn=59ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-one@@407494c8 total=108ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=60ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=62e7f2fd-6fb6-446e-bded-2866c26a968e::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-rrZN7p/wt-two@@5d681b07 total=109ms preflight=0ms auth=0ms host_env=52ms options=0ms provider_spawn=57ms daemon=true reattach=false"
+  ]
+}

--- a/tools/benchmarks/results/terminal-perf-fix-abd-2026-07-02T07-51-00-936Z.json
+++ b/tools/benchmarks/results/terminal-perf-fix-abd-2026-07-02T07-51-00-936Z.json
@@ -1,0 +1,1061 @@
+{
+  "label": "fix-abd",
+  "startedAt": "2026-07-02T07:51:00.936Z",
+  "platform": "win32 10.0.26200",
+  "shell": "default",
+  "args": {
+    "iterations": 8,
+    "switches": 24,
+    "cycles": 12
+  },
+  "scenarios": {
+    "tab-create": {
+      "samples": [
+        {
+          "index": 0,
+          "storeCreateMs": 4.199999988079071,
+          "ptyBindMs": 6850.600000023842,
+          "firstOutputMs": 6893.800000011921,
+          "paintSettleMs": 6897.199999988079,
+          "timedOut": false
+        },
+        {
+          "index": 1,
+          "storeCreateMs": 2.299999952316284,
+          "ptyBindMs": 553.2999999523163,
+          "firstOutputMs": 576.5999999642372,
+          "paintSettleMs": 578.0999999642372,
+          "timedOut": false
+        },
+        {
+          "index": 2,
+          "storeCreateMs": 2.699999988079071,
+          "ptyBindMs": 565.6000000238419,
+          "firstOutputMs": 584.5,
+          "paintSettleMs": 585.4000000357628,
+          "timedOut": false
+        },
+        {
+          "index": 3,
+          "storeCreateMs": 2.899999976158142,
+          "ptyBindMs": 542.8999999761581,
+          "firstOutputMs": 571.1999999880791,
+          "paintSettleMs": 573.8000000119209,
+          "timedOut": false
+        },
+        {
+          "index": 4,
+          "storeCreateMs": 2.300000011920929,
+          "ptyBindMs": 423,
+          "firstOutputMs": 457.19999998807907,
+          "paintSettleMs": 464.80000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 5,
+          "storeCreateMs": 2.399999976158142,
+          "ptyBindMs": 478.5999999642372,
+          "firstOutputMs": 497,
+          "paintSettleMs": 498.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 6,
+          "storeCreateMs": 2.099999964237213,
+          "ptyBindMs": 531,
+          "firstOutputMs": 548.3999999761581,
+          "paintSettleMs": 549.3999999761581,
+          "timedOut": false
+        },
+        {
+          "index": 7,
+          "storeCreateMs": 3.199999988079071,
+          "ptyBindMs": 612,
+          "firstOutputMs": 624.0999999642372,
+          "paintSettleMs": 629.0999999642372,
+          "timedOut": false
+        }
+      ],
+      "longtasks": [
+        478, 78, 204, 149, 218, 203, 145, 218, 202, 165, 223, 189, 163, 210, 86, 162, 280, 68, 110,
+        323, 66, 76, 345, 130, 114
+      ]
+    },
+    "tab-switch": {
+      "samples": [
+        {
+          "index": 0,
+          "targetTabId": "87a752ed-2a66-411e-8c00-b7b0b24b5d10",
+          "storeMs": 2.599999964237213,
+          "paneVisibleMs": 2.599999964237213,
+          "paintSettleMs": 158.5999999642372,
+          "timedOut": false
+        },
+        {
+          "index": 1,
+          "targetTabId": "03cc8628-e72d-478c-90f7-3ed264097afb",
+          "storeMs": 2.399999976158142,
+          "paneVisibleMs": 2.399999976158142,
+          "paintSettleMs": 155.5,
+          "timedOut": false
+        },
+        {
+          "index": 2,
+          "targetTabId": "993f77d3-4e18-4b17-b386-adead86c80c8",
+          "storeMs": 2.699999988079071,
+          "paneVisibleMs": 2.699999988079071,
+          "paintSettleMs": 99.39999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 3,
+          "targetTabId": "2e38aeb9-4c66-440e-adbf-de538b4ddcbb",
+          "storeMs": 2.199999988079071,
+          "paneVisibleMs": 2.199999988079071,
+          "paintSettleMs": 66.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 4,
+          "targetTabId": "87a752ed-2a66-411e-8c00-b7b0b24b5d10",
+          "storeMs": 2.5,
+          "paneVisibleMs": 2.5,
+          "paintSettleMs": 87.89999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 5,
+          "targetTabId": "03cc8628-e72d-478c-90f7-3ed264097afb",
+          "storeMs": 2.599999964237213,
+          "paneVisibleMs": 2.599999964237213,
+          "paintSettleMs": 158.5,
+          "timedOut": false
+        },
+        {
+          "index": 6,
+          "targetTabId": "993f77d3-4e18-4b17-b386-adead86c80c8",
+          "storeMs": 2.299999952316284,
+          "paneVisibleMs": 2.299999952316284,
+          "paintSettleMs": 150,
+          "timedOut": false
+        },
+        {
+          "index": 7,
+          "targetTabId": "2e38aeb9-4c66-440e-adbf-de538b4ddcbb",
+          "storeMs": 2.5,
+          "paneVisibleMs": 2.5,
+          "paintSettleMs": 70.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 8,
+          "targetTabId": "87a752ed-2a66-411e-8c00-b7b0b24b5d10",
+          "storeMs": 2.300000011920929,
+          "paneVisibleMs": 2.300000011920929,
+          "paintSettleMs": 60.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 9,
+          "targetTabId": "03cc8628-e72d-478c-90f7-3ed264097afb",
+          "storeMs": 2.5,
+          "paneVisibleMs": 2.5,
+          "paintSettleMs": 155.0999999642372,
+          "timedOut": false
+        },
+        {
+          "index": 10,
+          "targetTabId": "993f77d3-4e18-4b17-b386-adead86c80c8",
+          "storeMs": 2.099999964237213,
+          "paneVisibleMs": 2.099999964237213,
+          "paintSettleMs": 159.5,
+          "timedOut": false
+        },
+        {
+          "index": 11,
+          "targetTabId": "2e38aeb9-4c66-440e-adbf-de538b4ddcbb",
+          "storeMs": 2.300000011920929,
+          "paneVisibleMs": 2.300000011920929,
+          "paintSettleMs": 68.70000004768372,
+          "timedOut": false
+        },
+        {
+          "index": 12,
+          "targetTabId": "87a752ed-2a66-411e-8c00-b7b0b24b5d10",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 66.39999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 13,
+          "targetTabId": "03cc8628-e72d-478c-90f7-3ed264097afb",
+          "storeMs": 2.5,
+          "paneVisibleMs": 2.5,
+          "paintSettleMs": 54.90000003576279,
+          "timedOut": false
+        },
+        {
+          "index": 14,
+          "targetTabId": "993f77d3-4e18-4b17-b386-adead86c80c8",
+          "storeMs": 2.199999988079071,
+          "paneVisibleMs": 2.199999988079071,
+          "paintSettleMs": 149.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 15,
+          "targetTabId": "2e38aeb9-4c66-440e-adbf-de538b4ddcbb",
+          "storeMs": 2.300000011920929,
+          "paneVisibleMs": 2.400000035762787,
+          "paintSettleMs": 151.9000000357628,
+          "timedOut": false
+        },
+        {
+          "index": 16,
+          "targetTabId": "87a752ed-2a66-411e-8c00-b7b0b24b5d10",
+          "storeMs": 2,
+          "paneVisibleMs": 2,
+          "paintSettleMs": 90.59999996423721,
+          "timedOut": false
+        },
+        {
+          "index": 17,
+          "targetTabId": "03cc8628-e72d-478c-90f7-3ed264097afb",
+          "storeMs": 2.300000011920929,
+          "paneVisibleMs": 2.300000011920929,
+          "paintSettleMs": 57.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 18,
+          "targetTabId": "993f77d3-4e18-4b17-b386-adead86c80c8",
+          "storeMs": 2.100000023841858,
+          "paneVisibleMs": 2.100000023841858,
+          "paintSettleMs": 59.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 19,
+          "targetTabId": "2e38aeb9-4c66-440e-adbf-de538b4ddcbb",
+          "storeMs": 2.099999964237213,
+          "paneVisibleMs": 2.099999964237213,
+          "paintSettleMs": 143.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 20,
+          "targetTabId": "87a752ed-2a66-411e-8c00-b7b0b24b5d10",
+          "storeMs": 1,
+          "paneVisibleMs": 1,
+          "paintSettleMs": 117.80000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 21,
+          "targetTabId": "03cc8628-e72d-478c-90f7-3ed264097afb",
+          "storeMs": 2.100000023841858,
+          "paneVisibleMs": 2.100000023841858,
+          "paintSettleMs": 94,
+          "timedOut": false
+        },
+        {
+          "index": 22,
+          "targetTabId": "993f77d3-4e18-4b17-b386-adead86c80c8",
+          "storeMs": 1.5999999642372131,
+          "paneVisibleMs": 1.5999999642372131,
+          "paintSettleMs": 56.299999952316284,
+          "timedOut": false
+        },
+        {
+          "index": 23,
+          "targetTabId": "2e38aeb9-4c66-440e-adbf-de538b4ddcbb",
+          "storeMs": 1.7000000476837158,
+          "paneVisibleMs": 1.7000000476837158,
+          "paintSettleMs": 134.10000002384186,
+          "timedOut": false
+        }
+      ],
+      "longtasks": [
+        145, 146, 89, 54, 80, 151, 138, 62, 53, 143, 151, 60, 59, 53, 142, 141, 83, 50, 129, 112,
+        83, 126
+      ]
+    },
+    "workspace-switch": {
+      "samples": [
+        {
+          "index": 0,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@14096c3d",
+          "activationMs": 281,
+          "ptyBindMs": 283,
+          "paintSettleMs": 293
+        },
+        {
+          "index": 1,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one@@0b21e66f",
+          "activationMs": 344,
+          "ptyBindMs": 524,
+          "paintSettleMs": 538
+        },
+        {
+          "index": 2,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f",
+          "activationMs": 428,
+          "ptyBindMs": 545,
+          "paintSettleMs": 559
+        },
+        {
+          "index": 3,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@14096c3d",
+          "activationMs": 147,
+          "ptyBindMs": 167,
+          "paintSettleMs": 180
+        },
+        {
+          "index": 4,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one@@0b21e66f",
+          "activationMs": 320,
+          "ptyBindMs": 348,
+          "paintSettleMs": 356
+        },
+        {
+          "index": 5,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f",
+          "activationMs": 125,
+          "ptyBindMs": 146,
+          "paintSettleMs": 155
+        },
+        {
+          "index": 6,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@14096c3d",
+          "activationMs": 135,
+          "ptyBindMs": 168,
+          "paintSettleMs": 175
+        },
+        {
+          "index": 7,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one@@0b21e66f",
+          "activationMs": 129,
+          "ptyBindMs": 155,
+          "paintSettleMs": 166
+        },
+        {
+          "index": 8,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f",
+          "activationMs": 121,
+          "ptyBindMs": 147,
+          "paintSettleMs": 154
+        },
+        {
+          "index": 9,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@14096c3d",
+          "activationMs": 298,
+          "ptyBindMs": 318,
+          "paintSettleMs": 328
+        },
+        {
+          "index": 10,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one@@0b21e66f",
+          "activationMs": 113,
+          "ptyBindMs": 131,
+          "paintSettleMs": 139
+        },
+        {
+          "index": 11,
+          "worktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two",
+          "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f",
+          "activationMs": 117,
+          "ptyBindMs": 140,
+          "paintSettleMs": 150
+        }
+      ]
+    }
+  },
+  "summaries": [
+    {
+      "name": "tab-create",
+      "samples": 8,
+      "timedOut": 0,
+      "fields": {
+        "storeCreateMs": {
+          "count": 8,
+          "median": 3,
+          "p95": 4,
+          "max": 4
+        },
+        "ptyBindMs": {
+          "count": 8,
+          "median": 553,
+          "p95": 6851,
+          "max": 6851
+        },
+        "firstOutputMs": {
+          "count": 8,
+          "median": 577,
+          "p95": 6894,
+          "max": 6894
+        },
+        "paintSettleMs": {
+          "count": 8,
+          "median": 578,
+          "p95": 6897,
+          "max": 6897
+        }
+      },
+      "longtaskCount": 25,
+      "longtaskMaxMs": 478
+    },
+    {
+      "name": "tab-switch",
+      "samples": 24,
+      "timedOut": 0,
+      "fields": {
+        "storeMs": {
+          "count": 24,
+          "median": 2,
+          "p95": 3,
+          "max": 3
+        },
+        "paneVisibleMs": {
+          "count": 24,
+          "median": 2,
+          "p95": 3,
+          "max": 3
+        },
+        "paintSettleMs": {
+          "count": 24,
+          "median": 99,
+          "p95": 159,
+          "max": 160
+        }
+      },
+      "longtaskCount": 22,
+      "longtaskMaxMs": 151
+    },
+    {
+      "name": "workspace-switch",
+      "samples": 12,
+      "timedOut": 0,
+      "fields": {
+        "activationMs": {
+          "count": 12,
+          "median": 147,
+          "p95": 344,
+          "max": 428
+        },
+        "ptyBindMs": {
+          "count": 12,
+          "median": 168,
+          "p95": 524,
+          "max": 545
+        },
+        "paintSettleMs": {
+          "count": 12,
+          "median": 180,
+          "p95": 538,
+          "max": 559
+        }
+      },
+      "longtaskCount": 0,
+      "longtaskMaxMs": 0
+    }
+  ],
+  "finalDiagnostics": {
+    "hasStore": true,
+    "workspaceSessionReady": true,
+    "hydrationSucceeded": true,
+    "activeView": "terminal",
+    "activeRepoId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d",
+    "activeWorktreeId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two",
+    "activeTabType": "terminal",
+    "activeTabId": "e1284ad8-dc0b-4bb7-bcd0-f2b24b8f4083",
+    "terminalGpuAcceleration": "auto",
+    "repoCount": 1,
+    "worktreeCountsByRepo": {
+      "f5b2567a-69b4-41a3-ba29-8c4bd357042d": 3
+    },
+    "ptyIdsByTabId": [
+      "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f"
+    ],
+    "paneManagerCount": 3,
+    "activePane": {
+      "id": 1,
+      "leafId": "6aaaf90a-6cb7-48f9-b7c9-6869278038a7",
+      "ptyId": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f",
+      "cols": 175,
+      "rows": 73,
+      "buffer": {
+        "baseY": 0,
+        "viewportY": 0,
+        "cursorY": 0,
+        "length": 73
+      }
+    },
+    "renderingDiagnostics": [
+      {
+        "paneId": 1,
+        "terminalGpuAcceleration": "auto",
+        "gpuRenderingEnabled": true,
+        "webglAttachmentDeferred": false,
+        "webglDisabledAfterContextLoss": false,
+        "hasComplexScriptOutput": false,
+        "terminalWebglAutoDecision": {
+          "allowWebgl": true,
+          "reason": "non-linux",
+          "renderer": null,
+          "vendor": null
+        },
+        "hasWebgl": true
+      }
+    ],
+    "allPaneManagersDiagnostics": [
+      {
+        "tabId": "93e4a957-3325-4987-a180-5dac10bebbc0",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": true,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      },
+      {
+        "tabId": "6f6ad43f-ecf2-47c1-b6dd-816bfc4638d7",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": true,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      },
+      {
+        "tabId": "e1284ad8-dc0b-4bb7-bcd0-f2b24b8f4083",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": false,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      }
+    ],
+    "webglContextCounts": {
+      "attachedWebglCount": 3,
+      "deferredWebglCount": 2,
+      "managerCount": 3,
+      "paneCount": 3
+    },
+    "webglIdentity": {
+      "available": true,
+      "vendor": "Google Inc. (Intel)",
+      "renderer": "ANGLE (Intel, Intel(R) Arc(TM) Graphics (0x00007D55) Direct3D11 vs_5_0 ps_5_0, D3D11)"
+    },
+    "rendererProbe": {
+      "intervalMs": 50,
+      "last": 39444.30000001192,
+      "maxDriftMs": 504,
+      "samples": 351,
+      "startedAt": 11431.800000011921,
+      "lastTickAt": 39444.30000001192
+    },
+    "ptySessions": {
+      "value": [
+        {
+          "id": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@14096c3d",
+          "cwd": "",
+          "title": "shell"
+        },
+        {
+          "id": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one@@0b21e66f",
+          "cwd": "",
+          "title": "shell"
+        },
+        {
+          "id": "f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f",
+          "cwd": "",
+          "title": "shell"
+        }
+      ]
+    },
+    "rendererDeliveryDebug": {
+      "value": {
+        "pendingPtyCount": 0,
+        "pendingChars": 0,
+        "maxPendingCharsByPty": 0,
+        "rendererInFlightPtyCount": 0,
+        "rendererInFlightChars": 0,
+        "maxRendererInFlightCharsByPty": 0,
+        "activeRendererPtyCount": 1,
+        "flushScheduled": false,
+        "peakPendingChars": 82,
+        "peakMaxPendingCharsByPty": 82,
+        "peakRendererInFlightChars": 82,
+        "peakMaxRendererInFlightCharsByPty": 82,
+        "ackGatedFlushSkipCount": 0
+      }
+    }
+  },
+  "cleanupErrors": [],
+  "elapsedMs": 53646,
+  "appLogsTail": [
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-folder-workspaces-done t=13271 rendererT=10691 durationMs=32",
+      "at": 1782978685796
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktrees-done t=13272 rendererT=10691 durationMs=0",
+      "at": 1782978685797
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktree-lineage-done t=13288 rendererT=10708 durationMs=17",
+      "at": 1782978685813
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktree-lineage-done t=13290 rendererT=10709 durationMs=19",
+      "at": 1782978685815
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ui-get-done t=13303 rendererT=10723 durationMs=14",
+      "at": 1782978685828
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-persisted-ui-done t=13303 rendererT=10723 durationMs=0",
+      "at": 1782978685828
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ui-get-done t=13305 rendererT=10725 durationMs=15",
+      "at": 1782978685830
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-persisted-ui-done t=13305 rendererT=10725 durationMs=0",
+      "at": 1782978685830
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-session-get-done t=13313 rendererT=10733 durationMs=10",
+      "at": 1782978685838
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-session-get-done t=13314 rendererT=10734 durationMs=8",
+      "at": 1782978685839
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-keybindings-done t=13828 rendererT=10799 durationMs=66",
+      "at": 1782978686354
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-keybindings-done t=13829 rendererT=10833 durationMs=99",
+      "at": 1782978686354
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-session-stores-done t=13829 rendererT=10837 durationMs=4",
+      "at": 1782978686354
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-visit-timestamp-prune-done t=13829 rendererT=10838 durationMs=1",
+      "at": 1782978686354
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-browser-session-profiles-done t=13840 rendererT=11257 durationMs=418",
+      "at": 1782978686365
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-onboarding-get-done t=13842 rendererT=11260 durationMs=4",
+      "at": 1782978686367
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ssh-reconnect-skipped t=13842 rendererT=11261 connectionIds=0",
+      "at": 1782978686367
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-first-window-services-await-done t=13880 rendererT=11295 durationMs=34",
+      "at": 1782978686405
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-reconnect-terminals-done t=13914 rendererT=11334 durationMs=39",
+      "at": 1782978686439
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-startup-hydration-done t=13916 rendererT=11335 durationMs=1709",
+      "at": 1782978686441
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=14429 maxGapMs=446",
+      "at": 1782978686954
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=16441 maxGapMs=409",
+      "at": 1782978688966
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=18453 maxGapMs=7",
+      "at": 1782978690978
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035132.336:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=93e4a957-3325-4987-a180-5dac10bebbc0 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=93e4a957-3325-4987-a180-5dac10bebbc0:d285da80-e34b-422f-a0a4-14a68a6c5cb5\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978692336
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035132.336:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978692336
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035132.387:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=766de809-5863-49f7-a603-3faa5fdf4693 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=766de809-5863-49f7-a603-3faa5fdf4693:3747de82-0192-46c3-a130-e114e78bb00d\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978692387
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035132.387:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978692387
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=20469 maxGapMs=30",
+      "at": 1782978692994
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=22492 maxGapMs=7",
+      "at": 1782978695018
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@14096c3d total=2796ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=2749ms daemon=true reattach=false",
+      "at": 1782978695134
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@ccc87346 total=2805ms preflight=0ms auth=0ms host_env=52ms options=0ms provider_spawn=2753ms daemon=true reattach=false",
+      "at": 1782978695192
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035136.133:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=9efaa7fd-442b-4efe-bf23-52d7143a0219 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=9efaa7fd-442b-4efe-bf23-52d7143a0219:df4d3047-f992-48ce-b5f1-6d0637523a9e\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978696133
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035136.133:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978696133
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@ec755bef total=116ms preflight=0ms auth=0ms host_env=51ms options=0ms provider_spawn=65ms daemon=true reattach=false",
+      "at": 1782978696250
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=24506 maxGapMs=36",
+      "at": 1782978697031
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035137.119:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=694f725c-29d1-4107-8648-81d285f6ab4b restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=694f725c-29d1-4107-8648-81d285f6ab4b:90413477-6d54-4dda-8c37-59e718741517\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978697120
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035137.120:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978697120
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035137.171:INFO:CONSOLE:397] \"Tooltip is changing from controlled to uncontrolled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.\", source: http://localhost:5173/@fs/C:/Users/jinwo/orca/workspaces/orca/windows-performance-improvement/node_modules/.vite/deps/chunk-22L5D3A7.js?v=43681c89 (397)",
+      "at": 1782978697172
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@90e4e78e total=113ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=65ms daemon=true reattach=false",
+      "at": 1782978697234
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035138.128:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=adc6529c-4b75-45a8-8ea2-1bcf637da544 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=adc6529c-4b75-45a8-8ea2-1bcf637da544:91dc16c6-f567-4e05-994c-94ae19376ee7\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978698128
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035138.128:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978698128
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@b172fe7e total=118ms preflight=0ms auth=0ms host_env=54ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+      "at": 1782978698247
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=26510 maxGapMs=51",
+      "at": 1782978699035
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035139.097:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=f891d153-855c-43cb-9fdb-fd8682070724 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=f891d153-855c-43cb-9fdb-fd8682070724:5d0971c2-c663-4e44-ae1c-825dc948489a\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978699097
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035139.097:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978699097
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@2ff2b79f total=113ms preflight=0ms auth=0ms host_env=49ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+      "at": 1782978699211
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035140.045:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=939ae529-7ad7-4d46-b4c0-4b3997ab6b98 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=939ae529-7ad7-4d46-b4c0-4b3997ab6b98:b3224a5c-19ae-42b8-b756-965f04806e49\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978700046
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035140.046:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978700046
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@0965fd8c total=114ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=66ms daemon=true reattach=false",
+      "at": 1782978700161
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035141.002:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=5749668e-dbd3-41ff-bbe5-c93c12925763 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=5749668e-dbd3-41ff-bbe5-c93c12925763:e3a00c11-d53b-4747-b215-ce9f19bb0da0\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978701002
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035141.002:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978701002
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=28532 maxGapMs=50",
+      "at": 1782978701057
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@9c46ce32 total=124ms preflight=0ms auth=0ms host_env=54ms options=0ms provider_spawn=70ms daemon=true reattach=false",
+      "at": 1782978701126
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035141.986:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=2546b0b6-5198-4067-b59b-698e914160d0 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=2546b0b6-5198-4067-b59b-698e914160d0:fecf7693-17a1-4cdc-8d35-1ba415e0760d\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978701986
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035141.986:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978701986
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@ea5607d8 total=116ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=68ms daemon=true reattach=false",
+      "at": 1782978702102
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035143.024:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=87a752ed-2a66-411e-8c00-b7b0b24b5d10 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=87a752ed-2a66-411e-8c00-b7b0b24b5d10:9258e63f-4dee-455c-8f8f-543569e4ce24\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978703024
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035143.024:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978703025
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=30557 maxGapMs=47",
+      "at": 1782978703082
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@10666ccc total=116ms preflight=0ms auth=0ms host_env=53ms options=0ms provider_spawn=63ms daemon=true reattach=false",
+      "at": 1782978703141
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035143.510:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=03cc8628-e72d-478c-90f7-3ed264097afb restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=03cc8628-e72d-478c-90f7-3ed264097afb:b30207cc-752f-4836-8ea5-6f095e97f32d\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978703510
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035143.510:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978703510
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@566d348e total=120ms preflight=0ms auth=0ms host_env=52ms options=0ms provider_spawn=68ms daemon=true reattach=false",
+      "at": 1782978703630
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035144.065:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=993f77d3-4e18-4b17-b386-adead86c80c8 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=993f77d3-4e18-4b17-b386-adead86c80c8:ee549cc0-14c4-4211-922b-918f0810da85\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978704066
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035144.066:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978704066
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@aedde862 total=122ms preflight=0ms auth=0ms host_env=51ms options=0ms provider_spawn=71ms daemon=true reattach=false",
+      "at": 1782978704188
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035144.838:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=2e38aeb9-4c66-440e-adbf-de538b4ddcbb restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=2e38aeb9-4c66-440e-adbf-de538b4ddcbb:26a39262-f10c-4e3a-a246-8646617d0b05\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978704838
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035144.838:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978704838
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@dd291490 total=147ms preflight=0ms auth=0ms host_env=54ms options=0ms provider_spawn=93ms daemon=true reattach=false",
+      "at": 1782978704985
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=32571 maxGapMs=116",
+      "at": 1782978705096
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=34594 maxGapMs=18",
+      "at": 1782978707119
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=36594 maxGapMs=13",
+      "at": 1782978709119
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=38594 maxGapMs=11",
+      "at": 1782978711119
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035151.953:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=6f6ad43f-ecf2-47c1-b6dd-816bfc4638d7 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=6f6ad43f-ecf2-47c1-b6dd-816bfc4638d7:9002711a-d8da-4d46-a938-d1ab106322eb\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978711953
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035151.953:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978711953
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one@@0b21e66f total=115ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=67ms daemon=true reattach=false",
+      "at": 1782978712070
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035152.571:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=e1284ad8-dc0b-4bb7-bcd0-f2b24b8f4083 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=e1284ad8-dc0b-4bb7-bcd0-f2b24b8f4083:6aaaf90a-6cb7-48f9-b7c9-6869278038a7\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978712571
+    },
+    {
+      "source": "stderr",
+      "line": "[48724:0702/035152.571:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782978712571
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f total=118ms preflight=0ms auth=1ms host_env=54ms options=0ms provider_spawn=63ms daemon=true reattach=false",
+      "at": 1782978712689
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=40618 maxGapMs=40",
+      "at": 1782978713143
+    }
+  ],
+  "ptySpawnTimings": [
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@14096c3d total=2796ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=2749ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@ccc87346 total=2805ms preflight=0ms auth=0ms host_env=52ms options=0ms provider_spawn=2753ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@ec755bef total=116ms preflight=0ms auth=0ms host_env=51ms options=0ms provider_spawn=65ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@90e4e78e total=113ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=65ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@b172fe7e total=118ms preflight=0ms auth=0ms host_env=54ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@2ff2b79f total=113ms preflight=0ms auth=0ms host_env=49ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@0965fd8c total=114ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=66ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@9c46ce32 total=124ms preflight=0ms auth=0ms host_env=54ms options=0ms provider_spawn=70ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@ea5607d8 total=116ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=68ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@10666ccc total=116ms preflight=0ms auth=0ms host_env=53ms options=0ms provider_spawn=63ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@566d348e total=120ms preflight=0ms auth=0ms host_env=52ms options=0ms provider_spawn=68ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@aedde862 total=122ms preflight=0ms auth=0ms host_env=51ms options=0ms provider_spawn=71ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/repo@@dd291490 total=147ms preflight=0ms auth=0ms host_env=54ms options=0ms provider_spawn=93ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-one@@0b21e66f total=115ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=67ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=f5b2567a-69b4-41a3-ba29-8c4bd357042d::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-J3tKUm/wt-two@@e63f448f total=118ms preflight=0ms auth=1ms host_env=54ms options=0ms provider_spawn=63ms daemon=true reattach=false"
+  ]
+}

--- a/tools/benchmarks/results/terminal-perf-fix-abdf-2026-07-02T07-59-11-820Z.json
+++ b/tools/benchmarks/results/terminal-perf-fix-abdf-2026-07-02T07-59-11-820Z.json
@@ -1,0 +1,1058 @@
+{
+  "label": "fix-abdf",
+  "startedAt": "2026-07-02T07:59:11.820Z",
+  "platform": "win32 10.0.26200",
+  "shell": "default",
+  "args": {
+    "iterations": 8,
+    "switches": 24,
+    "cycles": 12
+  },
+  "scenarios": {
+    "tab-create": {
+      "samples": [
+        {
+          "index": 0,
+          "storeCreateMs": 3.299999952316284,
+          "ptyBindMs": 4816.899999976158,
+          "firstOutputMs": 4856.899999976158,
+          "paintSettleMs": 4864,
+          "timedOut": false
+        },
+        {
+          "index": 1,
+          "storeCreateMs": 2.800000011920929,
+          "ptyBindMs": 529,
+          "firstOutputMs": 554.5,
+          "paintSettleMs": 556.8000000119209,
+          "timedOut": false
+        },
+        {
+          "index": 2,
+          "storeCreateMs": 2.400000035762787,
+          "ptyBindMs": 423.10000002384186,
+          "firstOutputMs": 464.80000001192093,
+          "paintSettleMs": 470,
+          "timedOut": false
+        },
+        {
+          "index": 3,
+          "storeCreateMs": 1.800000011920929,
+          "ptyBindMs": 438.4000000357628,
+          "firstOutputMs": 453.69999998807907,
+          "paintSettleMs": 455.80000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 4,
+          "storeCreateMs": 1.600000023841858,
+          "ptyBindMs": 497.10000002384186,
+          "firstOutputMs": 508.80000001192093,
+          "paintSettleMs": 515.8999999761581,
+          "timedOut": false
+        },
+        {
+          "index": 5,
+          "storeCreateMs": 1.9000000357627869,
+          "ptyBindMs": 471.80000001192093,
+          "firstOutputMs": 488.10000002384186,
+          "paintSettleMs": 491.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 6,
+          "storeCreateMs": 1.199999988079071,
+          "ptyBindMs": 512.6999999880791,
+          "firstOutputMs": 524.2999999523163,
+          "paintSettleMs": 531.6999999880791,
+          "timedOut": false
+        },
+        {
+          "index": 7,
+          "storeCreateMs": 1.5,
+          "ptyBindMs": 468.10000002384186,
+          "firstOutputMs": 483.19999998807907,
+          "paintSettleMs": 484.19999998807907,
+          "timedOut": false
+        }
+      ],
+      "longtasks": [
+        52, 397, 67, 187, 133, 214, 192, 152, 196, 90, 154, 255, 61, 71, 296, 76, 68, 258, 92, 68,
+        244, 161, 63, 176, 178, 137
+      ]
+    },
+    "tab-switch": {
+      "samples": [
+        {
+          "index": 0,
+          "targetTabId": "aa62c8e8-2ef4-4aa3-ac4d-b9063cfa527e",
+          "storeMs": 1.9000000357627869,
+          "paneVisibleMs": 1.9000000357627869,
+          "paintSettleMs": 76.20000004768372,
+          "timedOut": false
+        },
+        {
+          "index": 1,
+          "targetTabId": "66083463-228e-4fb0-90c5-231dc75e8da6",
+          "storeMs": 1.0999999642372131,
+          "paneVisibleMs": 1.0999999642372131,
+          "paintSettleMs": 113.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 2,
+          "targetTabId": "b99bb441-7027-40a9-beb2-a558ece6f979",
+          "storeMs": 2.5,
+          "paneVisibleMs": 2.5,
+          "paintSettleMs": 130.9000000357628,
+          "timedOut": false
+        },
+        {
+          "index": 3,
+          "targetTabId": "490084ae-1bdb-4359-bb86-097e26902f98",
+          "storeMs": 2.099999964237213,
+          "paneVisibleMs": 2.099999964237213,
+          "paintSettleMs": 70.09999996423721,
+          "timedOut": false
+        },
+        {
+          "index": 4,
+          "targetTabId": "aa62c8e8-2ef4-4aa3-ac4d-b9063cfa527e",
+          "storeMs": 1.899999976158142,
+          "paneVisibleMs": 1.899999976158142,
+          "paintSettleMs": 54.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 5,
+          "targetTabId": "66083463-228e-4fb0-90c5-231dc75e8da6",
+          "storeMs": 2.5,
+          "paneVisibleMs": 2.5,
+          "paintSettleMs": 52.69999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 6,
+          "targetTabId": "b99bb441-7027-40a9-beb2-a558ece6f979",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 119.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 7,
+          "targetTabId": "490084ae-1bdb-4359-bb86-097e26902f98",
+          "storeMs": 1.399999976158142,
+          "paneVisibleMs": 1.399999976158142,
+          "paintSettleMs": 104.29999995231628,
+          "timedOut": false
+        },
+        {
+          "index": 8,
+          "targetTabId": "aa62c8e8-2ef4-4aa3-ac4d-b9063cfa527e",
+          "storeMs": 2.399999976158142,
+          "paneVisibleMs": 2.5,
+          "paintSettleMs": 78.39999997615814,
+          "timedOut": false
+        },
+        {
+          "index": 9,
+          "targetTabId": "66083463-228e-4fb0-90c5-231dc75e8da6",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 49.59999996423721,
+          "timedOut": false
+        },
+        {
+          "index": 10,
+          "targetTabId": "b99bb441-7027-40a9-beb2-a558ece6f979",
+          "storeMs": 1.300000011920929,
+          "paneVisibleMs": 1.300000011920929,
+          "paintSettleMs": 47.10000002384186,
+          "timedOut": false
+        },
+        {
+          "index": 11,
+          "targetTabId": "490084ae-1bdb-4359-bb86-097e26902f98",
+          "storeMs": 3.100000023841858,
+          "paneVisibleMs": 3.100000023841858,
+          "paintSettleMs": 120.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 12,
+          "targetTabId": "aa62c8e8-2ef4-4aa3-ac4d-b9063cfa527e",
+          "storeMs": 1.600000023841858,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 108.19999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 13,
+          "targetTabId": "66083463-228e-4fb0-90c5-231dc75e8da6",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 51.69999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 14,
+          "targetTabId": "b99bb441-7027-40a9-beb2-a558ece6f979",
+          "storeMs": 1.600000023841858,
+          "paneVisibleMs": 1.600000023841858,
+          "paintSettleMs": 45.30000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 15,
+          "targetTabId": "490084ae-1bdb-4359-bb86-097e26902f98",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 44.69999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 16,
+          "targetTabId": "aa62c8e8-2ef4-4aa3-ac4d-b9063cfa527e",
+          "storeMs": 1.399999976158142,
+          "paneVisibleMs": 1.399999976158142,
+          "paintSettleMs": 58.69999998807907,
+          "timedOut": false
+        },
+        {
+          "index": 17,
+          "targetTabId": "66083463-228e-4fb0-90c5-231dc75e8da6",
+          "storeMs": 1.899999976158142,
+          "paneVisibleMs": 1.899999976158142,
+          "paintSettleMs": 136.5999999642372,
+          "timedOut": false
+        },
+        {
+          "index": 18,
+          "targetTabId": "b99bb441-7027-40a9-beb2-a558ece6f979",
+          "storeMs": 2,
+          "paneVisibleMs": 2,
+          "paintSettleMs": 136.0999999642372,
+          "timedOut": false
+        },
+        {
+          "index": 19,
+          "targetTabId": "490084ae-1bdb-4359-bb86-097e26902f98",
+          "storeMs": 1.600000023841858,
+          "paneVisibleMs": 1.600000023841858,
+          "paintSettleMs": 53.80000001192093,
+          "timedOut": false
+        },
+        {
+          "index": 20,
+          "targetTabId": "aa62c8e8-2ef4-4aa3-ac4d-b9063cfa527e",
+          "storeMs": 2.100000023841858,
+          "paneVisibleMs": 2.100000023841858,
+          "paintSettleMs": 51.5,
+          "timedOut": false
+        },
+        {
+          "index": 21,
+          "targetTabId": "66083463-228e-4fb0-90c5-231dc75e8da6",
+          "storeMs": 1.800000011920929,
+          "paneVisibleMs": 1.800000011920929,
+          "paintSettleMs": 122.40000003576279,
+          "timedOut": false
+        },
+        {
+          "index": 22,
+          "targetTabId": "b99bb441-7027-40a9-beb2-a558ece6f979",
+          "storeMs": 1.699999988079071,
+          "paneVisibleMs": 1.699999988079071,
+          "paintSettleMs": 118.5,
+          "timedOut": false
+        },
+        {
+          "index": 23,
+          "targetTabId": "490084ae-1bdb-4359-bb86-097e26902f98",
+          "storeMs": 2.300000011920929,
+          "paneVisibleMs": 2.300000011920929,
+          "paintSettleMs": 62.69999998807907,
+          "timedOut": false
+        }
+      ],
+      "longtasks": [66, 102, 123, 64, 115, 96, 74, 113, 102, 52, 125, 130, 117, 110, 53]
+    },
+    "workspace-switch": {
+      "samples": [
+        {
+          "index": 0,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@5810ae88",
+          "activationMs": 217,
+          "ptyBindMs": 219,
+          "paintSettleMs": 233
+        },
+        {
+          "index": 1,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one@@c450cf26",
+          "activationMs": 480,
+          "ptyBindMs": 575,
+          "paintSettleMs": 601
+        },
+        {
+          "index": 2,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06",
+          "activationMs": 382,
+          "ptyBindMs": 557,
+          "paintSettleMs": 573
+        },
+        {
+          "index": 3,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@5810ae88",
+          "activationMs": 268,
+          "ptyBindMs": 295,
+          "paintSettleMs": 299
+        },
+        {
+          "index": 4,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one@@c450cf26",
+          "activationMs": 154,
+          "ptyBindMs": 178,
+          "paintSettleMs": 184
+        },
+        {
+          "index": 5,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06",
+          "activationMs": 145,
+          "ptyBindMs": 166,
+          "paintSettleMs": 178
+        },
+        {
+          "index": 6,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@5810ae88",
+          "activationMs": 159,
+          "ptyBindMs": 184,
+          "paintSettleMs": 192
+        },
+        {
+          "index": 7,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one@@c450cf26",
+          "activationMs": 328,
+          "ptyBindMs": 349,
+          "paintSettleMs": 354
+        },
+        {
+          "index": 8,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06",
+          "activationMs": 139,
+          "ptyBindMs": 158,
+          "paintSettleMs": 167
+        },
+        {
+          "index": 9,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@5810ae88",
+          "activationMs": 150,
+          "ptyBindMs": 177,
+          "paintSettleMs": 183
+        },
+        {
+          "index": 10,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one@@c450cf26",
+          "activationMs": 150,
+          "ptyBindMs": 169,
+          "paintSettleMs": 179
+        },
+        {
+          "index": 11,
+          "worktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two",
+          "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06",
+          "activationMs": 134,
+          "ptyBindMs": 166,
+          "paintSettleMs": 182
+        }
+      ]
+    }
+  },
+  "summaries": [
+    {
+      "name": "tab-create",
+      "samples": 8,
+      "timedOut": 0,
+      "fields": {
+        "storeCreateMs": {
+          "count": 8,
+          "median": 2,
+          "p95": 3,
+          "max": 3
+        },
+        "ptyBindMs": {
+          "count": 8,
+          "median": 497,
+          "p95": 4817,
+          "max": 4817
+        },
+        "firstOutputMs": {
+          "count": 8,
+          "median": 509,
+          "p95": 4857,
+          "max": 4857
+        },
+        "paintSettleMs": {
+          "count": 8,
+          "median": 516,
+          "p95": 4864,
+          "max": 4864
+        }
+      },
+      "longtaskCount": 26,
+      "longtaskMaxMs": 397
+    },
+    {
+      "name": "tab-switch",
+      "samples": 24,
+      "timedOut": 0,
+      "fields": {
+        "storeMs": {
+          "count": 24,
+          "median": 2,
+          "p95": 3,
+          "max": 3
+        },
+        "paneVisibleMs": {
+          "count": 24,
+          "median": 2,
+          "p95": 3,
+          "max": 3
+        },
+        "paintSettleMs": {
+          "count": 24,
+          "median": 76,
+          "p95": 136,
+          "max": 137
+        }
+      },
+      "longtaskCount": 15,
+      "longtaskMaxMs": 130
+    },
+    {
+      "name": "workspace-switch",
+      "samples": 12,
+      "timedOut": 0,
+      "fields": {
+        "activationMs": {
+          "count": 12,
+          "median": 159,
+          "p95": 382,
+          "max": 480
+        },
+        "ptyBindMs": {
+          "count": 12,
+          "median": 184,
+          "p95": 557,
+          "max": 575
+        },
+        "paintSettleMs": {
+          "count": 12,
+          "median": 192,
+          "p95": 573,
+          "max": 601
+        }
+      },
+      "longtaskCount": 0,
+      "longtaskMaxMs": 0
+    }
+  ],
+  "finalDiagnostics": {
+    "hasStore": true,
+    "workspaceSessionReady": true,
+    "hydrationSucceeded": true,
+    "activeView": "terminal",
+    "activeRepoId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b",
+    "activeWorktreeId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two",
+    "activeTabType": "terminal",
+    "activeTabId": "15055907-3232-4ca1-8814-e5484ba78a5b",
+    "terminalGpuAcceleration": "auto",
+    "repoCount": 1,
+    "worktreeCountsByRepo": {
+      "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b": 3
+    },
+    "ptyIdsByTabId": [
+      "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06"
+    ],
+    "paneManagerCount": 3,
+    "activePane": {
+      "id": 1,
+      "leafId": "78b7478c-39a9-4111-aed8-1e2ddf568c24",
+      "ptyId": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06",
+      "cols": 175,
+      "rows": 73,
+      "buffer": {
+        "baseY": 0,
+        "viewportY": 0,
+        "cursorY": 0,
+        "length": 73
+      }
+    },
+    "renderingDiagnostics": [
+      {
+        "paneId": 1,
+        "terminalGpuAcceleration": "auto",
+        "gpuRenderingEnabled": true,
+        "webglAttachmentDeferred": false,
+        "webglDisabledAfterContextLoss": false,
+        "hasComplexScriptOutput": false,
+        "terminalWebglAutoDecision": {
+          "allowWebgl": true,
+          "reason": "non-linux",
+          "renderer": null,
+          "vendor": null
+        },
+        "hasWebgl": true
+      }
+    ],
+    "allPaneManagersDiagnostics": [
+      {
+        "tabId": "c46e04e4-af5f-4674-9a38-72253480baef",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": true,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      },
+      {
+        "tabId": "769013c6-b5b8-4be9-b188-4444a6094567",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": true,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      },
+      {
+        "tabId": "15055907-3232-4ca1-8814-e5484ba78a5b",
+        "diagnostics": [
+          {
+            "paneId": 1,
+            "terminalGpuAcceleration": "auto",
+            "gpuRenderingEnabled": true,
+            "webglAttachmentDeferred": false,
+            "webglDisabledAfterContextLoss": false,
+            "hasComplexScriptOutput": false,
+            "terminalWebglAutoDecision": {
+              "allowWebgl": true,
+              "reason": "non-linux",
+              "renderer": null,
+              "vendor": null
+            },
+            "hasWebgl": true
+          }
+        ]
+      }
+    ],
+    "webglContextCounts": {
+      "attachedWebglCount": 3,
+      "deferredWebglCount": 2,
+      "managerCount": 3,
+      "paneCount": 3
+    },
+    "webglIdentity": {
+      "available": true,
+      "vendor": "Google Inc. (Intel)",
+      "renderer": "ANGLE (Intel, Intel(R) Arc(TM) Graphics (0x00007D55) Direct3D11 vs_5_0 ps_5_0, D3D11)"
+    },
+    "rendererProbe": {
+      "intervalMs": 50,
+      "last": 35644.5,
+      "maxDriftMs": 413.89999997615814,
+      "samples": 309,
+      "startedAt": 11829.5,
+      "lastTickAt": 35644.5
+    },
+    "ptySessions": {
+      "value": [
+        {
+          "id": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@5810ae88",
+          "cwd": "",
+          "title": "shell"
+        },
+        {
+          "id": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one@@c450cf26",
+          "cwd": "",
+          "title": "shell"
+        },
+        {
+          "id": "cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06",
+          "cwd": "",
+          "title": "shell"
+        }
+      ]
+    },
+    "rendererDeliveryDebug": {
+      "value": {
+        "pendingPtyCount": 0,
+        "pendingChars": 0,
+        "maxPendingCharsByPty": 0,
+        "rendererInFlightPtyCount": 0,
+        "rendererInFlightChars": 0,
+        "maxRendererInFlightCharsByPty": 0,
+        "activeRendererPtyCount": 1,
+        "flushScheduled": false,
+        "peakPendingChars": 82,
+        "peakMaxPendingCharsByPty": 82,
+        "peakRendererInFlightChars": 82,
+        "peakMaxRendererInFlightCharsByPty": 82,
+        "ackGatedFlushSkipCount": 0
+      }
+    }
+  },
+  "cleanupErrors": [],
+  "elapsedMs": 50234,
+  "appLogsTail": [
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-folder-workspaces-done t=13833 rendererT=11239 durationMs=53",
+      "at": 1782979177594
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktrees-done t=13833 rendererT=11240 durationMs=1",
+      "at": 1782979177594
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-folder-workspaces-done t=13835 rendererT=11241 durationMs=55",
+      "at": 1782979177596
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktrees-done t=13835 rendererT=11242 durationMs=0",
+      "at": 1782979177596
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktree-lineage-done t=13838 rendererT=11246 durationMs=6",
+      "at": 1782979177599
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-worktree-lineage-done t=13841 rendererT=11249 durationMs=8",
+      "at": 1782979177602
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ui-get-done t=13842 rendererT=11250 durationMs=4",
+      "at": 1782979177603
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-persisted-ui-done t=13842 rendererT=11250 durationMs=0",
+      "at": 1782979177603
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ui-get-done t=13844 rendererT=11251 durationMs=2",
+      "at": 1782979177605
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-persisted-ui-done t=13844 rendererT=11251 durationMs=0",
+      "at": 1782979177605
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-session-get-done t=13844 rendererT=11252 durationMs=2",
+      "at": 1782979177605
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-session-get-done t=13846 rendererT=11254 durationMs=3",
+      "at": 1782979177607
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-keybindings-done t=14263 rendererT=11346 durationMs=94",
+      "at": 1782979178024
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-keybindings-done t=14263 rendererT=11426 durationMs=172",
+      "at": 1782979178024
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-hydrate-session-stores-done t=14263 rendererT=11430 durationMs=4",
+      "at": 1782979178024
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-visit-timestamp-prune-done t=14263 rendererT=11431 durationMs=1",
+      "at": 1782979178024
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-fetch-browser-session-profiles-done t=14277 rendererT=11685 durationMs=255",
+      "at": 1782979178038
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-onboarding-get-done t=14282 rendererT=11691 durationMs=5",
+      "at": 1782979178043
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-ssh-reconnect-skipped t=14283 rendererT=11691 connectionIds=0",
+      "at": 1782979178044
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-first-window-services-await-done t=14324 rendererT=11732 durationMs=41",
+      "at": 1782979178085
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-reconnect-terminals-done t=14366 rendererT=11774 durationMs=42",
+      "at": 1782979178127
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] renderer-startup-hydration-done t=14367 rendererT=11775 durationMs=1992",
+      "at": 1782979178128
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=14580 maxGapMs=453",
+      "at": 1782979178342
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=16597 maxGapMs=336",
+      "at": 1782979180358
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=18612 maxGapMs=15",
+      "at": 1782979182373
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035942.829:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=c46e04e4-af5f-4674-9a38-72253480baef restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=c46e04e4-af5f-4674-9a38-72253480baef:8089e7c5-e739-4785-b3b4-6844f99c0a86\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979182829
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035942.829:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979182829
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035942.876:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=e62346f1-a808-4397-8be7-422efa0aaebb restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=e62346f1-a808-4397-8be7-422efa0aaebb:e9b9d9ce-241c-458b-be93-01a657de7fd7\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979182877
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035942.876:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979182877
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@5810ae88 total=1300ms preflight=0ms auth=1ms host_env=44ms options=0ms provider_spawn=1255ms daemon=true reattach=false",
+      "at": 1782979184130
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@2c485ebc total=1308ms preflight=0ms auth=0ms host_env=49ms options=0ms provider_spawn=1259ms daemon=true reattach=false",
+      "at": 1782979184185
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=20628 maxGapMs=48",
+      "at": 1782979184389
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035945.089:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=894d9793-e2ae-40bf-864e-eef357f271c1 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=894d9793-e2ae-40bf-864e-eef357f271c1:1b683a77-2230-4238-96eb-5118ea595604\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979185089
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035945.089:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979185089
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@c3018b1f total=108ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=61ms daemon=true reattach=false",
+      "at": 1782979185197
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035946.036:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=8fd459b0-a0a8-416d-b698-521da990ace3 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=8fd459b0-a0a8-416d-b698-521da990ace3:74040bad-c0d6-42c6-af48-21150176be1c\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979186035
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035946.036:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979186035
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@59074e83 total=123ms preflight=0ms auth=0ms host_env=50ms options=0ms provider_spawn=73ms daemon=true reattach=false",
+      "at": 1782979186159
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=22635 maxGapMs=34",
+      "at": 1782979186396
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035946.971:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=6559b19f-a2e8-4691-8057-2efd9ba67d0e restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=6559b19f-a2e8-4691-8057-2efd9ba67d0e:8b41e717-29fe-49fb-a710-c96e41a1d112\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979186971
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035946.971:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979186971
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@562113d2 total=111ms preflight=0ms auth=0ms host_env=51ms options=0ms provider_spawn=60ms daemon=true reattach=false",
+      "at": 1782979187082
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035947.872:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=04620d6d-4629-40b3-8150-c7eec447d262 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=04620d6d-4629-40b3-8150-c7eec447d262:5992fb07-187a-43c3-9434-d424f1312155\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979187872
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035947.873:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979187873
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@b5230dba total=105ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=57ms daemon=true reattach=false",
+      "at": 1782979187978
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=24659 maxGapMs=46",
+      "at": 1782979188420
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035948.434:INFO:CONSOLE:397] \"Tooltip is changing from controlled to uncontrolled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.\", source: http://localhost:5173/@fs/C:/Users/jinwo/orca/workspaces/orca/windows-performance-improvement/node_modules/.vite/deps/chunk-22L5D3A7.js?v=43681c89 (397)",
+      "at": 1782979188434
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035948.761:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=bc4db6bc-b408-472a-9c15-77a428f98d99 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=bc4db6bc-b408-472a-9c15-77a428f98d99:11ff82bf-57d3-4e85-9293-77c0935f7d08\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979188761
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035948.762:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979188761
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@95bb2f74 total=101ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=54ms daemon=true reattach=false",
+      "at": 1782979188862
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035949.641:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=57b2a6d7-7fd2-41b2-9772-44e39bc9cee6 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=57b2a6d7-7fd2-41b2-9772-44e39bc9cee6:d186da0c-c1c4-45ca-90f1-e1f3b8fa4505\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979189640
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035949.641:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979189640
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@09fc3731 total=94ms preflight=0ms auth=0ms host_env=41ms options=0ms provider_spawn=53ms daemon=true reattach=false",
+      "at": 1782979189734
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=26688 maxGapMs=39",
+      "at": 1782979190449
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035950.510:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=6883a556-63dd-4c0a-87fa-9682db6f4cf0 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=6883a556-63dd-4c0a-87fa-9682db6f4cf0:e0e844db-da79-459b-b791-52ea58bab4da\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979190509
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035950.510:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979190510
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@fceb8b39 total=91ms preflight=0ms auth=0ms host_env=39ms options=1ms provider_spawn=51ms daemon=true reattach=false",
+      "at": 1782979190601
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035951.407:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=aa62c8e8-2ef4-4aa3-ac4d-b9063cfa527e restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=aa62c8e8-2ef4-4aa3-ac4d-b9063cfa527e:c2c02ac2-e421-4c29-a8b6-4c97c11bf1dc\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979191407
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035951.407:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979191407
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@badd8d38 total=104ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=56ms daemon=true reattach=false",
+      "at": 1782979191511
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035951.824:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=66083463-228e-4fb0-90c5-231dc75e8da6 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=66083463-228e-4fb0-90c5-231dc75e8da6:e4fc0e83-57a8-44f0-9732-936e2914292b\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979191824
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035951.824:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979191824
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@ad09f3fe total=102ms preflight=0ms auth=0ms host_env=38ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+      "at": 1782979191926
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035952.310:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=b99bb441-7027-40a9-beb2-a558ece6f979 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=b99bb441-7027-40a9-beb2-a558ece6f979:f5f1c1e2-72ac-4152-958b-b0b80e1213cc\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979192310
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035952.311:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979192310
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@0bb8c245 total=112ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+      "at": 1782979192422
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=28705 maxGapMs=52",
+      "at": 1782979192466
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035952.723:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=490084ae-1bdb-4359-bb86-097e26902f98 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=490084ae-1bdb-4359-bb86-097e26902f98:c3647cbf-2f6e-4b4b-89c1-8bea8b949d66\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979192723
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035952.723:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979192723
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@3ef141e6 total=152ms preflight=0ms auth=0ms host_env=41ms options=0ms provider_spawn=111ms daemon=true reattach=false",
+      "at": 1782979192875
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=30719 maxGapMs=43",
+      "at": 1782979194480
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=32744 maxGapMs=12",
+      "at": 1782979196505
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=34767 maxGapMs=14",
+      "at": 1782979198528
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035959.350:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=769013c6-b5b8-4be9-b188-4444a6094567 restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=769013c6-b5b8-4be9-b188-4444a6094567:2a72038c-911c-4095-9fe8-0cd8c7f4978b\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979199349
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035959.350:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979199349
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one@@c450cf26 total=113ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=66ms daemon=true reattach=false",
+      "at": 1782979199463
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035959.852:INFO:CONSOLE:479] \"[pty-connect] pane=1 tab=15055907-3232-4ca1-8814-e5484ba78a5b restored=null existing=null detached=null reattach=null hasTransport=false pendingKey=15055907-3232-4ca1-8814-e5484ba78a5b:78b7478c-39a9-4111-aed8-1e2ddf568c24\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979199852
+    },
+    {
+      "source": "stderr",
+      "line": "[47624:0702/035959.853:INFO:CONSOLE:479] \"[pty-connect] pane=1 -> FRESH SPAWN\", source: http://localhost:5173/src/components/terminal-pane/pty-connection.ts (479)",
+      "at": 1782979199853
+    },
+    {
+      "source": "stdout",
+      "line": "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06 total=104ms preflight=0ms auth=0ms host_env=43ms options=0ms provider_spawn=61ms daemon=true reattach=false",
+      "at": 1782979199957
+    },
+    {
+      "source": "stderr",
+      "line": "[startup] event-loop-stall t=36789 maxGapMs=49",
+      "at": 1782979200550
+    }
+  ],
+  "ptySpawnTimings": [
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@5810ae88 total=1300ms preflight=0ms auth=1ms host_env=44ms options=0ms provider_spawn=1255ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@2c485ebc total=1308ms preflight=0ms auth=0ms host_env=49ms options=0ms provider_spawn=1259ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@c3018b1f total=108ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=61ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@59074e83 total=123ms preflight=0ms auth=0ms host_env=50ms options=0ms provider_spawn=73ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@562113d2 total=111ms preflight=0ms auth=0ms host_env=51ms options=0ms provider_spawn=60ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@b5230dba total=105ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=57ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@95bb2f74 total=101ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=54ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@09fc3731 total=94ms preflight=0ms auth=0ms host_env=41ms options=0ms provider_spawn=53ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@fceb8b39 total=91ms preflight=0ms auth=0ms host_env=39ms options=1ms provider_spawn=51ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@badd8d38 total=104ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=56ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@ad09f3fe total=102ms preflight=0ms auth=0ms host_env=38ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@0bb8c245 total=112ms preflight=0ms auth=0ms host_env=48ms options=0ms provider_spawn=64ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/repo@@3ef141e6 total=152ms preflight=0ms auth=0ms host_env=41ms options=0ms provider_spawn=111ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-one@@c450cf26 total=113ms preflight=0ms auth=0ms host_env=47ms options=0ms provider_spawn=66ms daemon=true reattach=false",
+    "[pty-spawn-timing] id=cd78ddb3-9689-4d21-b87b-8e38f92d2e7b::C:/Users/jinwo/AppData/Local/Temp/orca-termperf-IyoYoT/wt-two@@ae6fdb06 total=104ms preflight=0ms auth=0ms host_env=43ms options=0ms provider_spawn=61ms daemon=true reattach=false"
+  ]
+}

--- a/tools/benchmarks/terminal-perf-bench.mjs
+++ b/tools/benchmarks/terminal-perf-bench.mjs
@@ -459,7 +459,11 @@ function summarizeScenario(name, result) {
   }
   const fields = {}
   const keys = new Set()
-  for (const sample of result.samples) {
+  // Why: a timed-out sample carries its timeout ceiling as the measurement,
+  // which would masquerade as a giant latency in median/p95/max. Timeouts are
+  // reported through the separate timedOut count instead.
+  const completedSamples = result.samples.filter((sample) => !sample.timedOut)
+  for (const sample of completedSamples) {
     for (const [key, value] of Object.entries(sample)) {
       if (typeof value === 'number' && key !== 'index') {
         keys.add(key)
@@ -467,7 +471,7 @@ function summarizeScenario(name, result) {
     }
   }
   for (const key of keys) {
-    fields[key] = summarize(result.samples.map((sample) => sample[key]))
+    fields[key] = summarize(completedSamples.map((sample) => sample[key]))
   }
   const longtasks = result.longtasks ?? []
   return {
@@ -482,14 +486,9 @@ function summarizeScenario(name, result) {
 
 async function main() {
   const args = parseArgs()
-  const fixture = createLocalRepoFixture()
-  const cdpPort = await pickFreePort()
-  const userDataDir = createGpuUserDataDirectory('bench')
-  console.log(`[terminal-perf] fixture=${fixture.baseDir} userData=${userDataDir} cdp=${cdpPort}`)
-  const launched = launchDevApp({ cdpPort, userDataDir })
-  let browser = null
-  let page = null
   const startedAt = Date.now()
+  // Why: the report and clocks exist before any setup so a launch/setup
+  // failure still produces a report and reaches the cleanup below.
   const report = {
     label: args.label,
     startedAt: new Date(startedAt).toISOString(),
@@ -501,7 +500,17 @@ async function main() {
     finalDiagnostics: null,
     cleanupErrors: []
   }
+  let fixture = null
+  let userDataDir = null
+  let launched = null
+  let browser = null
+  let page = null
   try {
+    fixture = createLocalRepoFixture()
+    const cdpPort = await pickFreePort()
+    userDataDir = createGpuUserDataDirectory('bench')
+    console.log(`[terminal-perf] fixture=${fixture.baseDir} userData=${userDataDir} cdp=${cdpPort}`)
+    launched = launchDevApp({ cdpPort, userDataDir })
     const connected = await connectToApp(cdpPort)
     browser = connected.browser
     page = connected.page
@@ -554,16 +563,28 @@ async function main() {
     if (browser) {
       await browser.close().catch(() => undefined)
     }
-    await stopDevApp(launched.child)
-    report.appLogsTail = launched.logs.slice(-80)
-    // Main-process phase attribution (requires ORCA_PTY_SPAWN_TIMING=1 in the
-    // benchmark's environment; launchDevApp inherits it into the app).
-    report.ptySpawnTimings = launched.logs
-      .filter((entry) => entry.line.includes('[pty-spawn-timing]'))
-      .map((entry) => entry.line.slice(entry.line.indexOf('[pty-spawn-timing]')))
+    if (launched) {
+      // Why: a shutdown failure must not abort the rest of teardown — the
+      // report still gets written and temp dirs still get removed.
+      try {
+        await stopDevApp(launched.child)
+      } catch (error) {
+        report.cleanupErrors.push(error instanceof Error ? error.message : String(error))
+      }
+      report.appLogsTail = launched.logs.slice(-80)
+      // Main-process phase attribution (requires ORCA_PTY_SPAWN_TIMING=1 in the
+      // benchmark's environment; launchDevApp inherits it into the app).
+      report.ptySpawnTimings = launched.logs
+        .filter((entry) => entry.line.includes('[pty-spawn-timing]'))
+        .map((entry) => entry.line.slice(entry.line.indexOf('[pty-spawn-timing]')))
+    }
     if (!args.keep) {
-      safeRemoveLocalDirectory(fixture.baseDir, report.cleanupErrors)
-      safeRemoveLocalDirectory(userDataDir, report.cleanupErrors)
+      if (fixture) {
+        safeRemoveLocalDirectory(fixture.baseDir, report.cleanupErrors)
+      }
+      if (userDataDir) {
+        safeRemoveLocalDirectory(userDataDir, report.cleanupErrors)
+      }
     }
     const stamp = new Date(startedAt).toISOString().replace(/[:.]/g, '-')
     const reportPath = path.resolve(

--- a/tools/benchmarks/terminal-perf-bench.mjs
+++ b/tools/benchmarks/terminal-perf-bench.mjs
@@ -1,0 +1,600 @@
+#!/usr/bin/env node
+// Terminal interaction latency benchmark: tab creation, tab switching, and
+// workspace switching against the real Electron dev app over CDP. Produces
+// median/p95 phase timings so Windows terminal slowness can be attributed to
+// store work, PTY spawn, shell startup, or renderer paint — not guessed at.
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import {
+  collectRendererDiagnostics,
+  connectToApp,
+  createGpuUserDataDirectory,
+  installRendererProbe,
+  launchDevApp,
+  pickFreePort,
+  stopDevApp,
+  waitForStoreReady
+} from '../../config/scripts/windows-apphang-repro/electron-dev-session.mjs'
+import {
+  pollUntil,
+  rendererActionTimeoutMs,
+  runWithTimeout,
+  setupTimeoutMs
+} from '../../config/scripts/windows-apphang-repro/repro-timing.mjs'
+import { safeRemoveLocalDirectory } from '../../config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs'
+
+const rootDir = path.resolve(fileURLToPath(new URL('../..', import.meta.url)))
+const scenarioTimeoutMs = 300_000
+const defaultIterations = 8
+const defaultSwitches = 24
+const defaultCycles = 12
+
+function parseArgs() {
+  const args = {
+    label: 'run',
+    iterations: defaultIterations,
+    switches: defaultSwitches,
+    cycles: defaultCycles,
+    shell: null,
+    scenarios: ['tab-create', 'tab-switch', 'workspace-switch'],
+    reportPath: null,
+    keep: false
+  }
+  for (const arg of process.argv.slice(2)) {
+    if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    }
+    if (arg === '--keep') {
+      args.keep = true
+      continue
+    }
+    const [name, value] = arg.split('=', 2)
+    if (name === '--label') {
+      args.label = value?.trim() || 'run'
+      continue
+    }
+    if (name === '--iterations') {
+      args.iterations = parsePositiveInt(name, value)
+      continue
+    }
+    if (name === '--switches') {
+      args.switches = parsePositiveInt(name, value)
+      continue
+    }
+    if (name === '--cycles') {
+      args.cycles = parsePositiveInt(name, value)
+      continue
+    }
+    if (name === '--shell') {
+      args.shell = value?.trim() || null
+      continue
+    }
+    if (name === '--scenarios') {
+      const scenarios = (value ?? '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+      const known = new Set(['tab-create', 'tab-switch', 'workspace-switch'])
+      if (scenarios.length === 0 || scenarios.some((scenario) => !known.has(scenario))) {
+        throw new Error(
+          `Unsupported --scenarios=${value}. Use tab-create,tab-switch,workspace-switch.`
+        )
+      }
+      args.scenarios = scenarios
+      continue
+    }
+    if (name === '--report') {
+      args.reportPath = value?.trim() || null
+      continue
+    }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+  return args
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node tools/benchmarks/terminal-perf-bench.mjs [options]
+
+Options:
+  --label=NAME             Label recorded in the report filename/JSON. Default: run.
+  --iterations=N           Terminal tab create/close iterations. Default: ${defaultIterations}.
+  --switches=N             Tab switch alternations. Default: ${defaultSwitches}.
+  --cycles=N               Workspace switch cycles. Default: ${defaultCycles}.
+  --shell=PATH             Shell override for created tabs (e.g. cmd.exe). Default: app default.
+  --scenarios=a,b          Subset of tab-create,tab-switch,workspace-switch.
+  --report=PATH            Report JSON path. Default: tools/benchmarks/results/terminal-perf-<label>-<ts>.json.
+  --keep                   Keep the temp fixture and user data dir.`)
+}
+
+function parsePositiveInt(name, value) {
+  const parsed = Number.parseInt(value ?? '', 10)
+  if (!Number.isInteger(parsed) || parsed <= 0 || String(parsed) !== value) {
+    throw new Error(`${name} requires a positive integer.`)
+  }
+  return parsed
+}
+
+function git(cwd, ...cmd) {
+  execFileSync('git', cmd, { cwd, stdio: 'pipe' })
+}
+
+/** Local (native-path) git repo with two external worktrees — three workspace
+ *  cards total. Native paths keep the benchmark portable and representative of
+ *  the default local workflow, unlike the WSL-specific apphang fixture. */
+function createLocalRepoFixture() {
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), 'orca-termperf-'))
+  const repoPath = path.join(baseDir, 'repo')
+  mkdirSync(repoPath, { recursive: true })
+  git(repoPath, 'init', '--initial-branch=main')
+  git(repoPath, 'config', 'user.email', 'bench@orca.local')
+  git(repoPath, 'config', 'user.name', 'Orca Bench')
+  writeFileSync(path.join(repoPath, 'README.md'), '# terminal perf fixture\n')
+  git(repoPath, 'add', '.')
+  git(repoPath, 'commit', '-m', 'init', '--no-gpg-sign')
+  const worktreePaths = []
+  for (const name of ['wt-one', 'wt-two']) {
+    const worktreePath = path.join(baseDir, name)
+    git(repoPath, 'worktree', 'add', worktreePath, '-b', name)
+    worktreePaths.push(worktreePath)
+  }
+  return { baseDir, repoPath, worktreePaths }
+}
+
+async function setupWorkspaces(page, fixture) {
+  return await runWithTimeout(
+    'fixture registration in Orca',
+    () =>
+      page.evaluate(
+        async ({ repoPath, importedWorktreePaths }) => {
+          const store = window.__store
+          if (!store) {
+            throw new Error('window.__store is unavailable.')
+          }
+          await store.getState().fetchSettings?.()
+          const addResult = await window.api.repos.add({ path: repoPath, kind: 'git' })
+          if ('error' in addResult) {
+            throw new Error(addResult.error)
+          }
+          await store.getState().fetchRepos()
+          const state = store.getState()
+          const repo =
+            state.repos.find((candidate) => candidate.path === repoPath) ?? addResult.repo
+          await state.updateRepo(repo.id, {
+            externalWorktreeVisibility: 'show',
+            externalWorktreeVisibilityPromptDismissedAt: Date.now(),
+            importedExternalWorktreePaths: importedWorktreePaths,
+            externalWorktreeInboxBaselinePaths: importedWorktreePaths
+          })
+          await store.getState().fetchWorktrees(repo.id, { requireAuthoritative: true })
+          const nextState = store.getState()
+          nextState.setSidebarOpen(true)
+          nextState.setGroupBy('none')
+          nextState.setSortBy('recent')
+          nextState.setShowActiveOnly(false)
+          nextState.setActiveView('terminal')
+          const worktrees = nextState.worktreesByRepo[repo.id] ?? []
+          return {
+            repoId: repo.id,
+            worktrees: worktrees.map((worktree) => ({
+              id: worktree.id,
+              path: worktree.path,
+              displayName: worktree.displayName,
+              isMainWorktree: worktree.isMainWorktree
+            }))
+          }
+        },
+        { repoPath: fixture.repoPath, importedWorktreePaths: fixture.worktreePaths }
+      ),
+    setupTimeoutMs
+  )
+}
+
+async function clickWorktreeCard(page, worktreeId) {
+  const rect = await runWithTimeout(
+    `locate worktree card ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const rows = Array.from(document.querySelectorAll('[data-worktree-id]'))
+        const row = rows.find((candidate) => candidate.getAttribute('data-worktree-id') === id)
+        if (!row) {
+          return null
+        }
+        row.scrollIntoView({ block: 'center', inline: 'nearest' })
+        const surface = row.querySelector('[data-worktree-card-surface="true"]') ?? row
+        const bounds = surface.getBoundingClientRect()
+        if (bounds.width <= 0 || bounds.height <= 0) {
+          return null
+        }
+        return { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 }
+      }, worktreeId),
+    rendererActionTimeoutMs
+  )
+  if (!rect) {
+    throw new Error(`Could not find rendered worktree card for ${worktreeId}`)
+  }
+  await runWithTimeout(
+    `click worktree card ${worktreeId}`,
+    () => page.mouse.click(rect.x, rect.y),
+    rendererActionTimeoutMs
+  )
+}
+
+async function activateWorktree(page, worktreeId) {
+  await clickWorktreeCard(page, worktreeId)
+  await pollUntil(
+    `active worktree ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        return state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+      }, worktreeId),
+    Boolean,
+    30_000
+  )
+}
+
+/** Runs entirely in the renderer so phase timestamps come from one
+ *  performance.now() clock with no CDP round-trip skew. */
+async function runTabCreateScenario(page, worktreeId, iterations, shell) {
+  return await runWithTimeout(
+    'tab-create scenario',
+    () =>
+      page.evaluate(
+        async ({ worktreeId, iterations, shell }) => {
+          const store = window.__store
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+          const raf2 = () =>
+            new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+          const longtasks = []
+          const observer = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+              longtasks.push(entry.duration)
+            }
+          })
+          observer.observe({ entryTypes: ['longtask'] })
+          const samples = []
+          for (let index = 0; index < iterations; index++) {
+            const t0 = performance.now()
+            const tab = store.getState().createTab(worktreeId, undefined, shell ?? undefined)
+            const tCreated = performance.now()
+            const readPane = () => {
+              const manager = window.__paneManagers?.get(tab.id)
+              return manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+            }
+            let ptyId = null
+            while (!ptyId && performance.now() - t0 < 60_000) {
+              ptyId = readPane()?.container?.dataset?.ptyId ?? null
+              if (!ptyId) {
+                await sleep(5)
+              }
+            }
+            const tPty = performance.now()
+            let sawOutput = false
+            while (!sawOutput && performance.now() - t0 < 60_000) {
+              const content = readPane()?.serializeAddon?.serialize?.() ?? ''
+              sawOutput = content.trim().length > 0
+              if (!sawOutput) {
+                await sleep(10)
+              }
+            }
+            const tOutput = performance.now()
+            await raf2()
+            const tPainted = performance.now()
+            samples.push({
+              index,
+              storeCreateMs: tCreated - t0,
+              ptyBindMs: tPty - t0,
+              firstOutputMs: tOutput - t0,
+              paintSettleMs: tPainted - t0,
+              timedOut: !ptyId || !sawOutput
+            })
+            store.getState().closeTab(tab.id)
+            await sleep(400)
+          }
+          observer.disconnect()
+          return { samples, longtasks }
+        },
+        { worktreeId, iterations, shell }
+      ),
+    scenarioTimeoutMs
+  )
+}
+
+/** K tabs are created up-front (PTY bound), then activation alternates across
+ *  them. switchMs = setActiveTab call → active pane manager/pane for the new
+ *  tab present → two RAFs (paint settled). */
+async function runTabSwitchScenario(page, worktreeId, switches, shell) {
+  return await runWithTimeout(
+    'tab-switch scenario',
+    () =>
+      page.evaluate(
+        async ({ worktreeId, switches, shell }) => {
+          const store = window.__store
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+          const raf2 = () =>
+            new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+          const tabCount = 4
+          const tabs = []
+          for (let index = 0; index < tabCount; index++) {
+            const tab = store.getState().createTab(worktreeId, undefined, shell ?? undefined)
+            tabs.push(tab.id)
+            const started = performance.now()
+            let bound = false
+            while (!bound && performance.now() - started < 60_000) {
+              const manager = window.__paneManagers?.get(tab.id)
+              const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+              bound = Boolean(pane?.container?.dataset?.ptyId)
+              if (!bound) {
+                await sleep(10)
+              }
+            }
+          }
+          await sleep(500)
+          const longtasks = []
+          const observer = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+              longtasks.push(entry.duration)
+            }
+          })
+          observer.observe({ entryTypes: ['longtask'] })
+          const samples = []
+          for (let index = 0; index < switches; index++) {
+            const targetTabId = tabs[index % tabs.length]
+            if (store.getState().activeTabId === targetTabId) {
+              continue
+            }
+            const t0 = performance.now()
+            store.getState().setActiveTab(targetTabId)
+            const tStore = performance.now()
+            let visible = false
+            while (!visible && performance.now() - t0 < 10_000) {
+              const manager = window.__paneManagers?.get(targetTabId)
+              const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+              visible = Boolean(pane?.container?.isConnected)
+              if (!visible) {
+                await sleep(2)
+              }
+            }
+            const tVisible = performance.now()
+            await raf2()
+            const tPainted = performance.now()
+            samples.push({
+              index,
+              targetTabId,
+              storeMs: tStore - t0,
+              paneVisibleMs: tVisible - t0,
+              paintSettleMs: tPainted - t0,
+              timedOut: !visible
+            })
+            await sleep(120)
+          }
+          observer.disconnect()
+          for (const tabId of tabs) {
+            store.getState().closeTab(tabId)
+          }
+          return { samples, longtasks }
+        },
+        { worktreeId, switches, shell }
+      ),
+    scenarioTimeoutMs
+  )
+}
+
+async function runWorkspaceSwitchScenario(page, worktreeIds, cycles) {
+  const samples = []
+  for (let index = 0; index < cycles; index++) {
+    const worktreeId = worktreeIds[index % worktreeIds.length]
+    const t0 = Date.now()
+    await clickWorktreeCard(page, worktreeId)
+    await pollUntil(
+      `workspace activation ${worktreeId}`,
+      () =>
+        page.evaluate((id) => {
+          const state = window.__store?.getState?.()
+          return state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+        }, worktreeId),
+      Boolean,
+      30_000,
+      10
+    )
+    const activationMs = Date.now() - t0
+    const pty = await pollUntil(
+      `workspace pty ${worktreeId}`,
+      () =>
+        page.evaluate((id) => {
+          const state = window.__store?.getState?.()
+          const tabId =
+            state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+              ? state.activeTabId
+              : (state?.activeTabIdByWorktree?.[id] ?? null)
+          const manager = tabId ? window.__paneManagers?.get(tabId) : null
+          const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+          return pane?.container?.dataset?.ptyId ?? null
+        }, worktreeId),
+      Boolean,
+      30_000,
+      10
+    )
+    const ptyBindMs = Date.now() - t0
+    await runWithTimeout(
+      'paint settle',
+      () =>
+        page.evaluate(
+          () =>
+            new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+        ),
+      rendererActionTimeoutMs
+    )
+    const paintSettleMs = Date.now() - t0
+    samples.push({ index, worktreeId, ptyId: pty, activationMs, ptyBindMs, paintSettleMs })
+  }
+  return { samples }
+}
+
+function summarize(values) {
+  const sorted = values.filter((value) => Number.isFinite(value)).sort((a, b) => a - b)
+  if (sorted.length === 0) {
+    return null
+  }
+  const at = (fraction) =>
+    sorted[Math.min(sorted.length - 1, Math.round(fraction * (sorted.length - 1)))]
+  return {
+    count: sorted.length,
+    median: Math.round(at(0.5)),
+    p95: Math.round(at(0.95)),
+    max: Math.round(sorted.at(-1))
+  }
+}
+
+function summarizeScenario(name, result) {
+  if (!result) {
+    return null
+  }
+  const fields = {}
+  const keys = new Set()
+  for (const sample of result.samples) {
+    for (const [key, value] of Object.entries(sample)) {
+      if (typeof value === 'number' && key !== 'index') {
+        keys.add(key)
+      }
+    }
+  }
+  for (const key of keys) {
+    fields[key] = summarize(result.samples.map((sample) => sample[key]))
+  }
+  const longtasks = result.longtasks ?? []
+  return {
+    name,
+    samples: result.samples.length,
+    timedOut: result.samples.filter((sample) => sample.timedOut).length,
+    fields,
+    longtaskCount: longtasks.length,
+    longtaskMaxMs: longtasks.length ? Math.round(Math.max(...longtasks)) : 0
+  }
+}
+
+async function main() {
+  const args = parseArgs()
+  const fixture = createLocalRepoFixture()
+  const cdpPort = await pickFreePort()
+  const userDataDir = createGpuUserDataDirectory('bench')
+  console.log(`[terminal-perf] fixture=${fixture.baseDir} userData=${userDataDir} cdp=${cdpPort}`)
+  const launched = launchDevApp({ cdpPort, userDataDir })
+  let browser = null
+  let page = null
+  const startedAt = Date.now()
+  const report = {
+    label: args.label,
+    startedAt: new Date(startedAt).toISOString(),
+    platform: `${process.platform} ${os.release()}`,
+    shell: args.shell ?? 'default',
+    args: { iterations: args.iterations, switches: args.switches, cycles: args.cycles },
+    scenarios: {},
+    summaries: [],
+    finalDiagnostics: null,
+    cleanupErrors: []
+  }
+  try {
+    const connected = await connectToApp(cdpPort)
+    browser = connected.browser
+    page = connected.page
+    await waitForStoreReady(page)
+    await installRendererProbe(page)
+    const setup = await setupWorkspaces(page, fixture)
+    const worktrees = setup.worktrees
+    if (worktrees.length < 2) {
+      throw new Error(`Expected >=2 worktrees, got ${worktrees.length}`)
+    }
+    const primary = worktrees.find((worktree) => worktree.isMainWorktree) ?? worktrees[0]
+    await activateWorktree(page, primary.id)
+
+    if (args.scenarios.includes('tab-create')) {
+      console.log(`[terminal-perf] scenario=tab-create iterations=${args.iterations}`)
+      report.scenarios['tab-create'] = await runTabCreateScenario(
+        page,
+        primary.id,
+        args.iterations,
+        args.shell
+      )
+    }
+    if (args.scenarios.includes('tab-switch')) {
+      console.log(`[terminal-perf] scenario=tab-switch switches=${args.switches}`)
+      report.scenarios['tab-switch'] = await runTabSwitchScenario(
+        page,
+        primary.id,
+        args.switches,
+        args.shell
+      )
+    }
+    if (args.scenarios.includes('workspace-switch')) {
+      console.log(`[terminal-perf] scenario=workspace-switch cycles=${args.cycles}`)
+      const targets = worktrees.slice(0, 3).map((worktree) => worktree.id)
+      report.scenarios['workspace-switch'] = await runWorkspaceSwitchScenario(
+        page,
+        targets,
+        args.cycles
+      )
+    }
+    report.finalDiagnostics = await collectRendererDiagnostics(page)
+  } finally {
+    report.elapsedMs = Date.now() - startedAt
+    for (const [name, result] of Object.entries(report.scenarios)) {
+      const summary = summarizeScenario(name, result)
+      if (summary) {
+        report.summaries.push(summary)
+      }
+    }
+    if (browser) {
+      await browser.close().catch(() => undefined)
+    }
+    await stopDevApp(launched.child)
+    report.appLogsTail = launched.logs.slice(-80)
+    // Main-process phase attribution (requires ORCA_PTY_SPAWN_TIMING=1 in the
+    // benchmark's environment; launchDevApp inherits it into the app).
+    report.ptySpawnTimings = launched.logs
+      .filter((entry) => entry.line.includes('[pty-spawn-timing]'))
+      .map((entry) => entry.line.slice(entry.line.indexOf('[pty-spawn-timing]')))
+    if (!args.keep) {
+      safeRemoveLocalDirectory(fixture.baseDir, report.cleanupErrors)
+      safeRemoveLocalDirectory(userDataDir, report.cleanupErrors)
+    }
+    const stamp = new Date(startedAt).toISOString().replace(/[:.]/g, '-')
+    const reportPath = path.resolve(
+      args.reportPath ??
+        path.join(
+          rootDir,
+          'tools',
+          'benchmarks',
+          'results',
+          `terminal-perf-${args.label}-${stamp}.json`
+        )
+    )
+    mkdirSync(path.dirname(reportPath), { recursive: true })
+    writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+    console.log(`[terminal-perf] report=${reportPath}`)
+    for (const summary of report.summaries) {
+      console.log(
+        `[terminal-perf] ${summary.name}: samples=${summary.samples} timedOut=${summary.timedOut} longtasks=${summary.longtaskCount} (max ${summary.longtaskMaxMs}ms)`
+      )
+      for (const [field, stats] of Object.entries(summary.fields)) {
+        if (stats) {
+          console.log(
+            `[terminal-perf]   ${field}: median=${stats.median}ms p95=${stats.p95}ms max=${stats.max}ms`
+          )
+        }
+      }
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error))
+  process.exit(1)
+})


### PR DESCRIPTION
﻿## Summary

Windows terminal interactions (workspace switching, terminal creation, tab switching) are noticeably slower than macOS, and #6874-style hangs were reported around terminal activation. This PR benchmarks the gaps, fixes the highest-impact Windows-specific costs, and supersedes #7080 (its commits are merged in here).

No WebGL disabling anywhere — every fix keeps GPU rendering and addresses the actual waste.

## What's included

**From #7080 (merged in, unchanged):** eager WebGL context release on pane disposal, `pty:kill` synthesizing `pty:exit` when provider shutdown is silent (stale-terminal recovery), and the Windows/WSL AppHang repro harness.

**New in this branch:**

1. **Retain terminal WebGL contexts across workspace hide/show** (`pane-webgl-context-retention.ts`)
   Workspace switches disposed every hidden pane's WebGL context and recreated it on return — ~5ms on macOS but 100–500ms per pane on Windows (ANGLE → D3D11), paid synchronously on the switch path (the old code comment admitted this). The dispose-on-hide policy guarded Chromium's 16-context budget, which #7064 raised to 128, so the premise is stale. Suspended panes now keep live contexts in an LRU (cap 32, sized for ~10–16 worktrees × ~2 terminals hot sets; evictions disposed through the #7080 release path); resume repaints instead of recreating. Atlas-recovery bursts now skip suspended panes, so recovery cost scales with visible panes instead of total panes across all workspaces. **Retention is gated to Windows** (runtime platform check): context creation is ~5ms on macOS/Linux GL, so those platforms keep the long-proven dispose-on-hide behavior and pay no retention GPU-memory cost. The atlas-recovery scoping applies on all platforms.

2. **Bundled ConPTY for LocalPtyProvider spawns** (`local-pty-utils.ts`)
   The daemon spawn path passes `useConptyDll: true`; degraded-mode/fresh-local spawns silently ran on the legacy system ConPTY (which the daemon path's own comment blames for full-width TUI scrollback corruption). Now consistent.

3. **Warm the daemon's first ConPTY at boot** (`windows-conpty-warmup.ts`)
   The first ConPTY spawn in the daemon pays one-time costs (conpty native module load, bundled conpty.dll + OpenConsole.exe first launch, Defender scans): measured **2.75s** inside `provider.spawn` vs ~70ms warm — previously paid by the user's first terminal. A throwaway `cmd.exe /c exit` at daemon boot absorbs it.

4. **Measurement infrastructure**
   - `tools/benchmarks/terminal-perf-bench.mjs`: CDP-driven benchmark of tab-create / tab-switch / workspace-switch with renderer-clock phase timings (store → PTY bind → first output → paint settle), longtask counts, WebGL context diagnostics.
   - `ORCA_PTY_SPAWN_TIMING=1`: one log line per `pty:spawn` attributing latency to barrier/auth/host-env/provider phases (`pty-spawn-timing.ts`).

## Measurements (Windows 11, dev build, JSON reports in tools/benchmarks/results/)

| metric | baseline | after |
|---|---|---|
| first-terminal `provider_spawn` (cold daemon) | 2749ms | 1255ms¹ |
| workspace-switch activation (median) | 202ms | 159ms |
| hidden panes keeping WebGL contexts (3-pane fixture) | 1/3 | 3/3 |
| steady-state spawn, main-process handler total | ~115ms (host_env≈50, provider_spawn≈68) | unchanged |

¹ The benchmark opens a terminal ~1s after app-ready, so the real spawn still queues behind the in-flight warm-up; with a realistic gap the cost is fully absorbed. Workspace-switch gains scale with panes-per-worktree and GPU slowness; the fixture is 1 pane/worktree on a fast GPU.

Spawn-phase attribution also shows steady-state tab-create (~500ms) is dominated by renderer-side work (xterm open + WebGL context creation for the new pane), not the PTY path — see follow-ups.

## Follow-ups (documented in notes/windows-perf-progress.md)

- Tab-switch paint settle (median ~80ms) is the light-tab-resume atlas recovery burst (3× shared-atlas clear + all-pane refresh per switch). Risky output already schedules parse-time recovery, so the reveal-time burst can likely become a scoped repaint — but #7058 touched this and was reverted (#7073), so it needs that context first.
- Renderer-side ~400ms of tab creation (possibly defer WebGL attach for brand-new panes).
- Cold-restore respawn fan-out has no concurrency cap; node-pty ≥1.2.0-beta defers ConPTY connect (spawn returns fast), which would stop respawn storms serializing the daemon loop.

## Verification

- `pnpm exec vitest run` on pane-manager (317), terminal-pane (1421), providers + daemon suites, focused pty kill/exit tests — all pass.
- `pnpm run typecheck`, `oxlint` on changed files — clean.
- Benchmark before/after reports committed; retention verified via WebGL context diagnostics.
- Pre-existing Windows-only failures (also on main; CI is ubuntu-only): 5 attribution-shim PATH assertions in `src/main/ipc/pty.test.ts`, 1 WSL env-import test in `pty-subprocess.test.ts`.

Supersedes #7080. Refs #6874.

