### PR TITLE
fix(i18n): persist UI language across restart and retranslate settings nav on live switch

### DIFF
--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.language-switch.test.tsx
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.language-switch.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { UI_LANGUAGE_CHINESE, UI_LANGUAGE_ENGLISH } from '../../../shared/ui-language'
+import { i18n } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import type { SettingsNavSection } from '@/lib/settings-navigation-types'
+import { useSettingsNavigationMetadata } from './useSettingsNavigationMetadata'
+
+// Why: bug 2 lives in the hook's memoization, not the pure builder — the plain
+// builder tests in useSettingsNavigationMetadata.test.ts translate correctly at
+// call time and can never catch a stale useMemo. This spec renders the real
+// hook and switches the live locale, so a memo whose deps miss the active
+// locale returns the previous language's sections and fails here.
+
+const initialAppState = useAppStore.getInitialState()
+
+// The "General" nav row: distinct en ("General") / zh ("通用") titles, always
+// present, no platform/runtime gating.
+function generalTitle(sections: SettingsNavSection[]): string | undefined {
+  return sections.find((section) => section.id === 'general')?.title
+}
+
+describe('useSettingsNavigationMetadata live language switch', () => {
+  beforeEach(async () => {
+    useAppStore.setState(initialAppState, true)
+    await i18n.changeLanguage(UI_LANGUAGE_ENGLISH)
+  })
+
+  afterEach(async () => {
+    await i18n.changeLanguage(UI_LANGUAGE_ENGLISH)
+  })
+
+  it('retranslates nav section titles when the UI language changes without a remount', async () => {
+    const { result } = renderHook(() => useSettingsNavigationMetadata())
+
+    // Baseline: the hook memoizes English sections on first render.
+    expect(generalTitle(result.current)).toBe('General')
+
+    // Same signal the live Language select fires: useTranslation reruns the hook.
+    await act(async () => {
+      await i18n.changeLanguage(UI_LANGUAGE_CHINESE)
+    })
+
+    // The rerender alone is not enough: the memo must recompute against the new
+    // active locale, or the sidebar/Cmd+J stay English until Settings remounts.
+    expect(generalTitle(result.current)).toBe('通用')
+  })
+})

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -551,9 +551,12 @@ export function buildSettingsNavigationMetadata({
 }
 
 export function useSettingsNavigationMetadata(): SettingsNavSection[] {
-  // Why: subscribe metadata consumers to language changes; translated memo
-  // contents refresh on rerender without depending on i18n.language directly.
-  useTranslation()
+  // Why: useTranslation subscribes to language changes, and the active locale
+  // must be a memo dependency below — a rerender alone returns the cached
+  // previous-language sections, leaving the Settings sidebar and Cmd+J palette
+  // stuck in the old language until remount.
+  const { i18n } = useTranslation()
+  const activeLocale = i18n.language
   const repos = useAppStore((state) => state.repos)
   const settings = useAppStore((state) => state.settings)
   const isMac = isMacUserAgent()
@@ -584,6 +587,7 @@ export function useSettingsNavigationMetadata(): SettingsNavSection[] {
         isDev: import.meta.env.DEV,
         repos
       }),
-    [isMac, isWindows, isWindowsTerminalHost, isWebClient, repos]
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- activeLocale is read implicitly by the translate() calls inside buildSettingsNavigationMetadata; without it the memo keeps the previous language's sections.
+    [isMac, isWindows, isWindowsTerminalHost, isWebClient, repos, activeLocale]
   )
 }

