### PR TITLE
Allow manual sorting of Project Groups

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -135,6 +135,8 @@ import {
 } from '@/lib/scroll-to-current-workspace-status'
 import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
 import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
+import { useProjectGroupHeaderDrag } from './project-group-header-drag'
+import { getSidebarOrderedProjectGroupHeaderIdsByBucket } from './project-group-header-drop'
 import {
   buildManualOrderUpdatesForGroupDrop,
   buildManualOrderUpdatesForVisibleGroups,
@@ -1377,7 +1379,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const suppressWorktreeClickUntilRef = useRef(0)
   const hasProjectGroups = projectGroups.length > 0
   const canReorderRepoHeaders = groupBy === 'repo' && projectOrderBy === 'manual'
+  const canReorderProjectGroupHeaders = groupBy === 'repo' && hasProjectGroups
   const moveProjectToGroup = useAppStore((s) => s.moveProjectToGroup)
+  const updateProjectGroup = useAppStore((s) => s.updateProjectGroup)
   const lastVisibleRefreshKeyRef = useRef('')
   const reportVisibleGitHubPRRefreshCandidates = useAppStore(
     (s) => s.reportVisibleGitHubPRRefreshCandidates
@@ -1397,6 +1401,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           .filter((group) => group.createdFrom === 'folder-scan')
           .map((group) => group.id)
       ),
+    [projectGroups]
+  )
+  const projectGroupByIdForHeaderDrag = useMemo(
+    () => new Map(projectGroups.map((group) => [group.id, group])),
     [projectGroups]
   )
 
@@ -1567,6 +1575,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       ),
     [rows]
   )
+  const sidebarProjectGroupHeaderIdsByBucket = useMemo(
+    () =>
+      getSidebarOrderedProjectGroupHeaderIdsByBucket(
+        rows.filter((row): row is Row => row.type !== 'host-header'),
+        projectGroupByIdForHeaderDrag
+      ),
+    [projectGroupByIdForHeaderDrag, rows]
+  )
   const repoHeaderIndexByRepoId = useMemo(() => {
     const map = new Map<string, number>()
     for (const repoIds of sidebarRepoHeaderIdsByBucket.values()) {
@@ -1585,11 +1601,42 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     }
     return map
   }, [sidebarRepoHeaderIdsByBucket])
+  const projectGroupHeaderIndexByGroupId = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const groupIds of sidebarProjectGroupHeaderIdsByBucket.values()) {
+      groupIds.forEach((groupId, index) => {
+        map.set(groupId, index)
+      })
+    }
+    return map
+  }, [sidebarProjectGroupHeaderIdsByBucket])
+  const projectGroupHeaderBucketByGroupId = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const [bucketKey, groupIds] of sidebarProjectGroupHeaderIdsByBucket) {
+      for (const groupId of groupIds) {
+        map.set(groupId, bucketKey)
+      }
+    }
+    return map
+  }, [sidebarProjectGroupHeaderIdsByBucket])
   const commitProjectGroupOrder = useCallback(
     (repoId: string, projectGroupId: string | null, order: number) => {
       void moveProjectToGroup(repoId, projectGroupId, order)
     },
     [moveProjectToGroup]
+  )
+  const commitProjectGroupHeaderOrder = useCallback(
+    (groupId: string, tabOrder: number) => {
+      if (!Number.isFinite(tabOrder)) {
+        return
+      }
+      const suppressUntil =
+        window.performance.now() + USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS
+      suppressMeasurementAdjustmentUntilRef.current = suppressUntil
+      directScrollInputUntilRef.current = suppressUntil
+      void updateProjectGroup(groupId, { tabOrder })
+    },
+    [updateProjectGroup]
   )
   // Drag is only meaningful when repo headers are using manual order. The
   // controller is still constructed for hook order stability when inert.
@@ -1600,6 +1647,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     usesProjectGroupOrdering: hasProjectGroups,
     onCommitRepoOrder: commitRepoReorder,
     onCommitProjectGroupOrder: commitProjectGroupOrder,
+    getScrollContainer: () => scrollRef.current
+  })
+  const projectGroupDrag = useProjectGroupHeaderDrag({
+    sidebarProjectGroupHeaderIdsByBucket,
+    projectGroupById: projectGroupByIdForHeaderDrag,
+    onCommitProjectGroupTabOrder: commitProjectGroupHeaderOrder,
     getScrollContainer: () => scrollRef.current
   })
   const [primaryActiveWorktreeRow, setPrimaryActiveWorktreeRow] = useState<{
@@ -3909,6 +3962,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               style={{ top: `${repoDrag.state.dropIndicatorY}px` }}
             />
           ) : null}
