### PR TITLE
Bound streamed git status reads

### DIFF
--- a/src/main/git/runner-stream-timeout.test.ts
+++ b/src/main/git/runner-stream-timeout.test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, execFileSyncMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock,
+  spawn: spawnMock
+}))
+
+import { gitStreamStdout } from './runner'
+
+function createChild(pid: number): EventEmitter & {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  kill: ReturnType<typeof vi.fn>
+  unref: ReturnType<typeof vi.fn>
+  pid: number
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+    unref: ReturnType<typeof vi.fn>
+    pid: number
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  child.unref = vi.fn()
+  child.pid = pid
+  return child
+}
+
+describe('gitStreamStdout timeout', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    spawnMock.mockReset()
+    execFileMock.mockReset()
+    execFileSyncMock.mockReset()
+  })
+
+  it('rejects and kills the spawned git tree when the timeout elapses', async () => {
+    vi.useFakeTimers()
+    const gitChild = createChild(1234)
+    const taskkillChild = createChild(9999)
+    spawnMock.mockReturnValueOnce(gitChild).mockReturnValueOnce(taskkillChild)
+
+    const resultPromise = gitStreamStdout(['status'], {
+      cwd: 'C:\\repo',
+      timeout: 25,
+      onStdout: vi.fn()
+    }).then(
+      () => 'resolved',
+      (error: unknown) => error
+    )
+
+    await vi.advanceTimersByTimeAsync(25)
+    await Promise.resolve()
+
+    const result = await Promise.race([resultPromise, Promise.resolve('pending')])
+
+    expect(result).toBeInstanceOf(Error)
+    expect((result as Error).message).toBe('git timed out.')
+    if (process.platform === 'win32') {
+      expect(spawnMock).toHaveBeenNthCalledWith(2, 'taskkill', ['/pid', '1234', '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true
+      })
+      expect(taskkillChild.unref).toHaveBeenCalled()
+    } else {
+      expect(gitChild.kill).toHaveBeenCalled()
+    }
+  })
+})

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -837,6 +837,7 @@ type GitStreamOptions = {
   env?: NodeJS.ProcessEnv
   wslDistro?: string
   signal?: AbortSignal
+  timeout?: number
   /** Byte backstop; defaults to DEFAULT_GIT_MAX_BUFFER. */
   maxBuffer?: number
   /**
@@ -881,6 +882,7 @@ export async function gitStreamStdout(
       let stdoutBytes = 0
       let stderr = ''
       let stderrBytes = 0
+      let timer: NodeJS.Timeout | null = null
       // Why: decode statefully so a multibyte UTF-8 character split across two
       // chunks (common with non-ASCII filenames) isn't corrupted into
       // replacement characters and mis-parsed.
@@ -893,6 +895,10 @@ export async function gitStreamStdout(
         child.off('error', onError)
         child.off('close', onClose)
         options.signal?.removeEventListener('abort', onAbort)
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
         // Flush any bytes the decoders were holding for an incomplete sequence.
         stdoutDecoder.end()
         stderrDecoder.end()
@@ -963,12 +969,19 @@ export async function gitStreamStdout(
         killSpawnedCommandTree(child)
         finish(createAbortError())
       }
+      function onTimeout(): void {
+        killSpawnedCommandTree(child)
+        finish(new Error('git timed out.'))
+      }
 
       child.stdout?.on('data', onStdoutData)
       child.stderr?.on('data', onStderrData)
       child.on('error', onError)
       child.on('close', onClose)
       options.signal?.addEventListener('abort', onAbort, { once: true })
+      if (options.timeout && options.timeout > 0) {
+        timer = setTimeout(onTimeout, options.timeout)
+      }
       if (options.signal?.aborted) {
         onAbort()
       }

--- a/src/main/git/status-stream-timeout.test.ts
+++ b/src/main/git/status-stream-timeout.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, gitStreamStdoutMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  gitStreamStdoutMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitExecFileAsyncBuffer: vi.fn(),
+  gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => ({
+    ...env,
+    GIT_OPTIONAL_LOCKS: '0'
+  }),
+  gitStreamStdout: gitStreamStdoutMock
+}))
+
+import { getStatus } from './status'
+
+describe('getStatus streamed git timeout', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    gitStreamStdoutMock.mockReset()
+    gitStreamStdoutMock.mockImplementation(
+      async (_args: string[], options: { onStdout: (chunk: string) => boolean | void }) => {
+        options.onStdout('')
+        return { stoppedEarly: false }
+      }
+    )
+  })
+
+  it('bounds streamed git status reads with a timeout while preserving abort signals', async () => {
+    const controller = new AbortController()
+
+    await getStatus('C:\\repo', { signal: controller.signal })
+
+    expect(gitStreamStdoutMock).toHaveBeenCalledWith(
+      [
+        '-c',
+        'core.quotePath=false',
+        'status',
+        '--porcelain=v2',
+        '--branch',
+        '--untracked-files=all'
+      ],
+      expect.objectContaining({
+        cwd: 'C:\\repo',
+        signal: controller.signal,
+        timeout: 60_000
+      })
+    )
+  })
+})

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -54,6 +54,7 @@ import { parseGitRevListFirstParentOid } from '../../shared/git-rev-list-output'
 const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
 const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
 const BULK_CHUNK_SIZE = 100
+const GIT_STATUS_TIMEOUT_MS = 60_000
 const EFFECTIVE_UPSTREAM_NEGATIVE_CACHE_TTL_MS = 5 * 60_000
 const MAX_EFFECTIVE_UPSTREAM_NEGATIVE_CACHE_ENTRIES = 512
 
@@ -217,6 +218,9 @@ async function runGetStatus(
       // terminal Git commands on `.git/worktrees/*/index.lock`.
       env: gitOptionalLocksDisabledEnv(),
       signal: options.signal,
+      // Why: Windows crash bundles show status scans taking tens of seconds.
+      // Bound true hangs while leaving slow-but-successful large repos room.
+      timeout: GIT_STATUS_TIMEOUT_MS,
       onStdout: (chunk) => parser.update(chunk, limit)
     })
     if (!stoppedEarly) {


### PR DESCRIPTION
## Description
- add timeout support to `gitStreamStdout` and kill the spawned git command tree when the timeout fires
- bound local streamed `git status --porcelain=v2` reads to 60s
- add regression coverage for status passing the timeout and the stream runner rejecting/killing on timeout

## Crash evidence
- Windows crash reports 02 and 03 were dominated by git refresh churn: thousands of `git status` / `git diff` spans during the diagnostic windows.
- Report 04 had modest renderer heap, but git work against `D:\Maqia-web` included a max git command duration of 33.9s. The slow command was `git status`, not `git worktree list`.
- New report `fd240d89-a877-4cd9-bbf0-1248b9981e58` did not prove worktree-list as the cause: the crash-time `git worktree list` succeeded in 5.7s, while the `0xC0000142` `git status` failures in that bundle were historical. This PR therefore treats stuck/very slow local status scans as the actionable hardening surface rather than claiming an exact native-crash reproduction.

## ELI5
When Orca asks Git what changed in a repo, Git can sometimes get stuck or take a very long time on Windows. Orca now stops waiting after 60 seconds and kills that stuck Git check, so one bad status scan cannot hang around forever.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/status-stream-timeout.test.ts src/main/git/runner-stream-timeout.test.ts src/main/git/status.test.ts src/main/git/status-upstream-probe-churn.test.ts src/main/git/runner.test.ts src/main/git/runner-command-exec.test.ts src/main/ipc/filesystem.test.ts` passed: 207 tests.
- `pnpm run typecheck` passed.
- Windows Electron/CDP smoke on this branch launched Orca with an isolated temp profile, added a disposable repo with spaces through real renderer/preload IPC, called `window.api.git.status({ worktreePath })` 20 times, and each call returned the expected 2 status entries with no `process_gone`, renderer killed/OOM, or `git timed out` trace entries. The launched process tree and temp dirs were cleaned up afterward.

## Tradeoffs / gaps
- A legitimately huge local repo whose status takes longer than 60s will temporarily show degraded/empty status until a later poll succeeds.
- This changes the local streamed Git runner path. SSH providers have separate status implementations and are not changed here.
- This is a bounded-process hardening fix for the observed Git workload shape, not a perfect reproduction of the native Windows renderer exits.