### PR TITLE
Inject serve-sim camera dylib from an unquarantined runtime copy

### DIFF
--- a/src/main/emulator/serve-sim-execution.ts
+++ b/src/main/emulator/serve-sim-execution.ts
@@ -12,6 +12,7 @@ import { app } from 'electron'
 import { platform, tmpdir } from 'node:os'
 import { delimiter, dirname, join } from 'node:path'
 import { EmulatorError } from './emulator-errors'
+import { materializeServeSimRuntime } from './serve-sim-runtime-materializer'
 
 const EXEC_TIMEOUT_MS = 90_000
 const MAC_OPEN_SHIM_DIR = join(tmpdir(), 'orca-serve-sim-open-shim')
@@ -67,6 +68,27 @@ function getServeSimEnv(executable: ServeSimExecutable): NodeJS.ProcessEnv {
   return env
 }
 
+// Cached per process: materialization is a one-time copy; later calls only stat.
+let materializedServeSimPackageDir: string | null | undefined
+
+function resolveMaterializedServeSimPackageDir(bundledPackageDir: string): string | null {
+  if (materializedServeSimPackageDir !== undefined) {
+    return materializedServeSimPackageDir
+  }
+  materializedServeSimPackageDir = materializeServeSimRuntime({
+    bundledPackageDir,
+    targetRootDir: join(app.getPath('userData'), 'serve-sim-runtime'),
+    version: app.getVersion()
+  })
+  if (materializedServeSimPackageDir === null) {
+    console.warn(
+      '[serve-sim] runtime materialization failed; running from the app bundle ' +
+        '(camera injection may hit Gatekeeper on quarantined installs)'
+    )
+  }
+  return materializedServeSimPackageDir
+}
+
 export function resolveServeSimExecutable(): ServeSimExecutable {
   const bundledResourcesPath =
     process.resourcesPath ??
@@ -75,6 +97,21 @@ export function resolveServeSimExecutable(): ServeSimExecutable {
       : join(app.getPath('exe'), '..', 'resources'))
   const bundled = join(bundledResourcesPath, 'serve-sim', 'dist', 'serve-sim.js')
   if (existsSync(bundled)) {
+    if (process.platform === 'darwin') {
+      // Why: the bundled camera dylib is signed but has no Gatekeeper ticket
+      // (iOS-simulator arch), so injecting it from the quarantined app bundle
+      // can trip syspolicyd; run serve-sim from an unquarantined copy instead.
+      const materializedDir = resolveMaterializedServeSimPackageDir(
+        join(bundledResourcesPath, 'serve-sim')
+      )
+      if (materializedDir) {
+        return {
+          command: process.execPath,
+          baseArgs: [join(materializedDir, 'dist', 'serve-sim.js')],
+          usesElectronAsNode: true
+        }
+      }
+    }
     return { command: process.execPath, baseArgs: [bundled], usesElectronAsNode: true }
   }
 

--- a/src/main/emulator/serve-sim-runtime-materializer.test.ts
+++ b/src/main/emulator/serve-sim-runtime-materializer.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { materializeServeSimRuntime } from './serve-sim-runtime-materializer'
+
+const DYLIB_CONTENT = Buffer.from('signed-simcam-dylib-mach-o-bytes')
+
+async function createBundledServeSimPackage(root: string): Promise<string> {
+  const packageDir = join(root, 'bundled-serve-sim')
+  await mkdir(join(packageDir, 'dist', 'simcam'), { recursive: true })
+  await mkdir(join(packageDir, 'bin'), { recursive: true })
+  await writeFile(join(packageDir, 'dist', 'serve-sim.js'), 'console.log("serve-sim")')
+  await writeFile(join(packageDir, 'dist', 'simcam', 'libSimCameraInjector.dylib'), DYLIB_CONTENT, {
+    mode: 0o644
+  })
+  await writeFile(join(packageDir, 'dist', 'simcam', 'serve-sim-camera-helper'), 'helper', {
+    mode: 0o644
+  })
+  await writeFile(join(packageDir, 'bin', 'serve-sim-bin'), 'bin', { mode: 0o644 })
+  return packageDir
+}
+
+describe('materializeServeSimRuntime', () => {
+  const cleanupPaths: string[] = []
+
+  afterEach(async () => {
+    for (const path of cleanupPaths.splice(0)) {
+      await rm(path, { recursive: true, force: true })
+    }
+  })
+
+  async function createRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-simcam-materializer-'))
+    cleanupPaths.push(root)
+    return root
+  }
+
+  it('copies the signed dylib through unchanged and clears quarantine', async () => {
+    const root = await createRoot()
+    const bundledPackageDir = await createBundledServeSimPackage(root)
+    const clearQuarantine = vi.fn()
+
+    const materialized = materializeServeSimRuntime({
+      bundledPackageDir,
+      targetRootDir: join(root, 'runtime'),
+      version: '1.2.3',
+      clearQuarantine
+    })
+
+    expect(materialized).toBe(join(root, 'runtime', '1.2.3'))
+    // The dylib must be byte-identical to the bundled (Developer-ID-signed) copy.
+    const dylibPath = join(materialized!, 'dist', 'simcam', 'libSimCameraInjector.dylib')
+    expect(await readFile(dylibPath)).toEqual(DYLIB_CONTENT)
+    expect(clearQuarantine).toHaveBeenCalledTimes(1)
+    expect(clearQuarantine).toHaveBeenCalledWith(expect.stringContaining('.staging-1.2.3-'))
+    if (process.platform !== 'win32') {
+      for (const executable of [
+        join(materialized!, 'bin', 'serve-sim-bin'),
+        join(materialized!, 'dist', 'simcam', 'serve-sim-camera-helper')
+      ]) {
+        expect(((await stat(executable)).mode & 0o111) !== 0).toBe(true)
+      }
+    }
+  })
+
+  it('returns the existing runtime without re-copying', async () => {
+    const root = await createRoot()
+    const bundledPackageDir = await createBundledServeSimPackage(root)
+    const clearQuarantine = vi.fn()
+    const options = {
+      bundledPackageDir,
+      targetRootDir: join(root, 'runtime'),
+      version: '1.2.3',
+      clearQuarantine
+    }
+
+    const first = materializeServeSimRuntime(options)
+    const second = materializeServeSimRuntime(options)
+
+    expect(second).toBe(first)
+    expect(clearQuarantine).toHaveBeenCalledTimes(1)
+  })
+
+  it('prunes runtimes left behind by older app versions', async () => {
+    const root = await createRoot()
+    const bundledPackageDir = await createBundledServeSimPackage(root)
+    const targetRootDir = join(root, 'runtime')
+    await mkdir(join(targetRootDir, '1.0.0', 'dist'), { recursive: true })
+    await writeFile(join(targetRootDir, '1.0.0', 'dist', 'serve-sim.js'), 'old')
+
+    materializeServeSimRuntime({
+      bundledPackageDir,
+      targetRootDir,
+      version: '1.2.3',
+      clearQuarantine: () => {}
+    })
+
+    await expect(stat(join(targetRootDir, '1.0.0'))).rejects.toThrow()
+  })
+
+  it('returns null and leaves no staging behind when quarantine clearing fails', async () => {
+    const root = await createRoot()
+    const bundledPackageDir = await createBundledServeSimPackage(root)
+    const targetRootDir = join(root, 'runtime')
+
+    const materialized = materializeServeSimRuntime({
+      bundledPackageDir,
+      targetRootDir,
+      version: '1.2.3',
+      clearQuarantine: () => {
+        throw new Error('xattr failed')
+      }
+    })
+
+    expect(materialized).toBeNull()
+    await expect(stat(join(targetRootDir, '1.2.3'))).rejects.toThrow()
+    const { readdir } = await import('node:fs/promises')
+    const leftovers = (await readdir(targetRootDir)).filter((name) => name.startsWith('.staging'))
+    expect(leftovers).toEqual([])
+  })
+
+  it('returns null when the bundled package is missing', async () => {
+    const root = await createRoot()
+
+    const materialized = materializeServeSimRuntime({
+      bundledPackageDir: join(root, 'does-not-exist'),
+      targetRootDir: join(root, 'runtime'),
+      version: '1.2.3',
+      clearQuarantine: () => {}
+    })
+
+    expect(materialized).toBeNull()
+  })
+})

