### PR TITLE
Keep runtime mirror sized with desktop terminal resizes

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3829,6 +3829,62 @@ describe('registerPtyHandlers', () => {
       const reported = await handlers.get('pty:getSize')!(null, { id })
       expect(reported).toEqual({ cols: 100, rows: 30 })
     })
+
+    it('fans out accepted desktop resizes to the runtime after provider resize', async () => {
+      const resize = vi.fn()
+      setupProviderWithAppliedSize({ applied: { cols: 120, rows: 30 }, resize })
+      const runtime = {
+        setPtyController: vi.fn(),
+        createPreAllocatedTerminalHandle: vi.fn(() => null),
+        registerPty: vi.fn(),
+        getDriver: vi.fn(() => ({ kind: 'host' })),
+        isResizeSuppressed: vi.fn(() => false),
+        onPtySpawned: vi.fn(),
+        onPtyExit: vi.fn(),
+        onPtyData: vi.fn(),
+        onExternalPtyResize: vi.fn()
+      }
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, runtime as never)
+      const spawn = await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, env: {} })
+      const id = (spawn as { id: string }).id
+
+      resizeListener()(mainWindowIpcEvent, { id, cols: 120, rows: 30 })
+
+      expect(resize).toHaveBeenCalledWith(id, 120, 30)
+      expect(runtime.onExternalPtyResize).toHaveBeenCalledWith(id, 120, 30)
+      expect(resize.mock.invocationCallOrder[0]).toBeLessThan(
+        runtime.onExternalPtyResize.mock.invocationCallOrder[0]!
+      )
+    })
+
+    it('does not fan out rejected desktop resizes to the runtime', async () => {
+      setupProviderWithAppliedSize({
+        applied: { cols: 80, rows: 24 },
+        resize: () => {
+          throw new Error('resize rejected')
+        }
+      })
+      const runtime = {
+        setPtyController: vi.fn(),
+        createPreAllocatedTerminalHandle: vi.fn(() => null),
+        registerPty: vi.fn(),
+        getDriver: vi.fn(() => ({ kind: 'host' })),
+        isResizeSuppressed: vi.fn(() => false),
+        onPtySpawned: vi.fn(),
+        onPtyExit: vi.fn(),
+        onPtyData: vi.fn(),
+        onExternalPtyResize: vi.fn()
+      }
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, runtime as never)
+      const spawn = await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, env: {} })
+      const id = (spawn as { id: string }).id
+
+      resizeListener()(mainWindowIpcEvent, { id, cols: 120, rows: 30 })
+
+      expect(runtime.onExternalPtyResize).not.toHaveBeenCalled()
+    })
   })
 
   it('injects ORCA_TERMINAL_HANDLE for non-local PTY providers', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -52,6 +52,7 @@ import {
   recentTerminalOutputIncludesPath,
   type RuntimeTerminalAgentStatusEvent
 } from './orca-runtime'
+import { HeadlessEmulator } from '../daemon/headless-emulator'
 import type { RuntimeMobileSessionTabsResult } from '../../shared/runtime-types'
 import {
   TERMINAL_INPUT_CHUNK_MAX_BYTES,
@@ -717,6 +718,64 @@ function syncSinglePty(
       }
     ]
   })
