### PR TITLE
Tune worktree card drag targets

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1499,6 +1499,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       groupKey: string
       rects: readonly WorktreeSidebarDragRect[]
       draggedIds: readonly string[]
+      draggingWorktreeId?: string | null
     }): WorktreeSidebarDropPreview | null => {
       const container = scrollRef.current
       if (!container) {
@@ -1515,7 +1516,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         scrollTop: container.scrollTop,
         rects: args.rects,
         groupIds: group.worktreeIds,
-        draggedIds: args.draggedIds
+        draggedIds: args.draggedIds,
+        draggingWorktreeId: args.draggingWorktreeId
       })
     },
     [worktreeDragUnitGroups]
@@ -1530,7 +1532,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         pointerY,
         groupKey: session.sourceGroupKey,
         rects: session.rects,
-        draggedIds: session.reorderUnitDraggedIds
+        draggedIds: session.reorderUnitDraggedIds,
+        draggingWorktreeId: session.draggingWorktreeId
       })
     },
     [computeWorktreeDropForGroup]
@@ -1550,7 +1553,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         pointerY: args.pointerY,
         groupKey,
         rects: getWorktreeSidebarDragRectsForGroup(container, groupKey),
-        draggedIds: args.draggedIds
+        draggedIds: args.draggedIds,
+        draggingWorktreeId: worktreeDragSessionRef.current?.draggingWorktreeId ?? null
       })
     },
     [computeWorktreeDropForGroup]

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -180,6 +180,10 @@ import {
   type WorktreeSidebarTrackedStatusDropTarget,
   type WorktreeSidebarDropPreview
 } from './worktree-sidebar-drop-preview'
+import {
+  getReorderedWorktreeIdsToUnnest,
+  getWorktreeLineageDropTargetId
+} from './worktree-lineage-drag-drop'
 import { resolveProjectGroupHeaderColor } from './project-header-color'
 import {
   REPO_HEADER_ACTION_BUTTON_CLASS,
@@ -984,11 +988,11 @@ function getPointerDropStatusTarget(args: {
   if (pinTarget && args.container.contains(pinTarget)) {
     return { status: null, isPinDrop: true, lineageParentId: null }
   }
-  const rowTarget = target.closest<HTMLElement>('[data-worktree-drag-id]')
-  let lineageParentId: string | null = null
-  if (rowTarget && args.container.contains(rowTarget)) {
-    lineageParentId = rowTarget.dataset.worktreeDragId ?? null
-  }
+  const lineageParentId = getWorktreeLineageDropTargetId({
+    container: args.container,
+    target,
+    pointerY: args.y
+  })
   const statusTarget = target.closest<HTMLElement>('[data-workspace-status-drop-target]')
   return {
     status:
@@ -1314,6 +1318,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const [highlightedRevealRowKey, setHighlightedRevealRowKey] = useState<string | null>(null)
   const setRenamingWorktreeId = useAppStore((s) => s.setRenamingWorktreeId)
   const assignWorktreeParent = useAppStore((s) => s.assignWorktreeParent)
+  const updateWorktreeLineage = useAppStore((s) => s.updateWorktreeLineage)
   const worktreeDragSessionRef = useRef<WorktreeSidebarDragSession | null>(null)
   const worktreePointerDragRef = useRef<WorktreePointerDrag | null>(null)
   const worktreePointerAutoscrollFrameIdRef = useRef<number | null>(null)
@@ -2587,6 +2592,37 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     [assignWorktreeParent, getEligibleLineageDropTarget]
   )
 
+  const clearReorderedWorktreeParents = useCallback(
+    (args: { draggedIds: readonly string[]; sourceGroupKey: string }) => {
+      const sourceGroup = worktreeDragGroups.find((group) => group.key === args.sourceGroupKey)
+      if (!sourceGroup) {
+        return
+      }
+      const ids = getReorderedWorktreeIdsToUnnest({
+        draggedIds: args.draggedIds,
+        sourceGroupIds: sourceGroup.worktreeIds,
+        lineageById: worktreeLineageById
+      })
+      if (ids.length === 0) {
+        return
+      }
+      // Why: dropping a nested card onto a reorder line is the escape hatch
+      // from accidental nesting, so clear only the directly dragged children.
+      void Promise.all(ids.map((id) => updateWorktreeLineage(id, { noParent: true }))).catch(
+        (err) => {
+          console.error('Failed to unnest workspace:', err)
+          toast.error(
+            translate(
+              'auto.components.sidebar.WorktreeList.failedUnnestWorkspace',
+              'Failed to unnest workspace'
+            )
+          )
+        }
+      )
+    },
+    [updateWorktreeLineage, worktreeDragGroups, worktreeLineageById]
+  )
+
   const flushWorktreePointerDrag = useCallback(() => {
     const drag = worktreePointerDragRef.current
     if (!drag) {
@@ -3101,6 +3137,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               dropIndex: drop.dropIndex
             })
           })
+          clearReorderedWorktreeParents({
+            draggedIds: drag.draggedIds,
+            sourceGroupKey: drag.sourceGroupKey
+          })
         } else if (scrollRef.current) {
           const currentTarget = preferredStatusTarget
           const currentPreview = currentTarget.status
@@ -3157,6 +3197,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   }, [
     beginWorktreePointerDrag,
     clearWorktreeDrag,
+    clearReorderedWorktreeParents,
     commitWorktreeLineageParentDrop,
     computeWorktreeDrop,
     computeWorktreeStatusDrop,
@@ -3504,10 +3545,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           dropIndex: drop.dropIndex
         })
       })
