### PR TITLE
Fix manual sorting for project headers and groups

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -34,6 +34,11 @@ import {
   useWorktreeMap
 } from '@/store/selectors'
 import WorktreeCard, { type ActiveSurfaceVariant } from './WorktreeCard'
+import { WorktreeSidebarDropIndicator } from './WorktreeSidebarDropIndicator'
+import {
+  getProjectGroupHeaderSectionEndByGroupId,
+  getRepoHeaderSectionEndByRepoId
+} from './worktree-header-section-boundaries'
 import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
 import { PendingWorktreeRow } from './PendingWorktreeRow'
 import { SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT } from './WorktreeCardAgents'
@@ -1710,6 +1715,31 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const firstHeaderIndex = useMemo(
     () => renderRows.findIndex((row) => row.type === 'header' || row.type === 'host-header'),
     [renderRows]
+  )
+  const repoHeaderSectionEndByRepoId = useMemo(
+    () =>
+      getRepoHeaderSectionEndByRepoId({
+        rows: renderRows,
+        firstHeaderIndex,
+        sidebarRepoHeaderIdsByBucket,
+        repoHeaderBucketByRepoId
+      }),
+    [firstHeaderIndex, renderRows, repoHeaderBucketByRepoId, sidebarRepoHeaderIdsByBucket]
+  )
+  const projectGroupHeaderSectionEndByGroupId = useMemo(
+    () =>
+      getProjectGroupHeaderSectionEndByGroupId({
+        rows: renderRows,
+        firstHeaderIndex,
+        sidebarProjectGroupHeaderIdsByBucket,
+        projectGroupHeaderBucketByGroupId
+      }),
+    [
+      firstHeaderIndex,
+      projectGroupHeaderBucketByGroupId,
+      renderRows,
+      sidebarProjectGroupHeaderIdsByBucket
+    ]
   )
   const firstHeaderIndexRef = useRef(firstHeaderIndex)
   firstHeaderIndexRef.current = firstHeaderIndex
