### PR TITLE
Warn when running the Intel build under Rosetta on Apple Silicon

### DIFF
--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -9,6 +9,7 @@ import type { AppIdentity } from '../../shared/app-identity'
 import type { FloatingTerminalCwdRequest, MarkdownDocument } from '../../shared/types'
 import type { Store } from '../persistence'
 import { getDevInstanceIdentity } from '../startup/dev-instance-identity'
+import { isRunningTranslatedOnAppleSilicon } from '../startup/rosetta-detection'
 import { isPwshAvailable } from '../pwsh'
 import { isWslAvailable, listWslDistros } from '../wsl'
 import { isGitBashAvailable } from '../git-bash'
@@ -224,6 +225,21 @@ async function readKeyboardInputSourceId(): Promise<string | null> {
 
 export function registerAppHandlers(store: Store, options: RegisterAppHandlersOptions = {}): void {
   ipcMain.handle('app:getFeatureWallAssetBaseUrl', (): string => getFeatureWallAssetBaseUrl())
+
+  // Why: the x64 build under Rosetta on Apple Silicon is severely laggy but
+  // gives users no signal they installed the wrong dmg. Surface it so the
+  // renderer can nudge them to the native arm64 build; dismissal is main-owned
+  // so it survives restarts.
+  ipcMain.handle(
+    'app:getArchAdvisory',
+    (): { translated: boolean; dismissed: boolean } => ({
+      translated: isRunningTranslatedOnAppleSilicon(),
+      dismissed: store.getUI().archAdvisoryDismissed ?? false
+    })
+  )
+  ipcMain.handle('app:dismissArchAdvisory', (): void => {
+    store.updateUI({ archAdvisoryDismissed: true })
+  })
 
   ipcMain.handle('app:getIdentity', (): AppIdentity => {
     const identity = getDevInstanceIdentity(is.dev)

--- a/src/main/startup/rosetta-detection.test.ts
+++ b/src/main/startup/rosetta-detection.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { appMock, execFileSyncMock } = vi.hoisted(() => ({
+  appMock: {} as { runningUnderARM64Translation?: boolean },
+  execFileSyncMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({ app: appMock }))
+vi.mock('node:child_process', () => ({ execFileSync: execFileSyncMock }))
+
+import { isRunningTranslatedOnAppleSilicon } from './rosetta-detection'
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+  delete appMock.runningUnderARM64Translation
+  execFileSyncMock.mockReset()
+})
+
+describe('isRunningTranslatedOnAppleSilicon', () => {
+  it('is false off macOS, without probing', () => {
+    setPlatform('linux')
+    appMock.runningUnderARM64Translation = true
+    expect(isRunningTranslatedOnAppleSilicon()).toBe(false)
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('trusts the Electron translation flag when present (true)', () => {
+    setPlatform('darwin')
+    appMock.runningUnderARM64Translation = true
+    expect(isRunningTranslatedOnAppleSilicon()).toBe(true)
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('trusts the Electron translation flag when present (false)', () => {
+    setPlatform('darwin')
+    appMock.runningUnderARM64Translation = false
+    expect(isRunningTranslatedOnAppleSilicon()).toBe(false)
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to sysctl when the flag is absent — translated', () => {
+    setPlatform('darwin')
+    execFileSyncMock.mockReturnValue('1\n')
+    expect(isRunningTranslatedOnAppleSilicon()).toBe(true)
+  })
+
+  it('falls back to sysctl when the flag is absent — native', () => {
+    setPlatform('darwin')
+    execFileSyncMock.mockReturnValue('0\n')
+    expect(isRunningTranslatedOnAppleSilicon()).toBe(false)
+  })
+
+  it('treats a sysctl failure as native (false)', () => {
+    setPlatform('darwin')
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('sysctl: unknown oid')
+    })
+    expect(isRunningTranslatedOnAppleSilicon()).toBe(false)
+  })
+})

--- a/src/main/startup/rosetta-detection.ts
+++ b/src/main/startup/rosetta-detection.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from 'node:child_process'
+import { app } from 'electron'
+
+/**
+ * True when this is the x64 build running under Rosetta 2 on Apple Silicon.
+ *
+ * Why: users routinely download the Intel `.dmg` onto an Apple Silicon Mac and
+ * hit severe, unexplained lag — the entire app is binary-translated. We surface
+ * this so the renderer can nudge them to the native arm64 build. Non-macOS
+ * platforms have no Rosetta, so this is always false off darwin.
+ */
+export function isRunningTranslatedOnAppleSilicon(): boolean {
+  if (process.platform !== 'darwin') {
+    return false
+  }
+
+  // Electron exposes the translation flag synchronously; prefer it when present.
+  const translated = (app as { runningUnderARM64Translation?: boolean })
+    .runningUnderARM64Translation
+  if (typeof translated === 'boolean') {
+    return translated
+  }
+
+  // Fallback: Apple's documented sysctl flag (1 = process is translated). `-i`
+  // ignores the OID on Intel Macs where it doesn't exist; a failure just skips
+  // the nudge rather than blocking startup.
+  try {
+    const out = execFileSync('sysctl', ['-in', 'sysctl.proc_translated'], {
+      encoding: 'utf8'
+    })
+    return out.trim() === '1'
+  } catch {
+    return false
+  }
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -798,6 +798,12 @@ export type NativeChatApi = {
 export type AppApi = {
   /** Returns the app identity currently exposed to native chrome and the titlebar. */
   getIdentity: () => Promise<AppIdentity>
+  /** True when Orca is the x64 build running under Rosetta on Apple Silicon,
+   *  plus whether the resulting "download the native build" advisory has already
+   *  been dismissed. */
+  getArchAdvisory: () => Promise<{ translated: boolean; dismissed: boolean }>
+  /** Permanently dismisses the Rosetta/native-build advisory. */
+  dismissArchAdvisory: () => Promise<void>
   /** Returns a URL base for feature-wall assets. In dev this is Vite /@fs;
    *  in packaged builds this is file:// resources. Renderer appends filenames. */
   getFeatureWallAssetBaseUrl: () => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -441,6 +441,9 @@ const startupDiagnosticsEnabled = process.env.ORCA_STARTUP_DIAGNOSTICS === '1'
 const api = {
   app: {
     getIdentity: (): Promise<AppIdentity> => ipcRenderer.invoke('app:getIdentity'),
+    getArchAdvisory: (): Promise<{ translated: boolean; dismissed: boolean }> =>
+      ipcRenderer.invoke('app:getArchAdvisory'),
+    dismissArchAdvisory: (): Promise<void> => ipcRenderer.invoke('app:dismissArchAdvisory'),
     getFeatureWallAssetBaseUrl: (): Promise<string> =>
       ipcRenderer.invoke('app:getFeatureWallAssetBaseUrl'),
     relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -55,6 +55,7 @@ import {
   useSystemPrefersDark
 } from './components/terminal-pane/use-system-prefers-dark'
 import RightSidebar from './components/right-sidebar'
+import { ArchAdvisoryCard } from './components/ArchAdvisoryCard'
 import { StarNagCard } from './components/StarNagCard'
 import { StarNagAgentValueMomentObserver } from './components/star-nag/StarNagAgentValueMomentObserver'
 import { StarNagToastHost } from './components/star-nag/StarNagToastHost'
@@ -2556,6 +2557,14 @@ function App(): React.JSX.Element {
                 </RecoverableRenderErrorBoundary>
               </Suspense>
             ) : null}
+            <RecoverableRenderErrorBoundary
+              boundaryId="overlay.arch-advisory"
+              surface="overlay"
+              resetKey={activeView}
+              compact
+            >
+              <ArchAdvisoryCard />
+            </RecoverableRenderErrorBoundary>
             <RecoverableRenderErrorBoundary
               boundaryId="overlay.star-nag"
               surface="overlay"

--- a/src/renderer/src/components/ArchAdvisoryCard.tsx
+++ b/src/renderer/src/components/ArchAdvisoryCard.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import { Cpu, X } from 'lucide-react'
+import { Card } from './ui/card'
+import { Button } from './ui/button'
+import { translate } from '@/i18n/i18n'
+
+// Canonical download page; picks the right architecture for the visitor.
+const DOWNLOAD_URL = 'https://onorca.dev/download'
+
+/**
+ * One-time nudge shown when Orca is the Intel build running under Rosetta 2 on
+ * Apple Silicon. Why: binary translation makes the whole app severely laggy and
+ * users rarely realize they installed the wrong dmg. Detection is main-owned and
+ * static for the session, so the card fetches once on mount and self-gates.
+ */
+export function ArchAdvisoryCard() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.api.app.getArchAdvisory().then((advisory) => {
+      if (!cancelled && advisory.translated && !advisory.dismissed) {
+        setVisible(true)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (!visible) {
+    return null
+  }
+
+  const handleDismiss = () => {
+    // Optimistically hide; persistence is best-effort and must not block the UI.
+    setVisible(false)
+    void window.api.app.dismissArchAdvisory()
+  }
+
+  const title = translate('auto.components.ArchAdvisoryCard.title', 'Running the Intel build')
+
+  return (
+    <div
+      className="fixed bottom-10 right-4 z-40 w-[360px] max-w-[calc(100vw-32px)]
+      max-[480px]:left-4 max-[480px]:right-4 max-[480px]:w-auto"
+    >
+      <Card role="complementary" aria-label={title} aria-live="polite" className="py-0 gap-0">
+        <div className="flex flex-col gap-2.5 p-3.5">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <Cpu className="size-4 shrink-0 text-muted-foreground" />
+              <h3 className="text-sm font-semibold">{title}</h3>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0 -m-1"
+              onClick={handleDismiss}
+              aria-label={translate('auto.components.ArchAdvisoryCard.dismiss', 'Dismiss')}
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+
+          <p className="text-sm text-muted-foreground">
+            {translate(
+              'auto.components.ArchAdvisoryCard.body',
+              'Orca is running the Intel build under Rosetta on your Apple Silicon Mac, which makes everything noticeably slower. Download the Apple Silicon build for full-speed performance.'
+            )}
+          </p>
+
+          <Button
+            variant="default"
+            size="sm"
+            className="mt-0.5 w-full cursor-pointer"
+            onClick={() => void window.api.shell.openUrl(DOWNLOAD_URL)}
+          >
+            {translate('auto.components.ArchAdvisoryCard.download', 'Download Apple Silicon build')}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3317,6 +3317,9 @@ export type PersistedUIState = {
   /** App version that already consumed the first successful-agent value-moment ask.
    *  Main-owned so remote/web clients cannot spoof the once-per-version cap. */
   starNagAgentValueMomentAppVersion?: string | null
+  /** Once dismissed, permanently suppress the "running the Intel build under
+   *  Rosetta on Apple Silicon" advisory. Main-owned so it survives restarts. */
+  archAdvisoryDismissed?: boolean
   trustedOrcaHooks?: PersistedTrustedOrcaHooks
   setupScriptPromptDismissedRepoIds?: string[]
   /** Whether the experimental pet overlay is currently visible. Separate


### PR DESCRIPTION
> **Draft / WIP** — opening early for CI feedback and to confirm direction with maintainers (see #7117). I couldn't run the local checks in my setup (out of disk), so I'm relying on CI to verify; the i18n catalog entries for the new card still need `pnpm sync:localization-catalog`.

## Summary

If you install the Intel (x64) build on an Apple Silicon Mac, the whole app runs under Rosetta and feels sluggish everywhere — UI and terminals — and nothing in the app tells you that's what happened. This adds a small startup check that notices when we're translated on Apple Silicon and shows a one-time card pointing to the arm64 download. It only does anything on macOS.

Closes #7117

## Screenshots

_(screenshot of the card — see Notes for how to trigger it locally)_

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Went over the change carefully since it touches startup and an Electron API. Cross-platform was the main thing to get right: detection returns false immediately unless we're on macOS, so Linux and Windows do nothing, and the card only mounts once the check comes back true. Nothing hardcodes paths, shortcuts, or shell behavior, and the one platform call (sysctl) is macOS-only and wrapped in try/catch. The card also sits behind the same error boundary as the other overlays, so it can't take down the app.

## Security Audit

The only new process call is `execFileSync('sysctl', ['-in', 'sysctl.proc_translated'])` — fixed command, fixed args, no shell, no user input, so nothing to inject. The two new IPC calls sit on the existing `app` namespace: one reads the advisory state, the other writes a single boolean when the user dismisses it. No path handling, secrets, auth, or new dependencies.

## Notes

- I considered shipping a universal binary instead, which would make the wrong-arch case impossible, but it roughly doubles the download and means reworking the release/signing setup — felt like too big a change for this, and the two can coexist. Happy to go that way instead if you'd prefer.
- Dismissal is stored on the main side (`ui.archAdvisoryDismissed`), so it shows once and stays gone.
- This only warns; it doesn't change how builds are produced. Homebrew already picks the right arch, so this mainly helps people downloading the dmg by hand.
- To see the card locally on Apple Silicon (where it normally wouldn't show), temporarily hardcode `translated: true` in the `app:getArchAdvisory` handler.

## ELI5

Running the Intel build under Rosetta on Apple Silicon shows a clear warning. You’re told why the app feels slow and that the ARM build is the right install.