+      clearReorderedWorktreeParents({
+        draggedIds: session.draggedIds,
+        sourceGroupKey: session.sourceGroupKey
+      })
       clearWorktreeDrag()
     },
     [
       clearWorktreeDrag,
+      clearReorderedWorktreeParents,
       commitWorktreeLineageParentDrop,
       computeWorktreeDrop,
       computeWorktreeStatusDrop,
@@ -3757,6 +3803,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           dropIndex: drop.dropIndex
         })
       })
+      clearReorderedWorktreeParents({
+        draggedIds: session.draggedIds,
+        sourceGroupKey: session.sourceGroupKey
+      })
       clearWorktreeDrag()
     }
 
@@ -3764,6 +3814,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     return () => document.removeEventListener('drop', handleDocumentDrop, true)
   }, [
     clearWorktreeDrag,
+    clearReorderedWorktreeParents,
     commitWorktreeLineageParentDrop,
     computeWorktreeDrop,
     computeWorktreeStatusDrop,
@@ -4615,11 +4666,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   onClickCapture={handleWorktreeRowClickCapture}
                   onDoubleClick={nested ? stopNestedWorktreeCardBubble : undefined}
                   onDragStart={nested ? stopNestedWorktreeCardBubble : undefined}
-                  onPointerDown={(event) =>
-                    nested
-                      ? undefined
-                      : handleWorktreeRowPointerDown(event, itemRow.worktree.id, itemRow.rowKey)
-                  }
+                  onPointerDown={(event) => {
+                    if (nested) {
+                      event.stopPropagation()
+                    }
+                    handleWorktreeRowPointerDown(event, itemRow.worktree.id, itemRow.rowKey)
+                  }}
                   style={{
                     paddingLeft: surfaceInset > 0 ? `${surfaceInset}px` : undefined
                   }}

--- a/src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts
+++ b/src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts
@@ -40,12 +40,20 @@ function getFallbackGap(rects: readonly WorktreeDragPreviewRect[]): number {
 
 function getPreviewLayoutDraggedIds(
   groupIds: readonly string[],
-  draggedIds: readonly string[]
+  draggedIds: readonly string[],
+  draggingWorktreeId?: string | null
 ): readonly string[] {
   if (draggedIds.length <= 1) {
     return draggedIds
   }
   const draggedSet = new Set(draggedIds)
+  if (
+    draggingWorktreeId &&
+    draggedSet.has(draggingWorktreeId) &&
+    groupIds.includes(draggingWorktreeId)
+  ) {
+    return [draggingWorktreeId]
+  }
   const firstVisibleDraggedId = groupIds.find((id) => draggedSet.has(id))
   return firstVisibleDraggedId ? [firstVisibleDraggedId] : draggedIds.slice(0, 1)
 }
@@ -53,18 +61,32 @@ function getPreviewLayoutDraggedIds(
 export function buildWorktreeDragPreviewOffsets(args: {
   groupIds: readonly string[]
   draggedIds: readonly string[]
+  draggingWorktreeId?: string | null
   dropIndex: number
   rects: readonly WorktreeDragPreviewRect[]
 }): Map<string, number> {
+  const committedNextIds = moveWorktreeIdsWithinGroup(
+    args.groupIds,
+    args.draggedIds,
+    args.dropIndex
+  )
+  if (arraysEqual(committedNextIds, args.groupIds)) {
+    return new Map()
+  }
+
   // Why: dragging a large multi-select batch should advertise the insertion
   // point without opening a giant hole that makes the sidebar jump around.
-  const layoutDraggedIds = getPreviewLayoutDraggedIds(args.groupIds, args.draggedIds)
+  const layoutDraggedIds = getPreviewLayoutDraggedIds(
+    args.groupIds,
+    args.draggedIds,
+    args.draggingWorktreeId
+  )
   const nextIds = moveWorktreeIdsWithinGroup(args.groupIds, layoutDraggedIds, args.dropIndex)
   if (arraysEqual(nextIds, args.groupIds)) {
     return new Map()
   }
 
-  const draggedSet = new Set(args.draggedIds)
+  const draggedSet = new Set(layoutDraggedIds)
   const newIndexById = new Map<string, number>()
   nextIds.forEach((id, index) => newIndexById.set(id, index))
 

--- a/src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts
+++ b/src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts
@@ -38,13 +38,28 @@ function getFallbackGap(rects: readonly WorktreeDragPreviewRect[]): number {
   return gaps[Math.floor(gaps.length / 2)]!
 }
 
+function getPreviewLayoutDraggedIds(
+  groupIds: readonly string[],
+  draggedIds: readonly string[]
+): readonly string[] {
+  if (draggedIds.length <= 1) {
+    return draggedIds
+  }
+  const draggedSet = new Set(draggedIds)
+  const firstVisibleDraggedId = groupIds.find((id) => draggedSet.has(id))
+  return firstVisibleDraggedId ? [firstVisibleDraggedId] : draggedIds.slice(0, 1)
+}
+
 export function buildWorktreeDragPreviewOffsets(args: {
   groupIds: readonly string[]
   draggedIds: readonly string[]
   dropIndex: number
   rects: readonly WorktreeDragPreviewRect[]
 }): Map<string, number> {
-  const nextIds = moveWorktreeIdsWithinGroup(args.groupIds, args.draggedIds, args.dropIndex)
+  // Why: dragging a large multi-select batch should advertise the insertion
+  // point without opening a giant hole that makes the sidebar jump around.
+  const layoutDraggedIds = getPreviewLayoutDraggedIds(args.groupIds, args.draggedIds)
+  const nextIds = moveWorktreeIdsWithinGroup(args.groupIds, layoutDraggedIds, args.dropIndex)
   if (arraysEqual(nextIds, args.groupIds)) {
     return new Map()
   }

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getReorderedWorktreeIdsToUnnest,
+  getWorktreeLineageDropTargetId,
+  isWorktreeLineageDropZoneHit
+} from './worktree-lineage-drag-drop'
+
+describe('isWorktreeLineageDropZoneHit', () => {
+  it('keeps the top and bottom of a card available for reorder drops', () => {
+    const rect = { top: 100, bottom: 200 } as DOMRect
+
+    expect(isWorktreeLineageDropZoneHit({ pointerY: 120, rect })).toBe(false)
+    expect(isWorktreeLineageDropZoneHit({ pointerY: 150, rect })).toBe(true)
+    expect(isWorktreeLineageDropZoneHit({ pointerY: 180, rect })).toBe(false)
+  })
+
+  it('caps the parent-drop band on tall cards', () => {
+    const rect = { top: 0, bottom: 180 } as DOMRect
+
+    expect(isWorktreeLineageDropZoneHit({ pointerY: 67, rect })).toBe(false)
+    expect(isWorktreeLineageDropZoneHit({ pointerY: 90, rect })).toBe(true)
+    expect(isWorktreeLineageDropZoneHit({ pointerY: 113, rect })).toBe(false)
+  })
+})
+
+describe('getWorktreeLineageDropTargetId', () => {
+  it('returns the row id only when the pointer is in the card content middle band', () => {
+    const { container, target } = makeTarget({ worktreeId: 'parent', top: 100, bottom: 200 })
+
+    expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 120 })).toBeNull()
+    expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 150 })).toBe('parent')
+  })
+
+  it('ignores content targets outside the sidebar container', () => {
+    const { container, target } = makeTarget({
+      worktreeId: 'parent',
+      top: 100,
+      bottom: 200,
+      contained: false
+    })
+
+    expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 150 })).toBeNull()
+  })
+})
+
+describe('getReorderedWorktreeIdsToUnnest', () => {
+  it('clears parents only for directly dragged nested cards', () => {
+    expect(
+      getReorderedWorktreeIdsToUnnest({
+        draggedIds: ['child', 'child', 'root', 'grandchild'],
+        sourceGroupIds: ['child', 'root', 'grandchild'],
+        lineageById: {
+          child: true,
+          grandchild: true
+        }
+      })
+    ).toEqual(['child', 'grandchild'])
+  })
+
+  it('does not clear selected nested cards outside the reordered source group', () => {
+    expect(
+      getReorderedWorktreeIdsToUnnest({
+        draggedIds: ['source-child', 'other-child'],
+        sourceGroupIds: ['source-child'],
+        lineageById: {
+          'source-child': true,
+          'other-child': true
+        }
+      })
+    ).toEqual(['source-child'])
+  })
+})
+
+function makeTarget(args: {
+  worktreeId: string
+  top: number
+  bottom: number
+  contained?: boolean
+}): {
+  container: HTMLElement
+  target: Element
+} {
+  const row = {
+    getAttribute: (name: string) => (name === 'data-worktree-drag-id' ? args.worktreeId : null)
+  } as HTMLElement
+  const content = {
+    getBoundingClientRect: () => ({ top: args.top, bottom: args.bottom }),
+    closest: (selector: string) => (selector === '[data-worktree-drag-id]' ? row : null)
+  } as HTMLElement
+  const target = {
+    closest: (selector: string) =>
+      selector === '[data-worktree-card-hover-trigger]' ? content : null
+  } as Element
+  const contained = args.contained ?? true
+  const container = {
+    contains: (element: Element) => contained && (element === content || element === row)
+  } as HTMLElement
+  return { container, target }
+}

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
@@ -1,0 +1,68 @@
+const WORKTREE_CARD_CONTENT_TARGET_SELECTOR = '[data-worktree-card-hover-trigger]'
+const WORKTREE_DRAG_ROW_SELECTOR = '[data-worktree-drag-id]'
+
+const LINEAGE_DROP_ZONE_RATIO = 0.4
+const LINEAGE_DROP_ZONE_MAX_HEIGHT_PX = 44
+
+type VerticalRect = Pick<DOMRect, 'top' | 'bottom'>
+
+export function isWorktreeLineageDropZoneHit(args: {
+  pointerY: number
+  rect: VerticalRect
+}): boolean {
+  const height = Math.max(0, args.rect.bottom - args.rect.top)
+  if (height <= 0) {
+    return false
+  }
+
+  const zoneHeight = Math.min(height * LINEAGE_DROP_ZONE_RATIO, LINEAGE_DROP_ZONE_MAX_HEIGHT_PX)
+  const zoneTop = args.rect.top + (height - zoneHeight) / 2
+  const zoneBottom = args.rect.bottom - (height - zoneHeight) / 2
+  return args.pointerY >= zoneTop && args.pointerY <= zoneBottom
+}
+
+export function getWorktreeLineageDropTargetId(args: {
+  container: HTMLElement
+  target: Element
+  pointerY: number
+}): string | null {
+  const contentTarget = args.target.closest<HTMLElement>(WORKTREE_CARD_CONTENT_TARGET_SELECTOR)
+  if (!contentTarget || !args.container.contains(contentTarget)) {
+    return null
+  }
+
+  // Why: nesting should be deliberate; the top/bottom of a card stays available
+  // for reorder drops instead of treating the whole card as a parent target.
+  if (
+    !isWorktreeLineageDropZoneHit({
+      pointerY: args.pointerY,
+      rect: contentTarget.getBoundingClientRect()
+    })
+  ) {
+    return null
+  }
+
+  const rowTarget = contentTarget.closest<HTMLElement>(WORKTREE_DRAG_ROW_SELECTOR)
+  if (!rowTarget || !args.container.contains(rowTarget)) {
+    return null
+  }
+  return rowTarget.getAttribute('data-worktree-drag-id')
+}
+
+export function getReorderedWorktreeIdsToUnnest(args: {
+  draggedIds: readonly string[]
+  sourceGroupIds: readonly string[]
+  lineageById: Readonly<Record<string, unknown>>
+}): string[] {
+  const ids: string[] = []
+  const seen = new Set<string>()
+  const sourceGroupIdSet = new Set(args.sourceGroupIds)
+  for (const id of args.draggedIds) {
+    if (seen.has(id) || !sourceGroupIdSet.has(id) || !args.lineageById[id]) {
+      continue
+    }
+    seen.add(id)
+    ids.push(id)
+  }
+  return ids
+}

