### PR TITLE
Handle Windows SSH directory browsing fallback

### DIFF
--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -209,6 +209,42 @@ describe('registerSshBrowseHandler', () => {
     expect(script).toContain('$dir = $HOME')
   })
 
+  // The renderer rebuilds forward-slash Windows paths with POSIX helpers: the
+  // breadcrumb prepends a spurious leading '/' before the drive, and "Up" from a
+  // first-level dir yields a bare drive letter. Both must be rooted for
+  // Set-Location, or navigation lands in the drive-relative cwd / errors.
+  it.each([
+    { dirPath: '/C:/Users', expected: "$dir = 'C:/Users'" },
+    { dirPath: 'C:', expected: "$dir = 'C:/'" }
+  ])(
+    'roots the Windows drive path $dirPath in the PowerShell fallback',
+    async ({ dirPath, expected }) => {
+      const posixChannel = createMockChannel()
+      const windowsChannel = createMockChannel()
+      const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
+      const getConnectionManager = () => ({
+        getConnection: () => ({ exec })
+      })
+      registerSshBrowseHandler(getConnectionManager as never)
+
+      const resultPromise = handler(null, { targetId: 'ssh-1', dirPath })
+      await Promise.resolve()
+      posixChannel.stderr.emit('data', Buffer.from('"exec" is not recognized'))
+      posixChannel.emit('exit', 9009)
+      posixChannel.emit('close')
+      await vi.waitFor(() => {
+        expect(windowsChannel.listenerCount('close')).toBe(1)
+      })
+      windowsChannel.emit('data', Buffer.from('C:/Users\r\n'))
+      windowsChannel.emit('exit', 0)
+      windowsChannel.emit('close')
+
+      await expect(resultPromise).resolves.toEqual({ resolvedPath: 'C:/Users', entries: [] })
+      const script = decodeEncodedCommand(exec.mock.calls[1]?.[0] ?? '')
+      expect(script).toContain(expected)
+    }
+  )
+
   it('does not retry with PowerShell for an ordinary POSIX browse failure', async () => {
     const channel = createMockChannel()
     const exec = vi.fn().mockResolvedValue(channel)

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -120,12 +120,14 @@ describe('registerSshBrowseHandler', () => {
     })
     // Windows OpenSSH exec emits CRLF; the parser must strip \r so directories
     // aren't misclassified as files with a stray carriage return in the name.
-    windowsChannel.emit('data', Buffer.from('C:\\Users\\alice\r\nDesktop/\r\nnotes.txt\r\n'))
+    // The script emits a forward-slash resolvedPath (the -replace '\\','/' line)
+    // so the renderer's parentPath/joinPath, which only split on `/`, still work.
+    windowsChannel.emit('data', Buffer.from('C:/Users/alice\r\nDesktop/\r\nnotes.txt\r\n'))
     windowsChannel.emit('exit', 0)
     windowsChannel.emit('close')
 
     await expect(resultPromise).resolves.toEqual({
-      resolvedPath: 'C:\\Users\\alice',
+      resolvedPath: 'C:/Users/alice',
       entries: [
         { name: 'Desktop', isDirectory: true },
         { name: 'notes.txt', isDirectory: false }
@@ -143,6 +145,9 @@ describe('registerSshBrowseHandler', () => {
     expect(script).toContain('[Console]::OutputEncoding = [System.Text.Encoding]::UTF8')
     expect(script).toContain("$dir = 'C:/Users/alice'")
     expect(script).toContain('Get-ChildItem -LiteralPath $resolved -Force')
+    // resolvedPath must be emitted with forward slashes so the renderer's
+    // parentPath/joinPath (which only split on `/`) keep working on Windows.
+    expect(script).toContain("Write-Output ($resolved -replace '\\\\', '/')")
   })
 
   it('escapes single quotes in the PowerShell literal path', async () => {
@@ -164,12 +169,12 @@ describe('registerSshBrowseHandler', () => {
     await vi.waitFor(() => {
       expect(windowsChannel.listenerCount('close')).toBe(1)
     })
-    windowsChannel.emit('data', Buffer.from("C:\\O'Brien\r\n"))
+    windowsChannel.emit('data', Buffer.from("C:/O'Brien\r\n"))
     windowsChannel.emit('exit', 0)
     windowsChannel.emit('close')
 
     await expect(resultPromise).resolves.toEqual({
-      resolvedPath: "C:\\O'Brien",
+      resolvedPath: "C:/O'Brien",
       entries: []
     })
     const script = decodeEncodedCommand(exec.mock.calls[1]?.[0] ?? '')
@@ -194,11 +199,11 @@ describe('registerSshBrowseHandler', () => {
     await vi.waitFor(() => {
       expect(windowsChannel.listenerCount('close')).toBe(1)
     })
-    windowsChannel.emit('data', Buffer.from('C:\\Users\\alice\r\n'))
+    windowsChannel.emit('data', Buffer.from('C:/Users/alice\r\n'))
     windowsChannel.emit('exit', 0)
     windowsChannel.emit('close')
 
-    await expect(resultPromise).resolves.toEqual({ resolvedPath: 'C:\\Users\\alice', entries: [] })
+    await expect(resultPromise).resolves.toEqual({ resolvedPath: 'C:/Users/alice', entries: [] })
     const script = decodeEncodedCommand(exec.mock.calls[1]?.[0] ?? '')
     // ~ must expand to $HOME, not be passed literally to Set-Location.
     expect(script).toContain('$dir = $HOME')

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -215,7 +215,9 @@ describe('registerSshBrowseHandler', () => {
   // Set-Location, or navigation lands in the drive-relative cwd / errors.
   it.each([
     { dirPath: '/C:/Users', expected: "$dir = 'C:/Users'" },
-    { dirPath: 'C:', expected: "$dir = 'C:/'" }
+    { dirPath: 'C:', expected: "$dir = 'C:/'" },
+    // Combined strip + root, so a future refactor can't break the ordering.
+    { dirPath: '/C:', expected: "$dir = 'C:/'" }
   ])(
     'roots the Windows drive path $dirPath in the PowerShell fallback',
     async ({ dirPath, expected }) => {

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -25,6 +25,16 @@ function createMockChannel(): EventEmitter & { stderr: EventEmitter } {
   })
 }
 
+// Recover the PowerShell script from a `powershell.exe ... -EncodedCommand <b64>`
+// command so tests can assert on the actual (UTF-16LE) payload sent to the host.
+function decodeEncodedCommand(command: string): string {
+  const match = /-EncodedCommand (\S+)/.exec(command)
+  if (!match) {
+    throw new Error(`no -EncodedCommand in: ${command}`)
+  }
+  return Buffer.from(match[1], 'base64').toString('utf16le')
+}
+
 describe('registerSshBrowseHandler', () => {
   let handler: BrowseHandler
 
@@ -125,6 +135,65 @@ describe('registerSshBrowseHandler', () => {
     expect(exec).toHaveBeenNthCalledWith(1, "cd 'C:/Users/alice' && pwd && command ls -1Ap")
     expect(exec.mock.calls[1]?.[0]).toMatch(/^powershell\.exe /)
     expect(exec.mock.calls[1]?.[1]).toEqual({ wrapCommand: false })
+
+    // Decode the -EncodedCommand payload so an accidental switch from the
+    // single-quote-escaped PowerShell literal to raw interpolation (an injection
+    // regression) is caught, and to lock in the UTF-8 output pin.
+    const script = decodeEncodedCommand(exec.mock.calls[1]?.[0] ?? '')
+    expect(script).toContain('[Console]::OutputEncoding = [System.Text.Encoding]::UTF8')
+    expect(script).toContain("$dir = 'C:/Users/alice'")
+    expect(script).toContain('Get-ChildItem -LiteralPath $resolved -Force')
+  })
+
+  it('escapes single quotes in the PowerShell literal path', async () => {
+    const posixChannel = createMockChannel()
+    const windowsChannel = createMockChannel()
+    const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: "C:/O'Brien" })
+    await Promise.resolve()
+    // cmd.exe returns ERRORLEVEL 9009 for an unrecognized command in every locale;
+    // the fallback must trigger off that even when stderr text isn't English/Spanish.
+    posixChannel.stderr.emit('data', Buffer.from('Der Befehl "exec" ist falsch geschrieben'))
+    posixChannel.emit('exit', 9009)
+    posixChannel.emit('close')
+    await vi.waitFor(() => {
+      expect(windowsChannel.listenerCount('close')).toBe(1)
+    })
+    windowsChannel.emit('data', Buffer.from("C:\\O'Brien\r\n"))
+    windowsChannel.emit('exit', 0)
+    windowsChannel.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      resolvedPath: "C:\\O'Brien",
+      entries: []
+    })
+    const script = decodeEncodedCommand(exec.mock.calls[1]?.[0] ?? '')
+    // Single quote must be doubled inside the PowerShell literal, not passed raw.
+    expect(script).toContain("$dir = 'C:/O''Brien'")
+  })
+
+  it('does not retry with PowerShell for an ordinary POSIX browse failure', async () => {
+    const channel = createMockChannel()
+    const exec = vi.fn().mockResolvedValue(channel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '/root/secret' })
+    await Promise.resolve()
+    channel.stderr.emit('data', Buffer.from('ls: /root/secret: Permission denied'))
+    channel.emit('exit', 1)
+    channel.emit('close')
+
+    await expect(resultPromise).rejects.toThrow('Permission denied')
+    // A permission failure must surface directly — no masking PowerShell retry.
+    expect(exec).toHaveBeenCalledTimes(1)
   })
 
   it('rejects and detaches listeners when the browse channel errors', async () => {

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -196,6 +196,60 @@ describe('registerSshBrowseHandler', () => {
     expect(exec).toHaveBeenCalledTimes(1)
   })
 
+  it('surfaces the PowerShell error when a 9009 Windows fallback also fails', async () => {
+    const posixChannel = createMockChannel()
+    const windowsChannel = createMockChannel()
+    const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: 'C:/missing' })
+    await Promise.resolve()
+    posixChannel.stderr.emit('data', Buffer.from('"exec" is not recognized'))
+    posixChannel.emit('exit', 9009)
+    posixChannel.emit('close')
+    await vi.waitFor(() => {
+      expect(windowsChannel.listenerCount('close')).toBe(1)
+    })
+    windowsChannel.stderr.emit('data', Buffer.from('Cannot find path C:/missing'))
+    windowsChannel.emit('exit', 1)
+    windowsChannel.emit('close')
+
+    // 9009 proves the host is Windows, so PowerShell's error is the real cause —
+    // surface it rather than the cmd.exe "exec is not recognized" prose.
+    await expect(resultPromise).rejects.toThrow('Cannot find path')
+  })
+
+  it('surfaces the original POSIX error when a heuristic-matched fallback also fails', async () => {
+    const posixChannel = createMockChannel()
+    const windowsChannel = createMockChannel()
+    const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '/opt/exec' })
+    await Promise.resolve()
+    // A POSIX error that merely mentions exec/not found matches the string
+    // heuristic (exit code is a plain non-9009), so the fallback is a false start.
+    posixChannel.stderr.emit('data', Buffer.from('exec: command not found'))
+    posixChannel.emit('exit', 127)
+    posixChannel.emit('close')
+    await vi.waitFor(() => {
+      expect(windowsChannel.listenerCount('close')).toBe(1)
+    })
+    windowsChannel.stderr.emit('data', Buffer.from('sh: powershell.exe: not found'))
+    windowsChannel.emit('exit', 127)
+    windowsChannel.emit('close')
+
+    // The original POSIX failure is the real one — don't mask it with the
+    // misleading "powershell.exe: not found" from the doomed retry.
+    await expect(resultPromise).rejects.toThrow('exec: command not found')
+  })
+
   it('rejects and detaches listeners when the browse channel errors', async () => {
     const channel = createMockChannel()
     const exec = vi.fn().mockResolvedValue(channel)

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -177,6 +177,33 @@ describe('registerSshBrowseHandler', () => {
     expect(script).toContain("$dir = 'C:/O''Brien'")
   })
 
+  it('expands ~ to $HOME in the PowerShell fallback (the default browse path)', async () => {
+    const posixChannel = createMockChannel()
+    const windowsChannel = createMockChannel()
+    const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '~' })
+    await Promise.resolve()
+    posixChannel.stderr.emit('data', Buffer.from('"exec" is not recognized'))
+    posixChannel.emit('exit', 9009)
+    posixChannel.emit('close')
+    await vi.waitFor(() => {
+      expect(windowsChannel.listenerCount('close')).toBe(1)
+    })
+    windowsChannel.emit('data', Buffer.from('C:\\Users\\alice\r\n'))
+    windowsChannel.emit('exit', 0)
+    windowsChannel.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({ resolvedPath: 'C:\\Users\\alice', entries: [] })
+    const script = decodeEncodedCommand(exec.mock.calls[1]?.[0] ?? '')
+    // ~ must expand to $HOME, not be passed literally to Set-Location.
+    expect(script).toContain('$dir = $HOME')
+  })
+
   it('does not retry with PowerShell for an ordinary POSIX browse failure', async () => {
     const channel = createMockChannel()
     const exec = vi.fn().mockResolvedValue(channel)

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -150,6 +150,43 @@ describe('registerSshBrowseHandler', () => {
     expect(script).toContain("Write-Output ($resolved -replace '\\\\', '/')")
   })
 
+  it('falls back for a non-English cmd.exe reject (exit 1, localized stderr)', async () => {
+    // Regression: real Windows OpenSSH + cmd.exe forwards exit 1 (not 9009) with
+    // localized stderr. The old 9009/English-string trigger silently missed this,
+    // so German/Japanese/etc. hosts never fell back. Keying off the non-zero exit
+    // of a RemoteBrowseError fixes it regardless of OS display language.
+    const posixChannel = createMockChannel()
+    const windowsChannel = createMockChannel()
+    const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: 'C:/Users' })
+    await Promise.resolve()
+    // Japanese cmd.exe "not recognized" text — matches none of the removed English
+    // /Spanish substrings, and exit 1 is not the removed 9009 sentinel.
+    posixChannel.stderr.emit(
+      'data',
+      Buffer.from("'exec' は、内部コマンドとして認識されていません。")
+    )
+    posixChannel.emit('exit', 1)
+    posixChannel.emit('close')
+    await vi.waitFor(() => {
+      expect(windowsChannel.listenerCount('close')).toBe(1)
+    })
+    windowsChannel.emit('data', Buffer.from('C:/Users\r\nAdmin/\r\n'))
+    windowsChannel.emit('exit', 0)
+    windowsChannel.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      resolvedPath: 'C:/Users',
+      entries: [{ name: 'Admin', isDirectory: true }]
+    })
+    expect(exec).toHaveBeenCalledTimes(2)
+  })
+
   it('escapes single quotes in the PowerShell literal path', async () => {
     const posixChannel = createMockChannel()
     const windowsChannel = createMockChannel()
@@ -161,10 +198,11 @@ describe('registerSshBrowseHandler', () => {
 
     const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: "C:/O'Brien" })
     await Promise.resolve()
-    // cmd.exe returns ERRORLEVEL 9009 for an unrecognized command in every locale;
-    // the fallback must trigger off that even when stderr text isn't English/Spanish.
+    // A cmd.exe reject exits 1 over SSH (its 9009 ERRORLEVEL never crosses the
+    // process boundary) with localized German stderr. The fallback must still fire,
+    // since it keys off the non-zero exit, not the (localized, unmatchable) text.
     posixChannel.stderr.emit('data', Buffer.from('Der Befehl "exec" ist falsch geschrieben'))
-    posixChannel.emit('exit', 9009)
+    posixChannel.emit('exit', 1)
     posixChannel.emit('close')
     await vi.waitFor(() => {
       expect(windowsChannel.listenerCount('close')).toBe(1)
@@ -194,7 +232,7 @@ describe('registerSshBrowseHandler', () => {
     const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '~' })
     await Promise.resolve()
     posixChannel.stderr.emit('data', Buffer.from('"exec" is not recognized'))
-    posixChannel.emit('exit', 9009)
+    posixChannel.emit('exit', 1)
     posixChannel.emit('close')
     await vi.waitFor(() => {
       expect(windowsChannel.listenerCount('close')).toBe(1)
@@ -232,7 +270,7 @@ describe('registerSshBrowseHandler', () => {
       const resultPromise = handler(null, { targetId: 'ssh-1', dirPath })
       await Promise.resolve()
       posixChannel.stderr.emit('data', Buffer.from('"exec" is not recognized'))
-      posixChannel.emit('exit', 9009)
+      posixChannel.emit('exit', 1)
       posixChannel.emit('close')
       await vi.waitFor(() => {
         expect(windowsChannel.listenerCount('close')).toBe(1)
@@ -247,9 +285,10 @@ describe('registerSshBrowseHandler', () => {
     }
   )
 
-  it('does not retry with PowerShell for an ordinary POSIX browse failure', async () => {
-    const channel = createMockChannel()
-    const exec = vi.fn().mockResolvedValue(channel)
+  it('surfaces the original POSIX failure when the PowerShell retry shows the host is not Windows', async () => {
+    const posixChannel = createMockChannel()
+    const windowsChannel = createMockChannel()
+    const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
     const getConnectionManager = () => ({
       getConnection: () => ({ exec })
     })
@@ -257,16 +296,25 @@ describe('registerSshBrowseHandler', () => {
 
     const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '/root/secret' })
     await Promise.resolve()
-    channel.stderr.emit('data', Buffer.from('ls: /root/secret: Permission denied'))
-    channel.emit('exit', 1)
-    channel.emit('close')
+    // A genuine POSIX permission failure exits non-zero; it's indistinguishable
+    // from a Windows shell reject without probing, so the fallback is attempted...
+    posixChannel.stderr.emit('data', Buffer.from('ls: /root/secret: Permission denied'))
+    posixChannel.emit('exit', 1)
+    posixChannel.emit('close')
+    await vi.waitFor(() => {
+      expect(windowsChannel.listenerCount('close')).toBe(1)
+    })
+    // ...but on a POSIX host the login shell can't find powershell.exe (exit 127),
+    // so the original permission error is surfaced, never masked by the retry.
+    windowsChannel.stderr.emit('data', Buffer.from('bash: powershell.exe: command not found'))
+    windowsChannel.emit('exit', 127)
+    windowsChannel.emit('close')
 
     await expect(resultPromise).rejects.toThrow('Permission denied')
-    // A permission failure must surface directly — no masking PowerShell retry.
-    expect(exec).toHaveBeenCalledTimes(1)
+    expect(exec).toHaveBeenCalledTimes(2)
   })
 
-  it('surfaces the PowerShell error when a 9009 Windows fallback also fails', async () => {
+  it('surfaces the PowerShell error when the Windows fallback runs but fails', async () => {
     const posixChannel = createMockChannel()
     const windowsChannel = createMockChannel()
     const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
@@ -278,7 +326,7 @@ describe('registerSshBrowseHandler', () => {
     const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: 'C:/missing' })
     await Promise.resolve()
     posixChannel.stderr.emit('data', Buffer.from('"exec" is not recognized'))
-    posixChannel.emit('exit', 9009)
+    posixChannel.emit('exit', 1)
     posixChannel.emit('close')
     await vi.waitFor(() => {
       expect(windowsChannel.listenerCount('close')).toBe(1)
@@ -287,12 +335,12 @@ describe('registerSshBrowseHandler', () => {
     windowsChannel.emit('exit', 1)
     windowsChannel.emit('close')
 
-    // 9009 proves the host is Windows, so PowerShell's error is the real cause —
-    // surface it rather than the cmd.exe "exec is not recognized" prose.
+    // PowerShell exited non-127, so it genuinely ran on a Windows host — its error
+    // is the real cause. Surface it rather than the cmd.exe "not recognized" prose.
     await expect(resultPromise).rejects.toThrow('Cannot find path')
   })
 
-  it('surfaces the original POSIX error when a heuristic-matched fallback also fails', async () => {
+  it('surfaces the original POSIX error when the fallback shows powershell.exe is missing', async () => {
     const posixChannel = createMockChannel()
     const windowsChannel = createMockChannel()
     const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
@@ -303,8 +351,7 @@ describe('registerSshBrowseHandler', () => {
 
     const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '/opt/exec' })
     await Promise.resolve()
-    // A POSIX error that merely mentions exec/not found matches the string
-    // heuristic (exit code is a plain non-9009), so the fallback is a false start.
+    // A non-zero POSIX failure triggers the fallback probe on any host...
     posixChannel.stderr.emit('data', Buffer.from('exec: command not found'))
     posixChannel.emit('exit', 127)
     posixChannel.emit('close')
@@ -333,6 +380,9 @@ describe('registerSshBrowseHandler', () => {
     channel.emit('error', new Error('remote disconnected'))
 
     await expect(resultPromise).rejects.toThrow('remote disconnected')
+    // A transport failure is not a RemoteBrowseError, so it must not trigger a
+    // pointless PowerShell retry.
+    expect(exec).toHaveBeenCalledTimes(1)
     expect(channel.listenerCount('data')).toBe(0)
     expect(channel.listenerCount('exit')).toBe(0)
     expect(channel.listenerCount('close')).toBe(0)

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -88,6 +88,43 @@ describe('registerSshBrowseHandler', () => {
     expect(exec).toHaveBeenCalledWith("cd '/tmp/it'\\''s here' && pwd && command ls -1Ap")
   })
 
+  it('falls back to PowerShell when a Windows SSH shell rejects POSIX exec', async () => {
+    const posixChannel = createMockChannel()
+    const windowsChannel = createMockChannel()
+    const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: 'C:/Users/alice' })
+    await Promise.resolve()
+    posixChannel.stderr.emit(
+      'data',
+      Buffer.from('"exec" no se reconoce como un comando interno o externo')
+    )
+    posixChannel.emit('exit', 1)
+    posixChannel.emit('close')
+    await vi.waitFor(() => {
+      expect(windowsChannel.listenerCount('close')).toBe(1)
+    })
+    windowsChannel.emit('data', Buffer.from('C:\\Users\\alice\nDesktop/\nnotes.txt\n'))
+    windowsChannel.emit('exit', 0)
+    windowsChannel.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      resolvedPath: 'C:\\Users\\alice',
+      entries: [
+        { name: 'Desktop', isDirectory: true },
+        { name: 'notes.txt', isDirectory: false }
+      ]
+    })
+    expect(exec).toHaveBeenCalledTimes(2)
+    expect(exec).toHaveBeenNthCalledWith(1, "cd 'C:/Users/alice' && pwd && command ls -1Ap")
+    expect(exec.mock.calls[1]?.[0]).toMatch(/^powershell\.exe /)
+    expect(exec.mock.calls[1]?.[1]).toEqual({ wrapCommand: false })
+  })
+
   it('rejects and detaches listeners when the browse channel errors', async () => {
     const channel = createMockChannel()
     const exec = vi.fn().mockResolvedValue(channel)

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -108,7 +108,9 @@ describe('registerSshBrowseHandler', () => {
     await vi.waitFor(() => {
       expect(windowsChannel.listenerCount('close')).toBe(1)
     })
-    windowsChannel.emit('data', Buffer.from('C:\\Users\\alice\nDesktop/\nnotes.txt\n'))
+    // Windows OpenSSH exec emits CRLF; the parser must strip \r so directories
+    // aren't misclassified as files with a stray carriage return in the name.
+    windowsChannel.emit('data', Buffer.from('C:\\Users\\alice\r\nDesktop/\r\nnotes.txt\r\n'))
     windowsChannel.emit('exit', 0)
     windowsChannel.emit('close')
 

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -10,12 +10,12 @@ export type RemoteDirEntry = {
 
 const SSH_BROWSE_TIMEOUT_MS = 15_000
 
-// Why: cmd.exe returns ERRORLEVEL 9009 for an unrecognized command regardless of
-// OS display language, so on the ssh2 transport (which surfaces the remote exit
-// code intact) it's the locale-independent signal that a Windows host rejected
-// Orca's POSIX `exec` wrapper. The system-ssh transport truncates the exit code
-// to 8 bits (9009 -> 49), so localized stderr text ("no se reconoce", etc.)
-// remains the only heuristic there.
+// Why: a cmd.exe DefaultShell returns ERRORLEVEL 9009 for an unrecognized command
+// regardless of OS display language, so on the ssh2 transport (which surfaces the
+// remote exit code intact) it's the locale-independent signal that a Windows host
+// rejected Orca's POSIX `exec` wrapper. Two cases still fall back only via the
+// localized stderr heuristics below: the system-ssh transport (truncates the exit
+// code to 8 bits, 9009 -> 49) and a powershell.exe DefaultShell (exits 1, not 9009).
 const WINDOWS_COMMAND_NOT_FOUND_EXIT = 9009
 
 // Carries the raw exit code so the Windows-fallback predicate can key off the

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -313,5 +313,16 @@ function powerShellPathExpression(s: string): string {
   if (s.startsWith('~/') || s.startsWith('~\\')) {
     return `Join-Path $HOME ${powerShellLiteral(s.slice(2))}`
   }
-  return powerShellLiteral(s)
+  return powerShellLiteral(normalizeWindowsDrivePath(s))
+}
+
+// Why: browse emits forward-slash Windows paths, so the renderer rebuilds them
+// with POSIX helpers — the breadcrumb prepends a spurious leading '/' before the
+// drive (/C:/Users) and "Up" from a first-level dir yields a bare drive letter
+// (C:). Both are wrong for Set-Location: a leading '/' means the current drive's
+// root, and 'C:' is drive-relative (the process cwd), not 'C:\'. Normalize both
+// back to a rooted drive path here so navigation lands where the user clicked.
+function normalizeWindowsDrivePath(s: string): string {
+  const stripped = s.replace(/^\/(?=[A-Za-z]:(?:[/\\]|$))/, '')
+  return /^[A-Za-z]:$/.test(stripped) ? `${stripped}/` : stripped
 }

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -10,16 +10,23 @@ export type RemoteDirEntry = {
 
 const SSH_BROWSE_TIMEOUT_MS = 15_000
 
-// Why: a cmd.exe DefaultShell returns ERRORLEVEL 9009 for an unrecognized command
-// regardless of OS display language, so on the ssh2 transport (which surfaces the
-// remote exit code intact) it's the locale-independent signal that a Windows host
-// rejected Orca's POSIX `exec` wrapper. Two cases still fall back only via the
-// localized stderr heuristics below: the system-ssh transport (truncates the exit
-// code to 8 bits, 9009 -> 49) and a powershell.exe DefaultShell (exits 1, not 9009).
-const WINDOWS_COMMAND_NOT_FOUND_EXIT = 9009
+// Why: a POSIX login shell that can't find powershell.exe exits 127 (the POSIX
+// "command not found" convention, identical across sh/bash/zsh and locales). It's
+// the locale-independent signal that the Windows fallback never actually ran, so
+// the original POSIX failure — not the doomed retry — is the real error.
+//
+// Note: cmd.exe's ERRORLEVEL for an unrecognized command is 9009, but that value
+// never crosses cmd.exe's process boundary. sshd forwards cmd.exe's *process* exit
+// code, which is 1 — verified on real Windows OpenSSH + cmd.exe over both the ssh2
+// and system-ssh transports. So a Windows host rejecting Orca's POSIX `exec`
+// wrapper is detected by "the remote command ran and exited non-zero"
+// (RemoteBrowseError), not by a magic exit code or localized stderr text.
+const POSIX_COMMAND_NOT_FOUND_EXIT = 127
 
-// Carries the raw exit code so the Windows-fallback predicate can key off the
-// locale-independent 9009 rather than parsing localized shell prose.
+// Carries the raw exit code so the fallback can (a) recognize that the remote
+// command actually ran and failed — the locale-independent trigger for the
+// Windows retry — and (b) tell a POSIX "powershell.exe not found" (127) apart
+// from a genuine PowerShell error, without parsing localized shell prose.
 class RemoteBrowseError extends Error {
   constructor(
     message: string,
@@ -56,19 +63,24 @@ export function registerSshBrowseHandler(
 
       try {
         return await browseWithPosixShell(conn, args.dirPath)
-      } catch (error) {
-        if (!shouldFallbackToWindowsBrowse(error)) {
-          throw error
+      } catch (posixError) {
+        // Why: a Windows login shell (cmd.exe/PowerShell) rejects Orca's POSIX
+        // `exec` wrapper, and the only locale-independent signal for that is "the
+        // remote command executed and exited non-zero" (RemoteBrowseError). Its
+        // stderr prose is localized, and cmd.exe's 9009 ERRORLEVEL never reaches
+        // us (sshd forwards process exit 1). Transport errors/timeouts aren't
+        // RemoteBrowseErrors, so a dropped connection is never retried as Windows.
+        if (!(posixError instanceof RemoteBrowseError)) {
+          throw posixError
         }
         try {
           return await browseWithWindowsPowerShell(conn, args.dirPath)
         } catch (fallbackError) {
-          // Why: a 9009 exit proves the host is Windows (remote POSIX exits are
-          // 8-bit), so PowerShell genuinely ran and its error is the real cause
-          // (e.g. "Cannot find path"/"Access is denied") — surface it. The string
-          // heuristic can match a POSIX false positive, so there we rethrow the
-          // original shell failure instead of a misleading "powershell.exe not found".
-          throw isWindowsCommandNotFound(error) ? fallbackError : error
+          // Why: if the login shell couldn't find powershell.exe (exit 127) the
+          // host isn't Windows — surface the original POSIX failure rather than a
+          // misleading "powershell.exe: not found". Otherwise PowerShell genuinely
+          // ran and its error (e.g. "Cannot find path") is the real cause.
+          throw isPosixCommandNotFound(fallbackError) ? posixError : fallbackError
         }
       }
     }
@@ -265,27 +277,11 @@ async function runBrowseCommand(
   })
 }
 
-// Why: cmd.exe's 9009 exit is the locale-independent proof that a Windows host
-// rejected Orca's POSIX `exec` wrapper — remote POSIX shells report 8-bit exit
-// codes, so 9009 can only originate from cmd.exe's ERRORLEVEL.
-function isWindowsCommandNotFound(error: unknown): boolean {
-  return error instanceof RemoteBrowseError && error.exitCode === WINDOWS_COMMAND_NOT_FOUND_EXIT
-}
-
-function shouldFallbackToWindowsBrowse(error: unknown): boolean {
-  // Fires the fallback even on German/French/Japanese/etc. hosts whose localized
-  // stderr text the string heuristics below would miss.
-  if (isWindowsCommandNotFound(error)) {
-    return true
-  }
-  const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
-  // Why: only retry when the remote login shell rejects Orca's POSIX wrapper.
-  // Ordinary POSIX browse failures (permission denied, missing path, etc.)
-  // should surface directly instead of being masked by a PowerShell retry.
-  return (
-    msg.includes('exec') &&
-    (msg.includes('not recognized') || msg.includes('no se reconoce') || msg.includes('not found'))
-  )
+// Why: a POSIX login shell that can't find powershell.exe exits 127, marking the
+// Windows fallback as "never ran" — the host isn't Windows, so the original POSIX
+// failure, not the doomed retry, is the error worth surfacing.
+function isPosixCommandNotFound(error: unknown): boolean {
+  return error instanceof RemoteBrowseError && error.exitCode === POSIX_COMMAND_NOT_FOUND_EXIT
 }
 
 // Why: prevent shell injection in the directory path. Single-quote wrapping

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -104,7 +104,11 @@ function browseWithWindowsPowerShell(
     `$dir = ${powerShellPathExpression(dirPath)}`,
     'Set-Location -LiteralPath $dir',
     '$resolved = (Get-Location).ProviderPath',
-    'Write-Output $resolved',
+    // Why: the renderer's parentPath/joinPath only split on `/`, so a native
+    // backslash path (C:\Users\alice) breaks "Up" and mixes separators. Emit a
+    // forward-slash resolvedPath (matching the POSIX branch) while keeping the
+    // native $resolved for Get-ChildItem -LiteralPath.
+    "Write-Output ($resolved -replace '\\\\', '/')",
     'Get-ChildItem -LiteralPath $resolved -Force | ForEach-Object {',
     "  if ($_.PSIsContainer) { Write-Output ($_.Name + '/') } else { Write-Output $_.Name }",
     '}'

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -178,7 +178,11 @@ async function runBrowseCommand(
         return
       }
 
-      const lines = stdout.trim().split('\n')
+      // Why: Windows OpenSSH exec emits CRLF, so split on \r?\n — otherwise a
+      // trailing \r defeats the endsWith('/') dir check and leaves a stray CR
+      // in every name. Splitting on the CR too preserves POSIX filenames whose
+      // names contain legitimate leading/trailing spaces.
+      const lines = stdout.trim().split(/\r?\n/)
       if (lines.length === 0) {
         rejectOnce(new Error('Empty response from remote'))
         return

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -11,9 +11,11 @@ export type RemoteDirEntry = {
 const SSH_BROWSE_TIMEOUT_MS = 15_000
 
 // Why: cmd.exe returns ERRORLEVEL 9009 for an unrecognized command regardless of
-// OS display language, so it's the locale-independent signal that a Windows host
-// rejected Orca's POSIX `exec` wrapper. Localized stderr text ("no se reconoce",
-// German/French/etc.) is only a fallback heuristic.
+// OS display language, so on the ssh2 transport (which surfaces the remote exit
+// code intact) it's the locale-independent signal that a Windows host rejected
+// Orca's POSIX `exec` wrapper. The system-ssh transport truncates the exit code
+// to 8 bits (9009 -> 49), so localized stderr text ("no se reconoce", etc.)
+// remains the only heuristic there.
 const WINDOWS_COMMAND_NOT_FOUND_EXIT = 9009
 
 // Carries the raw exit code so the Windows-fallback predicate can key off the
@@ -60,11 +62,13 @@ export function registerSshBrowseHandler(
         }
         try {
           return await browseWithWindowsPowerShell(conn, args.dirPath)
-        } catch {
-          // Why: if the PowerShell retry also fails (e.g. the predicate matched a
-          // POSIX error that merely mentioned "exec"/"not found"), surface the
-          // original shell failure — not a misleading "powershell.exe not found".
-          throw error
+        } catch (fallbackError) {
+          // Why: a 9009 exit proves the host is Windows (remote POSIX exits are
+          // 8-bit), so PowerShell genuinely ran and its error is the real cause
+          // (e.g. "Cannot find path"/"Access is denied") — surface it. The string
+          // heuristic can match a POSIX false positive, so there we rethrow the
+          // original shell failure instead of a misleading "powershell.exe not found".
+          throw isWindowsCommandNotFound(error) ? fallbackError : error
         }
       }
     }
@@ -257,11 +261,17 @@ async function runBrowseCommand(
   })
 }
 
+// Why: cmd.exe's 9009 exit is the locale-independent proof that a Windows host
+// rejected Orca's POSIX `exec` wrapper — remote POSIX shells report 8-bit exit
+// codes, so 9009 can only originate from cmd.exe's ERRORLEVEL.
+function isWindowsCommandNotFound(error: unknown): boolean {
+  return error instanceof RemoteBrowseError && error.exitCode === WINDOWS_COMMAND_NOT_FOUND_EXIT
+}
+
 function shouldFallbackToWindowsBrowse(error: unknown): boolean {
-  // Why: cmd.exe's 9009 exit is the locale-independent signal that a Windows
-  // host rejected Orca's POSIX `exec` wrapper — it fires the fallback even on
-  // German/French/Japanese/etc. hosts whose stderr text the heuristics miss.
-  if (error instanceof RemoteBrowseError && error.exitCode === WINDOWS_COMMAND_NOT_FOUND_EXIT) {
+  // Fires the fallback even on German/French/Japanese/etc. hosts whose localized
+  // stderr text the string heuristics below would miss.
+  if (isWindowsCommandNotFound(error)) {
     return true
   }
   const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -10,6 +10,24 @@ export type RemoteDirEntry = {
 
 const SSH_BROWSE_TIMEOUT_MS = 15_000
 
+// Why: cmd.exe returns ERRORLEVEL 9009 for an unrecognized command regardless of
+// OS display language, so it's the locale-independent signal that a Windows host
+// rejected Orca's POSIX `exec` wrapper. Localized stderr text ("no se reconoce",
+// German/French/etc.) is only a fallback heuristic.
+const WINDOWS_COMMAND_NOT_FOUND_EXIT = 9009
+
+// Carries the raw exit code so the Windows-fallback predicate can key off the
+// locale-independent 9009 rather than parsing localized shell prose.
+class RemoteBrowseError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: number | null
+  ) {
+    super(message)
+    this.name = 'RemoteBrowseError'
+  }
+}
+
 // Why: the relay's fs.readDir enforces workspace root ACLs, which aren't
 // registered until a repo is added. This handler uses a raw SSH exec channel
 // to list directories, allowing the user to browse the remote filesystem
@@ -40,7 +58,14 @@ export function registerSshBrowseHandler(
         if (!shouldFallbackToWindowsBrowse(error)) {
           throw error
         }
-        return browseWithWindowsPowerShell(conn, args.dirPath)
+        try {
+          return await browseWithWindowsPowerShell(conn, args.dirPath)
+        } catch {
+          // Why: if the PowerShell retry also fails (e.g. the predicate matched a
+          // POSIX error that merely mentioned "exec"/"not found"), surface the
+          // original shell failure — not a misleading "powershell.exe not found".
+          throw error
+        }
       }
     }
   )
@@ -68,6 +93,10 @@ function browseWithWindowsPowerShell(
 ): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> {
   const script = [
     "$ErrorActionPreference = 'Stop'",
+    // Why: Windows PowerShell 5.1 writes redirected stdout in the legacy OEM
+    // code page, but runBrowseCommand decodes as UTF-8; pin UTF-8 output so
+    // non-ASCII names (e.g. C:\Users\José, CJK, Cyrillic) don't come back mojibake.
+    '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8',
     `$dir = ${powerShellPathExpression(dirPath)}`,
     'Set-Location -LiteralPath $dir',
     '$resolved = (Get-Location).ProviderPath',
@@ -170,7 +199,7 @@ async function runBrowseCommand(
           (exitCode === null
             ? 'Remote listing failed (channel closed without exit status)'
             : `Remote listing failed (exit ${exitCode})`)
-        rejectOnce(new Error(msg))
+        rejectOnce(new RemoteBrowseError(msg, exitCode))
         return
       }
       if (stderr.trim() && !stdout.trim()) {
@@ -180,8 +209,7 @@ async function runBrowseCommand(
 
       // Why: Windows OpenSSH exec emits CRLF, so split on \r?\n — otherwise a
       // trailing \r defeats the endsWith('/') dir check and leaves a stray CR
-      // in every name. Splitting on the CR too preserves POSIX filenames whose
-      // names contain legitimate leading/trailing spaces.
+      // in every name.
       const lines = stdout.trim().split(/\r?\n/)
       if (lines.length === 0) {
         rejectOnce(new Error('Empty response from remote'))
@@ -230,6 +258,12 @@ async function runBrowseCommand(
 }
 
 function shouldFallbackToWindowsBrowse(error: unknown): boolean {
+  // Why: cmd.exe's 9009 exit is the locale-independent signal that a Windows
+  // host rejected Orca's POSIX `exec` wrapper — it fires the fallback even on
+  // German/French/Japanese/etc. hosts whose stderr text the heuristics miss.
+  if (error instanceof RemoteBrowseError && error.exitCode === WINDOWS_COMMAND_NOT_FOUND_EXIT) {
+    return true
+  }
   const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
   // Why: only retry when the remote login shell rejects Orca's POSIX wrapper.
   // Ordinary POSIX browse failures (permission denied, missing path, etc.)

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -1,5 +1,7 @@
 import { ipcMain } from 'electron'
 import type { SshConnectionManager } from '../ssh/ssh-connection'
+import type { SshExecOptions } from '../ssh/ssh-connection-utils'
+import { powerShellCommand, powerShellLiteral } from '../ssh/ssh-remote-powershell'
 
 export type RemoteDirEntry = {
   name: string
@@ -32,153 +34,205 @@ export function registerSshBrowseHandler(
         throw new Error(`SSH connection "${args.targetId}" not found`)
       }
 
-      // Why: using one line per entry preserves filenames containing spaces.
-      // `command ls` bypasses user aliases/functions like `ls='eza ...'`.
-      // The -1 flag outputs one entry per line. The -p flag appends / to directories.
-      // We resolve ~ and get the absolute path via `cd <path> && pwd`.
-      // `cd` and `ls` are chained with `&&` so a failing `ls` (e.g. permission
-      // denied after a readable `cd ... && pwd`) propagates as a non-zero exit
-      // code rather than being indistinguishable from an empty directory.
-      const command = `cd ${shellEscape(args.dirPath)} && pwd && command ls -1Ap`
-      const channel = await conn.exec(command)
-
-      return new Promise((resolve, reject) => {
-        let stdout = ''
-        let stderr = ''
-        let exitCode: number | null = null
-        let settled = false
-        let timeout: ReturnType<typeof setTimeout> | null = null
-
-        const cleanup = (): void => {
-          if (timeout) {
-            clearTimeout(timeout)
-            timeout = null
-          }
-          channel.off('data', onStdoutData)
-          channel.stderr.off('data', onStderrData)
-          channel.off('exit', onExit)
-          channel.off('close', onClose)
-          channel.off('error', onError)
-          channel.stderr.off('error', onError)
+      try {
+        return await browseWithPosixShell(conn, args.dirPath)
+      } catch (error) {
+        if (!shouldFallbackToWindowsBrowse(error)) {
+          throw error
         }
-        const rejectOnce = (error: Error): void => {
-          if (settled) {
-            return
-          }
-          settled = true
-          cleanup()
-          reject(error)
-        }
-        const closeChannel = (): void => {
-          const closable = channel as { close?: () => void; destroy?: () => void }
-          try {
-            if (typeof closable.close === 'function') {
-              closable.close()
-            } else if (typeof closable.destroy === 'function') {
-              closable.destroy()
-            }
-          } catch {
-            /* best effort */
-          }
-        }
-        const onTimeout = (): void => {
-          // Why: remote browsing runs before a relay workspace root exists, so
-          // it cannot rely on relay request deadlines. Bound this raw exec
-          // channel directly to keep Add Remote Project from hanging forever.
-          rejectOnce(new Error('Remote directory listing timed out'))
-          closeChannel()
-        }
-        const resolveOnce = (result: { entries: RemoteDirEntry[]; resolvedPath: string }): void => {
-          if (settled) {
-            return
-          }
-          settled = true
-          cleanup()
-          resolve(result)
-        }
-
-        const onStdoutData = (data: Buffer): void => {
-          stdout += data.toString()
-        }
-        const onStderrData = (data: Buffer): void => {
-          stderr += data.toString()
-        }
-        // `exit` fires before `close`; capture the code so we can distinguish
-        // a failed `ls` that still produced `pwd` output from an empty listing.
-        const onExit = (code: number | null): void => {
-          exitCode = code
-        }
-        const onError = (error: Error): void => {
-          rejectOnce(error)
-        }
-        const onClose = (): void => {
-          // A null exitCode means the server closed the channel without
-          // sending an exit-status message (or signalled termination). We
-          // can't assume success — falling back to "empty stdout = empty
-          // directory" is exactly the bug the exit-code branch was added to
-          // fix. Treat any non-zero OR null exit as a failure when stderr
-          // has content, and otherwise require stdout to contain at least
-          // the resolved `pwd` line before accepting the result.
-          if (exitCode !== 0) {
-            const msg =
-              stderr.trim() ||
-              (exitCode === null
-                ? 'Remote listing failed (channel closed without exit status)'
-                : `Remote listing failed (exit ${exitCode})`)
-            rejectOnce(new Error(msg))
-            return
-          }
-          if (stderr.trim() && !stdout.trim()) {
-            rejectOnce(new Error(stderr.trim()))
-            return
-          }
-
-          const lines = stdout.trim().split('\n')
-          if (lines.length === 0) {
-            rejectOnce(new Error('Empty response from remote'))
-            return
-          }
-
-          const resolvedPath = lines[0]
-          const entries: RemoteDirEntry[] = []
-
-          for (let i = 1; i < lines.length; i++) {
-            const line = lines[i]
-            if (!line || line === './' || line === '../') {
-              continue
-            }
-            if (line.endsWith('/')) {
-              entries.push({ name: line.slice(0, -1), isDirectory: true })
-            } else {
-              entries.push({ name: line, isDirectory: false })
-            }
-          }
-
-          // Sort: directories first, then alphabetical
-          entries.sort((a, b) => {
-            if (a.isDirectory !== b.isDirectory) {
-              return a.isDirectory ? -1 : 1
-            }
-            return a.name.localeCompare(b.name)
-          })
-
-          resolveOnce({ entries, resolvedPath })
-        }
-
-        channel.on('data', onStdoutData)
-        channel.stderr.on('data', onStderrData)
-        channel.on('exit', onExit)
-        channel.on('close', onClose)
-        // Why: SSH exec streams emit `error` on transport loss; without a
-        // scoped listener, a disappearing remote can become process-fatal.
-        channel.on('error', onError)
-        channel.stderr.on('error', onError)
-        timeout = setTimeout(onTimeout, SSH_BROWSE_TIMEOUT_MS)
-        if (typeof timeout.unref === 'function') {
-          timeout.unref()
-        }
-      })
+        return browseWithWindowsPowerShell(conn, args.dirPath)
+      }
     }
+  )
+}
+
+type SshBrowseConnection = NonNullable<ReturnType<SshConnectionManager['getConnection']>>
+
+function browseWithPosixShell(
+  conn: SshBrowseConnection,
+  dirPath: string
+): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> {
+  // Why: using one line per entry preserves filenames containing spaces.
+  // `command ls` bypasses user aliases/functions like `ls='eza ...'`.
+  // The -1 flag outputs one entry per line. The -p flag appends / to directories.
+  // We resolve ~ and get the absolute path via `cd <path> && pwd`.
+  // `cd` and `ls` are chained with `&&` so a failing `ls` (e.g. permission
+  // denied after a readable `cd ... && pwd`) propagates as a non-zero exit
+  // code rather than being indistinguishable from an empty directory.
+  return runBrowseCommand(conn, `cd ${shellEscape(dirPath)} && pwd && command ls -1Ap`)
+}
+
+function browseWithWindowsPowerShell(
+  conn: SshBrowseConnection,
+  dirPath: string
+): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> {
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    `$dir = ${powerShellPathExpression(dirPath)}`,
+    'Set-Location -LiteralPath $dir',
+    '$resolved = (Get-Location).ProviderPath',
+    'Write-Output $resolved',
+    'Get-ChildItem -LiteralPath $resolved -Force | ForEach-Object {',
+    "  if ($_.PSIsContainer) { Write-Output ($_.Name + '/') } else { Write-Output $_.Name }",
+    '}'
+  ].join('; ')
+
+  return runBrowseCommand(conn, powerShellCommand(script), { wrapCommand: false })
+}
+
+async function runBrowseCommand(
+  conn: SshBrowseConnection,
+  command: string,
+  options?: SshExecOptions
+): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> {
+  const channel = options ? await conn.exec(command, options) : await conn.exec(command)
+
+  return new Promise((resolve, reject) => {
+    let stdout = ''
+    let stderr = ''
+    let exitCode: number | null = null
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+
+    const cleanup = (): void => {
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      channel.off('data', onStdoutData)
+      channel.stderr.off('data', onStderrData)
+      channel.off('exit', onExit)
+      channel.off('close', onClose)
+      channel.off('error', onError)
+      channel.stderr.off('error', onError)
+    }
+    const rejectOnce = (error: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      reject(error)
+    }
+    const closeChannel = (): void => {
+      const closable = channel as { close?: () => void; destroy?: () => void }
+      try {
+        if (typeof closable.close === 'function') {
+          closable.close()
+        } else if (typeof closable.destroy === 'function') {
+          closable.destroy()
+        }
+      } catch {
+        /* best effort */
+      }
+    }
+    const onTimeout = (): void => {
+      // Why: remote browsing runs before a relay workspace root exists, so
+      // it cannot rely on relay request deadlines. Bound this raw exec
+      // channel directly to keep Add Remote Project from hanging forever.
+      rejectOnce(new Error('Remote directory listing timed out'))
+      closeChannel()
+    }
+    const resolveOnce = (result: { entries: RemoteDirEntry[]; resolvedPath: string }): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      resolve(result)
+    }
+
+    const onStdoutData = (data: Buffer): void => {
+      stdout += data.toString()
+    }
+    const onStderrData = (data: Buffer): void => {
+      stderr += data.toString()
+    }
+    // `exit` fires before `close`; capture the code so we can distinguish
+    // a failed `ls` that still produced `pwd` output from an empty listing.
+    const onExit = (code: number | null): void => {
+      exitCode = code
+    }
+    const onError = (error: Error): void => {
+      rejectOnce(error)
+    }
+    const onClose = (): void => {
+      // A null exitCode means the server closed the channel without
+      // sending an exit-status message (or signalled termination). We
+      // can't assume success — falling back to "empty stdout = empty
+      // directory" is exactly the bug the exit-code branch was added to
+      // fix. Treat any non-zero OR null exit as a failure when stderr
+      // has content, and otherwise require stdout to contain at least
+      // the resolved `pwd` line before accepting the result.
+      if (exitCode !== 0) {
+        const msg =
+          stderr.trim() ||
+          (exitCode === null
+            ? 'Remote listing failed (channel closed without exit status)'
+            : `Remote listing failed (exit ${exitCode})`)
+        rejectOnce(new Error(msg))
+        return
+      }
+      if (stderr.trim() && !stdout.trim()) {
+        rejectOnce(new Error(stderr.trim()))
+        return
+      }
+
+      const lines = stdout.trim().split('\n')
+      if (lines.length === 0) {
+        rejectOnce(new Error('Empty response from remote'))
+        return
+      }
+
+      const resolvedPath = lines[0]
+      const entries: RemoteDirEntry[] = []
+
+      for (let i = 1; i < lines.length; i++) {
+        const line = lines[i]
+        if (!line || line === './' || line === '../') {
+          continue
+        }
+        if (line.endsWith('/')) {
+          entries.push({ name: line.slice(0, -1), isDirectory: true })
+        } else {
+          entries.push({ name: line, isDirectory: false })
+        }
+      }
+
+      // Sort: directories first, then alphabetical
+      entries.sort((a, b) => {
+        if (a.isDirectory !== b.isDirectory) {
+          return a.isDirectory ? -1 : 1
+        }
+        return a.name.localeCompare(b.name)
+      })
+
+      resolveOnce({ entries, resolvedPath })
+    }
+
+    channel.on('data', onStdoutData)
+    channel.stderr.on('data', onStderrData)
+    channel.on('exit', onExit)
+    channel.on('close', onClose)
+    // Why: SSH exec streams emit `error` on transport loss; without a
+    // scoped listener, a disappearing remote can become process-fatal.
+    channel.on('error', onError)
+    channel.stderr.on('error', onError)
+    timeout = setTimeout(onTimeout, SSH_BROWSE_TIMEOUT_MS)
+    if (typeof timeout.unref === 'function') {
+      timeout.unref()
+    }
+  })
+}
+
+function shouldFallbackToWindowsBrowse(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
+  // Why: only retry when the remote login shell rejects Orca's POSIX wrapper.
+  // Ordinary POSIX browse failures (permission denied, missing path, etc.)
+  // should surface directly instead of being masked by a PowerShell retry.
+  return (
+    msg.includes('exec') &&
+    (msg.includes('not recognized') || msg.includes('no se reconoce') || msg.includes('not found'))
   )
 }
 
@@ -198,4 +252,14 @@ function shellEscape(s: string): string {
 
 function shellEscapeRaw(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`
+}
+
+function powerShellPathExpression(s: string): string {
+  if (s === '~') {
+    return '$HOME'
+  }
+  if (s.startsWith('~/') || s.startsWith('~\\')) {
+    return `Join-Path $HOME ${powerShellLiteral(s.slice(2))}`
+  }
+  return powerShellLiteral(s)
 }


### PR DESCRIPTION
## Summary

Adds a narrow Windows fallback for SSH directory browsing during Add Remote Project. Orca still tries the existing POSIX browse command first; if the remote shell rejects Orca's POSIX `exec` wrapper (for example Windows OpenSSH with `cmd.exe`), it retries with a PowerShell listing that returns the same resolved-path + entries shape.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - not run in full; ran focused lint below
- [x] `pnpm typecheck` - covered node scope with `npx --yes pnpm@10.24.0 run typecheck:node`
- [ ] `pnpm test` - not run in full; ran focused test below
- [ ] `pnpm build` - not run; change is covered by focused test, lint, formatting, and node typecheck
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification:
- `npx --yes pnpm@10.24.0 exec vitest run --config config/vitest.config.ts src/main/ipc/ssh-browse.test.ts`
- `npx --yes pnpm@10.24.0 exec oxlint src/main/ipc/ssh-browse.ts src/main/ipc/ssh-browse.test.ts`
- `npx --yes pnpm@10.24.0 exec oxfmt --check src/main/ipc/ssh-browse.ts src/main/ipc/ssh-browse.test.ts`
- `npx --yes pnpm@10.24.0 run typecheck:node`

## AI Review Report

AI review checked that the existing Linux/macOS POSIX behavior remains the primary path, that the Windows fallback is constrained to shell-wrapper rejection errors, and that path quoting uses existing PowerShell helpers instead of string interpolation. CodeRabbit flagged two cleanup items: replace a manual async polling loop in the test with `vi.waitFor`, and document why the fallback predicate is intentionally narrow. Both were applied.

Cross-platform compatibility checked: macOS/Linux keep the original POSIX command path; Windows SSH/cmd can fall back to PowerShell; path handling for `~`/`~/...` is translated to `$HOME`; no shortcuts, labels, or Electron UI platform behavior changed.

## Security Audit

Reviewed command execution, path handling, and IPC exposure for `ssh:browseDir`. User-provided paths continue to be escaped for POSIX and are passed to PowerShell using single-quoted literals / `$HOME` expressions. The fallback only triggers for remote shell-wrapper rejection errors, so ordinary browse failures are not masked. No new dependencies, auth changes, secrets handling, or IPC channels were added.

## Notes

Not live-tested against a Windows OpenSSH host; the Windows/cmd failure mode is covered with a channel-level regression test. This PR intentionally targets only pre-relay directory browsing, not full Windows remote-host support.