### PR TITLE
Fix Vim alternate-screen terminal redraw recovery

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8989,9 +8989,192 @@ describe('connectPanePty', () => {
       capturedDataCallback.current?.('\x1b[?1049h\x1b[2J\x1b[HVim package.json')
 
       expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+      // Why: xterm switches to the alternate buffer while parsing the chunk;
+      // the write callback observes the post-parse buffer state.
+      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
       parseCallback?.()
       expect(refresh).toHaveBeenCalledWith(0, 39, true)
       expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('schedules WebGL atlas recovery when the alternate-screen enter sequence splits across chunks', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      const refresh = vi.fn()
+      let parseCallback: (() => void) | undefined
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        parseCallback = callback
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      // Why: PTY reads split CSI sequences at arbitrary byte boundaries (real
+      // vim sessions split cursor moves at 1024-byte chunk edges), so the
+      // enter sequence itself can straddle two onData chunks.
+      capturedDataCallback.current?.('\x1b[?104')
+      parseCallback?.()
+      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+
+      capturedDataCallback.current?.('9h\x1b[2J\x1b[H~\x1b[K')
+      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
+      parseCallback?.()
+      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('schedules WebGL atlas recovery when a foreground rewrite leaves alternate screen', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
+      const refresh = vi.fn()
+      let parseCallback: (() => void) | undefined
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        parseCallback = callback
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      // Vim's final frame erases the status line and restores the normal
+      // buffer in one chunk; the atlas must still rebuild for the restored
+      // prompt even though the post-parse buffer is back to normal.
+      capturedDataCallback.current?.('\x1b[34;1H\x1b[K\x1b[34;1H\x1b[?1049l\x1b[?25h')
+      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'normal'
+      parseCallback?.()
+      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('schedules WebGL atlas recovery when one chunk enters and exits alternate screen', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      let bufferChangeListener: (() => void) | undefined
+      ;(
+        pane.terminal.buffer as {
+          onBufferChange?: (listener: () => void) => { dispose: () => void }
+        }
+      ).onBufferChange = (listener) => {
+        bufferChangeListener = listener
+        return { dispose: vi.fn() }
+      }
+      const refresh = vi.fn()
+      let parseCallback: (() => void) | undefined
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        parseCallback = callback
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      // A coalesced backlog flush can parse a whole enter -> draw -> exit TUI
+      // interaction in one write, netting buffer type back to 'normal'; the
+      // buffer-switch count is what still marks it as alternate-screen work.
+      capturedDataCallback.current?.('\x1b[?1049h\x1b[2J\x1b[Hpager frame\x1b[K\x1b[?1049l')
+      bufferChangeListener?.()
+      bufferChangeListener?.()
+      parseCallback?.()
+      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('schedules WebGL atlas recovery for real captured Vim redraw chunks split mid-sequence', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
+      const refresh = vi.fn()
+      let parseCallback: (() => void) | undefined
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        parseCallback = callback
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      // Captured from a real `vim package.json` session: a 1024-byte PTY read
+      // boundary cuts the cursor move \x1b[30;5H into "\x1b[30" + ";5H".
+      capturedDataCallback.current?.('"rules": {\x1b[29;15H\x1b[K\x1b[30')
+      parseCallback?.()
+      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
+
+      capturedDataCallback.current?.(
+        ';5H  "js-combine-iterations": "off"\r\n    }\x1b[31;6H\x1b[K\x1b[33;1H\x1b[?25h'
+      )
+      parseCallback?.()
+      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(2)
     } finally {
       restoreNavigator()
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8916,6 +8916,125 @@ describe('connectPanePty', () => {
     expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
   })
 
+  it('schedules WebGL atlas recovery for Vim-style foreground alternate-screen redraws', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
+      const refresh = vi.fn()
+      let parseCallback: (() => void) | undefined
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        parseCallback = callback
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      capturedDataCallback.current?.(
+        '\x1b[2J\x1b[H{"name":"eepo"}\r\n\x1b[2;1H{"name":"expo"}\x1b[K'
+      )
+
+      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+      parseCallback?.()
+      expect(refresh).toHaveBeenCalledWith(0, 39, true)
+      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('schedules WebGL atlas recovery when a foreground rewrite enters alternate screen', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      const refresh = vi.fn()
+      let parseCallback: (() => void) | undefined
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        parseCallback = callback
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      capturedDataCallback.current?.('\x1b[?1049h\x1b[2J\x1b[HVim package.json')
+
+      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+      parseCallback?.()
+      expect(refresh).toHaveBeenCalledWith(0, 39, true)
+      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('does not schedule WebGL atlas recovery for ordinary foreground shell rewrites', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      const refresh = vi.fn()
+      let parseCallback: (() => void) | undefined
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        parseCallback = callback
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      capturedDataCallback.current?.('\r\x1b[Korca % npm test')
+
+      parseCallback?.()
+      expect(refresh).toHaveBeenCalledWith(0, 39, true)
+      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+    } finally {
+      restoreNavigator()
+    }
+  })
+
   it('does not schedule WebGL atlas recovery for plain synchronized foreground frames', async () => {
     const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
     try {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -195,6 +195,7 @@ const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
 const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 128 * 1024
 const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
+const ALTERNATE_SCREEN_PRIVATE_MODE_CODES = new Set(['47', '1047', '1049'])
 // Why: a submit repaint can take longer than one keystroke echo to fully
 // arrive, so a synchronized frame that *began* this close to a keystroke stays
 // latency-sensitive even when ConPTY splits its end marker past the redraw
@@ -932,6 +933,33 @@ function containsCursorPositionSequence(data: string): boolean {
       index += 1
     }
     offset = data.indexOf('\x1b[', offset + 2)
+  }
+  return false
+}
+
+function containsAlternateScreenEnterSequence(data: string): boolean {
+  let offset = data.indexOf('\x1b[?')
+  while (offset !== -1) {
+    let index = offset + 3
+    let params = ''
+    while (index < data.length) {
+      const char = data[index]
+      if (char >= '0' && char <= '9') {
+        params += char
+        index += 1
+        continue
+      }
+      if (char === ';') {
+        params += char
+        index += 1
+        continue
+      }
+      if (char === 'h') {
+        return params.split(';').some((param) => ALTERNATE_SCREEN_PRIVATE_MODE_CODES.has(param))
+      }
+      break
+    }
+    offset = data.indexOf('\x1b[?', offset + 3)
   }
   return false
 }
@@ -3771,6 +3799,13 @@ export function connectPanePty(
       return decision.prefersRenderRefresh
     }
 
+    function foregroundAlternateScreenRewriteNeedsAtlasRecovery(data: string): boolean {
+      return (
+        pane.terminal.buffer.active.type === 'alternate' ||
+        containsAlternateScreenEnterSequence(data)
+      )
+    }
+
     function shouldForceForegroundRenderRefresh(data: string): {
       refresh: boolean
       inPlaceRewrite: boolean
@@ -3789,7 +3824,13 @@ export function connectPanePty(
       if (rewriteOutputPrefersRenderRefresh) {
         // Why: resize fixes these panes because xterm's buffer is right but
         // in-place redraw cells can remain stale in the renderer until repaint.
-        return { refresh: true, inPlaceRewrite: true, recoverWebglAtlasAfterParse: false }
+        return {
+          refresh: true,
+          inPlaceRewrite: true,
+          // Why: Vim-style full-screen redraws are plain ASCII but can still
+          // leave stale WebGL glyphs after erases until the shared atlas rebuilds.
+          recoverWebglAtlasAfterParse: foregroundAlternateScreenRewriteNeedsAtlasRecovery(data)
+        }
       }
       if (
         windowsEastAsianOutputPrefersRenderRefresh(data, {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -195,7 +195,6 @@ const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
 const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 128 * 1024
 const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
-const ALTERNATE_SCREEN_PRIVATE_MODE_CODES = new Set(['47', '1047', '1049'])
 // Why: a submit repaint can take longer than one keystroke echo to fully
 // arrive, so a synchronized frame that *began* this close to a keystroke stays
 // latency-sensitive even when ConPTY splits its end marker past the redraw
@@ -933,33 +932,6 @@ function containsCursorPositionSequence(data: string): boolean {
       index += 1
     }
     offset = data.indexOf('\x1b[', offset + 2)
-  }
-  return false
-}
-
-function containsAlternateScreenEnterSequence(data: string): boolean {
-  let offset = data.indexOf('\x1b[?')
-  while (offset !== -1) {
-    let index = offset + 3
-    let params = ''
-    while (index < data.length) {
-      const char = data[index]
-      if (char >= '0' && char <= '9') {
-        params += char
-        index += 1
-        continue
-      }
-      if (char === ';') {
-        params += char
-        index += 1
-        continue
-      }
-      if (char === 'h') {
-        return params.split(';').some((param) => ALTERNATE_SCREEN_PRIVATE_MODE_CODES.has(param))
-      }
-      break
-    }
-    offset = data.indexOf('\x1b[?', offset + 3)
   }
   return false
 }
@@ -2576,6 +2548,14 @@ export function connectPanePty(
     forwardPtyResize(cols, rows)
   })
 
+  // Why: a rewrite chunk can enter AND exit the alternate screen in one parse
+  // (fast-quitting TUI), netting buffer.active.type back to 'normal'; counting
+  // switches keeps those redraws visible to the atlas-recovery check.
+  let alternateScreenBufferSwitches = 0
+  const onBufferChangeDisposable = pane.terminal.buffer.onBufferChange?.(() => {
+    alternateScreenBufferSwitches += 1
+  })
+
   // Why: renderer resize forwarding is fire-and-forget. A visible pane can
   // finish with xterm at the right grid while the PTY silently kept an older
   // grid, so Codex keeps composing against stale columns. Fit first so xterm's
@@ -3799,11 +3779,23 @@ export function connectPanePty(
       return decision.prefersRenderRefresh
     }
 
-    function foregroundAlternateScreenRewriteNeedsAtlasRecovery(data: string): boolean {
-      return (
-        pane.terminal.buffer.active.type === 'alternate' ||
-        containsAlternateScreenEnterSequence(data)
-      )
+    // Why: Vim-style TUI redraws are plain-ASCII in-place rewrites whose erased
+    // cells can keep stale WebGL glyphs until the shared atlas rebuilds. Whether
+    // a rewrite touched the alternate screen is only authoritative once xterm
+    // parses the chunk (enter/exit sequences can split across PTY chunks), so
+    // capture the pre-parse state and decide the rest at parse completion.
+    function alternateScreenRewriteAtlasRecoveryOnParsed(): () => void {
+      const wasAlternateScreenBuffer = pane.terminal.buffer.active.type === 'alternate'
+      const switchesBeforeParse = alternateScreenBufferSwitches
+      return () => {
+        if (
+          wasAlternateScreenBuffer ||
+          alternateScreenBufferSwitches !== switchesBeforeParse ||
+          pane.terminal.buffer.active.type === 'alternate'
+        ) {
+          scheduleTerminalWebglAtlasRecovery()
+        }
+      }
     }
 
     function shouldForceForegroundRenderRefresh(data: string): {
@@ -3824,13 +3816,7 @@ export function connectPanePty(
       if (rewriteOutputPrefersRenderRefresh) {
         // Why: resize fixes these panes because xterm's buffer is right but
         // in-place redraw cells can remain stale in the renderer until repaint.
-        return {
-          refresh: true,
-          inPlaceRewrite: true,
-          // Why: Vim-style full-screen redraws are plain ASCII but can still
-          // leave stale WebGL glyphs after erases until the shared atlas rebuilds.
-          recoverWebglAtlasAfterParse: foregroundAlternateScreenRewriteNeedsAtlasRecovery(data)
-        }
+        return { refresh: true, inPlaceRewrite: true, recoverWebglAtlasAfterParse: false }
       }
       if (
         windowsEastAsianOutputPrefersRenderRefresh(data, {
@@ -3899,6 +3885,13 @@ export function connectPanePty(
         !foregroundOutput && hiddenOutputNeedsAtlasRecoveryAfterParse(data)
       const recoverWebglAtlasAfterParse =
         renderRefreshDecision.recoverWebglAtlasAfterParse || recoverHiddenWebglAtlasAfterParse
+      // Why: atlas recovery must repaint from the parsed xterm buffer, not a
+      // pre-write snapshot that a late TUI redraw can immediately stale.
+      const onParsedAtlasRecovery = recoverWebglAtlasAfterParse
+        ? scheduleTerminalWebglAtlasRecovery
+        : renderRefreshDecision.inPlaceRewrite
+          ? alternateScreenRewriteAtlasRecoveryOnParsed()
+          : undefined
       const foregroundRenderRefreshNeeded = renderRefreshDecision.refresh
       // Why: see nativeWindowsRewriteNeedsFollowupRenderRefresh — Claude Code's
       // in-place prompt redraws on Windows ConPTY can paint one frame late, so a
@@ -3945,9 +3938,7 @@ export function connectPanePty(
             foregroundRenderRefreshNeeded),
         followupForegroundRefresh:
           nativeWindowsCursorRestore || nativeWindowsInPlaceRewriteFollowup,
-        // Why: atlas recovery must repaint from the parsed xterm buffer, not
-        // a pre-write snapshot that a late TUI redraw can immediately stale.
-        onParsed: recoverWebglAtlasAfterParse ? scheduleTerminalWebglAtlasRecovery : undefined,
+        onParsed: onParsedAtlasRecovery,
         stripTransientCursorShows: shouldProtectNativeWindowsSynchronizedOutput && foreground,
         coalesceForeground: synchronizedForegroundOutput && synchronizedOutputEnded,
         holdForeground: synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive
@@ -5581,6 +5572,7 @@ export function connectPanePty(
       onDataDisposable.dispose()
       terminalCapabilityRepliesDisposable.dispose()
       onResizeDisposable.dispose()
+      onBufferChangeDisposable?.dispose()
       pane.container.removeEventListener(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT, onHeldPtyResizeFlush)
       geometryReportObserver?.disconnect()
       if (pendingGeometryReportRaf !== null) {

--- a/src/renderer/src/components/terminal-pane/terminal-alternate-screen-parse.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-alternate-screen-parse.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { Terminal } from '@xterm/headless'
+
+function writeChunk(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, resolve))
+}
+
+// Pins the xterm contract the alternate-screen atlas recovery relies on: by the
+// time a chunk's write callback runs, buffer.active.type reflects any
+// alternate-screen enter/exit parsed from that chunk — even when the sequence
+// splits across PTY chunk boundaries.
+describe('alternate-screen buffer state at write-callback time', () => {
+  it('reflects an enter sequence split across two chunks', async () => {
+    const term = new Terminal({ cols: 120, rows: 34, allowProposedApi: true })
+    await writeChunk(term, '\x1b[?104')
+    expect(term.buffer.active.type).toBe('normal')
+    await writeChunk(term, '9h\x1b[2J\x1b[H~\x1b[K')
+    expect(term.buffer.active.type).toBe('alternate')
+    term.dispose()
+  })
+
+  it('fires onBufferChange for each switch when one chunk enters and exits', async () => {
+    const term = new Terminal({ cols: 120, rows: 34, allowProposedApi: true })
+    let switches = 0
+    const disposable = term.buffer.onBufferChange(() => {
+      switches += 1
+    })
+    await writeChunk(term, '\x1b[?1049h\x1b[2J\x1b[Hpager frame\x1b[K\x1b[?1049l')
+    expect(term.buffer.active.type).toBe('normal')
+    expect(switches).toBe(2)
+    disposable.dispose()
+    term.dispose()
+  })
+
+  it('tracks enter, split redraw, and exit from a real captured vim session', async () => {
+    const term = new Terminal({ cols: 120, rows: 34, allowProposedApi: true })
+    // Captured from `vim package.json` (macOS, TERM=xterm-256color): startup chunk.
+    await writeChunk(
+      term,
+      '\x1b[?1049h\x1b[>4;2m\x1b[?1h\x1b=\x1b[?2004h\x1b[?1004h\x1b[1;34r\x1b[?12h\x1b[?12l\x1b[22;2t\x1b[22;1t'
+    )
+    expect(term.buffer.active.type).toBe('alternate')
+    // Mid-session redraw where a 1024-byte PTY read split \x1b[30;5H in two.
+    await writeChunk(term, '"rules": {\x1b[29;15H\x1b[K\x1b[30')
+    await writeChunk(
+      term,
+      ';5H  "js-combine-iterations": "off"\r\n    }\x1b[31;6H\x1b[K\x1b[33;1H\x1b[?25h'
+    )
+    expect(term.buffer.active.type).toBe('alternate')
+    // Vim quit: erase the status line and restore the normal buffer in one chunk.
+    await writeChunk(
+      term,
+      '\x1b[23;2t\x1b[23;1t\x1b[34;1H\x1b[K\x1b[34;1H\x1b[?1004l\x1b[?2004l\x1b[?1l\x1b>\x1b[?1049l\x1b[?25h\x1b[>4;m'
+    )
+    expect(term.buffer.active.type).toBe('normal')
+    term.dispose()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #7070 — Vim (and other full-screen TUIs) ghosting/garbled redraws in Orca's terminal.

Vim redraws with plain-ASCII cursor-move/erase rewrites that xterm parses correctly, but the shared WebGL glyph atlas can keep stale glyphs until it is rebuilt, so erased cells ghost ("eepo" over "expo"). Orca already forced a viewport refresh for in-place rewrites; this PR additionally schedules the existing coalesced WebGL atlas recovery for rewrites that touch the alternate screen.

**How the alternate-screen check works.** Whether a rewrite touched the alternate screen is decided at parse completion, not by scanning raw chunk bytes. xterm's `write(data, callback)` contract runs the callback after the parser has processed that chunk (FIFO per chunk), and the alternate-screen switch (DECSET 47/1047/1049) happens synchronously inside the parse — so `buffer.active.type` read inside the callback is authoritative. Two captures make the coverage complete: the pre-parse buffer type (so a TUI's final frame — redraw + `?1049l` restore in one chunk — still rebuilds the atlas for the restored prompt), and a `buffer.onBufferChange` switch count (so a full enter→draw→exit cycle parsed in one write — e.g. a coalesced backlog flush — is still seen even though the buffer type nets back to `normal`).

This supersedes the first revision of this PR, which scanned each raw chunk for `?47h`/`?1047h`/`?1049h` enter sequences. That scan missed sequences split across PTY chunk boundaries — and real vim output does split CSI sequences at 1024-byte PTY read boundaries (see Evidence). The post-parse check closes that gap and deletes the hand-rolled CSI parser outright; xterm's parser is the single authority on alternate-screen state.

## Screenshots

No visual change (bug fix; live-app verification below confirms clean vim rendering).

## Testing

- [x] `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/terminal-alternate-screen-parse.test.ts`
- [x] `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts` (334 tests)
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-alternate-screen-parse.test.ts src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts`
- [x] Added regression tests that fail without the fix (details below)

## Evidence of fix

**1. Real PTY capture proves the failure mode is real.** Captured a real `vim -u NONE -N package.json` session through node-pty (120×34, macOS, `TERM=xterm-256color`): vim enters with `\x1b[?1049h`, redraws via plain-ASCII `\x1b[K`/cursor-move rewrites, and a 1024-byte PTY read boundary split the cursor move `\x1b[30;5H` across two `onData` chunks (`…\x1b[K\x1b[30` + `;5H…`). Any sequence — including the alternate-screen enter — can straddle a chunk boundary, which is exactly what byte scanning cannot see. The captured bytes are now regression fixtures.

**2. Before/after regression test.** `schedules WebGL atlas recovery when the alternate-screen enter sequence splits across chunks` fails against the first revision's chunk scanner (`scheduleTerminalWebglAtlasRecovery` called 0 times) and passes with the post-parse check. Additional tests pin: already-in-alternate redraws, the exit chunk (recovery for the restored prompt), the single-write enter+exit cycle (switch-count path), the real captured split-mid-CSI redraw bytes, and the negative case (ordinary shell rewrites never schedule recovery).

**3. Parser contract pin.** `terminal-alternate-screen-parse.test.ts` runs the real `@xterm/headless` parser and locks the semantics the fix depends on: `buffer.active.type` reflects alternate-screen enter/exit by write-callback time, including the split-chunk case and the captured vim enter/redraw/exit chunks. If a future xterm upgrade changed this, the pin fails before ghosting could return.

**4. Live app verification.** Dev build with `scheduleTerminalWebglAtlasRecovery` temporarily instrumented (call + coalesced-burst counters), real `vim` driven through the rendered terminal via keyboard events, exercising the exact repro from #7070 (open JSON file, scroll `G`/`gg`/`Ctrl-D`/`Ctrl-U`, `ciw` edit, `:q!`):

| Step | recovery calls | coalesced bursts | Meaning |
|---|---|---|---|
| Baseline after startup | 1 | 1 | — |
| Shell commands incl. `\r` in-place rewrite | 1 | 1 | no recovery outside alternate screen |
| `vim` opens | 3 | 2 | recovery on entry paint |
| Scroll + `ciw` edit (issue repro) | 19 | 7 | 16 calls coalesced into 5 bursts |
| `:q!` exit chunk | 23 | 9 | recovery for restored prompt |
| Shell after quit | 23 | 9 | scoping restored, no further recovery |

Rendering stayed pixel-clean throughout — no ghosting on scroll, on the in-place edit, or on the restored prompt. The instrumentation was removed before commit.

## AI Review Report

Multi-agent adversarial review over four lenses (correctness, performance, test quality, codebase consistency), each finding independently verified against the real control flow before acceptance:

- **Correctness:** traced the scheduler's queue/coalesce/split paths — a split chunk fires `onParsed` more than once, which the parse-time predicate self-corrects (the final firing sees fully parsed state); the hidden-pane recovery path and Windows branches (ConPTY synchronized frames, East-Asian refresh) are untouched; snapshot-restore/replay writes bypass this path entirely. The review surfaced the single-write enter+exit cycle gap; fixed with the `onBufferChange` switch count plus regression tests (mock wiring + real-parser pin).
- **Performance:** foreground writes already always pass a write callback, so no new xterm callback is introduced; the change allocates one closure per in-place-rewrite chunk in place of the removed per-chunk scan; recovery-burst frequency in the alternate screen is identical to the first revision (same gate, same single-burst latch).
- **Cross-platform:** no keyboard, path, label, or shell behavior involved; the decision logic is byte-stream based and identical across macOS/Linux/Windows and SSH (verified the Windows-specific branches keep their existing semantics).
- **Consistency:** formatter (oxfmt) clean, dead code from the removed scanner fully gone, comment/naming conventions checked against AGENTS.md.

## Security Audit

No input execution, path handling, auth, secrets, or IPC surface touched. The change consumes already-parsed terminal state from xterm's public buffer API instead of pattern-matching raw PTY bytes, which removes a bespoke escape-sequence parser (strictly less code interpreting untrusted terminal output). Recovery scheduling remains coalesced (single-burst latch), so hostile output storms cannot queue unbounded timers.

## Notes

- Recovery stays scoped: it requires an in-place-rewrite chunk (backspace / standalone CR / erase sequence) that touched the alternate screen, so ordinary prompt rewrites never pay for it. Repeated TUI frames coalesce into the existing recovery latch (measured above: 16 calls → 5 bursts under continuous scrolling).
- The known follow-up about global atlas-recovery cost on tab resume (#7085) is unaffected — this PR fires recovery no more often than the first revision did.
- SSH sessions take the same renderer path (the decision runs on renderer-side PTY chunks regardless of transport).
