### PR TITLE
fix: add 'hooks' to CODEX_SYSTEM_RESOURCE_ENTRIES

### DIFF
--- a/src/main/codex/codex-home-paths.test.ts
+++ b/src/main/codex/codex-home-paths.test.ts
@@ -217,4 +217,16 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
     expect(lstatSync(runtimeProfilePath).isSymbolicLink()).toBe(false)
     expect(readFileSync(runtimeProfilePath, 'utf-8')).toBe('second\n')
   })
+
+  it('mirrors hooks directory into the managed runtime home (regression test for 127 exit)', () => {
+    const systemHooksPath = join(getSystemCodexHomePath(), 'hooks')
+    const runtimeHooksPath = join(getRuntimeCodexHomePath(), 'hooks')
+    mkdirSync(systemHooksPath, { recursive: true })
+    writeFileSync(join(systemHooksPath, 'observe-tool-use.sh'), '#!/bin/bash\necho ok\n')
+
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(lstatSync(runtimeHooksPath).isSymbolicLink()).toBe(true)
+    expectSymbolicLinkTargetIfLinked(runtimeHooksPath, systemHooksPath)
+  })
 })

--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -16,6 +16,7 @@ import { dirname, join } from 'node:path'
 
 const CODEX_SYSTEM_RESOURCE_ENTRIES = [
   'skills',
+  'hooks',
   'plugins',
   'plugin-state',
   'profile-v2',


### PR DESCRIPTION
## Summary

Add `'hooks'` to `CODEX_SYSTEM_RESOURCE_ENTRIES` so Orca mirrors `~/.codex/hooks` into the managed Codex runtime home. Fixes hook scripts exiting 127 in Orca-launched Codex sessions.

## Why

Orca launches Codex CLI with `CODEX_HOME` pointed at a managed runtime home and mirrors `~/.codex` resources into it at every launch (`syncSystemCodexResourcesIntoManagedHome`). The hardcoded allowlist omits `'hooks'`, so hook scripts stored under `~/.codex/hooks` are never reachable via `$CODEX_HOME/hooks`, and command hooks referencing them fail with exit 127 on every tool call. `hooks.json` and hook trust state are already handled by the config merge layer — only the scripts directory is missing from the mirror.

## What

- `src/main/codex/codex-home-paths.ts` — add `'hooks'` to `CODEX_SYSTEM_RESOURCE_ENTRIES`
- `src/main/codex/codex-home-paths.test.ts` — regression test asserting a `~/.codex/hooks` dir is symlinked into the managed home by the sync

## How

Same mechanism as the other mirrored entries (`linkSystemCodexResource`): symlink when possible, Windows falls back to junction/copy via the existing code path, and existing runtime-owned entries are never clobbered — users who already created `<managed>/hooks` manually keep their state because the sync skips entries that already exist.

## Test plan

- [x] Regression test added following the existing patterns in `codex-home-paths.test.ts` (temp-HOME mocks): `mirrors hooks directory into the managed runtime home`
- [ ] Full vitest suite on CI (could not complete a local run in my sandboxed environment due to package-manager restrictions; the product change is the one-line const addition)

Related issues with similar symptoms but different causes: #6163, #3190, #6078

🤖 Generated with [Claude Code](https://claude.com/claude-code)