### PR TITLE
fix: skip daemon-pty-adapter tests on Windows

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -15,7 +15,7 @@ const { getMacDaemonSystemResolverHealthMock } = vi.hoisted(() => ({
   getMacDaemonSystemResolverHealthMock: vi.fn(async () => 'unknown')
 }))
 
-const itOnPosix = process.platform === 'win32' ? it.skip : it
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe
 
 vi.mock('./daemon-health', async (importOriginal) => {
   const actual = await importOriginal<typeof DaemonHealthModule>()
@@ -71,7 +71,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void
   }
 }
 
-describe('DaemonPtyAdapter (IPtyProvider)', () => {
+describeOnPosix('DaemonPtyAdapter (IPtyProvider)', () => {
   let dir: string
   let socketPath: string
   let tokenPath: string
@@ -127,7 +127,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(result.id).toContain('wt-1')
     })
 
-    itOnPosix('keeps plain Codex startup on the short daemon shell-ready timeout', async () => {
+    it('keeps plain Codex startup on the short daemon shell-ready timeout', async () => {
       await adapter.spawn({
         cols: 80,
         rows: 24,
@@ -139,7 +139,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(lastSubprocess.write).toHaveBeenCalledWith('codex\n')
     })
 
-    itOnPosix('waits for shell-ready for delivery-hinted Codex startup', async () => {
+    it('waits for shell-ready for delivery-hinted Codex startup', async () => {
       await adapter.spawn({
         cols: 80,
         rows: 24,


### PR DESCRIPTION
## Summary

The entire \DaemonPtyAdapter\ test suite relies on \
ode:net\ Unix socket semantics (unlinkSync, socket file cleanup, respawn-on-death checks) that don't map to Windows named pipes. This causes ~61 test failures on Windows.

## Change

- Replaced \const itOnPosix\ with \const describeOnPosix\ at the module level, matching the pattern in \shell-ready.test.ts\
- Changed \describe(...)\ to \describeOnPosix(...)\ to skip the entire suite on Windows
- Converted the 2 existing \itOnPosix\ tests back to regular \it\ (already covered by the describe-level skip)

## Verification

- Tests continue to run on Linux/macOS (CI) as before
- No functional change — only test infrastructure

## Cross-platform notes

- **Windows**: this is the fix — the suite is now skipped instead of failing
- **macOS/Linux**: unchanged, all tests still run
- The daemon PTY infrastructure is exercised through the terminal-perf E2E suite on Ubuntu CI