+          {canReorderProjectGroupHeaders &&
+          projectGroupDrag.state.draggingGroupId !== null &&
+          projectGroupDrag.state.dropIndicatorY !== null ? (
+            <div
+              role="presentation"
+              className="pointer-events-none absolute left-2 right-2 z-30 border-t border-dashed border-muted-foreground/70"
+              style={{ top: `${projectGroupDrag.state.dropIndicatorY}px` }}
+            />
+          ) : null}
           {hostDrag.state.draggingHostId !== null && hostDrag.state.dropIndicatorY !== null ? (
             <div
               role="presentation"
@@ -3998,6 +4060,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               const isRepoHeader = groupBy === 'repo' && row.repo !== undefined
               const isProjectGroupHeader = groupBy === 'repo' && row.projectGroup !== undefined
               const projectIdForHeader = isRepoHeader ? row.repo!.id : undefined
+              const projectGroupIdForHeader =
+                isProjectGroupHeader && !row.repo && typeof row.projectGroup?.id === 'string'
+                  ? row.projectGroup.id
+                  : undefined
               const repoHeaderIndex =
                 projectIdForHeader !== undefined
                   ? repoHeaderIndexByRepoId.get(projectIdForHeader)
@@ -4006,6 +4072,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 projectIdForHeader !== undefined
                   ? repoHeaderBucketByRepoId.get(projectIdForHeader)
                   : undefined
+              const projectGroupHeaderIndex =
+                projectGroupIdForHeader !== undefined
+                  ? projectGroupHeaderIndexByGroupId.get(projectGroupIdForHeader)
+                  : undefined
+              const projectGroupHeaderBucketKey =
+                projectGroupIdForHeader !== undefined
+                  ? projectGroupHeaderBucketByGroupId.get(projectGroupIdForHeader)
+                  : undefined
               const isDraggableRepoHeader = Boolean(
                 canReorderRepoHeaders &&
                 isRepoHeader &&
@@ -4013,10 +4087,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 repoHeaderBucketKey &&
                 (sidebarRepoHeaderIdsByBucket.get(repoHeaderBucketKey)?.length ?? 0) > 1
               )
+              const isDraggableProjectGroupHeader = Boolean(
+                canReorderProjectGroupHeaders &&
+                projectGroupIdForHeader &&
+                projectGroupHeaderBucketKey &&
+                (sidebarProjectGroupHeaderIdsByBucket.get(projectGroupHeaderBucketKey)?.length ??
+                  0) > 1
+              )
               const isDraggingThis =
                 canReorderRepoHeaders &&
                 repoDrag.state.draggingRepoId !== null &&
                 repoDrag.state.draggingRepoId === projectIdForHeader
+              const isDraggingThisProjectGroup =
+                canReorderProjectGroupHeaders &&
+                projectGroupDrag.state.draggingGroupId !== null &&
+                projectGroupDrag.state.draggingGroupId === projectGroupIdForHeader
               const headerWorkspaceStatus =
                 groupBy === 'workspace-status'
                   ? getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses)
@@ -4100,6 +4185,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     data-repo-header-id={projectIdForHeader}
                     data-repo-header-index={repoHeaderIndex}
                     data-repo-header-bucket={repoHeaderBucketKey}
+                    data-project-group-header-id={projectGroupIdForHeader}
+                    data-project-group-header-index={projectGroupHeaderIndex}
+                    data-project-group-header-bucket={projectGroupHeaderBucketKey}
                     data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
                     data-workspace-status={headerWorkspaceStatus ?? undefined}
                     data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
@@ -4108,7 +4196,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       'cursor-pointer',
                       highlightedRevealRowKey === row.key &&
                         'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/50',
-                      isDraggingThis &&
+                      (isDraggingThis || isDraggingThisProjectGroup) &&
                         'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
                       headerWorkspaceStatus &&
                         dragOverStatus === headerWorkspaceStatus &&
@@ -4157,15 +4245,25 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     {row.icon ? (
                       <div
                         data-repo-header-drag-handle={isDraggableRepoHeader ? '' : undefined}
+                        data-project-group-header-drag-handle={
+                          isDraggableProjectGroupHeader ? '' : undefined
+                        }
                         className={cn(
                           'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
                           repoHeaderColor ? 'text-muted-foreground' : row.tone,
-                          isDraggableRepoHeader && 'hover:cursor-grab active:cursor-grabbing'
+                          (isDraggableRepoHeader || isDraggableProjectGroupHeader) &&
+                            'hover:cursor-grab active:cursor-grabbing'
                         )}
                         onPointerDown={
                           isDraggableRepoHeader && projectIdForHeader
                             ? (event) => repoDrag.onHandlePointerDown(event, projectIdForHeader)
-                            : undefined
+                            : isDraggableProjectGroupHeader && projectGroupIdForHeader
+                              ? (event) =>
+                                  projectGroupDrag.onHandlePointerDown(
+                                    event,
+                                    projectGroupIdForHeader
+                                  )
+                              : undefined
                         }
                       >
                         {row.repo ? (

--- a/src/renderer/src/components/sidebar/project-group-header-dom.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-dom.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+function readWorktreeListSource(): string {
+  return readFileSync(fileURLToPath(new URL('./WorktreeList.tsx', import.meta.url)), 'utf8')
+}
+
+describe('Project Group header drag DOM source', () => {
+  it('renders concrete Project Group header drag attributes separately from repo headers', () => {
+    const source = readWorktreeListSource()
+
+    expect(source).toContain('data-project-group-header-id={projectGroupIdForHeader}')
+    expect(source).toContain('data-project-group-header-index={projectGroupHeaderIndex}')
+    expect(source).toContain('data-project-group-header-bucket={projectGroupHeaderBucketKey}')
+    expect(source).toContain('data-project-group-header-drag-handle=')
+  })
+
+  it('commits Project Group manual sorting through updateProjectGroup tabOrder', () => {
+    const source = readWorktreeListSource()
+
+    expect(source).toContain('const updateProjectGroup = useAppStore((s) => s.updateProjectGroup)')
+    expect(source).toContain('void updateProjectGroup(groupId, { tabOrder })')
+  })
+})

--- a/src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+
+import { commitProjectGroupHeaderDragDrop } from './project-group-header-drag-commit'
+import type { ProjectGroupHeaderDragSession } from './project-group-header-drag-contract'
+import type { ProjectGroup } from '../../../../shared/types'
+
+function group(id: string, overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeSession(
+  groupId: string,
+  sidebarProjectGroupHeaderIds: readonly string[]
+): ProjectGroupHeaderDragSession {
+  return {
+    groupId,
+    bucketKey: 'root',
+    sidebarProjectGroupHeaderIds,
+    pointerId: 1,
+    headerRects: [],
+    handleEl: document.createElement('div'),
+    startX: 0,
+    startY: 0,
+    latestPointerY: 0,
+    promoted: true
+  }
+}
+
+describe('commitProjectGroupHeaderDragDrop', () => {
+  it('commits a finite tabOrder for the dragged Project Group', () => {
+    const onCommitProjectGroupTabOrder = vi.fn()
+    const groups = [
+      group('a', { tabOrder: 0 }),
+      group('b', { tabOrder: 10 }),
+      group('c', { tabOrder: 20 })
+    ]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+
+    commitProjectGroupHeaderDragDrop({
+      session: makeSession('c', ['a', 'b', 'c']),
+      sidebarDropIndex: 0,
+      projectGroupById,
+      onCommitProjectGroupTabOrder
+    })
+
+    expect(onCommitProjectGroupTabOrder).toHaveBeenCalledWith('c', -1)
+  })
+
+  it('computes order only from the captured sibling bucket', () => {
+    const onCommitProjectGroupTabOrder = vi.fn()
+    const root = group('root')
+    const siblingA = group('sibling-a', { parentGroupId: root.id, tabOrder: 0 })
+    const siblingB = group('sibling-b', { parentGroupId: root.id, tabOrder: 10 })
+    const otherParentGroup = group('other-parent-group', { tabOrder: -100 })
+    const projectGroupById = new Map(
+      [root, siblingA, siblingB, otherParentGroup].map((entry) => [entry.id, entry])
+    )
+
+    commitProjectGroupHeaderDragDrop({
+      session: makeSession('sibling-b', ['sibling-a', 'sibling-b']),
+      sidebarDropIndex: 0,
+      projectGroupById,
+      onCommitProjectGroupTabOrder
+    })
+
+    expect(onCommitProjectGroupTabOrder).toHaveBeenCalledWith('sibling-b', -1)
+  })
+
+  it('does not commit when the drop keeps the group in the same slot', () => {
+    const onCommitProjectGroupTabOrder = vi.fn()
+    const groups = [group('a'), group('b'), group('c')]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+
+    commitProjectGroupHeaderDragDrop({
+      session: makeSession('b', ['a', 'b', 'c']),
+      sidebarDropIndex: 2,
+      projectGroupById,
+      onCommitProjectGroupTabOrder
+    })
+
+    expect(onCommitProjectGroupTabOrder).not.toHaveBeenCalled()
+  })
+
+  it('does not commit when a stale session no longer contains the dragged group', () => {
+    const onCommitProjectGroupTabOrder = vi.fn()
+    const groups = [group('a'), group('b'), group('c')]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+
+    commitProjectGroupHeaderDragDrop({
+      session: makeSession('c', ['a', 'b']),
+      sidebarDropIndex: 0,
+      projectGroupById,
+      onCommitProjectGroupTabOrder
+    })
+
+    expect(onCommitProjectGroupTabOrder).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/project-group-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-commit.ts
@@ -1,0 +1,50 @@
+import {
+  getProjectGroupTabOrderForSidebarDrop,
+  mapSidebarProjectGroupDropIndexToSiblingInsertIndex
+} from './project-group-header-drop'
+import type { ProjectGroupHeaderDragSession } from './project-group-header-drag-contract'
+import type { ProjectGroup } from '../../../../shared/types'
+
+export function commitProjectGroupHeaderDragDrop(args: {
+  session: ProjectGroupHeaderDragSession
+  sidebarDropIndex: number
+  projectGroupById: ReadonlyMap<string, ProjectGroup>
+  onCommitProjectGroupTabOrder: (groupId: string, tabOrder: number) => void
+}): void {
+  const draggedGroup = args.projectGroupById.get(args.session.groupId)
+  if (!draggedGroup) {
+    return
+  }
+
+  const sidebarProjectGroupHeaderIds = args.session.sidebarProjectGroupHeaderIds
+  const sourceIndex = sidebarProjectGroupHeaderIds.indexOf(args.session.groupId)
+  if (sourceIndex === -1) {
+    return
+  }
+  if (args.sidebarDropIndex === sourceIndex) {
+    return
+  }
+
+  const siblings = sidebarProjectGroupHeaderIds
+    .filter((groupId) => groupId !== args.session.groupId)
+    .map((groupId) => args.projectGroupById.get(groupId))
+    .filter((group): group is ProjectGroup => group !== undefined)
+  const siblingDropIndex = mapSidebarProjectGroupDropIndexToSiblingInsertIndex({
+    sidebarDropIndex: args.sidebarDropIndex,
+    sourceIndex,
+    siblingCount: siblings.length
+  })
+  const sourceIndexInSiblings = Math.min(sourceIndex, siblings.length)
+  if (siblingDropIndex === sourceIndexInSiblings) {
+    return
+  }
+
+  const tabOrder = getProjectGroupTabOrderForSidebarDrop({
+    siblings,
+    dropIndex: siblingDropIndex
+  })
+  if (!Number.isFinite(tabOrder)) {
+    return
+  }
+  args.onCommitProjectGroupTabOrder(draggedGroup.id, tabOrder)
+}

--- a/src/renderer/src/components/sidebar/project-group-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-contract.ts
@@ -1,0 +1,77 @@
+import type { PointerEvent } from 'react'
+
+import type {
+  ProjectGroupHeaderDragBucketKey,
+  ProjectGroupHeaderDragRect
+} from './project-group-header-drop'
+import type { ProjectGroup } from '../../../../shared/types'
+
+export type ProjectGroupDragState = {
+  draggingGroupId: string | null
+  dropIndex: number | null
+  dropIndicatorY: number | null
+}
+
+export const INITIAL_PROJECT_GROUP_DRAG_STATE: ProjectGroupDragState = {
+  draggingGroupId: null,
+  dropIndex: null,
+  dropIndicatorY: null
+}
+
+export type UseProjectGroupHeaderDragArgs = {
+  sidebarProjectGroupHeaderIdsByBucket: ReadonlyMap<
+    ProjectGroupHeaderDragBucketKey,
+    readonly string[]
+  >
+  projectGroupById: ReadonlyMap<string, ProjectGroup>
+  onCommitProjectGroupTabOrder: (groupId: string, tabOrder: number) => void
+  getScrollContainer: () => HTMLElement | null
+}
+
+export type ProjectGroupHeaderDragController = {
+  state: ProjectGroupDragState
+  onHandlePointerDown: (event: PointerEvent<HTMLElement>, groupId: string) => void
+}
+
+export type ProjectGroupHeaderDragSession = {
+  groupId: string
+  bucketKey: ProjectGroupHeaderDragBucketKey
+  sidebarProjectGroupHeaderIds: readonly string[]
+  pointerId: number
+  headerRects: ProjectGroupHeaderDragRect[]
+  handleEl: HTMLElement
+  startX: number
+  startY: number
+  latestPointerY: number
+  promoted: boolean
+}
+
+export const PROJECT_GROUP_HEADER_DRAG_THRESHOLD_PX = 4
+
+const PROJECT_GROUP_HEADER_DRAG_HANDLE_SELECTOR = '[data-project-group-header-drag-handle]'
+
+const PROJECT_GROUP_HEADER_ACTION_SELECTOR =
+  '[data-repo-header-action], [data-repo-header-collapse-affordance], button, a, input, textarea, select, [contenteditable=""], [contenteditable="true"]'
+
+export function isProjectGroupHeaderDragHandleTarget(
+  target: EventTarget | null,
+  currentTarget: HTMLElement
+): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  const dragHandle = target.closest(PROJECT_GROUP_HEADER_DRAG_HANDLE_SELECTOR)
+  return dragHandle !== null && currentTarget.contains(dragHandle)
+}
+
+export function isProjectGroupHeaderActionTarget(
+  target: EventTarget | null,
+  currentTarget: HTMLElement
+): boolean {
+  if (!(target instanceof HTMLElement) || target === currentTarget) {
+    return false
+  }
+  return (
+    currentTarget.contains(target) && target.closest(PROJECT_GROUP_HEADER_ACTION_SELECTOR) !== null
+  )
+}

--- a/src/renderer/src/components/sidebar/project-group-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-start.ts
@@ -1,0 +1,64 @@
+import type { PointerEvent } from 'react'
+
+import {
+  getProjectGroupHeaderDragBucketKey,
+  measureProjectGroupHeaderDragRects,
+  type ProjectGroupHeaderDragBucketKey
+} from './project-group-header-drop'
+import {
+  isProjectGroupHeaderActionTarget,
+  isProjectGroupHeaderDragHandleTarget,
+  type ProjectGroupHeaderDragSession
+} from './project-group-header-drag-contract'
+import type { ProjectGroup } from '../../../../shared/types'
+
+export function createProjectGroupHeaderDragSession(args: {
+  event: PointerEvent<HTMLElement>
+  groupId: string
+  projectGroupById: ReadonlyMap<string, ProjectGroup>
+  sidebarProjectGroupHeaderIdsByBucket: ReadonlyMap<
+    ProjectGroupHeaderDragBucketKey,
+    readonly string[]
+  >
+  getScrollContainer: () => HTMLElement | null
+}): ProjectGroupHeaderDragSession | null {
+  if (args.event.button !== 0) {
+    return null
+  }
+  if (!isProjectGroupHeaderDragHandleTarget(args.event.target, args.event.currentTarget)) {
+    return null
+  }
+  if (isProjectGroupHeaderActionTarget(args.event.target, args.event.currentTarget)) {
+    return null
+  }
+  const group = args.projectGroupById.get(args.groupId)
+  if (!group) {
+    return null
+  }
+  const bucketKey = getProjectGroupHeaderDragBucketKey(group, args.projectGroupById)
+  const sidebarProjectGroupHeaderIds =
+    args.sidebarProjectGroupHeaderIdsByBucket.get(bucketKey) ?? []
+  // Why: a lone group in a parent bucket cannot move without reparenting.
+  if (sidebarProjectGroupHeaderIds.length <= 1) {
+    return null
+  }
+  const container = args.getScrollContainer()
+  if (!container) {
+    return null
+  }
+  const handleEl = args.event.currentTarget
+  // Why: defer pointer capture until the threshold so ordinary group header
+  // clicks still toggle collapse through the row handler.
+  return {
+    groupId: args.groupId,
+    bucketKey,
+    sidebarProjectGroupHeaderIds,
+    pointerId: args.event.pointerId,
+    headerRects: measureProjectGroupHeaderDragRects(container, bucketKey),
+    handleEl,
+    startX: args.event.clientX,
+    startY: args.event.clientY,
+    latestPointerY: args.event.clientY,
+    promoted: false
+  }
+}

--- a/src/renderer/src/components/sidebar/project-group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag.ts
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import {
+  computeProjectGroupHeaderDropPreview,
+  measureProjectGroupHeaderDragRects
+} from './project-group-header-drop'
+import { commitProjectGroupHeaderDragDrop } from './project-group-header-drag-commit'
+import {
+  INITIAL_PROJECT_GROUP_DRAG_STATE,
+  PROJECT_GROUP_HEADER_DRAG_THRESHOLD_PX,
+  type ProjectGroupDragState,
+  type ProjectGroupHeaderDragController,
+  type ProjectGroupHeaderDragSession,
+  type UseProjectGroupHeaderDragArgs
+} from './project-group-header-drag-contract'
+import { createProjectGroupHeaderDragSession } from './project-group-header-drag-start'
+import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+
+// Why pointer events instead of HTML5 DnD: Project Group rows are virtualized
+// and may unmount while scrolling; cached row-model indices keep drops stable.
+
+export function useProjectGroupHeaderDrag({
+  sidebarProjectGroupHeaderIdsByBucket,
+  projectGroupById,
+  onCommitProjectGroupTabOrder,
+  getScrollContainer
+}: UseProjectGroupHeaderDragArgs): ProjectGroupHeaderDragController {
+  const [state, setState] = useState<ProjectGroupDragState>(INITIAL_PROJECT_GROUP_DRAG_STATE)
+  const [sessionArmed, setSessionArmed] = useState(false)
+  const latestDropIndexRef = useRef<number | null>(null)
+  latestDropIndexRef.current = state.dropIndex
+  const sidebarProjectGroupHeaderIdsByBucketRef = useRef(sidebarProjectGroupHeaderIdsByBucket)
+  sidebarProjectGroupHeaderIdsByBucketRef.current = sidebarProjectGroupHeaderIdsByBucket
+  const projectGroupByIdRef = useRef(projectGroupById)
+  projectGroupByIdRef.current = projectGroupById
+  const onCommitProjectGroupTabOrderRef = useRef(onCommitProjectGroupTabOrder)
+  onCommitProjectGroupTabOrderRef.current = onCommitProjectGroupTabOrder
+  const getContainerRef = useRef(getScrollContainer)
+  getContainerRef.current = getScrollContainer
+  const autoscrollLastFrameTimeRef = useRef<number | null>(null)
+  const autoscrollFrameIdRef = useRef<number | null>(null)
+
+  const dragSessionRef = useRef<ProjectGroupHeaderDragSession | null>(null)
+  const clickSwallowTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const refreshHeaderRects = useCallback(() => {
+    const container = getContainerRef.current()
+    const session = dragSessionRef.current
+    if (!container || !session) {
+      return []
+    }
+    const rects = measureProjectGroupHeaderDragRects(container, session.bucketKey)
+    session.headerRects = rects
+    return rects
+  }, [])
+
+  const computeDrop = useCallback(
+    (pointerY: number): { dropIndex: number; dropIndicatorY: number } | null => {
+      const session = dragSessionRef.current
+      const container = getContainerRef.current()
+      if (!session || !container) {
+        return null
+      }
+      const containerRect = container.getBoundingClientRect()
+      return computeProjectGroupHeaderDropPreview({
+        pointerY,
+        containerTop: containerRect.top,
+        scrollTop: container.scrollTop,
+        rects: session.headerRects,
+        sidebarProjectGroupHeaderIds: session.sidebarProjectGroupHeaderIds
+      })
+    },
+    []
+  )
+
+  const cancelAutoscroll = useCallback(() => {
+    if (autoscrollFrameIdRef.current !== null) {
+      window.cancelAnimationFrame(autoscrollFrameIdRef.current)
+      autoscrollFrameIdRef.current = null
+    }
+    autoscrollLastFrameTimeRef.current = null
+  }, [])
+
+  const endDrag = useCallback(
+    (commit: boolean) => {
+      cancelAutoscroll()
+      const session = dragSessionRef.current
+      if (!session) {
+        setState(INITIAL_PROJECT_GROUP_DRAG_STATE)
+        setSessionArmed(false)
+        return
+      }
+      try {
+        session.handleEl.releasePointerCapture(session.pointerId)
+      } catch {
+        // capture may already be released (pointercancel, element unmounted)
+      }
+      if (session.promoted) {
+        const handleEl = session.handleEl
+        const swallow = (event: MouseEvent): void => {
+          const target = event.target as Node | null
+          if (target && handleEl.contains(target)) {
+            event.stopPropagation()
+            event.preventDefault()
+          }
+          window.removeEventListener('click', swallow, true)
+        }
+        window.addEventListener('click', swallow, true)
+        clickSwallowTimeoutRef.current = setTimeout(() => {
+          window.removeEventListener('click', swallow, true)
+          clickSwallowTimeoutRef.current = null
+        }, 0)
+      }
+      const sidebarDropIndex =
+        commit && session.promoted && latestDropIndexRef.current !== null
+          ? latestDropIndexRef.current
+          : null
+      dragSessionRef.current = null
+      setState(INITIAL_PROJECT_GROUP_DRAG_STATE)
+      setSessionArmed(false)
+      if (sidebarDropIndex === null) {
+        return
+      }
+
+      commitProjectGroupHeaderDragDrop({
+        session,
+        sidebarDropIndex,
+        projectGroupById: projectGroupByIdRef.current,
+        onCommitProjectGroupTabOrder: onCommitProjectGroupTabOrderRef.current
+      })
+    },
+    [cancelAutoscroll]
+  )
+
+  const runAutoscrollFrame = useCallback(
+    (frameTime: number) => {
+      autoscrollFrameIdRef.current = null
+      const session = dragSessionRef.current
+      const container = getContainerRef.current()
+      if (!session?.promoted || !container) {
+        cancelAutoscroll()
+        return
+      }
+
+      const previousFrameTime = autoscrollLastFrameTimeRef.current ?? frameTime
+      autoscrollLastFrameTimeRef.current = frameTime
+      const autoscroll = getWorktreeSidebarDragAutoscroll({
+        point: { clientX: 0, clientY: session.latestPointerY },
+        containerRect: container.getBoundingClientRect(),
+        scrollTop: container.scrollTop,
+        scrollHeight: container.scrollHeight,
+        clientHeight: container.clientHeight,
+        elapsedMs: frameTime - previousFrameTime
+      })
+      if (autoscroll) {
+        container.scrollTop = autoscroll.scrollTop
+        refreshHeaderRects()
+      }
+
+      const drop = computeDrop(session.latestPointerY)
+      if (drop) {
+        setState((prev) =>
+          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
+            ? prev
+            : { draggingGroupId: session.groupId, ...drop }
+        )
+      }
+
+      autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
+    },
+    [cancelAutoscroll, computeDrop, refreshHeaderRects]
+  )
+
+  const ensureAutoscroll = useCallback(() => {
+    if (autoscrollFrameIdRef.current !== null) {
+      return
+    }
+    autoscrollLastFrameTimeRef.current = null
+    autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
+  }, [runAutoscrollFrame])
+
+  useEffect(() => {
+    if (!sessionArmed) {
+      return
+    }
+    const onPointerMove = (event: PointerEvent): void => {
+      const session = dragSessionRef.current
+      if (!session || event.pointerId !== session.pointerId) {
+        return
+      }
+      session.latestPointerY = event.clientY
+      if (!session.promoted) {
+        const dx = event.clientX - session.startX
+        const dy = event.clientY - session.startY
+        if (
+          dx * dx + dy * dy <
+          PROJECT_GROUP_HEADER_DRAG_THRESHOLD_PX * PROJECT_GROUP_HEADER_DRAG_THRESHOLD_PX
+        ) {
+          return
+        }
+        session.promoted = true
+        // Why: virtualized headers may detach during drag; global listeners
+        // still keep the operation alive if pointer capture is unavailable.
+        if (session.handleEl.isConnected) {
+          try {
+            session.handleEl.setPointerCapture(session.pointerId)
+          } catch {
+            // Ignore capture failure; global listeners will handle the drag.
+          }
+        }
+        refreshHeaderRects()
+        setState({ draggingGroupId: session.groupId, dropIndex: null, dropIndicatorY: null })
+      }
+      refreshHeaderRects()
+      const drop = computeDrop(event.clientY)
+      if (drop) {
+        setState((prev) =>
+          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
+            ? prev
+            : { draggingGroupId: session.groupId, ...drop }
+        )
+      }
+      ensureAutoscroll()
+    }
+    const onPointerUp = (event: PointerEvent): void => {
+      const session = dragSessionRef.current
+      if (!session || event.pointerId !== session.pointerId) {
+        return
+      }
+      endDrag(true)
+    }
+    const onPointerCancel = (event: PointerEvent): void => {
+      const session = dragSessionRef.current
+      if (!session || event.pointerId !== session.pointerId) {
+        return
+      }
+      endDrag(false)
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        endDrag(false)
+      }
+    }
+    const onBlur = (): void => endDrag(false)
+
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+    window.addEventListener('pointercancel', onPointerCancel)
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+      window.removeEventListener('pointercancel', onPointerCancel)
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('blur', onBlur)
+      cancelAutoscroll()
+      if (clickSwallowTimeoutRef.current !== null) {
+        clearTimeout(clickSwallowTimeoutRef.current)
+        clickSwallowTimeoutRef.current = null
+      }
+    }
+  }, [cancelAutoscroll, computeDrop, endDrag, ensureAutoscroll, refreshHeaderRects, sessionArmed])
+
+  useEffect(() => {
+    if (state.draggingGroupId === null) {
+      return
+    }
+    const body = document.body
+    const prevCursor = body.style.cursor
+    const prevUserSelect = body.style.userSelect
+    body.style.cursor = 'grabbing'
+    body.style.userSelect = 'none'
+    return () => {
+      body.style.cursor = prevCursor
+      body.style.userSelect = prevUserSelect
+    }
+  }, [state.draggingGroupId])
+
+  const onHandlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>, groupId: string) => {
+      const session = createProjectGroupHeaderDragSession({
+        event,
+        groupId,
+        projectGroupById: projectGroupByIdRef.current,
+        sidebarProjectGroupHeaderIdsByBucket: sidebarProjectGroupHeaderIdsByBucketRef.current,
+        getScrollContainer: getContainerRef.current
+      })
+      if (!session) {
+        return
+      }
+      dragSessionRef.current = session
+      setSessionArmed(true)
+    },
+    []
+  )
+
+  return { state, onHandlePointerDown }
+}
+
+export {
+  isProjectGroupHeaderActionTarget,
+  isProjectGroupHeaderDragHandleTarget
+} from './project-group-header-drag-contract'

--- a/src/renderer/src/components/sidebar/project-group-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drop.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeProjectGroupHeaderDropPreview,
+  getProjectGroupHeaderDragBucketKey,
+  getProjectGroupTabOrderForSidebarDrop,
+  getSidebarOrderedProjectGroupHeaderIdsByBucket,
+  mapSidebarProjectGroupDropIndexToSiblingInsertIndex
+} from './project-group-header-drop'
+import type { Row } from './worktree-list-groups'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
+
+function group(id: string, overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('getProjectGroupHeaderDragBucketKey', () => {
+  it('uses root for top-level groups', () => {
+    expect(getProjectGroupHeaderDragBucketKey(group('root'))).toBe('root')
+  })
+
+  it('scopes child groups to their parent bucket', () => {
+    const root = group('root')
+    const child = group('child', { parentGroupId: root.id })
+    const groupsById = new Map([
+      [root.id, root],
+      [child.id, child]
+    ])
+
+    expect(getProjectGroupHeaderDragBucketKey(child, groupsById)).toBe('parent:root')
+  })
+
+  it('falls back to root when persisted parent metadata is missing', () => {
+    const orphan = group('orphan', { parentGroupId: 'missing' })
+
+    expect(getProjectGroupHeaderDragBucketKey(orphan, new Map([[orphan.id, orphan]]))).toBe('root')
+  })
+})
+
+describe('getSidebarOrderedProjectGroupHeaderIdsByBucket', () => {
+  it('groups Project Group headers by effective parent bucket', () => {
+    const rootA = group('root-a')
+    const rootB = group('root-b')
+    const childA = group('child-a', { parentGroupId: rootA.id })
+    const repo = { id: 'repo-a', projectGroupId: rootA.id } as Repo
+    const groupsById = new Map([
+      [rootA.id, rootA],
+      [rootB.id, rootB],
+      [childA.id, childA]
+    ])
+    const rows = [
+      {
+        type: 'header',
+        key: 'project-group:root-a',
+        label: 'A',
+        count: 0,
+        tone: '',
+        projectGroup: rootA
+      },
+      { type: 'header', key: 'repo:repo-a', label: 'repo', count: 0, tone: '', repo },
+      {
+        type: 'header',
+        key: 'project-group:child-a',
+        label: 'A child',
+        count: 0,
+        tone: '',
+        projectGroup: childA
+      },
+      {
+        type: 'header',
+        key: 'project-group:root-b',
+        label: 'B',
+        count: 0,
+        tone: '',
+        projectGroup: rootB
+      }
+    ] as Row[]
+
+    expect(getSidebarOrderedProjectGroupHeaderIdsByBucket(rows, groupsById)).toEqual(
+      new Map([
+        ['root', ['root-a', 'root-b']],
+        ['parent:root-a', ['child-a']]
+      ])
+    )
+  })
+})
+
+describe('mapSidebarProjectGroupDropIndexToSiblingInsertIndex', () => {
+  it('keeps upward drops at the same target index after removing the source', () => {
+    expect(
+      mapSidebarProjectGroupDropIndexToSiblingInsertIndex({
+        sidebarDropIndex: 0,
+        sourceIndex: 2,
+        siblingCount: 2
+      })
+    ).toBe(0)
+  })
+
+  it('shifts downward drops because the source header is removed first', () => {
+    expect(
+      mapSidebarProjectGroupDropIndexToSiblingInsertIndex({
+        sidebarDropIndex: 3,
+        sourceIndex: 0,
+        siblingCount: 2
+      })
+    ).toBe(2)
+  })
+})
+
+describe('computeProjectGroupHeaderDropPreview', () => {
+  it('uses row-model header indices instead of mounted subset order', () => {
+    const preview = computeProjectGroupHeaderDropPreview({
+      pointerY: 105,
+      containerTop: 0,
+      scrollTop: 0,
+      sidebarProjectGroupHeaderIds: ['a', 'b', 'c', 'd', 'e'],
+      rects: [
+        { groupId: 'b', bucketKey: 'root', headerIndex: 1, top: 100, bottom: 128 },
+        { groupId: 'c', bucketKey: 'root', headerIndex: 2, top: 200, bottom: 228 },
+        { groupId: 'd', bucketKey: 'root', headerIndex: 3, top: 300, bottom: 328 }
+      ]
+    })
+
+    expect(preview).toEqual({ dropIndex: 1, dropIndicatorY: 96 })
+  })
+})
+
+describe('getProjectGroupTabOrderForSidebarDrop', () => {
+  it('uses a midpoint between sibling tab orders when there is room', () => {
+    expect(
+      getProjectGroupTabOrderForSidebarDrop({
+        siblings: [group('a', { tabOrder: 0 }), group('b', { tabOrder: 10 })],
+        dropIndex: 1
+      })
+    ).toBe(5)
+  })
+
+  it('assigns an order before the first sibling', () => {
+    expect(
+      getProjectGroupTabOrderForSidebarDrop({
+        siblings: [group('a', { tabOrder: 10 }), group('b', { tabOrder: 20 })],
+        dropIndex: 0
+      })
+    ).toBe(9)
+  })
+
+  it('keeps a deterministic finite anchor when sibling orders collide', () => {
+    const tabOrder = getProjectGroupTabOrderForSidebarDrop({
+      siblings: [group('a', { tabOrder: 10 }), group('b', { tabOrder: 10 })],
+      dropIndex: 1
+    })
+
+    expect(tabOrder).toBe(11)
+    expect(Number.isFinite(tabOrder)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/sidebar/project-group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drop.ts
@@ -1,0 +1,210 @@
+import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
+import type { Row } from './worktree-list-groups'
+import type { ProjectGroup } from '../../../../shared/types'
+
+export type ProjectGroupHeaderDragBucketKey = string
+
+export type ProjectGroupHeaderDragRect = {
+  groupId: string
+  bucketKey: ProjectGroupHeaderDragBucketKey
+  // Index among sibling Project Group headers in the row model, not mounted DOM.
+  headerIndex: number
+  top: number
+  bottom: number
+}
+
+export type ProjectGroupHeaderDropPreview = {
+  dropIndex: number
+  dropIndicatorY: number
+}
+
+const INDICATOR_GAP_PX = 4
+const ROOT_PROJECT_GROUP_HEADER_BUCKET = 'root'
+
+type SidebarProjectGroupHeader = ProjectGroup | { id: null } | undefined
+
+function isConcreteProjectGroup(
+  projectGroup: SidebarProjectGroupHeader
+): projectGroup is ProjectGroup {
+  return typeof projectGroup?.id === 'string'
+}
+
+export function getProjectGroupHeaderDragBucketKey(
+  group: Pick<ProjectGroup, 'parentGroupId'>,
+  projectGroupById?: ReadonlyMap<string, ProjectGroup>
+): ProjectGroupHeaderDragBucketKey {
+  const parentGroupId = group.parentGroupId ?? null
+  if (!parentGroupId) {
+    return ROOT_PROJECT_GROUP_HEADER_BUCKET
+  }
+  if (projectGroupById && !projectGroupById.has(parentGroupId)) {
+    return ROOT_PROJECT_GROUP_HEADER_BUCKET
+  }
+  return `parent:${parentGroupId}`
+}
+
+export function getSidebarOrderedProjectGroupHeaderIdsByBucket(
+  rows: readonly Row[],
+  projectGroupById?: ReadonlyMap<string, ProjectGroup>
+): Map<ProjectGroupHeaderDragBucketKey, string[]> {
+  const buckets = new Map<ProjectGroupHeaderDragBucketKey, string[]>()
+  for (const row of rows) {
+    if (row.type !== 'header' || row.repo || !isConcreteProjectGroup(row.projectGroup)) {
+      continue
+    }
+    const bucketKey = getProjectGroupHeaderDragBucketKey(row.projectGroup, projectGroupById)
+    const list = buckets.get(bucketKey) ?? []
+    list.push(row.projectGroup.id)
+    buckets.set(bucketKey, list)
+  }
+  return buckets
+}
+
+export function getProjectGroupTabOrderForSidebarDrop(args: {
+  siblings: readonly ProjectGroup[]
+  dropIndex: number
+}): number {
+  const ordered = args.siblings.slice()
+  if (ordered.length === 0) {
+    return 0
+  }
+  const getOrder = (group: ProjectGroup | undefined): number | undefined =>
+    group && Number.isFinite(group.tabOrder) ? group.tabOrder : undefined
+  const before = getOrder(ordered[args.dropIndex - 1])
+  const after = getOrder(ordered[args.dropIndex])
+  if (before === undefined && after === undefined) {
+    return 0
+  }
+  if (before === undefined) {
+    return after !== undefined ? after - 1 : 0
+  }
+  if (after === undefined) {
+    return before + 1
+  }
+  if (after > before) {
+    const midpoint = before + (after - before) / 2
+    return Number.isFinite(midpoint) ? midpoint : before / 2 + after / 2
+  }
+  // Why: duplicate legacy ranks leave no slot between siblings; a finite anchor
+  // lets the next drag establish a stable persisted order.
+  return before + 1
+}
+
+export function mapSidebarProjectGroupDropIndexToSiblingInsertIndex(args: {
+  sidebarDropIndex: number
+  sourceIndex: number
+  siblingCount: number
+}): number {
+  // Why: sidebar drop indices include the dragged header, but tabOrder is
+  // computed against the sibling list after that header is removed.
+  const adjustedDropIndex =
+    args.sourceIndex >= 0 && args.sidebarDropIndex > args.sourceIndex
+      ? args.sidebarDropIndex - 1
+      : args.sidebarDropIndex
+  return Math.max(0, Math.min(args.siblingCount, adjustedDropIndex))
+}
+
+function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
+  if (!virtualRow) {
+    return null
+  }
+  const rawStart = virtualRow.getAttribute('data-worktree-virtual-row-start')
+  if (rawStart === null) {
+    return null
+  }
+  const start = Number(rawStart)
+  return Number.isFinite(start) ? start : null
+}
+
+export function measureProjectGroupHeaderDragRects(
+  container: HTMLElement,
+  bucketKey?: ProjectGroupHeaderDragBucketKey
+): ProjectGroupHeaderDragRect[] {
+  const containerRect = container.getBoundingClientRect()
+  const rects: ProjectGroupHeaderDragRect[] = []
+  container.querySelectorAll<HTMLElement>('[data-project-group-header-id]').forEach((element) => {
+    const groupId = element.getAttribute('data-project-group-header-id')
+    const elementBucketKey = element.getAttribute('data-project-group-header-bucket')
+    const rawHeaderIndex = element.getAttribute('data-project-group-header-index')
+    const headerIndex = rawHeaderIndex === null ? Number.NaN : Number(rawHeaderIndex)
+    if (!groupId || !elementBucketKey || !Number.isFinite(headerIndex)) {
+      return
+    }
+    if (bucketKey !== undefined && elementBucketKey !== bucketKey) {
+      return
+    }
+    const rect = element.getBoundingClientRect()
+    const virtualRow = element.closest<HTMLElement>('[data-worktree-virtual-row]')
+    const virtualRowStart = getVirtualRowStart(virtualRow)
+    const top =
+      virtualRow && virtualRowStart !== null
+        ? virtualRowStart + rect.top - virtualRow.getBoundingClientRect().top
+        : rect.top - containerRect.top + container.scrollTop
+    rects.push({
+      groupId,
+      bucketKey: elementBucketKey,
+      headerIndex,
+      top,
+      bottom: top + rect.height
+    })
+  })
+  rects.sort((left, right) => left.top - right.top)
+  return rects
+}
+
+export function computeProjectGroupHeaderDropPreview(args: {
+  pointerY: number
+  containerTop: number
+  scrollTop: number
+  rects: readonly ProjectGroupHeaderDragRect[]
+  sidebarProjectGroupHeaderIds: readonly string[]
+}): ProjectGroupHeaderDropPreview | null {
+  const { rects, sidebarProjectGroupHeaderIds } = args
+  if (rects.length === 0 || sidebarProjectGroupHeaderIds.length === 0) {
+    return null
+  }
+
+  const localY = args.pointerY - args.containerTop + args.scrollTop
+  const first = rects[0]!
+  const last = rects.at(-1)!
+  const boundaryDrop = getWorktreeSidebarBoundaryDrop({
+    localY,
+    firstRect: {
+      worktreeId: first.groupId,
+      groupIndex: first.headerIndex,
+      top: first.top,
+      bottom: first.bottom
+    },
+    lastRect: {
+      worktreeId: last.groupId,
+      groupIndex: last.headerIndex,
+      top: last.top,
+      bottom: last.bottom
+    },
+    sourceGroupSize: sidebarProjectGroupHeaderIds.length
+  })
+  if (boundaryDrop.kind === 'outside') {
+    return null
+  }
+
+  let dropIndex = last.headerIndex + 1
+  let indicatorY = last.bottom + INDICATOR_GAP_PX
+  if (boundaryDrop.kind === 'drop') {
+    dropIndex = boundaryDrop.dropIndex
+    indicatorY = boundaryDrop.indicatorY
+  } else {
+    for (const rect of rects) {
+      const mid = (rect.top + rect.bottom) / 2
+      if (localY < mid) {
+        dropIndex = rect.headerIndex
+        indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
+        break
+      }
+    }
+  }
+
+  return {
+    dropIndex,
+    dropIndicatorY: Math.max(args.scrollTop, indicatorY)
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -2275,6 +2275,67 @@ describe('project groups', () => {
     ])
   })
 
+  it('orders Project Group siblings by tabOrder within each parent bucket', () => {
+    const rootA: ProjectGroup = {
+      id: 'group-root-a',
+      name: 'Platform',
+      parentPath: '/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 20,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const rootB: ProjectGroup = {
+      ...rootA,
+      id: 'group-root-b',
+      name: 'Infrastructure',
+      tabOrder: 10
+    }
+    const childLate: ProjectGroup = {
+      ...rootA,
+      id: 'group-child-late',
+      name: 'late',
+      parentGroupId: rootB.id,
+      tabOrder: 30
+    }
+    const childEarly: ProjectGroup = {
+      ...rootA,
+      id: 'group-child-early',
+      name: 'early',
+      parentGroupId: rootB.id,
+      tabOrder: 5
+    }
+
+    const rows = buildRows(
+      'repo',
+      [],
+      new Map(),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      'recent',
+      {},
+      undefined,
+      false,
+      undefined,
+      [rootA, rootB, childLate, childEarly]
+    )
+
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:group-root-b',
+      'project-group:group-child-early',
+      'project-group:group-child-late',
+      'project-group:group-root-a'
+    ])
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.projectGroupDepth)).toEqual(
+      [0, 1, 1, 0]
+    )
+  })
+
   it('renders nested Project Groups before repos assigned to their leaf group', () => {
     const rootGroup: ProjectGroup = {
       id: 'group-root',


### PR DESCRIPTION
## Description

Closes #6609.

This adds manual vertical sorting for Project Group headers in the repo-grouped sidebar. Users can drag the folder icon on a Project Group header when that group has reorderable siblings, and the new order persists through the existing `updateProjectGroup(groupId, { tabOrder })` path.

The implementation keeps Project Group movement sibling-only by bucketing headers by their effective `parentGroupId`. That means root groups can be reordered with root groups, nested groups can be reordered with siblings under the same parent, and a drag never implicitly reparents a group.

## ELI5

You can now grab a Project Group folder in the sidebar and move it above or below the other groups next to it. Orca remembers that order. It will not accidentally move the group into a different parent group while you are sorting.

## Trade-offs

- Sorting uses the existing numeric `ProjectGroup.tabOrder` field with midpoint-style ranks, matching the lightweight ordering model already used nearby. This avoids schema/runtime changes, but it does mean repeated insert-between operations can create fractional ranks instead of compacting every sibling order.
- Dragging is intentionally sibling-only. That is safer for a sorting feature, but it does not add drag-to-reparent behavior.
- Evidence is focused unit/source coverage rather than an Electron mouse-drag recording. The drag logic mirrors the existing repo-header pointer/virtualizer pattern and is covered at the pure drop/commit level.

## Evidence

- Codex self-review of the final diff: no blocking findings.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/project-group-header-drop.test.ts src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts src/renderer/src/components/sidebar/project-group-header-dom.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/project-header-drop.test.ts src/renderer/src/components/sidebar/project-header-drag-commit.test.ts` — 6 files, 123 tests passed.
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/project-group-header-dom.test.ts src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts src/renderer/src/components/sidebar/project-group-header-drag-commit.ts src/renderer/src/components/sidebar/project-group-header-drag-contract.ts src/renderer/src/components/sidebar/project-group-header-drag-start.ts src/renderer/src/components/sidebar/project-group-header-drag.ts src/renderer/src/components/sidebar/project-group-header-drop.test.ts src/renderer/src/components/sidebar/project-group-header-drop.ts` — passed.
- `pnpm run typecheck:web` — passed.
- `git diff --check` — passed.
- Commit hook on `3101fc13e2`: `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` passed on staged files.