### PR TITLE
Fix Codex pane output tearing after app occlusion

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7022,6 +7022,17 @@ describe('connectPanePty', () => {
   })
 
   it('does not apply stale background Codex query chunks after hidden snapshot restore', async () => {
+    const visibilityChangeHandler: { current: (() => void) | null } = { current: null }
+    ;(globalThis as { document?: Document }).document = {
+      visibilityState: 'visible',
+      addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'visibilitychange') {
+          visibilityChangeHandler.current = listener as () => void
+        }
+      }),
+      removeEventListener: vi.fn()
+    } as unknown as Document
+
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
     const capturedDataCallback: {
@@ -7046,6 +7057,8 @@ describe('connectPanePty', () => {
     const currentFrame = '\r\x1b[2KWorking current'
     const staleSeq = hiddenFrame.length + staleQueryFrame.length
     const currentSeq = staleSeq + currentFrame.length
+    // The main emulator has already parsed every frame, so the snapshot covers
+    // the query frame that is still in flight on the pty:data channel.
     getMainBufferSnapshot.mockResolvedValue({
       data: currentFrame,
       cols: 80,
@@ -7070,17 +7083,21 @@ describe('connectPanePty', () => {
       rawLength: hiddenFrame.length
     })
     ;(deps.isVisibleRef as { current: boolean }).current = true
-    capturedDataCallback.current?.(currentFrame, {
-      seq: currentSeq,
-      rawLength: currentFrame.length
-    })
+    visibilityChangeHandler.current?.()
     await flushAsyncTicks(20)
 
+    // The in-flight chunks arrive in channel order after the restore already
+    // rebuilt the buffer from the newer snapshot.
     vi.useFakeTimers()
     try {
       capturedDataCallback.current?.(staleQueryFrame, {
         seq: staleSeq,
         rawLength: staleQueryFrame.length,
+        background: true
+      })
+      capturedDataCallback.current?.(currentFrame, {
+        seq: currentSeq,
+        rawLength: currentFrame.length,
         background: true
       })
       vi.advanceTimersByTime(50)
@@ -7098,6 +7115,164 @@ describe('connectPanePty', () => {
 
     expect(writes).not.toContain(staleQueryFrame)
     expect(rendererBuffer).toEqual(referenceBuffer)
+    binding.dispose()
+  })
+
+  it('restores hidden Codex output after a suppressed exit revives the same ptyId with a restarted seq counter', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current:
+        | ((
+            data: string,
+            meta?: { seq?: number; rawLength?: number; background?: boolean }
+          ) => void)
+        | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+
+    const hiddenFrame = '\r\x1b[2KWorking hidden'
+    const visibleFrame = '\r\x1b[2KWorking now'
+    const hiddenSeq = hiddenFrame.length
+    const visibleSeq = hiddenSeq + visibleFrame.length
+    // Why 3 extra bytes: the main emulator typically runs ahead of the chunks
+    // the renderer has received, so the snapshot seq exceeds the channel seq.
+    const preExitSnapshotSeq = visibleSeq + 3
+    getMainBufferSnapshot.mockResolvedValue({
+      data: visibleFrame,
+      cols: 80,
+      rows: 8,
+      seq: preExitSnapshotSeq
+    })
+
+    const pane = createPane(1)
+    pane.terminal.cols = 80
+    pane.terminal.rows = 8
+    const { writes } = captureCallbackTerminalWrites(pane)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false },
+      startup: { command: 'codex' },
+      consumeSuppressedPtyExit: vi.fn(() => true)
+    })
+    const binding = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hiddenFrame, { seq: hiddenSeq, rawLength: hiddenFrame.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(visibleFrame, {
+      seq: visibleSeq,
+      rawLength: visibleFrame.length
+    })
+    await flushAsyncTicks(20)
+
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as ((ptyId: string) => void) | undefined
+    expect(onPtyExit).toBeTypeOf('function')
+    onPtyExit?.('pty-id')
+
+    // Revived session: same ptyId, main seq counter restarted. The first
+    // revived chunk lands below the pre-exit snapshot seq but above the last
+    // channel seq, so only the exit reset can stop it being judged covered.
+    ;(deps.isVisibleRef as { current: boolean }).current = false
+    const revivedHiddenFrame = '\r\x1b[2KWorking revived'
+    capturedDataCallback.current?.(revivedHiddenFrame, {
+      seq: preExitSnapshotSeq - 1,
+      rawLength: revivedHiddenFrame.length
+    })
+
+    const revivedSnapshotFrame = '\r\x1b[2KREVIVED SNAPSHOT'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: revivedSnapshotFrame,
+      cols: 80,
+      rows: 8,
+      seq: preExitSnapshotSeq - 1
+    })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    const revivedVisibleFrame = '\r\x1b[2Kafter revive'
+    capturedDataCallback.current?.(revivedVisibleFrame, {
+      seq: preExitSnapshotSeq - 1 + revivedVisibleFrame.length,
+      rawLength: revivedVisibleFrame.length
+    })
+    await flushAsyncTicks(20)
+
+    const written = writes.join('')
+    expect(written).toContain('REVIVED SNAPSHOT')
+    expect(written).toContain('after revive')
+    binding.dispose()
+  })
+
+  it('restores hidden Codex output when the pty seq counter restarts without an observed exit', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current:
+        | ((
+            data: string,
+            meta?: { seq?: number; rawLength?: number; background?: boolean }
+          ) => void)
+        | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+
+    const pane = createPane(1)
+    pane.terminal.cols = 80
+    pane.terminal.rows = 8
+    const { writes } = captureCallbackTerminalWrites(pane)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: true },
+      startup: { command: 'codex' }
+    })
+    const binding = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    const establishedFrame = '\r\x1b[2KWorking established'
+    capturedDataCallback.current?.(establishedFrame, {
+      seq: 50_000,
+      rawLength: establishedFrame.length
+    })
+    await flushAsyncTicks(6)
+
+    // Main lost the pty silently (no exit reached the renderer) and the seq
+    // counter restarted: the channel seq regression must invalidate the old
+    // high-water mark instead of covering the new stream.
+    ;(deps.isVisibleRef as { current: boolean }).current = false
+    const revivedHiddenFrame = '\r\x1b[2KWorking revived'
+    capturedDataCallback.current?.(revivedHiddenFrame, {
+      seq: revivedHiddenFrame.length,
+      rawLength: revivedHiddenFrame.length
+    })
+
+    const revivedSnapshotFrame = '\r\x1b[2KREVIVED SNAPSHOT2'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: revivedSnapshotFrame,
+      cols: 80,
+      rows: 8,
+      seq: revivedHiddenFrame.length
+    })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    const revivedVisibleFrame = '\r\x1b[2Kafter revive'
+    capturedDataCallback.current?.(revivedVisibleFrame, {
+      seq: revivedHiddenFrame.length + revivedVisibleFrame.length,
+      rawLength: revivedVisibleFrame.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(writes.join('')).toContain('REVIVED SNAPSHOT2')
     binding.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines */
 import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Terminal } from '@xterm/headless'
 import {
   POST_REPLAY_LIVE_AGENT_REATTACH_RESET,
   POST_REPLAY_MODE_RESET,
@@ -42,6 +43,26 @@ async function drainPendingTimeouts(pendingTimeouts: (() => void)[], limit = 100
     iterations += 1
     pendingTimeouts.shift()?.()
     await flushAsyncTicks()
+  }
+}
+
+function writeHeadlessTerminal(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, resolve))
+}
+
+async function renderHeadlessBuffer(writes: string[], cols = 80, rows = 8): Promise<string[]> {
+  const term = new Terminal({ cols, rows, allowProposedApi: true })
+  try {
+    for (const write of writes) {
+      await writeHeadlessTerminal(term, write)
+    }
+    const lines: string[] = []
+    for (let lineIndex = 0; lineIndex < term.buffer.active.length; lineIndex++) {
+      lines.push(term.buffer.active.getLine(lineIndex)?.translateToString(true) ?? '')
+    }
+    return lines
+  } finally {
+    term.dispose()
   }
 }
 
