### PR TITLE
Fix lazy chunk reload crash classification

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -828,7 +828,8 @@ function openMainWindow(): BrowserWindow {
       onBeforeRelaunch: async () => {
         isQuitting = true
         await preserveAgentAuthBeforeRestart({ codexRuntimeHome, claudeRuntimeAuth, store })
-      }
+      },
+      markExpectedRendererReload
     }
   )
   automations.setWebContents(window.webContents)

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -734,6 +734,26 @@ describe('registerCrashReportingHandlers', () => {
     expect(spanEndMock).toHaveBeenCalledTimes(1)
   })
 
+  it('marks expected renderer reloads using the sender webContents id', () => {
+    const markExpectedRendererReload = vi.fn()
+    registerCrashReportingHandlers(
+      {
+        getLatestPending: vi.fn(),
+        getById: vi.fn(),
+        dismiss: vi.fn(),
+        markSent: vi.fn(),
+        listRecent: vi.fn(),
+        record: vi.fn(),
+        formatDiagnosticText: vi.fn()
+      } as never,
+      { markExpectedRendererReload }
+    )
+
+    listeners.get('crashReports:markExpectedRendererReload')?.({ sender: { id: 774 } } as never)
+
+    expect(markExpectedRendererReload).toHaveBeenCalledWith(774)
+  })
+
   it('ignores renderer breadcrumbs without a string name', () => {
     registerCrashReportingHandlers({
       getLatestPending: vi.fn(),

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -377,7 +377,10 @@ function collectCrashDiagnosticBundleAttachment(): CrashDiagnosticBundleAttachme
   }
 }
 
-export function registerCrashReportingHandlers(store: CrashReportStore): void {
+export function registerCrashReportingHandlers(
+  store: CrashReportStore,
+  options: { markExpectedRendererReload?: (webContentsId: number) => void } = {}
+): void {
   ipcMain.removeHandler('crashReports:getLatestPending')
   ipcMain.handle('crashReports:getLatestPending', () => getLatestPendingReport(store))
 
@@ -408,6 +411,13 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
       recordRendererBreadcrumbTrace(args.name, data)
     }
   )
+
+  ipcMain.removeAllListeners('crashReports:markExpectedRendererReload')
+  ipcMain.on('crashReports:markExpectedRendererReload', (event) => {
+    // Why: lazy chunk recovery intentionally reloads the renderer; Electron can
+    // report that teardown as killed(1), which must not become a crash prompt.
+    options.markExpectedRendererReload?.(event.sender.id)
+  })
 
   ipcMain.removeHandler('crashReports:copyLatestDiagnostics')
   ipcMain.handle(

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -74,6 +74,7 @@ let registered = false
 type CoreHandlerLifecycleOptions = {
   onBeforeRelaunch?: () => void | Promise<void>
   getAdditionalAiVaultCodexHomePaths?: () => readonly string[]
+  markExpectedRendererReload?: (webContentsId: number) => void
 }
 
 export function registerCoreHandlers(
@@ -125,7 +126,9 @@ export function registerCoreHandlers(
   registerJiraHandlers()
   registerFeedbackHandlers()
   if (crashReports) {
-    registerCrashReportingHandlers(crashReports)
+    registerCrashReportingHandlers(crashReports, {
+      markExpectedRendererReload: lifecycleOptions.markExpectedRendererReload
+    })
   }
   registerExportHandlers()
   registerStatsHandlers(stats)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1233,6 +1233,7 @@ export type PreloadApi = {
       args: ReactErrorBoundaryReportArgs
     ) => Promise<ReactErrorBoundaryReportResult>
     recordBreadcrumb: (args: { name: string; data?: CrashReportBreadcrumbData }) => void
+    markExpectedRendererReload: () => void
     submit: (args: CrashReportSubmitArgs) => Promise<CrashReportSubmitResult>
     copyLatestDiagnostics: (args?: {
       reportId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -995,6 +995,8 @@ const api = {
       ipcRenderer.invoke('crashReports:recordRendererError', args),
     recordBreadcrumb: (args: { name: string; data?: CrashReportBreadcrumbData }): void =>
       ipcRenderer.send('crashReports:recordBreadcrumb', args),
+    markExpectedRendererReload: (): void =>
+      ipcRenderer.send('crashReports:markExpectedRendererReload'),
     submit: (args: CrashReportSubmitArgs): Promise<CrashReportSubmitResult> =>
       ipcRenderer.invoke('crashReports:submit', args),
     copyLatestDiagnostics: (args?: { reportId?: string; notes?: string }) =>

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -673,6 +673,7 @@ describe('connectPanePty', () => {
       markAgentCompletionPaneUnread: vi.fn()
     } as StoreState
     ;(globalThis as unknown as { window: unknown }).window = {
+      dispatchEvent: vi.fn(() => true),
       api: {
         ssh: {
           connect: vi.fn().mockResolvedValue({ status: 'connected' }),

--- a/src/renderer/src/lib/lazy-with-retry.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.test.ts
@@ -17,10 +17,16 @@ function spyOnReload(): ReturnType<typeof vi.fn> {
   return reload
 }
 
-function stubCrashReportsBreadcrumb(): ReturnType<typeof vi.fn> {
+function stubCrashReportsRecoveryApis(): {
+  recordBreadcrumb: ReturnType<typeof vi.fn>
+  markExpectedRendererReload: ReturnType<typeof vi.fn>
+} {
   const recordBreadcrumb = vi.fn()
-  Object.assign(window, { api: { crashReports: { recordBreadcrumb } } })
-  return recordBreadcrumb
+  const markExpectedRendererReload = vi.fn()
+  Object.assign(window, {
+    api: { crashReports: { recordBreadcrumb, markExpectedRendererReload } }
+  })
+  return { recordBreadcrumb, markExpectedRendererReload }
 }
 
 // Why: happy-dom's Storage is a Proxy that vi.spyOn cannot reliably restore, so
@@ -206,7 +212,7 @@ describe('loadLazyWithRetry', () => {
 
   it('records a lazy_chunk_reload breadcrumb (with reloadKey) before reloading', async () => {
     const reload = spyOnReload()
-    const recordBreadcrumb = stubCrashReportsBreadcrumb()
+    const { recordBreadcrumb, markExpectedRendererReload } = stubCrashReportsRecoveryApis()
     const factory = vi.fn(() => Promise.reject(chunkParseError()))
 
     const loaded = loadLazyWithRetry(factory, { retries: 0, reloadKey: 'right-sidebar' })
@@ -221,11 +227,15 @@ describe('loadLazyWithRetry', () => {
     )
     await vi.advanceTimersByTimeAsync(5000)
 
+    expect(markExpectedRendererReload).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith({
       name: 'lazy_chunk_reload',
       data: { reloadKey: 'right-sidebar', message: "Unexpected token ']'" }
     })
+    expect(markExpectedRendererReload.mock.invocationCallOrder[0]).toBeLessThan(
+      recordBreadcrumb.mock.invocationCallOrder[0]
+    )
     // The breadcrumb must land before window.location.reload() tears the page down.
     expect(recordBreadcrumb.mock.invocationCallOrder[0]).toBeLessThan(
       reload.mock.invocationCallOrder[0]

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -84,6 +84,15 @@ function recordReloadBreadcrumb(reloadKey: string, message: string): void {
   }
 }
 
+function markExpectedRendererReload(): void {
+  try {
+    const api = (window as Window & { api?: Window['api'] }).api
+    api?.crashReports.markExpectedRendererReload()
+  } catch {
+    // Expected-reload classification is best-effort; recovery must still reload.
+  }
+}
+
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 // Suspends the React.lazy boundary while window.location.reload() tears the page
@@ -145,6 +154,7 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
     if (!markChunkReloadAttempted()) {
       throw lastError
     }
+    markExpectedRendererReload()
     recordReloadBreadcrumb(
       options.reloadKey ?? 'unknown',
       lastError instanceof Error ? lastError.message : String(lastError)

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -523,6 +523,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       dismiss: () => Promise.resolve(null),
       recordRendererError: () => Promise.resolve({ ok: true, report: null, deduped: true }),
       recordBreadcrumb: () => {},
+      markExpectedRendererReload: () => {},
       submit: () =>
         Promise.resolve({
           ok: false,


### PR DESCRIPTION
## Description

Fixes the report-01 crash bucket from `windows-renderer-crashes-2026-06-30/01-renderer-killed-surenge` (report `9b46af08-2f01-4652-9e1d-3827280090b7`).

The crash bundle showed a `lazy_chunk_reload` breadcrumb for a recovered dynamic-import parse failure (`Unexpected identifier 'as'`), followed by a fresh renderer bootstrap, then the old renderer's `render-process-gone` event as `killed (1)`. That sequence means recovery worked, but main did not know the renderer teardown was expected, so the intentional reload could still be surfaced as a crash.

This PR adds a preload IPC signal for lazy chunk recovery. Before `window.location.reload()`, the renderer marks its current `webContents` as an expected reload in main, then records the existing breadcrumb and reloads.

## ELI5

When Orca sees that one of its downloaded app pieces is stale or broken, it intentionally refreshes the window to get a clean copy. On Windows, that refresh can look like "the renderer was killed" from the outside. Now the renderer tells the main process "I am about to refresh on purpose" before it does, so Orca does not mistake its own recovery refresh for a scary crash.

## Evidence

- Crash-bundle diagnosis: `01-renderer-killed-surenge` had `lazy_chunk_reload` -> new renderer bootstrap -> old renderer `killed (1)`, matching intentional lazy chunk recovery rather than a native crash.
- Head tested: `92d75cfe8f3ffe0f7e771277bf50da949b231cbe`.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/lazy-with-retry.test.ts src/main/ipc/crash-reporting.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` -> 3 files / 305 tests passed.
- `pnpm run typecheck` -> node, cli, and web TypeScript checks passed.
- Pre-commit hooks ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` on staged files.
- GitHub checks passed on the updated PR head: `verify` and `wayland terminal input`.
- Windows Electron smoke via CDP on port 9336 with isolated profile:
  - Verified app identity for this worktree/branch.
  - Added disposable Git repo with 8 external worktrees under `%TEMP%`, including paths with spaces, dirty tracked files, untracked files, and ignored files.
  - Made external worktrees visible, opened Source Control, and activated all 9 checkouts across 3 rounds.
  - Ran 27 status refresh cycles using `git.status({ includeIgnored: true })`, ignored-path checks, diffs for changed files, upstream probes, and worktree rediscovery.
  - Kept a real browser webview open (`https://example.com/`) during the smoke.
  - Final visible UI showed `repro/worktree-8` selected with Source Control open and 80 changed files rendered.
  - CDP target list still had both the Orca page and the browser webview; smoke marker stayed alive; no Playwright page crash/pageerror events; logs had no process-gone/OOM/fatal lines.

## Tradeoffs

- The new expected-reload marker is best-effort. If IPC is unavailable or races with teardown, recovery still reloads, and classification falls back to existing behavior.
- This only marks the lazy-chunk recovery reload path. Native renderer crashes, OOMs, GPU crashes, and unrelated kills still go through normal crash reporting.
- The web preload implementation is a no-op because web builds do not have Electron `webContents` process-gone classification.
