### PR TITLE
Wake hibernated agent panes on reveal instead of leaving an inert ghost

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1080,6 +1080,10 @@ describe('connectPanePty', () => {
 
     const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
     expect(onPtyExit).toBeTypeOf('function')
+    // The deferred connect attached this transport to the persisted tab PTY,
+    // so the hibernation kill's exit must carry that id for the wake guard's
+    // same-pty check to model reality.
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('tab-pty')
     const connectCallsBeforeExit = transport.connect.mock.calls.length
     onPtyExit?.('tab-pty')
     await flushAsyncTicks()
@@ -1146,6 +1150,10 @@ describe('connectPanePty', () => {
 
     const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
     expect(onPtyExit).toBeTypeOf('function')
+    // The deferred connect attached this transport to the persisted tab PTY,
+    // so the hibernation kill's exit must carry that id for the wake guard's
+    // same-pty check to model reality.
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('tab-pty')
     const connectCallsBeforeExit = transport.connect.mock.calls.length
     onPtyExit?.('tab-pty')
     await flushAsyncTicks()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1051,8 +1051,11 @@ describe('connectPanePty', () => {
     const transport = createMockTransport('pty-pane-2')
     transportFactoryQueue.push(transport)
     const manager = createManager(1)
+    // Hibernation only targets hidden background panes, so the exit lands while
+    // the pane is not visible and the wake must wait for the reveal.
     const deps = createDeps({
-      consumeSuppressedPtyExit: vi.fn(() => true)
+      consumeSuppressedPtyExit: vi.fn(() => true),
+      isVisibleRef: { current: false }
     })
     const pane = createPane(2)
     const paneKey = `tab-1:${leafIdForPane(2)}`
@@ -1079,13 +1082,14 @@ describe('connectPanePty', () => {
     expect(onPtyExit).toBeTypeOf('function')
     const connectCallsBeforeExit = transport.connect.mock.calls.length
     onPtyExit?.('tab-pty')
+    await flushAsyncTicks()
 
     // The frozen frame's input-eating modes are disarmed at hibernation-exit
     // time (mouse tracking / bracketed paste would otherwise swallow clicks).
     const writesAfterExit = pane.terminal.write.mock.calls.flat().join('')
     expect(writesAfterExit).toContain('\x1b[?1003l')
     expect(writesAfterExit).toContain('\x1b[?2004l')
-    // Hibernation must not immediately respawn — wake waits for reveal.
+    // A hidden pane must not respawn on exit — the wake waits for the reveal.
     expect(transport.connect.mock.calls.length).toBe(connectCallsBeforeExit)
 
     binding.noteVisibilityResume()
@@ -1099,6 +1103,63 @@ describe('connectPanePty', () => {
     expect(resumeConnectOptions?.command).toContain('sess-hibernated-1')
 
     // The wake is one-shot: a second reveal must not spawn again.
+    const connectCallsAfterWake = transport.connect.mock.calls.length
+    binding.noteVisibilityResume()
+    await flushAsyncTicks()
+    expect(transport.connect.mock.calls.length).toBe(connectCallsAfterWake)
+  })
+
+  it('auto-resumes a hibernated pane when its kill lands after the pane is already revealed', async () => {
+    // Race: the user reveals the background tab in the window between the
+    // coordinator confirming the candidate and the kill's exit arriving. The
+    // reveal's noteVisibilityResume runs before onExit arms the wake, so the
+    // arm-time foreground check must resume the pane instead of stranding a
+    // disarmed-but-dead frame until the next hide/reveal.
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-pane-2')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps({
+      consumeSuppressedPtyExit: vi.fn(() => true),
+      isVisibleRef: { current: true }
+    })
+    const pane = createPane(2)
+    const paneKey = `tab-1:${leafIdForPane(2)}`
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'sess-hibernated-2' },
+      prompt: 'test prompt',
+      state: 'done',
+      capturedAt: 1,
+      updatedAt: 1,
+      origin: 'worktree-sleep'
+    }
+
+    const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
+      noteVisibilityResume: () => void
+      dispose: () => void
+    }
+    await flushAsyncTicks()
+
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
+    expect(onPtyExit).toBeTypeOf('function')
+    const connectCallsBeforeExit = transport.connect.mock.calls.length
+    onPtyExit?.('tab-pty')
+    await flushAsyncTicks()
+
+    // No second reveal was needed: the foreground pane resumed its recorded
+    // session directly from the arm-time wake.
+    expect(transport.connect.mock.calls.length).toBeGreaterThan(connectCallsBeforeExit)
+    const resumeConnectOptions = transport.connect.mock.calls.at(-1)?.[0] as
+      | { command?: string }
+      | undefined
+    expect(resumeConnectOptions?.command).toContain('--resume')
+    expect(resumeConnectOptions?.command).toContain('sess-hibernated-2')
+
+    // Still one-shot: a later reveal must not spawn again.
     const connectCallsAfterWake = transport.connect.mock.calls.length
     binding.noteVisibilityResume()
     await flushAsyncTicks()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1174,6 +1174,63 @@ describe('connectPanePty', () => {
     expect(transport.connect.mock.calls.length).toBe(connectCallsAfterWake)
   })
 
+  it('invalidates the hibernation wake when another flow rebinds the pane before reveal', async () => {
+    // Intentional restarts use the same exit suppression as hibernation. When
+    // one rebinds the pane to a fresh PTY while hidden, its spawn owns the
+    // pane: the armed wake must be discarded on reveal instead of launching a
+    // second resume over the restarted session — and discarded means gone, so
+    // a later death of the rebound PTY cannot revive the stale wake either.
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-pane-2')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps({
+      consumeSuppressedPtyExit: vi.fn(() => true),
+      isVisibleRef: { current: false }
+    })
+    const pane = createPane(2)
+    const paneKey = `tab-1:${leafIdForPane(2)}`
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'sess-hibernated-3' },
+      prompt: 'test prompt',
+      state: 'done',
+      capturedAt: 1,
+      updatedAt: 1,
+      origin: 'worktree-sleep'
+    }
+
+    const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
+      noteVisibilityResume: () => void
+      dispose: () => void
+    }
+    await flushAsyncTicks()
+
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
+    expect(onPtyExit).toBeTypeOf('function')
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('tab-pty')
+    const connectCallsBeforeExit = transport.connect.mock.calls.length
+    onPtyExit?.('tab-pty')
+    await flushAsyncTicks()
+
+    // Another flow rebinds the pane to a fresh PTY while it is still hidden.
+    transport.getPtyId.mockReturnValue('pty-restarted')
+    binding.noteVisibilityResume()
+    await flushAsyncTicks()
+    // The rebound pane keeps its own session: no wake-driven resume spawn.
+    expect(transport.connect.mock.calls.length).toBe(connectCallsBeforeExit)
+
+    // The rebound PTY later dies without a new sleeping record; the stale wake
+    // must not fire on the next reveal.
+    transport.getPtyId.mockReturnValue(null)
+    binding.noteVisibilityResume()
+    await flushAsyncTicks()
+    expect(transport.connect.mock.calls.length).toBe(connectCallsBeforeExit)
+  })
+
   it('keeps a fresh split pane mounted when its newborn PTY exits before output or input', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-pane-2')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1041,6 +1041,70 @@ describe('connectPanePty', () => {
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
+  it('disarms input modes and resumes a hibernated agent session on visibility reveal', async () => {
+    // Regression: agent hibernation suppresses its kill's PTY exit while the
+    // pane is hidden. Before the wake fix, onExit consumed the suppression and
+    // permanently latched handledExitPtyId, so revealing the tab left a frozen
+    // alt-screen frame with mouse-tracking armed and no PTY — a fully inert
+    // ghost pane (no resume, no input, no selection).
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-pane-2')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps({
+      consumeSuppressedPtyExit: vi.fn(() => true)
+    })
+    const pane = createPane(2)
+    const paneKey = `tab-1:${leafIdForPane(2)}`
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'sess-hibernated-1' },
+      prompt: 'test prompt',
+      state: 'done',
+      capturedAt: 1,
+      updatedAt: 1,
+      origin: 'worktree-sleep'
+    }
+
+    const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
+      noteVisibilityResume: () => void
+      dispose: () => void
+    }
+    await flushAsyncTicks()
+
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
+    expect(onPtyExit).toBeTypeOf('function')
+    const connectCallsBeforeExit = transport.connect.mock.calls.length
+    onPtyExit?.('tab-pty')
+
+    // The frozen frame's input-eating modes are disarmed at hibernation-exit
+    // time (mouse tracking / bracketed paste would otherwise swallow clicks).
+    const writesAfterExit = pane.terminal.write.mock.calls.flat().join('')
+    expect(writesAfterExit).toContain('\x1b[?1003l')
+    expect(writesAfterExit).toContain('\x1b[?2004l')
+    // Hibernation must not immediately respawn — wake waits for reveal.
+    expect(transport.connect.mock.calls.length).toBe(connectCallsBeforeExit)
+
+    binding.noteVisibilityResume()
+    await flushAsyncTicks()
+
+    expect(transport.connect.mock.calls.length).toBeGreaterThan(connectCallsBeforeExit)
+    const resumeConnectOptions = transport.connect.mock.calls.at(-1)?.[0] as
+      | { command?: string }
+      | undefined
+    expect(resumeConnectOptions?.command).toContain('--resume')
+    expect(resumeConnectOptions?.command).toContain('sess-hibernated-1')
+
+    // The wake is one-shot: a second reveal must not spawn again.
+    const connectCallsAfterWake = transport.connect.mock.calls.length
+    binding.noteVisibilityResume()
+    await flushAsyncTicks()
+    expect(transport.connect.mock.calls.length).toBe(connectCallsAfterWake)
+  })
+
   it('keeps a fresh split pane mounted when its newborn PTY exits before output or input', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-pane-2')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1702,6 +1702,32 @@ export function connectPanePty(
   // it and relaunches the recorded agent session on next reveal.
   let hibernatedWakePtyId: string | null = null
   let wakeHibernatedAgentPane: (() => void) | null = null
+  // Why: reveal is the normal wake trigger, but a reveal that lands *during* the
+  // in-flight hibernation kill runs noteVisibilityResume before onExit arms the
+  // wake. Sharing the guarded consume lets both the reveal hook and the
+  // arm-time foreground check resume the pane exactly once.
+  const consumeHibernatedAgentWake = (): void => {
+    if (hibernatedWakePtyId === null || disposed) {
+      return
+    }
+    if (deps.paneTransportsRef.current.get(pane.id) !== transport) {
+      return
+    }
+    const currentPtyId = transport.getPtyId()
+    // Why: a real pty:exit clears the transport's ptyId before onExit while a
+    // reconcile-driven exit leaves it bound; both mean "nothing respawned since
+    // hibernation". A different non-null id means another flow (e.g. an
+    // intentional restart) already rebound the pane — its spawn wins.
+    if (currentPtyId !== null && currentPtyId !== hibernatedWakePtyId) {
+      hibernatedWakePtyId = null
+      return
+    }
+    hibernatedWakePtyId = null
+    // Why: reveal is the wake signal for a hibernated pane. Resume the recorded
+    // agent session (or fall back to a fresh shell) instead of leaving the
+    // frozen frame with no PTY behind it.
+    wakeHibernatedAgentPane?.()
+  }
   const onExit = (ptyId: string): void => {
     if (handledExitPtyId === ptyId) {
       return
@@ -1751,6 +1777,13 @@ export function connectPanePty(
         // modes now and arm the reveal-time wake.
         replayIntoTerminal(pane, deps.replayingPanesRef, POST_REPLAY_MODE_RESET)
         hibernatedWakePtyId = ptyId
+        if (deps.isVisibleRef.current) {
+          // Why: a reveal that raced this kill already ran noteVisibilityResume
+          // before the exit landed, so it saw nothing armed. Consume the wake
+          // now (deferred off the exit handler) so a foreground pane still
+          // resumes without needing a second hide/reveal.
+          queueMicrotask(consumeHibernatedAgentWake)
+        }
       }
       return
     }
@@ -5476,26 +5509,7 @@ export function connectPanePty(
     // xterm's transient hidden DOM fallback.
     noteVisibilityResume() {
       ptySizeReassertion.request({ fit: false })
-      if (hibernatedWakePtyId === null || disposed) {
-        return
-      }
-      if (deps.paneTransportsRef.current.get(pane.id) !== transport) {
-        return
-      }
-      const currentPtyId = transport.getPtyId()
-      // Why: a real pty:exit clears the transport's ptyId before onExit while
-      // a reconcile-driven exit leaves it bound; both mean "nothing respawned
-      // since hibernation". A different non-null id means another flow (e.g.
-      // an intentional restart) already rebound the pane — its spawn wins.
-      if (currentPtyId !== null && currentPtyId !== hibernatedWakePtyId) {
-        hibernatedWakePtyId = null
-        return
-      }
-      hibernatedWakePtyId = null
-      // Why: reveal is the wake signal for a hibernated pane. Resume the
-      // recorded agent session (or fall back to a fresh shell) instead of
-      // leaving the frozen frame with no PTY behind it.
-      wakeHibernatedAgentPane?.()
+      consumeHibernatedAgentWake()
     },
     reconcileIfSessionDead,
     reconcileIfSessionMissing,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1696,6 +1696,12 @@ export function connectPanePty(
   // on a brand-new worktree keeps its dead terminal visible instead of bouncing
   // the user to Landing.
   let spawnedFreshPtyId: string | null = null
+  // Why: hibernation suppresses its kill's exit while the pane is hidden, so
+  // onExit must not tear the pane down — but the pane still owes the user a
+  // wake. Remember the hibernated ptyId; the visibility-resume hook consumes
+  // it and relaunches the recorded agent session on next reveal.
+  let hibernatedWakePtyId: string | null = null
+  let wakeHibernatedAgentPane: (() => void) | null = null
   const onExit = (ptyId: string): void => {
     if (handledExitPtyId === ptyId) {
       return
@@ -1738,6 +1744,14 @@ export function connectPanePty(
       // Why: the action that suppressed the exit owns whether the leaf binding
       // is a wake hint or should be discarded; runtime cleanup above is enough.
       manager.setPaneGpuRendering(pane.id, true)
+      if (getSleepingRecordForPane(useAppStore.getState())) {
+        // Why: hibernation killed this pane's PTY while hidden. The frozen TUI
+        // frame still has mouse-tracking/bracketed-paste armed, which silently
+        // eats every click and keystroke against a dead transport — disarm the
+        // modes now and arm the reveal-time wake.
+        replayIntoTerminal(pane, deps.replayingPanesRef, POST_REPLAY_MODE_RESET)
+        hibernatedWakePtyId = ptyId
+      }
       return
     }
     manager.setPaneGpuRendering(pane.id, true)
@@ -3171,6 +3185,9 @@ export function connectPanePty(
       applyColdRestoreAgentResumeStartup(startup)
       startFreshSpawn(startup)
     }
+    // Why: the hibernation wake fires from noteVisibilityResume in the outer
+    // connection scope, long after this deferred-connect closure has run.
+    wakeHibernatedAgentPane = () => startFreshColdRestoreAgentResume()
     const isStartupPasteTargetCurrent = (ptyId: string | null): boolean =>
       !disposed &&
       deps.paneTransportsRef.current.get(pane.id) === transport &&
@@ -5459,6 +5476,26 @@ export function connectPanePty(
     // xterm's transient hidden DOM fallback.
     noteVisibilityResume() {
       ptySizeReassertion.request({ fit: false })
+      if (hibernatedWakePtyId === null || disposed) {
+        return
+      }
+      if (deps.paneTransportsRef.current.get(pane.id) !== transport) {
+        return
+      }
+      const currentPtyId = transport.getPtyId()
+      // Why: a real pty:exit clears the transport's ptyId before onExit while
+      // a reconcile-driven exit leaves it bound; both mean "nothing respawned
+      // since hibernation". A different non-null id means another flow (e.g.
+      // an intentional restart) already rebound the pane — its spawn wins.
+      if (currentPtyId !== null && currentPtyId !== hibernatedWakePtyId) {
+        hibernatedWakePtyId = null
+        return
+      }
+      hibernatedWakePtyId = null
+      // Why: reveal is the wake signal for a hibernated pane. Resume the
+      // recorded agent session (or fall back to a fresh shell) instead of
+      // leaving the frozen frame with no PTY behind it.
+      wakeHibernatedAgentPane?.()
     },
     reconcileIfSessionDead,
     reconcileIfSessionMissing,

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -2957,6 +2957,71 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
   })
 
+  it('persists the sleeping record and suppression before issuing the hibernation kill', async () => {
+    // pty:exit can beat the kill promise back to the renderer, and the pane's
+    // exit handler arms the hibernation wake only if the sleeping record is
+    // already in the store. A record written after the kill resolves passes
+    // every end-state assertion while still losing that race, so this test
+    // observes the store at the moment the kill is issued.
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Claude', ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: targetLeaf },
+          activeLeafId: targetLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-agent'] }
+    })
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'resume target', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'sess-ordering-1' } }
+      )
+    let recordAtKillTime: unknown = null
+    let suppressionAtKillTime: boolean | undefined
+    mockApi.pty.kill.mockImplementationOnce(async () => {
+      const atKill = store.getState()
+      recordAtKillTime = atKill.sleepingAgentSessionsByPaneKey[targetPaneKey]
+      suppressionAtKillTime = atKill.suppressedPtyExitIds['pty-agent']
+    })
+
+    await store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+      paneKey: targetPaneKey,
+      tabId: 'tab-1',
+      leafId: targetLeaf,
+      ptyId: 'pty-agent'
+    })
+
+    expect(mockApi.pty.kill).toHaveBeenCalledWith('pty-agent', { keepHistory: true })
+    expect(recordAtKillTime).toMatchObject({
+      paneKey: targetPaneKey,
+      providerSession: { key: 'session_id', id: 'sess-ordering-1' }
+    })
+    expect(suppressionAtKillTime).toBe(true)
+    // The record must survive the successful kill so the reveal-time wake can
+    // consume it.
+    const state = store.getState()
+    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBeDefined()
+  })
+
   it('keeps manual sleep worktree-wide', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -2840,6 +2840,69 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(dropByWorktree).not.toHaveBeenCalled()
   })
 
