### PR TITLE
Back off open-file git status polling

### DIFF
--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
@@ -254,6 +254,26 @@ describe('useGitStatusPolling', () => {
     expect(globalThis.setInterval).toHaveBeenCalledWith(expect.any(Function), 30_000)
   })
 
+  it('uses the slower cadence when an editor file is open without visible git UI', async () => {
+    const { gitStatus } = await usePollingOnce(
+      {
+        entries: [],
+        conflictOperation: 'unknown',
+        head: 'abc123',
+        branch: 'refs/heads/main'
+      },
+      {
+        stateOverrides: {
+          rightSidebarOpen: false,
+          openFiles: [{ id: '/repo/a.ts', worktreeId: worktree.id }]
+        }
+      }
+    )
+
+    expect(gitStatus).toHaveBeenCalledTimes(1)
+    expect(globalThis.setInterval).toHaveBeenCalledWith(expect.any(Function), 30_000)
+  })
+
   it('does not install the visible git status poll while disabled', async () => {
     const { state, gitStatus } = await usePollingOnce(
       {

--- a/src/renderer/src/lib/passive-macos-app-data-access.test.ts
+++ b/src/renderer/src/lib/passive-macos-app-data-access.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { isMacAppDataPath, shouldPollActiveGitStatus } from './passive-macos-app-data-access'
+import {
+  hasInteractiveActiveGitStatusConsumer,
+  isMacAppDataPath,
+  shouldPollActiveGitStatus
+} from './passive-macos-app-data-access'
 import type { ActiveRightSidebarTab, OpenFile } from '@/store/slices/editor'
 
 const MAC = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
@@ -68,6 +72,29 @@ describe('shouldPollActiveGitStatus', () => {
     }
 
     expect(shouldPollActiveGitStatus(pollArgs({ openFiles: [openFile] }))).toBe(true)
+  })
+
+  it('does not treat open editor files as an interactive status consumer', () => {
+    const openFile: OpenFile = {
+      id: 'file-1',
+      worktreeId: 'wt-1',
+      filePath: '/Users/me/dev/repo/a.ts',
+      relativePath: 'a.ts',
+      language: 'typescript',
+      isDirty: false,
+      mode: 'edit'
+    }
+
+    expect(hasInteractiveActiveGitStatusConsumer(pollArgs({ openFiles: [openFile] }))).toBe(false)
+    expect(
+      hasInteractiveActiveGitStatusConsumer(
+        pollArgs({
+          openFiles: [openFile],
+          rightSidebarOpen: true,
+          rightSidebarTab: 'source-control'
+        })
+      )
+    ).toBe(true)
   })
 
   it('treats missing open files as no editor-visible worktree', () => {

--- a/src/renderer/src/lib/passive-macos-app-data-access.ts
+++ b/src/renderer/src/lib/passive-macos-app-data-access.ts
@@ -30,6 +30,10 @@ export type ActiveGitStatusPollingArgs = {
   userAgent?: string
 }
 
+function hasOpenFileInActiveWorktree(args: ActiveGitStatusPollingArgs): boolean {
+  return (args.openFiles ?? []).some((file) => file.worktreeId === args.activeWorktreeId)
+}
+
 export function hasInteractiveActiveGitStatusConsumer(args: ActiveGitStatusPollingArgs): boolean {
   if (!args.activeWorktreeId || !args.worktreePath) {
     return false
@@ -42,9 +46,6 @@ export function hasInteractiveActiveGitStatusConsumer(args: ActiveGitStatusPolli
   ) {
     return true
   }
-  if ((args.openFiles ?? []).some((file) => file.worktreeId === args.activeWorktreeId)) {
-    return true
-  }
   return false
 }
 
@@ -53,6 +54,9 @@ export function shouldPollActiveGitStatus(args: ActiveGitStatusPollingArgs): boo
     return false
   }
   if (hasInteractiveActiveGitStatusConsumer(args)) {
+    return true
+  }
+  if (hasOpenFileInActiveWorktree(args)) {
     return true
   }
   // Why: macOS app-container paths can trigger the "data from other apps"


### PR DESCRIPTION
## Description

Back off the active Git status polling cadence when the only interactive signal is an open editor file in the active worktree.

Open files still keep Git status polling enabled, including for macOS app-container paths where terminal-only passive polling is intentionally suppressed. They just no longer upgrade the poller to the hottest 3-second cadence unless Source Control, file Explorer, or Checks are actually visible.

## Evidence

Crash report `02-renderer-crashed-bbiyakfather` (`fea918b3-0c10-450d-a4f2-0af121adb7df`) ended with a Windows renderer native crash:

- App `1.4.110`, Windows `10.0.26200`, renderer `crashed (-1073741819)`.
- Renderer heap stayed modest near the crash: about `93 MB` used / `117 MB` total, so this did not look like a normal renderer JS leak.
- The submitted crash window was dominated by active-worktree Git polling: `2453` `diff` spans and `2436` `status` spans before the crash.
- The final seconds show the exact hot cadence this code controls: `git status` + `git diff` for `C:\Users\eicic.AIDEN-DESKTOP\Documents\Claude\Projects\kier-smk` every roughly 3 seconds up to `2026-06-30T12:48:51.979Z`, immediately before the native renderer crash at `2026-06-30T12:48:52.340Z`.

This does not claim a byte-for-byte native crash reproduction, because the original Windows repos and native crash stack are unavailable. It removes one concrete pressure source that matches the trace: open-editor-only sessions no longer keep status/diff polling at the fastest cadence.

Validation run locally on Windows:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/passive-macos-app-data-access.test.ts src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts`
- `pnpm run typecheck`
- Pre-commit hooks: `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --write`

## ELI5

If a file was open, Orca treated that like the Git sidebar was being watched and kept asking Git for status every 3 seconds. The crash log shows that kind of repeated status/diff work right before the renderer died. Now an open file still lets Orca check Git, but it uses the slower background rhythm unless the Git UI is actually visible.

## Tradeoffs

- Open-file-only sessions may notice branch/status changes via the fallback poll more slowly when neither file-watch nor terminal command-finished signals fire.
- Visible Source Control, Explorer file view, and Checks keep the fast cadence, so the interactive Git UI should stay responsive.
- SSH behavior remains guarded by the existing connection readiness checks; this change only adjusts the cadence decision.