### PR TITLE
Fail e2e on abnormal Electron shutdown

### DIFF
--- a/tests/e2e/helpers/electron-process-shutdown.ts
+++ b/tests/e2e/helpers/electron-process-shutdown.ts
@@ -44,6 +44,18 @@ function waitForExit(proc: ChildProcess, timeoutMs: number): Promise<boolean> {
   })
 }
 
+function describeAbnormalExit(proc: ChildProcess): string | null {
+  if (proc.exitCode === null && proc.signalCode === null) {
+    return null
+  }
+  if (proc.exitCode === 0 && proc.signalCode === null) {
+    return null
+  }
+  return `Electron app exited abnormally during e2e shutdown: code=${String(
+    proc.exitCode
+  )} signal=${String(proc.signalCode)}`
+}
+
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timeout: NodeJS.Timeout | null = null
   try {
@@ -146,11 +158,20 @@ export async function closeElectronAppForE2E(app: ElectronApplication): Promise<
       const exited = await waitForExit(proc, PROCESS_EXIT_TIMEOUT_MS)
       if (!exited) {
         await forceKillProcessTree(proc)
+        return
+      }
+      const abnormalExit = describeAbnormalExit(proc)
+      if (abnormalExit) {
+        throw new Error(abnormalExit)
       }
     }
-  } catch {
+  } catch (error) {
+    const abnormalExit = proc ? describeAbnormalExit(proc) : null
     if (proc) {
       await forceKillProcessTree(proc)
+    }
+    if (abnormalExit) {
+      throw new Error(abnormalExit, { cause: error })
     }
   }
 }

--- a/tests/e2e/helpers/electron-process-shutdown.unit.test.ts
+++ b/tests/e2e/helpers/electron-process-shutdown.unit.test.ts
@@ -1,0 +1,66 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { describe, expect, it, vi } from 'vitest'
+import { closeElectronAppForE2E } from './electron-process-shutdown'
+
+class FakeElectronProcess extends EventEmitter {
+  exitCode: number | null = null
+  signalCode: NodeJS.Signals | null = null
+  pid?: number
+}
+
+function createApp(proc: FakeElectronProcess, close: () => Promise<void>): ElectronApplication {
+  return {
+    close,
+    process: () => proc as unknown as ChildProcess
+  } as unknown as ElectronApplication
+}
+
+describe('closeElectronAppForE2E', () => {
+  it('allows a clean Electron shutdown', async () => {
+    const proc = new FakeElectronProcess()
+    const app = createApp(proc, async () => {
+      proc.exitCode = 0
+      proc.emit('exit', 0, null)
+    })
+
+    await expect(closeElectronAppForE2E(app)).resolves.toBeUndefined()
+  })
+
+  it('fails when Electron reports a native crash exit code during shutdown', async () => {
+    const proc = new FakeElectronProcess()
+    const app = createApp(proc, async () => {
+      proc.exitCode = 3221225477
+      proc.emit('exit', 3221225477, null)
+    })
+
+    await expect(closeElectronAppForE2E(app)).rejects.toThrow(
+      'Electron app exited abnormally during e2e shutdown: code=3221225477 signal=null'
+    )
+  })
+
+  it('fails when Electron reports a signal during shutdown', async () => {
+    const proc = new FakeElectronProcess()
+    const app = createApp(proc, async () => {
+      proc.signalCode = 'SIGSEGV'
+      proc.emit('exit', null, 'SIGSEGV')
+    })
+
+    await expect(closeElectronAppForE2E(app)).rejects.toThrow(
+      'Electron app exited abnormally during e2e shutdown: code=null signal=SIGSEGV'
+    )
+  })
+
+  it('preserves existing cleanup tolerance when close itself fails first', async () => {
+    const proc = new FakeElectronProcess()
+    const app = createApp(
+      proc,
+      vi.fn(async () => {
+        throw new Error('close failed')
+      })
+    )
+
+    await expect(closeElectronAppForE2E(app)).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
﻿## Description

- Make the shared Electron e2e shutdown helper fail when Electron has already exited with a non-zero code or signal.
- Keep the existing cleanup tolerance for close failures/timeouts where the process is still alive and the helper needs to force-kill it.
- Add unit coverage for clean shutdown, Windows native crash exit code `3221225477` (`0xC0000005`), signal exits, and the existing close-failure cleanup tolerance.

## Evidence

Crash-pass context: while restoring the Windows worktree-switch smoke, one local run had passing Playwright assertions but forwarded this Electron process exit:

```text
exit: code=3221225477 signal=null
```

That unsigned Windows value is the same access-violation status family as the original renderer crash code `-1073741819` (`0xC0000005`). The exit did not reproduce in the next four smoke runs and left no recent Application Error / Windows Error Reporting event, so this PR does not claim a product crash root cause. It does fix the test blind spot: an abnormal Electron exit during e2e shutdown should fail the run instead of only appearing in forwarded logs.

Validation run on Windows:

```text
pnpm exec vitest run --config config/vitest.config.ts tests/e2e/helpers/electron-process-shutdown.unit.test.ts
pnpm exec oxlint tests/e2e/helpers/electron-process-shutdown.ts tests/e2e/helpers/electron-process-shutdown.unit.test.ts
pnpm exec oxfmt --check tests/e2e/helpers/electron-process-shutdown.ts tests/e2e/helpers/electron-process-shutdown.unit.test.ts
pnpm run typecheck
```

Result: all passed.

## ELI5

If the app crashes right as a test is closing it, the test should not smile and say everything passed. This makes the test notice that bad exit code and fail loudly.

## Tradeoffs

- A real abnormal Electron shutdown will now fail e2e teardown, so this can expose existing native shutdown flakiness that was previously hidden.
- Forced cleanup after a close timeout is still tolerated to avoid turning already-known teardown cleanup races into a broader behavior change.
