### PR TITLE
fix(sidebar): keep independent same-host checkouts of one repo as separate projects

### DIFF
--- a/src/renderer/src/components/cmd-j/palette-results.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-results.test.ts
@@ -357,7 +357,10 @@ describe('Cmd+J project and repo-group search', () => {
     ])
   })
 
-  it('uses project header keys for multi-setup projects on one host', () => {
+  it('splits independent same-host checkouts of one project into per-setup keys', () => {
+    // Why: two `cloned` checkouts share the project's remote identity but are
+    // distinct user clones; the palette follows the sidebar and surfaces each as
+    // its own jump target rather than collapsing them. See #5374.
     const results = searchCmdJProjectResults({
       query: 'platform',
       projectGroups: [],
@@ -366,6 +369,27 @@ describe('Cmd+J project and repo-group search', () => {
       projectHostSetups: [
         setup('setup-1', 'project-1', 'local', 'repo-1'),
         setup('setup-2', 'project-1', 'local', 'repo-2')
+      ]
+    })
+
+    expect(results.map((result) => result.rowKey)).toEqual([
+      'project:project-1::setup:repo-1',
+      'project:project-1::setup:repo-2'
+    ])
+  })
+
+  it('keeps a provisioned runtime copy under one project key alongside a same-host checkout', () => {
+    // Why: a `provisioned` (recipe-created ephemeral) copy shares the project's
+    // remote identity but must not split the user's real checkout; it nests
+    // under the single project key. Mirrors the sidebar grouping. See #6320 / #5374.
+    const results = searchCmdJProjectResults({
+      query: 'platform',
+      projectGroups: [],
+      repos: [repo('repo-1', 'platform-a'), repo('repo-2', 'platform-runtime')],
+      projects: [project('project-1', 'Platform')],
+      projectHostSetups: [
+        setup('setup-1', 'project-1', 'local', 'repo-1'),
+        { ...setup('setup-2', 'project-1', 'local', 'repo-2'), setupMethod: 'provisioned' }
       ]
     })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -629,7 +629,7 @@ describe('buildRows with pinned worktrees', () => {
     })
   })
 
-  it('keeps same-host checkouts of one project under the project header', () => {
+  it('splits same-host checkouts of one project into separate per-setup groups', () => {
     const repoB: Repo = { ...repo, id: 'repo-2', path: '/tmp/orca-2', displayName: 'orca-2' }
     const worktreeB: Worktree = {
       ...worktree,
@@ -676,15 +676,22 @@ describe('buildRows with pinned worktrees', () => {
     )
 
     const headers = rows.filter((row) => row.type === 'header')
-    expect(headers).toHaveLength(1)
-    expect(headers[0]).toMatchObject({
-      key: 'project:github:stablyai/orca',
-      label: 'Orca',
-      count: 2
-    })
+    expect(headers).toHaveLength(2)
+    expect(headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'project:github:stablyai/orca::setup:repo-1',
+          label: 'orca'
+        }),
+        expect.objectContaining({
+          key: 'project:github:stablyai/orca::setup:repo-2',
+          label: 'orca-2'
+        })
+      ])
+    )
   })
 
-  it('keeps runtime copies under the project header when one host has duplicate checkouts', () => {
+  it('splits all project setups when one host has duplicate checkouts', () => {
     const localRepoB: Repo = {
       ...repo,
       id: 'repo-local-b',
@@ -738,8 +745,75 @@ describe('buildRows with pinned worktrees', () => {
     )
 
     const headers = rows.filter((row) => row.type === 'header')
-    expect(headers.map((row) => row.key)).toEqual(['project:github:stablyai/orca'])
-    expect(headers[0]).toMatchObject({ label: 'Orca', count: 3 })
+    expect(headers.map((row) => row.key)).toEqual([
+      'project:github:stablyai/orca::setup:repo-1',
+      'project:github:stablyai/orca::setup:repo-local-b',
+      'project:github:stablyai/orca::setup:repo-remote'
+    ])
+  })
+
+  it('keeps a provisioned runtime copy under the project header alongside a same-host checkout', () => {
+    const runtimeRepoB: Repo = {
+      ...repo,
+      id: 'repo-runtime-b',
+      path: '/tmp/orca-runtime-b',
+      displayName: 'orca-runtime-b'
+    }
+    const runtimeWorktreeB: Worktree = {
+      ...worktree,
+      id: 'wt-runtime-b',
+      repoId: runtimeRepoB.id,
+      path: '/tmp/orca-runtime-b-feature',
+      displayName: 'feature-runtime-b'
+    }
+    // Why: a `provisioned` (recipe-created ephemeral) copy shares the project's
+    // remote identity but must not split the user's real checkout into two
+    // headers; it nests under the project. See #6320 / #5374.
+    const runtimeSetupB: ProjectHostSetup = {
+      ...projectHostSetups[0]!,
+      id: runtimeRepoB.id,
+      repoId: runtimeRepoB.id,
+      path: runtimeRepoB.path,
+      displayName: runtimeRepoB.displayName,
+      setupMethod: 'provisioned'
+    }
+    const rows = buildRows(
+      'repo',
+      [worktree, runtimeWorktreeB],
+      new Map([
+        [repo.id, repo],
+        [runtimeRepoB.id, runtimeRepoB]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([
+        [worktree.id, worktree],
+        [runtimeWorktreeB.id, runtimeWorktreeB]
+      ]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      new Map(),
+      [],
+      {
+        projects: [{ ...project, sourceRepoIds: [repo.id, runtimeRepoB.id] }],
+        projectHostSetups: [projectHostSetups[0]!, runtimeSetupB]
+      }
+    )
+
+    const headers = rows.filter((row) => row.type === 'header')
+    expect(headers).toHaveLength(1)
+    expect(headers[0]).toMatchObject({
+      key: 'project:github:stablyai/orca',
+      label: 'Orca',
+      count: 2
+    })
   })
 
   it('groups Windows host and WSL setups on the same runtime host', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -816,6 +816,101 @@ describe('buildRows with pinned worktrees', () => {
     })
   })
 
+  it('splits duplicate user checkouts while a provisioned copy nests, on one host', () => {
+    // Why: guards the intersection of #5374 (real same-host checkouts split) and
+    // #6320 (provisioned copies nest). Two legacy checkouts must each get their own
+    // header while a provisioned copy of the same project stays under the plain
+    // project header — all on one host surface, simultaneously.
+    const localRepoB: Repo = {
+      ...repo,
+      id: 'repo-local-b',
+      path: '/tmp/orca-b',
+      displayName: 'orca-b'
+    }
+    const localWorktreeB: Worktree = {
+      ...worktree,
+      id: 'wt-local-b',
+      repoId: localRepoB.id,
+      path: '/tmp/orca-b-feature',
+      displayName: 'feature-b'
+    }
+    const localSetupB: ProjectHostSetup = {
+      ...projectHostSetups[0]!,
+      id: localRepoB.id,
+      repoId: localRepoB.id,
+      path: localRepoB.path,
+      displayName: localRepoB.displayName
+    }
+    const runtimeRepoB: Repo = {
+      ...repo,
+      id: 'repo-runtime-b',
+      path: '/tmp/orca-runtime-b',
+      displayName: 'orca-runtime-b'
+    }
+    const runtimeWorktreeB: Worktree = {
+      ...worktree,
+      id: 'wt-runtime-b',
+      repoId: runtimeRepoB.id,
+      path: '/tmp/orca-runtime-b-feature',
+      displayName: 'feature-runtime-b'
+    }
+    const runtimeSetupB: ProjectHostSetup = {
+      ...projectHostSetups[0]!,
+      id: runtimeRepoB.id,
+      repoId: runtimeRepoB.id,
+      path: runtimeRepoB.path,
+      displayName: runtimeRepoB.displayName,
+      setupMethod: 'provisioned'
+    }
+    const rows = buildRows(
+      'repo',
+      [worktree, localWorktreeB, runtimeWorktreeB],
+      new Map([
+        [repo.id, repo],
+        [localRepoB.id, localRepoB],
+        [runtimeRepoB.id, runtimeRepoB]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([
+        [worktree.id, worktree],
+        [localWorktreeB.id, localWorktreeB],
+        [runtimeWorktreeB.id, runtimeWorktreeB]
+      ]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      new Map(),
+      [],
+      {
+        projects: [{ ...project, sourceRepoIds: [repo.id, localRepoB.id, runtimeRepoB.id] }],
+        projectHostSetups: [projectHostSetups[0]!, localSetupB, runtimeSetupB]
+      }
+    )
+
+    const headers = rows.filter((row) => row.type === 'header')
+    expect(headers.map((row) => row.key).sort()).toEqual([
+      'project:github:stablyai/orca',
+      'project:github:stablyai/orca::setup:repo-1',
+      'project:github:stablyai/orca::setup:repo-local-b'
+    ])
+    // The provisioned copy nests under the plain project key with only its own
+    // worktree; it never gets a path-scoped `::setup:` header like the real
+    // checkouts do. (buildRows disambiguates its visible label to the repo name.)
+    expect(
+      headers.some((row) => row.key === 'project:github:stablyai/orca::setup:repo-runtime-b')
+    ).toBe(false)
+    expect(headers.find((row) => row.key === 'project:github:stablyai/orca')).toMatchObject({
+      count: 1
+    })
+  })
+
   it('groups Windows host and WSL setups on the same runtime host', () => {
     const runtimeHostId = 'runtime:g16'
     const windowsRepo: Repo = {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -36,6 +36,7 @@ import { getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import { translate } from '@/i18n/i18n'
 import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
 import { parseWslUncPath } from '../../../../shared/wsl-paths'
+import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 
 export { branchName }
 
@@ -158,10 +159,8 @@ type ProjectGroupingIndex = {
 
 const projectGroupingIndexCache = new WeakMap<ProjectGroupingModel, ProjectGroupingIndex | null>()
 
-// Why: `provisioned` setups are recipe-created ephemeral runtime copies of a
-// project; they nest under the project header. Only real user checkouts
-// (legacy-repo / imported-existing-folder / cloned) count as distinct sidebar
-// entries when duplicated on one host surface. See #5374.
+// Why: `provisioned` setups are ephemeral recipe-created runtime copies that
+// nest under the project header; every other method is a real user checkout. See #5374.
 function isDistinctUserCheckout(setup: ProjectHostSetup): boolean {
   return setup.setupMethod !== 'provisioned'
 }
@@ -170,10 +169,10 @@ function getProjectSetupSurfaceKey(setup: ProjectHostSetup): string {
   const wslPath = parseWslUncPath(setup.path)
   if (wslPath) {
     // Why: Windows host and WSL on one machine are separate execution surfaces;
-    // only duplicate checkouts within the same surface make project grouping ambiguous.
+    // only duplicate checkouts within one surface make project grouping ambiguous.
     return `${setup.projectId}::${setup.hostId}::wsl:${wslPath.distro.toLowerCase()}`
   }
-  if (/^[A-Za-z]:[\\/]/.test(setup.path)) {
+  if (isWindowsAbsolutePathLike(setup.path)) {
     return `${setup.projectId}::${setup.hostId}::windows-host`
   }
   return `${setup.projectId}::${setup.hostId}::default`
@@ -193,21 +192,25 @@ function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupin
     projectGroupingIndexCache.set(model, null)
     return null
   }
-  const setupCountByProjectSurface = new Map<string, number>()
+  // Count real user checkouts per host surface (provisioned copies excluded so
+  // they keep nesting); more than one on a surface makes that project ambiguous.
+  const checkoutsByProjectSurface = new Map<string, { projectId: string; count: number }>()
   for (const setup of projectHostSetups) {
     if (!isDistinctUserCheckout(setup)) {
       continue
     }
     const key = getProjectSetupSurfaceKey(setup)
-    setupCountByProjectSurface.set(key, (setupCountByProjectSurface.get(key) ?? 0) + 1)
+    const existing = checkoutsByProjectSurface.get(key)
+    if (existing) {
+      existing.count += 1
+    } else {
+      checkoutsByProjectSurface.set(key, { projectId: setup.projectId, count: 1 })
+    }
   }
   const projectIdsRequiringSetupGroups = new Set<string>()
-  for (const setup of projectHostSetups) {
-    if (!isDistinctUserCheckout(setup)) {
-      continue
-    }
-    if ((setupCountByProjectSurface.get(getProjectSetupSurfaceKey(setup)) ?? 0) > 1) {
-      projectIdsRequiringSetupGroups.add(setup.projectId)
+  for (const { projectId, count } of checkoutsByProjectSurface.values()) {
+    if (count > 1) {
+      projectIdsRequiringSetupGroups.add(projectId)
     }
   }
   const index = {
@@ -245,9 +248,8 @@ function getProjectGroupingForRepo(
     projectIndex?.projectIdsRequiringSetupGroups.has(setup.projectId) &&
     isDistinctUserCheckout(setup)
   ) {
-    // Why: once a project has multiple independent user checkouts on one host
-    // surface, each must stay its own sidebar entry; they cannot be safely
-    // attached to one another without explicit linking. See #5374.
+    // Why: independent user checkouts of one project on the same host surface
+    // can't be safely merged, so each keeps its own sidebar entry. See #5374.
     return {
       key: `project:${project.id}::setup:${repoId}`,
       label: repo?.displayName ?? setup.displayName,
@@ -255,9 +257,8 @@ function getProjectGroupingForRepo(
       projectId: project.id
     }
   }
-  // Why: recipe-created runtime copies (`provisioned`) and local worktrees can be
-  // separate checkouts of the same Git project; those follow project identity
-  // rather than path-scoped setup identity so they stay in one project.
+  // Why: provisioned runtime copies and non-ambiguous checkouts follow project
+  // identity rather than path-scoped setup identity, so they stay in one project.
   return {
     key: `project:${project.id}`,
     label: project.displayName,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -35,6 +35,7 @@ import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from '../../store/slic
 import { getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import { translate } from '@/i18n/i18n'
 import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
+import { parseWslUncPath } from '../../../../shared/wsl-paths'
 
 export { branchName }
 
@@ -152,9 +153,31 @@ type WorktreeGroupEntry = {
 type ProjectGroupingIndex = {
   projectById: Map<string, Project>
   setupByRepoId: Map<string, ProjectHostSetup>
+  projectIdsRequiringSetupGroups: Set<string>
 }
 
 const projectGroupingIndexCache = new WeakMap<ProjectGroupingModel, ProjectGroupingIndex | null>()
+
+// Why: `provisioned` setups are recipe-created ephemeral runtime copies of a
+// project; they nest under the project header. Only real user checkouts
+// (legacy-repo / imported-existing-folder / cloned) count as distinct sidebar
+// entries when duplicated on one host surface. See #5374.
+function isDistinctUserCheckout(setup: ProjectHostSetup): boolean {
+  return setup.setupMethod !== 'provisioned'
+}
+
+function getProjectSetupSurfaceKey(setup: ProjectHostSetup): string {
+  const wslPath = parseWslUncPath(setup.path)
+  if (wslPath) {
+    // Why: Windows host and WSL on one machine are separate execution surfaces;
+    // only duplicate checkouts within the same surface make project grouping ambiguous.
+    return `${setup.projectId}::${setup.hostId}::wsl:${wslPath.distro.toLowerCase()}`
+  }
+  if (/^[A-Za-z]:[\\/]/.test(setup.path)) {
+    return `${setup.projectId}::${setup.hostId}::windows-host`
+  }
+  return `${setup.projectId}::${setup.hostId}::default`
+}
 
 function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupingIndex | null {
   if (!model) {
@@ -170,9 +193,27 @@ function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupin
     projectGroupingIndexCache.set(model, null)
     return null
   }
+  const setupCountByProjectSurface = new Map<string, number>()
+  for (const setup of projectHostSetups) {
+    if (!isDistinctUserCheckout(setup)) {
+      continue
+    }
+    const key = getProjectSetupSurfaceKey(setup)
+    setupCountByProjectSurface.set(key, (setupCountByProjectSurface.get(key) ?? 0) + 1)
+  }
+  const projectIdsRequiringSetupGroups = new Set<string>()
+  for (const setup of projectHostSetups) {
+    if (!isDistinctUserCheckout(setup)) {
+      continue
+    }
+    if ((setupCountByProjectSurface.get(getProjectSetupSurfaceKey(setup)) ?? 0) > 1) {
+      projectIdsRequiringSetupGroups.add(setup.projectId)
+    }
+  }
   const index = {
     projectById: new Map(projects.map((project) => [project.id, project])),
-    setupByRepoId: new Map(projectHostSetups.map((setup) => [setup.repoId, setup]))
+    setupByRepoId: new Map(projectHostSetups.map((setup) => [setup.repoId, setup])),
+    projectIdsRequiringSetupGroups
   }
   projectGroupingIndexCache.set(model, index)
   return index
@@ -200,9 +241,23 @@ function getProjectGroupingForRepo(
       repo
     }
   }
-  // Why: recipe-created runtimes and local worktrees can be separate checkouts
-  // of the same Git project; the sidebar should follow project identity rather
-  // than path-scoped setup identity so those workspaces stay in one project.
+  if (
+    projectIndex?.projectIdsRequiringSetupGroups.has(setup.projectId) &&
+    isDistinctUserCheckout(setup)
+  ) {
+    // Why: once a project has multiple independent user checkouts on one host
+    // surface, each must stay its own sidebar entry; they cannot be safely
+    // attached to one another without explicit linking. See #5374.
+    return {
+      key: `project:${project.id}::setup:${repoId}`,
+      label: repo?.displayName ?? setup.displayName,
+      repo,
+      projectId: project.id
+    }
+  }
+  // Why: recipe-created runtime copies (`provisioned`) and local worktrees can be
+  // separate checkouts of the same Git project; those follow project identity
+  // rather than path-scoped setup identity so they stay in one project.
   return {
     key: `project:${project.id}`,
     label: project.displayName,


### PR DESCRIPTION
## Description

In the sidebar, multiple **independent local checkouts of the same git repo on one host** (e.g. `app`, `app-clone-2`, `app-hotfix`, all cloned from one `github.com/owner/repo`) collapse into a **single project header** instead of appearing as separate projects. All their worktrees nest under one arbitrarily-named project.

This is a **re-regression of #5374**. The sidebar groups checkouts by a host-independent project identity (`github:owner/repo`, derived from the git remote) so the same repo on Local + SSH shows as one project — but that same identity also collapses genuinely independent checkouts on one host. #5375 (and #6430 for WSL/Windows) fixed this by splitting same-host duplicates at the grouping layer. **#6320 ("Per-Workspace Environments")** then deleted that split so its new `provisioned` ephemeral-runtime copies would nest under one header — but it had no way to tell a provisioned copy from a genuine user checkout, so it collapsed everything.

This PR restores same-host checkout separation, scoped by the discriminator the data model already carries — `ProjectHostSetup.setupMethod`:

- **`provisioned`** (recipe-created ephemeral-runtime copies) → still **nest** under the project header, preserving #6320's feature.
- **`legacy-repo` / `imported-existing-folder` / `cloned`** (real user checkouts) → each becomes its **own** sidebar entry when duplicated on one host surface, fixing #5374.

Implemented in `src/renderer/src/components/sidebar/worktree-list-groups.ts`:
- `isDistinctUserCheckout(setup)` = `setup.setupMethod !== 'provisioned'`.
- `getProjectSetupSurfaceKey(setup)` = `projectId::hostId::{wsl:<distro> | windows-host | default}`, classified by the checkout's path string (not the client OS, so SSH/remote clients holding a `C:\` or `\\wsl.localhost\` path for a remote host classify correctly). A Windows checkout and its WSL checkout of one project (same runtime host, different execution surfaces) are therefore **not** treated as duplicates.
- `buildProjectGroupingIndex` counts real user checkouts per surface in one pass; a project with >1 on one surface is flagged in `projectIdsRequiringSetupGroups`.
- `getProjectGroupingForRepo` returns the per-setup key `project:${id}::setup:${repoId}` only for a flagged project's distinct user checkouts; provisioned copies still return `project:${id}`.

The Cmd+J palette shares this grouping (via `getProjectHeaderRevealTarget`), so it surfaces each independent checkout as its own jump target too. The `::setup:` key format is a pre-existing #5375/#6430 shape already parsed by `WorktreeList.tsx` reveal/drop logic (`getProjectIdFromHeaderRowKey` / `getRepoIdsFromHeaderRowKey`), so no downstream regression.

### Maintainer take-over notes (@nwparker)

This PR was taken over for validation and polish. On top of the original author's work:
- Merged latest `main` (no conflicts).
- **Reproduced the bug first** on `main` with the added tests, then verified the fix flips them green (evidence below).
- Replaced an inline Windows drive-letter regex with the shared `isWindowsAbsolutePathLike` helper (`src/shared/cross-platform-path.ts`) — deduplicates the pattern used in 8+ call sites and additionally buckets UNC `\\server\share` paths as a Windows surface instead of `default`. Safe direction: coarser bucketing can only *increase* splitting, never wrongly merge distinct checkouts.
- Collapsed `buildProjectGroupingIndex`'s two passes over `projectHostSetups` into one (each surface key computed once).
- Tightened comments to AGENTS.md's two-line rule.

Reviewed under a hostile-author security screen (pure client-side, read-only grouping; no network/IPC/shell/filesystem/auth/dependency changes) — clean.

## Evidence

**Reproduced-before (fix reverted to `main`, PR tests kept) — 4 split assertions fail:**

```
× splits independent same-host checkouts of one project into per-setup keys
× splits same-host checkouts of one project into separate per-setup groups
× splits all project setups when one host has duplicate checkouts
× splits duplicate user checkouts while a provisioned copy nests, on one host

AssertionError: expected [ 'project:project-1' ] to deeply equal [ …(2) ]
AssertionError: expected [ { type: 'header', …(7) } ] to have a length of 2 but got 1
AssertionError: expected [ 'project:github:stablyai/orca' ] to deeply equal [ …(3) ]
 Test Files  2 failed (2)
      Tests  4 failed | 119 passed (123)
```

The collapse is visible directly: same-host checkouts resolve to a single `project:github:stablyai/orca` header instead of one header per checkout.

**Fixed-after (this branch) — all green:**

```
 Test Files  2 passed (2)
      Tests  123 passed (123)
```

- `pnpm typecheck` (node + cli + web) — pass
- `oxlint` on touched files — pass
- Downstream key round-trip verified in `WorktreeList.tsx` (`::setup:` parsing already present).

Provisioned-nesting coverage, the split×nest intersection, and the Windows+WSL-on-one-host case are all covered by the added unit tests.

## ELI5

Imagine your sidebar is a shelf of labeled folders. If you download the same book (repo) into three different boxes on your desk, you want three folders on the shelf — one per box. A recent change meant to handle temporary "loaner" copies of a book accidentally started shoving **all** copies — including your three real ones — into a single folder with one box's name, hiding the other two. This change teaches the shelf to tell a real copy from a temporary loaner: real copies each get their own folder again, while temporary loaner copies still tuck neatly inside the main folder.

## Trade-offs

- **Deliberate behavior:** once a project has 2+ real checkouts on **one** host surface, **all** of that project's real checkouts render as separate per-setup headers — including a lone checkout on a *different* host. There's no safe way to pick which header a lone remote copy should merge into once one surface is ambiguous. This matches the restored #5375/#6430 behavior.
- The `provisioned` gate is a denylist (`!== 'provisioned'`). A future `setupMethod` that should also nest would default to "distinct" until this predicate is updated — kept as-is to mirror the data model's framing.
- **No regressions** to #6320: provisioned/ephemeral-runtime copies still nest under a single project header (covered by tests). No user-visible change for single-checkout projects or for the same repo spread across different hosts.