+  it('aborts pane hibernation without side effects when no resume record can be captured', async () => {
+    // The prod ghost pane was killed with NO sleeping record captured, so
+    // nothing could ever wake it. Planner eligibility can go stale between
+    // ticks, so the shutdown must throw before any suppression or kill when the
+    // capture comes back empty (a done agent with no resumable provider
+    // session), leaving the pane fully intact for a later retry.
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const siblingLeaf = '22222222-2222-4222-8222-222222222222'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex', ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: targetLeaf },
+            second: { type: 'leaf', leafId: siblingLeaf }
+          },
+          activeLeafId: siblingLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent', [siblingLeaf]: 'pty-shell' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-agent', 'pty-shell'] }
+    })
+    // A done agent with no provider session yields no resumable sleeping record.
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'resume target', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt }
+      )
+
+    await expect(
+      store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+        paneKey: targetPaneKey,
+        tabId: 'tab-1',
+        leafId: targetLeaf,
+        ptyId: 'pty-agent'
+      })
+    ).rejects.toThrow('agent_hibernation_capture_missing')
+
+    const state = store.getState()
+    // Nothing was suppressed, killed, or persisted — the pane is untouched.
+    expect(mockApi.pty.kill).not.toHaveBeenCalled()
+    expect(state.suppressedPtyExitIds['pty-agent']).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBeUndefined()
+    expect(state.ptyIdsByTabId['tab-1']).toEqual(['pty-agent', 'pty-shell'])
+    expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
+  })
+
   it('keeps manual sleep worktree-wide', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -2903,6 +2903,60 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
   })
 
