### PR TITLE
Move githubCache out of the durable state file into a quit-time sidecar

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4584,6 +4584,49 @@ describe('Store', () => {
     expect(statSync(dataFile()).ino).toBe(inoBefore)
   })
 
+  // ── GitHub cache sidecar ───────────────────────────────────────────
+
+  it('cache refreshes never rewrite the durable state file', async () => {
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+      store.updateUI({ sidebarWidth: 411 })
+      vi.advanceTimersByTime(1000)
+      await store.waitForPendingWrite()
+      const inoBefore = statSync(dataFile()).ino
+      expect((readDataFile() as { githubCache?: unknown }).githubCache).toBeUndefined()
+
+      store.setGitHubCache({ pr: { 'o/r#1': { fetchedAt: 123 } as never }, issue: {} })
+      vi.advanceTimersByTime(6000)
+      await store.waitForPendingWrite()
+
+      expect(statSync(dataFile()).ino).toBe(inoBefore)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('snapshots the cache at flush and seeds the next Store from the sidecar', async () => {
+    const store = await createStore()
+    store.setGitHubCache({ pr: { 'o/r#7': { fetchedAt: 7 } as never }, issue: {} })
+    store.flush()
+    expect(existsSync(join(testState.dir, 'orca-github-cache.json'))).toBe(true)
+
+    const restarted = await createStore()
+    expect(restarted.getGitHubCache().pr['o/r#7']).toEqual({ fetchedAt: 7 })
+  })
+
+  it('keeps a legacy in-file cache as the seed and strips it from disk', async () => {
+    writeDataFile({ githubCache: { pr: { legacy: { fetchedAt: 1 } }, issue: {} } })
+
+    const store = await createStore()
+    expect(store.getGitHubCache().pr.legacy).toEqual({ fetchedAt: 1 })
+
+    // The legacy key marks the state dirty at load; the next write drops it.
+    store.flush()
+    expect((readDataFile() as { githubCache?: unknown }).githubCache).toBeUndefined()
+  })
+
   // ── UI state ───────────────────────────────────────────────────────
 
   it('updateUI merges partial updates', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -338,11 +338,12 @@ function getGithubCacheFile(): string {
 function readGithubCacheSnapshot(): PersistedState['githubCache'] | null {
   try {
     const parsed = JSON.parse(readFileSync(getGithubCacheFile(), 'utf-8')) as unknown
+    const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+      typeof value === 'object' && value !== null && !Array.isArray(value)
     if (
-      parsed &&
-      typeof parsed === 'object' &&
-      typeof (parsed as { pr?: unknown }).pr === 'object' &&
-      typeof (parsed as { issue?: unknown }).issue === 'object'
+      isPlainRecord(parsed) &&
+      isPlainRecord((parsed as { pr?: unknown }).pr) &&
+      isPlainRecord((parsed as { issue?: unknown }).issue)
     ) {
       return parsed as PersistedState['githubCache']
     }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -325,6 +325,33 @@ function getDataFile(): string {
   return _dataFile
 }
 
+// Why a sidecar: githubCache is a refetchable 5-min-TTL poll cache whose
+// fetchedAt stamps change on every refresh — keeping it inside orca-data.json
+// made every poll cycle rewrite the whole multi-MB durable state (defeating
+// the content-hash guard by design). It lives in memory during the session
+// and is snapshotted here best-effort at quit so PR/issue badges still paint
+// instantly on the next launch. Loss of this file costs nothing.
+function getGithubCacheFile(): string {
+  return join(dirname(getDataFile()), 'orca-github-cache.json')
+}
+
+function readGithubCacheSnapshot(): PersistedState['githubCache'] | null {
+  try {
+    const parsed = JSON.parse(readFileSync(getGithubCacheFile(), 'utf-8')) as unknown
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as { pr?: unknown }).pr === 'object' &&
+      typeof (parsed as { issue?: unknown }).issue === 'object'
+    ) {
+      return parsed as PersistedState['githubCache']
+    }
+  } catch {
+    // Missing or corrupt snapshot: start with an empty cache and refetch.
+  }
+  return null
+}
+
 /**
  * Return the userData directory captured at initDataPath() time, before
  * app.setName() can change how app.getPath('userData') resolves.
@@ -2451,6 +2478,7 @@ export class Store {
   // on-disk bytes differ even for identical state.
   private lastWrittenStateHash: string | null = null
   private firstPendingSaveAt: number | null = null
+  private githubCacheDirty = false
   private gitUsernameCache = new Map<string, string>()
   private loadNeedsSave = false
   private settingsChangeListeners = new Set<
@@ -3294,6 +3322,24 @@ export class Store {
     result = folderScopeConnectionMigration.state
 
     const migrated = this.migrateTelemetry(result, fileExistedOnLoad)
+
+    // githubCache lives in a sidecar file now (see getGithubCacheFile). A
+    // legacy in-file cache (pre-sidecar build, or a downgrade round-trip) is
+    // kept as this session's seed and stripped from the durable file by the
+    // save scheduled below; otherwise seed from the sidecar snapshot.
+    const legacyCache = migrated.githubCache
+    const hasLegacyCache =
+      Object.keys(legacyCache?.pr ?? {}).length > 0 ||
+      Object.keys(legacyCache?.issue ?? {}).length > 0
+    if (hasLegacyCache) {
+      this.loadNeedsSave = true
+      // Why: mark dirty so the first flush writes the sidecar even if no
+      // poll refresh happens this session — the seed survives the migration.
+      this.githubCacheDirty = true
+    } else {
+      migrated.githubCache = readGithubCacheSnapshot() ?? migrated.githubCache
+    }
+
     logPersistenceStartupMilestone('persistence-load-done', {
       repos: migrated.repos.length,
       workspaceSessionBytes: Buffer.byteLength(JSON.stringify(migrated.workspaceSession))
@@ -3403,8 +3449,16 @@ export class Store {
     }
   }
 
+  // Why githubCache is omitted: it is memory-only during the session (see
+  // getGithubCacheFile) — excluding it from both the payload and the hash
+  // keeps cache refreshes from ever touching the durable file.
+  private getDurableState(): Omit<PersistedState, 'githubCache'> {
+    const { githubCache: _memoryOnly, ...durable } = this.state
+    return durable
+  }
+
   private computeStateHash(): string {
-    return createHash('sha1').update(JSON.stringify(this.state)).digest('hex')
+    return createHash('sha1').update(JSON.stringify(this.getDurableState())).digest('hex')
   }
 
   // Why: builds the on-disk payload synchronously so the hash and the
@@ -3414,7 +3468,7 @@ export class Store {
     // Why: secrets must be encrypted on disk. Clone state so the in-memory
     // this.state stays plaintext for the rest of the app.
     const stateToSave = {
-      ...this.state,
+      ...this.getDurableState(),
       settings: {
         ...this.state.settings,
         opencodeSessionCookie: encrypt(this.state.settings.opencodeSessionCookie),
@@ -5241,8 +5295,12 @@ export class Store {
   }
 
   setGitHubCache(cache: PersistedState['githubCache']): void {
+    // Why no scheduleSave: the cache is memory-only during the session and
+    // snapshotted to its sidecar file at flush (quit/reload) time. Every poll
+    // refresh restamps fetchedAt, so persisting here rewrote the whole
+    // durable state file once per poll cycle for refetchable data.
     this.state.githubCache = cache
-    this.scheduleSave()
+    this.githubCacheDirty = true
   }
 
   // ── Workspace Session ─────────────────────────────────────────────
@@ -5946,6 +6004,29 @@ export class Store {
       this.flushOrThrow()
     } catch (err) {
       console.error('[persistence] Failed to flush state:', err)
+    }
+    this.writeGithubCacheSnapshotSync()
+  }
+
+  // Why best-effort: the sidecar is a refetchable cache — a failed write only
+  // costs a cold badge paint on next launch, never data.
+  private writeGithubCacheSnapshotSync(): void {
+    if (!this.githubCacheDirty) {
+      return
+    }
+    const cacheFile = getGithubCacheFile()
+    const tmpFile = `${cacheFile}.${process.pid}.tmp`
+    try {
+      writeFileSync(tmpFile, JSON.stringify(this.state.githubCache), 'utf-8')
+      renameSync(tmpFile, cacheFile)
+      this.githubCacheDirty = false
+    } catch (err) {
+      try {
+        unlinkSync(tmpFile)
+      } catch {
+        // Best-effort cleanup.
+      }
+      console.warn('[persistence] Failed to write github cache snapshot:', err)
     }
   }
 }


### PR DESCRIPTION
Follow-up to #7092: `githubCache` was the last remaining non-user-driven writer of `orca-data.json`.

## Problem

Every PR/issue poll restamps `fetchedAt` even when the fetched data is unchanged, which defeats #7092's content-hash guard by construction: ~100KB of refetchable, 5-minute-TTL cache rewrote the entire 1.6MB durable state file once per refresh cycle (~every 2 minutes with visible PRs), forever.

## Fix — the "unobservable" variant

- The cache is **memory-only during the session**: `setGitHubCache` no longer schedules saves, and both the durable payload and the content hash omit the field (`getDurableState()`), so cache refreshes can never touch `orca-data.json` again.
- At `flush()` time (app quit, updater quit, window reload, agent-auth restart) it's snapshotted best-effort to a sidecar `orca-github-cache.json` (tmp+rename, dirty-gated, no backups, failures swallowed) and loaded opportunistically at startup — so **PR/issue badges still paint instantly on the next launch**. There is no user-observable behavior change short of a hard crash, and even then the cost is one cold badge paint of refetchable data.
- Migration: a legacy in-file cache is used as this session's seed (and marked dirty so the first flush writes the sidecar), then stripped from the durable file by the next write. Downgrades simply recreate the key; the next upgrade strips it again — bounded ping-pong, no data loss possible.

## Result

`orca-data.json` writes are now purely user/session-action-driven, and the file shrinks ~100KB. Renderer, web (localStorage-based), and mobile (`meta.linkedPR` fallback) consumers are untouched — verified by call-site audit.

## Review

Independent adversarial review verified six invariants (no durable writer can reinclude the key — including the offline CLI round-trip and pre-upgrade backup restores; hash/payload consistency; migration & ping-pong bounds; sidecar dirty-flag lifecycle across all flush call sites; consumer tolerance; type-safety through zod-failure/backup-recursion paths). Its one finding — sidecar validation accepted `null`/array `pr`/`issue` shapes, which could crash mobile PR grouping on a corrupt sidecar — is fixed in the second commit. 329 persistence tests pass (3 new: no-rewrite-on-refresh, flush-snapshot + restart seeding, legacy strip).

Made with [Orca](https://github.com/stablyai/orca) 🐋
