### PR TITLE
Fix hovercard text selection opening workspace board

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import { isSidebarPointerDragBlocked } from './worktree-sidebar-pointer-drag-dom'
+
+describe('worktree sidebar pointer drag DOM guards', () => {
+  it('allows plain row targets to start pointer drags', () => {
+    const row = document.createElement('div')
+    const card = document.createElement('div')
+    row.appendChild(card)
+
+    expect(isSidebarPointerDragBlocked(card, row)).toBe(false)
+  })
+
+  it('blocks portaled hover card targets outside the row', () => {
+    const row = document.createElement('div')
+    const hoverCardContent = document.createElement('div')
+    document.body.append(row, hoverCardContent)
+
+    expect(isSidebarPointerDragBlocked(hoverCardContent, row)).toBe(true)
+
+    hoverCardContent.remove()
+    row.remove()
+  })
+
+  it('blocks interactive targets inside the row', () => {
+    const row = document.createElement('div')
+    const button = document.createElement('button')
+    row.appendChild(button)
+
+    expect(isSidebarPointerDragBlocked(button, row)).toBe(true)
+  })
+
+  it('blocks icon targets inside interactive row controls', () => {
+    const row = document.createElement('div')
+    const button = document.createElement('button')
+    const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    button.appendChild(icon)
+    row.appendChild(button)
+
+    expect(isSidebarPointerDragBlocked(icon, row)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.ts
@@ -17,7 +17,15 @@ const INTERACTIVE_DRAG_BLOCKER_SELECTOR = [
 ].join(',')
 
 export function isSidebarPointerDragBlocked(target: EventTarget | null, row: HTMLElement): boolean {
-  if (!(target instanceof HTMLElement)) {
+  if (!(target instanceof Node)) {
+    return false
+  }
+  // Why: Radix hover cards portal outside the row, but React still bubbles their
+  // pointer events through row handlers; text selection there must not drag rows.
+  if (!row.contains(target)) {
+    return true
+  }
+  if (!(target instanceof Element)) {
     return false
   }
   const blocker = target.closest(INTERACTIVE_DRAG_BLOCKER_SELECTOR)


### PR DESCRIPTION
## Summary
- block sidebar row pointer drags when the event target comes from a portaled hovercard outside the row DOM
- add DOM guard coverage for normal row targets, portaled hovercard targets, and interactive row controls

## Testing
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.test.ts src/renderer/src/components/sidebar/WorktreeCardMeta.interaction.test.tsx src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.test.ts
- pnpm run typecheck:web
- Electron validation: drag-selected text in the real worktree hovercard; selection appeared and workspace board preview/open selectors stayed at 0