+  it('rolls back the sleeping record and suppression when the hibernation kill fails', async () => {
+    // The sleeping record must be visible to the pane's exit handler BEFORE the
+    // kill (pty:exit can beat the kill promise back to the renderer), so it is
+    // written alongside the suppression — and both must roll back if the kill
+    // fails, or a live pane would carry a stale wake record.
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Claude', ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: targetLeaf },
+          activeLeafId: targetLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-agent'] }
+    })
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'resume target', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'sess-rollback-1' } }
+      )
+    mockApi.pty.kill.mockRejectedValueOnce(new Error('kill_failed'))
+
+    await expect(
+      store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+        paneKey: targetPaneKey,
+        tabId: 'tab-1',
+        leafId: targetLeaf,
+        ptyId: 'pty-agent'
+      })
+    ).rejects.toThrow('kill_failed')
+
+    const state = store.getState()
+    expect(state.suppressedPtyExitIds['pty-agent']).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBeUndefined()
+    expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
+  })
+
   it('keeps manual sleep worktree-wide', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1849,13 +1849,35 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
     }
 
-    const clearTargetSuppressions = (): void => {
+    // Why: the pane's exit handler consults sleepingAgentSessionsByPaneKey to
+    // tell a hibernation kill from other suppressed exits. pty:exit can reach
+    // the renderer before the kill promise resolves, so the record must be in
+    // the store BEFORE the kill is issued — and rolled back if the kill fails.
+    const sleepingRecordKeys = Object.keys(sleepingAgentSessionRecords)
+    const replacedSleepingRecords: Record<string, (typeof sleepingAgentSessionRecords)[string]> = {}
+    for (const key of sleepingRecordKeys) {
+      const existing = state.sleepingAgentSessionsByPaneKey[key]
+      if (existing) {
+        replacedSleepingRecords[key] = existing
+      }
+    }
+
+    const rollbackTargetShutdownState = (): void => {
       set((s) => {
         const next = { ...s.suppressedPtyExitIds }
         for (const ptyId of shutdownPtyIds) {
           delete next[ptyId]
         }
-        return { suppressedPtyExitIds: next }
+        const nextSleeping = { ...s.sleepingAgentSessionsByPaneKey }
+        for (const key of sleepingRecordKeys) {
+          const replaced = replacedSleepingRecords[key]
+          if (replaced) {
+            nextSleeping[key] = replaced
+          } else {
+            delete nextSleeping[key]
+          }
+        }
+        return { suppressedPtyExitIds: next, sleepingAgentSessionsByPaneKey: nextSleeping }
       })
     }
 
@@ -1863,13 +1885,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       suppressedPtyExitIds: {
         ...s.suppressedPtyExitIds,
         ...Object.fromEntries(shutdownPtyIds.map((ptyId) => [ptyId, true] as const))
+      },
+      sleepingAgentSessionsByPaneKey: {
+        ...s.sleepingAgentSessionsByPaneKey,
+        ...sleepingAgentSessionRecords
       }
     }))
 
     if (expectedRuntimePtyIds.length > 0) {
       const runtimeEnvironmentId = resolveTerminalStopRuntimeEnvironmentId(get(), worktreeId)
       if (!runtimeEnvironmentId) {
-        clearTargetSuppressions()
+        rollbackTargetShutdownState()
         throw new Error('missing_runtime_for_exact_terminal_stop')
       }
       let stopResult: {
@@ -1896,18 +1922,18 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           { timeoutMs: 15_000 }
         )
       } catch (err) {
-        clearTargetSuppressions()
+        rollbackTargetShutdownState()
         throw err
       }
       const stoppedPtyIds = sortedUniquePtyIds(stopResult.stoppedPtyIds)
       const livePtyIds = sortedUniquePtyIds(stopResult.livePtyIds)
       const targetWasLive = expectedRuntimePtyIds.every((ptyId) => livePtyIds.includes(ptyId))
       if (!equalStringSets(stoppedPtyIds, expectedRuntimePtyIds) || !targetWasLive) {
-        clearTargetSuppressions()
+        rollbackTargetShutdownState()
         throw new Error('exact_terminal_stop_mismatch')
       }
       if (stopResult.postStopVerified !== true) {
-        clearTargetSuppressions()
+        rollbackTargetShutdownState()
         throw new Error(stopResult.postStopFailure ?? 'exact_terminal_stop_unverified')
       }
       unregisterPtyDataHandlers(shutdownPtyIds)
