### PR TITLE
fix(i18n): apply persisted UI language at startup instead of OS locale

### DIFF
--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.language-switch.test.tsx
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.language-switch.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n/i18n'
+import { useSettingsNavigationMetadata } from './useSettingsNavigationMetadata'
+import type { SettingsNavSection } from '@/lib/settings-navigation-types'
+
+// Why: the Settings sidebar / Cmd+J nav labels are produced by translate() at
+// build time and memoized. Before the fix the memo deps excluded the active
+// locale, so a live language switch left the nav stuck in the old language
+// until Settings was remounted. This pins that the labels retranslate live.
+
+const roots: Root[] = []
+let latest: SettingsNavSection[] | null = null
+
+function Probe(): null {
+  latest = useSettingsNavigationMetadata()
+  return null
+}
+
+async function renderProbe(): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(createElement(Probe))
+  })
+}
+
+function agentsTitle(): string | undefined {
+  return latest?.find((section) => section.id === 'agents')?.title
+}
+
+afterEach(async () => {
+  for (const root of roots) {
+    await act(async () => {
+      root.unmount()
+    })
+  }
+  roots.length = 0
+  latest = null
+  await act(async () => {
+    await i18n.changeLanguage('en')
+  })
+  vi.restoreAllMocks()
+})
+
+it('retranslates the settings nav labels when the UI language changes live', async () => {
+  await act(async () => {
+    await i18n.changeLanguage('en')
+  })
+  await renderProbe()
+  expect(agentsTitle()).toBe('Agents')
+
+  // Same path as the Settings → Appearance language switch.
+  await act(async () => {
+    await i18n.changeLanguage('es')
+  })
+
+  // Without the active-locale memo dep this stays 'Agents' (stale cache).
+  expect(agentsTitle()).toBe('Agentes')
+})

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -551,9 +551,12 @@ export function buildSettingsNavigationMetadata({
 }
 
 export function useSettingsNavigationMetadata(): SettingsNavSection[] {
-  // Why: subscribe metadata consumers to language changes; translated memo
-  // contents refresh on rerender without depending on i18n.language directly.
-  useTranslation()
+  // Why: useTranslation subscribes to language changes, but the active locale
+  // must also be a memo dependency below — a rerender alone returns the cached
+  // previous-language sections, leaving the Settings sidebar and Cmd+J palette
+  // stuck in the old language until Settings is remounted.
+  const { i18n } = useTranslation()
+  const activeLocale = i18n.language
   const repos = useAppStore((state) => state.repos)
   const settings = useAppStore((state) => state.settings)
   const isMac = isMacUserAgent()
@@ -584,6 +587,7 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
         isDev: import.meta.env.DEV,
         repos
       }),
-    [isMac, isWindows, isWindowsTerminalHost, isWebClient, repos]
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- activeLocale is read implicitly by the translate() calls inside buildSettingsNavigationMetadata; without it the memo keeps the previous language's sections.
+    [isMac, isWindows, isWindowsTerminalHost, isWebClient, repos, activeLocale]
   )
 }

