### PR TITLE
Fix Codex hook trust hash for matcherless events (UserPromptSubmit/Stop)

### DIFF
--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -150,6 +150,46 @@ describe('computeTrustedHash', () => {
     expect(a).not.toBe(b)
   })
 
+  it('drops the matcher on user_prompt_submit/stop like matcher_pattern_for_event', () => {
+    // Why: Codex ignores matchers on these two events and hashes the
+    // identity WITHOUT the matcher field. A definition carrying
+    // `"matcher": ""` (common in third-party installers) must therefore
+    // hash identically to one without a matcher, or the system-trust
+    // mirror misses and the stale-entry sweep deletes the trust Codex
+    // wrote — re-prompting the user on every launch.
+    for (const eventLabel of ['user_prompt_submit', 'stop'] as const) {
+      const base: CodexTrustEntry = {
+        sourcePath: '/x/hooks.json',
+        eventLabel,
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'foo'
+      }
+      const bare = computeTrustedHash(base)
+      expect(computeTrustedHash({ ...base, matcher: '' })).toBe(bare)
+      expect(computeTrustedHash({ ...base, matcher: 'anything' })).toBe(bare)
+    }
+  })
+
+  it('pins the matcher-omitted hash for a Stop entry that carries an empty matcher', () => {
+    // Why: regression pin for the shape observed in the wild (a real
+    // Codex 0.140 config.toml, path anonymized): Codex stores the
+    // matcher-omitted hash for Stop even when hooks.json carries
+    // `"matcher": ""`, so we must never fold the matcher into this
+    // identity. If serialization or normalization drifts, this constant
+    // fails loudly.
+    expect(
+      computeTrustedHash({
+        sourcePath: '/home/user/.codex/hooks.json',
+        eventLabel: 'stop',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: '/home/user/.tma1/hooks/agent-hook.sh',
+        matcher: ''
+      })
+    ).toBe('sha256:f8b48c31eabfba63f117b8570b839a5f6efc1d67867512d661775b5312df946f')
+  })
+
   it('produces a different hash when statusMessage is set', () => {
     const a = computeTrustedHash({
       sourcePath: '/x/hooks.json',

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -100,10 +100,37 @@ function canonicalize(value: unknown): unknown {
   return value
 }
 
+// Why: reproduces matcher_pattern_for_event (codex-rs
+// hooks/src/events/common.rs). Codex ignores matchers on
+// UserPromptSubmit/Stop and drops them from the hook identity BEFORE
+// hashing, so a hooks.json entry carrying `"matcher": ""` on those
+// events must hash the same as one without it. Including it computes a
+// hash Codex never writes: system trust then looks stale, and
+// removeStaleRuntimeHookTrustEntries deletes the entry Codex wrote on
+// every launch — an endless re-trust prompt for those two events.
+function matcherPatternForEvent(
+  eventLabel: CodexEventLabel,
+  matcher: string | undefined
+): string | undefined {
+  switch (eventLabel) {
+    case 'user_prompt_submit':
+    case 'stop':
+      return undefined
+    case 'pre_tool_use':
+    case 'permission_request':
+    case 'post_tool_use':
+    case 'pre_compact':
+    case 'post_compact':
+    case 'session_start':
+      return matcher
+  }
+}
+
 // Why: reproduces command_hook_hash. NormalizedHookIdentity has `group:
 // MatcherGroup` flattened in, so the wire shape is { event_name, matcher?,
 // hooks: [<normalized handler>] }. `matcher` is omitted (not null) when
-// absent — Rust's Option<String>=None drops through the TOML→JSON path.
+// absent — Rust's Option<String>=None drops through the TOML→JSON path —
+// and normalized per event first (see matcherPatternForEvent).
 // Handler is normalized to timeout=600 (or explicit, min 1) and async=false.
 export function computeTrustedHash(entry: CodexTrustEntry): string {
   const handler: Record<string, unknown> = {
@@ -119,8 +146,9 @@ export function computeTrustedHash(entry: CodexTrustEntry): string {
     event_name: entry.eventLabel,
     hooks: [handler]
   }
-  if (entry.matcher !== undefined) {
-    identity.matcher = entry.matcher
+  const matcher = matcherPatternForEvent(entry.eventLabel, entry.matcher)
+  if (matcher !== undefined) {
+    identity.matcher = matcher
   }
   const serialized = JSON.stringify(canonicalize(identity))
   return `sha256:${createHash('sha256').update(serialized).digest('hex')}`


### PR DESCRIPTION
## Summary

Fixes an endless hook re-trust loop for Codex user hooks on the `UserPromptSubmit` and `Stop` events.

**Symptom.** A user hook registered in `~/.codex/hooks.json` with `"matcher": ""` (a shape some third-party hook installers write on every event) can never be durably trusted inside Orca's managed `CODEX_HOME`. Every launch shows:

```
Stop hooks
1 hook needs review before it can run.
[!] Hook 2 · new
Trust    New hook - review required
```

Pressing `t` trusts it for that session, but the prompt is back on the next launch — even when the same hook is already trusted in system-level Codex.

**Root cause.** Codex does not support matchers on `UserPromptSubmit`/`Stop` and drops them from the hook trust identity *before* hashing ([codex-rs `hooks/src/events/common.rs`, `matcher_pattern_for_event`](https://github.com/openai/codex/blob/main/codex-rs/hooks/src/events/common.rs): `UserPromptSubmit | Stop => None`; the trust check in `discovery.rs` is a strict hash equality). Orca's `computeTrustedHash` reproduces `command_hook_hash` but folds a present matcher into the identity for **every** event. For a definition carrying `"matcher": ""` on those two events, Orca therefore computes a hash Codex never stores, and two things go wrong on every launch:

1. `getTrustedSystemUserHookSignatures` compares its expected hash against the system config's `trusted_hash` (which Codex wrote matcher-omitted), misses, and refuses to mirror the system-level trust into the runtime home.
2. `removeStaleRuntimeHookTrustEntries` deletes the runtime trust entry that Codex itself wrote when the user pressed `t` (matcher-omitted, so it never matches Orca's expected hash) → the review prompt reappears next launch, forever.

The other events (`SessionStart`/`PreToolUse`/`PostToolUse`) are unaffected because Codex keeps the matcher there, so both sides already agree — which is exactly the asymmetry observed in the wild.

Verified by recomputing both hash variants against a real Codex 0.140 `config.toml`: the stored `user_prompt_submit`/`stop` hashes match only the matcher-omitted identity, while the other events' hashes match only the matcher-included identity.

**Fix.** Replicate `matcher_pattern_for_event` in `config-toml-trust.ts` (`matcherPatternForEvent`) and apply it in `computeTrustedHash`, so the matcher is dropped from `user_prompt_submit`/`stop` identities exactly like Codex does. The switch is written exhaustively over `CodexEventLabel` to satisfy `lint:switch-exhaustiveness` and to fail compilation if Codex adds an event label.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — **fails identically on unmodified `main` in my environment** (`verify:localization-catalog` wants a catalog sync unrelated to this PR, and `tsgolint` crashes with a Go runtime panic). Scoped checks on the two changed files pass: `oxlint src/main/codex/config-toml-trust.ts src/main/codex/config-toml-trust.test.ts` is clean, and `pnpm run lint:switch-exhaustiveness` passes across the repo.
- [x] `pnpm typecheck` — passes.
- [x] Affected suites: `vitest run src/main/codex/config-toml-trust.test.ts src/main/codex/hook-service.test.ts` — 106 passed / 7 skipped (and the trust suite alone after the final revision: 83 passed / 2 skipped).
- [ ] Full `pnpm test` / `pnpm build` — not runnable in my environment: the native-runtime preflight requires Node 24 prebuilds (node-pty) and I'm on Node 26; failures are all Electron/node-pty environment errors also present without this change. CI should exercise these.
- [x] Added high-quality tests:
  - `drops the matcher on user_prompt_submit/stop like matcher_pattern_for_event` — equality of `matcher: ''`/`matcher: 'anything'`/absent for both events (this is the regression that caused the loop).
  - A pinned-constant test for the matcher-omitted Stop identity hash (shape observed in a real config, path anonymized), so serialization/normalization drift fails loudly — same spirit as the existing `REAL_APPROVED_HASH` fixture.
- [x] Manually verified end-to-end on a live setup: with hashes aligned, the mirrored trust entries survive `removeStaleRuntimeHookTrustEntries`, Codex accepts them, and the re-trust prompt is gone across launches.

## AI Review Report

Review performed with Claude Code against the real Codex source as ground truth:

- **Correctness:** the normalization is byte-for-byte aligned with `matcher_pattern_for_event` (only `UserPromptSubmit`/`Stop` drop the matcher; `PreCompact`/`PostCompact`/`SessionStart`/tool events keep it, including empty string). Confirmed the fix converges both failure paths (system-trust mirroring and stale-entry sweep) because both flow through `computeTrustedHash`.
- **Blast radius:** `computeTrustedHash` is the single choke point for hash derivation; `getTrustSignature` (definition↔definition matching) intentionally untouched since both sides always come from the same hooks.json shapes. No behavior change for events where Codex keeps the matcher.
- **Cross-platform:** pure string/hash logic, no paths, shells, or shortcuts involved; applies identically on macOS/Linux/Windows. Windows path-separator handling in trust keys is untouched.
- **SSH/remote:** the remote hook detection path reads definitions only (no hash comparison against remote state), so behavior there is unchanged.
- **Agent/integration compatibility:** Codex-specific module; no other agent's hook flow imports it.
- **Performance:** one switch per hash computation — negligible.

## Security Audit

- No new input parsing, command execution, or file I/O; the change only alters which fields feed an SHA-256 identity.
- Trust semantics get *stricter in the right direction*: Orca now computes the same identity Codex verifies, so it neither deletes valid trust (availability issue fixed) nor trusts anything Codex wouldn't (the mirrored hash still has to match the system config's Codex-written value).
- Test fixtures use anonymized paths; no secrets or personal data.

## Notes

- The installer that motivated this (TMA1) also writes `"matcher": ""` on events that can't have one; I've sent the complementary fix upstream there too (tma1-ai/tma1#63). Orca's fix stands on its own: any hooks.json in this shape, from any installer or hand-edit, currently loops.
- If Codex ever adds new event labels, the exhaustive switch fails typecheck/lint here, forcing a conscious decision about the new event's matcher semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
