### PR TITLE
feat(settings): add light mode option for markdown file preview (#1)

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -9,6 +9,22 @@
   flex: 1;
 }
 
+/* Why: when markdownPreviewLightBackground is enabled we apply .markdown-light
+   exclusively to this container so the reading surface (bg + text) becomes
+   light while the global app (and its CSS vars) stay in the chosen theme.
+   Rules are scoped to .markdown-preview.markdown-light so they never leak. */
+.markdown-preview.markdown-light {
+  background: #ffffff;
+  color: #24292f;
+}
+
+/* Scope toolbar and search to light surface values when preview light mode is active. */
+.markdown-preview.markdown-light .markdown-preview-search,
+.markdown-preview.markdown-light .markdown-review-toolbar {
+  background: color-mix(in srgb, #f6f8fa 94%, white);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
 .markdown-preview-shell {
   position: relative;
   display: flex;

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -13,9 +13,12 @@
    exclusively to this container so the reading surface (bg + text) becomes
    light while the global app (and its CSS vars) stay in the chosen theme.
    Rules are scoped to .markdown-preview.markdown-light so they never leak. */
-.markdown-preview.markdown-light {
-  background: #ffffff;
-  color: #24292f;
+.markdown-preview-shell.markdown-light,
+.markdown-preview.markdown-light,
+.markdown-light .markdown-body,
+.markdown-preview.markdown-light .markdown-body {
+  background: #ffffff !important;
+  color: #24292f !important;
 }
 
 /* Scope toolbar and search to light surface values when preview light mode is active.

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -18,11 +18,118 @@
   color: #24292f;
 }
 
-/* Scope toolbar and search to light surface values when preview light mode is active. */
+/* Scope toolbar and search to light surface values when preview light mode is active.
+   Why: when app theme is dark, global --* vars are dark; these ensure the forced-light
+   preview surface and its controls remain legible and isolated (no leakage to chrome/terminal). */
 .markdown-preview.markdown-light .markdown-preview-search,
 .markdown-preview.markdown-light .markdown-review-toolbar {
   background: color-mix(in srgb, #f6f8fa 94%, white);
   border-color: rgba(0, 0, 0, 0.08);
+}
+
+/* Comprehensive light overrides for descendants (search, toolbar, headings, links,
+   checkboxes, details, tables, frontmatter) so forced light preview never inherits
+   dark app vars for contrast/visibility. Scoped to .markdown-preview.markdown-light
+   or .markdown-light to preserve strict isolation. */
+.markdown-preview.markdown-light .markdown-preview-search-field {
+  border-color: rgba(0, 0, 0, 0.15);
+  background: #ffffff;
+}
+.markdown-preview.markdown-light .markdown-preview-search-status,
+.markdown-preview.markdown-light .markdown-preview-search-input::placeholder,
+.markdown-preview.markdown-light .markdown-preview-search-button {
+  color: #6e7781;
+}
+.markdown-preview.markdown-light .markdown-preview-search-divider {
+  background: rgba(0, 0, 0, 0.1);
+}
+.markdown-preview.markdown-light .markdown-preview-search-button:hover:not(:disabled) {
+  background: #f3f4f6;
+  color: #24292f;
+}
+
+.markdown-preview.markdown-light .markdown-review-toolbar-button,
+.markdown-preview.markdown-light .markdown-review-icon-button {
+  color: #6e7781;
+}
+.markdown-preview.markdown-light .markdown-review-toolbar-button:hover:not(:disabled),
+.markdown-preview.markdown-light .markdown-review-toolbar-button[aria-expanded='true'],
+.markdown-preview.markdown-light .markdown-review-icon-button:hover:not(:disabled) {
+  border-color: rgba(0, 0, 0, 0.12);
+  background: #f6f8fa;
+  color: #24292f;
+}
+.markdown-preview.markdown-light .markdown-review-count {
+  background: rgba(0, 0, 0, 0.08);
+  color: #6e7781;
+}
+
+.markdown-light .markdown-body h5 {
+  color: #6e7781;
+}
+
+.markdown-light .markdown-body .markdown-doc-link-broken {
+  color: #6e7781;
+}
+
+.markdown-preview.markdown-light .markdown-body details.orca-details > summary::before {
+  color: #6e7781;
+}
+
+/* Light checkbox rendering for contrast on white preview surface (avoids dark --foreground mix). */
+.markdown-light .markdown-body li > input[type='checkbox'] {
+  border-color: color-mix(in srgb, #24292f 55%, transparent);
+}
+.markdown-light .markdown-body li > input[type='checkbox']:checked {
+  background: #0969da;
+  border-color: #0969da;
+}
+.markdown-light .markdown-body li > input[type='checkbox']:checked::after {
+  border-color: #ffffff;
+}
+
+/* Table borders and frontmatter use light values inside forced-light surface. */
+.markdown-light .markdown-body th,
+.markdown-light .markdown-body td {
+  border-color: #d0d7de;
+}
+.markdown-preview.markdown-light .markdown-body .border-border\/60 {
+  border-color: rgba(0, 0, 0, 0.12) !important;
+}
+.markdown-preview.markdown-light .markdown-body .bg-muted\/40 {
+  background-color: rgba(0, 0, 0, 0.04) !important;
+}
+.markdown-preview.markdown-light .markdown-body .text-muted-foreground {
+  color: #6e7781 !important;
+}
+
+/* TOC panel light treatment for visual continuity when next to light preview surface.
+   Class applied to shell so sibling panel inherits. */
+.markdown-light .markdown-toc-panel {
+  background: #f6f8fa;
+  border-right-color: rgba(0, 0, 0, 0.08);
+}
+.markdown-light .markdown-toc-header {
+  color: #6e7781;
+  border-bottom-color: rgba(0, 0, 0, 0.08);
+}
+.markdown-light .markdown-toc-row {
+  color: #24292f;
+}
+.markdown-light .markdown-toc-row:hover {
+  background: #f3f4f6;
+}
+.markdown-light .markdown-toc-level-button {
+  color: #6e7781;
+}
+.markdown-light .markdown-toc-level-button:hover {
+  color: #24292f;
+}
+.markdown-light .markdown-toc-empty {
+  color: #6e7781;
+}
+.markdown-light .markdown-toc-disclosure:hover {
+  background: rgba(0, 0, 0, 0.06);
 }
 
 .markdown-preview-shell {

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -132,6 +132,97 @@
   background: rgba(0, 0, 0, 0.06);
 }
 
+/* Why: complete isolation for the light reading surface (annotations, composer, diff comment cards, actions pill, copy buttons, TOC icons and all descendants) when markdownPreviewLightBackground enabled. No dark cards or low-contrast elements inside the preview area. Annotation/composer/diff cards use var(--editor-surface) etc (dark on light when app theme dark). .code-block-copy-btn hover used muted/accent vars. TOC ListTree/Chevron use text-muted-foreground. Override with explicit light values + !important for var/tailwind descendants. Scoped to .markdown-light (applied to shell+preview) + .markdown-preview.markdown-light. */
+.markdown-light .text-muted-foreground,
+.markdown-preview.markdown-light .text-muted-foreground {
+  color: #6e7781 !important;
+}
+
+/* Force via added markdown-toc-icon class on ListTree/Chevron (per isolation pass) */
+.markdown-light .markdown-toc-icon {
+  color: #6e7781 !important;
+}
+
+.markdown-light .orca-diff-comment-card,
+.markdown-preview.markdown-light .orca-diff-comment-card {
+  background: #ffffff !important;
+  border-color: rgba(0, 0, 0, 0.1) !important;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.06),
+    0 4px 12px rgba(0, 0, 0, 0.04) !important;
+}
+
+.markdown-light .orca-diff-comment-actions-pill,
+.markdown-preview.markdown-light .orca-diff-comment-actions-pill {
+  background: #ffffff !important;
+  border-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.markdown-light .orca-diff-comment-pill-btn,
+.markdown-preview.markdown-light .orca-diff-comment-pill-btn {
+  color: #6e7781;
+}
+.markdown-light .orca-diff-comment-pill-btn:hover,
+.markdown-preview.markdown-light .orca-diff-comment-pill-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: #24292f;
+}
+
+.markdown-light .markdown-annotation-composer,
+.markdown-preview.markdown-light .markdown-annotation-composer {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  color: #24292f;
+}
+
+.markdown-light .markdown-annotation-card.is-active > .orca-diff-comment-card,
+.markdown-preview.markdown-light .markdown-annotation-card.is-active > .orca-diff-comment-card {
+  background: #ffffff !important;
+  border-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.markdown-light .orca-diff-comment-popover,
+.markdown-preview.markdown-light .orca-diff-comment-popover,
+.markdown-light .orca-diff-comment-popover-textarea,
+.markdown-preview.markdown-light .orca-diff-comment-popover-textarea {
+  background: #ffffff !important;
+  border-color: rgba(0, 0, 0, 0.12) !important;
+  color: #24292f !important;
+}
+
+.markdown-light .orca-diff-comment-popover-label,
+.markdown-preview.markdown-light .orca-diff-comment-popover-label {
+  color: #6e7781;
+}
+
+.markdown-light .orca-diff-comment-body,
+.markdown-preview.markdown-light .orca-diff-comment-body {
+  color: #24292f;
+}
+
+/* code-block-copy-btn hover on light code blocks (inside forced light preview) */
+.markdown-preview.markdown-light .code-block-copy-btn {
+  color: #6e7781;
+}
+.markdown-preview.markdown-light .code-block-copy-btn:hover {
+  background: #f3f4f6;
+  color: #24292f;
+}
+
+/* Annotation rail add button inside light preview surface */
+.markdown-preview.markdown-light .markdown-annotation-add,
+.markdown-light .markdown-annotation-add {
+  background: #ffffff;
+  color: #6e7781;
+  border-color: rgba(0, 0, 0, 0.12);
+}
+.markdown-preview.markdown-light .markdown-annotation-add:hover,
+.markdown-light .markdown-annotation-add:hover {
+  background: #f3f4f6;
+  color: #24292f;
+}
+
 .markdown-preview-shell {
   position: relative;
   display: flex;

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -13,12 +13,29 @@
    exclusively to this container so the reading surface (bg + text) becomes
    light while the global app (and its CSS vars) stay in the chosen theme.
    Rules are scoped to .markdown-preview.markdown-light so they never leak. */
+.markdown-light {
+  /* GitHub-markdown light palette, local to this scope so it stays
+     independent of main.css's theme tokens (see AGENTS.md token rule). */
+  --md-light-bg: #ffffff;
+  --md-light-fg: #24292f;
+  --md-light-muted: #6e7781;
+  --md-light-accent: #0969da;
+  --md-light-surface: #f6f8fa;
+  --md-light-surface-hover: #f3f4f6;
+  --md-light-border: #d0d7de;
+  --md-light-border-soft: rgba(0, 0, 0, 0.08);
+  --md-light-border-strong: rgba(0, 0, 0, 0.12);
+  --md-light-hairline: rgba(0, 0, 0, 0.1);
+  --md-light-scrim: rgba(0, 0, 0, 0.06);
+  --md-light-scrim-soft: rgba(0, 0, 0, 0.04);
+}
+
 .markdown-preview-shell.markdown-light,
 .markdown-preview.markdown-light,
 .markdown-light .markdown-body,
 .markdown-preview.markdown-light .markdown-body {
-  background: #ffffff !important;
-  color: #24292f !important;
+  background: var(--md-light-bg) !important;
+  color: var(--md-light-fg) !important;
 }
 
 /* Scope toolbar and search to light surface values when preview light mode is active.
@@ -26,8 +43,8 @@
    preview surface and its controls remain legible and isolated (no leakage to chrome/terminal). */
 .markdown-preview.markdown-light .markdown-preview-search,
 .markdown-preview.markdown-light .markdown-review-toolbar {
-  background: color-mix(in srgb, #f6f8fa 94%, white);
-  border-color: rgba(0, 0, 0, 0.08);
+  background: color-mix(in srgb, var(--md-light-surface) 94%, white);
+  border-color: var(--md-light-border-soft);
 }
 
 /* Comprehensive light overrides for descendants (search, toolbar, headings, links,
@@ -36,194 +53,194 @@
    or .markdown-light to preserve strict isolation. */
 .markdown-preview.markdown-light .markdown-preview-search-field {
   border-color: rgba(0, 0, 0, 0.15);
-  background: #ffffff;
+  background: var(--md-light-bg);
 }
 .markdown-preview.markdown-light .markdown-preview-search-status,
 .markdown-preview.markdown-light .markdown-preview-search-input::placeholder,
 .markdown-preview.markdown-light .markdown-preview-search-button {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 .markdown-preview.markdown-light .markdown-preview-search-divider {
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--md-light-hairline);
 }
 .markdown-preview.markdown-light .markdown-preview-search-button:hover:not(:disabled) {
-  background: #f3f4f6;
-  color: #24292f;
+  background: var(--md-light-surface-hover);
+  color: var(--md-light-fg);
 }
 
 .markdown-preview.markdown-light .markdown-review-toolbar-button,
 .markdown-preview.markdown-light .markdown-review-icon-button {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 .markdown-preview.markdown-light .markdown-review-toolbar-button:hover:not(:disabled),
 .markdown-preview.markdown-light .markdown-review-toolbar-button[aria-expanded='true'],
 .markdown-preview.markdown-light .markdown-review-icon-button:hover:not(:disabled) {
-  border-color: rgba(0, 0, 0, 0.12);
-  background: #f6f8fa;
-  color: #24292f;
+  border-color: var(--md-light-border-strong);
+  background: var(--md-light-surface);
+  color: var(--md-light-fg);
 }
 .markdown-preview.markdown-light .markdown-review-count {
-  background: rgba(0, 0, 0, 0.08);
-  color: #6e7781;
+  background: var(--md-light-border-soft);
+  color: var(--md-light-muted);
 }
 
 .markdown-light .markdown-body h5 {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 
 .markdown-light .markdown-body .markdown-doc-link-broken {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 
 .markdown-preview.markdown-light .markdown-body details.orca-details > summary::before {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 
 /* Light checkbox rendering for contrast on white preview surface (avoids dark --foreground mix). */
 .markdown-light .markdown-body li > input[type='checkbox'] {
-  border-color: color-mix(in srgb, #24292f 55%, transparent);
+  border-color: color-mix(in srgb, var(--md-light-fg) 55%, transparent);
 }
 .markdown-light .markdown-body li > input[type='checkbox']:checked {
-  background: #0969da;
-  border-color: #0969da;
+  background: var(--md-light-accent);
+  border-color: var(--md-light-accent);
 }
 .markdown-light .markdown-body li > input[type='checkbox']:checked::after {
-  border-color: #ffffff;
+  border-color: var(--md-light-bg);
 }
 
 /* Table borders and frontmatter use light values inside forced-light surface. */
 .markdown-light .markdown-body th,
 .markdown-light .markdown-body td {
-  border-color: #d0d7de;
+  border-color: var(--md-light-border);
 }
 .markdown-preview.markdown-light .markdown-body .border-border\/60 {
-  border-color: rgba(0, 0, 0, 0.12) !important;
+  border-color: var(--md-light-border-strong) !important;
 }
 .markdown-preview.markdown-light .markdown-body .bg-muted\/40 {
-  background-color: rgba(0, 0, 0, 0.04) !important;
+  background-color: var(--md-light-scrim-soft) !important;
 }
 .markdown-preview.markdown-light .markdown-body .text-muted-foreground {
-  color: #6e7781 !important;
+  color: var(--md-light-muted) !important;
 }
 
 /* TOC panel light treatment for visual continuity when next to light preview surface.
    Class applied to shell so sibling panel inherits. */
 .markdown-light .markdown-toc-panel {
-  background: #f6f8fa;
-  border-right-color: rgba(0, 0, 0, 0.08);
+  background: var(--md-light-surface);
+  border-right-color: var(--md-light-border-soft);
 }
 .markdown-light .markdown-toc-header {
-  color: #6e7781;
-  border-bottom-color: rgba(0, 0, 0, 0.08);
+  color: var(--md-light-muted);
+  border-bottom-color: var(--md-light-border-soft);
 }
 .markdown-light .markdown-toc-row {
-  color: #24292f;
+  color: var(--md-light-fg);
 }
 .markdown-light .markdown-toc-row:hover {
-  background: #f3f4f6;
+  background: var(--md-light-surface-hover);
 }
 .markdown-light .markdown-toc-level-button {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 .markdown-light .markdown-toc-level-button:hover {
-  color: #24292f;
+  color: var(--md-light-fg);
 }
 .markdown-light .markdown-toc-empty {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 .markdown-light .markdown-toc-disclosure:hover {
-  background: rgba(0, 0, 0, 0.06);
+  background: var(--md-light-scrim);
 }
 
 /* Why: complete isolation for the light reading surface (annotations, composer, diff comment cards, actions pill, copy buttons, TOC icons and all descendants) when markdownPreviewLightBackground enabled. No dark cards or low-contrast elements inside the preview area. Annotation/composer/diff cards use var(--editor-surface) etc (dark on light when app theme dark). .code-block-copy-btn hover used muted/accent vars. TOC ListTree/Chevron use text-muted-foreground. Override with explicit light values + !important for var/tailwind descendants. Scoped to .markdown-light (applied to shell+preview) + .markdown-preview.markdown-light. */
 .markdown-light .text-muted-foreground,
 .markdown-preview.markdown-light .text-muted-foreground {
-  color: #6e7781 !important;
+  color: var(--md-light-muted) !important;
 }
 
 /* Force via added markdown-toc-icon class on ListTree/Chevron (per isolation pass) */
 .markdown-light .markdown-toc-icon {
-  color: #6e7781 !important;
+  color: var(--md-light-muted) !important;
 }
 
 .markdown-light .orca-diff-comment-card,
 .markdown-preview.markdown-light .orca-diff-comment-card {
-  background: #ffffff !important;
-  border-color: rgba(0, 0, 0, 0.1) !important;
+  background: var(--md-light-bg) !important;
+  border-color: var(--md-light-hairline) !important;
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.06),
-    0 4px 12px rgba(0, 0, 0, 0.04) !important;
+    0 4px 12px var(--md-light-scrim-soft) !important;
 }
 
 .markdown-light .orca-diff-comment-actions-pill,
 .markdown-preview.markdown-light .orca-diff-comment-actions-pill {
-  background: #ffffff !important;
-  border-color: rgba(0, 0, 0, 0.1) !important;
+  background: var(--md-light-bg) !important;
+  border-color: var(--md-light-hairline) !important;
 }
 
 .markdown-light .orca-diff-comment-pill-btn,
 .markdown-preview.markdown-light .orca-diff-comment-pill-btn {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 .markdown-light .orca-diff-comment-pill-btn:hover,
 .markdown-preview.markdown-light .orca-diff-comment-pill-btn:hover {
-  background: rgba(0, 0, 0, 0.06);
-  color: #24292f;
+  background: var(--md-light-scrim);
+  color: var(--md-light-fg);
 }
 
 .markdown-light .markdown-annotation-composer,
 .markdown-preview.markdown-light .markdown-annotation-composer {
-  background: #ffffff;
-  border-color: rgba(0, 0, 0, 0.12);
+  background: var(--md-light-bg);
+  border-color: var(--md-light-border-strong);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
-  color: #24292f;
+  color: var(--md-light-fg);
 }
 
 .markdown-light .markdown-annotation-card.is-active > .orca-diff-comment-card,
 .markdown-preview.markdown-light .markdown-annotation-card.is-active > .orca-diff-comment-card {
-  background: #ffffff !important;
-  border-color: rgba(0, 0, 0, 0.1) !important;
+  background: var(--md-light-bg) !important;
+  border-color: var(--md-light-hairline) !important;
 }
 
 .markdown-light .orca-diff-comment-popover,
 .markdown-preview.markdown-light .orca-diff-comment-popover,
 .markdown-light .orca-diff-comment-popover-textarea,
 .markdown-preview.markdown-light .orca-diff-comment-popover-textarea {
-  background: #ffffff !important;
-  border-color: rgba(0, 0, 0, 0.12) !important;
-  color: #24292f !important;
+  background: var(--md-light-bg) !important;
+  border-color: var(--md-light-border-strong) !important;
+  color: var(--md-light-fg) !important;
 }
 
 .markdown-light .orca-diff-comment-popover-label,
 .markdown-preview.markdown-light .orca-diff-comment-popover-label {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 
 .markdown-light .orca-diff-comment-body,
 .markdown-preview.markdown-light .orca-diff-comment-body {
-  color: #24292f;
+  color: var(--md-light-fg);
 }
 
 /* code-block-copy-btn hover on light code blocks (inside forced light preview) */
 .markdown-preview.markdown-light .code-block-copy-btn {
-  color: #6e7781;
+  color: var(--md-light-muted);
 }
 .markdown-preview.markdown-light .code-block-copy-btn:hover {
-  background: #f3f4f6;
-  color: #24292f;
+  background: var(--md-light-surface-hover);
+  color: var(--md-light-fg);
 }
 
 /* Annotation rail add button inside light preview surface */
 .markdown-preview.markdown-light .markdown-annotation-add,
 .markdown-light .markdown-annotation-add {
-  background: #ffffff;
-  color: #6e7781;
-  border-color: rgba(0, 0, 0, 0.12);
+  background: var(--md-light-bg);
+  color: var(--md-light-muted);
+  border-color: var(--md-light-border-strong);
 }
 .markdown-preview.markdown-light .markdown-annotation-add:hover,
 .markdown-light .markdown-annotation-add:hover {
-  background: #f3f4f6;
-  color: #24292f;
+  background: var(--md-light-surface-hover);
+  color: var(--md-light-fg);
 }
 
 .markdown-preview-shell {
@@ -800,7 +817,7 @@
 }
 
 .markdown-light .markdown-body a {
-  color: #0969da;
+  color: var(--md-light-accent);
 }
 
 .markdown-dark .markdown-body a {
@@ -841,8 +858,8 @@
 }
 
 .markdown-light .markdown-body pre {
-  background: #f6f8fa;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: var(--md-light-surface);
+  border: 1px solid var(--md-light-border-soft);
 }
 
 .markdown-body pre code {
@@ -1066,12 +1083,12 @@
 /* ── Syntax Highlighting (GitHub-inspired) ────────── */
 
 .markdown-light .hljs {
-  color: #24292f;
+  color: var(--md-light-fg);
 }
 
 .markdown-light .hljs-comment,
 .markdown-light .hljs-quote {
-  color: #6e7781;
+  color: var(--md-light-muted);
   font-style: italic;
 }
 

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -11,6 +11,32 @@
   background: var(--editor-surface);
 }
 
+/* Why: markdownPreviewLightBackground forces a light reading surface here
+   regardless of app theme. The rest of the file is entirely token-driven
+   (var(--editor-surface), var(--background), color-mix(...) with theme vars),
+   so remapping the tokens this subtree reads is enough to relight every
+   descendant without touching each rule. Values match main.css's light theme.
+   `color` is set explicitly (not just --foreground) because it's an inherited
+   property computed at `body` (text-foreground) using the app's dark-theme
+   value; without re-declaring it here, descendants inherit that stale computed
+   color instead of picking up the remapped variable. */
+.rich-markdown-editor-shell.markdown-light {
+  --editor-surface: #ffffff;
+  --background: #ffffff;
+  --foreground: #0a0a0a;
+  --popover: #ffffff;
+  --popover-foreground: #0a0a0a;
+  --primary: #171717;
+  --primary-foreground: #fafafa;
+  --muted: #f5f5f5;
+  --muted-foreground: #737373;
+  --accent: #f5f5f5;
+  --border: #e5e5e5;
+  --ring: #a1a1a1;
+  --annotation-highlight: #f59e0b;
+  color: var(--foreground);
+}
+
 .rich-markdown-editor-layout {
   position: relative;
   display: flex;

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -92,8 +92,9 @@ export function EditorPanelHeader({
   const markdownPreviewLightBackground = useAppStore(
     (s) => !!s.settings?.markdownPreviewLightBackground
   )
-  const toggleMarkdownPreviewLightBackground = (): void =>
-    updateSettings({ markdownPreviewLightBackground: !markdownPreviewLightBackground })
+  const toggleMarkdownPreviewLightBackground = (): void => {
+    void updateSettings({ markdownPreviewLightBackground: !markdownPreviewLightBackground })
+  }
   const fileDiffComments = useMemo(
     () => diffComments.filter((comment) => comment.filePath === activeFile.relativePath),
     [activeFile.relativePath, diffComments]

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -92,6 +92,8 @@ export function EditorPanelHeader({
   const markdownPreviewLightBackground = useAppStore(
     (s) => !!s.settings?.markdownPreviewLightBackground
   )
+  const toggleMarkdownPreviewLightBackground = (): void =>
+    updateSettings({ markdownPreviewLightBackground: !markdownPreviewLightBackground })
   const fileDiffComments = useMemo(
     () => diffComments.filter((comment) => comment.filePath === activeFile.relativePath),
     [activeFile.relativePath, diffComments]
@@ -264,11 +266,7 @@ export function EditorPanelHeader({
                     ? 'bg-accent text-foreground'
                     : 'text-muted-foreground'
                 }`}
-                onClick={() =>
-                  updateSettings({
-                    markdownPreviewLightBackground: !markdownPreviewLightBackground
-                  })
-                }
+                onClick={toggleMarkdownPreviewLightBackground}
                 aria-label={translate(
                   'auto.components.editor.EditorPanelHeader.markdownPreviewLightBackground',
                   'Markdown Preview Light Background'
@@ -300,11 +298,7 @@ export function EditorPanelHeader({
         markdownPreviewLightBackground={markdownPreviewLightBackground}
         onToggleDiffWordWrap={() => void updateSettings({ diffWordWrap: !diffWordWrap })}
         onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
-        onToggleMarkdownPreviewLightBackground={() =>
-          updateSettings({
-            markdownPreviewLightBackground: !markdownPreviewLightBackground
-          })
-        }
+        onToggleMarkdownPreviewLightBackground={toggleMarkdownPreviewLightBackground}
         onExportMarkdownToPdf={onExportMarkdownToPdf}
       />
     </div>

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Columns2, Eye, FileText, ListTree, Rows2 } from 'lucide-react'
+import { Columns2, Eye, FileText, ListTree, Rows2, Sun } from 'lucide-react'
 import { useAppStore } from '@/store'
 import type { OpenFile } from '@/store/slices/editor'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -27,6 +27,8 @@ type EditorPanelHeaderProps = {
   effectiveToggleValue: EditorToggleValue
   canOpenPreviewToSide: boolean
   canShowMarkdownPreview: boolean
+  isMarkdownPreviewSurface: boolean
+  isRichMarkdownSurface: boolean
   canShowMarkdownTableOfContents: boolean
   isMarkdownTableOfContentsDisabled: boolean
   shouldShowMarkdownExportAction: boolean
@@ -61,6 +63,8 @@ export function EditorPanelHeader({
   effectiveToggleValue,
   canOpenPreviewToSide,
   canShowMarkdownPreview,
+  isMarkdownPreviewSurface,
+  isRichMarkdownSurface,
   canShowMarkdownTableOfContents,
   isMarkdownTableOfContentsDisabled,
   shouldShowMarkdownExportAction,
@@ -85,6 +89,9 @@ export function EditorPanelHeader({
   const activeGroupId = useAppStore((s) => s.activeGroupIdByWorktree[activeFile.worktreeId])
   const diffWordWrap = useAppStore((s) => s.settings?.diffWordWrap === true)
   const updateSettings = useAppStore((s) => s.updateSettings)
+  const markdownPreviewLightBackground = useAppStore(
+    (s) => !!s.settings?.markdownPreviewLightBackground
+  )
   const fileDiffComments = useMemo(
     () => diffComments.filter((comment) => comment.filePath === activeFile.relativePath),
     [activeFile.relativePath, diffComments]
@@ -246,16 +253,58 @@ export function EditorPanelHeader({
           </Tooltip>
         </TooltipProvider>
       )}
+      {isMarkdown && !isDiffSurface && (isMarkdownPreviewSurface || isRichMarkdownSurface) && (
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className={`p-1 rounded hover:bg-accent hover:text-foreground transition-colors flex-shrink-0 ${
+                  markdownPreviewLightBackground
+                    ? 'bg-accent text-foreground'
+                    : 'text-muted-foreground'
+                }`}
+                onClick={() =>
+                  updateSettings({
+                    markdownPreviewLightBackground: !markdownPreviewLightBackground
+                  })
+                }
+                aria-label={translate(
+                  'auto.components.editor.EditorPanelHeader.markdownPreviewLightBackground',
+                  'Markdown Preview Light Background'
+                )}
+                aria-pressed={markdownPreviewLightBackground}
+              >
+                <Sun size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={4}>
+              {translate(
+                'auto.components.editor.EditorPanelHeader.markdownPreviewLightBackground',
+                'Markdown Preview Light Background'
+              )}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
       <EditorPanelMarkdownActionsMenu
         isMarkdown={isMarkdown}
         isDiffSurface={isDiffSurface}
+        isMarkdownPreviewSurface={isMarkdownPreviewSurface}
+        isRichMarkdownSurface={isRichMarkdownSurface}
         diffWordWrap={diffWordWrap}
         shouldShowMarkdownExportAction={shouldShowMarkdownExportAction}
         canExportMarkdownToPdf={canExportMarkdownToPdf}
         canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={markdownFrontmatterVisible}
+        markdownPreviewLightBackground={markdownPreviewLightBackground}
         onToggleDiffWordWrap={() => void updateSettings({ diffWordWrap: !diffWordWrap })}
         onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
+        onToggleMarkdownPreviewLightBackground={() =>
+          updateSettings({
+            markdownPreviewLightBackground: !markdownPreviewLightBackground
+          })
+        }
         onExportMarkdownToPdf={onExportMarkdownToPdf}
       />
     </div>

--- a/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
@@ -43,7 +43,8 @@ export function EditorPanelMarkdownActionsMenu({
   onToggleMarkdownPreviewLightBackground,
   onExportMarkdownToPdf
 }: EditorPanelMarkdownActionsMenuProps): React.JSX.Element | null {
-  const isLightBackgroundEligibleSurface = isMarkdownPreviewSurface || isRichMarkdownSurface
+  const isLightBackgroundEligibleSurface =
+    !isDiffSurface && (isMarkdownPreviewSurface || isRichMarkdownSurface)
   const hasMarkdownActions =
     isMarkdown &&
     (shouldShowMarkdownExportAction ||
@@ -101,19 +102,24 @@ export function EditorPanelMarkdownActionsMenu({
                     'Show front matter'
                   )}
             </DropdownMenuItem>
-            {shouldShowMarkdownExportAction ? <DropdownMenuSeparator /> : null}
+            {shouldShowMarkdownExportAction && !isLightBackgroundEligibleSurface ? (
+              <DropdownMenuSeparator />
+            ) : null}
           </>
         ) : null}
         {isMarkdown && isLightBackgroundEligibleSurface ? (
-          <DropdownMenuCheckboxItem
-            checked={markdownPreviewLightBackground}
-            onCheckedChange={onToggleMarkdownPreviewLightBackground}
-          >
-            {translate(
-              'auto.components.editor.EditorPanelMarkdownActionsMenu.markdownPreviewLightBackground',
-              'Light background'
-            )}
-          </DropdownMenuCheckboxItem>
+          <>
+            <DropdownMenuCheckboxItem
+              checked={markdownPreviewLightBackground}
+              onCheckedChange={onToggleMarkdownPreviewLightBackground}
+            >
+              {translate(
+                'auto.components.editor.EditorPanelMarkdownActionsMenu.markdownPreviewLightBackground',
+                'Light background'
+              )}
+            </DropdownMenuCheckboxItem>
+            {shouldShowMarkdownExportAction ? <DropdownMenuSeparator /> : null}
+          </>
         ) : null}
         {shouldShowMarkdownExportAction ? (
           <DropdownMenuItem

--- a/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
@@ -13,30 +13,42 @@ import { translate } from '@/i18n/i18n'
 type EditorPanelMarkdownActionsMenuProps = {
   isMarkdown: boolean
   isDiffSurface: boolean
+  isMarkdownPreviewSurface: boolean
+  isRichMarkdownSurface: boolean
   diffWordWrap: boolean
   shouldShowMarkdownExportAction: boolean
   canExportMarkdownToPdf: boolean
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
+  markdownPreviewLightBackground: boolean
   onToggleDiffWordWrap: () => void
   onToggleMarkdownFrontmatter: () => void
+  onToggleMarkdownPreviewLightBackground: () => void
   onExportMarkdownToPdf: () => void
 }
 
 export function EditorPanelMarkdownActionsMenu({
   isMarkdown,
   isDiffSurface,
+  isMarkdownPreviewSurface,
+  isRichMarkdownSurface,
   diffWordWrap,
   shouldShowMarkdownExportAction,
   canExportMarkdownToPdf,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
+  markdownPreviewLightBackground,
   onToggleDiffWordWrap,
   onToggleMarkdownFrontmatter,
+  onToggleMarkdownPreviewLightBackground,
   onExportMarkdownToPdf
 }: EditorPanelMarkdownActionsMenuProps): React.JSX.Element | null {
+  const isLightBackgroundEligibleSurface = isMarkdownPreviewSurface || isRichMarkdownSurface
   const hasMarkdownActions =
-    isMarkdown && (shouldShowMarkdownExportAction || canShowMarkdownFrontmatterToggle)
+    isMarkdown &&
+    (shouldShowMarkdownExportAction ||
+      canShowMarkdownFrontmatterToggle ||
+      isLightBackgroundEligibleSurface)
   if (!isDiffSurface && !hasMarkdownActions) {
     return null
   }
@@ -91,6 +103,17 @@ export function EditorPanelMarkdownActionsMenu({
             </DropdownMenuItem>
             {shouldShowMarkdownExportAction ? <DropdownMenuSeparator /> : null}
           </>
+        ) : null}
+        {isMarkdown && isLightBackgroundEligibleSurface ? (
+          <DropdownMenuCheckboxItem
+            checked={markdownPreviewLightBackground}
+            onCheckedChange={onToggleMarkdownPreviewLightBackground}
+          >
+            {translate(
+              'auto.components.editor.EditorPanelMarkdownActionsMenu.markdownPreviewLightBackground',
+              'Light background'
+            )}
+          </DropdownMenuCheckboxItem>
         ) : null}
         {shouldShowMarkdownExportAction ? (
           <DropdownMenuItem

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -108,6 +108,8 @@ export function EditorPanelShell({
           effectiveToggleValue={model.effectiveToggleValue}
           canOpenPreviewToSide={model.canOpenPreviewToSide}
           canShowMarkdownPreview={model.canShowMarkdownPreview}
+          isMarkdownPreviewSurface={model.isMarkdownPreviewSurface}
+          isRichMarkdownSurface={model.isRichMarkdownSurface}
           canShowMarkdownTableOfContents={model.canShowMarkdownTableOfContents}
           isMarkdownTableOfContentsDisabled={model.isMarkdownTableOfContentsDisabled}
           shouldShowMarkdownExportAction={model.shouldShowMarkdownExportAction}

--- a/src/renderer/src/components/editor/MarkdownPreview.test.ts
+++ b/src/renderer/src/components/editor/MarkdownPreview.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import type { Worktree } from '../../../../shared/types'
 import {
   decodeMarkdownPreviewAnchor,
@@ -10,6 +11,36 @@ import {
   resolveMarkdownPreviewSourceWorktree
 } from './MarkdownPreview'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+
+// Additional tests for markdownPreviewLightBackground flag (per plan for issue #1).
+// We render the real MarkdownPreview to verify the class applied to the preview
+// container is controlled by the flag (light forced) vs app theme.
+
+// Mocks must be hoisted before any imports that use them.
+vi.mock('@/store', () => {
+  const useAppStore: any = vi.fn()
+  return { useAppStore }
+})
+vi.mock('@/store/slices/worktree-helpers', () => ({ findWorktreeById: () => null }))
+vi.mock('@/runtime/runtime-rpc-client', () => ({ settingsForRuntimeOwner: (s: any) => s }))
+vi.mock('@/runtime/runtime-file-client', () => ({ statRuntimePath: vi.fn(async () => ({ isDirectory: false })) }))
+vi.mock('@/lib/connection-context', () => ({ getConnectionId: () => null }))
+vi.mock('@/i18n/i18n', () => ({ translate: (_k: string, fb: string) => fb }))
+vi.mock('./useLocalImageSrc', () => ({ useLocalImageSrc: (src?: string) => src }))
+vi.mock('./MermaidBlock', () => ({ default: () => null }))
+vi.mock('./CodeBlockCopyButton', () => ({ default: ({ children }: { children: any }) => children }))
+vi.mock('../diff-comments/DiffCommentCard', () => ({ DiffCommentCard: () => null }))
+vi.mock('./NotesSendMenu', () => ({ NotesSendMenu: () => null }))
+vi.mock('./MarkdownTableOfContentsPanel', () => ({ MarkdownTableOfContentsPanel: () => null }))
+vi.mock('./usePreserveSectionDuringExternalEdit', () => ({
+  usePreserveSectionDuringExternalEdit: (c: string) => c
+}))
+
+import MarkdownPreview from './MarkdownPreview'
+import { useAppStore } from '@/store'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import * as React from 'react'
 
 function makeWorktree(id: string, path: string): Worktree {
   return {
@@ -170,5 +201,114 @@ describe('MarkdownPreview source link routing', () => {
     }
 
     expect(getMarkdownPreviewAnchorScrollTop(container, target)).toBe(493)
+  })
+})
+
+// --- markdownPreviewLightBackground flag + isolated class tests ---
+
+const mockSettingsBase = {
+  theme: 'dark' as const,
+  markdownPreviewLightBackground: false
+}
+
+let containerEl: HTMLDivElement
+let root: any
+
+function setupStore(overrides: { markdownPreviewLightBackground?: boolean; theme?: 'dark' | 'light' | 'system' } = {}) {
+  const settings = { ...mockSettingsBase, ...overrides }
+  const storeState = {
+    settings,
+    openFile: vi.fn(),
+    activateMarkdownLink: vi.fn(),
+    openMarkdownPreview: vi.fn(),
+    setMarkdownViewMode: vi.fn(),
+    markdownFrontmatterVisible: {},
+    setPendingEditorReveal: vi.fn(),
+    addDiffComment: vi.fn(),
+    deleteDiffComment: vi.fn(),
+    updateDiffComment: vi.fn(),
+    clearDeliveredDiffComments: vi.fn(),
+    keybindings: {},
+    worktreesByRepo: {},
+    openFiles: [],
+    activeFileIdByWorktree: {},
+    editorFontZoomLevel: 0
+  }
+  vi.mocked(useAppStore).mockImplementation((selector: any) => selector(storeState))
+  // also support getState if used
+  ;(useAppStore as any).getState = () => storeState
+  return storeState
+}
+
+describe('MarkdownPreview light background flag (isolated surface)', () => {
+  beforeEach(() => {
+    containerEl = document.createElement('div')
+    document.body.appendChild(containerEl)
+    // default to dark app theme
+    setupStore({ markdownPreviewLightBackground: false, theme: 'dark' })
+  })
+
+  afterEach(() => {
+    if (root) {
+      root.unmount()
+    }
+    if (containerEl && containerEl.parentNode) {
+      containerEl.parentNode.removeChild(containerEl)
+    }
+    vi.clearAllMocks()
+  })
+
+  it('renders with markdown-dark class by default (follows app dark theme)', async () => {
+    await act(async () => {
+      root = createRoot(containerEl)
+      root.render(
+        React.createElement(MarkdownPreview as any, {
+          content: '# hi',
+          filePath: '/tmp/test.md',
+          scrollCacheKey: 'test-dark'
+        })
+      )
+    })
+    // allow effects
+    await act(async () => {})
+    const preview = containerEl.querySelector('.markdown-preview')
+    expect(preview?.className).toContain('markdown-dark')
+    expect(preview?.className).not.toContain('markdown-light') // when not forced
+  })
+
+  it('renders with markdown-light class when markdownPreviewLightBackground is true (even on dark app theme)', async () => {
+    setupStore({ markdownPreviewLightBackground: true, theme: 'dark' })
+    await act(async () => {
+      root = createRoot(containerEl)
+      root.render(
+        React.createElement(MarkdownPreview as any, {
+          content: '# hi light',
+          filePath: '/tmp/test.md',
+          scrollCacheKey: 'test-light'
+        })
+      )
+    })
+    await act(async () => {})
+    const preview = containerEl.querySelector('.markdown-preview')
+    expect(preview?.className).toContain('markdown-light')
+    // does not have dark
+    expect(preview?.className).not.toContain('markdown-dark')
+  })
+
+  it('uses markdown-light when app is light and flag is unset (follows theme)', async () => {
+    setupStore({ markdownPreviewLightBackground: false, theme: 'light' })
+    await act(async () => {
+      root = createRoot(containerEl)
+      root.render(
+        React.createElement(MarkdownPreview as any, {
+          content: '# hi',
+          filePath: '/tmp/test.md',
+          scrollCacheKey: 'test-light-app'
+        })
+      )
+    })
+    await act(async () => {})
+    const preview = containerEl.querySelector('.markdown-preview')
+    expect(preview?.className).toContain('markdown-light')
   })
 })

--- a/src/renderer/src/components/editor/MarkdownPreview.test.ts
+++ b/src/renderer/src/components/editor/MarkdownPreview.test.ts
@@ -293,6 +293,9 @@ describe('MarkdownPreview light background flag (isolated surface)', () => {
     expect(preview?.className).toContain('markdown-light')
     // does not have dark
     expect(preview?.className).not.toContain('markdown-dark')
+    // TOC shell receives light class too for visual continuity (see UI review)
+    const shell = containerEl.querySelector('.markdown-preview-shell')
+    expect(shell?.className).toContain('markdown-light')
   })
 
   it('uses markdown-light when app is light and flag is unset (follows theme)', async () => {

--- a/src/renderer/src/components/editor/MarkdownPreview.test.ts
+++ b/src/renderer/src/components/editor/MarkdownPreview.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach, type Mock } from 'vitest'
 import type { Worktree } from '../../../../shared/types'
 import {
   decodeMarkdownPreviewAnchor,
@@ -18,17 +18,22 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 
 // Mocks must be hoisted before any imports that use them.
 vi.mock('@/store', () => {
-  const useAppStore: any = vi.fn()
+  const useAppStore = vi.fn()
   return { useAppStore }
 })
-vi.mock('@/store/slices/worktree-helpers', () => ({ findWorktreeById: () => null }))
-vi.mock('@/runtime/runtime-rpc-client', () => ({ settingsForRuntimeOwner: (s: any) => s }))
-vi.mock('@/runtime/runtime-file-client', () => ({ statRuntimePath: vi.fn(async () => ({ isDirectory: false })) }))
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  settingsForRuntimeOwner: (s: unknown) => s
+}))
+vi.mock('@/runtime/runtime-file-client', () => ({
+  statRuntimePath: vi.fn(async () => ({ isDirectory: false }))
+}))
 vi.mock('@/lib/connection-context', () => ({ getConnectionId: () => null }))
 vi.mock('@/i18n/i18n', () => ({ translate: (_k: string, fb: string) => fb }))
 vi.mock('./useLocalImageSrc', () => ({ useLocalImageSrc: (src?: string) => src }))
 vi.mock('./MermaidBlock', () => ({ default: () => null }))
-vi.mock('./CodeBlockCopyButton', () => ({ default: ({ children }: { children: any }) => children }))
+vi.mock('./CodeBlockCopyButton', () => ({
+  default: ({ children }: { children: React.ReactNode }) => children
+}))
 vi.mock('../diff-comments/DiffCommentCard', () => ({ DiffCommentCard: () => null }))
 vi.mock('./NotesSendMenu', () => ({ NotesSendMenu: () => null }))
 vi.mock('./MarkdownTableOfContentsPanel', () => ({ MarkdownTableOfContentsPanel: () => null }))
@@ -38,7 +43,7 @@ vi.mock('./usePreserveSectionDuringExternalEdit', () => ({
 
 import MarkdownPreview from './MarkdownPreview'
 import { useAppStore } from '@/store'
-import { createRoot } from 'react-dom/client'
+import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 import * as React from 'react'
 
@@ -212,9 +217,11 @@ const mockSettingsBase = {
 }
 
 let containerEl: HTMLDivElement
-let root: any
+let root: Root | null = null
 
-function setupStore(overrides: { markdownPreviewLightBackground?: boolean; theme?: 'dark' | 'light' | 'system' } = {}) {
+function setupStore(
+  overrides: { markdownPreviewLightBackground?: boolean; theme?: 'dark' | 'light' | 'system' } = {}
+) {
   const settings = { ...mockSettingsBase, ...overrides }
   const storeState = {
     settings,
@@ -234,9 +241,14 @@ function setupStore(overrides: { markdownPreviewLightBackground?: boolean; theme
     activeFileIdByWorktree: {},
     editorFontZoomLevel: 0
   }
-  vi.mocked(useAppStore).mockImplementation((selector: any) => selector(storeState))
+  // Store fixture is intentionally partial (only fields this component reads),
+  // so the mock is typed against `unknown` rather than the full AppState shape.
+  const mockedUseAppStore = useAppStore as unknown as Mock<
+    (selector: (state: unknown) => unknown) => unknown
+  >
+  mockedUseAppStore.mockImplementation((selector) => selector(storeState))
   // also support getState if used
-  ;(useAppStore as any).getState = () => storeState
+  Object.assign(useAppStore, { getState: () => storeState })
   return storeState
 }
 
@@ -262,7 +274,7 @@ describe('MarkdownPreview light background flag (isolated surface)', () => {
     await act(async () => {
       root = createRoot(containerEl)
       root.render(
-        React.createElement(MarkdownPreview as any, {
+        React.createElement(MarkdownPreview, {
           content: '# hi',
           filePath: '/tmp/test.md',
           scrollCacheKey: 'test-dark'
@@ -281,7 +293,7 @@ describe('MarkdownPreview light background flag (isolated surface)', () => {
     await act(async () => {
       root = createRoot(containerEl)
       root.render(
-        React.createElement(MarkdownPreview as any, {
+        React.createElement(MarkdownPreview, {
           content: '# hi light',
           filePath: '/tmp/test.md',
           scrollCacheKey: 'test-light'
@@ -303,7 +315,7 @@ describe('MarkdownPreview light background flag (isolated surface)', () => {
     await act(async () => {
       root = createRoot(containerEl)
       root.render(
-        React.createElement(MarkdownPreview as any, {
+        React.createElement(MarkdownPreview, {
           content: '# hi',
           filePath: '/tmp/test.md',
           scrollCacheKey: 'test-light-app'

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -544,9 +544,7 @@ export default function MarkdownPreview({
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
-  // Why: the light-preview flag forces an isolated reading surface using
-  // .markdown-light only on this container; false follows app theme via isDark.
-  // Never mutates global document theme.
+  // Why: forces .markdown-light on this container only (never the global theme).
   const lightPreview = !!settings?.markdownPreviewLightBackground
   const previewThemeClass = lightPreview || !isDark ? 'markdown-light' : 'markdown-dark'
   // Why: mermaid (and any future dark-aware preview children) must use light theme

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -548,7 +548,11 @@ export default function MarkdownPreview({
   // .markdown-light only on this container; false follows app theme via isDark.
   // Never mutates global document theme.
   const lightPreview = !!settings?.markdownPreviewLightBackground
-  const previewThemeClass = lightPreview ? 'markdown-light' : (isDark ? 'markdown-dark' : 'markdown-light')
+  const previewThemeClass = lightPreview
+    ? 'markdown-light'
+    : isDark
+      ? 'markdown-dark'
+      : 'markdown-light'
   // Why: mermaid (and any future dark-aware preview children) must use light theme
   // when lightPreview forces the reading surface light, regardless of app theme.
   const effectiveIsDark = lightPreview ? false : isDark
@@ -1538,7 +1542,11 @@ export default function MarkdownPreview({
       code: ({ className, children, ...props }) => {
         if (/language-mermaid/.test(className || '')) {
           return (
-            <MermaidBlock content={String(children).trimEnd()} isDark={effectiveIsDark} htmlLabels={false} />
+            <MermaidBlock
+              content={String(children).trimEnd()}
+              isDark={effectiveIsDark}
+              htmlLabels={false}
+            />
           )
         }
         return (
@@ -1689,8 +1697,13 @@ export default function MarkdownPreview({
     wrapAnnotatedBlock
   ])
 
+  const lightSurfaceStyle = lightPreview ? { background: '#ffffff', color: '#24292f' } : undefined
+
   return (
-    <div className={`markdown-preview-shell${lightPreview ? ' markdown-light' : ''}`}>
+    <div
+      className={`markdown-preview-shell${lightPreview ? ' markdown-light' : ''}`}
+      style={lightSurfaceStyle}
+    >
       {showTableOfContents ? (
         <MarkdownTableOfContentsPanel
           items={tableOfContentsItems}
@@ -1701,8 +1714,8 @@ export default function MarkdownPreview({
       <div
         ref={setRootRef}
         tabIndex={0}
-        style={{ fontSize: `${editorFontSize}px` }}
-        className={`markdown-preview h-full min-h-0 overflow-auto scrollbar-editor ${previewThemeClass}`}
+        style={{ fontSize: `${editorFontSize}px`, ...lightSurfaceStyle }}
+        className={`markdown-preview h-full min-h-0 overflow-auto scrollbar-editor flex-1 ${previewThemeClass}`}
       >
         {isSearchOpen ? (
           <div className="markdown-preview-search" onKeyDown={(event) => event.stopPropagation()}>
@@ -1849,7 +1862,11 @@ export default function MarkdownPreview({
             ) : null}
           </div>
         ) : null}
-        <div ref={bodyRef} className="markdown-body">
+        <div
+          ref={bodyRef}
+          className={`markdown-body${lightPreview ? ' markdown-light' : ''}`}
+          style={lightSurfaceStyle}
+        >
           {/* Why: remarkFrontmatter strips front matter from normal markdown
         output. When the user opts in from the preview actions menu, render the
         raw metadata as a compact read-only block above the document body. */}

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -549,6 +549,9 @@ export default function MarkdownPreview({
   // Never mutates global document theme.
   const lightPreview = !!settings?.markdownPreviewLightBackground
   const previewThemeClass = lightPreview ? 'markdown-light' : (isDark ? 'markdown-dark' : 'markdown-light')
+  // Why: mermaid (and any future dark-aware preview children) must use light theme
+  // when lightPreview forces the reading surface light, regardless of app theme.
+  const effectiveIsDark = lightPreview ? false : isDark
 
   const renderedContent = usePreserveSectionDuringExternalEdit(content, bodyRef)
 
@@ -1535,7 +1538,7 @@ export default function MarkdownPreview({
       code: ({ className, children, ...props }) => {
         if (/language-mermaid/.test(className || '')) {
           return (
-            <MermaidBlock content={String(children).trimEnd()} isDark={isDark} htmlLabels={false} />
+            <MermaidBlock content={String(children).trimEnd()} isDark={effectiveIsDark} htmlLabels={false} />
           )
         }
         return (
@@ -1665,7 +1668,7 @@ export default function MarkdownPreview({
   }, [
     filePath,
     activateMarkdownLink,
-    isDark,
+    effectiveIsDark,
     isMac,
     imageRuntimeContext,
     getMarkdownCommentsForRange,
@@ -1687,7 +1690,7 @@ export default function MarkdownPreview({
   ])
 
   return (
-    <div className="markdown-preview-shell">
+    <div className={`markdown-preview-shell${lightPreview ? ' markdown-light' : ''}`}>
       {showTableOfContents ? (
         <MarkdownTableOfContentsPanel
           items={tableOfContentsItems}

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -548,11 +548,7 @@ export default function MarkdownPreview({
   // .markdown-light only on this container; false follows app theme via isDark.
   // Never mutates global document theme.
   const lightPreview = !!settings?.markdownPreviewLightBackground
-  const previewThemeClass = lightPreview
-    ? 'markdown-light'
-    : isDark
-      ? 'markdown-dark'
-      : 'markdown-light'
+  const previewThemeClass = lightPreview || !isDark ? 'markdown-light' : 'markdown-dark'
   // Why: mermaid (and any future dark-aware preview children) must use light theme
   // when lightPreview forces the reading surface light, regardless of app theme.
   const effectiveIsDark = lightPreview ? false : isDark

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -544,6 +544,12 @@ export default function MarkdownPreview({
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
+  // Why: the light-preview flag forces an isolated reading surface using
+  // .markdown-light only on this container; false follows app theme via isDark.
+  // Never mutates global document theme.
+  const lightPreview = !!settings?.markdownPreviewLightBackground
+  const previewThemeClass = lightPreview ? 'markdown-light' : (isDark ? 'markdown-dark' : 'markdown-light')
+
   const renderedContent = usePreserveSectionDuringExternalEdit(content, bodyRef)
 
   useEffect(() => {
@@ -1693,7 +1699,7 @@ export default function MarkdownPreview({
         ref={setRootRef}
         tabIndex={0}
         style={{ fontSize: `${editorFontSize}px` }}
-        className={`markdown-preview h-full min-h-0 overflow-auto scrollbar-editor ${isDark ? 'markdown-dark' : 'markdown-light'}`}
+        className={`markdown-preview h-full min-h-0 overflow-auto scrollbar-editor ${previewThemeClass}`}
       >
         {isSearchOpen ? (
           <div className="markdown-preview-search" onKeyDown={(event) => event.stopPropagation()}>

--- a/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.tsx
+++ b/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.tsx
@@ -79,7 +79,7 @@ function MarkdownTocRow({
           >
             <ChevronRight
               className={cn(
-                'size-3 shrink-0 text-muted-foreground transition-transform',
+                'size-3 shrink-0 text-muted-foreground markdown-toc-icon transition-transform',
                 expanded && 'rotate-90'
               )}
             />
@@ -171,7 +171,7 @@ export function MarkdownTableOfContentsPanel({
       )}
     >
       <div className="markdown-toc-header">
-        <ListTree className="size-3.5 text-muted-foreground" />
+        <ListTree className="size-3.5 text-muted-foreground markdown-toc-icon" />
         <span>
           {translate(
             'auto.components.editor.MarkdownTableOfContentsPanel.06357eea60',

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -73,6 +73,7 @@ export default function RichMarkdownEditor({
 }: RichMarkdownEditorProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
   const settings = useAppStore((s) => s.settings)
+  const markdownPreviewLightBackground = !!settings?.markdownPreviewLightBackground
   const richMarkdownSpellcheckEnabled = settings?.richMarkdownSpellcheckEnabled ?? true
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const activateMarkdownLink = useAppStore((s) => s.activateMarkdownLink)
@@ -352,6 +353,7 @@ export default function RichMarkdownEditor({
     <RichMarkdownEditorSurface
       editor={editor}
       editorFontZoomLevel={editorFontZoomLevel}
+      lightBackground={markdownPreviewLightBackground}
       rootRef={setRootElement}
       scrollContainerRef={scrollContainerRef}
       headerSlot={headerSlot}

--- a/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
@@ -37,6 +37,7 @@ function shouldFocusEmptyEditorFromSurfaceClick(
 type RichMarkdownEditorSurfaceProps = {
   editor: Editor | null
   editorFontZoomLevel: number
+  lightBackground: boolean
   rootRef: (node: HTMLDivElement | null) => void
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
   headerSlot?: React.ReactNode
@@ -119,6 +120,7 @@ type RichMarkdownEditorSurfaceProps = {
 export function RichMarkdownEditorSurface({
   editor,
   editorFontZoomLevel,
+  lightBackground,
   rootRef,
   scrollContainerRef,
   headerSlot,
@@ -184,7 +186,7 @@ export function RichMarkdownEditorSurface({
         ref={rootRef}
         className={`rich-markdown-editor-shell ${
           reviewRailExpanded ? 'has-rich-markdown-review-notes' : ''
-        }`.trim()}
+        } ${lightBackground ? 'markdown-light' : ''}`.trim()}
         style={{ '--editor-font-zoom-level': editorFontZoomLevel } as React.CSSProperties}
       >
         <RichMarkdownToolbar

--- a/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
@@ -174,7 +174,9 @@ export function RichMarkdownEditorSurface({
   onCloseTableOfContents
 }: RichMarkdownEditorSurfaceProps): React.JSX.Element {
   return (
-    <div className="rich-markdown-editor-layout">
+    <div
+      className={`rich-markdown-editor-layout ${lightBackground ? 'markdown-light' : ''}`.trim()}
+    >
       {showTableOfContents ? (
         <MarkdownTableOfContentsPanel
           items={tableOfContentsItems}

--- a/src/renderer/src/components/editor/editor-panel-render-model.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.test.ts
@@ -120,3 +120,54 @@ describe('getEditorPanelRenderModel markdown export affordance', () => {
     ).toBe(false)
   })
 })
+
+describe('getEditorPanelRenderModel isMarkdownPreviewSurface', () => {
+  it('is false for a markdown file open in edit (source/rich) mode', () => {
+    expect(
+      renderModel({ activeFile: markdownFile({ mode: 'edit' }) }).isMarkdownPreviewSurface
+    ).toBe(false)
+  })
+
+  it('is true for a markdown file open in markdown-preview mode', () => {
+    const preview = markdownFile({
+      id: 'preview:/repo/README.md',
+      mode: 'markdown-preview',
+      markdownPreviewSourceFileId: '/repo/README.md'
+    } as Partial<OpenFile>)
+
+    expect(renderModel({ activeFile: preview }).isMarkdownPreviewSurface).toBe(true)
+  })
+})
+
+describe('getEditorPanelRenderModel isRichMarkdownSurface', () => {
+  it('is true when a markdown edit tab renders the rich editor', () => {
+    const model = renderModel({ markdownViewMode: { '/repo/README.md': 'rich' } })
+
+    expect(model.isRichMarkdownSurface).toBe(true)
+  })
+
+  it('is false when the markdown edit tab renders source (Monaco)', () => {
+    const model = renderModel({ markdownViewMode: { '/repo/README.md': 'source' } })
+
+    expect(model.isRichMarkdownSurface).toBe(false)
+  })
+
+  it('is false for a large file that falls back to source despite rich view mode', () => {
+    const model = renderModel({
+      markdownViewMode: { '/repo/README.md': 'rich' },
+      editorDrafts: { '/repo/README.md': `${'a'.repeat(RICH_MARKDOWN_MAX_SIZE_BYTES)}é` }
+    })
+
+    expect(model.isRichMarkdownSurface).toBe(false)
+  })
+
+  it('is false for markdown-preview mode (that surface is isMarkdownPreviewSurface instead)', () => {
+    const preview = markdownFile({
+      id: 'preview:/repo/README.md',
+      mode: 'markdown-preview',
+      markdownPreviewSourceFileId: '/repo/README.md'
+    } as Partial<OpenFile>)
+
+    expect(renderModel({ activeFile: preview }).isRichMarkdownSurface).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -162,11 +162,8 @@ export function getEditorPanelRenderModel({
     canShowMarkdownTableOfContents:
       resolvedLanguage === 'markdown' &&
       (hasViewModeToggle || activeFile.mode === 'markdown-preview'),
-    // Why: markdownPreviewLightBackground styles MarkdownPreview and
-    // RichMarkdownEditor. The toggle must only show where one of those two
-    // actually mounts — tied to the same render-mode decision EditorContent
-    // uses, so the control never appears over a surface it can't affect
-    // (Monaco source view has no light styling to apply).
+    // Why: gates the light-background toggle to surfaces it can actually affect
+    // (mirrors EditorContent's render-mode decision; Monaco has no light styling).
     isMarkdownPreviewSurface: activeFile.mode === 'markdown-preview',
     isRichMarkdownSurface: activeFile.mode === 'edit' && inlineMarkdownRenderMode === 'rich-editor',
     canShowMarkdownPreview: canOpenMarkdownPreview({

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -162,6 +162,13 @@ export function getEditorPanelRenderModel({
     canShowMarkdownTableOfContents:
       resolvedLanguage === 'markdown' &&
       (hasViewModeToggle || activeFile.mode === 'markdown-preview'),
+    // Why: markdownPreviewLightBackground styles MarkdownPreview and
+    // RichMarkdownEditor. The toggle must only show where one of those two
+    // actually mounts — tied to the same render-mode decision EditorContent
+    // uses, so the control never appears over a surface it can't affect
+    // (Monaco source view has no light styling to apply).
+    isMarkdownPreviewSurface: activeFile.mode === 'markdown-preview',
+    isRichMarkdownSurface: activeFile.mode === 'edit' && inlineMarkdownRenderMode === 'rich-editor',
     canShowMarkdownPreview: canOpenMarkdownPreview({
       language: resolvedLanguage,
       mode: activeFile.mode,

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -382,37 +382,6 @@ export function GeneralEditorSettingsSection({
           }
         />
       </SearchableSetting>
-
-      {/* Light preview toggle is intentionally after review notes; both are
-          markdown-editor surface controls and keep the editor subsection compact. */}
-      <SearchableSetting
-        title={translate(
-          'auto.components.settings.GeneralEditorSettingsSection.7a2b9c4e1f',
-          'Markdown Preview Light Background'
-        )}
-        description={translate(
-          'auto.components.settings.GeneralEditorSettingsSection.3d8f1a6b2e',
-          'Use a light reading background for markdown file previews (only affects the preview surface).'
-        )}
-        keywords={['markdown', 'preview', 'light', 'background', 'reading']}
-      >
-        <SettingsSwitchRow
-          label={translate(
-            'auto.components.settings.GeneralEditorSettingsSection.7a2b9c4e1f',
-            'Markdown Preview Light Background'
-          )}
-          description={translate(
-            'auto.components.settings.GeneralEditorSettingsSection.3d8f1a6b2e',
-            'Use a light reading background for markdown file previews (only affects the preview surface).'
-          )}
-          checked={!!settings.markdownPreviewLightBackground}
-          onChange={() =>
-            updateSettings({
-              markdownPreviewLightBackground: !settings.markdownPreviewLightBackground
-            })
-          }
-        />
-      </SearchableSetting>
     </section>
   )
 }

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -16,43 +16,18 @@ import {
   SettingsSwitchRow
 } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
+import {
+  createAutoSaveDelayDraftState,
+  resolveAutoSaveDelayDraftState,
+  updateAutoSaveDelayDraftState
+} from './auto-save-delay-draft-state'
 import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
 
-export type AutoSaveDelayDraftState = {
-  sourceDelayMs: number
-  draft: string
-}
-
-export function createAutoSaveDelayDraftState(
-  editorAutoSaveDelayMs: number
-): AutoSaveDelayDraftState {
-  return {
-    sourceDelayMs: editorAutoSaveDelayMs,
-    draft: String(editorAutoSaveDelayMs)
-  }
-}
-
-function resolveAutoSaveDelayDraftState(
-  state: AutoSaveDelayDraftState,
-  editorAutoSaveDelayMs: number
-): AutoSaveDelayDraftState {
-  return state.sourceDelayMs === editorAutoSaveDelayMs
-    ? state
-    : createAutoSaveDelayDraftState(editorAutoSaveDelayMs)
-}
-
-export function updateAutoSaveDelayDraftState(
-  state: AutoSaveDelayDraftState,
-  editorAutoSaveDelayMs: number,
-  draft: string
-): AutoSaveDelayDraftState {
-  return {
-    // Why: settings persistence is async, so a committed draft must stay tied
-    // to the current source until the persisted value reloads.
-    ...resolveAutoSaveDelayDraftState(state, editorAutoSaveDelayMs),
-    draft
-  }
-}
+export {
+  createAutoSaveDelayDraftState,
+  updateAutoSaveDelayDraftState,
+  type AutoSaveDelayDraftState
+} from './auto-save-delay-draft-state'
 
 type GeneralEditorSettingsSectionProps = {
   settings: GlobalSettings

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -407,6 +407,37 @@ export function GeneralEditorSettingsSection({
           }
         />
       </SearchableSetting>
+
+      {/* Light preview toggle is intentionally after review notes; both are
+          markdown-editor surface controls and keep the editor subsection compact. */}
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.7a2b9c4e1f',
+          'Markdown Preview Light Background'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.3d8f1a6b2e',
+          'Use a light reading background for markdown file previews (only affects the preview surface).'
+        )}
+        keywords={['markdown', 'preview', 'light', 'background', 'reading']}
+      >
+        <SettingsSwitchRow
+          label={translate(
+            'auto.components.settings.GeneralEditorSettingsSection.7a2b9c4e1f',
+            'Markdown Preview Light Background'
+          )}
+          description={translate(
+            'auto.components.settings.GeneralEditorSettingsSection.3d8f1a6b2e',
+            'Use a light reading background for markdown file previews (only affects the preview surface).'
+          )}
+          checked={!!settings.markdownPreviewLightBackground}
+          onChange={() =>
+            updateSettings({
+              markdownPreviewLightBackground: !settings.markdownPreviewLightBackground
+            })
+          }
+        />
+      </SearchableSetting>
     </section>
   )
 }

--- a/src/renderer/src/components/settings/auto-save-delay-draft-state.ts
+++ b/src/renderer/src/components/settings/auto-save-delay-draft-state.ts
@@ -1,0 +1,35 @@
+export type AutoSaveDelayDraftState = {
+  sourceDelayMs: number
+  draft: string
+}
+
+export function createAutoSaveDelayDraftState(
+  editorAutoSaveDelayMs: number
+): AutoSaveDelayDraftState {
+  return {
+    sourceDelayMs: editorAutoSaveDelayMs,
+    draft: String(editorAutoSaveDelayMs)
+  }
+}
+
+export function resolveAutoSaveDelayDraftState(
+  state: AutoSaveDelayDraftState,
+  editorAutoSaveDelayMs: number
+): AutoSaveDelayDraftState {
+  return state.sourceDelayMs === editorAutoSaveDelayMs
+    ? state
+    : createAutoSaveDelayDraftState(editorAutoSaveDelayMs)
+}
+
+export function updateAutoSaveDelayDraftState(
+  state: AutoSaveDelayDraftState,
+  editorAutoSaveDelayMs: number,
+  draft: string
+): AutoSaveDelayDraftState {
+  return {
+    // Why: settings persistence is async, so a committed draft must stay tied
+    // to the current source until the persisted value reloads.
+    ...resolveAutoSaveDelayDraftState(state, editorAutoSaveDelayMs),
+    draft
+  }
+}

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -118,5 +118,22 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
       ),
       ...translateSearchKeyword('auto.components.settings.general.search.baa263d6d8', 'agents')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.general.search.markdownPreviewLightBackground',
+      'Markdown Preview Light Background'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.9f2e4c1a7b',
+      'Use a light reading background for markdown file previews.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.d05f629d2c', 'markdown'),
+      ...translateSearchKeyword('auto.components.settings.general.search.8c3d1f9e2a', 'preview'),
+      ...translateSearchKeyword('auto.components.settings.general.search.5e7b2d4f1c', 'light'),
+      ...translateSearchKeyword('auto.components.settings.general.search.2a9c6e8b3d', 'background'),
+      ...translateSearchKeyword('auto.components.settings.general.search.4f1a7c9e5b', 'reading')
+    ]
   }
 ])

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -118,22 +118,5 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
       ),
       ...translateSearchKeyword('auto.components.settings.general.search.baa263d6d8', 'agents')
     ]
-  },
-  {
-    title: translate(
-      'auto.components.settings.general.search.markdownPreviewLightBackground',
-      'Markdown Preview Light Background'
-    ),
-    description: translate(
-      'auto.components.settings.general.search.9f2e4c1a7b',
-      'Use a light reading background for markdown file previews.'
-    ),
-    keywords: [
-      ...translateSearchKeyword('auto.components.settings.general.search.d05f629d2c', 'markdown'),
-      ...translateSearchKeyword('auto.components.settings.general.search.8c3d1f9e2a', 'preview'),
-      ...translateSearchKeyword('auto.components.settings.general.search.5e7b2d4f1c', 'light'),
-      ...translateSearchKeyword('auto.components.settings.general.search.2a9c6e8b3d', 'background'),
-      ...translateSearchKeyword('auto.components.settings.general.search.4f1a7c9e5b', 'reading')
-    ]
   }
 ])

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5164,6 +5164,8 @@
           "4aa4d9fb73": "Wrap long lines in diff editors instead of requiring horizontal scrolling.",
           "bf16ef0af2": "Off",
           "3f6892f307": "On",
+          "7a2b9c4e1f": "Markdown Preview Light Background",
+          "3d8f1a6b2e": "Use a light reading background for markdown file previews (only affects the preview surface).",
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
@@ -7456,6 +7458,8 @@
             "8e593f04fc": "Show a confirmation dialog before a pinned tab is closed.",
             "defaultProjectRuntime": "Default Project Runtime",
             "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "markdownPreviewLightBackground": "Markdown Preview Light Background",
+            "9f2e4c1a7b": "Use a light reading background for markdown file previews.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
@@ -11019,14 +11023,16 @@
           "c98ce191da": "This diff has no modified-side file to open",
           "9b80bbe1de": "Open file tab",
           "f0fd4174b5": "Open file tab to use rich markdown editing",
-          "a10d9b8337": "Open file"
+          "a10d9b8337": "Open file",
+          "markdownPreviewLightBackground": "Markdown Preview Light Background"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "Export as PDF",
           "561251019a": "More actions",
           "8c8b7f5ff5": "Show front matter",
           "10c39d58c1": "Hide front matter",
-          "1eef809708": "Word Wrap"
+          "1eef809708": "Word Wrap",
+          "markdownPreviewLightBackground": "Light background"
         },
         "EditorPanelShell": {
           "e2c4dec350": "Loading editor..."

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5164,6 +5164,8 @@
           "4aa4d9fb73": "Ajuste líneas largas en editores de diferencias en lugar de requerir desplazamiento horizontal.",
           "bf16ef0af2": "Apagado",
           "3f6892f307": "En",
+          "7a2b9c4e1f": "Markdown Preview Light Background",
+          "3d8f1a6b2e": "Use a light reading background for markdown file previews (only affects the preview surface).",
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
@@ -7419,6 +7421,8 @@
             "8e593f04fc": "Muestra un diálogo de confirmación antes de cerrar una pestaña fijada.",
             "defaultProjectRuntime": "Default Project Runtime",
             "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "markdownPreviewLightBackground": "Markdown Preview Light Background",
+            "9f2e4c1a7b": "Use a light reading background for markdown file previews.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
@@ -8825,7 +8829,7 @@
             "b234ab25b4": "No se pudo copiar el archivo al portapapeles",
             "f9d7ca753d": "Copiar rutas",
             "3161c4e425": "carpeta",
-            "e887fa4b2e": "Abrir en terminal"
+            "e887fa4b2e": "Open in Terminal"
           },
           "FileExplorerToolbar": {
             "d238264654": "Mostrar archivos ignorados de Git",
@@ -11019,14 +11023,16 @@
           "c98ce191da": "Esta diferenciación no tiene ningún archivo del lado modificado para abrir",
           "9b80bbe1de": "Abrir pestaña de archivo",
           "f0fd4174b5": "Abra la pestaña de archivo para utilizar la edición de markdowns enriquecida",
-          "a10d9b8337": "Abrir archivo"
+          "a10d9b8337": "Abrir archivo",
+          "markdownPreviewLightBackground": "Markdown Preview Light Background"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "Exportar como PDF",
           "561251019a": "Más acciones",
           "8c8b7f5ff5": "Mostrar portada",
           "10c39d58c1": "Ocultar materia preliminar",
-          "1eef809708": "Ajuste de palabras"
+          "1eef809708": "Ajuste de palabras",
+          "markdownPreviewLightBackground": "Light background"
         },
         "EditorPanelShell": {
           "e2c4dec350": "Cargando editor..."

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5149,6 +5149,8 @@
           "4aa4d9fb73": "水平スクロールを必要とせずに、差分エディターで長い行を折り返します。",
           "bf16ef0af2": "オフ",
           "3f6892f307": "オン",
+          "7a2b9c4e1f": "Markdown Preview Light Background",
+          "3d8f1a6b2e": "Use a light reading background for markdown file previews (only affects the preview surface).",
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
@@ -7441,6 +7443,8 @@
             "8e593f04fc": "ピン留めしたタブを閉じる前に確認ダイアログを表示します。",
             "defaultProjectRuntime": "Default Project Runtime",
             "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
+            "markdownPreviewLightBackground": "Markdown Preview Light Background",
+            "9f2e4c1a7b": "Use a light reading background for markdown file previews.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
@@ -8825,7 +8829,7 @@
             "b234ab25b4": "ファイルをクリップボードにコピーできませんでした",
             "f9d7ca753d": "パスのコピー",
             "3161c4e425": "フォルダ",
-            "e887fa4b2e": "ターミナルで開く"
+            "e887fa4b2e": "Open in Terminal"
           },
           "FileExplorerToolbar": {
             "d238264654": "Git で無視されたファイルを表示",
@@ -11019,14 +11023,16 @@
           "c98ce191da": "この差分には開くための変更側ファイルがありません",
           "9b80bbe1de": "ファイルタブを開く",
           "f0fd4174b5": "ファイル タブを開いてリッチ markdown 編集を使用する",
-          "a10d9b8337": "ファイルを開く"
+          "a10d9b8337": "ファイルを開く",
+          "markdownPreviewLightBackground": "Markdown Preview Light Background"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "PDFとしてエクスポート",
           "561251019a": "その他の操作",
           "8c8b7f5ff5": "前付を表示",
           "10c39d58c1": "前付を隠す",
-          "1eef809708": "ワードラップ"
+          "1eef809708": "ワードラップ",
+          "markdownPreviewLightBackground": "Light background"
         },
         "EditorPanelShell": {
           "e2c4dec350": "エディターを読み込み中..."

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5149,6 +5149,8 @@
           "4aa4d9fb73": "가로 스크롤을 요구하는 대신 diff 편집기에서 긴 줄을 줄 바꿈합니다.",
           "bf16ef0af2": "끄다",
           "3f6892f307": "~에",
+          "7a2b9c4e1f": "Markdown Preview Light Background",
+          "3d8f1a6b2e": "Use a light reading background for markdown file previews (only affects the preview surface).",
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
@@ -7404,6 +7406,8 @@
             "8e593f04fc": "고정된 탭을 닫기 전에 확인 대화상자를 표시합니다.",
             "defaultProjectRuntime": "기본 프로젝트 런타임",
             "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다.",
+            "markdownPreviewLightBackground": "Markdown Preview Light Background",
+            "9f2e4c1a7b": "Use a light reading background for markdown file previews.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
@@ -8825,7 +8829,7 @@
             "b234ab25b4": "파일을 클립보드에 복사하지 못했습니다",
             "f9d7ca753d": "경로 복사",
             "3161c4e425": "폴더",
-            "e887fa4b2e": "터미널에서 열기"
+            "e887fa4b2e": "Open in Terminal"
           },
           "FileExplorerToolbar": {
             "d238264654": "Git이 무시한 파일 표시",
@@ -11019,14 +11023,16 @@
           "c98ce191da": "이 차이점에는 열 수 있는 수정된 측면 파일이 없습니다.",
           "9b80bbe1de": "파일 탭 열기",
           "f0fd4174b5": "풍부한 markdown 편집을 사용하려면 파일 탭을 엽니다.",
-          "a10d9b8337": "파일 열기"
+          "a10d9b8337": "파일 열기",
+          "markdownPreviewLightBackground": "Markdown Preview Light Background"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "PDF로 내보내기",
           "561251019a": "추가 작업",
           "8c8b7f5ff5": "머리말 표시",
           "10c39d58c1": "머리말 숨기기",
-          "1eef809708": "단어 줄 바꿈"
+          "1eef809708": "단어 줄 바꿈",
+          "markdownPreviewLightBackground": "Light background"
         },
         "EditorPanelShell": {
           "e2c4dec350": "편집기 로드 중..."

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5149,6 +5149,8 @@
           "4aa4d9fb73": "在差异编辑器中换行显示长行，而不是要求水平滚动。",
           "bf16ef0af2": "关闭",
           "3f6892f307": "开启",
+          "7a2b9c4e1f": "Markdown Preview Light Background",
+          "3d8f1a6b2e": "Use a light reading background for markdown file previews (only affects the preview surface).",
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
         },
@@ -7404,6 +7406,8 @@
             "8e593f04fc": "关闭固定标签页前显示确认对话框。",
             "defaultProjectRuntime": "默认项目运行时",
             "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。",
+            "markdownPreviewLightBackground": "Markdown Preview Light Background",
+            "9f2e4c1a7b": "Use a light reading background for markdown file previews.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
           }
@@ -8825,7 +8829,7 @@
             "b234ab25b4": "无法将文件复制到剪贴板",
             "f9d7ca753d": "复制路径",
             "3161c4e425": "文件夹",
-            "e887fa4b2e": "在终端中打开"
+            "e887fa4b2e": "Open in Terminal"
           },
           "FileExplorerToolbar": {
             "d238264654": "显示 Git 忽略的文件",
@@ -11019,14 +11023,16 @@
           "c98ce191da": "此差异没有可打开的修改端文件",
           "9b80bbe1de": "打开文件选项卡",
           "f0fd4174b5": "打开文件选项卡以使用丰富的 Markdown 编辑",
-          "a10d9b8337": "打开文件"
+          "a10d9b8337": "打开文件",
+          "markdownPreviewLightBackground": "Markdown Preview Light Background"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "导出为 PDF",
           "561251019a": "更多操作",
           "8c8b7f5ff5": "显示前面的内容",
           "10c39d58c1": "隐藏前面的内容",
-          "1eef809708": "自动换行"
+          "1eef809708": "自动换行",
+          "markdownPreviewLightBackground": "Light background"
         },
         "EditorPanelShell": {
           "e2c4dec350": "正在加载编辑器..."

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -205,6 +205,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorMinimapEnabled: false,
     richMarkdownSpellcheckEnabled: true,
     markdownReviewToolsEnabled: true,
+    markdownPreviewLightBackground: false,
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),
     primarySelectionMiddleClickPasteDefaultedForLinux:
       typeof process !== 'undefined' && process.platform === 'linux',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2476,6 +2476,13 @@ export type GlobalSettings = {
   richMarkdownSpellcheckEnabled?: boolean
   /** Whether local markdown review note controls and the review panel are shown. */
   markdownReviewToolsEnabled: boolean
+  /**
+   * When true, the markdown file preview uses an isolated light background for
+   * comfortable reading. Only the preview surface is affected; app chrome,
+   * terminal, and other UI follow the normal theme. Default (false) follows
+   * current app theme.
+   */
+  markdownPreviewLightBackground?: boolean
   /** Why: mirrors terminal selection-paste muscle memory without mutating the
    *  normal system clipboard; Linux and macOS enable it by default, Windows
    *  leaves middle-click semantics unchanged unless the user opts in. */


### PR DESCRIPTION
## Summary

Add a user-facing, persisted option so the markdown file preview renders its reading surface with a light background. When enabled, only the preview container (and its immediate reading elements: content, search, toolbar, TOC, annotations, code blocks, diagrams, etc.) uses light styling; the rest of Orca (terminal, chrome, other editor surfaces, global theme) remains on the user's configured theme.

## Approach

- Added `markdownPreviewLightBackground` flag to GlobalSettings (types + defaults).
- Wired the flag in MarkdownPreview to force `.markdown-light` class exclusively on the preview shell + content (effectiveIsDark=false for Mermaid when active).
- Extended `.markdown-preview.markdown-light` / `.markdown-light` CSS with comprehensive scoped rules (and icon class) for full isolation of all descendants including annotations, copy buttons, TOC, checkboxes, tables, etc.
- Toggle reachable from the editor header Sun icon and markdown overflow menu (a separate settings-row entry was removed as redundant surface area per UI review).
- Added unit tests asserting the flag controls the class on the correct elements.
- Follow-up clean-code pass: deduped the toggle callback shared by the header button and overflow menu, and simplified the preview theme class ternary to a single positive condition.

This leverages the pre-existing preview isolation architecture (MarkdownPreview + dedicated CSS + settings extension points).

## Changes

| File | Change |
|------|--------|
| `src/shared/types.ts` | Add `markdownPreviewLightBackground?: boolean` to GlobalSettings |
| `src/shared/constants.ts` | Default `markdownPreviewLightBackground: false` in getDefaultSettings |
| `src/renderer/src/components/editor/EditorPanelHeader.tsx` | Sun-icon + overflow-menu toggle, shared callback |
| `src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx` | Overflow menu entry for the toggle |
| `src/renderer/src/components/editor/MarkdownPreview.tsx` | Consume flag; compute previewThemeClass + effectiveIsDark for isolation; pass to Mermaid |
| `src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx` | Apply light class to rich-editor TOC panel ancestor |
| `src/renderer/src/assets/markdown-preview.css` | Comprehensive `.markdown-light` rules (bg, text, search, TOC, annotations, copy buttons, checkboxes, tables, etc.) |
| `src/renderer/src/assets/rich-markdown-editor.css` | Light-surface rules for the rich editor |
| `src/renderer/src/components/editor/MarkdownTableOfContentsPanel.tsx` | Add `markdown-toc-icon` class to icons for light override targeting |
| `src/renderer/src/components/editor/MarkdownPreview.test.ts` | Tests for flag → class on preview container + shell (happy/dark/light cases) |

## AI Code Review Summary

- **Cross-platform (macOS/Linux/Windows):** No platform-specific APIs, paths, or keyboard shortcuts touched. Pure React state + CSS class toggle. Safe on all three.
- **SSH / remote / local:** The preview renders entirely in the renderer process from already-loaded file content; the toggle only flips a locally-persisted UI setting. No new file, process, or network access is introduced, so behavior is identical whether the underlying worktree is local or an SSH-backed remote.
- **Agent / integration / git-provider compatibility:** No agent, CLI-integration, or git-provider-specific code paths are touched. The feature is provider-neutral by construction (a settings flag + CSS).
- **Performance:** Negligible — one boolean read from settings state and a static class-name computation per render; CSS is static (no runtime style computation, no added reflows beyond a normal class toggle).
- **Security:** No new input sinks — the change only reads/writes a boolean in `GlobalSettings` via the existing `updateSettings` path already used by every other preference in this file.
- **UI quality / design-system note (flagging honestly):** The new `.markdown-light` rules in `markdown-preview.css` / `rich-markdown-editor.css` use hardcoded hex/`rgba()` values rather than the CSS custom-property tokens in `src/renderer/src/assets/main.css`, which the project's style guide calls for ("never hardcode a hex value in component code if a variable already covers it"). This was a deliberate scoping choice to keep the light surface visually isolated from the app's dark-mode tokens regardless of the user's active theme, but it does deviate from the documented token convention and a maintainer may want it reworked into dedicated light-surface tokens in `main.css` instead of inline hex.

## Test Results

- Unit tests: relevant MarkdownPreview suite green (14/14) via `vitest run --config config/vitest.config.ts`
- Full suite: `pnpm test` → 23406 passed, 29 skipped, 1 failed (`src/main/daemon/pty-subprocess.test.ts`, a WSL env-snapshot assertion). Confirmed pre-existing and unrelated: reproduces identically on `main` at the same commit, untouched by this diff.
- Lint: `pnpm lint` clean (no `max-lines`, no `no-explicit-any`)
- Type check: `pnpm typecheck` clean
- Build: `pnpm run build:desktop` (the JS/Electron build) completes successfully. `build:native` fails locally on a `lipo` step for the unrelated Swift `computer-use-macos` binary due to a missing cross-arch build artifact in this environment — not something this diff's code touches.

No visual regression testing beyond the automated suite was performed in this environment (headless); screenshots/recording to follow.

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| A user-facing option exists to show markdown file preview with a light reading background | pass — Sun-icon toggle + overflow menu entry |
| When enabled, only the markdown preview reading surface uses the light appearance; terminal, editor chrome, and other UI remain on the user's existing theme | pass — `.markdown-light` scoped to preview/rich-editor shells only; document-theme untouched |
| When disabled or unset, markdown preview behavior matches today's default | pass — falls back to app `isDark` |
| The preference persists across sessions | pass — stored in GlobalSettings via `updateSettings` + `getDefaultSettings` |
| The option applies in the standard markdown file preview experience | pass — same `MarkdownPreview` path used across preview surfaces |


## Screenshots

_light background_

<img width="3680" height="2390" alt="image" src="https://github.com/user-attachments/assets/48507a41-256c-4639-968a-98bf248ea447" />

_dark background_

<img width="3680" height="2390" alt="image" src="https://github.com/user-attachments/assets/4c253041-f228-4fa4-8634-8d6f2709383e" />

## ELI5

Markdown preview can use a light reading background while the rest of Orca stays themed. Only the preview surface goes light when you enable the setting.