--- a/src/renderer/src/i18n/I18nProvider.test.tsx
+++ b/src/renderer/src/i18n/I18nProvider.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getDefaultSettings } from '../../../shared/constants'
+import { UI_LANGUAGE_ENGLISH, UI_LANGUAGE_SPANISH } from '../../../shared/ui-language'
+import { useAppStore } from '@/store'
+import { i18n } from './i18n'
+import { I18nProvider } from './I18nProvider'
+
+// Why: settings arrive async over IPC after first render. The provider used to
+// fall back to the 'system' language while settings were null, kicking off an
+// OS-locale changeLanguage that raced with — and could permanently override —
+// the persisted preference. These tests pin the fixed ordering.
+
+const initialAppState = useAppStore.getInitialState()
+const roots: Root[] = []
+
+async function renderProvider(): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(createElement(I18nProvider, null, null))
+  })
+}
+
+beforeEach(() => {
+  useAppStore.setState(initialAppState, true)
+})
+
+afterEach(async () => {
+  for (const root of roots) {
+    await act(async () => {
+      root.unmount()
+    })
+  }
+  roots.length = 0
+  useAppStore.setState(initialAppState, true)
+  vi.restoreAllMocks()
+})
+
+describe('I18nProvider startup language', () => {
+  it('does not apply any language while settings are still loading', async () => {
+    const changeLanguage = vi.spyOn(i18n, 'changeLanguage')
+
+    await renderProvider()
+
+    expect(changeLanguage).not.toHaveBeenCalled()
+  })
+
+  it('applies the persisted language once settings load', async () => {
+    const changeLanguage = vi.spyOn(i18n, 'changeLanguage')
+
+    await renderProvider()
+    await act(async () => {
+      useAppStore.setState({
+        settings: { ...getDefaultSettings('/tmp'), uiLanguage: UI_LANGUAGE_SPANISH }
+      })
+    })
+
+    expect(changeLanguage).toHaveBeenCalledWith('es')
+  })
+
+  it('applies persisted English even if i18n reports it as already active', async () => {
+    // Why: i18n.language stays stale while a lazy catalog load is in flight; a
+    // guard comparing against it skipped the correction back to the persisted
+    // language and let the in-flight OS locale win.
+    const changeLanguage = vi.spyOn(i18n, 'changeLanguage')
+
+    await renderProvider()
+    await act(async () => {
+      useAppStore.setState({
+        settings: { ...getDefaultSettings('/tmp'), uiLanguage: UI_LANGUAGE_ENGLISH }
+      })
+    })
+
+    expect(changeLanguage).toHaveBeenCalledWith('en')
+  })
+
+  it('switches language when the setting changes after startup', async () => {
+    const changeLanguage = vi.spyOn(i18n, 'changeLanguage')
+
+    await renderProvider()
+    await act(async () => {
+      useAppStore.setState({
+        settings: { ...getDefaultSettings('/tmp'), uiLanguage: UI_LANGUAGE_ENGLISH }
+      })
+    })
+    await act(async () => {
+      useAppStore.setState({
+        settings: { ...getDefaultSettings('/tmp'), uiLanguage: UI_LANGUAGE_SPANISH }
+      })
+    })
+
+    expect(changeLanguage).toHaveBeenLastCalledWith('es')
+  })
+})

--- a/src/renderer/src/i18n/I18nProvider.test.tsx
+++ b/src/renderer/src/i18n/I18nProvider.test.tsx
@@ -18,6 +18,14 @@ import { I18nProvider } from './I18nProvider'
 const initialAppState = useAppStore.getInitialState()
 const roots: Root[] = []
 
+// Why: the 'system' UI language resolves through navigator.language; stubbing it
+// lets these tests simulate a non-English OS locale (the #7188 repro) without
+// depending on the host machine's locale.
+const ORIGINAL_SYSTEM_LOCALE = navigator.language
+function stubSystemLocale(tag: string): void {
+  Object.defineProperty(navigator, 'language', { value: tag, configurable: true })
+}
+
 async function renderProvider(): Promise<void> {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -40,6 +48,7 @@ afterEach(async () => {
   }
   roots.length = 0
   useAppStore.setState(initialAppState, true)
+  stubSystemLocale(ORIGINAL_SYSTEM_LOCALE)
   vi.restoreAllMocks()
 })
 
@@ -79,6 +88,28 @@ describe('I18nProvider startup language', () => {
     })
 
     expect(changeLanguage).toHaveBeenCalledWith('en')
