### PR TITLE
Support Jira Server and Data Center sites

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -11,6 +11,7 @@ Keep this folder for versioned reference docs that are meant to survive past a s
 - Headless Linux server setup for remote `orca serve` hosts. See [Headless Linux Server](./headless-linux-server.md).
 - Feature education state, interaction tracking, and retention analytics notes that define how contextual tours are persisted and measured. See [Feature Education State](./feature-education-state.md), [Feature Discovery Interaction Tracking](./feature-discovery-interaction-tracking.md), and [Feature Education Retention Analytics](./feature-education-retention-analytics.md).
 - New-user parallel work telemetry notes that define how the parallel-work tour and setup guide should be measured against retention. See [New User Parallel Work Telemetry](./new-user-parallel-work-telemetry.md).
+- Jira Server/Data Center support notes that define how the existing Jira Cloud integration should grow deployment-aware authentication, REST adapters, and remote-runtime support. See [Jira Server/Data Center Support](./jira-server-support.md).
 
 ## What Stays Out
 

--- a/docs/reference/jira-server-support.md
+++ b/docs/reference/jira-server-support.md
@@ -1,0 +1,632 @@
+# Jira Server/Data Center Support
+
+## Goal
+
+Add Jira Server/Data Center support to Orca's existing Jira integration without
+regressing Jira Cloud behavior. Target Jira Server/Data Center 9.x instances
+first, using the REST API v2 surface those deployments expose.
+
+This document is the implementation reference for the Jira Server/Data Center
+support PR. It records the contribution constraints, repository boundaries, API
+mapping, and verification plan that the implementation must satisfy.
+
+## Single PR Scope
+
+Land the core Server/DC feature in one PR. Internal commits may be split by
+layer, but the final PR must include Server/DC support for all Jira capabilities
+that Orca exposes today:
+
+- Connect, test connection, disconnect, and status.
+- List assigned issues and run custom JQL searches.
+- Get issue details.
+- Create issues, including project, issue type, description, and required create
+  fields. Priority and labels are supported when Jira exposes them through create
+  metadata/custom fields.
+- Update supported issue fields: summary/title, labels, priority, assignee, and
+  transition.
+- Add and list comments.
+- List projects, issue types, create fields, priorities, assignable users, and
+  transitions.
+- Assign, unassign, and transition issues.
+
+Do not split a connect-only Server/DC PR from the remaining issue operations.
+The contribution is only complete when Cloud and Server/DC both work across
+local IPC and remote runtime paths.
+
+## Pre-Change State
+
+Orca's Jira integration is currently Jira Cloud oriented:
+
+- Connection verification calls `/rest/api/3/myself`.
+- Authorization is always Basic auth over `email:apiToken`.
+- Issue operations use Cloud REST API v3 paths such as
+  `/rest/api/3/search/jql`, `/rest/api/3/project/search`, and
+  `/rest/api/3/issue/createmeta/...`.
+- User identity is modeled around Cloud `accountId`.
+- Create and comment bodies use Atlassian Document Format (ADF).
+- The UI copy says "Jira Cloud site URL", "Atlassian email", and "API token".
+
+Jira Server/DC 9.x exposes:
+
+- `/rest/api/2/serverInfo` with `deploymentType: "Server"` or
+  `"Data Center"` plus version information.
+- `/rest/api/2/myself` as the authenticated Server/DC identity endpoint.
+- `/rest/api/3/*` paths that redirect to `login.jsp` when unauthenticated and
+  are not a reliable Server/DC integration surface.
+
+## Constraints From Repository Contribution Docs
+
+Implementation must follow the repository's contribution rules:
+
+- Keep changes scoped and preserve macOS, Linux, and Windows support.
+- Do not assume local-only execution; Jira must work through local and remote
+  runtime paths.
+- Keep provider-specific behavior behind explicit checks.
+- For UI work, follow `docs/STYLEGUIDE.md`, use existing tokens, and use shadcn
+  primitives from `src/renderer/src/components/ui/`.
+- Do not add `max-lines` disables. Split Jira code into concrete, named modules
+  when adding Server/DC behavior.
+- Do not introduce vague module names such as `helpers`, `utils`, or `common`.
+- Keep project-owned types in `.ts` files, not `.d.ts`.
+- Do not log credentials or include PR evidence images in the repo.
+
+## Non-Goals
+
+- Do not replace the current Jira Cloud integration.
+- Do not create a separate task provider named `jira-server`.
+- Do not implement OAuth, SAML browser login, cookie-based auth, or interactive
+  SSO flows.
+- Do not migrate existing Cloud users to new credentials or force reconnect.
+- Do not add GitHub-specific concepts to Jira task or review code.
+
+## Architecture
+
+Keep a single Jira provider in the UI and store, but route authenticated
+operations through deployment-specific main-process adapters:
+
+- `cloud`: existing Jira Cloud behavior using REST API v3 and `accountId`.
+- `server`: Jira Server/Data Center behavior using REST API v2 and Server/DC
+  user identifiers.
+
+The renderer should not know endpoint details. It should pass a connection
+payload, show the saved site metadata, and call the same Jira store/runtime
+methods it calls today.
+
+## Data Model
+
+Extend the shared Jira site and connection types:
+
+```ts
+export type JiraDeploymentType = 'cloud' | 'server'
+export type JiraAuthMode = 'basic' | 'bearer'
+
+export type JiraSite = {
+  id: string
+  siteUrl: string
+  email: string
+  displayName: string
+  accountId: string
+  viewerUserId: string
+  deploymentType: JiraDeploymentType
+  authMode: JiraAuthMode
+  authUsername?: string
+}
+
+export type JiraUser = {
+  userId: string
+  accountId: string
+  displayName: string
+  email?: string | null
+  avatarUrl?: string
+}
+
+export type JiraCloudConnectArgs = {
+  deploymentType?: 'cloud'
+  siteUrl: string
+  email: string
+  apiToken: string
+}
+
+export type JiraServerBasicConnectArgs = {
+  deploymentType: 'server'
+  authMode: 'basic'
+  siteUrl: string
+  username: string
+  passwordOrToken: string
+}
+
+export type JiraServerBearerConnectArgs = {
+  deploymentType: 'server'
+  authMode: 'bearer'
+  siteUrl: string
+  bearerToken: string
+}
+
+export type JiraConnectArgs =
+  | JiraCloudConnectArgs
+  | JiraServerBasicConnectArgs
+  | JiraServerBearerConnectArgs
+
+export type JiraIssueUpdate = {
+  title?: string
+  labels?: string[]
+  priorityId?: string | null
+  assigneeUserId?: string | null
+  assigneeAccountId?: string | null
+  transitionId?: string
+}
+```
+
+Compatibility rules:
+
+- Legacy callers may omit `deploymentType`; normalize those payloads to Cloud
+  only at the IPC/RPC/store boundary before they reach the Jira client.
+- Existing saved sites with no `deploymentType` are treated as `cloud`.
+- Existing saved sites with no `authMode` are treated as `basic`.
+- Existing Cloud site ids must remain stable.
+- Server/DC site ids should be derived from
+  `siteUrl + deploymentType + authMode + viewerIdentityId`, where
+  `viewerIdentityId` is returned by the successful `/rest/api/2/myself` response.
+  This avoids storing or hashing Bearer token material while still keeping
+  multiple Server/DC users on the same site separate.
+- Server/DC sites should keep the existing `email` field populated with
+  `emailAddress ?? username ?? ''` for renderer compatibility, but UI labels
+  should prefer `authUsername` when the site is Server/DC.
+- Populate `viewerUserId` with the deployment-specific identity. Keep
+  `accountId` populated for backward compatibility, but treat it as a legacy
+  alias outside Cloud-specific adapter code.
+- Populate `JiraUser.userId` with the deployment-specific identity. Keep
+  `JiraUser.accountId` as a deprecated alias so old Cloud-oriented call sites
+  continue to render while they migrate.
+
+The shared update shape must use `assigneeUserId` as the renderer-facing
+assignee field. Keep `assigneeAccountId` as a deprecated compatibility alias for
+existing Cloud callers until all call sites are migrated. Write adapters must
+branch on deployment type rather than blindly sending either value as a Cloud
+`accountId`.
+
+## Authentication
+
+### Cloud
+
+Cloud keeps current behavior:
+
+- Required fields: `siteUrl`, `email`, `apiToken`.
+- Header: `Authorization: Basic base64(email:apiToken)`.
+- Verify: `GET /rest/api/3/myself`.
+- Viewer id: `accountId`.
+
+### Server/Data Center
+
+Server/DC supports two explicit auth modes:
+
+- Basic: `Authorization: Basic base64(username:passwordOrToken)`.
+- Bearer: `Authorization: Bearer <bearerToken>`.
+
+Verification:
+
+- Verify Basic and Bearer credentials with `GET /rest/api/2/myself`.
+- Map viewer id from `name ?? key ?? emailAddress ?? displayName`.
+- Do not treat a 403 as token revocation. Keep the existing rule that only 401
+  clears saved credentials.
+
+Credential storage:
+
+- Reuse the existing per-site token storage boundary.
+- Store only the secret token/password in the encrypted token file.
+- Store non-secret site metadata in `jira-sites.json`.
+- Never write credential values to logs, telemetry, snapshots, or PR evidence.
+
+## Deployment Detection
+
+Connection should not rely on URL shape alone.
+
+Implemented behavior:
+
+1. Let the user pick `Cloud` or `Server/Data Center` in the connection dialog.
+2. Treat the user selection as authoritative. This avoids relying on URL shape
+   or unauthenticated probes that many private deployments block or redirect.
+3. Validate the final selected deployment by calling that deployment's `/myself`
+   endpoint.
+
+Detection outcomes:
+
+- `deploymentType === "cloud"` calls Cloud REST API v3.
+- `deploymentType === "server"` calls Server/DC REST API v2.
+- The credential verification endpoint decides success or failure.
+- A future enhancement may add an optional `serverInfo` preflight, but this PR
+  does not require it for correctness.
+
+## File Structure
+
+Split main-process Jira behavior into concrete modules instead of expanding the
+original Jira files further:
+
+- `src/main/jira/site-storage.ts`
+  - Read, normalize, migrate, and write `jira-sites.json`.
+  - Own token path construction and saved site filtering.
+- `src/main/jira/auth-headers.ts`
+  - Build Basic and Bearer auth headers.
+  - Keep credential string handling in one small surface.
+- `src/main/jira/jira-request.ts`
+  - Own Electron `net.fetch`, proxy bridging, Jira error parsing, and shared
+    authenticated request helpers.
+- `src/main/jira/jira-user-identity.ts`
+  - Map Cloud and Server/DC user objects into Orca's shared `JiraUser` shape.
+  - Build deployment-specific assignee update payloads.
+- `src/main/jira/issue-mappers.ts`
+  - Map Jira issue, project, priority, status, comment, and create-field
+    responses into shared Orca types.
+- `src/main/jira/issue-rest-routing.ts`
+  - Select REST API v2 or v3 paths from the saved deployment type.
+- `src/main/jira/issue-page-fetcher.ts`
+  - Share Jira pagination handling across comments and metadata reads.
+- `src/main/jira/issue-search.ts`
+  - List issues, run JQL searches, and fetch single issue details.
+- `src/main/jira/issue-comments.ts`
+  - Add and list comments while preserving Cloud ADF and Server/DC plain text
+    behavior.
+- `src/main/jira/issue-metadata.ts`
+  - List projects, issue types, create fields, priorities, assignable users,
+    and transitions.
+- `src/main/jira/issues.ts`
+  - Keep create/update issue mutations and re-export search, comment, mapper,
+    and metadata methods from the focused modules.
+- `src/main/jira/client.ts`
+  - Keep concurrency, public connection methods, status, selection, and
+    disconnect behavior.
+  - Delegate storage, auth-header, and identity details to the focused modules
+    above.
+
+This split avoids new `max-lines` disables and gives each module one concrete
+responsibility.
+
+## Server/Data Center REST Mapping
+
+Use Jira Server/Data Center REST API v2 for Server/DC sites.
+
+| Operation | Server/DC endpoint | Notes |
+| --- | --- | --- |
+| Verify connection | `GET /rest/api/2/myself` | User id from `name`, `key`, or fallback fields. |
+| Search issues | `POST /rest/api/2/search` | Body: `{ jql, maxResults, fields }`. |
+| Get issue | `GET /rest/api/2/issue/{key}?fields=...` | Same field list as Cloud where available. |
+| Create issue | `POST /rest/api/2/issue` | Description and textarea create fields are plain text, not ADF. |
+| Update issue fields | `PUT /rest/api/2/issue/{key}` | Summary, labels, priority map similarly. |
+| Assign issue | `PUT /rest/api/2/issue/{key}/assignee` | Body: `{ name: userName }` or `{ name: null }`. |
+| Transitions | `POST /rest/api/2/issue/{key}/transitions` | Same transition id shape. |
+| Add comment | `POST /rest/api/2/issue/{key}/comment` | Body: `{ body: string }`. |
+| List comments | `GET /rest/api/2/issue/{key}/comment?...` | Response uses `comments`. |
+| List projects | `GET /rest/api/2/project` | Response is usually an array, not `{ values }`. |
+| List issue types | `GET /rest/api/2/issue/createmeta/{projectIdOrKey}/issuetypes?...` | Use the Jira 9.x replacement endpoint. |
+| List create fields | `GET /rest/api/2/issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}?...` | Use the Jira 9.x replacement endpoint. |
+| List priorities | `GET /rest/api/2/priority` | Response is an array. |
+| Assignable users | `GET /rest/api/2/user/assignable/search` | Use `issueKey`, `username`, and `maxResults`; do not send Cloud `query`. |
+
+Do not use the removed aggregate `GET /rest/api/2/issue/createmeta` endpoint for
+Jira 9.x Server/DC support.
+
+## Cloud REST Mapping
+
+Keep existing Cloud REST API v3 behavior:
+
+- Search: `POST /rest/api/3/search/jql`.
+- Project list: `GET /rest/api/3/project/search`.
+- Issue type metadata:
+  `/rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes`.
+- Create fields:
+  `/rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}`.
+- Assignable users: `/rest/api/3/user/assignable/search?issueKey=...&query=...`.
+- Assignee update body: `{ accountId }`.
+- Description and comments: ADF documents.
+
+Cloud tests should assert these paths remain unchanged.
+
+## User Identity Rules
+
+Define a deployment-aware user identity layer:
+
+```ts
+export type JiraUserIdentity = {
+  userId: string
+  displayName: string
+  email?: string | null
+  avatarUrl?: string
+  serverName?: string
+  serverKey?: string
+}
+```
+
+Mapping:
+
+- Cloud `userId`: `accountId`.
+- Server/DC `userId`: `name ?? key ?? emailAddress ?? displayName`.
+- Keep `JiraUser.accountId` equal to `userId` for Server/DC until all renderer
+  call sites stop relying on the legacy property name.
+- Server/DC assignment payload:
+  - If clearing assignee: `{ name: null }`.
+  - If assigning:
+    `{ name: updates.assigneeUserId !== undefined ? updates.assigneeUserId : updates.assigneeAccountId }`.
+- Cloud assignment payload:
+  - If clearing assignee: `{ accountId: null }`.
+  - If assigning:
+    `{ accountId: updates.assigneeUserId !== undefined ? updates.assigneeUserId : updates.assigneeAccountId }`.
+
+Renderer-facing code should read and write the opaque `assigneeUserId` field.
+Migrate `JiraIssueWorkspace.tsx` mutations from `assigneeAccountId` to
+`assigneeUserId`, using `user.userId` from assignable-user results. Keep the
+deprecated alias only to protect older runtime or store callers during the
+transition. Main-process adapters must never assume a renderer-provided assignee
+id is a Cloud `accountId` unless the site is Cloud.
+
+## Description And Comment Format
+
+Cloud:
+
+- Continue converting text to ADF with `textToAdf`.
+- Continue rendering ADF to Markdown with `adfToMarkdownText`.
+
+Server/DC:
+
+- Send plain text strings for description and comments.
+- Send plain text strings for textarea create fields.
+- Accept both string bodies and ADF-like objects when reading. The existing
+  renderer of Jira body content already handles string input.
+
+## UI Design
+
+Update Jira connection UI in one reusable component:
+
+- Reuse `JiraConnectDialog` for Settings, onboarding, and Tasks.
+- Replace the duplicate inline Jira connect form in `TaskPage` with
+  `JiraConnectDialog`.
+- Add a deployment type segmented control:
+  - `Cloud`
+  - `Server/Data Center`
+- Cloud mode fields:
+  - Jira Cloud site URL.
+  - Atlassian email.
+  - API token.
+- Server/DC mode fields:
+  - Jira site URL.
+  - Auth mode: `Username + password/PAT` or `Bearer PAT`.
+  - Username and password/token for Basic.
+  - Bearer token for Bearer.
+
+Copy rules:
+
+- Do not say Orca supports only Cloud after this change.
+- Do not call Server/DC credentials an Atlassian Cloud API token.
+- Explain credential storage using the existing local/remote runtime wording.
+- Keep errors factual: for example, "Jira Server rejected these credentials" or
+  "This Jira site did not respond to the selected deployment type."
+
+Style rules:
+
+- Use existing `Dialog`, `Input`, `Label`, `Button`, and select/segmented
+  primitives.
+- Use existing color tokens only.
+- Keep form controls compact and aligned with Settings form conventions.
+- Verify light/dark mode and remote latency behavior.
+
+## IPC, Preload, Store, And Remote Runtime
+
+Every connection argument and shared type change must cross all Jira boundaries:
+
+- `src/shared/jira-types.ts`
+- `src/preload/api-types.ts`
+- `src/preload/index.ts`
+- `src/main/ipc/jira.ts`
+- `src/main/runtime/rpc/methods/jira.ts`
+- `src/main/runtime/orca-runtime.ts`
+- `src/renderer/src/runtime/runtime-jira-client.ts`
+- `src/renderer/src/store/slices/jira.ts`
+- `src/renderer/src/components/JiraIssueWorkspace.tsx`
+- `src/renderer/src/components/TaskPage.tsx`
+
+Remote runtime behavior:
+
+- When active runtime is remote, connection credentials must be sent to the
+  selected runtime and stored there, as today.
+- Status, test connection, issue reads, mutations, metadata reads, and comments
+  must behave identically through local IPC and runtime RPC.
+- `src/main/runtime/orca-runtime.ts` must expose the same Server/DC-aware Jira
+  bridge methods as local IPC, including connect, list/search, create, comments,
+  assignee, and transitions.
+- Zod RPC schemas must accept Cloud and Server/DC connect payloads and reject
+  malformed mixed-mode payloads.
+
+## Error Handling
+
+- Keep only-401-clears-token behavior.
+- Surface 403 as permission or endpoint access denial, not as disconnected.
+- For "all sites" fan-out, preserve current partial-success behavior.
+- For a selected single site, surface Server/DC adapter errors with status code
+  context where available.
+- If optional deployment probing is added later and fails, `/myself` should
+  remain the authoritative connection check for the selected mode.
+- If `/myself` returns HTML from a login redirect, report a clear selected-mode
+  mismatch or authentication failure instead of a JSON parse error.
+
+## Migration
+
+Implement migration in `site-storage.ts`:
+
+1. Read existing `jira-sites.json`.
+2. Normalize each site.
+3. For sites without `deploymentType`, write `deploymentType: "cloud"`.
+4. For sites without `authMode`, write `authMode: "basic"`.
+5. Preserve existing `id` for Cloud sites so token filenames keep working.
+6. Drop only malformed sites or sites with missing token files, matching current
+   behavior.
+
+Server/DC sites are only created by the new connection flow, so no old Server/DC
+site migration is needed.
+
+## Testing Plan
+
+### Main Jira Client
+
+Add or update `src/main/jira/client.test.ts`:
+
+- Existing Cloud site files migrate to `deploymentType: "cloud"` without
+  changing site id or token path.
+- Cloud connect still calls `/rest/api/3/myself` with
+  `Basic base64(email:apiToken)`.
+- Server Basic connect calls `/rest/api/2/myself` with
+  `Basic base64(username:passwordOrToken)`.
+- Server Bearer connect calls `/rest/api/2/myself` with `Bearer <token>`.
+- Server/DC viewer maps `name` or `key` into the stored user id.
+- 403 is not treated as auth revocation; 401 is.
+
+### Issue Operations
+
+Add or update `src/main/jira/issues.test.ts` and new adapter tests:
+
+- Cloud paths and request bodies remain unchanged.
+- Server search uses `POST /rest/api/2/search`.
+- Server create sends plain text `description`.
+- Server required textarea create fields send plain strings, while Cloud keeps
+  sending ADF documents for textarea create fields.
+- Server comments send `{ body: string }`.
+- Server project list handles direct array responses from `/rest/api/2/project`.
+- Server issue type list uses
+  `/rest/api/2/issue/createmeta/{projectIdOrKey}/issuetypes`.
+- Server create fields use
+  `/rest/api/2/issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}`.
+- Server assignable users send `issueKey`, `username`, and `maxResults`, not
+  Cloud `query`.
+- Server assignee update sends `{ name }` or `{ name: null }`.
+- Server user mapping preserves display name, email, and avatar where present.
+
+### IPC And Runtime RPC
+
+Add or update:
+
+- `src/main/ipc/jira.test.ts`
+- `src/main/runtime/rpc/methods/jira.test.ts`
+- `src/renderer/src/runtime/runtime-jira-client.test.ts`
+
+Coverage:
+
+- Cloud connect payload validates.
+- Server Basic connect payload validates.
+- Server Bearer connect payload validates.
+- Mixed payloads fail with a useful error.
+- Runtime RPC forwards deployment and auth mode fields unchanged.
+- The Orca runtime bridge keeps forwarding Server/DC-aware Jira calls for
+  connect, status, list/search, create, comment, assign, and transition.
+
+### Renderer Store And UI
+
+Add or update:
+
+- `src/renderer/src/store/slices/jira.test.ts`
+- `src/renderer/src/components/jira-connect-dialog.test.tsx`
+- `src/renderer/src/components/settings/jira-integration-card.test.tsx`
+
+Coverage:
+
+- Connect dialog switches between Cloud and Server/DC fields.
+- Settings card copy no longer claims that Jira support is limited to Cloud.
+- Successful connect refreshes status and clears stale Jira issue/search caches.
+- Failed connect surfaces inline error text.
+- `JiraIssueWorkspace` sends `assigneeUserId` for assign and unassign
+  mutations and uses `user.userId` from assignable users. This path is
+  typechecked and included in manual validation because this component does not
+  currently have a dedicated component-test harness.
+- There is no duplicate connect form behavior between Settings and TaskPage.
+
+### Optional E2E
+
+Only add E2E coverage if DOM behavior cannot be covered with component tests.
+If adding E2E tests:
+
+- Use `pnpm run test:e2e` for the default path.
+- For fast iteration, build with `pnpm exec electron-vite build --mode e2e`
+  before using `SKIP_BUILD=1`.
+- Use `window.__store` only for setup.
+- Final assertions must target user-visible DOM.
+
+## Verification Commands
+
+Run focused tests while implementing:
+
+```bash
+pnpm vitest run --config config/vitest.config.ts src/main/jira/client.test.ts src/main/jira/issues.test.ts
+pnpm vitest run --config config/vitest.config.ts src/main/ipc/jira.test.ts src/main/runtime/rpc/methods/jira.test.ts
+pnpm vitest run --config config/vitest.config.ts src/renderer/src/runtime/runtime-jira-client.test.ts src/renderer/src/store/slices/jira.test.ts
+pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/jira-connect-dialog.test.tsx src/renderer/src/components/settings/jira-integration-card.test.tsx
+```
+
+Run full contribution checks before opening a PR:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+## Manual Validation
+
+Use a non-production or low-risk Jira Server/DC account when possible.
+
+Server/DC manual checks:
+
+1. Connect to a Server/DC URL with Basic auth.
+2. Connect to a Server/DC URL with Bearer PAT if available.
+3. Verify Settings shows the connected Server/DC site.
+4. List assigned issues.
+5. Run a custom JQL search.
+6. Open an issue detail view.
+7. Add a comment.
+8. Create an issue with required custom fields.
+9. Assign and unassign an issue.
+10. Transition an issue.
+
+Cloud regression checks:
+
+1. Connect to an Atlassian Cloud site.
+2. List, search, create, comment, assign, and transition issues.
+3. Confirm ADF description/comment behavior remains unchanged.
+
+Remote runtime checks:
+
+1. Configure a remote runtime.
+2. Connect Jira Server/DC while remote runtime is active.
+3. Confirm credentials are stored by the remote runtime.
+4. List and search issues through the remote runtime.
+5. Create, comment, assign, unassign, and transition issues through the remote
+   runtime.
+
+## Security Review Checklist
+
+- Credentials never appear in logs, telemetry, traces, screenshots, or thrown
+  error messages.
+- Basic and Bearer auth headers are built only in main/runtime code.
+- Renderer receives saved metadata but never receives stored token contents.
+- Server/DC password/PAT fields use password inputs.
+- RPC schemas reject malformed auth payloads.
+- Redirected HTML login pages produce sanitized error messages.
+- Remote runtime credential storage copy remains accurate.
+
+## PR Checklist
+
+In the PR description:
+
+- Summarize user-visible behavior: Jira integration supports Cloud and
+  Server/Data Center sites.
+- Include screenshots or a screen recording for the updated connect dialog.
+- Include test evidence for focused Jira tests and full repo checks.
+- In the AI Review Report, explicitly cover cross-platform support,
+  SSH/remote/local runtime behavior, Jira Cloud regression risk, Server/DC auth,
+  performance, UI quality, and provider compatibility.
+- In the Security Audit, cover credential handling, auth headers, path handling,
+  IPC/RPC validation, and logging.
+
+## References
+
+- Jira Server/Data Center REST API 9.17.0:
+  <https://docs.atlassian.com/software/jira/docs/api/REST/9.17.0/>
+- Jira REST API examples and create metadata replacement notes:
+  <https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/>