+}
+
+function makeDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+function makeStatusFrame(index: number, first: boolean): string {
+  const pad = '·'.repeat(60)
+  const rows = [
+    `✻ 执行任务中… (esc to interrupt) [${index}] ${pad}`,
+    `  ⎿ 正在分析代码库结构与依赖关系，请稍候… ${pad}`,
+    `  ⎿ tokens: ${1000 + index * 137} · elapsed: ${index}s ${pad}`
+  ]
+  return `${first ? '' : '\x1b[2A'}\r${rows.map((row) => `\x1b[K${row}`).join('\r\n')}\r`
+}
+
+async function writeHeadless(emulator: HeadlessEmulator, data: string): Promise<void> {
+  await emulator.write(data)
+}
+
+function visibleNonEmptyLines(emulator: HeadlessEmulator): string[] {
+  return emulator.getVisibleLines().filter((line) => line.length > 0)
+}
+
+async function parseHeadlessSnapshotLines(
+  snapshot: { data: string; cols: number; rows: number },
+  display: { cols: number; rows: number }
+): Promise<string[]> {
+  const restored = new HeadlessEmulator({ cols: display.cols, rows: display.rows })
+  try {
+    restored.resize(snapshot.cols, snapshot.rows)
+    await writeHeadless(restored, `\x1b[2J\x1b[3J\x1b[H${snapshot.data}`)
+    restored.resize(display.cols, display.rows)
+    return visibleNonEmptyLines(restored)
+  } finally {
+    restored.dispose()
+  }
+}
+
+async function referenceStatusFrameLines(
+  spawn: { cols: number; rows: number },
+  resized: { cols: number; rows: number }
+): Promise<string[]> {
+  const truth = new HeadlessEmulator({ cols: spawn.cols, rows: spawn.rows })
+  try {
+    await writeHeadless(truth, 'user@host % claude\r\n')
+    truth.resize(resized.cols, resized.rows)
+    for (let index = 0; index < 5; index += 1) {
+      await writeHeadless(truth, makeStatusFrame(index, index === 0))
+    }
+    return visibleNonEmptyLines(truth)
+  } finally {
+    truth.dispose()
+  }
 }
 
 const TEST_WINDOW_ID = 1
@@ -5409,6 +5468,90 @@ describe('OrcaRuntimeService', () => {
       source: 'headless',
       lastTitle: 'Codex working'
     })
+  })
+
+  it('resizes the headless mirror after an accepted desktop PTY resize', async () => {
+    const spawn = { cols: 80, rows: 24 }
+    const resized = { cols: 120, rows: 30 }
+    let currentSize = spawn
+    const runtime = createRuntime()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      getSize: () => currentSize
+    })
+    syncSinglePty(runtime, 'pty-1')
+
+    runtime.onPtyData('pty-1', 'user@host % claude\r\n', 100)
+    currentSize = resized
+    runtime.onExternalPtyResize('pty-1', resized.cols, resized.rows)
+    for (let index = 0; index < 5; index += 1) {
+      runtime.onPtyData('pty-1', makeStatusFrame(index, index === 0), 200 + index)
+    }
+
+    const snapshot = await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 5000 })
+    expect(snapshot).toMatchObject({ cols: resized.cols, rows: resized.rows, source: 'headless' })
+    await expect(parseHeadlessSnapshotLines(snapshot!, resized)).resolves.toEqual(
+      await referenceStatusFrameLines(spawn, resized)
+    )
+  })
+
+  it('orders headless mirror resizes behind queued PTY writes', async () => {
+    const spawn = { cols: 80, rows: 10 }
+    const resized = { cols: 120, rows: 10 }
+    let currentSize = spawn
+    const runtime = createRuntime()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      getSize: () => currentSize,
+      resize: () => {
+        currentSize = resized
+        return true
+      }
+    })
+    syncSinglePty(runtime, 'pty-1')
+    runtime.onPtyData('pty-1', 'prompt\r\n', 100)
+    await runtime.serializeMainTerminalBuffer('pty-1')
+
+    type HeadlessStateForTest = {
+      emulator: HeadlessEmulator
+      writeChain: Promise<void>
+    }
+    const headless = (
+      runtime as unknown as { headlessTerminals: Map<string, HeadlessStateForTest> }
+    ).headlessTerminals.get('pty-1')
+    expect(headless).toBeDefined()
+    const originalWrite = headless!.emulator.write.bind(headless!.emulator)
+    const queuedWriteStarted = makeDeferred()
+    const releaseQueuedWrite = makeDeferred()
+    headless!.emulator.write = async (data: string): Promise<void> => {
+      queuedWriteStarted.resolve()
+      await releaseQueuedWrite.promise
+      await originalWrite(data)
+    }
+
+    try {
+      runtime.onPtyData('pty-1', '\x1b[90GOLD', 200)
+      await queuedWriteStarted.promise
+      await runtime.updateDesktopViewport('pty-1', resized)
+      runtime.onPtyData('pty-1', '\r\nNEXT', 300)
+      releaseQueuedWrite.resolve()
+
+      const snapshot = await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 100 })
+      expect(snapshot).toMatchObject({ cols: resized.cols, rows: resized.rows })
+      await expect(parseHeadlessSnapshotLines(snapshot!, resized)).resolves.toEqual([
+        'prompt',
+        '                                                                               O',
+        'LD',
+        'NEXT'
+      ])
+    } finally {
+      headless!.emulator.write = originalWrite
+      releaseQueuedWrite.resolve()
+    }
   })
 
   it('adopts renderer-seeded titles into headless main terminal snapshots', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5760,7 +5760,21 @@ export class OrcaRuntimeService {
   }
 
   private resizeHeadlessTerminal(ptyId: string, cols: number, rows: number): void {
-    this.headlessTerminals.get(ptyId)?.emulator.resize(cols, rows)
+    const state = this.headlessTerminals.get(ptyId)
+    if (!state) {
+      return
+    }
+    // Why: terminal reflow is a parser operation. It must sit in the same
+    // per-PTY stream as output bytes or restore snapshots can bake in wraps
+    // from the wrong terminal width.
+    state.writeChain = state.writeChain
+      .then(() => {
+        state.emulator.resize(cols, rows)
+      })
+      .catch(() => {
+        // Best-effort mirror tracking; live PTY streaming must continue even
+        // if xterm rejects a raced resize during teardown.
+      })
   }
 
   private createHeadlessEmulator(
@@ -7052,7 +7066,6 @@ export class OrcaRuntimeService {
     if (!resized) {
       return false
     }
-    this.resizeHeadlessTerminal(ptyId, cols, rows)
     this.onExternalPtyResize(ptyId, cols, rows)
     return true
   }
@@ -7880,12 +7893,9 @@ export class OrcaRuntimeService {
     }
   }
 
-  // Why: called from the pty:resize IPC handler whenever the desktop renderer
-  // resizes a PTY (e.g. via safeFit after window resize, split, or desktop-mode
-  // restore). Stores the renderer-reported size so handleMobileSubscribe can use
-  // the actual pane geometry instead of a stale PTY size for previousCols.
-  // This is a passive geometry report — it does NOT call applyLayout; the
-  // PTY is already at the reported size.
+  // Why: called after a desktop renderer path has successfully resized the
+  // PTY (local IPC or remote desktop viewport). The runtime mirror must take
+  // the same accepted geometry so hidden-output restore parses at PTY width.
   onExternalPtyResize(ptyId: string, cols: number, rows: number): void {
     // The pty:resize IPC handler is supposed to gate via `isResizeSuppressed`
     // before calling here, but defend against callers that don't.
@@ -7905,6 +7915,7 @@ export class OrcaRuntimeService {
     if (activeOverride && activeOverride.cols === cols && activeOverride.rows === rows) {
       return
     }
+    this.resizeHeadlessTerminal(ptyId, cols, rows)
     this.refreshRendererGeometry(ptyId, cols, rows)
   }
 


### PR DESCRIPTION
## Symptom
Hidden-output restore snapshots come from the main-process runtime mirror. On desktop, accepted PTY resizes updated the PTY and renderer geometry state, but the runtime mirror stayed at its birth dimensions. That explains the v1.4.119 garble report: normal-buffer TUI status repaints could soft-wrap inside the stale-width mirror, so cursor-up repaints stacked instead of overwriting and later restores painted the corrupted ladder back into the renderer.

## Mechanism
Desktop has three terminal parsers involved in restore correctness: the PTY, the renderer terminal, and the runtime mirror. The local `pty:resize` handler resized the provider PTY and cached accepted size, then only reported geometry to the runtime. Remote desktop viewport resize already touched the mirror, but did so immediately instead of preserving output ordering.

## Fix
- Queue runtime mirror resizes on the same per-PTY `writeChain` used for PTY output bytes.
- Fan accepted desktop resizes through `onExternalPtyResize`, so local desktop IPC and remote desktop viewport resizes both update the mirror after the provider accepts the resize.
- Preserve existing suppression/mobile-fit override gates and rejected-provider behavior.

## Ordering Rationale (F3)
Resize reflow is parser state. If it jumps queued output bytes, the mirror can parse bytes at the wrong width and bake a bad snapshot even when the final dimensions are right. This PR serializes mirror resize reflow with output writes, matching the daemon-side discipline where emulator and PTY resize order are coupled.

## Tests
Red-proven before the fix:
- `resizes the headless mirror after an accepted desktop PTY resize` failed with snapshot `80x24` instead of `120x30`.
- `orders headless mirror resizes behind queued PTY writes` failed because `ESC[90GOLD` parsed at `120` columns instead of the queued `80`-column position.

Green validation:
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "headless mirror"`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts -t "desktop resizes"`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.test.ts` (745 passed)
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime src/main/daemon src/main/ipc 2>&1 | tail -n 80` (3503 passed; one known unrelated `pty-subprocess.test.ts` WSL env assertion failed, matching the brief's known-failure note)
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` (295 passed)
- `pnpm run typecheck`
- Commit hook: oxlint, oxlint react doctor, oxfmt

## Perf Note
No polling, timers, renderer hot-path work, or per-output-chunk cost was added. The only new cost is one runtime mirror reflow per accepted resize for an existing headless mirror. Resize storms serialize naturally through the existing per-PTY chain; this keeps correctness without debounce windows that could reintroduce stale mirror dimensions.

## Reliability Proof
Reliability invariant: `terminal-session.snapshot-freshness` / `terminal-geometry.visible-convergence` — hidden-output restore snapshots must be parsed at the PTY geometry that accepted subsequent bytes, and resize reflow must not jump queued output.

Material impact: this blocks the stale-runtime-mirror class that turns in-place TUI repaints into permanent restore corruption.

Product change type: mixed runtime hardening plus regression coverage.

Performance risk inventory: touches resize, hidden-output snapshot freshness, runtime mirror parser ordering, local desktop IPC, and remote desktop viewport resize. It does not touch renderer rendering, typing, focus, startup, provider listing, or polling loops.

No-regression evidence: the targeted red/green tests prove both geometry fan-out and write-chain ordering; touched files and the broader runtime/daemon/ipc sweep were run; typecheck and hook lint/format passed.

Provider/platform coverage: local desktop PTY resize is covered through IPC tests; remote desktop resize is covered through `updateDesktopViewport`; daemon/SSH/WSL/Windows provider differences are preserved by only acting after provider resize acceptance and by retaining rejected-resize behavior. Mobile/relay layout paths keep using the same mirror resize primitive, now ordered. Live Windows/SSH device runs are not included.

Residual gaps: F2/F4/F5/F6/F7 remain follow-ups by design. This PR does not add new manifest promotion; gate status is partial through deterministic unit/integration coverage.

Rollback or demotion rule: if resize storms show measurable mirror reflow pressure, if provider resize drops are observed to update snapshots incorrectly, or if hidden-output restore shows fresh stale-dimension ladders, demote the gate and revert this fan-out while preserving the red tests as the diagnostic oracle.

## Out Of Scope
F2, F4, F5, F6, and F7 are intentionally left for follow-up PRs.

Made with [Orca](https://github.com/stablyai/orca) 🐋
