### PR TITLE
Add rich Markdown spellcheck setting

### DIFF
--- a/src/renderer/src/components/LinearIssueMarkdownDescriptionEditor.tsx
+++ b/src/renderer/src/components/LinearIssueMarkdownDescriptionEditor.tsx
@@ -11,6 +11,11 @@ import { LinearIssueMarkdownToolbar } from '@/components/LinearIssueMarkdownTool
 import { isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import {
+  getRichMarkdownSpellcheckAttribute,
+  useRichMarkdownSpellcheckAttribute
+} from '@/components/editor/rich-markdown-spellcheck'
 
 type LinearIssueMarkdownDescriptionEditorProps = {
   value: string
@@ -46,6 +51,9 @@ export function LinearIssueMarkdownDescriptionEditor({
   const language = i18n.resolvedLanguage ?? i18n.language
   const lastEditorMarkdownRef = useRef(value)
   const editorRef = useRef<Editor | null>(null)
+  const richMarkdownSpellcheckEnabled = useAppStore(
+    (s) => s.settings?.richMarkdownSpellcheckEnabled ?? true
+  )
   const linearIssueMarkdownExtensions = useMemo(() => {
     // Why: Tiptap freezes extension options when the editor is created; the
     // language value is the recreation key for translated extension options.
@@ -63,7 +71,7 @@ export function LinearIssueMarkdownDescriptionEditor({
       editorProps: {
         attributes: {
           class: 'rich-markdown-editor',
-          spellcheck: 'true',
+          spellcheck: getRichMarkdownSpellcheckAttribute(richMarkdownSpellcheckEnabled),
           'aria-label': 'Issue description'
         },
         handleKeyDown: (_view, event) => {
@@ -93,6 +101,7 @@ export function LinearIssueMarkdownDescriptionEditor({
     },
     [language]
   )
+  useRichMarkdownSpellcheckAttribute(editor, richMarkdownSpellcheckEnabled)
 
   useEffect(() => {
     editorRef.current = editor

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -21,6 +21,7 @@ import {
   isRichMarkdownContextCommandTarget,
   runRichMarkdownContextCommand
 } from './rich-markdown-context-command-routing'
+import { useRichMarkdownSpellcheckAttribute } from './rich-markdown-spellcheck'
 
 type RichMarkdownEditorProps = {
   fileId: string
@@ -72,6 +73,7 @@ export default function RichMarkdownEditor({
 }: RichMarkdownEditorProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
   const settings = useAppStore((s) => s.settings)
+  const richMarkdownSpellcheckEnabled = settings?.richMarkdownSpellcheckEnabled ?? true
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const activateMarkdownLink = useAppStore((s) => s.activateMarkdownLink)
   const addDiffComment = useAppStore((s) => s.addDiffComment)
@@ -209,6 +211,7 @@ export default function RichMarkdownEditor({
     worktreeRoot,
     runtimeEnvironmentId,
     isMac,
+    richMarkdownSpellcheckEnabled,
     settings,
     activateMarkdownLink,
     rootRef,
@@ -246,6 +249,7 @@ export default function RichMarkdownEditor({
     setSlashMenu: menu.setSlashMenu,
     setDocLinkMenu: menu.setDocLinkMenu
   })
+  useRichMarkdownSpellcheckAttribute(editor, richMarkdownSpellcheckEnabled)
 
   // Why: use useLayoutEffect (synchronous cleanup) so the pending serialization
   // flush runs before useEditor's cleanup destroys the editor instance on tab

--- a/src/renderer/src/components/editor/rich-markdown-editor-config.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-editor-config.test.ts
@@ -1,0 +1,90 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
+import type { Editor } from '@tiptap/react'
+import type { DocLinkMenuState } from './rich-markdown-commands'
+import { describe, expect, it, vi } from 'vitest'
+import type { LinkBubbleState } from './RichMarkdownLinkBubble'
+import {
+  createRichMarkdownEditorConfig,
+  type EditorConfigParams
+} from './rich-markdown-editor-config'
+import type { SlashMenuState } from './rich-markdown-slash-commands'
+
+function ref<T>(current: T): MutableRefObject<T> {
+  return { current }
+}
+
+function stateSetter<T>(): Dispatch<SetStateAction<T>> {
+  return vi.fn() as Dispatch<SetStateAction<T>>
+}
+
+function getSpellcheckAttribute(config: ReturnType<typeof createRichMarkdownEditorConfig>): string {
+  const attributes = config.editorProps?.attributes
+  return typeof attributes === 'function'
+    ? attributes({} as never).spellcheck
+    : (attributes?.spellcheck ?? '')
+}
+
+function createConfigParams(overrides: Partial<EditorConfigParams> = {}): EditorConfigParams {
+  return {
+    content: '',
+    filePath: '/repo/README.md',
+    worktreeId: 'worktree-1',
+    worktreeRoot: '/repo',
+    runtimeEnvironmentId: null,
+    isMac: false,
+    richMarkdownSpellcheckEnabled: true,
+    settings: { activeRuntimeEnvironmentId: null },
+    activateMarkdownLink: vi.fn(),
+    rootRef: ref<HTMLDivElement | null>(null),
+    editorRef: ref<Editor | null>(null),
+    lastCommittedMarkdownRef: ref(''),
+    onContentChangeRef: ref(vi.fn()),
+    onDirtyStateHintRef: ref(vi.fn()),
+    onSaveRef: ref(vi.fn()),
+    onOpenDocLinkRef: ref(undefined),
+    isEditingLinkRef: ref(false),
+    slashMenuRef: ref(null),
+    filteredSlashCommandsRef: ref([]),
+    selectedCommandIndexRef: ref(0),
+    docLinkMenuRef: ref(null),
+    filteredDocLinkRowsRef: ref([]),
+    selectedDocLinkIndexRef: ref(0),
+    handleLocalImagePickRef: ref(vi.fn()),
+    handleEmojiPickRef: ref(vi.fn()),
+    typedEmptyOrderedListMarkerRef: ref(false),
+    cancelAutoFocusRef: ref(null),
+    serializeTimerRef: ref(null),
+    isInitializingRef: ref(false),
+    isApplyingProgrammaticUpdateRef: ref(false),
+    markdownCommentsRef: ref([]),
+    markdownSourceLineOffsetRef: ref(0),
+    flushPendingSerialization: vi.fn(),
+    openSearchRef: ref(vi.fn()),
+    syncAnnotationTarget: vi.fn(),
+    clearAnnotationTarget: vi.fn(),
+    scrollRichMarkdownReviewNoteCardIntoView: vi.fn(),
+    setIsEditingLink: stateSetter<boolean>(),
+    setLinkBubble: stateSetter<LinkBubbleState | null>(),
+    setSelectedCommandIndex: stateSetter<number>(),
+    setSelectedDocLinkIndex: stateSetter<number>(),
+    setSlashMenu: stateSetter<SlashMenuState | null>(),
+    setDocLinkMenu: stateSetter<DocLinkMenuState | null>(),
+    ...overrides
+  }
+}
+
+describe('createRichMarkdownEditorConfig', () => {
+  it('disables browser spellcheck when the rich Markdown setting is off', () => {
+    const config = createRichMarkdownEditorConfig(
+      createConfigParams({ richMarkdownSpellcheckEnabled: false })
+    )
+
+    expect(getSpellcheckAttribute(config)).toBe('false')
+  })
+
+  it('keeps browser spellcheck enabled by default', () => {
+    const config = createRichMarkdownEditorConfig(createConfigParams())
+
+    expect(getSpellcheckAttribute(config)).toBe('true')
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-editor-config.ts
+++ b/src/renderer/src/components/editor/rich-markdown-editor-config.ts
@@ -26,6 +26,7 @@ import {
   createRichMarkdownImageResolverContext,
   setRichMarkdownImageResolverContext
 } from './rich-markdown-image-context'
+import { getRichMarkdownSpellcheckAttribute } from './rich-markdown-spellcheck'
 import type { MutableRefObject, Dispatch, SetStateAction } from 'react'
 import type { DiffComment } from '../../../../shared/types'
 
@@ -36,6 +37,7 @@ export type EditorConfigParams = {
   worktreeRoot: string | null
   runtimeEnvironmentId?: string | null
   isMac: boolean
+  richMarkdownSpellcheckEnabled: boolean
   settings: RichMarkdownRuntimeSettings
   activateMarkdownLink: ActivateMarkdownLink
   rootRef: MutableRefObject<HTMLDivElement | null>
@@ -82,6 +84,7 @@ export function createRichMarkdownEditorConfig(params: EditorConfigParams): UseE
     worktreeRoot,
     runtimeEnvironmentId,
     isMac,
+    richMarkdownSpellcheckEnabled,
     settings,
     activateMarkdownLink,
     rootRef,
@@ -127,7 +130,7 @@ export function createRichMarkdownEditorConfig(params: EditorConfigParams): UseE
     editorProps: {
       attributes: {
         class: 'rich-markdown-editor',
-        spellcheck: 'true'
+        spellcheck: getRichMarkdownSpellcheckAttribute(richMarkdownSpellcheckEnabled)
       },
       handleDOMEvents: {
         cut: handleRichMarkdownCut

--- a/src/renderer/src/components/editor/rich-markdown-spellcheck.ts
+++ b/src/renderer/src/components/editor/rich-markdown-spellcheck.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react'
+import type { Editor } from '@tiptap/react'
+
+export function getRichMarkdownSpellcheckAttribute(enabled: boolean): 'true' | 'false' {
+  return enabled ? 'true' : 'false'
+}
+
+export function useRichMarkdownSpellcheckAttribute(editor: Editor | null, enabled: boolean): void {
+  useEffect(() => {
+    editor?.view.dom.setAttribute('spellcheck', getRichMarkdownSpellcheckAttribute(enabled))
+  }, [editor, enabled])
+}

--- a/src/renderer/src/components/github/GitHubMarkdownComposer.tsx
+++ b/src/renderer/src/components/github/GitHubMarkdownComposer.tsx
@@ -25,6 +25,11 @@ import { hasBoundedGitHubMarkdownImageUrlText } from '@/components/github/github
 import { useImageInput } from '@/components/github/use-image-input'
 import type { GitHubOwnerRepo } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import {
+  getRichMarkdownSpellcheckAttribute,
+  useRichMarkdownSpellcheckAttribute
+} from '@/components/editor/rich-markdown-spellcheck'
 
 type GitHubMarkdownComposerProps = {
   value: string
@@ -59,6 +64,9 @@ export function GitHubMarkdownComposer({
   const onSubmitShortcutRef = useRef(onSubmitShortcut)
   const disabledRef = useRef(disabled)
   const isEditingLinkRef = useRef(false)
+  const richMarkdownSpellcheckEnabled = useAppStore(
+    (s) => s.settings?.richMarkdownSpellcheckEnabled ?? true
+  )
   const [activeTab, setActiveTab] = useState<ComposerTab>('write')
   const [linkBubble, setLinkBubble] = useState<LinkBubbleState | null>(null)
   const [isEditingLink, setIsEditingLink] = useState(false)
@@ -114,7 +122,7 @@ export function GitHubMarkdownComposer({
     editorProps: {
       attributes: {
         class: cn('rich-markdown-editor github-markdown-composer-editor', minHeightClassName),
-        spellcheck: 'true'
+        spellcheck: getRichMarkdownSpellcheckAttribute(richMarkdownSpellcheckEnabled)
       },
       handleKeyDown: (_view, event) => {
         if (isScreenSubmitShortcut(event)) {
@@ -179,6 +187,7 @@ export function GitHubMarkdownComposer({
       setLinkBubble(null)
     }
   })
+  useRichMarkdownSpellcheckAttribute(editor, richMarkdownSpellcheckEnabled)
 
   useEffect(() => {
     if (!editor) {

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -16,6 +16,7 @@ import {
   SettingsSwitchRow
 } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
+import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
 
 export type AutoSaveDelayDraftState = {
   sourceDelayMs: number
@@ -377,6 +378,8 @@ export function GeneralEditorSettingsSection({
           onChange={() => updateSettings({ editorMinimapEnabled: !settings.editorMinimapEnabled })}
         />
       </SearchableSetting>
+
+      <RichMarkdownSpellcheckSetting settings={settings} updateSettings={updateSettings} />
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/components/settings/GeneralPane.test.ts
+++ b/src/renderer/src/components/settings/GeneralPane.test.ts
@@ -95,6 +95,13 @@ describe('GeneralPane search entries', () => {
     expect(matchesSettingsSearch('wsl', entries)).toBe(true)
   })
 
+  it('includes rich Markdown spellcheck keywords', () => {
+    const entries = getGeneralPaneSearchEntries()
+
+    expect(matchesSettingsSearch('spellcheck', entries)).toBe(true)
+    expect(matchesSettingsSearch('red underline', entries)).toBe(true)
+  })
+
   it('omits the default project runtime setting when Windows runtimes are unsupported', () => {
     const entries = getGeneralPaneSearchEntries({ includeProjectRuntime: false })
 

--- a/src/renderer/src/components/settings/RichMarkdownSpellcheckSetting.tsx
+++ b/src/renderer/src/components/settings/RichMarkdownSpellcheckSetting.tsx
@@ -1,0 +1,44 @@
+import type React from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
+
+type RichMarkdownSpellcheckSettingProps = {
+  settings: Pick<GlobalSettings, 'richMarkdownSpellcheckEnabled'>
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function RichMarkdownSpellcheckSetting({
+  settings,
+  updateSettings
+}: RichMarkdownSpellcheckSettingProps): React.JSX.Element {
+  const enabled = settings.richMarkdownSpellcheckEnabled ?? true
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.b82f86d7d2',
+        'Rich Markdown Spellcheck'
+      )}
+      description={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.5195f0b9ef',
+        'Show browser spelling underlines and suggestions while editing rich Markdown.'
+      )}
+      keywords={['spellcheck', 'spell check', 'spelling', 'markdown', 'red underline']}
+    >
+      <SettingsSwitchRow
+        label={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.b82f86d7d2',
+          'Rich Markdown Spellcheck'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.5195f0b9ef',
+          'Show browser spelling underlines and suggestions while editing rich Markdown.'
+        )}
+        checked={enabled}
+        onChange={() => updateSettings({ richMarkdownSpellcheckEnabled: !enabled })}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -80,6 +80,29 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate(
+      'auto.components.settings.general.search.d2d2d929c0',
+      'Rich Markdown Spellcheck'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.4497e2e2bb',
+      'Show browser spelling underlines and suggestions while editing rich Markdown.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.f96cdaf37d', 'spellcheck'),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.a51d23f4a1',
+        'spell check'
+      ),
+      ...translateSearchKeyword('auto.components.settings.general.search.641358460a', 'spelling'),
+      ...translateSearchKeyword('auto.components.settings.general.search.d05f629d2c', 'markdown'),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.d755962089',
+        'red underline'
+      )
+    ]
+  },
+  {
     title: translate('auto.components.settings.general.search.128bc09325', 'Markdown Review Notes'),
     description: translate(
       'auto.components.settings.general.search.694613d47f',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4118,7 +4118,8 @@
           "groupDeleteFailed": "Failed to delete group",
           "groupDeleteFailedDesc": "Something went wrong while deleting the group. No projects were removed.",
           "failedNestWorkspace": "Failed to nest workspace",
-          "sidebarRowMissing": "Target no longer exists"
+          "sidebarRowMissing": "Target no longer exists",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancel",
@@ -5162,7 +5163,9 @@
           "8f1afdfbd8": "Diff Word Wrap",
           "4aa4d9fb73": "Wrap long lines in diff editors instead of requiring horizontal scrolling.",
           "bf16ef0af2": "Off",
-          "3f6892f307": "On"
+          "3f6892f307": "On",
+          "b82f86d7d2": "Rich Markdown Spellcheck",
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -6404,8 +6407,6 @@
           "a62b4cb39a": "Save Changes",
           "29af933cd5": "New SSH Target",
           "f2331ce599": "Edit SSH Target",
-          "7c13f58c91": "Until reset",
-          "55c56cf2c7": "Timeout after disconnect (seconds)",
           "4a342f44c1": "Advanced Connection",
           "e9609ddca6": "Proxy, jump host, and connection reuse",
           "8c922dffba": "Reuse SSH connection for faster setup",
@@ -7454,7 +7455,9 @@
             "161a86a9da": "Confirm before closing pinned tabs",
             "8e593f04fc": "Show a confirmation dialog before a pinned tab is closed.",
             "defaultProjectRuntime": "Default Project Runtime",
-            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects."
+            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "d2d2d929c0": "Rich Markdown Spellcheck",
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4095,7 +4095,8 @@
           "hostAuthNeeded": "Autenticación requerida",
           "hostDisconnected": "Desconectado",
           "failedNestWorkspace": "No se pudo anidar el espacio de trabajo",
-          "sidebarRowMissing": "El destino ya no existe"
+          "sidebarRowMissing": "El destino ya no existe",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",
@@ -5162,7 +5163,9 @@
           "8f1afdfbd8": "Ajuste de palabras diferencial",
           "4aa4d9fb73": "Ajuste líneas largas en editores de diferencias en lugar de requerir desplazamiento horizontal.",
           "bf16ef0af2": "Apagado",
-          "3f6892f307": "En"
+          "3f6892f307": "En",
+          "b82f86d7d2": "Rich Markdown Spellcheck",
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "host local, 127.0.0.1, *.interno",
@@ -7415,7 +7418,9 @@
             "161a86a9da": "Confirmar antes de cerrar pestañas fijadas",
             "8e593f04fc": "Muestra un diálogo de confirmación antes de cerrar una pestaña fijada.",
             "defaultProjectRuntime": "Default Project Runtime",
-            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects."
+            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "d2d2d929c0": "Rich Markdown Spellcheck",
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4076,7 +4076,8 @@
           "hostAuthNeeded": "認証が必要です",
           "hostDisconnected": "切断済み",
           "failedNestWorkspace": "ワークスペースをネストできませんでした",
-          "sidebarRowMissing": "対象はもう存在しません"
+          "sidebarRowMissing": "対象はもう存在しません",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",
@@ -5147,7 +5148,9 @@
           "8f1afdfbd8": "差分ワードラップ",
           "4aa4d9fb73": "水平スクロールを必要とせずに、差分エディターで長い行を折り返します。",
           "bf16ef0af2": "オフ",
-          "3f6892f307": "オン"
+          "3f6892f307": "オン",
+          "b82f86d7d2": "Rich Markdown Spellcheck",
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "ローカルホスト、127.0.0.1、*.internal",
@@ -7437,7 +7440,9 @@
             "161a86a9da": "ピン留めしたタブを閉じる前に確認",
             "8e593f04fc": "ピン留めしたタブを閉じる前に確認ダイアログを表示します。",
             "defaultProjectRuntime": "Default Project Runtime",
-            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects."
+            "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "d2d2d929c0": "Rich Markdown Spellcheck",
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4076,7 +4076,8 @@
           "hostAuthNeeded": "인증 필요",
           "hostDisconnected": "연결 끊김",
           "failedNestWorkspace": "워크스페이스를 중첩하지 못했습니다",
-          "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다"
+          "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "취소",
@@ -5147,7 +5148,9 @@
           "8f1afdfbd8": "차이점 단어 줄 바꿈",
           "4aa4d9fb73": "가로 스크롤을 요구하는 대신 diff 편집기에서 긴 줄을 줄 바꿈합니다.",
           "bf16ef0af2": "끄다",
-          "3f6892f307": "~에"
+          "3f6892f307": "~에",
+          "b82f86d7d2": "Rich Markdown Spellcheck",
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "로컬호스트, 127.0.0.1, *.internal",
@@ -7400,7 +7403,9 @@
             "161a86a9da": "고정된 탭을 닫기 전에 확인",
             "8e593f04fc": "고정된 탭을 닫기 전에 확인 대화상자를 표시합니다.",
             "defaultProjectRuntime": "기본 프로젝트 런타임",
-            "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다."
+            "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다.",
+            "d2d2d929c0": "Rich Markdown Spellcheck",
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4076,7 +4076,8 @@
           "hostAuthNeeded": "需要身份验证",
           "hostDisconnected": "已断开连接",
           "failedNestWorkspace": "无法嵌套工作区",
-          "sidebarRowMissing": "目标不再存在"
+          "sidebarRowMissing": "目标不再存在",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",
@@ -5147,7 +5148,9 @@
           "8f1afdfbd8": "差异自动换行",
           "4aa4d9fb73": "在差异编辑器中换行显示长行，而不是要求水平滚动。",
           "bf16ef0af2": "关闭",
-          "3f6892f307": "开启"
+          "3f6892f307": "开启",
+          "b82f86d7d2": "Rich Markdown Spellcheck",
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "本地主机，127.0.0.1，*.internal",
@@ -7400,7 +7403,9 @@
             "161a86a9da": "关闭固定标签页前确认",
             "8e593f04fc": "关闭固定标签页前显示确认对话框。",
             "defaultProjectRuntime": "默认项目运行时",
-            "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。"
+            "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。",
+            "d2d2d929c0": "Rich Markdown Spellcheck",
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
         },
         "git": {

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -51,6 +51,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').confirmClosePinnedTab).toBe(true)
   })
 
+  it('keeps rich Markdown spellcheck enabled by default', () => {
+    expect(getDefaultSettings('/tmp').richMarkdownSpellcheckEnabled).toBe(true)
+  })
+
   it('enables Source Control AI by default without pinning a separate agent', () => {
     expect(getDefaultSettings('/tmp').commitMessageAi).toMatchObject({
       enabled: true,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -203,6 +203,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
     editorMinimapEnabled: false,
+    richMarkdownSpellcheckEnabled: true,
     markdownReviewToolsEnabled: true,
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),
     primarySelectionMiddleClickPasteDefaultedForLinux:

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2469,6 +2469,8 @@ export type GlobalSettings = {
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number
   editorMinimapEnabled: boolean
+  /** Persisted opt-out for browser spellcheck noise in rich Markdown editing surfaces. */
+  richMarkdownSpellcheckEnabled?: boolean
   /** Whether local markdown review note controls and the review panel are shown. */
   markdownReviewToolsEnabled: boolean
   /** Why: mirrors terminal selection-paste muscle memory without mutating the


### PR DESCRIPTION
## Summary
- Add a dedicated Editor settings page so editor preferences live outside General while remaining searchable and localized.
- Add a persisted rich Markdown spellcheck preference that defaults on, preserving the current Markdown editing behavior.
- Keep source-code editor surfaces aligned with code-editor expectations by preventing browser spellcheck in Monaco-backed code, diff, and notebook editors.

## Decision
Markdown remains spellchecked by default because rich Markdown is prose-first and this preserves existing user-visible behavior. Users can disable it persistently from Settings -> Editor when technical identifiers create noisy spelling marks.

Source-code surfaces explicitly opt out of browser spellcheck, so code, diffs, and notebooks keep editor-style behavior while regular prose inputs can still use platform spellcheck.

## Closes
Closes #6966

## Test plan
- `pnpm exec vitest run --config config/vitest.config.ts` for the targeted editor/settings coverage
- `pnpm run verify:localization-catalog`
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --check`
