### PR TITLE
Fix stale terminal frames on worktree return: clear alt screen on snapshot restore + WebGL reveal hardening

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7316,7 +7316,7 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
-  it('preserves scrollback by skipping the destructive clear when restoring an alternate-screen snapshot', async () => {
+  it('clears only the alternate screen when restoring an alternate-screen snapshot', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedDataCallback: {
@@ -7364,6 +7364,19 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
       '\x1b[2J\x1b[3J\x1b[H',
       expect.any(Function)
+    )
+    // Why: the snapshot's ?1049h no-ops on an already-alt pane and serialized
+    // frames skip blank cells, so the pre-hide frame bleeds through unless the
+    // alt screen is cleared (without \x1b[3J) before the snapshot paints.
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b[?1049h\x1b[2J\x1b[H',
+      expect.any(Function)
+    )
+    const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map(
+      (call) => call[0]
+    )
+    expect(writes.indexOf('\x1b[?1049h\x1b[2J\x1b[H')).toBeLessThan(
+      writes.indexOf('altscreen-snapshot\r\n')
     )
     expect(pane.terminal.write).toHaveBeenCalledWith('altscreen-snapshot\r\n', expect.any(Function))
     disposable.dispose()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4393,6 +4393,13 @@ export function connectPanePty(
         // clearing on restore loses scroll-up after a hidden->visible return.
         // Mirrors the attach-time guard in pty-transport.ts.
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+      } else {
+        // Why: the snapshot's own ?1049h is a no-op when the pane is already on
+        // the alternate screen, and the serialized frame skips blank cells — so
+        // without clearing the alt screen the pre-hide frame bleeds through
+        // every cell the final frame leaves blank. \x1b[2J on the alt buffer
+        // does not touch the normal buffer's scrollback the TUI returns to.
+        writeReplayData('\x1b[?1049h\x1b[2J\x1b[H')
       }
       writeReplayData(snapshot.data)
       writeReplayData(POST_REPLAY_LIVE_SNAPSHOT_RESET)

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import {
+  recoverVisibleTerminalWindowWake,
+  resumeTerminalVisibility
+} from './terminal-visibility-resume'
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', () => ({
+  resetAndRefreshAllTerminalWebglAtlases: vi.fn()
+}))
+vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
+  flushTerminalOutput: vi.fn(),
+  requestTerminalBacklogRecovery: vi.fn()
+}))
+vi.mock('@/lib/pane-manager/terminal-scroll-intent', () => ({
+  enforceTerminalCurrentScrollIntent: vi.fn()
+}))
+vi.mock('./pane-helpers', () => ({
+  fitAndFocusPanes: vi.fn(),
+  fitPanes: vi.fn(),
+  focusActivePane: vi.fn()
+}))
+vi.mock('./terminal-webgl-atlas-recovery', () => ({
+  scheduleTerminalWebglAtlasRecovery: vi.fn()
+}))
+
+type FakeManager = {
+  getPanes: ReturnType<typeof vi.fn>
+  resumeRendering: ReturnType<typeof vi.fn>
+  scheduleRevealRepaint: ReturnType<typeof vi.fn>
+}
+
+function createManager(order: string[] = []): FakeManager {
+  return {
+    getPanes: vi.fn(() => []),
+    resumeRendering: vi.fn(() => order.push('resume-rendering')),
+    scheduleRevealRepaint: vi.fn(() => order.push('reveal-repaint'))
+  }
+}
+
+function resumeArgs(manager: FakeManager, shouldUseLightTabResume: boolean) {
+  return {
+    manager: manager as never as PaneManager,
+    isActive: true,
+    wasVisible: false,
+    shouldUseLightTabResume,
+    captureViewportPositions: vi.fn(() => new Map()),
+    withSuppressedScrollTracking: (callback: () => void) => callback()
+  }
+}
+
+describe('resumeTerminalVisibility reveal repaint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('schedules a pane-scoped repaint on a light tab reveal', () => {
+    // The light path is the "click the tab that was not open" gesture: it has
+    // no rendering resume or fit, so without this repaint a hidden-while-
+    // working pane keeps compositing pre-hide pixels.
+    const manager = createManager()
+    resumeTerminalVisibility(resumeArgs(manager, true))
+
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+    expect(manager.resumeRendering).not.toHaveBeenCalled()
+  })
+
+  it('schedules the repaint after rendering resumes on a heavy reveal', () => {
+    const order: string[] = []
+    const manager = createManager(order)
+    resumeTerminalVisibility(resumeArgs(manager, false))
+
+    expect(order).toEqual(['resume-rendering', 'reveal-repaint'])
+  })
+
+  it('schedules the repaint on window-wake recovery', () => {
+    const manager = createManager()
+    recoverVisibleTerminalWindowWake({
+      manager: manager as never as PaneManager,
+      isActive: false
+    })
+
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -75,6 +75,10 @@ export function resumeTerminalVisibility({
       // terminals; refresh after reset so rebuilt atlases repaint from xterm.
       resetAndRefreshAllTerminalWebglAtlases()
     }
+    // Why: the synchronous recovery above can fire before the revealed pane is
+    // attached and laid out, where the WebGL renderer drops redraw requests
+    // without retry. Follow up with a settled-frame, pane-scoped repaint.
+    manager.scheduleRevealRepaint()
   })
 }
 
