### PR TITLE
Fix Activity thread options trigger ref loop

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -873,6 +873,61 @@ function EventTime({ timestamp }: { timestamp: number }): React.JSX.Element {
   )
 }
 
+export function ActivityThreadOptionsMenu({
+  compactMode,
+  hasUnreadThreads,
+  onCompactModeChange,
+  onMarkAllThreadsRead
+}: {
+  compactMode: boolean
+  hasUnreadThreads: boolean
+  onCompactModeChange: (compactMode: boolean) => void
+  onMarkAllThreadsRead: () => void
+}): React.JSX.Element {
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {/* Why: keep Tooltip and Dropdown from composing refs onto the same
+              button; the crash report's stack loops through Radix setRef. */}
+          <span className="inline-flex shrink-0">
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="size-8 shrink-0 border-input bg-transparent p-0 text-muted-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-transparent dark:hover:bg-accent dark:hover:text-accent-foreground"
+                aria-label={translate(
+                  'auto.components.activity.ActivityPrototypePage.db8a1878b5',
+                  'Thread list options'
+                )}
+              >
+                <MoreVertical className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {translate('auto.components.activity.ActivityPrototypePage.a472a14700', 'More options')}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" sideOffset={6}>
+        <DropdownMenuCheckboxItem
+          checked={compactMode}
+          onCheckedChange={(checked) => onCompactModeChange(checked === true)}
+          onSelect={(event) => event.preventDefault()}
+        >
+          {translate('auto.components.activity.ActivityPrototypePage.f70e4bec47', 'Compact mode')}
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onMarkAllThreadsRead} disabled={!hasUnreadThreads}>
+          {translate('auto.components.activity.ActivityPrototypePage.023ff75afe', 'Mark all read')}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
 function EventRepoBadge({ repo }: { repo: Repo | null }): React.JSX.Element | null {
   if (!repo) {
     return null
@@ -1823,54 +1878,12 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                   the toolbar focused on the high-frequency Filter + unread
                   toggle while still giving the action a stable home next to
                   the list it acts on (rather than the titlebar). */}
-              <DropdownMenu>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="size-8 shrink-0 border-input bg-transparent p-0 text-muted-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-transparent dark:hover:bg-accent dark:hover:text-accent-foreground"
-                        aria-label={translate(
-                          'auto.components.activity.ActivityPrototypePage.db8a1878b5',
-                          'Thread list options'
-                        )}
-                      >
-                        <MoreVertical className="size-3.5" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {translate(
-                      'auto.components.activity.ActivityPrototypePage.a472a14700',
-                      'More options'
-                    )}
-                  </TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent align="end" sideOffset={6}>
-                  <DropdownMenuCheckboxItem
-                    checked={compactMode}
-                    onCheckedChange={(checked) => setCompactMode(checked === true)}
-                    onSelect={(event) => event.preventDefault()}
-                  >
-                    {translate(
-                      'auto.components.activity.ActivityPrototypePage.f70e4bec47',
-                      'Compact mode'
-                    )}
-                  </DropdownMenuCheckboxItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onSelect={() => markAllThreadsRead()}
-                    disabled={!hasUnreadThreads}
-                  >
-                    {translate(
-                      'auto.components.activity.ActivityPrototypePage.023ff75afe',
-                      'Mark all read'
-                    )}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <ActivityThreadOptionsMenu
+                compactMode={compactMode}
+                hasUnreadThreads={hasUnreadThreads}
+                onCompactModeChange={setCompactMode}
+                onMarkAllThreadsRead={markAllThreadsRead}
+              />
             </div>
           </div>
           <div className="min-h-0 flex-1 overflow-auto scrollbar-sleek">

--- a/src/renderer/src/components/activity/ActivityThreadOptionsMenu.test.tsx
+++ b/src/renderer/src/components/activity/ActivityThreadOptionsMenu.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { ActivityThreadOptionsMenu } from './ActivityPrototypePage'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+function Harness({
+  compactMode = false,
+  hasUnreadThreads = true
+}: {
+  compactMode?: boolean
+  hasUnreadThreads?: boolean
+}): ReactElement {
+  return (
+    <TooltipProvider>
+      <ActivityThreadOptionsMenu
+        compactMode={compactMode}
+        hasUnreadThreads={hasUnreadThreads}
+        onCompactModeChange={vi.fn()}
+        onMarkAllThreadsRead={vi.fn()}
+      />
+    </TooltipProvider>
+  )
+}
+
+describe('ActivityThreadOptionsMenu', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    document.body.replaceChildren()
+  })
+
+  it('opens without recursively updating composed Radix trigger refs', async () => {
+    await act(async () => {
+      root.render(<Harness />)
+    })
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Thread list options"]'
+    )
+
+    expect(trigger).not.toBeNull()
+    expect(trigger?.parentElement?.tagName).toBe('SPAN')
+
+    await act(async () => {
+      trigger?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }))
+    })
+
+    expect(document.body.textContent).toContain('Compact mode')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes crash report `fb583dd8-8c87-4cc7-9ea1-167b1d291f3d` from Linux/WSL2 Activity view.

The crash stack was React error #185 with `setRef -> Array.map -> setRef` under `TooltipTrigger`, which points at Radix composed refs recursively updating. The Activity thread-list overflow button had `TooltipTrigger asChild` wrapped directly around `DropdownMenuTrigger asChild`, so both Radix triggers composed refs onto the same button.

This PR extracts the thread options menu and inserts a real wrapper span as the tooltip target. The dropdown trigger still owns the button, but Tooltip no longer composes its ref onto the same DOM node.

## Reproduction / Fix Evidence

- Crash evidence: report `fb583dd8-8c87-4cc7-9ea1-167b1d291f3d`, boundary `app.workspace-shell`, active view `activity`, stack includes `setRef`, `Array.map`, `TooltipTrigger`.
- Repro guard before fix: the new `ActivityThreadOptionsMenu` test failed because the button had no wrapper target, preserving the same same-node Radix ref composition from the report.
- Fix evidence after patch:
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/activity/ActivityThreadOptionsMenu.test.tsx src/renderer/src/components/activity/ActivityPrototypePage.test.ts` -> 2 files / 25 tests passed.
  - `pnpm exec oxlint src/renderer/src/components/activity/ActivityPrototypePage.tsx src/renderer/src/components/activity/ActivityThreadOptionsMenu.test.tsx` -> passed.
  - `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json` -> passed.
  - `git diff --check` -> passed.

## ELI5

The same button was wearing two different “I need to hold onto this element” hats. In some Activity sessions, those two hats could keep handing the button back and forth until React hit its safety limit and crashed the Activity page. Now the tooltip holds a tiny wrapper, and the menu holds the button, so they stop fighting over the same thing.

## Trade-offs

- Adds one inline wrapper span around the menu button. Layout is unchanged because it uses the same inline-flex/shrink behavior already used in similar toolbar menus.
- The regression test locks the DOM structure because happy-dom did not deterministically reproduce the full packaged Electron/Linux update-depth loop. The structure is the risky condition shown by the production stack.
