### PR TITLE
Treat check-ignore no-match as expected

### DIFF
--- a/src/main/git/check-ignored-paths.test.ts
+++ b/src/main/git/check-ignored-paths.test.ts
@@ -30,13 +30,17 @@ describe('checkIgnoredPaths', () => {
         'src/index.ts',
         '.env'
       ],
-      { cwd: '/repo' }
+      { cwd: '/repo', successExitCodes: [1] }
     )
   })
 
-  it('treats exit code 1 as no ignored paths', async () => {
-    gitExecFileAsyncMock.mockRejectedValue(Object.assign(new Error('no matches'), { code: 1 }))
+  it('treats Git exit code 1 as an expected no-ignored-paths result', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
 
     await expect(checkIgnoredPaths('/repo', ['src/index.ts'])).resolves.toEqual([])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['-c', 'core.quotePath=false', 'check-ignore', '--', 'src/index.ts'],
+      { cwd: '/repo', successExitCodes: [1] }
+    )
   })
 })

--- a/src/main/git/check-ignored-paths.ts
+++ b/src/main/git/check-ignored-paths.ts
@@ -4,8 +4,6 @@ import { gitExecFileAsync } from './runner'
 
 const CHECK_IGNORE_CHUNK_SIZE = 100
 
-type GitExecError = Error & { stdout?: string; code?: number | string }
-
 function parseCheckIgnoreOutput(stdout: string): string[] {
   return stdout.split(/\r?\n/).filter(Boolean)
 }