--- a/src/main/ipc/jira.test.ts
+++ b/src/main/ipc/jira.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { connectMock, handleMock, updateIssueMock } = vi.hoisted(() => ({
+  connectMock: vi.fn(),
+  handleMock: vi.fn(),
+  updateIssueMock: vi.fn()
+}))
+
+type IpcHandler = (_event: unknown, args?: unknown) => Promise<unknown> | unknown
+
+const handlers = new Map<string, IpcHandler>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: IpcHandler) => {
+      handlers.set(channel, handler)
+      handleMock(channel, handler)
+    }
+  }
+}))
+
+vi.mock('../jira/client', () => ({
+  connect: (...args: unknown[]) => connectMock(...args),
+  disconnect: vi.fn(),
+  getStatus: vi.fn(() => ({ connected: false, viewer: null })),
+  selectSite: vi.fn(() => ({ connected: false, viewer: null })),
+  testConnection: vi.fn(() => ({ ok: false, error: 'Not connected to Jira.' }))
+}))
+
+vi.mock('../jira/issues', () => ({
+  addIssueComment: vi.fn(),
+  createIssue: vi.fn(),
+  getIssue: vi.fn(),
+  getIssueComments: vi.fn(),
+  listAssignableUsers: vi.fn(),
+  listCreateFields: vi.fn(),
+  listIssueTypes: vi.fn(),
+  listIssues: vi.fn(),
+  listPriorities: vi.fn(),
+  listProjects: vi.fn(),
+  listTransitions: vi.fn(),
+  searchIssues: vi.fn(),
+  updateIssue: (...args: unknown[]) => updateIssueMock(...args)
+}))
+
+vi.mock('./preflight', () => ({
+  _resetPreflightCache: vi.fn()
+}))
+
+async function registerHandlers(): Promise<void> {
+  handlers.clear()
+  vi.resetModules()
+  const { registerJiraHandlers } = await import('./jira')
+  registerJiraHandlers()
+}
+
+function handler(channel: string): IpcHandler {
+  const registered = handlers.get(channel)
+  if (!registered) {
+    throw new Error(`Missing IPC handler ${channel}`)
+  }
+  return registered
+}
+
+describe('Jira IPC handlers', () => {
+  beforeEach(async () => {
+    connectMock.mockReset()
+    updateIssueMock.mockReset()
+    connectMock.mockResolvedValue({ ok: true, viewer: { displayName: 'Ada' } })
+    updateIssueMock.mockResolvedValue({ ok: true })
+    await registerHandlers()
+  })
+
+  it('accepts Jira Server Basic connect payloads', async () => {
+    await expect(
+      handler('jira:connect')(
+        {},
+        {
+          deploymentType: 'server',
+          authMode: 'basic',
+          siteUrl: ' https://jira.example.internal ',
+          username: ' ada ',
+          passwordOrToken: ' secret '
+        }
+      )
+    ).resolves.toMatchObject({ ok: true })
+
+    expect(connectMock).toHaveBeenCalledWith({
+      deploymentType: 'server',
+      authMode: 'basic',
+      siteUrl: 'https://jira.example.internal',
+      username: 'ada',
+      passwordOrToken: 'secret'
+    })
+  })
+
+  it('accepts Jira Server Bearer connect payloads', async () => {
+    await expect(
+      handler('jira:connect')(
+        {},
+        {
+          deploymentType: 'server',
+          authMode: 'bearer',
+          siteUrl: 'https://jira.example.internal',
+          bearerToken: ' pat-secret '
+        }
+      )
+    ).resolves.toMatchObject({ ok: true })
+
+    expect(connectMock).toHaveBeenCalledWith({
+      deploymentType: 'server',
+      authMode: 'bearer',
+      siteUrl: 'https://jira.example.internal',
+      bearerToken: 'pat-secret'
+    })
+  })
+
+  it('rejects mixed Jira connect payloads', async () => {
+    await expect(
+      handler('jira:connect')(
+        {},
+        {
+          deploymentType: 'server',
+          authMode: 'bearer',
+          siteUrl: 'https://jira.example.internal',
+          username: 'ada',
+          bearerToken: 'pat-secret'
+        }
+      )
+    ).resolves.toEqual({ ok: false, error: 'Invalid Jira connection settings.' })
+
+    expect(connectMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts assigneeUserId issue updates', async () => {
+    await expect(
+      handler('jira:updateIssue')(
+        {},
+        {
+          key: 'SRV-1',
+          siteId: 'server-1',
+          updates: { assigneeUserId: null }
+        }
+      )
+    ).resolves.toEqual({ ok: true })
+
+    expect(updateIssueMock).toHaveBeenCalledWith('SRV-1', { assigneeUserId: null }, 'server-1')
+  })
+
+  it('rejects invalid assigneeUserId issue updates', async () => {
+    await expect(
+      handler('jira:updateIssue')(
+        {},
+        {
+          key: 'SRV-1',
+          updates: { assigneeUserId: 123 }
+        }
+      )
+    ).resolves.toEqual({ ok: false, error: 'Updates object is required.' })
+
+    expect(updateIssueMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -47,6 +47,64 @@ function normalizeStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) && value.every((item) => typeof item === 'string') ? value : undefined
 }
 
+function hasOnlyKeys(record: Record<string, unknown>, allowedKeys: ReadonlySet<string>): boolean {
+  return Object.keys(record).every((key) => allowedKeys.has(key))
+}
+
+function normalizeRequiredString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function normalizeConnectArgs(value: unknown): JiraConnectArgs | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const input = value as Record<string, unknown>
+  // Why: older renderer/runtime callers omitted deploymentType before Server/DC support.
+  const deploymentType = input.deploymentType ?? 'cloud'
+  if (deploymentType === 'cloud') {
+    if (!hasOnlyKeys(input, new Set(['deploymentType', 'siteUrl', 'email', 'apiToken']))) {
+      return null
+    }
+    const siteUrl = normalizeRequiredString(input.siteUrl)
+    const email = normalizeRequiredString(input.email)
+    const apiToken = normalizeRequiredString(input.apiToken)
+    return siteUrl && email && apiToken
+      ? { deploymentType: 'cloud', siteUrl, email, apiToken }
+      : null
+  }
+  if (deploymentType !== 'server') {
+    return null
+  }
+  if (input.authMode === 'basic') {
+    if (
+      !hasOnlyKeys(
+        input,
+        new Set(['deploymentType', 'authMode', 'siteUrl', 'username', 'passwordOrToken'])
+      )
+    ) {
+      return null
+    }
+    const siteUrl = normalizeRequiredString(input.siteUrl)
+    const username = normalizeRequiredString(input.username)
+    const passwordOrToken = normalizeRequiredString(input.passwordOrToken)
+    return siteUrl && username && passwordOrToken
+      ? { deploymentType: 'server', authMode: 'basic', siteUrl, username, passwordOrToken }
+      : null
+  }
+  if (input.authMode === 'bearer') {
+    if (!hasOnlyKeys(input, new Set(['deploymentType', 'authMode', 'siteUrl', 'bearerToken']))) {
+      return null
+    }
+    const siteUrl = normalizeRequiredString(input.siteUrl)
+    const bearerToken = normalizeRequiredString(input.bearerToken)
+    return siteUrl && bearerToken
+      ? { deploymentType: 'server', authMode: 'bearer', siteUrl, bearerToken }
+      : null
+  }
+  return null
+}
+
 function normalizeIssueUpdate(value: unknown): JiraIssueUpdate | null {
   if (!value || typeof value !== 'object') {
     return null
@@ -56,6 +114,13 @@ function normalizeIssueUpdate(value: unknown): JiraIssueUpdate | null {
     return null
   }
   if (input.labels !== undefined && normalizeStringArray(input.labels) === undefined) {
+    return null
+  }
+  if (
+    input.assigneeUserId !== undefined &&
+    input.assigneeUserId !== null &&
+    typeof input.assigneeUserId !== 'string'
+  ) {
     return null
   }
   if (
@@ -80,18 +145,11 @@ function normalizeIssueUpdate(value: unknown): JiraIssueUpdate | null {
 
 export function registerJiraHandlers(): void {
   ipcMain.handle('jira:connect', async (_event, args: JiraConnectArgs) => {
-    if (
-      typeof args?.siteUrl !== 'string' ||
-      typeof args?.email !== 'string' ||
-      typeof args?.apiToken !== 'string'
-    ) {
-      return { ok: false, error: 'Site URL, email, and API token are required.' }
+    const normalized = normalizeConnectArgs(args)
+    if (!normalized) {
+      return { ok: false, error: 'Invalid Jira connection settings.' }
     }
-    const result = await connect({
-      siteUrl: args.siteUrl,
-      email: args.email,
-      apiToken: args.apiToken
-    })
+    const result = await connect(normalized)
     if (result.ok) {
       _resetPreflightCache()
     }

--- a/src/main/jira/auth-headers.ts
+++ b/src/main/jira/auth-headers.ts
@@ -1,0 +1,12 @@
+import type { JiraSite } from '../../shared/types'
+
+export function basicAuthHeader(username: string, secret: string): string {
+  return `Basic ${Buffer.from(`${username}:${secret}`).toString('base64')}`
+}
+
+export function jiraAuthorizationHeader(site: JiraSite, secret: string): string {
+  if (site.deploymentType === 'server' && site.authMode === 'bearer') {
+    return `Bearer ${secret}`
+  }
+  return basicAuthHeader(site.authUsername ?? site.email, secret)
+}

--- a/src/main/jira/client.test.ts
+++ b/src/main/jira/client.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
@@ -56,6 +56,12 @@ function writeJiraFiles(siteId: string, token: string | Buffer): void {
     { encoding: 'utf-8' }
   )
   writeFileSync(tokenPathForSite(siteId), token)
+}
+
+function readJiraSiteFile(): { sites?: unknown[] } {
+  return JSON.parse(
+    readFileSync(join(tempHome, '.orca', 'jira-sites.json'), { encoding: 'utf-8' })
+  ) as { sites?: unknown[] }
 }
 
 function writeMultiSiteFiles(
@@ -133,6 +139,190 @@ afterEach(() => {
 })
 
 describe('Jira client credential storage', () => {
+  it('normalizes legacy saved Cloud sites to deployment-aware metadata', async () => {
+    const siteId = 'site-alpha'
+    writeJiraFiles(siteId, 'token-alpha')
+    const jira = await loadClientModule()
+
+    expect(jira.getStatus()).toMatchObject({
+      connected: true,
+      viewer: {
+        accountId: 'account-alpha',
+        userId: 'account-alpha',
+        displayName: 'Ada',
+        email: 'ada@example.com'
+      },
+      sites: [
+        {
+          id: siteId,
+          deploymentType: 'cloud',
+          authMode: 'basic',
+          accountId: 'account-alpha',
+          viewerUserId: 'account-alpha'
+        }
+      ]
+    })
+    expect(readJiraSiteFile().sites?.[0]).toMatchObject({
+      id: siteId,
+      deploymentType: 'cloud',
+      authMode: 'basic',
+      viewerUserId: 'account-alpha'
+    })
+  })
+
+  it('strips URL credentials before storing Jira site metadata', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: 'ada',
+          displayName: 'Ada Server',
+          emailAddress: 'ada@example.internal'
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const jira = await loadClientModule()
+
+    await expect(
+      jira.connect({
+        deploymentType: 'server',
+        authMode: 'basic',
+        siteUrl: 'https://url-user:url-secret@jira.example.internal/',
+        username: 'ada',
+        passwordOrToken: 'server-secret'
+      })
+    ).resolves.toMatchObject({ ok: true })
+
+    expect(jira.getStatus().sites?.[0]?.siteUrl).toBe('https://jira.example.internal')
+    expect(String(netFetchMock.mock.calls[0]?.[0])).toBe(
+      'https://jira.example.internal/rest/api/2/myself'
+    )
+  })
+
+  it('connects to Jira Server with Basic credentials through REST API v2', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: 'ada',
+          key: 'JIRAUSER10000',
+          displayName: 'Ada Server',
+          emailAddress: 'ada@example.internal'
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const jira = await loadClientModule()
+
+    await expect(
+      jira.connect({
+        deploymentType: 'server',
+        authMode: 'basic',
+        siteUrl: 'jira.example.internal',
+        username: 'ada',
+        passwordOrToken: 'server-secret'
+      })
+    ).resolves.toEqual({
+      ok: true,
+      viewer: {
+        accountId: 'ada',
+        userId: 'ada',
+        displayName: 'Ada Server',
+        email: 'ada@example.internal',
+        avatarUrl: undefined
+      }
+    })
+
+    expect(resolveProxyMock).toHaveBeenCalledWith('https://jira.example.internal/rest/api/2/myself')
+    const connectHeaders = netFetchMock.mock.calls[0]?.[1]?.headers as Headers
+    expect(connectHeaders.get('Authorization')).toBe(
+      `Basic ${Buffer.from('ada:server-secret').toString('base64')}`
+    )
+
+    const savedSite = jira.getStatus().sites?.[0]
+    expect(savedSite).toMatchObject({
+      siteUrl: 'https://jira.example.internal',
+      email: 'ada@example.internal',
+      displayName: 'Ada Server',
+      accountId: 'ada',
+      viewerUserId: 'ada',
+      deploymentType: 'server',
+      authMode: 'basic',
+      authUsername: 'ada'
+    })
+    expect(jira.getClients(savedSite?.id)[0]?.authorization).toBe(
+      `Basic ${Buffer.from('ada:server-secret').toString('base64')}`
+    )
+  })
+
+  it('connects to Jira Server with Bearer credentials through REST API v2', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: 'pat-user',
+          displayName: 'PAT User',
+          emailAddress: 'pat@example.internal'
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const jira = await loadClientModule()
+
+    await expect(
+      jira.connect({
+        deploymentType: 'server',
+        authMode: 'bearer',
+        siteUrl: 'https://jira.example.internal/',
+        bearerToken: 'bearer-secret'
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      viewer: {
+        accountId: 'pat-user',
+        userId: 'pat-user',
+        displayName: 'PAT User'
+      }
+    })
+
+    const connectHeaders = netFetchMock.mock.calls[0]?.[1]?.headers as Headers
+    expect(resolveProxyMock).toHaveBeenCalledWith('https://jira.example.internal/rest/api/2/myself')
+    expect(connectHeaders.get('Authorization')).toBe('Bearer bearer-secret')
+
+    const savedSite = jira.getStatus().sites?.[0]
+    expect(savedSite).toMatchObject({
+      siteUrl: 'https://jira.example.internal',
+      deploymentType: 'server',
+      authMode: 'bearer',
+      accountId: 'pat-user',
+      viewerUserId: 'pat-user',
+      authUsername: 'pat-user'
+    })
+    expect(jira.getClients(savedSite?.id)[0]?.authorization).toBe('Bearer bearer-secret')
+  })
+
+  it('reports Server login redirects without leaking JSON parse errors', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      new Response('<html><body>login</body></html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' }
+      })
+    )
+    const jira = await loadClientModule()
+
+    await expect(
+      jira.connect({
+        deploymentType: 'server',
+        authMode: 'basic',
+        siteUrl: 'https://jira.example.internal',
+        username: 'ada',
+        passwordOrToken: 'server-secret'
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error:
+        'Jira returned a non-JSON response. Check the selected deployment type and credentials.'
+    })
+  })
+
   it('preserves plaintext fallback and reaches Jira auth header construction', async () => {
     const siteId = 'site-alpha'
     writeJiraFiles(siteId, 'token-alpha')

--- a/src/main/jira/client.ts
+++ b/src/main/jira/client.ts
@@ -1,18 +1,5 @@
-/* eslint-disable max-lines -- Why: Jira credential storage and authenticated
-request plumbing share one boundary so encrypted token lifecycle and
-multi-site selection cannot drift between task operations. */
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
-import { net, safeStorage, session } from 'electron'
-import {
-  CredentialDecryptionError,
-  credentialFileHasContent,
-  readStoredCredentialToken
-} from '../integration-credential-file'
-import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
-import { withSpan } from '../observability/tracer'
+import { CredentialDecryptionError } from '../integration-credential-file'
 import type {
   JiraConnectArgs,
   JiraConnectionStatus,
@@ -20,13 +7,24 @@ import type {
   JiraSiteSelection,
   JiraViewer
 } from '../../shared/types'
+import { basicAuthHeader, jiraAuthorizationHeader } from './auth-headers'
+import {
+  JiraApiError,
+  jiraRequest,
+  jiraRequestWithAuthorization,
+  type JiraClientForSite
+} from './jira-request'
+import {
+  deleteJiraSiteSecret,
+  getJiraCredentialError,
+  getSiteFile,
+  readJiraSiteSecret,
+  saveJiraSiteSecret,
+  writeSiteFile
+} from './site-storage'
+import { jiraSiteToViewer, toCloudJiraViewer, toServerJiraViewer } from './jira-user-identity'
 
-// Why: Atlassian's XSRF filter rejects POST/PUT REST calls that carry a browser
-// User-Agent, failing them with "XSRF check failed" even under API-token auth.
-// Electron's net.fetch sends a Chrome UA, so issue search/create/update/comment
-// all 403'd while GET calls (connect, /myself) passed. A non-browser UA is the
-// reliable fix; X-Atlassian-Token: no-check is not honored for this case.
-const JIRA_API_USER_AGENT = 'Orca'
+export { JiraApiError, jiraRequest, type JiraClientForSite } from './jira-request'
 
 const MAX_CONCURRENT = 4
 let running = 0
@@ -53,222 +51,13 @@ export function release(): void {
   }
 }
 
-type JiraSiteFile = {
-  version: 1
-  activeSiteId: string | null
-  selectedSiteId: JiraSiteSelection | null
-  sites: JiraSite[]
-}
-
-export type JiraClientForSite = {
-  site: JiraSite
-  authorization: string
-}
-
-export class JiraApiError extends Error {
-  status: number | null
-
-  constructor(message: string, status: number | null = null) {
-    super(message)
-    this.status = status
-  }
-}
-
-let cachedSiteFile: JiraSiteFile | null = null
-let siteFileLoaded = false
-const cachedTokens = new Map<string, string>()
-// Why: decrypt failures are recorded per site so getStatus can explain
-// failing reads without re-touching the keychain on every status poll.
-const credentialErrors = new Map<string, string>()
-
-function getOrcaDir(): string {
-  return join(homedir(), '.orca')
-}
-
-function getSiteFilePath(): string {
-  return join(getOrcaDir(), 'jira-sites.json')
-}
-
-function getTokenDir(): string {
-  return join(getOrcaDir(), 'jira-tokens')
-}
-
-function getTokenPath(siteId: string): string {
-  return join(getTokenDir(), `${Buffer.from(siteId).toString('base64url')}.enc`)
-}
-
-function ensureOrcaDir(): void {
-  const dir = getOrcaDir()
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
-  }
-}
-
-function ensureTokenDir(): void {
-  const dir = getTokenDir()
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
-  }
-}
-
-function emptySiteFile(): JiraSiteFile {
-  return {
-    version: 1,
-    activeSiteId: null,
-    selectedSiteId: null,
-    sites: []
-  }
-}
-
-function hasStoredToken(siteId: string): boolean {
-  return cachedTokens.has(siteId) || credentialFileHasContent(getTokenPath(siteId))
-}
-
-function normalizeSite(input: unknown): JiraSite | null {
-  if (!input || typeof input !== 'object') {
-    return null
-  }
-  const record = input as Record<string, unknown>
-  if (
-    typeof record.id !== 'string' ||
-    typeof record.siteUrl !== 'string' ||
-    typeof record.email !== 'string' ||
-    typeof record.displayName !== 'string' ||
-    typeof record.accountId !== 'string'
-  ) {
-    return null
-  }
-  return {
-    id: record.id,
-    siteUrl: record.siteUrl,
-    email: record.email,
-    displayName: record.displayName,
-    accountId: record.accountId
-  }
-}
-
-function readSiteFileFromDisk(): JiraSiteFile {
-  const path = getSiteFilePath()
-  if (!existsSync(path)) {
-    return emptySiteFile()
-  }
-  try {
-    const parsed = JSON.parse(readFileSync(path, { encoding: 'utf-8' })) as Partial<JiraSiteFile>
-    const sites = Array.isArray(parsed.sites)
-      ? parsed.sites
-          .map((site) => normalizeSite(site))
-          .filter((site): site is JiraSite => site !== null)
-          .filter((site) => hasStoredToken(site.id))
-      : []
-    const activeSiteId =
-      typeof parsed.activeSiteId === 'string' &&
-      sites.some((site) => site.id === parsed.activeSiteId)
-        ? parsed.activeSiteId
-        : (sites[0]?.id ?? null)
-    const selectedSiteId =
-      parsed.selectedSiteId === 'all' ||
-      (typeof parsed.selectedSiteId === 'string' &&
-        sites.some((site) => site.id === parsed.selectedSiteId))
-        ? parsed.selectedSiteId
-        : activeSiteId
-    return { version: 1, activeSiteId, selectedSiteId, sites }
-  } catch {
-    return emptySiteFile()
-  }
-}
-
-function getSiteFile(): JiraSiteFile {
-  if (!siteFileLoaded || !cachedSiteFile) {
-    cachedSiteFile = readSiteFileFromDisk()
-    siteFileLoaded = true
-  }
-  return cachedSiteFile
-}
-
-function writeSiteFile(file: JiraSiteFile): void {
-  ensureOrcaDir()
-  const sites = file.sites.filter((site) => hasStoredToken(site.id))
-  const activeSiteId =
-    file.activeSiteId && sites.some((site) => site.id === file.activeSiteId)
-      ? file.activeSiteId
-      : (sites[0]?.id ?? null)
-  const selectedSiteId =
-    file.selectedSiteId === 'all'
-      ? 'all'
-      : file.selectedSiteId && sites.some((site) => site.id === file.selectedSiteId)
-        ? file.selectedSiteId
-        : activeSiteId
-
-  cachedSiteFile = {
-    version: 1,
-    activeSiteId,
-    selectedSiteId,
-    sites
-  }
-  siteFileLoaded = true
-  writeFileSync(getSiteFilePath(), JSON.stringify(cachedSiteFile, null, 2), {
-    encoding: 'utf-8',
-    mode: 0o600
-  })
-}
-
-function writeEncryptedToken(path: string, apiToken: string): void {
-  if (safeStorage.isEncryptionAvailable()) {
-    writeFileSync(path, safeStorage.encryptString(apiToken), { mode: 0o600 })
-    return
-  }
-  console.warn('[jira] safeStorage encryption unavailable — storing token in plaintext')
-  writeFileSync(path, apiToken, { encoding: 'utf-8', mode: 0o600 })
-}
-
-function readToken(siteId: string): string | null {
-  const cached = cachedTokens.get(siteId)
-  if (cached !== undefined) {
-    return cached
-  }
-  const path = getTokenPath(siteId)
-  if (!existsSync(path)) {
-    return null
-  }
-  try {
-    const raw = readFileSync(path)
-    const token = readStoredCredentialToken('Jira', raw)
-    if (token) {
-      cachedTokens.set(siteId, token)
-    }
-    credentialErrors.delete(siteId)
-    return token
-  } catch (error) {
-    if (error instanceof CredentialDecryptionError) {
-      credentialErrors.set(siteId, error.message)
-      throw error
-    }
-    return null
-  }
-}
-
-function saveToken(siteId: string, apiToken: string): void {
-  ensureOrcaDir()
-  ensureTokenDir()
-  writeEncryptedToken(getTokenPath(siteId), apiToken)
-  cachedTokens.set(siteId, apiToken)
-  credentialErrors.delete(siteId)
-}
-
-function deleteToken(siteId: string): void {
-  cachedTokens.delete(siteId)
-  credentialErrors.delete(siteId)
-  try {
-    unlinkSync(getTokenPath(siteId))
-  } catch {
-    // Token may not exist — safe to ignore.
-  }
-}
-
 export function normalizeJiraSiteUrl(siteUrl: string): string {
   const trimmed = siteUrl.trim()
   const withProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
   const url = new URL(withProtocol)
+  // Why: credentials belong in encrypted token storage, never site metadata or UI.
+  url.username = ''
+  url.password = ''
   url.pathname = url.pathname.replace(/\/+$/, '')
   url.search = ''
   url.hash = ''
@@ -282,152 +71,15 @@ function getSiteId(siteUrl: string, email: string): string {
     .slice(0, 24)
 }
 
-function toViewer(data: Record<string, unknown>, fallbackEmail: string): JiraViewer {
-  const avatarUrls = data.avatarUrls as Record<string, unknown> | undefined
-  return {
-    accountId: typeof data.accountId === 'string' ? data.accountId : '',
-    displayName: typeof data.displayName === 'string' ? data.displayName : fallbackEmail,
-    email: typeof data.emailAddress === 'string' ? data.emailAddress : fallbackEmail,
-    avatarUrl:
-      typeof avatarUrls?.['48x48'] === 'string'
-        ? avatarUrls['48x48']
-        : typeof avatarUrls?.['32x32'] === 'string'
-          ? avatarUrls['32x32']
-          : undefined
-  }
-}
-
-function siteToViewer(site: JiraSite | null): JiraViewer | null {
-  if (!site) {
-    return null
-  }
-  return {
-    accountId: site.accountId,
-    displayName: site.displayName,
-    email: site.email
-  }
-}
-
-function authHeader(email: string, apiToken: string): string {
-  return `Basic ${Buffer.from(`${email}:${apiToken}`).toString('base64')}`
-}
-
-function describeErrorCause(error: unknown): string | undefined {
-  if (!error || typeof error !== 'object' || !('cause' in error)) {
-    return undefined
-  }
-  const cause = (error as { cause?: unknown }).cause
-  if (cause instanceof Error) {
-    return `${cause.name}: ${cause.message}`
-  }
-  return cause === undefined ? undefined : String(cause)
-}
-
-async function jiraFetch(url: string, init: RequestInit): Promise<Response> {
-  return withSpan(
-    'jira.request',
-    async (span) => {
-      span.setAttribute('jira.siteUrl', new URL(url).origin)
-      await ensureElectronProxyFromEnvironment({
-        proxySession: session.defaultSession,
-        probeUrl: url
-      }).catch((error) => {
-        span.addEvent('jira.proxySetupFailed', {
-          errorName: error instanceof Error ? error.name : typeof error,
-          errorMessage: error instanceof Error ? error.message : String(error)
-        })
-      })
-      try {
-        // Why: Electron's network stack follows Chromium proxy/session state,
-        // avoiding undici's stale keep-alive sockets after VPN path changes.
-        return await net.fetch(url, init)
-      } catch (error) {
-        span.setAttribute(
-          'jira.transportErrorName',
-          error instanceof Error ? error.name : typeof error
-        )
-        span.setAttribute(
-          'jira.transportErrorMessage',
-          error instanceof Error ? error.message : String(error)
-        )
-        const cause = describeErrorCause(error)
-        if (cause) {
-          span.setAttribute('jira.transportErrorCause', cause)
-        }
-        throw error
-      }
-    },
-    { kind: 'client' }
-  )
-}
-
-async function requestWithCredentials(
+function getServerSiteId(
   siteUrl: string,
-  email: string,
-  apiToken: string,
-  path: string,
-  init?: RequestInit
-): Promise<unknown> {
-  const headers = new Headers(init?.headers)
-  headers.set('Accept', 'application/json')
-  headers.set('Content-Type', 'application/json')
-  headers.set('User-Agent', JIRA_API_USER_AGENT)
-  headers.set('Authorization', authHeader(email, apiToken))
-  const response = await jiraFetch(`${siteUrl}${path}`, {
-    ...init,
-    headers
-  })
-  if (!response.ok) {
-    throw new JiraApiError(await readJiraError(response), response.status)
-  }
-  if (response.status === 204) {
-    return null
-  }
-  return response.json()
-}
-
-async function readJiraError(response: Response): Promise<string> {
-  try {
-    const data = (await response.json()) as {
-      errorMessages?: string[]
-      errors?: Record<string, string>
-      message?: string
-    }
-    const messages = [
-      ...(Array.isArray(data.errorMessages) ? data.errorMessages : []),
-      ...Object.values(data.errors ?? {}),
-      ...(data.message ? [data.message] : [])
-    ].filter(Boolean)
-    if (messages.length > 0) {
-      return messages.join('; ')
-    }
-  } catch {
-    // Fall through to status text.
-  }
-  return response.statusText || `Jira request failed (${response.status})`
-}
-
-export async function jiraRequest<T>(
-  client: JiraClientForSite,
-  path: string,
-  init?: RequestInit
-): Promise<T> {
-  const headers = new Headers(init?.headers)
-  headers.set('Accept', 'application/json')
-  headers.set('Content-Type', 'application/json')
-  headers.set('User-Agent', JIRA_API_USER_AGENT)
-  headers.set('Authorization', client.authorization)
-  const response = await jiraFetch(`${client.site.siteUrl}${path}`, {
-    ...init,
-    headers
-  })
-  if (!response.ok) {
-    throw new JiraApiError(await readJiraError(response), response.status)
-  }
-  if (response.status === 204) {
-    return null as T
-  }
-  return (await response.json()) as T
+  authMode: JiraSite['authMode'],
+  viewerIdentityId: string
+): string {
+  return createHash('sha256')
+    .update(`${siteUrl}\nserver\n${authMode}\n${viewerIdentityId}`)
+    .digest('base64url')
+    .slice(0, 24)
 }
 
 export function getClients(selection?: JiraSiteSelection | null): JiraClientForSite[] {
@@ -441,10 +93,10 @@ export function getClients(selection?: JiraSiteSelection | null): JiraClientForS
   return sites.flatMap((site) => {
     let token: string | null
     try {
-      token = readToken(site.id)
+      token = readJiraSiteSecret(site.id)
     } catch (error) {
       // Why: under an 'all' selection one un-decryptable site must not collapse
-      // reads for the healthy ones. readToken already recorded the per-site
+      // reads for the healthy ones. readJiraSiteSecret already recorded the per-site
       // credentialError for getStatus to surface, so skip this site like a
       // missing token. A specific-site selection still rethrows so the renderer
       // can surface the decrypt banner promptly.
@@ -453,20 +105,20 @@ export function getClients(selection?: JiraSiteSelection | null): JiraClientForS
       }
       throw error
     }
-    return token ? [{ site, authorization: authHeader(site.email, token) }] : []
+    return token ? [{ site, authorization: jiraAuthorizationHeader(site, token) }] : []
   })
 }
 
 export function getStatus(): JiraConnectionStatus {
   const file = getSiteFile()
-  const sites = file.sites.filter((site) => hasStoredToken(site.id))
+  const sites = file.sites
   const activeSite = sites.find((site) => site.id === file.activeSiteId) ?? sites[0] ?? null
   const credentialError = sites
-    .map((site) => credentialErrors.get(site.id))
+    .map((site) => getJiraCredentialError(site.id))
     .find((message) => message !== undefined)
   return {
     connected: sites.length > 0,
-    viewer: siteToViewer(activeSite),
+    viewer: jiraSiteToViewer(activeSite),
     sites,
     activeSiteId: activeSite?.id ?? null,
     selectedSiteId: file.selectedSiteId ?? activeSite?.id ?? null,
@@ -484,36 +136,73 @@ export async function connect(
     return { ok: false, error: 'Enter a valid Jira site URL.' }
   }
 
-  const email = args.email.trim()
-  const apiToken = args.apiToken.trim()
-  if (!email || !apiToken) {
-    return { ok: false, error: 'Email and API token are required.' }
-  }
-
   await acquire()
   try {
-    const viewer = toViewer(
-      (await requestWithCredentials(siteUrl, email, apiToken, '/rest/api/3/myself')) as Record<
-        string,
-        unknown
-      >,
-      email
-    )
-    const id = getSiteId(siteUrl, email)
-    const site: JiraSite = {
-      id,
-      siteUrl,
-      email,
-      displayName: viewer.displayName,
-      accountId: viewer.accountId
+    let viewer: JiraViewer
+    let site: JiraSite
+    let secret: string
+    if (args.deploymentType === 'server') {
+      const authMode = args.authMode
+      const username = authMode === 'basic' ? args.username.trim() : ''
+      secret = authMode === 'basic' ? args.passwordOrToken.trim() : args.bearerToken.trim()
+      if ((authMode === 'basic' && !username) || !secret) {
+        return { ok: false, error: 'Jira Server credentials are required.' }
+      }
+      const authorization =
+        authMode === 'bearer' ? `Bearer ${secret}` : basicAuthHeader(username, secret)
+      viewer = toServerJiraViewer(
+        (await jiraRequestWithAuthorization(
+          siteUrl,
+          authorization,
+          '/rest/api/2/myself'
+        )) as Record<string, unknown>,
+        username
+      )
+      const id = getServerSiteId(siteUrl, authMode, viewer.userId)
+      site = {
+        id,
+        siteUrl,
+        email: viewer.email ?? username,
+        displayName: viewer.displayName,
+        accountId: viewer.accountId,
+        viewerUserId: viewer.userId,
+        deploymentType: 'server',
+        authMode,
+        authUsername: username || viewer.userId
+      }
+    } else {
+      const email = args.email.trim()
+      secret = args.apiToken.trim()
+      if (!email || !secret) {
+        return { ok: false, error: 'Email and API token are required.' }
+      }
+      viewer = toCloudJiraViewer(
+        (await jiraRequestWithAuthorization(
+          siteUrl,
+          basicAuthHeader(email, secret),
+          '/rest/api/3/myself'
+        )) as Record<string, unknown>,
+        email
+      )
+      const id = getSiteId(siteUrl, email)
+      site = {
+        id,
+        siteUrl,
+        email,
+        displayName: viewer.displayName,
+        accountId: viewer.accountId,
+        viewerUserId: viewer.userId,
+        deploymentType: 'cloud',
+        authMode: 'basic'
+      }
     }
-    saveToken(id, apiToken)
+    saveJiraSiteSecret(site.id, secret)
     const file = getSiteFile()
     writeSiteFile({
       version: 1,
-      activeSiteId: id,
-      selectedSiteId: id,
-      sites: [site, ...file.sites.filter((entry) => entry.id !== id)]
+      activeSiteId: site.id,
+      selectedSiteId: site.id,
+      sites: [site, ...file.sites.filter((entry) => entry.id !== site.id)]
     })
     return { ok: true, viewer }
   } catch (error) {
@@ -527,7 +216,7 @@ export function disconnect(siteId?: string): void {
   const file = getSiteFile()
   const ids = siteId ? [siteId] : file.sites.map((site) => site.id)
   for (const id of ids) {
-    deleteToken(id)
+    deleteJiraSiteSecret(id)
   }
   writeSiteFile({
     version: 1,
@@ -564,10 +253,14 @@ export async function testConnection(
   }
   await acquire()
   try {
-    const viewer = toViewer(
-      (await jiraRequest(client, '/rest/api/3/myself')) as Record<string, unknown>,
-      client.site.email
-    )
+    const rawViewer = (await jiraRequest(
+      client,
+      client.site.deploymentType === 'server' ? '/rest/api/2/myself' : '/rest/api/3/myself'
+    )) as Record<string, unknown>
+    const viewer =
+      client.site.deploymentType === 'server'
+        ? toServerJiraViewer(rawViewer, client.site.authUsername ?? client.site.email)
+        : toCloudJiraViewer(rawViewer, client.site.email)
     return { ok: true, viewer }
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : 'Connection failed.' }
@@ -577,7 +270,7 @@ export async function testConnection(
 }
 
 export function clearToken(siteId: string): void {
-  deleteToken(siteId)
+  deleteJiraSiteSecret(siteId)
   const file = getSiteFile()
   writeSiteFile({ ...file, sites: file.sites.filter((site) => site.id !== siteId) })
 }

--- a/src/main/jira/issue-comments.ts
+++ b/src/main/jira/issue-comments.ts
@@ -1,0 +1,74 @@
+import type { JiraComment } from '../../shared/types'
+import { acquire, clearToken, getClients, isAuthError, jiraRequest, release } from './client'
+import { textToAdf } from './adf-markdown'
+import { fetchPagedRecords } from './issue-page-fetcher'
+import { mapComment } from './issue-mappers'
+import { isServerSite, restApiBase, shouldSurfaceSiteFailure } from './issue-rest-routing'
+import { toJiraErrorWithStatus } from './jira-request'
+
+export async function addIssueComment(
+  key: string,
+  body: string,
+  siteId?: string | null
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return { ok: false, error: 'Not connected to Jira.' }
+  }
+  await acquire()
+  try {
+    const comment = await jiraRequest<{ id: string }>(
+      entry,
+      `${restApiBase(entry.site)}/issue/${encodeURIComponent(key)}/comment`,
+      {
+        method: 'POST',
+        // Why: Server/DC comment bodies are plain text; Cloud comment bodies require ADF.
+        body: JSON.stringify({ body: isServerSite(entry.site) ? body : textToAdf(body) })
+      }
+    )
+    return { ok: true, id: comment.id }
+  } catch (error) {
+    if (isAuthError(error)) {
+      clearToken(entry.site.id)
+      throw error
+    }
+    return { ok: false, error: error instanceof Error ? error.message : 'Failed to add comment.' }
+  } finally {
+    release()
+  }
+}
+
+export async function getIssueComments(
+  key: string,
+  siteId?: string | null
+): Promise<JiraComment[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  await acquire()
+  try {
+    const comments = await fetchPagedRecords(entry, 'comments', (startAt, maxResults) => {
+      const params = new URLSearchParams({
+        maxResults: String(maxResults),
+        orderBy: 'created',
+        startAt: String(startAt)
+      })
+      return `${restApiBase(entry.site)}/issue/${encodeURIComponent(key)}/comment?${params.toString()}`
+    })
+    return comments.map((comment) => mapComment(comment, entry.site))
+  } catch (error) {
+    const surfacedError = toJiraErrorWithStatus(error)
+    if (isAuthError(error)) {
+      clearToken(entry.site.id)
+      throw surfacedError
+    }
+    if (shouldSurfaceSiteFailure(siteId, 1)) {
+      throw surfacedError
+    }
+    console.warn('[jira] getIssueComments failed:', error)
+    return []
+  } finally {
+    release()
+  }
+}

--- a/src/main/jira/issue-mappers.ts
+++ b/src/main/jira/issue-mappers.ts
@@ -1,0 +1,225 @@
+import type {
+  JiraComment,
+  JiraCreateField,
+  JiraCreateFieldAllowedValue,
+  JiraIssue,
+  JiraIssueType,
+  JiraPriority,
+  JiraProject,
+  JiraSite,
+  JiraStatus
+} from '../../shared/types'
+import { adfToMarkdownText } from './adf-markdown'
+import { mapJiraUser } from './jira-user-identity'
+
+export const ISSUE_FIELDS = [
+  'summary',
+  'description',
+  'project',
+  'issuetype',
+  'status',
+  'assignee',
+  'reporter',
+  'priority',
+  'labels',
+  'created',
+  'updated'
+]
+
+export type JiraRecord = Record<string, unknown>
+
+export type JiraPagedResponse<T> = {
+  startAt?: number
+  maxResults?: number
+  total?: number
+  isLast?: boolean
+  values?: T[]
+  issueTypes?: T[]
+  comments?: T[]
+  fields?: T[] | Record<string, T>
+}
+
+export type JiraPageItemKey = 'values' | 'issueTypes' | 'comments'
+
+export function asRecord(value: unknown): JiraRecord {
+  return value && typeof value === 'object' ? (value as JiraRecord) : {}
+}
+
+export function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+export function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : []
+}
+
+export function asFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+export function getPageItems<T>(response: JiraPagedResponse<T>, key: JiraPageItemKey): T[] {
+  const keyedItems = response[key]
+  if (Array.isArray(keyedItems)) {
+    return keyedItems
+  }
+  return response.values ?? []
+}
+
+export function shouldFetchNextPage<T>(
+  response: JiraPagedResponse<T>,
+  startAt: number,
+  items: T[],
+  requestedMaxResults: number
+): boolean {
+  if (response.isLast === true || items.length === 0) {
+    return false
+  }
+  const total = asFiniteNumber(response.total)
+  const pageSize = asFiniteNumber(response.maxResults)
+  if (total !== null) {
+    return startAt + items.length < total && (pageSize ?? requestedMaxResults) > 0
+  }
+  if (response.isLast === false) {
+    return (pageSize ?? requestedMaxResults) > 0
+  }
+  return pageSize !== null && items.length >= pageSize
+}
+
+export function mapProject(value: unknown, site?: JiraSite): JiraProject {
+  const project = asRecord(value)
+  return {
+    id: asString(project.id),
+    key: asString(project.key),
+    name: asString(project.name, asString(project.key)),
+    siteId: site?.id,
+    siteName: site?.displayName
+  }
+}
+
+export function mapIssueType(value: unknown): JiraIssueType {
+  const issueType = asRecord(value)
+  return {
+    id: asString(issueType.id),
+    name: asString(issueType.name, 'Issue'),
+    description: asString(issueType.description) || undefined,
+    iconUrl: asString(issueType.iconUrl) || undefined,
+    subtask: typeof issueType.subtask === 'boolean' ? issueType.subtask : undefined
+  }
+}
+
+function mapCreateFieldAllowedValue(value: unknown): JiraCreateFieldAllowedValue {
+  const option = asRecord(value)
+  return {
+    id: asString(option.id) || undefined,
+    value: asString(option.value) || undefined,
+    name: asString(option.name) || undefined
+  }
+}
+
+export function mapCreateField(value: unknown, fallbackKey = ''): JiraCreateField | null {
+  const field = asRecord(value)
+  const schema = asRecord(field.schema)
+  const key =
+    asString(field.key) ||
+    asString(field.fieldId) ||
+    asString(field.id) ||
+    asString(field.fieldKey) ||
+    fallbackKey
+  if (!key) {
+    return null
+  }
+  const allowedValues = Array.isArray(field.allowedValues)
+    ? field.allowedValues.map(mapCreateFieldAllowedValue)
+    : undefined
+  return {
+    key,
+    name: asString(field.name, key),
+    required: field.required === true,
+    schema: {
+      type: asString(schema.type) || undefined,
+      items: asString(schema.items) || undefined,
+      custom: asString(schema.custom) || undefined
+    },
+    allowedValues
+  }
+}
+
+export function getCreateFieldRecords(response: JiraPagedResponse<JiraRecord>): JiraRecord[] {
+  if (Array.isArray(response.values)) {
+    return response.values
+  }
+  if (Array.isArray(response.fields)) {
+    return response.fields
+  }
+  if (response.fields && typeof response.fields === 'object') {
+    return Object.entries(response.fields).map(([key, value]) => ({
+      key,
+      ...asRecord(value)
+    }))
+  }
+  return []
+}
+
+export function mapPriority(value: unknown): JiraPriority | undefined {
+  const priority = asRecord(value)
+  const id = asString(priority.id)
+  if (!id) {
+    return undefined
+  }
+  return {
+    id,
+    name: asString(priority.name, 'Priority'),
+    iconUrl: asString(priority.iconUrl) || undefined
+  }
+}
+
+export function mapStatus(value: unknown): JiraStatus {
+  const status = asRecord(value)
+  const category = asRecord(status.statusCategory)
+  return {
+    id: asString(status.id),
+    name: asString(status.name, 'Unknown'),
+    categoryKey: asString(category.key, 'undefined'),
+    categoryName: asString(category.name, 'No Category'),
+    colorName: asString(category.colorName) || undefined
+  }
+}
+
+export function issueUrl(site: JiraSite, key: string): string {
+  return `${site.siteUrl}/browse/${encodeURIComponent(key)}`
+}
+
+export function mapJiraIssue(site: JiraSite, raw: JiraRecord): JiraIssue {
+  const fields = asRecord(raw.fields)
+  const key = asString(raw.key)
+  return {
+    id: asString(raw.id, key),
+    key,
+    siteId: site.id,
+    siteName: site.displayName,
+    title: asString(fields.summary, key || 'Untitled issue'),
+    description: adfToMarkdownText(fields.description),
+    url: issueUrl(site, key),
+    project: mapProject(fields.project, site),
+    issueType: mapIssueType(fields.issuetype),
+    status: mapStatus(fields.status),
+    labels: asStringArray(fields.labels),
+    assignee: mapJiraUser(fields.assignee, site),
+    reporter: mapJiraUser(fields.reporter, site),
+    priority: mapPriority(fields.priority),
+    createdAt: asString(fields.created, new Date().toISOString()),
+    updatedAt: asString(fields.updated, new Date().toISOString())
+  }
+}
+
+export function mapComment(raw: JiraRecord, site: JiraSite): JiraComment {
+  return {
+    id: asString(raw.id),
+    body: adfToMarkdownText(raw.body),
+    createdAt: asString(raw.created, new Date().toISOString()),
+    updatedAt: asString(raw.updated) || undefined,
+    user: mapJiraUser(raw.author, site)
+  }
+}

--- a/src/main/jira/issue-metadata.ts
+++ b/src/main/jira/issue-metadata.ts
@@ -1,0 +1,206 @@
+import type {
+  JiraCreateField,
+  JiraIssueType,
+  JiraPriority,
+  JiraProject,
+  JiraSiteSelection,
+  JiraTransition,
+  JiraUser
+} from '../../shared/types'
+import {
+  acquire,
+  clearToken,
+  getClients,
+  isAuthError,
+  jiraRequest,
+  release,
+  type JiraClientForSite
+} from './client'
+import { fetchPagedRecords } from './issue-page-fetcher'
+import {
+  asString,
+  getCreateFieldRecords,
+  mapCreateField,
+  mapIssueType,
+  mapPriority,
+  mapProject,
+  mapStatus,
+  type JiraRecord
+} from './issue-mappers'
+import { isServerSite, restApiBase, shouldSurfaceSiteFailure } from './issue-rest-routing'
+import { toJiraErrorWithStatus } from './jira-request'
+import { mapJiraUser } from './jira-user-identity'
+
+async function withSingleEntryJiraList<T>(
+  entry: JiraClientForSite,
+  siteId: string | null | undefined,
+  label: string,
+  request: () => Promise<T[]>
+): Promise<T[]> {
+  await acquire()
+  try {
+    return await request()
+  } catch (error) {
+    const surfacedError = toJiraErrorWithStatus(error)
+    if (isAuthError(error)) {
+      clearToken(entry.site.id)
+      throw surfacedError
+    }
+    if (shouldSurfaceSiteFailure(siteId, 1)) {
+      throw surfacedError
+    }
+    console.warn(`[jira] ${label} failed:`, error)
+    return []
+  } finally {
+    release()
+  }
+}
+
+export async function listProjects(siteId?: JiraSiteSelection | null): Promise<JiraProject[]> {
+  const entries = getClients(siteId)
+  if (entries.length === 0) {
+    return []
+  }
+  const results = await Promise.all(
+    entries.map(async (entry) => {
+      await acquire()
+      try {
+        if (isServerSite(entry.site)) {
+          const projects = await jiraRequest<JiraRecord[]>(entry, '/rest/api/2/project')
+          return projects.map((project) => mapProject(project, entry.site))
+        }
+        const projects = await fetchPagedRecords(entry, 'values', (startAt, maxResults) => {
+          const params = new URLSearchParams({
+            maxResults: String(maxResults),
+            startAt: String(startAt)
+          })
+          return `/rest/api/3/project/search?${params.toString()}`
+        })
+        return projects.map((project) => mapProject(project, entry.site))
+      } catch (error) {
+        const surfacedError = toJiraErrorWithStatus(error)
+        if (isAuthError(error)) {
+          clearToken(entry.site.id)
+          if (shouldSurfaceSiteFailure(siteId, entries.length)) {
+            throw surfacedError
+          }
+          // Why: all-sites calls should keep healthy sites visible while clearing invalid tokens.
+          console.warn('[jira] listProjects auth failure (token cleared):', error)
+        } else {
+          if (shouldSurfaceSiteFailure(siteId, entries.length)) {
+            throw surfacedError
+          }
+          console.warn('[jira] listProjects failed:', error)
+        }
+        return []
+      } finally {
+        release()
+      }
+    })
+  )
+  return results.flat().sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export async function listIssueTypes(
+  projectIdOrKey: string,
+  siteId?: string | null
+): Promise<JiraIssueType[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  return withSingleEntryJiraList(entry, siteId, 'listIssueTypes', async () => {
+    const issueTypes = await fetchPagedRecords(entry, 'issueTypes', (startAt, maxResults) => {
+      const params = new URLSearchParams({
+        maxResults: String(maxResults),
+        startAt: String(startAt)
+      })
+      return `${restApiBase(entry.site)}/issue/createmeta/${encodeURIComponent(
+        projectIdOrKey
+      )}/issuetypes?${params.toString()}`
+    })
+    return issueTypes.map(mapIssueType)
+  })
+}
+
+export async function listCreateFields(
+  projectIdOrKey: string,
+  issueTypeId: string,
+  siteId?: string | null
+): Promise<JiraCreateField[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  return withSingleEntryJiraList(entry, siteId, 'listCreateFields', async () => {
+    const records = await fetchPagedRecords(entry, getCreateFieldRecords, (startAt, maxResults) => {
+      const params = new URLSearchParams({
+        maxResults: String(maxResults),
+        startAt: String(startAt)
+      })
+      return `${restApiBase(entry.site)}/issue/createmeta/${encodeURIComponent(
+        projectIdOrKey
+      )}/issuetypes/${encodeURIComponent(issueTypeId)}?${params.toString()}`
+    })
+    return records
+      .map((record) => mapCreateField(record))
+      .filter((field): field is JiraCreateField => field !== null)
+  })
+}
+
+export async function listPriorities(siteId?: string | null): Promise<JiraPriority[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  return withSingleEntryJiraList(entry, siteId, 'listPriorities', async () => {
+    const response = await jiraRequest<JiraRecord[]>(entry, `${restApiBase(entry.site)}/priority`)
+    return response.map(mapPriority).filter((priority): priority is JiraPriority => !!priority)
+  })
+}
+
+export async function listAssignableUsers(
+  key: string,
+  query?: string,
+  siteId?: string | null
+): Promise<JiraUser[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  const params = new URLSearchParams({ issueKey: key, maxResults: '50' })
+  if (query?.trim()) {
+    // Why: Server/DC filters assignable users by username; Cloud uses query.
+    params.set(isServerSite(entry.site) ? 'username' : 'query', query.trim())
+  }
+  return withSingleEntryJiraList(entry, siteId, 'listAssignableUsers', async () => {
+    const response = await jiraRequest<JiraRecord[]>(
+      entry,
+      `${restApiBase(entry.site)}/user/assignable/search?${params.toString()}`
+    )
+    return response
+      .map((user) => mapJiraUser(user, entry.site))
+      .filter((user): user is JiraUser => !!user)
+  })
+}
+
+export async function listTransitions(
+  key: string,
+  siteId?: string | null
+): Promise<JiraTransition[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  return withSingleEntryJiraList(entry, siteId, 'listTransitions', async () => {
+    const response = await jiraRequest<{ transitions?: JiraRecord[] }>(
+      entry,
+      `${restApiBase(entry.site)}/issue/${encodeURIComponent(key)}/transitions`
+    )
+    return (response.transitions ?? []).map((transition) => ({
+      id: asString(transition.id),
+      name: asString(transition.name),
+      to: mapStatus(transition.to)
+    }))
+  })
+}

--- a/src/main/jira/issue-page-fetcher.ts
+++ b/src/main/jira/issue-page-fetcher.ts
@@ -1,0 +1,40 @@
+import { jiraRequest, type JiraClientForSite } from './client'
+import {
+  getPageItems,
+  shouldFetchNextPage,
+  type JiraPageItemKey,
+  type JiraPagedResponse,
+  type JiraRecord
+} from './issue-mappers'
+
+type JiraPageItemSelector =
+  | JiraPageItemKey
+  | ((response: JiraPagedResponse<JiraRecord>) => JiraRecord[])
+
+export async function fetchPagedRecords(
+  entry: JiraClientForSite,
+  itemSelector: JiraPageItemSelector,
+  pathForPage: (startAt: number, maxResults: number) => string,
+  maxResults = 100
+): Promise<JiraRecord[]> {
+  const records: JiraRecord[] = []
+  let startAt = 0
+  for (let guard = 0; guard < 100; guard += 1) {
+    const response = await jiraRequest<JiraPagedResponse<JiraRecord>>(
+      entry,
+      pathForPage(startAt, maxResults)
+    )
+    const items =
+      typeof itemSelector === 'function'
+        ? itemSelector(response)
+        : getPageItems(response, itemSelector)
+    records.push(...items)
+    if (!shouldFetchNextPage(response, startAt, items, maxResults)) {
+      break
+    }
+    // Why: Jira may return short pages while more records remain; advancing by
+    // the requested page size can skip records.
+    startAt += items.length
+  }
+  return records
+}

--- a/src/main/jira/issue-rest-routing.ts
+++ b/src/main/jira/issue-rest-routing.ts
@@ -1,0 +1,18 @@
+import type { JiraSite, JiraSiteSelection } from '../../shared/types'
+
+export function isServerSite(site: JiraSite): boolean {
+  return site.deploymentType === 'server'
+}
+
+export function restApiBase(site: JiraSite): string {
+  return isServerSite(site) ? '/rest/api/2' : '/rest/api/3'
+}
+
+export function shouldSurfaceSiteFailure(
+  selection: JiraSiteSelection | null | undefined,
+  entryCount: number
+): boolean {
+  // getClients can resolve an omitted selection to the persisted 'all' choice;
+  // multi-entry reads need the same resilient fan-out policy as explicit 'all'.
+  return selection !== 'all' && entryCount <= 1
+}

--- a/src/main/jira/issue-search.ts
+++ b/src/main/jira/issue-search.ts
@@ -1,0 +1,154 @@
+import type { JiraIssue, JiraIssueFilter, JiraSiteSelection } from '../../shared/types'
+import {
+  acquire,
+  clearToken,
+  getClients,
+  isAuthError,
+  jiraRequest,
+  release,
+  type JiraClientForSite
+} from './client'
+import { ISSUE_FIELDS, mapJiraIssue, type JiraRecord } from './issue-mappers'
+import { isServerSite, restApiBase, shouldSurfaceSiteFailure } from './issue-rest-routing'
+import { toJiraErrorWithStatus } from './jira-request'
+
+type JiraSearchResponse = {
+  issues?: JiraRecord[]
+}
+
+type JiraIssueSearchFailure = {
+  error: unknown
+  auth: boolean
+}
+
+function clampLimit(limit: number | undefined, fallback = 30): number {
+  return Math.min(Math.max(1, Number.isFinite(limit) ? Number(limit) : fallback), 100)
+}
+
+function sortAndLimitIssues(issues: JiraIssue[], limit: number): JiraIssue[] {
+  return issues
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .slice(0, limit)
+}
+
+function filterToJql(filter: JiraIssueFilter): string {
+  if (filter === 'assigned') {
+    return 'assignee = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
+  }
+  if (filter === 'reported') {
+    return 'reporter = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
+  }
+  if (filter === 'done') {
+    return 'assignee = currentUser() AND resolution IS NOT EMPTY ORDER BY updated DESC'
+  }
+  return 'resolution = Unresolved ORDER BY updated DESC'
+}
+
+async function searchIssuesForClient(
+  entry: JiraClientForSite,
+  jql: string,
+  limit: number
+): Promise<JiraIssue[]> {
+  const result = await jiraRequest<JiraSearchResponse>(
+    entry,
+    isServerSite(entry.site) ? '/rest/api/2/search' : '/rest/api/3/search/jql',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        jql,
+        maxResults: limit,
+        fields: ISSUE_FIELDS
+      })
+    }
+  )
+  return (result.issues ?? []).map((issue) => mapJiraIssue(entry.site, issue))
+}
+
+export async function listIssues(
+  filter: JiraIssueFilter = 'assigned',
+  limit = 30,
+  siteId?: JiraSiteSelection | null
+): Promise<JiraIssue[]> {
+  return searchIssues(filterToJql(filter), limit, siteId)
+}
+
+export async function searchIssues(
+  jql: string,
+  limit = 30,
+  siteId?: JiraSiteSelection | null
+): Promise<JiraIssue[]> {
+  const entries = getClients(siteId)
+  if (entries.length === 0 || !jql.trim()) {
+    return []
+  }
+  const safeLimit = clampLimit(limit)
+  const failures: (JiraIssueSearchFailure | undefined)[] = Array.from({ length: entries.length })
+  const surfaceSiteFailure = shouldSurfaceSiteFailure(siteId, entries.length)
+  const results = await Promise.all(
+    entries.map(async (entry, index) => {
+      await acquire()
+      try {
+        return await searchIssuesForClient(entry, jql.trim(), safeLimit)
+      } catch (error) {
+        const authFailure = isAuthError(error)
+        if (authFailure) {
+          clearToken(entry.site.id)
+        }
+        if (surfaceSiteFailure) {
+          throw toJiraErrorWithStatus(error)
+        }
+        console.warn('[jira] searchIssues failed:', error)
+        failures[index] = { error: toJiraErrorWithStatus(error), auth: authFailure }
+        return [] as JiraIssue[]
+      } finally {
+        release()
+      }
+    })
+  )
+  // 'all' fan-out: only surface an error when every connected site failed, so a
+  // partial success (or a genuinely empty result) is not reported as an error.
+  const recordedFailures = failures.filter(
+    (failure): failure is JiraIssueSearchFailure => failure !== undefined
+  )
+  if (recordedFailures.length === entries.length) {
+    throw (recordedFailures.find((failure) => !failure.auth) ?? recordedFailures[0]).error
+  }
+  return entries.length === 1
+    ? results.flat().slice(0, safeLimit)
+    : sortAndLimitIssues(results.flat(), safeLimit)
+}
+
+export async function getIssue(
+  key: string,
+  siteId?: JiraSiteSelection | null
+): Promise<JiraIssue | null> {
+  const entries = getClients(siteId)
+  for (const entry of entries) {
+    await acquire()
+    try {
+      const issue = await jiraRequest<JiraRecord>(
+        entry,
+        `${restApiBase(entry.site)}/issue/${encodeURIComponent(key)}?fields=${encodeURIComponent(
+          ISSUE_FIELDS.join(',')
+        )}`
+      )
+      return mapJiraIssue(entry.site, issue)
+    } catch (error) {
+      const surfacedError = toJiraErrorWithStatus(error)
+      if (isAuthError(error)) {
+        clearToken(entry.site.id)
+        if (shouldSurfaceSiteFailure(siteId, entries.length)) {
+          throw surfacedError
+        }
+      } else {
+        if (shouldSurfaceSiteFailure(siteId, entries.length)) {
+          throw surfacedError
+        }
+        console.warn('[jira] getIssue failed:', error)
+      }
+    } finally {
+      release()
+    }
+  }
+  return null
+}

--- a/src/main/jira/issues.test.ts
+++ b/src/main/jira/issues.test.ts
@@ -25,9 +25,29 @@ function makeEntry(id = 'site-1'): JiraClientForSite {
       siteUrl: 'https://example.atlassian.net',
       email: 'ada@example.com',
       displayName: 'Example Jira',
-      accountId: 'account-1'
+      accountId: 'account-1',
+      viewerUserId: 'account-1',
+      deploymentType: 'cloud',
+      authMode: 'basic'
     },
     authorization: 'Basic token'
+  }
+}
+
+function makeServerEntry(id = 'server-1'): JiraClientForSite {
+  return {
+    site: {
+      id,
+      siteUrl: 'https://jira.example.internal',
+      email: 'ada@example.internal',
+      displayName: 'Example Jira Server',
+      accountId: 'ada',
+      viewerUserId: 'ada',
+      deploymentType: 'server',
+      authMode: 'basic',
+      authUsername: 'ada'
+    },
+    authorization: 'Basic server-token'
   }
 }
 
@@ -89,6 +109,26 @@ describe('Jira issue operations', () => {
     await expect(searchIssues('project = ALP', 20, 'all')).resolves.toMatchObject([
       { key: 'BRV-1', title: 'Healthy' }
     ])
+  })
+
+  it('surfaces single-site Jira issue detail failures', async () => {
+    const error = Object.assign(new Error('Forbidden'), { status: 403 })
+    getClientsMock.mockReturnValue([makeEntry('site-1')])
+    jiraRequestMock.mockRejectedValueOnce(error)
+    const { getIssue } = await import('./issues')
+
+    await expect(getIssue('ALP-1', 'site-1')).rejects.toThrow('Error 403: Forbidden')
+  })
+
+  it('surfaces single-site Jira metadata failures', async () => {
+    const error = Object.assign(new Error('Create metadata unavailable'), { status: 500 })
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockRejectedValueOnce(error)
+    const { listCreateFields } = await import('./issues')
+
+    await expect(listCreateFields('10000', '1', 'server-1')).rejects.toThrow(
+      'Error 500: Create metadata unavailable'
+    )
   })
 
   it('keeps healthy sites when the saved selection fans out without an explicit site', async () => {
@@ -154,6 +194,62 @@ describe('Jira issue operations', () => {
     expect(jiraRequestMock).toHaveBeenCalledTimes(2)
     expect(String(jiraRequestMock.mock.calls[0][1])).toContain('startAt=0')
     expect(String(jiraRequestMock.mock.calls[1][1])).toContain('startAt=2')
+  })
+
+  it('logs swallowed Jira project auth failures when all-sites keeps healthy sites', async () => {
+    const authError = new Error('Unauthorized')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    getClientsMock.mockReturnValue([makeEntry('site-1'), makeEntry('site-2')])
+    isAuthErrorMock.mockImplementation((error) => error === authError)
+    jiraRequestMock.mockRejectedValueOnce(authError).mockResolvedValueOnce({
+      values: [{ id: '2', key: 'BRV', name: 'Bravo' }]
+    })
+
+    const { listProjects } = await import('./issues')
+
+    try {
+      await expect(listProjects('all')).resolves.toMatchObject([
+        { id: '2', key: 'BRV', name: 'Bravo', siteId: 'site-2' }
+      ])
+      expect(clearTokenMock).toHaveBeenCalledWith('site-1')
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[jira] listProjects auth failure (token cleared):',
+        authError
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('advances Jira project pagination by returned records on short pages', async () => {
+    jiraRequestMock
+      .mockResolvedValueOnce({
+        startAt: 0,
+        maxResults: 100,
+        total: 3,
+        values: [{ id: '1', key: 'ALP', name: 'Alpha' }]
+      })
+      .mockResolvedValueOnce({
+        startAt: 1,
+        maxResults: 100,
+        total: 3,
+        values: [
+          { id: '2', key: 'BRV', name: 'Bravo' },
+          { id: '3', key: 'CHR', name: 'Charlie' }
+        ]
+      })
+
+    const { listProjects } = await import('./issues')
+
+    await expect(listProjects('site-1')).resolves.toMatchObject([
+      { id: '1', key: 'ALP', name: 'Alpha', siteId: 'site-1' },
+      { id: '2', key: 'BRV', name: 'Bravo', siteId: 'site-1' },
+      { id: '3', key: 'CHR', name: 'Charlie', siteId: 'site-1' }
+    ])
+
+    expect(jiraRequestMock).toHaveBeenCalledTimes(2)
+    const secondPagePath = String(jiraRequestMock.mock.calls[1][1])
+    expect(new URL(secondPagePath, 'https://jira.example').searchParams.get('startAt')).toBe('1')
   })
 
   it('maps create-metadata issue types from the Jira issueTypes page key', async () => {
@@ -227,6 +323,33 @@ describe('Jira issue operations', () => {
     expect(String(jiraRequestMock.mock.calls[0][1])).toContain(
       '/rest/api/3/issue/createmeta/10000/issuetypes/10001?'
     )
+  })
+
+  it('advances create field pagination by returned records on short pages', async () => {
+    jiraRequestMock
+      .mockResolvedValueOnce({
+        startAt: 0,
+        maxResults: 100,
+        total: 2,
+        values: [{ fieldId: 'customfield_1', name: 'Severity' }]
+      })
+      .mockResolvedValueOnce({
+        startAt: 1,
+        maxResults: 100,
+        total: 2,
+        values: [{ fieldId: 'customfield_2', name: 'Risk' }]
+      })
+
+    const { listCreateFields } = await import('./issues')
+
+    await expect(listCreateFields('10000', '10001', 'site-1')).resolves.toMatchObject([
+      { key: 'customfield_1', name: 'Severity' },
+      { key: 'customfield_2', name: 'Risk' }
+    ])
+
+    expect(jiraRequestMock).toHaveBeenCalledTimes(2)
+    const secondPagePath = String(jiraRequestMock.mock.calls[1][1])
+    expect(new URL(secondPagePath, 'https://jira.example').searchParams.get('startAt')).toBe('1')
   })
 
   it('includes custom create fields when creating Jira issues', async () => {
@@ -393,9 +516,172 @@ describe('Jira issue operations', () => {
         id: 'comment-1',
         body: 'Looks reproducible.',
         createdAt: '2026-05-30T12:00:00.000Z',
-        user: { accountId: 'user-1', displayName: 'Ada', avatarUrl: undefined, email: undefined },
+        user: {
+          userId: 'user-1',
+          accountId: 'user-1',
+          displayName: 'Ada',
+          avatarUrl: undefined,
+          email: undefined
+        },
         updatedAt: undefined
       }
+    ])
+  })
+
+  it('surfaces single-site Jira comment list failures', async () => {
+    const error = Object.assign(new Error('Comments unavailable'), { status: 500 })
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockRejectedValueOnce(error)
+    const { getIssueComments } = await import('./issues')
+
+    await expect(getIssueComments('SRV-1', 'server-1')).rejects.toThrow(
+      'Error 500: Comments unavailable'
+    )
+  })
+
+  it('searches Jira Server issues through REST API v2', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValueOnce({
+      issues: [
+        {
+          id: '10001',
+          key: 'SRV-1',
+          fields: {
+            summary: 'Server issue',
+            description: 'Plain server description',
+            project: { id: '10000', key: 'SRV', name: 'Server Project' },
+            issuetype: { id: '1', name: 'Task' },
+            status: {
+              id: '3',
+              name: 'In Progress',
+              statusCategory: { key: 'indeterminate', name: 'In Progress' }
+            },
+            assignee: { name: 'ada', displayName: 'Ada Server' },
+            labels: ['server'],
+            created: '2026-06-01T00:00:00.000Z',
+            updated: '2026-06-02T00:00:00.000Z'
+          }
+        }
+      ]
+    })
+
+    const { searchIssues } = await import('./issues')
+
+    await expect(searchIssues('project = SRV', 20, 'server-1')).resolves.toMatchObject([
+      {
+        key: 'SRV-1',
+        title: 'Server issue',
+        description: 'Plain server description',
+        assignee: { userId: 'ada', accountId: 'ada', displayName: 'Ada Server' }
+      }
+    ])
+    expect(jiraRequestMock.mock.calls[0][1]).toBe('/rest/api/2/search')
+    expect(JSON.parse((jiraRequestMock.mock.calls[0][2] as { body: string }).body)).toMatchObject({
+      jql: 'project = SRV',
+      maxResults: 20
+    })
+  })
+
+  it('creates Jira Server issues with plain text descriptions', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValueOnce({
+      id: '10001',
+      key: 'SRV-1',
+      self: 'https://jira.example.internal/rest/api/2/issue/10001'
+    })
+
+    const { createIssue } = await import('./issues')
+
+    await expect(
+      createIssue({
+        siteId: 'server-1',
+        projectId: '10000',
+        issueTypeId: '1',
+        title: 'Create on Server',
+        description: 'Plain text body'
+      })
+    ).resolves.toMatchObject({ ok: true, key: 'SRV-1' })
+
+    expect(jiraRequestMock.mock.calls[0][1]).toBe('/rest/api/2/issue')
+    expect(
+      JSON.parse((jiraRequestMock.mock.calls[0][2] as { body: string }).body).fields
+    ).toMatchObject({
+      summary: 'Create on Server',
+      description: 'Plain text body'
+    })
+  })
+
+  it('updates Jira Server assignees with opaque user ids as names', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValue(undefined)
+
+    const { updateIssue } = await import('./issues')
+
+    await expect(updateIssue('SRV-1', { assigneeUserId: 'ada' }, 'server-1')).resolves.toEqual({
+      ok: true
+    })
+
+    expect(jiraRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ site: expect.objectContaining({ deploymentType: 'server' }) }),
+      '/rest/api/2/issue/SRV-1/assignee',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ name: 'ada' })
+      })
+    )
+  })
+
+  it('uses Jira Server metadata and user endpoints', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock
+      .mockResolvedValueOnce([{ id: '10000', key: 'SRV', name: 'Server Project' }])
+      .mockResolvedValueOnce({ issueTypes: [{ id: '1', name: 'Task' }] })
+      .mockResolvedValueOnce({ values: [{ fieldId: 'customfield_1', name: 'Severity' }] })
+      .mockResolvedValueOnce([{ id: '2', name: 'High' }])
+      .mockResolvedValueOnce([{ name: 'ada', displayName: 'Ada Server' }])
+      .mockResolvedValueOnce({
+        transitions: [{ id: '31', name: 'Done', to: { id: '5', name: 'Done' } }]
+      })
+
+    const {
+      listAssignableUsers,
+      listCreateFields,
+      listIssueTypes,
+      listPriorities,
+      listProjects,
+      listTransitions
+    } = await import('./issues')
+
+    await expect(listProjects('server-1')).resolves.toEqual([
+      {
+        id: '10000',
+        key: 'SRV',
+        name: 'Server Project',
+        siteId: 'server-1',
+        siteName: 'Example Jira Server'
+      }
+    ])
+    await expect(listIssueTypes('10000', 'server-1')).resolves.toMatchObject([
+      { id: '1', name: 'Task' }
+    ])
+    await expect(listCreateFields('10000', '1', 'server-1')).resolves.toMatchObject([
+      { key: 'customfield_1', name: 'Severity' }
+    ])
+    await expect(listPriorities('server-1')).resolves.toMatchObject([{ id: '2', name: 'High' }])
+    await expect(listAssignableUsers('SRV-1', 'ad', 'server-1')).resolves.toMatchObject([
+      { userId: 'ada', accountId: 'ada', displayName: 'Ada Server' }
+    ])
+    await expect(listTransitions('SRV-1', 'server-1')).resolves.toMatchObject([
+      { id: '31', name: 'Done' }
+    ])
+
+    expect(jiraRequestMock.mock.calls.map((call) => String(call[1]))).toEqual([
+      '/rest/api/2/project',
+      '/rest/api/2/issue/createmeta/10000/issuetypes?maxResults=100&startAt=0',
+      '/rest/api/2/issue/createmeta/10000/issuetypes/1?maxResults=100&startAt=0',
+      '/rest/api/2/priority',
+      '/rest/api/2/user/assignable/search?issueKey=SRV-1&maxResults=50&username=ad',
+      '/rest/api/2/issue/SRV-1/transitions'
     ])
   })
 })

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -1,446 +1,14 @@
-/* eslint-disable max-lines -- Why: Jira task reads and mutations share ADF
-   mapping, multi-site fan-out, and auth-clearing behavior; keeping the API
-   boundary together avoids subtle drift between operations. */
 import type {
-  JiraComment,
-  JiraCreateField,
-  JiraCreateFieldAllowedValue,
   JiraCreateIssueArgs,
   JiraCreateIssueResult,
-  JiraIssue,
-  JiraIssueFilter,
-  JiraIssueType,
   JiraIssueUpdate,
-  JiraMutationResult,
-  JiraPriority,
-  JiraProject,
-  JiraSite,
-  JiraSiteSelection,
-  JiraStatus,
-  JiraTransition,
-  JiraUser
+  JiraMutationResult
 } from '../../shared/types'
-import {
-  acquire,
-  clearToken,
-  getClients,
-  isAuthError,
-  jiraRequest,
-  release,
-  type JiraClientForSite
-} from './client'
-import { adfToMarkdownText, textToAdf } from './adf-markdown'
-
-const ISSUE_FIELDS = [
-  'summary',
-  'description',
-  'project',
-  'issuetype',
-  'status',
-  'assignee',
-  'reporter',
-  'priority',
-  'labels',
-  'created',
-  'updated'
-]
-
-type JiraRecord = Record<string, unknown>
-
-type JiraSearchResponse = {
-  issues?: JiraRecord[]
-}
-
-type JiraPagedResponse<T> = {
-  startAt?: number
-  maxResults?: number
-  total?: number
-  isLast?: boolean
-  values?: T[]
-  issueTypes?: T[]
-  comments?: T[]
-  fields?: T[] | Record<string, T>
-}
-
-type JiraPageItemKey = 'values' | 'issueTypes' | 'comments'
-
-function clampLimit(limit: number | undefined, fallback = 30): number {
-  return Math.min(Math.max(1, Number.isFinite(limit) ? Number(limit) : fallback), 100)
-}
-
-type JiraIssueSearchFailure = {
-  error: unknown
-  auth: boolean
-}
-
-function getErrorStatus(error: unknown): number | null {
-  if (!error || typeof error !== 'object' || !('status' in error)) {
-    return null
-  }
-  const status = (error as { status?: unknown }).status
-  return typeof status === 'number' && Number.isFinite(status) ? status : null
-}
-
-function toIssueSearchFailureError(error: unknown): unknown {
-  const status = getErrorStatus(error)
-  if (
-    status === null ||
-    !(error instanceof Error) ||
-    error.message.startsWith(`Error ${status}:`)
-  ) {
-    return error
-  }
-  return new Error(`Error ${status}: ${error.message}`)
-}
-
-function shouldSurfaceSiteFailure(
-  selection: JiraSiteSelection | null | undefined,
-  entryCount: number
-): boolean {
-  // getClients can resolve an omitted selection to the persisted 'all' choice;
-  // multi-entry reads need the same resilient fan-out policy as explicit 'all'.
-  return selection !== 'all' && entryCount <= 1
-}
-
-function asRecord(value: unknown): JiraRecord {
-  return value && typeof value === 'object' ? (value as JiraRecord) : {}
-}
-
-function asString(value: unknown, fallback = ''): string {
-  return typeof value === 'string' ? value : fallback
-}
-
-function asStringArray(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === 'string')
-    : []
-}
-
-function asFiniteNumber(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null
-}
-
-function getPageItems<T>(response: JiraPagedResponse<T>, key: JiraPageItemKey): T[] {
-  const keyedItems = response[key]
-  if (Array.isArray(keyedItems)) {
-    return keyedItems
-  }
-  return response.values ?? []
-}
-
-function shouldFetchNextPage<T>(
-  response: JiraPagedResponse<T>,
-  startAt: number,
-  items: T[],
-  requestedMaxResults: number
-): boolean {
-  if (response.isLast === true || items.length === 0) {
-    return false
-  }
-  const total = asFiniteNumber(response.total)
-  const pageSize = asFiniteNumber(response.maxResults)
-  if (total !== null) {
-    return startAt + items.length < total && (pageSize ?? requestedMaxResults) > 0
-  }
-  if (response.isLast === false) {
-    return (pageSize ?? requestedMaxResults) > 0
-  }
-  return pageSize !== null && items.length >= pageSize
-}
-
-async function fetchPagedRecords(
-  entry: JiraClientForSite,
-  key: JiraPageItemKey,
-  pathForPage: (startAt: number, maxResults: number) => string,
-  maxResults = 100
-): Promise<JiraRecord[]> {
-  const records: JiraRecord[] = []
-  let startAt = 0
-  for (let guard = 0; guard < 100; guard += 1) {
-    const response = await jiraRequest<JiraPagedResponse<JiraRecord>>(
-      entry,
-      pathForPage(startAt, maxResults)
-    )
-    const items = getPageItems(response, key)
-    records.push(...items)
-    if (!shouldFetchNextPage(response, startAt, items, maxResults)) {
-      break
-    }
-    startAt += asFiniteNumber(response.maxResults) ?? maxResults
-  }
-  return records
-}
-
-function avatarUrl(value: unknown): string | undefined {
-  const avatars = asRecord(value)
-  return (
-    asString(avatars['48x48']) ||
-    asString(avatars['32x32']) ||
-    asString(avatars['24x24']) ||
-    undefined
-  )
-}
-
-function mapUser(value: unknown): JiraUser | undefined {
-  const user = asRecord(value)
-  const accountId = asString(user.accountId)
-  if (!accountId) {
-    return undefined
-  }
-  return {
-    accountId,
-    displayName: asString(user.displayName, 'Unknown'),
-    email: typeof user.emailAddress === 'string' ? user.emailAddress : undefined,
-    avatarUrl: avatarUrl(user.avatarUrls)
-  }
-}
-
-function mapProject(value: unknown, site?: JiraSite): JiraProject {
-  const project = asRecord(value)
-  return {
-    id: asString(project.id),
-    key: asString(project.key),
-    name: asString(project.name, asString(project.key)),
-    siteId: site?.id,
-    siteName: site?.displayName
-  }
-}
-
-function mapIssueType(value: unknown): JiraIssueType {
-  const issueType = asRecord(value)
-  return {
-    id: asString(issueType.id),
-    name: asString(issueType.name, 'Issue'),
-    description: asString(issueType.description) || undefined,
-    iconUrl: asString(issueType.iconUrl) || undefined,
-    subtask: typeof issueType.subtask === 'boolean' ? issueType.subtask : undefined
-  }
-}
-
-function mapCreateFieldAllowedValue(value: unknown): JiraCreateFieldAllowedValue {
-  const option = asRecord(value)
-  return {
-    id: asString(option.id) || undefined,
-    value: asString(option.value) || undefined,
-    name: asString(option.name) || undefined
-  }
-}
-
-function mapCreateField(value: unknown, fallbackKey = ''): JiraCreateField | null {
-  const field = asRecord(value)
-  const schema = asRecord(field.schema)
-  const key =
-    asString(field.key) ||
-    asString(field.fieldId) ||
-    asString(field.id) ||
-    asString(field.fieldKey) ||
-    fallbackKey
-  if (!key) {
-    return null
-  }
-  const allowedValues = Array.isArray(field.allowedValues)
-    ? field.allowedValues.map(mapCreateFieldAllowedValue)
-    : undefined
-  return {
-    key,
-    name: asString(field.name, key),
-    required: field.required === true,
-    schema: {
-      type: asString(schema.type) || undefined,
-      items: asString(schema.items) || undefined,
-      custom: asString(schema.custom) || undefined
-    },
-    allowedValues
-  }
-}
-
-function getCreateFieldRecords(response: JiraPagedResponse<JiraRecord>): JiraRecord[] {
-  if (Array.isArray(response.values)) {
-    return response.values
-  }
-  if (Array.isArray(response.fields)) {
-    return response.fields
-  }
-  if (response.fields && typeof response.fields === 'object') {
-    return Object.entries(response.fields).map(([key, value]) => ({
-      key,
-      ...asRecord(value)
-    }))
-  }
-  return []
-}
-
-function mapPriority(value: unknown): JiraPriority | undefined {
-  const priority = asRecord(value)
-  const id = asString(priority.id)
-  if (!id) {
-    return undefined
-  }
-  return {
-    id,
-    name: asString(priority.name, 'Priority'),
-    iconUrl: asString(priority.iconUrl) || undefined
-  }
-}
-
-function mapStatus(value: unknown): JiraStatus {
-  const status = asRecord(value)
-  const category = asRecord(status.statusCategory)
-  return {
-    id: asString(status.id),
-    name: asString(status.name, 'Unknown'),
-    categoryKey: asString(category.key, 'undefined'),
-    categoryName: asString(category.name, 'No Category'),
-    colorName: asString(category.colorName) || undefined
-  }
-}
-
-function issueUrl(site: JiraSite, key: string): string {
-  return `${site.siteUrl}/browse/${encodeURIComponent(key)}`
-}
-
-export function mapJiraIssue(site: JiraSite, raw: JiraRecord): JiraIssue {
-  const fields = asRecord(raw.fields)
-  const key = asString(raw.key)
-  return {
-    id: asString(raw.id, key),
-    key,
-    siteId: site.id,
-    siteName: site.displayName,
-    title: asString(fields.summary, key || 'Untitled issue'),
-    description: adfToMarkdownText(fields.description),
-    url: issueUrl(site, key),
-    project: mapProject(fields.project, site),
-    issueType: mapIssueType(fields.issuetype),
-    status: mapStatus(fields.status),
-    labels: asStringArray(fields.labels),
-    assignee: mapUser(fields.assignee),
-    reporter: mapUser(fields.reporter),
-    priority: mapPriority(fields.priority),
-    createdAt: asString(fields.created, new Date().toISOString()),
-    updatedAt: asString(fields.updated, new Date().toISOString())
-  }
-}
-
-function sortAndLimitIssues(issues: JiraIssue[], limit: number): JiraIssue[] {
-  return issues
-    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-    .slice(0, limit)
-}
-
-function filterToJql(filter: JiraIssueFilter): string {
-  if (filter === 'assigned') {
-    return 'assignee = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
-  }
-  if (filter === 'reported') {
-    return 'reporter = currentUser() AND resolution = Unresolved ORDER BY updated DESC'
-  }
-  if (filter === 'done') {
-    return 'assignee = currentUser() AND resolution IS NOT EMPTY ORDER BY updated DESC'
-  }
-  return 'resolution = Unresolved ORDER BY updated DESC'
-}
-
-async function searchIssuesForClient(
-  entry: JiraClientForSite,
-  jql: string,
-  limit: number
-): Promise<JiraIssue[]> {
-  const result = await jiraRequest<JiraSearchResponse>(entry, '/rest/api/3/search/jql', {
-    method: 'POST',
-    body: JSON.stringify({
-      jql,
-      maxResults: limit,
-      fields: ISSUE_FIELDS
-    })
-  })
-  return (result.issues ?? []).map((issue) => mapJiraIssue(entry.site, issue))
-}
-
-export async function listIssues(
-  filter: JiraIssueFilter = 'assigned',
-  limit = 30,
-  siteId?: JiraSiteSelection | null
-): Promise<JiraIssue[]> {
-  return searchIssues(filterToJql(filter), limit, siteId)
-}
-
-export async function searchIssues(
-  jql: string,
-  limit = 30,
-  siteId?: JiraSiteSelection | null
-): Promise<JiraIssue[]> {
-  const entries = getClients(siteId)
-  if (entries.length === 0 || !jql.trim()) {
-    return []
-  }
-  const safeLimit = clampLimit(limit)
-  const failures: (JiraIssueSearchFailure | undefined)[] = Array.from({ length: entries.length })
-  const surfaceSiteFailure = shouldSurfaceSiteFailure(siteId, entries.length)
-  const results = await Promise.all(
-    entries.map(async (entry, index) => {
-      await acquire()
-      try {
-        return await searchIssuesForClient(entry, jql.trim(), safeLimit)
-      } catch (error) {
-        const authFailure = isAuthError(error)
-        if (authFailure) {
-          clearToken(entry.site.id)
-        }
-        if (surfaceSiteFailure) {
-          throw toIssueSearchFailureError(error)
-        }
-        console.warn('[jira] searchIssues failed:', error)
-        failures[index] = { error: toIssueSearchFailureError(error), auth: authFailure }
-        return [] as JiraIssue[]
-      } finally {
-        release()
-      }
-    })
-  )
-  // 'all' fan-out: only surface an error when every connected site failed, so a
-  // partial success (or a genuinely empty result) is not reported as an error.
-  const recordedFailures = failures.filter(
-    (failure): failure is JiraIssueSearchFailure => failure !== undefined
-  )
-  if (recordedFailures.length === entries.length) {
-    throw (recordedFailures.find((failure) => !failure.auth) ?? recordedFailures[0]).error
-  }
-  return entries.length === 1
-    ? results.flat().slice(0, safeLimit)
-    : sortAndLimitIssues(results.flat(), safeLimit)
-}
-
-export async function getIssue(
-  key: string,
-  siteId?: JiraSiteSelection | null
-): Promise<JiraIssue | null> {
-  const entries = getClients(siteId)
-  for (const entry of entries) {
-    await acquire()
-    try {
-      const issue = await jiraRequest<JiraRecord>(
-        entry,
-        `/rest/api/3/issue/${encodeURIComponent(key)}?fields=${encodeURIComponent(
-          ISSUE_FIELDS.join(',')
-        )}`
-      )
-      return mapJiraIssue(entry.site, issue)
-    } catch (error) {
-      if (isAuthError(error)) {
-        clearToken(entry.site.id)
-        if (shouldSurfaceSiteFailure(siteId, entries.length)) {
-          throw error
-        }
-      } else {
-        console.warn('[jira] getIssue failed:', error)
-      }
-    } finally {
-      release()
-    }
-  }
-  return null
-}
+import { acquire, clearToken, getClients, isAuthError, jiraRequest, release } from './client'
+import { textToAdf } from './adf-markdown'
+import { issueUrl, type JiraRecord } from './issue-mappers'
+import { isServerSite, restApiBase } from './issue-rest-routing'
+import { jiraAssigneePayload } from './jira-user-identity'
 
 export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreateIssueResult> {
   const entry = getClients(args.siteId)[0]
@@ -460,7 +28,10 @@ export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreate
       summary: title
     }
     if (args.description?.trim()) {
-      fields.description = textToAdf(args.description.trim())
+      // Why: Server/DC accepts plain text fields; Cloud issue create requires ADF.
+      fields.description = isServerSite(entry.site)
+        ? args.description.trim()
+        : textToAdf(args.description.trim())
     }
     for (const [fieldKey, value] of Object.entries(args.customFields ?? {})) {
       if (!fieldKey || value === undefined || value === null || value === '') {
@@ -470,7 +41,7 @@ export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreate
     }
     const created = await jiraRequest<{ id: string; key: string; self: string }>(
       entry,
-      '/rest/api/3/issue',
+      `${restApiBase(entry.site)}/issue`,
       {
         method: 'POST',
         body: JSON.stringify({ fields })
@@ -510,22 +81,34 @@ export async function updateIssue(
       fields.priority = updates.priorityId ? { id: updates.priorityId } : null
     }
     if (Object.keys(fields).length > 0) {
-      await jiraRequest(entry, `/rest/api/3/issue/${encodeURIComponent(key)}`, {
+      await jiraRequest(entry, `${restApiBase(entry.site)}/issue/${encodeURIComponent(key)}`, {
         method: 'PUT',
         body: JSON.stringify({ fields })
       })
     }
-    if (updates.assigneeAccountId !== undefined) {
-      await jiraRequest(entry, `/rest/api/3/issue/${encodeURIComponent(key)}/assignee`, {
-        method: 'PUT',
-        body: JSON.stringify({ accountId: updates.assigneeAccountId })
-      })
+    const hasAssigneeUpdate =
+      updates.assigneeUserId !== undefined || updates.assigneeAccountId !== undefined
+    const assigneeUserId =
+      updates.assigneeUserId !== undefined ? updates.assigneeUserId : updates.assigneeAccountId
+    if (hasAssigneeUpdate) {
+      await jiraRequest(
+        entry,
+        `${restApiBase(entry.site)}/issue/${encodeURIComponent(key)}/assignee`,
+        {
+          method: 'PUT',
+          body: JSON.stringify(jiraAssigneePayload(entry.site, assigneeUserId))
+        }
+      )
     }
     if (updates.transitionId) {
-      await jiraRequest(entry, `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`, {
-        method: 'POST',
-        body: JSON.stringify({ transition: { id: updates.transitionId } })
-      })
+      await jiraRequest(
+        entry,
+        `${restApiBase(entry.site)}/issue/${encodeURIComponent(key)}/transitions`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ transition: { id: updates.transitionId } })
+        }
+      )
     }
     return { ok: true }
   } catch (error) {
@@ -539,274 +122,14 @@ export async function updateIssue(
   }
 }
 
-export async function addIssueComment(
-  key: string,
-  body: string,
-  siteId?: string | null
-): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
-  const entry = getClients(siteId)[0]
-  if (!entry) {
-    return { ok: false, error: 'Not connected to Jira.' }
-  }
-  await acquire()
-  try {
-    const comment = await jiraRequest<{ id: string }>(
-      entry,
-      `/rest/api/3/issue/${encodeURIComponent(key)}/comment`,
-      {
-        method: 'POST',
-        body: JSON.stringify({ body: textToAdf(body) })
-      }
-    )
-    return { ok: true, id: comment.id }
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken(entry.site.id)
-      throw error
-    }
-    return { ok: false, error: error instanceof Error ? error.message : 'Failed to add comment.' }
-  } finally {
-    release()
-  }
-}
-
-function mapComment(raw: JiraRecord): JiraComment {
-  return {
-    id: asString(raw.id),
-    body: adfToMarkdownText(raw.body),
-    createdAt: asString(raw.created, new Date().toISOString()),
-    updatedAt: asString(raw.updated) || undefined,
-    user: mapUser(raw.author)
-  }
-}
-
-export async function getIssueComments(
-  key: string,
-  siteId?: string | null
-): Promise<JiraComment[]> {
-  const entry = getClients(siteId)[0]
-  if (!entry) {
-    return []
-  }
-  await acquire()
-  try {
-    const comments = await fetchPagedRecords(entry, 'comments', (startAt, maxResults) => {
-      const params = new URLSearchParams({
-        maxResults: String(maxResults),
-        orderBy: 'created',
-        startAt: String(startAt)
-      })
-      return `/rest/api/3/issue/${encodeURIComponent(key)}/comment?${params.toString()}`
-    })
-    return comments.map(mapComment)
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken(entry.site.id)
-      throw error
-    }
-    console.warn('[jira] getIssueComments failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
-
-export async function listProjects(siteId?: JiraSiteSelection | null): Promise<JiraProject[]> {
-  const entries = getClients(siteId)
-  if (entries.length === 0) {
-    return []
-  }
-  const results = await Promise.all(
-    entries.map(async (entry) => {
-      await acquire()
-      try {
-        const projects = await fetchPagedRecords(entry, 'values', (startAt, maxResults) => {
-          const params = new URLSearchParams({
-            maxResults: String(maxResults),
-            startAt: String(startAt)
-          })
-          return `/rest/api/3/project/search?${params.toString()}`
-        })
-        return projects.map((project) => mapProject(project, entry.site))
-      } catch (error) {
-        if (isAuthError(error)) {
-          clearToken(entry.site.id)
-          if (shouldSurfaceSiteFailure(siteId, entries.length)) {
-            throw error
-          }
-        } else {
-          console.warn('[jira] listProjects failed:', error)
-        }
-        return []
-      } finally {
-        release()
-      }
-    })
-  )
-  return results.flat().sort((a, b) => a.name.localeCompare(b.name))
-}
-
-export async function listIssueTypes(
-  projectIdOrKey: string,
-  siteId?: string | null
-): Promise<JiraIssueType[]> {
-  const entry = getClients(siteId)[0]
-  if (!entry) {
-    return []
-  }
-  await acquire()
-  try {
-    const issueTypes = await fetchPagedRecords(entry, 'issueTypes', (startAt, maxResults) => {
-      const params = new URLSearchParams({
-        maxResults: String(maxResults),
-        startAt: String(startAt)
-      })
-      return `/rest/api/3/issue/createmeta/${encodeURIComponent(
-        projectIdOrKey
-      )}/issuetypes?${params.toString()}`
-    })
-    return issueTypes.map(mapIssueType)
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken(entry.site.id)
-      throw error
-    }
-    console.warn('[jira] listIssueTypes failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
-
-export async function listCreateFields(
-  projectIdOrKey: string,
-  issueTypeId: string,
-  siteId?: string | null
-): Promise<JiraCreateField[]> {
-  const entry = getClients(siteId)[0]
-  if (!entry) {
-    return []
-  }
-  await acquire()
-  try {
-    const fields: JiraCreateField[] = []
-    let startAt = 0
-    const maxResults = 100
-    for (let guard = 0; guard < 100; guard += 1) {
-      const params = new URLSearchParams({
-        maxResults: String(maxResults),
-        startAt: String(startAt)
-      })
-      const response = await jiraRequest<JiraPagedResponse<JiraRecord>>(
-        entry,
-        `/rest/api/3/issue/createmeta/${encodeURIComponent(
-          projectIdOrKey
-        )}/issuetypes/${encodeURIComponent(issueTypeId)}?${params.toString()}`
-      )
-      const records = getCreateFieldRecords(response)
-      fields.push(
-        ...records
-          .map((record) => mapCreateField(record))
-          .filter((field): field is JiraCreateField => field !== null)
-      )
-      if (!shouldFetchNextPage(response, startAt, records, maxResults)) {
-        break
-      }
-      startAt += asFiniteNumber(response.maxResults) ?? maxResults
-    }
-    return fields
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken(entry.site.id)
-      throw error
-    }
-    console.warn('[jira] listCreateFields failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
-
-export async function listPriorities(siteId?: string | null): Promise<JiraPriority[]> {
-  const entry = getClients(siteId)[0]
-  if (!entry) {
-    return []
-  }
-  await acquire()
-  try {
-    const response = await jiraRequest<JiraRecord[]>(entry, '/rest/api/3/priority')
-    return response.map(mapPriority).filter((priority): priority is JiraPriority => !!priority)
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken(entry.site.id)
-      throw error
-    }
-    console.warn('[jira] listPriorities failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
-
-export async function listAssignableUsers(
-  key: string,
-  query?: string,
-  siteId?: string | null
-): Promise<JiraUser[]> {
-  const entry = getClients(siteId)[0]
-  if (!entry) {
-    return []
-  }
-  const params = new URLSearchParams({ issueKey: key, maxResults: '50' })
-  if (query?.trim()) {
-    params.set('query', query.trim())
-  }
-  await acquire()
-  try {
-    const response = await jiraRequest<JiraRecord[]>(
-      entry,
-      `/rest/api/3/user/assignable/search?${params.toString()}`
-    )
-    return response.map(mapUser).filter((user): user is JiraUser => !!user)
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken(entry.site.id)
-      throw error
-    }
-    console.warn('[jira] listAssignableUsers failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
-
-export async function listTransitions(
-  key: string,
-  siteId?: string | null
-): Promise<JiraTransition[]> {
-  const entry = getClients(siteId)[0]
-  if (!entry) {
-    return []
-  }
-  await acquire()
-  try {
-    const response = await jiraRequest<{ transitions?: JiraRecord[] }>(
-      entry,
-      `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`
-    )
-    return (response.transitions ?? []).map((transition) => ({
-      id: asString(transition.id),
-      name: asString(transition.name),
-      to: mapStatus(transition.to)
-    }))
-  } catch (error) {
-    if (isAuthError(error)) {
-      clearToken(entry.site.id)
-      throw error
-    }
-    console.warn('[jira] listTransitions failed:', error)
-    return []
-  } finally {
-    release()
-  }
-}
+export { addIssueComment, getIssueComments } from './issue-comments'
+export {
+  listAssignableUsers,
+  listCreateFields,
+  listIssueTypes,
+  listPriorities,
+  listProjects,
+  listTransitions
+} from './issue-metadata'
+export { getIssue, listIssues, searchIssues } from './issue-search'
+export { mapJiraIssue } from './issue-mappers'

--- a/src/main/jira/jira-request.ts
+++ b/src/main/jira/jira-request.ts
@@ -1,0 +1,166 @@
+import { net, session } from 'electron'
+import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
+import { withSpan } from '../observability/tracer'
+import type { JiraSite } from '../../shared/types'
+
+// Why: Atlassian's XSRF filter rejects POST/PUT REST calls that carry a browser
+// User-Agent, failing them with "XSRF check failed" even under API-token auth.
+// Electron's net.fetch sends a Chrome UA, so issue search/create/update/comment
+// all 403'd while GET calls (connect, /myself) passed. A non-browser UA is the
+// reliable fix; X-Atlassian-Token: no-check is not honored for this case.
+const JIRA_API_USER_AGENT = 'Orca'
+
+export type JiraClientForSite = {
+  site: JiraSite
+  authorization: string
+}
+
+export class JiraApiError extends Error {
+  status: number | null
+
+  constructor(message: string, status: number | null = null) {
+    super(message)
+    this.status = status
+  }
+}
+
+function getJiraErrorStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object' || !('status' in error)) {
+    return null
+  }
+  const status = (error as { status?: unknown }).status
+  return typeof status === 'number' && Number.isFinite(status) ? status : null
+}
+
+export function toJiraErrorWithStatus(error: unknown): unknown {
+  const status = getJiraErrorStatus(error)
+  if (
+    status === null ||
+    !(error instanceof Error) ||
+    error.message.startsWith(`Error ${status}:`)
+  ) {
+    return error
+  }
+  return new Error(`Error ${status}: ${error.message}`)
+}
+
+function describeErrorCause(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object' || !('cause' in error)) {
+    return undefined
+  }
+  const cause = (error as { cause?: unknown }).cause
+  if (cause instanceof Error) {
+    return `${cause.name}: ${cause.message}`
+  }
+  return cause === undefined ? undefined : String(cause)
+}
+
+async function jiraFetch(url: string, init: RequestInit): Promise<Response> {
+  return withSpan(
+    'jira.request',
+    async (span) => {
+      span.setAttribute('jira.siteUrl', new URL(url).origin)
+      await ensureElectronProxyFromEnvironment({
+        proxySession: session.defaultSession,
+        probeUrl: url
+      }).catch((error) => {
+        span.addEvent('jira.proxySetupFailed', {
+          errorName: error instanceof Error ? error.name : typeof error,
+          errorMessage: error instanceof Error ? error.message : String(error)
+        })
+      })
+      try {
+        // Why: Electron's network stack follows Chromium proxy/session state,
+        // avoiding undici's stale keep-alive sockets after VPN path changes.
+        return await net.fetch(url, init)
+      } catch (error) {
+        span.setAttribute(
+          'jira.transportErrorName',
+          error instanceof Error ? error.name : typeof error
+        )
+        span.setAttribute(
+          'jira.transportErrorMessage',
+          error instanceof Error ? error.message : String(error)
+        )
+        const cause = describeErrorCause(error)
+        if (cause) {
+          span.setAttribute('jira.transportErrorCause', cause)
+        }
+        throw error
+      }
+    },
+    { kind: 'client' }
+  )
+}
+
+async function readJiraError(response: Response): Promise<string> {
+  try {
+    const data = (await response.json()) as {
+      errorMessages?: string[]
+      errors?: Record<string, string>
+      message?: string
+    }
+    const messages = [
+      ...(Array.isArray(data.errorMessages) ? data.errorMessages : []),
+      ...Object.values(data.errors ?? {}),
+      ...(data.message ? [data.message] : [])
+    ].filter(Boolean)
+    if (messages.length > 0) {
+      return messages.join('; ')
+    }
+  } catch {
+    // Fall through to status text.
+  }
+  return response.statusText || `Jira request failed (${response.status})`
+}
+
+async function readJiraJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    // Why: private Server/DC deployments often answer auth mismatches with an
+    // HTML login page; callers should see a sanitized Jira-mode/auth error.
+    throw new JiraApiError(
+      'Jira returned a non-JSON response. Check the selected deployment type and credentials.',
+      response.status
+    )
+  }
+}
+
+export async function jiraRequestWithAuthorization(
+  siteUrl: string,
+  authorization: string,
+  path: string,
+  init?: RequestInit
+): Promise<unknown> {
+  const headers = new Headers(init?.headers)
+  headers.set('Accept', 'application/json')
+  headers.set('Content-Type', 'application/json')
+  headers.set('User-Agent', JIRA_API_USER_AGENT)
+  headers.set('Authorization', authorization)
+  const response = await jiraFetch(`${siteUrl}${path}`, {
+    ...init,
+    headers
+  })
+  if (!response.ok) {
+    throw new JiraApiError(await readJiraError(response), response.status)
+  }
+  if (response.status === 204) {
+    return null
+  }
+  return readJiraJson(response)
+}
+
+export async function jiraRequest<T>(
+  client: JiraClientForSite,
+  path: string,
+  init?: RequestInit
+): Promise<T> {
+  const response = await jiraRequestWithAuthorization(
+    client.site.siteUrl,
+    client.authorization,
+    path,
+    init
+  )
+  return response as T
+}

--- a/src/main/jira/jira-user-identity.ts
+++ b/src/main/jira/jira-user-identity.ts
@@ -1,0 +1,85 @@
+import type { JiraSite, JiraUser, JiraViewer } from '../../shared/types'
+
+type JiraRecord = Record<string, unknown>
+
+function asRecord(value: unknown): JiraRecord {
+  return value && typeof value === 'object' ? (value as JiraRecord) : {}
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+export function getJiraAvatarUrl(data: JiraRecord): string | undefined {
+  const avatarUrls = asRecord(data.avatarUrls)
+  return (
+    asString(avatarUrls['48x48']) ||
+    asString(avatarUrls['32x32']) ||
+    asString(avatarUrls['24x24']) ||
+    undefined
+  )
+}
+
+export function jiraSiteToViewer(site: JiraSite | null): JiraViewer | null {
+  if (!site) {
+    return null
+  }
+  return {
+    userId: site.viewerUserId,
+    accountId: site.accountId,
+    displayName: site.displayName,
+    email: site.email
+  }
+}
+
+export function toCloudJiraViewer(data: JiraRecord, fallbackEmail: string): JiraViewer {
+  const accountId = asString(data.accountId)
+  return {
+    userId: accountId,
+    accountId,
+    displayName: asString(data.displayName, fallbackEmail),
+    email: asString(data.emailAddress, fallbackEmail),
+    avatarUrl: getJiraAvatarUrl(data)
+  }
+}
+
+export function toServerJiraViewer(data: JiraRecord, fallbackUsername = ''): JiraViewer {
+  const userId =
+    asString(data.name) ||
+    asString(data.key) ||
+    asString(data.emailAddress) ||
+    asString(data.displayName) ||
+    fallbackUsername
+  return {
+    userId,
+    accountId: userId,
+    displayName: asString(data.displayName, userId || fallbackUsername),
+    email: typeof data.emailAddress === 'string' ? data.emailAddress : null,
+    avatarUrl: getJiraAvatarUrl(data)
+  }
+}
+
+export function mapJiraUser(value: unknown, site?: JiraSite): JiraUser | undefined {
+  const user = asRecord(value)
+  const cloudAccountId = asString(user.accountId)
+  const serverUserId =
+    asString(user.name) ||
+    asString(user.key) ||
+    asString(user.emailAddress) ||
+    asString(user.displayName)
+  const userId = site?.deploymentType === 'server' ? serverUserId : cloudAccountId
+  if (!userId) {
+    return undefined
+  }
+  return {
+    userId,
+    accountId: cloudAccountId || userId,
+    displayName: asString(user.displayName, 'Unknown'),
+    email: typeof user.emailAddress === 'string' ? user.emailAddress : undefined,
+    avatarUrl: getJiraAvatarUrl(user)
+  }
+}
+
+export function jiraAssigneePayload(site: JiraSite, userId: string | null | undefined): JiraRecord {
+  return site.deploymentType === 'server' ? { name: userId } : { accountId: userId }
+}

--- a/src/main/jira/site-storage.ts
+++ b/src/main/jira/site-storage.ts
@@ -1,0 +1,255 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { safeStorage } from 'electron'
+import {
+  CredentialDecryptionError,
+  credentialFileHasContent,
+  readStoredCredentialToken
+} from '../integration-credential-file'
+import type { JiraSite, JiraSiteSelection } from '../../shared/types'
+
+export type JiraSiteFile = {
+  version: 1
+  activeSiteId: string | null
+  selectedSiteId: JiraSiteSelection | null
+  sites: JiraSite[]
+}
+
+let cachedSiteFile: JiraSiteFile | null = null
+let siteFileLoaded = false
+const cachedSecrets = new Map<string, string>()
+// Why: decrypt failures are recorded per site so status can explain failing
+// reads without re-touching the keychain on every status poll.
+const credentialErrors = new Map<string, string>()
+
+function getOrcaDir(): string {
+  return join(homedir(), '.orca')
+}
+
+function getSiteFilePath(): string {
+  return join(getOrcaDir(), 'jira-sites.json')
+}
+
+function getTokenDir(): string {
+  return join(getOrcaDir(), 'jira-tokens')
+}
+
+function getTokenPath(siteId: string): string {
+  return join(getTokenDir(), `${Buffer.from(siteId).toString('base64url')}.enc`)
+}
+
+function ensureOrcaDir(): void {
+  const dir = getOrcaDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+function ensureTokenDir(): void {
+  const dir = getTokenDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+function emptySiteFile(): JiraSiteFile {
+  return {
+    version: 1,
+    activeSiteId: null,
+    selectedSiteId: null,
+    sites: []
+  }
+}
+
+export function hasJiraSiteSecret(siteId: string): boolean {
+  return cachedSecrets.has(siteId) || credentialFileHasContent(getTokenPath(siteId))
+}
+
+function normalizeDeploymentType(value: unknown): JiraSite['deploymentType'] {
+  return value === 'server' ? 'server' : 'cloud'
+}
+
+function normalizeAuthMode(
+  deploymentType: JiraSite['deploymentType'],
+  value: unknown
+): JiraSite['authMode'] {
+  if (deploymentType === 'cloud') {
+    return 'basic'
+  }
+  return value === 'bearer' ? 'bearer' : 'basic'
+}
+
+function normalizeSite(input: unknown): JiraSite | null {
+  if (!input || typeof input !== 'object') {
+    return null
+  }
+  const record = input as Record<string, unknown>
+  if (
+    typeof record.id !== 'string' ||
+    typeof record.siteUrl !== 'string' ||
+    typeof record.email !== 'string' ||
+    typeof record.displayName !== 'string' ||
+    typeof record.accountId !== 'string'
+  ) {
+    return null
+  }
+  const deploymentType = normalizeDeploymentType(record.deploymentType)
+  const authMode = normalizeAuthMode(deploymentType, record.authMode)
+  const viewerUserId =
+    typeof record.viewerUserId === 'string' && record.viewerUserId.trim()
+      ? record.viewerUserId
+      : record.accountId
+  const site: JiraSite = {
+    id: record.id,
+    siteUrl: record.siteUrl,
+    email: record.email,
+    displayName: record.displayName,
+    accountId: record.accountId,
+    viewerUserId,
+    deploymentType,
+    authMode
+  }
+  if (typeof record.authUsername === 'string' && record.authUsername.trim()) {
+    site.authUsername = record.authUsername
+  }
+  return site
+}
+
+function writeMigratedSiteFileIfNeeded(
+  filePath: string,
+  parsed: Partial<JiraSiteFile>,
+  file: JiraSiteFile
+): void {
+  if (JSON.stringify(parsed.sites ?? []) === JSON.stringify(file.sites)) {
+    return
+  }
+  try {
+    writeFileSync(filePath, JSON.stringify(file, null, 2), { encoding: 'utf-8', mode: 0o600 })
+  } catch {
+    // Migration is best-effort; in-memory normalized metadata is still used.
+  }
+}
+
+function readSiteFileFromDisk(): JiraSiteFile {
+  const path = getSiteFilePath()
+  if (!existsSync(path)) {
+    return emptySiteFile()
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, { encoding: 'utf-8' })) as Partial<JiraSiteFile>
+    const sites = Array.isArray(parsed.sites)
+      ? parsed.sites
+          .map((site) => normalizeSite(site))
+          .filter((site): site is JiraSite => site !== null)
+          .filter((site) => hasJiraSiteSecret(site.id))
+      : []
+    const activeSiteId =
+      typeof parsed.activeSiteId === 'string' &&
+      sites.some((site) => site.id === parsed.activeSiteId)
+        ? parsed.activeSiteId
+        : (sites[0]?.id ?? null)
+    const selectedSiteId =
+      parsed.selectedSiteId === 'all' ||
+      (typeof parsed.selectedSiteId === 'string' &&
+        sites.some((site) => site.id === parsed.selectedSiteId))
+        ? parsed.selectedSiteId
+        : activeSiteId
+    const file = { version: 1 as const, activeSiteId, selectedSiteId, sites }
+    writeMigratedSiteFileIfNeeded(path, parsed, file)
+    return file
+  } catch {
+    return emptySiteFile()
+  }
+}
+
+export function getSiteFile(): JiraSiteFile {
+  if (!siteFileLoaded || !cachedSiteFile) {
+    cachedSiteFile = readSiteFileFromDisk()
+    siteFileLoaded = true
+  }
+  return cachedSiteFile
+}
+
+export function writeSiteFile(file: JiraSiteFile): void {
+  ensureOrcaDir()
+  const sites = file.sites.filter((site) => hasJiraSiteSecret(site.id))
+  const activeSiteId =
+    file.activeSiteId && sites.some((site) => site.id === file.activeSiteId)
+      ? file.activeSiteId
+      : (sites[0]?.id ?? null)
+  const selectedSiteId =
+    file.selectedSiteId === 'all'
+      ? 'all'
+      : file.selectedSiteId && sites.some((site) => site.id === file.selectedSiteId)
+        ? file.selectedSiteId
+        : activeSiteId
+
+  cachedSiteFile = {
+    version: 1,
+    activeSiteId,
+    selectedSiteId,
+    sites
+  }
+  siteFileLoaded = true
+  writeFileSync(getSiteFilePath(), JSON.stringify(cachedSiteFile, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600
+  })
+}
+
+function writeEncryptedToken(path: string, secret: string): void {
+  if (safeStorage.isEncryptionAvailable()) {
+    writeFileSync(path, safeStorage.encryptString(secret), { mode: 0o600 })
+    return
+  }
+  console.warn('[jira] safeStorage encryption unavailable - storing token in plaintext')
+  writeFileSync(path, secret, { encoding: 'utf-8', mode: 0o600 })
+}
+
+export function readJiraSiteSecret(siteId: string): string | null {
+  const cached = cachedSecrets.get(siteId)
+  if (cached !== undefined) {
+    return cached
+  }
+  const path = getTokenPath(siteId)
+  if (!existsSync(path)) {
+    return null
+  }
+  try {
+    const token = readStoredCredentialToken('Jira', readFileSync(path))
+    if (token) {
+      cachedSecrets.set(siteId, token)
+    }
+    credentialErrors.delete(siteId)
+    return token
+  } catch (error) {
+    if (error instanceof CredentialDecryptionError) {
+      credentialErrors.set(siteId, error.message)
+      throw error
+    }
+    return null
+  }
+}
+
+export function saveJiraSiteSecret(siteId: string, secret: string): void {
+  ensureOrcaDir()
+  ensureTokenDir()
+  writeEncryptedToken(getTokenPath(siteId), secret)
+  cachedSecrets.set(siteId, secret)
+  credentialErrors.delete(siteId)
+}
+
+export function deleteJiraSiteSecret(siteId: string): void {
+  cachedSecrets.delete(siteId)
+  credentialErrors.delete(siteId)
+  try {
+    unlinkSync(getTokenPath(siteId))
+  } catch {
+    // Token may not exist - safe to ignore.
+  }
+}
+
+export function getJiraCredentialError(siteId: string): string | undefined {
+  return credentialErrors.get(siteId)
+}

--- a/src/main/runtime/rpc/methods/jira.test.ts
+++ b/src/main/runtime/rpc/methods/jira.test.ts
@@ -35,12 +35,77 @@ describe('jira RPC methods', () => {
     expect(runtime.jiraStatus).toHaveBeenCalled()
     expect(runtime.jiraTestConnection).toHaveBeenCalled()
     expect(runtime.jiraConnect).toHaveBeenCalledWith({
+      deploymentType: 'cloud',
       siteUrl: 'https://example.atlassian.net',
       email: 'ada@example.com',
       apiToken: 'token'
     })
     expect(runtime.jiraSelectSite).toHaveBeenCalledWith('site-1')
     expect(runtime.jiraDisconnect).toHaveBeenCalled()
+  })
+
+  it('routes Jira Server connect payloads to the runtime server', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      jiraConnect: vi.fn().mockResolvedValue({ ok: true, viewer: { displayName: 'Ada' } })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: JIRA_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('jira.connect', {
+        deploymentType: 'server',
+        authMode: 'basic',
+        siteUrl: 'https://jira.example.internal',
+        username: 'ada',
+        passwordOrToken: 'secret'
+      })
+    )
+    await dispatcher.dispatch(
+      makeRequest('jira.connect', {
+        deploymentType: 'server',
+        authMode: 'bearer',
+        siteUrl: 'https://jira.example.internal',
+        bearerToken: 'pat-secret'
+      })
+    )
+
+    expect(runtime.jiraConnect).toHaveBeenNthCalledWith(1, {
+      deploymentType: 'server',
+      authMode: 'basic',
+      siteUrl: 'https://jira.example.internal',
+      username: 'ada',
+      passwordOrToken: 'secret'
+    })
+    expect(runtime.jiraConnect).toHaveBeenNthCalledWith(2, {
+      deploymentType: 'server',
+      authMode: 'bearer',
+      siteUrl: 'https://jira.example.internal',
+      bearerToken: 'pat-secret'
+    })
+  })
+
+  it('rejects mixed Jira connect auth payloads', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      jiraConnect: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: JIRA_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('jira.connect', {
+        deploymentType: 'server',
+        authMode: 'bearer',
+        siteUrl: 'https://jira.example.internal',
+        username: 'ada',
+        bearerToken: 'pat-secret'
+      })
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: 'invalid_argument' }
+    })
+    expect(runtime.jiraConnect).not.toHaveBeenCalled()
   })
 
   it('routes Jira issue queries and mutations to the runtime server', async () => {
@@ -79,7 +144,7 @@ describe('jira RPC methods', () => {
         siteId: 'site-1',
         updates: {
           title: 'Fixed title',
-          assigneeAccountId: null,
+          assigneeUserId: null,
           priorityId: '2',
           labels: ['bug'],
           transitionId: '31'
@@ -106,7 +171,7 @@ describe('jira RPC methods', () => {
       'ABC-3',
       {
         title: 'Fixed title',
-        assigneeAccountId: null,
+        assigneeUserId: null,
         priorityId: '2',
         labels: ['bug'],
         transitionId: '31'

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -15,11 +15,36 @@ const SiteSelection = z
   })
   .optional()
 
-const Connect = z.object({
-  siteUrl: requiredString('Site URL is required'),
-  email: requiredString('Email is required'),
-  apiToken: requiredString('API token is required')
-})
+const CloudConnect = z
+  .object({
+    deploymentType: z.literal('cloud').optional(),
+    siteUrl: requiredString('Site URL is required'),
+    email: requiredString('Email is required'),
+    apiToken: requiredString('API token is required')
+  })
+  .strict()
+  .transform((value) => ({ ...value, deploymentType: 'cloud' as const }))
+
+const ServerBasicConnect = z
+  .object({
+    deploymentType: z.literal('server'),
+    authMode: z.literal('basic'),
+    siteUrl: requiredString('Site URL is required'),
+    username: requiredString('Username is required'),
+    passwordOrToken: requiredString('Password or token is required')
+  })
+  .strict()
+
+const ServerBearerConnect = z
+  .object({
+    deploymentType: z.literal('server'),
+    authMode: z.literal('bearer'),
+    siteUrl: requiredString('Site URL is required'),
+    bearerToken: requiredString('Bearer token is required')
+  })
+  .strict()
+
+const Connect = z.union([ServerBasicConnect, ServerBearerConnect, CloudConnect])
 
 const SelectSite = z.object({
   siteId: requiredString('Site ID is required')
@@ -59,6 +84,7 @@ const IssueUpdate = z.object({
   updates: z.object({
     title: OptionalString,
     labels: z.array(z.string()).optional(),
+    assigneeUserId: z.union([z.string(), z.null()]).optional(),
     assigneeAccountId: z.union([z.string(), z.null()]).optional(),
     priorityId: z.union([z.string(), z.null()]).optional(),
     transitionId: OptionalString
@@ -92,12 +118,31 @@ export const JIRA_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'jira.connect',
     params: Connect,
-    handler: async (params, { runtime }) =>
-      runtime.jiraConnect({
+    handler: async (params, { runtime }) => {
+      if (params.deploymentType === 'server') {
+        if (params.authMode === 'bearer') {
+          return runtime.jiraConnect({
+            deploymentType: 'server',
+            authMode: 'bearer',
+            siteUrl: params.siteUrl.trim(),
+            bearerToken: params.bearerToken.trim()
+          })
+        }
+        return runtime.jiraConnect({
+          deploymentType: 'server',
+          authMode: 'basic',
+          siteUrl: params.siteUrl.trim(),
+          username: params.username.trim(),
+          passwordOrToken: params.passwordOrToken.trim()
+        })
+      }
+      return runtime.jiraConnect({
+        deploymentType: 'cloud',
         siteUrl: params.siteUrl.trim(),
         email: params.email.trim(),
         apiToken: params.apiToken.trim()
       })
+    }
   }),
   defineMethod({
     name: 'jira.disconnect',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -88,6 +88,7 @@ import type {
   ListWorkItemsResult,
   IssueInfo,
   JiraComment,
+  JiraConnectArgs,
   JiraConnectionStatus,
   JiraCreateField,
   JiraCreateIssueArgs,
@@ -1790,11 +1791,9 @@ export type PreloadApi = {
     teamMembers: (args: { teamId: string; workspaceId?: string }) => Promise<LinearMember[]>
   }
   jira: {
-    connect: (args: {
-      siteUrl: string
-      email: string
-      apiToken: string
-    }) => Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }>
+    connect: (
+      args: JiraConnectArgs
+    ) => Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }>
     disconnect: (args?: { siteId?: string }) => Promise<void>
     selectSite: (args: { siteId: JiraSiteSelection }) => Promise<JiraConnectionStatus>
     status: () => Promise<JiraConnectionStatus>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -31,6 +31,8 @@ import type {
   GitForkSyncResult,
   GitUpstreamStatus,
   GhosttyImportPreview,
+  JiraConnectArgs,
+  JiraViewer,
   ListWorkItemsResult,
   LinearProjectDetail,
   MemorySnapshot,
@@ -1537,11 +1539,9 @@ const api = {
   },
 
   jira: {
-    connect: (args: {
-      siteUrl: string
-      email: string
-      apiToken: string
-    }): Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }> =>
+    connect: (
+      args: JiraConnectArgs
+    ): Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }> =>
       ipcRenderer.invoke('jira:connect', args),
 
     disconnect: (args?: { siteId?: string }): Promise<void> =>
@@ -1554,7 +1554,7 @@ const api = {
 
     testConnection: (args?: {
       siteId?: string
-    }): Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }> =>
+    }): Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }> =>
       ipcRenderer.invoke('jira:testConnection', args),
 
     searchIssues: (args: { jql: string; limit?: number; siteId?: string }): Promise<unknown[]> =>

--- a/src/renderer/src/components/JiraIssueWorkspace.tsx
+++ b/src/renderer/src/components/JiraIssueWorkspace.tsx
@@ -339,7 +339,7 @@ export default function JiraIssueWorkspace({
         id: result.id || createBrowserUuid(),
         body: bodyState.body,
         createdAt: new Date().toISOString(),
-        user: { accountId: 'local', displayName: 'You' }
+        user: { userId: 'local', accountId: 'local', displayName: 'You' }
       }
       optimisticCommentsRef.current.push(comment)
       setComments((prev) => [...prev, comment])
@@ -566,7 +566,7 @@ export default function JiraIssueWorkspace({
                     onClick={() =>
                       void mutateIssue(
                         'assignee',
-                        { assigneeAccountId: null },
+                        { assigneeUserId: null },
                         { assignee: undefined }
                       )
                     }
@@ -576,12 +576,12 @@ export default function JiraIssueWorkspace({
                   </button>
                   {users.map((user) => (
                     <button
-                      key={user.accountId}
+                      key={user.userId}
                       type="button"
                       onClick={() =>
                         void mutateIssue(
                           'assignee',
-                          { assigneeAccountId: user.accountId },
+                          { assigneeUserId: user.userId },
                           { assignee: user }
                         )
                       }

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -27,7 +27,6 @@ import {
   GitPullRequestDraft,
   List,
   LoaderCircle,
-  Lock,
   Minus,
   Plus,
   RefreshCw,
@@ -90,6 +89,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import TaskProjectSourceCombobox from '@/components/task-project-source-combobox'
+import { JiraConnectDialog } from '@/components/jira-connect-dialog'
 import { LinearApiKeyDialog } from '@/components/linear-api-key-dialog'
 import { LinearScopeSelector } from '@/components/linear-scope-selector'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
@@ -233,7 +233,11 @@ import {
 } from '@/components/task-page-jira-load-state'
 import { deriveTaskPagePRCheckSummary } from '@/components/task-page-pr-check-summary'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
-import { buildJiraCreateTextAdf } from '@/components/jira-create-adf'
+import {
+  buildJiraCreateCustomFields,
+  getJiraCreateAllowedValueLabel,
+  isVisibleJiraCreateField
+} from '@/components/jira-create-field-payload'
 import {
   GITHUB_PR_MERGE_METHOD_LABELS,
   resolveGitHubPRMergeMethods
@@ -247,6 +251,7 @@ import type {
   GitLabTodo,
   GitLabWorkItem,
   JiraCreateField,
+  JiraDeploymentType,
   LinearCollectionResult,
   LinearCustomViewModel,
   LinearCustomViewSummary,
@@ -944,84 +949,6 @@ function compareJiraProjectsByDisplayLabel(
     return nameComparison
   }
   return jiraProjectLabelCollator.compare(a.key, b.key)
-}
-
-const JIRA_CREATE_SYSTEM_FIELD_KEYS = new Set(['project', 'issuetype', 'summary', 'description'])
-
-function isVisibleJiraCreateField(field: JiraCreateField): boolean {
-  return field.required && !JIRA_CREATE_SYSTEM_FIELD_KEYS.has(field.key)
-}
-
-function getJiraCreateAllowedValueLabel(
-  value: NonNullable<JiraCreateField['allowedValues']>[number]
-): string {
-  return value.name ?? value.value ?? value.id ?? 'Option'
-}
-
-function findJiraCreateAllowedValue(field: JiraCreateField, draftValue: string) {
-  return field.allowedValues?.find((value) => {
-    return value.id === draftValue || value.value === draftValue || value.name === draftValue
-  })
-}
-
-function getJiraCreateOptionPayload(
-  value: NonNullable<JiraCreateField['allowedValues']>[number] | undefined,
-  fallback: string
-): Record<string, string> | string {
-  if (value?.id) {
-    return { id: value.id }
-  }
-  if (value?.value) {
-    return { value: value.value }
-  }
-  if (value?.name) {
-    return { name: value.name }
-  }
-  return fallback
-}
-
-function buildJiraCreateFieldValue(field: JiraCreateField, draftValue: string): unknown {
-  const trimmed = draftValue.trim()
-  if (!trimmed) {
-    return undefined
-  }
-  if (field.schema?.type === 'array') {
-    const parts = trimmed
-      .split(',')
-      .map((part) => part.trim())
-      .filter(Boolean)
-    if (field.allowedValues?.length) {
-      return parts.map((part) =>
-        getJiraCreateOptionPayload(findJiraCreateAllowedValue(field, part), part)
-      )
-    }
-    return parts
-  }
-  if (field.allowedValues?.length) {
-    return getJiraCreateOptionPayload(findJiraCreateAllowedValue(field, trimmed), trimmed)
-  }
-  if (field.schema?.type === 'number') {
-    const numberValue = Number(trimmed)
-    return Number.isFinite(numberValue) ? numberValue : trimmed
-  }
-  if (field.schema?.custom?.includes(':textarea') || field.schema?.type === 'textarea') {
-    return buildJiraCreateTextAdf(trimmed)
-  }
-  return trimmed
-}
-
-function buildJiraCreateCustomFields(
-  fields: readonly JiraCreateField[],
-  values: Record<string, string>
-): Record<string, unknown> | undefined {
-  const customFields: Record<string, unknown> = {}
-  for (const field of fields) {
-    const value = buildJiraCreateFieldValue(field, values[field.key] ?? '')
-    if (value !== undefined) {
-      customFields[field.key] = value
-    }
-  }
-  return Object.keys(customFields).length > 0 ? customFields : undefined
 }
 
 function GHStatusCell({
@@ -3069,7 +2996,6 @@ export default function TaskPage(): React.JSX.Element {
   const jiraStatus = useAppStore((s) => s.jiraStatus)
   const jiraStatusChecked = useAppStore((s) => s.jiraStatusChecked)
   const jiraStatusContextKey = useAppStore((s) => s.jiraStatusContextKey)
-  const connectJira = useAppStore((s) => s.connectJira)
   const selectJiraSite = useAppStore((s) => s.selectJiraSite)
   const searchJiraIssues = useAppStore((s) => s.searchJiraIssues)
   const listJiraIssues = useAppStore((s) => s.listJiraIssues)
@@ -5616,11 +5542,6 @@ export default function TaskPage(): React.JSX.Element {
     Record<string, string>
   >({})
   const [jiraConnectOpen, setJiraConnectOpen] = useState(false)
-  const [jiraSiteUrlDraft, setJiraSiteUrlDraft] = useState('')
-  const [jiraEmailDraft, setJiraEmailDraft] = useState('')
-  const [jiraApiTokenDraft, setJiraApiTokenDraft] = useState('')
-  const [jiraConnectState, setJiraConnectState] = useState<'idle' | 'connecting' | 'error'>('idle')
-  const [jiraConnectError, setJiraConnectError] = useState<string | null>(null)
   const includeJiraSiteNameInProjectLabel = selectedJiraSiteId === 'all'
   const previousProviderRuntimeContextKeyRef = useRef(providerRuntimeContextKey)
 
@@ -5691,6 +5612,14 @@ export default function TaskPage(): React.JSX.Element {
   const newJiraIssueTargetProjectSelectionKey = newJiraIssueTargetProject
     ? getJiraProjectSelectionKey(newJiraIssueTargetProject)
     : ''
+
+  const newJiraIssueTargetDeploymentType = useMemo<JiraDeploymentType>(() => {
+    const siteId = newJiraIssueTargetProject?.siteId
+    if (!siteId) {
+      return 'cloud'
+    }
+    return jiraStatus.sites?.find((site) => site.id === siteId)?.deploymentType ?? 'cloud'
+  }, [jiraStatus.sites, newJiraIssueTargetProject?.siteId])
 
   const newJiraIssueTargetType = useMemo(
     () =>
@@ -6908,7 +6837,8 @@ export default function TaskPage(): React.JSX.Element {
     }
     const customFields = buildJiraCreateCustomFields(
       visibleJiraCreateFields,
-      newJiraIssueCustomFieldValues
+      newJiraIssueCustomFieldValues,
+      newJiraIssueTargetDeploymentType
     )
     setNewJiraIssueSubmitting(true)
     const submitProviderRuntimeContextKey = providerRuntimeContextKey
@@ -6978,6 +6908,7 @@ export default function TaskPage(): React.JSX.Element {
     newJiraIssueBody,
     newJiraIssueCustomFieldValues,
     newJiraIssueSubmitting,
+    newJiraIssueTargetDeploymentType,
     newJiraIssueTargetProject,
     newJiraIssueTargetType,
     newJiraIssueTitle,
@@ -7777,33 +7708,6 @@ export default function TaskPage(): React.JSX.Element {
     },
     [openComposerForJiraItem]
   )
-
-  const handleJiraConnect = useCallback(async (): Promise<void> => {
-    const siteUrl = jiraSiteUrlDraft.trim()
-    const email = jiraEmailDraft.trim()
-    const apiToken = jiraApiTokenDraft.trim()
-    if (!siteUrl || !email || !apiToken) {
-      return
-    }
-    setJiraConnectState('connecting')
-    setJiraConnectError(null)
-    try {
-      const result = await connectJira({ siteUrl, email, apiToken })
-      if (result.ok) {
-        setJiraSiteUrlDraft('')
-        setJiraEmailDraft('')
-        setJiraApiTokenDraft('')
-        setJiraConnectState('idle')
-        setJiraConnectOpen(false)
-      } else {
-        setJiraConnectState('error')
-        setJiraConnectError(result.error)
-      }
-    } catch (error) {
-      setJiraConnectState('error')
-      setJiraConnectError(error instanceof Error ? error.message : 'Connection failed')
-    }
-  }, [connectJira, jiraApiTokenDraft, jiraEmailDraft, jiraSiteUrlDraft])
 
   const taskPageListChromeHidden = shouldHideTaskPageListChrome({
     taskSource,
@@ -9724,11 +9628,6 @@ export default function TaskPage(): React.JSX.Element {
                 <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
                   <Button
                     onClick={() => {
-                      setJiraSiteUrlDraft('')
-                      setJiraEmailDraft('')
-                      setJiraApiTokenDraft('')
-                      setJiraConnectState('idle')
-                      setJiraConnectError(null)
                       setJiraConnectOpen(true)
                     }}
                   >
@@ -12465,137 +12364,7 @@ export default function TaskPage(): React.JSX.Element {
         onConnected={handleLinearAccessConnected}
       />
 
-      <Dialog
-        open={jiraConnectOpen}
-        onOpenChange={(open) => {
-          if (jiraConnectState !== 'connecting') {
-            setJiraConnectOpen(open)
-          }
-        }}
-      >
-        <DialogContent
-          className="sm:max-w-md"
-          onKeyDown={(e) => {
-            if (
-              e.key === 'Enter' &&
-              jiraSiteUrlDraft.trim() &&
-              jiraEmailDraft.trim() &&
-              jiraApiTokenDraft.trim() &&
-              jiraConnectState !== 'connecting'
-            ) {
-              e.preventDefault()
-              void handleJiraConnect()
-            }
-          }}
-        >
-          <DialogHeader className="gap-3">
-            <DialogTitle className="leading-tight">
-              {translate('auto.components.TaskPage.60f806ce99', 'Connect Jira site')}
-            </DialogTitle>
-            <DialogDescription>
-              {translate(
-                'auto.components.TaskPage.33fc2bcb30',
-                'Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.'
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-3">
-            <Input
-              autoFocus
-              placeholder={translate(
-                'auto.components.TaskPage.163df31e0e',
-                'https://example.atlassian.net'
-              )}
-              value={jiraSiteUrlDraft}
-              onChange={(e) => {
-                setJiraSiteUrlDraft(e.target.value)
-                if (jiraConnectState === 'error') {
-                  setJiraConnectState('idle')
-                  setJiraConnectError(null)
-                }
-              }}
-              disabled={jiraConnectState === 'connecting'}
-            />
-            <Input
-              type="email"
-              placeholder={translate('auto.components.TaskPage.68df347677', 'you@example.com')}
-              value={jiraEmailDraft}
-              onChange={(e) => {
-                setJiraEmailDraft(e.target.value)
-                if (jiraConnectState === 'error') {
-                  setJiraConnectState('idle')
-                  setJiraConnectError(null)
-                }
-              }}
-              disabled={jiraConnectState === 'connecting'}
-            />
-            <Input
-              type="password"
-              placeholder={translate('auto.components.TaskPage.b95623e93f', 'Atlassian API token')}
-              value={jiraApiTokenDraft}
-              onChange={(e) => {
-                setJiraApiTokenDraft(e.target.value)
-                if (jiraConnectState === 'error') {
-                  setJiraConnectState('idle')
-                  setJiraConnectError(null)
-                }
-              }}
-              disabled={jiraConnectState === 'connecting'}
-            />
-            {jiraConnectState === 'error' && jiraConnectError && (
-              <p className="text-xs text-destructive">{jiraConnectError}</p>
-            )}
-            <p className="text-xs text-muted-foreground">
-              {translate('auto.components.TaskPage.59c14d34a2', 'Create a token in')}{' '}
-              <button
-                className="text-primary underline-offset-2 hover:underline"
-                onClick={() =>
-                  window.api.shell.openUrl(
-                    'https://id.atlassian.com/manage-profile/security/api-tokens'
-                  )
-                }
-              >
-                {translate('auto.components.TaskPage.246c2b3dd3', 'Atlassian account settings')}
-              </button>
-              .
-            </p>
-            <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
-              <Lock className="size-3 shrink-0" />
-              {translate(
-                'auto.components.TaskPage.2abe22ef76',
-                'Your token is encrypted via the OS keychain and stored locally.'
-              )}
-            </p>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setJiraConnectOpen(false)}
-              disabled={jiraConnectState === 'connecting'}
-            >
-              {translate('auto.components.TaskPage.ff69a30681', 'Cancel')}
-            </Button>
-            <Button
-              onClick={() => void handleJiraConnect()}
-              disabled={
-                !jiraSiteUrlDraft.trim() ||
-                !jiraEmailDraft.trim() ||
-                !jiraApiTokenDraft.trim() ||
-                jiraConnectState === 'connecting'
-              }
-            >
-              {jiraConnectState === 'connecting' ? (
-                <>
-                  <LoaderCircle className="size-4 animate-spin" />
-                  {translate('auto.components.TaskPage.513cddfa7a', 'Verifying…')}
-                </>
-              ) : (
-                translate('auto.components.TaskPage.887efe9140', 'Connect')
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <JiraConnectDialog open={jiraConnectOpen} onOpenChange={setJiraConnectOpen} />
     </div>
   )
 }

--- a/src/renderer/src/components/feature-interaction-writer-boundaries.test.ts
+++ b/src/renderer/src/components/feature-interaction-writer-boundaries.test.ts
@@ -206,7 +206,7 @@ describe('feature interaction writer boundaries', () => {
     const jiraWriter = "recordFeatureInteraction('jira-tasks')"
 
     expect(
-      sourceBetween(taskPageSource, 'const handleUseJiraItem', 'const handleJiraConnect')
+      sourceBetween(taskPageSource, 'const handleUseJiraItem', 'const taskPageListChromeHidden')
     ).toContain(jiraWriter)
   })
 

--- a/src/renderer/src/components/jira-connect-dialog.test.tsx
+++ b/src/renderer/src/components/jira-connect-dialog.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { JiraConnectDialog } from './jira-connect-dialog'
+
+type StoreState = {
+  connectJira: (
+    args: unknown
+  ) => Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }>
+  settings: { activeRuntimeEnvironmentId: string | null }
+}
+
+const mocks = vi.hoisted(() => ({
+  store: { current: null as StoreState | null },
+  connectJira: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: StoreState) => unknown) => {
+    if (!mocks.store.current) {
+      throw new Error('Store state was not installed')
+    }
+    return selector(mocks.store.current)
+  }
+}))
+
+function installStore(): void {
+  mocks.store.current = {
+    connectJira: mocks.connectJira,
+    settings: { activeRuntimeEnvironmentId: null }
+  }
+}
+
+function inputValue(label: string): string {
+  return (screen.getByLabelText(label) as HTMLInputElement).value
+}
+
+describe('JiraConnectDialog', () => {
+  beforeEach(() => {
+    installStore()
+    mocks.connectJira.mockReset()
+    mocks.connectJira.mockResolvedValue({ ok: true, viewer: { displayName: 'Ada' } })
+    Object.assign(window, {
+      api: {
+        shell: {
+          openUrl: vi.fn()
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    mocks.store.current = null
+    Reflect.deleteProperty(window, 'api')
+  })
+
+  it('uses a Server/Data Center URL placeholder in server mode', () => {
+    render(<JiraConnectDialog open onOpenChange={() => {}} />)
+
+    expect(screen.getByPlaceholderText('https://example.atlassian.net')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Server/Data Center' }))
+
+    expect(screen.getByPlaceholderText('https://jira.example.com')).toBeTruthy()
+  })
+
+  it('clears inactive credential fields when switching Jira modes', () => {
+    render(<JiraConnectDialog open onOpenChange={() => {}} />)
+
+    fireEvent.change(screen.getByLabelText('Atlassian email'), {
+      target: { value: 'ada@example.com' }
+    })
+    fireEvent.change(screen.getByLabelText('API token'), { target: { value: 'cloud-secret' } })
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Server/Data Center' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Cloud' }))
+
+    expect(inputValue('Atlassian email')).toBe('')
+    expect(inputValue('API token')).toBe('')
+  })
+
+  it('clears inactive Server/Data Center credential fields when switching auth modes', () => {
+    render(<JiraConnectDialog open onOpenChange={() => {}} />)
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Server/Data Center' }))
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'ada' } })
+    fireEvent.change(screen.getByLabelText('Password or token'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('radio', { name: 'Bearer PAT' }))
+    fireEvent.change(screen.getByLabelText('Bearer token'), { target: { value: 'pat-secret' } })
+    fireEvent.click(screen.getByRole('radio', { name: 'Username + password/PAT' }))
+
+    expect(inputValue('Username')).toBe('')
+    expect(inputValue('Password or token')).toBe('')
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Bearer PAT' }))
+
+    expect(inputValue('Bearer token')).toBe('')
+  })
+
+  it('submits Jira Server Basic credentials', async () => {
+    render(<JiraConnectDialog open onOpenChange={() => {}} />)
+
+    expect(screen.getByText(/Cloud or Server\/Data Center site/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Server/Data Center' }))
+    fireEvent.change(screen.getByLabelText('Jira site URL'), {
+      target: { value: 'https://jira.example.internal' }
+    })
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'ada' } })
+    fireEvent.change(screen.getByLabelText('Password or token'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    expect(mocks.connectJira).toHaveBeenCalledWith({
+      deploymentType: 'server',
+      authMode: 'basic',
+      siteUrl: 'https://jira.example.internal',
+      username: 'ada',
+      passwordOrToken: 'secret'
+    })
+  })
+
+  it('submits Jira Server Bearer credentials', async () => {
+    render(<JiraConnectDialog open onOpenChange={() => {}} />)
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Server/Data Center' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Bearer PAT' }))
+    fireEvent.change(screen.getByLabelText('Jira site URL'), {
+      target: { value: 'https://jira.example.internal' }
+    })
+    fireEvent.change(screen.getByLabelText('Bearer token'), { target: { value: 'pat-secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    expect(mocks.connectJira).toHaveBeenCalledWith({
+      deploymentType: 'server',
+      authMode: 'bearer',
+      siteUrl: 'https://jira.example.internal',
+      bearerToken: 'pat-secret'
+    })
+  })
+})

--- a/src/renderer/src/components/jira-connect-dialog.tsx
+++ b/src/renderer/src/components/jira-connect-dialog.tsx
@@ -13,9 +13,11 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { cn } from '@/lib/utils'
 import { hasRemoteProviderRuntime } from '@/lib/provider-runtime-context'
 import { translate } from '@/i18n/i18n'
+import { JiraServerAuthFields, type JiraServerAuthMode } from '@/components/jira-server-auth-fields'
 
 type JiraConnectDialogProps = {
   open: boolean
@@ -26,10 +28,10 @@ type JiraConnectDialogProps = {
 }
 
 type ConnectState = 'idle' | 'connecting' | 'error'
+type DeploymentType = 'cloud' | 'server'
 
-// Why: mirrors the inline Jira connect dialog in TaskPage so the onboarding
-// "Connect integrations" step can reuse the same site URL + email + API token
-// flow without depending on TaskPage's local state.
+// Why: one dialog serves Settings, onboarding, and Tasks so Cloud and
+// Server/DC validation cannot drift across entry points.
 export function JiraConnectDialog({
   open,
   onOpenChange,
@@ -43,28 +45,83 @@ export function JiraConnectDialog({
   const siteUrlId = useId()
   const emailId = useId()
   const tokenId = useId()
+  const usernameId = useId()
+  const passwordOrTokenId = useId()
+  const bearerTokenId = useId()
   const errorId = useId()
 
+  const [deploymentType, setDeploymentType] = useState<DeploymentType>('cloud')
+  const [serverAuthMode, setServerAuthMode] = useState<JiraServerAuthMode>('basic')
   const [siteUrl, setSiteUrl] = useState('')
   const [email, setEmail] = useState('')
   const [apiToken, setApiToken] = useState('')
+  const [username, setUsername] = useState('')
+  const [passwordOrToken, setPasswordOrToken] = useState('')
+  const [bearerToken, setBearerToken] = useState('')
   const [connectState, setConnectState] = useState<ConnectState>('idle')
   const [connectError, setConnectError] = useState<string | null>(null)
 
   const canSubmit =
+    connectState !== 'connecting' &&
     Boolean(siteUrl.trim()) &&
-    Boolean(email.trim()) &&
-    Boolean(apiToken.trim()) &&
-    connectState !== 'connecting'
+    (deploymentType === 'cloud'
+      ? Boolean(email.trim()) && Boolean(apiToken.trim())
+      : serverAuthMode === 'basic'
+        ? Boolean(username.trim()) && Boolean(passwordOrToken.trim())
+        : Boolean(bearerToken.trim()))
   const credentialStorageCopy = hasRemoteProviderRuntime(settings)
-    ? 'Your token is sent to the selected remote runtime and stored there with runtime-supported encryption.'
-    : 'Your token is stored locally and encrypted when local runtime storage supports it.'
+    ? translate(
+        'auto.components.jira.connect.dialog.remoteCredentialStorage',
+        'Your credential is sent to the selected remote runtime and stored there with runtime-supported encryption.'
+      )
+    : translate(
+        'auto.components.jira.connect.dialog.localCredentialStorage',
+        'Your credential is stored locally and encrypted when local runtime storage supports it.'
+      )
+  const siteUrlPlaceholder =
+    deploymentType === 'cloud'
+      ? translate('auto.components.jira.connect.dialog.70fcd360c4', 'https://example.atlassian.net')
+      : translate(
+          'auto.components.jira.connect.dialog.serverUrlPlaceholder',
+          'https://jira.example.com'
+        )
 
   const clearErrorOnEdit = (): void => {
     if (connectState === 'error') {
       setConnectState('idle')
       setConnectError(null)
     }
+  }
+
+  const clearAllCredentialFields = (): void => {
+    setEmail('')
+    setApiToken('')
+    setUsername('')
+    setPasswordOrToken('')
+    setBearerToken('')
+  }
+
+  const handleDeploymentTypeChange = (value: string): void => {
+    if ((value === 'cloud' || value === 'server') && value !== deploymentType) {
+      // Why: hidden credential fields should not keep stale secrets after mode switches.
+      clearAllCredentialFields()
+      setDeploymentType(value)
+      clearErrorOnEdit()
+    }
+  }
+
+  const handleServerAuthModeChange = (value: JiraServerAuthMode): void => {
+    if (value === serverAuthMode) {
+      return
+    }
+    if (value === 'basic') {
+      setBearerToken('')
+    } else {
+      setUsername('')
+      setPasswordOrToken('')
+    }
+    setServerAuthMode(value)
+    clearErrorOnEdit()
   }
 
   const handleOpenChange = (nextOpen: boolean): void => {
@@ -77,17 +134,37 @@ export function JiraConnectDialog({
     const trimmedSite = siteUrl.trim()
     const trimmedEmail = email.trim()
     const trimmedToken = apiToken.trim()
-    if (!trimmedSite || !trimmedEmail || !trimmedToken || connectState === 'connecting') {
+    const trimmedUsername = username.trim()
+    const trimmedPasswordOrToken = passwordOrToken.trim()
+    const trimmedBearerToken = bearerToken.trim()
+    if (!canSubmit || !trimmedSite) {
       return
     }
     setConnectState('connecting')
     setConnectError(null)
     try {
-      const result = await connectJira({
-        siteUrl: trimmedSite,
-        email: trimmedEmail,
-        apiToken: trimmedToken
-      })
+      const result =
+        deploymentType === 'cloud'
+          ? await connectJira({
+              deploymentType: 'cloud',
+              siteUrl: trimmedSite,
+              email: trimmedEmail,
+              apiToken: trimmedToken
+            })
+          : serverAuthMode === 'basic'
+            ? await connectJira({
+                deploymentType: 'server',
+                authMode: 'basic',
+                siteUrl: trimmedSite,
+                username: trimmedUsername,
+                passwordOrToken: trimmedPasswordOrToken
+              })
+            : await connectJira({
+                deploymentType: 'server',
+                authMode: 'bearer',
+                siteUrl: trimmedSite,
+                bearerToken: trimmedBearerToken
+              })
       if (!mountedRef.current) {
         return
       }
@@ -95,6 +172,9 @@ export function JiraConnectDialog({
         setSiteUrl('')
         setEmail('')
         setApiToken('')
+        setUsername('')
+        setPasswordOrToken('')
+        setBearerToken('')
         setConnectState('idle')
         onOpenChange(false)
         onConnected?.()
@@ -122,8 +202,8 @@ export function JiraConnectDialog({
           </DialogTitle>
           <DialogDescription>
             {translate(
-              'auto.components.jira.connect.dialog.d785c42b8b',
-              'Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.'
+              'auto.components.jira.connect.dialog.cloudServerDescription',
+              'Connect a Jira Cloud or Server/Data Center site to browse and update issues.'
             )}
           </DialogDescription>
         </DialogHeader>
@@ -136,16 +216,41 @@ export function JiraConnectDialog({
         >
           <div className="flex flex-col gap-3">
             <div className="space-y-2">
+              <Label className="text-xs">
+                {translate('auto.components.jira.connect.dialog.deploymentType', 'Jira type')}
+              </Label>
+              <ToggleGroup
+                type="single"
+                value={deploymentType}
+                onValueChange={handleDeploymentTypeChange}
+                variant="outline"
+                size="sm"
+                className="w-full"
+              >
+                <ToggleGroupItem value="cloud" className="flex-1">
+                  {translate('auto.components.jira.connect.dialog.cloud', 'Cloud')}
+                </ToggleGroupItem>
+                <ToggleGroupItem value="server" className="flex-1">
+                  {translate(
+                    'auto.components.jira.connect.dialog.serverDataCenter',
+                    'Server/Data Center'
+                  )}
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+            <div className="space-y-2">
               <Label htmlFor={siteUrlId} className="text-xs">
-                {translate('auto.components.jira.connect.dialog.e176f9d0c5', 'Jira Cloud site URL')}
+                {deploymentType === 'cloud'
+                  ? translate(
+                      'auto.components.jira.connect.dialog.e176f9d0c5',
+                      'Jira Cloud site URL'
+                    )
+                  : translate('auto.components.jira.connect.dialog.serverUrl', 'Jira site URL')}
               </Label>
               <Input
                 id={siteUrlId}
                 autoFocus
-                placeholder={translate(
-                  'auto.components.jira.connect.dialog.70fcd360c4',
-                  'https://example.atlassian.net'
-                )}
+                placeholder={siteUrlPlaceholder}
                 value={siteUrl}
                 onChange={(event) => {
                   setSiteUrl(event.target.value)
@@ -154,69 +259,101 @@ export function JiraConnectDialog({
                 disabled={connectState === 'connecting'}
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor={emailId} className="text-xs">
-                {translate('auto.components.jira.connect.dialog.2849ddb295', 'Atlassian email')}
-              </Label>
-              <Input
-                id={emailId}
-                type="email"
-                placeholder={translate(
-                  'auto.components.jira.connect.dialog.e91b9a4073',
-                  'you@example.com'
-                )}
-                value={email}
-                onChange={(event) => {
-                  setEmail(event.target.value)
+            {deploymentType === 'cloud' ? (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor={emailId} className="text-xs">
+                    {translate('auto.components.jira.connect.dialog.2849ddb295', 'Atlassian email')}
+                  </Label>
+                  <Input
+                    id={emailId}
+                    type="email"
+                    placeholder={translate(
+                      'auto.components.jira.connect.dialog.e91b9a4073',
+                      'you@example.com'
+                    )}
+                    value={email}
+                    onChange={(event) => {
+                      setEmail(event.target.value)
+                      clearErrorOnEdit()
+                    }}
+                    disabled={connectState === 'connecting'}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={tokenId} className="text-xs">
+                    {translate('auto.components.jira.connect.dialog.3d81bf3ab3', 'API token')}
+                  </Label>
+                  <Input
+                    id={tokenId}
+                    type="password"
+                    placeholder={translate(
+                      'auto.components.jira.connect.dialog.7b3967c12f',
+                      'Atlassian API token'
+                    )}
+                    value={apiToken}
+                    onChange={(event) => {
+                      setApiToken(event.target.value)
+                      clearErrorOnEdit()
+                    }}
+                    disabled={connectState === 'connecting'}
+                    aria-invalid={connectState === 'error'}
+                    aria-describedby={connectState === 'error' ? errorId : undefined}
+                  />
+                </div>
+              </>
+            ) : (
+              <JiraServerAuthFields
+                authMode={serverAuthMode}
+                onAuthModeChange={handleServerAuthModeChange}
+                username={username}
+                onUsernameChange={(value) => {
+                  setUsername(value)
                   clearErrorOnEdit()
                 }}
-                disabled={connectState === 'connecting'}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor={tokenId} className="text-xs">
-                {translate('auto.components.jira.connect.dialog.3d81bf3ab3', 'API token')}
-              </Label>
-              <Input
-                id={tokenId}
-                type="password"
-                placeholder={translate(
-                  'auto.components.jira.connect.dialog.7b3967c12f',
-                  'Atlassian API token'
-                )}
-                value={apiToken}
-                onChange={(event) => {
-                  setApiToken(event.target.value)
+                passwordOrToken={passwordOrToken}
+                onPasswordOrTokenChange={(value) => {
+                  setPasswordOrToken(value)
                   clearErrorOnEdit()
                 }}
+                bearerToken={bearerToken}
+                onBearerTokenChange={(value) => {
+                  setBearerToken(value)
+                  clearErrorOnEdit()
+                }}
+                usernameId={usernameId}
+                passwordOrTokenId={passwordOrTokenId}
+                bearerTokenId={bearerTokenId}
                 disabled={connectState === 'connecting'}
-                aria-invalid={connectState === 'error'}
-                aria-describedby={connectState === 'error' ? errorId : undefined}
+                hasError={connectState === 'error'}
+                errorId={errorId}
               />
-            </div>
+            )}
             {connectState === 'error' && connectError ? (
               <p id={errorId} className="text-xs text-destructive">
                 {connectError}
               </p>
             ) : null}
-            <p className="text-xs text-muted-foreground">
-              {translate('auto.components.jira.connect.dialog.8090504a3e', 'Create a token in')}{' '}
-              <button
-                type="button"
-                className="text-primary underline-offset-2 hover:underline"
-                onClick={() =>
-                  window.api.shell.openUrl(
-                    'https://id.atlassian.com/manage-profile/security/api-tokens'
-                  )
-                }
-              >
-                {translate(
-                  'auto.components.jira.connect.dialog.fdd26d81cc',
-                  'Atlassian account settings'
-                )}
-              </button>
-              .
-            </p>
+            {deploymentType === 'cloud' ? (
+              <p className="text-xs text-muted-foreground">
+                {translate('auto.components.jira.connect.dialog.8090504a3e', 'Create a token in')}{' '}
+                <button
+                  type="button"
+                  className="text-primary underline-offset-2 hover:underline"
+                  onClick={() =>
+                    window.api.shell.openUrl(
+                      'https://id.atlassian.com/manage-profile/security/api-tokens'
+                    )
+                  }
+                >
+                  {translate(
+                    'auto.components.jira.connect.dialog.fdd26d81cc',
+                    'Atlassian account settings'
+                  )}
+                </button>
+                .
+              </p>
+            ) : null}
             <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
               <Lock className="size-3 shrink-0" />
               {credentialStorageCopy}

--- a/src/renderer/src/components/jira-create-field-payload.test.ts
+++ b/src/renderer/src/components/jira-create-field-payload.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import type { JiraCreateField } from '../../../shared/types'
+import { buildJiraCreateCustomFields } from './jira-create-field-payload'
+
+const TEXTAREA_FIELD: JiraCreateField = {
+  key: 'customfield_10010',
+  name: 'Steps to reproduce',
+  required: true,
+  schema: {
+    type: 'textarea',
+    custom: 'com.atlassian.jira.plugin.system.customfieldtypes:textarea'
+  }
+}
+
+describe('buildJiraCreateCustomFields', () => {
+  it('keeps Jira Server textarea custom fields as plain text', () => {
+    expect(
+      buildJiraCreateCustomFields(
+        [TEXTAREA_FIELD],
+        { customfield_10010: 'First line\nSecond line' },
+        'server'
+      )
+    ).toEqual({
+      customfield_10010: 'First line\nSecond line'
+    })
+  })
+
+  it('keeps Jira Cloud textarea custom fields as ADF documents', () => {
+    expect(
+      buildJiraCreateCustomFields(
+        [TEXTAREA_FIELD],
+        { customfield_10010: 'First line\nSecond line' },
+        'cloud'
+      )
+    ).toEqual({
+      customfield_10010: {
+        type: 'doc',
+        version: 1,
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'First line' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Second line' }] }
+        ]
+      }
+    })
+  })
+})

--- a/src/renderer/src/components/jira-create-field-payload.ts
+++ b/src/renderer/src/components/jira-create-field-payload.ts
@@ -1,0 +1,86 @@
+import type { JiraCreateField, JiraDeploymentType } from '../../../shared/types'
+import { buildJiraCreateTextAdf } from '@/components/jira-create-adf'
+
+const JIRA_CREATE_SYSTEM_FIELD_KEYS = new Set(['project', 'issuetype', 'summary', 'description'])
+
+export function isVisibleJiraCreateField(field: JiraCreateField): boolean {
+  return field.required && !JIRA_CREATE_SYSTEM_FIELD_KEYS.has(field.key)
+}
+
+export function getJiraCreateAllowedValueLabel(
+  value: NonNullable<JiraCreateField['allowedValues']>[number]
+): string {
+  return value.name ?? value.value ?? value.id ?? 'Option'
+}
+
+function findJiraCreateAllowedValue(field: JiraCreateField, draftValue: string) {
+  return field.allowedValues?.find((value) => {
+    return value.id === draftValue || value.value === draftValue || value.name === draftValue
+  })
+}
+
+function getJiraCreateOptionPayload(
+  value: NonNullable<JiraCreateField['allowedValues']>[number] | undefined,
+  fallback: string
+): Record<string, string> | string {
+  if (value?.id) {
+    return { id: value.id }
+  }
+  if (value?.value) {
+    return { value: value.value }
+  }
+  if (value?.name) {
+    return { name: value.name }
+  }
+  return fallback
+}
+
+function buildJiraCreateFieldValue(
+  field: JiraCreateField,
+  draftValue: string,
+  deploymentType: JiraDeploymentType
+): unknown {
+  const trimmed = draftValue.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  if (field.schema?.type === 'array') {
+    const parts = trimmed
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+    if (field.allowedValues?.length) {
+      return parts.map((part) =>
+        getJiraCreateOptionPayload(findJiraCreateAllowedValue(field, part), part)
+      )
+    }
+    return parts
+  }
+  if (field.allowedValues?.length) {
+    return getJiraCreateOptionPayload(findJiraCreateAllowedValue(field, trimmed), trimmed)
+  }
+  if (field.schema?.type === 'number') {
+    const numberValue = Number(trimmed)
+    return Number.isFinite(numberValue) ? numberValue : trimmed
+  }
+  if (field.schema?.custom?.includes(':textarea') || field.schema?.type === 'textarea') {
+    // Why: Server/DC accepts raw strings; Cloud create metadata textareas require ADF.
+    return deploymentType === 'server' ? trimmed : buildJiraCreateTextAdf(trimmed)
+  }
+  return trimmed
+}
+
+export function buildJiraCreateCustomFields(
+  fields: readonly JiraCreateField[],
+  values: Record<string, string>,
+  deploymentType: JiraDeploymentType
+): Record<string, unknown> | undefined {
+  const customFields: Record<string, unknown> = {}
+  for (const field of fields) {
+    const value = buildJiraCreateFieldValue(field, values[field.key] ?? '', deploymentType)
+    if (value !== undefined) {
+      customFields[field.key] = value
+    }
+  }
+  return Object.keys(customFields).length > 0 ? customFields : undefined
+}

--- a/src/renderer/src/components/jira-server-auth-fields.tsx
+++ b/src/renderer/src/components/jira-server-auth-fields.tsx
@@ -1,0 +1,116 @@
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { translate } from '@/i18n/i18n'
+
+export type JiraServerAuthMode = 'basic' | 'bearer'
+
+type JiraServerAuthFieldsProps = {
+  authMode: JiraServerAuthMode
+  onAuthModeChange: (value: JiraServerAuthMode) => void
+  username: string
+  onUsernameChange: (value: string) => void
+  passwordOrToken: string
+  onPasswordOrTokenChange: (value: string) => void
+  bearerToken: string
+  onBearerTokenChange: (value: string) => void
+  usernameId: string
+  passwordOrTokenId: string
+  bearerTokenId: string
+  disabled: boolean
+  hasError: boolean
+  errorId: string
+}
+
+export function JiraServerAuthFields({
+  authMode,
+  onAuthModeChange,
+  username,
+  onUsernameChange,
+  passwordOrToken,
+  onPasswordOrTokenChange,
+  bearerToken,
+  onBearerTokenChange,
+  usernameId,
+  passwordOrTokenId,
+  bearerTokenId,
+  disabled,
+  hasError,
+  errorId
+}: JiraServerAuthFieldsProps): React.JSX.Element {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label className="text-xs">
+          {translate('auto.components.jira.connect.dialog.authMode', 'Auth mode')}
+        </Label>
+        <ToggleGroup
+          type="single"
+          value={authMode}
+          onValueChange={(value) => {
+            if (value === 'basic' || value === 'bearer') {
+              onAuthModeChange(value)
+            }
+          }}
+          variant="outline"
+          size="sm"
+          className="w-full"
+        >
+          <ToggleGroupItem value="basic" className="flex-1">
+            {translate('auto.components.jira.connect.dialog.basicAuth', 'Username + password/PAT')}
+          </ToggleGroupItem>
+          <ToggleGroupItem value="bearer" className="flex-1">
+            {translate('auto.components.jira.connect.dialog.bearerAuth', 'Bearer PAT')}
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+      {authMode === 'basic' ? (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor={usernameId} className="text-xs">
+              {translate('auto.components.jira.connect.dialog.username', 'Username')}
+            </Label>
+            <Input
+              id={usernameId}
+              value={username}
+              onChange={(event) => onUsernameChange(event.target.value)}
+              disabled={disabled}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={passwordOrTokenId} className="text-xs">
+              {translate(
+                'auto.components.jira.connect.dialog.passwordOrToken',
+                'Password or token'
+              )}
+            </Label>
+            <Input
+              id={passwordOrTokenId}
+              type="password"
+              value={passwordOrToken}
+              onChange={(event) => onPasswordOrTokenChange(event.target.value)}
+              disabled={disabled}
+              aria-invalid={hasError}
+              aria-describedby={hasError ? errorId : undefined}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="space-y-2">
+          <Label htmlFor={bearerTokenId} className="text-xs">
+            {translate('auto.components.jira.connect.dialog.bearerToken', 'Bearer token')}
+          </Label>
+          <Input
+            id={bearerTokenId}
+            type="password"
+            value={bearerToken}
+            onChange={(event) => onBearerTokenChange(event.target.value)}
+            disabled={disabled}
+            aria-invalid={hasError}
+            aria-describedby={hasError ? errorId : undefined}
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { installWindowLocalStorage } from '@/test/memory-storage'
 import {
   DEFAULT_PR_COMMENT_PRESENTATION_VARIANT,
   getPRCommentPresentationClasses,
@@ -8,6 +9,10 @@ import {
 } from './pr-comment-presentation'
 
 describe('pr-comment-presentation', () => {
+  beforeEach(() => {
+    installWindowLocalStorage()
+  })
+
   it('defaults to cards layout', () => {
     expect(DEFAULT_PR_COMMENT_PRESENTATION_VARIANT).toBe('cards')
   })

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
@@ -4,6 +4,7 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { installWindowLocalStorage } from '@/test/memory-storage'
 
 vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -52,6 +53,7 @@ let container: HTMLDivElement
 let root: Root
 
 beforeEach(() => {
+  installWindowLocalStorage()
   clearPRCommentsListSelection('review:42')
   container = document.createElement('div')
   document.body.appendChild(container)

--- a/src/renderer/src/components/settings/integrations-search.ts
+++ b/src/renderer/src/components/settings/integrations-search.ts
@@ -143,8 +143,8 @@ export const getIntegrationsPaneSearchEntries = createLocalizedCatalog(() => [
   {
     title: translate('auto.components.settings.integrations.search.617603509b', 'Jira Integration'),
     description: translate(
-      'auto.components.settings.integrations.search.76f6af7c57',
-      'Connect Jira Cloud or update Jira API token credentials.'
+      'auto.components.settings.integrations.search.jiraCloudServerCredentials',
+      'Connect Jira Cloud or Server/Data Center credentials.'
     ),
     keywords: [
       ...translateSearchKeyword('auto.components.settings.integrations.search.e1263dd748', 'jira'),
@@ -163,6 +163,14 @@ export const getIntegrationsPaneSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword(
         'auto.components.settings.integrations.search.20540996ef',
         'credentials'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.integrations.search.jiraServerKeyword',
+        'server'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.integrations.search.jiraDataCenterKeyword',
+        'data center'
       ),
       ...translateSearchKeyword(
         'auto.components.settings.integrations.search.3c3d3d8ffa',

--- a/src/renderer/src/components/settings/jira-integration-card.test.tsx
+++ b/src/renderer/src/components/settings/jira-integration-card.test.tsx
@@ -9,7 +9,14 @@ import { JiraIntegrationCard } from './jira-integration-card'
 type StoreState = {
   jiraStatus: {
     connected: boolean
-    sites?: { id: string; displayName: string; siteUrl: string; email?: string }[]
+    sites?: {
+      id: string
+      displayName: string
+      siteUrl: string
+      email?: string
+      deploymentType?: 'cloud' | 'server'
+      authUsername?: string
+    }[]
   }
   jiraStatusChecked: boolean
   jiraStatusContextKey: string | null
@@ -115,5 +122,37 @@ describe('JiraIntegrationCard account scope', () => {
       repoId: null,
       sectionId: 'default-runtime'
     })
+  })
+
+  it('describes Jira Cloud and Server/Data Center setup when disconnected', async () => {
+    const state = installStore({ activeRuntimeEnvironmentId: null })
+    state.jiraStatus = { connected: false }
+
+    const rendered = await renderCard()
+
+    expect(rendered.textContent).toContain('Browse, create, and start work from Jira issues.')
+    expect(rendered.textContent).toContain('Connect a Jira Cloud or Server/Data Center site.')
+    expect(rendered.textContent).not.toContain('Connect a Jira Cloud site')
+  })
+
+  it('shows Server/Data Center auth username instead of Cloud email labels', async () => {
+    const state = installStore({ activeRuntimeEnvironmentId: null })
+    state.jiraStatus.sites = [
+      {
+        id: 'server-1',
+        displayName: 'Internal Jira',
+        siteUrl: 'https://jira.example.internal',
+        email: 'ada@example.internal',
+        deploymentType: 'server',
+        authUsername: 'ada'
+      }
+    ]
+
+    const rendered = await renderCard()
+
+    expect(rendered.textContent).toContain('https://jira.example.internal · ada')
+    expect(rendered.textContent).not.toContain(
+      'https://jira.example.internal · ada@example.internal'
+    )
   })
 })

--- a/src/renderer/src/components/settings/jira-integration-card.tsx
+++ b/src/renderer/src/components/settings/jira-integration-card.tsx
@@ -38,8 +38,14 @@ export function JiraIntegrationCard(): React.JSX.Element {
   const siteCount = sites.length || (connected ? 1 : 0)
   const accountScope = getProviderAccountScope(settings)
   const credentialCopy = hasRemoteProviderRuntime(settings)
-    ? 'Connect a Jira Cloud site with your Atlassian email and an API token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.'
-    : 'Connect a Jira Cloud site with your Atlassian email and an API token. Credentials are stored locally and encrypted when local runtime storage supports it.'
+    ? translate(
+        'auto.components.settings.task.tracker.integration.cards.jiraCloudServerRemoteCredentialCopy',
+        'Connect a Jira Cloud or Server/Data Center site. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.'
+      )
+    : translate(
+        'auto.components.settings.task.tracker.integration.cards.jiraCloudServerLocalCredentialCopy',
+        'Connect a Jira Cloud or Server/Data Center site. Credentials are stored locally and encrypted when local runtime storage supports it.'
+      )
   const subordinateRowClass = useIntegrationSubordinateRowClass('flex items-center gap-3')
   const accountScopeRowClass = useIntegrationSubordinateRowClass('text-xs')
 
@@ -85,8 +91,8 @@ export function JiraIntegrationCard(): React.JSX.Element {
                 'Checking Jira access before showing setup actions.'
               )
             : translate(
-                'auto.components.settings.task.tracker.integration.cards.7ca5ffffdb',
-                'Browse, create, and start work from Jira Cloud issues.'
+                'auto.components.settings.task.tracker.integration.cards.jiraCloudServerIssueDescription',
+                'Browse, create, and start work from Jira issues.'
               )
       }
       checking={checking}
@@ -126,6 +132,8 @@ export function JiraIntegrationCard(): React.JSX.Element {
             {sites.map((site) => {
               const testResult = testResultBySite[site.id]
               const testing = testingSiteId === site.id
+              const identityLabel =
+                site.deploymentType === 'server' ? site.authUsername || site.email : site.email
               return (
                 <div key={site.id} className={subordinateRowClass}>
                   <div className="min-w-0 flex-1">
@@ -134,7 +142,7 @@ export function JiraIntegrationCard(): React.JSX.Element {
                     </p>
                     <p className="truncate text-xs text-muted-foreground">
                       {site.siteUrl}
-                      {site.email ? ` · ${site.email}` : ''}
+                      {identityLabel ? ` · ${identityLabel}` : ''}
                     </p>
                   </div>
                   {testResult?.state === 'ok' ? (
@@ -189,8 +197,8 @@ export function JiraIntegrationCard(): React.JSX.Element {
             })}
             <p className="text-[11px] text-muted-foreground/70">
               {translate(
-                'auto.components.settings.task.tracker.integration.cards.8c20e76308',
-                'Each connected Jira site has one token stored by the active runtime.'
+                'auto.components.settings.task.tracker.integration.cards.connectedJiraCredentialStorage',
+                'Each connected Jira site has one credential stored by the active runtime.'
               )}
             </p>
           </div>

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { LINEAR_AGENT_SKILL_NAMES } from '@/lib/agent-feature-install-commands'
+import { installWindowLocalStorage } from '@/test/memory-storage'
 import {
   LinearAgentSkillSetupPrompt,
   _linearAgentSkillSetupPromptInternalsForTests
@@ -173,6 +174,7 @@ describe('LinearAgentSkillSetupPrompt reminder toast', () => {
     mocks.toastWarning.mockClear()
     mocks.toastWarning.mockReturnValue('linear-setup-toast-id')
     mocks.panelProps.length = 0
+    installWindowLocalStorage()
     window.localStorage.clear()
     _linearAgentSkillSetupPromptInternalsForTests.resetSessionReminders()
     Object.defineProperty(window, 'api', {

--- a/src/renderer/src/components/sidebar/SidebarToolbar.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.test.tsx
@@ -3,6 +3,7 @@
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installWindowLocalStorage } from '@/test/memory-storage'
 import type { AppState } from '@/store'
 import SidebarToolbar from './SidebarToolbar'
 
@@ -66,6 +67,7 @@ async function renderToolbar(onWorkspaceBoardToggle = vi.fn()): Promise<{
 describe('SidebarToolbar moved workspace board hint', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    installWindowLocalStorage()
     window.localStorage.clear()
     mocks.activeTooltipOpen = false
     mocks.state = {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7554,6 +7554,8 @@
             "e1263dd748": "jira",
             "76f6af7c57": "Connect Jira Cloud or update Jira API token credentials.",
             "617603509b": "Jira Integration",
+            "jiraServerKeyword": "server",
+            "jiraDataCenterKeyword": "data center",
             "8c568d761c": "pull request",
             "33180e8c10": "self-hosted",
             "129fc59aa8": "gitea",
@@ -7576,7 +7578,8 @@
             "41ccade05c": "gh",
             "b79c21bd42": "github",
             "7166b9090c": "GitHub authentication via the gh CLI.",
-            "f16e41cc72": "GitHub Integration"
+            "f16e41cc72": "GitHub Integration",
+            "jiraCloudServerCredentials": "Connect Jira Cloud or Server/Data Center credentials."
           }
         },
         "jira": {
@@ -8409,7 +8412,11 @@
                 "fe9231215b": "Checking Linear access before showing setup actions.",
                 "e1f5e6424c": "{{value0}} workspace{{value1}} connected",
                 "disconnect_all": "Disconnect",
-                "account_scope_prefix": "Account scope"
+                "account_scope_prefix": "Account scope",
+                "jiraCloudServerRemoteCredentialCopy": "Connect a Jira Cloud or Server/Data Center site. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
+                "jiraCloudServerLocalCredentialCopy": "Connect a Jira Cloud or Server/Data Center site. Credentials are stored locally and encrypted when local runtime storage supports it.",
+                "jiraCloudServerIssueDescription": "Browse, create, and start work from Jira issues.",
+                "connectedJiraCredentialStorage": "Each connected Jira site has one credential stored by the active runtime."
               }
             }
           }
@@ -12137,7 +12144,21 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud site URL",
             "d785c42b8b": "Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.",
-            "8388bdea2b": "Connect Jira site"
+            "8388bdea2b": "Connect Jira site",
+            "cloudServerDescription": "Connect a Jira Cloud or Server/Data Center site to browse and update issues.",
+            "deploymentType": "Jira type",
+            "cloud": "Cloud",
+            "serverDataCenter": "Server/Data Center",
+            "serverUrl": "Jira site URL",
+            "serverUrlPlaceholder": "https://jira.example.com",
+            "authMode": "Auth mode",
+            "basicAuth": "Username + password/PAT",
+            "bearerAuth": "Bearer PAT",
+            "username": "Username",
+            "passwordOrToken": "Password or token",
+            "bearerToken": "Bearer token",
+            "remoteCredentialStorage": "Your credential is sent to the selected remote runtime and stored there with runtime-supported encryption.",
+            "localCredentialStorage": "Your credential is stored locally and encrypted when local runtime storage supports it."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4096,7 +4096,7 @@
           "hostDisconnected": "Desconectado",
           "failedNestWorkspace": "No se pudo anidar el espacio de trabajo",
           "sidebarRowMissing": "El destino ya no existe",
-          "failedUnnestWorkspace": "Failed to unnest workspace"
+          "failedUnnestWorkspace": "No se pudo desanidar el espacio de trabajo"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",
@@ -7517,6 +7517,8 @@
             "e1263dd748": "jira",
             "76f6af7c57": "Conecte Jira Cloud o actualice las credenciales del token API de Jira.",
             "617603509b": "Integración de Jira",
+            "jiraServerKeyword": "server",
+            "jiraDataCenterKeyword": "data center",
             "8c568d761c": "solicitud de extracción",
             "33180e8c10": "autohospedado",
             "129fc59aa8": "gitea",
@@ -7539,7 +7541,8 @@
             "41ccade05c": "gh",
             "b79c21bd42": "github",
             "7166b9090c": "Autenticación de GitHub a través de la CLI de gh.",
-            "f16e41cc72": "Integración de GitHub"
+            "f16e41cc72": "Integración de GitHub",
+            "jiraCloudServerCredentials": "Conecta credenciales de Jira Cloud o Server/Data Center."
           }
         },
         "jira": {
@@ -8401,7 +8404,11 @@
                 "fe9231215b": "Checking Linear access before showing setup actions.",
                 "e1f5e6424c": "{{value0}} workspace{{value1}} connected",
                 "disconnect_all": "Desconectar todo",
-                "account_scope_prefix": "Account scope"
+                "account_scope_prefix": "Account scope",
+                "jiraCloudServerRemoteCredentialCopy": "Conecta un sitio de Jira Cloud o Server/Data Center. Las credenciales se envían al runtime remoto seleccionado y se almacenan allí con el cifrado que admita el runtime.",
+                "jiraCloudServerLocalCredentialCopy": "Conecta un sitio de Jira Cloud o Server/Data Center. Las credenciales se almacenan localmente y se cifran cuando el almacenamiento del runtime local lo admite.",
+                "jiraCloudServerIssueDescription": "Explora, crea y empieza a trabajar desde incidencias de Jira.",
+                "connectedJiraCredentialStorage": "Cada sitio de Jira conectado tiene una credencial almacenada por el runtime activo."
               }
             }
           }
@@ -12137,7 +12144,21 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud site URL",
             "d785c42b8b": "Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.",
-            "8388bdea2b": "Connect Jira site"
+            "8388bdea2b": "Connect Jira site",
+            "cloudServerDescription": "Conecta un sitio de Jira Cloud o Server/Data Center para explorar y actualizar incidencias.",
+            "deploymentType": "Tipo de Jira",
+            "cloud": "Cloud",
+            "serverDataCenter": "Server/Data Center",
+            "serverUrl": "URL del sitio Jira",
+            "serverUrlPlaceholder": "https://jira.example.com",
+            "authMode": "Modo de autenticación",
+            "basicAuth": "Usuario + contraseña/PAT",
+            "bearerAuth": "Bearer PAT",
+            "username": "Usuario",
+            "passwordOrToken": "Contraseña o token",
+            "bearerToken": "Token Bearer",
+            "remoteCredentialStorage": "Tu credencial se envía al runtime remoto seleccionado y se almacena allí con el cifrado que admita el runtime.",
+            "localCredentialStorage": "Tu credencial se almacena localmente y se cifra cuando el almacenamiento del runtime local lo admite."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4077,7 +4077,7 @@
           "hostDisconnected": "切断済み",
           "failedNestWorkspace": "ワークスペースをネストできませんでした",
           "sidebarRowMissing": "対象はもう存在しません",
-          "failedUnnestWorkspace": "Failed to unnest workspace"
+          "failedUnnestWorkspace": "ワークスペースのネスト解除に失敗しました"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",
@@ -7539,6 +7539,8 @@
             "e1263dd748": "Jira",
             "76f6af7c57": "Jira Cloud に接続するか、Jira API トークンの認証情報を更新します。",
             "617603509b": "Jira 連携",
+            "jiraServerKeyword": "server",
+            "jiraDataCenterKeyword": "data center",
             "8c568d761c": "PR",
             "33180e8c10": "自己ホスト型",
             "129fc59aa8": "Gitea",
@@ -7561,7 +7563,8 @@
             "41ccade05c": "gh",
             "b79c21bd42": "GitHub",
             "7166b9090c": "gh CLI を介した GitHub 認証。",
-            "f16e41cc72": "GitHub 連携"
+            "f16e41cc72": "GitHub 連携",
+            "jiraCloudServerCredentials": "Jira Cloud または Server/Data Center の認証情報を接続します。"
           }
         },
         "jira": {
@@ -8401,7 +8404,11 @@
                 "fe9231215b": "Checking Linear access before showing setup actions.",
                 "e1f5e6424c": "{{value0}} workspace{{value1}} connected",
                 "disconnect_all": "切断",
-                "account_scope_prefix": "Account scope"
+                "account_scope_prefix": "Account scope",
+                "jiraCloudServerRemoteCredentialCopy": "Jira Cloud または Server/Data Center サイトに接続します。認証情報は選択したリモート runtime に送信され、その runtime が対応する暗号化で保存されます。",
+                "jiraCloudServerLocalCredentialCopy": "Jira Cloud または Server/Data Center サイトに接続します。認証情報はローカルに保存され、ローカル runtime のストレージが対応している場合は暗号化されます。",
+                "jiraCloudServerIssueDescription": "Jira の課題を参照、作成し、作業を開始できます。",
+                "connectedJiraCredentialStorage": "接続済みの各 Jira サイトには、アクティブな runtime が保存する認証情報が 1 つあります。"
               }
             }
           }
@@ -12137,7 +12144,21 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud site URL",
             "d785c42b8b": "Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.",
-            "8388bdea2b": "Connect Jira site"
+            "8388bdea2b": "Connect Jira site",
+            "cloudServerDescription": "Jira Cloud または Server/Data Center サイトに接続して、課題を参照、更新します。",
+            "deploymentType": "Jira の種類",
+            "cloud": "Cloud",
+            "serverDataCenter": "Server/Data Center",
+            "serverUrl": "Jira サイト URL",
+            "serverUrlPlaceholder": "https://jira.example.com",
+            "authMode": "認証モード",
+            "basicAuth": "ユーザー名 + パスワード/PAT",
+            "bearerAuth": "Bearer PAT",
+            "username": "ユーザー名",
+            "passwordOrToken": "パスワードまたはトークン",
+            "bearerToken": "Bearer トークン",
+            "remoteCredentialStorage": "認証情報は選択したリモート runtime に送信され、その runtime が対応する暗号化で保存されます。",
+            "localCredentialStorage": "認証情報はローカルに保存され、ローカル runtime のストレージが対応している場合は暗号化されます。"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4077,7 +4077,7 @@
           "hostDisconnected": "연결 끊김",
           "failedNestWorkspace": "워크스페이스를 중첩하지 못했습니다",
           "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다",
-          "failedUnnestWorkspace": "Failed to unnest workspace"
+          "failedUnnestWorkspace": "워크스페이스 중첩 해제에 실패했습니다"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "취소",
@@ -7502,6 +7502,8 @@
             "e1263dd748": "Jira",
             "76f6af7c57": "Jira Cloud를 연결하거나 Jira API 토큰 자격 증명을 업데이트하세요.",
             "617603509b": "Jira 연동",
+            "jiraServerKeyword": "server",
+            "jiraDataCenterKeyword": "data center",
             "8c568d761c": "PR",
             "33180e8c10": "자체 호스팅",
             "129fc59aa8": "Gitea",
@@ -7524,7 +7526,8 @@
             "41ccade05c": "gh",
             "b79c21bd42": "GitHub",
             "7166b9090c": "gh CLI를 통한 GitHub 인증.",
-            "f16e41cc72": "GitHub 연동"
+            "f16e41cc72": "GitHub 연동",
+            "jiraCloudServerCredentials": "Jira Cloud 또는 Server/Data Center 자격 증명을 연결합니다."
           }
         },
         "jira": {
@@ -8401,7 +8404,11 @@
                 "fe9231215b": "설정 작업을 표시하기 전에 Linear 액세스를 확인하는 중입니다.",
                 "e1f5e6424c": "{{value0}}개 워크스페이스{{value1}} 연결됨",
                 "disconnect_all": "연결 해제",
-                "account_scope_prefix": "계정 범위"
+                "account_scope_prefix": "계정 범위",
+                "jiraCloudServerRemoteCredentialCopy": "Jira Cloud 또는 Server/Data Center 사이트를 연결합니다. 자격 증명은 선택한 원격 런타임으로 전송되어 런타임이 지원하는 암호화로 저장됩니다.",
+                "jiraCloudServerLocalCredentialCopy": "Jira Cloud 또는 Server/Data Center 사이트를 연결합니다. 자격 증명은 로컬에 저장되며 로컬 런타임 저장소가 지원하는 경우 암호화됩니다.",
+                "jiraCloudServerIssueDescription": "Jira 이슈를 탐색하고 만들고 작업을 시작합니다.",
+                "connectedJiraCredentialStorage": "연결된 각 Jira 사이트에는 활성 런타임이 저장한 자격 증명 하나가 있습니다."
               }
             }
           }
@@ -12137,7 +12144,21 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud 사이트 URL",
             "d785c42b8b": "Jira Cloud 사이트 URL, Atlassian 이메일, API 토큰을 사용해 이슈를 탐색합니다.",
-            "8388bdea2b": "Jira 사이트 연결"
+            "8388bdea2b": "Jira 사이트 연결",
+            "cloudServerDescription": "Jira Cloud 또는 Server/Data Center 사이트를 연결해 이슈를 탐색하고 업데이트합니다.",
+            "deploymentType": "Jira 유형",
+            "cloud": "Cloud",
+            "serverDataCenter": "Server/Data Center",
+            "serverUrl": "Jira 사이트 URL",
+            "serverUrlPlaceholder": "https://jira.example.com",
+            "authMode": "인증 모드",
+            "basicAuth": "사용자 이름 + 비밀번호/PAT",
+            "bearerAuth": "Bearer PAT",
+            "username": "사용자 이름",
+            "passwordOrToken": "비밀번호 또는 토큰",
+            "bearerToken": "Bearer 토큰",
+            "remoteCredentialStorage": "자격 증명은 선택한 원격 런타임으로 전송되어 런타임이 지원하는 암호화로 저장됩니다.",
+            "localCredentialStorage": "자격 증명은 로컬에 저장되며 로컬 런타임 저장소가 지원하는 경우 암호화됩니다."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4077,7 +4077,7 @@
           "hostDisconnected": "已断开连接",
           "failedNestWorkspace": "无法嵌套工作区",
           "sidebarRowMissing": "目标不再存在",
-          "failedUnnestWorkspace": "Failed to unnest workspace"
+          "failedUnnestWorkspace": "无法取消嵌套工作区"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",
@@ -7502,6 +7502,8 @@
             "e1263dd748": "Jira",
             "76f6af7c57": "连接 Jira Cloud 或更新 Jira API 令牌凭据。",
             "617603509b": "Jira 集成",
+            "jiraServerKeyword": "server",
+            "jiraDataCenterKeyword": "data center",
             "8c568d761c": "PR",
             "33180e8c10": "自托管",
             "129fc59aa8": "Gitea",
@@ -7524,7 +7526,8 @@
             "41ccade05c": "gh",
             "b79c21bd42": "GitHub",
             "7166b9090c": "通过 gh CLI 进行 GitHub 身份验证。",
-            "f16e41cc72": "GitHub 集成"
+            "f16e41cc72": "GitHub 集成",
+            "jiraCloudServerCredentials": "连接 Jira Cloud 或 Server/Data Center 凭据。"
           }
         },
         "jira": {
@@ -8401,7 +8404,11 @@
                 "fe9231215b": "在显示设置操作前正在检查 Linear 访问权限。",
                 "e1f5e6424c": "{{value0}} workspace{{value1}} connected",
                 "disconnect_all": "断开连接",
-                "account_scope_prefix": "账户范围"
+                "account_scope_prefix": "账户范围",
+                "jiraCloudServerRemoteCredentialCopy": "连接 Jira Cloud 或 Server/Data Center 站点。凭据会发送到所选远程运行时，并以该运行时支持的加密方式存储。",
+                "jiraCloudServerLocalCredentialCopy": "连接 Jira Cloud 或 Server/Data Center 站点。凭据会存储在本地，并在本地运行时存储支持时加密。",
+                "jiraCloudServerIssueDescription": "浏览、创建并开始处理 Jira 议题。",
+                "connectedJiraCredentialStorage": "每个已连接的 Jira 站点都有一份由当前运行时存储的凭据。"
               }
             }
           }
@@ -12137,7 +12144,21 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud 站点 URL",
             "d785c42b8b": "使用 Jira Cloud 站点 URL、Atlassian 邮箱和 API 令牌来浏览议题。",
-            "8388bdea2b": "连接 Jira 站点"
+            "8388bdea2b": "连接 Jira 站点",
+            "cloudServerDescription": "连接 Jira Cloud 或 Server/Data Center 站点以浏览和更新议题。",
+            "deploymentType": "Jira 类型",
+            "cloud": "Cloud",
+            "serverDataCenter": "Server/Data Center",
+            "serverUrl": "Jira 站点 URL",
+            "serverUrlPlaceholder": "https://jira.example.com",
+            "authMode": "认证方式",
+            "basicAuth": "用户名 + 密码/PAT",
+            "bearerAuth": "Bearer PAT",
+            "username": "用户名",
+            "passwordOrToken": "密码或令牌",
+            "bearerToken": "Bearer 令牌",
+            "remoteCredentialStorage": "凭据会发送到所选远程运行时，并以该运行时支持的加密方式存储。",
+            "localCredentialStorage": "凭据会存储在本地，并在本地运行时存储支持时加密。"
           }
         }
       },

--- a/src/renderer/src/runtime/runtime-jira-client.test.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.test.ts
@@ -1,19 +1,23 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { jiraListAssignableUsers, jiraSearchIssues } from './runtime-jira-client'
+import { markRuntimeEnvironmentCompatible } from './runtime-rpc-client'
+import { jiraConnect, jiraListAssignableUsers, jiraSearchIssues } from './runtime-jira-client'
 
+const jiraConnectLocal = vi.fn()
 const jiraSearchIssuesLocal = vi.fn()
 const jiraListAssignableUsersLocal = vi.fn()
 const runtimeCall = vi.fn()
 
 beforeEach(() => {
+  jiraConnectLocal.mockReset()
   jiraSearchIssuesLocal.mockReset()
   jiraListAssignableUsersLocal.mockReset()
   runtimeCall.mockReset()
   vi.stubGlobal('window', {
     api: {
       jira: {
+        connect: jiraConnectLocal,
         searchIssues: jiraSearchIssuesLocal,
         listAssignableUsers: jiraListAssignableUsersLocal
       },
@@ -29,6 +33,50 @@ afterEach(() => {
 })
 
 describe('runtime Jira client search bounds', () => {
+  it('forwards Jira Server connect payloads to local IPC', async () => {
+    jiraConnectLocal.mockResolvedValueOnce({ ok: true, viewer: { displayName: 'Ada' } })
+
+    const payload = {
+      deploymentType: 'server' as const,
+      authMode: 'basic' as const,
+      siteUrl: 'https://jira.example.internal',
+      username: 'ada',
+      passwordOrToken: 'secret'
+    }
+
+    await expect(jiraConnect(null, payload)).resolves.toEqual({
+      ok: true,
+      viewer: { displayName: 'Ada' }
+    })
+    expect(jiraConnectLocal).toHaveBeenCalledWith(payload)
+  })
+
+  it('forwards Jira Server connect payloads to remote runtime RPC', async () => {
+    markRuntimeEnvironmentCompatible('env-1')
+    runtimeCall.mockResolvedValueOnce({
+      ok: true,
+      result: { ok: true, viewer: { displayName: 'Ada' } }
+    })
+
+    const payload = {
+      deploymentType: 'server' as const,
+      authMode: 'bearer' as const,
+      siteUrl: 'https://jira.example.internal',
+      bearerToken: 'pat-secret'
+    }
+
+    await expect(jiraConnect({ activeRuntimeEnvironmentId: 'env-1' }, payload)).resolves.toEqual({
+      ok: true,
+      viewer: { displayName: 'Ada' }
+    })
+    expect(runtimeCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'jira.connect',
+      params: payload,
+      timeoutMs: 30_000
+    })
+  })
+
   it('rejects oversized local Jira search before IPC', async () => {
     await expect(jiraSearchIssues(null, 'secret-token-value'.repeat(1024), 30)).resolves.toEqual([])
 

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -1,6 +1,7 @@
 import type {
   GlobalSettings,
   JiraComment,
+  JiraConnectArgs,
   JiraConnectionStatus,
   JiraCreateField,
   JiraCreateIssueArgs,
@@ -56,7 +57,7 @@ export async function jiraStatus(settings: RuntimeJiraSettings): Promise<JiraCon
 
 export async function jiraConnect(
   settings: RuntimeJiraSettings,
-  args: { siteUrl: string; email: string; apiToken: string }
+  args: JiraConnectArgs
 ): Promise<JiraConnectResult> {
   const target = getJiraRuntimeTarget(settings)
   return target.kind === 'environment'

--- a/src/renderer/src/store/slices/jira.ts
+++ b/src/renderer/src/store/slices/jira.ts
@@ -4,6 +4,7 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type {
+  JiraConnectArgs,
   JiraConnectionStatus,
   JiraIssue,
   JiraIssueFilter,
@@ -159,11 +160,9 @@ export type JiraSlice = {
   jiraSearchCache: Record<string, CacheEntry<JiraIssue[]>>
 
   checkJiraConnection: () => Promise<void>
-  connectJira: (args: {
-    siteUrl: string
-    email: string
-    apiToken: string
-  }) => Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }>
+  connectJira: (
+    args: JiraConnectArgs
+  ) => Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }>
   testJiraConnection: (
     siteId?: string | null
   ) => Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }>

--- a/src/renderer/src/test/memory-storage.ts
+++ b/src/renderer/src/test/memory-storage.ts
@@ -1,0 +1,31 @@
+export function createMemoryStorage(): Storage {
+  const values = new Map<string, string>()
+
+  return {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value)
+    }
+  }
+}
+
+export function installWindowLocalStorage(storage: Storage = createMemoryStorage()): Storage {
+  // Why: Node 25 exposes a non-DOM localStorage object unless a storage file is configured.
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage
+  })
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage
+  })
+  return storage
+}

--- a/src/shared/jira-types.ts
+++ b/src/shared/jira-types.ts
@@ -1,12 +1,20 @@
+export type JiraDeploymentType = 'cloud' | 'server'
+export type JiraAuthMode = 'basic' | 'bearer'
+
 export type JiraSite = {
   id: string
   siteUrl: string
   email: string
   displayName: string
   accountId: string
+  viewerUserId: string
+  deploymentType: JiraDeploymentType
+  authMode: JiraAuthMode
+  authUsername?: string
 }
 
 export type JiraViewer = {
+  userId: string
   accountId: string
   displayName: string
   email: string | null
@@ -61,6 +69,7 @@ export type JiraCreateField = {
 }
 
 export type JiraUser = {
+  userId: string
   accountId: string
   displayName: string
   email?: string | null
@@ -117,6 +126,7 @@ export type JiraComment = {
 export type JiraIssueUpdate = {
   title?: string
   labels?: string[]
+  assigneeUserId?: string | null
   assigneeAccountId?: string | null
   priorityId?: string | null
   transitionId?: string
@@ -124,11 +134,32 @@ export type JiraIssueUpdate = {
 
 export type JiraIssueFilter = 'assigned' | 'reported' | 'all' | 'done'
 
-export type JiraConnectArgs = {
+export type JiraCloudConnectArgs = {
+  deploymentType?: 'cloud'
   siteUrl: string
   email: string
   apiToken: string
 }
+
+export type JiraServerBasicConnectArgs = {
+  deploymentType: 'server'
+  authMode: 'basic'
+  siteUrl: string
+  username: string
+  passwordOrToken: string
+}
+
+export type JiraServerBearerConnectArgs = {
+  deploymentType: 'server'
+  authMode: 'bearer'
+  siteUrl: string
+  bearerToken: string
+}
+
+export type JiraConnectArgs =
+  | JiraCloudConnectArgs
+  | JiraServerBasicConnectArgs
+  | JiraServerBearerConnectArgs
 
 export type JiraCreateIssueArgs = {
   siteId?: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1816,6 +1816,7 @@ export type {
   JiraCreateFieldAllowedValue,
   JiraCreateIssueArgs,
   JiraCreateIssueResult,
+  JiraDeploymentType,
   JiraIssue,
   JiraIssueFilter,
   JiraIssueType,


### PR DESCRIPTION
## Summary

Adds Jira Server/Data Center support alongside existing Jira Cloud support.

This PR adds Server/DC authentication, REST routing, issue listing/searching, issue creation, comments, assignment/unassignment, and transitions. It also wires the renderer connection flow and settings UI so users can connect either Jira Cloud or Jira Server/Data Center sites from the same integration surface.

## Screenshots

Updated Jira connect dialog supports Cloud and Server/Data Center selection, plus Server/DC Basic or Bearer authentication.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Additional focused coverage:

- Jira main client, issue operations, auth headers, storage, IPC, and runtime RPC tests
- Renderer Jira runtime client, store slice, connect dialog, create-field payload, and settings card tests
- Jira Cloud regression coverage for existing ADF/comment behavior and issue operations

## AI Review Report

The review checked the full Jira Server/Data Center implementation across main process, IPC/RPC boundaries, preload APIs, shared types, renderer state, and UI wiring.

Main risks reviewed:

- Cross-platform compatibility for macOS, Linux, and Windows
- SSH/remote runtime behavior and credential storage routing
- Jira Cloud regression risk
- Server/DC auth behavior for Basic and Bearer PAT
- REST path differences between Cloud and Server/DC APIs
- Renderer/UI quality and contribution style constraints
- File size and module naming constraints
- Localization coverage
- Performance risk from pagination, metadata fetching, and issue operations

Issues found during review were fixed before commit, including splitting oversized Jira modules and extracting the Server/DC auth fields from the connect dialog to satisfy `max-lines` without disabling lint rules.

## Security Audit

Reviewed auth, IPC/RPC validation, request construction, logging, and credential handling.

Security notes:

- Credentials are stored through the existing main/runtime credential storage path, not persisted in renderer state.
- Basic and Bearer auth headers are built in main/runtime code.
- Renderer receives connection metadata, not stored token contents.
- Server/DC password/PAT inputs use password fields.
- IPC/RPC payloads validate Jira deployment and auth shapes before use.
- Request errors are sanitized so credentials are not included in thrown messages.
- No private deployment domains are included in code, docs, tests, or localization.
- No new dependencies or shell command execution paths were added.

## Notes

- Orca now supports Jira Cloud and Jira Server/Data Center for connect, list, search, create, comment, assign, unassign, and transition.
- Remote runtime behavior was considered so Jira credentials can be stored and used where the runtime executes.