@@ -133,6 +137,7 @@ export function recoverVisibleTerminalWindowWake({
   }
   enforceTerminalViewportIntents(manager)
   resetAndRefreshAllTerminalWebglAtlases()
+  manager.scheduleRevealRepaint()
 }
 
 function requestLightTabBacklogRecovery(manager: PaneManager): void {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -130,6 +130,7 @@ function useMountForFileDrop(
     getPanes: ReturnType<typeof vi.fn>
     resumeRendering: ReturnType<typeof vi.fn>
     resetWebglTextureAtlases: ReturnType<typeof vi.fn>
+    scheduleRevealRepaint: ReturnType<typeof vi.fn>
     suspendRendering: ReturnType<typeof vi.fn>
     getActivePane: ReturnType<typeof vi.fn>
   }
@@ -146,6 +147,7 @@ function useMountForFileDrop(
     getPanes: vi.fn(() => []),
     resumeRendering: vi.fn(),
     resetWebglTextureAtlases: vi.fn(),
+    scheduleRevealRepaint: vi.fn(),
     suspendRendering: vi.fn(),
     getActivePane: vi.fn(() => null)
   }
@@ -222,6 +224,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       ]),
       resumeRendering: vi.fn(() => order.push('resume')),
       resetWebglTextureAtlases: vi.fn(() => order.push('reset-atlas')),
+      scheduleRevealRepaint: vi.fn(() => order.push('reveal-repaint')),
       refreshAllPanes: vi.fn(() => order.push('refresh')),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -280,7 +283,8 @@ describe('useTerminalPaneGlobalEffects', () => {
       'intent:terminal-a',
       'intent:terminal-b',
       'reset-atlas',
-      'refresh'
+      'refresh',
+      'reveal-repaint'
     ])
     expect(mocks.restoreScrollStateAfterLayout).not.toHaveBeenCalled()
     expect(mocks.flushTerminalOutput).toHaveBeenNthCalledWith(1, terminalA, {
@@ -308,6 +312,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [{ id: 1, terminal }]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -387,6 +392,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [{ id: 1, terminal }]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -448,6 +454,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [{ id: 1, terminal }]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -501,6 +508,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [{ id: 1, terminal }]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -578,6 +586,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [{ id: 1, terminal: { name: 'terminal-a' } }]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
     }
@@ -609,6 +618,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [{ id: 1, terminal: terminalA }]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
@@ -667,6 +677,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => []),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
@@ -711,6 +722,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [{ id: 1, terminal }]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal }))
@@ -775,6 +787,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => []),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
@@ -829,6 +842,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => []),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
@@ -874,6 +888,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [pane]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => pane)
     }
@@ -929,6 +944,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => [pane]),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => pane)
     }
@@ -1044,6 +1060,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => []),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
@@ -1077,6 +1094,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       getPanes: vi.fn(() => []),
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null)

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -38,6 +38,7 @@ import {
 } from './pane-rendering-control'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import { registerLivePaneManager, unregisterLivePaneManager } from './pane-manager-registry'
+import { schedulePaneRevealRepaint } from './pane-reveal-repaint'
 import { PaneIdentityRegistry } from './pane-identity-registry'
 import { closeManagedPane, splitManagedPane } from './pane-split-close'
 import { FIRST_PANE_ID } from '../../../../shared/pane-key'