@@ -15,19 +13,16 @@ async function runCheckIgnoreChunk(
   relativePaths: string[],
   options: GitRuntimeOptions = {}
 ): Promise<string[]> {
-  try {
-    const { stdout } = await gitExecFileAsync(
-      ['-c', 'core.quotePath=false', 'check-ignore', '--', ...relativePaths],
-      gitOptionsForWorktree(worktreePath, options)
-    )
-    return parseCheckIgnoreOutput(stdout)
-  } catch (error) {
-    const gitError = error as GitExecError
-    if (gitError.code === 1) {
-      return parseCheckIgnoreOutput(gitError.stdout ?? '')
+  const { stdout } = await gitExecFileAsync(
+    ['-c', 'core.quotePath=false', 'check-ignore', '--', ...relativePaths],
+    {
+      ...gitOptionsForWorktree(worktreePath, options),
+      // Why: Git uses exit 1 for the normal "none of these paths are ignored"
+      // result. Treating it as success avoids hot-path exception churn.
+      successExitCodes: [1]
     }
-    throw error
-  }
+  )
+  return parseCheckIgnoreOutput(stdout)
 }
 
 export async function checkIgnoredPaths(

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -218,6 +218,21 @@ describe('runner execFile timeout handling', () => {
     expect(child.kill).toHaveBeenCalled()
   })
 
+  it('resolves git executions with configured success exit codes', async () => {
+    const child = createMockChildProcess(1234)
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error('no matches'), { code: '1' }), 'ignored.log\n', 'note\n')
+      return child
+    })
+
+    await expect(
+      gitExecFileAsync(['check-ignore', '--', 'src/index.ts'], {
+        cwd: '/repo',
+        successExitCodes: [1]
+      })
+    ).resolves.toEqual({ stdout: 'ignored.log\n', stderr: 'note\n' })
+  })
+
   it('rejects gh executions that never call back using the default timeout', async () => {
     const child = createMockChildProcess(1234)
     execFileMock.mockReturnValue(child)

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -254,6 +254,7 @@ type GitExecOptions = {
   env?: NodeJS.ProcessEnv
   signal?: AbortSignal
   wslDistro?: string
+  successExitCodes?: readonly number[]
   useConfiguredSshCommandForNetwork?: boolean
 }
 
@@ -284,6 +285,28 @@ function shouldRetryWindowsCommandShim(error: unknown, resolved: ResolvedCommand
     !hasPathSeparator(resolved.binary) &&
     !/\.[A-Za-z0-9]+$/.test(resolved.binary)
   )
+}
+
+function exitCodeFromError(error: unknown): number | null {
+  if (!error || typeof error !== 'object') {
+    return null
+  }
+  const code = (error as { code?: unknown }).code
+  if (typeof code === 'number' && Number.isFinite(code)) {
+    return code
+  }
+  if (typeof code === 'string' && /^-?\d+$/.test(code)) {
+    return Number(code)
+  }
+  return null
+}
+
+function isConfiguredSuccessExit(
+  error: unknown,
+  successExitCodes: readonly number[] | undefined
+): boolean {
+  const code = exitCodeFromError(error)
+  return code !== null && successExitCodes?.includes(code) === true
 }
 
 function createAbortError(): Error {
@@ -319,6 +342,29 @@ type ExecFileCaptureOptions = Omit<ExecFileOptions, 'timeout'> & {
 
 function emptyExecFileOutput(options: ExecFileCaptureOptions): string | Buffer {
   return options.encoding === 'buffer' ? Buffer.alloc(0) : ''
+}
+
+function capturedExecErrorOutput(
+  error: unknown,
+  options: ExecFileCaptureOptions
+): { stdout: string | Buffer; stderr: string | Buffer } {
+  if (!error || typeof error !== 'object') {
+    return {
+      stdout: emptyExecFileOutput(options),
+      stderr: emptyExecFileOutput(options)
+    }
+  }
+  const captured = error as { stdout?: unknown; stderr?: unknown }
+  return {
+    stdout:
+      typeof captured.stdout === 'string' || Buffer.isBuffer(captured.stdout)
+        ? captured.stdout
+        : emptyExecFileOutput(options),
+    stderr:
+      typeof captured.stderr === 'string' || Buffer.isBuffer(captured.stderr)
+        ? captured.stderr
+        : emptyExecFileOutput(options)
+  }
 }
 
 function isExecFileResultObject(
@@ -742,19 +788,25 @@ export async function gitExecFileAsync(
         ? await buildNetworkSshPolicyEnv(options)
         : { env: nonInteractiveGitEnv(options.env), mode: 'default' as const }
       let result: { stdout: string | Buffer; stderr: string | Buffer }
+      const execOptions = {
+        cwd: resolved.cwd,
+        encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
+        maxBuffer: options.maxBuffer,
+        timeout: options.timeout,
+        stdin: options.stdin,
+        // Why: never let a git read-path call block on an interactive prompt
+        // (issue #5308) — fail fast instead of hanging the runtime.
+        env: policy.env,
+        signal: options.signal
+      }
       try {
-        result = await execFileCapture(resolved.binary, resolved.args, {
-          cwd: resolved.cwd,
-          encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
-          maxBuffer: options.maxBuffer,
-          timeout: options.timeout,
-          stdin: options.stdin,
-          // Why: never let a git read-path call block on an interactive prompt
-          // (issue #5308) — fail fast instead of hanging the runtime.
-          env: policy.env,
-          signal: options.signal
-        })
+        result = await execFileCapture(resolved.binary, resolved.args, execOptions)
       } catch (error) {
+        if (isConfiguredSuccessExit(error, options.successExitCodes)) {
+          result = capturedExecErrorOutput(error, execOptions)
+          const { stdout, stderr } = result
+          return { stdout: stdout as string, stderr: stderr as string }
+        }
         if (options.useConfiguredSshCommandForNetwork && error && typeof error === 'object') {
           Object.assign(error, { gitSshPolicyMode: policy.mode })
         }


### PR DESCRIPTION
## Description

Treat `git check-ignore` exit code `1` as an expected result for the file-explorer ignore probe instead of throwing through the git runner.

Git uses exit `1` to mean “none of these paths are ignored.” The Windows crash bundles showed this normal no-match case being recorded as repeated failed `git.exec` spans during Source Control/file-explorer refresh, especially in `04-renderer-killed-mtt-nakasone`.

This adds an opt-in `successExitCodes` option to `gitExecFileAsync` and uses it only for `checkIgnoredPaths`, so other git failures keep surfacing normally.

## Evidence

Crash evidence:
- `04-renderer-killed-mtt-nakasone` had 13 `git check-ignore` failure spans around `D:\Maqia-web` / `D:\tmp\paidy-payment-error-logging`; the command text matched Git’s no-match exit-1 shape.
- `02-renderer-crashed-bbiyakfather` also had no-match `check-ignore` failure spans amid the same heavy git refresh loop.
- Local repro probe confirmed Git behavior: `git check-ignore -- src/a.ts` exits `1` when no paths are ignored, while mixed ignored paths exit `0` and print matches.

Validation:
- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/check-ignored-paths.test.ts src/main/git/runner-command-exec.test.ts`
- `pnpm run typecheck`
- `git diff --check HEAD~1 HEAD`

## ELI5

Orca was asking Git, “are any of these files ignored?” Git answered “no” using exit code `1`. That is not actually an error, but Orca’s runner still treated it like one. Now this one question knows that `1` can be a normal answer.

## Tradeoffs

- The new runner option is opt-in; only `checkIgnoredPaths` uses it.
- Real `check-ignore` errors, like a bad repo or unsupported command failure, still throw.
- This reduces exception/span noise and refresh churn; it does not claim to be the exact native renderer crash root cause for reports 02/04.