### PR TITLE
Bound PTY output queues under backpressure

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -200,6 +200,73 @@
       "demotionRule": "Cannot promote while it only checks visual rendering."
     },
     {
+      "id": "terminal-session.pty-output-backpressure",
+      "title": "PTY output queues stay bounded under stalled consumers",
+      "maturity": "experimental",
+      "owner": "terminal-runtime",
+      "layer": "main-renderer-runtime-unit",
+      "surfaces": [
+        "PTY output",
+        "daemon stream batching",
+        "main-to-renderer IPC",
+        "runtime terminal streams",
+        "hidden terminal replay"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime", "mobile/relay"],
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/pull/7001",
+        "https://github.com/stablyai/orca/pull/7008",
+        "https://github.com/stablyai/orca/pull/7005",
+        "https://github.com/stablyai/orca/pull/7004",
+        "https://github.com/stablyai/orca/pull/7006",
+        "https://github.com/stablyai/orca/pull/7007"
+      ],
+      "invariant": "PTY output crossing daemon sockets, main-to-renderer IPC, renderer replay, and runtime/mobile streams must retain bounded queues under stalled consumers while active terminal output has a bounded priority lane and accepted output order is preserved.",
+      "oracle": "Focused tests force socket.write(false), missing renderer ACKs, active-vs-background backlog, repeated replay snapshots, exit-time pending output, and snapshot-time live-output buffering; they assert drain waits, byte/char/line caps, newest-tail trimming, dropped-char debug counters, and FIFO ordering for accepted work.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts --testNamePattern \"renderer backpressure|pending renderer output|interactive output|active PTY|in-flight output|PTY exit\"",
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts --testNamePattern \"remote replay\"",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-output-batching.test.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts"
+      ],
+      "testFiles": [
+        "src/main/daemon/daemon-stream-data-batcher.test.ts",
+        "src/main/ipc/pty.test.ts",
+        "src/renderer/src/components/terminal-pane/pty-connection.test.ts",
+        "src/main/runtime/rpc/terminal-output-batching.test.ts",
+        "src/main/runtime/rpc/terminal-subscribe-buffer.test.ts",
+        "src/main/runtime/rpc/terminal-multiplex.test.ts"
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 45,
+        "scope": "focused daemon/main/renderer/runtime unit tests"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "New experimental gate; needs soak history before promotion."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Tests encode socket drain, pending caps, active priority, replay queue, and runtime pending-output cap regressions. Needs saved intentional-break artifact before blocking promotion."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Tests count bytes, chars, queued lines, writes, ACK-gated flush skips, exit-flush drops, listener cleanup, and array-shift avoidance; no polling, subprocesses, startup awaits, or hidden-pane scan loops are introduced."
+      },
+      "promotionCriteria": [
+        "Run in soak across macOS, Linux, and Windows for at least the manifest blocking-promotion window.",
+        "Attach red/green evidence for each queue cap and active-priority lane.",
+        "Add real terminal throughput/hidden-output soak evidence before considering this blocking."
+      ],
+      "knownGaps": [
+        "Current coverage is deterministic unit/integration evidence, not a real SSH or relay soak.",
+        "Hidden-output renderer wakeup and active keystroke latency under real TUI floods remain perf-review and soak follow-ups.",
+        "The gate proves explicit byte/queue/count limits, not absolute terminal throughput regressions."
+      ],
+      "demotionRule": "Keep experimental or demote if failures are non-actionable, if runtime exceeds budget repeatedly, or if real terminal soak finds latency regressions not represented by these contracts."
+    },
+    {
       "id": "startup-upgrade.persisted-session-corpus",
       "title": "Current Orca preserves or recovers old production persisted sessions",
       "maturity": "experimental",

--- a/src/main/daemon/daemon-stream-backpressure-queue.ts
+++ b/src/main/daemon/daemon-stream-backpressure-queue.ts
@@ -1,0 +1,200 @@
+import type { Socket } from 'node:net'
+
+export type DaemonBackpressuredStreamLine = {
+  sessionId: string
+  line: string
+  priority: boolean
+}
+
+type BackpressuredStreamWrites = {
+  socket: Socket
+  lines: DaemonBackpressuredStreamLine[]
+  queuedBytes: number
+  onDrain: () => void
+  onClose: () => void
+}
+
+const DEFAULT_MAX_BACKPRESSURED_STREAM_BYTES = 8 * 1024 * 1024
+const DEFAULT_MAX_BACKPRESSURED_STREAM_LINES = 8_192
+
+export type DaemonStreamBackpressureQueueOptions = {
+  maxBackpressuredBytes?: number
+  maxBackpressuredLines?: number
+}
+
+export class DaemonStreamBackpressureQueue {
+  private backpressuredByClient = new Map<string, BackpressuredStreamWrites>()
+  private maxBackpressuredBytes: number
+  private maxBackpressuredLines: number
+
+  constructor(options: DaemonStreamBackpressureQueueOptions = {}) {
+    this.maxBackpressuredBytes = Math.max(
+      1,
+      options.maxBackpressuredBytes ?? DEFAULT_MAX_BACKPRESSURED_STREAM_BYTES
+    )
+    this.maxBackpressuredLines = Math.max(
+      1,
+      Math.floor(options.maxBackpressuredLines ?? DEFAULT_MAX_BACKPRESSURED_STREAM_LINES)
+    )
+  }
+
+  clientIds(): Iterable<string> {
+    return this.backpressuredByClient.keys()
+  }
+
+  writeLines(
+    clientId: string,
+    streamSocket: Socket,
+    lines: DaemonBackpressuredStreamLine[],
+    options: { priority?: boolean } = {}
+  ): void {
+    const existing = this.backpressuredByClient.get(clientId)
+    if (existing) {
+      if (existing.socket === streamSocket && !streamSocket.destroyed) {
+        this.appendBackpressuredLines(existing, lines, options)
+        return
+      }
+      this.clear(clientId)
+    }
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const accepted = streamSocket.write(lines[index].line)
+      if (!accepted) {
+        this.deferUntilDrain(clientId, streamSocket, lines.slice(index + 1))
+        return
+      }
+    }
+  }
+
+  clear(clientId: string): void {
+    const pending = this.backpressuredByClient.get(clientId)
+    if (!pending) {
+      return
+    }
+    this.backpressuredByClient.delete(clientId)
+    pending.socket.off('drain', pending.onDrain)
+    pending.socket.off('close', pending.onClose)
+    pending.socket.off('error', pending.onClose)
+  }
+
+  private deferUntilDrain(
+    clientId: string,
+    streamSocket: Socket,
+    lines: DaemonBackpressuredStreamLine[]
+  ): void {
+    const onDrain = (): void => {
+      const pending = this.backpressuredByClient.get(clientId)
+      if (!pending || pending.socket !== streamSocket) {
+        return
+      }
+      this.backpressuredByClient.delete(clientId)
+      streamSocket.off('close', pending.onClose)
+      streamSocket.off('error', pending.onClose)
+      if (!streamSocket.destroyed) {
+        this.writeLines(clientId, streamSocket, pending.lines)
+      }
+    }
+    const onClose = (): void => this.clear(clientId)
+    const pending: BackpressuredStreamWrites = {
+      socket: streamSocket,
+      lines: [],
+      queuedBytes: 0,
+      onDrain,
+      onClose
+    }
+    this.backpressuredByClient.set(clientId, pending)
+    streamSocket.once('drain', onDrain)
+    streamSocket.once('close', onClose)
+    streamSocket.once('error', onClose)
+    this.appendBackpressuredLines(pending, lines)
+  }
+
+  private appendBackpressuredLines(
+    pending: BackpressuredStreamWrites,
+    lines: DaemonBackpressuredStreamLine[],
+    options: { priority?: boolean } = {}
+  ): void {
+    if (options.priority === true && lines.length > 0) {
+      // Why: input-triggered daemon output should not sit behind an unrelated
+      // hidden-output flood once the socket drains, while same-session bytes
+      // keep their original order.
+      const sessionId = lines[0].sessionId
+      let lastSameSessionIndex = -1
+      for (let index = pending.lines.length - 1; index >= 0; index -= 1) {
+        if (pending.lines[index].sessionId === sessionId) {
+          lastSameSessionIndex = index
+          break
+        }
+      }
+      if (lastSameSessionIndex >= 0) {
+        pending.lines.splice(lastSameSessionIndex + 1, 0, ...lines)
+      } else {
+        const firstBackgroundIndex = pending.lines.findIndex((line) => !line.priority)
+        pending.lines.splice(
+          firstBackgroundIndex === -1 ? pending.lines.length : firstBackgroundIndex,
+          0,
+          ...lines
+        )
+      }
+    } else {
+      pending.lines.push(...lines)
+    }
+    pending.queuedBytes += this.measureLinesBytes(lines)
+    this.trimToBudget(pending)
+  }
+
+  private trimToBudget(pending: BackpressuredStreamWrites): void {
+    if (
+      pending.lines.length <= this.maxBackpressuredLines &&
+      pending.queuedBytes <= this.maxBackpressuredBytes
+    ) {
+      return
+    }
+
+    let queuedBytes = pending.queuedBytes
+    let lineCount = pending.lines.length
+    const backgroundTrim: { line: DaemonBackpressuredStreamLine; bytes: number }[] = []
+
+    // Why: drop oldest background work first while scanning once. Priority
+    // output still stays bounded by the second pass if it alone exceeds caps.
+    for (const line of pending.lines) {
+      const bytes = this.measureLineBytes(line)
+      const overLineBudget = lineCount > this.maxBackpressuredLines
+      const overByteBudget = queuedBytes > this.maxBackpressuredBytes
+      if (lineCount > 1 && !line.priority && (overLineBudget || overByteBudget)) {
+        queuedBytes -= bytes
+        lineCount -= 1
+        continue
+      }
+      backgroundTrim.push({ line, bytes })
+    }
+
+    const retained: DaemonBackpressuredStreamLine[] = []
+    let retainedBytes = 0
+    for (const entry of backgroundTrim) {
+      const overLineBudget = lineCount > this.maxBackpressuredLines
+      const overByteBudget = queuedBytes > this.maxBackpressuredBytes
+      if (lineCount > 1 && (overLineBudget || overByteBudget)) {
+        queuedBytes -= entry.bytes
+        lineCount -= 1
+        continue
+      }
+      retained.push(entry.line)
+      retainedBytes += entry.bytes
+    }
+    pending.lines = retained
+    pending.queuedBytes = retainedBytes
+  }
+
+  private measureLinesBytes(lines: DaemonBackpressuredStreamLine[]): number {
+    let bytes = 0
+    for (const line of lines) {
+      bytes += this.measureLineBytes(line)
+    }
+    return bytes
+  }
+
+  private measureLineBytes(line: DaemonBackpressuredStreamLine): number {
+    return Buffer.byteLength(line.line, 'utf8')
+  }
+}

