### PR TITLE
Keep terminals responsive under agent output load

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -898,10 +898,66 @@ describe('pane terminal output scheduler', () => {
     expect(terminal.write).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(0)
-    expect(terminal.write).toHaveBeenCalledTimes(16)
+    expect(terminal.write).toHaveBeenCalledTimes(2)
 
-    vi.advanceTimersByTime(1)
-    expect(terminal.write).toHaveBeenCalledTimes(32)
+    vi.advanceTimersByTime(4)
+    expect(terminal.write).toHaveBeenCalledTimes(4)
+  })
+
+  it('yields high-priority backlog drains when writes spend the frame budget', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+    const chunk = 'x'.repeat(16 * 1024)
+    let now = 0
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
+    terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      now += 9
+      callback?.()
+    })
+
+    try {
+      for (let i = 0; i < 64; i++) {
+        writeTerminalOutput(terminal, chunk, { foreground: false })
+      }
+
+      vi.advanceTimersByTime(0)
+      expect(terminal.write).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(4)
+      expect(terminal.write).toHaveBeenCalledTimes(2)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('uses Date.now for drain budgeting when performance is unavailable', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('performance', undefined)
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+    const chunk = 'x'.repeat(16 * 1024)
+    let now = 0
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      now += 9
+      callback?.()
+    })
+
+    try {
+      for (let i = 0; i < 64; i++) {
+        writeTerminalOutput(terminal, chunk, { foreground: false })
+      }
+
+      vi.advanceTimersByTime(0)
+      expect(terminal.write).toHaveBeenCalledTimes(1)
+      expect(nowSpy).toHaveBeenCalled()
+
+      vi.advanceTimersByTime(4)
+      expect(terminal.write).toHaveBeenCalledTimes(2)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('caps hidden backlog memory and writes a warning instead of retaining all output', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -68,10 +68,11 @@ type QueueEntry = {
 
 const BACKGROUND_FLUSH_DELAY_MS = 50
 const BACKGROUND_DRAIN_INTERVAL_MS = 16
-const HIGH_PRIORITY_DRAIN_INTERVAL_MS = 1
+const HIGH_PRIORITY_DRAIN_INTERVAL_MS = 4
 const BACKGROUND_CHUNK_CHARS = 16 * 1024
 const MAX_WRITES_PER_DRAIN = 2
-const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 16
+const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 2
+const DRAIN_TIME_BUDGET_MS = 8
 const LARGE_BACKLOG_CHARS = 512 * 1024
 const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024
 const MAX_BACKGROUND_QUEUE_CHARS = 2 * 1024 * 1024
@@ -728,10 +729,18 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
   return queuedWrite.foreground ? 'foreground' : 'background'
 }
 
+function getDrainNow(): number {
+  if (typeof performance !== 'undefined') {
+    return performance.now()
+  }
+  return Date.now()
+}
+
 function drainQueuedOutput(): void {
   drainTimer = null
   drainTimerDelayMs = null
   let writes = 0
+  const startedAt = getDrainNow()
   const maxWrites = hasHighPriorityBacklog()
     ? HIGH_PRIORITY_MAX_WRITES_PER_DRAIN
     : MAX_WRITES_PER_DRAIN
@@ -759,6 +768,11 @@ function drainQueuedOutput(): void {
       entry.highPriority = false
       clearForegroundCoalesce(entry)
       clearForegroundHoldSafety(entry)
+    }
+    // Why: xterm parsing and DOM work share the renderer thread with input.
+    // Keep backlog draining cooperative so WSL/agent output cannot pin the UI.
+    if (writes > 0 && getDrainNow() - startedAt >= DRAIN_TIME_BUDGET_MS) {
+      break
     }
   }
 


### PR DESCRIPTION
## Summary
- Makes terminal backlog draining cooperative so heavy agent/WSL output yields to renderer input and scrolling.
- Reduces high-priority terminal drain bursts to 2 writes every 4ms and adds an 8ms per-drain time budget.
- Adds focused regression coverage for the new burst/cadence, expensive-write yielding, and `Date.now()` fallback.

Refs #7017.

## Design Review
- Scratch design doc: `.tmp/issue-7017/design.md` (not committed).
- Design review subagent completed clean after narrowing scope to renderer terminal responsiveness rather than claiming a full fix for all memory/crash causes.
- The design explicitly covers SSH/cross-platform behavior and leaves process-level memory attribution as follow-up if memory growth continues.

## Implementation
- Changed `src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts` to limit high-priority drain cadence/burst and yield after the renderer-thread budget is spent.
- Updated `src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts` for the new behavior.
- No agent-visible prompt text or provider-specific behavior was added.

## Verification
- Completeness verifier: clean against the reviewed design.
- Code review loop: fresh two-reviewer round returned clean from both reviewers.
- `brennan-test-changes`: verdict `land`.

## Tests and Checks
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts` passed, 45/45.
- `pnpm run typecheck` passed.
- `pnpm run lint` passed with existing warnings outside this diff.
- `git diff --check` passed with only Windows CRLF conversion warnings.
- `$env:VITE_EXPOSE_STORE='true'; pnpm exec electron-vite build --mode e2e` passed.

## Product-Surface Validation
- Fresh Windows/WSL Electron harness with 4 sessions and long key sample:
  - Run 1: median key echo 16ms, worst 139ms, max timer drift 881.4ms, peak queued chars 118,486, dropped backlogs 0.
  - Run 2: median key echo 15ms, worst 153ms, max timer drift 975.8ms, peak queued chars 175,548, dropped backlogs 0.
- Earlier patched runs also removed the reproduced second-scale key echo shape; pre-fix repro showed worst key echo around 1176ms and timer drift around 1060ms.
- No screenshot evidence attached: validation was metric-based Electron/WSL performance automation, not a visible UI layout change.

## Accepted Gaps / Residual Risk
- `pnpm run test:e2e:terminal-perf:scale:report` failed before the Playwright workload on Windows with `spawn EINVAL`; the report was empty.
- Direct Playwright same-workspace perf attempt failed before terminal load because the temp workspace was not selected. The page showed the temp repo in the sidebar, so this appears to be harness setup rather than scheduler behavior.
- Timer drift remains noisy in the scratch WSL harness, so this does not prove every UI stutter or memory/crash path from #7017 is fixed. If reports continue, we still need process-level attribution: Orca renderer/main/utility process vs agent CLIs vs WSL/vmmem, whether memory drops after stopping agents/closing terminals/restart, Orca version, and local/SSH/server context.

## Post-PR Stabilization
- Completed the required 8-minute wait after opening the PR.
- `gh pr checks 7139 --repo stablyai/orca` reports all checks passing: `verify`, `track-community-pr`, `golden e2e linux experiment`, and `golden e2e mac experiment`.
- CodeRabbit posted a walkthrough/pre-merge summary only; no actionable review comments or line comments were present.