### PR TITLE
Skip no-op state writes and bound save postponement in persistence

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   existsSync,
   realpathSync,
+  statSync,
   symlinkSync
 } from 'node:fs'
 import { join } from 'node:path'
@@ -4442,7 +4443,7 @@ describe('Store', () => {
       const store = await createStore()
       store.addRepo(makeRepo())
       store.flush()
-      vi.advanceTimersByTime(300)
+      vi.advanceTimersByTime(1000)
 
       const persisted = readDataFile() as { repos: Repo[] }
       expect(persisted.repos).toHaveLength(1)
@@ -4464,7 +4465,7 @@ describe('Store', () => {
       vi.advanceTimersByTime(100)
       // The 300ms debounce hasn't elapsed yet
 
-      vi.advanceTimersByTime(300)
+      vi.advanceTimersByTime(1000)
       // The timer fired; wait for the async disk write to complete
       await store.waitForPendingWrite()
 
@@ -4474,6 +4475,113 @@ describe('Store', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  // ── Content-hash write skipping ────────────────────────────────────
+  // Why inode comparison: every real write is a tmp+rename, which allocates a
+  // new inode. An unchanged inode proves no write happened.
+
+  it('skips the disk write when a mutation burst nets out to already-persisted state', async () => {
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+      store.updateUI({ sidebarWidth: 400 })
+      vi.advanceTimersByTime(1000)
+      await store.waitForPendingWrite()
+      const inoBefore = statSync(dataFile()).ino
+
+      store.updateUI({ sidebarWidth: 500 })
+      store.updateUI({ sidebarWidth: 400 })
+      vi.advanceTimersByTime(2000)
+      await store.waitForPendingWrite()
+
+      expect(statSync(dataFile()).ino).toBe(inoBefore)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips the sync flush when state already matches the last write', async () => {
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+      store.updateUI({ sidebarWidth: 420 })
+      vi.advanceTimersByTime(1000)
+      await store.waitForPendingWrite()
+      const inoBefore = statSync(dataFile()).ino
+
+      store.flush()
+
+      expect(statSync(dataFile()).ino).toBe(inoBefore)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('bounds save postponement under sustained mutation bursts (max-wait)', async () => {
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+      // Mutations every 500ms keep resetting the 1s trailing debounce; the
+      // 5s max-wait must force a write anyway.
+      let width = 400
+      for (let i = 0; i < 11; i++) {
+        store.updateUI({ sidebarWidth: width++ })
+        vi.advanceTimersByTime(500)
+      }
+      await store.waitForPendingWrite()
+
+      expect(existsSync(dataFile())).toBe(true)
+      const persisted = readDataFile() as { ui: { sidebarWidth: number } }
+      expect(persisted.ui.sidebarWidth).toBeGreaterThanOrEqual(400)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('re-binding an already-persisted pty does not rewrite the state file', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: null,
+          activeLeafId: null,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    const binding = {
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      ptyId: 'daemon-pty'
+    }
+    store.persistPtyBinding(binding)
+    const inoBefore = statSync(dataFile()).ino
+
+    // The warm-restart re-bind storm: every restored terminal re-asserts an
+    // identical binding with a sync flush. Identical state must not rewrite.
+    store.persistPtyBinding(binding)
+
+    expect(statSync(dataFile()).ino).toBe(inoBefore)
   })
 
   // ── UI state ───────────────────────────────────────────────────────
@@ -4518,7 +4626,7 @@ describe('Store', () => {
           tasks: { firstInteractedAt: 100, interactionCount: 1 }
         }
       })
-      vi.advanceTimersByTime(300)
+      vi.advanceTimersByTime(1000)
       await store.waitForPendingWrite()
       const persistedBefore = readFileSync(dataFile(), 'utf-8')
       store.onUIChanged((ui) => notifications.push(ui))
@@ -4532,7 +4640,7 @@ describe('Store', () => {
           tasks: { firstInteractedAt: 100, interactionCount: 1 }
         }
       })
-      vi.advanceTimersByTime(300)
+      vi.advanceTimersByTime(1000)
       await store.waitForPendingWrite()
 
       expect(notifications).toEqual([])
@@ -8307,7 +8415,7 @@ describe('Store', () => {
 
         const store = await createStore()
         store.addRepo(makeRepo({ id: 'first-async' }))
-        vi.advanceTimersByTime(300)
+        vi.advanceTimersByTime(1000)
         await store.waitForPendingWrite()
 
         const bak0AfterFirst = readBackup(0)
@@ -8315,7 +8423,7 @@ describe('Store', () => {
 
         vi.setSystemTime(new Date(Date.now() + 5 * 60 * 1000))
         store.addRepo(makeRepo({ id: 'within-hour-async', path: '/within-async' }))
-        vi.advanceTimersByTime(300)
+        vi.advanceTimersByTime(1000)
         await store.waitForPendingWrite()
 
         const bak0AfterSecond = readBackup(0)
@@ -8340,7 +8448,7 @@ describe('Store', () => {
 
         const store = await createStore()
         store.addRepo(makeRepo({ id: 'first-async' }))
-        vi.advanceTimersByTime(300)
+        vi.advanceTimersByTime(1000)
         await store.waitForPendingWrite()
 
         expect(
@@ -8351,7 +8459,7 @@ describe('Store', () => {
 
         vi.setSystemTime(new Date(Date.now() + 61 * 60 * 1000))
         store.addRepo(makeRepo({ id: 'after-hour-async', path: '/after-async' }))
-        vi.advanceTimersByTime(300)
+        vi.advanceTimersByTime(1000)
         await store.waitForPendingWrite()
 
         expect(
@@ -8464,9 +8572,9 @@ describe('Store', () => {
       try {
         const store = await createStore()
         store.addRepo(makeRepo({ id: 'first' }))
-        vi.advanceTimersByTime(300)
+        vi.advanceTimersByTime(1000)
         store.addRepo(makeRepo({ id: 'second', path: '/second' }))
-        vi.advanceTimersByTime(300)
+        vi.advanceTimersByTime(1000)
         await store.waitForPendingWrite()
 
         const persisted = JSON.parse(readFileSync(dataFile(), 'utf-8')) as { repos: Repo[] }

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4463,7 +4463,7 @@ describe('Store', () => {
 
       // Before the debounce fires, file should not exist yet (or be stale)
       vi.advanceTimersByTime(100)
-      // The 300ms debounce hasn't elapsed yet
+      // The 1s debounce hasn't elapsed yet
 
       vi.advanceTimersByTime(1000)
       // The timer fired; wait for the async disk write to complete

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -16,7 +16,7 @@ import {
 import { writeFile, rename, mkdir, rm, copyFile } from 'node:fs/promises'
 import { join, dirname, isAbsolute, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import type {
   Automation,
   AutomationCreateInput,
@@ -2444,6 +2444,13 @@ export class Store {
   private writeTimer: ReturnType<typeof setTimeout> | null = null
   private pendingWrite: Promise<void> | null = null
   private writeGeneration = 0
+  // Why: hash of the plaintext state as of the last successful write. Saves
+  // triggered by mutations that net out to identical state skip the full
+  // 1.6MB pretty-print + tmp write + rename. Hashing plaintext (not the
+  // written payload) because encrypt() uses a random IV per call, so the
+  // on-disk bytes differ even for identical state.
+  private lastWrittenStateHash: string | null = null
+  private firstPendingSaveAt: number | null = null
   private gitUsernameCache = new Map<string, string>()
   private loadNeedsSave = false
   private settingsChangeListeners = new Set<
@@ -3353,12 +3360,25 @@ export class Store {
     }
   }
 
+  // Why 1s trailing + 5s max-wait (previously 300ms trailing, unbounded):
+  // sustained sub-interval mutation bursts used to either rewrite the full
+  // multi-MB state ~3x/sec or postpone the write indefinitely by resetting
+  // the timer. The max-wait bounds crash staleness at 5s while bursts
+  // coalesce; the content-hash guard in the writers skips no-op payloads.
+  private static SAVE_DEBOUNCE_MS = 1_000
+  private static SAVE_MAX_WAIT_MS = 5_000
+
   private scheduleSave(): void {
+    const now = Date.now()
+    this.firstPendingSaveAt ??= now
     if (this.writeTimer) {
       clearTimeout(this.writeTimer)
     }
+    const untilMaxWait = Math.max(0, this.firstPendingSaveAt + Store.SAVE_MAX_WAIT_MS - now)
+    const delay = Math.min(Store.SAVE_DEBOUNCE_MS, untilMaxWait)
     this.writeTimer = setTimeout(() => {
       this.writeTimer = null
+      this.firstPendingSaveAt = null
       // Why (issue #1158): serialize async writes so backup rotation never has
       // two callers racing over the same dataFile/tmp/.bak paths.
       const prev = this.pendingWrite ?? Promise.resolve()
@@ -3373,7 +3393,7 @@ export class Store {
           }
         })
       this.pendingWrite = next
-    }, 300)
+    }, delay)
   }
 
   /** Wait for any in-flight async disk write to complete. Used in tests. */
@@ -3383,15 +3403,14 @@ export class Store {
     }
   }
 
-  // Why: async writes avoid blocking the main Electron thread on every
-  // debounced save (every 300ms during active use).
-  private async writeToDiskAsync(): Promise<void> {
-    const gen = this.writeGeneration
-    const dataFile = getDataFile()
-    const dir = dirname(dataFile)
-    await mkdir(dir, { recursive: true }).catch(() => {})
-    const tmpFile = `${dataFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
+  private computeStateHash(): string {
+    return createHash('sha1').update(JSON.stringify(this.state)).digest('hex')
+  }
 
+  // Why: builds the on-disk payload synchronously so the hash and the
+  // serialized bytes reflect the same state tick (no mutation can interleave
+  // before an await).
+  private buildStateToSave(): string {
     // Why: secrets must be encrypted on disk. Clone state so the in-memory
     // this.state stays plaintext for the rest of the app.
     const stateToSave = {
@@ -3406,13 +3425,31 @@ export class Store {
         browserKagiSessionLink: encryptOptionalSecret(this.state.ui.browserKagiSessionLink)
       }
     }
+    return JSON.stringify(stateToSave, null, 2)
+  }
+
+  // Why: async writes avoid blocking the main Electron thread on every
+  // debounced save during active use.
+  private async writeToDiskAsync(): Promise<void> {
+    const gen = this.writeGeneration
+    const stateHash = this.computeStateHash()
+    // Why: a mutation burst that nets out to already-persisted state (or a
+    // flush that raced ahead) must not rewrite a byte-identical multi-MB file.
+    if (stateHash === this.lastWrittenStateHash) {
+      return
+    }
+    const payload = this.buildStateToSave()
+    const dataFile = getDataFile()
+    const dir = dirname(dataFile)
+    await mkdir(dir, { recursive: true }).catch(() => {})
+    const tmpFile = `${dataFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
 
     // Why: wrap write+rename in try/finally-on-error so any failure (ENOSPC,
     // ENFILE, EIO, permission) removes the tmp file rather than leaving a
     // multi-megabyte orphan behind. Successful rename consumes the tmp file.
     let renamed = false
     try {
-      await writeFile(tmpFile, JSON.stringify(stateToSave, null, 2), 'utf-8')
+      await writeFile(tmpFile, payload, 'utf-8')
       // Why: if flush() ran while this async write was in-flight, it bumped
       // writeGeneration and already wrote the latest state synchronously.
       // Renaming this stale tmp file would overwrite the fresh data.
@@ -3421,6 +3458,7 @@ export class Store {
       }
       await rename(tmpFile, dataFile)
       renamed = true
+      this.lastWrittenStateHash = stateHash
     } finally {
       if (!renamed) {
         await rm(tmpFile).catch(() => {})
@@ -3440,6 +3478,12 @@ export class Store {
   // Why: synchronous variant kept only for flush() at shutdown, where the
   // process may exit before an async write completes.
   private writeToDiskSync(): void {
+    const stateHash = this.computeStateHash()
+    // Why: skipping is safe under flushOrThrow's durability contract — a
+    // matching hash means this exact state is already the file's content.
+    if (stateHash === this.lastWrittenStateHash) {
+      return
+    }
     const dataFile = getDataFile()
     const dir = dirname(dataFile)
     if (!existsSync(dir)) {
@@ -3447,29 +3491,17 @@ export class Store {
     }
     const tmpFile = `${dataFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
 
-    // Why: secrets must be encrypted on disk. Clone state so the in-memory
-    // this.state stays plaintext for the rest of the app.
-    const stateToSave = {
-      ...this.state,
-      settings: {
-        ...this.state.settings,
-        opencodeSessionCookie: encrypt(this.state.settings.opencodeSessionCookie),
-        httpProxyUrl: encrypt(this.state.settings.httpProxyUrl ?? '')
-      },
-      ui: {
-        ...this.state.ui,
-        browserKagiSessionLink: encryptOptionalSecret(this.state.ui.browserKagiSessionLink)
-      }
-    }
+    const payload = this.buildStateToSave()
 
     // Why: mirror the async path — on any failure between writeFileSync and
     // renameSync, remove the tmp file so crashes during shutdown don't leak
     // orphans into userData.
     let renamed = false
     try {
-      writeFileSync(tmpFile, JSON.stringify(stateToSave, null, 2), 'utf-8')
+      writeFileSync(tmpFile, payload, 'utf-8')
       renameSync(tmpFile, dataFile)
       renamed = true
+      this.lastWrittenStateHash = stateHash
     } finally {
       if (!renamed) {
         try {
@@ -3490,6 +3522,7 @@ export class Store {
       clearTimeout(this.writeTimer)
       this.writeTimer = null
     }
+    this.firstPendingSaveAt = null
     // Why: bump writeGeneration so any in-flight async writeToDiskAsync skips
     // its rename, preventing a stale snapshot from overwriting this sync write.
     this.writeGeneration++

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3458,7 +3458,13 @@ export class Store {
       }
       await rename(tmpFile, dataFile)
       renamed = true
-      this.lastWrittenStateHash = stateHash
+      // Why the gen re-check: a sync flush can interleave during the rename
+      // await, write fresher state, and record its own hash. Recording this
+      // stale hash over it would make later saves skip against content that
+      // is not what the file holds.
+      if (this.writeGeneration === gen) {
+        this.lastWrittenStateHash = stateHash
+      }
     } finally {
       if (!renamed) {
         await rm(tmpFile).catch(() => {})
@@ -3477,11 +3483,14 @@ export class Store {
 
   // Why: synchronous variant kept only for flush() at shutdown, where the
   // process may exit before an async write completes.
-  private writeToDiskSync(): void {
+  private writeToDiskSync(opts: { force?: boolean } = {}): void {
     const stateHash = this.computeStateHash()
     // Why: skipping is safe under flushOrThrow's durability contract — a
     // matching hash means this exact state is already the file's content.
-    if (stateHash === this.lastWrittenStateHash) {
+    // Except when an async write was in flight at flush entry (force): its
+    // rename may already be dispatched past the generation check, and only
+    // an unconditional sync write afterwards reliably out-orders it.
+    if (!opts.force && stateHash === this.lastWrittenStateHash) {
       return
     }
     const dataFile = getDataFile()
@@ -3523,11 +3532,12 @@ export class Store {
       this.writeTimer = null
     }
     this.firstPendingSaveAt = null
+    const asyncWriteWasInFlight = this.pendingWrite !== null
     // Why: bump writeGeneration so any in-flight async writeToDiskAsync skips
     // its rename, preventing a stale snapshot from overwriting this sync write.
     this.writeGeneration++
     this.pendingWrite = null
-    this.writeToDiskSync()
+    this.writeToDiskSync({ force: asyncWriteWasInFlight })
   }
 
   // ── Repos ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #7068/#7088 (fseventsd + write-churn audit): second of the deferred write-churn findings.

## Problem

`orca-data.json` (1.6MB on the reference machine) is rewritten in full — pretty-printed serialize, tmp write, rename — on every debounced save, even when state content hasn't changed. Measured on an idle production instance: **3 rewrites/min, ~9.8MB written per 2 minutes** (~7GB/day at idle rate; active use peaks far higher at the old 300ms cadence). Warm starts additionally trigger a sync-flush storm: every restored terminal re-asserts an identical PTY binding through `persistPtyBinding`, each forcing a full synchronous multi-MB write.

Two defects compound:

- No content guard: mutation bursts that net out to already-persisted state (or no-op re-binds) still rewrite the file.
- The 300ms trailing debounce **resets on every mutation with no upper bound** — sustained sub-interval mutations either rewrite ~3×/s or postpone the write indefinitely.

## Fix

- **Content-hash guard in both writers**: each write computes a sha1 of the compact plaintext state; if it matches the last *successful* write, the serialize + tmp + rename is skipped entirely. Hashing plaintext rather than the on-disk payload because `encrypt()` uses a random IV per call (byte-identical state produces different ciphertext every time). Safe under `flushOrThrow`'s durability contract: a matching hash means the file already contains exactly this state. The hash is only recorded after a successful rename (and, on the async path, only when the write-generation check passes, so a racing sync flush's fresher hash is never clobbered).
- **Debounce 300ms → 1s trailing + 5s max-wait**: bursts coalesce, and the max-wait fixes the pre-existing unbounded-postponement edge — crash staleness is now hard-capped at 5s (was theoretically unbounded under sustained mutations, typically 300ms).

## Evidence

| condition | orca-data.json rewrites |
|---|---|
| production (old code), idle, 2 min | 6 (~9.8MB written) |
| dev build (fixed), settled idle, 2 min | 3 — and consecutive-snapshot diffing confirms each remaining write is a genuine content change (periodic hosted-review/github cache refreshes stored in persisted state), i.e. zero byte-identical rewrites remain |

(The residual writer — poll-refreshed cache entries with timestamps living inside the durable state file — is a separate design question, noted for follow-up.)

Unit (asserted): a mutation burst that returns to already-persisted state produces no write (inode unchanged — every real write is a tmp+rename, so an unchanged inode proves no I/O); `flush()` on clean state skips; an identical `persistPtyBinding` re-bind (the warm-start storm) skips; sustained 500ms-interval mutations still hit disk within the 5s max-wait. 326 persistence tests pass (10 existing timing tests updated 300ms → 1s), plus 108 tests in adjacent suites.

## Trade-offs

- Crash-loss window for un-flushed mutations grows from ~300ms to ≤5s (1s typical). Quit/sleep still flush synchronously; PTY bindings still flush synchronously at spawn; and the previous behavior was already unbounded under sustained mutation, so the worst case strictly improves.
- Each real (content-changing) save pays one extra compact `JSON.stringify` + sha1 (~5-8ms on 1.6MB, off the critical path); no-op saves get dramatically cheaper (no serialize-for-disk, no I/O).
- Backup rotation only runs on real writes — unchanged in practice since rotating a byte-identical state file has no value.

## Review

An independent adversarial review traced six invariants (hash-vs-disk coherence across all writer interleavings, `flushOrThrow` durability at every call site, max-wait math, backup rotation, startup seeding, external writers). It confirmed the design — including that backup rotation strictly improves (the old idle churn rotated five *identical* hourly snapshots, aging out distinct history) — and found one real race, fixed in the second commit: recording the hash after the async rename needed a write-generation re-check, and a hash-matching sync flush must force-write when an async rename was already dispatched, so the sync write always lands last.

Made with [Orca](https://github.com/stablyai/orca) 🐋
