### PR TITLE
feat: add global hotkey support for showing/hiding Orca window

### DIFF
--- a/src/main/global-hotkey/global-hotkey-manager.test.ts
+++ b/src/main/global-hotkey/global-hotkey-manager.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserWindow } from 'electron'
+import { GlobalHotkeyManager } from './global-hotkey-manager'
+import type { Store } from '../persistence'
+
+const registerMock = vi.fn<(accelerator: string, callback: () => void) => boolean>()
+const unregisterMock = vi.fn<(accelerator: string) => void>()
+const appHideMock = vi.fn()
+
+vi.mock('electron', () => ({
+  app: {
+    hide: (...args: unknown[]) => appHideMock(...args),
+    focus: vi.fn(),
+    isReady: () => true
+  },
+  globalShortcut: {
+    register: (accelerator: string, callback: () => void) => registerMock(accelerator, callback),
+    unregister: (accelerator: string) => unregisterMock(accelerator)
+  }
+}))
+
+const focusExistingMainWindowMock = vi.fn()
+vi.mock('../window/focus-existing-window', () => ({
+  focusExistingMainWindow: (...args: unknown[]) => focusExistingMainWindowMock(...args)
+}))
+
+type SettingsListener = (updates: Record<string, unknown>) => void
+
+function createStoreFake(globalHotkey: string | undefined): {
+  store: Store
+  emitSettingsChange: (updates: Record<string, unknown>) => void
+  unsubscribed: () => boolean
+} {
+  const state = { listener: null as SettingsListener | null, unsubscribed: false }
+  const store = {
+    getSettings: () => ({ globalHotkey }),
+    onSettingsChanged: (listener: SettingsListener) => {
+      state.listener = listener
+      return () => {
+        state.unsubscribed = true
+        state.listener = null
+      }
+    }
+  } as unknown as Store
+  return {
+    store,
+    emitSettingsChange: (updates) => state.listener?.(updates),
+    unsubscribed: () => state.unsubscribed
+  }
+}
+
+function createWindowFake(options: { visible?: boolean; focused?: boolean; destroyed?: boolean }) {
+  return {
+    isDestroyed: () => options.destroyed ?? false,
+    isVisible: () => options.visible ?? true,
+    isFocused: () => options.focused ?? true,
+    hide: vi.fn()
+  }
+}
+
+function createManager(options: {
+  globalHotkey?: string
+  window?: ReturnType<typeof createWindowFake> | null
+  warn?: (message: string, error?: unknown) => void
+}) {
+  const storeFake = createStoreFake(options.globalHotkey)
+  const manager = new GlobalHotkeyManager({
+    store: storeFake.store,
+    getMainWindow: () => (options.window ?? null) as unknown as BrowserWindow | null,
+    openMainWindow: () => (options.window ?? createWindowFake({})) as unknown as BrowserWindow,
+    warn: options.warn
+  })
+  return { manager, ...storeFake }
+}
+
+beforeEach(() => {
+  registerMock.mockReset()
+  registerMock.mockReturnValue(true)
+  unregisterMock.mockReset()
+  appHideMock.mockReset()
+  focusExistingMainWindowMock.mockReset()
+})
+
+describe('GlobalHotkeyManager', () => {
+  it('registers the configured accelerator on start', () => {
+    const { manager } = createManager({ globalHotkey: 'Alt+Space' })
+    manager.start()
+    expect(registerMock).toHaveBeenCalledTimes(1)
+    expect(registerMock).toHaveBeenCalledWith('Alt+Space', expect.any(Function))
+  })
+
+  it('does not register anything when the setting is empty or unset', () => {
+    const empty = createManager({ globalHotkey: '' })
+    empty.manager.start()
+    const unset = createManager({})
+    unset.manager.start()
+    expect(registerMock).not.toHaveBeenCalled()
+  })
+
+  it('re-registers when the setting changes and unregisters the old accelerator', () => {
+    const { manager, emitSettingsChange } = createManager({ globalHotkey: 'Alt+Space' })
+    manager.start()
+    emitSettingsChange({ globalHotkey: 'Super+K' })
+    expect(unregisterMock).toHaveBeenCalledWith('Alt+Space')
+    expect(registerMock).toHaveBeenLastCalledWith('Super+K', expect.any(Function))
+  })
+
+  it('unregisters without re-registering when the setting is cleared', () => {
+    const { manager, emitSettingsChange } = createManager({ globalHotkey: 'Alt+Space' })
+    manager.start()
+    registerMock.mockClear()
+    emitSettingsChange({ globalHotkey: '' })
+    expect(unregisterMock).toHaveBeenCalledWith('Alt+Space')
+    expect(registerMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores settings changes that do not touch the hotkey', () => {
+    const { manager, emitSettingsChange } = createManager({ globalHotkey: 'Alt+Space' })
+    manager.start()
+    registerMock.mockClear()
+    emitSettingsChange({ theme: 'dark' })
+    expect(registerMock).not.toHaveBeenCalled()
+    expect(unregisterMock).not.toHaveBeenCalled()
+  })
+
+  it('warns and keeps no binding when registration is rejected', () => {
+    const warn = vi.fn()
+    registerMock.mockReturnValue(false)
+    const { manager, emitSettingsChange } = createManager({ globalHotkey: 'Alt+Space', warn })
+    manager.start()
+    expect(warn).toHaveBeenCalledTimes(1)
+    // A rejected registration must not be unregistered later.
+    emitSettingsChange({ globalHotkey: 'Super+K' })
+    expect(unregisterMock).not.toHaveBeenCalled()
+  })
+
+  it('warns instead of throwing when registration throws', () => {
+    const warn = vi.fn()
+    registerMock.mockImplementation(() => {
+      throw new Error('bad accelerator')
+    })
+    const { manager } = createManager({ globalHotkey: 'not an accelerator', warn })
+    expect(() => manager.start()).not.toThrow()
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('stop() unregisters and stops listening for settings changes', () => {
+    const { manager, emitSettingsChange, unsubscribed } = createManager({
+      globalHotkey: 'Alt+Space'
+    })
+    manager.start()
+    manager.stop()
+    expect(unregisterMock).toHaveBeenCalledWith('Alt+Space')
+    expect(unsubscribed()).toBe(true)
+    registerMock.mockClear()
+    emitSettingsChange({ globalHotkey: 'Super+K' })
+    expect(registerMock).not.toHaveBeenCalled()
+  })
+
+  it('hides a visible focused window when the hotkey fires', () => {
+    const window = createWindowFake({ visible: true, focused: true })
+    const { manager } = createManager({ globalHotkey: 'Alt+Space', window })
+    manager.start()
+    const hotkeyCallback = registerMock.mock.calls[0]![1]
+    hotkeyCallback()
+    expect(window.hide).toHaveBeenCalledTimes(1)
+    expect(appHideMock).toHaveBeenCalledTimes(1)
+    expect(focusExistingMainWindowMock).not.toHaveBeenCalled()
+  })
+
+  it('focuses the window when it is visible but not focused', () => {
+    const window = createWindowFake({ visible: true, focused: false })
+    const { manager } = createManager({ globalHotkey: 'Alt+Space', window })
+    manager.start()
+    const hotkeyCallback = registerMock.mock.calls[0]![1]
+    hotkeyCallback()
+    expect(window.hide).not.toHaveBeenCalled()
+    expect(focusExistingMainWindowMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens/reveals the window when none exists', () => {
+    const { manager } = createManager({ globalHotkey: 'Alt+Space', window: null })
+    manager.start()
+    const hotkeyCallback = registerMock.mock.calls[0]![1]
+    hotkeyCallback()
+    expect(focusExistingMainWindowMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/global-hotkey/global-hotkey-manager.test.ts
+++ b/src/main/global-hotkey/global-hotkey-manager.test.ts
@@ -144,6 +144,12 @@ describe('GlobalHotkeyManager', () => {
     expect(warn).toHaveBeenCalledTimes(1)
   })
 
+  it('treats a non-string persisted value as disabled instead of throwing', () => {
+    const { manager } = createManager({ globalHotkey: 12345 as unknown as string })
+    expect(() => manager.start()).not.toThrow()
+    expect(registerMock).not.toHaveBeenCalled()
+  })
+
   it('stop() unregisters and stops listening for settings changes', () => {
     const { manager, emitSettingsChange, unsubscribed } = createManager({
       globalHotkey: 'Alt+Space'

--- a/src/main/global-hotkey/global-hotkey-manager.ts
+++ b/src/main/global-hotkey/global-hotkey-manager.ts
@@ -30,7 +30,7 @@ export class GlobalHotkeyManager {
     this.register(settings.globalHotkey ?? '')
 
     this.unsubscribeSettings = this.options.store.onSettingsChanged((updates) => {
-      if ('globalHotkey' in updates && updates.globalHotkey !== undefined) {
+      if (typeof updates.globalHotkey === 'string') {
         this.register(updates.globalHotkey)
       }
     })
@@ -81,27 +81,20 @@ export class GlobalHotkeyManager {
 
   private handleHotkeyPressed(): void {
     const win = this.options.getMainWindow()
-    const isVisibleAndFocused = Boolean(
-      win && !win.isDestroyed() && win.isVisible() && win.isFocused()
-    )
-
-    if (isVisibleAndFocused) {
-      // Window is frontmost, hide it.
-      if (win && !win.isDestroyed()) {
-        win.hide()
-      }
-      // Why: app.hide() is macOS-only; on Linux/Win we just hide the window.
+    if (win && !win.isDestroyed() && win.isVisible() && win.isFocused()) {
+      win.hide()
+      // Why: app.hide() exists only on macOS; there it also returns focus to
+      // the previously active app, which win.hide() alone does not.
       if (typeof app.hide === 'function') {
         app.hide()
       }
-    } else {
-      // Show and focus the window.
-      focusExistingMainWindow({
-        app,
-        getWindow: () => this.options.getMainWindow(),
-        openWindow: () => this.options.openMainWindow(),
-        warn: this.options.warn
-      })
+      return
     }
+    focusExistingMainWindow({
+      app,
+      getWindow: () => this.options.getMainWindow(),
+      openWindow: () => this.options.openMainWindow(),
+      warn: this.options.warn
+    })
   }
 }

--- a/src/main/global-hotkey/global-hotkey-manager.ts
+++ b/src/main/global-hotkey/global-hotkey-manager.ts
@@ -1,0 +1,107 @@
+import { app, globalShortcut } from 'electron'
+import type { BrowserWindow } from 'electron'
+import type { Store } from '../persistence'
+import { focusExistingMainWindow } from '../window/focus-existing-window'
+
+export type GlobalHotkeyManagerOptions = {
+  store: Store
+  getMainWindow: () => BrowserWindow | null
+  openMainWindow: () => BrowserWindow
+  warn?: (message: string, error?: unknown) => void
+}
+
+/**
+ * Manages registration of a system-wide global hotkey that toggles the Orca
+ * main window visibility. Listens for settings changes to re-register the
+ * hotkey when the user changes it in preferences.
+ */
+export class GlobalHotkeyManager {
+  private readonly options: GlobalHotkeyManagerOptions
+  private currentAccelerator: string | null = null
+  private unsubscribeSettings: (() => void) | null = null
+
+  constructor(options: GlobalHotkeyManagerOptions) {
+    this.options = options
+  }
+
+  /** Register the initial hotkey and start listening for setting changes. */
+  start(): void {
+    const settings = this.options.store.getSettings()
+    this.register(settings.globalHotkey ?? '')
+
+    this.unsubscribeSettings = this.options.store.onSettingsChanged((updates) => {
+      if ('globalHotkey' in updates && updates.globalHotkey !== undefined) {
+        this.register(updates.globalHotkey)
+      }
+    })
+  }
+
+  /** Unregister the hotkey and stop listening for setting changes. */
+  stop(): void {
+    this.unregister()
+    this.unsubscribeSettings?.()
+    this.unsubscribeSettings = null
+  }
+
+  private register(accelerator: string): void {
+    // Always unregister the previous binding first.
+    this.unregister()
+
+    const trimmed = accelerator.trim()
+    if (!trimmed) {
+      return
+    }
+
+    try {
+      const registered = globalShortcut.register(trimmed, () => {
+        this.handleHotkeyPressed()
+      })
+      if (registered) {
+        this.currentAccelerator = trimmed
+      } else {
+        this.options.warn?.(
+          `[global-hotkey] Failed to register global hotkey "${trimmed}". It may already be in use by another application.`
+        )
+      }
+    } catch (error) {
+      this.options.warn?.('[global-hotkey] Error registering global hotkey', error)
+    }
+  }
+
+  private unregister(): void {
+    if (this.currentAccelerator) {
+      try {
+        globalShortcut.unregister(this.currentAccelerator)
+      } catch {
+        // Best-effort cleanup.
+      }
+      this.currentAccelerator = null
+    }
+  }
+
+  private handleHotkeyPressed(): void {
+    const win = this.options.getMainWindow()
+    const isVisibleAndFocused = Boolean(
+      win && !win.isDestroyed() && win.isVisible() && win.isFocused()
+    )
+
+    if (isVisibleAndFocused) {
+      // Window is frontmost, hide it.
+      if (win && !win.isDestroyed()) {
+        win.hide()
+      }
+      // Why: app.hide() is macOS-only; on Linux/Win we just hide the window.
+      if (typeof app.hide === 'function') {
+        app.hide()
+      }
+    } else {
+      // Show and focus the window.
+      focusExistingMainWindow({
+        app,
+        getWindow: () => this.options.getMainWindow(),
+        openWindow: () => this.options.openMainWindow(),
+        warn: this.options.warn
+      })
+    }
+  }
+}

--- a/src/main/global-hotkey/global-hotkey-manager.ts
+++ b/src/main/global-hotkey/global-hotkey-manager.ts
@@ -47,7 +47,9 @@ export class GlobalHotkeyManager {
     // Always unregister the previous binding first.
     this.unregister()
 
-    const trimmed = accelerator.trim()
+    // Why: the store load path does not sanitize this field, so a hand-edited
+    // settings file must not be able to throw during startup registration.
+    const trimmed = typeof accelerator === 'string' ? accelerator.trim() : ''
     if (!trimmed) {
       return
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1806,8 +1806,9 @@ app.whenReady().then(async () => {
   agentAwakeService = new AgentAwakeService()
   agentAwakeService.setEnabled(store.getSettings().keepComputerAwakeWhileAgentsRun)
   // Why: register the global show/hide hotkey early so it's available as soon
-  // as the app launches, even before the main window finishes loading.
-  if (!isServeMode && store) {
+  // as the app launches, even before the main window finishes loading. Serve
+  // mode is headless (SSH/web-client host) and must not grab OS-level keys.
+  if (!isServeMode) {
     globalHotkeyManager = new GlobalHotkeyManager({
       store,
       getMainWindow: () => mainWindow,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,6 +61,7 @@ import {
   configureDevUserDataPath,
   configureOrcaUserDataPathEnv,
   enableMainProcessGpuFeatures,
+  enableWaylandGlobalShortcutsPortal,
   installDevParentDisconnectQuit,
   installDevParentSignalQuit,
   installDevParentWatchdog,
@@ -661,6 +662,9 @@ if (hasSingleInstanceLock) {
     platform: process.platform
   })
   configureElectronNetworkCompatibility()
+  if (!isServeMode) {
+    enableWaylandGlobalShortcutsPortal()
+  }
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()
   if (!gpuFallbackActiveThisLaunch) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -128,6 +128,7 @@ import {
 } from './tray/system-tray'
 import { focusExistingMainWindow } from './window/focus-existing-window'
 import { notifyMainWindowBecameVisible } from './window/main-window-visibility'
+import { GlobalHotkeyManager } from './global-hotkey/global-hotkey-manager'
 import { CodexAccountService } from './codex-accounts/service'
 import { CodexRuntimeHomeService } from './codex-accounts/runtime-home-service'
 import {
@@ -249,6 +250,7 @@ const recoveryReloadInFlight = createWebContentsTimedFlag()
 // Why: a tray/menu-bar "Settings…" click can precede the renderer attaching
 // its ui:openSettings listener; the renderer pulls this one-shot on mount.
 const pendingOpenSettings = createWebContentsTimedFlag()
+let globalHotkeyManager: GlobalHotkeyManager | null = null
 let firstWindowStartupServicesReady: Promise<void> = Promise.resolve()
 let managedWslCliReconciliationReady: Promise<void> = Promise.resolve()
 let managedWslCliStartupBarrierReady: Promise<void> = Promise.resolve()
@@ -1803,6 +1805,17 @@ app.whenReady().then(async () => {
   unsubscribeSystemResumeBroadcast = registerSystemResumeBroadcast()
   agentAwakeService = new AgentAwakeService()
   agentAwakeService.setEnabled(store.getSettings().keepComputerAwakeWhileAgentsRun)
+  // Why: register the global show/hide hotkey early so it's available as soon
+  // as the app launches, even before the main window finishes loading.
+  if (!isServeMode && store) {
+    globalHotkeyManager = new GlobalHotkeyManager({
+      store,
+      getMainWindow: () => mainWindow,
+      openMainWindow: () => openMainWindow(),
+      warn: console.warn
+    })
+    globalHotkeyManager.start()
+  }
   // Why: disk-hydrated status rows are UI continuity only. The service starts
   // from an empty snapshot; only hook events observed in this runtime can keep
   // the local computer awake.
@@ -2401,6 +2414,9 @@ app.on('will-quit', (e) => {
   // Why: before-quit can still be aborted by renderer beforeunload; wait until
   // the committed quit path before removing the Windows notification icon.
   destroySystemTray()
+  // Why: unregister the global hotkey on quit to avoid leaked OS-level registrations.
+  globalHotkeyManager?.stop()
+  globalHotkeyManager = null
   // Why: stats.flush() must run before killAllPty() so it can read the
   // live agent state and emit synthetic agent_stop events for agents that
   // are still running. killAllPty() does not call runtime.onPtyExit(),

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -125,6 +125,11 @@ export function registerSettingsHandlers(
     if ('uiLanguage' in args) {
       sanitizedArgs.uiLanguage = normalizeUiLanguage(args.uiLanguage)
     }
+    if ('globalHotkey' in args) {
+      // Why: coerce to string so a non-string renderer payload can never
+      // persist a truthy non-string that later breaks accelerator registration.
+      sanitizedArgs.globalHotkey = typeof args.globalHotkey === 'string' ? args.globalHotkey : ''
+    }
     if (args.theme) {
       nativeTheme.themeSource = args.theme
     }

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -125,11 +125,6 @@ export function registerSettingsHandlers(
     if ('uiLanguage' in args) {
       sanitizedArgs.uiLanguage = normalizeUiLanguage(args.uiLanguage)
     }
-    if ('globalHotkey' in args) {
-      // Why: coerce to string so a non-string renderer payload can never
-      // persist a truthy non-string that later breaks accelerator registration.
-      sanitizedArgs.globalHotkey = typeof args.globalHotkey === 'string' ? args.globalHotkey : ''
-    }
     if (args.theme) {
       nativeTheme.themeSource = args.theme
     }

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -680,6 +680,19 @@ describe('Store', () => {
     expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
   })
 
+  it('defaults globalHotkey to disabled and sanitizes updates', async () => {
+    const store = await createStore()
+    // Why: the global hotkey is opt-in; a non-empty default would grab an
+    // OS-wide chord for every install.
+    expect(store.getSettings().globalHotkey).toBe('')
+    store.updateSettings({ globalHotkey: '  Alt+Space  ' })
+    expect(store.getSettings().globalHotkey).toBe('Alt+Space')
+    store.updateSettings({ globalHotkey: 42 as unknown as string })
+    expect(store.getSettings().globalHotkey).toBe('')
+    store.updateSettings({ globalHotkey: 'X'.repeat(200) })
+    expect(store.getSettings().globalHotkey).toHaveLength(64)
+  })
+
   it('persists minimizeToTrayOnClose true/false round-trip', async () => {
     const store = await createStore()
     store.updateSettings({ minimizeToTrayOnClose: true })

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -5271,6 +5271,12 @@ export class Store {
     if ('showMenuBarIcon' in updates) {
       sanitizedUpdates.showMenuBarIcon = updates.showMenuBarIcon === true
     }
+    if ('globalHotkey' in updates) {
+      // Why: sanitize here (not the IPC edge) so mobile/web RPC writes are
+      // covered too; only a bounded string may reach accelerator registration.
+      sanitizedUpdates.globalHotkey =
+        typeof updates.globalHotkey === 'string' ? updates.globalHotkey.trim().slice(0, 64) : ''
+    }
     if ('disabledTuiAgents' in updates) {
       sanitizedUpdates.disabledTuiAgents = normalizeDisabledTuiAgents(updates.disabledTuiAgents)
     }

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -260,6 +260,53 @@ describe('configureElectronNetworkCompatibility', () => {
   })
 })
 
+describe('enableWaylandGlobalShortcutsPortal', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  const originalWaylandDisplay = process.env.WAYLAND_DISPLAY
+
+  afterEach(async () => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    if (originalWaylandDisplay === undefined) {
+      delete process.env.WAYLAND_DISPLAY
+    } else {
+      process.env.WAYLAND_DISPLAY = originalWaylandDisplay
+    }
+    const { app } = await import('electron')
+    vi.mocked(app.commandLine.getSwitchValue).mockReset().mockReturnValue('')
+  })
+
+  it('enables Electron global shortcuts through the portal on Wayland', async () => {
+    const { app } = await import('electron')
+    const { enableWaylandGlobalShortcutsPortal } = await import('./configure-process')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    process.env.WAYLAND_DISPLAY = 'wayland-1'
+    vi.mocked(app.commandLine.getSwitchValue).mockImplementation((switchName: string) =>
+      switchName === 'enable-features' ? 'ExistingFeature' : ''
+    )
+
+    enableWaylandGlobalShortcutsPortal()
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'enable-features',
+      'ExistingFeature,GlobalShortcutsPortal'
+    )
+  })
+
+  it('does not enable the portal outside Wayland', async () => {
+    const { app } = await import('electron')
+    const { enableWaylandGlobalShortcutsPortal } = await import('./configure-process')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    delete process.env.WAYLAND_DISPLAY
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+
+    enableWaylandGlobalShortcutsPortal()
+
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalled()
+  })
+})
+
 describe('enableMainProcessGpuFeatures', () => {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
   const originalE2EUserDataDir = process.env.ORCA_E2E_USER_DATA_DIR

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -296,6 +296,36 @@ export function installDevParentSignalQuit(isDev: boolean): void {
   process.once('SIGTERM', onSignal)
 }
 
+function isLinuxWaylandSession(): boolean {
+  const ozonePlatform = (app.commandLine.getSwitchValue('ozone-platform') ?? '').toLowerCase()
+  const ozonePlatformHint = (process.env.ELECTRON_OZONE_PLATFORM_HINT ?? '').toLowerCase()
+  const isLinuxX11Override =
+    ozonePlatform === 'x11' || (ozonePlatform === '' && ozonePlatformHint === 'x11')
+  return (
+    process.platform === 'linux' &&
+    !isLinuxX11Override &&
+    (Boolean(process.env.WAYLAND_DISPLAY) ||
+      process.env.XDG_SESSION_TYPE === 'wayland' ||
+      ozonePlatformHint === 'wayland' ||
+      ozonePlatform === 'wayland')
+  )
+}
+
+export function enableWaylandGlobalShortcutsPortal(): void {
+  if (!isLinuxWaylandSession()) {
+    return
+  }
+
+  const existingFeatures = app.commandLine.getSwitchValue('enable-features')
+  const features = existingFeatures ? existingFeatures.split(',') : []
+  if (!features.includes('GlobalShortcutsPortal')) {
+    // Why: Electron's globalShortcut API requires the desktop portal on
+    // Wayland; without it, a configured hotkey silently never registers.
+    features.push('GlobalShortcutsPortal')
+  }
+  app.commandLine.appendSwitch('enable-features', features.join(','))
+}
+
 export function enableMainProcessGpuFeatures(): void {
   if (process.platform === 'linux' && getMainE2EConfig().userDataDir) {
     // Why: Ubuntu/Xvfb runners can fail Electron startup with
@@ -313,18 +343,8 @@ export function enableMainProcessGpuFeatures(): void {
   // 128 covers real layouts while keeping a bound so context leaks surface.
   app.commandLine.appendSwitch('max-active-webgl-contexts', '128')
 
-  const ozonePlatform = (app.commandLine.getSwitchValue('ozone-platform') ?? '').toLowerCase()
-  const ozonePlatformHint = (process.env.ELECTRON_OZONE_PLATFORM_HINT ?? '').toLowerCase()
-  const isLinuxX11Override =
-    ozonePlatform === 'x11' || (ozonePlatform === '' && ozonePlatformHint === 'x11')
-  const isLinuxWaylandSession =
-    process.platform === 'linux' &&
-    !isLinuxX11Override &&
-    (Boolean(process.env.WAYLAND_DISPLAY) ||
-      process.env.XDG_SESSION_TYPE === 'wayland' ||
-      ozonePlatformHint === 'wayland' ||
-      ozonePlatform === 'wayland')
-  if (isLinuxWaylandSession) {
+  const linuxWaylandSession = isLinuxWaylandSession()
+  if (linuxWaylandSession) {
     // Why: #5319 reproduces when Wayland loses the eager GPU channel. Keep
     // acceleration available, but drop the GPU sandbox and let Chromium open
     // the GPU channel lazily on this compositor path.
@@ -336,7 +356,7 @@ export function enableMainProcessGpuFeatures(): void {
     // Why: mirror VS Code's conservative Electron GPU-channel startup flags
     // instead of opting into Vulkan/SkiaGraphite/unsafe WebGPU globally.
     // Terminal acceleration is controlled by xterm WebGL in the renderer.
-    ...(isLinuxWaylandSession ? [] : ['EarlyEstablishGpuChannel', 'EstablishGpuChannelAsync']),
+    ...(linuxWaylandSession ? [] : ['EarlyEstablishGpuChannel', 'EstablishGpuChannelAsync']),
     existingFeatures
   ]
     .filter(Boolean)

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -24,6 +24,7 @@ import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormContr
 import { translate } from '@/i18n/i18n'
 import { DefaultWindowsProjectRuntimeSetting } from './DefaultWindowsProjectRuntimeSetting'
 import { GlobalHotkeySetting } from './GlobalHotkeySetting'
+import { isWebClientLocation } from '@/lib/web-client-location'
 
 export {
   createAutoSaveDelayDraftState,
@@ -138,28 +139,30 @@ export function GeneralPane({
             }
           />
         </SearchableSetting>
-        <SearchableSetting
-          title={translate('auto.components.settings.GeneralPane.globalHotkey', 'Global Hotkey')}
-          description={translate(
-            'auto.components.settings.GeneralPane.globalHotkeyDescription',
-            'Show or hide the Orca window from anywhere with a system-wide keyboard shortcut.'
-          )}
-          keywords={[
-            'hotkey',
-            'shortcut',
-            'global',
-            'show',
-            'hide',
-            'toggle',
-            'window',
-            'spotlight'
-          ]}
-        >
-          <GlobalHotkeySetting
-            value={settings.globalHotkey}
-            onChange={(accelerator) => updateSettings({ globalHotkey: accelerator })}
-          />
-        </SearchableSetting>
+        {isWebClientLocation() ? null : (
+          <SearchableSetting
+            title={translate('auto.components.settings.GeneralPane.globalHotkey', 'Global hotkey')}
+            description={translate(
+              'auto.components.settings.GeneralPane.globalHotkeyDescription',
+              'Show or hide the Orca window from anywhere with a system-wide keyboard shortcut.'
+            )}
+            keywords={[
+              'hotkey',
+              'shortcut',
+              'global',
+              'show',
+              'hide',
+              'toggle',
+              'window',
+              'spotlight'
+            ]}
+          >
+            <GlobalHotkeySetting
+              value={settings.globalHotkey}
+              onChange={(accelerator) => updateSettings({ globalHotkey: accelerator })}
+            />
+          </SearchableSetting>
+        )}
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, getGeneralWorkspaceSearchEntries()) ? (

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -23,6 +23,7 @@ import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 import { DefaultWindowsProjectRuntimeSetting } from './DefaultWindowsProjectRuntimeSetting'
+import { GlobalHotkeySetting } from './GlobalHotkeySetting'
 
 export {
   createAutoSaveDelayDraftState,
@@ -135,6 +136,28 @@ export function GeneralPane({
             onChange={() =>
               updateSettings({ confirmClosePinnedTab: !(settings.confirmClosePinnedTab ?? true) })
             }
+          />
+        </SearchableSetting>
+        <SearchableSetting
+          title={translate('auto.components.settings.GeneralPane.globalHotkey', 'Global Hotkey')}
+          description={translate(
+            'auto.components.settings.GeneralPane.globalHotkeyDescription',
+            'Show or hide the Orca window from anywhere with a system-wide keyboard shortcut.'
+          )}
+          keywords={[
+            'hotkey',
+            'shortcut',
+            'global',
+            'show',
+            'hide',
+            'toggle',
+            'window',
+            'spotlight'
+          ]}
+        >
+          <GlobalHotkeySetting
+            value={settings.globalHotkey}
+            onChange={(accelerator) => updateSettings({ globalHotkey: accelerator })}
           />
         </SearchableSetting>
       </section>

--- a/src/renderer/src/components/settings/GlobalHotkeySetting.test.tsx
+++ b/src/renderer/src/components/settings/GlobalHotkeySetting.test.tsx
@@ -58,6 +58,38 @@ describe('eventToAccelerator', () => {
       'Alt+Up'
     )
   })
+
+  it('rejects Shift-only chords: Shift is never a sufficient modifier', () => {
+    // Every Shift+<key> combo collides with ordinary Shift usage (capitals,
+    // symbols, soft-newline, reverse-tab, selection), so a global grab would
+    // swallow that keystroke in every application.
+    expect(eventToAccelerator(keyEvent({ shiftKey: true, key: 'A', code: 'KeyA' }))).toBeNull()
+    expect(eventToAccelerator(keyEvent({ shiftKey: true, key: '1', code: 'Digit1' }))).toBeNull()
+    expect(eventToAccelerator(keyEvent({ shiftKey: true, key: ' ', code: 'Space' }))).toBeNull()
+    expect(eventToAccelerator(keyEvent({ shiftKey: true, key: 'Enter', code: 'Enter' }))).toBeNull()
+    expect(eventToAccelerator(keyEvent({ shiftKey: true, key: 'Tab', code: 'Tab' }))).toBeNull()
+    expect(
+      eventToAccelerator(keyEvent({ shiftKey: true, key: 'ArrowUp', code: 'ArrowUp' }))
+    ).toBeNull()
+    expect(eventToAccelerator(keyEvent({ shiftKey: true, key: 'F5', code: 'F5' }))).toBeNull()
+    // Shift combined with a real modifier stays valid.
+    expect(
+      eventToAccelerator(keyEvent({ altKey: true, shiftKey: true, key: 'A', code: 'KeyA' }))
+    ).toBe('Alt+Shift+A')
+    expect(
+      eventToAccelerator(keyEvent({ ctrlKey: true, shiftKey: true, key: 'F5', code: 'F5' }))
+    ).toBe('Control+Shift+F5')
+  })
+
+  it('escapes "+" and rejects non-ASCII or multi-char fallback keys', () => {
+    // "+" is the accelerator separator; it must serialize to the literal "Plus".
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: '+', code: 'Equal' }))).toBe('Alt+Plus')
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: '=', code: 'Equal' }))).toBe('Alt+=')
+    // "ß".toUpperCase() === "SS" (multi-char) and "ö" is non-ASCII: both would
+    // make Electron reject the accelerator, so the recorder must ignore them.
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: 'ß', code: 'Semicolon' }))).toBeNull()
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: 'ö', code: 'Semicolon' }))).toBeNull()
+  })
 })
 
 describe('acceleratorToKeys', () => {

--- a/src/renderer/src/components/settings/GlobalHotkeySetting.test.tsx
+++ b/src/renderer/src/components/settings/GlobalHotkeySetting.test.tsx
@@ -36,7 +36,7 @@ describe('eventToAccelerator', () => {
       eventToAccelerator(
         keyEvent({ metaKey: true, ctrlKey: true, shiftKey: true, key: 'p', code: 'KeyP' })
       )
-    ).toBe('Super+Control+Shift+P')
+    ).toBe('Control+Super+Shift+P')
   })
 
   it('rejects chords without a modifier', () => {

--- a/src/renderer/src/components/settings/GlobalHotkeySetting.test.tsx
+++ b/src/renderer/src/components/settings/GlobalHotkeySetting.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GlobalHotkeySetting, acceleratorToKeys, eventToAccelerator } from './GlobalHotkeySetting'
+
+function keyEvent(overrides: Partial<Parameters<typeof eventToAccelerator>[0]>) {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    key: '',
+    code: '',
+    ...overrides
+  }
+}
+
+describe('eventToAccelerator', () => {
+  it('maps Alt+Space to the Electron accelerator', () => {
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: ' ', code: 'Space' }))).toBe(
+      'Alt+Space'
+    )
+  })
+
+  it('keeps Control and Meta distinct instead of collapsing to CommandOrControl', () => {
+    expect(eventToAccelerator(keyEvent({ ctrlKey: true, key: 'k', code: 'KeyK' }))).toBe(
+      'Control+K'
+    )
+    expect(eventToAccelerator(keyEvent({ metaKey: true, key: 'k', code: 'KeyK' }))).toBe('Super+K')
+  })
+
+  it('combines multiple modifiers', () => {
+    expect(
+      eventToAccelerator(
+        keyEvent({ metaKey: true, ctrlKey: true, shiftKey: true, key: 'p', code: 'KeyP' })
+      )
+    ).toBe('Super+Control+Shift+P')
+  })
+
+  it('rejects chords without a modifier', () => {
+    expect(eventToAccelerator(keyEvent({ key: 'a', code: 'KeyA' }))).toBeNull()
+    expect(eventToAccelerator(keyEvent({ key: 'F5', code: 'F5' }))).toBeNull()
+  })
+
+  it('rejects pure modifier presses', () => {
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: 'Alt', code: 'AltLeft' }))).toBeNull()
+    expect(
+      eventToAccelerator(keyEvent({ metaKey: true, key: 'Meta', code: 'MetaLeft' }))
+    ).toBeNull()
+  })
+
+  it('maps digits, F-keys, and named keys', () => {
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: '1', code: 'Digit1' }))).toBe('Alt+1')
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: 'F6', code: 'F6' }))).toBe('Alt+F6')
+    expect(eventToAccelerator(keyEvent({ altKey: true, key: 'ArrowUp', code: 'ArrowUp' }))).toBe(
+      'Alt+Up'
+    )
+  })
+})
+
+describe('acceleratorToKeys', () => {
+  it('returns no keys for an empty accelerator', () => {
+    expect(acceleratorToKeys('')).toEqual([])
+    expect(acceleratorToKeys('  ')).toEqual([])
+  })
+
+  it('splits an accelerator into display labels', () => {
+    // happy-dom's user agent is not a Mac, so labels use the non-Mac branch.
+    expect(acceleratorToKeys('Alt+Space')).toEqual(['Alt', 'Space'])
+    expect(acceleratorToKeys('Super+Shift+K')).toEqual(['Win', 'Shift', 'K'])
+  })
+})
+
+describe('GlobalHotkeySetting', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  function renderSetting(value: string | undefined, onChange = vi.fn()) {
+    act(() => {
+      root.render(<GlobalHotkeySetting value={value} onChange={onChange} />)
+    })
+    const recordButton = container.querySelector('button')!
+    return { onChange, recordButton }
+  }
+
+  function pressKey(
+    target: Element,
+    init: { key: string; code: string; altKey?: boolean; ctrlKey?: boolean }
+  ) {
+    act(() => {
+      target.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }))
+    })
+  }
+
+  it('shows the record affordance when disabled and the combo when set', () => {
+    const disabled = renderSetting('')
+    expect(disabled.recordButton.textContent).toContain('Click to record')
+
+    const enabled = renderSetting('Alt+Space')
+    expect(enabled.recordButton.textContent).toContain('Alt')
+    expect(enabled.recordButton.textContent).toContain('Space')
+  })
+
+  it('records a chord and reports it through onChange', () => {
+    const { onChange, recordButton } = renderSetting('')
+    act(() => {
+      recordButton.click()
+    })
+    expect(recordButton.getAttribute('aria-pressed')).toBe('true')
+    pressKey(recordButton, { key: ' ', code: 'Space', altKey: true })
+    expect(onChange).toHaveBeenCalledWith('Alt+Space')
+    expect(recordButton.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('cancels recording on Escape without changing the value', () => {
+    const { onChange, recordButton } = renderSetting('Alt+Space')
+    act(() => {
+      recordButton.click()
+    })
+    pressKey(recordButton, { key: 'Escape', code: 'Escape' })
+    expect(onChange).not.toHaveBeenCalled()
+    expect(recordButton.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('ignores modifier-less presses while recording', () => {
+    const { onChange, recordButton } = renderSetting('')
+    act(() => {
+      recordButton.click()
+    })
+    pressKey(recordButton, { key: 'a', code: 'KeyA' })
+    expect(onChange).not.toHaveBeenCalled()
+    expect(recordButton.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('clears the hotkey via the disable button', () => {
+    const { onChange } = renderSetting('Alt+Space')
+    const clearButton = container.querySelectorAll('button')[1]!
+    act(() => {
+      clearButton.click()
+    })
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('offers no disable button when already disabled', () => {
+    renderSetting('')
+    expect(container.querySelectorAll('button')).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
+++ b/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
@@ -64,13 +64,22 @@ export function eventToAccelerator(event: {
 }): string | null {
   const parts: string[] = []
 
-  // Why: Super (not CommandOrControl) so recording Ctrl+X and Cmd+X stay
-  // distinct chords; Electron maps Super to Cmd on macOS and Win elsewhere.
-  if (event.metaKey) {
-    parts.push('Super')
-  }
-  if (event.ctrlKey) {
-    parts.push('Control')
+  // Why: keep the platform-primary modifier first while preserving the other
+  // physical modifier as a distinct chord instead of aliasing both to CmdOrCtrl.
+  if (isMac) {
+    if (event.metaKey) {
+      parts.push('Super')
+    }
+    if (event.ctrlKey) {
+      parts.push('Control')
+    }
+  } else {
+    if (event.ctrlKey) {
+      parts.push('Control')
+    }
+    if (event.metaKey) {
+      parts.push('Super')
+    }
   }
   if (event.altKey) {
     parts.push('Alt')

--- a/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
+++ b/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { Button } from '../ui/button'
 import { ShortcutKeyCombo } from '../ShortcutKeyCombo'
 import { translate } from '@/i18n/i18n'
@@ -7,18 +7,16 @@ import { CircleX } from 'lucide-react'
 
 const isMac = navigator.userAgent.includes('Mac')
 
-const DEFAULT_HOTKEY_ACCELERATOR = 'Alt+Space'
-
 type GlobalHotkeySettingProps = {
   value: string | undefined
   onChange: (accelerator: string) => void
 }
 
 /**
- * Parse an Electron accelerator string (e.g. "Alt+Space", "CommandOrControl+K")
- * into an array of display key labels suitable for ShortcutKeyCombo.
+ * Parse an Electron accelerator string (e.g. "Alt+Space", "Super+K") into an
+ * array of display key labels suitable for ShortcutKeyCombo.
  */
-function acceleratorToKeys(accelerator: string): string[] {
+export function acceleratorToKeys(accelerator: string): string[] {
   if (!accelerator.trim()) {
     return []
   }
@@ -40,7 +38,7 @@ function acceleratorToKeys(accelerator: string): string[] {
     if (lower === 'shift') {
       return isMac ? '⇧' : 'Shift'
     }
-    if (lower === 'space' || lower === 'Space') {
+    if (lower === 'space') {
       return 'Space'
     }
     if (lower.length === 1) {
@@ -55,13 +53,23 @@ function acceleratorToKeys(accelerator: string): string[] {
  * Convert a keyboard event into an Electron accelerator string.
  * Returns null if the event does not represent a valid hotkey chord.
  */
-function eventToAccelerator(event: React.KeyboardEvent): string | null {
+export function eventToAccelerator(event: {
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  key: string
+  code: string
+}): string | null {
   const parts: string[] = []
 
+  // Why: Super (not CommandOrControl) so recording Ctrl+X and Cmd+X stay
+  // distinct chords; Electron maps Super to Cmd on macOS and Win elsewhere.
   if (event.metaKey) {
-    parts.push('CommandOrControl')
-  } else if (event.ctrlKey) {
-    parts.push('CommandOrControl')
+    parts.push('Super')
+  }
+  if (event.ctrlKey) {
+    parts.push('Control')
   }
   if (event.altKey) {
     parts.push('Alt')
@@ -86,7 +94,7 @@ function eventToAccelerator(event: React.KeyboardEvent): string | null {
     keyPart = code.slice(3) // e.g. "KeyA" -> "A"
   } else if (code.startsWith('Digit')) {
     keyPart = code.slice(5) // e.g. "Digit1" -> "1"
-  } else if (code.startsWith('F') && /^F\d+$/.test(code)) {
+  } else if (/^F\d+$/.test(code)) {
     keyPart = code // F1-F24
   } else if (key === 'Enter' || key === 'Return') {
     keyPart = 'Enter'
@@ -114,7 +122,8 @@ function eventToAccelerator(event: React.KeyboardEvent): string | null {
     return null
   }
 
-  // A valid global hotkey needs at least one modifier.
+  // Why: an OS-global chord without a modifier would shadow plain typing keys
+  // in every application, so require at least one modifier.
   if (parts.length === 0) {
     return null
   }
@@ -130,33 +139,13 @@ export function GlobalHotkeySetting({
   const [recording, setRecording] = useState(false)
   const recordButtonRef = useRef<HTMLButtonElement | null>(null)
 
-  const currentAccelerator = value?.trim() ?? ''
-  const hasCustom = currentAccelerator !== ''
-  const effectiveAccelerator = hasCustom ? currentAccelerator : DEFAULT_HOTKEY_ACCELERATOR
-
-  const displayKeys = acceleratorToKeys(effectiveAccelerator)
-
-  useEffect(() => {
-    if (recording) {
-      recordButtonRef.current?.focus()
-    }
-  }, [recording])
-
-  const startRecording = useCallback(() => {
-    setRecording(true)
-  }, [])
-
-  const cancelRecording = useCallback(() => {
-    setRecording(false)
-  }, [])
+  // Empty or unset means the hotkey is disabled (the feature is opt-in).
+  const accelerator = value?.trim() ?? ''
+  const displayKeys = acceleratorToKeys(accelerator)
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent): void => {
       if (!recording) {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          startRecording()
-        }
         return
       }
 
@@ -164,28 +153,20 @@ export function GlobalHotkeySetting({
       event.stopPropagation()
 
       if (event.key === 'Escape') {
-        cancelRecording()
+        setRecording(false)
         return
       }
 
-      const accelerator = eventToAccelerator(event)
-      if (!accelerator) {
+      const next = eventToAccelerator(event)
+      if (!next) {
         return
       }
 
-      onChange(accelerator)
+      onChange(next)
       setRecording(false)
     },
-    [recording, onChange, startRecording, cancelRecording]
+    [recording, onChange]
   )
-
-  const clearHotkey = useCallback(() => {
-    onChange('')
-  }, [onChange])
-
-  const resetToDefault = useCallback(() => {
-    onChange(DEFAULT_HOTKEY_ACCELERATOR)
-  }, [onChange])
 
   const recordingLabel = translate(
     'auto.components.settings.GlobalHotkeySetting.recording',
@@ -201,11 +182,13 @@ export function GlobalHotkeySetting({
           aria-label={recording ? recordingLabel : undefined}
           aria-pressed={recording}
           onClick={() => {
-            if (!recording) {
-              startRecording()
-            }
+            setRecording(true)
+            // Why: recording listens on this button's keydown, so it must own
+            // focus even when the click did not focus it.
+            recordButtonRef.current?.focus()
           }}
           onKeyDown={handleKeyDown}
+          onBlur={() => setRecording(false)}
           className={cn(
             'flex min-h-8 min-w-[8rem] items-center justify-center gap-1 rounded-md border px-3 py-1.5 text-sm outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50',
             recording
@@ -221,17 +204,20 @@ export function GlobalHotkeySetting({
             <ShortcutKeyCombo keys={displayKeys} />
           ) : (
             <span className="text-xs text-muted-foreground">
-              {translate('auto.components.settings.GlobalHotkeySetting.disabled', 'Disabled')}
+              {translate(
+                'auto.components.settings.GlobalHotkeySetting.clickToRecord',
+                'Click to record'
+              )}
             </span>
           )}
         </button>
 
-        {hasCustom ? (
+        {accelerator !== '' && !recording ? (
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            onClick={clearHotkey}
+            onClick={() => onChange('')}
             title={translate(
               'auto.components.settings.GlobalHotkeySetting.disable',
               'Disable global hotkey'
@@ -240,23 +226,15 @@ export function GlobalHotkeySetting({
             <CircleX className="size-4" />
           </Button>
         ) : null}
-
-        {!hasCustom && effectiveAccelerator !== DEFAULT_HOTKEY_ACCELERATOR ? (
-          <Button type="button" variant="ghost" size="sm" onClick={resetToDefault}>
-            {translate(
-              'auto.components.settings.GlobalHotkeySetting.resetDefault',
-              'Reset to default'
-            )}
-          </Button>
-        ) : null}
       </div>
 
       <p className="text-xs text-muted-foreground">
-        {translate(
-          'auto.components.settings.GlobalHotkeySetting.description',
-          'Press this key combination anywhere to show or hide the Orca window. Default: {{value0}}+Space',
-          { value0: isMac ? '⌥' : 'Alt' }
-        )}
+        {recording
+          ? recordingLabel
+          : translate(
+              'auto.components.settings.GlobalHotkeySetting.description',
+              'Press this key combination anywhere to show or hide the Orca window.'
+            )}
       </p>
     </div>
   )

--- a/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
+++ b/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react'
 import { Button } from '../ui/button'
+import { SettingsRow } from './SettingsFormControls'
 import { ShortcutKeyCombo } from '../ShortcutKeyCombo'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
@@ -174,68 +175,70 @@ export function GlobalHotkeySetting({
   )
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <button
-          ref={recordButtonRef}
-          type="button"
-          aria-label={recording ? recordingLabel : undefined}
-          aria-pressed={recording}
-          onClick={() => {
-            setRecording(true)
-            // Why: recording listens on this button's keydown, so it must own
-            // focus even when the click did not focus it.
-            recordButtonRef.current?.focus()
-          }}
-          onKeyDown={handleKeyDown}
-          onBlur={() => setRecording(false)}
-          className={cn(
-            'flex min-h-8 min-w-[8rem] items-center justify-center gap-1 rounded-md border px-3 py-1.5 text-sm outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50',
-            recording
-              ? 'border-ring bg-accent text-accent-foreground ring-[3px] ring-ring/30'
-              : 'border-border/70 bg-background hover:bg-accent/50'
-          )}
-        >
-          {recording ? (
-            <span className="text-xs text-muted-foreground">
-              {translate('auto.components.settings.GlobalHotkeySetting.pressKeys', 'Press keys…')}
-            </span>
-          ) : displayKeys.length > 0 ? (
-            <ShortcutKeyCombo keys={displayKeys} />
-          ) : (
-            <span className="text-xs text-muted-foreground">
-              {translate(
-                'auto.components.settings.GlobalHotkeySetting.clickToRecord',
-                'Click to record'
-              )}
-            </span>
-          )}
-        </button>
-
-        {accelerator !== '' && !recording ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => onChange('')}
-            title={translate(
-              'auto.components.settings.GlobalHotkeySetting.disable',
-              'Disable global hotkey'
-            )}
-          >
-            <CircleX className="size-4" />
-          </Button>
-        ) : null}
-      </div>
-
-      <p className="text-xs text-muted-foreground">
-        {recording
+    <SettingsRow
+      label={translate('auto.components.settings.GlobalHotkeySetting.label', 'Global hotkey')}
+      description={
+        recording
           ? recordingLabel
           : translate(
               'auto.components.settings.GlobalHotkeySetting.description',
               'Press this key combination anywhere to show or hide the Orca window.'
+            )
+      }
+      control={
+        <div className="flex items-center gap-2">
+          <button
+            ref={recordButtonRef}
+            type="button"
+            aria-label={recording ? recordingLabel : undefined}
+            aria-pressed={recording}
+            onClick={() => {
+              setRecording(true)
+              // Why: recording listens on this button's keydown, so it must own
+              // focus even when the click did not focus it.
+              recordButtonRef.current?.focus()
+            }}
+            onKeyDown={handleKeyDown}
+            onBlur={() => setRecording(false)}
+            className={cn(
+              'flex min-h-8 min-w-[8rem] items-center justify-center gap-1 rounded-md border px-3 py-1.5 text-sm outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50',
+              recording
+                ? 'border-ring bg-accent text-accent-foreground ring-[3px] ring-ring/30'
+                : 'border-border/70 bg-background hover:bg-accent/50'
             )}
-      </p>
-    </div>
+          >
+            {recording ? (
+              <span className="text-xs text-muted-foreground">
+                {translate('auto.components.settings.GlobalHotkeySetting.pressKeys', 'Press keys…')}
+              </span>
+            ) : displayKeys.length > 0 ? (
+              <ShortcutKeyCombo keys={displayKeys} />
+            ) : (
+              <span className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.GlobalHotkeySetting.clickToRecord',
+                  'Click to record'
+                )}
+              </span>
+            )}
+          </button>
+
+          {accelerator !== '' && !recording ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onChange('')}
+              title={translate(
+                'auto.components.settings.GlobalHotkeySetting.disable',
+                'Disable global hotkey'
+              )}
+            >
+              <CircleX className="size-4" />
+            </Button>
+          ) : null}
+        </div>
+      }
+    />
   )
 }

--- a/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
+++ b/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
@@ -115,7 +115,13 @@ export function eventToAccelerator(event: {
     keyPart = 'Left'
   } else if (key === 'ArrowRight') {
     keyPart = 'Right'
-  } else if (key.length === 1) {
+  } else if (key === '+') {
+    // Why: "+" is the accelerator separator, so Electron requires the literal "Plus".
+    keyPart = 'Plus'
+  } else if (key.length === 1 && key.charCodeAt(0) <= 0x7f) {
+    // Why: only single ASCII characters are valid accelerator key codes. A
+    // non-ASCII key or a multi-char uppercase (e.g. "ß" -> "SS") would make
+    // Electron reject the accelerator and silently drop the previous binding.
     keyPart = key.toUpperCase()
   }
 
@@ -123,9 +129,12 @@ export function eventToAccelerator(event: {
     return null
   }
 
-  // Why: an OS-global chord without a modifier would shadow plain typing keys
-  // in every application, so require at least one modifier.
-  if (parts.length === 0) {
+  // Why: Shift alone is never a sufficient modifier for a system-wide chord.
+  // Every Shift+<key> combo collides with ordinary Shift usage — capitals and
+  // symbols (Shift+A, Shift+1), Shift+Enter soft-newlines, Shift+Tab, and
+  // Shift+Arrow selection — so a global grab would swallow it in every app.
+  // Require at least one of Control, Alt, or Super/Command.
+  if (!event.metaKey && !event.ctrlKey && !event.altKey) {
     return null
   }
 
@@ -169,9 +178,13 @@ export function GlobalHotkeySetting({
     [recording, onChange]
   )
 
+  // Why: Shift alone is rejected (see eventToAccelerator), so name the accepted
+  // modifiers per platform instead of the misleading "any modifier".
+  const modifierHint = isMac ? '⌘, Ctrl, or Option' : 'Ctrl, Alt, or Win'
   const recordingLabel = translate(
     'auto.components.settings.GlobalHotkeySetting.recording',
-    'Press a key combination (at least one modifier). Escape cancels.'
+    'Press a key combination that includes {{value0}}. Escape cancels.',
+    { value0: modifierHint }
   )
 
   return (

--- a/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
+++ b/src/renderer/src/components/settings/GlobalHotkeySetting.tsx
@@ -1,0 +1,263 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '../ui/button'
+import { ShortcutKeyCombo } from '../ShortcutKeyCombo'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import { CircleX } from 'lucide-react'
+
+const isMac = navigator.userAgent.includes('Mac')
+
+const DEFAULT_HOTKEY_ACCELERATOR = 'Alt+Space'
+
+type GlobalHotkeySettingProps = {
+  value: string | undefined
+  onChange: (accelerator: string) => void
+}
+
+/**
+ * Parse an Electron accelerator string (e.g. "Alt+Space", "CommandOrControl+K")
+ * into an array of display key labels suitable for ShortcutKeyCombo.
+ */
+function acceleratorToKeys(accelerator: string): string[] {
+  if (!accelerator.trim()) {
+    return []
+  }
+  const parts = accelerator.split('+').map((p) => p.trim())
+  return parts.map((part) => {
+    const lower = part.toLowerCase()
+    if (lower === 'command' || lower === 'cmd' || lower === 'meta' || lower === 'super') {
+      return isMac ? '⌘' : 'Win'
+    }
+    if (lower === 'commandorcontrol' || lower === 'cmdorctrl') {
+      return isMac ? '⌘' : 'Ctrl'
+    }
+    if (lower === 'control' || lower === 'ctrl') {
+      return isMac ? '⌃' : 'Ctrl'
+    }
+    if (lower === 'alt' || lower === 'option') {
+      return isMac ? '⌥' : 'Alt'
+    }
+    if (lower === 'shift') {
+      return isMac ? '⇧' : 'Shift'
+    }
+    if (lower === 'space' || lower === 'Space') {
+      return 'Space'
+    }
+    if (lower.length === 1) {
+      return lower.toUpperCase()
+    }
+    // F-keys, Enter, Escape, etc.
+    return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+  })
+}
+
+/**
+ * Convert a keyboard event into an Electron accelerator string.
+ * Returns null if the event does not represent a valid hotkey chord.
+ */
+function eventToAccelerator(event: React.KeyboardEvent): string | null {
+  const parts: string[] = []
+
+  if (event.metaKey) {
+    parts.push('CommandOrControl')
+  } else if (event.ctrlKey) {
+    parts.push('CommandOrControl')
+  }
+  if (event.altKey) {
+    parts.push('Alt')
+  }
+  if (event.shiftKey) {
+    parts.push('Shift')
+  }
+
+  const key = event.key
+  const code = event.code
+
+  // Ignore pure modifier presses.
+  if (key === 'Meta' || key === 'Control' || key === 'Alt' || key === 'Shift' || key === 'OS') {
+    return null
+  }
+
+  // Map common keys to Electron accelerator names.
+  let keyPart: string | null = null
+  if (code === 'Space' || key === ' ') {
+    keyPart = 'Space'
+  } else if (code.startsWith('Key')) {
+    keyPart = code.slice(3) // e.g. "KeyA" -> "A"
+  } else if (code.startsWith('Digit')) {
+    keyPart = code.slice(5) // e.g. "Digit1" -> "1"
+  } else if (code.startsWith('F') && /^F\d+$/.test(code)) {
+    keyPart = code // F1-F24
+  } else if (key === 'Enter' || key === 'Return') {
+    keyPart = 'Enter'
+  } else if (key === 'Escape' || key === 'Esc') {
+    keyPart = 'Escape'
+  } else if (key === 'Tab') {
+    keyPart = 'Tab'
+  } else if (key === 'Backspace') {
+    keyPart = 'Backspace'
+  } else if (key === 'Delete') {
+    keyPart = 'Delete'
+  } else if (key === 'ArrowUp') {
+    keyPart = 'Up'
+  } else if (key === 'ArrowDown') {
+    keyPart = 'Down'
+  } else if (key === 'ArrowLeft') {
+    keyPart = 'Left'
+  } else if (key === 'ArrowRight') {
+    keyPart = 'Right'
+  } else if (key.length === 1) {
+    keyPart = key.toUpperCase()
+  }
+
+  if (!keyPart) {
+    return null
+  }
+
+  // A valid global hotkey needs at least one modifier.
+  if (parts.length === 0) {
+    return null
+  }
+
+  parts.push(keyPart)
+  return parts.join('+')
+}
+
+export function GlobalHotkeySetting({
+  value,
+  onChange
+}: GlobalHotkeySettingProps): React.JSX.Element {
+  const [recording, setRecording] = useState(false)
+  const recordButtonRef = useRef<HTMLButtonElement | null>(null)
+
+  const currentAccelerator = value?.trim() ?? ''
+  const hasCustom = currentAccelerator !== ''
+  const effectiveAccelerator = hasCustom ? currentAccelerator : DEFAULT_HOTKEY_ACCELERATOR
+
+  const displayKeys = acceleratorToKeys(effectiveAccelerator)
+
+  useEffect(() => {
+    if (recording) {
+      recordButtonRef.current?.focus()
+    }
+  }, [recording])
+
+  const startRecording = useCallback(() => {
+    setRecording(true)
+  }, [])
+
+  const cancelRecording = useCallback(() => {
+    setRecording(false)
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent): void => {
+      if (!recording) {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          startRecording()
+        }
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      if (event.key === 'Escape') {
+        cancelRecording()
+        return
+      }
+
+      const accelerator = eventToAccelerator(event)
+      if (!accelerator) {
+        return
+      }
+
+      onChange(accelerator)
+      setRecording(false)
+    },
+    [recording, onChange, startRecording, cancelRecording]
+  )
+
+  const clearHotkey = useCallback(() => {
+    onChange('')
+  }, [onChange])
+
+  const resetToDefault = useCallback(() => {
+    onChange(DEFAULT_HOTKEY_ACCELERATOR)
+  }, [onChange])
+
+  const recordingLabel = translate(
+    'auto.components.settings.GlobalHotkeySetting.recording',
+    'Press a key combination (at least one modifier). Escape cancels.'
+  )
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <button
+          ref={recordButtonRef}
+          type="button"
+          aria-label={recording ? recordingLabel : undefined}
+          aria-pressed={recording}
+          onClick={() => {
+            if (!recording) {
+              startRecording()
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          className={cn(
+            'flex min-h-8 min-w-[8rem] items-center justify-center gap-1 rounded-md border px-3 py-1.5 text-sm outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50',
+            recording
+              ? 'border-ring bg-accent text-accent-foreground ring-[3px] ring-ring/30'
+              : 'border-border/70 bg-background hover:bg-accent/50'
+          )}
+        >
+          {recording ? (
+            <span className="text-xs text-muted-foreground">
+              {translate('auto.components.settings.GlobalHotkeySetting.pressKeys', 'Press keys…')}
+            </span>
+          ) : displayKeys.length > 0 ? (
+            <ShortcutKeyCombo keys={displayKeys} />
+          ) : (
+            <span className="text-xs text-muted-foreground">
+              {translate('auto.components.settings.GlobalHotkeySetting.disabled', 'Disabled')}
+            </span>
+          )}
+        </button>
+
+        {hasCustom ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={clearHotkey}
+            title={translate(
+              'auto.components.settings.GlobalHotkeySetting.disable',
+              'Disable global hotkey'
+            )}
+          >
+            <CircleX className="size-4" />
+          </Button>
+        ) : null}
+
+        {!hasCustom && effectiveAccelerator !== DEFAULT_HOTKEY_ACCELERATOR ? (
+          <Button type="button" variant="ghost" size="sm" onClick={resetToDefault}>
+            {translate(
+              'auto.components.settings.GlobalHotkeySetting.resetDefault',
+              'Reset to default'
+            )}
+          </Button>
+        ) : null}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {translate(
+          'auto.components.settings.GlobalHotkeySetting.description',
+          'Press this key combination anywhere to show or hide the Orca window. Default: {{value0}}+Space',
+          { value0: isMac ? '⌥' : 'Alt' }
+        )}
+      </p>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -132,6 +132,23 @@ export const getGeneralNavigationSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.general.search.9f8558233a', 'confirm'),
       ...translateSearchKeyword('auto.components.settings.general.search.afa37a34e1', 'close')
     ]
+  },
+  {
+    title: translate('auto.components.settings.general.search.globalHotkey', 'Global Hotkey'),
+    description: translate(
+      'auto.components.settings.general.search.globalHotkeyDescription',
+      'System-wide keyboard shortcut to show or hide the Orca window.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.hotkey', 'hotkey'),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.globalShortcut',
+        'global shortcut'
+      ),
+      ...translateSearchKeyword('auto.components.settings.general.search.showHide', 'show window'),
+      ...translateSearchKeyword('auto.components.settings.general.search.toggle', 'toggle'),
+      ...translateSearchKeyword('auto.components.settings.general.search.spotlight', 'spotlight')
+    ]
   }
 ])
 

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -3,6 +3,7 @@ import { getGeneralEditorSearchEntries } from './general-editor-search'
 import { translate } from '@/i18n/i18n'
 import { searchKeywords, translateSearchKeyword } from './settings-search-keywords'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+import { isWebClientLocation } from '@/lib/web-client-location'
 import { getGeneralProjectRuntimeSearchEntries } from './general-project-runtime-search'
 import { getGeneralSupportSearchEntries } from './general-support-search'
 
@@ -133,23 +134,35 @@ export const getGeneralNavigationSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.general.search.afa37a34e1', 'close')
     ]
   },
-  {
-    title: translate('auto.components.settings.general.search.globalHotkey', 'Global Hotkey'),
-    description: translate(
-      'auto.components.settings.general.search.globalHotkeyDescription',
-      'System-wide keyboard shortcut to show or hide the Orca window.'
-    ),
-    keywords: [
-      ...translateSearchKeyword('auto.components.settings.general.search.hotkey', 'hotkey'),
-      ...translateSearchKeyword(
-        'auto.components.settings.general.search.globalShortcut',
-        'global shortcut'
-      ),
-      ...translateSearchKeyword('auto.components.settings.general.search.showHide', 'show window'),
-      ...translateSearchKeyword('auto.components.settings.general.search.toggle', 'toggle'),
-      ...translateSearchKeyword('auto.components.settings.general.search.spotlight', 'spotlight')
-    ]
-  }
+  // Why: OS-global hotkeys only exist in the desktop app; hiding the entry on
+  // web clients keeps search from rendering an orphaned Navigation section.
+  ...(isWebClientLocation()
+    ? []
+    : [
+        {
+          title: translate('auto.components.settings.general.search.globalHotkey', 'Global hotkey'),
+          description: translate(
+            'auto.components.settings.general.search.globalHotkeyDescription',
+            'System-wide keyboard shortcut to show or hide the Orca window.'
+          ),
+          keywords: [
+            ...translateSearchKeyword('auto.components.settings.general.search.hotkey', 'hotkey'),
+            ...translateSearchKeyword(
+              'auto.components.settings.general.search.globalShortcut',
+              'global shortcut'
+            ),
+            ...translateSearchKeyword(
+              'auto.components.settings.general.search.showHide',
+              'show window'
+            ),
+            ...translateSearchKeyword('auto.components.settings.general.search.toggle', 'toggle'),
+            ...translateSearchKeyword(
+              'auto.components.settings.general.search.spotlight',
+              'spotlight'
+            )
+          ]
+        }
+      ])
 ])
 
 export const getGeneralCliSearchEntries = createLocalizedCatalog(() => [

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5519,7 +5519,9 @@
           "5cb5475664": "Confirm before closing pinned tabs",
           "36b2a5dc6d": "Show a confirmation dialog before a pinned tab is closed.",
           "projectRuntime": "Project Runtime",
-          "projectRuntimeDescription": "Default runtime for local Windows projects that do not override it."
+          "projectRuntimeDescription": "Default runtime for local Windows projects that do not override it.",
+          "globalHotkey": "Global hotkey",
+          "globalHotkeyDescription": "Show or hide the Orca window from anywhere with a system-wide keyboard shortcut."
         },
         "GeneralSupportSection": {
           "af7d9f4396": "Thanks for the support!",
@@ -7815,7 +7817,9 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
             "e61157e926": "Editor Word Wrap",
-            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling.",
+            "globalHotkey": "Global hotkey",
+            "globalHotkeyDescription": "System-wide keyboard shortcut to show or hide the Orca window."
           }
         },
         "git": {
@@ -9183,6 +9187,13 @@
           "availability": "Available on",
           "testFlight": "TestFlight",
           "androidApk": "Android APK"
+        },
+        "GlobalHotkeySetting": {
+          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "pressKeys": "Press keys…",
+          "clickToRecord": "Click to record",
+          "disable": "Disable global hotkey",
+          "description": "Press this key combination anywhere to show or hide the Orca window."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9193,7 +9193,8 @@
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",
-          "description": "Press this key combination anywhere to show or hide the Orca window."
+          "description": "Press this key combination anywhere to show or hide the Orca window.",
+          "label": "Global hotkey"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9189,7 +9189,7 @@
           "androidApk": "Android APK"
         },
         "GlobalHotkeySetting": {
-          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "recording": "Press a key combination that includes {{value0}}. Escape cancels.",
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5496,7 +5496,9 @@
           "5cb5475664": "Confirmar antes de cerrar pestañas fijadas",
           "36b2a5dc6d": "Muestra un diálogo de confirmación antes de cerrar una pestaña fijada.",
           "projectRuntime": "Runtime del proyecto",
-          "projectRuntimeDescription": "Runtime predeterminado para proyectos locales de Windows que no lo sobrescriben."
+          "projectRuntimeDescription": "Runtime predeterminado para proyectos locales de Windows que no lo sobrescriben.",
+          "globalHotkey": "Global hotkey",
+          "globalHotkeyDescription": "Show or hide the Orca window from anywhere with a system-wide keyboard shortcut."
         },
         "GeneralSupportSection": {
           "af7d9f4396": "¡Gracias por el apoyo!",
@@ -7755,7 +7757,9 @@
             "d2d2d929c0": "Corrector ortográfico de Rich Markdown",
             "4497e2e2bb": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
             "e61157e926": "Ajuste de línea en el editor",
-            "005be5c699": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal."
+            "005be5c699": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal.",
+            "globalHotkey": "Global hotkey",
+            "globalHotkeyDescription": "System-wide keyboard shortcut to show or hide the Orca window."
           }
         },
         "git": {
@@ -9160,6 +9164,13 @@
           "availability": "Disponible en",
           "testFlight": "TestFlight",
           "androidApk": "APK de Android"
+        },
+        "GlobalHotkeySetting": {
+          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "pressKeys": "Press keys…",
+          "clickToRecord": "Click to record",
+          "disable": "Disable global hotkey",
+          "description": "Press this key combination anywhere to show or hide the Orca window."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9166,7 +9166,7 @@
           "androidApk": "APK de Android"
         },
         "GlobalHotkeySetting": {
-          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "recording": "Press a key combination that includes {{value0}}. Escape cancels.",
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9170,7 +9170,8 @@
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",
-          "description": "Press this key combination anywhere to show or hide the Orca window."
+          "description": "Press this key combination anywhere to show or hide the Orca window.",
+          "label": "Global hotkey"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5481,7 +5481,9 @@
           "5cb5475664": "ピン留めしたタブを閉じる前に確認",
           "36b2a5dc6d": "ピン留めしたタブを閉じる前に確認ダイアログを表示します。",
           "projectRuntime": "Project Runtime",
-          "projectRuntimeDescription": "Default runtime for local Windows projects that do not override it."
+          "projectRuntimeDescription": "Default runtime for local Windows projects that do not override it.",
+          "globalHotkey": "Global hotkey",
+          "globalHotkeyDescription": "Show or hide the Orca window from anywhere with a system-wide keyboard shortcut."
         },
         "GeneralSupportSection": {
           "af7d9f4396": "サポートありがとうございます!",
@@ -7777,7 +7779,9 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
             "e61157e926": "エディターのワードラップ",
-            "005be5c699": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。"
+            "005be5c699": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。",
+            "globalHotkey": "Global hotkey",
+            "globalHotkeyDescription": "System-wide keyboard shortcut to show or hide the Orca window."
           }
         },
         "git": {
@@ -9160,6 +9164,13 @@
           "availability": "利用可能:",
           "testFlight": "TestFlight",
           "androidApk": "Android APK"
+        },
+        "GlobalHotkeySetting": {
+          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "pressKeys": "Press keys…",
+          "clickToRecord": "Click to record",
+          "disable": "Disable global hotkey",
+          "description": "Press this key combination anywhere to show or hide the Orca window."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9166,7 +9166,7 @@
           "androidApk": "Android APK"
         },
         "GlobalHotkeySetting": {
-          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "recording": "Press a key combination that includes {{value0}}. Escape cancels.",
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9170,7 +9170,8 @@
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",
-          "description": "Press this key combination anywhere to show or hide the Orca window."
+          "description": "Press this key combination anywhere to show or hide the Orca window.",
+          "label": "Global hotkey"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5481,7 +5481,9 @@
           "5cb5475664": "고정된 탭을 닫기 전에 확인",
           "36b2a5dc6d": "고정된 탭을 닫기 전에 확인 대화상자를 표시합니다.",
           "projectRuntime": "프로젝트 런타임",
-          "projectRuntimeDescription": "별도로 재정의하지 않은 로컬 Windows 프로젝트의 기본 런타임입니다."
+          "projectRuntimeDescription": "별도로 재정의하지 않은 로컬 Windows 프로젝트의 기본 런타임입니다.",
+          "globalHotkey": "Global hotkey",
+          "globalHotkeyDescription": "Show or hide the Orca window from anywhere with a system-wide keyboard shortcut."
         },
         "GeneralSupportSection": {
           "af7d9f4396": "지원해 주셔서 감사합니다!",
@@ -7740,7 +7742,9 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
             "e61157e926": "편집기 자동 줄 바꿈",
-            "005be5c699": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다."
+            "005be5c699": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다.",
+            "globalHotkey": "Global hotkey",
+            "globalHotkeyDescription": "System-wide keyboard shortcut to show or hide the Orca window."
           }
         },
         "git": {
@@ -9160,6 +9164,13 @@
           "availability": "이용 가능:",
           "testFlight": "TestFlight",
           "androidApk": "Android APK"
+        },
+        "GlobalHotkeySetting": {
+          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "pressKeys": "Press keys…",
+          "clickToRecord": "Click to record",
+          "disable": "Disable global hotkey",
+          "description": "Press this key combination anywhere to show or hide the Orca window."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9166,7 +9166,7 @@
           "androidApk": "Android APK"
         },
         "GlobalHotkeySetting": {
-          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "recording": "Press a key combination that includes {{value0}}. Escape cancels.",
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9170,7 +9170,8 @@
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",
-          "description": "Press this key combination anywhere to show or hide the Orca window."
+          "description": "Press this key combination anywhere to show or hide the Orca window.",
+          "label": "Global hotkey"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5481,7 +5481,9 @@
           "5cb5475664": "关闭固定标签页前确认",
           "36b2a5dc6d": "关闭固定标签页前显示确认对话框。",
           "projectRuntime": "项目运行时",
-          "projectRuntimeDescription": "不覆盖此项的本地 Windows 项目的默认运行时。"
+          "projectRuntimeDescription": "不覆盖此项的本地 Windows 项目的默认运行时。",
+          "globalHotkey": "Global hotkey",
+          "globalHotkeyDescription": "Show or hide the Orca window from anywhere with a system-wide keyboard shortcut."
         },
         "GeneralSupportSection": {
           "af7d9f4396": "感谢您的支持！",
@@ -7740,7 +7742,9 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
             "e61157e926": "编辑器自动换行",
-            "005be5c699": "在文件编辑器中自动换行长行，而无需水平滚动。"
+            "005be5c699": "在文件编辑器中自动换行长行，而无需水平滚动。",
+            "globalHotkey": "Global hotkey",
+            "globalHotkeyDescription": "System-wide keyboard shortcut to show or hide the Orca window."
           }
         },
         "git": {
@@ -9160,6 +9164,13 @@
           "availability": "可用平台：",
           "testFlight": "TestFlight",
           "androidApk": "Android APK"
+        },
+        "GlobalHotkeySetting": {
+          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "pressKeys": "Press keys…",
+          "clickToRecord": "Click to record",
+          "disable": "Disable global hotkey",
+          "description": "Press this key combination anywhere to show or hide the Orca window."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9166,7 +9166,7 @@
           "androidApk": "Android APK"
         },
         "GlobalHotkeySetting": {
-          "recording": "Press a key combination (at least one modifier). Escape cancels.",
+          "recording": "Press a key combination that includes {{value0}}. Escape cancels.",
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9170,7 +9170,8 @@
           "pressKeys": "Press keys…",
           "clickToRecord": "Click to record",
           "disable": "Disable global hotkey",
-          "description": "Press this key combination anywhere to show or hide the Orca window."
+          "description": "Press this key combination anywhere to show or hide the Orca window.",
+          "label": "Global hotkey"
         }
       },
       "right": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -287,9 +287,9 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     openAgentTabsInChatByDefault: false,
     experimentalNativeChat: false,
     nativeChatSessionOptions: {},
-    // Why: default global hotkey is Alt+Space (Option+Space on macOS) to
-    // match Spotlight/Raycast/Alfred conventions. Empty string disables it.
-    globalHotkey: process.platform === 'darwin' ? 'Alt+Space' : 'Alt+Space',
+    // Why: opt-in. A non-empty default would grab an OS-wide chord for every
+    // existing install on upgrade (Alt+Space is the Windows window-menu key).
+    globalHotkey: '',
     openInApplications: [...DEFAULT_OPEN_IN_APPLICATIONS],
     rightSidebarOpenByDefault: true,
     showGitIgnoredFiles: true,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -287,6 +287,9 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     openAgentTabsInChatByDefault: false,
     experimentalNativeChat: false,
     nativeChatSessionOptions: {},
+    // Why: default global hotkey is Alt+Space (Option+Space on macOS) to
+    // match Spotlight/Raycast/Alfred conventions. Empty string disables it.
+    globalHotkey: process.platform === 'darwin' ? 'Alt+Space' : 'Alt+Space',
     openInApplications: [...DEFAULT_OPEN_IN_APPLICATIONS],
     rightSidebarOpenByDefault: true,
     showGitIgnoredFiles: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2711,9 +2711,9 @@ export type GlobalSettings = {
   /** Last explicit native-chat model and model-scoped option selections. Live
    * panes still require an applied/dispatched record before showing a value. */
   nativeChatSessionOptions?: PersistedNativeChatSessionOptions
-  /** Global system-wide hotkey to show/hide the Orca window. Uses Electron
-   *  accelerator format (e.g. "Alt+Space" on macOS/Linux, "Alt+Space" on
-   *  Windows). Empty string means no global hotkey is registered. */
+  /** System-wide hotkey that shows/hides the Orca window, in Electron
+   *  accelerator format (e.g. "Alt+Space"). Empty or unset means disabled;
+   *  the feature is opt-in from Settings → General. */
   globalHotkey?: string
   /** Extra launcher rows for the worktree "Open in" submenu. VS Code is always shown first. */
   openInApplications?: OpenInApplication[]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2711,6 +2711,10 @@ export type GlobalSettings = {
   /** Last explicit native-chat model and model-scoped option selections. Live
    * panes still require an applied/dispatched record before showing a value. */
   nativeChatSessionOptions?: PersistedNativeChatSessionOptions
+  /** Global system-wide hotkey to show/hide the Orca window. Uses Electron
+   *  accelerator format (e.g. "Alt+Space" on macOS/Linux, "Alt+Space" on
+   *  Windows). Empty string means no global hotkey is registered. */
+  globalHotkey?: string
   /** Extra launcher rows for the worktree "Open in" submenu. VS Code is always shown first. */
   openInApplications?: OpenInApplication[]
   /** Deprecated: migration/backward-compat only. Use PersistedUIState.rightSidebarOpen. */


### PR DESCRIPTION
Add a configurable system-wide global hotkey (default: Alt+Space / Option+Space) that toggles the Orca main window visibility, similar to Spotlight, Raycast, or Alfred.

- Add globalHotkey setting to GlobalSettings type
- Create GlobalHotkeyManager in main process that registers/unregisters via Electron's globalShortcut API and listens for settings changes
- Wire into app startup (after store init) and will-quit cleanup
- Add sanitization in settings IPC handler
- Add GlobalHotkeySetting component in renderer with key recording UI
- Integrate into GeneralPane settings under Navigation section
- Add search entry for discoverability in settings search

## Summary

Describe the user-visible change.

## Screenshots

- Add screenshots or a screen recording for any new or changed UI behavior.
- If there is no visual change, say `No visual change`.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Summarize the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or verified as a result.
Confirm that the review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and any Electron-specific platform differences touched by this PR.

## Security Audit

Provide a basic security audit summary from your AI coding agent. Call out any input handling, command execution, path handling, auth, secrets, dependency, or IPC risks that were reviewed, plus any follow-up needed.

## Notes

Call out any platform-specific behavior, risks, or follow-up work.

## ELI5

A system-wide hotkey (default Alt/Option+Space) shows or hides the Orca window. Configurable like Spotlight/Raycast for quick access.
