### PR TITLE
Fix terminal theme selection persistence

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2828,6 +2828,24 @@ describe('Store', () => {
     expect(store.getSettings().terminalUseSeparateLightTheme).toBe(false)
   })
 
+  it('round-trips selected terminal theme names across reload', async () => {
+    const store = await createStore()
+
+    store.updateSettings({
+      terminalThemeDark: 'One Light',
+      terminalThemeLight: 'GitHub Light'
+    })
+    store.flush()
+
+    const persisted = readDataFile() as PersistedState
+    expect(persisted.settings.terminalThemeDark).toBe('One Light')
+    expect(persisted.settings.terminalThemeLight).toBe('GitHub Light')
+
+    const reopened = await createStore()
+    expect(reopened.getSettings().terminalThemeDark).toBe('One Light')
+    expect(reopened.getSettings().terminalThemeLight).toBe('GitHub Light')
+  })
+
   // ── 5. addRepo and getRepo ──────────────────────────────────────────
 
   it('addRepo stores a repo retrievable by getRepo', async () => {

--- a/src/renderer/src/components/settings/TerminalThemeSections.lifecycle.test.ts
+++ b/src/renderer/src/components/settings/TerminalThemeSections.lifecycle.test.ts
@@ -8,12 +8,15 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
   return {
     ...actual,
-    useState: <T>(initial: T) => [
-      themeTarget ?? initial,
-      (value: T) => {
-        themeTarget = value as 'dark' | 'light'
-      }
-    ]
+    useState: <T>(initial: T | (() => T)) => {
+      const initialValue = typeof initial === 'function' ? (initial as () => T)() : initial
+      return [
+        themeTarget ?? initialValue,
+        (value: T) => {
+          themeTarget = value as 'dark' | 'light'
+        }
+      ]
+    }
   }
 })
 
@@ -23,7 +26,10 @@ vi.mock('./TerminalSettingsPreview', () => ({
   }
 }))
 
