### PR TITLE
Pin local worktree editors to local when a runtime environment is active

### DIFF
--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -447,7 +447,7 @@ describe('createEditorSlice openDiff', () => {
     expect(store.getState().openFiles).toEqual([
       expect.objectContaining({
         id: 'wt-1::diff::unstaged::file.ts',
-        runtimeEnvironmentId: undefined
+        runtimeEnvironmentId: null
       }),
       expect.objectContaining({
         id: 'editor-diff:wt-1:env-1:unstaged:file.ts',
@@ -487,6 +487,48 @@ describe('createEditorSlice openDiff', () => {
         runtimeEnvironmentId: 'env-1'
       })
     )
+  })
+
+  it('pins a local-owned worktree diff to local even when a runtime environment is globally active', () => {
+    const store = createEditorStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'remote-env' } as AppState['settings'],
+      repos: [{ id: 'repo-1', executionHostId: 'local' }] as unknown as AppState['repos'],
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'repo-1::/local/worktree',
+            repoId: 'repo-1',
+            hostId: 'local'
+          }
+        ]
+      } as unknown as AppState['worktreesByRepo']
+    })
+
+    store
+      .getState()
+      .openDiff(
+        'repo-1::/local/worktree',
+        '/local/worktree/src/file.ts',
+        'src/file.ts',
+        'typescript',
+        false
+      )
+    store.getState().openFile({
+      filePath: '/local/worktree/notes.md',
+      relativePath: 'notes.md',
+      worktreeId: 'repo-1::/local/worktree',
+      language: 'markdown',
+      mode: 'edit'
+    })
+
+    // Why: a local-owned worktree must never inherit the globally-active runtime
+    // environment, or its diff/content RPCs route to a remote runtime that does
+    // not know the worktree and fail with `selector_not_found`.
+    expect(store.getState().openFiles.map((file) => file.runtimeEnvironmentId)).toEqual([
+      null,
+      null
+    ])
   })
 
   it('repairs an existing diff tab entry to the correct mode and staged state', () => {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -310,7 +310,9 @@ function resolveDiffRuntimeEnvironmentId(
   }
   // Why: Source Control callers often know only the worktree. Runtime-host
   // diffs still need their owner stamped so content loads through runtime RPC.
-  return getRuntimeEnvironmentIdForWorktree(state, worktreeId) ?? undefined
+  // Preserve a resolved `null`: a local-owned worktree must pin to local, not
+  // collapse to `undefined` and inherit the globally-active runtime environment.
+  return getRuntimeEnvironmentIdForWorktree(state, worktreeId)
 }
 
 export type PendingEditorReveal = {
@@ -1528,7 +1530,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           : (file.runtimeEnvironmentId ??
             (options?.suppressActiveRuntimeFallback
               ? null
-              : (s.settings?.activeRuntimeEnvironmentId?.trim() ?? undefined)))
+              : getRuntimeEnvironmentIdForWorktree(s, worktreeId)))
       const reusableOpenFileModes = getReusableOpenFileModes(file.mode)
       const existing = s.openFiles.find(
         (f) =>
@@ -1814,8 +1816,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       file.runtimeEnvironmentId === null
         ? null
         : (file.runtimeEnvironmentId ??
-          initialState.settings?.activeRuntimeEnvironmentId?.trim() ??
-          undefined)
+          getRuntimeEnvironmentIdForWorktree(initialState, file.worktreeId))
     const sourceFileId =
       options?.sourceFileId ??
       resolveEditorFileIdForOwner(


### PR DESCRIPTION
## Summary

Opening the diff (or a markdown file) of a **local-owned worktree** could fail with:

```
Error loading diff: RuntimeRpcCallError: selector_not_found
```

and log `Failed to list markdown documents: RuntimeRpcCallError: selector_not_found`.

**Root cause.** When a runtime environment is globally active (`activeRuntimeEnvironmentId` is set, e.g. because the same project also has remote/SSH worktrees), three editor-open paths stamped the wrong runtime owner onto files from a **local** worktree, so their git/file RPCs were routed to the remote runtime — which does not know the local worktree and rejects the selector with `selector_not_found`.

The offending paths (`src/renderer/src/store/slices/editor.ts`):

- `openFile` and `openMarkdownPreview` fell back to the raw global `activeRuntimeEnvironmentId` instead of resolving the worktree's own owner, so a local worktree inherited the active remote environment. (This is the markdown / Changes-view path from the report.)
- `resolveDiffRuntimeEnvironmentId` resolved the owner correctly but collapsed a `null` (local) result to `undefined` via `?? undefined`; `undefined` then re-inherits the active environment in `settingsForRuntimeOwner`. (This broke non-markdown local diffs the same way.)

**Fix.** All three paths now resolve through `getRuntimeEnvironmentIdForWorktree` and preserve `null`, so a local-owned worktree pins to local regardless of the globally-active runtime environment. `null` and `undefined` stay equivalent for tab identity and owner matching (`runtimeOwnerKey`), so only RPC routing changes — no new tabs, no changed ids.

## Screenshots

No visual change. Behavior change only: the diff of a local worktree file now renders instead of showing `Error loading diff: selector_not_found`.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Notes on the checklist:

- **`pnpm typecheck`**: passes.
- **`pnpm test`**: full suite green on Node 24 (the repo-required version) — **23400 passed, 31 skipped, 0 code failures**. (One local flake in `terminal-attribution.test.ts` was traced to a machine-global `core.hooksPath` overriding the test's per-repo hook; it passes with `GIT_CONFIG_GLOBAL=/dev/null` and is unrelated to this change.)
- **`pnpm lint`**: `oxlint` is clean on the changed files. The `lint` script currently fails on an unrelated, pre-existing missing localization key (`auto.components.sidebar.WorktreeList.failedUnnestWorkspace` in `WorktreeList.tsx`) that this PR does not touch; left out of scope.
- **Tests added**: a regression test that reproduces the exact conditions — a local-owned worktree while a runtime environment is globally active — and asserts both `openDiff` and `openFile` resolve the owner to `null` (local). Verified it fails without the fix (`[undefined, 'remote-env']`) and passes with it (`[null, null]`).

## AI Review Report

Reviewed with an AI coding agent focused on this routing change.

- **Cross-platform (macOS/Linux/Windows)**: no platform-specific code touched — pure store-level runtime-owner resolution, no keyboard shortcuts, labels, paths, or shell/Electron behavior. No `metaKey`/path/CmdOrCtrl surfaces involved.
- **SSH / remote / local**: this is the core of the change. The fix makes local-owned worktrees route locally while genuinely remote/SSH-owned worktrees (worktree `hostId` or repo `executionHostId` of `runtime:`/`ssh:`) keep resolving to their own environment via `getRuntimeEnvironmentIdForWorktree`. Worktrees with no explicit owner still inherit the active environment, preserving prior behavior.
- **Git-provider neutrality**: no provider-specific logic; operates on generic worktree/runtime ownership.
- **Regression surface**: `null` vs `undefined` was audited against tab-id generation (`buildDiffEditorFileId`/`buildOwnedEditorFileId`) and owner matching (`isSameEditorOwner`) — both normalize through `runtimeOwnerKey`, so identity is unchanged; only `settingsForRuntimeOwner` routing differs, which is the intended fix. One existing test assertion updated from `undefined` to `null` (same local routing).

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change narrows where RPCs are routed (local worktrees no longer address a remote runtime they don't own), which is strictly more conservative. No follow-up needed.

## Notes

- Only manifests when `activeRuntimeEnvironmentId` is set (a remote/SSH runtime active) **and** a local-owned worktree's file is opened — commonly a project that has both local and remote worktrees.
- Pre-existing unrelated `pnpm lint` localization-catalog failure noted above is intentionally not fixed here to keep the PR focused.

## ELI5

Opening a local worktree’s diff while a remote runtime was active hit “selector not found”. Local-owned files stay pinned to the local runtime even when another environment is selected.
