### PR TITLE
Avoid unborn HEAD branch probe failures

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename-test-harness.ts
+++ b/src/main/agent-hooks/first-work-branch-rename-test-harness.ts
@@ -27,8 +27,15 @@ export function gitResponder(opts: {
       }
       throw noUpstreamError
     }
-    if (args[0] === 'rev-parse') {
+    if (args[0] === 'symbolic-ref') {
       return { stdout: `${opts.currentBranch}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse' && args.includes('--verify')) {
+      const ref = args.at(-1) ?? ''
+      if ((opts.existingRefs ?? []).includes(ref)) {
+        return { stdout: '', stderr: '' }
+      }
+      throw new Error('not found')
     }
     if (args[0] === 'show-ref') {
       const ref = args.at(-1) ?? ''

--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -97,6 +97,47 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
   })
 
+  it('reads the current branch without dereferencing an unborn HEAD', async () => {
+    const unbornHeadError = new Error(
+      "fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree."
+    )
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref' && args[2] === 'HEAD') {
+        throw unbornHeadError
+      }
+      if (args[0] === 'symbolic-ref' && args[1] === '--quiet' && args[2] === '--short') {
+        return { stdout: 'you/Nautilus\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.some((arg) => arg.includes('@{u}'))) {
+        throw noUpstreamError
+      }
+      if (args[0] === 'show-ref') {
+        throw new Error('not found')
+      }
+      if (args[0] === 'branch' && args[1] === '-m') {
+        return { stdout: '', stderr: '' }
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+
+    const { deps, onRenamed } = makeDeps()
+    await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalledWith(
+      ['rev-parse', '--abbrev-ref', 'HEAD'],
+      expect.anything()
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+      expect.objectContaining({ cwd: '/repo/wt' })
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['branch', '-m', 'you/fix-auth'],
+      expect.objectContaining({ cwd: '/repo/wt' })
+    )
+    expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
+  })
+
   it('asks to align the on-disk folder with the generated slug after renaming', async () => {
     const { deps, renameWorktreeFolder } = makeDeps()
     await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
@@ -401,7 +442,7 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
   it('does not rename when the branch changes while generation is running', async () => {
     let branchReadCount = 0
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
-      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref' && args[2] === 'HEAD') {
+      if (args[0] === 'symbolic-ref') {
         branchReadCount += 1
         return { stdout: `${branchReadCount === 1 ? 'you/Nautilus' : 'you/manual'}\n`, stderr: '' }
       }
@@ -428,9 +469,6 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
   it('does not rename when the branch gains an upstream while generation is running', async () => {
     let upstreamReadCount = 0
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
-      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref' && args[2] === 'HEAD') {
-        return { stdout: 'you/Nautilus\n', stderr: '' }
-      }
       if (args[0] === 'symbolic-ref') {
         return { stdout: 'you/Nautilus\n', stderr: '' }
       }

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -83,6 +83,13 @@ export function resetFirstWorkBranchRenameState(): void {
   settledWorktreeIds.clear()
 }
 
+async function readCurrentBranch(exec: GitExec): Promise<string> {
+  // Why: `rev-parse --abbrev-ref HEAD` dereferences HEAD and fails in unborn
+  // repos; symbolic-ref reads the branch ref without requiring a first commit.
+  const { stdout } = await exec(['symbolic-ref', '--quiet', '--short', 'HEAD'])
+  return stdout.trim()
+}
+
 function rememberSettledWorktreeId(worktreeId: string): void {
   // Why: the app can see unbounded worktree ids over a long session; evicting
   // oldest entries trades a rare re-probe for bounded process memory.
@@ -195,7 +202,7 @@ async function runAutoRename(
     ? (args) => provider.exec(args, worktreePath)
     : (args) => gitExecFileAsync(args, { cwd: worktreePath })
 
-  const currentBranch = (await exec(['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.trim()
+  const currentBranch = await readCurrentBranch(exec)
   if (!currentBranch || currentBranch === 'HEAD') {
     return retry(`no checked-out branch (${currentBranch || 'empty'})`)
   }
@@ -246,7 +253,7 @@ async function runAutoRename(
 
   // Re-validate after generation (it can take seconds): the branch must be the
   // same unpublished creature branch we started from, or we leave it alone.
-  const branchNow = (await exec(['rev-parse', '--abbrev-ref', 'HEAD'])).stdout.trim()
+  const branchNow = await readCurrentBranch(exec)
   if (branchNow !== currentBranch) {
     return retry(`branch changed during generation (${currentBranch} -> ${branchNow})`)
   }


### PR DESCRIPTION
## Description
- read the first-work auto-rename current branch with `git symbolic-ref --quiet --short HEAD`
- keep the post-generation branch recheck on the same non-dereferencing branch probe
- add a regression for an unborn/empty repo where `rev-parse --abbrev-ref HEAD` fails with `ambiguous argument HEAD`

## Crash evidence
- Original report `03-renderer-oom-taifunk` recorded a renderer OOM on Windows at `2026-06-30T21:53:16.870Z`.
- The crash breadcrumbs were dominated by agent `working` transitions, which is the signal that triggers first-work branch auto-rename.
- The NDJSON crash window includes repeated `git rev-parse --abbrev-ref HEAD` failures against `C:\Users\taifu\CLAUDE` with `fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.`
- That error is the normal behavior of `rev-parse --abbrev-ref HEAD` in an unborn repo. The hook only needs the symbolic branch name, and `git symbolic-ref --quiet --short HEAD` reads it without requiring a commit.

## ELI5
Orca was asking Git “what branch am I on?” in a way that only works after the branch has at least one commit. In brand-new or unusual repos, Git answered with an error every time the auto-rename helper woke up. Now Orca asks the branch-name question directly, so it does not trip over repos whose `HEAD` has no commit yet.

## Validation
- Confirmed the new regression failed before the fix: the hook called `rev-parse --abbrev-ref HEAD`, logged the unborn-HEAD error, and did not rename.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/first-work-branch-rename.test.ts src/main/git/branch-rename.test.ts src/main/git/upstream.test.ts src/main/git/status-upstream-probe-churn.test.ts src/main/git/status-upstream-negative-cache.test.ts` passed: 69 tests.
- `pnpm run typecheck` passed.
- Pre-commit hooks ran `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, and `oxfmt --write` on staged files.

## Tradeoffs / gaps
- This removes the repeated unborn-HEAD failure path from the auto-rename hook. It is not proof that the native renderer OOM in report 03 is fully fixed without the original `C:\Users\taifu\...` repos or a fresh current-build crash bundle.
- Detached HEAD still returns no symbolic branch and remains a retry/skip path for the convenience auto-rename feature.
- The fix applies to both local and SSH auto-rename branch probes because the helper uses the shared `GitExec` abstraction.