### PR TITLE
[codex] Fix worktree context menu right click

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -669,6 +669,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     >
       {children}
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpenState} modal={false}>
+        {/* Why: viewport coordinates in a body portal avoid offsets from transformed virtualized rows. */}
         {createPortal(
           <DropdownMenuTrigger asChild>
             <button

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: this menu keeps row targeting, batch actions, and ctrl-click event guards together so nested worktree menus share one event policy. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -659,8 +660,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
         contextMenuOpenedAtRef.current = Date.now()
         window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))
         setContextWorktrees(onContextMenuSelect?.(event) ?? effectiveSelectedWorktrees)
-        const bounds = event.currentTarget.getBoundingClientRect()
-        setMenuPoint({ x: event.clientX - bounds.left, y: event.clientY - bounds.top })
+        setMenuPoint({ x: event.clientX, y: event.clientY })
         setMenuOpenState(true)
       }}
       onClickCapture={(event) => {
@@ -669,14 +669,17 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     >
       {children}
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpenState} modal={false}>
-        <DropdownMenuTrigger asChild>
-          <button
-            aria-hidden
-            tabIndex={-1}
-            className="pointer-events-none absolute size-px opacity-0"
-            style={{ left: menuPoint.x, top: menuPoint.y }}
-          />
-        </DropdownMenuTrigger>
+        {createPortal(
+          <DropdownMenuTrigger asChild>
+            <button
+              aria-hidden
+              tabIndex={-1}
+              className="pointer-events-none fixed size-px opacity-0"
+              style={{ left: menuPoint.x, top: menuPoint.y }}
+            />
+          </DropdownMenuTrigger>,
+          document.body
+        )}
         <DropdownMenuContent
           className={cn('w-52', contentClassName)}
           sideOffset={0}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4118,7 +4118,8 @@
           "groupDeleteFailed": "Failed to delete group",
           "groupDeleteFailedDesc": "Something went wrong while deleting the group. No projects were removed.",
           "failedNestWorkspace": "Failed to nest workspace",
-          "sidebarRowMissing": "Target no longer exists"
+          "sidebarRowMissing": "Target no longer exists",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancel",
@@ -6404,8 +6405,6 @@
           "a62b4cb39a": "Save Changes",
           "29af933cd5": "New SSH Target",
           "f2331ce599": "Edit SSH Target",
-          "7c13f58c91": "Until reset",
-          "55c56cf2c7": "Timeout after disconnect (seconds)",
           "4a342f44c1": "Advanced Connection",
           "e9609ddca6": "Proxy, jump host, and connection reuse",
           "8c922dffba": "Reuse SSH connection for faster setup",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6405,6 +6405,8 @@
           "a62b4cb39a": "Save Changes",
           "29af933cd5": "New SSH Target",
           "f2331ce599": "Edit SSH Target",
+          "7c13f58c91": "Until reset",
+          "55c56cf2c7": "Timeout after disconnect (seconds)",
           "4a342f44c1": "Advanced Connection",
           "e9609ddca6": "Proxy, jump host, and connection reuse",
           "8c922dffba": "Reuse SSH connection for faster setup",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6379,8 +6379,6 @@
         "SshTargetForm": {
           "fea9cb402e": "Cancel",
           "1b19b00e93": "Bounded timeouts must be between 60 seconds and 7 days.",
-          "7c13f58c91": "Until reset",
-          "55c56cf2c7": "Timeout after disconnect (seconds)",
           "137e88ce8d": "Remote terminals keep running after Orca disconnects from this host.",
           "b574994adc": "Use End Remote Terminals or Reset Relay when you want to stop them.",
           "71fc546097": "Keep terminals alive until reset",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4095,7 +4095,8 @@
           "hostAuthNeeded": "Autenticación requerida",
           "hostDisconnected": "Desconectado",
           "failedNestWorkspace": "No se pudo anidar el espacio de trabajo",
-          "sidebarRowMissing": "El destino ya no existe"
+          "sidebarRowMissing": "El destino ya no existe",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4076,7 +4076,8 @@
           "hostAuthNeeded": "認証が必要です",
           "hostDisconnected": "切断済み",
           "failedNestWorkspace": "ワークスペースをネストできませんでした",
-          "sidebarRowMissing": "対象はもう存在しません"
+          "sidebarRowMissing": "対象はもう存在しません",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4076,7 +4076,8 @@
           "hostAuthNeeded": "인증 필요",
           "hostDisconnected": "연결 끊김",
           "failedNestWorkspace": "워크스페이스를 중첩하지 못했습니다",
-          "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다"
+          "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "취소",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4076,7 +4076,8 @@
           "hostAuthNeeded": "需要身份验证",
           "hostDisconnected": "已断开连接",
           "failedNestWorkspace": "无法嵌套工作区",
-          "sidebarRowMissing": "目标不再存在"
+          "sidebarRowMissing": "目标不再存在",
+          "failedUnnestWorkspace": "Failed to unnest workspace"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",

--- a/tests/e2e/worktree-context-menu.spec.ts
+++ b/tests/e2e/worktree-context-menu.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady, waitForActiveWorktree } from './helpers/store'
+import { worktreeRowSurface } from './worktree-row-locators'
+
+test.describe('Worktree context menu', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('opens delete actions from a right-click on a non-primary worktree', async ({
+    orcaPage
+  }) => {
+    const worktreeId = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      return (
+        Object.values(state?.worktreesByRepo ?? {})
+          .flat()
+          .find((worktree) => !worktree.isMainWorktree)?.id ?? null
+      )
+    })
+
+    if (!worktreeId) {
+      throw new Error('Expected the seeded E2E repo to include a non-primary worktree')
+    }
+
+    const surface = worktreeRowSurface(orcaPage, worktreeId)
+    await surface.scrollIntoViewIfNeeded()
+    await expect(surface).toBeVisible()
+
+    await surface.click({ button: 'right' })
+
+    await expect(orcaPage.getByRole('menu').filter({ hasText: 'Workspace' })).toBeVisible()
+    await expect(orcaPage.getByRole('menuitem', { name: /^Delete$/ })).toBeVisible()
+  })
+})

