### PR TITLE
Keep terminals responsive under agent output load

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -898,10 +898,66 @@ describe('pane terminal output scheduler', () => {
     expect(terminal.write).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(0)
-    expect(terminal.write).toHaveBeenCalledTimes(16)
+    expect(terminal.write).toHaveBeenCalledTimes(2)
 
-    vi.advanceTimersByTime(1)
-    expect(terminal.write).toHaveBeenCalledTimes(32)
+    vi.advanceTimersByTime(4)
+    expect(terminal.write).toHaveBeenCalledTimes(4)
+  })
+
+  it('yields high-priority backlog drains when writes spend the frame budget', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+    const chunk = 'x'.repeat(16 * 1024)
+    let now = 0
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
+    terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      now += 9
+      callback?.()
+    })
+
+    try {
+      for (let i = 0; i < 64; i++) {
+        writeTerminalOutput(terminal, chunk, { foreground: false })
+      }
+
+      vi.advanceTimersByTime(0)
+      expect(terminal.write).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(4)
+      expect(terminal.write).toHaveBeenCalledTimes(2)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('uses Date.now for drain budgeting when performance is unavailable', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('performance', undefined)
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+    const chunk = 'x'.repeat(16 * 1024)
+    let now = 0
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      now += 9
+      callback?.()
+    })
+
+    try {
+      for (let i = 0; i < 64; i++) {
+        writeTerminalOutput(terminal, chunk, { foreground: false })
+      }
+
+      vi.advanceTimersByTime(0)
+      expect(terminal.write).toHaveBeenCalledTimes(1)
+      expect(nowSpy).toHaveBeenCalled()
+
+      vi.advanceTimersByTime(4)
+      expect(terminal.write).toHaveBeenCalledTimes(2)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('caps hidden backlog memory and writes a warning instead of retaining all output', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -68,10 +68,11 @@ type QueueEntry = {
 
 const BACKGROUND_FLUSH_DELAY_MS = 50
 const BACKGROUND_DRAIN_INTERVAL_MS = 16
-const HIGH_PRIORITY_DRAIN_INTERVAL_MS = 1
+const HIGH_PRIORITY_DRAIN_INTERVAL_MS = 4
 const BACKGROUND_CHUNK_CHARS = 16 * 1024
 const MAX_WRITES_PER_DRAIN = 2
-const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 16
+const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 2
+const DRAIN_TIME_BUDGET_MS = 8
 const LARGE_BACKLOG_CHARS = 512 * 1024
 const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024
 const MAX_BACKGROUND_QUEUE_CHARS = 2 * 1024 * 1024
@@ -728,10 +729,18 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
   return queuedWrite.foreground ? 'foreground' : 'background'
 }
 
+function getDrainNow(): number {
+  if (typeof performance !== 'undefined') {
+    return performance.now()
+  }
+  return Date.now()
+}
+
 function drainQueuedOutput(): void {
   drainTimer = null
   drainTimerDelayMs = null
   let writes = 0
+  const startedAt = getDrainNow()
   const maxWrites = hasHighPriorityBacklog()
     ? HIGH_PRIORITY_MAX_WRITES_PER_DRAIN
     : MAX_WRITES_PER_DRAIN
@@ -759,6 +768,11 @@ function drainQueuedOutput(): void {
       entry.highPriority = false
       clearForegroundCoalesce(entry)
       clearForegroundHoldSafety(entry)
+    }
+    // Why: xterm parsing and DOM work share the renderer thread with input.
+    // Keep backlog draining cooperative so WSL/agent output cannot pin the UI.
+    if (writes > 0 && getDrainNow() - startedAt >= DRAIN_TIME_BUDGET_MS) {
+      break
     }
   }
 


### PR DESCRIPTION
## Summary

Keeps the renderer responsive while agents stream terminal output, by pacing how fast the output scheduler feeds xterm:

- `HIGH_PRIORITY_MAX_WRITES_PER_DRAIN` 16 → 2 (at most ~32 KB handed to xterm per drain tick, down from ~256 KB)
- `HIGH_PRIORITY_DRAIN_INTERVAL_MS` 1 → 4 (matches Chromium's clamped nested-timer floor, cuts timer churn)
- New `DRAIN_TIME_BUDGET_MS` (8 ms): a drain yields after the current write once the tick's wall-clock budget is spent. This has a real production trigger — after user input, xterm's `write()` parses synchronously inside the call (`_didUserInput` fast path, up to its 12 ms slice), so a slow first write no longer drags a second synchronous parse into the same tick.

## Why

Under multi-agent output load the scheduler could feed xterm up to 256 KB/ms. xterm parses on the renderer main thread in ~12 ms slices, so sustained output kept the thread near-100% busy and starved input/paint — the "terminal gets laggy, then the whole app" escalation in #7017's Windows/WSL report. Keystroke echo is unaffected: latency-sensitive foreground writes still bypass the queue.

**Might fix #7175** — "Not responding" with >3 parallel sessions on Windows is consistent with this renderer-saturation mechanism, since all sessions share one renderer and output load scales with session count. Note it does not address memory-driven crashes (#7175's crash on 32 GB could also be OOM), nor main-process load from many projects.

Related: #7017

## Testing

- `pane-terminal-output-scheduler.test.ts`: 45/45, including two new tests (drain yields when writes spend the frame budget; `Date.now` fallback when `performance` is unavailable)
- Consumer suites (`terminal-shutdown-layout-capture`, `use-terminal-pane-global-effects`, `use-terminal-scroll-visibility-memory`): 31/31
- `typecheck:web` clean
- Local `test:e2e:terminal-perf` run failed for environmental reasons (harness fixture `repos.add` fails before any test body; reproduced identically with main's scheduler files) — relying on CI for the perf gates (typing latency, redraw freeze, output scheduler, artificial OpenCode load)

## Follow-ups (pre-existing, not addressed here)

- The foreground/high-priority backlog is unbounded, and PTY ACKs are sent on receipt, so bulk visible output faster than the drain rate accumulates in renderer strings. Before this change the excess landed in xterm's write buffer instead, which throws at 50 MB pending and gets treated as a disposed terminal (silent backlog drop) — the failure mode shifts from data loss toward memory growth. Worth capping foreground backlogs with the existing warning + snapshot-recovery machinery, or ACKing after drain.
- The visible pane shares the per-drain write budget round-robin with backlogged hidden panes (no active-terminal-first ordering anymore), so heavy multi-agent load adds some visible TUI paint latency. CI's typing-latency and redraw-freeze specs are the gate to watch.
