### PR TITLE
Keep terminal auto WebGL off software renderers

### DIFF
--- a/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts
@@ -104,6 +104,37 @@ describe('terminal WebGL auto policy', () => {
     })
   })
 
+  it.each([
+    ['ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)))'],
+    ['ANGLE (Microsoft, Microsoft Basic Render Driver Direct3D11 vs_5_0 ps_5_0)'],
+    ['ANGLE (Microsoft, D3D11 WARP Direct3D11 vs_5_0 ps_5_0)']
+  ])('keeps Windows auto panes on DOM for software renderer %s', (renderer) => {
+    stubNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    stubWebglRendererInfo({ renderer, vendor: 'Google Inc. (Microsoft)' })
+
+    expect(getTerminalWebglAutoDecision()).toEqual({
+      allowWebgl: false,
+      reason: 'non-linux-software-renderer',
+      renderer,
+      vendor: 'Google Inc. (Microsoft)'
+    })
+  })
+
+  it('allows Windows auto panes for identifiable hardware renderers', () => {
+    stubNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    stubWebglRendererInfo({
+      renderer: 'ANGLE (NVIDIA, NVIDIA GeForce RTX 4070 Direct3D11 vs_5_0 ps_5_0)',
+      vendor: 'Google Inc. (NVIDIA)'
+    })
+
+    expect(getTerminalWebglAutoDecision()).toEqual({
+      allowWebgl: true,
+      reason: 'non-linux',
+      renderer: 'ANGLE (NVIDIA, NVIDIA GeForce RTX 4070 Direct3D11 vs_5_0 ps_5_0)',
+      vendor: 'Google Inc. (NVIDIA)'
+    })
+  })
+
   it('allows Linux auto panes for identifiable hardware renderers', () => {
     stubNavigator('Linux x86_64', 'Mozilla/5.0 (X11; Linux x86_64)')
     stubWebglRendererInfo({

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts
@@ -130,6 +130,21 @@ describe('terminal WebGL auto policy', () => {
     })
   })
 
+  it('keeps Windows auto panes on DOM when WebGL2 is unavailable', () => {
+    stubNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    const probe = stubWebglRendererInfo({ hasWebgl2: false })
+
+    expect(getTerminalWebglAutoDecision()).toEqual({
+      allowWebgl: false,
+      reason: 'non-linux-webgl2-unavailable',
+      renderer: null,
+      vendor: null
+    })
+    expect(probe.loseContext).not.toHaveBeenCalled()
+    expect(probe.canvas.width).toBe(0)
+    expect(probe.canvas.height).toBe(0)
+  })
+
   it('allows Windows auto panes for identifiable hardware renderers', () => {
     stubNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
     stubWebglRendererInfo({

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts
@@ -21,18 +21,26 @@ function stubWebglRendererInfo({
   vendor = 'Intel',
   hasWebgl2 = true,
   hasDebugInfo = true
-}: MockWebglRendererInfo): void {
+}: MockWebglRendererInfo): {
+  canvas: { width: number; height: number }
+  loseContext: ReturnType<typeof vi.fn>
+} {
   const rendererKey = 0x9246
   const vendorKey = 0x9245
+  const loseContext = vi.fn()
   const gl = {
-    getExtension: vi.fn(() =>
-      hasDebugInfo
-        ? {
-            UNMASKED_RENDERER_WEBGL: rendererKey,
-            UNMASKED_VENDOR_WEBGL: vendorKey
-          }
-        : null
-    ),
+    getExtension: vi.fn((extensionName: string) => {
+      if (extensionName === 'WEBGL_lose_context') {
+        return { loseContext }
+      }
+      if (extensionName !== 'WEBGL_debug_renderer_info' || !hasDebugInfo) {
+        return null
+      }
+      return {
+        UNMASKED_RENDERER_WEBGL: rendererKey,
+        UNMASKED_VENDOR_WEBGL: vendorKey
+      }
+    }),
     getParameter: vi.fn((key: number) => {
       if (key === rendererKey) {
         return renderer
@@ -43,19 +51,21 @@ function stubWebglRendererInfo({
       return null
     })
   }
+  const canvas = {
+    width: 300,
+    height: 150,
+    getContext: vi.fn((contextName: string) => (hasWebgl2 && contextName === 'webgl2' ? gl : null))
+  }
 
   vi.stubGlobal('document', {
     createElement: vi.fn((tagName: string) => {
       if (tagName === 'canvas') {
-        return {
-          getContext: vi.fn((contextName: string) =>
-            hasWebgl2 && contextName === 'webgl2' ? gl : null
-          )
-        }
+        return canvas
       }
       return {}
     })
   })
+  return { canvas, loseContext }
 }
 
 function stubNoDocument(): void {
@@ -133,6 +143,22 @@ describe('terminal WebGL auto policy', () => {
       renderer: 'ANGLE (NVIDIA, NVIDIA GeForce RTX 4070 Direct3D11 vs_5_0 ps_5_0)',
       vendor: 'Google Inc. (NVIDIA)'
     })
+  })
+
+  it('releases the renderer identity probe context', () => {
+    stubNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    const probe = stubWebglRendererInfo({
+      renderer: 'ANGLE (Microsoft, Microsoft Basic Render Driver Direct3D11 vs_5_0 ps_5_0)',
+      vendor: 'Google Inc. (Microsoft)'
+    })
+
+    expect(getTerminalWebglAutoDecision()).toMatchObject({
+      allowWebgl: false,
+      reason: 'non-linux-software-renderer'
+    })
+    expect(probe.loseContext).toHaveBeenCalledTimes(1)
+    expect(probe.canvas.width).toBe(0)
+    expect(probe.canvas.height).toBe(0)
   })
 
   it('allows Linux auto panes for identifiable hardware renderers', () => {

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.ts
@@ -39,6 +39,23 @@ function readRendererDisplayServer(): 'wayland' | 'x11' | null {
   }
 }
 
+function releaseWebglProbe(
+  canvas: HTMLCanvasElement | null,
+  gl: WebGL2RenderingContext | null
+): void {
+  try {
+    // Why: auto policy only needs renderer identity; keeping the probe context
+    // alive defeats the software-renderer fallback this check is protecting.
+    gl?.getExtension('WEBGL_lose_context')?.loseContext()
+  } catch {
+    /* ignore - renderer probing must stay best-effort */
+  }
+  if (canvas) {
+    canvas.width = 0
+    canvas.height = 0
+  }
+}
+
 function readWebglRendererInfo(): Pick<TerminalWebglAutoDecision, 'renderer' | 'vendor'> & {
   hasWebgl2: boolean
   hasRendererInfo: boolean
@@ -47,9 +64,11 @@ function readWebglRendererInfo(): Pick<TerminalWebglAutoDecision, 'renderer' | '
     return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
   }
 
+  let canvas: HTMLCanvasElement | null = null
+  let gl: WebGL2RenderingContext | null = null
   try {
-    const canvas = document.createElement('canvas')
-    const gl = canvas.getContext('webgl2')
+    canvas = document.createElement('canvas')
+    gl = canvas.getContext('webgl2')
     if (!gl) {
       return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
     }
@@ -69,6 +88,8 @@ function readWebglRendererInfo(): Pick<TerminalWebglAutoDecision, 'renderer' | '
     }
   } catch {
     return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
+  } finally {
+    releaseWebglProbe(canvas, gl)
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.ts
@@ -2,6 +2,7 @@ export type TerminalWebglAutoDecision = {
   allowWebgl: boolean
   reason:
     | 'non-linux'
+    | 'non-linux-software-renderer'
     | 'linux-wayland'
     | 'linux-hardware-renderer'
     | 'linux-webgl2-unavailable'
@@ -13,8 +14,8 @@ export type TerminalWebglAutoDecision = {
 
 let cachedDecision: TerminalWebglAutoDecision | null = null
 
-const LINUX_SOFTWARE_RENDERER_PATTERN =
-  /\b(swiftshader|llvmpipe|softpipe|software rasterizer|software adapter|basic render|virgl|svga3d)\b/i
+const SOFTWARE_RENDERER_PATTERN =
+  /\b(swiftshader|llvmpipe|softpipe|software rasterizer|software adapter|basic render|microsoft basic render(?: driver)?|d3d11 warp|virgl|svga3d)\b/i
 
 export function resetTerminalWebglAutoDecision(): void {
   cachedDecision = null
@@ -77,11 +78,25 @@ export function getTerminalWebglAutoDecision(): TerminalWebglAutoDecision {
   }
 
   if (!isLinuxRendererHost()) {
+    const rendererInfo = readWebglRendererInfo()
+    const identity = `${rendererInfo.vendor ?? ''} ${rendererInfo.renderer ?? ''}`
+    if (rendererInfo.hasRendererInfo && SOFTWARE_RENDERER_PATTERN.test(identity)) {
+      // Why: Windows software rendering fallback disables GPU compositing, but
+      // xterm WebGL can still attach through ANGLE/SwiftShader unless auto
+      // recognizes the software renderer and chooses the DOM renderer.
+      cachedDecision = {
+        allowWebgl: false,
+        reason: 'non-linux-software-renderer',
+        renderer: rendererInfo.renderer,
+        vendor: rendererInfo.vendor
+      }
+      return cachedDecision
+    }
     cachedDecision = {
       allowWebgl: true,
       reason: 'non-linux',
-      renderer: null,
-      vendor: null
+      renderer: rendererInfo.renderer,
+      vendor: rendererInfo.vendor
     }
     return cachedDecision
   }
@@ -122,7 +137,7 @@ export function getTerminalWebglAutoDecision(): TerminalWebglAutoDecision {
   }
 
   const identity = `${rendererInfo.vendor ?? ''} ${rendererInfo.renderer ?? ''}`
-  if (LINUX_SOFTWARE_RENDERER_PATTERN.test(identity)) {
+  if (SOFTWARE_RENDERER_PATTERN.test(identity)) {
     cachedDecision = {
       allowWebgl: false,
       reason: 'linux-software-renderer',

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.ts
@@ -2,6 +2,7 @@ export type TerminalWebglAutoDecision = {
   allowWebgl: boolean
   reason:
     | 'non-linux'
+    | 'non-linux-webgl2-unavailable'
     | 'non-linux-software-renderer'
     | 'linux-wayland'
     | 'linux-hardware-renderer'
@@ -59,9 +60,16 @@ function releaseWebglProbe(
 function readWebglRendererInfo(): Pick<TerminalWebglAutoDecision, 'renderer' | 'vendor'> & {
   hasWebgl2: boolean
   hasRendererInfo: boolean
+  probeAvailable: boolean
 } {
   if (typeof document === 'undefined') {
-    return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
+    return {
+      hasWebgl2: false,
+      hasRendererInfo: false,
+      probeAvailable: false,
+      renderer: null,
+      vendor: null
+    }
   }
 
   let canvas: HTMLCanvasElement | null = null
@@ -70,12 +78,24 @@ function readWebglRendererInfo(): Pick<TerminalWebglAutoDecision, 'renderer' | '
     canvas = document.createElement('canvas')
     gl = canvas.getContext('webgl2')
     if (!gl) {
-      return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
+      return {
+        hasWebgl2: false,
+        hasRendererInfo: false,
+        probeAvailable: true,
+        renderer: null,
+        vendor: null
+      }
     }
 
     const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
     if (!debugInfo) {
-      return { hasWebgl2: true, hasRendererInfo: false, renderer: null, vendor: null }
+      return {
+        hasWebgl2: true,
+        hasRendererInfo: false,
+        probeAvailable: true,
+        renderer: null,
+        vendor: null
+      }
     }
 
     const renderer = String(gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) ?? '')
@@ -83,11 +103,18 @@ function readWebglRendererInfo(): Pick<TerminalWebglAutoDecision, 'renderer' | '
     return {
       hasWebgl2: true,
       hasRendererInfo: renderer.length > 0 || vendor.length > 0,
+      probeAvailable: true,
       renderer: renderer || null,
       vendor: vendor || null
     }
   } catch {
-    return { hasWebgl2: false, hasRendererInfo: false, renderer: null, vendor: null }
+    return {
+      hasWebgl2: false,
+      hasRendererInfo: false,
+      probeAvailable: true,
+      renderer: null,
+      vendor: null
+    }
   } finally {
     releaseWebglProbe(canvas, gl)
   }
@@ -100,6 +127,15 @@ export function getTerminalWebglAutoDecision(): TerminalWebglAutoDecision {
 
   if (!isLinuxRendererHost()) {
     const rendererInfo = readWebglRendererInfo()
+    if (rendererInfo.probeAvailable && !rendererInfo.hasWebgl2) {
+      cachedDecision = {
+        allowWebgl: false,
+        reason: 'non-linux-webgl2-unavailable',
+        renderer: rendererInfo.renderer,
+        vendor: rendererInfo.vendor
+      }
+      return cachedDecision
+    }
     const identity = `${rendererInfo.vendor ?? ''} ${rendererInfo.renderer ?? ''}`
     if (rendererInfo.hasRendererInfo && SOFTWARE_RENDERER_PATTERN.test(identity)) {
       // Why: Windows software rendering fallback disables GPU compositing, but

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -219,7 +219,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalTuiScrollSensitivity: 1,
     terminalTuiScrollSensitivityDefaultedToOne: true,
     // Why: "auto" should use WebGL when supported while keeping DOM fallback
-    // for renderer failures and Linux software/unknown GPU renderers.
+    // for renderer failures, software renderers, and unknown Linux GPUs.
     terminalGpuAcceleration: 'auto',
     // Why 'auto': when the user has picked a known ligature font we want the
     // feature enabled by default, but we never force it if they pick a font


### PR DESCRIPTION
## Description

Keep terminal `auto` WebGL off known software renderers on non-Linux platforms. The existing policy already kept Linux auto panes on DOM for SwiftShader/llvmpipe/software renderers, but Windows/macOS returned `allowWebgl: true` before checking renderer identity. That meant Windows could enter Orca's software-rendering fallback and still have xterm terminals create WebGL contexts through ANGLE/SwiftShader/WARP.

This PR extends the software-renderer check to non-Linux hosts while preserving the existing fast path for hardware or unknown renderers. It also keeps `auto` on DOM when the renderer probe shows WebGL2 is unavailable, and explicitly releases the temporary WebGL renderer-probe context after identity detection, so the safety probe does not keep a software WebGL context alive. Users who explicitly choose terminal GPU acceleration `on` still get the old forced-WebGL behavior.

## Crash Evidence

- `02-renderer-crashed-bbiyakfather` reports a native Windows renderer crash: `crashed (-1073741819)` on Orca `1.4.110` with renderer heap only about `93 MB / 117 MB` near the crash and no renderer JS exception or unhandled rejection in the bundle.
- `04-renderer-killed-mtt-nakasone` reports Windows renderer `killed (1)` on Orca `1.4.111` about a minute after startup with heap about `18 MB / 22 MB`; the trace is native process-gone rather than a JS memory leak.
- Re-audit of the final crash windows did not find a long-running git command immediately before the renderer exits: report 02 is a steady ~3s status/diff cadence at ~40-60ms, and report 04 is quiet for ~30s before process-gone.
- Current code already persists a Windows GPU software fallback marker for GPU child crash bursts, but terminal `auto` skipped renderer probing on every non-Linux host and would still attempt xterm WebGL on software renderers.

## ELI5

When Orca decides the graphics driver is shaky, it can run the app in a safer software graphics mode. But the terminal still said, "I am on Windows, so WebGL is fine," and tried to use the risky path anyway. Now `auto` checks whether WebGL is actually backed by software like SwiftShader or Microsoft Basic Render Driver and uses the safer DOM terminal renderer in that case.

## Tradeoffs

- Some Windows users on software graphics will lose terminal WebGL acceleration in `auto`, which is intentional for stability.
- Hardware Windows renderers still use WebGL in `auto`.
- Explicit `terminalGpuAcceleration: 'on'` remains an override for users who want to force WebGL.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/terminal-webgl-auto-policy.test.ts src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts`
- `pnpm run typecheck`
- `git diff --check` (clean, with Windows line-ending warnings only)