--- a/src/renderer/src/i18n/I18nProvider.test.tsx
+++ b/src/renderer/src/i18n/I18nProvider.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UI_LANGUAGE_ENGLISH } from '../../../shared/ui-language'
+import type { AppState } from '@/store/types'
+import { useAppStore } from '@/store'
+import { i18n } from './i18n'
+import { I18nProvider } from './I18nProvider'
+
+// Why: bug 1 is a boot race — on a non-English system the provider kicks off an
+// async system-locale switch whose lazy catalog is still loading when the
+// persisted language arrives. The removed `i18n.language !== locale` guard read
+// the still-active init default and skipped the correction, so the stale
+// in-flight switch finished and won. This spec pins the fix's cause: the effect
+// must always issue the corrective switch, even when i18n.language already reads
+// the target (the exact state the guard mishandled). The full persisted-wins
+// behavior over a real in-flight switch is covered by the restart e2e, which
+// reproduces the timing window a unit test cannot deterministically hit.
+
+const initialAppState = useAppStore.getInitialState()
+
+function setPersistedUiLanguage(uiLanguage: string): void {
+  useAppStore.setState({ settings: { uiLanguage } as AppState['settings'] })
+}
+
+describe('I18nProvider persisted-language boot race', () => {
+  beforeEach(async () => {
+    useAppStore.setState(initialAppState, true)
+    await i18n.changeLanguage(UI_LANGUAGE_ENGLISH)
+  })
+
+  afterEach(async () => {
+    cleanup()
+    vi.restoreAllMocks()
+    await i18n.changeLanguage(UI_LANGUAGE_ENGLISH)
+  })
+
+  it('issues the corrective changeLanguage even when i18n.language already reads the target', async () => {
+    // Reproduces the exact skip: the persisted locale is 'en' and i18n.language
+    // also reads 'en' (the in-flight system switch has not landed). The old
+    // guard saw en === en and never drove i18next to the persisted language.
+    setPersistedUiLanguage(UI_LANGUAGE_ENGLISH)
+    const changeLanguageSpy = vi.spyOn(i18n, 'changeLanguage')
+
+    await act(async () => {
+      render(
+        <I18nProvider>
+          <div />
+        </I18nProvider>
+      )
+    })
+
+    expect(changeLanguageSpy).toHaveBeenCalledWith(UI_LANGUAGE_ENGLISH)
+  })
+})

--- a/src/renderer/src/i18n/I18nProvider.tsx
+++ b/src/renderer/src/i18n/I18nProvider.tsx
@@ -11,12 +11,17 @@ export function I18nProvider({ children }: { children: ReactNode }): React.JSX.E
   const locale = resolveUiLocale(uiLanguage)
 
   useEffect(() => {
-    if (i18n.language !== locale) {
-      // Why: changeLanguage triggers the lazy locale backend, which fetches the
-      // non-English catalog before activating it — so the switch resolves real
-      // translations without bundling every locale at startup.
-      void i18n.changeLanguage(locale)
-    }
+    // Why: changeLanguage triggers the lazy locale backend, which fetches the
+    // non-English catalog before activating it — so the switch resolves real
+    // translations without bundling every locale at startup.
+    // Why: no `i18n.language !== locale` guard. At boot the system-locale
+    // switch can still be lazy-loading its catalog when the persisted language
+    // arrives; i18n.language then still reads as the init default, the guard
+    // skips the correction, and the stale switch finishes and wins (UI renders
+    // the system language while settings show the persisted one). Calling
+    // changeLanguage unconditionally makes i18next's own last-call-wins
+    // handling discard the stale in-flight switch.
+    void i18n.changeLanguage(locale)
   }, [locale])
 
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -37,6 +37,14 @@ type RestartSession = {
   dispose: () => Promise<void>
 }
 
+type RestartSessionOptions = {
+  /**
+   * Extra Chromium/Electron switches prepended to every launch, e.g.
+   * `--lang=zh-CN` to simulate a non-English system locale on both launches.
+   */
+  extraElectronArgs?: string[]
+}
+
 async function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     const timeout = setTimeout(resolve, ms)
@@ -82,10 +90,14 @@ function launchEnv(userDataDir: string, headful: boolean): NodeJS.ProcessEnv {
  * env stripping, headful toggle) so behavior differences between fixtures
  * don't leak in as false positives for persistence bugs.
  */
