### PR TITLE
Fix WebSocket fallback for reserved Windows ports

### DIFF
--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -531,7 +531,13 @@ describe('WebSocketTransport', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const tryListenSpy = vi.spyOn(privateTransport, 'tryListen')
     tryListenSpy
-      .mockRejectedValueOnce(Object.assign(new Error('listen EACCES'), { code: 'EACCES' }))
+      .mockRejectedValueOnce(
+        Object.assign(new Error('listen EACCES'), {
+          code: 'EACCES',
+          syscall: 'listen',
+          port: 6769
+        })
+      )
       .mockImplementation((port) => originalTryListen(port))
 
     try {
@@ -711,17 +717,24 @@ describe('WebSocketTransport', () => {
       expect(transport.resolvedPort).toBe(preferredPort)
     })
 
-    it('still throws when the preferred port fails with a non-EADDRINUSE error', async () => {
+    it('still throws when EACCES did not come from listening on the preferred port', async () => {
+      const preferredPort = await reserveFreePort()
       const transport = new WebSocketTransport({
         host: '127.0.0.1',
-        port: await reserveFreePort()
+        port: preferredPort
       })
       transports.push(transport)
       const withListen = transport as unknown as { tryListen(port: number): Promise<void> }
       withListen.tryListen = () =>
-        Promise.reject(Object.assign(new Error('listen EACCES'), { code: 'EACCES' }))
+        Promise.reject(
+          Object.assign(new Error('open EACCES'), {
+            code: 'EACCES',
+            syscall: 'open',
+            port: preferredPort
+          })
+        )
 
-      await expect(transport.start()).rejects.toThrow('listen EACCES')
+      await expect(transport.start()).rejects.toThrow('open EACCES')
     })
 
     it('retries the persisted fallback port before an OS-assigned one', async () => {

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -514,6 +514,41 @@ describe('WebSocketTransport', () => {
     ws.close()
   })
 
+  it('falls back to OS-assigned port when preferred port is reserved', async () => {
+    const tls = makeTls()
+    const transport = new WebSocketTransport({
+      host: '127.0.0.1',
+      port: 6769,
+      tlsCert: tls.cert,
+      tlsKey: tls.key
+    })
+    transports.push(transport)
+
+    const privateTransport = transport as unknown as {
+      tryListen: (port: number) => Promise<void>
+    }
+    const originalTryListen = privateTransport.tryListen.bind(transport)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const tryListenSpy = vi.spyOn(privateTransport, 'tryListen')
+    tryListenSpy
+      .mockRejectedValueOnce(Object.assign(new Error('listen EACCES'), { code: 'EACCES' }))
+      .mockImplementation((port) => originalTryListen(port))
+
+    try {
+      await transport.start()
+    } finally {
+      warnSpy.mockRestore()
+    }
+
+    expect(tryListenSpy).toHaveBeenNthCalledWith(1, 6769)
+    expect(tryListenSpy).toHaveBeenNthCalledWith(2, 0)
+    expect(transport.resolvedPort).not.toBe(6769)
+    expect(transport.resolvedPort).toBeGreaterThan(0)
+
+    const ws = await connectWs(transport.resolvedPort)
+    ws.close()
+  })
+
   it('reaps a half-open client that stops responding to pings', async () => {
     // Why: regression cover for the half-open-socket leak that would
     // strand mobile clients in the connection pool until OS TCP keepalive

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -148,10 +148,10 @@ export class WebSocketTransport implements RpcTransport {
         await this.tryListen(port)
         return
       } catch (error: unknown) {
-        // Why: a persisted fallback may fail for any reason, while configured ports fall through only when occupied or Windows-reserved.
+        // Why: a persisted fallback may fail for any reason, while configured ports fall through only when their listen is occupied or denied.
         if (
           port !== persistedFallbackPort &&
-          (!isPortListenFallbackError(error) || port === 0)
+          (!isPortListenFallbackError(error, port) || port === 0)
         ) {
           throw error
         }
@@ -330,10 +330,18 @@ export class WebSocketTransport implements RpcTransport {
   }
 }
 
-function isPortListenFallbackError(error: unknown): boolean {
+function isPortListenFallbackError(error: unknown, port: number): boolean {
+  if (!(error instanceof Error) || !('code' in error)) {
+    return false
+  }
+  if (error.code === 'EADDRINUSE') {
+    return true
+  }
   return (
-    error instanceof Error &&
-    'code' in error &&
-    (error.code === 'EADDRINUSE' || error.code === 'EACCES')
+    error.code === 'EACCES' &&
+    'syscall' in error &&
+    error.syscall === 'listen' &&
+    'port' in error &&
+    error.port === port
   )
 }

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -148,8 +148,11 @@ export class WebSocketTransport implements RpcTransport {
         await this.tryListen(port)
         return
       } catch (error: unknown) {
-        // Why: any fallback-port failure must degrade to the next candidate (Windows can reserve the port → EACCES, not just EADDRINUSE); only non-EADDRINUSE preferred-port failures are fatal.
-        if (port !== persistedFallbackPort && (!isEAddressInUse(error) || port === 0)) {
+        // Why: a persisted fallback may fail for any reason, while configured ports fall through only when occupied or Windows-reserved.
+        if (
+          port !== persistedFallbackPort &&
+          (!isPortListenFallbackError(error) || port === 0)
+        ) {
           throw error
         }
         console.warn(
@@ -327,6 +330,10 @@ export class WebSocketTransport implements RpcTransport {
   }
 }
 
-function isEAddressInUse(error: unknown): boolean {
-  return error instanceof Error && 'code' in error && error.code === 'EADDRINUSE'
+function isPortListenFallbackError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error.code === 'EADDRINUSE' || error.code === 'EACCES')
+  )
 }


### PR DESCRIPTION
## Summary
- Treat Windows reserved-port listen failures (`EACCES`) like occupied-port failures for the runtime WebSocket transport.
- Fall back to an OS-assigned port so mobile pairing can still advertise a live WebSocket endpoint.
- Add regression coverage for the reserved-port fallback path.

## Testing
- `pnpm --config.script-shell="C:\Program Files\PowerShell\7\pwsh.exe" exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/ws-transport.test.ts`
- `pnpm --config.script-shell="C:\Program Files\PowerShell\7\pwsh.exe" exec vitest run --config config/vitest.config.ts config/scripts/electron-builder-config.test.mjs`

## ELI5

On Windows, reserved ports could block WebSocket listen and break mobile pairing. Those failures fall back to an OS-assigned port so pairing still advertises a live endpoint.
