### PR TITLE
Bound git worktree list reads

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -803,6 +803,7 @@ describe('listWorktrees', () => {
     ])
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], {
       cwd: 'C:\\Users\\me\\repo',
+      timeout: 30_000,
       wslDistro: 'Ubuntu'
     })
     expect(translateWslOutputPathsMock).toHaveBeenCalledWith(
@@ -824,7 +825,8 @@ describe('listWorktrees', () => {
     await expect(listWorktrees('/workspace/deleted-repo')).resolves.toEqual([])
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], {
-      cwd: '/workspace/deleted-repo'
+      cwd: '/workspace/deleted-repo',
+      timeout: 30_000
     })
     expect(statMock).toHaveBeenCalledWith('/workspace/deleted-repo')
     expect(warnSpy).toHaveBeenCalledWith(
@@ -846,7 +848,8 @@ describe('listWorktrees', () => {
     await expect(listWorktrees('/private/tmp/orca-issue-1582-test/my-repo')).resolves.toEqual([])
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], {
-      cwd: '/private/tmp/orca-issue-1582-test/my-repo'
+      cwd: '/private/tmp/orca-issue-1582-test/my-repo',
+      timeout: 30_000
     })
     expect(warnSpy).not.toHaveBeenCalled()
     warnSpy.mockRestore()
@@ -997,6 +1000,10 @@ describe('listWorktrees', () => {
     expect(getGitCalls()).toEqual([
       'git worktree list --porcelain -z',
       'git worktree list --porcelain'
+    ])
+    expect(gitExecFileAsyncMock.mock.calls.map(([args, options]) => [args, options])).toEqual([
+      [['worktree', 'list', '--porcelain', '-z'], { cwd: '/repo', timeout: 30_000 }],
+      [['worktree', 'list', '--porcelain'], { cwd: '/repo', timeout: 30_000 }]
     ])
   })
 })

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -268,7 +268,8 @@ branch refs/heads/feature/test
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], {
-      cwd: '/repo'
+      cwd: '/repo',
+      timeout: 30_000
     })
   })
 

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -31,6 +31,7 @@ type SparseWorktreeCreateError = Error & {
 export type GitWorktreeExecOptions = {
   wslDistro?: string
   signal?: AbortSignal
+  timeout?: number
 }
 
 export type AddWorktreeOptions = GitWorktreeExecOptions & {
@@ -67,6 +68,7 @@ type LocalBaseRefRefreshability =
     }
 
 const SPARSE_CHECKOUT_DETECTION_CONCURRENCY = 8
+const GIT_WORKTREE_LIST_TIMEOUT_MS = 30_000
 
 function gitExecOptions(
   cwd: string,
@@ -76,6 +78,18 @@ function gitExecOptions(
     cwd,
     ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
     ...(options.signal ? { signal: options.signal } : {})
+  }
+}
+
+function gitWorktreeListExecOptions(
+  cwd: string,
+  options: GitWorktreeExecOptions = {}
+): { cwd: string; wslDistro?: string; signal?: AbortSignal; timeout: number } {
+  return {
+    ...gitExecOptions(cwd, options),
+    // Why: Windows startup traces show slow `git worktree list` during renderer
+    // death; keep enumeration from becoming an unbounded startup read.
+    timeout: options.timeout ?? GIT_WORKTREE_LIST_TIMEOUT_MS
   }
 }
 
@@ -547,8 +561,7 @@ async function readWorktreeList(
 ): Promise<GitWorktreeInfo[]> {
   try {
     const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain', '-z'], {
-      cwd: repoPath,
-      ...options
+      ...gitWorktreeListExecOptions(repoPath, options)
     })
     return normalizeMainWorktreePath(
       repoPath,
@@ -564,8 +577,7 @@ async function readWorktreeList(
   // Why: `-z` is required to preserve worktree paths containing newlines, but
   // Git <2.36 rejects it. Keep the old parser as a compatibility fallback.
   const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain'], {
-    cwd: repoPath,
-    ...options
+    ...gitWorktreeListExecOptions(repoPath, options)
   })
   return normalizeMainWorktreePath(repoPath, parseWorktreeList(stdout), options)
 }


### PR DESCRIPTION
## Description

Bounds local `git worktree list` reads to 30 seconds for both the NUL-delimited path and the legacy porcelain fallback. If Git hangs or stalls during startup/worktree refresh, Orca now lets the read fail through the existing listWorktrees fallback instead of waiting forever.

## Crash Evidence

- New Windows crash `fd240d89-a877-4cd9-bbf0-1248b9981e58` died shortly after startup.
- The crash-time diagnostics show `git worktree list` on `E:/SZ/javaPro/cgj-xc/flood/flood-manage` starting at `2026-07-01T07:30:32.504Z`, running for `5733 ms`, and finishing about 200 ms before `electron.process_gone` recorded `renderer killed (1)` at `2026-07-01T07:30:38.444Z`.
- The same bundle contains slower worktree spans elsewhere, including `18982 ms`, `15085 ms`, and `14048 ms` worktree operations, so this Windows environment can make worktree enumeration materially slow.
- This is hardening for the startup/worktree-list crash window, not a byte-for-byte reproduction of the renderer kill.

## ELI5

When Orca starts, it asks Git for the list of worktrees. On the crash machine, that question could take several seconds and was the last main-process Git work before the renderer died. This change gives Git a timer for that specific question, so Orca can stop waiting and keep going instead of letting a stuck Git read pile up during startup.

## Tradeoffs

- A machine where `git worktree list` genuinely needs more than 30 seconds may temporarily show no refreshed worktree list for that poll.
- The existing renderer/store behavior already treats transient empty/failed worktree refreshes conservatively, so this prefers a stale/missing refresh over an unbounded startup read.
- Worktree create/remove mutations are not given this timeout; only list reads are bounded.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/remove-worktree.test.ts src/main/git/worktree.test.ts` passed: 72 tests.
- `pnpm run typecheck` passed.