-export function createRestartSession(testInfo: TestInfo): RestartSession {
+export function createRestartSession(
+  testInfo: TestInfo,
+  options: RestartSessionOptions = {}
+): RestartSession {
   const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
   const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-restart-'))
   const headful = shouldLaunchHeadful(testInfo)
+  const extraElectronArgs = options.extraElectronArgs ?? []
 
   // Why: this helper bypasses the shared `electronApp` fixture, so it must
   // seed the same completed onboarding profile or first-run overlays cover
@@ -97,7 +109,7 @@ export function createRestartSession(testInfo: TestInfo): RestartSession {
 
   const launch = async (): Promise<LaunchedOrca> => {
     const app = await electron.launch({
-      args: getOrcaElectronLaunchArgs(mainPath, headful),
+      args: [...extraElectronArgs, ...getOrcaElectronLaunchArgs(mainPath, headful)],
       env: launchEnv(userDataDir, headful)
     })
     const page = await app.firstWindow({ timeout: 120_000 })

--- a/tests/e2e/settings-sidebar-language-switch.spec.ts
+++ b/tests/e2e/settings-sidebar-language-switch.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * E2E repro: switching the UI language while Settings is open must retranslate
+ * the Settings sidebar navigation items immediately.
+ *
+ * User report: after changing the language (e.g. English → Chinese), the main
+ * settings pane switches live, but the left sidebar nav items ("General",
+ * "Appearance", …) stay in the previous language until Settings is closed and
+ * reopened. No app restart involved.
+ *
+ * Suspected mechanism: useSettingsNavigationMetadata() subscribes to language
+ * changes via useTranslation(), but memoizes the translated section list with
+ * deps that do not change on a language switch — so the rerender returns the
+ * stale previous-language array. Remounting Settings recomputes the memo,
+ * which is why reopening "fixes" it.
+ */
+
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import './helpers/runtime-types'
+
+const GENERAL_NAV_EN = 'General'
+const GENERAL_NAV_ZH = '通用'
+const SEARCH_SETTINGS_PLACEHOLDER_EN = 'Search settings'
+const SEARCH_SETTINGS_PLACEHOLDER_ZH = '搜索设置'
+
+async function openSettingsPage(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__store!.getState().openSettingsPage()
+  })
+}
+
+async function closeSettingsPage(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__store!.getState().closeSettingsPage()
+  })
+}
+
+/** The "General" sidebar nav row, matched exactly in the given language. */
+function generalNavItem(page: Page, label: string) {
+  return page.getByRole('button', { name: label, exact: true }).first()
+}
+
+test('settings sidebar nav retranslates immediately when the UI language changes', async ({
+  orcaPage
+}) => {
+  // Establish a known-English baseline regardless of the host system locale:
+  // pick English, wait for the render-time-translated search placeholder to
+  // flip, then remount Settings so the nav metadata is computed in English.
+  await orcaPage.evaluate(async () => {
+    await window.__store!.getState().updateSettings({ uiLanguage: 'en' })
+  })
+  await openSettingsPage(orcaPage)
+  await expect(orcaPage.getByPlaceholder(SEARCH_SETTINGS_PLACEHOLDER_EN)).toBeVisible({
+    timeout: 15_000
+  })
+  await closeSettingsPage(orcaPage)
+  await openSettingsPage(orcaPage)
+  await expect(generalNavItem(orcaPage, GENERAL_NAV_EN)).toBeVisible({ timeout: 15_000 })
+
+  // Same code path as the Language select in Settings → Appearance.
+  await orcaPage.evaluate(async () => {
+    await window.__store!.getState().updateSettings({ uiLanguage: 'zh' })
+  })
+
+  // The zh catalog is active once render-time translations show Chinese: the
+  // sidebar's own search placeholder retranslates on the language-change
+  // rerender, so it flipping proves everything except the memoized nav list
+  // has switched.
+  await expect(orcaPage.getByPlaceholder(SEARCH_SETTINGS_PLACEHOLDER_ZH)).toBeVisible({
+    timeout: 15_000
+  })
+
+  // Expected behavior: the nav item is Chinese without reopening Settings.
+  await expect(generalNavItem(orcaPage, GENERAL_NAV_ZH)).toBeVisible({ timeout: 5_000 })
+
+  // Reopening Settings must also show the Chinese nav (the user's workaround).
+  await closeSettingsPage(orcaPage)
+  await openSettingsPage(orcaPage)
+  await expect(generalNavItem(orcaPage, GENERAL_NAV_ZH)).toBeVisible({ timeout: 15_000 })
+})

