### PR TITLE
feat(appearance): add saved presets and custom colors for terminal + …

### DIFF
--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -17,6 +17,7 @@ import { normalizeAppIconId } from '../../shared/app-icon'
 import { normalizeUiLanguage } from '../../shared/ui-language'
 import { applyAppIcon } from '../app-icon'
 import { normalizeTerminalCustomThemes } from '../../shared/terminal-custom-themes'
+import { normalizeAppearancePresets } from '../../shared/appearance-presets'
 import { normalizeDesktopTerminalScrollbackRows } from '../../shared/terminal-scrollback-policy'
 import { prepareLocalWorktreeRootsForRepos } from '../worktree-root-preparation'
 import { scheduleCurrentWorktreeBaseDirectoryWatcherSync } from './worktree-base-directory-watcher'
@@ -89,6 +90,9 @@ export function registerSettingsHandlers(
     }
     if ('terminalCustomThemes' in args) {
       sanitizedArgs.terminalCustomThemes = normalizeTerminalCustomThemes(args.terminalCustomThemes)
+    }
+    if ('appearancePresets' in args) {
+      sanitizedArgs.appearancePresets = normalizeAppearancePresets(args.appearancePresets)
     }
     if ('terminalScrollbackRows' in args) {
       sanitizedArgs.terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -127,6 +127,7 @@ import {
 } from './startup/startup-diagnostics'
 import { shouldRenderPetOverlay } from './components/pet/pet-overlay-visibility'
 import { applyDocumentTheme } from './lib/document-theme'
+import { applyInterfaceColorOverrides } from './lib/interface-color-overrides'
 import { isEditableTarget } from './lib/editable-target'
 import { getSelectedTextForFileSearch } from './lib/file-search-selection'
 import { useShortcutLabel } from './hooks/useShortcutLabel'
@@ -1390,6 +1391,12 @@ function App(): React.JSX.Element {
       buildAppFontFamily(settings?.appFontFamily)
     )
   }, [settings?.appFontFamily])