-import { TerminalThemeCatalogSection } from './TerminalThemeSections'
+import {
+  resetTerminalThemeTargetMemoryForTests,
+  TerminalThemeCatalogSection
+} from './TerminalThemeSections'
 
 type ReactElementLike = {
   type: unknown
@@ -50,6 +56,7 @@ const warpThemesMock: UseWarpThemeImportReturn = {
 
 function makeSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
   return {
+    theme: 'system',
     terminalUseSeparateLightTheme: false,
     terminalThemeDark: 'Ghostty Default Style Dark',
     terminalThemeLight: 'Builtin Tango Light',
@@ -64,12 +71,13 @@ function renderCatalog(
   settings = makeSettings(),
   updateSettings = vi.fn(),
   target?: 'dark' | 'light',
-  preferredTarget?: 'dark' | 'light'
+  preferredTarget?: 'dark' | 'light',
+  systemPrefersDark = true
 ): React.JSX.Element {
   themeTarget = target
   return TerminalThemeCatalogSection({
     settings,
-    systemPrefersDark: true,
+    systemPrefersDark,
     themeSearch: '',
     setThemeSearch: () => {},
     updateSettings,
@@ -167,6 +175,7 @@ function findButtonTexts(node: unknown): string[] {
 describe('TerminalThemeCatalogSection', () => {
   beforeEach(() => {
     themeTarget = 'dark'
+    resetTerminalThemeTargetMemoryForTests()
     vi.clearAllMocks()
   })
 
@@ -178,6 +187,72 @@ describe('TerminalThemeCatalogSection', () => {
     expect(findElementByTypeName(element, 'TerminalSettingsPreview')?.props?.modeOverride).toBe(
       'dark'
     )
+  })
+
+  it('opens on the active light theme when the system appearance is light', () => {
+    const updateSettings = vi.fn()
+    const element = renderCatalog(
+      makeSettings({ terminalUseSeparateLightTheme: true }),
+      updateSettings,
+      undefined,
+      undefined,
+      false
+    )
+    const picker = findElementByTypeName(element, 'ThemePicker')
+    const preview = findElementByTypeName(element, 'TerminalSettingsPreview')
+    const selectTheme = picker?.props?.onSelectTheme as (theme: string) => void
+
+    expect(picker?.props?.selectedTheme).toBe('Builtin Tango Light')
+    expect(preview?.props?.modeOverride).toBe('light')
+
+    selectTheme('GitHub Light')
+
+    expect(updateSettings).toHaveBeenCalledWith({ terminalThemeLight: 'GitHub Light' })
+  })
+
+  it('reopens the manually edited light target while the active appearance is dark', () => {
+    const firstOpen = renderCatalog(
+      makeSettings({ terminalUseSeparateLightTheme: true }),
+      vi.fn(),
+      undefined,
+      undefined,
+      true
+    )
+    const targetControl = findElementByTypeName(firstOpen, 'SettingsSegmentedControl')
+    const selectTarget = targetControl?.props?.onChange as (target: 'dark' | 'light') => void
+
+    selectTarget('light')
+
+    const reopened = renderCatalog(
+      makeSettings({ terminalUseSeparateLightTheme: true }),
+      vi.fn(),
+      undefined,
+      undefined,
+      true
+    )
+    const picker = findElementByTypeName(reopened, 'ThemePicker')
+    const preview = findElementByTypeName(reopened, 'TerminalSettingsPreview')
+
+    expect(picker?.props?.selectedTheme).toBe('Builtin Tango Light')
+    expect(preview?.props?.modeOverride).toBe('light')
+  })
+
+  it('opens a customized light-only theme after reload even when the active appearance is dark', () => {
+    const element = renderCatalog(
+      makeSettings({
+        terminalUseSeparateLightTheme: true,
+        terminalThemeLight: 'GitHub Light'
+      }),
+      vi.fn(),
+      undefined,
+      undefined,
+      true
+    )
+    const picker = findElementByTypeName(element, 'ThemePicker')
+    const preview = findElementByTypeName(element, 'TerminalSettingsPreview')
+
+    expect(picker?.props?.selectedTheme).toBe('GitHub Light')
+    expect(preview?.props?.modeOverride).toBe('light')
   })
 
   it('keeps the light target enabled while separate light theme is disabled', () => {

--- a/src/renderer/src/components/settings/TerminalThemeSections.tsx
+++ b/src/renderer/src/components/settings/TerminalThemeSections.tsx
@@ -12,11 +12,55 @@ import { TerminalSettingsPreview } from './TerminalSettingsPreview'
 import { WarpThemeImportButton } from './WarpThemeImportButton'
 import { YamlThemeImportButton } from './YamlThemeImportButton'
 import type { UseWarpThemeImportReturn } from './useWarpThemeImport'
-import { getAvailableTerminalThemeOptions } from '@/lib/terminal-theme'
+import {
+  DEFAULT_TERMINAL_THEME_DARK,
+  DEFAULT_TERMINAL_THEME_LIGHT,
+  getAvailableTerminalThemeOptions,
+  resolveEffectiveTerminalAppearance
+} from '@/lib/terminal-theme'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 
 type TerminalThemeTarget = 'dark' | 'light'
+
+let lastEditedTerminalThemeTarget: TerminalThemeTarget | null = null
+
+function rememberTerminalThemeTarget(target: TerminalThemeTarget): void {
+  lastEditedTerminalThemeTarget = target
+}
+
+export function resetTerminalThemeTargetMemoryForTests(): void {
+  lastEditedTerminalThemeTarget = null
+}
+
+function isCustomizedTheme(themeName: string, defaultThemeName: string): boolean {
+  const trimmed = themeName.trim()
+  return trimmed.length > 0 && trimmed !== defaultThemeName
+}
+
+function getInitialTerminalThemeTarget(
+  settings: GlobalSettings,
+  systemPrefersDark: boolean,
+  preferredTarget?: TerminalThemeTarget
+): TerminalThemeTarget {
+  if (preferredTarget) {
+    return preferredTarget
+  }
+  if (lastEditedTerminalThemeTarget) {
+    return lastEditedTerminalThemeTarget
+  }
+  const customizedDark = isCustomizedTheme(settings.terminalThemeDark, DEFAULT_TERMINAL_THEME_DARK)
+  const customizedLight = isCustomizedTheme(
+    settings.terminalThemeLight,
+    DEFAULT_TERMINAL_THEME_LIGHT
+  )
+  if (customizedDark !== customizedLight) {
+    return customizedDark ? 'dark' : 'light'
+  }
+  // Why: the picker edits mode-specific slots. Defaulting to the active
+  // terminal mode makes the selected theme apply immediately in system-light.
+  return resolveEffectiveTerminalAppearance(settings, systemPrefersDark).mode
+}
 
 type TerminalThemeCatalogSectionProps = {
   settings: GlobalSettings
@@ -45,7 +89,13 @@ export function TerminalThemeCatalogSection({
   preferredTarget,
   advancedContent
 }: TerminalThemeCatalogSectionProps): React.JSX.Element {
-  const [target, setTarget] = useState<TerminalThemeTarget>(preferredTarget ?? 'dark')
+  const [target, setTargetState] = useState<TerminalThemeTarget>(() =>
+    getInitialTerminalThemeTarget(settings, systemPrefersDark, preferredTarget)
+  )
+  const setTarget = (nextTarget: TerminalThemeTarget): void => {
+    rememberTerminalThemeTarget(nextTarget)
+    setTargetState(nextTarget)
+  }
   const themeOptions = getAvailableTerminalThemeOptions(settings)
   const isLightTarget = target === 'light'
   const matchDarkMode = !settings.terminalUseSeparateLightTheme
@@ -200,11 +250,12 @@ export function TerminalThemeCatalogSection({
                   themeOptions={themeOptions}
                   query={themeSearch}
                   onQueryChange={setThemeSearch}
-                  onSelectTheme={(theme) =>
+                  onSelectTheme={(theme) => {
+                    rememberTerminalThemeTarget(target)
                     updateSettings(
                       isLightTarget ? { terminalThemeLight: theme } : { terminalThemeDark: theme }
                     )
-                  }
+                  }}
                   importedHighlightSignal={importedHighlightSignal}
                 />
               </SearchableSetting>


### PR DESCRIPTION
﻿## Description
Fixes #7166.

This updates the terminal theme catalog so light theme selections no longer look like they reset to the dark theme after leaving Settings. The picker now:

- opens on the active terminal appearance mode on first use
- remembers the last dark/light target the user edited while Settings is open/reopened in the same desktop session
- opens the only customized dark/light slot after reload, so a customized light theme like `GitHub Light` or `One Light` remains visible instead of falling back to the default dark slot
- preserves selected terminal theme names through the persisted settings store

## ELI5
The settings screen has two shelves for terminal themes: one for dark mode and one for light mode. Before, Settings kept opening the dark shelf first, so if you had just picked a light theme it looked like Orca forgot. Now Orca opens the shelf you were actually using or the shelf you customized, so your choice is still where you left it.

## Tradeoffs
- This does not add a new persisted settings field just to remember which shelf was last viewed. Instead, it infers the right shelf from the active/customized theme state and keeps a small in-session memory for explicit edits.
- If both dark and light terminal themes are customized after a full app restart, the picker defaults back to the active app appearance because there is no persisted last-viewed shelf metadata. The selected theme values themselves still persist.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/TerminalThemeSections.lifecycle.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-theme.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts -t "round-trips selected terminal theme names"`
- `pnpm exec oxlint src/renderer/src/components/settings/TerminalThemeSections.tsx src/renderer/src/components/settings/TerminalThemeSections.lifecycle.test.ts src/main/persistence.test.ts`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- `git diff --check`