--- a/tests/e2e/ui-language-restart-persistence.spec.ts
+++ b/tests/e2e/ui-language-restart-persistence.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * E2E repro: the persisted UI language must survive an app restart.
+ *
+ * User report: on a Chinese-locale system, switching the UI language to
+ * English works immediately, but after quitting and relaunching the app the
+ * UI renders in Chinese again — even though the settings pane still shows
+ * "English" as the selected language.
+ *
+ * The suspected mechanism is a boot race in I18nProvider: on first render the
+ * settings slice is still null, so the language falls back to "system"
+ * (Chinese) and kicks off an async changeLanguage('zh') that lazily imports
+ * the zh catalog. When the persisted settings ('en') arrive moments later,
+ * the provider's `i18n.language !== locale` guard sees the still-active 'en'
+ * (the zh switch has not completed yet) and skips the corrective change; the
+ * in-flight zh switch then lands and the UI ends up Chinese.
+ *
+ * Both launches pass `--lang=zh-CN` so navigator.language / app.getLocale()
+ * report a Chinese system locale regardless of the host machine.
+ */
+
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { createRestartSession } from './helpers/orca-restart'
+import './helpers/runtime-types'
+
+// Why: this spec does a full quit→relaunch cycle (two Electron instances
+// back-to-back); serial keeps cold-start contention out of the failure mode.
+test.describe.configure({ mode: 'serial' })
+
+const SEARCH_SETTINGS_PLACEHOLDER_EN = 'Search settings'
+const SEARCH_SETTINGS_PLACEHOLDER_ZH = '搜索设置'
+
+async function openSettingsPage(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__store!.getState().openSettingsPage()
+  })
+}
+
+/**
+ * The settings search input placeholder is the language probe: it renders on
+ * every settings open, has distinct en/zh translations, and needs no pointer
+ * interaction (first-run announcement overlays can cover the pane).
+ */
+function settingsSearchInput(page: Page, placeholder: string) {
+  return page.getByPlaceholder(placeholder)
+}
+
+// oxlint-disable-next-line no-empty-pattern -- Playwright fixture callbacks require object destructuring here.
+test('UI language set to English survives an app restart on a Chinese-locale system', async ({}, testInfo) => {
+  const session = createRestartSession(testInfo, { extraElectronArgs: ['--lang=zh-CN'] })
+
+  try {
+    // ── Launch 1: default settings (uiLanguage: system) on a zh system ──
+    const first = await session.launch()
+
+    await openSettingsPage(first.page)
+    // System locale zh applies after the lazy zh catalog loads.
+    await expect(settingsSearchInput(first.page, SEARCH_SETTINGS_PLACEHOLDER_ZH)).toBeVisible({
+      timeout: 15_000
+    })
+
+    // Same code path as the Language select in Settings → Appearance.
+    await first.page.evaluate(async () => {
+      await window.__store!.getState().updateSettings({ uiLanguage: 'en' })
+    })
+
+    // The switch to English takes effect live, as the user reported.
+    await expect(settingsSearchInput(first.page, SEARCH_SETTINGS_PLACEHOLDER_EN)).toBeVisible({
+      timeout: 15_000
+    })
+
+    await session.close(first.app)
+
+    // ── Launch 2: same userDataDir — persisted uiLanguage must win ──
+    const second = await session.launch()
+
+    // The persisted setting really is English (matches what the settings
+    // pane displays after restart in the user report).
+    const persistedUiLanguage = await second.page.evaluate(async () => {
+      const settings = await window.api.settings.get()
+      return settings.uiLanguage
+    })
+    expect(persistedUiLanguage).toBe('en')
+
+    // Wait until the renderer store has hydrated the persisted settings, so
+    // the I18nProvider has seen uiLanguage 'en'.
+    await second.page.waitForFunction(
+      () => window.__store?.getState().settings?.uiLanguage === 'en',
+      null,
+      { timeout: 30_000 }
+    )
+
+    // Why: the bug is a race where an in-flight system-locale (zh) catalog
+    // load lands *after* the persisted 'en' was observed. Give any pending
+    // lazy locale load ample time to settle before asserting, otherwise the
+    // still-English transient boot state would make this a false pass.
+    await second.page.waitForTimeout(3_000)
+
+    await openSettingsPage(second.page)
+    const searchInputAnyLanguage = second.page
+      .locator(
+        `input[placeholder="${SEARCH_SETTINGS_PLACEHOLDER_EN}"], ` +
+          `input[placeholder="${SEARCH_SETTINGS_PLACEHOLDER_ZH}"]`
+      )
+      .first()
+    await expect(searchInputAnyLanguage).toBeVisible({ timeout: 15_000 })
+    const placeholderAfterRestart = await searchInputAnyLanguage.getAttribute('placeholder')
+
+    // Expected behavior: the UI is still English after the restart.
+    expect(placeholderAfterRestart).toBe(SEARCH_SETTINGS_PLACEHOLDER_EN)
+
+    await session.close(second.app)
+  } finally {
+    await session.dispose()
+  }
+})


