### PR TITLE
Normalize e2e repo path matching

### DIFF
--- a/tests/e2e/git-no-upstream-polling-churn.spec.ts
+++ b/tests/e2e/git-no-upstream-polling-churn.spec.ts
@@ -2,6 +2,11 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from 'node:fs'
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
+import {
+  findPrimaryWorktreeSnapshot,
+  findRepoSnapshotByRuntimePath,
+  formatRepoPathSnapshots
+} from './helpers/e2e-runtime-path-matching'
 
 // Repro command:
 //   SKIP_BUILD=1 pnpm exec playwright test tests/e2e/git-no-upstream-polling-churn.spec.ts --config tests/playwright.config.ts --project electron-headless --reporter=json
@@ -55,35 +60,58 @@ async function selectRepoForActivePolling(
   repoPath: string,
   worktreePath: string
 ): Promise<void> {
+  const repoCandidates = await page.evaluate(async () => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Expected e2e store to be exposed')
+    }
+
+    await store.getState().fetchRepos()
+    return store.getState().repos.map((repo) => ({ id: repo.id, path: repo.path }))
+  })
+  const repo = findRepoSnapshotByRuntimePath(repoCandidates, repoPath)
+  if (!repo) {
+    throw new Error(
+      `Expected repo to be loaded: ${repoPath}; candidates: ${formatRepoPathSnapshots(
+        repoCandidates
+      )}`
+    )
+  }
+
+  const worktreeCandidates = await page.evaluate(async (repoId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Expected e2e store to be exposed')
+    }
+
+    await store.getState().fetchWorktrees(repoId)
+    return (store.getState().worktreesByRepo[repoId] ?? []).map((worktree) => ({
+      id: worktree.id,
+      path: worktree.path
+    }))
+  }, repo.id)
+  const worktree = findPrimaryWorktreeSnapshot(worktreeCandidates, worktreePath)
+  if (!worktree) {
+    throw new Error(
+      `Expected active-polling worktree to exist: ${worktreePath}; saw ${worktreeCandidates
+        .map((candidate) => candidate.path)
+        .join(', ')}`
+    )
+  }
+
   await page.evaluate(
-    async ({ targetRepoPath, targetWorktreePath }) => {
+    ({ worktreeId }) => {
       const store = window.__store
       if (!store) {
         throw new Error('Expected e2e store to be exposed')
       }
 
-      let state = store.getState()
-      const repo = state.repos.find((candidate) => candidate.path === targetRepoPath)
-      if (!repo) {
-        throw new Error(`Expected repo to be loaded: ${targetRepoPath}`)
-      }
-      await state.fetchWorktrees(repo.id)
-
-      state = store.getState()
-      const worktrees = Object.values(state.worktreesByRepo).flat()
-      const worktree = worktrees.find((candidate) => candidate.path === targetWorktreePath)
-      if (!worktree) {
-        throw new Error(
-          `Expected active-polling worktree to exist: ${targetWorktreePath}; saw ${worktrees
-            .map((candidate) => candidate.path)
-            .join(', ')}`
-        )
-      }
-      state.setActiveWorktree(worktree.id)
+      const state = store.getState()
+      state.setActiveWorktree(worktreeId)
       state.setRightSidebarOpen(true)
       state.setRightSidebarTab('source-control')
     },
-    { targetRepoPath: repoPath, targetWorktreePath: worktreePath }
+    { worktreeId: worktree.id }
   )
 }
 

--- a/tests/e2e/helpers/e2e-runtime-path-matching.ts
+++ b/tests/e2e/helpers/e2e-runtime-path-matching.ts
@@ -1,0 +1,40 @@
+import {
+  isPathInsideOrEqual,
+  normalizeRuntimePathForComparison
+} from '../../../src/shared/cross-platform-path'
+
+type RepoPathSnapshot = {
+  id: string
+  path: string
+}
+
+type WorktreePathSnapshot = {
+  id: string
+  path: string
+}
+
+export function findRepoSnapshotByRuntimePath(
+  repos: readonly RepoPathSnapshot[],
+  repoPath: string
+): RepoPathSnapshot | undefined {
+  const expectedPath = normalizeRuntimePathForComparison(repoPath)
+  return repos.find((repo) => normalizeRuntimePathForComparison(repo.path) === expectedPath)
+}
+
+export function findPrimaryWorktreeSnapshot(
+  worktrees: readonly WorktreePathSnapshot[],
+  repoPath: string
+): WorktreePathSnapshot | undefined {
+  return worktrees.find(
+    (worktree) =>
+      normalizeRuntimePathForComparison(worktree.path) ===
+        normalizeRuntimePathForComparison(repoPath) || isPathInsideOrEqual(repoPath, worktree.path)
+  )
+}
+
+export function formatRepoPathSnapshots(repos: readonly RepoPathSnapshot[]): string {
+  if (repos.length === 0) {
+    return 'none'
+  }
+  return repos.map((repo) => `${repo.id}:${repo.path}`).join(', ')
+}

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -21,23 +21,19 @@ import {
   type ElectronApplication,
   type TestInfo
 } from '@stablyai/playwright-test'