--- a/src/main/emulator/serve-sim-runtime-materializer.test.ts
+++ b/src/main/emulator/serve-sim-runtime-materializer.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -89,14 +90,39 @@ describe('materializeServeSimRuntime', () => {
     await mkdir(join(targetRootDir, '1.0.0', 'dist'), { recursive: true })
     await writeFile(join(targetRootDir, '1.0.0', 'dist', 'serve-sim.js'), 'old')
 
-    materializeServeSimRuntime({
+    const materialized = materializeServeSimRuntime({
       bundledPackageDir,
       targetRootDir,
       version: '1.2.3',
       clearQuarantine: () => {}
     })
 
+    expect(materialized).toBe(join(targetRootDir, '1.2.3'))
     await expect(stat(join(targetRootDir, '1.0.0'))).rejects.toThrow()
+  })
+
+  it('tolerates a concurrent instance winning the rename', async () => {
+    const root = await createRoot()
+    const bundledPackageDir = await createBundledServeSimPackage(root)
+    const targetRootDir = join(root, 'runtime')
+    const targetDir = join(targetRootDir, '1.2.3')
+
+    // Simulate another instance finishing first: right before our rename, drop a
+    // complete target dir in place so renameSync fails but the entry exists.
+    const materialized = materializeServeSimRuntime({
+      bundledPackageDir,
+      targetRootDir,
+      version: '1.2.3',
+      clearQuarantine: () => {
+        mkdirSync(join(targetDir, 'dist'), { recursive: true })
+        writeFileSync(join(targetDir, 'dist', 'serve-sim.js'), 'winner')
+      }
+    })
+
+    expect(materialized).toBe(targetDir)
+    expect(await readFile(join(targetDir, 'dist', 'serve-sim.js'), 'utf8')).toBe('winner')
+    const leftovers = (await readdir(targetRootDir)).filter((name) => name.startsWith('.staging'))
+    expect(leftovers).toEqual([])
   })
 
   it('returns null and leaves no staging behind when quarantine clearing fails', async () => {
@@ -115,7 +141,6 @@ describe('materializeServeSimRuntime', () => {
 
     expect(materialized).toBeNull()
     await expect(stat(join(targetRootDir, '1.2.3'))).rejects.toThrow()
-    const { readdir } = await import('node:fs/promises')
     const leftovers = (await readdir(targetRootDir)).filter((name) => name.startsWith('.staging'))
     expect(leftovers).toEqual([])
   })

--- a/src/main/emulator/serve-sim-runtime-materializer.ts
+++ b/src/main/emulator/serve-sim-runtime-materializer.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type ServeSimRuntimeMaterializerOptions = {
+  bundledPackageDir: string
+  targetRootDir: string
+  version: string
+  clearQuarantine?: (dir: string) => void
+}
+
+const EXECUTABLE_RELATIVE_PATHS = [
+  join('bin', 'serve-sim-bin'),
+  join('dist', 'simcam', 'serve-sim-camera-helper')
+]
+
+function defaultClearQuarantine(dir: string): void {
+  if (process.platform !== 'darwin') {
+    return
+  }
+  // Why: a downloaded/updated .app carries com.apple.quarantine, and cpSync
+  // clones it onto the copy. serve-sim DYLD-injects libSimCameraInjector.dylib
+  // (an iOS-simulator binary Apple never Gatekeeper-tickets) into a simulator
+  // process; if that copy is quarantined, syspolicyd malware-rejects the load.
+  // Running from an unquarantined copy is what avoids the rejection (#6877).
+  execFileSync('/usr/bin/xattr', ['-cr', dir], { timeout: 30_000 })
+}
+
+function pruneStaleServeSimRuntimes(targetRootDir: string, keepVersion: string): void {
+  let entries: string[]
+  try {
+    entries = readdirSync(targetRootDir)
+  } catch {
+    return
+  }
+  for (const entryName of entries) {
+    if (entryName === keepVersion) {
+      continue
+    }
+    try {
+      rmSync(join(targetRootDir, entryName), { recursive: true, force: true })
+    } catch {
+      // Old-version cleanup is best-effort; a locked file must not block materialization.
+    }
+  }
+}
+
+// Copies the bundled serve-sim package to a per-version directory outside the
+// signed app bundle and strips quarantine, so the camera dylib injected from
+// it is not subject to Gatekeeper assessment. The bundled dylib stays signed
+// and in place (it must, or the app fails notarization) — this only relocates
+// the copy that actually gets DYLD-injected. serve-sim resolves the dylib and
+// helper relative to its own entry, so the whole package moves together.
+export function materializeServeSimRuntime(
+  options: ServeSimRuntimeMaterializerOptions
+): string | null {
+  const { bundledPackageDir, targetRootDir, version } = options
+  const clearQuarantine = options.clearQuarantine ?? defaultClearQuarantine
+  const targetDir = join(targetRootDir, version)
+  const entryPath = join(targetDir, 'dist', 'serve-sim.js')
+  if (existsSync(entryPath)) {
+    return targetDir
+  }
+  const stagingDir = join(targetRootDir, `.staging-${version}-${process.pid}`)
+  try {
+    mkdirSync(targetRootDir, { recursive: true })
+    pruneStaleServeSimRuntimes(targetRootDir, version)
+    rmSync(stagingDir, { recursive: true, force: true })
+    rmSync(targetDir, { recursive: true, force: true })
+    cpSync(bundledPackageDir, stagingDir, { recursive: true })
+    for (const relativePath of EXECUTABLE_RELATIVE_PATHS) {
+      const executablePath = join(stagingDir, relativePath)
+      if (existsSync(executablePath)) {
+        chmodSync(executablePath, 0o755)
+      }
+    }
+    clearQuarantine(stagingDir)
+    try {
+      renameSync(stagingDir, targetDir)
+    } catch (error) {
+      // Another app instance sharing userData may have finished first.
+      if (!existsSync(entryPath)) {
+        throw error
+      }
+    }
+    return existsSync(entryPath) ? targetDir : null
+  } catch {
+    return null
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true })
+  }
+}

--- a/src/main/emulator/serve-sim-runtime-materializer.ts
+++ b/src/main/emulator/serve-sim-runtime-materializer.ts
@@ -23,7 +23,9 @@ function defaultClearQuarantine(dir: string): void {
   // (an iOS-simulator binary Apple never Gatekeeper-tickets) into a simulator
   // process; if that copy is quarantined, syspolicyd malware-rejects the load.
   // Running from an unquarantined copy is what avoids the rejection (#6877).
-  execFileSync('/usr/bin/xattr', ['-cr', dir], { timeout: 30_000 })
+  // Remove only the quarantine attribute (not `-cr`, which strips every xattr);
+  // recursive `-d` exits 0 even for files that never had it.
+  execFileSync('/usr/bin/xattr', ['-rd', 'com.apple.quarantine', dir], { timeout: 30_000 })
 }
 
 function pruneStaleServeSimRuntimes(targetRootDir: string, keepVersion: string): void {


### PR DESCRIPTION
## Summary

Fixes #6877. Third and — I believe — correct attempt, after diagnosing why the first two failed.

## What the first two attempts got wrong

Both #7077 (notarize the dylib separately) and #7168 (gzip it out of the signer's view) were built on a false premise: that a simulator-platform dylib **cannot be in a notarized bundle**. The rc.3 notary failure disproved it — the errors were not "simulator arch rejected", they were:

```
"message": "The binary is not signed."
"message": "The signature does not include a secure timestamp."
path: .../libSimCameraInjector.dylib.gz/libSimCameraInjector.dylib
```

Gzipping the dylib in `afterPack` hid it from the code-signing pass (a `.gz` is not a Mach-O), so notary decompressed the archive and found **unsigned** code. The proof it was never a "sim binaries can't notarize" problem: **rc.2 notarized successfully with the raw dylib present**, because there electron-builder deep-signed it (Developer ID + hardened runtime + secure timestamp). Verified against the shipped rc.2 artifact:

```
Authority=Developer ID Application: Lovecast LLC (6CX3WHS9HZ)
Timestamp=Jul 2 2026 ...
flags=0x10000(runtime)
```

So the actual issue in #6877 was never the build — it's **runtime**: the signed-but-unticketed dylib, injected via `DYLD_INSERT_LIBRARIES` straight from the quarantined app bundle, can trip syspolicyd's Gatekeeper assessment on some installs.

## The fix

**Packaging is deliberately untouched.** The signed dylib stays in the bundle exactly as it ships today, so notarization is byte-for-byte the proven rc.2 path — this removes the entire class of failure that sank the last two PRs (they can't recur because Apple's notary never sees anything new).

The only change is runtime: on macOS packaged builds, `resolveServeSimExecutable` materializes the serve-sim package into `userData/serve-sim-runtime/<version>/` once per version — copy, chmod the helpers, strip `com.apple.quarantine` (`xattr -cr`), atomic-rename, prune old versions — and runs serve-sim from there. serve-sim resolves the dylib and camera helper relative to its own entry, so the whole package moves together. The injected dylib is then an unquarantined copy, not subject to Gatekeeper assessment. On any failure it falls back to the bundled entry, so emulator streaming still works.

## Validation

Unit (206 emulator tests incl. 5 new materializer tests), typecheck, oxlint, oxfmt — all pass.

End-to-end against a real local `pnpm build:unpack`:

- Bundle layout identical to rc.2: signed dylib present in both serve-sim copies, no archive payloads (nothing that can hide unsigned code from the signer).
- Stamped `com.apple.quarantine` on every packed serve-sim file (simulating a downloaded install), ran the real materializer: result had **zero** quarantine xattrs, dylib **byte-identical** to the bundled copy.
- Live camera injection on a booted iPhone 17 Pro simulator (iOS 26.5) driven from the materialized runtime via the packed app's own Electron binary: `Injected camera into com.apple.Preferences`, `lsof` confirmed the dylib **mapped into the simulator process**, and `log show` showed **zero syspolicyd rejections**.

## What I can and cannot claim this time

- **Notarization safety: high confidence** — packaging is unchanged from rc.2, which notarized. Still, the true confirmation is the RC mac build; I'll verify it before calling this done, rather than declaring victory pre-release.
- **The runtime injection path works from an unquarantined copy: verified** above.
- **The reporter's exact `syspolicyd` "Malware rejection": not reproduced.** I could not reproduce it on my dev machine even with the old artifact (quarantine enforcement varies by machine/OS state), so I can't show a literal before/after of that log line. This fix is the correct defensive measure for that class of problem (inject from unquarantined code), but I'm flagging the residual uncertainty rather than overstating.
- **Cosmetic residual:** the bundled dylib copy still fails per-file `spctl -a` (no ticket for sim arch). That is expected and harmless for a simulator binary that's never executed by Gatekeeper directly — only the unquarantined materialized copy is ever injected. If the reporter re-runs `spctl` on the bundled file they'll still see "rejected"; that specific line is not fixable (Apple won't ticket sim arch) and does not indicate a functional problem.

Made with [Orca](https://github.com/stablyai/orca) 🐋
