### PR TITLE
Place terminal URL tooltip at pane corner

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.test.ts
@@ -57,6 +57,22 @@ afterEach(() => {
 })
 
 describe('createPaneDOM link tooltips', () => {
+  it('anchors WebLinks hover text to the unpadded terminal window corner', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
+    const pane = createPaneDOM(
+      1,
+      leafId,
+      {},
+      { active: null } as never,
+      {} as never,
+      vi.fn(),
+      vi.fn()
+    )
+
+    expect(pane.linkTooltip.style.left).toBe('0px')
+    expect(pane.linkTooltip.style.bottom).toBe('0px')
+  })
+
   it('uses desktop modifier-click text for WebLinks hover hints', () => {
     const leafId = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
 

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -66,8 +66,10 @@ export function createPaneDOM(
   const linkTooltip = document.createElement('div')
   linkTooltip.className = 'pane-link-tooltip'
   linkTooltip.classList.add('xterm-hover')
+  // Why: Ghostty-style URL hover belongs to the terminal window corner; do not
+  // let terminal content padding shift it inward.
   linkTooltip.style.cssText =
-    'display:none;position:absolute;bottom:4px;left:8px;z-index:40;' +
+    'display:none;position:absolute;bottom:0;left:0;z-index:40;' +
     'padding:5px 8px;border-radius:4px;font-size:11px;font-family:inherit;' +
     'color:#a1a1aa;background:rgba(24,24,27,0.85);border:1px solid rgba(63,63,70,0.6);' +
     'pointer-events:none;max-width:80%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;'

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -444,14 +444,32 @@ describe('openTerminal — Unicode 11 ordering', () => {
       }
     }
 
-    const fakeContainer = {
+    const fakePaneContainer = {
       appendChild: vi.fn(),
       addEventListener: vi.fn()
     } as unknown as HTMLDivElement
+    const fakeXtermContainer = {
+      appendChild: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    } as unknown as HTMLDivElement
     const fakeTooltip = {} as unknown as HTMLDivElement
+    const fakeTerminalElement = {
+      appendChild: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      querySelector: vi.fn(() => null),
+      classList: { contains: vi.fn(() => false) }
+    } as unknown as HTMLElement
+    vi.stubGlobal(
+      'MutationObserver',
+      vi.fn(function MutationObserver() {
+        return { observe: vi.fn(), disconnect: vi.fn() }
+      })
+    )
 
     const terminal = {
-      element: null as HTMLElement | null,
+      element: fakeTerminalElement,
       textarea: null,
       cols: 80,
       rows: 24,
@@ -485,8 +503,8 @@ describe('openTerminal — Unicode 11 ordering', () => {
       leafId,
       stablePaneId: leafId,
       terminal,
-      container: fakeContainer,
-      xtermContainer: fakeContainer,
+      container: fakePaneContainer,
+      xtermContainer: fakeXtermContainer,
       linkTooltip: fakeTooltip,
       terminalGpuAcceleration: 'off',
       gpuRenderingEnabled: false,
@@ -507,19 +525,26 @@ describe('openTerminal — Unicode 11 ordering', () => {
       debugLabel: null
     }
 
-    openTerminal(pane)
+    try {
+      openTerminal(pane)
 
-    expect(events).toContain('loadAddon:unicode11')
-    expect(events).toContain('activeVersion=11')
+      expect(fakePaneContainer.appendChild).toHaveBeenCalledWith(fakeTooltip)
+      expect(fakeXtermContainer.appendChild).not.toHaveBeenCalled()
+      expect(fakeTerminalElement.appendChild).not.toHaveBeenCalled()
+      expect(events).toContain('loadAddon:unicode11')
+      expect(events).toContain('activeVersion=11')
 
-    const unicodeIdx = events.indexOf('activeVersion=11')
-    const writeIdx = events.indexOf('write')
-    if (writeIdx !== -1) {
-      expect(unicodeIdx).toBeLessThan(writeIdx)
+      const unicodeIdx = events.indexOf('activeVersion=11')
+      const writeIdx = events.indexOf('write')
+      if (writeIdx !== -1) {
+        expect(unicodeIdx).toBeLessThan(writeIdx)
+      }
+
+      const loadUnicodeIdx = events.indexOf('loadAddon:unicode11')
+      expect(loadUnicodeIdx).toBeLessThan(unicodeIdx)
+      expect(events.indexOf('open')).toBeLessThan(loadUnicodeIdx)
+    } finally {
+      vi.unstubAllGlobals()
     }
-
-    const loadUnicodeIdx = events.indexOf('loadAddon:unicode11')
-    expect(loadUnicodeIdx).toBeLessThan(unicodeIdx)
-    expect(events.indexOf('open')).toBeLessThan(loadUnicodeIdx)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -29,6 +29,7 @@ export { createPaneDOM } from './pane-dom-creation'
 export function openTerminal(pane: ManagedPaneInternal): void {
   const {
     terminal,
+    container,
     xtermContainer,
     linkTooltip,
     terminalTuiScrollSensitivity,
@@ -41,8 +42,9 @@ export function openTerminal(pane: ManagedPaneInternal): void {
 
   // Open terminal into DOM
   terminal.open(xtermContainer)
-  const linkTooltipContainer = terminal.element ?? xtermContainer
-  linkTooltipContainer.appendChild(linkTooltip)
+  // Why: terminal.element sits under the padded xterm container. Pane-level
+  // placement keeps the hover URL on the true bottom-left window corner.
+  container.appendChild(linkTooltip)
 
   // Load addons (order matters: WebGL must be after open())
   terminal.loadAddon(fitAddon)


### PR DESCRIPTION
## Descrip

Follow-up to #7219. Terminal URL hover text now sits in the pane's true bottom-left corner, Ghostty-style, instead of inheriting the padded xterm content offset.

## Evidence

- Code path: `openTerminal` now appends `pane.linkTooltip` to the pane container instead of `terminal.element` / `.xterm-container`, so terminal content padding does not move the tooltip.
- Style path: the tooltip's absolute offsets are now `left: 0` and `bottom: 0`.
- Visual smoke: captured a dev-app screenshot with temporary `--pane-padding-x/y: 24px` to make the offset easy to see. DOM geometry was:
  - `tooltipLeftFromPane: 0`
  - `tooltipBottomFromPane: 0`
  - `xtermLeftFromPane: 24`
  - `xtermTopFromPane: 24`
- Screenshot evidence is attached in a PR comment.

## ELI5

The terminal text area has a little cushion around it. The URL label used to sit inside that cushioned area, so it was nudged inward. This moves the label to the outer terminal pane, so the text can keep its cushion while the URL label stays glued to the bottom-left corner.

## Trade-offs

- The tooltip is now pane-level chrome rather than xterm-child chrome. That is intentional for Ghostty-style placement, and existing pane cleanup still removes it with the pane container.
- No new behavior for SSH/local link handling; this only changes where the existing URL text is mounted and positioned.

## Testing

- [x] `pnpm lint` (passes; existing warnings only, outside this branch)
- [x] `pnpm typecheck`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-dom-creation.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts`
- [x] `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-dom-creation.ts src/renderer/src/lib/pane-manager/pane-lifecycle.ts src/renderer/src/lib/pane-manager/pane-dom-creation.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts --quiet`
- [x] `git diff --check origin/main..HEAD`
- [x] Added focused tests for zero-offset tooltip positioning and pane-level tooltip mounting.

## AI Review Report

Reviewed the diff against the requested Ghostty-style behavior and checked the terminal DOM ownership chain. The main risk was anchoring to the wrong positioning parent: `.xterm-container` carries terminal padding, while `.pane` is the unpadded positioning container. No in-scope issues remained after review. Cross-platform review: no shortcut, path, shell, provider, or OS-specific behavior changes; existing macOS vs Ctrl tooltip copy remains untouched.

## Security Audit

No new input handling, IPC, command execution, auth, dependency, path handling, or secret surface. The change only re-parents and repositions an existing non-interactive DOM tooltip (`pointer-events: none`) that displays already-derived link text.

## Notes

CI was not waited on per request.
