### PR TITLE
Add Windows inner signature evidence gate

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1067,6 +1067,62 @@ jobs:
           }
           $signature.SignerCertificate | Format-List Subject,Issuer,NotBefore,NotAfter,Thumbprint
 
+      - name: Check signed Windows inner executable
+        if: matrix.platform == 'win'
+        shell: pwsh
+        env:
+          ORCA_WINDOWS_EXPECTED_SIGNERS: |
+            CN=SignPath Foundation, O=SignPath Foundation, L=Lewes, S=Delaware, C=US
+            CN=SignPath Foundation, O=SignPath Foundation, L=Lewes, ST=Delaware, C=US
+          ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED: ${{ vars.ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED || 'false' }}
+        run: |
+          $requiredValue = if ($null -eq $env:ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED) { '' } else { $env:ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED.Trim().ToLowerInvariant() }
+          $innerSignatureRequired = @('1', 'true', 'yes', 'required') -contains $requiredValue
+
+          try {
+            # Why: recursive PE signing is a SignPath artifact setting, so keep
+            # releases observable until the server-side setting is proven.
+            $installerExtractDir = Join-Path $env:RUNNER_TEMP 'orca-windows-installer-extract'
+            $appExtractDir = Join-Path $env:RUNNER_TEMP 'orca-windows-app-extract'
+            Remove-Item -LiteralPath $installerExtractDir, $appExtractDir -Recurse -Force -ErrorAction SilentlyContinue
+            New-Item -ItemType Directory -Path $installerExtractDir, $appExtractDir -Force | Out-Null
+
+            & 7z x -y "-o$installerExtractDir" 'dist/orca-windows-setup.exe'
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to extract signed Windows installer with 7z (exit $LASTEXITCODE)."
+            }
+
+            $appArchives = @(Get-ChildItem -LiteralPath $installerExtractDir -Recurse -File -Filter 'app-*.7z')
+            if ($appArchives.Count -ne 1) {
+              $foundArchives = if ($appArchives.Count -eq 0) { '<none>' } else { ($appArchives | ForEach-Object { $_.FullName }) -join "`n" }
+              throw "Expected exactly one app-*.7z payload in signed Windows installer, found $($appArchives.Count):`n$foundArchives"
+            }
+
+            & 7z x -y "-o$appExtractDir" $appArchives[0].FullName
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to extract Windows app payload with 7z (exit $LASTEXITCODE)."
+            }
+
+            $innerExecutables = @(Get-ChildItem -LiteralPath $appExtractDir -File -Filter 'Orca.exe')
+            if ($innerExecutables.Count -ne 1) {
+              $foundExecutables = if ($innerExecutables.Count -eq 0) { '<none>' } else { ($innerExecutables | ForEach-Object { $_.FullName }) -join "`n" }
+              throw "Expected exactly one app-root Orca.exe in the signed Windows app payload, found $($innerExecutables.Count):`n$foundExecutables"
+            }
+
+            & node config/scripts/verify-windows-inner-signature.mjs $innerExecutables[0].FullName
+            if ($LASTEXITCODE -ne 0) {
+              throw "Windows inner executable signature verifier failed with exit $LASTEXITCODE."
+            }
+          } catch {
+            if ($innerSignatureRequired) {
+              throw
+            }
+
+            $warningMessage = "Windows inner executable signature evidence did not complete: $($_.Exception.Message)"
+            $warningMessage = $warningMessage.Replace('%', '%25').Replace("`r", '%0D').Replace("`n", '%0A')
+            Write-Host "::warning::$warningMessage"
+          }
+
       - name: Publish signed Windows release artifacts
         if: matrix.platform == 'win'
         uses: nick-fields/retry@v4

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -221,7 +221,7 @@ describe('Electron runtime package contract', () => {
     expect(installRun).not.toMatch(/throw\s+\$_/)
   })
 
