### PR TITLE
Fix git worktree list fallback for older Git

### DIFF
--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -237,6 +237,12 @@ bare
 })
 
 describe('listWorktreeGraph', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileSyncMock.mockReset()
+    translateWslOutputPathsMock.mockClear()
+  })
+
   it('returns the worktree graph without sparse-checkout annotation probes', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout: `worktree /repo
@@ -270,6 +276,48 @@ branch refs/heads/feature/test
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], {
       cwd: '/repo'
     })
+  })
+
+  it('falls back when older Git rejects worktree list -z with usage exit code', async () => {
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error('git usage error'), {
+          code: 129,
+          stderr: 'usage: git worktree list [<options>]\n'
+        })
+      )
+      .mockResolvedValueOnce({
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-main-2
+HEAD def456
+branch refs/heads/main-2
+`
+      })
+
+    await expect(listWorktreeGraph('/repo')).resolves.toEqual([
+      {
+        path: '/repo',
+        head: 'abc123',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: '/repo-main-2',
+        head: 'def456',
+        branch: 'refs/heads/main-2',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [['worktree', 'list', '--porcelain', '-z'], { cwd: '/repo' }],
+      [['worktree', 'list', '--porcelain'], { cwd: '/repo' }]
+    ])
   })
 
   it('returns an empty graph for paths Git reports as non-repositories', async () => {

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -320,6 +320,56 @@ branch refs/heads/main-2
     ])
   })
 