@@ -6997,6 +7018,86 @@ describe('connectPanePty', () => {
     expect(window.api.pty.getMainBufferSnapshot).not.toHaveBeenCalled()
     expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b[6n', expect.any(Function))
 
+    binding.dispose()
+  })
+
+  it('does not apply stale background Codex query chunks after hidden snapshot restore', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current:
+        | ((
+            data: string,
+            meta?: { seq?: number; rawLength?: number; background?: boolean }
+          ) => void)
+        | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+
+    const hiddenFrame = '\r\x1b[2KWorking hidden'
+    const staleQueryFrame = '\r\x1b[2KWorking stale\x1b[6n'
+    const currentFrame = '\r\x1b[2KWorking current'
+    const staleSeq = hiddenFrame.length + staleQueryFrame.length
+    const currentSeq = staleSeq + currentFrame.length
+    getMainBufferSnapshot.mockResolvedValue({
+      data: currentFrame,
+      cols: 80,
+      rows: 8,
+      seq: currentSeq
+    })
+
+    const pane = createPane(1)
+    pane.terminal.cols = 80
+    pane.terminal.rows = 8
+    const { writes } = captureCallbackTerminalWrites(pane)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false },
+      startup: { command: 'codex' }
+    })
+    const binding = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hiddenFrame, {
+      seq: hiddenFrame.length,
+      rawLength: hiddenFrame.length
+    })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(currentFrame, {
+      seq: currentSeq,
+      rawLength: currentFrame.length
+    })
+    await flushAsyncTicks(20)
+
+    vi.useFakeTimers()
+    try {
+      capturedDataCallback.current?.(staleQueryFrame, {
+        seq: staleSeq,
+        rawLength: staleQueryFrame.length,
+        background: true
+      })
+      vi.advanceTimersByTime(50)
+      await flushAsyncTicks(6)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    const rendererBuffer = await renderHeadlessBuffer(writes, 80, 8)
+    const referenceBuffer = await renderHeadlessBuffer(
+      [hiddenFrame, staleQueryFrame, currentFrame],
+      80,
+      8
+    )
+
+    expect(writes).not.toContain(staleQueryFrame)
+    expect(rendererBuffer).toEqual(referenceBuffer)
     binding.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3646,6 +3646,8 @@ export function connectPanePty(
     let hiddenSynchronizedOutputMarkerTail = ''
     let hiddenRewriteChunkEndedWithCarriageReturn = false
     let hiddenRewriteCsiScanTail = ''
+    let rendererOrderedPtyId: string | null = null
+    let rendererOrderedSeq: number | null = null
 
     function canUseMainBufferSnapshot(ptyId: string | null): ptyId is string {
       return Boolean(ptyId) && !isRemoteRuntimePtyId(ptyId)
@@ -4120,6 +4122,39 @@ export function connectPanePty(
       return chunk.data.slice(offset)
     }
 
+    function recordRendererOrderedSeq(meta?: Pick<PtyDataMeta, 'seq'>): void {
+      if (typeof meta?.seq !== 'number') {
+        return
+      }
+      const ptyId = transport.getPtyId()
+      if (!ptyId) {
+        return
+      }
+      if (rendererOrderedPtyId !== ptyId) {
+        rendererOrderedPtyId = ptyId
+        rendererOrderedSeq = meta.seq
+        return
+      }
+      rendererOrderedSeq = Math.max(rendererOrderedSeq ?? 0, meta.seq)
+    }
+
+    function getHiddenRendererDataAfterOrderedSeq(
+      data: string,
+      meta: PtyDataMeta | undefined
+    ): string | null {
+      if (
+        rendererOrderedPtyId === null ||
+        rendererOrderedSeq === null ||
+        transport.getPtyId() !== rendererOrderedPtyId
+      ) {
+        return data
+      }
+      return getChunkDataAfterSnapshot(
+        { data, seq: meta?.seq, rawLength: meta?.rawLength },
+        rendererOrderedSeq
+      )
+    }
+
     function drainPendingLiveChunksAfterSnapshot(snapshotSeq: number | undefined): boolean {
       if (hiddenOutputRestorePendingOverflow) {
         hiddenOutputRestorePendingOverflow = false
@@ -4143,6 +4178,7 @@ export function connectPanePty(
           }
           if (data) {
             writePtyOutputToXterm(data, true)
+            recordRendererOrderedSeq(chunk)
           }
         }
         if (hiddenOutputRestorePendingOverflow) {
@@ -4404,6 +4440,7 @@ export function connectPanePty(
       writeReplayData(snapshot.data)
       writeReplayData(POST_REPLAY_LIVE_SNAPSHOT_RESET)
       hiddenRendererStateDirty = false
+      recordRendererOrderedSeq(snapshot)
       resetHiddenRendererRiskState()
       recordTerminalOutput(pane.terminal)
       const currentPtyId = transport.getPtyId()
@@ -4632,6 +4669,20 @@ export function connectPanePty(
         meta,
         pendingForegroundQuery?.consumedCurrentChars ?? 0
       )
+      const orderedRendererData = foreground
+        ? rendererData
+        : getHiddenRendererDataAfterOrderedSeq(rendererData, rendererMeta)
+      if (orderedRendererData === null) {
+        // Why: renderer-side filtering cannot map cleaned text back onto raw
+        // sequence offsets. Rebuild from main instead of risking stale bytes.
+        markHiddenOutputRestoreNeeded()
+        schedulePendingStartupCommandDelivery()
+        return
+      }
+      if (!foreground && orderedRendererData.length === 0) {
+        schedulePendingStartupCommandDelivery()
+        return
+      }
       if (pendingForegroundQuery?.statelessQueryData) {
         writePtyOutputToXterm(pendingForegroundQuery.statelessQueryData, true, {
           hiddenStartupRendererQuery: true
@@ -4650,11 +4701,11 @@ export function connectPanePty(
         meta?.background === true &&
         shouldWritePtyOutputForeground(deps.isVisibleRef.current) &&
         pane.terminal.buffer.active.type === 'alternate' &&
-        !containsStatefulRendererQuery(data)
+        !containsStatefulRendererQuery(orderedRendererData)
       if (skipBackgroundAlternateScreenFrame) {
-        skipBackgroundAlternateScreenOutput(data)
-      } else if (shouldSkipHiddenRendererOutput(foreground, data)) {
-        skipHiddenRendererOutput(data)
+        skipBackgroundAlternateScreenOutput(orderedRendererData)
+      } else if (shouldSkipHiddenRendererOutput(foreground, orderedRendererData)) {
+        skipHiddenRendererOutput(orderedRendererData)
       } else if (
         (hiddenOutputRestoreNeeded || hiddenOutputRestoreInFlight) &&
         restoreAppliesToCurrentPty
@@ -4663,7 +4714,7 @@ export function connectPanePty(
           if (pendingForegroundQuery?.statefulQueryData) {
             queueLiveChunkDuringRestore(pendingForegroundQuery.statefulQueryData)
           }
-          queueLiveChunkDuringRestore(rendererData, rendererMeta)
+          queueLiveChunkDuringRestore(orderedRendererData, rendererMeta)
           requestHiddenOutputRestoreIfNeeded()
         } else if (hiddenOutputRestoreInFlight) {
           resetSkippedHiddenRendererRiskState()
@@ -4676,7 +4727,10 @@ export function connectPanePty(
             hiddenStartupRendererQuery: true
           })
         }
-        writePtyOutputToXterm(rendererData, foreground)
+        writePtyOutputToXterm(orderedRendererData, foreground)
+        if (foreground) {
+          recordRendererOrderedSeq(rendererMeta)
+        }
       }
 
       schedulePendingStartupCommandDelivery()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1035,6 +1035,7 @@ export function connectPanePty(
   let unregisterDocumentVisibilityRecovery: (() => void) | null = null
   let cleanupHiddenOutputRestoreDeferredRetry = (): void => {}
   let cleanupHiddenOutputRestoreForegroundDeadline = (): void => {}
+  let resetRendererOrderedSeqForPtyExit: (exitedPtyId: string) => void = () => {}
   let cleanupStartupDraftPasteTimers = (): void => {}
   let unregisterE2ePtyDataInjection = (): void => {}
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
@@ -1700,6 +1701,7 @@ export function connectPanePty(
     if (handledExitPtyId === ptyId) {
       return
     }
+    resetRendererOrderedSeqForPtyExit(ptyId)
     const currentPaneTransport = deps.paneTransportsRef.current.get(pane.id)
     if (currentPaneTransport && currentPaneTransport !== transport) {
       // Why: an old transport can deliver a late exit after this pane has
@@ -3648,6 +3650,8 @@ export function connectPanePty(
     let hiddenRewriteCsiScanTail = ''
     let rendererOrderedPtyId: string | null = null
     let rendererOrderedSeq: number | null = null
+    let rendererChannelSeqPtyId: string | null = null
+    let rendererChannelSeq: number | null = null
 
     function canUseMainBufferSnapshot(ptyId: string | null): ptyId is string {
       return Boolean(ptyId) && !isRemoteRuntimePtyId(ptyId)
@@ -4136,6 +4140,46 @@ export function connectPanePty(
         return
       }
       rendererOrderedSeq = Math.max(rendererOrderedSeq ?? 0, meta.seq)
+    }
+
+    resetRendererOrderedSeqForPtyExit = (exitedPtyId: string): void => {
+      // Why: an exit ends this ptyId's seq domain. A revived session can reuse
+      // the id with a restarted main-side counter, and a stale high-water mark
+      // would wrongly cover — and silently drop — every hidden byte it emits.
+      if (rendererOrderedPtyId === exitedPtyId) {
+        rendererOrderedPtyId = null
+        rendererOrderedSeq = null
+      }
+      if (rendererChannelSeqPtyId === exitedPtyId) {
+        rendererChannelSeqPtyId = null
+        rendererChannelSeq = null
+      }
+    }
+
+    function observeRendererOrderedSeqRegression(meta: PtyDataMeta | undefined): void {
+      if (typeof meta?.seq !== 'number') {
+        return
+      }
+      const ptyId = transport.getPtyId()
+      if (!ptyId) {
+        return
+      }
+      if (rendererChannelSeqPtyId !== ptyId) {
+        rendererChannelSeqPtyId = ptyId
+        rendererChannelSeq = meta.seq
+        return
+      }
+      if (rendererChannelSeq !== null && meta.seq < rendererChannelSeq) {
+        // Why: pty:data delivery is FIFO per pty, so seq only moves backwards
+        // when the session was revived without an observed exit and restarted
+        // its counter. Drop the stale ordered baseline instead of letting it
+        // cover the new stream's bytes.
+        if (rendererOrderedPtyId === ptyId) {
+          rendererOrderedPtyId = null
+          rendererOrderedSeq = null
+        }
+      }
+      rendererChannelSeq = meta.seq
     }
 
     function getHiddenRendererDataAfterOrderedSeq(
@@ -4669,6 +4713,7 @@ export function connectPanePty(
         meta,
         pendingForegroundQuery?.consumedCurrentChars ?? 0
       )
+      observeRendererOrderedSeqRegression(meta)
       const orderedRendererData = foreground
         ? rendererData
         : getHiddenRendererDataAfterOrderedSeq(rendererData, rendererMeta)


### PR DESCRIPTION
## Summary

Fixes renderer-buffer tearing in Codex terminal panes after the app has been occluded while hidden-output snapshot recovery is active.

The failing layer is the renderer terminal buffer: raw PTY bytes and main-owned snapshots can be clean, while a late renderer delivery can still mutate the pane after a newer restore. This PR does not use `orca terminal read` as evidence because its retention-tail normalization is known to flatten spinner frames.

Root cause: after hidden snapshot restore or newer foreground bytes advanced the renderer to a later PTY seq, a delayed background-origin Codex chunk containing a stateful terminal query could still take the hidden live-write path when `hiddenRendererStateDirty` was false. That allowed an older redraw/query chunk to be written into the renderer after a newer snapshot rebuilt the buffer.

Fix: track the latest PTY seq accepted by the renderer for the current PTY through hidden snapshot restore and foreground drains/writes. Hidden/background renderer data is filtered against that ordered seq before it can reach the terminal. Fully covered stale chunks are dropped; unmappable overlap falls back to main snapshot recovery instead of risking duplicate/stale renderer bytes.

## Review hardening

Review coverage for this PR: an independent adversarial agent pass over the seq-filter machinery and its lifecycle, maintainer diff review, and CodeRabbit. (A separate terminal-based reviewer agent was also attempted but could not run due to model-gateway errors.)

The adversarial pass found one real hole in the original fix, closed in the follow-up commit:

- **Stale ordered-seq baseline across pty stream restarts (silent data loss).** Main deletes its per-pty seq counter on `runtime.onPtyExit` — including suppressed/synthetic kills — so a revived session that reuses the same ptyId (agent-hibernation wake, kill + cold-restore into a still-mounted pane) restarts seq near zero while the renderer still holds the old high-water mark. Every hidden/background chunk from the revived stream was then judged "already covered" and dropped without marking a snapshot restore, permanently freezing hidden output for that pane; foreground writes could only ratchet the stale baseline upward. Two constant-time guards close it: any observed pty exit clears the baseline for the exiting ptyId, and a per-pty channel seq-regression detector (`pty:data` is FIFO per pty with a monotonic counter, so an in-order arrival below the last seen seq can only mean a restarted counter) covers restarts whose exit never reached the renderer. Each guard has a regression test verified to fail with that guard removed.
- The original regression test was reworked to deliver chunks in the only order the FIFO data channel can produce: the snapshot RPC outruns in-flight chunks, and the stale query frame then arrives in channel order after the restore completed. The reworked test still fails against the pre-fix renderer, so the original coverage is preserved.

Findings triaged and rejected (no code change):

- Dropping a fully covered chunk without marking restore is sound under monotonic seq: coverage only advances via an applied snapshot or a chunk already written in channel order, so covered bytes are always represented in the buffer. The stream-restart case above was the one exception, now guarded.
- The unmappable-partial-chunk fallback (`markHiddenOutputRestoreNeeded`) always has a snapshot source available: seq metadata is only attached by the local and SSH-relay data channels, both snapshot-capable; the remote-runtime transport sends no seq metadata, which leaves the filter inert there by design.
- Chunks queued during an in-flight restore are never trimmed (trimming applies only to non-foreground chunks; only foreground chunks are queued), and the drain's unmappable-chunk path is loss-free — it discards the queue and refetches a fresher snapshot that already covers those bytes.
- Stale stateful queries (CPR) are now dropped rather than answered against rebuilt buffer state. This matches the existing skip-path design, which already drops stateful queries whenever the hidden renderer state is dirty; answering a stale CPR after a newer restore was part of the corruption this PR fixes.
- CodeRabbit's one nitpick (the regression test's frames all rewrite a single line, weakening the buffer-equality assertion) was reviewed and skipped: the equality compares against a reference parsed from the clean in-order stream, so it already proves every buffer row is free of stale residue, and the single-line rewrite shape mirrors the real Codex spinner frames the bug manifested in.

## Reliability proof

- Reliability invariant: `terminal-session.snapshot-freshness` / renderer hidden-output ordering. A hidden/background chunk must not mutate the renderer terminal buffer after the renderer has already accepted a snapshot or foreground stream position that covers that chunk's PTY seq — and that acceptance mark must not outlive the pty stream that produced it.
- Material impact: makes the Codex occlusion tear class harder to reintroduce by locking the bug at the renderer write-order seam, including stateful-query chunks that previously bypassed hidden skipping when the hidden renderer looked clean, and protects revived sessions from silent hidden-output loss.
- Product change type: mixed product hardening plus deterministic regression coverage.
- Performance risk inventory: touches hidden output, PTY output, visibility resume, render/snapshot replay. Does not touch typing input routing, focus ownership, resize, startup awaits, provider listing, store subscribers, git/worktree scans, subprocesses, SSH process inspection, WSL path handling, or mobile/relay routing.
- No-regression evidence: the fix adds no polling, timers, background wake loop, unbounded buffering, provider calls, PTY resizes, or scans. It performs constant-time seq checks on the existing per-chunk path and reuses existing snapshot drain offset logic. The review-hardening guards add two integer comparisons per chunk and an O(1) reset per pty exit.
- Correctness evidence: three deterministic regression tests. The first records renderer writes, reconstructs the renderer buffer with a headless terminal parser, and compares it to a reference parse of the clean ordered raw stream; it fails before the fix because the stale background Codex query frame is written after restore. The other two cover session revival with a restarted seq counter — with and without an observed pty exit — and each fails when its guard is removed.
- Provider/platform coverage: local and daemon PTY paths covered by the test's main snapshot + seq contract. SSH relay uses the same monotonic seq source and snapshot path. Remote-runtime providers send no seq metadata and keep existing behavior. macOS, Linux, and Windows are unaffected by platform-specific assumptions.
- Residual gaps: no live macOS occlusion Playwright run in this PR; remote-runtime provider-specific ordering is not separately exercised; the known retention-tail normalizer limitation is not addressed here.
- Manifest status / promotion: no `config/reliability-gates.jsonc` exists in this worktree, so there is no manifest entry to promote. Treat this as a partial gate carried by `pty-connection.test.ts`.
- Rollback or demotion rule: if this test flakes or blocks legitimate hidden stateful-query replies for chunks newer than the renderer seq, demote the gate and capture the offending seq/rawLength/provider metadata before changing behavior.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` - 288 passed
- `pnpm run typecheck` - passed
- `oxlint` on changed files - clean

Made with [Orca](https://github.com/stablyai/orca) 🐋
