### PR TITLE
Restore process-table agent identity via OSC 133-triggered foreground reads

### DIFF
--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPaneForegroundAgentTracker } from './pane-foreground-agent-tracker'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+
+const COMMAND_SETTLE_MS = 350
+const WRAPPER_RESOLVE_RETRY_MS = 1200
+
+describe('createPaneForegroundAgentTracker', () => {
+  const readForegroundProcess = vi.fn<(ptyId: string) => Promise<string | null>>()
+  const publish = vi.fn<(entry: PaneForegroundAgentEntry) => void>()
+  let ptyId: string | null = 'pty-1'
+
+  function makeTracker(): ReturnType<typeof createPaneForegroundAgentTracker> {
+    return createPaneForegroundAgentTracker({
+      getPtyId: () => ptyId,
+      isTrackablePtyId: (id) => !id.startsWith('remote:') && !id.startsWith('ssh:'),
+      readForegroundProcess,
+      publish
+    })
+  }
+
+  async function flushSettleRead(ms: number): Promise<void> {
+    await vi.advanceTimersByTimeAsync(ms)
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    readForegroundProcess.mockReset()
+    publish.mockReset()
+    ptyId = 'pty-1'
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('reads the foreground once after a command starts and publishes the recognized agent', async () => {
+    readForegroundProcess.mockResolvedValue('claude')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    expect(publish).toHaveBeenCalledExactlyOnceWith({ agent: null, shellForeground: false })
+    expect(readForegroundProcess).not.toHaveBeenCalled()
+
+    await flushSettleRead(COMMAND_SETTLE_MS)
+
+    expect(readForegroundProcess).toHaveBeenCalledExactlyOnceWith('pty-1')
+    expect(publish).toHaveBeenLastCalledWith({ agent: 'claude', shellForeground: false })
+  })
+
+  it('re-reads once when the first read still sees an interpreter wrapper', async () => {
+    readForegroundProcess.mockResolvedValueOnce('node').mockResolvedValueOnce('claude')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    await flushSettleRead(COMMAND_SETTLE_MS)
+    expect(readForegroundProcess).toHaveBeenCalledTimes(1)
+    expect(publish).toHaveBeenLastCalledWith({ agent: null, shellForeground: false })
+
+    await flushSettleRead(WRAPPER_RESOLVE_RETRY_MS)
+    expect(readForegroundProcess).toHaveBeenCalledTimes(2)
+    expect(publish).toHaveBeenLastCalledWith({ agent: 'claude', shellForeground: false })
+  })
+
+  it('publishes shell foreground when the read lands after a fast command already exited', async () => {
+    readForegroundProcess.mockResolvedValue('zsh')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    await flushSettleRead(COMMAND_SETTLE_MS)
+
+    expect(publish).toHaveBeenLastCalledWith({ agent: null, shellForeground: true })
+  })
+
+  it('marks shell foreground on command finished without any foreground read', () => {
+    const tracker = makeTracker()
+
+    tracker.onCommandFinished()
+
+    expect(publish).toHaveBeenCalledExactlyOnceWith({ agent: null, shellForeground: true })
+    expect(readForegroundProcess).not.toHaveBeenCalled()
+  })
+
+  it('cancels a pending read when the command finishes first', async () => {
+    readForegroundProcess.mockResolvedValue('claude')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    tracker.onCommandFinished()
+    await flushSettleRead(COMMAND_SETTLE_MS + WRAPPER_RESOLVE_RETRY_MS)
+
+    expect(readForegroundProcess).not.toHaveBeenCalled()
+    expect(publish).toHaveBeenLastCalledWith({ agent: null, shellForeground: true })
+  })
+
+  it('never reads or publishes for remote or ssh panes', async () => {
+    ptyId = 'remote:web-env-1@@terminal-1'
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    tracker.onCommandFinished()
+    await flushSettleRead(COMMAND_SETTLE_MS + WRAPPER_RESOLVE_RETRY_MS)
+
+    ptyId = 'ssh:conn@@pty-9'
+    tracker.onCommandStarted()
+    tracker.onCommandFinished()
+    await flushSettleRead(COMMAND_SETTLE_MS + WRAPPER_RESOLVE_RETRY_MS)
+
+    expect(readForegroundProcess).not.toHaveBeenCalled()
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it('drops a stale read result when a newer command superseded it', async () => {
+    let resolveFirstRead: (value: string | null) => void = () => {}
+    readForegroundProcess
+      .mockImplementationOnce(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveFirstRead = resolve
+          })
+      )
+      .mockResolvedValueOnce('codex')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    await flushSettleRead(COMMAND_SETTLE_MS)
+    tracker.onCommandStarted()
+    resolveFirstRead('claude')
+    await flushSettleRead(COMMAND_SETTLE_MS)
+
+    expect(publish).toHaveBeenLastCalledWith({ agent: 'codex', shellForeground: false })
+    expect(publish).not.toHaveBeenCalledWith({ agent: 'claude', shellForeground: false })
+  })
+
+  it('stops publishing after dispose', async () => {
+    readForegroundProcess.mockResolvedValue('claude')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    publish.mockReset()
+    tracker.dispose()
+    await flushSettleRead(COMMAND_SETTLE_MS + WRAPPER_RESOLVE_RETRY_MS)
+
+    expect(readForegroundProcess).not.toHaveBeenCalled()
+    expect(publish).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
@@ -1,0 +1,104 @@
+import { recognizeAgentProcess } from '../../../../shared/agent-process-recognition'
+import { isShellProcess } from '../../../../shared/agent-detection'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+
+// Why: the read must land after the shell has exec'd the command; and when it
+// still sees a node/python wrapper, the daemon resolves that ancestry
+// asynchronously, so give its cache one bounded re-read — not a retry ladder.
+const COMMAND_SETTLE_MS = 350
+const WRAPPER_RESOLVE_RETRY_MS = 1200
+
+type PaneForegroundAgentTrackerDeps = {
+  getPtyId: () => string | null
+  /** Local panes only — remote/SSH foreground reads are expensive RPCs and
+   *  their replayed OSC streams must not produce process evidence. */
+  isTrackablePtyId: (ptyId: string) => boolean
+  readForegroundProcess: (ptyId: string) => Promise<string | null>
+  publish: (entry: PaneForegroundAgentEntry) => void
+}
+
+/**
+ * Publishes process-table identity for a pane at OSC 133 command boundaries:
+ * one foreground read when a command starts (that is when the foreground
+ * changes), and a no-RPC shell-foreground mark when it finishes — 133;D itself
+ * proves the command exited back to the prompt.
+ */
+export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTrackerDeps): {
+  onCommandStarted: () => void
+  onCommandFinished: () => void
+  dispose: () => void
+} {
+  let disposed = false
+  let readTimer: number | null = null
+  let readGeneration = 0
+
+  const trackablePtyId = (): string | null => {
+    const ptyId = deps.getPtyId()
+    return ptyId && deps.isTrackablePtyId(ptyId) ? ptyId : null
+  }
+
+  const cancelPendingRead = (): void => {
+    readGeneration += 1
+    if (readTimer !== null) {
+      window.clearTimeout(readTimer)
+      readTimer = null
+    }
+  }
+
+  const scheduleRead = (delayMs: number, allowWrapperRetry: boolean): void => {
+    const generation = readGeneration
+    readTimer = window.setTimeout(() => {
+      readTimer = null
+      void readForeground(generation, allowWrapperRetry)
+    }, delayMs)
+  }
+
+  async function readForeground(generation: number, allowWrapperRetry: boolean): Promise<void> {
+    const ptyId = trackablePtyId()
+    if (disposed || generation !== readGeneration || !ptyId) {
+      return
+    }
+    const processName = await deps.readForegroundProcess(ptyId).catch(() => null)
+    if (disposed || generation !== readGeneration) {
+      return
+    }
+    const recognized = recognizeAgentProcess(processName)
+    if (recognized) {
+      deps.publish({ agent: recognized.agent, shellForeground: false })
+      return
+    }
+    if (processName && isShellProcess(processName)) {
+      deps.publish({ agent: null, shellForeground: true })
+      return
+    }
+    if (allowWrapperRetry && processName) {
+      scheduleRead(WRAPPER_RESOLVE_RETRY_MS, false)
+      return
+    }
+    deps.publish({ agent: null, shellForeground: false })
+  }
+
+  return {
+    onCommandStarted() {
+      cancelPendingRead()
+      if (!trackablePtyId()) {
+        return
+      }
+      // Why: the foreground left the prompt the moment C fired — stale
+      // shell-foreground evidence must not clear the command that just started.
+      deps.publish({ agent: null, shellForeground: false })
+      scheduleRead(COMMAND_SETTLE_MS, true)
+    },
+    onCommandFinished() {
+      cancelPendingRead()
+      if (!trackablePtyId()) {
+        return
+      }
+      deps.publish({ agent: null, shellForeground: true })
+    },
+    dispose() {
+      disposed = true
+      cancelPendingRead()
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -135,6 +135,8 @@ type StoreState = {
   setAgentStatus: ReturnType<typeof vi.fn>
   removeAgentStatus: ReturnType<typeof vi.fn>
   dropAgentStatus: ReturnType<typeof vi.fn>
+  setPaneForegroundAgent: ReturnType<typeof vi.fn>
+  clearPaneForegroundAgent: ReturnType<typeof vi.fn>
   markTerminalTabUnread: ReturnType<typeof vi.fn>
   markTerminalPaneUnread: ReturnType<typeof vi.fn>
   markAgentCompletionPaneUnread: ReturnType<typeof vi.fn>
@@ -716,6 +718,8 @@ describe('connectPanePty', () => {
       }),
       removeAgentStatus: vi.fn(),
       dropAgentStatus: vi.fn(),
+      setPaneForegroundAgent: vi.fn(),
+      clearPaneForegroundAgent: vi.fn(),
       markTerminalTabUnread: vi.fn(),
       markTerminalPaneUnread: vi.fn(),
       markAgentCompletionPaneUnread: vi.fn()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -87,6 +87,8 @@ import {
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { makePaneKey, parseLegacyNumericPaneKey } from '../../../../shared/stable-pane-id'
 import { createTerminalCommandLifecycle } from './terminal-command-lifecycle'
+import { createPaneForegroundAgentTracker } from './pane-foreground-agent-tracker'
+import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import { dispatchTerminalCommandFinishedEvent } from '@/hooks/terminal-command-finished-event'
 import { e2eConfig } from '@/lib/e2e-config'
 import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
@@ -1519,8 +1521,16 @@ export function connectPanePty(
     }
     return pendingWrite.then(() => interruptInference.flushPending())
   }
+  const paneForegroundAgentTracker = createPaneForegroundAgentTracker({
+    getPtyId: () => transport.getPtyId(),
+    isTrackablePtyId: (id) => !isRemoteRuntimePtyId(id) && parseAppSshPtyId(id) === null,
+    readForegroundProcess: (id) => window.api.pty.getForegroundProcess(id),
+    publish: (entry) => useAppStore.getState().setPaneForegroundAgent(cacheKey, entry)
+  })
   const commandLifecycle = createTerminalCommandLifecycle({
+    onCommandStarted: () => paneForegroundAgentTracker.onCommandStarted(),
     onCommandFinished: () => {
+      paneForegroundAgentTracker.onCommandFinished()
       // Why: the finished command may have moved HEAD or the index (e.g.
       // `git checkout`); nudge git UI now instead of waiting for a poll.
       dispatchTerminalCommandFinishedEvent(deps.worktreeId)
@@ -1726,6 +1736,7 @@ export function connectPanePty(
     // Why: a dead terminal has no running agent — remove its explicit status
     // entry so the hover UI only shows what is running *now*.
     useAppStore.getState().removeAgentStatus(cacheKey)
+    useAppStore.getState().clearPaneForegroundAgent(cacheKey)
     // The runtime graph is the CLI's source for live terminal bindings, so
     // we must republish when a pane loses its PTY instead of waiting for a
     // broader layout change that may never happen.
@@ -5547,6 +5558,7 @@ export function connectPanePty(
         pendingGeometryReportRaf = null
       }
       commandLifecycle.dispose()
+      paneForegroundAgentTracker.dispose()
       agentCompletionCoordinator.dispose()
     }
   }

--- a/src/renderer/src/components/terminal-pane/terminal-command-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-command-lifecycle.ts
@@ -2,6 +2,8 @@ import type { Terminal, IDisposable } from '@xterm/xterm'
 
 type TerminalCommandLifecycleOptions = {
   onCommandFinished: (bestEffortExitCode: number | null) => void
+  /** OSC 133;C — the shell exec'd a command; the pane's foreground changed. */
+  onCommandStarted?: () => void
 }
 
 type OscTerminator = {
@@ -54,6 +56,10 @@ export function createTerminalCommandLifecycle(options: TerminalCommandLifecycle
 
   const handleOsc133 = (payload: string): void => {
     const [sequence, exitCode] = payload.split(';')
+    if (sequence === 'C') {
+      options.onCommandStarted?.()
+      return
+    }
     if (sequence === 'D') {
       options.onCommandFinished(parseBestEffortExitCode(exitCode))
     }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1178,6 +1178,7 @@ export function useTerminalPaneLifecycle({
           useAppStore.getState().setCacheTimerStartedAt(paneKey, null)
           clearTerminalPaneUnread(paneKey)
           useAppStore.getState().dropAgentStatus(paneKey)
+          useAppStore.getState().clearPaneForegroundAgent(paneKey)
         }
         if (transport) {
           const ptyId = suppressIntentionalPaneCloseExit(

--- a/src/renderer/src/lib/use-tab-agent-process-signals.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-process-signals.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type { TerminalTab, TuiAgent } from '../../../shared/types'
+import { resolveTabAgentFromSignals, useTabAgent } from './use-tab-agent'
+
+const initialAppState = useAppStore.getInitialState()
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = makePaneKey('tab-1', LEAF_ID)
+let latestHookAgent: TuiAgent | null | undefined
+const hookRoots: Root[] = []
+
+function HookProbe({ tab }: { tab: TerminalTab }): null {
+  latestHookAgent = useTabAgent(tab)
+  return null
+}
+
+async function renderHookProbe(tab: TerminalTab): Promise<Root> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  hookRoots.push(root)
+  await act(async () => {
+    root.render(createElement(HookProbe, { tab }))
+  })
+  return root
+}
+
+async function setPaneForeground(entry: PaneForegroundAgentEntry): Promise<void> {
+  await act(async () => {
+    useAppStore.getState().setPaneForegroundAgent(PANE_KEY, entry)
+  })
+}
+
+describe('resolveTabAgentFromSignals process identity', () => {
+  it('ranks the recognized foreground process above title and launch bootstrap', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✦ Gemini CLI',
+        hookAgent: null,
+        processAgent: 'aider',
+        launchAgent: 'codex'
+      })
+    ).toBe('aider')
+  })
+
+  it('keeps live hook identity above process identity', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'Terminal 1',
+        hookAgent: 'claude',
+        processAgent: 'aider',
+        launchAgent: undefined
+      })
+    ).toBe('claude')
+  })
+
+  it('suppresses launch identity on shell-foreground evidence despite a stale agent title', () => {
+    // Why: OSC 133;D is process-grade exit proof — a TUI that died without
+    // restoring its title must not keep painting the tab.
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✳ Claude Code',
+        hookAgent: null,
+        processAgent: null,
+        processShellForeground: true,
+        launchAgent: 'claude'
+      })
+    ).toBeNull()
+  })
+
+  it('keeps launch identity while the recognized process is still in the foreground', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'zsh',
+        hookAgent: null,
+        processAgent: 'codex',
+        launchAgent: 'codex'
+      })
+    ).toBe('codex')
+  })
+})
+
+describe('useTabAgent process signals', () => {
+  const clearTabLaunchAgent = vi.fn()
+  const baseTab: TerminalTab = {
+    id: 'tab-1',
+    ptyId: 'pty-1',
+    worktreeId: 'wt-1',
+    title: 'Terminal 1',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+
+  beforeEach(() => {
+    latestHookAgent = undefined
+    clearTabLaunchAgent.mockReset()
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        }
+      },
+      agentStatusByPaneKey: {},
+      clearTabLaunchAgent
+    })
+  })
+
+  afterEach(() => {
+    hookRoots.splice(0).forEach((root) => {
+      act(() => root.unmount())
+    })
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+  })
+
+  it('shows the recognized foreground agent for a manual launch with no hooks or titles', async () => {
+    await renderHookProbe(baseTab)
+    expect(latestHookAgent).toBeNull()
+
+    await setPaneForeground({ agent: 'aider', shellForeground: false })
+
+    expect(latestHookAgent).toBe('aider')
+    expect(clearTabLaunchAgent).not.toHaveBeenCalled()
+  })
+
+  it('clears hookless launch identity on shell-foreground evidence despite a stale title', async () => {
+    const launchedTab = { ...baseTab, launchAgent: 'aider' as const, title: '⠸ aider working' }
+    const root = await renderHookProbe(launchedTab)
+
+    await setPaneForeground({ agent: 'aider', shellForeground: false })
+    expect(latestHookAgent).toBe('aider')
+    expect(clearTabLaunchAgent).not.toHaveBeenCalled()
+
+    // Why: OSC 133;D marks the launched command exiting; the stale spinner
+    // title must not keep the launch identity alive.
+    await setPaneForeground({ agent: null, shellForeground: true })
+    await act(async () => {
+      root.render(createElement(HookProbe, { tab: launchedTab }))
+    })
+
+    expect(clearTabLaunchAgent).toHaveBeenCalledWith('tab-1')
+  })
+
+  it('does not clear launch identity from shell foreground before any agent activity', async () => {
+    const launchedTab = { ...baseTab, launchAgent: 'aider' as const }
+    await renderHookProbe(launchedTab)
+
+    // Pre-start window: the shell prompt (or a quick setup command) finishing
+    // is not evidence the launched agent ever ran.
+    await setPaneForeground({ agent: null, shellForeground: true })
+
+    expect(latestHookAgent).toBe('aider')
+    expect(clearTabLaunchAgent).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -3,7 +3,7 @@ import { useAppStore } from '@/store'
 import { isShellProcess } from '../../../shared/agent-detection'
 import { worktreeUsesRemoteConnection } from '@/store/slices/terminals'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
-import { isTerminalLeafId } from '../../../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
 import {
   resolveFocusedCompletedTabAgent,
   resolveFocusedTabAgent,
@@ -37,12 +37,18 @@ export function resolveLaunchedAgentExitEvidence(args: {
   hookAgent: TuiAgent | null
   siblingHookAgent?: TuiAgent | null
   hasCompletedHook: boolean
+  processAgent?: TuiAgent | null
+  processShellForeground?: boolean
 }): boolean {
-  if (
-    !titleShowsNoAgent(args.title, args.defaultTitle) ||
-    args.hookAgent ||
-    args.siblingHookAgent
-  ) {
+  if (args.hookAgent || args.siblingHookAgent || args.processAgent) {
+    return false
+  }
+  // Why: OSC 133;D proved the foreground returned to the shell — process-grade
+  // exit evidence that doesn't depend on the agent leaving a clean title.
+  if (args.processShellForeground && args.hasObservedAgentSignal) {
+    return true
+  }
+  if (!titleShowsNoAgent(args.title, args.defaultTitle)) {
     return false
   }
   return args.hasCompletedHook || (!args.isRemote && args.hasObservedAgentSignal)
@@ -57,6 +63,8 @@ export function resolveTabAgentFromSignals(args: {
   siblingHookAgent?: TuiAgent | null
   focusedCompletedHookAgent?: TuiAgent | null
   siblingCompletedHookAgent?: TuiAgent | null
+  processAgent?: TuiAgent | null
+  processShellForeground?: boolean
   launchAgent?: TuiAgent
 }): TuiAgent | null {
   const launchAgent = args.launchAgent ?? null
@@ -92,15 +100,20 @@ export function resolveTabAgentFromSignals(args: {
     hasObservedAgentSignal: args.hasObservedAgentSignal,
     hookAgent: focusedHookAgent,
     siblingHookAgent: args.siblingHookAgent,
-    hasCompletedHook
+    hasCompletedHook,
+    processAgent: args.processAgent,
+    processShellForeground: args.processShellForeground
   })
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
+  const processAgent = args.processAgent ?? null
   // Why: titleAgent ranks ahead of launch/fallback hooks because, once the
   // pane has shown activity, a live explicit title is the freshest identity
   // signal — it beats a launchAgent gone stale through pane reuse. Before any
   // activity, titleAgent is null while launchAgent exists, so launch bootstrap
-  // still wins the startup window.
-  return focusedHookAgent ?? titleAgent ?? activeLaunchAgent ?? fallbackHookAgent
+  // still wins the startup window. Process identity (the recognized foreground
+  // process) is ground truth below hooks — it covers agents that emit neither
+  // hooks nor titles.
+  return focusedHookAgent ?? processAgent ?? titleAgent ?? activeLaunchAgent ?? fallbackHookAgent
 }
 
 /**
@@ -112,9 +125,14 @@ export function resolveTabAgentFromSignals(args: {
  * 1. Hook status — provider identity from native integrations; the live entry
  *    for the pane, dropped by the same OSC 133 command-finished machinery that
  *    clears the sidebar row when the process exits.
- * 2. launchAgent — what Orca launched here; instant bootstrap before hooks
- *    arrive, cleared once hook/title evidence shows the launched agent exited.
- * 3. Title — legacy/unknown-session fallback, and the live override when a pane
+ * 2. Process identity — the recognized foreground process, read at OSC 133
+ *    command boundaries (local panes only); covers agents that emit neither
+ *    hooks nor titles, and its shell-foreground mark is title-independent
+ *    exit evidence.
+ * 3. launchAgent — what Orca launched here; instant bootstrap before hooks
+ *    arrive, cleared once hook/process/title evidence shows the launched
+ *    agent exited.
+ * 4. Title — legacy/unknown-session fallback, and the live override when a pane
  *    is reused: once the pane has shown activity, a title that explicitly names
  *    a different agent than launchAgent wins over that stale launch identity.
  *    Otherwise it is ignored while launchAgent exists, and generic spinner-only
@@ -143,6 +161,18 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
   )
   const hasCompletedHook = focusedCompletedHookAgent !== null
   const clearTabLaunchAgent = useAppStore((s) => s.clearTabLaunchAgent)
+  const focusedPaneKey = useAppStore((s) => {
+    const activeLeafId = s.terminalLayoutsByTabId[tab.id]?.activeLeafId
+    return activeLeafId && isTerminalLeafId(activeLeafId) ? makePaneKey(tab.id, activeLeafId) : null
+  })
+  const processAgent = useAppStore((s) =>
+    focusedPaneKey ? (s.paneForegroundAgentByPaneKey[focusedPaneKey]?.agent ?? null) : null
+  )
+  const processShellForeground = useAppStore((s) =>
+    focusedPaneKey
+      ? Boolean(s.paneForegroundAgentByPaneKey[focusedPaneKey]?.shellForeground)
+      : false
+  )
 
   // The focused pane's PTY (single-pane tabs have exactly one leaf). Only used
   // to reset per-process-generation signals when the pane is respawned.
@@ -199,7 +229,9 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     const fallbackAgentSignal = tab.launchAgent
       ? explicitTitleAgent === tab.launchAgent
       : Boolean(explicitTitleAgent || siblingHookAgent)
-    if (focusedHookAgent || completedHookEvidence || fallbackAgentSignal) {
+    // Why: a recognized foreground process is focused-pane ground truth, so it
+    // arms exit clearing even for agents with no hook or title integration.
+    if (focusedHookAgent || completedHookEvidence || processAgent || fallbackAgentSignal) {
       hasObservedAgentSignalRef.current = true
       setHasObservedAgentSignal(true)
     }
@@ -208,6 +240,7 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     isRemoteLike,
     focusedHookAgent,
     completedHookEvidence,
+    processAgent,
     siblingHookAgent,
     tab.launchAgent,
     tab.title
@@ -227,7 +260,9 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
       hasObservedAgentSignal: hasObservedAgentSignal && hasObservedAgentSignalRef.current,
       hookAgent: focusedHookAgent,
       siblingHookAgent,
-      hasCompletedHook: completedHookEvidence
+      hasCompletedHook: completedHookEvidence,
+      processAgent,
+      processShellForeground
     })
     if (launchedAgentExited) {
       clearTabLaunchAgent(tab.id)
@@ -239,6 +274,8 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     siblingHookAgent,
     hasObservedAgentSignal,
     isRemoteLike,
+    processAgent,
+    processShellForeground,
     tab.defaultTitle,
     tab.id,
     tab.launchAgent,
@@ -254,6 +291,8 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     siblingHookAgent,
     focusedCompletedHookAgent,
     siblingCompletedHookAgent,
+    processAgent,
+    processShellForeground,
     launchAgent: tab.launchAgent
   })
 }

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -24,6 +24,7 @@ import { createBrowserSlice } from './slices/browser'
 import { createRateLimitSlice } from './slices/rate-limits'
 import { createSshSlice } from './slices/ssh'
 import { createAgentStatusSlice } from './slices/agent-status'
+import { createPaneForegroundAgentSlice } from './slices/pane-foreground-agent'
 import { createDiffCommentsSlice } from './slices/diffComments'
 import { createDetectedAgentsSlice } from './slices/detected-agents'
 import { createWorktreeNavHistorySlice } from './slices/worktree-nav-history'
@@ -61,6 +62,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createRateLimitSlice(...a),
   ...createSshSlice(...a),
   ...createAgentStatusSlice(...a),
+  ...createPaneForegroundAgentSlice(...a),
   ...createDiffCommentsSlice(...a),
   ...createDetectedAgentsSlice(...a),
   ...createWorktreeNavHistorySlice(...a),

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -131,6 +131,7 @@ import { createBrowserSlice } from './browser'
 import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
 import { createAgentStatusSlice } from './agent-status'
+import { createPaneForegroundAgentSlice } from './pane-foreground-agent'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
@@ -167,6 +168,7 @@ function createTestStore() {
     ...createRateLimitSlice(...a),
     ...createSshSlice(...a),
     ...createAgentStatusSlice(...a),
+    ...createPaneForegroundAgentSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a),

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -1,0 +1,56 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import type { TuiAgent } from '../../../../shared/types'
+
+export type PaneForegroundAgentEntry = {
+  /** Recognized agent process in the pane's foreground; null when unknown. */
+  agent: TuiAgent | null
+  /** True once the foreground is proven back at the shell (OSC 133;D) —
+   *  process-grade launched-agent exit evidence, independent of titles. */
+  shellForeground: boolean
+}
+
+/**
+ * Process-table identity for local panes, read at OSC 133 command boundaries
+ * (see pane-foreground-agent-tracker). Sits below hook rows in the tab-icon
+ * resolution; covers agents that emit neither hooks nor titles.
+ */
+export type PaneForegroundAgentSlice = {
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
+  setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
+  clearPaneForegroundAgent: (paneKey: string) => void
+}
+
+export const createPaneForegroundAgentSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  PaneForegroundAgentSlice
+> = (set) => ({
+  paneForegroundAgentByPaneKey: {},
+  setPaneForegroundAgent: (paneKey, entry) => {
+    set((s) => {
+      const current = s.paneForegroundAgentByPaneKey[paneKey]
+      if (
+        current &&
+        current.agent === entry.agent &&
+        current.shellForeground === entry.shellForeground
+      ) {
+        return s
+      }
+      return {
+        paneForegroundAgentByPaneKey: { ...s.paneForegroundAgentByPaneKey, [paneKey]: entry }
+      }
+    })
+  },
+  clearPaneForegroundAgent: (paneKey) => {
+    set((s) => {
+      if (!(paneKey in s.paneForegroundAgentByPaneKey)) {
+        return s
+      }
+      const next = { ...s.paneForegroundAgentByPaneKey }
+      delete next[paneKey]
+      return { paneForegroundAgentByPaneKey: next }
+    })
+  }
+})

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -32,6 +32,7 @@ import { createBrowserSlice } from './browser'
 import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
 import { createAgentStatusSlice } from './agent-status'
+import { createPaneForegroundAgentSlice } from './pane-foreground-agent'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
@@ -77,6 +78,7 @@ export function createTestStore() {
     ...createRateLimitSlice(...a),
     ...createSshSlice(...a),
     ...createAgentStatusSlice(...a),
+    ...createPaneForegroundAgentSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),
     ...createWorktreeNavHistorySlice(...a),

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -22,6 +22,7 @@ import type { BrowserSlice } from './slices/browser'
 import type { RateLimitSlice } from './slices/rate-limits'
 import type { SshSlice } from './slices/ssh'
 import type { AgentStatusSlice } from './slices/agent-status'
+import type { PaneForegroundAgentSlice } from './slices/pane-foreground-agent'
 import type { DiffCommentsSlice } from './slices/diffComments'
 import type { DetectedAgentsSlice } from './slices/detected-agents'
 import type { WorktreeNavHistorySlice } from './slices/worktree-nav-history'
@@ -56,6 +57,7 @@ export type AppState = RepoSlice &
   RateLimitSlice &
   SshSlice &
   AgentStatusSlice &
+  PaneForegroundAgentSlice &
   DiffCommentsSlice &
   DetectedAgentsSlice &
   WorktreeNavHistorySlice &


### PR DESCRIPTION
## Summary
Stacked on #7059. Restores the one capability the probe removal genuinely lost — process-table identity for agents that emit **neither hooks nor titles** (aider/goose-class, manual launches) — without resurrecting the parallel per-tab probe pipeline that #7059 was directed to remove.

Process identity is now a **producer into the shared store**, read at OSC 133 command boundaries, and consumed by the same tab-icon resolver that layers hook/title/launch evidence. One identity hub; no per-tab probe state machine, no retry ladders, no per-title-frame RPCs.

## How it works
- **Trigger**: `terminal-command-lifecycle` (the existing OSC 133 parser riding on data xterm already parses — zero new stream scanning) now also surfaces `133;C` (command started). That is exactly the moment a pane's foreground changes.
- **Read**: on C, a new `pane-foreground-agent-tracker` waits a short settle (350ms), reads `getForegroundProcess` once (the still-alive daemon RPC with shell/helper→agent ancestry resolution), and maps it through the shared `recognizeAgentProcess` (covers all `TUI_AGENT_CONFIG` agents). If the read still sees an interpreter wrapper (`node`/`python`), one bounded re-read (1.2s) — not a retry ladder.
- **Clear**: on `133;D`, the tracker marks shell-foreground with **no RPC at all** — D itself proves the foreground command exited back to the prompt. A new C immediately clears that mark (the foreground left the prompt), closing the stale-evidence window.
- **Store**: `paneForegroundAgentByPaneKey` (new slice) — pane-keyed `{ agent, shellForeground }`, cleaned up at the existing pane-close and PTY-exit teardown sites.
- **Consumption**: the tab resolver ranks process identity **below live hook rows, above titles/launch bootstrap**, and `resolveLaunchedAgentExitEvidence` treats the shell-foreground mark as **title-independent** exit evidence — a TUI that dies without restoring its title no longer keeps painting the tab. A recognized foreground process also arms exit clearing (`hasObservedAgentSignal`) for launched agents with no hook/title integration.

## Scope guards
- **Local panes only.** Remote/SSH pty ids never read (15s-timeout RPC) and never publish — replayed/mirrored OSC streams on reconnect must not fabricate process evidence. Remote behavior is byte-identical to #7059.
- **Requires shell integration** (OSC 133) — the same dependency #7059's hook-row lifecycle already has. Without it the feature is inert and behavior is unchanged.
- Stale read results are dropped by generation; dispose cancels timers.

## What this fixes (vs #7059 alone)
- Manual `aider`/`goose`/etc. in a plain terminal tab: correct icon while running (was: no icon).
- Orca-launched hookless agents: launch icon clears on exit via process evidence (was: stale forever).
- Launched agents that die leaving a stuck title: exit now proven by 133;D instead of title heuristics.

## Deferred
- Sidebar rows for process-only agents (they have no state machine; today's sidebar never showed them, so no regression) — possible follow-up if we want full surface parity for hookless agents.
- Serve-mode/headless hosts have no renderer to run the tracker; same coverage boundary as the pre-#7059 probe.

## Checks
- `pnpm exec vitest run` over `pane-foreground-agent-tracker.test.ts` (8), `use-tab-agent-process-signals.test.ts` (7), plus the full `terminal-pane/`, `use-tab-agent`, `tab-agent`, `diffComments` suites — 1526 tests passed
- Regression pins: read only on C (settle + single wrapper re-read), D publishes shell-foreground with zero RPCs, remote/ssh ids never read or publish, stale reads dropped on supersede, dispose cancels; resolver ranks hooks > process > title > launch; shell-foreground clears launch despite a stale agent title; shell-foreground before any agent activity does not clear.
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed

Made with [Orca](https://github.com/stablyai/orca) 🐋