+  it('falls back on a localized (non-English) older-Git usage error via exit code 129', async () => {
+    // Git under a non-English locale translates the usage text, so stderr
+    // matching alone misses it; the 129 exit code must still trigger fallback.
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error('git worktree list --porcelain -z'), {
+          code: 129,
+          stderr: 'Fehler: Unbekannter Schalter »z«\nAufruf: git worktree list [<Optionen>]\n'
+        })
+      )
+      .mockResolvedValueOnce({
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      })
+
+    await expect(listWorktreeGraph('/repo')).resolves.toEqual([
+      {
+        path: '/repo',
+        head: 'abc123',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [['worktree', 'list', '--porcelain', '-z'], { cwd: '/repo' }],
+      [['worktree', 'list', '--porcelain'], { cwd: '/repo' }]
+    ])
+  })
+
+  it('does not retry without -z for non-usage Git failures', async () => {
+    // A fatal error (exit 128) is not an unsupported-flag signal, so the -z
+    // command must not be silently re-run without it.
+    gitExecFileAsyncMock.mockRejectedValueOnce(
+      Object.assign(new Error('git worktree list --porcelain -z'), {
+        code: 128,
+        stderr: 'fatal: unable to read tree\n'
+      })
+    )
+
+    await expect(listWorktreeGraph('/repo')).resolves.toEqual([])
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [['worktree', 'list', '--porcelain', '-z'], { cwd: '/repo' }]
+    ])
+  })
+
   it('returns an empty graph for paths Git reports as non-repositories', async () => {
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('fatal: not a git repository'))
 

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -104,15 +104,14 @@ function isNotGitRepositoryError(error: unknown): boolean {
 }
 
 function isUnsupportedWorktreeListZError(error: unknown): boolean {
-  // Why: this fixed command's only compatibility-sensitive flag is `-z`;
-  // localized Git usage errors still exit 129 when older versions reject it.
+  // Older Git (<2.36) rejects `-z`, this command's only version-sensitive flag,
+  // so Git's usage exit 129 identifies it regardless of locale. The stderr
+  // matcher is a fallback for runners that drop the numeric exit code.
   if (getErrorCode(error) === '129') {
     return true
   }
 
-  return /(?:unknown|invalid|unrecognized) (?:switch|option).*`?-?z'?/i.test(
-    getErrorText(error)
-  )
+  return /(?:unknown|invalid|unrecognized) (?:switch|option).*`?-?z'?/i.test(getErrorText(error))
 }
 
 function isUnsupportedRevParsePathFormatError(error: unknown): boolean {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -104,9 +104,8 @@ function isNotGitRepositoryError(error: unknown): boolean {
 }
 
 function isUnsupportedWorktreeListZError(error: unknown): boolean {
-  // Older Git (<2.36) rejects `-z`, this command's only version-sensitive flag,
-  // so Git's usage exit 129 identifies it regardless of locale. The stderr
-  // matcher is a fallback for runners that drop the numeric exit code.
+  // `-z` is this command's only flag older Git (<2.36) lacks, so its usage
+  // exit 129 signals the rejection in any locale; stderr match is a fallback.
   if (getErrorCode(error) === '129') {
     return true
   }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -104,7 +104,13 @@ function isNotGitRepositoryError(error: unknown): boolean {
 }
 
 function isUnsupportedWorktreeListZError(error: unknown): boolean {
-  return /(?:unknown|invalid) (?:switch|option).*`?-z'?|(?:unknown|invalid) (?:switch|option).*`?z'?/i.test(
+  // Why: this fixed command's only compatibility-sensitive flag is `-z`;
+  // localized Git usage errors still exit 129 when older versions reject it.
+  if (getErrorCode(error) === '129') {
+    return true
+  }
+
+  return /(?:unknown|invalid|unrecognized) (?:switch|option).*`?-?z'?/i.test(
     getErrorText(error)
   )
 }

--- a/src/relay/git-handler-utils.test.ts
+++ b/src/relay/git-handler-utils.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from 'vitest'
 import { parseStatusOutput } from './git-status-output-parser'
+import { isUnsupportedWorktreeListZError } from './git-handler-utils'
+
+describe('isUnsupportedWorktreeListZError', () => {
+  it('detects an English unknown-switch usage error', () => {
+    const error = Object.assign(new Error('worktree list -z'), {
+      code: 129,
+      stderr: "error: unknown switch `z'\nusage: git worktree list [<options>]\n"
+    })
+    expect(isUnsupportedWorktreeListZError(error)).toBe(true)
+  })
+
+  it('detects a localized (non-English) usage error via exit code 129', () => {
+    // The SSH remote may run under a non-English locale where the stderr text is
+    // translated; the numeric exit code must still classify the -z rejection.
+    const error = Object.assign(new Error('worktree list -z'), {
+      code: 129,
+      stderr: 'Fehler: Unbekannter Schalter »z«\nAufruf: git worktree list [<Optionen>]\n'
+    })
+    expect(isUnsupportedWorktreeListZError(error)).toBe(true)
+  })
+
+  it('does not classify a fatal (exit 128) error as an unsupported -z rejection', () => {
+    const error = Object.assign(new Error('fatal'), {
+      code: 128,
+      stderr: 'fatal: unable to read tree\n'
+    })
+    expect(isUnsupportedWorktreeListZError(error)).toBe(false)
+  })
+})
 
 describe('parseStatusOutput', () => {
   it('parses upstream ahead/behind from porcelain v2 branch headers', () => {

--- a/src/relay/git-handler-utils.test.ts
+++ b/src/relay/git-handler-utils.test.ts
@@ -3,9 +3,10 @@ import { parseStatusOutput } from './git-status-output-parser'
 import { isUnsupportedWorktreeListZError } from './git-handler-utils'
 
 describe('isUnsupportedWorktreeListZError', () => {
-  it('detects an English unknown-switch usage error', () => {
+  it('detects an unknown-switch usage error from stderr when the exit code is absent', () => {
+    // Isolates the regex fallback: no numeric code, so only the stderr text
+    // (a runner that dropped the exit code) can classify the rejection.
     const error = Object.assign(new Error('worktree list -z'), {
-      code: 129,
       stderr: "error: unknown switch `z'\nusage: git worktree list [<options>]\n"
     })
     expect(isUnsupportedWorktreeListZError(error)).toBe(true)

--- a/src/relay/git-handler-utils.ts
+++ b/src/relay/git-handler-utils.ts
@@ -147,10 +147,20 @@ function getErrorText(error: unknown): string {
   return String(error)
 }
 
+function getErrorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined
+}
+
 export function isUnsupportedWorktreeListZError(error: unknown): boolean {
-  return /(?:unknown|invalid) (?:switch|option).*`?-z'?|(?:unknown|invalid) (?:switch|option).*`?z'?/i.test(
-    getErrorText(error)
-  )
+  // `-z` is this command's only flag older Git (<2.36) lacks, so its usage exit
+  // 129 signals the rejection in any locale; key for SSH remotes on old Git.
+  if (getErrorCode(error) === '129') {
+    return true
+  }
+
+  return /(?:unknown|invalid|unrecognized) (?:switch|option).*`?-?z'?/i.test(getErrorText(error))
 }
 
 export function parseWorktreeList(


### PR DESCRIPTION
## Description

Fix worktree discovery on older Git versions (`< 2.36`) that reject `git worktree list --porcelain -z`. The `-z` flag landed in Git 2.36 (May 2022); before that — e.g. Git 2.25.1 on Ubuntu 20.04 LTS — the command fails with usage exit code `129`.

Orca already had a fallback to the non-`-z` command, but it fired only when it could regex-match the *English* usage text (`unknown switch`). Under a non-English locale, Git translates that text, the regex misses, and worktree listing breaks entirely (returns an empty graph).

This change treats Git's usage exit code `129` as the unsupported-`-z` signal, which is locale-independent. `-z` is the only version-sensitive flag in this fixed command, and modern Git never exits `129` for it, so `129` here uniquely means "this Git is too old for `-z`". The English stderr matcher is kept as a secondary signal for runners that surface the failure without a numeric exit code, and is broadened slightly (`unrecognized`, `-?z`).

The same fix is applied to the **relay (SSH) worktree path** (`src/relay/git-handler-utils.ts`), which has its own copy of this helper. This matters most over SSH: the relay runs `git` on the *remote* host, which is exactly where older distro Git lives.

Exit code `129` (usage error) is distinct from `128` (fatal, e.g. "not a git repository"), which is handled separately — verified against real Git.

## Evidence

Reproduction is a unit test that feeds a **localized (German)** older-Git usage error (`Fehler: Unbekannter Schalter »z«`, exit `129`) — the case the English regex cannot catch.

**Before (origin/main), main process** — `listWorktreeGraph` silently returns `[]` (fallback never runs):
```
FAIL  ... falls back when Git 2.25 rejects -z with a GERMAN (localized) usage error
AssertionError: expected [] to deeply equal [ { path: '/repo', … }, …(1) ]
+ Received  []
```

**After (this PR), main process:**
```
Test Files  1 passed (1)
     Tests  1 passed (1)
```

**Relay/SSH path** — same localized case, run against origin/main's relay helper then the fix:
```
Before:  × detects a localized (non-English) usage error via exit code 129
After:   Tests  8 passed (8)
```

Full touched-area suite: **158 passed**. `pnpm run typecheck` clean. `oxlint` clean on all touched files. Verified end-to-end that Node's `execFile` sets `error.code = 129` (number) for a real `git worktree list -Q` usage error, so the discriminator works in production, not just under mocks.

## ELI5

Old versions of Git don't understand a speed-up flag (`-z`) we ask for. When Git doesn't understand a flag it complains and quits with error number `129`. We used to recognize that complaint only when Git spoke English; on a computer set to German (or any other language) we didn't recognize it and showed no worktrees at all. Now we look at the error *number* `129` instead of the words, so it works in every language — including on remote servers you connect to over SSH, which often run older Git.

## Trade-offs

- **Extra subprocess on old Git only.** On Git `< 2.36`, each worktree listing now runs the failing `-z` probe and then the fallback (2 git invocations). On modern Git (the overwhelming majority) there is no extra cost. The failure is re-probed per call rather than cached — deliberately, because the caller may target different Git versions across local, WSL, and SSH remotes, so a cached "unsupported" verdict would be wrong for a heterogeneous environment.
- **`129` is Git's generic usage code.** For this *fixed* argv it can realistically only mean the `-z` rejection, and treating it as such at worst triggers one harmless fallback retry. Genuine repo failures exit `128` (not `129`) and are unaffected.
- **No behavior change on modern Git.** NUL-delimited parsing (which preserves worktree paths containing newlines) is still used whenever `-z` is supported; the fallback's older limitation around newline paths is retained only for old Git, exactly as before.
- **No new dependencies, IPC, shell strings, file writes, or provider-specific behavior.**