### PR TITLE
Fix Android terminal WebView compatibility

### DIFF
--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -1,13 +1,14 @@
-import { useRef, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo } from 'react'
+import { useRef, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo, useState } from 'react'
 import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native'
 import { WebView } from 'react-native-webview'
-import type { WebViewMessageEvent } from 'react-native-webview'
 import type { RuntimeMobileTerminalTheme } from '../../../src/shared/runtime-types'
 import { colors } from '../theme/mobile-theme'
+import { TerminalWebViewFrame } from './TerminalWebViewFrame'
 import type { TerminalOscLinkRange } from './terminal-osc-link-ranges'
-import { XTERM_HTML } from './terminal-webview-html'
+import { useTerminalWebViewMessageHandler } from './terminal-webview-message-handler'
 import type { TerminalWebViewCommand } from './terminal-webview-messages'
 import { createTerminalWebViewPendingMessages } from './terminal-webview-pending-messages'
+import { XTERM_WEBVIEW_SOURCE } from './terminal-webview-source'
 
 type TerminalMouseTrackingMode = 'none' | 'x10' | 'vt200' | 'drag' | 'any'
 type TerminalOscLinks = TerminalOscLinkRange[]
@@ -81,10 +82,6 @@ type Props = {
   onWebReady?: () => void
 } & TerminalSelectionEvents
 
-// Why: WebView treats source identity as page identity on some platforms; keep
-// parent/session re-renders from reloading xterm and forcing fresh snapshots.
-const XTERM_WEBVIEW_SOURCE = { html: XTERM_HTML }
-
 export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function TerminalWebView(
   {
     style,
@@ -109,6 +106,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   const isWebReadyRef = useRef(false)
   const pendingMessages = useMemo(() => createTerminalWebViewPendingMessages(), [])
   const messageIdRef = useRef(0)
+  const [webViewError, setWebViewError] = useState<string | null>(null)
   const terminalThemeKey = useMemo(() => JSON.stringify(terminalTheme ?? null), [terminalTheme])
   const measureResolveRef = useRef<
     ((result: { cols: number; rows: number } | null) => void) | null
@@ -140,129 +138,30 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     [pendingMessages, sendToWebView]
   )
 
-  const handleMessage = useCallback(
-    (event: WebViewMessageEvent) => {
-      let msg: Record<string, unknown>
-      try {
-        msg = JSON.parse(event.nativeEvent.data) as Record<string, unknown>
-      } catch {
-        return
-      }
-
-      if (msg.type === 'web-ready') {
-        isWebReadyRef.current = true
-        onWebReady?.()
-        flushPendingMessages()
-      } else if (msg.type === 'ready') {
-        // Why: the WebView's init() rAF chain has run — term is open,
-        // renderService is populated, first paint has happened. Resolve
-        // any pending awaitReady() so a queued measure can now safely
-        // read cell dims.
-        const resolve = readyResolveRef.current
-        readyResolveRef.current = null
-        readyPromiseRef.current = null
-        resolve?.()
-      } else if (msg.type === 'measure-result') {
-        const resolve = measureResolveRef.current
-        measureResolveRef.current = null
-        if (resolve) {
-          const cols = typeof msg.cols === 'number' ? msg.cols : null
-          const rows = typeof msg.rows === 'number' ? msg.rows : null
-          resolve(cols && rows && cols >= 20 && rows >= 8 ? { cols, rows } : null)
-        }
-      } else if (msg.type === 'log') {
-        // Surface fit-scale diagnostics in the RN/Metro console.
-        const tag = typeof msg.tag === 'string' ? msg.tag : '[fit]'
-        // eslint-disable-next-line no-console
-        console.log(tag, msg.payload)
-      } else if (msg.type === 'set-select-mode') {
-        onSelectionMode?.(!!msg.enabled)
-      } else if (msg.type === 'selection') {
-        const text = typeof msg.text === 'string' ? msg.text : ''
-        onSelectionCopy?.(text)
-      } else if (msg.type === 'selection-evicted') {
-        onSelectionEvicted?.()
-      } else if (msg.type === 'modes') {
-        const mouseTrackingMode =
-          msg.mouseTrackingMode === 'x10' ||
-          msg.mouseTrackingMode === 'vt200' ||
-          msg.mouseTrackingMode === 'drag' ||
-          msg.mouseTrackingMode === 'any'
-            ? msg.mouseTrackingMode
-            : 'none'
-        onModesChanged?.({
-          bracketedPasteMode: !!msg.bracketedPasteMode,
-          altScreen: !!msg.altScreen,
-          mouseTrackingMode,
-          sgrMouseMode: !!msg.sgrMouseMode,
-          sgrMousePixelsMode: !!msg.sgrMousePixelsMode
-        })
-      } else if (msg.type === 'terminal-input') {
-        const bytes = typeof msg.bytes === 'string' ? msg.bytes : ''
-        if (bytes.length > 0) {
-          onTerminalInput?.(bytes)
-        }
-      } else if (msg.type === 'terminal-tap') {
-        onTerminalTap?.()
-      } else if (msg.type === 'terminal-file-tap') {
-        const pathText = typeof msg.pathText === 'string' ? msg.pathText : ''
-        if (pathText.length > 0) {
-          const line = typeof msg.line === 'number' ? msg.line : null
-          const column = typeof msg.column === 'number' ? msg.column : null
-          onFileTap?.(pathText, line, column)
-        }
-      } else if (msg.type === 'open-url') {
-        const url = typeof msg.url === 'string' ? msg.url : ''
-        if (url.length > 0) {
-          onOpenUrl?.(url)
-        }
-      } else if (msg.type === 'keyboard-avoidance-metrics') {
-        const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
-        const rows = typeof msg.rows === 'number' ? msg.rows : 0
-        onKeyboardAvoidanceMetrics?.({
-          cursorY,
-          rows,
-          altScreen: !!msg.altScreen
-        })
-      } else if (msg.type === 'haptic') {
-        const kind = msg.kind
-        if (
-          kind === 'selection' ||
-          kind === 'success' ||
-          kind === 'error' ||
-          kind === 'edge-bump'
-        ) {
-          onHaptic?.(kind)
-        }
-      } else if (msg.type === 'font-scale-changed') {
-        const scale = typeof msg.fontScale === 'number' ? msg.fontScale : 0
-        if (scale > 0) {
-          onTextScaleChange?.(scale)
-        }
-      } else if (msg.type === 'mobile-clip-cancel-by-pinch') {
-        // eslint-disable-next-line no-console
-        console.warn('[mobile-clip] selection cancelled by pinch')
-      }
-    },
-    [
-      flushPendingMessages,
-      onWebReady,
-      onSelectionMode,
-      onSelectionCopy,
-      onSelectionEvicted,
-      onModesChanged,
-      onKeyboardAvoidanceMetrics,
-      onHaptic,
-      onTerminalInput,
-      onTerminalTap,
-      onFileTap,
-      onOpenUrl,
-      onTextScaleChange
-    ]
-  )
+  const handleMessage = useTerminalWebViewMessageHandler({
+    flushPendingMessages,
+    isWebReadyRef,
+    measureResolveRef,
+    onFileTap,
+    onHaptic,
+    onKeyboardAvoidanceMetrics,
+    onModesChanged,
+    onOpenUrl,
+    onSelectionCopy,
+    onSelectionEvicted,
+    onSelectionMode,
+    onTerminalInput,
+    onTerminalTap,
+    onTextScaleChange,
+    onWebReady,
+    readyPromiseRef,
+    readyResolveRef,
+    setWebViewError
+  })
 
   const handleLoadStart = useCallback(() => {
     isWebReadyRef.current = false
+    setWebViewError(null)
     // Why: messages queued for a previous WebView generation are stale after a reload;
     // dropping them avoids replaying terminal chunks before the next init snapshot.
     pendingMessages.clear()
@@ -395,23 +294,25 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   )
 
   return (
-    <WebView
-      ref={webViewRef}
-      source={XTERM_WEBVIEW_SOURCE}
-      style={[styles.webview, style]}
-      originWhitelist={['*']}
-      javaScriptEnabled
-      scrollEnabled={false}
-      // Why: Android parent gesture containers can intercept vertical drags
-      // before the injected xterm scroll router sees them.
-      nestedScrollEnabled
-      scalesPageToFit={false}
-      // Why: Android WebView defaults textZoom to the system font scale, inflating
-      // xterm's DOM glyphs past its canvas-measured cell grid (#4579). iOS ignores it.
-      textZoom={100}
-      onLoadStart={handleLoadStart}
-      onMessage={handleMessage}
-    />
+    <TerminalWebViewFrame style={style} webViewError={webViewError}>
+      <WebView
+        ref={webViewRef}
+        source={XTERM_WEBVIEW_SOURCE}
+        style={styles.webview}
+        originWhitelist={['*']}
+        javaScriptEnabled
+        scrollEnabled={false}
+        // Why: Android parent gesture containers can intercept vertical drags
+        // before the injected xterm scroll router sees them.
+        nestedScrollEnabled
+        scalesPageToFit={false}
+        // Why: Android WebView defaults textZoom to the system font scale, inflating
+        // xterm's DOM glyphs past its canvas-measured cell grid (#4579). iOS ignores it.
+        textZoom={100}
+        onLoadStart={handleLoadStart}
+        onMessage={handleMessage}
+      />
+    </TerminalWebViewFrame>
   )
 })
 

