### PR TITLE
Prioritize renderer recovery scheduling

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2498,6 +2498,38 @@ describe('createMainWindow', () => {
     consoleError.mockRestore()
   })
 
+  it('arms renderer recovery before invoking the crash recorder', () => {
+    vi.useFakeTimers()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const { windowHandlers } = createRendererRecoveryWindowHarness()
+    let recoveryTimerWasArmedBeforeRecorder = false
+
+    try {
+      createMainWindow(null, {
+        onRendererProcessGone: () => {
+          recoveryTimerWasArmedBeforeRecorder = setTimeoutSpy.mock.calls.some(
+            (call) => call[1] === 250
+          )
+        }
+      })
+
+      windowHandlers['render-process-gone']?.(
+        {} as never,
+        {
+          reason: 'crashed',
+          exitCode: 5
+        } as Electron.RenderProcessGoneDetails
+      )
+
+      expect(recoveryTimerWasArmedBeforeRecorder).toBe(true)
+    } finally {
+      setTimeoutSpy.mockRestore()
+      consoleError.mockRestore()
+    }
+  })
+
   it('does not reload after renderer loss when recovery is disabled', () => {
     vi.useFakeTimers()
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -720,6 +720,9 @@ export function createMainWindow(
     resetTerminalInputFocus()
     resetFloatingTerminalInputFocus()
     resetShortcutRecorderFocus()
+    // Why: crash recording captures diagnostics synchronously before its async
+    // write. Arm recovery first so diagnostics cannot postpone the reload timer.
+    scheduleRendererRecovery(details)
     // Why: macOS can report BrowserWindow teardown as renderer `killed`/SIGKILL
     // after a confirmed close; that is window lifecycle noise, not a crash.
     if (
@@ -731,7 +734,6 @@ export function createMainWindow(
     if (!windowClosing) {
       console.error('[window] Renderer process gone; close confirmation will be bypassed', details)
     }
-    scheduleRendererRecovery(details)
   })
   mainWindow.webContents.on('destroyed', () => {
     resetMarkdownEditorFocus()


### PR DESCRIPTION
## Description

Arm the renderer auto-recovery timer before invoking the crash-recorder hook when Electron reports `render-process-gone`.

The crash recorder captures process metrics and trace attributes synchronously before its async write. With the previous ordering, any synchronous work in that path ran before Orca even armed the 250 ms renderer reload timer. This keeps the existing recovery gate/circuit-breaker behavior, but moves timer scheduling ahead of crash reporting so the recovery timer is due as soon as the handler yields.

## Evidence

Crash evidence:
- `04-renderer-killed-mtt-nakasone` recorded `electron.process_gone` at `2026-06-30T23:47:33.835Z`.
- The next renderer bootstrap breadcrumb was not until `2026-06-30T23:49:16.991Z`, about 103 seconds later, even though the recovery code is intended to reload after 250 ms.
- The same report had tiny renderer heap (`18 MB / 22 MB`) and no browser webviews, so the recovery delay itself is one of the few concrete report-specific gaps left to harden.
- In the existing handler, `opts.onRendererProcessGone` ran before `scheduleRendererRecovery(details)`, so crash diagnostic work could delay arming the reload timer.

Validation:
- Added a regression test that verifies the 250 ms recovery timer is already armed when the crash recorder callback runs.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts`
- `pnpm run typecheck`
- `git diff --check HEAD~1 HEAD`

## ELI5

When the app window crashes, Orca should start its “reload the window” timer immediately. Before this change, Orca first did crash-report bookkeeping and only then started the reload timer. Now it starts the reload timer first, then writes down what happened.

## Tradeoffs

- Crash reports are still recorded; only the ordering changes.
- The recovery predicate and crash-loop circuit breaker still run before any reload.
- A fully blocked main event loop can still delay timer execution; this PR removes crash recording as a reason the timer was not armed yet.
- This hardens the delayed-recovery shape seen in report 04, but it does not prove the original native renderer kill source.