### PR TITLE
Skip VM resume for local sidebar activations

### DIFF
--- a/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
@@ -12,6 +12,10 @@ const mocks = vi.hoisted(() => {
         state.ptyIdsByTabId[tab.id] = []
       }
     }),
+    repos: [] as { id: string; connectionId?: string | null; executionHostId?: string | null }[],
+    settings: { activeRuntimeEnvironmentId: null as string | null },
+    runtimeEnvironments: [] as { id: string; source?: 'manual' | 'ephemeral-vm' }[],
+    worktreesByRepo: {} as Record<string, { id: string; repoId: string; hostId?: string }[]>,
     tabsByWorktree: {} as Record<string, { id: string }[]>,
     ptyIdsByTabId: {} as Record<string, string[]>
   }
@@ -64,6 +68,17 @@ describe('sleep flow vs slept-workspace activation', () => {
         mocks.state.ptyIdsByTabId[tab.id] = []
       }
     })
+    mocks.state.repos = [{ id: 'repo-1', connectionId: null, executionHostId: 'local' }]
+    mocks.state.settings = { activeRuntimeEnvironmentId: null }
+    mocks.state.runtimeEnvironments = [{ id: 'vm-env', source: 'ephemeral-vm' }]
+    mocks.state.worktreesByRepo = {
+      'repo-1': [
+        { id: 'wt-parent', repoId: 'repo-1', hostId: 'runtime:vm-env' },
+        { id: 'wt-child-1', repoId: 'repo-1', hostId: 'runtime:vm-env' },
+        { id: 'wt-child-2', repoId: 'repo-1', hostId: 'runtime:vm-env' },
+        { id: 'wt-child-3', repoId: 'repo-1', hostId: 'runtime:vm-env' }
+      ]
+    }
     mocks.state.tabsByWorktree = {
       'wt-parent': [{ id: 'tab-parent' }],
       'wt-child-1': [{ id: 'tab-child-1' }],
@@ -94,6 +109,33 @@ describe('sleep flow vs slept-workspace activation', () => {
     await runSleepWorktrees(['wt-child-1', 'wt-child-2', 'wt-child-3'])
 
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it('activates a local worktree without a VM resume round trip', async () => {
+    mocks.state.worktreesByRepo = {
+      'repo-1': [{ id: 'wt-local', repoId: 'repo-1', hostId: 'local' }]
+    }
+
+    await activateWorktreeFromSidebar('wt-local')
+
+    expect(mocks.resumeWorkspace).not.toHaveBeenCalled()
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-local', {
+      revealInSidebar: false
+    })
+  })
+
+  it('activates a user-managed runtime worktree without a VM resume round trip', async () => {
+    mocks.state.runtimeEnvironments = [{ id: 'manual-env', source: 'manual' }]
+    mocks.state.worktreesByRepo = {
+      'repo-1': [{ id: 'wt-manual', repoId: 'repo-1', hostId: 'runtime:manual-env' }]
+    }
+
+    await activateWorktreeFromSidebar('wt-manual')
+
+    expect(mocks.resumeWorkspace).not.toHaveBeenCalled()
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-manual', {
+      revealInSidebar: false
+    })
   })
 
   it('does not activate a slept worktree when VM resume fails', async () => {

--- a/src/renderer/src/lib/sidebar-worktree-activation.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.ts
@@ -2,9 +2,28 @@ import {
   activateAndRevealFolderWorkspace,
   activateAndRevealWorktree
 } from '@/lib/worktree-activation'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { useAppStore } from '@/store'
+import { isEphemeralVmRuntimeEnvironment } from '../../../shared/runtime-environments'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
+
+function shouldResumeEphemeralVmWorkspace(worktreeId: string): boolean {
+  const state = useAppStore.getState()
+  const runtimeEnvironmentId = getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  if (!runtimeEnvironmentId) {
+    return false
+  }
+
+  const runtimeEnvironment = state.runtimeEnvironments.find(
+    (environment) => environment.id === runtimeEnvironmentId
+  )
+  // Why: runtime metadata hydrates asynchronously at startup. If an explicitly
+  // runtime-owned workspace has not loaded its source yet, main can still no-op
+  // non-VM workspace ids while preserving wake for suspended VM workspaces.
+  return runtimeEnvironment ? isEphemeralVmRuntimeEnvironment(runtimeEnvironment) : true
+}
 
 export async function activateWorktreeFromSidebar(worktreeId: string): Promise<void> {
   const workspaceScope = parseWorkspaceKey(worktreeId)
@@ -13,7 +32,11 @@ export async function activateWorktreeFromSidebar(worktreeId: string): Promise<v
     return
   }
 
-  if (typeof window !== 'undefined' && window.api?.ephemeralVm?.resumeWorkspace) {
+  if (
+    shouldResumeEphemeralVmWorkspace(worktreeId) &&
+    typeof window !== 'undefined' &&
+    window.api?.ephemeralVm?.resumeWorkspace
+  ) {
     try {
       await window.api.ephemeralVm.resumeWorkspace({ workspaceId: worktreeId })
     } catch (error) {


### PR DESCRIPTION
## Description

Sidebar clicks used to await `window.api.ephemeralVm.resumeWorkspace` for every worktree before activating it. Local worktrees and user-managed runtime worktrees do not need an ephemeral VM wake, so that IPC round trip could delay the selected workspace update on Windows.

This change gates the VM resume call to worktrees whose explicit runtime environment is actually `ephemeral-vm`. Local worktrees and manual runtime worktrees activate immediately; unknown runtime metadata still preserves the old resume path so suspended VM workspaces keep waking during startup hydration.

## Evidence

- Reproduced with the Windows worktree-switch responsiveness diagnostic: local sidebar activation was entering the VM-resume path before selection could settle.
- After the fix, the same diagnostic showed `resumeWorkspaceCalls: 0` for local worktree switches and the store `activeWorktreeId` changed during the click task.
- The remaining e2e failure was a separate terminal mount/refit long task, so that larger render issue is intentionally not folded into this PR.
- `pnpm exec oxfmt --check src/renderer/src/lib/sidebar-worktree-activation.ts src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/sidebar-worktree-activation.ts src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts src/renderer/src/lib/sidebar-worktree-activation.test.ts`
- `pnpm run typecheck`

Note: clean e2e execution on this base is still blocked by the Windows e2e repo path matching issue covered by #7217.

## ELI5

Clicking a local workspace was asking the app to wake a VM first, even though no VM was involved. Now local workspaces just open, and only VM-backed workspaces ask the VM system to wake up.

## Tradeoffs

- If runtime metadata has not hydrated yet, explicit runtime-owned workspaces still call the VM resume IPC. That keeps suspended VM wakeups safe, but a very early manual-runtime click may still pay the old no-op round trip until metadata arrives.
- This does not fix the separate terminal render long task observed during rapid worktree switches.