@@ -288,6 +289,10 @@ export class PaneManager {
 
   resetWebglTextureAtlases(): void {
     resetPaneWebglTextureAtlases(this.panes.values())
+  }
+
+  scheduleRevealRepaint(): void {
+    schedulePaneRevealRepaint(() => this.panes.values())
   }
 
   suspendRendering(): void {

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -292,7 +292,10 @@ export class PaneManager {
   }
 
   scheduleRevealRepaint(): void {
-    schedulePaneRevealRepaint(() => this.panes.values())
+    // Why: the settled-frame callback can fire after destroy(); repainting
+    // disposed panes could throw in attach and latch the global WebGL
+    // attach backoff, downgrading unrelated new panes to the DOM renderer.
+    schedulePaneRevealRepaint(() => (this.destroyed ? [] : this.panes.values()))
   }
 
   suspendRendering(): void {

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { schedulePaneRevealRepaint } from './pane-reveal-repaint'
+import { resetTerminalWebglSuggestion } from './pane-webgl-renderer'
+
+type FakeWebglAddon = { clearTextureAtlas: ReturnType<typeof vi.fn> }
+
+function createPane(options: { webglAddon?: FakeWebglAddon | null } = {}): ManagedPaneInternal {
+  const leafId = '33333333-3333-4333-8333-333333333333' as never
+  return {
+    id: 1,
+    leafId,
+    stablePaneId: leafId,
+    terminal: {
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn(),
+      loadAddon: vi.fn()
+    } as never,
+    container: {} as never,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'on',
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    webglAddon: (options.webglAddon ?? null) as never,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    pendingWebglRefreshRafId: null,
+    fitAddon: {
+      proposeDimensions: vi.fn(() => ({ cols: 80, rows: 23 })),
+      fit: vi.fn()
+    } as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+describe('schedulePaneRevealRepaint', () => {
+  let rafQueue: FrameRequestCallback[]
+
+  function flushFrame(): void {
+    const queue = rafQueue
+    rafQueue = []
+    for (const callback of queue) {
+      callback(16)
+    }
+  }
+
+  beforeEach(() => {
+    resetTerminalWebglSuggestion()
+    rafQueue = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      rafQueue.push(callback)
+      return rafQueue.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('repaints only after the post-reveal frame has settled', () => {
+    const webglAddon = { clearTextureAtlas: vi.fn() }
+    const pane = createPane({ webglAddon })
+    schedulePaneRevealRepaint(() => [pane])
+
+    // First frame: reveal layout may still be in flight; redraw requests fired
+    // here can be dropped by the renderer without retry.
+    flushFrame()
+    expect(webglAddon.clearTextureAtlas).not.toHaveBeenCalled()
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+
+    flushFrame()
+    expect(webglAddon.clearTextureAtlas).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('reattaches a missing WebGL addon before repainting', () => {
+    const pane = createPane()
+    schedulePaneRevealRepaint(() => [pane])
+
+    flushFrame()
+    flushFrame()
+
+    expect(pane.webglAddon).not.toBeNull()
+    expect(pane.terminal.refresh).toHaveBeenCalled()
+  })
+
+  it('resolves the pane list at repaint time, not at scheduling time', () => {
+    const stalePane = createPane({ webglAddon: { clearTextureAtlas: vi.fn() } })
+    const livePane = createPane({ webglAddon: { clearTextureAtlas: vi.fn() } })
+    const panes = [stalePane]
+    schedulePaneRevealRepaint(() => panes)
+    panes.splice(0, panes.length, livePane)
+
+    flushFrame()
+    flushFrame()
+
+    expect(
+      (stalePane.webglAddon as never as FakeWebglAddon).clearTextureAtlas
+    ).not.toHaveBeenCalled()
+    expect(
+      (livePane.webglAddon as never as FakeWebglAddon).clearTextureAtlas
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to a timeout when animation frames are unavailable', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', undefined)
+    const webglAddon = { clearTextureAtlas: vi.fn() }
+    const pane = createPane({ webglAddon })
+
+    schedulePaneRevealRepaint(() => [pane])
+    vi.runAllTimers()
+
+    expect(webglAddon.clearTextureAtlas).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
@@ -115,6 +115,23 @@ describe('schedulePaneRevealRepaint', () => {
     ).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps repainting remaining panes when one pane throws', () => {
+    const explosivePane = {
+      get gpuRenderingEnabled(): boolean {
+        throw new Error('pane torn down mid-frame')
+      }
+    } as never as ManagedPaneInternal
+    const webglAddon = { clearTextureAtlas: vi.fn() }
+    const livePane = createPane({ webglAddon })
+    schedulePaneRevealRepaint(() => [explosivePane, livePane])
+
+    flushFrame()
+    flushFrame()
+
+    expect(webglAddon.clearTextureAtlas).toHaveBeenCalledTimes(1)
+    expect(livePane.terminal.refresh).toHaveBeenCalled()
+  })
+
   it('falls back to a timeout when animation frames are unavailable', () => {
     vi.useFakeTimers()
     vi.stubGlobal('requestAnimationFrame', undefined)

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
@@ -28,8 +28,12 @@ function scheduleSettledFrame(callback: () => void): void {
 export function schedulePaneRevealRepaint(getPanes: () => Iterable<ManagedPaneInternal>): void {
   scheduleSettledFrame(() => {
     for (const pane of getPanes()) {
-      reattachWebglIfNeeded(pane)
-      resetWebglTextureAtlas(pane)
+      try {
+        reattachWebglIfNeeded(pane)
+        resetWebglTextureAtlas(pane)
+      } catch {
+        /* ignore — one pane's failure must not block repaint of the rest */
+      }
     }
   })
 }

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
@@ -1,0 +1,35 @@
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { reattachWebglIfNeeded } from './pane-webgl-reattach'
+import { resetWebglTextureAtlas } from './pane-webgl-renderer'
+
+function scheduleSettledFrame(callback: () => void): void {
+  if (typeof globalThis.requestAnimationFrame !== 'function') {
+    globalThis.setTimeout(callback, 0)
+    return
+  }
+  // Why: the first frame after a reveal can still be laying out the tab
+  // overlay; the WebGL renderer silently drops redraw requests until the pane
+  // is attached and measured, so repaint on the frame after layout settles.
+  globalThis.requestAnimationFrame(() => {
+    globalThis.requestAnimationFrame(callback)
+  })
+}
+
+/**
+ * Repaints a revealed tab's panes from their xterm buffers.
+ *
+ * Why: while a pane is hidden, parsed output can update the WebGL renderer's
+ * per-cell model without ever presenting a frame. At reveal the model diff
+ * reports those cells unchanged, so plain refreshes skip them and the canvas
+ * keeps compositing pre-hide pixels until a selection or resize rebuilds the
+ * model. Clearing the model per pane — after (re)attach, once layout has
+ * settled — forces a full rebuild from the buffer without any PTY resize.
+ */
+export function schedulePaneRevealRepaint(getPanes: () => Iterable<ManagedPaneInternal>): void {
+  scheduleSettledFrame(() => {
+    for (const pane of getPanes()) {
+      reattachWebglIfNeeded(pane)
+      resetWebglTextureAtlas(pane)
+    }
+  })
+}

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WebglAddon } from '@xterm/addon-webgl'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import {
+  attachWebgl,
+  resetTerminalWebglSuggestion,
+  resetWebglTextureAtlas
+} from './pane-webgl-renderer'
+
+function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneInternal {
+  const leafId = '22222222-2222-4222-8222-222222222222' as never
+  return {
+    id: 1,
+    leafId,
+    stablePaneId: leafId,
+    terminal: {
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn(),
+      loadAddon: vi.fn(options.loadAddon)
+    } as never,
+    container: {} as never,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'on',
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    webglAddon: null,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    pendingWebglRefreshRafId: null,
+    fitAddon: {
+      proposeDimensions: vi.fn(() => ({ cols: 80, rows: 23 })),
+      fit: vi.fn()
+    } as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+describe('terminal WebGL addon lifecycle', () => {
+  beforeEach(() => {
+    resetTerminalWebglSuggestion()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('disposes a live addon when attach bails instead of orphaning it', () => {
+    const pane = createPane()
+    attachWebgl(pane)
+    const liveAddon = pane.webglAddon
+    expect(liveAddon).not.toBeNull()
+    const disposeSpy = vi.spyOn(liveAddon as WebglAddon, 'dispose')
+
+    // An undisposed addon here kept painting stale frames while atlas resets,
+    // reattach checks, and diagnostics all treated the pane as DOM-rendered.
+    pane.webglAttachmentDeferred = true
+    attachWebgl(pane)
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(pane.webglAddon).toBeNull()
+  })
+
+  it('disposes the previous addon before attaching a replacement', () => {
+    const pane = createPane()
+    attachWebgl(pane)
+    const firstAddon = pane.webglAddon
+    expect(firstAddon).not.toBeNull()
+    const disposeSpy = vi.spyOn(firstAddon as WebglAddon, 'dispose')
+
+    attachWebgl(pane)
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(pane.webglAddon).not.toBeNull()
+    expect(pane.webglAddon).not.toBe(firstAddon)
+  })
+
+  it('disposes the constructed addon when loading it fails', () => {
+    const disposeSpy = vi.spyOn(WebglAddon.prototype, 'dispose')
+    const pane = createPane({
+      loadAddon: () => {
+        throw new Error('WebGL2 not supported null')
+      }
+    })
+
+    attachWebgl(pane)
+
+    expect(pane.webglAddon).toBeNull()
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('still refreshes the terminal when resetting a pane without a WebGL addon', () => {
+    const pane = createPane()
+    expect(pane.webglAddon).toBeNull()
+
+    resetWebglTextureAtlas(pane)
+
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('skips the reset while WebGL is latched off after a context loss', () => {
+    const pane = createPane()
+    pane.webglDisabledAfterContextLoss = true
+
+    resetWebglTextureAtlas(pane)
+
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -47,10 +47,13 @@ function refreshTerminalAfterWebglAttach(pane: ManagedPaneInternal): void {
 }
 
 export function cancelPendingWebglRefresh(pane: ManagedPaneInternal): void {
-  if (pane.pendingWebglRefreshRafId != null) {
-    cancelAnimationFrame(pane.pendingWebglRefreshRafId)
-    pane.pendingWebglRefreshRafId = null
+  if (pane.pendingWebglRefreshRafId == null) {
+    return
   }
+  if (typeof globalThis.cancelAnimationFrame === 'function') {
+    globalThis.cancelAnimationFrame(pane.pendingWebglRefreshRafId)
+  }
+  pane.pendingWebglRefreshRafId = null
 }
 
 export function disposeWebgl(
@@ -87,14 +90,16 @@ export function markComplexScriptOutput(pane: ManagedPaneInternal): void {
 }
 
 export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
-  if (!pane.webglAddon || pane.webglDisabledAfterContextLoss) {
+  if (pane.webglDisabledAfterContextLoss) {
     return
   }
   try {
     // Why: rapid TUI redraws can corrupt xterm's WebGL glyph atlas without a
     // context-loss event. Clearing the atlas preserves GPU rendering and forces
     // a fresh paint when the pane becomes visible/focused again.
-    pane.webglAddon.clearTextureAtlas()
+    pane.webglAddon?.clearTextureAtlas()
+    // Why: refresh even without a WebGL addon so recovery never silently
+    // no-ops — a DOM-rendered pane can hold stale pixels after reveal too.
     pane.terminal.refresh(0, pane.terminal.rows - 1)
   } catch {
     /* ignore — pane may have been disposed in the meantime */
@@ -110,12 +115,20 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
     pane.webglDisabledAfterContextLoss ||
     webglAttachFailedSinceRecovery
   ) {
-    pane.webglAddon = null
+    // Why: nulling the reference here used to leak a still-loaded addon that
+    // kept painting stale frames while every recovery path (atlas reset,
+    // reattach, diagnostics) treated the pane as DOM-rendered. Dispose so the
+    // pane genuinely falls back to the DOM renderer.
+    disposeWebgl(pane, { refreshDimensions: true })
     return
   }
+  // Single-addon invariant: never stack a second addon on a live one.
+  disposeWebgl(pane)
+  let webglAddon: WebglAddon | null = null
   try {
-    const webglAddon = new WebglAddon()
-    webglAddon.onContextLoss(() => {
+    webglAddon = new WebglAddon()
+    const addon = webglAddon
+    addon.onContextLoss(() => {
       console.warn(
         '[terminal] WebGL context lost for pane',
         pane.id,
@@ -128,8 +141,8 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       pane.webglDisabledAfterContextLoss = true
       disposeWebgl(pane, { refreshDimensions: true })
     })
-    pane.terminal.loadAddon(webglAddon)
-    pane.webglAddon = webglAddon
+    pane.terminal.loadAddon(addon)
+    pane.webglAddon = addon
     refreshTerminalAfterWebglAttach(pane)
   } catch (err) {
     if (pane.terminalGpuAcceleration === 'auto') {
@@ -140,6 +153,11 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
     webglAttachFailedSinceRecovery = true
     // WebGL not available — default DOM renderer is fine, but log it for debugging
     console.warn('[terminal] WebGL unavailable for pane', pane.id, '— using DOM renderer:', err)
+    try {
+      webglAddon?.dispose()
+    } catch {
+      /* ignore — a half-constructed addon may throw on dispose */
+    }
     pane.webglAddon = null
   }
 }


### PR DESCRIPTION
## Symptom

Start two agents in a worktree's terminal tabs, switch to another worktree while they work, come back when they're done, and check the tabs: one shows the frozen/overlapping mid-work frame (old prompt echo and banner text bleeding through the final output) until you select text or resize. Reported by @brennanb2025; reproduced twice, and the second reproduction was captured **live** and dissected layer by layer.

## Root cause (proven on the live specimen)

The corrupted pane is a **cell-level merge inside the renderer's xterm buffer**: the pre-hide frame (banner + prompt echo) bleeding through every cell the final frame leaves blank. The render model matched the buffer exactly, the WebGL context was healthy, and a forced full redraw reproduced the same pixels — the rendering stack was faithfully painting a merged buffer.

The merge happens in the hidden-output restore (`applyMainBufferSnapshot`):

1. While a pane is hidden, risky TUI bytes are skipped renderer-side; at reveal, the pane is restored from the main-process buffer snapshot.
2. For **alternate-screen** snapshots the destructive clear (`\x1b[2J\x1b[3J\x1b[H`) is deliberately skipped, to protect the normal buffer's scrollback.
3. But the snapshot stream's own `?1049h` is a **no-op on a pane that's already on the alternate screen**, and the serialized frame **skips blank cells** (cursor-forward jumps) — so nothing ever erases the pre-hide frame. Every skipped cell keeps its stale content.
4. On a fresh terminal, `?1049h` enters-and-clears the alt screen — which is why this never reproduced in fresh windows and survived earlier fix attempts (#7054, reverted #7058).

Live proof both ways: byte capture of the snapshot stream shows `?1049h` + modes + `[H` + cursor-jump content with no clear; and writing the *same snapshot* prefixed with an alt-screen clear repaired the corrupted pane pixel-perfectly.

## Fix

**Primary — `pty-connection.ts`:** for alternate-screen snapshots, write `\x1b[?1049h\x1b[2J\x1b[H` before the snapshot data. `\x1b[2J` on the alt buffer clears only the alt screen; the normal buffer's scrollback (what the original guard was protecting) is untouched, and there is still no `\x1b[3J`.

**Hardening — WebGL reveal path** (first commit, kept): a related render-level variant (buffer clean, pixels stale) was captured in an earlier session. Three defects fixed: `attachWebgl` could orphan a live addon on its bail path (making every recovery sweep a silent no-op for exactly the broken pane), `resetWebglTextureAtlas` early-returned without refreshing when the addon ref was null, and reveal recovery could fire redraw requests before the revealed pane was attached/measured (where the renderer drops them without retry). Now: dispose-on-bail + single-addon invariant, refresh-always, and a settled-frame pane-scoped repaint on tab reveal / worktree resume / window wake. No PTY resize anywhere, so the grid never drifts.

## Relationship to #7054 / #7058 / #7073

#7054's hidden-output skip machinery is what makes the restore path load-bearing; #7058 (reverted in #7073) retriggered global atlas resets on reveal, which cannot repair either variant (the buffer merge is below the renderer; the render variant's per-pane reset no-op'd on orphaned refs). This PR supersedes that approach and does not re-land it.

## Tests

- `pty-connection.test.ts` — alt-screen restore now asserts the alt-only clear is written **before** the snapshot data, and still asserts the destructive `3J` clear is not.
- `pane-webgl-renderer.test.ts`, `pane-reveal-repaint.test.ts`, `terminal-visibility-resume.test.ts` — reveal-hardening regression tests (dispose-on-bail, repaint ordering, all three reveal seams).
- Full terminal-pane suite: 1437 tests passing; pane-manager suite: 349 passing; typecheck + oxlint clean (`verify:localization-catalog` fails on main for an unrelated `WorktreeList` key).
- Live validation on the reproduced specimen: fixed preamble + identical snapshot bytes → pixel-perfect final frame.