--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -146,6 +146,23 @@ describe('buildWorktreeDragPreviewOffsets', () => {
 
     expect(Array.from(offsets)).toEqual([['parent', 108]])
   })
+
+  it('reserves one card-height slot while previewing a multi-select batch', () => {
+    const offsets = buildWorktreeDragPreviewOffsets({
+      groupIds: ['a', 'b', 'c', 'd', 'e'],
+      draggedIds: ['b', 'c', 'd'],
+      dropIndex: 5,
+      rects: [
+        { worktreeId: 'a', groupIndex: 0, top: 0, bottom: 50 },
+        { worktreeId: 'b', groupIndex: 1, top: 56, bottom: 106 },
+        { worktreeId: 'c', groupIndex: 2, top: 112, bottom: 162 },
+        { worktreeId: 'd', groupIndex: 3, top: 168, bottom: 218 },
+        { worktreeId: 'e', groupIndex: 4, top: 224, bottom: 274 }
+      ]
+    })
+
+    expect(Array.from(offsets)).toEqual([['e', -56]])
+  })
 })
 
 describe('buildManualOrderUpdatesForVisibleGroups', () => {

--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -151,6 +151,29 @@ describe('buildWorktreeDragPreviewOffsets', () => {
     const offsets = buildWorktreeDragPreviewOffsets({
       groupIds: ['a', 'b', 'c', 'd', 'e'],
       draggedIds: ['b', 'c', 'd'],
+      draggingWorktreeId: 'b',
+      dropIndex: 5,
+      rects: [
+        { worktreeId: 'a', groupIndex: 0, top: 0, bottom: 50 },
+        { worktreeId: 'b', groupIndex: 1, top: 56, bottom: 106 },
+        { worktreeId: 'c', groupIndex: 2, top: 112, bottom: 162 },
+        { worktreeId: 'd', groupIndex: 3, top: 168, bottom: 218 },
+        { worktreeId: 'e', groupIndex: 4, top: 224, bottom: 274 }
+      ]
+    })
+
+    expect(Array.from(offsets)).toEqual([
+      ['c', -56],
+      ['d', -56],
+      ['e', -56]
+    ])
+  })
+
+  it('uses the grabbed selected card as the one preview placeholder', () => {
+    const offsets = buildWorktreeDragPreviewOffsets({
+      groupIds: ['a', 'b', 'c', 'd', 'e'],
+      draggedIds: ['b', 'c', 'd'],
+      draggingWorktreeId: 'd',
       dropIndex: 5,
       rects: [
         { worktreeId: 'a', groupIndex: 0, top: 0, bottom: 50 },
@@ -162,6 +185,24 @@ describe('buildWorktreeDragPreviewOffsets', () => {
     })
 
     expect(Array.from(offsets)).toEqual([['e', -56]])
+  })
+
+  it('returns no preview offsets for a no-op multi-select hover', () => {
+    const offsets = buildWorktreeDragPreviewOffsets({
+      groupIds: ['a', 'b', 'c', 'd', 'e'],
+      draggedIds: ['b', 'c', 'd'],
+      draggingWorktreeId: 'b',
+      dropIndex: 4,
+      rects: [
+        { worktreeId: 'a', groupIndex: 0, top: 0, bottom: 50 },
+        { worktreeId: 'b', groupIndex: 1, top: 56, bottom: 106 },
+        { worktreeId: 'c', groupIndex: 2, top: 112, bottom: 162 },
+        { worktreeId: 'd', groupIndex: 3, top: 168, bottom: 218 },
+        { worktreeId: 'e', groupIndex: 4, top: 224, bottom: 274 }
+      ]
+    })
+
+    expect(offsets.size).toBe(0)
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts
@@ -183,7 +183,7 @@ describe('refreshWorktreeSidebarDragSession', () => {
     ).toBeNull()
     expect(
       refreshWorktreeSidebarDragSession({
-        session: SESSION,
+        session: { ...SESSION, reorderUnitDraggedIds: ['missing'] },
         groups: [{ key: 'repo:one', worktreeIds: ['a', 'b'] }],
         unitGroups: [{ key: 'repo:one', worktreeIds: ['a'], units: [] }],
         rects: []
@@ -200,6 +200,39 @@ describe('refreshWorktreeSidebarDragSession', () => {
         rects: []
       })
     ).toEqual({ ...SESSION, rects: [] })
+  })
+
+  it('keeps child-card reorder drags even when the child is not a top-level unit', () => {
+    const childSession: WorktreeSidebarDragSession = {
+      ...SESSION,
+      draggingWorktreeId: 'child',
+      draggedIds: ['child'],
+      reorderDraggedIds: ['child'],
+      reorderUnitDraggedIds: ['child']
+    }
+    const rects: WorktreeSidebarDragRect[] = [
+      { worktreeId: 'parent', groupIndex: 0, top: 0, bottom: 80 },
+      { worktreeId: 'child', groupIndex: 1, top: 88, bottom: 128 },
+      { worktreeId: 'sibling', groupIndex: 2, top: 136, bottom: 176 }
+    ]
+
+    expect(
+      refreshWorktreeSidebarDragSession({
+        session: childSession,
+        groups: [{ key: 'repo:one', worktreeIds: ['parent', 'child', 'sibling'] }],
+        unitGroups: [
+          {
+            key: 'repo:one',
+            worktreeIds: ['parent', 'sibling'],
+            units: [
+              { worktreeId: 'parent', worktreeIds: ['parent', 'child'] },
+              { worktreeId: 'sibling', worktreeIds: ['sibling'] }
+            ]
+          }
+        ],
+        rects
+      })
+    ).toEqual({ ...childSession, rects })
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.ts
@@ -180,8 +180,13 @@ export function refreshWorktreeSidebarDragSession(args: {
     return null
   }
 
+  const sourceGroupIds = new Set(sourceGroup.worktreeIds)
   const sourceUnitIds = new Set(sourceUnitGroup.worktreeIds)
-  if (args.session.reorderUnitDraggedIds.some((worktreeId) => !sourceUnitIds.has(worktreeId))) {
+  if (
+    args.session.reorderUnitDraggedIds.some(
+      (worktreeId) => !sourceUnitIds.has(worktreeId) && !sourceGroupIds.has(worktreeId)
+    )
+  ) {
     return null
   }
 

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
@@ -60,6 +60,58 @@ describe('computeWorktreeSidebarDropPreview', () => {
     })
     expect(Array.from(preview?.previewOffsetsByWorktreeId ?? [])).toEqual([['sibling', -288]])
   })
+
+  it('uses one card-height placeholder for multi-select reorder previews', () => {
+    const preview = computeWorktreeSidebarDropPreview({
+      pointerY: 280,
+      containerTop: 0,
+      scrollTop: 0,
+      rects: [
+        { worktreeId: 'a', groupIndex: 0, top: 0, bottom: 50 },
+        { worktreeId: 'b', groupIndex: 1, top: 56, bottom: 106 },
+        { worktreeId: 'c', groupIndex: 2, top: 112, bottom: 162 },
+        { worktreeId: 'd', groupIndex: 3, top: 168, bottom: 218 },
+        { worktreeId: 'e', groupIndex: 4, top: 224, bottom: 274 }
+      ],
+      groupIds: ['a', 'b', 'c', 'd', 'e'],
+      draggedIds: ['b', 'c', 'd'],
+      draggingWorktreeId: 'b'
+    })
+
+    expect(preview).toMatchObject({
+      dropIndex: 5,
+      dropIndicatorY: 277
+    })
+    expect(Array.from(preview?.previewOffsetsByWorktreeId ?? [])).toEqual([
+      ['c', -56],
+      ['d', -56],
+      ['e', -56]
+    ])
+  })
+
+  it('uses the grabbed selected card as the multi-select preview placeholder', () => {
+    const preview = computeWorktreeSidebarDropPreview({
+      pointerY: 280,
+      containerTop: 0,
+      scrollTop: 0,
+      rects: [
+        { worktreeId: 'a', groupIndex: 0, top: 0, bottom: 50 },
+        { worktreeId: 'b', groupIndex: 1, top: 56, bottom: 106 },
+        { worktreeId: 'c', groupIndex: 2, top: 112, bottom: 162 },
+        { worktreeId: 'd', groupIndex: 3, top: 168, bottom: 218 },
+        { worktreeId: 'e', groupIndex: 4, top: 224, bottom: 274 }
+      ],
+      groupIds: ['a', 'b', 'c', 'd', 'e'],
+      draggedIds: ['b', 'c', 'd'],
+      draggingWorktreeId: 'd'
+    })
+
+    expect(preview).toMatchObject({
+      dropIndex: 5,
+      dropIndicatorY: 277
+    })
+    expect(Array.from(preview?.previewOffsetsByWorktreeId ?? [])).toEqual([['e', -56]])
+  })
 })
 
 describe('resolveWorktreeSidebarStatusDropCommitTarget', () => {

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts
@@ -99,6 +99,7 @@ export function computeWorktreeSidebarDropPreview(args: {
   rects: readonly WorktreeSidebarDragRect[]
   groupIds: readonly string[]
   draggedIds: readonly string[]
+  draggingWorktreeId?: string | null
 }): WorktreeSidebarDropPreview | null {
   const rects = getWorktreeSidebarDragUnitRects({
     rects: args.rects,
@@ -139,6 +140,7 @@ export function computeWorktreeSidebarDropPreview(args: {
   const previewOffsetsByWorktreeId = buildWorktreeDragPreviewOffsets({
     groupIds: args.groupIds,
     draggedIds: args.draggedIds,
+    draggingWorktreeId: args.draggingWorktreeId,
     dropIndex,
     rects
   })


### PR DESCRIPTION
## Summary
- Shrink worktree-card nesting to an intentional middle band so top/bottom card drags favor reorder.
- Allow nested child cards to start their own reorder drag and clear their parent link when dropped on a reorder line.
- Keep multi-select reorder previews to a single card-height allowance instead of opening space for the whole selected stack.

## Review until clean
- Ran 3 review rounds.
- Fixed child-card drag session refresh so child IDs outside top-level units stay valid.
- Fixed unnest scoping so selected nested cards outside the reordered source group are not cleared.
- No in-scope issues remain after round 3.

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-manual-order.test.ts src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts src/renderer/src/components/sidebar/worktree-drag-units.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts src/renderer/src/components/sidebar/worktree-manual-order.test.ts src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.ts src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts --quiet
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json
- git diff --cached --check