--- a/src/main/daemon/daemon-stream-backpressure-queue.ts
+++ b/src/main/daemon/daemon-stream-backpressure-queue.ts
@@ -59,7 +59,7 @@ export class DaemonStreamBackpressureQueue {
 
     for (let index = 0; index < lines.length; index += 1) {
       const accepted = streamSocket.write(lines[index].line)
-      if (!accepted) {
+      if (accepted === false) {
         this.deferUntilDrain(clientId, streamSocket, lines.slice(index + 1))
         return
       }

--- a/src/main/daemon/daemon-stream-data-batcher.test.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Socket } from 'node:net'
+import { EventEmitter } from 'node:events'
 import { DaemonStreamDataBatcher } from './daemon-stream-data-batcher'
 import { createNdjsonParser } from './ndjson'
 
+class FakeStreamSocket extends EventEmitter {
+  destroyed = false
+  write = vi.fn((_line: string) => true)
+}
+
 function createBatcher(options?: ConstructorParameters<typeof DaemonStreamDataBatcher>[1]) {
-  const streamSocket = {
-    destroyed: false,
-    write: vi.fn()
-  } as unknown as Socket & { write: ReturnType<typeof vi.fn> }
+  const streamSocket = new FakeStreamSocket() as unknown as Socket & FakeStreamSocket
   const batcher = new DaemonStreamDataBatcher(() => ({ streamSocket }), options)
   return { batcher, streamSocket }
 }
@@ -125,6 +128,117 @@ describe('DaemonStreamDataBatcher', () => {
           .map(([message]) => (message as { payload?: { data?: string } }).payload?.data ?? '')
           .join('')
       ).toBe(data)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('pauses daemon stream writes after socket backpressure until drain', () => {
+    vi.useFakeTimers()
+    try {
+      const { batcher, streamSocket } = createBatcher({ maxLineBytes: 128 })
+      streamSocket.write
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
+
+      batcher.enqueue('client-1', 'session-1', 'a'.repeat(512))
+      vi.advanceTimersByTime(8)
+
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+      batcher.enqueue('client-1', 'session-2', 'interactive', {
+        flushImmediately: true,
+        flushMaxChars: 1024
+      })
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+
+      streamSocket.emit('drain')
+
+      expect(streamSocket.write.mock.calls.length).toBeGreaterThan(1)
+      const lines = streamSocket.write.mock.calls.map(([line]) => String(line))
+      expect(lines.some((line) => line.includes('"sessionId":"session-2"'))).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('prioritizes flush-immediate output ahead of queued background backlog on drain', () => {
+    vi.useFakeTimers()
+    try {
+      const { batcher, streamSocket } = createBatcher({ maxLineBytes: 128 })
+      streamSocket.write.mockReturnValueOnce(false).mockReturnValue(true)
+
+      batcher.enqueue('client-1', 'session-background', 'b'.repeat(512))
+      vi.advanceTimersByTime(8)
+      batcher.enqueue('client-1', 'session-active', 'active', {
+        flushImmediately: true,
+        flushMaxChars: 1024
+      })
+      streamSocket.write.mockClear()
+
+      streamSocket.emit('drain')
+
+      const firstWrittenAfterDrain = String(streamSocket.write.mock.calls[0]?.[0] ?? '')
+      expect(firstWrittenAfterDrain).toContain('"sessionId":"session-active"')
+      expect(firstWrittenAfterDrain).toContain('"data":"active"')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps queued daemon stream writes to the newest tail while backpressured', () => {
+    vi.useFakeTimers()
+    try {
+      const { batcher, streamSocket } = createBatcher({
+        maxBackpressuredBytes: 512,
+        maxLineBytes: 256
+      })
+      streamSocket.write.mockReturnValueOnce(false).mockReturnValue(true)
+
+      batcher.enqueue('client-1', 'session-1', 'first-background')
+      vi.advanceTimersByTime(8)
+      for (let index = 0; index < 30; index += 1) {
+        batcher.enqueue('client-1', `session-${index + 2}`, `chunk-${index}`)
+      }
+      vi.advanceTimersByTime(8)
+      streamSocket.write.mockClear()
+
+      streamSocket.emit('drain')
+
+      const written = streamSocket.write.mock.calls.map(([line]) => String(line)).join('\n')
+      expect(written).not.toContain('chunk-0')
+      expect(written).toContain('chunk-29')
+      expect(streamSocket.listenerCount('drain')).toBe(0)
+      expect(streamSocket.listenerCount('close')).toBe(0)
+      expect(streamSocket.listenerCount('error')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps queued daemon stream writes by line count for tiny chunks', () => {
+    vi.useFakeTimers()
+    try {
+      const { batcher, streamSocket } = createBatcher({
+        maxBackpressuredBytes: 1024 * 1024,
+        maxBackpressuredLines: 4
+      })
+      streamSocket.write.mockReturnValueOnce(false).mockReturnValue(true)
+
+      batcher.enqueue('client-1', 'session-1', 'initial')
+      vi.advanceTimersByTime(8)
+      for (let index = 0; index < 20; index += 1) {
+        batcher.enqueue('client-1', `session-${index + 2}`, `tiny-${index}`)
+      }
+      vi.advanceTimersByTime(8)
+      streamSocket.write.mockClear()
+
+      streamSocket.emit('drain')
+
+      const written = streamSocket.write.mock.calls.map(([line]) => String(line))
+      expect(written).toHaveLength(4)
+      expect(written.join('\n')).not.toContain('tiny-0')
+      expect(written.join('\n')).toContain('tiny-19')
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -1,5 +1,10 @@
 import type { Socket } from 'node:net'
 import { encodeNdjson, NDJSON_MAX_LINE_BYTES } from './ndjson'
+import {
+  DaemonStreamBackpressureQueue,
+  type DaemonBackpressuredStreamLine,
+  type DaemonStreamBackpressureQueueOptions
+} from './daemon-stream-backpressure-queue'
 
 type StreamDataClient = {
   streamSocket: Socket | null
@@ -22,7 +27,7 @@ type EnqueueOptions = {
 
 type DaemonStreamDataBatcherOptions = {
   maxLineBytes?: number
-}
+} & DaemonStreamBackpressureQueueOptions
 
 function encodeStreamDataEvent(sessionId: string, data: string): string {
   return encodeNdjson({
@@ -104,6 +109,7 @@ function splitStreamDataForNdjson(sessionId: string, data: string, maxLineBytes:
 
 export class DaemonStreamDataBatcher {
   private pendingByClient = new Map<string, PendingStreamDataBatch>()
+  private backpressureQueue: DaemonStreamBackpressureQueue
   private getClient: (clientId: string) => StreamDataClient | undefined
   private maxLineBytes: number
 
@@ -113,6 +119,7 @@ export class DaemonStreamDataBatcher {
   ) {
     this.getClient = getClient
     this.maxLineBytes = Math.max(1, options.maxLineBytes ?? NDJSON_MAX_LINE_BYTES)
+    this.backpressureQueue = new DaemonStreamBackpressureQueue(options)
   }
 
   enqueue(clientId: string, sessionId: string, data: string, options: EnqueueOptions = {}): void {
@@ -166,7 +173,7 @@ export class DaemonStreamDataBatcher {
     }
 
     for (const entry of batch.queue) {
-      this.writeStreamDataEvent(client.streamSocket, entry.sessionId, entry.data)
+      this.writeStreamDataEvent(clientId, client.streamSocket, entry.sessionId, entry.data)
     }
   }
 
@@ -217,30 +224,47 @@ export class DaemonStreamDataBatcher {
     }
 
     for (const entry of flushed) {
-      this.writeStreamDataEvent(client.streamSocket, entry.sessionId, entry.data)
+      this.writeStreamDataEvent(clientId, client.streamSocket, entry.sessionId, entry.data, {
+        priority: true
+      })
     }
   }
 
   clear(clientId?: string): void {
-    const batches =
+    const clientIds =
       clientId === undefined
-        ? Array.from(this.pendingByClient.entries())
-        : [[clientId, this.pendingByClient.get(clientId)] as const]
+        ? new Set([...this.pendingByClient.keys(), ...this.backpressureQueue.clientIds()])
+        : new Set([clientId])
 
-    for (const [id, batch] of batches) {
+    for (const id of clientIds) {
+      const batch = this.pendingByClient.get(id)
       if (batch?.timer) {
         clearTimeout(batch.timer)
       }
       this.pendingByClient.delete(id)
+      this.backpressureQueue.clear(id)
     }
   }
 
-  private writeStreamDataEvent(streamSocket: Socket, sessionId: string, data: string): void {
+  private writeStreamDataEvent(
+    clientId: string,
+    streamSocket: Socket,
+    sessionId: string,
+    data: string,
+    options: { priority?: boolean } = {}
+  ): void {
     // Why: createNdjsonParser rejects oversized lines. Terminal output can
     // burst faster than the batch interval, so writer-side chunking prevents
     // the daemon from dropping its own stream events at the receiver.
-    for (const chunk of splitStreamDataForNdjson(sessionId, data, this.maxLineBytes)) {
-      streamSocket.write(encodeStreamDataEvent(sessionId, chunk))
-    }
+    const lines: DaemonBackpressuredStreamLine[] = splitStreamDataForNdjson(
+      sessionId,
+      data,
+      this.maxLineBytes
+    ).map((chunk) => ({
+      sessionId,
+      line: encodeStreamDataEvent(sessionId, chunk),
+      priority: options.priority === true
+    }))
+    this.backpressureQueue.writeLines(clientId, streamSocket, lines, options)
   }
 }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -6431,6 +6431,173 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('caps pending renderer output per PTY and preserves the newest tail', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData(`${'a'.repeat(1024 * 1024)}${'b'.repeat(2 * 1024 * 1024)}`)
+      vi.advanceTimersByTime(8)
+
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(1, 'pty:data', {
+        id: spawnResult.id,
+        data: 'b'.repeat(16 * 1024)
+      })
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingChars: 2 * 1024 * 1024 - 16 * 1024,
+        maxPendingCharsByPty: 2 * 1024 * 1024 - 16 * 1024,
+        rendererInFlightChars: 16 * 1024,
+        droppedPendingChars: 1024 * 1024,
+        peakDroppedPendingChars: 1024 * 1024
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps total pending renderer output and trims background PTYs before active PTYs', async () => {
+    vi.useFakeTimers()
+    const procs = Array.from({ length: 11 }, () => createMockProc())
+    for (const proc of procs) {
+      spawnMock.mockReturnValueOnce(proc.proc)
+    }
+    let activePtyId: string | null = null
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawns: { id: string }[] = []
+      for (const _proc of procs) {
+        spawns.push(
+          (await handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            cwd: '/tmp'
+          })) as { id: string }
+        )
+      }
+      const setActiveRendererPty = getPtySetActiveRendererPtyListener()
+      const activeIndex = procs.length - 1
+      activePtyId = spawns[activeIndex]!.id
+      setActiveRendererPty(null, { id: activePtyId, active: true })
+      mainWindow.webContents.send.mockClear()
+
+      for (let index = 0; index < procs.length; index++) {
+        procs[index]!.emitData(String.fromCharCode(65 + index).repeat(2 * 1024 * 1024))
+      }
+
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingChars: 16 * 1024 * 1024,
+        droppedPendingChars: 6 * 1024 * 1024,
+        peakDroppedPendingChars: 6 * 1024 * 1024
+      })
+
+      vi.advanceTimersByTime(8)
+
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(1, 'pty:data', {
+        id: spawns[activeIndex]!.id,
+        data: String.fromCharCode(65 + activeIndex).repeat(16 * 1024)
+      })
+    } finally {
+      if (activePtyId) {
+        getPtySetActiveRendererPtyListener()(null, { id: activePtyId, active: false })
+      }
+      vi.useRealTimers()
+    }
+  })
+
+  it('bounds pending output flushed during PTY exit to one renderer slice', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('z'.repeat(20 * 1024))
+      mockProc.emitExit(0)
+
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(1, 'pty:data', {
+        id: spawnResult.id,
+        data: 'z'.repeat(16 * 1024)
+      })
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(2, 'pty:exit', {
+        id: spawnResult.id,
+        code: 0
+      })
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingChars: 0,
+        rendererInFlightChars: 16 * 1024,
+        droppedPendingChars: 4 * 1024
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('drops pending exit output when renderer ACK backpressure is saturated', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const ackData = getPtyAckDataListener()
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('x'.repeat(600 * 1024))
+      vi.advanceTimersByTime(8)
+      for (let index = 0; index < 31; index++) {
+        vi.advanceTimersByTime(1)
+      }
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(32)
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingChars: 88 * 1024,
+        rendererInFlightChars: 512 * 1024
+      })
+
+      mockProc.emitExit(0)
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(33)
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(33, 'pty:exit', {
+        id: spawnResult.id,
+        code: 0
+      })
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingChars: 0,
+        rendererInFlightChars: 512 * 1024,
+        droppedPendingChars: 88 * 1024
+      })
+
+      ackData(null, { id: spawnResult.id, charCount: 16 * 1024 })
+
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        rendererInFlightChars: 496 * 1024
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('forwards only actually in-flight bytes to provider ACK backpressure', async () => {
     vi.useFakeTimers()
     const acknowledgeDataEvent = vi.fn()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1136,6 +1136,8 @@ export type PtyRendererDeliveryDebugSnapshot = {
   peakRendererInFlightChars: number
   peakMaxRendererInFlightCharsByPty: number
   ackGatedFlushSkipCount: number
+  droppedPendingChars: number
+  peakDroppedPendingChars: number
 }
 
 const EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT: PtyRendererDeliveryDebugSnapshot = {
@@ -1151,7 +1153,9 @@ const EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT: PtyRendererDeliveryDebugSnapsh
   peakMaxPendingCharsByPty: 0,
   peakRendererInFlightChars: 0,
   peakMaxRendererInFlightCharsByPty: 0,
-  ackGatedFlushSkipCount: 0
+  ackGatedFlushSkipCount: 0,
+  droppedPendingChars: 0,
+  peakDroppedPendingChars: 0
 }
 
 let readPtyRendererDeliveryDebugSnapshot = (): PtyRendererDeliveryDebugSnapshot => ({
@@ -1308,6 +1312,7 @@ export function registerPtyHandlers(
   const rendererInFlightCharsByPty = new Map<string, number>()
   const trustedTerminalHandleEnv = new Set<string>()
   let flushTimer: ReturnType<typeof setTimeout> | null = null
+  let totalPendingChars = 0
   let rendererInFlightTotalChars = 0
   const PTY_BATCH_INTERVAL_MS = 8
   const PTY_BATCH_DRAIN_CONTINUE_MS = 1
@@ -1315,6 +1320,8 @@ export function registerPtyHandlers(
   const PTY_BATCH_FLUSH_MAX_WRITES = 2
   const PTY_RENDERER_IN_FLIGHT_HIGH_WATER_CHARS = 512 * 1024
   const PTY_RENDERER_TOTAL_IN_FLIGHT_HIGH_WATER_CHARS = 8 * 1024 * 1024
+  const PTY_RENDERER_PENDING_HIGH_WATER_CHARS_BY_PTY = 2 * 1024 * 1024
+  const PTY_RENDERER_TOTAL_PENDING_HIGH_WATER_CHARS = 16 * 1024 * 1024
   const PTY_RENDERER_INTERACTIVE_RESERVE_CHARS = 256 * 1024
   // Why: active panes need a bounded lane through old hidden bulk output so a
   // keystroke redraw can reach the renderer before every background ACK lands.
@@ -1330,6 +1337,8 @@ export function registerPtyHandlers(
   let peakRendererInFlightChars = 0
   let peakMaxRendererInFlightCharsByPty = 0
   let ackGatedFlushSkipCount = 0
+  let droppedPendingChars = 0
+  let peakDroppedPendingChars = 0
 
   function getMaxMapValue(values: Iterable<number>): number {
     let max = 0
@@ -1340,16 +1349,14 @@ export function registerPtyHandlers(
   }
 
   function readCurrentPtyRendererDeliveryDebugSnapshot(): PtyRendererDeliveryDebugSnapshot {
-    let pendingChars = 0
     let maxPendingCharsByPty = 0
     for (const pending of pendingData.values()) {
       const chars = pending.data.length
-      pendingChars += chars
       maxPendingCharsByPty = Math.max(maxPendingCharsByPty, chars)
     }
     return {
       pendingPtyCount: pendingData.size,
-      pendingChars,
+      pendingChars: totalPendingChars,
       maxPendingCharsByPty,
       rendererInFlightPtyCount: rendererInFlightCharsByPty.size,
       rendererInFlightChars: rendererInFlightTotalChars,
@@ -1360,7 +1367,9 @@ export function registerPtyHandlers(
       peakMaxPendingCharsByPty,
       peakRendererInFlightChars,
       peakMaxRendererInFlightCharsByPty,
-      ackGatedFlushSkipCount
+      ackGatedFlushSkipCount,
+      droppedPendingChars,
+      peakDroppedPendingChars
     }
   }
 
@@ -1373,6 +1382,7 @@ export function registerPtyHandlers(
       peakMaxRendererInFlightCharsByPty,
       current.maxRendererInFlightCharsByPty
     )
+    peakDroppedPendingChars = Math.max(peakDroppedPendingChars, droppedPendingChars)
   }
 
   readPtyRendererDeliveryDebugSnapshot = readCurrentPtyRendererDeliveryDebugSnapshot
@@ -1382,6 +1392,8 @@ export function registerPtyHandlers(
     peakRendererInFlightChars = 0
     peakMaxRendererInFlightCharsByPty = 0
     ackGatedFlushSkipCount = 0
+    droppedPendingChars = 0
+    peakDroppedPendingChars = 0
     recordPtyRendererDeliveryPressure()
   }
 
@@ -1461,6 +1473,31 @@ export function registerPtyHandlers(
     mainWindow.webContents.send('pty:data', payload)
   }
 
+  function setPendingPtyData(id: string, pending: PendingPtyData): void {
+    const previousChars = pendingData.get(id)?.data.length ?? 0
+    if (pending.data.length === 0) {
+      pendingData.delete(id)
+      totalPendingChars -= previousChars
+      return
+    }
+    pendingData.set(id, pending)
+    totalPendingChars += pending.data.length - previousChars
+  }
+
+  function deletePendingPtyData(id: string): PendingPtyData | undefined {
+    const pending = pendingData.get(id)
+    if (pending) {
+      pendingData.delete(id)
+      totalPendingChars -= pending.data.length
+    }
+    return pending
+  }
+
+  function clearPendingPtyData(): void {
+    pendingData.clear()
+    totalPendingChars = 0
+  }
+
   function getPendingPtyFlushEntries(): [string, PendingPtyData][] {
     const entries = Array.from(pendingData.entries())
     const active: [string, PendingPtyData][] = []
@@ -1482,16 +1519,78 @@ export function registerPtyHandlers(
     preservesSeq: boolean
   ): PendingPtyData {
     if (!preservesSeq) {
-      return { data: (existing?.data ?? '') + data }
+      return clampPendingPtyData({ data: (existing?.data ?? '') + data })
     }
     if (!existing) {
-      return typeof startSeq === 'number' ? { data, startSeq } : { data }
+      return clampPendingPtyData(typeof startSeq === 'number' ? { data, startSeq } : { data })
     }
     const next: PendingPtyData = { data: existing.data + data }
     if (typeof existing.startSeq === 'number') {
       next.startSeq = existing.startSeq
     }
+    return clampPendingPtyData(next)
+  }
+
+  function clampPendingPtyData(pending: PendingPtyData): PendingPtyData {
+    if (pending.data.length <= PTY_RENDERER_PENDING_HIGH_WATER_CHARS_BY_PTY) {
+      return pending
+    }
+    const dropped = pending.data.length - PTY_RENDERER_PENDING_HIGH_WATER_CHARS_BY_PTY
+    droppedPendingChars += dropped
+    const next: PendingPtyData = { data: pending.data.slice(dropped) }
+    if (typeof pending.startSeq === 'number') {
+      // Why: overlap trimming depends on raw output sequence. When overload
+      // drops old pending bytes, the surviving tail keeps its true start.
+      next.startSeq = pending.startSeq + dropped
+    }
     return next
+  }
+
+  function getPendingTrimOrder(): string[] {
+    const background: string[] = []
+    const active: string[] = []
+    for (const id of pendingData.keys()) {
+      if (activeRendererPtys.has(id)) {
+        active.push(id)
+      } else {
+        background.push(id)
+      }
+    }
+    return [...background, ...active]
+  }
+
+  function enforceTotalPendingDataBudget(): void {
+    let total = totalPendingChars
+    if (total <= PTY_RENDERER_TOTAL_PENDING_HIGH_WATER_CHARS) {
+      return
+    }
+    for (const id of getPendingTrimOrder()) {
+      if (total <= PTY_RENDERER_TOTAL_PENDING_HIGH_WATER_CHARS) {
+        break
+      }
+      const pending = pendingData.get(id)
+      if (!pending) {
+        continue
+      }
+      const targetLength = Math.max(
+        0,
+        pending.data.length - (total - PTY_RENDERER_TOTAL_PENDING_HIGH_WATER_CHARS)
+      )
+      if (targetLength === 0) {
+        droppedPendingChars += pending.data.length
+        total -= pending.data.length
+        deletePendingPtyData(id)
+        continue
+      }
+      const dropped = pending.data.length - targetLength
+      droppedPendingChars += dropped
+      const next: PendingPtyData = { data: pending.data.slice(dropped) }
+      if (typeof pending.startSeq === 'number') {
+        next.startSeq = pending.startSeq + dropped
+      }
+      setPendingPtyData(id, next)
+      total -= dropped
+    }
   }
 
   function schedulePendingDataFlush(delayMs: number): void {
@@ -1504,7 +1603,7 @@ export function registerPtyHandlers(
   function flushPendingData(): void {
     flushTimer = null
     if (mainWindow.isDestroyed()) {
-      pendingData.clear()
+      clearPendingPtyData()
       rendererInFlightCharsByPty.clear()
       rendererInFlightTotalChars = 0
       recordPtyRendererDeliveryPressure()
@@ -1518,7 +1617,7 @@ export function registerPtyHandlers(
       if (!canSendPtyDataToRenderer(id, { interactive: activeRendererPtys.has(id) })) {
         continue
       }
-      pendingData.delete(id)
+      deletePendingPtyData(id)
       const { data } = pending
       const chunk = data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
       const remaining = data.slice(PTY_BATCH_FLUSH_CHUNK_CHARS)
@@ -1527,7 +1626,7 @@ export function registerPtyHandlers(
         if (typeof pending.startSeq === 'number') {
           nextPending.startSeq = pending.startSeq + chunk.length
         }
-        pendingData.set(id, nextPending)
+        setPendingPtyData(id, nextPending)
       }
       sendPtyDataToRenderer(id, makePtyDataPayload(id, chunk, pending.startSeq))
       writes++
@@ -1582,7 +1681,7 @@ export function registerPtyHandlers(
           clearTimeout(flushTimer)
           flushTimer = null
         }
-        pendingData.clear()
+        clearPendingPtyData()
         rendererInFlightCharsByPty.clear()
         rendererInFlightTotalChars = 0
         recordPtyRendererDeliveryPressure()
@@ -1604,11 +1703,12 @@ export function registerPtyHandlers(
         // terminal output already handed to the renderer. The reserve is
         // bounded, and the per-PTY cap still prevents an active TUI runaway.
         if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
-          pendingData.set(payload.id, pending)
+          setPendingPtyData(payload.id, pending)
+          enforceTotalPendingDataBudget()
           recordPtyRendererDeliveryPressure()
           return
         }
-        pendingData.delete(payload.id)
+        deletePendingPtyData(payload.id)
         clearFlushTimerIfIdle()
         // Why: agent TUIs redraw small prompt regions after every keystroke.
         // Waiting for the throughput batch timer adds visible input latency.
@@ -1621,7 +1721,8 @@ export function registerPtyHandlers(
         })
         return
       }
-      pendingData.set(payload.id, pending)
+      setPendingPtyData(payload.id, pending)
+      enforceTotalPendingDataBudget()
       recordPtyRendererDeliveryPressure()
       if (!flushTimer) {
         schedulePendingDataFlush(PTY_BATCH_INTERVAL_MS)
@@ -1638,21 +1739,30 @@ export function registerPtyHandlers(
         // Why: flush any batched data for this PTY before sending the exit event,
         // otherwise the last ≤8ms of output is silently lost because the renderer
         // tears down the terminal on pty:exit before the batch timer fires.
-        const remaining = pendingData.get(payload.id)
+        const remaining = deletePendingPtyData(payload.id)
         if (remaining) {
-          sendPtyDataToRenderer(
-            payload.id,
-            makePtyDataPayload(payload.id, remaining.data, remaining.startSeq)
-          )
-          pendingData.delete(payload.id)
+          if (
+            canSendPtyDataToRenderer(payload.id, {
+              interactive: activeRendererPtys.has(payload.id)
+            })
+          ) {
+            // Why: exit must not blast a multi-MiB pending tail past the same
+            // renderer ACK budget that protects live output.
+            const chunk = remaining.data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
+            const dropped = remaining.data.length - chunk.length
+            if (dropped > 0) {
+              droppedPendingChars += dropped
+            }
+            sendPtyDataToRenderer(
+              payload.id,
+              makePtyDataPayload(payload.id, chunk, remaining.startSeq)
+            )
+          } else {
+            droppedPendingChars += remaining.data.length
+          }
         }
         lastInputAtByPty.delete(payload.id)
         interactiveOutputCharsByPty.delete(payload.id)
-        rendererInFlightTotalChars = Math.max(
-          0,
-          rendererInFlightTotalChars - (rendererInFlightCharsByPty.get(payload.id) ?? 0)
-        )
-        rendererInFlightCharsByPty.delete(payload.id)
         recordPtyRendererDeliveryPressure()
         mainWindow.webContents.send('pty:exit', payload)
       }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7710,6 +7710,71 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('bounds remote replay payloads queued while parsing is in progress', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    enableActiveRuntimeEnvironment()
+    const transport = createMockTransport('remote:env-1@@terminal-1')
+    const capturedReplayCallback: {
+      current: ((data: string) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedReplayCallback.current = callbacks.onReplayData ?? null
+      return { id: 'remote:env-1@@terminal-1', replay: '' }
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const pendingParses: (() => void)[] = []
+    pane.terminal.write = vi.fn((_data: string, callback?: () => void) => {
+      if (callback) {
+        pendingParses.push(callback)
+      }
+    })
+    const manager = createManager(1)
+    const deps = createDeps()
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedReplayCallback.current?.('replay-0')
+    await flushAsyncTicks(2)
+    expect(pane.terminal.write).toHaveBeenNthCalledWith(
+      1,
+      '\x1b[2J\x1b[3J\x1b[H',
+      expect.any(Function)
+    )
+
+    for (let index = 1; index <= 12; index += 1) {
+      capturedReplayCallback.current?.(`replay-${index}`)
+    }
+
+    for (let index = 0; index < 80; index += 1) {
+      const next = pendingParses.shift()
+      if (!next) {
+        await flushAsyncTicks(1)
+        continue
+      }
+      next()
+      await flushAsyncTicks(1)
+    }
+
+    const replayedPayloads = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls
+      .map(([data]) => data)
+      .filter((data): data is string => typeof data === 'string' && data.startsWith('replay-'))
+    expect(replayedPayloads).toEqual([
+      'replay-0',
+      'replay-1',
+      'replay-2',
+      'replay-3',
+      'replay-4',
+      'replay-5',
+      'replay-6',
+      'replay-7',
+      'replay-12'
+    ])
+    expect(manager.rebuildPaneWebgl).toHaveBeenCalledTimes(9)
+    disposable.dispose()
+  })
+
   it('does not switch renderers for Arabic output', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2894,29 +2894,40 @@ export function connectPanePty(
 
     let replayWriteQueue = Promise.resolve()
     let pendingReplayData: string | null = null
+    const replayDataQueue: string[] = []
+    const maxQueuedReplaySnapshots = 8
     let replayDrainQueued = false
+    let replayDrainInProgress = false
     const drainReplayDataQueue = async (): Promise<void> => {
-      while (pendingReplayData !== null) {
-        const data = pendingReplayData
-        pendingReplayData = null
-        // Relay replay buffer holds the last 100 KB of output, which may
-        // overlap with content already rendered in xterm before the
-        // disconnect. Clear first to prevent duplication on SSH reconnect.
-        await writeReplayDataAsync('\x1b[2J\x1b[3J\x1b[H')
-        await writeReplayDataAsync(data)
-        await writeReplayDataAsync(POST_REPLAY_REATTACH_RESET)
-        if (disposed) {
+      replayDrainInProgress = true
+      try {
+        while (pendingReplayData !== null || replayDataQueue.length > 0) {
+          const data = replayDataQueue.shift() ?? pendingReplayData
           pendingReplayData = null
-          return
+          if (data === null) {
+            continue
+          }
+          // Relay replay buffer holds the last 100 KB of output, which may
+          // overlap with content already rendered in xterm before the
+          // disconnect. Clear first to prevent duplication on SSH reconnect.
+          await writeReplayDataAsync('\x1b[2J\x1b[3J\x1b[H')
+          await writeReplayDataAsync(data)
+          await writeReplayDataAsync(POST_REPLAY_REATTACH_RESET)
+          if (disposed) {
+            pendingReplayData = null
+            replayDataQueue.length = 0
+            return
+          }
+          // Why: remote-runtime snapshots can arrive after WebGL attached to an
+          // empty buffer; rebuilding after replay parses seeds the glyph atlas
+          // from the now-populated xterm state.
+          manager.rebuildPaneWebgl(pane.id)
         }
-        // Why: remote-runtime snapshots can arrive after WebGL attached to an
-        // empty buffer; rebuilding after replay parses seeds the glyph atlas
-        // from the now-populated xterm state.
-        manager.rebuildPaneWebgl(pane.id)
+      } finally {
+        replayDrainInProgress = false
       }
     }
-    const replayDataCallback = (data: string): void => {
-      pendingReplayData = data
+    const scheduleReplayDrain = (): void => {
       if (replayDrainQueued) {
         return
       }
@@ -2926,10 +2937,27 @@ export function connectPanePty(
         .then(drainReplayDataQueue)
         .finally(() => {
           replayDrainQueued = false
-          if (pendingReplayData !== null) {
-            replayDataCallback(pendingReplayData)
+          if (pendingReplayData !== null || replayDataQueue.length > 0) {
+            scheduleReplayDrain()
           }
         })
+    }
+    const replayDataCallback = (data: string): void => {
+      if (replayDrainInProgress) {
+        if (replayDataQueue.length >= maxQueuedReplaySnapshots) {
+          // Why: replay payloads are snapshots. Preserve accepted FIFO work,
+          // then coalesce the burst tail so slow xterm parsing cannot grow
+          // memory without bound on repeated remote replay notifications.
+          replayDataQueue[replayDataQueue.length - 1] = data
+        } else {
+          replayDataQueue.push(data)
+        }
+      } else {
+        // Why: before xterm starts parsing, replay snapshots supersede one
+        // another; once parsing starts, accepted snapshots drain FIFO.
+        pendingReplayData = data
+      }
+      scheduleReplayDrain()
     }
 
     type PendingHiddenOutputRestoreChunk = {


### PR DESCRIPTION
## Summary

This PR hardens PTY output delivery across daemon stream sockets, main-to-renderer IPC, renderer replay, and runtime/mobile terminal streams. It adds bounded backpressure queues, explicit pending-output caps, active-output priority lanes, and deterministic reliability-gate coverage.

Headline behavior status: implemented for the focused queue/backpressure slice. This does not replace broader terminal perf review or soak testing.

## Stack Fit / Relationship to Other PRs

This is the high-value bounded-output/backpressure slice in the terminal reliability stack. It fits alongside #7001, #7008, #7005, #7004, #7006, and #7007 as the queue/IPC/runtime-stream hardening layer: those PRs cover adjacent terminal/session/runtime reliability work, while this PR focuses on stalled consumers, pending live output, and active-output starvation.

Perf review remains separate because these tests prove explicit byte/char/line/count contracts, not real-world keypress-to-paint latency across every TUI/provider/platform combination.

## Anti-Regression Guarantees

Not an absolute no-regression guarantee. The evidence proves:

- daemon stream writes stop after `socket.write(false)` and resume on `drain`;
- daemon backpressure queues are bounded by encoded bytes and line count;
- flush-immediate output can move ahead of background backlog without unbounded growth;
- main-to-renderer pending output is capped per PTY and globally in chars;
- renderer ACK/in-flight counters remain the pressure boundary, including exit flushes;
- replay snapshots are bounded while preserving FIFO for accepted work and newest-tail behavior under floods;
- runtime/mobile stream snapshot and pending live-output byte caps remain covered by existing deterministic tests.

## ELI5

When terminals print too much text and the receiver is slow, Orca now stops piling up unlimited output. It keeps a bounded recent tail, gives the active terminal a small priority lane, and records exactly when output was dropped because a queue hit its cap.

## Performance Proof

The daemon socket queue now honors drain, has both byte and line caps, and trims in one pass over a bounded queue. Main IPC uses rolling pending-output accounting instead of summing every pending PTY on each output event. Exit-time output is capped to one normal slice when the renderer lane has room; otherwise the pending tail is dropped and counted instead of bypassing ACK backpressure.

Perf audit result: initial findings on daemon tiny-line complexity, main pending total scans, and exit flush accounting were fixed and re-reviewed clean.

## Usefulness / Material Impact

This makes hidden/background terminal floods less able to starve active terminal redraws or grow memory without bound. It also gives future regressions a focused gate with byte/char/line/drop evidence instead of relying on broad terminal flows.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts --testNamePattern "renderer backpressure|pending renderer output|interactive output|active PTY|in-flight output|PTY exit"`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts --testNamePattern "remote replay"`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-output-batching.test.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts`
- `pnpm run check:reliability-gates`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm run typecheck:cli`
- `git diff --check`

Design review: completed; doc wording was corrected to distinguish main IPC char caps from runtime byte caps. Completeness/code review: completed; code review found no issues. Perf review: completed after fixes and re-review.

## Residual Gaps

- The new gate is experimental, not blocking.
- This is deterministic unit/integration evidence, not real SSH, WSL, relay, or physical mobile soak.
- Hidden-output renderer wake counts, scheduler queue depth, event-loop delay, and real TUI keypress-to-paint latency remain perf-soak follow-ups.
- No Playwright test was added because the requested oracles are lower-level queue/ACK contracts and no visible UI changed.

## Merge Order

Open against `brennanb2025/fix-terminal-reliability`. This can merge with the terminal reliability stack once CI/review are clean, but it should not be treated as a substitute for the separate perf review/soak work.

## Post-PR Stabilization

Pending automated checks and review feedback after PR creation.

Made with [Orca](https://github.com/stablyai/orca) 🐋