--- a/tests/e2e/worktree-context-menu.spec.ts
+++ b/tests/e2e/worktree-context-menu.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from './helpers/orca-app'
 import { waitForSessionReady, waitForActiveWorktree } from './helpers/store'
 import { worktreeRowSurface } from './worktree-row-locators'
 
+const MENU_POSITION_TOLERANCE_PX = 24
+
 test.describe('Worktree context menu', () => {
   test.beforeEach(async ({ orcaPage }) => {
     await waitForSessionReady(orcaPage)
@@ -28,9 +30,28 @@ test.describe('Worktree context menu', () => {
     await surface.scrollIntoViewIfNeeded()
     await expect(surface).toBeVisible()
 
-    await surface.click({ button: 'right' })
+    const surfaceBox = await surface.boundingBox()
+    if (!surfaceBox) {
+      throw new Error('Expected worktree row surface to have a bounding box')
+    }
+    const clickPoint = {
+      x: surfaceBox.x + Math.min(40, Math.max(1, surfaceBox.width / 2)),
+      y: surfaceBox.y + Math.min(20, Math.max(1, surfaceBox.height / 2))
+    }
 
-    await expect(orcaPage.getByRole('menu').filter({ hasText: 'Workspace' })).toBeVisible()
+    await surface.click({
+      button: 'right',
+      position: { x: clickPoint.x - surfaceBox.x, y: clickPoint.y - surfaceBox.y }
+    })
+
+    const menu = orcaPage.getByRole('menu').filter({ hasText: 'Workspace' })
+    await expect(menu).toBeVisible()
+    const menuBox = await menu.boundingBox()
+    if (!menuBox) {
+      throw new Error('Expected worktree context menu to have a bounding box')
+    }
+    expect(Math.abs(menuBox.x - clickPoint.x)).toBeLessThanOrEqual(MENU_POSITION_TOLERANCE_PX)
+    expect(Math.abs(menuBox.y - clickPoint.y)).toBeLessThanOrEqual(MENU_POSITION_TOLERANCE_PX)
     await expect(orcaPage.getByRole('menuitem', { name: /^Delete$/ })).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

Fixes #7115 by anchoring the worktree context-menu trigger in `document.body` with viewport coordinates, so virtualized/transformed sidebar rows no longer offset the hidden Radix dropdown trigger away from the right-click point.

Also syncs the localization catalog key that current `main` needed for `pnpm lint`.

## Screenshots

No visual change; interaction-only fix.

## Testing

- [x] `pnpm lint` (Node 24; existing warnings only)
- [x] `pnpm typecheck` (also covered by `pnpm build`)
- [x] `pnpm test` (Node 24: 23402 passed, 29 skipped)
- [x] `pnpm build` (Node 24; non-fatal local `/usr/local/bin/orca-dev` symlink permission warning)
- [x] Added E2E regression test: `pnpm run test:e2e -- tests/e2e/worktree-context-menu.spec.ts --workers=1`

## AI Review Report

Reviewed the diff for macOS/Linux/Windows behavior, shortcuts/labels/paths/shell behavior, Electron renderer semantics, SSH/local/remote compatibility, supported agent/provider neutrality, performance, and UI quality. Main risk checked: moving the hidden dropdown trigger out of the virtualized row must preserve row selection, nested menu guards, native-context-menu escape hatches, and Radix positioning. Verified those guards remain unchanged and the Electron E2E proves a non-primary worktree right-click opens the menu and exposes Delete.

## Security Audit

No new IPC, command execution, auth, secrets, filesystem path handling, or dependency changes. The change only repositions an existing hidden renderer DOM trigger. No additional security follow-up needed.

## Notes

X handle: @Avichal2205.

## ELI5

Right-clicking a worktree in a virtualized sidebar opened the menu in the wrong place. The menu is anchored to the click coordinates so it appears under the cursor.