### PR DESCRIPTION
## Summary

Fixes two UI-language bugs, both reproduced and locked down with new E2E specs.

### Bug 1: persisted language reverts to the system language after restart

**Repro** (automated in `tests/e2e/ui-language-restart-persistence.spec.ts`):
1. On a Chinese-locale system (forced via `--lang=zh-CN`), set the UI language to English — the UI switches immediately and the setting persists as `'en'`.
2. Quit and relaunch the app against the same userData dir.
3. **Before:** the UI renders in Chinese again even though Settings still shows "English" as the selected language. **After:** the UI stays English.

**Root cause:** a boot race in `I18nProvider`. On first render the settings slice is still `null`, so the language falls back to "system" (zh) and kicks off an async `changeLanguage('zh')` that lazy-loads the zh catalog. When the persisted `'en'` arrives moments later, the provider's `i18n.language !== locale` guard still reads the init default `'en'` (the zh switch hasn't completed), skips the correction, and the in-flight zh switch lands and wins.

**Fix:** call `i18n.changeLanguage(locale)` unconditionally when the resolved locale changes. i18next's own last-call-wins handling (`isLanguageChangingTo`) discards the stale in-flight switch, so the persisted language always wins.

### Bug 2: Settings sidebar nav stays in the old language on live switch

**Repro** (automated in `tests/e2e/settings-sidebar-language-switch.spec.ts`):
1. With Settings open in English, switch the UI language to Chinese.
2. **Before:** the main pane, group headers, and search placeholder retranslate immediately, but the sidebar nav items ("General", "Appearance", …) stay English until Settings is closed and reopened. **After:** the nav items retranslate immediately, no remount needed.

**Root cause:** `useSettingsNavigationMetadata()` memoizes the translated section list with deps that never change on a language switch. `useTranslation()` triggers the rerender, but `useMemo` returns the cached previous-language array; only a remount recomputed it.

**Fix:** add the active locale (`i18n.language`) to the memo dependency array so the nav metadata is rebuilt with the new catalog. This also fixes the Cmd+J jump palette, which consumes the same hook.

## Change scope

- `src/renderer/src/i18n/I18nProvider.tsx` — remove the stale-read language guard; rely on i18next last-call-wins semantics.
- `src/renderer/src/hooks/useSettingsNavigationMetadata.ts` — recompute nav metadata when the active locale changes.
- `tests/e2e/ui-language-restart-persistence.spec.ts` — new regression E2E: quit/relaunch cycle under a forced zh-CN system locale.
- `tests/e2e/settings-sidebar-language-switch.spec.ts` — new regression E2E: live-switch retranslation of the settings sidebar, locale-independent.
- `tests/e2e/helpers/orca-restart.ts` — restart helper accepts extra Electron switches (used to force `--lang=zh-CN` on both launches).

## Test scope

- Both new E2E specs fail before the fixes (reproducing the reports) and pass after: restart persistence 7.6s, sidebar live switch 4.8s.
- Existing i18n unit tests (8) and `useSettingsNavigationMetadata` unit tests (14) pass; typecheck and oxlint clean.

## User impact

- Non-English-system users who pick a fixed UI language no longer see the app silently fall back to the system language after every restart.
- Switching languages now retranslates the Settings sidebar and Cmd+J palette immediately instead of requiring Settings to be reopened.
- No behavior change for users whose selected language already matches their system locale.