### PR TITLE
Fix terminal path probe renderer rejections

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -1369,6 +1369,34 @@ describe('createFilePathLinkProvider range bounds', () => {
     })
   })
 
+  it('treats remote path probe failures as missing links', async () => {
+    setPlatform('Windows')
+    const pathExistsCache = new Map<string, boolean>()
+    runtimeEnvironmentCallMock.mockResolvedValueOnce({
+      id: 'stat',
+      ok: false,
+      error: {
+        code: 'runtime_error',
+        message: "ENAMETOOLONG: name too long, realpath '/repo/too-long.ts'"
+      },
+      _meta: { runtimeId: 'env-1' }
+    })
+    const { provider } = createProviderSetup([makeBufferLine('too-long.ts')], pathExistsCache, {
+      runtimeEnvironmentId: 'env-1'
+    })
+
+    const links = await new Promise<ILink[]>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('link provider callback not called')), 100)
+      provider.provideLinks(1, (provided) => {
+        clearTimeout(timeout)
+        resolve(provided ?? [])
+      })
+    })
+
+    expect(links).toEqual([])
+    expect(pathExistsCache.get('env-1\0/repo/too-long.ts')).toBe(false)
+  })
+
   it('opens a single-row file path from a direct modifier-click fallback', async () => {
     setPlatform('Macintosh')
     const pathExists = createDeferred<boolean>()

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -5,7 +5,7 @@ import {
   resolveTerminalFileLink
 } from '@/lib/terminal-links'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import { isRemoteRuntimeFileOperation, runtimePathExists } from '@/runtime/runtime-file-client'
+import { isRemoteRuntimeFileOperation } from '@/runtime/runtime-file-client'
 import {
   buildCandidateLogicalLinesForBufferPosition,
   dedupeLogicalLines,
@@ -23,11 +23,8 @@ import {
   rangeForParsedFileLink,
   type WrappedLogicalLine
 } from './wrapped-terminal-link-ranges'
-import {
-  getTerminalPathExistsCacheKey,
-  readTerminalPathExistsCache,
-  writeTerminalPathExistsCache
-} from './terminal-path-exists-cache'
+import { getTerminalPathExistsCacheKey } from './terminal-path-exists-cache'
+import { probeTerminalPathExists } from './terminal-path-exists-probe'
 import {
   getTerminalHtmlFileOpenHint,
   getTerminalOrcaFileOpenHint,
@@ -160,13 +157,13 @@ export function createFilePathLinkProvider(
               // Why: exact known workspace roots must stay clickable for SSH or
               // stale local paths even when filesystem probing says "missing".
               if (!worktreeRootLink) {
-                const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
-                const exists =
-                  cachedExists ??
-                  (fileContext.connectionId || isRemoteRuntimePath
-                    ? await runtimePathExists(fileContext, resolved.absolutePath)
-                    : await window.api.shell.pathExists(resolved.absolutePath))
-                writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+                const exists = await probeTerminalPathExists({
+                  absolutePath: resolved.absolutePath,
+                  cacheKey,
+                  fileContext,
+                  isRemoteRuntimePath,
+                  pathExistsCache
+                })
                 if (!exists) {
                   return null
                 }

--- a/src/renderer/src/components/terminal-pane/terminal-path-exists-probe.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-path-exists-probe.ts
@@ -1,0 +1,38 @@
+import { runtimePathExists, type RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import {
+  readTerminalPathExistsCache,
+  writeTerminalPathExistsCache
+} from './terminal-path-exists-cache'
+
+export async function probeTerminalPathExists({
+  absolutePath,
+  cacheKey,
+  fileContext,
+  isRemoteRuntimePath,
+  pathExistsCache
+}: {
+  absolutePath: string
+  cacheKey: string
+  fileContext: RuntimeFileOperationArgs
+  isRemoteRuntimePath: boolean
+  pathExistsCache: Map<string, boolean>
+}): Promise<boolean> {
+  const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
+  if (cachedExists !== undefined) {
+    return cachedExists
+  }
+
+  try {
+    const exists =
+      fileContext.connectionId || isRemoteRuntimePath
+        ? await runtimePathExists(fileContext, absolutePath)
+        : await window.api.shell.pathExists(absolutePath)
+    writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+    return exists
+  } catch {
+    // Why: terminal link probing is best effort. Long Windows paths and
+    // disconnected SSH/runtime hosts should not become renderer rejections.
+    writeTerminalPathExistsCache(pathExistsCache, cacheKey, false)
+    return false
+  }
+}


### PR DESCRIPTION
## Description
- Fail closed when terminal file-link existence probes reject for local, SSH, or runtime paths.
- Cache the failed probe as a missing path so repeated hover/link scans do not keep rethrowing.
- Add a Windows-flavored regression for a runtime `ENAMETOOLONG: realpath ...` failure.

## Crash Evidence
- New crash bundle `fe2bf016-8967-43d0-ad0a-4149136652f3` had repeated `renderer_unhandled_rejection` breadcrumbs with `RuntimeRpcCallError: ENAMETOOLONG: name too long, realpath ...`.
- The terminal link provider used `Promise.all(...).then(...)` without a rejection handler, so a best-effort path probe failure could escape into the renderer global unhandled-rejection path.
- `fd240d89-a877-4cd9-bbf0-1248b9981e58` was investigated separately; current HEAD already has Network Service suppression and renderer recovery coverage. I left a status note in that artifact folder with the remaining replay gap.

## ELI5
When Orca sees something that looks like a file path in terminal output, it asks “does this file exist?” before making it clickable. On Windows, some very long or remote paths can make that question fail. Now Orca treats that as “do not make a link” instead of letting the error bubble up and poison the renderer.

## Trade-offs
- A path whose existence check fails transiently may not become clickable until a later fresh probe, because the failed probe is cached as missing.
- Known workspace-root links still bypass the probe, so SSH/runtime workspace switching remains available even when filesystem checks are stale or unavailable.
- This hardens a concrete unhandled-rejection clue from the high-memory crash bundle, but it is not a claim that every high-memory renderer kill is fixed.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/crash-reporting/process-gone-diagnostics.test.ts src/main/window/createMainWindow.test.ts src/renderer/src/store/slices/worktree-removal-maps-leak.test.ts src/renderer/src/store/slices/editor-state-worktree-purge-leak.test.ts src/main/repo-worktrees.test.ts` -> 169 tests passed.
- `pnpm run typecheck` passed.
- Windows Electron/CDP smoke in this worktree: added disposable repos/worktrees, refreshed worktrees, repeatedly activated visible sidebar rows, forced GC, retained heap returned to 111 MB, and logs had no renderer process-gone/OOM/fatal entries.