--- a/mobile/src/terminal/TerminalWebViewFrame.tsx
+++ b/mobile/src/terminal/TerminalWebViewFrame.tsx
@@ -1,0 +1,48 @@
+import type { PropsWithChildren } from 'react'
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+
+type Props = PropsWithChildren<{
+  style?: StyleProp<ViewStyle>
+  webViewError: string | null
+}>
+
+export function TerminalWebViewFrame({ children, style, webViewError }: Props) {
+  return (
+    <View style={[styles.container, style]}>
+      {children}
+      {webViewError ? (
+        <View pointerEvents="none" style={styles.diagnostic}>
+          <Text style={styles.diagnosticText} numberOfLines={3}>
+            Terminal WebView error: {webViewError}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.terminalBg
+  },
+  diagnostic: {
+    position: 'absolute',
+    left: spacing.sm,
+    right: spacing.sm,
+    bottom: spacing.sm,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.button,
+    borderWidth: 1,
+    borderColor: colors.statusRed,
+    backgroundColor: colors.bgPanel
+  },
+  diagnosticText: {
+    color: colors.textPrimary,
+    fontSize: typography.metaSize,
+    fontFamily: typography.monoFamily,
+    lineHeight: spacing.lg
+  }
+})

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -33,6 +33,28 @@ const DEFAULT_TERMINAL_THEME: RuntimeMobileTerminalTheme['theme'] = {
   brightWhite: '#c0caf5'
 }
 
+const XTERM_CSS = `.xterm{cursor:text;position:relative;user-select:none;-ms-user-select:none;-webkit-user-select:none}.xterm.focus,.xterm:focus{outline:0}.xterm .xterm-helpers{position:absolute;top:0;z-index:5}.xterm .xterm-helper-textarea{padding:0;border:0;margin:0;position:absolute;opacity:0;left:-9999em;top:0;width:0;height:0;z-index:-5;white-space:nowrap;overflow:hidden;resize:none}.xterm .composition-view{background:#000;color:#fff;display:none;position:absolute;white-space:nowrap;z-index:1}.xterm .composition-view.active{display:block}.xterm .xterm-viewport{overflow-y:scroll;cursor:default;position:absolute;right:0;left:0;top:0;bottom:0}.xterm:not(.allow-transparency) .xterm-viewport{background-color:#000}.xterm .xterm-screen{position:relative}.xterm .xterm-screen canvas{position:absolute;left:0;top:0}.xterm.enable-mouse-events{cursor:default}.xterm .xterm-cursor-pointer,.xterm.xterm-cursor-pointer{cursor:pointer}.xterm.column-select.focus{cursor:crosshair}.xterm .xterm-accessibility:not(.debug),.xterm .xterm-message{position:absolute;left:0;top:0;bottom:0;right:0;z-index:10;color:transparent;pointer-events:none}.xterm .xterm-accessibility-tree:not(.debug) ::selection{color:transparent}.xterm .xterm-accessibility-tree{font-family:monospace;user-select:text;white-space:pre}.xterm .xterm-accessibility-tree>div{transform-origin:left;width:fit-content}.xterm .live-region{position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden}.xterm-dim{opacity:1!important}.xterm-underline-1{text-decoration:underline}.xterm-underline-2{text-decoration:double underline}.xterm-underline-3{text-decoration:wavy underline}.xterm-underline-4{text-decoration:dotted underline}.xterm-underline-5{text-decoration:dashed underline}.xterm-overline{text-decoration:overline}.xterm-overline.xterm-underline-1{text-decoration:overline underline}.xterm-overline.xterm-underline-2{text-decoration:overline double underline}.xterm-overline.xterm-underline-3{text-decoration:overline wavy underline}.xterm-overline.xterm-underline-4{text-decoration:overline dotted underline}.xterm-overline.xterm-underline-5{text-decoration:overline dashed underline}.xterm-strikethrough{text-decoration:line-through}.xterm-screen .xterm-decoration-container .xterm-decoration{z-index:6;position:absolute}.xterm-screen .xterm-decoration-container .xterm-decoration.xterm-decoration-top-layer{z-index:7}.xterm-decoration-overview-ruler{z-index:8;position:absolute;top:0;right:0;pointer-events:none}.xterm-decoration-top{z-index:2;position:relative}.xterm .xterm-scrollable-element>.xterm-scrollbar{cursor:default}.xterm .xterm-scrollable-element>.xterm-scrollbar>.xterm-scra{cursor:pointer;background-color:var(--vscode-scrollbarSliderBackground,rgba(100,100,100,.4));mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 11 11'><path d='M2.5 8.5 L5.5 2.5 L8.5 8.5 Z' fill='black'/></svg>");-webkit-mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 11 11'><path d='M2.5 8.5 L5.5 2.5 L8.5 8.5 Z' fill='black'/></svg>");mask-repeat:no-repeat;-webkit-mask-repeat:no-repeat;mask-position:center center;-webkit-mask-position:center center;mask-size:100% 100%;-webkit-mask-size:100% 100%}.xterm .xterm-scrollable-element>.xterm-scrollbar>.xterm-scra.xterm-arrow-down{transform:rotate(180deg)}.xterm .xterm-scrollable-element>.xterm-visible{opacity:1;background:rgba(0,0,0,0);transition:opacity .1s linear;z-index:11}.xterm .xterm-scrollable-element>.xterm-invisible{opacity:0;pointer-events:none}.xterm .xterm-scrollable-element>.xterm-invisible.xterm-fade{transition:opacity .8s linear}.xterm .xterm-scrollable-element>.xterm-shadow{position:absolute;display:none}.xterm .xterm-scrollable-element>.xterm-shadow.xterm-shadow-top{display:block;top:0;left:3px;height:3px;width:100%;box-shadow:var(--vscode-scrollbar-shadow,#000) 0 6px 6px -6px inset}.xterm .xterm-scrollable-element>.xterm-shadow.xterm-shadow-left{display:block;top:3px;left:0;height:100%;width:3px;box-shadow:var(--vscode-scrollbar-shadow,#000) 6px 0 6px -6px inset}.xterm .xterm-scrollable-element>.xterm-shadow.xterm-shadow-top-left-corner{display:block;top:0;left:0;height:3px;width:3px}.xterm .xterm-scrollable-element>.xterm-shadow.xterm-shadow-top.xterm-shadow-left{box-shadow:var(--vscode-scrollbar-shadow,#000) 6px 0 6px -6px inset}`
+
+// Why: older Android-compatible WebViews, including HarmonyOS 2's Chromium 92,
+// lack structuredClone while xterm 6 needs it to construct terminal modes.
+const STRUCTURED_CLONE_POLYFILL_SCRIPT = `<script>if(typeof globalThis.structuredClone!=='function'){globalThis.structuredClone=function structuredClone(value){if(value==null||typeof value!=='object')return value;if(Array.isArray(value))return value.map(function(item){return globalThis.structuredClone(item)});var output={};for(var key in value){if(Object.prototype.hasOwnProperty.call(value,key)){output[key]=globalThis.structuredClone(value[key])}}return output}}</script>`
+
+const XTERM_WEBGL_SCRIPT =
+  '<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-webgl@0.20.0-beta.284/lib/addon-webgl.js" onerror="window.__orcaXtermLoadError=&quot;@xterm/addon-webgl failed to load&quot;"></script>'
+
+function xtermAddonScripts(enableWebgl: boolean): string {
+  return `<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.1.0-beta.285/lib/xterm.min.js" onerror="window.__orcaXtermLoadError=&quot;@xterm/xterm failed to load&quot;"></script><script src="https://cdn.jsdelivr.net/npm/@xterm/addon-unicode11@0.10.0-beta.285/lib/addon-unicode11.js" onerror="window.__orcaXtermLoadError=&quot;@xterm/addon-unicode11 failed to load&quot;"></script>${enableWebgl ? XTERM_WEBGL_SCRIPT : ''}`
+}
+
+const LOAD_WEBGL_ADDON_JS = `
+    if (window.WebglAddon && window.WebglAddon.WebglAddon) {
+      try { var webglAddon = new window.WebglAddon.WebglAddon(); term.loadAddon(webglAddon); if (webglAddon.onContextLoss) webglAddon.onContextLoss(function() { try { webglAddon && webglAddon.dispose && webglAddon.dispose(); } catch (e) {} }); } catch (e) {}
+    }`
+
+type XtermHtmlOptions = {
+  enableWebgl: boolean
+}
+
 // Why: TUI apps (Claude Code / Ink) emit escape codes with absolute cursor
 // positioning designed for the desktop's terminal dimensions (~150+ cols).
 // We initialize xterm at the desktop's exact cols/rows so those escape codes
@@ -42,12 +64,13 @@ const DEFAULT_TERMINAL_THEME: RuntimeMobileTerminalTheme['theme'] = {
 // any terminal column count (80, 150, 200+). All touch gestures (scroll,
 // pinch-to-zoom, pan) are handled by custom JS rather than native WebView
 // behavior, so they work correctly with the CSS scale transform.
-export const XTERM_HTML = `<!DOCTYPE html>
+export function createXtermHtml({ enableWebgl }: XtermHtmlOptions): string {
+  return `<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.1.0-beta.285/css/xterm.min.css">
+<style>${XTERM_CSS}</style>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   html, body {
@@ -192,7 +215,8 @@ export const XTERM_HTML = `<!DOCTYPE html>
     <button id="sel-menu-all">Select All</button>
   </div>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@6.1.0-beta.285/lib/xterm.min.js"></script><script src="https://cdn.jsdelivr.net/npm/@xterm/addon-unicode11@0.10.0-beta.285/lib/addon-unicode11.js"></script><script src="https://cdn.jsdelivr.net/npm/@xterm/addon-webgl@0.20.0-beta.284/lib/addon-webgl.js"></script>
+${STRUCTURED_CLONE_POLYFILL_SCRIPT}
+${xtermAddonScripts(enableWebgl)}
 <script>
 (function() {
   var surface = document.getElementById('terminal-surface');
@@ -729,9 +753,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
       allowProposedApi: true
     });
     term.open(surface);
-    if (window.WebglAddon && window.WebglAddon.WebglAddon) {
-      try { var webglAddon = new window.WebglAddon.WebglAddon(); term.loadAddon(webglAddon); if (webglAddon.onContextLoss) webglAddon.onContextLoss(function() { try { webglAddon && webglAddon.dispose && webglAddon.dispose(); } catch (e) {} }); } catch (e) {}
-    }
+${enableWebgl ? LOAD_WEBGL_ADDON_JS : ''}
     if (window.Unicode11Addon && window.Unicode11Addon.Unicode11Addon) try { term.loadAddon(new window.Unicode11Addon.Unicode11Addon()); term.unicode.activeVersion = '11'; } catch (e) {}
     if (typeof replayData === 'string' && replayData.length > 0) {
       enqueueWrite(replayData);
@@ -804,6 +826,49 @@ export const XTERM_HTML = `<!DOCTYPE html>
     }
   }
 
+  function notifyError(stage, error) {
+    var message = stage;
+    if (error) {
+      if (typeof error.message === 'string' && error.message.length > 0) {
+        message += ': ' + error.message;
+      } else {
+        message += ': ' + String(error);
+      }
+    }
+    notify({ type: 'error', message: message });
+  }
+
+  function handleRawMessage(rawData) {
+    try {
+      handleMsg(typeof rawData === 'string' ? JSON.parse(rawData) : rawData);
+    } catch (error) {
+      notifyError('terminal message failed', error);
+    }
+  }
+
+  function notifyPaintHealth(stage) {
+    if (!term || !term.element) return;
+    requestAnimationFrame(function() {
+      if (!term || !term.element) return;
+      var screen = term.element.querySelector('.xterm-screen');
+      var canvas = term.element.querySelector('canvas');
+      notify({
+        type: 'paint-health',
+        stage: stage,
+        cols: term.cols || 0,
+        rows: term.rows || 0,
+        cellWidth: getCellWidth(),
+        cellHeight: getCellHeight(),
+        scrollWidth: term.element.scrollWidth || 0,
+        scrollHeight: term.element.scrollHeight || 0,
+        screenWidth: screen ? screen.clientWidth : 0,
+        screenHeight: screen ? screen.clientHeight : 0,
+        hasCanvas: !!canvas,
+        scale: getTotalScale()
+      });
+    });
+  }
+
   function measureFitDimensions(containerHeightPx, retriesLeft) {
     if (typeof retriesLeft !== 'number') retriesLeft = 30;
     // Why: init and measure are posted back-to-back from React, but
@@ -868,6 +933,9 @@ export const XTERM_HTML = `<!DOCTYPE html>
   }
 
   function handleMsg(msg) {
+    if (!msg || typeof msg !== 'object') {
+      return;
+    }
     if (typeof msg.id === 'number') {
       if (handledMessageIds.indexOf(msg.id) !== -1) return;
       handledMessageIds.push(msg.id);
@@ -875,6 +943,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
     }
     if (msg.type === 'init') {
       init(msg.cols, msg.rows, msg.initialData, msg.terminalTheme, msg.fontScale, msg.preserveScroll, msg.oscLinks);
+      notifyPaintHealth('after-init-message');
     } else if (msg.type === 'set-font-scale') {
       // Why: ignore RN echoing back the value a pinch just set (msg.fontScale ===
       // currentTextScale) so the post-pinch state isn't reset; only apply changes.
@@ -1802,15 +1871,11 @@ export const XTERM_HTML = `<!DOCTYPE html>
   attachSurfaceEventHandlers(surface);
 
   window.addEventListener('message', function(e) {
-    try {
-      handleMsg(typeof e.data === 'string' ? JSON.parse(e.data) : e.data);
-    } catch(ex) {}
+    handleRawMessage(e.data);
   });
 
   document.addEventListener('message', function(e) {
-    try {
-      handleMsg(typeof e.data === 'string' ? JSON.parse(e.data) : e.data);
-    } catch(ex) {}
+    handleRawMessage(e.data);
   });
 
   window.addEventListener('resize', function() {
@@ -1828,9 +1893,13 @@ export const XTERM_HTML = `<!DOCTYPE html>
   if (window.Terminal) {
     notify({ type: 'web-ready' });
   } else {
-    notify({ type: 'error', message: 'xterm failed to load' });
+    notify({ type: 'error', message: window.__orcaXtermLoadError || 'xterm failed to load' });
   }
 })();
 </script>
 </body>
 </html>`
+}
+
+export const XTERM_HTML = createXtermHtml({ enableWebgl: true })
+export const XTERM_HTML_ANDROID = createXtermHtml({ enableWebgl: false })

--- a/mobile/src/terminal/terminal-webview-message-handler.ts
+++ b/mobile/src/terminal/terminal-webview-message-handler.ts
@@ -1,0 +1,175 @@
+import { useCallback } from 'react'
+import type { WebViewMessageEvent } from 'react-native-webview'
+import type { TerminalSelectionEvents } from './TerminalWebView'
+
+type MutableRef<T> = {
+  current: T
+}
+
+type MeasureResult = { cols: number; rows: number }
+
+type TerminalWebViewMessageHandlerOptions = TerminalSelectionEvents & {
+  flushPendingMessages: () => void
+  isWebReadyRef: MutableRef<boolean>
+  measureResolveRef: MutableRef<((result: MeasureResult | null) => void) | null>
+  onWebReady?: () => void
+  readyPromiseRef: MutableRef<Promise<void> | null>
+  readyResolveRef: MutableRef<(() => void) | null>
+  setWebViewError: (message: string | null) => void
+}
+
+export function useTerminalWebViewMessageHandler({
+  flushPendingMessages,
+  isWebReadyRef,
+  measureResolveRef,
+  onFileTap,
+  onHaptic,
+  onKeyboardAvoidanceMetrics,
+  onModesChanged,
+  onOpenUrl,
+  onSelectionCopy,
+  onSelectionEvicted,
+  onSelectionMode,
+  onTerminalInput,
+  onTerminalTap,
+  onTextScaleChange,
+  onWebReady,
+  readyPromiseRef,
+  readyResolveRef,
+  setWebViewError
+}: TerminalWebViewMessageHandlerOptions) {
+  return useCallback(
+    (event: WebViewMessageEvent) => {
+      let msg: Record<string, unknown>
+      try {
+        msg = JSON.parse(event.nativeEvent.data) as Record<string, unknown>
+      } catch {
+        return
+      }
+
+      if (msg.type === 'web-ready') {
+        isWebReadyRef.current = true
+        setWebViewError(null)
+        onWebReady?.()
+        flushPendingMessages()
+      } else if (msg.type === 'ready') {
+        // Why: the WebView's init() rAF chain has run, so queued measures can
+        // safely read cell dimensions now.
+        const resolve = readyResolveRef.current
+        readyResolveRef.current = null
+        readyPromiseRef.current = null
+        resolve?.()
+      } else if (msg.type === 'measure-result') {
+        const resolve = measureResolveRef.current
+        measureResolveRef.current = null
+        if (resolve) {
+          const cols = typeof msg.cols === 'number' ? msg.cols : null
+          const rows = typeof msg.rows === 'number' ? msg.rows : null
+          resolve(cols && rows && cols >= 20 && rows >= 8 ? { cols, rows } : null)
+        }
+      } else if (msg.type === 'log') {
+        const tag = typeof msg.tag === 'string' ? msg.tag : '[fit]'
+        // eslint-disable-next-line no-console
+        console.log(tag, msg.payload)
+      } else if (msg.type === 'paint-health') {
+        // eslint-disable-next-line no-console
+        console.log('[terminal-webview][paint]', msg)
+      } else if (msg.type === 'error') {
+        const message =
+          typeof msg.message === 'string' && msg.message.length > 0
+            ? msg.message
+            : 'Unknown terminal WebView error'
+        setWebViewError(message)
+        // eslint-disable-next-line no-console
+        console.error('[terminal-webview]', message)
+      } else if (msg.type === 'set-select-mode') {
+        onSelectionMode?.(!!msg.enabled)
+      } else if (msg.type === 'selection') {
+        const text = typeof msg.text === 'string' ? msg.text : ''
+        onSelectionCopy?.(text)
+      } else if (msg.type === 'selection-evicted') {
+        onSelectionEvicted?.()
+      } else if (msg.type === 'modes') {
+        const mouseTrackingMode =
+          msg.mouseTrackingMode === 'x10' ||
+          msg.mouseTrackingMode === 'vt200' ||
+          msg.mouseTrackingMode === 'drag' ||
+          msg.mouseTrackingMode === 'any'
+            ? msg.mouseTrackingMode
+            : 'none'
+        onModesChanged?.({
+          bracketedPasteMode: !!msg.bracketedPasteMode,
+          altScreen: !!msg.altScreen,
+          mouseTrackingMode,
+          sgrMouseMode: !!msg.sgrMouseMode,
+          sgrMousePixelsMode: !!msg.sgrMousePixelsMode
+        })
+      } else if (msg.type === 'terminal-input') {
+        const bytes = typeof msg.bytes === 'string' ? msg.bytes : ''
+        if (bytes.length > 0) {
+          onTerminalInput?.(bytes)
+        }
+      } else if (msg.type === 'terminal-tap') {
+        onTerminalTap?.()
+      } else if (msg.type === 'terminal-file-tap') {
+        const pathText = typeof msg.pathText === 'string' ? msg.pathText : ''
+        if (pathText.length > 0) {
+          const line = typeof msg.line === 'number' ? msg.line : null
+          const column = typeof msg.column === 'number' ? msg.column : null
+          onFileTap?.(pathText, line, column)
+        }
+      } else if (msg.type === 'open-url') {
+        const url = typeof msg.url === 'string' ? msg.url : ''
+        if (url.length > 0) {
+          onOpenUrl?.(url)
+        }
+      } else if (msg.type === 'keyboard-avoidance-metrics') {
+        const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
+        const rows = typeof msg.rows === 'number' ? msg.rows : 0
+        onKeyboardAvoidanceMetrics?.({
+          cursorY,
+          rows,
+          altScreen: !!msg.altScreen
+        })
+      } else if (msg.type === 'haptic') {
+        const kind = msg.kind
+        if (
+          kind === 'selection' ||
+          kind === 'success' ||
+          kind === 'error' ||
+          kind === 'edge-bump'
+        ) {
+          onHaptic?.(kind)
+        }
+      } else if (msg.type === 'font-scale-changed') {
+        const scale = typeof msg.fontScale === 'number' ? msg.fontScale : 0
+        if (scale > 0) {
+          onTextScaleChange?.(scale)
+        }
+      } else if (msg.type === 'mobile-clip-cancel-by-pinch') {
+        // eslint-disable-next-line no-console
+        console.warn('[mobile-clip] selection cancelled by pinch')
+      }
+    },
+    [
+      flushPendingMessages,
+      isWebReadyRef,
+      measureResolveRef,
+      onFileTap,
+      onHaptic,
+      onKeyboardAvoidanceMetrics,
+      onModesChanged,
+      onOpenUrl,
+      onSelectionCopy,
+      onSelectionEvicted,
+      onSelectionMode,
+      onTerminalInput,
+      onTerminalTap,
+      onTextScaleChange,
+      onWebReady,
+      readyPromiseRef,
+      readyResolveRef,
+      setWebViewError
+    ]
+  )
+}

--- a/mobile/src/terminal/terminal-webview-source.ts
+++ b/mobile/src/terminal/terminal-webview-source.ts
@@ -1,0 +1,10 @@
+import { Platform } from 'react-native'
+import { XTERM_HTML, XTERM_HTML_ANDROID } from './terminal-webview-html'
+
+// Why: WebView treats source identity as page identity on some platforms; keep
+// parent/session re-renders from reloading xterm and forcing fresh snapshots.
+const XTERM_DEFAULT_WEBVIEW_SOURCE = { html: XTERM_HTML }
+const XTERM_ANDROID_WEBVIEW_SOURCE = { html: XTERM_HTML_ANDROID }
+
+export const XTERM_WEBVIEW_SOURCE =
+  Platform.OS === 'android' ? XTERM_ANDROID_WEBVIEW_SOURCE : XTERM_DEFAULT_WEBVIEW_SOURCE

--- a/mobile/src/terminal/terminal-webview-text-zoom.test.ts
+++ b/mobile/src/terminal/terminal-webview-text-zoom.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { Script } from 'node:vm'
 import { describe, expect, it } from 'vitest'
+import { XTERM_HTML, XTERM_HTML_ANDROID } from './terminal-webview-html'
 
 const terminalWebViewSource = readFileSync(
   new URL('./TerminalWebView.tsx', import.meta.url),
@@ -10,12 +11,24 @@ const terminalHtmlSource = readFileSync(
   new URL('./terminal-webview-html.ts', import.meta.url),
   'utf8'
 )
+const terminalWebViewFrameSource = readFileSync(
+  new URL('./TerminalWebViewFrame.tsx', import.meta.url),
+  'utf8'
+)
+const terminalWebViewMessageHandlerSource = readFileSync(
+  new URL('./terminal-webview-message-handler.ts', import.meta.url),
+  'utf8'
+)
+const terminalWebViewSourceModuleSource = readFileSync(
+  new URL('./terminal-webview-source.ts', import.meta.url),
+  'utf8'
+)
 
 function extractStatusDotNormalizer() {
   const declarationStart = terminalHtmlSource.indexOf('  var CLAUDE_STATUS_DOT =')
   const declarationEnd = terminalHtmlSource.indexOf('  var PRIVATE_MODE_SCAN_TAIL_LIMIT')
   const functionStart = terminalHtmlSource.indexOf('  function isStatusDotPresentationSelector')
-  const functionEnd = terminalHtmlSource.indexOf('\n\n  function enqueueWrite', functionStart)
+  const functionEnd = terminalHtmlSource.indexOf('  function enqueueWrite', functionStart)
   expect(declarationStart).toBeGreaterThanOrEqual(0)
   expect(declarationEnd).toBeGreaterThan(declarationStart)
   expect(functionStart).toBeGreaterThan(declarationEnd)
@@ -42,15 +55,22 @@ describe('TerminalWebView text zoom', () => {
     expect(webViewProps).toContain('textZoom={100}')
   })
 
-  it('keeps the HTML source object stable so parent renders do not reload xterm', () => {
+  it('keeps platform HTML source objects stable so parent renders do not reload xterm', () => {
     const start = terminalWebViewSource.indexOf('<WebView')
     expect(start).toBeGreaterThanOrEqual(0)
     const end = terminalWebViewSource.indexOf('/>', start)
     expect(end).toBeGreaterThan(start)
     const webViewProps = terminalWebViewSource.slice(start, end)
-    expect(terminalWebViewSource).toContain('const XTERM_WEBVIEW_SOURCE = { html: XTERM_HTML }')
+    expect(terminalWebViewSourceModuleSource).toContain(
+      'const XTERM_DEFAULT_WEBVIEW_SOURCE = { html: XTERM_HTML }'
+    )
+    expect(terminalWebViewSourceModuleSource).toContain(
+      'const XTERM_ANDROID_WEBVIEW_SOURCE = { html: XTERM_HTML_ANDROID }'
+    )
+    expect(terminalWebViewSourceModuleSource).toContain("Platform.OS === 'android'")
     expect(webViewProps).toContain('source={XTERM_WEBVIEW_SOURCE}')
     expect(webViewProps).not.toContain('source={{ html: XTERM_HTML }}')
+    expect(webViewProps).not.toContain('source={{ html: XTERM_HTML_ANDROID }}')
   })
 
   it('forces the Claude status dot to text presentation before xterm writes', () => {
@@ -123,11 +143,56 @@ describe('TerminalWebView text zoom', () => {
     expect(replay).toBeGreaterThan(unicode)
   })
 
-  it('uses the newer WebGL-capable xterm stack and desktop font fallbacks', () => {
+  it('inlines xterm CSS so Android release rendering does not depend on a stylesheet request', () => {
+    expect(terminalHtmlSource).toContain('const XTERM_CSS = `')
+    expect(terminalHtmlSource).toContain('<style>${XTERM_CSS}</style>')
+    expect(XTERM_HTML_ANDROID).toContain('.xterm .xterm-screen canvas')
+    expect(XTERM_HTML_ANDROID).not.toContain('css/xterm.min.css')
+  })
+
+  it('reports WebView-side message and paint failures instead of swallowing them', () => {
+    expect(terminalHtmlSource).toContain('function notifyError(stage, error)')
+    expect(terminalHtmlSource).toContain("notifyError('terminal message failed', error)")
+    expect(terminalHtmlSource).toContain('function notifyPaintHealth(stage)')
+    expect(terminalHtmlSource).toContain("notifyPaintHealth('after-init-message')")
+    expect(terminalWebViewMessageHandlerSource).toContain("msg.type === 'paint-health'")
+    expect(terminalWebViewMessageHandlerSource).toContain("console.log('[terminal-webview][paint]', msg)")
+  })
+
+  it('loads the structuredClone polyfill before xterm for older Android WebViews', () => {
+    expect(terminalHtmlSource).toContain('const STRUCTURED_CLONE_POLYFILL_SCRIPT = `<script>')
+    expect(terminalHtmlSource).toContain("globalThis.structuredClone=function structuredClone(value)")
+    expect(XTERM_HTML_ANDROID.indexOf('function structuredClone(value)')).toBeGreaterThanOrEqual(0)
+    expect(XTERM_HTML_ANDROID.indexOf('function structuredClone(value)')).toBeLessThan(
+      XTERM_HTML_ANDROID.indexOf('@xterm/xterm@6.1.0-beta.285')
+    )
+  })
+
+  it('keeps default/iOS WebGL enabled and disables WebGL in Android HTML', () => {
     expect(terminalHtmlSource).toContain('@xterm/addon-webgl@0.20.0-beta.284')
+    expect(XTERM_HTML).toContain('@xterm/addon-webgl@0.20.0-beta.284')
+    expect(XTERM_HTML).toContain('new window.WebglAddon.WebglAddon()')
+    expect(XTERM_HTML_ANDROID).not.toContain('@xterm/addon-webgl@0.20.0-beta.284')
+    expect(XTERM_HTML_ANDROID).not.toContain('new window.WebglAddon.WebglAddon()')
+    expect(XTERM_HTML_ANDROID).toContain('@xterm/addon-unicode11@0.10.0-beta.285')
+  })
+
+  it('keeps desktop font fallbacks with the newer xterm stack', () => {
+    expect(XTERM_HTML).toContain('@xterm/xterm@6.1.0-beta.285')
     expect(terminalHtmlSource).toContain('"SF Mono", "Menlo", "Monaco", "Cascadia Mono"')
     expect(terminalHtmlSource).toContain("fontWeight: '300'")
     expect(terminalHtmlSource).toContain("fontWeightBold: '500'")
-    expect(terminalHtmlSource).toContain('new window.WebglAddon.WebglAddon()')
+  })
+
+  it('surfaces WebView error messages in a compact themed diagnostic', () => {
+    expect(terminalWebViewMessageHandlerSource).toContain("msg.type === 'error'")
+    expect(terminalWebViewMessageHandlerSource).toContain('setWebViewError(message)')
+    expect(terminalWebViewMessageHandlerSource).toContain(
+      "console.error('[terminal-webview]', message)"
+    )
+    expect(terminalWebViewFrameSource).toContain('Terminal WebView error: {webViewError}')
+    expect(terminalWebViewFrameSource).toContain('styles.diagnostic')
+    expect(terminalWebViewFrameSource).toContain('borderColor: colors.statusRed')
+    expect(terminalWebViewFrameSource).toContain('backgroundColor: colors.bgPanel')
   })
 })


### PR DESCRIPTION
## Summary

- Fix Android mobile terminal WebView startup on older Android-compatible WebViews that do not provide `structuredClone`.
- Inline xterm CSS into the generated WebView HTML and keep Android on the DOM renderer while preserving the default WebGL path for non-Android platforms.
- Add WebView paint/error diagnostics and source-invariant tests covering the Android compatibility path.

## Screenshots

Manual real-device verification was performed on a Huawei WLZ-AN00 running HarmonyOS 2.0.0. Before the fix, the terminal pane rendered blank. After the fix, the same standalone release APK flow rendered terminal text with no WebView error overlay.

## Testing

- [ ] `pnpm lint`
  - Ran from an isolated worktree checked out to `fix/android-terminal-webview-compat`.
  - Failed in `verify:localization-catalog` because `src/renderer/src/components/sidebar/WorktreeList.tsx` is missing `auto.components.sidebar.WorktreeList.failedUnnestWorkspace` in `src/renderer/src/i18n/locales/en.json`. This file/key is outside this WebView-only PR.
  - `oxlint` itself completed with 0 errors and 26 warnings in unrelated files.
- [x] `pnpm typecheck`
- [ ] `pnpm test`
  - Ran from the same isolated PR worktree.
  - Failed in unrelated Windows/environment-sensitive suites, including symlink permission failures, `/bin/sh` ENOENT, `/tmp` mkdtemp ENOENT, missing `openssl`, Windows file URL expectations, and unrelated rate-limit/worktree watcher assertions. The changed mobile terminal files were not among the failing areas.
- [x] `pnpm build`
- [x] Tests added or updated
  - Updated `mobile/src/terminal/terminal-webview-text-zoom.test.ts` to cover inline CSS, diagnostics, Android no-WebGL source selection, default WebGL preservation, and structuredClone polyfill ordering.

Additional targeted checks completed:

- `mobile`: `corepack pnpm exec tsc --noEmit`
- `mobile`: `corepack pnpm lint`
- `mobile`: `corepack pnpm exec vitest run src/terminal/terminal-webview-text-zoom.test.ts src/browser/mobile-browser-pane-source.test.ts src/session/mobile-session-startup-source.test.ts` (`18 passed`)
- Standalone release APK installed on Huawei WLZ-AN00 with `adb reverse tcp:6768 tcp:6768`; terminal text rendered after opening a paired session.

## AI Review Report

- Scope review confirmed the PR contains one commit and only mobile terminal WebView files:
  - `mobile/src/terminal/TerminalWebView.tsx`
  - `mobile/src/terminal/TerminalWebViewFrame.tsx`
  - `mobile/src/terminal/terminal-webview-html.ts`
  - `mobile/src/terminal/terminal-webview-message-handler.ts`
  - `mobile/src/terminal/terminal-webview-source.ts`
  - `mobile/src/terminal/terminal-webview-text-zoom.test.ts`
- Backend terminal streaming was verified separately, so the fix stays in the mobile WebView/xterm render path rather than changing PTY, RPC, or desktop terminal behavior.
- The Android compatibility branch uses `Platform.OS === 'android'`; there is no Huawei-, HarmonyOS-, or model-specific special case.
- Default/non-Android WebView behavior keeps the existing WebGL-capable path.

## Security Audit

- No new dependencies, endpoints, authentication flows, IPC channels, or command execution paths were added.
- The `structuredClone` polyfill is feature-detected and scoped to the local terminal WebView HTML before xterm loads.
- WebView messages continue to be JSON parsed and handled by explicit message types; added diagnostics expose initialization/render failures instead of silently swallowing them.

## Notes

The full required commands were run as requested. `pnpm lint` and `pnpm test` are left unchecked because they did not exit successfully in this Windows worktree; the concrete failures are documented above and are outside the WebView-only diff.