### PR TITLE
Bump mobile app.json to 0.0.20

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.18",
+    "version": "0.0.20",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump mobile/app.json expo.version to 0.0.20 for the next Android mobile release.
- Leave ios.buildNumber and android.versionCode unchanged for the release workflow to manage.

## Verification
- node -e "const a=require('./mobile/app.json'); console.log(a.expo.version, a.expo.ios.buildNumber, a.expo.android.versionCode)"
- pnpm --dir mobile format:check
- git diff --check