### PR TITLE
Bound hot-terminal full-snapshot checkpoints with a per-session cooldown

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -719,6 +719,108 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(checkpoint).not.toHaveBeenCalled()
     })
 
+    describe('full-snapshot cooldown', () => {
+      type CooldownInternals = {
+        client: { request: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }
+        historyManager: {
+          checkpoint: ReturnType<typeof vi.fn>
+          appendIncrements: ReturnType<typeof vi.fn>
+          dispose: ReturnType<typeof vi.fn>
+        }
+        checkpointSessions(
+          sessionIds: Iterable<string>,
+          opts?: { final?: boolean; teardown?: boolean }
+        ): Promise<Set<string>>
+        sessionsNeedingFullCheckpoint: Set<string>
+        lastFullCheckpointAt: Map<string, number>
+      }
+
+      function makeCooldownHarness(takeResult: {
+        overflowed: boolean
+        appendResult?: 'ok' | 'needs-checkpoint'
+      }): CooldownInternals {
+        historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+        const request = vi.fn(async (_type: string, payload: Record<string, unknown>) => {
+          if (payload.includeSnapshot === true) {
+            return { records: [], seq: 2, overflowed: false, snapshot: { cols: 80, rows: 24 } }
+          }
+          return {
+            records: [{ kind: 'output', data: 'x' }],
+            seq: 1,
+            overflowed: takeResult.overflowed,
+            snapshot: null
+          }
+        })
+        const internals = historyAdapter as unknown as CooldownInternals
+        internals.client = { request, disconnect: vi.fn() }
+        internals.historyManager = {
+          checkpoint: vi.fn(async () => {}),
+          appendIncrements: vi.fn(async () => takeResult.appendResult ?? 'ok'),
+          dispose: vi.fn(async () => {})
+        }
+        return internals
+      }
+
+      it('bounds overflow-triggered full snapshots to one per cooldown window', async () => {
+        const internals = makeCooldownHarness({ overflowed: true })
+
+        // First overflow: full snapshot allowed immediately.
+        await expect(internals.checkpointSessions(['hot'])).resolves.toEqual(new Set(['hot']))
+        expect(internals.historyManager.checkpoint).toHaveBeenCalledTimes(1)
+
+        // Second tick inside the cooldown: the overflow defers and flags the
+        // session; no snapshot write.
+        await expect(internals.checkpointSessions(['hot'])).resolves.toEqual(new Set())
+        expect(internals.historyManager.checkpoint).toHaveBeenCalledTimes(1)
+        expect(internals.sessionsNeedingFullCheckpoint.has('hot')).toBe(true)
+        const requestsAfterSecondTick = internals.client.request.mock.calls.length
+
+        // Ticks 3..24 (a hot session over ~2 minutes): flagged + cooling down
+        // short-circuits with ZERO daemon RPCs and zero disk writes.
+        for (let i = 0; i < 22; i++) {
+          await expect(internals.checkpointSessions(['hot'])).resolves.toEqual(new Set())
+        }
+        expect(internals.historyManager.checkpoint).toHaveBeenCalledTimes(1)
+        expect(internals.client.request.mock.calls.length).toBe(requestsAfterSecondTick)
+
+        // Cooldown expiry: the deferred full snapshot lands and clears the flag.
+        internals.lastFullCheckpointAt.set('hot', Date.now() - 46_000)
+        await expect(internals.checkpointSessions(['hot'])).resolves.toEqual(new Set(['hot']))
+        expect(internals.historyManager.checkpoint).toHaveBeenCalledTimes(2)
+        expect(internals.sessionsNeedingFullCheckpoint.has('hot')).toBe(false)
+      })
+
+      it('lets final checkpoints bypass the cooldown', async () => {
+        const internals = makeCooldownHarness({ overflowed: true })
+        await internals.checkpointSessions(['hot'])
+        expect(internals.historyManager.checkpoint).toHaveBeenCalledTimes(1)
+
+        // Cooldown is active, but quit/sleep-time persistence must not be
+        // deferred — stale-on-crash is acceptable, stale-on-clean-exit is not.
+        await expect(internals.checkpointSessions(['hot'], { final: true })).resolves.toEqual(
+          new Set(['hot'])
+        )
+        expect(internals.historyManager.checkpoint).toHaveBeenCalledTimes(2)
+      })
+
+      it('defers log-cap (needs-checkpoint) snapshots inside the cooldown', async () => {
+        const internals = makeCooldownHarness({
+          overflowed: false,
+          appendResult: 'needs-checkpoint'
+        })
+        internals.lastFullCheckpointAt.set('capped', Date.now())
+
+        await expect(internals.checkpointSessions(['capped'])).resolves.toEqual(new Set())
+        expect(internals.historyManager.checkpoint).not.toHaveBeenCalled()
+        expect(internals.sessionsNeedingFullCheckpoint.has('capped')).toBe(true)
+
+        internals.lastFullCheckpointAt.set('capped', Date.now() - 46_000)
+        await expect(internals.checkpointSessions(['capped'])).resolves.toEqual(new Set(['capped']))
+        expect(internals.historyManager.checkpoint).toHaveBeenCalledTimes(1)
+        expect(internals.sessionsNeedingFullCheckpoint.has('capped')).toBe(false)
+      })
+    })
+
     it('does not schedule a checkpoint timer until a session is dirty', async () => {
       const adapterClass = DaemonPtyAdapter as unknown as { CHECKPOINT_INTERVAL_MS: number }
       const previousInterval = adapterClass.CHECKPOINT_INTERVAL_MS

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1183,6 +1183,62 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
     })
 