-import {
-  existsSync,
-  mkdtempSync,
-  mkdirSync,
-  readFileSync,
-  realpathSync,
-  rmSync,
-  writeFileSync
-} from 'node:fs'
-import { execSync } from 'node:child_process'
-import { randomUUID } from 'node:crypto'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { TEST_REPO_PATH_FILE } from '../global-setup'
+import {
+  findPrimaryWorktreeSnapshot,
+  findRepoSnapshotByRuntimePath,
+  formatRepoPathSnapshots
+} from './e2e-runtime-path-matching'
 import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
 import { getOrcaElectronLaunchArgs } from './electron-launch-args'
 import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
+import { createSeededTestRepo, isValidGitRepo } from './seeded-e2e-git-repo'
 
 type OrcaTestFixtures = {
   electronApp: ElectronApplication
@@ -120,62 +116,6 @@ function forwardElectronProcessLogs(app: ElectronApplication, testInfo: TestInfo
   child.on('exit', (code, signal) => {
     console.log(`${prefix} exit: code=${code ?? 'null'} signal=${signal ?? 'null'}`)
   })
-}
-
-function isValidGitRepo(repoPath: string): boolean {
-  if (!repoPath || !existsSync(repoPath)) {
-    return false
-  }
-
-  try {
-    return (
-      execSync('git rev-parse --is-inside-work-tree', {
-        cwd: repoPath,
-        stdio: 'pipe',
-        encoding: 'utf8'
-      }).trim() === 'true'
-    )
-  } catch {
-    return false
-  }
-}
-
-function createSeededTestRepo(): string {
-  // Why: realpathSync so the seeded path matches the store's repo.path on
-  // macOS, where os.tmpdir() (/var/...) symlinks to /private/var/... and the
-  // app canonicalizes repo.path via `git rev-parse --show-toplevel` on add.
-  const testRepoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-repo-')))
-
-  execSync('git init', { cwd: testRepoDir, stdio: 'pipe' })
-  execSync('git config user.email "e2e@test.local"', { cwd: testRepoDir, stdio: 'pipe' })
-  execSync('git config user.name "E2E Test"', { cwd: testRepoDir, stdio: 'pipe' })
-
-  writeFileSync(
-    path.join(testRepoDir, 'README.md'),
-    '# Orca E2E Test Repo\n\nThis repo was created automatically for Playwright tests.\n'
-  )
-  writeFileSync(path.join(testRepoDir, 'CLAUDE.md'), '# CLAUDE.md\n\nTest instructions for E2E.\n')
-  writeFileSync(
-    path.join(testRepoDir, 'package.json'),
-    `${JSON.stringify({ name: 'orca-e2e-test', version: '0.0.0', private: true }, null, 2)}\n`
-  )
-  writeFileSync(path.join(testRepoDir, '.gitignore'), 'node_modules/\n')
-  mkdirSync(path.join(testRepoDir, 'src'), { recursive: true })
-  writeFileSync(path.join(testRepoDir, 'src', 'index.ts'), 'export const hello = "world"\n')
-
-  execSync('git add -A', { cwd: testRepoDir, stdio: 'pipe' })
-  execSync('git commit -m "Initial commit for E2E tests"', { cwd: testRepoDir, stdio: 'pipe' })
-
-  // Why: worker-scoped fixture fallbacks can run in parallel; UUIDs avoid
-  // colliding on the same temp repo/worktree when workers start together.
-  const worktreeDir = path.join(testRepoDir, '..', `orca-e2e-worktree-${randomUUID()}`)
-  execSync(`git worktree add "${worktreeDir}" -b e2e-secondary`, {
-    cwd: testRepoDir,
-    stdio: 'pipe'
-  })
-
-  writeFileSync(TEST_REPO_PATH_FILE, testRepoDir)
-  return testRepoDir
 }
 
 /**
@@ -315,35 +255,44 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     }, repoPath)
 
     // Fetch repos in the renderer store so it picks up the new repo
-    await page.evaluate(async (repoPath) => {
+    const repoCandidates = await page.evaluate(async () => {
       const store = window.__store
       if (!store) {
-        return
+        return []
       }
 
       await store.getState().fetchRepos()
-      const repo = store.getState().repos.find((candidate) => candidate.path === repoPath)
-      if (!repo) {
-        throw new Error(`Expected e2e repo to be loaded: ${repoPath}`)
+      return store.getState().repos.map((repo) => ({ id: repo.id, path: repo.path }))
+    })
+    const repo = findRepoSnapshotByRuntimePath(repoCandidates, repoPath)
+    if (!repo) {
+      throw new Error(
+        `Expected e2e repo to be loaded: ${repoPath}; candidates: ${formatRepoPathSnapshots(
+          repoCandidates
+        )}`
+      )
+    }
+
+    // Why: the fixture deliberately creates external Git worktrees. New
+    // repos hide those by default after the visibility rollout, so opt this
+    // disposable repo into showing them before specs assert on worktree state.
+    await page.evaluate(async (repoId) => {
+      const store = window.__store
+      if (!store) {
+        return
       }
-      // Why: the fixture deliberately creates external Git worktrees. New
-      // repos hide those by default after the visibility rollout, so opt this
-      // disposable repo into showing them before specs assert on worktree state.
-      await store.getState().updateRepo(repo.id, { externalWorktreeVisibility: 'show' })
-    }, repoPath)
+      await store.getState().updateRepo(repoId, { externalWorktreeVisibility: 'show' })
+    }, repo.id)
 
     // Wait for the repo to appear and fetch its worktrees
-    await page.evaluate(async () => {
+    await page.evaluate(async (repoId) => {
       const store = window.__store
       if (!store) {
         return
       }
 
-      const repos = store.getState().repos
-      for (const repo of repos) {
-        await store.getState().fetchWorktrees(repo.id)
-      }
-    })
+      await store.getState().fetchWorktrees(repoId)
+    }, repo.id)
 
     // Why: parallel specs mutate real git worktrees in the shared fixture repo.
     // A first scan can briefly return no rows while git holds a worktree lock,
@@ -351,18 +300,14 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     await playwrightExpect
       .poll(
         () =>
-          page.evaluate(async (repoPath) => {
+          page.evaluate(async (repoId) => {
             const store = window.__store
             if (!store) {
               return 0
             }
-            const repo = store.getState().repos.find((candidate) => candidate.path === repoPath)
-            if (!repo) {
-              return 0
-            }
-            await store.getState().fetchWorktrees(repo.id)
-            return store.getState().worktreesByRepo[repo.id]?.length ?? 0
-          }, repoPath),
+            await store.getState().fetchWorktrees(repoId)
+            return store.getState().worktreesByRepo[repoId]?.length ?? 0
+          }, repo.id),
         {
           timeout: 30_000,
           message: 'seeded e2e worktrees did not load'
@@ -384,21 +329,24 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     // Why: workspaceSessionReady restoration can overwrite activeWorktreeId
     // after earlier setup calls. Selecting it here ensures every test starts on
     // the seeded repo instead of the "Select a worktree" empty state.
-    await page.evaluate((repoPath: string) => {
+    const worktreeCandidates = await page.evaluate((repoId) => {
       const store = window.__store
       if (!store) {
-        return
+        return []
       }
 
       const state = store.getState()
-      const allWorktrees = Object.values(state.worktreesByRepo).flat()
-      const testWorktree = allWorktrees.find(
-        (worktree) => worktree.path === repoPath || worktree.path.startsWith(repoPath)
-      )
-      if (testWorktree) {
-        state.setActiveWorktree(testWorktree.id)
-      }
-    }, repoPath)
+      return (state.worktreesByRepo[repoId] ?? []).map((worktree) => ({
+        id: worktree.id,
+        path: worktree.path
+      }))
+    }, repo.id)
+    const testWorktree = findPrimaryWorktreeSnapshot(worktreeCandidates, repoPath)
+    if (testWorktree) {
+      await page.evaluate((worktreeId) => {
+        window.__store?.getState().setActiveWorktree(worktreeId)
+      }, testWorktree.id)
+    }
 
     // Best-effort seed of a baseline terminal tab when a fresh isolated
     // profile has none yet.

--- a/tests/e2e/helpers/seeded-e2e-git-repo.ts
+++ b/tests/e2e/helpers/seeded-e2e-git-repo.ts
@@ -1,0 +1,62 @@
+import { execSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { TEST_REPO_PATH_FILE } from '../global-setup'
+
+export function isValidGitRepo(repoPath: string): boolean {
+  if (!repoPath || !existsSync(repoPath)) {
+    return false
+  }
+
+  try {
+    return (
+      execSync('git rev-parse --is-inside-work-tree', {
+        cwd: repoPath,
+        stdio: 'pipe',
+        encoding: 'utf8'
+      }).trim() === 'true'
+    )
+  } catch {
+    return false
+  }
+}
+
+export function createSeededTestRepo(): string {
+  // Why: realpathSync so the seeded path matches the store's repo.path on
+  // macOS, where os.tmpdir() (/var/...) symlinks to /private/var/... and the
+  // app canonicalizes repo.path via `git rev-parse --show-toplevel` on add.
+  const testRepoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-repo-')))
+
+  execSync('git init', { cwd: testRepoDir, stdio: 'pipe' })
+  execSync('git config user.email "e2e@test.local"', { cwd: testRepoDir, stdio: 'pipe' })
+  execSync('git config user.name "E2E Test"', { cwd: testRepoDir, stdio: 'pipe' })
+
+  writeFileSync(
+    path.join(testRepoDir, 'README.md'),
+    '# Orca E2E Test Repo\n\nThis repo was created automatically for Playwright tests.\n'
+  )
+  writeFileSync(path.join(testRepoDir, 'CLAUDE.md'), '# CLAUDE.md\n\nTest instructions for E2E.\n')
+  writeFileSync(
+    path.join(testRepoDir, 'package.json'),
+    `${JSON.stringify({ name: 'orca-e2e-test', version: '0.0.0', private: true }, null, 2)}\n`
+  )
+  writeFileSync(path.join(testRepoDir, '.gitignore'), 'node_modules/\n')
+  mkdirSync(path.join(testRepoDir, 'src'), { recursive: true })
+  writeFileSync(path.join(testRepoDir, 'src', 'index.ts'), 'export const hello = "world"\n')
+
+  execSync('git add -A', { cwd: testRepoDir, stdio: 'pipe' })
+  execSync('git commit -m "Initial commit for E2E tests"', { cwd: testRepoDir, stdio: 'pipe' })
+
+  // Why: worker-scoped fixture fallbacks can run in parallel; UUIDs avoid
+  // colliding on the same temp repo/worktree when workers start together.
+  const worktreeDir = path.join(testRepoDir, '..', `orca-e2e-worktree-${randomUUID()}`)
+  execSync(`git worktree add "${worktreeDir}" -b e2e-secondary`, {
+    cwd: testRepoDir,
+    stdio: 'pipe'
+  })
+
+  writeFileSync(TEST_REPO_PATH_FILE, testRepoDir)
+  return testRepoDir
+}


### PR DESCRIPTION
﻿## Description

- Normalize e2e repo/worktree path matching through the shared runtime path comparison helpers instead of strict string equality.
- Move seeded e2e git repo creation out of the oversized Playwright fixture into a concrete `seeded-e2e-git-repo` module.
- Move repo/worktree path snapshot matching into `e2e-runtime-path-matching` so the fixture stays under max-lines without disabling lint.
- Apply the same normalized matching to the no-upstream polling churn repro so that Windows path spelling differences do not block that crash-adjacent smoke.

## Evidence

Crash-pass context: while validating Windows renderer crash work, the worktree lifecycle smoke was blocked before it could exercise worktree switching because the fixture could not find the repo it had just added on Windows:

```text
Expected e2e repo to be loaded: C:\Users\neil\AppData\Local\Temp\orca-e2e-repo-...
```

The no-upstream polling churn repro hit the same Windows path identity blocker inside the spec itself:

```text
Expected repo to be loaded: C:\Users\neil\AppData\Local\Temp\orca-e2e-repo-...
```

Before this change, those focused smokes failed during setup. After this change, both reach their actual assertions and pass.

Validation run on Windows:

```text
pnpm exec oxlint tests/e2e/helpers/orca-app.ts tests/e2e/helpers/e2e-runtime-path-matching.ts tests/e2e/helpers/seeded-e2e-git-repo.ts
pnpm exec oxlint tests/e2e/git-no-upstream-polling-churn.spec.ts tests/e2e/helpers/e2e-runtime-path-matching.ts
pnpm exec oxfmt --check tests/e2e/helpers/orca-app.ts tests/e2e/helpers/e2e-runtime-path-matching.ts tests/e2e/helpers/seeded-e2e-git-repo.ts
pnpm exec oxfmt --check tests/e2e/git-no-upstream-polling-churn.spec.ts tests/e2e/helpers/e2e-runtime-path-matching.ts
pnpm run typecheck
SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 npx playwright test tests/e2e/worktree-lifecycle.spec.ts --grep 'switching worktrees preserves per-worktree state' --config tests/playwright.config.ts --project electron-headless --workers=1
SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 npx playwright test tests/e2e/git-no-upstream-polling-churn.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1
```

Result: typecheck/lint/format passed; both focused e2e smokes passed with Electron exit code 0.

## ELI5

The tests were comparing two Windows paths like they had to be typed exactly the same way. Windows paths can still point to the same folder when their slashes or capitalization differ, so the tests sometimes could not recognize their own temporary repo. This teaches the tests to compare paths the same way Orca does.

## Tradeoffs

- This is test/repro infrastructure, not a direct renderer crash fix.
- The fixture and no-upstream repro now do a tiny bit more work outside the renderer by collecting repo/worktree snapshots and selecting IDs in Node. That makes the path comparison consistent and keeps renderer `page.evaluate` calls simpler.