+  })
+
+  it('never applies the OS locale on a non-English system when English is persisted (#7188)', async () => {
+    // Why: on a Spanish OS the pre-fix provider kicked off changeLanguage('es')
+    // while settings were still null, and the in-flight OS switch then beat the
+    // persisted English preference. The fix applies nothing until settings load.
+    stubSystemLocale('es-ES')
+    const changeLanguage = vi.spyOn(i18n, 'changeLanguage')
+
+    await renderProvider()
+    // No OS-locale switch is kicked off while settings are still loading.
+    expect(changeLanguage).not.toHaveBeenCalled()
+
+    await act(async () => {
+      useAppStore.setState({
+        settings: { ...getDefaultSettings('/tmp'), uiLanguage: UI_LANGUAGE_ENGLISH }
+      })
+    })
+
+    // English wins and the Spanish OS locale is never requested.
+    expect(changeLanguage).toHaveBeenCalledWith('en')
+    expect(changeLanguage).not.toHaveBeenCalledWith('es')
   })
 
   it('switches language when the setting changes after startup', async () => {

--- a/src/renderer/src/i18n/I18nProvider.tsx
+++ b/src/renderer/src/i18n/I18nProvider.tsx
@@ -1,22 +1,28 @@
-import { useEffect, type ReactNode } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 import { I18nextProvider } from 'react-i18next'
 
-import { UI_LANGUAGE_SYSTEM } from '../../../shared/ui-language'
 import { useAppStore } from '../store'
 import { i18n } from './i18n'
 import { resolveUiLocale } from './supported-languages'
 
 export function I18nProvider({ children }: { children: ReactNode }): React.JSX.Element {
-  const uiLanguage = useAppStore((state) => state.settings?.uiLanguage ?? UI_LANGUAGE_SYSTEM)
-  const locale = resolveUiLocale(uiLanguage)
+  // Why: settings arrive async over IPC; until they load we must not apply any
+  // language. Falling back to 'system' here used to kick off an OS-locale
+  // changeLanguage that raced with (and could permanently override) the
+  // persisted preference applied moments later.
+  const uiLanguage = useAppStore((state) => state.settings?.uiLanguage ?? null)
+  const locale = uiLanguage === null ? null : resolveUiLocale(uiLanguage)
+  const requestedLocale = useRef<string | null>(null)
 
   useEffect(() => {
-    if (i18n.language !== locale) {
-      // Why: changeLanguage triggers the lazy locale backend, which fetches the
-      // non-English catalog before activating it — so the switch resolves real
-      // translations without bundling every locale at startup.
-      void i18n.changeLanguage(locale)
+    // Why: track the last *requested* locale instead of checking i18n.language —
+    // an in-flight lazy catalog load leaves i18n.language stale, which made the
+    // guard skip corrections back to the persisted language.
+    if (locale === null || requestedLocale.current === locale) {
+      return
     }
+    requestedLocale.current = locale
+    void i18n.changeLanguage(locale)
   }, [locale])
 
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>


### PR DESCRIPTION
## Summary

Fixes #7188 — Orca opened in the OS language instead of the UI language previously configured in Settings → Appearance → Language.

At startup, `I18nProvider` fell back to the `'system'` language while settings were still loading over IPC (`settings === null`), kicking off an async `i18n.changeLanguage(<OS locale>)`. When the persisted preference arrived moments later, the guard `if (i18n.language !== locale)` compared against `i18n.language`, which is stale while the lazy catalog load is in flight — so a persisted **English** preference was skipped entirely and the in-flight OS-locale change won permanently. Non-English preferences raced two concurrent `changeLanguage` calls with no ordering guarantee. Likely introduced by the lazy locale loading in #6804.

The fix (renderer only, `src/renderer/src/i18n/I18nProvider.tsx`):

- Apply no language until settings have loaded — removes the intermediate OS-locale switch. The app stays on the eagerly bundled English until the persisted preference is known, exactly as before #6804's behavior settled.
- Track the last *requested* locale in a ref instead of reading `i18n.language`, so an in-flight catalog load can't cause a correction to be skipped.

`uiLanguage: 'system'` still resolves to the OS locale once settings load — that behavior is intentional and unchanged. Main-process i18n (menus) was already correct and is untouched.

## Screenshots

No visual change (the fix restores the configured language at startup; UI layout/appearance is unchanged).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added `src/renderer/src/i18n/I18nProvider.test.tsx` with four regression tests: no language is applied while settings are loading; the persisted language is applied once settings load; persisted English is applied even when `i18n.language` already reports `'en'` (the exact stale-guard case behind this bug); and runtime language switches from Settings still work.

## AI Review Report

Reviewed with Claude Code. Main risks checked:

- **Race regression**: verified the new ref-based guard cannot skip a correction — it compares against the last *requested* locale, not i18next's async-lagging `i18n.language`. Duplicate `changeLanguage` calls for the same locale are still deduped.
- **Startup UX**: while settings load, the UI stays on the eagerly bundled English catalog (same as the pre-fix initial paint); the OS-locale intermediate switch is removed, so there is one language transition at most instead of two racing ones.
- **`'system'` setting**: confirmed it still resolves via `navigator.language` after settings load, and the settings-driven language switcher path (`updateSettings` → store → provider effect) is unchanged.
- **Cross-platform (macOS / Linux / Windows)**: the change is pure renderer React/i18next logic — no shortcuts, labels, file paths, shell usage, or Electron platform APIs are touched. `navigator.language` usage is platform-neutral and pre-existing. Main-process locale handling (`app.getLocale()`, menu rebuild) is untouched.
- **SSH/remote & providers**: no interaction — the change only affects when the local renderer applies its UI locale; nothing depends on local-only processes, git providers, or agent integrations.

Nothing was flagged that required further changes beyond the fix itself.

## Security Audit

No new attack surface. The change adds no input handling, command execution, path handling, auth, secrets, dependencies, or IPC endpoints. It only reorders when the renderer calls `i18n.changeLanguage` with values that come from the existing typed `UiLanguage` setting (already normalized in the main process via `normalizeUiLanguage`) and resolves them through the existing `resolveUiLocale` allowlist of supported locales, so no untrusted string reaches i18next. No follow-up needed.

## Notes

- The lazy locale-catalog loading from #6804 is preserved; only the application ordering in the provider changed.
- X handle: [@leynier41](https://x.com/leynier41)