+    it('clears a stale snapshot cooldown when the cold-restore re-anchor is flagged', async () => {
+      // Simulate a previous daemon crash with recoverable history on disk.
+      const sessionId = 'cold-restore-stale-cooldown'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/tmp',
+          cols: 80,
+          rows: 24,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      writeFileSync(join(sessionDir, 'scrollback.bin'), 'pre-crash output\r\n')
+
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const internals = historyAdapter as unknown as {
+        lastFullCheckpointAt: Map<string, number>
+        sessionsNeedingFullCheckpoint: Set<string>
+      }
+      // A daemon respawn inside one adapter keeps this map: seed a fresh
+      // cooldown as if the pre-crash generation just snapshotted.
+      internals.lastFullCheckpointAt.set(sessionId, Date.now())
+
+      await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+
+      // The revived generation has no checkpoint of its own — the re-anchor
+      // must not inherit the previous generation's cooldown.
+      expect(internals.sessionsNeedingFullCheckpoint.has(sessionId)).toBe(true)
+      expect(internals.lastFullCheckpointAt.has(sessionId)).toBe(false)
+    })
+
+    it('re-anchors a warm reattach the adapter was not already managing', async () => {
+      const sessionId = 'warm-reattach-reanchor'
+      const first = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      await first.spawn({ cols: 80, rows: 24, sessionId })
+      first.dispose()
+
+      // A fresh adapter (app relaunch) attaches to the still-live daemon
+      // session. The old adapter may have drained records it never persisted
+      // (deferred hot-session tick), so appends must not resume until a full
+      // snapshot re-anchors the log.
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const internals = historyAdapter as unknown as {
+        sessionsNeedingFullCheckpoint: Set<string>
+        lastFullCheckpointAt: Map<string, number>
+      }
+      const result = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+      expect(result.isReattach).toBe(true)
+      expect(internals.sessionsNeedingFullCheckpoint.has(sessionId)).toBe(true)
+      expect(internals.lastFullCheckpointAt.has(sessionId)).toBe(false)
+    })
+
     it('returns same cold restore on StrictMode double-mount (sticky cache)', async () => {
       const sessionId = 'sticky-cache-test'
       const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -97,6 +97,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // Against older daemons the tick falls back to full-snapshot checkpoints.
   private supportsIncrementalCheckpoints: boolean
   private static CHECKPOINT_INTERVAL_MS = 5_000
+  // Why: a streaming session (build logs, `yes`) re-triggers a full multi-MB
+  // snapshot checkpoint on every 5s tick via pending-buffer overflow or the
+  // log-size cap — hundreds of MB/min of disk writes from one busy terminal.
+  // Bounding cap/overflow-triggered snapshots per session trades bounded
+  // cold-crash scrollback staleness (warm reattach and final checkpoints are
+  // unaffected and bypass this) for a ~9x cut in worst-case write volume.
+  private static FULL_CHECKPOINT_COOLDOWN_MS = 45_000
+  private lastFullCheckpointAt = new Map<string, number>()
 
   constructor(opts: DaemonPtyAdapterOptions) {
     this.protocolVersion = opts.protocolVersion ?? PROTOCOL_VERSION
@@ -305,6 +313,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // (Under keepHistory the final checkpoint above already cleared the flag, so
     // this is a harmless no-op there — kept unconditional to cover both paths.)
     this.sessionsNeedingFullCheckpoint.delete(id)
+    this.lastFullCheckpointAt.delete(id)
     this.stopCheckpointTimerIfIdle()
     this.initialCwds.delete(id)
     // Why: history removal is for the "user explicitly closed this terminal"
@@ -504,6 +513,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     const ids = [...this.activeSessionIds]
     this.activeSessionIds.clear()
     this.dirtySessionVersions.clear()
+    this.lastFullCheckpointAt.clear()
     this.stopCheckpointTimer()
     for (const id of ids) {
       this.coldRestoreCache.delete(id)
@@ -563,6 +573,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   dispose(): void {
     this.stopCheckpointTimer()
     this.dirtySessionVersions.clear()
+    this.lastFullCheckpointAt.clear()
     this.coldRestoreCache.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
@@ -598,6 +609,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // and the pending getSnapshot RPCs would be rejected.
     await this.checkpointAllSessions()
     this.dirtySessionVersions.clear()
+    this.lastFullCheckpointAt.clear()
     this.coldRestoreCache.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
@@ -723,8 +735,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
           final: opts?.final === true,
           teardown: opts?.teardown === true
         })
-          .then(() => {
-            completed.add(sessionId)
+          .then((result) => {
+            // Why: deferred sessions stay dirty so the checkpoint timer keeps
+            // retrying until their full-snapshot cooldown expires.
+            if (result === 'done') {
+              completed.add(sessionId)
+            }
           })
           .catch((err) => console.warn('[history] checkpoint failed:', sessionId, err))
       }
@@ -739,18 +755,36 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return completed
   }
 
+  // Why cooldown starts only after a session's FIRST full snapshot: a session
+  // with no checkpoint on disk yet must be able to write one immediately or a
+  // cold restore would find nothing.
+  private isFullCheckpointCoolingDown(sessionId: string): boolean {
+    const last = this.lastFullCheckpointAt.get(sessionId)
+    return last !== undefined && Date.now() - last < DaemonPtyAdapter.FULL_CHECKPOINT_COOLDOWN_MS
+  }
+
+  // Why 'deferred' exists: a cap/overflow-triggered full snapshot inside the
+  // cooldown window is postponed, and the session must STAY dirty so the 5s
+  // timer keeps retrying until the cooldown expires. While deferred, no
+  // takePendingOutput/append runs for the session — appending past a dropped
+  // range would leave a hole in the log, whereas skipping keeps the on-disk
+  // state a consistent (merely stale) prefix that the eventual full snapshot
+  // re-anchors.
   private async checkpointSession(
     sessionId: string,
     opts: { final: boolean; teardown: boolean }
-  ): Promise<void> {
+  ): Promise<'done' | 'deferred'> {
     if (!this.supportsIncrementalCheckpoints) {
       const result = await this.client.request<GetSnapshotResult>('getSnapshot', { sessionId })
       if (result.snapshot && this.historyManager) {
         await this.historyManager.checkpoint(sessionId, result.snapshot)
       }
-      return
+      return 'done'
     }
     if (opts.final || this.sessionsNeedingFullCheckpoint.has(sessionId)) {
+      if (!opts.final && this.isFullCheckpointCoolingDown(sessionId)) {
+        return 'deferred'
+      }
       // Why take-with-snapshot instead of plain getSnapshot: the take clears
       // the daemon's pending records in the same synchronous turn as the
       // serialize. A plain snapshot would leave pre-snapshot records pending;
@@ -759,25 +793,29 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // contains them.
       await this.takeSnapshotAndCheckpoint(sessionId, { teardown: opts.teardown })
       this.sessionsNeedingFullCheckpoint.delete(sessionId)
-      return
+      return 'done'
     }
     const take = await this.client.request<TakePendingOutputResult | null>('takePendingOutput', {
       sessionId
     })
     if (!take) {
-      return
+      return 'done'
     }
     if (take.overflowed) {
       // Why: overflow dropped records, so the log has a hole — only a full
       // snapshot (which reflects everything ever written) can re-anchor it.
+      if (this.isFullCheckpointCoolingDown(sessionId)) {
+        this.sessionsNeedingFullCheckpoint.add(sessionId)
+        return 'deferred'
+      }
       await this.takeSnapshotAndCheckpoint(sessionId, { teardown: false })
-      return
+      return 'done'
     }
     if (take.records.length === 0) {
-      return
+      return 'done'
     }
     if (!this.historyManager) {
-      return
+      return 'done'
     }
     const appendResult = await this.historyManager.appendIncrements(
       sessionId,
@@ -787,8 +825,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
     if (appendResult === 'needs-checkpoint') {
       // Why dropping take.records is lossless: they were applied to the live
       // emulator before the take, so the snapshot below contains them.
+      if (this.isFullCheckpointCoolingDown(sessionId)) {
+        this.sessionsNeedingFullCheckpoint.add(sessionId)
+        return 'deferred'
+      }
       await this.takeSnapshotAndCheckpoint(sessionId, { teardown: false })
     }
+    return 'done'
   }
 
   private async takeSnapshotAndCheckpoint(
@@ -802,6 +845,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     })
     if (take?.snapshot && this.historyManager) {
       await this.historyManager.checkpoint(sessionId, take.snapshot)
+      this.lastFullCheckpointAt.set(sessionId, Date.now())
       if (take.records.length > 0) {
         // Why: take-with-snapshot usually returns no records because the
         // snapshot subsumes them. Held parser-state bytes, such as an

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -208,6 +208,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
     }
 
+    const wasAlreadyManaged = this.activeSessionIds.has(sessionId)
     this.activeSessionIds.add(sessionId)
 
     // Cold restore: daemon created a new session but disk history shows
@@ -231,6 +232,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
       if (this.historyManager) {
         this.historyManager.registerWriter(sessionId)
         this.sessionsNeedingFullCheckpoint.add(sessionId)
+        // Why: the revived generation has no valid checkpoint of its own; a
+        // cooldown inherited from the pre-crash generation (daemon respawn
+        // within one adapter) must not defer this re-anchor.
+        this.lastFullCheckpointAt.delete(sessionId)
       }
       if (scrollback) {
         const coldRestore = { scrollback, cwd: restoreInfo.cwd, oscLinks: restoreInfo.oscLinks }
@@ -254,6 +259,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // without overwriting meta.json or deleting the existing checkpoint
       // (which is the only valid recovery data until the next tick).
       this.historyManager.registerWriter(sessionId)
+      if (!wasAlreadyManaged) {
+        // Why: a previous adapter may have drained daemon records it never
+        // persisted (a deferred hot-session tick) before the app died.
+        // Appending increments past that unknown drain point would put a seq
+        // gap in the log, which the restore reader rejects wholesale. Force a
+        // full snapshot to re-anchor before any further appends.
+        this.sessionsNeedingFullCheckpoint.add(sessionId)
+        this.lastFullCheckpointAt.delete(sessionId)
+      }
     }
 
     const isReattach = !result.isNew
@@ -514,6 +528,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.activeSessionIds.clear()
     this.dirtySessionVersions.clear()
     this.lastFullCheckpointAt.clear()
+    this.sessionsNeedingFullCheckpoint.clear()
     this.stopCheckpointTimer()
     for (const id of ids) {
       this.coldRestoreCache.delete(id)
@@ -760,7 +775,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // cold restore would find nothing.
   private isFullCheckpointCoolingDown(sessionId: string): boolean {
     const last = this.lastFullCheckpointAt.get(sessionId)
-    return last !== undefined && Date.now() - last < DaemonPtyAdapter.FULL_CHECKPOINT_COOLDOWN_MS
+    if (last === undefined) {
+      return false
+    }
+    const elapsed = Date.now() - last
+    // Why elapsed < 0 counts as expired: a backward wall-clock jump must not
+    // extend the deferral window.
+    return elapsed >= 0 && elapsed < DaemonPtyAdapter.FULL_CHECKPOINT_COOLDOWN_MS
   }
 
   // Why 'deferred' exists: a cap/overflow-triggered full snapshot inside the
@@ -960,6 +981,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
         // full-checkpoint flag is dead state. Without this, a cold-restored
         // session that exits before its first checkpoint leaks a permanent entry.
         this.sessionsNeedingFullCheckpoint.delete(event.sessionId)
+        // Why: a reused sessionId (renderer respawns a persisted ptyId) must
+        // not inherit the dead session's snapshot cooldown.
+        this.lastFullCheckpointAt.delete(event.sessionId)
         this.stopCheckpointTimerIfIdle()
         if (this.historyManager) {
           void this.historyManager

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -50,8 +50,9 @@ export class HistoryReader {
     }
 
     // Why log replay is preferred over the checkpoint alone: the log carries
-    // byte-exact output up to ~5s before the crash, while the checkpoint can
-    // be a full log-cap (~5MB of output) stale.
+    // byte-exact output up to ~5s before the crash (up to the full-snapshot
+    // cooldown, ~45s, for a streaming session mid-deferral), while the
+    // checkpoint can be a full log-cap (~5MB of output) stale.
     const logRestore = this.restoreFromIncrementalLog(sessionDir, meta, checkpoint)
     if (logRestore) {
       return logRestore


### PR DESCRIPTION
Follow-up to #7068 (the fseventsd load audit): this addresses the top deferred finding — terminal-history checkpoints are Orca's dominant self-generated disk write source.

## Problem

The daemon adapter checkpoints dirty PTY sessions every 5s. For calm sessions that's a cheap increment append. But a **streaming session** (build logs, test runners, `yes`-style floods) hits the full-snapshot path on nearly every tick, two ways:

- `takePendingOutput` overflow: >2MB of output accumulated within one 5s tick, or
- the 5MB increment-log cap (`needs-checkpoint`) — recurring every ~5MB of output.

Each full snapshot is a multi-hundred-KB-to-multi-MB `checkpoint.json` write + rename + `output.log` header rewrite — up to **12×/min per hot session**, i.e. hundreds of MB/min of disk writes from a single busy terminal, and the largest Orca-generated contribution to system-wide filesystem event volume (see #7068 for why that matters on macOS).

Live baseline on an affected machine (146-worktree workload, quiet evening load): 72 file touches and ~1.3MB growth per 2 minutes in `terminal-history/`, 231MB accumulated across 2,851 files.

## Fix

Cap/overflow-triggered full snapshots now honor a **45s per-session cooldown**:

- While cooling down, the session's checkpoint work is deferred **entirely** — no `takePendingOutput` RPC, no increment appends. Appending past a dropped range would leave a hole in the log, so skipping keeps the on-disk state a consistent (merely stale) prefix that the eventual full snapshot re-anchors from the live emulator.
- Deferred sessions **stay dirty**, so the 5s timer keeps retrying until the cooldown expires (also self-heals across transient daemon RPC failures — verified live).
- **Bypassed** where staleness is not acceptable: final/teardown checkpoints (app quit, sleep shutdown, clean disconnect) and a session's **first-ever** snapshot (cold-restore re-anchor is never delayed).
- The legacy non-incremental protocol path (pre-v13 daemons) is unchanged.

An independent adversarial review of the first commit traced six invariants through the restore/reattach/respawn paths; the second commit hardens the edges it found:

- **Warm reattach re-anchor**: an adapter attaching to a daemon session it wasn't already managing (app relaunch) now forces a full snapshot before any increment appends — the previous adapter may have drained daemon records it never persisted, and appending past that unknown drain point would put a seq gap in the log, which the restore reader rejects wholesale (this window existed pre-cooldown at ~ms width; it's now closed entirely).
- **Cold-restore re-anchor** clears any cooldown inherited from the pre-crash generation (daemon respawn within one adapter), so a revived session's first snapshot is never deferred.
- Exit-event routing clears the cooldown timestamp (reused ptyIds can't inherit a dead session's cooldown); backward wall-clock jumps count as expired rather than extending the deferral.

## Evidence

Unit (asserted in `daemon-pty-adapter.test.ts`): 24 consecutive hot-session ticks (~2 simulated minutes of overflow) produce **1 full snapshot and zero further daemon RPCs** while cooling down; previously every tick produced one. Final checkpoints bypass; log-cap deferrals follow the same cycle.

Live (dev build, real daemon, `yes` flooding a PTY): first overflow snapshot lands immediately (423KB `checkpoint.json`), then the session defers — `output.log` stays at its 9-byte header instead of cycling 5MB generations, and `checkpoint.json` rewrites at the cooldown cadence instead of every 5s. Steady-state hot-session write volume drops from ~5MB/min (12 × 423KB) plus ~1MB/min log cycling to ~0.6MB/min — **~9× less**, with proportionally fewer filesystem events.

The live run also exercised an unplanned failure mode: the daemon client connection dropped mid-stream, the deferred session retried each tick (surfaced as `[history] checkpoint failed ... Not connected`, identical to old behavior under RPC failure), and the flagged snapshot landed on reconnect.

## Trade-off

For a session that is **mid-stream when the machine hard-crashes** (daemon dies too — power loss, kernel panic), cold restore can be up to 45s more stale for that session's tail scrollback. Warm reattach (daemon survives, e.g. app restart), quit/sleep-time final checkpoints, and calm sessions are unaffected. Increment appends for normal typing/output cadence are untouched.

## Notes

- `pty-subprocess.test.ts` has one WSL env-import test failing on `main` at this base commit — pre-existing, unrelated.
- Observed during testing (pre-existing, filed for follow-up consideration): a PTY with **no renderer consumer** ACKing data lets the main-process delivery queue grow to its 512MB cap under sustained flood before dropping. Real terminal panes ACK and are unaffected.

Made with [Orca](https://github.com/stablyai/orca) 🐋