-  it('temporarily allows publishing Windows after verifying the signed installer only', () => {
+  it('checks the Windows inner executable signature before publishing signed assets', () => {
     const releaseWorkflow = readFileSync(
       join(projectDir, '.github/workflows/release-cut.yml'),
       'utf8'
@@ -230,12 +230,42 @@ describe('Electron runtime package contract', () => {
     const steps = parsedWorkflow.jobs.build.steps
     const stepNames = steps.map((step) => step.name)
     const outerVerifyIndex = stepNames.indexOf('Verify signed Windows installer')
-    const innerVerifyIndex = stepNames.indexOf('Verify signed Windows inner executable')
+    const innerCheckIndex = stepNames.indexOf('Check signed Windows inner executable')
     const publishIndex = stepNames.indexOf('Publish signed Windows release artifacts')
 
     expect(outerVerifyIndex).toBeGreaterThan(-1)
-    expect(innerVerifyIndex).toBe(-1)
-    expect(publishIndex).toBe(outerVerifyIndex + 1)
+    expect(innerCheckIndex).toBe(outerVerifyIndex + 1)
+    expect(publishIndex).toBe(innerCheckIndex + 1)
+
+    const innerCheckStep = steps[innerCheckIndex]
+    const innerCheckRun = innerCheckStep.run
+
+    expect(innerCheckStep.if).toBe("matrix.platform == 'win'")
+    expect(innerCheckStep.shell).toBe('pwsh')
+    expect(innerCheckStep['continue-on-error']).toBeUndefined()
+    expect(innerCheckStep.env.ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED).toBe(
+      "${{ vars.ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED || 'false' }}"
+    )
+    expect(innerCheckStep.env.ORCA_WINDOWS_EXPECTED_SIGNERS).toContain(
+      'CN=SignPath Foundation, O=SignPath Foundation, L=Lewes, S=Delaware, C=US'
+    )
+    expect(innerCheckRun).toContain('$innerSignatureRequired')
+    expect(innerCheckRun).toContain('try {')
+    expect(innerCheckRun).toMatch(/catch \{\s+if \(\$innerSignatureRequired\) \{\s+throw\s+}/)
+    expect(innerCheckRun).toContain('Write-Host "::warning::$warningMessage"')
+    expect(innerCheckRun).toContain('& 7z x -y "-o$installerExtractDir"')
+    expect(innerCheckRun).toContain(
+      "Get-ChildItem -LiteralPath $installerExtractDir -Recurse -File -Filter 'app-*.7z'"
+    )
+    expect(innerCheckRun).toContain('if ($appArchives.Count -ne 1)')
+    expect(innerCheckRun).toContain('& 7z x -y "-o$appExtractDir"')
+    expect(innerCheckRun).toContain(
+      "Get-ChildItem -LiteralPath $appExtractDir -File -Filter 'Orca.exe'"
+    )
+    expect(innerCheckRun).toContain('if ($innerExecutables.Count -ne 1)')
+    expect(innerCheckRun).toContain(
+      'node config/scripts/verify-windows-inner-signature.mjs $innerExecutables[0].FullName'
+    )
   })
 
   it('publishes both Linux release matrix entries', () => {

--- a/config/scripts/verify-windows-inner-signature.mjs
+++ b/config/scripts/verify-windows-inner-signature.mjs
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url'
 
 export const DEFAULT_EXPECTED_SIGNER =
   'CN=SignPath Foundation, O=SignPath Foundation, L=Lewes, S=Delaware, C=US'
+export const INNER_SIGNATURE_REQUIRED_ENV = 'ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED'
 
 const POWERSHELL_SIGNATURE_SCRIPT = String.raw`
 $ErrorActionPreference = 'Stop'
@@ -58,6 +59,23 @@ export function parseExpectedThumbprints(value = process.env.ORCA_WINDOWS_EXPECT
     .split(/[\r\n,;]+/u)
     .map(normalizeThumbprint)
     .filter(Boolean)
+}
+
+export function parseInnerSignatureRequired(value = process.env[INNER_SIGNATURE_REQUIRED_ENV]) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return false
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'required'].includes(normalized)) {
+    return true
+  }
+
+  if (['0', 'false', 'no', 'optional', 'soft'].includes(normalized)) {
+    return false
+  }
+
+  throw new Error(`${INNER_SIGNATURE_REQUIRED_ENV} must be true or false.`)
 }
 
 export function parseSignatureJson(stdout) {
@@ -115,6 +133,14 @@ export function formatSignatureSummary(signature) {
   ].join('\n')
 }
 
+export function formatSignatureFailureMessage(classification) {
+  return `${classification.message}\n${formatSignatureSummary(classification.signature)}`
+}
+
+export function escapeGitHubActionsMessage(value) {
+  return String(value).replace(/%/gu, '%25').replace(/\r/gu, '%0D').replace(/\n/gu, '%0A')
+}
+
 export function validateExecutablePath(executablePath) {
   if (typeof executablePath !== 'string' || executablePath.trim() === '') {
     throw new Error('Usage: node config/scripts/verify-windows-inner-signature.mjs <Orca.exe>')
@@ -168,7 +194,7 @@ export function getPowerShellSignatureJson(executablePath, spawnSyncImpl = spawn
   return result.stdout
 }
 
-export function verifyWindowsInnerSignature({
+export function checkWindowsInnerSignature({
   executablePath,
   platform = process.platform,
   spawnSyncImpl = spawnSync,
@@ -183,21 +209,71 @@ export function verifyWindowsInnerSignature({
 
   const signature = parseSignatureJson(getPowerShellSignatureJson(executablePath, spawnSyncImpl))
   const classification = classifySignature(signature, { expectedSigners, expectedThumbprints })
+  return {
+    ...classification,
+    summary: formatSignatureSummary(signature)
+  }
+}
+
+export function verifyWindowsInnerSignature(options) {
+  const classification = checkWindowsInnerSignature(options)
   if (!classification.ok) {
-    throw new Error(`${classification.message}\n${formatSignatureSummary(signature)}`)
+    throw new Error(formatSignatureFailureMessage(classification))
   }
 
-  return signature
+  return classification.signature
+}
+
+export function reportWindowsInnerSignatureCheck(
+  classification,
+  { required = false, consoleImpl = console } = {}
+) {
+  if (classification.ok) {
+    consoleImpl.log('Verified Windows inner executable signature.')
+    consoleImpl.log(classification.summary)
+    return 0
+  }
+
+  if (required) {
+    consoleImpl.error(formatSignatureFailureMessage(classification))
+    return 1
+  }
+
+  const warning = `${classification.message} The release remains non-blocking because ${INNER_SIGNATURE_REQUIRED_ENV} is not true.`
+  consoleImpl.warn(`::warning::${escapeGitHubActionsMessage(warning)}`)
+  consoleImpl.log(classification.summary)
+  return 0
+}
+
+export function runWindowsInnerSignatureCli(
+  argv = process.argv.slice(2),
+  {
+    env = process.env,
+    platform = process.platform,
+    spawnSyncImpl = spawnSync,
+    consoleImpl = console
+  } = {}
+) {
+  try {
+    const classification = checkWindowsInnerSignature({
+      executablePath: argv[0],
+      platform,
+      spawnSyncImpl,
+      expectedSigners: parseExpectedSigners(env.ORCA_WINDOWS_EXPECTED_SIGNERS),
+      expectedThumbprints: parseExpectedThumbprints(env.ORCA_WINDOWS_EXPECTED_THUMBPRINTS)
+    })
+    const required = parseInnerSignatureRequired(env[INNER_SIGNATURE_REQUIRED_ENV])
+    return reportWindowsInnerSignatureCheck(classification, { required, consoleImpl })
+  } catch (error) {
+    consoleImpl.error(error.message)
+    return 1
+  }
 }
 
 export function main(argv = process.argv.slice(2)) {
-  try {
-    const signature = verifyWindowsInnerSignature({ executablePath: argv[0] })
-    console.log('Verified Windows inner executable signature.')
-    console.log(formatSignatureSummary(signature))
-  } catch (error) {
-    console.error(error.message)
-    process.exitCode = 1
+  const exitCode = runWindowsInnerSignatureCli(argv)
+  if (exitCode !== 0) {
+    process.exitCode = exitCode
   }
 }
 

--- a/config/scripts/verify-windows-inner-signature.test.mjs
+++ b/config/scripts/verify-windows-inner-signature.test.mjs
@@ -5,13 +5,17 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   DEFAULT_EXPECTED_SIGNER,
+  INNER_SIGNATURE_REQUIRED_ENV,
+  checkWindowsInnerSignature,
   classifySignature,
   getPowerShellSignatureJson,
   normalizeSignerSubject,
   normalizeThumbprint,
   parseExpectedSigners,
   parseExpectedThumbprints,
+  parseInnerSignatureRequired,
   parseSignatureJson,
+  runWindowsInnerSignatureCli,
   validateExecutablePath,
   verifyWindowsInnerSignature
 } from './verify-windows-inner-signature.mjs'
@@ -38,13 +42,32 @@ function withTempFile(callback) {
   }
 }
 
+function createConsoleRecorder() {
+  const messages = {
+    error: [],
+    log: [],
+    warn: []
+  }
+
+  return {
+    consoleImpl: {
+      error: (message = '') => messages.error.push(String(message)),
+      log: (message = '') => messages.log.push(String(message)),
+      warn: (message = '') => messages.warn.push(String(message))
+    },
+    messages
+  }
+}
+
 describe('verify-windows-inner-signature', () => {
   const originalExpectedSigners = process.env.ORCA_WINDOWS_EXPECTED_SIGNERS
   const originalExpectedThumbprints = process.env.ORCA_WINDOWS_EXPECTED_THUMBPRINTS
+  const originalInnerSignatureRequired = process.env[INNER_SIGNATURE_REQUIRED_ENV]
 
   beforeEach(() => {
     delete process.env.ORCA_WINDOWS_EXPECTED_SIGNERS
     delete process.env.ORCA_WINDOWS_EXPECTED_THUMBPRINTS
+    delete process.env[INNER_SIGNATURE_REQUIRED_ENV]
   })
 
   afterEach(() => {
@@ -58,6 +81,12 @@ describe('verify-windows-inner-signature', () => {
       delete process.env.ORCA_WINDOWS_EXPECTED_THUMBPRINTS
     } else {
       process.env.ORCA_WINDOWS_EXPECTED_THUMBPRINTS = originalExpectedThumbprints
+    }
+
+    if (originalInnerSignatureRequired === undefined) {
+      delete process.env[INNER_SIGNATURE_REQUIRED_ENV]
+    } else {
+      process.env[INNER_SIGNATURE_REQUIRED_ENV] = originalInnerSignatureRequired
     }
   })
 
@@ -89,6 +118,16 @@ describe('verify-windows-inner-signature', () => {
   it('normalizes optional thumbprint allowlists', () => {
     expect(normalizeThumbprint('aa bb:cc')).toBe('AABBCC')
     expect(parseExpectedThumbprints('aa bb cc,11:22:33')).toEqual(['AABBCC', '112233'])
+  })
+
+  it('parses the explicit release-blocking switch', () => {
+    expect(parseInnerSignatureRequired()).toBe(false)
+    expect(parseInnerSignatureRequired('')).toBe(false)
+    expect(parseInnerSignatureRequired('false')).toBe(false)
+    expect(parseInnerSignatureRequired('0')).toBe(false)
+    expect(parseInnerSignatureRequired('true')).toBe(true)
+    expect(parseInnerSignatureRequired('1')).toBe(true)
+    expect(() => parseInnerSignatureRequired('sometimes')).toThrow(/must be true or false/)
   })
 
   it('rejects missing, nonexistent, and directory executable paths before PowerShell', () => {
@@ -199,6 +238,94 @@ describe('verify-windows-inner-signature', () => {
       })
 
       expect(signature).toEqual(validSignature)
+    })
+  })
+
+  it('returns signature evidence without failing when the release gate is optional', () => {
+    withTempFile((filePath) => {
+      const classification = checkWindowsInnerSignature({
+        executablePath: filePath,
+        platform: 'win32',
+        spawnSyncImpl: () => ({
+          status: 0,
+          stdout: JSON.stringify({ ...validSignature, status: 'NotSigned' }),
+          stderr: ''
+        })
+      })
+
+      expect(classification.ok).toBe(false)
+      expect(classification.message).toBe('Windows inner executable signature status is NotSigned.')
+      expect(classification.summary).toContain('Status: NotSigned')
+    })
+  })
+
+  it('reports unsigned inner signatures as a non-blocking GitHub warning by default', () => {
+    withTempFile((filePath) => {
+      const { consoleImpl, messages } = createConsoleRecorder()
+      const exitCode = runWindowsInnerSignatureCli([filePath], {
+        consoleImpl,
+        env: {},
+        platform: 'win32',
+        spawnSyncImpl: () => ({
+          status: 0,
+          stdout: JSON.stringify({ ...validSignature, status: 'NotSigned' }),
+          stderr: ''
+        })
+      })
+
+      expect(exitCode).toBe(0)
+      expect(messages.warn.join('\n')).toContain('::warning::')
+      expect(messages.warn.join('\n')).toContain(INNER_SIGNATURE_REQUIRED_ENV)
+      expect(messages.log.join('\n')).toContain('Status: NotSigned')
+      expect(messages.error).toEqual([])
+    })
+  })
+
+  it('fails unsigned inner signatures when the release gate is required', () => {
+    withTempFile((filePath) => {
+      const { consoleImpl, messages } = createConsoleRecorder()
+      const exitCode = runWindowsInnerSignatureCli([filePath], {
+        consoleImpl,
+        env: {
+          [INNER_SIGNATURE_REQUIRED_ENV]: 'true'
+        },
+        platform: 'win32',
+        spawnSyncImpl: () => ({
+          status: 0,
+          stdout: JSON.stringify({ ...validSignature, status: 'NotSigned' }),
+          stderr: ''
+        })
+      })
+
+      expect(exitCode).toBe(1)
+      expect(messages.error.join('\n')).toContain(
+        'Windows inner executable signature status is NotSigned.'
+      )
+      expect(messages.error.join('\n')).toContain('Status: NotSigned')
+      expect(messages.warn).toEqual([])
+    })
+  })
+
+  it('passes valid inner signatures even when the release gate is required', () => {
+    withTempFile((filePath) => {
+      const { consoleImpl, messages } = createConsoleRecorder()
+      const exitCode = runWindowsInnerSignatureCli([filePath], {
+        consoleImpl,
+        env: {
+          [INNER_SIGNATURE_REQUIRED_ENV]: 'true'
+        },
+        platform: 'win32',
+        spawnSyncImpl: () => ({
+          status: 0,
+          stdout: JSON.stringify(validSignature),
+          stderr: ''
+        })
+      })
+
+      expect(exitCode).toBe(0)
+      expect(messages.log.join('\n')).toContain('Verified Windows inner executable signature.')
+      expect(messages.warn).toEqual([])
+      expect(messages.error).toEqual([])
     })
   })
 


### PR DESCRIPTION
## Summary
- add a Windows release evidence step that extracts the signed installer, finds the packaged app-root `Orca.exe`, and checks its Authenticode signature
- keep releases passing by default: unsigned/missing inner-signature evidence emits a GitHub warning unless `ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED=true`
- preserve the strict verifier for the future required gate, with tests for optional vs required behavior

## ELI5
Windows sees two important files during an Orca update: the installer we download and the `Orca.exe` that ends up installed on the machine. We already verify the signed installer, but the failed release showed the installed `Orca.exe` can still be `NotSigned` if SignPath is not recursively signing files inside the installer.

This PR makes the release job look inside the signed installer and report whether the installed `Orca.exe` is signed by the expected SignPath identity. It does not block releases by default, because the recursive signing switch lives in SignPath outside this repo and we already proved it is not enabled yet. Once SignPath is fixed and an RC shows `Status: Valid`, we can set `ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED=true` and the exact same check becomes a hard release gate.

## Attempt History
- #6806, `Prevent unsigned Windows app releases`, added the correct hard invariant: the Windows installer should not ship if the packaged inner `Orca.exe` is unsigned. That was the right security direction, but it was premature for `main` because SignPath was only signing the outer NSIS installer.
- #7135, `Fix Windows SignPath PSGallery preflight`, fixed the Windows release runner's SignPath PowerShell module setup so the release could reach the signing verification path reliably.
- #7136, `Fix Windows inner signature PowerShell path`, fixed the verifier's path handoff into PowerShell. After that fix, the release reached the real result: the outer installer was signed, but the inner `Orca.exe` reported `NotSigned`.
- #7137, `Temporarily bypass Windows inner signature gate`, restored releaseability by removing the hard inner-exe gate while we confirmed that recursive signing has to be enabled in SignPath's server-side artifact configuration.
- #7170, this PR, keeps the security signal from #6806 but changes rollout to evidence-first. It logs and warns on the inner `Orca.exe` signature state now, then lets us flip `ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED=true` after SignPath recursive signing is configured and proven on an RC.

## Why This Is Safe For Releases
- outer installer verification remains hard-blocking exactly as before
- inner executable checking is evidence-only by default, including extraction/layout failures
- every external command in the Windows PowerShell step checks `$LASTEXITCODE`
- the workflow contract test pins the order: outer installer verification -> inner evidence check -> upload

## What To Do After Landing
1. Run a normal RC/stable release as needed. This PR should not block release publication unless `ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED=true` is set.
2. Check the Windows release log for `Check signed Windows inner executable`.
3. If the log says `Status: NotSigned`, SignPath recursive PE signing is still not enabled for `github-actions-windows-installer`.
4. After SignPath is configured, cut an RC and confirm the inner executable logs `Status: Valid` with the expected SignPath signer.
5. Set repository variable `ORCA_WINDOWS_INNER_SIGNATURE_REQUIRED=true` only after that successful RC, so future regressions become release-blocking.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/verify-windows-inner-signature.test.mjs config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec oxfmt --check .github/workflows/release-cut.yml config/scripts/verify-windows-inner-signature.mjs config/scripts/verify-windows-inner-signature.test.mjs config/scripts/package-electron-runtime-contract.test.mjs`
- `git diff --check`

Note: local `oxlint`/pre-commit is currently blocked before file linting by `Rule 'no-array-fill-with-reference-type' not found in plugin 'unicorn'`, so the commit was made with `--no-verify` after the focused checks above passed.