@@ -3953,46 +3983,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           {canReorderRepoHeaders &&
           repoDrag.state.draggingRepoId !== null &&
           repoDrag.state.dropIndicatorY !== null ? (
-            <div
-              role="presentation"
-              // Why z-30 (not z-10): the sticky pinned header is z-20, so a
-              // lower indicator renders behind it whenever the drop slot is at
-              // the top while scrolled. Match the worktree indicator's tier.
-              className="pointer-events-none absolute left-2 right-2 z-30 border-t border-dashed border-muted-foreground/70"
-              style={{ top: `${repoDrag.state.dropIndicatorY}px` }}
-            />
+            <WorktreeSidebarDropIndicator y={repoDrag.state.dropIndicatorY} />
           ) : null}
           {canReorderProjectGroupHeaders &&
           projectGroupDrag.state.draggingGroupId !== null &&
           projectGroupDrag.state.dropIndicatorY !== null ? (
-            <div
-              role="presentation"
-              className="pointer-events-none absolute left-2 right-2 z-30 border-t border-dashed border-muted-foreground/70"
-              style={{ top: `${projectGroupDrag.state.dropIndicatorY}px` }}
-            />
+            <WorktreeSidebarDropIndicator y={projectGroupDrag.state.dropIndicatorY} />
           ) : null}
           {hostDrag.state.draggingHostId !== null && hostDrag.state.dropIndicatorY !== null ? (
-            <div
-              role="presentation"
-              className="pointer-events-none absolute left-3 right-2 z-40 flex h-3 -translate-y-1/2 items-center"
-              style={{ top: `${hostDrag.state.dropIndicatorY}px` }}
-            >
-              <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
-              <span className="h-0.5 flex-1 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
-              <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
-            </div>
+            <WorktreeSidebarDropIndicator y={hostDrag.state.dropIndicatorY} className="z-40" />
           ) : null}
           {worktreeDragState.draggingWorktreeId !== null &&
           worktreeDragState.dropIndicatorY !== null ? (
-            <div
-              role="presentation"
-              className="pointer-events-none absolute left-3 right-2 z-30 flex h-3 -translate-y-1/2 items-center"
-              style={{ top: `${worktreeDragState.dropIndicatorY}px` }}
-            >
-              <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
-              <span className="h-0.5 flex-1 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
-              <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
-            </div>
+            <WorktreeSidebarDropIndicator y={worktreeDragState.dropIndicatorY} />
           ) : null}
           {virtualItems.map((vItem) => {
             const row = renderRows[vItem.index]
@@ -4185,15 +4188,31 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     data-repo-header-id={projectIdForHeader}
                     data-repo-header-index={repoHeaderIndex}
                     data-repo-header-bucket={repoHeaderBucketKey}
+                    data-repo-header-section-end={
+                      projectIdForHeader
+                        ? repoHeaderSectionEndByRepoId.get(projectIdForHeader)
+                        : undefined
+                    }
+                    data-repo-header-drag-handle={isDraggableRepoHeader ? '' : undefined}
                     data-project-group-header-id={projectGroupIdForHeader}
                     data-project-group-header-index={projectGroupHeaderIndex}
                     data-project-group-header-bucket={projectGroupHeaderBucketKey}
+                    data-project-group-header-section-end={
+                      projectGroupIdForHeader
+                        ? projectGroupHeaderSectionEndByGroupId.get(projectGroupIdForHeader)
+                        : undefined
+                    }
+                    data-project-group-header-drag-handle={
+                      isDraggableProjectGroupHeader ? '' : undefined
+                    }
                     data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
                     data-workspace-status={headerWorkspaceStatus ?? undefined}
                     data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
                     className={cn(
                       'group relative flex h-7 w-full items-center gap-1.5 pr-2 text-left transition-all',
-                      'cursor-pointer',
+                      isDraggableRepoHeader || isDraggableProjectGroupHeader
+                        ? 'cursor-grab active:cursor-grabbing'
+                        : 'cursor-pointer',
                       highlightedRevealRowKey === row.key &&
                         'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/50',
                       (isDraggingThis || isDraggingThisProjectGroup) &&
@@ -4226,6 +4245,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         ? (event) => handleWorkspaceStatusDrop(event, headerWorkspaceStatus)
                         : undefined
                     }
+                    onPointerDown={
+                      isDraggableRepoHeader && projectIdForHeader
+                        ? (event) => repoDrag.onHandlePointerDown(event, projectIdForHeader)
+                        : isDraggableProjectGroupHeader && projectGroupIdForHeader
+                          ? (event) =>
+                              projectGroupDrag.onHandlePointerDown(event, projectGroupIdForHeader)
+                          : undefined
+                    }
                     onClick={(event) => {
                       if (shouldIgnoreRepoHeaderToggle(event)) {
                         return
@@ -4254,17 +4281,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                           (isDraggableRepoHeader || isDraggableProjectGroupHeader) &&
                             'hover:cursor-grab active:cursor-grabbing'
                         )}
-                        onPointerDown={
-                          isDraggableRepoHeader && projectIdForHeader
-                            ? (event) => repoDrag.onHandlePointerDown(event, projectIdForHeader)
-                            : isDraggableProjectGroupHeader && projectGroupIdForHeader
-                              ? (event) =>
-                                  projectGroupDrag.onHandlePointerDown(
-                                    event,
-                                    projectGroupIdForHeader
-                                  )
-                              : undefined
-                        }
                       >
                         {row.repo ? (
                           <RepoIconGlyph

--- a/src/renderer/src/components/sidebar/WorktreeSidebarDropIndicator.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeSidebarDropIndicator.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react'
+
+import { cn } from '@/lib/utils'
+
+type WorktreeSidebarDropIndicatorProps = {
+  y: number
+  className?: string
+}
+
+export function WorktreeSidebarDropIndicator({
+  y,
+  className
+}: WorktreeSidebarDropIndicatorProps): ReactElement {
+  return (
+    <div
+      role="presentation"
+      className={cn(
+        'pointer-events-none absolute left-3 right-2 z-30 flex h-3 -translate-y-1/2 items-center',
+        className
+      )}
+      style={{ top: `${y}px` }}
+    >
+      <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
+      <span className="h-0.5 flex-1 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
+      <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-ring shadow-[0_0_0_2px_var(--worktree-sidebar)]" />
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts
@@ -40,7 +40,7 @@ function makeSession(
 }
 
 describe('commitProjectGroupHeaderDragDrop', () => {
-  it('commits a finite tabOrder for the dragged Project Group', () => {
+  it('commits dense tabOrder updates for the affected Project Group siblings', () => {
     const onCommitProjectGroupTabOrder = vi.fn()
     const groups = [
       group('a', { tabOrder: 0 }),
@@ -56,7 +56,11 @@ describe('commitProjectGroupHeaderDragDrop', () => {
       onCommitProjectGroupTabOrder
     })
 
-    expect(onCommitProjectGroupTabOrder).toHaveBeenCalledWith('c', -1)
+    expect(onCommitProjectGroupTabOrder.mock.calls).toEqual([
+      ['c', 0],
+      ['a', 1],
+      ['b', 2]
+    ])
   })
 
   it('computes order only from the captured sibling bucket', () => {
@@ -76,7 +80,10 @@ describe('commitProjectGroupHeaderDragDrop', () => {
       onCommitProjectGroupTabOrder
     })
 
-    expect(onCommitProjectGroupTabOrder).toHaveBeenCalledWith('sibling-b', -1)
+    expect(onCommitProjectGroupTabOrder.mock.calls).toEqual([
+      ['sibling-b', 0],
+      ['sibling-a', 1]
+    ])
   })
 
   it('does not commit when the drop keeps the group in the same slot', () => {

--- a/src/renderer/src/components/sidebar/project-group-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-commit.ts
@@ -1,7 +1,4 @@
-import {
-  getProjectGroupTabOrderForSidebarDrop,
-  mapSidebarProjectGroupDropIndexToSiblingInsertIndex
-} from './project-group-header-drop'
+import { getProjectGroupTabOrderUpdatesForSidebarDrop } from './project-group-header-drop'
 import type { ProjectGroupHeaderDragSession } from './project-group-header-drag-contract'
 import type { ProjectGroup } from '../../../../shared/types'
 
@@ -11,40 +8,13 @@ export function commitProjectGroupHeaderDragDrop(args: {
   projectGroupById: ReadonlyMap<string, ProjectGroup>
   onCommitProjectGroupTabOrder: (groupId: string, tabOrder: number) => void
 }): void {
-  const draggedGroup = args.projectGroupById.get(args.session.groupId)
-  if (!draggedGroup) {
-    return
-  }
-
-  const sidebarProjectGroupHeaderIds = args.session.sidebarProjectGroupHeaderIds
-  const sourceIndex = sidebarProjectGroupHeaderIds.indexOf(args.session.groupId)
-  if (sourceIndex === -1) {
-    return
-  }
-  if (args.sidebarDropIndex === sourceIndex) {
-    return
-  }
-
-  const siblings = sidebarProjectGroupHeaderIds
-    .filter((groupId) => groupId !== args.session.groupId)
-    .map((groupId) => args.projectGroupById.get(groupId))
-    .filter((group): group is ProjectGroup => group !== undefined)
-  const siblingDropIndex = mapSidebarProjectGroupDropIndexToSiblingInsertIndex({
+  const updates = getProjectGroupTabOrderUpdatesForSidebarDrop({
+    sidebarProjectGroupHeaderIds: args.session.sidebarProjectGroupHeaderIds,
+    draggedGroupId: args.session.groupId,
     sidebarDropIndex: args.sidebarDropIndex,
-    sourceIndex,
-    siblingCount: siblings.length
+    projectGroupById: args.projectGroupById
   })
-  const sourceIndexInSiblings = Math.min(sourceIndex, siblings.length)
-  if (siblingDropIndex === sourceIndexInSiblings) {
-    return
+  for (const update of updates) {
+    args.onCommitProjectGroupTabOrder(update.groupId, update.tabOrder)
   }
-
-  const tabOrder = getProjectGroupTabOrderForSidebarDrop({
-    siblings,
-    dropIndex: siblingDropIndex
-  })
-  if (!Number.isFinite(tabOrder)) {
-    return
-  }
-  args.onCommitProjectGroupTabOrder(draggedGroup.id, tabOrder)
 }

--- a/src/renderer/src/components/sidebar/project-group-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-start.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+
+import { createProjectGroupHeaderDragSession } from './project-group-header-drag-start'
+import type { ProjectGroup } from '../../../../shared/types'
+
+function group(id: string, overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('createProjectGroupHeaderDragSession', () => {
+  it('arms a drag session from plain header text when the row is the drag handle', () => {
+    const header = document.createElement('div')
+    header.setAttribute('data-project-group-header-drag-handle', '')
+    header.setPointerCapture = vi.fn()
+    const label = document.createElement('span')
+    header.append(label)
+    const scrollContainer = document.createElement('div')
+    document.body.append(scrollContainer, header)
+
+    const projectGroupById = new Map<string, ProjectGroup>([
+      ['group-a', group('group-a')],
+      ['group-b', group('group-b')]
+    ])
+    const sidebarProjectGroupHeaderIdsByBucket = new Map([['root', ['group-a', 'group-b']]])
+
+    const session = createProjectGroupHeaderDragSession({
+      event: {
+        button: 0,
+        pointerId: 1,
+        clientX: 10,
+        clientY: 20,
+        target: label,
+        currentTarget: header
+      } as unknown as React.PointerEvent<HTMLElement>,
+      groupId: 'group-a',
+      projectGroupById,
+      sidebarProjectGroupHeaderIdsByBucket,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session?.groupId).toBe('group-a')
+    expect(header.setPointerCapture).not.toHaveBeenCalled()
+  })
+
+  it('does not arm from nested Project Group header actions', () => {
+    const header = document.createElement('div')
+    header.setAttribute('data-project-group-header-drag-handle', '')
+    const action = document.createElement('button')
+    action.type = 'button'
+    header.append(action)
+    const scrollContainer = document.createElement('div')
+    document.body.append(scrollContainer, header)
+
+    const projectGroupById = new Map<string, ProjectGroup>([
+      ['group-a', group('group-a')],
+      ['group-b', group('group-b')]
+    ])
+    const sidebarProjectGroupHeaderIdsByBucket = new Map([['root', ['group-a', 'group-b']]])
+
+    const session = createProjectGroupHeaderDragSession({
+      event: {
+        button: 0,
+        pointerId: 1,
+        clientX: 10,
+        clientY: 20,
+        target: action,
+        currentTarget: header
+      } as unknown as React.PointerEvent<HTMLElement>,
+      groupId: 'group-a',
+      projectGroupById,
+      sidebarProjectGroupHeaderIdsByBucket,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/project-group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag.ts
@@ -73,6 +73,23 @@ export function useProjectGroupHeaderDrag({
     []
   )
 
+  const applyDrop = useCallback(
+    (groupId: string, drop: { dropIndex: number; dropIndicatorY: number } | null) => {
+      latestDropIndexRef.current = drop?.dropIndex ?? null
+      const nextState: ProjectGroupDragState = drop
+        ? { draggingGroupId: groupId, ...drop }
+        : { draggingGroupId: groupId, dropIndex: null, dropIndicatorY: null }
+      setState((prev) =>
+        prev.draggingGroupId === nextState.draggingGroupId &&
+        prev.dropIndex === nextState.dropIndex &&
+        prev.dropIndicatorY === nextState.dropIndicatorY
+          ? prev
+          : nextState
+      )
+    },
+    []
+  )
+
   const cancelAutoscroll = useCallback(() => {
     if (autoscrollFrameIdRef.current !== null) {
       window.cancelAnimationFrame(autoscrollFrameIdRef.current)
@@ -157,18 +174,11 @@ export function useProjectGroupHeaderDrag({
         refreshHeaderRects()
       }
 
-      const drop = computeDrop(session.latestPointerY)
-      if (drop) {
-        setState((prev) =>
-          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
-            ? prev
-            : { draggingGroupId: session.groupId, ...drop }
-        )
-      }
+      applyDrop(session.groupId, computeDrop(session.latestPointerY))
 
       autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
     },
-    [cancelAutoscroll, computeDrop, refreshHeaderRects]
+    [applyDrop, cancelAutoscroll, computeDrop, refreshHeaderRects]
   )
 
   const ensureAutoscroll = useCallback(() => {
@@ -212,14 +222,7 @@ export function useProjectGroupHeaderDrag({
         setState({ draggingGroupId: session.groupId, dropIndex: null, dropIndicatorY: null })
       }
       refreshHeaderRects()
-      const drop = computeDrop(event.clientY)
-      if (drop) {
-        setState((prev) =>
-          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
-            ? prev
-            : { draggingGroupId: session.groupId, ...drop }
-        )
-      }
+      applyDrop(session.groupId, computeDrop(event.clientY))
       ensureAutoscroll()
     }
     const onPointerUp = (event: PointerEvent): void => {
@@ -260,7 +263,15 @@ export function useProjectGroupHeaderDrag({
         clickSwallowTimeoutRef.current = null
       }
     }
-  }, [cancelAutoscroll, computeDrop, endDrag, ensureAutoscroll, refreshHeaderRects, sessionArmed])
+  }, [
+    applyDrop,
+    cancelAutoscroll,
+    computeDrop,
+    endDrag,
+    ensureAutoscroll,
+    refreshHeaderRects,
+    sessionArmed
+  ])
 
   useEffect(() => {
     if (state.draggingGroupId === null) {

--- a/src/renderer/src/components/sidebar/project-group-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drop.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
   computeProjectGroupHeaderDropPreview,
   getProjectGroupHeaderDragBucketKey,
-  getProjectGroupTabOrderForSidebarDrop,
+  getProjectGroupTabOrderUpdatesForSidebarDrop,
   getSidebarOrderedProjectGroupHeaderIdsByBucket,
   mapSidebarProjectGroupDropIndexToSiblingInsertIndex
 } from './project-group-header-drop'
@@ -136,34 +136,80 @@ describe('computeProjectGroupHeaderDropPreview', () => {
 
     expect(preview).toEqual({ dropIndex: 1, dropIndicatorY: 96 })
   })
-})
 
-describe('getProjectGroupTabOrderForSidebarDrop', () => {
-  it('uses a midpoint between sibling tab orders when there is room', () => {
-    expect(
-      getProjectGroupTabOrderForSidebarDrop({
-        siblings: [group('a', { tabOrder: 0 }), group('b', { tabOrder: 10 })],
-        dropIndex: 1
-      })
-    ).toBe(5)
-  })
-
-  it('assigns an order before the first sibling', () => {
-    expect(
-      getProjectGroupTabOrderForSidebarDrop({
-        siblings: [group('a', { tabOrder: 10 }), group('b', { tabOrder: 20 })],
-        dropIndex: 0
-      })
-    ).toBe(9)
-  })
-
-  it('keeps a deterministic finite anchor when sibling orders collide', () => {
-    const tabOrder = getProjectGroupTabOrderForSidebarDrop({
-      siblings: [group('a', { tabOrder: 10 }), group('b', { tabOrder: 10 })],
-      dropIndex: 1
+  it('does not create a drop slot inside an expanded Project Group section', () => {
+    const preview = computeProjectGroupHeaderDropPreview({
+      pointerY: 350,
+      containerTop: 0,
+      scrollTop: 0,
+      sidebarProjectGroupHeaderIds: ['a', 'b', 'c'],
+      rects: [
+        {
+          groupId: 'c',
+          bucketKey: 'root',
+          headerIndex: 2,
+          top: 300,
+          bottom: 328,
+          sectionBottom: 380
+        }
+      ]
     })
 
-    expect(tabOrder).toBe(11)
-    expect(Number.isFinite(tabOrder)).toBe(true)
+    expect(preview).toBeNull()
+  })
+
+  it('uses the whole Project Group section for the final boundary slot', () => {
+    const preview = computeProjectGroupHeaderDropPreview({
+      pointerY: 400,
+      containerTop: 0,
+      scrollTop: 0,
+      sidebarProjectGroupHeaderIds: ['a', 'b', 'c'],
+      rects: [
+        {
+          groupId: 'c',
+          bucketKey: 'root',
+          headerIndex: 2,
+          top: 300,
+          bottom: 328,
+          sectionBottom: 380
+        }
+      ]
+    })
+
+    expect(preview).toEqual({ dropIndex: 3, dropIndicatorY: 383 })
+  })
+})
+
+describe('getProjectGroupTabOrderUpdatesForSidebarDrop', () => {
+  it('reindexes sibling groups so duplicate legacy tabOrder values can move between siblings', () => {
+    const groups = [group('a'), group('b'), group('c'), group('d')]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+
+    expect(
+      getProjectGroupTabOrderUpdatesForSidebarDrop({
+        sidebarProjectGroupHeaderIds: ['a', 'b', 'c', 'd'],
+        draggedGroupId: 'd',
+        sidebarDropIndex: 2,
+        projectGroupById
+      })
+    ).toEqual([
+      { groupId: 'b', tabOrder: 1 },
+      { groupId: 'd', tabOrder: 2 },
+      { groupId: 'c', tabOrder: 3 }
+    ])
+  })
+
+  it('returns no updates when the drop keeps the group in the same slot', () => {
+    const groups = [group('a', { tabOrder: 0 }), group('b', { tabOrder: 1 })]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+
+    expect(
+      getProjectGroupTabOrderUpdatesForSidebarDrop({
+        sidebarProjectGroupHeaderIds: ['a', 'b'],
+        draggedGroupId: 'a',
+        sidebarDropIndex: 1,
+        projectGroupById
+      })
+    ).toEqual([])
   })
 })

--- a/src/renderer/src/components/sidebar/project-group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drop.ts
@@ -1,4 +1,7 @@
-import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
+import {
+  computeWorktreeSidebarHeaderDropPreview,
+  type WorktreeSidebarHeaderDropPreview
+} from './worktree-sidebar-header-drop-preview'
 import type { Row } from './worktree-list-groups'
 import type { ProjectGroup } from '../../../../shared/types'
 
@@ -11,14 +14,16 @@ export type ProjectGroupHeaderDragRect = {
   headerIndex: number
   top: number
   bottom: number
+  sectionBottom?: number
 }
 
-export type ProjectGroupHeaderDropPreview = {
-  dropIndex: number
-  dropIndicatorY: number
+export type ProjectGroupHeaderDropPreview = WorktreeSidebarHeaderDropPreview
+
+export type ProjectGroupTabOrderUpdate = {
+  groupId: string
+  tabOrder: number
 }
 
-const INDICATOR_GAP_PX = 4
 const ROOT_PROJECT_GROUP_HEADER_BUCKET = 'root'
 
 type SidebarProjectGroupHeader = ProjectGroup | { id: null } | undefined
@@ -60,36 +65,6 @@ export function getSidebarOrderedProjectGroupHeaderIdsByBucket(
   return buckets
 }
 
-export function getProjectGroupTabOrderForSidebarDrop(args: {
-  siblings: readonly ProjectGroup[]
-  dropIndex: number
-}): number {
-  const ordered = args.siblings.slice()
-  if (ordered.length === 0) {
-    return 0
-  }
-  const getOrder = (group: ProjectGroup | undefined): number | undefined =>
-    group && Number.isFinite(group.tabOrder) ? group.tabOrder : undefined
-  const before = getOrder(ordered[args.dropIndex - 1])
-  const after = getOrder(ordered[args.dropIndex])
-  if (before === undefined && after === undefined) {
-    return 0
-  }
-  if (before === undefined) {
-    return after !== undefined ? after - 1 : 0
-  }
-  if (after === undefined) {
-    return before + 1
-  }
-  if (after > before) {
-    const midpoint = before + (after - before) / 2
-    return Number.isFinite(midpoint) ? midpoint : before / 2 + after / 2
-  }
-  // Why: duplicate legacy ranks leave no slot between siblings; a finite anchor
-  // lets the next drag establish a stable persisted order.
-  return before + 1
-}
-
 export function mapSidebarProjectGroupDropIndexToSiblingInsertIndex(args: {
   sidebarDropIndex: number
   sourceIndex: number
@@ -104,6 +79,47 @@ export function mapSidebarProjectGroupDropIndexToSiblingInsertIndex(args: {
   return Math.max(0, Math.min(args.siblingCount, adjustedDropIndex))
 }
 
+export function getProjectGroupTabOrderUpdatesForSidebarDrop(args: {
+  sidebarProjectGroupHeaderIds: readonly string[]
+  draggedGroupId: string
+  sidebarDropIndex: number
+  projectGroupById: ReadonlyMap<string, ProjectGroup>
+}): ProjectGroupTabOrderUpdate[] {
+  const sourceIndex = args.sidebarProjectGroupHeaderIds.indexOf(args.draggedGroupId)
+  if (sourceIndex === -1) {
+    return []
+  }
+  const siblingIds = args.sidebarProjectGroupHeaderIds.filter(
+    (groupId) => groupId !== args.draggedGroupId
+  )
+  const siblingDropIndex = mapSidebarProjectGroupDropIndexToSiblingInsertIndex({
+    sidebarDropIndex: args.sidebarDropIndex,
+    sourceIndex,
+    siblingCount: siblingIds.length
+  })
+  const sourceIndexInSiblings = Math.min(sourceIndex, siblingIds.length)
+  if (siblingDropIndex === sourceIndexInSiblings) {
+    return []
+  }
+
+  const orderedIds = siblingIds.slice()
+  orderedIds.splice(siblingDropIndex, 0, args.draggedGroupId)
+
+  const updates: ProjectGroupTabOrderUpdate[] = []
+  for (const [index, groupId] of orderedIds.entries()) {
+    const group = args.projectGroupById.get(groupId)
+    if (!group) {
+      continue
+    }
+    // Why: legacy groups can all have tabOrder=0, so a one-row midpoint update
+    // cannot express an insertion inside that equal-rank block.
+    if (group.tabOrder !== index) {
+      updates.push({ groupId, tabOrder: index })
+    }
+  }
+  return updates
+}
+
 function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
   if (!virtualRow) {
     return null
@@ -114,6 +130,15 @@ function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
   }
   const start = Number(rawStart)
   return Number.isFinite(start) ? start : null
+}
+
+function getOptionalNumberAttribute(element: HTMLElement, attribute: string): number | undefined {
+  const rawValue = element.getAttribute(attribute)
+  if (rawValue === null) {
+    return undefined
+  }
+  const value = Number(rawValue)
+  return Number.isFinite(value) ? value : undefined
 }
 
 export function measureProjectGroupHeaderDragRects(
@@ -145,7 +170,8 @@ export function measureProjectGroupHeaderDragRects(
       bucketKey: elementBucketKey,
       headerIndex,
       top,
-      bottom: top + rect.height
+      bottom: top + rect.height,
+      sectionBottom: getOptionalNumberAttribute(element, 'data-project-group-header-section-end')
     })
   })
   rects.sort((left, right) => left.top - right.top)
@@ -160,51 +186,12 @@ export function computeProjectGroupHeaderDropPreview(args: {
   sidebarProjectGroupHeaderIds: readonly string[]
 }): ProjectGroupHeaderDropPreview | null {
   const { rects, sidebarProjectGroupHeaderIds } = args
-  if (rects.length === 0 || sidebarProjectGroupHeaderIds.length === 0) {
-    return null
-  }
-
-  const localY = args.pointerY - args.containerTop + args.scrollTop
-  const first = rects[0]!
-  const last = rects.at(-1)!
-  const boundaryDrop = getWorktreeSidebarBoundaryDrop({
-    localY,
-    firstRect: {
-      worktreeId: first.groupId,
-      groupIndex: first.headerIndex,
-      top: first.top,
-      bottom: first.bottom
-    },
-    lastRect: {
-      worktreeId: last.groupId,
-      groupIndex: last.headerIndex,
-      top: last.top,
-      bottom: last.bottom
-    },
-    sourceGroupSize: sidebarProjectGroupHeaderIds.length
+  return computeWorktreeSidebarHeaderDropPreview({
+    pointerY: args.pointerY,
+    containerTop: args.containerTop,
+    scrollTop: args.scrollTop,
+    rects,
+    headerCount: sidebarProjectGroupHeaderIds.length,
+    getId: (rect) => rect.groupId
   })
-  if (boundaryDrop.kind === 'outside') {
-    return null
-  }
-
-  let dropIndex = last.headerIndex + 1
-  let indicatorY = last.bottom + INDICATOR_GAP_PX
-  if (boundaryDrop.kind === 'drop') {
-    dropIndex = boundaryDrop.dropIndex
-    indicatorY = boundaryDrop.indicatorY
-  } else {
-    for (const rect of rects) {
-      const mid = (rect.top + rect.bottom) / 2
-      if (localY < mid) {
-        dropIndex = rect.headerIndex
-        indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
-        break
-      }
-    }
-  }
-
-  return {
-    dropIndex,
-    dropIndicatorY: Math.max(args.scrollTop, indicatorY)
-  }
 }

--- a/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
@@ -46,12 +46,11 @@ describe('createProjectHeaderDragSession', () => {
     expect(handleEl.setPointerCapture).not.toHaveBeenCalled()
   })
 
-  it('does not arm drag when the pointer starts outside the project icon handle', () => {
+  it('arms a drag session from plain project header text when the row is the drag handle', () => {
     const header = document.createElement('div')
-    const handleEl = document.createElement('div')
-    handleEl.setAttribute('data-repo-header-drag-handle', '')
-    const chevron = document.createElement('span')
-    header.append(handleEl, chevron)
+    header.setAttribute('data-repo-header-drag-handle', '')
+    const label = document.createElement('span')
+    header.append(label)
     const scrollContainer = document.createElement('div')
     document.body.append(scrollContainer, header)
 
@@ -64,7 +63,7 @@ describe('createProjectHeaderDragSession', () => {
         pointerId: 1,
         clientX: 10,
         clientY: 20,
-        target: chevron,
+        target: label,
         currentTarget: header
       } as unknown as React.PointerEvent<HTMLElement>,
       repoId: 'repo-a',
@@ -73,6 +72,6 @@ describe('createProjectHeaderDragSession', () => {
       getScrollContainer: () => scrollContainer
     })
 
-    expect(session).toBeNull()
+    expect(session?.repoId).toBe('repo-a')
   })
 })

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -84,6 +84,23 @@ export function useRepoHeaderDrag({
     []
   )
 
+  const applyDrop = useCallback(
+    (repoId: string, drop: { dropIndex: number; dropIndicatorY: number } | null) => {
+      latestDropIndexRef.current = drop?.dropIndex ?? null
+      const nextState: RepoDragState = drop
+        ? { draggingRepoId: repoId, ...drop }
+        : { draggingRepoId: repoId, dropIndex: null, dropIndicatorY: null }
+      setState((prev) =>
+        prev.draggingRepoId === nextState.draggingRepoId &&
+        prev.dropIndex === nextState.dropIndex &&
+        prev.dropIndicatorY === nextState.dropIndicatorY
+          ? prev
+          : nextState
+      )
+    },
+    []
+  )
+
   const cancelAutoscroll = useCallback(() => {
     if (autoscrollFrameIdRef.current !== null) {
       window.cancelAnimationFrame(autoscrollFrameIdRef.current)
@@ -171,18 +188,11 @@ export function useRepoHeaderDrag({
         refreshHeaderRects()
       }
 
-      const drop = computeDrop(session.latestPointerY)
-      if (drop) {
-        setState((prev) =>
-          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
-            ? prev
-            : { draggingRepoId: session.repoId, ...drop }
-        )
-      }
+      applyDrop(session.repoId, computeDrop(session.latestPointerY))
 
       autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
     },
-    [cancelAutoscroll, computeDrop, refreshHeaderRects]
+    [applyDrop, cancelAutoscroll, computeDrop, refreshHeaderRects]
   )
 
   const ensureAutoscroll = useCallback(() => {
@@ -227,14 +237,7 @@ export function useRepoHeaderDrag({
         setState({ draggingRepoId: session.repoId, dropIndex: null, dropIndicatorY: null })
       }
       refreshHeaderRects()
-      const drop = computeDrop(e.clientY)
-      if (drop) {
-        setState((prev) =>
-          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
-            ? prev
-            : { draggingRepoId: session.repoId, ...drop }
-        )
-      }
+      applyDrop(session.repoId, computeDrop(e.clientY))
       ensureAutoscroll()
     }
     const onPointerUp = (e: PointerEvent): void => {
@@ -275,7 +278,15 @@ export function useRepoHeaderDrag({
         clickSwallowTimeoutRef.current = null
       }
     }
-  }, [cancelAutoscroll, computeDrop, endDrag, ensureAutoscroll, refreshHeaderRects, sessionArmed])
+  }, [
+    applyDrop,
+    cancelAutoscroll,
+    computeDrop,
+    endDrag,
+    ensureAutoscroll,
+    refreshHeaderRects,
+    sessionArmed
+  ])
 
   useEffect(() => {
     if (state.draggingRepoId === null) {

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -120,14 +120,66 @@ describe('computeProjectHeaderDropPreview', () => {
 
   it('supports boundary drops at the end of the full sidebar list', () => {
     const preview = computeProjectHeaderDropPreview({
-      pointerY: 360,
+      pointerY: 400,
       containerTop: 0,
       scrollTop: 0,
       sidebarRepoHeaderIds: ['a', 'b', 'c'],
-      rects: [{ repoId: 'c', bucketKey: 'ungrouped', headerIndex: 2, top: 300, bottom: 328 }]
+      rects: [
+        {
+          repoId: 'c',
+          bucketKey: 'ungrouped',
+          headerIndex: 2,
+          top: 300,
+          bottom: 328,
+          sectionBottom: 380
+        }
+      ]
     })
 
-    expect(preview).toEqual({ dropIndex: 3, dropIndicatorY: 331 })
+    expect(preview).toEqual({ dropIndex: 3, dropIndicatorY: 383 })
+  })
+
+  it('does not create a drop slot inside an expanded project section', () => {
+    const preview = computeProjectHeaderDropPreview({
+      pointerY: 350,
+      containerTop: 0,
+      scrollTop: 0,
+      sidebarRepoHeaderIds: ['a', 'b', 'c'],
+      rects: [
+        {
+          repoId: 'c',
+          bucketKey: 'ungrouped',
+          headerIndex: 2,
+          top: 300,
+          bottom: 328,
+          sectionBottom: 380
+        }
+      ]
+    })
+
+    expect(preview).toBeNull()
+  })
+
+  it('does not create a drop slot in the contents between sibling project headers', () => {
+    const preview = computeProjectHeaderDropPreview({
+      pointerY: 150,
+      containerTop: 0,
+      scrollTop: 0,
+      sidebarRepoHeaderIds: ['a', 'b'],
+      rects: [
+        {
+          repoId: 'a',
+          bucketKey: 'ungrouped',
+          headerIndex: 0,
+          top: 100,
+          bottom: 128,
+          sectionBottom: 220
+        },
+        { repoId: 'b', bucketKey: 'ungrouped', headerIndex: 1, top: 220, bottom: 248 }
+      ]
+    })
+
+    expect(preview).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -1,5 +1,8 @@
 import { getEffectiveProjectGroupManualRank } from '../../../../shared/project-groups'
-import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
+import {
+  computeWorktreeSidebarHeaderDropPreview,
+  type WorktreeSidebarHeaderDropPreview
+} from './worktree-sidebar-header-drop-preview'
 import type { Row } from './worktree-list-groups'
 import type { Repo } from '../../../../shared/types'
 
@@ -14,14 +17,10 @@ export type ProjectHeaderDragRect = {
   headerIndex: number
   top: number
   bottom: number
+  sectionBottom?: number
 }
 
-export type ProjectHeaderDropPreview = {
-  dropIndex: number
-  dropIndicatorY: number
-}
-
-const INDICATOR_GAP_PX = 4
+export type ProjectHeaderDropPreview = WorktreeSidebarHeaderDropPreview
 
 export function getProjectHeaderDragBucketKey(
   repo: Pick<Repo, 'projectGroupId'>
@@ -115,6 +114,15 @@ function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
   return Number.isFinite(start) ? start : null
 }
 
+function getOptionalNumberAttribute(element: HTMLElement, attribute: string): number | undefined {
+  const rawValue = element.getAttribute(attribute)
+  if (rawValue === null) {
+    return undefined
+  }
+  const value = Number(rawValue)
+  return Number.isFinite(value) ? value : undefined
+}
+
 export function measureProjectHeaderDragRects(
   container: HTMLElement,
   bucketKey?: ProjectHeaderDragBucketKey
@@ -144,7 +152,8 @@ export function measureProjectHeaderDragRects(
       bucketKey: elementBucketKey,
       headerIndex,
       top,
-      bottom: top + rect.height
+      bottom: top + rect.height,
+      sectionBottom: getOptionalNumberAttribute(element, 'data-repo-header-section-end')
     })
   })
   rects.sort((left, right) => left.top - right.top)
@@ -177,53 +186,14 @@ export function computeProjectHeaderDropPreview(args: {
   sidebarRepoHeaderIds: readonly string[]
 }): ProjectHeaderDropPreview | null {
   const { rects, sidebarRepoHeaderIds } = args
-  if (rects.length === 0 || sidebarRepoHeaderIds.length === 0) {
-    return null
-  }
-
-  const localY = args.pointerY - args.containerTop + args.scrollTop
-  const first = rects[0]!
-  const last = rects.at(-1)!
-  const boundaryDrop = getWorktreeSidebarBoundaryDrop({
-    localY,
-    firstRect: {
-      worktreeId: first.repoId,
-      groupIndex: first.headerIndex,
-      top: first.top,
-      bottom: first.bottom
-    },
-    lastRect: {
-      worktreeId: last.repoId,
-      groupIndex: last.headerIndex,
-      top: last.top,
-      bottom: last.bottom
-    },
-    sourceGroupSize: sidebarRepoHeaderIds.length
+  return computeWorktreeSidebarHeaderDropPreview({
+    pointerY: args.pointerY,
+    containerTop: args.containerTop,
+    scrollTop: args.scrollTop,
+    rects,
+    headerCount: sidebarRepoHeaderIds.length,
+    getId: (rect) => rect.repoId
   })
-  if (boundaryDrop.kind === 'outside') {
-    return null
-  }
-
-  let dropIndex = last.headerIndex + 1
-  let indicatorY = last.bottom + INDICATOR_GAP_PX
-  if (boundaryDrop.kind === 'drop') {
-    dropIndex = boundaryDrop.dropIndex
-    indicatorY = boundaryDrop.indicatorY
-  } else {
-    for (const rect of rects) {
-      const mid = (rect.top + rect.bottom) / 2
-      if (localY < mid) {
-        dropIndex = rect.headerIndex
-        indicatorY = Math.max(0, rect.top - INDICATOR_GAP_PX)
-        break
-      }
-    }
-  }
-
-  return {
-    dropIndex,
-    dropIndicatorY: Math.max(args.scrollTop, indicatorY)
-  }
 }
 
 export function applyAllRepoInsertAt(

--- a/src/renderer/src/components/sidebar/worktree-header-section-boundaries.ts
+++ b/src/renderer/src/components/sidebar/worktree-header-section-boundaries.ts
@@ -1,0 +1,131 @@
+import { estimateRenderRowSize, type RenderRow } from './worktree-list-virtual-rows'
+
+function getEstimatedRenderRowStarts(
+  rows: readonly RenderRow[],
+  firstHeaderIndex: number
+): number[] {
+  const starts: number[] = []
+  let offset = 0
+  for (let index = 0; index < rows.length; index++) {
+    starts[index] = offset
+    offset += estimateRenderRowSize(rows, index, firstHeaderIndex, null)
+  }
+  starts[rows.length] = offset
+  return starts
+}
+
+function findRepoHeaderRenderRowIndex(rows: readonly RenderRow[], repoId: string): number {
+  return rows.findIndex((row) => row.type === 'header' && row.repo?.id === repoId)
+}
+
+function findProjectGroupHeaderRenderRowIndex(rows: readonly RenderRow[], groupId: string): number {
+  return rows.findIndex(
+    (row) =>
+      row.type === 'header' &&
+      !row.repo &&
+      typeof row.projectGroup?.id === 'string' &&
+      row.projectGroup.id === groupId
+  )
+}
+
+function findNextHeaderRenderRowIndex(rows: readonly RenderRow[], startIndex: number): number {
+  for (let index = startIndex; index < rows.length; index++) {
+    const row = rows[index]
+    if (row?.type === 'header' || row?.type === 'host-header') {
+      return index
+    }
+  }
+  return rows.length
+}
+
+function findProjectGroupSectionEndIndex(
+  rows: readonly RenderRow[],
+  startIndex: number,
+  depth: number
+): number {
+  for (let index = startIndex; index < rows.length; index++) {
+    const row = rows[index]
+    if (!row) {
+      continue
+    }
+    if (row.type === 'host-header') {
+      return index
+    }
+    if (row.type !== 'header') {
+      continue
+    }
+    const rowDepth = row.projectGroupDepth ?? 0
+    if (rowDepth <= depth || (!row.repo && !row.projectGroup)) {
+      return index
+    }
+  }
+  return rows.length
+}
+
+export function getRepoHeaderSectionEndByRepoId(args: {
+  rows: readonly RenderRow[]
+  firstHeaderIndex: number
+  sidebarRepoHeaderIdsByBucket: ReadonlyMap<string, readonly string[]>
+  repoHeaderBucketByRepoId: ReadonlyMap<string, string>
+}): Map<string, number> {
+  const rowStarts = getEstimatedRenderRowStarts(args.rows, args.firstHeaderIndex)
+  const sectionEndByRepoId = new Map<string, number>()
+  for (let index = 0; index < args.rows.length; index++) {
+    const row = args.rows[index]
+    const repoId = row?.type === 'header' ? row.repo?.id : undefined
+    if (!repoId) {
+      continue
+    }
+    const bucketKey = args.repoHeaderBucketByRepoId.get(repoId)
+    const bucketRepoIds = bucketKey ? args.sidebarRepoHeaderIdsByBucket.get(bucketKey) : undefined
+    const bucketIndex = bucketRepoIds?.indexOf(repoId) ?? -1
+    const nextRepoId = bucketIndex >= 0 ? bucketRepoIds?.[bucketIndex + 1] : undefined
+    const endIndex = nextRepoId
+      ? findRepoHeaderRenderRowIndex(args.rows, nextRepoId)
+      : findNextHeaderRenderRowIndex(args.rows, index + 1)
+    sectionEndByRepoId.set(
+      repoId,
+      rowStarts[endIndex >= 0 ? endIndex : args.rows.length] ?? rowStarts[args.rows.length] ?? 0
+    )
+  }
+  return sectionEndByRepoId
+}
+
+export function getProjectGroupHeaderSectionEndByGroupId(args: {
+  rows: readonly RenderRow[]
+  firstHeaderIndex: number
+  sidebarProjectGroupHeaderIdsByBucket: ReadonlyMap<string, readonly string[]>
+  projectGroupHeaderBucketByGroupId: ReadonlyMap<string, string>
+}): Map<string, number> {
+  const rowStarts = getEstimatedRenderRowStarts(args.rows, args.firstHeaderIndex)
+  const sectionEndByGroupId = new Map<string, number>()
+  for (let index = 0; index < args.rows.length; index++) {
+    const row = args.rows[index]
+    const projectGroupHeader =
+      row?.type === 'header' &&
+      !row.repo &&
+      row.projectGroup &&
+      typeof row.projectGroup.id === 'string'
+        ? { row, groupId: row.projectGroup.id }
+        : null
+    const groupId = projectGroupHeader?.groupId
+    if (!groupId) {
+      continue
+    }
+    const bucketKey = args.projectGroupHeaderBucketByGroupId.get(groupId)
+    const bucketGroupIds = bucketKey
+      ? args.sidebarProjectGroupHeaderIdsByBucket.get(bucketKey)
+      : undefined
+    const bucketIndex = bucketGroupIds?.indexOf(groupId) ?? -1
+    const nextGroupId = bucketIndex >= 0 ? bucketGroupIds?.[bucketIndex + 1] : undefined
+    const depth = projectGroupHeader.row.projectGroupDepth ?? 0
+    const endIndex = nextGroupId
+      ? findProjectGroupHeaderRenderRowIndex(args.rows, nextGroupId)
+      : findProjectGroupSectionEndIndex(args.rows, index + 1, depth)
+    sectionEndByGroupId.set(
+      groupId,
+      rowStarts[endIndex >= 0 ? endIndex : args.rows.length] ?? rowStarts[args.rows.length] ?? 0
+    )
+  }
+  return sectionEndByGroupId
+}

--- a/src/renderer/src/components/sidebar/worktree-sidebar-header-drop-preview.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-header-drop-preview.ts
@@ -1,0 +1,79 @@
+import { getWorktreeSidebarBoundaryDrop } from './worktree-sidebar-drag-autoscroll'
+
+export type WorktreeSidebarHeaderDragRect = {
+  headerIndex: number
+  top: number
+  bottom: number
+  sectionBottom?: number
+}
+
+export type WorktreeSidebarHeaderDropPreview = {
+  dropIndex: number
+  dropIndicatorY: number
+}
+
+const INDICATOR_GAP_PX = 4
+
+export function computeWorktreeSidebarHeaderDropPreview<
+  TRect extends WorktreeSidebarHeaderDragRect
+>(args: {
+  pointerY: number
+  containerTop: number
+  scrollTop: number
+  rects: readonly TRect[]
+  headerCount: number
+  getId: (rect: TRect) => string
+}): WorktreeSidebarHeaderDropPreview | null {
+  if (args.rects.length === 0 || args.headerCount === 0) {
+    return null
+  }
+
+  const localY = args.pointerY - args.containerTop + args.scrollTop
+  const first = args.rects[0]!
+  const last = args.rects.at(-1)!
+  const lastBoundaryBottom = Math.max(last.bottom, last.sectionBottom ?? last.bottom)
+  const boundaryDrop = getWorktreeSidebarBoundaryDrop({
+    localY,
+    firstRect: {
+      worktreeId: args.getId(first),
+      groupIndex: first.headerIndex,
+      top: first.top,
+      bottom: first.bottom
+    },
+    lastRect: {
+      worktreeId: args.getId(last),
+      groupIndex: last.headerIndex,
+      top: last.top,
+      bottom: lastBoundaryBottom
+    },
+    sourceGroupSize: args.headerCount
+  })
+  if (boundaryDrop.kind === 'outside') {
+    return null
+  }
+  if (boundaryDrop.kind === 'drop') {
+    return {
+      dropIndex: boundaryDrop.dropIndex,
+      dropIndicatorY: Math.max(args.scrollTop, boundaryDrop.indicatorY)
+    }
+  }
+
+  const hoveredRect = args.rects.find((rect) => localY >= rect.top && localY <= rect.bottom)
+  if (!hoveredRect) {
+    return null
+  }
+
+  const mid = (hoveredRect.top + hoveredRect.bottom) / 2
+  const dropIndex = localY < mid ? hoveredRect.headerIndex : hoveredRect.headerIndex + 1
+  const nextRect =
+    localY < mid ? hoveredRect : args.rects.find((rect) => rect.headerIndex >= dropIndex)
+  const indicatorY = nextRect
+    ? Math.max(0, nextRect.top - INDICATOR_GAP_PX)
+    : Math.max(hoveredRect.bottom, hoveredRect.sectionBottom ?? hoveredRect.bottom) +
+      INDICATOR_GAP_PX
+
+  return {
+    dropIndex,
+    dropIndicatorY: Math.max(args.scrollTop, indicatorY)
+  }
+}

--- a/tests/e2e/project-group-manual-sort.spec.ts
+++ b/tests/e2e/project-group-manual-sort.spec.ts
@@ -1,0 +1,339 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtemp } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+import type { Page } from '@stablyai/playwright-test'
+
+const GROUP_NAMES = [
+  'E2E Manual Group Alpha',
+  'E2E Manual Group Bravo',
+  'E2E Manual Group Charlie',
+  'E2E Manual Group Delta'
+] as const
+
+const PROJECT_NAMES = [
+  'e2e-manual-project-alpha',
+  'e2e-manual-project-bravo',
+  'e2e-manual-project-charlie'
+] as const
+
+const tempRoots: string[] = []
+
+type SeededProjectGroupSortScenario = {
+  alphaId: string
+  bravoId: string
+  charlieId: string
+  deltaId: string
+}
+
+type SeededProjectHeaderSortScenario = {
+  alphaId: string
+  bravoId: string
+  charlieId: string
+}
+
+function initializeGitRepo(repoPath: string): void {
+  mkdirSync(repoPath, { recursive: true })
+  execFileSync('git', ['init'], { cwd: repoPath, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'e2e@test.local'], {
+    cwd: repoPath,
+    stdio: 'pipe'
+  })
+  execFileSync('git', ['config', 'user.name', 'E2E Test'], { cwd: repoPath, stdio: 'pipe' })
+  writeFileSync(path.join(repoPath, 'README.md'), `# ${path.basename(repoPath)}\n`)
+  execFileSync('git', ['add', 'README.md'], { cwd: repoPath, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: repoPath, stdio: 'pipe' })
+}
+
+async function createProjectHeaderSortFixture(): Promise<string[]> {
+  // Why: match the app's canonical repo.path on macOS, where os.tmpdir()
+  // can resolve through /var -> /private/var.
+  const root = realpathSync(await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-project-sort-')))
+  tempRoots.push(root)
+  const repoPaths = PROJECT_NAMES.map((name) => path.join(root, name))
+  for (const repoPath of repoPaths) {
+    initializeGitRepo(repoPath)
+  }
+  return repoPaths
+}
+
+async function seedProjectHeaderSortScenario(
+  page: Page,
+  repoPaths: readonly string[]
+): Promise<SeededProjectHeaderSortScenario> {
+  return page.evaluate(async (paths) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    for (const repoPath of paths) {
+      await window.api.repos.add({ path: repoPath })
+    }
+
+    const state = store.getState()
+    state.setActiveView('terminal')
+    state.setSidebarOpen(true)
+    state.setGroupBy('repo')
+    state.setProjectOrderBy('manual')
+    await state.fetchRepos()
+
+    const repos = paths.map((repoPath) => {
+      const repo = store.getState().repos.find((candidate) => candidate.path === repoPath)
+      if (!repo) {
+        throw new Error(`Expected project repo to be loaded: ${repoPath}`)
+      }
+      return repo
+    })
+
+    for (const repo of repos) {
+      await store.getState().fetchWorktrees(repo.id)
+    }
+
+    return {
+      alphaId: repos[0]!.id,
+      bravoId: repos[1]!.id,
+      charlieId: repos[2]!.id
+    }
+  }, repoPaths)
+}
+
+async function seedDuplicateTabOrderProjectGroups(
+  page: Page
+): Promise<SeededProjectGroupSortScenario> {
+  return page.evaluate(async (groupNames) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    const state = store.getState()
+    state.setActiveView('terminal')
+    state.setSidebarOpen(true)
+    state.setGroupBy('repo')
+    state.setProjectOrderBy('manual')
+
+    const groups = []
+    for (const name of groupNames) {
+      const created = await state.createProjectGroup(name)
+      if (!created) {
+        throw new Error(`Failed to create Project Group: ${name}`)
+      }
+      // Why: existing profiles can have several groups with the same legacy rank;
+      // the drag must still be able to insert one between its siblings.
+      await state.updateProjectGroup(created.id, { tabOrder: 0 })
+      groups.push(created)
+    }
+
+    return {
+      alphaId: groups[0]!.id,
+      bravoId: groups[1]!.id,
+      charlieId: groups[2]!.id,
+      deltaId: groups[3]!.id
+    }
+  }, GROUP_NAMES)
+}
+
+async function getProjectHeaderOrder(
+  page: Page,
+  projectIds: SeededProjectHeaderSortScenario
+): Promise<string[]> {
+  const expectedIds = new Set(Object.values(projectIds))
+  return page.locator('[data-worktree-sidebar] [data-repo-header-id]').evaluateAll(
+    (elements, ids) =>
+      elements
+        .map((element) => ({
+          id: element.getAttribute('data-repo-header-id') ?? '',
+          top: element.getBoundingClientRect().top
+        }))
+        .filter((entry) => ids.includes(entry.id))
+        .sort((left, right) => left.top - right.top)
+        .map((entry) => entry.id),
+    [...expectedIds]
+  )
+}
+
+async function getProjectGroupHeaderOrder(
+  page: Page,
+  groupIds: SeededProjectGroupSortScenario
+): Promise<string[]> {
+  const expectedIds = new Set(Object.values(groupIds))
+  return page.locator('[data-worktree-sidebar] [data-project-group-header-id]').evaluateAll(
+    (elements, ids) =>
+      elements
+        .map((element) => ({
+          id: element.getAttribute('data-project-group-header-id') ?? '',
+          top: element.getBoundingClientRect().top
+        }))
+        .filter((entry) => ids.includes(entry.id))
+        .sort((left, right) => left.top - right.top)
+        .map((entry) => entry.id),
+    [...expectedIds]
+  )
+}
+
+async function dragProjectBefore(args: {
+  page: Page
+  draggedProjectId: string
+  targetProjectId: string
+}): Promise<void> {
+  const source = args.page.locator(`[data-repo-header-id="${args.draggedProjectId}"]`)
+  const target = args.page.locator(`[data-repo-header-id="${args.targetProjectId}"]`)
+  await source.scrollIntoViewIfNeeded()
+  await target.scrollIntoViewIfNeeded()
+  const sourceBox = await source.boundingBox()
+  const targetBox = await target.boundingBox()
+  if (!sourceBox || !targetBox) {
+    throw new Error('Project header bounding box was not available')
+  }
+
+  await args.page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+  await args.page.mouse.down()
+  await args.page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + 3, { steps: 8 })
+  await args.page.mouse.up()
+}
+
+async function dragProjectIntoProjectBody(args: {
+  page: Page
+  draggedProjectId: string
+  targetProjectId: string
+}): Promise<void> {
+  const source = args.page.locator(`[data-repo-header-id="${args.draggedProjectId}"]`)
+  const targetHeader = args.page.locator(`[data-repo-header-id="${args.targetProjectId}"]`)
+  await source.scrollIntoViewIfNeeded()
+  await targetHeader.scrollIntoViewIfNeeded()
+  const sourceBox = await source.boundingBox()
+  const targetHeaderBox = await targetHeader.boundingBox()
+  if (!sourceBox || !targetHeaderBox) {
+    throw new Error('Project body drag bounding box was not available')
+  }
+
+  await args.page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+  await args.page.mouse.down()
+  await args.page.mouse.move(
+    targetHeaderBox.x + targetHeaderBox.width / 2,
+    targetHeaderBox.y + targetHeaderBox.height * 0.75,
+    { steps: 4 }
+  )
+  await args.page.mouse.move(
+    targetHeaderBox.x + targetHeaderBox.width / 2,
+    targetHeaderBox.y + targetHeaderBox.height + 32,
+    { steps: 8 }
+  )
+  await args.page.mouse.up()
+}
+
+async function dragProjectGroupBefore(args: {
+  page: Page
+  draggedGroupId: string
+  targetGroupId: string
+}): Promise<void> {
+  const source = args.page.locator(`[data-project-group-header-id="${args.draggedGroupId}"]`)
+  const target = args.page.locator(`[data-project-group-header-id="${args.targetGroupId}"]`)
+  await source.scrollIntoViewIfNeeded()
+  await target.scrollIntoViewIfNeeded()
+  const sourceBox = await source.boundingBox()
+  const targetBox = await target.boundingBox()
+  if (!sourceBox || !targetBox) {
+    throw new Error('Project Group header bounding box was not available')
+  }
+
+  await args.page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+  await args.page.mouse.down()
+  await args.page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + 3, { steps: 8 })
+  await args.page.mouse.up()
+}
+
+test.afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test.describe('Project Group manual sorting', () => {
+  test('dragging a project header body reorders the visible project headers', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const repoPaths = await createProjectHeaderSortFixture()
+    const projects = await seedProjectHeaderSortScenario(orcaPage, repoPaths)
+
+    await expect
+      .poll(() => getProjectHeaderOrder(orcaPage, projects), {
+        timeout: 12_000,
+        message: 'Project headers did not render in manual order'
+      })
+      .toEqual([projects.alphaId, projects.bravoId, projects.charlieId])
+
+    await dragProjectBefore({
+      page: orcaPage,
+      draggedProjectId: projects.charlieId,
+      targetProjectId: projects.bravoId
+    })
+
+    await expect
+      .poll(() => getProjectHeaderOrder(orcaPage, projects), {
+        timeout: 12_000,
+        message: 'Dragged project header body did not persist the requested visible order'
+      })
+      .toEqual([projects.alphaId, projects.charlieId, projects.bravoId])
+  })
+
+  test('dropping a project over another project body does not reorder projects', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const repoPaths = await createProjectHeaderSortFixture()
+    const projects = await seedProjectHeaderSortScenario(orcaPage, repoPaths)
+
+    await expect
+      .poll(() => getProjectHeaderOrder(orcaPage, projects), {
+        timeout: 12_000,
+        message: 'Project headers did not render in manual order'
+      })
+      .toEqual([projects.alphaId, projects.bravoId, projects.charlieId])
+
+    await dragProjectIntoProjectBody({
+      page: orcaPage,
+      draggedProjectId: projects.alphaId,
+      targetProjectId: projects.bravoId
+    })
+
+    await expect
+      .poll(() => getProjectHeaderOrder(orcaPage, projects), {
+        timeout: 12_000,
+        message: 'Dropping on a project body should not persist a project reorder'
+      })
+      .toEqual([projects.alphaId, projects.bravoId, projects.charlieId])
+  })
+
+  test('dragging a duplicate-ranked Project Group header reorders the visible headers', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const groups = await seedDuplicateTabOrderProjectGroups(orcaPage)
+
+    await expect
+      .poll(() => getProjectGroupHeaderOrder(orcaPage, groups), {
+        timeout: 12_000,
+        message: 'Project Group headers did not render in duplicate-rank name order'
+      })
+      .toEqual([groups.alphaId, groups.bravoId, groups.charlieId, groups.deltaId])
+
+    await dragProjectGroupBefore({
+      page: orcaPage,
+      draggedGroupId: groups.deltaId,
+      targetGroupId: groups.charlieId
+    })
+
+    await expect
+      .poll(() => getProjectGroupHeaderOrder(orcaPage, groups), {
+        timeout: 12_000,
+        message: 'Dragged Project Group header did not persist the requested visible order'
+      })
+      .toEqual([groups.alphaId, groups.bravoId, groups.deltaId, groups.charlieId])
+  })
+})


### PR DESCRIPTION
## Summary
- Reindex the affected Project Group sibling bucket after a drag, so legacy duplicate `tabOrder` values can still represent the requested visible order.
- Allow dragging from Project Group header rows and project header rows while preserving action/collapse opt-outs.
- Constrain project and Project Group drops to real header reorder slots; releasing over another project's body now clears the target and no-ops instead of reusing a stale reorder slot.
- Replace the dashed project/group reorder line with the same solid sidebar drop marker used by card/worktree reordering.
- Share the header drop-preview logic between project and Project Group sorting, and update the committed drop-index ref synchronously when a target clears.
- Add focused unit coverage and Electron E2E regressions for duplicate-ranked Project Group headers, project header body dragging, and project-body drop no-ops.

Fixes #6609. Follow-up to #7191 and https://github.com/stablyai/orca/issues/6609#issuecomment-4874594083.

## Evidence
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/project-header-drop.test.ts src/renderer/src/components/sidebar/project-group-header-drop.test.ts src/renderer/src/components/sidebar/project-header-drag-start.test.ts src/renderer/src/components/sidebar/project-group-header-drag-start.test.ts src/renderer/src/components/sidebar/project-header-drag-commit.test.ts src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts` - 6 files / 40 tests passed.
- `pnpm run test:e2e -- tests/e2e/project-group-manual-sort.spec.ts --workers=1` - rebuilt Electron E2E app; 3 tests passed in 34.7s.
- `pnpm run typecheck` - passed.
- `pnpm run lint` - passed; emitted existing warnings outside this change.
- `git diff --check` - passed.