+
+  // Custom IDE pane colors follow the effective light/dark mode, so re-apply
+  // on theme changes and system-preference flips, not just override edits.
+  useEffect(() => {
+    applyInterfaceColorOverrides(settings, systemPrefersDark)
+  }, [settings, systemPrefersDark])
 
   // Refresh GitHub data (PR/issue status) when window regains focus
   useEffect(() => {

--- a/src/renderer/src/components/settings/AppearanceColorsSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceColorsSection.tsx
@@ -1,0 +1,244 @@
+import type React from 'react'
+import { useState } from 'react'
+
+import type { GlobalSettings } from '../../../../shared/types'
+import type { InterfacePaneColorKey } from '../../../../shared/interface-color-overrides'
+import { SearchableSetting } from './SearchableSetting'
+import {
+  ColorField,
+  SettingsSegmentedControl,
+  SettingsSubsectionHeader
+} from './SettingsFormControls'
+import { Button } from '../ui/button'
+import { resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
+import {
+  INTERFACE_PANE_DEFAULT_COLORS,
+  resolveInterfaceModeIsDark
+} from '@/lib/interface-color-overrides'
+import { translate } from '@/i18n/i18n'
+
+type AppearanceColorsSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+  systemPrefersDark: boolean
+  forceVisiblePrimary?: boolean
+}
+
+type PaneColorRow = {
+  key: InterfacePaneColorKey
+  label: string
+  description: string
+}
+
+function getPaneColorRows(): PaneColorRow[] {
+  return [
+    {
+      key: 'background',
+      label: translate('auto.components.settings.AppearanceColorsSection.paneBackground', 'App Background'),
+      description: translate(
+        'auto.components.settings.AppearanceColorsSection.paneBackgroundDescription',
+        'The main window canvas behind all panes.'
+      )
+    },
+    {
+      key: 'sidebar',
+      label: translate('auto.components.settings.AppearanceColorsSection.paneSidebar', 'Sidebar'),
+      description: translate(
+        'auto.components.settings.AppearanceColorsSection.paneSidebarDescription',
+        'The workspace sidebar surface.'
+      )
+    },
+    {
+      key: 'editorSurface',
+      label: translate('auto.components.settings.AppearanceColorsSection.paneEditor', 'Editor'),
+      description: translate(
+        'auto.components.settings.AppearanceColorsSection.paneEditorDescription',
+        'Code and markdown editor panes.'
+      )
+    },
+    {
+      key: 'card',
+      label: translate('auto.components.settings.AppearanceColorsSection.paneCards', 'Panels & Cards'),
+      description: translate(
+        'auto.components.settings.AppearanceColorsSection.paneCardsDescription',
+        'Panels lifted off the canvas, like workspace cards.'
+      )
+    }
+  ]
+}
+
+export function AppearanceColorsSection({
+  settings,
+  updateSettings,
+  systemPrefersDark,
+  forceVisiblePrimary = false
+}: AppearanceColorsSectionProps): React.JSX.Element {
+  // Default to the mode the user is looking at right now.
+  const [editingMode, setEditingMode] = useState<'dark' | 'light'>(
+    resolveInterfaceModeIsDark(settings.theme, systemPrefersDark) ? 'dark' : 'light'
+  )
+
+  const terminalBackgroundFallback =
+    resolveEffectiveTerminalAppearance(settings, systemPrefersDark).theme?.background ?? '#000000'
+  const terminalBackgroundValue = settings.terminalColorOverrides?.background ?? ''
+
+  const modeColors = settings.interfaceColorOverrides?.[editingMode]
+  const hasModeOverrides = Boolean(modeColors && Object.values(modeColors).some(Boolean))
+
+  function updatePaneColor(key: InterfacePaneColorKey, value: string): void {
+    const current = settings.interfaceColorOverrides ?? {}
+    updateSettings({
+      interfaceColorOverrides: {
+        ...current,
+        [editingMode]: { ...current[editingMode], [key]: value || undefined }
+      }
+    })
+  }
+
+  function resetModeOverrides(): void {
+    const current = settings.interfaceColorOverrides ?? {}
+    updateSettings({
+      interfaceColorOverrides: { ...current, [editingMode]: undefined }
+    })
+  }
+
+  const terminalBackgroundTitle = translate(
+    'auto.components.settings.AppearanceColorsSection.terminalBackgroundTitle',
+    'Terminal Background'
+  )
+  const paneColorsTitle = translate(
+    'auto.components.settings.AppearanceColorsSection.paneColorsTitle',
+    'Interface Panes'
+  )
+
+  return (
+    <div className="space-y-2">
+      <div className="divide-y divide-border/40">
+        <SearchableSetting
+          title={terminalBackgroundTitle}
+          description={translate(
+            'auto.components.settings.AppearanceColorsSection.terminalBackgroundDescription',
+            'Override the background of the active terminal theme.'
+          )}
+          keywords={['terminal', 'background', 'color', 'custom']}
+          className="space-y-2 pb-3"
+          forceVisible={forceVisiblePrimary}
+        >
+          <SettingsSubsectionHeader title={terminalBackgroundTitle} />
+          <div className="ml-4">
+            <ColorField
+              label={translate(
+                'auto.components.settings.AppearanceColorsSection.terminalBackgroundLabel',
+                'Background'
+              )}
+              description={translate(
+                'auto.components.settings.AppearanceColorsSection.terminalBackgroundFieldDescription',
+                'Applied on top of the selected terminal theme in both modes.'
+              )}
+              value={terminalBackgroundValue}
+              fallback={terminalBackgroundFallback}
+              onChange={(value) =>
+                updateSettings({
+                  terminalColorOverrides: {
+                    ...settings.terminalColorOverrides,
+                    background: value || undefined
+                  }
+                })
+              }
+            />
+            {terminalBackgroundValue ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  updateSettings({
+                    terminalColorOverrides: {
+                      ...settings.terminalColorOverrides,
+                      background: undefined
+                    }
+                  })
+                }
+              >
+                {translate(
+                  'auto.components.settings.AppearanceColorsSection.terminalBackgroundReset',
+                  'Reset to theme background'
+                )}
+              </Button>
+            ) : null}
+          </div>
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={paneColorsTitle}
+          description={translate(
+            'auto.components.settings.AppearanceColorsSection.paneColorsDescription',
+            'Recolor the app background, sidebar, editor, and panels.'
+          )}
+          keywords={['pane', 'sidebar', 'editor', 'background', 'color', 'custom', 'workbench']}
+          className="space-y-3 pt-3"
+          forceVisible={forceVisiblePrimary}
+        >
+          <div className="flex items-center justify-between gap-4">
+            <SettingsSubsectionHeader title={paneColorsTitle} />
+            <SettingsSegmentedControl
+              value={editingMode}
+              onChange={setEditingMode}
+              ariaLabel={translate(
+                'auto.components.settings.AppearanceColorsSection.paneColorsModeAria',
+                'Choose which mode to edit pane colors for'
+              )}
+              options={[
+                {
+                  value: 'dark',
+                  label: translate('auto.components.settings.AppearancePane.7d26ccabe8', 'Dark')
+                },
+                {
+                  value: 'light',
+                  label: translate('auto.components.settings.AppearancePane.fd89b5487c', 'Light')
+                }
+              ]}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {editingMode === 'dark'
+              ? translate(
+                  'auto.components.settings.AppearanceColorsSection.paneColorsDarkHint',
+                  'These colors apply while Orca is in dark mode.'
+                )
+              : translate(
+                  'auto.components.settings.AppearanceColorsSection.paneColorsLightHint',
+                  'These colors apply while Orca is in light mode.'
+                )}
+          </p>
+          <div className="ml-4 space-y-2">
+            <div className="grid gap-2 sm:grid-cols-2">
+              {getPaneColorRows().map((row) => (
+                <ColorField
+                  key={row.key}
+                  label={row.label}
+                  description={row.description}
+                  value={settings.interfaceColorOverrides?.[editingMode]?.[row.key] ?? ''}
+                  fallback={INTERFACE_PANE_DEFAULT_COLORS[editingMode][row.key]}
+                  onChange={(value) => updatePaneColor(row.key, value)}
+                />
+              ))}
+            </div>
+            {hasModeOverrides ? (
+              <Button variant="outline" size="sm" onClick={resetModeOverrides}>
+                {editingMode === 'dark'
+                  ? translate(
+                      'auto.components.settings.AppearanceColorsSection.paneColorsResetDark',
+                      'Reset dark pane colors'
+                    )
+                  : translate(
+                      'auto.components.settings.AppearanceColorsSection.paneColorsResetLight',
+                      'Reset light pane colors'
+                    )}
+              </Button>
+            ) : null}
+          </div>
+        </SearchableSetting>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import { useState } from 'react'
-import { AppWindow, PanelLeft, TerminalSquare } from 'lucide-react'
+import { AppWindow, PanelLeft, Palette, SwatchBook, TerminalSquare } from 'lucide-react'
 
 import type { GlobalSettings } from '../../../../shared/types'
 
@@ -25,6 +25,10 @@ import {
 } from './appearance-search'
 import { getTerminalAppearanceSearchEntries } from './terminal-search'
 import { TerminalAppearanceSection } from './TerminalAppearanceSection'
+import { AppearancePresetsSection } from './AppearancePresetsSection'
+import { AppearanceColorsSection } from './AppearanceColorsSection'
+import { getAppearancePresetEntries } from './appearance-presets-search'
+import { getInterfaceColorEntries } from './appearance-colors-search'
 import type { UseGhosttyImportReturn } from './useGhosttyImport'
 import type { UseWarpThemeImportReturn } from './useWarpThemeImport'
 import { AppIconSelector } from './AppIconSelector'
@@ -50,7 +54,7 @@ type AppearancePaneProps = {
   warpThemes: UseWarpThemeImportReturn
 }
 
-type AppearanceSectionKey = 'interface' | 'terminal' | 'window'
+type AppearanceSectionKey = 'presets' | 'interface' | 'terminal' | 'colors' | 'window'
 
 function resolveThemeSummary(theme: GlobalSettings['theme']): string {
   if (theme === 'system') {
@@ -98,8 +102,19 @@ export function AppearancePane({
     'auto.components.settings.AppearancePane.windowSidebarSummary',
     'Sidebar, status bar, and file explorer'
   )
+  const presetsTitle = translate(
+    'auto.components.settings.AppearancePresetsSection.title',
+    'Presets'
+  )
+  const colorsTitle = translate('auto.components.settings.AppearancePane.colorsTitle', 'Colors')
+  const colorsSummary = translate(
+    'auto.components.settings.AppearancePane.colorsSummary',
+    'Terminal background and interface pane colors'
+  )
 
   // Search-entry buckets per section so a query can force-open the matching one.
+  const presetsSearchEntries = [{ title: presetsTitle }, ...getAppearancePresetEntries()]
+  const colorsSearchEntries = [{ title: colorsTitle }, ...getInterfaceColorEntries()]
   const interfaceSearchEntries = [
     { title: interfaceTitle },
     ...getThemeEntries(),
@@ -125,9 +140,13 @@ export function AppearancePane({
     getWorkspaceCardLayoutEntry()
   ]
 
+  const presetsMatches = matchesSettingsSearch(searchQuery, presetsSearchEntries)
+  const colorsMatches = matchesSettingsSearch(searchQuery, colorsSearchEntries)
   const interfaceMatches = matchesSettingsSearch(searchQuery, interfaceSearchEntries)
   const terminalMatches = matchesSettingsSearch(searchQuery, terminalSearchEntries)
   const windowMatches = matchesSettingsSearch(searchQuery, windowSearchEntries)
+  const presetsLabelMatches = matchesSettingsSearch(searchQuery, { title: presetsTitle })
+  const colorsLabelMatches = matchesSettingsSearch(searchQuery, { title: colorsTitle })
   const interfaceLabelMatches = matchesSettingsSearch(searchQuery, { title: interfaceTitle })
   const terminalLabelMatches = matchesSettingsSearch(searchQuery, { title: terminalTitle })
   const windowLabelMatches = matchesSettingsSearch(searchQuery, {
@@ -141,11 +160,18 @@ export function AppearancePane({
   // shows exactly one manually-chosen section.
   function isSectionOpen(key: AppearanceSectionKey): boolean {
     if (isSearching) {
-      return key === 'interface'
-        ? interfaceMatches
-        : key === 'terminal'
-          ? terminalMatches
-          : windowMatches
+      switch (key) {
+        case 'presets':
+          return presetsMatches
+        case 'interface':
+          return interfaceMatches
+        case 'terminal':
+          return terminalMatches
+        case 'colors':
+          return colorsMatches
+        case 'window':
+          return windowMatches
+      }
     }
     return manuallyOpenSection === key
   }
@@ -163,8 +189,40 @@ export function AppearancePane({
     translate('auto.components.settings.AppearancePane.terminalDefaultFont', 'Default font')
   } · ${settings.terminalFontSize}px`
 
+  const presetCount = settings.appearancePresets?.length ?? 0
+  const presetsSummary =
+    presetCount === 0
+      ? translate(
+          'auto.components.settings.AppearancePane.presetsSummaryEmpty',
+          'Save and switch appearance setups'
+        )
+      : translate(
+          'auto.components.settings.AppearancePane.presetsSummaryCount',
+          '{{count}} saved',
+          { count: presetCount }
+        )
+
   return (
     <div className="space-y-2.5">
+      {presetsMatches ? (
+        <AppearanceSection
+          id="presets"
+          icon={<SwatchBook aria-hidden="true" />}
+          title={presetsTitle}
+          summary={presetsSummary}
+          open={isSectionOpen('presets')}
+          onToggle={() => toggleSection('presets')}
+        >
+          <AppearancePresetsSection
+            settings={settings}
+            updateSettings={updateSettings}
+            applyTheme={applyTheme}
+            systemPrefersDark={systemPrefersDark}
+            forceVisiblePrimary={presetsLabelMatches}
+          />
+        </AppearanceSection>
+      ) : null}
+
       {interfaceMatches ? (
         <AppearanceSection
           id="interface"
@@ -208,6 +266,24 @@ export function AppearancePane({
             ghostty={ghostty}
             warpThemes={warpThemes}
             forceVisiblePrimary={terminalLabelMatches}
+          />
+        </AppearanceSection>
+      ) : null}
+
+      {colorsMatches ? (
+        <AppearanceSection
+          id="colors"
+          icon={<Palette aria-hidden="true" />}
+          title={colorsTitle}
+          summary={colorsSummary}
+          open={isSectionOpen('colors')}
+          onToggle={() => toggleSection('colors')}
+        >
+          <AppearanceColorsSection
+            settings={settings}
+            updateSettings={updateSettings}
+            systemPrefersDark={systemPrefersDark}
+            forceVisiblePrimary={colorsLabelMatches}
           />
         </AppearanceSection>
       ) : null}

--- a/src/renderer/src/components/settings/AppearancePresetsSection.tsx
+++ b/src/renderer/src/components/settings/AppearancePresetsSection.tsx
@@ -1,0 +1,340 @@
+import type React from 'react'
+import { useState } from 'react'
+import { MonitorCog, Moon, MoreHorizontal, Plus, Sun } from 'lucide-react'
+
+import type { GlobalSettings } from '../../../../shared/types'
+import {
+  appearanceSnapshotsEqual,
+  buildAppearancePresetSnapshot,
+  MAX_APPEARANCE_PRESETS,
+  type AppearancePreset
+} from '../../../../shared/appearance-presets'
+import { SearchableSetting } from './SearchableSetting'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '../ui/dropdown-menu'
+import { resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
+import {
+  INTERFACE_PANE_DEFAULT_COLORS,
+  resolveInterfaceModeIsDark
+} from '@/lib/interface-color-overrides'
+import { translate } from '@/i18n/i18n'
+
+type AppearancePresetsSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+  applyTheme: (theme: 'system' | 'dark' | 'light') => void
+  systemPrefersDark: boolean
+  forceVisiblePrimary?: boolean
+}
+
+type PresetNameDialogState =
+  | { kind: 'create' }
+  | { kind: 'rename'; preset: AppearancePreset }
+  | null
+
+function createPresetId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `preset-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  )
+}
+
+function PresetSwatches({
+  preset,
+  settings,
+  systemPrefersDark
+}: {
+  preset: AppearancePreset
+  settings: GlobalSettings
+  systemPrefersDark: boolean
+}): React.JSX.Element {
+  const { snapshot } = preset
+  const isDark = resolveInterfaceModeIsDark(snapshot.theme, systemPrefersDark)
+  const mode = isDark ? 'dark' : 'light'
+  // Custom themes live in the shared library, not the snapshot, so resolve
+  // against the preset's theme selections with the current library.
+  const terminalAppearance = resolveEffectiveTerminalAppearance(
+    { ...snapshot, terminalCustomThemes: settings.terminalCustomThemes },
+    systemPrefersDark
+  )
+  const terminalBackground =
+    snapshot.terminalColorOverrides.background ?? terminalAppearance.theme?.background ?? '#000000'
+  const paneColors = snapshot.interfaceColorOverrides[mode]
+  const appBackground = paneColors?.background ?? INTERFACE_PANE_DEFAULT_COLORS[mode].background
+  const sidebar = paneColors?.sidebar ?? INTERFACE_PANE_DEFAULT_COLORS[mode].sidebar
+
+  return (
+    <span className="flex shrink-0 items-center gap-1" aria-hidden="true">
+      {[appBackground, sidebar, terminalBackground].map((color, index) => (
+        <span
+          key={index}
+          className="size-3.5 rounded-full border border-border"
+          style={{ backgroundColor: color }}
+        />
+      ))}
+    </span>
+  )
+}
+
+function resolvePresetThemeIcon(theme: GlobalSettings['theme']): React.JSX.Element {
+  if (theme === 'dark') {
+    return <Moon className="size-3.5 text-muted-foreground" aria-hidden="true" />
+  }
+  if (theme === 'light') {
+    return <Sun className="size-3.5 text-muted-foreground" aria-hidden="true" />
+  }
+  return <MonitorCog className="size-3.5 text-muted-foreground" aria-hidden="true" />
+}
+
+export function AppearancePresetsSection({
+  settings,
+  updateSettings,
+  applyTheme,
+  systemPrefersDark,
+  forceVisiblePrimary = false
+}: AppearancePresetsSectionProps): React.JSX.Element {
+  const [nameDialog, setNameDialog] = useState<PresetNameDialogState>(null)
+  const [nameDraft, setNameDraft] = useState('')
+
+  const presets = settings.appearancePresets ?? []
+  const currentSnapshot = buildAppearancePresetSnapshot(settings)
+  const canSaveMore = presets.length < MAX_APPEARANCE_PRESETS
+
+  function openCreateDialog(): void {
+    setNameDraft('')
+    setNameDialog({ kind: 'create' })
+  }
+
+  function openRenameDialog(preset: AppearancePreset): void {
+    setNameDraft(preset.name)
+    setNameDialog({ kind: 'rename', preset })
+  }
+
+  function commitNameDialog(): void {
+    const name = nameDraft.trim()
+    if (!name || !nameDialog) {
+      return
+    }
+    if (nameDialog.kind === 'create') {
+      const preset: AppearancePreset = {
+        id: createPresetId(),
+        name,
+        savedAt: new Date().toISOString(),
+        snapshot: currentSnapshot
+      }
+      updateSettings({ appearancePresets: [...presets, preset] })
+    } else {
+      updateSettings({
+        appearancePresets: presets.map((preset) =>
+          preset.id === nameDialog.preset.id ? { ...preset, name } : preset
+        )
+      })
+    }
+    setNameDialog(null)
+  }
+
+  function applyPreset(preset: AppearancePreset): void {
+    updateSettings({ ...preset.snapshot })
+    // Match the Theme control: apply the document theme immediately rather
+    // than waiting for the settings round-trip.
+    applyTheme(preset.snapshot.theme)
+  }
+
+  function updatePresetFromCurrent(preset: AppearancePreset): void {
+    updateSettings({
+      appearancePresets: presets.map((entry) =>
+        entry.id === preset.id
+          ? { ...entry, savedAt: new Date().toISOString(), snapshot: currentSnapshot }
+          : entry
+      )
+    })
+  }
+
+  function deletePreset(preset: AppearancePreset): void {
+    updateSettings({ appearancePresets: presets.filter((entry) => entry.id !== preset.id) })
+  }
+
+  const title = translate('auto.components.settings.AppearancePresetsSection.title', 'Presets')
+
+  return (
+    <SearchableSetting
+      title={title}
+      description={translate(
+        'auto.components.settings.AppearancePresetsSection.description',
+        'Save the current appearance as a preset and switch between saved setups.'
+      )}
+      keywords={['preset', 'theme', 'save', 'profile', 'switch', 'color scheme']}
+      className="space-y-3"
+      forceVisible={forceVisiblePrimary}
+    >
+      {presets.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {translate(
+            'auto.components.settings.AppearancePresetsSection.emptyState',
+            'No presets yet. Save your current appearance to switch between setups quickly.'
+          )}
+        </p>
+      ) : (
+        <div className="divide-y divide-border/40 rounded-md border border-border/60">
+          {presets.map((preset) => {
+            const isActive = appearanceSnapshotsEqual(preset.snapshot, currentSnapshot)
+            return (
+              <div
+                key={preset.id}
+                className="flex items-center gap-2 px-3 py-2 transition-colors hover:bg-accent"
+              >
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 text-left"
+                  onClick={() => applyPreset(preset)}
+                >
+                  {resolvePresetThemeIcon(preset.snapshot.theme)}
+                  <span className="truncate text-sm">{preset.name}</span>
+                  <PresetSwatches
+                    preset={preset}
+                    settings={settings}
+                    systemPrefersDark={systemPrefersDark}
+                  />
+                  {isActive ? (
+                    <span className="shrink-0 text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                      {translate(
+                        'auto.components.settings.SettingsFormControls.9119fb2268',
+                        'Current'
+                      )}
+                    </span>
+                  ) : null}
+                </button>
+                {!isActive ? (
+                  <Button variant="outline" size="xs" onClick={() => applyPreset(preset)}>
+                    {translate('auto.components.settings.AppearancePresetsSection.apply', 'Apply')}
+                  </Button>
+                ) : null}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      aria-label={translate(
+                        'auto.components.settings.AppearancePresetsSection.presetActions',
+                        'Preset actions'
+                      )}
+                    >
+                      <MoreHorizontal />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onSelect={() => updatePresetFromCurrent(preset)}>
+                      {translate(
+                        'auto.components.settings.AppearancePresetsSection.updateFromCurrent',
+                        'Update from current appearance'
+                      )}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => openRenameDialog(preset)}>
+                      {translate(
+                        'auto.components.settings.AppearancePresetsSection.rename',
+                        'Rename…'
+                      )}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem variant="destructive" onSelect={() => deletePreset(preset)}>
+                      {translate(
+                        'auto.components.settings.AppearancePresetsSection.delete',
+                        'Delete'
+                      )}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <Button variant="outline" size="sm" onClick={openCreateDialog} disabled={!canSaveMore}>
+        <Plus />
+        {translate(
+          'auto.components.settings.AppearancePresetsSection.saveCurrent',
+          'Save Current as Preset'
+        )}
+      </Button>
+
+      <Dialog open={nameDialog !== null} onOpenChange={(open) => !open && setNameDialog(null)}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              {nameDialog?.kind === 'rename'
+                ? translate(
+                    'auto.components.settings.AppearancePresetsSection.renameTitle',
+                    'Rename Preset'
+                  )
+                : translate(
+                    'auto.components.settings.AppearancePresetsSection.createTitle',
+                    'Save Preset'
+                  )}
+            </DialogTitle>
+            {nameDialog?.kind === 'create' ? (
+              <DialogDescription>
+                {translate(
+                  'auto.components.settings.AppearancePresetsSection.createDescription',
+                  'Captures the current theme, terminal theme, and custom colors.'
+                )}
+              </DialogDescription>
+            ) : null}
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="appearance-preset-name">
+              {translate('auto.components.settings.AppearancePresetsSection.nameLabel', 'Name')}
+            </Label>
+            <Input
+              id="appearance-preset-name"
+              // Why: the dialog exists to collect this one field; focus must
+              // land where Enter submits.
+              autoFocus
+              value={nameDraft}
+              onChange={(e) => setNameDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  commitNameDialog()
+                }
+              }}
+              placeholder={translate(
+                'auto.components.settings.AppearancePresetsSection.namePlaceholder',
+                'e.g. Night coding'
+              )}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setNameDialog(null)}>
+              {translate('auto.components.settings.AppearancePresetsSection.cancel', 'Cancel')}
+            </Button>
+            <Button onClick={commitNameDialog} disabled={!nameDraft.trim()}>
+              {nameDialog?.kind === 'rename'
+                ? translate(
+                    'auto.components.settings.AppearancePresetsSection.renameConfirm',
+                    'Rename'
+                  )
+                : translate('auto.components.settings.AppearancePresetsSection.saveConfirm', 'Save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/appearance-colors-search.ts
+++ b/src/renderer/src/components/settings/appearance-colors-search.ts
@@ -1,0 +1,42 @@
+import type { SettingsSearchEntry } from './settings-search'
+import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export const getInterfaceColorEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+  {
+    title: translate(
+      'auto.components.settings.AppearanceColorsSection.terminalBackgroundTitle',
+      'Terminal Background'
+    ),
+    description: translate(
+      'auto.components.settings.AppearanceColorsSection.terminalBackgroundDescription',
+      'Override the background of the active terminal theme.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.background',
+        'background'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.color', 'color')
+    ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.AppearanceColorsSection.paneColorsTitle',
+      'Interface Panes'
+    ),
+    description: translate(
+      'auto.components.settings.AppearanceColorsSection.paneColorsDescription',
+      'Recolor the app background, sidebar, editor, and panels.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.appearance.search.pane', 'pane'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.workbench', 'workbench'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.customColors',
+        'custom colors'
+      )
+    ]
+  }
+])

--- a/src/renderer/src/components/settings/appearance-presets-search.ts
+++ b/src/renderer/src/components/settings/appearance-presets-search.ts
@@ -1,0 +1,19 @@
+import type { SettingsSearchEntry } from './settings-search'
+import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export const getAppearancePresetEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+  {
+    title: translate('auto.components.settings.AppearancePresetsSection.title', 'Presets'),
+    description: translate(
+      'auto.components.settings.AppearancePresetsSection.description',
+      'Save the current appearance as a preset and switch between saved setups.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.appearance.search.preset', 'preset'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.profile', 'profile'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.saveTheme', 'save theme')
+    ]
+  }
+])

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -8,6 +8,8 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { SHOW_UI_LANGUAGE_SETTING } from '@/i18n/supported-languages'
 import { getStatusBarToggles } from './appearance-status-bar-search'
+import { getAppearancePresetEntries } from './appearance-presets-search'
+import { getInterfaceColorEntries } from './appearance-colors-search'
 
 export { getStatusBarToggles }
 
@@ -250,6 +252,9 @@ const getAppearanceSectionEntries = createLocalizedCatalog((): SettingsSearchEnt
     title: translate('auto.components.settings.AppearancePane.interfaceTitle', 'Interface')
   },
   {
+    title: translate('auto.components.settings.AppearancePane.colorsTitle', 'Colors')
+  },
+  {
     title: translate('auto.components.settings.AppearancePane.terminalTitle', 'Terminal')
   },
   {
@@ -274,6 +279,8 @@ function buildAppearancePaneSearchEntries(
 ): SettingsSearchEntry[] {
   return [
     ...getAppearanceSectionEntries(),
+    ...getAppearancePresetEntries(),
+    ...getInterfaceColorEntries(),
     ...getThemeEntries(),
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),
     ...getTypographyEntries(),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4774,7 +4774,11 @@
           "windowSidebarSummary": "Sidebar, status bar, and file explorer",
           "statusBarCount": "{{value0}} indicators visible.",
           "gitIgnoredGlossary": "Files matched by .gitignore.",
-          "statusBarDescription": "Choose which indicators appear in the status bar."
+          "statusBarDescription": "Choose which indicators appear in the status bar.",
+          "colorsTitle": "Colors",
+          "colorsSummary": "Terminal background and interface pane colors",
+          "presetsSummaryEmpty": "Save and switch appearance setups",
+          "presetsSummaryCount": "{{count}} saved"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -8702,6 +8706,47 @@
         "ephemeralVmsExperimentalSetting": {
           "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
           "toggleLabel": "Toggle per-workspace environments"
+        },
+        "AppearanceColorsSection": {
+          "paneBackground": "App Background",
+          "paneBackgroundDescription": "The main window canvas behind all panes.",
+          "paneSidebar": "Sidebar",
+          "paneSidebarDescription": "The workspace sidebar surface.",
+          "paneEditor": "Editor",
+          "paneEditorDescription": "Code and markdown editor panes.",
+          "paneCards": "Panels & Cards",
+          "paneCardsDescription": "Panels lifted off the canvas, like workspace cards.",
+          "terminalBackgroundTitle": "Terminal Background",
+          "paneColorsTitle": "Interface Panes",
+          "terminalBackgroundDescription": "Override the background of the active terminal theme.",
+          "terminalBackgroundLabel": "Background",
+          "terminalBackgroundFieldDescription": "Applied on top of the selected terminal theme in both modes.",
+          "terminalBackgroundReset": "Reset to theme background",
+          "paneColorsDescription": "Recolor the app background, sidebar, editor, and panels.",
+          "paneColorsModeAria": "Choose which mode to edit pane colors for",
+          "paneColorsDarkHint": "These colors apply while Orca is in dark mode.",
+          "paneColorsLightHint": "These colors apply while Orca is in light mode.",
+          "paneColorsResetDark": "Reset dark pane colors",
+          "paneColorsResetLight": "Reset light pane colors"
+        },
+        "AppearancePresetsSection": {
+          "title": "Presets",
+          "description": "Save the current appearance as a preset and switch between saved setups.",
+          "emptyState": "No presets yet. Save your current appearance to switch between setups quickly.",
+          "apply": "Apply",
+          "presetActions": "Preset actions",
+          "updateFromCurrent": "Update from current appearance",
+          "rename": "Rename…",
+          "delete": "Delete",
+          "saveCurrent": "Save Current as Preset",
+          "renameTitle": "Rename Preset",
+          "createTitle": "Save Preset",
+          "createDescription": "Captures the current theme, terminal theme, and custom colors.",
+          "nameLabel": "Name",
+          "namePlaceholder": "e.g. Night coding",
+          "cancel": "Cancel",
+          "renameConfirm": "Rename",
+          "saveConfirm": "Save"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4774,7 +4774,11 @@
           "windowSidebarSummary": "Barra lateral, barra de estado y explorador de archivos",
           "statusBarCount": "Indicadores visibles: {{value0}}.",
           "gitIgnoredGlossary": "Archivos coincidentes con .gitignore.",
-          "statusBarDescription": "Choose which indicators appear in the status bar."
+          "statusBarDescription": "Choose which indicators appear in the status bar.",
+          "colorsTitle": "Colors",
+          "colorsSummary": "Terminal background and interface pane colors",
+          "presetsSummaryEmpty": "Save and switch appearance setups",
+          "presetsSummaryCount": "{{count}} saved"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -8702,6 +8706,47 @@
         "ephemeralVmsExperimentalSetting": {
           "description": "Muestra controles de configuración y objetivos de ejecución del espacio de trabajo para entornos bajo demanda de propiedad de repos.",
           "toggleLabel": "Alternar entornos por espacio de trabajo"
+        },
+        "AppearanceColorsSection": {
+          "paneBackground": "App Background",
+          "paneBackgroundDescription": "The main window canvas behind all panes.",
+          "paneSidebar": "Sidebar",
+          "paneSidebarDescription": "The workspace sidebar surface.",
+          "paneEditor": "Editor",
+          "paneEditorDescription": "Code and markdown editor panes.",
+          "paneCards": "Panels & Cards",
+          "paneCardsDescription": "Panels lifted off the canvas, like workspace cards.",
+          "terminalBackgroundTitle": "Terminal Background",
+          "paneColorsTitle": "Interface Panes",
+          "terminalBackgroundDescription": "Override the background of the active terminal theme.",
+          "terminalBackgroundLabel": "Background",
+          "terminalBackgroundFieldDescription": "Applied on top of the selected terminal theme in both modes.",
+          "terminalBackgroundReset": "Reset to theme background",
+          "paneColorsDescription": "Recolor the app background, sidebar, editor, and panels.",
+          "paneColorsModeAria": "Choose which mode to edit pane colors for",
+          "paneColorsDarkHint": "These colors apply while Orca is in dark mode.",
+          "paneColorsLightHint": "These colors apply while Orca is in light mode.",
+          "paneColorsResetDark": "Reset dark pane colors",
+          "paneColorsResetLight": "Reset light pane colors"
+        },
+        "AppearancePresetsSection": {
+          "title": "Presets",
+          "description": "Save the current appearance as a preset and switch between saved setups.",
+          "emptyState": "No presets yet. Save your current appearance to switch between setups quickly.",
+          "apply": "Apply",
+          "presetActions": "Preset actions",
+          "updateFromCurrent": "Update from current appearance",
+          "rename": "Rename…",
+          "delete": "Delete",
+          "saveCurrent": "Save Current as Preset",
+          "renameTitle": "Rename Preset",
+          "createTitle": "Save Preset",
+          "createDescription": "Captures the current theme, terminal theme, and custom colors.",
+          "nameLabel": "Name",
+          "namePlaceholder": "e.g. Night coding",
+          "cancel": "Cancel",
+          "renameConfirm": "Rename",
+          "saveConfirm": "Save"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4759,7 +4759,11 @@
           "windowSidebarSummary": "サイドバー、ステータスバー、ファイルエクスプローラー",
           "statusBarCount": "{{value0}} 個のインジケーターが表示中。",
           "gitIgnoredGlossary": ".gitignore に一致するファイル。",
-          "statusBarDescription": "Choose which indicators appear in the status bar."
+          "statusBarDescription": "Choose which indicators appear in the status bar.",
+          "colorsTitle": "Colors",
+          "colorsSummary": "Terminal background and interface pane colors",
+          "presetsSummaryEmpty": "Save and switch appearance setups",
+          "presetsSummaryCount": "{{count}} saved"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -8702,6 +8706,47 @@
         "ephemeralVmsExperimentalSetting": {
           "description": "repo が所有するオンデマンド環境のセットアップ コントロールとワークスペース実行ターゲットを示します。",
           "toggleLabel": "ワークスペースごとの環境を切り替える"
+        },
+        "AppearanceColorsSection": {
+          "paneBackground": "App Background",
+          "paneBackgroundDescription": "The main window canvas behind all panes.",
+          "paneSidebar": "Sidebar",
+          "paneSidebarDescription": "The workspace sidebar surface.",
+          "paneEditor": "Editor",
+          "paneEditorDescription": "Code and markdown editor panes.",
+          "paneCards": "Panels & Cards",
+          "paneCardsDescription": "Panels lifted off the canvas, like workspace cards.",
+          "terminalBackgroundTitle": "Terminal Background",
+          "paneColorsTitle": "Interface Panes",
+          "terminalBackgroundDescription": "Override the background of the active terminal theme.",
+          "terminalBackgroundLabel": "Background",
+          "terminalBackgroundFieldDescription": "Applied on top of the selected terminal theme in both modes.",
+          "terminalBackgroundReset": "Reset to theme background",
+          "paneColorsDescription": "Recolor the app background, sidebar, editor, and panels.",
+          "paneColorsModeAria": "Choose which mode to edit pane colors for",
+          "paneColorsDarkHint": "These colors apply while Orca is in dark mode.",
+          "paneColorsLightHint": "These colors apply while Orca is in light mode.",
+          "paneColorsResetDark": "Reset dark pane colors",
+          "paneColorsResetLight": "Reset light pane colors"
+        },
+        "AppearancePresetsSection": {
+          "title": "Presets",
+          "description": "Save the current appearance as a preset and switch between saved setups.",
+          "emptyState": "No presets yet. Save your current appearance to switch between setups quickly.",
+          "apply": "Apply",
+          "presetActions": "Preset actions",
+          "updateFromCurrent": "Update from current appearance",
+          "rename": "Rename…",
+          "delete": "Delete",
+          "saveCurrent": "Save Current as Preset",
+          "renameTitle": "Rename Preset",
+          "createTitle": "Save Preset",
+          "createDescription": "Captures the current theme, terminal theme, and custom colors.",
+          "nameLabel": "Name",
+          "namePlaceholder": "e.g. Night coding",
+          "cancel": "Cancel",
+          "renameConfirm": "Rename",
+          "saveConfirm": "Save"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4759,7 +4759,11 @@
           "windowSidebarSummary": "사이드바, 상태 표시줄 및 파일 탐색기",
           "statusBarCount": "{{value0}}개 표시기가 보입니다.",
           "gitIgnoredGlossary": ".gitignore와 일치하는 파일.",
-          "statusBarDescription": "Choose which indicators appear in the status bar."
+          "statusBarDescription": "Choose which indicators appear in the status bar.",
+          "colorsTitle": "Colors",
+          "colorsSummary": "Terminal background and interface pane colors",
+          "presetsSummaryEmpty": "Save and switch appearance setups",
+          "presetsSummaryCount": "{{count}} saved"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -8702,6 +8706,47 @@
         "ephemeralVmsExperimentalSetting": {
           "description": "repo 소유 온디맨드 환경에 대한 설정 제어 및 워크스페이스 실행 대상을 표시합니다.",
           "toggleLabel": "워크스페이스별 환경 전환"
+        },
+        "AppearanceColorsSection": {
+          "paneBackground": "App Background",
+          "paneBackgroundDescription": "The main window canvas behind all panes.",
+          "paneSidebar": "Sidebar",
+          "paneSidebarDescription": "The workspace sidebar surface.",
+          "paneEditor": "Editor",
+          "paneEditorDescription": "Code and markdown editor panes.",
+          "paneCards": "Panels & Cards",
+          "paneCardsDescription": "Panels lifted off the canvas, like workspace cards.",
+          "terminalBackgroundTitle": "Terminal Background",
+          "paneColorsTitle": "Interface Panes",
+          "terminalBackgroundDescription": "Override the background of the active terminal theme.",
+          "terminalBackgroundLabel": "Background",
+          "terminalBackgroundFieldDescription": "Applied on top of the selected terminal theme in both modes.",
+          "terminalBackgroundReset": "Reset to theme background",
+          "paneColorsDescription": "Recolor the app background, sidebar, editor, and panels.",
+          "paneColorsModeAria": "Choose which mode to edit pane colors for",
+          "paneColorsDarkHint": "These colors apply while Orca is in dark mode.",
+          "paneColorsLightHint": "These colors apply while Orca is in light mode.",
+          "paneColorsResetDark": "Reset dark pane colors",
+          "paneColorsResetLight": "Reset light pane colors"
+        },
+        "AppearancePresetsSection": {
+          "title": "Presets",
+          "description": "Save the current appearance as a preset and switch between saved setups.",
+          "emptyState": "No presets yet. Save your current appearance to switch between setups quickly.",
+          "apply": "Apply",
+          "presetActions": "Preset actions",
+          "updateFromCurrent": "Update from current appearance",
+          "rename": "Rename…",
+          "delete": "Delete",
+          "saveCurrent": "Save Current as Preset",
+          "renameTitle": "Rename Preset",
+          "createTitle": "Save Preset",
+          "createDescription": "Captures the current theme, terminal theme, and custom colors.",
+          "nameLabel": "Name",
+          "namePlaceholder": "e.g. Night coding",
+          "cancel": "Cancel",
+          "renameConfirm": "Rename",
+          "saveConfirm": "Save"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4759,7 +4759,11 @@
           "windowSidebarSummary": "侧边栏、状态栏和文件浏览器",
           "statusBarCount": "显示 {{value0}} 个指示器。",
           "gitIgnoredGlossary": "与 .gitignore 匹配的文件。",
-          "statusBarDescription": "Choose which indicators appear in the status bar."
+          "statusBarDescription": "Choose which indicators appear in the status bar.",
+          "colorsTitle": "Colors",
+          "colorsSummary": "Terminal background and interface pane colors",
+          "presetsSummaryEmpty": "Save and switch appearance setups",
+          "presetsSummaryCount": "{{count}} saved"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -8702,6 +8706,47 @@
         "ephemeralVmsExperimentalSetting": {
           "description": "显示仓库自带按需环境的设置控件和工作区运行目标。",
           "toggleLabel": "切换工作区专属环境"
+        },
+        "AppearanceColorsSection": {
+          "paneBackground": "App Background",
+          "paneBackgroundDescription": "The main window canvas behind all panes.",
+          "paneSidebar": "Sidebar",
+          "paneSidebarDescription": "The workspace sidebar surface.",
+          "paneEditor": "Editor",
+          "paneEditorDescription": "Code and markdown editor panes.",
+          "paneCards": "Panels & Cards",
+          "paneCardsDescription": "Panels lifted off the canvas, like workspace cards.",
+          "terminalBackgroundTitle": "Terminal Background",
+          "paneColorsTitle": "Interface Panes",
+          "terminalBackgroundDescription": "Override the background of the active terminal theme.",
+          "terminalBackgroundLabel": "Background",
+          "terminalBackgroundFieldDescription": "Applied on top of the selected terminal theme in both modes.",
+          "terminalBackgroundReset": "Reset to theme background",
+          "paneColorsDescription": "Recolor the app background, sidebar, editor, and panels.",
+          "paneColorsModeAria": "Choose which mode to edit pane colors for",
+          "paneColorsDarkHint": "These colors apply while Orca is in dark mode.",
+          "paneColorsLightHint": "These colors apply while Orca is in light mode.",
+          "paneColorsResetDark": "Reset dark pane colors",
+          "paneColorsResetLight": "Reset light pane colors"
+        },
+        "AppearancePresetsSection": {
+          "title": "Presets",
+          "description": "Save the current appearance as a preset and switch between saved setups.",
+          "emptyState": "No presets yet. Save your current appearance to switch between setups quickly.",
+          "apply": "Apply",
+          "presetActions": "Preset actions",
+          "updateFromCurrent": "Update from current appearance",
+          "rename": "Rename…",
+          "delete": "Delete",
+          "saveCurrent": "Save Current as Preset",
+          "renameTitle": "Rename Preset",
+          "createTitle": "Save Preset",
+          "createDescription": "Captures the current theme, terminal theme, and custom colors.",
+          "nameLabel": "Name",
+          "namePlaceholder": "e.g. Night coding",
+          "cancel": "Cancel",
+          "renameConfirm": "Rename",
+          "saveConfirm": "Save"
         }
       },
       "right": {

--- a/src/renderer/src/lib/interface-color-overrides.ts
+++ b/src/renderer/src/lib/interface-color-overrides.ts
@@ -1,0 +1,58 @@
+import type { GlobalSettings } from '../../../shared/types'
+import { HEX_COLOR_RE } from '../../../shared/color-validation'
+import {
+  INTERFACE_PANE_COLOR_KEYS,
+  type InterfacePaneColorKey,
+  type InterfacePaneColors
+} from '../../../shared/interface-color-overrides'
+
+// Why: sidebar has two token families (see left-sidebar-appearance.ts) — the
+// worktree sidebar plus the shadcn family older descendants still consume.
+const PANE_COLOR_CSS_VARS: Record<InterfacePaneColorKey, readonly string[]> = {
+  background: ['--background'],
+  sidebar: ['--worktree-sidebar', '--sidebar'],
+  editorSurface: ['--editor-surface'],
+  card: ['--card']
+}
+
+// Why: pickers need a concrete color to seed from and to show as the "default"
+// swatch. Mirrors the :root/.dark values in assets/main.css (canonical).
+export const INTERFACE_PANE_DEFAULT_COLORS: Record<
+  'dark' | 'light',
+  Record<InterfacePaneColorKey, string>
+> = {
+  light: { background: '#ffffff', sidebar: '#f5f5f5', editorSurface: '#ffffff', card: '#ffffff' },
+  dark: { background: '#0a0a0a', sidebar: '#2a2a2a', editorSurface: '#1e1e1e', card: '#171717' }
+}
+
+export function resolveInterfaceModeIsDark(
+  theme: GlobalSettings['theme'] | undefined,
+  systemPrefersDark: boolean
+): boolean {
+  return theme === 'dark' || (theme !== 'light' && systemPrefersDark)
+}
+
+/** Applies the active mode's pane overrides as inline CSS variables on the
+ *  document root. Inline vars beat the :root/.dark class rules, so overrides
+ *  must be re-resolved and re-applied whenever the effective mode flips. */
+export function applyInterfaceColorOverrides(
+  settings: Pick<GlobalSettings, 'theme' | 'interfaceColorOverrides'> | null,
+  systemPrefersDark: boolean
+): void {
+  const isDark = resolveInterfaceModeIsDark(settings?.theme, systemPrefersDark)
+  const colors: InterfacePaneColors =
+    settings?.interfaceColorOverrides?.[isDark ? 'dark' : 'light'] ?? {}
+  const rootStyle = document.documentElement.style
+  for (const key of INTERFACE_PANE_COLOR_KEYS) {
+    const value = colors[key]
+    // Values are persisted while the user types; only valid hex reaches CSS.
+    const applied = value && HEX_COLOR_RE.test(value.trim()) ? value.trim() : null
+    for (const cssVar of PANE_COLOR_CSS_VARS[key]) {
+      if (applied) {
+        rootStyle.setProperty(cssVar, applied)
+      } else {
+        rootStyle.removeProperty(cssVar)
+      }
+    }
+  }
+}

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -11,6 +11,7 @@ import { assertRuntimeStatusCompatible } from '@/runtime/runtime-protocol-compat
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import { normalizeTerminalQuickCommands } from '../../../../shared/terminal-quick-commands'
 import { normalizeTerminalCustomThemes } from '../../../../shared/terminal-custom-themes'
+import { normalizeAppearancePresets } from '../../../../shared/appearance-presets'
 import { normalizeTaskProviderSettings } from '../../../../shared/task-providers'
 import { normalizeOpenInApplications } from '../../../../shared/open-in-applications'
 import { createSettingsSearchState, type SettingsSearchState } from './settings-search-state'
@@ -93,6 +94,9 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
         sanitizedUpdates.terminalCustomThemes = normalizeTerminalCustomThemes(
           updates.terminalCustomThemes
         )
+      }
+      if ('appearancePresets' in updates) {
+        sanitizedUpdates.appearancePresets = normalizeAppearancePresets(updates.appearancePresets)
       }
       if ('visibleTaskProviders' in updates || 'defaultTaskSource' in updates) {
         const taskProviderSettings = normalizeTaskProviderSettings({

--- a/src/shared/appearance-presets.test.ts
+++ b/src/shared/appearance-presets.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appearanceSnapshotsEqual,
+  buildAppearancePresetSnapshot,
+  MAX_APPEARANCE_PRESETS,
+  normalizeAppearancePresets
+} from './appearance-presets'
+import { getDefaultSettings } from './constants'
+
+const defaults = (): ReturnType<typeof getDefaultSettings> => getDefaultSettings('/home/test')
+
+function validPreset(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'preset-1',
+    name: 'Night coding',
+    savedAt: '2026-07-02T00:00:00.000Z',
+    snapshot: buildAppearancePresetSnapshot(defaults()),
+    ...overrides
+  }
+}
+
+describe('normalizeAppearancePresets', () => {
+  it('returns empty for non-arrays', () => {
+    expect(normalizeAppearancePresets(undefined)).toEqual([])
+    expect(normalizeAppearancePresets('nope')).toEqual([])
+    expect(normalizeAppearancePresets({})).toEqual([])
+  })
+
+  it('keeps valid presets and drops entries without id or name', () => {
+    const result = normalizeAppearancePresets([
+      validPreset(),
+      validPreset({ id: '' }),
+      validPreset({ id: 'preset-2', name: '   ' }),
+      'garbage',
+      null
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('preset-1')
+    expect(result[0].name).toBe('Night coding')
+  })
+
+  it('dedupes by id keeping the last occurrence', () => {
+    const result = normalizeAppearancePresets([
+      validPreset({ name: 'First' }),
+      validPreset({ name: 'Second' })
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Second')
+  })
+
+  it('caps the list at MAX_APPEARANCE_PRESETS keeping the newest', () => {
+    const presets = Array.from({ length: MAX_APPEARANCE_PRESETS + 5 }, (_, index) =>
+      validPreset({ id: `preset-${index}` })
+    )
+    const result = normalizeAppearancePresets(presets)
+    expect(result).toHaveLength(MAX_APPEARANCE_PRESETS)
+    expect(result.at(-1)?.id).toBe(`preset-${MAX_APPEARANCE_PRESETS + 4}`)
+  })
+
+  it('repairs malformed snapshots with defaults and drops invalid colors', () => {
+    const result = normalizeAppearancePresets([
+      validPreset({
+        snapshot: {
+          theme: 'neon',
+          terminalDividerColorDark: 'not-a-color',
+          terminalBackgroundOpacity: 7,
+          terminalColorOverrides: { background: '#123456', foreground: 'nothex' },
+          interfaceColorOverrides: { light: { background: '#FFF', sidebar: 'zzz' } }
+        }
+      })
+    ])
+    const snapshot = result[0].snapshot
+    expect(snapshot.theme).toBe('system')
+    expect(snapshot.terminalDividerColorDark).toBe('#3f3f46')
+    expect(snapshot.terminalBackgroundOpacity).toBe(1)
+    expect(snapshot.terminalColorOverrides).toEqual({ background: '#123456' })
+    expect(snapshot.interfaceColorOverrides).toEqual({ light: { background: '#ffffff' } })
+  })
+})
+
+describe('buildAppearancePresetSnapshot', () => {
+  it('is total: every field concrete so applying a preset resets prior customization', () => {
+    const snapshot = buildAppearancePresetSnapshot(defaults())
+    for (const value of Object.values(snapshot)) {
+      expect(value).not.toBeUndefined()
+    }
+    expect(snapshot.terminalColorOverrides).toEqual({})
+    expect(snapshot.interfaceColorOverrides).toEqual({})
+  })
+
+  it('round-trips equality through normalization', () => {
+    const settings = {
+      ...defaults(),
+      interfaceColorOverrides: { light: { background: '#f7f4ec' } }
+    }
+    const a = buildAppearancePresetSnapshot(settings)
+    const [preset] = normalizeAppearancePresets([validPreset({ snapshot: a })])
+    expect(appearanceSnapshotsEqual(a, preset.snapshot)).toBe(true)
+    expect(
+      appearanceSnapshotsEqual(a, buildAppearancePresetSnapshot(defaults()))
+    ).toBe(false)
+  })
+})

--- a/src/shared/appearance-presets.ts
+++ b/src/shared/appearance-presets.ts
@@ -1,0 +1,135 @@
+import type { GlobalSettings } from './types'
+import {
+  normalizeTerminalColorOverrides,
+  normalizeTerminalHexColor,
+  normalizeTerminalThemeName
+} from './terminal-custom-themes'
+import {
+  DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
+  DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,
+  normalizeLeftSidebarAppearanceMode,
+  normalizeLeftSidebarTintOpacity
+} from './left-sidebar-appearance'
+import {
+  normalizeInterfaceColorOverrides,
+  type InterfaceColorOverrides
+} from './interface-color-overrides'
+import type { TerminalColorOverrides } from './types'
+
+export const MAX_APPEARANCE_PRESETS = 50
+
+// Why: mirror the shipped defaults in constants.ts so a snapshot is always
+// total — applying a preset must reset every appearance field, including ones
+// the preset never customized, or switching presets leaves stale colors behind.
+const FALLBACK_DARK_THEME = 'Ghostty Default Style Dark'
+const FALLBACK_LIGHT_THEME = 'Builtin Tango Light'
+const FALLBACK_DIVIDER_DARK = '#3f3f46'
+const FALLBACK_DIVIDER_LIGHT = '#d4d4d8'
+
+/** Every field is required: presets capture the complete appearance state so
+ *  applying one is deterministic regardless of what was customized before. */
+export type AppearancePresetSnapshot = {
+  theme: GlobalSettings['theme']
+  leftSidebarAppearanceMode: GlobalSettings['leftSidebarAppearanceMode']
+  leftSidebarTintColor: string
+  leftSidebarTintOpacity: number
+  terminalThemeDark: string
+  terminalUseSeparateLightTheme: boolean
+  terminalThemeLight: string
+  terminalDividerColorDark: string
+  terminalDividerColorLight: string
+  terminalBackgroundOpacity: number
+  terminalColorOverrides: TerminalColorOverrides
+  interfaceColorOverrides: InterfaceColorOverrides
+}
+
+export type AppearancePreset = {
+  id: string
+  name: string
+  savedAt: string
+  snapshot: AppearancePresetSnapshot
+}
+
+function normalizeTheme(value: unknown): GlobalSettings['theme'] {
+  return value === 'dark' || value === 'light' || value === 'system' ? value : 'system'
+}
+
+function normalizeBackgroundOpacity(value: unknown): number {
+  const parsed = typeof value === 'number' && Number.isFinite(value) ? value : 1
+  return Math.min(1, Math.max(0, parsed))
+}
+
+function normalizeSnapshot(value: unknown): AppearancePresetSnapshot {
+  const input =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}
+  return {
+    theme: normalizeTheme(input.theme),
+    leftSidebarAppearanceMode: normalizeLeftSidebarAppearanceMode(input.leftSidebarAppearanceMode),
+    leftSidebarTintColor:
+      normalizeTerminalHexColor(input.leftSidebarTintColor) ?? DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
+    leftSidebarTintOpacity:
+      typeof input.leftSidebarTintOpacity === 'number'
+        ? normalizeLeftSidebarTintOpacity(input.leftSidebarTintOpacity)
+        : DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,
+    terminalThemeDark:
+      typeof input.terminalThemeDark === 'string' && input.terminalThemeDark.trim()
+        ? input.terminalThemeDark
+        : FALLBACK_DARK_THEME,
+    terminalUseSeparateLightTheme: input.terminalUseSeparateLightTheme !== false,
+    terminalThemeLight:
+      typeof input.terminalThemeLight === 'string' && input.terminalThemeLight.trim()
+        ? input.terminalThemeLight
+        : FALLBACK_LIGHT_THEME,
+    terminalDividerColorDark:
+      normalizeTerminalHexColor(input.terminalDividerColorDark) ?? FALLBACK_DIVIDER_DARK,
+    terminalDividerColorLight:
+      normalizeTerminalHexColor(input.terminalDividerColorLight) ?? FALLBACK_DIVIDER_LIGHT,
+    terminalBackgroundOpacity: normalizeBackgroundOpacity(input.terminalBackgroundOpacity),
+    terminalColorOverrides: normalizeTerminalColorOverrides(input.terminalColorOverrides),
+    interfaceColorOverrides: normalizeInterfaceColorOverrides(input.interfaceColorOverrides)
+  }
+}
+
+export function buildAppearancePresetSnapshot(
+  settings: Pick<GlobalSettings, keyof AppearancePresetSnapshot>
+): AppearancePresetSnapshot {
+  return normalizeSnapshot(settings)
+}
+
+export function appearanceSnapshotsEqual(
+  a: AppearancePresetSnapshot,
+  b: AppearancePresetSnapshot
+): boolean {
+  // Both sides come out of normalizeSnapshot, so key order is deterministic.
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+export function normalizeAppearancePresets(value: unknown): AppearancePreset[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const byId = new Map<string, AppearancePreset>()
+  for (const entry of value.slice(-MAX_APPEARANCE_PRESETS)) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue
+    }
+    const input = entry as Record<string, unknown>
+    const id = typeof input.id === 'string' ? input.id.trim() : ''
+    const name = normalizeTerminalThemeName(input.name, '')
+    if (!id || !name) {
+      continue
+    }
+    byId.set(id, {
+      id,
+      name,
+      savedAt:
+        typeof input.savedAt === 'string' && input.savedAt.trim()
+          ? input.savedAt
+          : new Date(0).toISOString(),
+      snapshot: normalizeSnapshot(input.snapshot)
+    })
+  }
+  return [...byId.values()].slice(-MAX_APPEARANCE_PRESETS)
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -234,6 +234,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalThemeLight: 'Builtin Tango Light',
     terminalCustomThemes: [],
     terminalDividerColorLight: '#d4d4d8',
+    appearancePresets: [],
     terminalInactivePaneOpacity: 0.8,
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 140,

--- a/src/shared/interface-color-overrides.test.ts
+++ b/src/shared/interface-color-overrides.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeInterfaceColorOverrides,
+  normalizeInterfacePaneColors
+} from './interface-color-overrides'
+
+describe('normalizeInterfacePaneColors', () => {
+  it('returns empty for non-objects', () => {
+    expect(normalizeInterfacePaneColors(undefined)).toEqual({})
+    expect(normalizeInterfacePaneColors([])).toEqual({})
+    expect(normalizeInterfacePaneColors('x')).toEqual({})
+  })
+
+  it('keeps only known keys with valid hex, expanding shorthand', () => {
+    expect(
+      normalizeInterfacePaneColors({
+        background: '#ABC',
+        sidebar: 'red',
+        editorSurface: '#1e1e1e',
+        card: 42,
+        unknownKey: '#ffffff'
+      })
+    ).toEqual({ background: '#aabbcc', editorSurface: '#1e1e1e' })
+  })
+})
+
+describe('normalizeInterfaceColorOverrides', () => {
+  it('drops empty modes so untouched settings stay clean', () => {
+    expect(normalizeInterfaceColorOverrides({ dark: {}, light: { sidebar: 'zzz' } })).toEqual({})
+    expect(
+      normalizeInterfaceColorOverrides({ dark: { background: '#0b0b12' }, light: null })
+    ).toEqual({ dark: { background: '#0b0b12' } })
+  })
+})

--- a/src/shared/interface-color-overrides.ts
+++ b/src/shared/interface-color-overrides.ts
@@ -1,0 +1,48 @@
+import { normalizeTerminalHexColor } from './terminal-custom-themes'
+
+/** Pane surfaces users can recolor. Each key maps to one or more CSS tokens
+ *  in `assets/main.css` (see renderer `lib/interface-color-overrides.ts`). */
+export const INTERFACE_PANE_COLOR_KEYS = ['background', 'sidebar', 'editorSurface', 'card'] as const
+
+export type InterfacePaneColorKey = (typeof INTERFACE_PANE_COLOR_KEYS)[number]
+
+export type InterfacePaneColors = Partial<Record<InterfacePaneColorKey, string>>
+
+/** Keyed per resolved mode: a hex that works on dark chrome rarely works on
+ *  light, so overrides never leak across the light/dark boundary. */
+export type InterfaceColorOverrides = {
+  dark?: InterfacePaneColors
+  light?: InterfacePaneColors
+}
+
+export function normalizeInterfacePaneColors(value: unknown): InterfacePaneColors {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  const input = value as Record<string, unknown>
+  const output: InterfacePaneColors = {}
+  for (const key of INTERFACE_PANE_COLOR_KEYS) {
+    const color = normalizeTerminalHexColor(input[key])
+    if (color) {
+      output[key] = color
+    }
+  }
+  return output
+}
+
+export function normalizeInterfaceColorOverrides(value: unknown): InterfaceColorOverrides {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  const input = value as Record<string, unknown>
+  const output: InterfaceColorOverrides = {}
+  const dark = normalizeInterfacePaneColors(input.dark)
+  const light = normalizeInterfacePaneColors(input.light)
+  if (Object.keys(dark).length > 0) {
+    output.dark = dark
+  }
+  if (Object.keys(light).length > 0) {
+    output.light = light
+  }
+  return output
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,6 +33,8 @@ import type { AgentKind, LaunchSource, RequestKind } from './telemetry-events'
 import type { SleepingAgentLaunchConfig, SleepingAgentSessionRecord } from './agent-session-resume'
 import type { ClaudeAgentTeamsMode } from './claude-agent-teams-tmux-compat'
 import type { TerminalCustomTheme } from './terminal-custom-themes'
+import type { InterfaceColorOverrides } from './interface-color-overrides'
+import type { AppearancePreset } from './appearance-presets'
 import type { UiLanguage } from './ui-language'
 import type { ForkSyncMode } from './git-fork-sync'
 import type { GitRemoteIdentity } from './git-remote-identity'
@@ -2523,6 +2525,12 @@ export type GlobalSettings = {
   terminalDividerThicknessPx: number
   terminalBackgroundOpacity?: number
   terminalColorOverrides?: TerminalColorOverrides
+  /** Per-mode (dark/light) hex overrides for IDE pane surfaces (app
+   *  background, sidebar, editor, cards). Applied as CSS variables. */
+  interfaceColorOverrides?: InterfaceColorOverrides
+  /** Named snapshots of the full appearance state (theme, terminal theme,
+   *  color overrides, sidebar appearance) the user can switch between. */
+  appearancePresets?: AppearancePreset[]
   terminalPaddingX?: number
   terminalPaddingY?: number
   terminalMouseHideWhileTyping?: boolean


### PR DESCRIPTION
…IDE panes

Adds two new Appearance settings sections:

- Presets: save the full appearance state (theme, terminal theme, color overrides, sidebar appearance) as named snapshots with one-click apply, rename, update-from-current, and delete. Snapshots are total so applying a preset deterministically resets every appearance field.
- Colors: quick override for the terminal background plus per-mode (dark/light) hex overrides for IDE pane surfaces (app background, sidebar, editor, panels/cards), applied live as CSS variables on the document root.

New GlobalSettings fields (appearancePresets, interfaceColorOverrides) are normalized in both the renderer settings slice and main settings IPC, following the terminalCustomThemes pattern.

## Summary

Describe the user-visible change.

## Screenshots

- Add screenshots or a screen recording for any new or changed UI behavior.
- If there is no visual change, say `No visual change`.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Summarize the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or verified as a result.
Confirm that the review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and any Electron-specific platform differences touched by this PR.

## Security Audit

Provide a basic security audit summary from your AI coding agent. Call out any input handling, command execution, path handling, auth, secrets, dependency, or IPC risks that were reviewed, plus any follow-up needed.

## Notes

Call out any platform-specific behavior, risks, or follow-up work.