@@ -1919,7 +1945,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         await window.api.pty.kill(opts.ptyId, { keepHistory: true })
       } catch (err) {
         restorePtyDataHandlersAfterFailedShutdown(handlerSnapshots)
-        clearTargetSuppressions()
+        rollbackTargetShutdownState()
         throw err
       }
     }
@@ -1995,13 +2021,6 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         lastTerminalInputAtByPaneKey: nextLastTerminalInputAtByPaneKey
       }
     })
-
-    set((s) => ({
-      sleepingAgentSessionsByPaneKey: {
-        ...s.sleepingAgentSessionsByPaneKey,
-        ...sleepingAgentSessionRecords
-      }
-    }))
 
     get().dropHibernatedAgentStatusPane(worktreeId, opts.paneKey, {
       retainedCompletionEvidence

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1833,6 +1833,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       worktreeId,
       paneKeys
     )
+    if (!sleepingAgentSessionRecords[opts.paneKey]) {
+      // Why: killing the PTY without a persisted resume record strands the
+      // pane — nothing can ever wake it. Planner eligibility can go stale
+      // between ticks; abort this round instead of hibernating unrecoverably.
+      throw new Error('agent_hibernation_capture_missing')
+    }
 
     const capture = shutdownBufferCaptures.get(opts.tabId)
     if (capture) {


### PR DESCRIPTION
## Symptom

With `experimentalAgentHibernation` enabled, an idle agent session in a hidden tab gets its PTY killed by the 30-minute hibernation timer. When the user later reveals that tab, the pane shows the frozen last frame and is **completely uninteractable** — no clicks, no focus, no selection, no typing, no resume. Three separate occurrences were forensically confirmed in production (claude and codex sessions; daemon meta `exitCode: -1` + `endedAt` set, sleeping records with `origin: worktree-sleep`). All three kills happened while the machine was awake — machine sleep was a red herring; the trigger is idle + hidden. The exact frozen-ghost state was also reproduced live in a dev build (mounted hidden pane + hibernation kill + reveal) before the fix.

## What changes

- **Revealing a hibernated pane wakes it.** `onExit`'s suppressed branch recognizes hibernation (a sleeping record exists for the pane), disarms the frozen frame's input-eating terminal modes (`POST_REPLAY_MODE_RESET`; alt-screen content preserved), and arms a one-shot wake. `noteVisibilityResume` consumes it on the pane's own hidden→visible transition and relaunches the recorded session through the existing cold-restore resume path (`claude --resume <session>` etc., falling back to a fresh shell if no resume argv can be built). A pane rebound by another flow (intentional codex restart uses the same suppression mechanism) invalidates the wake instead.
- **A reveal that races the in-flight kill still wakes.** If the pane is visible at arm time (the reveal ran before the exit landed), the wake is consumed via a deferred microtask that re-checks disposed/transport/ptyId — one-shot semantics preserved.
- **Hibernation can no longer kill a session it cannot resume.** `shutdownCompletedAgentPaneForHibernation` aborts with `agent_hibernation_capture_missing` when the sleeping-record capture produced nothing for the pane, before any suppression or kill (one prod codex pane was killed record-less and was unrecoverable). The coordinator handles the throw (warn + retry next tick); planner and capture share the same eligibility predicate, so a miss is only a transient race, never a permanent warn-loop.

## What does not change

Hibernation's trigger policy (30-min idle timer, hidden-only eligibility) is untouched. There is intentionally no new UI in this PR: auto-resume on reveal is silent. Two design follow-ups surfaced during review for a separate decision: a visible "sleeping / resuming" placeholder state instead of a live-looking frame, and resume-then-deliver for programmatic input sent to a still-hidden sleeping pane.

## Validation (Brennan's PR process)

- **Regression tests**: the frozen-ghost path is pinned by a `connectPanePty`-level test (suppressed exit + reveal) that fails without the fix; a second test pins the reveal-races-kill path (fails without the deferred wake); a store-level test pins the capture gate (no kill, no suppression, no record write on capture miss). Focused suites: `pty-connection.test.ts` + `store-cascades.test.ts` + `agent-hibernation-coordinator.test.ts` = **411 passed**. `pnpm run typecheck` clean. (`pnpm run lint` fails only on a pre-existing localization-catalog key in `WorktreeList.tsx`, unrelated to this branch.)
- **Perf audit**: clean. The wake check on the visibility hot path is a single null compare when unarmed (O(1), allocation-free); the sleeping-record lookup runs only on suppressed exits; no new timers/subscriptions/listeners/retention; the capture-miss throw is cheaper than the success path and bounded to one warn per 60s tick.
- **Code-review loop**: two rounds, two independent reviewers per round; round 1 produced the reveal-races-kill fix and the capture-gate test, round 2 returned clean from both reviewers.
- **End-to-end (dev build, screenshots captured)**: unfixed build → revealed pane is a frozen, fully inert ghost (typing/clicking changes nothing, pixel-identical screenshots). Fixed build, same arrangement → pane auto-resumes (`--- session restored ---`, `claude --resume <id>` process confirmed, conversation restored, typing works). Re-validated after the review-loop changes landed.
- **SSH/remote**: the wake reuses the pane's own transport and the existing cold-restore machinery (which already handles remote variants); the reveal path's remote guards are untouched, and the capture gate is transport-agnostic.

## Residual risks / accepted gaps

- Silent auto-resume (no placeholder UI) is an accepted product decision for this fix; see follow-ups above.
- The E2E repro exercised local PTYs; the remote-runtime `terminal.stopExact` ordering was reviewed but not E2E-exercised — worth a follow-up only if remote-runtime ghosts are ever reported.
- A separate prod observation is intentionally out of scope: one pane hibernated despite a typed draft (the planner's input-after-done guard should have blocked it); the draft was lost. Needs its own investigation.