### PR TITLE
fix(rate-limits): route hidden Claude usage PTY through the configured proxy

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1610,6 +1610,7 @@ app.whenReady().then(async () => {
     }
   })
   rateLimits.setGeminiCliOAuthEnabledResolver(() => store!.getSettings().geminiCliOAuthEnabled)
+  rateLimits.setNetworkProxySettingsResolver(() => store!.getSettings())
   keybindings = new KeybindingService({
     homePath: app.getPath('home'),
     getLegacyOverrides: () => store!.getSettings().keybindings

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -14,6 +14,7 @@ import type {
   UsageRateLimitSource
 } from '../../shared/rate-limit-types'
 import { parseWslUncPath } from '../../shared/wsl-paths'
+import type { NetworkProxySettings } from '../../shared/network-proxy'
 import { fetchViaPty } from './claude-pty'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import {
@@ -505,9 +506,13 @@ async function fetchClaudeUsageViaCli(input: {
   authPreparation?: ClaudeRuntimeAuthPreparation
   oauthCredentials: OAuthCredentialReadResult
   attempts: ClaudeUsageAttemptState
+  networkProxySettings?: NetworkProxySettings
 }): Promise<ProviderRateLimits> {
   recordAttempt(input.attempts, 'cli')
-  const limits = await fetchViaPty({ authPreparation: input.authPreparation })
+  const limits = await fetchViaPty({
+    authPreparation: input.authPreparation,
+    networkProxySettings: input.networkProxySettings
+  })
   return withClaudeUsageMetadata(
     limits,
     metadataForAttempt({
@@ -561,6 +566,7 @@ async function supplementOAuthUsageFromCli(input: {
   oauthCredentials: OAuthCredentialReadResult
   attempts: ClaudeUsageAttemptState
   allowUsagePanelSupplement: boolean
+  networkProxySettings?: NetworkProxySettings
 }): Promise<ProviderRateLimits> {
   if (!canSupplementOAuthUsageFromCli(input)) {
     return input.oauthLimits
@@ -569,7 +575,8 @@ async function supplementOAuthUsageFromCli(input: {
     const cliLimits = await fetchClaudeUsageViaCli({
       authPreparation: input.authPreparation,
       oauthCredentials: input.oauthCredentials,
-      attempts: input.attempts
+      attempts: input.attempts,
+      networkProxySettings: input.networkProxySettings
     })
     return mergeClaudeUsageWindows(input.oauthLimits, cliLimits)
   } catch (err) {
@@ -635,7 +642,8 @@ async function attemptCliRepairThenRetryOAuth(input: {
     cliResult = await fetchClaudeUsageViaCli({
       authPreparation: input.options?.authPreparation,
       oauthCredentials: input.oauthCredentials,
-      attempts: input.attempts
+      attempts: input.attempts,
+      networkProxySettings: input.options?.networkProxySettings
     })
   } catch (err) {
     warnClaudeUsageFetchFailure(input.options?.authPreparation, input.oauthCredentials, err)
@@ -674,6 +682,7 @@ export type FetchClaudeRateLimitsOptions = {
   authPreparation?: ClaudeRuntimeAuthPreparation
   allowPtyFallback?: boolean
   allowUsagePanelSupplement?: boolean
+  networkProxySettings?: NetworkProxySettings
 }
 
 export async function fetchClaudeRateLimits(
@@ -711,6 +720,7 @@ export async function fetchClaudeRateLimits(
         authPreparation: options?.authPreparation,
         oauthCredentials,
         attempts,
+        networkProxySettings: options?.networkProxySettings,
         allowUsagePanelSupplement:
           options?.allowUsagePanelSupplement ?? isManagedClaudeAuth(options?.authPreparation)
       })
@@ -751,7 +761,8 @@ export async function fetchClaudeRateLimits(
           return await fetchClaudeUsageViaCli({
             authPreparation: options?.authPreparation,
             oauthCredentials,
-            attempts
+            attempts,
+            networkProxySettings: options?.networkProxySettings
           })
         } catch (ptyError) {
           warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, ptyError)
@@ -808,7 +819,8 @@ export async function fetchClaudeRateLimits(
       return await fetchClaudeUsageViaCli({
         authPreparation: options?.authPreparation,
         oauthCredentials,
-        attempts
+        attempts,
+        networkProxySettings: options?.networkProxySettings
       })
     } catch (err) {
       warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, err)
@@ -853,7 +865,8 @@ export async function fetchClaudeRateLimits(
       return await fetchClaudeUsageViaCli({
         authPreparation: options?.authPreparation,
         oauthCredentials,
-        attempts
+        attempts,
+        networkProxySettings: options?.networkProxySettings
       })
     } catch (err) {
       warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, err)
@@ -1060,13 +1073,17 @@ async function fetchManagedUsagePanelSupplement(input: {
   location: ManagedCredentialsLocation
   credentialsJson: string
   oauthLimits: ProviderRateLimits
+  networkProxySettings?: NetworkProxySettings
 }): Promise<ProviderRateLimits | null> {
   const authPreparation = getManagedUsagePanelAuthPreparation(input.account, input.location)
   if (!authPreparation) {
     return null
   }
   return withManagedPreviewKeychainCredentials(input.location, input.credentialsJson, async () => {
-    const cliLimits = await fetchViaPty({ authPreparation })
+    const cliLimits = await fetchViaPty({
+      authPreparation,
+      networkProxySettings: input.networkProxySettings
+    })
     if (
       !canTrustManagedUsagePanelSupplement(input.oauthLimits, cliLimits, {
         requireMatchingOAuthWindow: input.location.kind === 'keychain'
@@ -1084,7 +1101,7 @@ async function fetchManagedUsagePanelSupplement(input: {
 
 export async function fetchManagedAccountUsage(
   account: InactiveClaudeAccountInfo,
-  options: { allowUsagePanelSupplement?: boolean } = {}
+  options: { allowUsagePanelSupplement?: boolean; networkProxySettings?: NetworkProxySettings } = {}
 ): Promise<ProviderRateLimits> {
   const location = resolveManagedCredentialsLocation(account)
   let credentialsJson = location ? await readManagedCredentialsJson(location) : null
@@ -1148,7 +1165,8 @@ export async function fetchManagedAccountUsage(
       account,
       location,
       credentialsJson,
-      oauthLimits
+      oauthLimits,
+      networkProxySettings: options.networkProxySettings
     })
     return mergeClaudeUsageWindows(oauthLimits, cliLimits)
   } catch (err) {

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -685,6 +685,11 @@ export type FetchClaudeRateLimitsOptions = {
   networkProxySettings?: NetworkProxySettings
 }
 
+export type FetchManagedAccountUsageOptions = {
+  allowUsagePanelSupplement?: boolean
+  networkProxySettings?: NetworkProxySettings
+}
+
 export async function fetchClaudeRateLimits(
   options?: FetchClaudeRateLimitsOptions
 ): Promise<ProviderRateLimits> {
@@ -1101,7 +1106,7 @@ async function fetchManagedUsagePanelSupplement(input: {
 
 export async function fetchManagedAccountUsage(
   account: InactiveClaudeAccountInfo,
-  options: { allowUsagePanelSupplement?: boolean; networkProxySettings?: NetworkProxySettings } = {}
+  options: FetchManagedAccountUsageOptions = {}
 ): Promise<ProviderRateLimits> {
   const location = resolveManagedCredentialsLocation(account)
   let credentialsJson = location ? await readManagedCredentialsJson(location) : null

--- a/src/main/rate-limits/claude-pty.test.ts
+++ b/src/main/rate-limits/claude-pty.test.ts
@@ -79,6 +79,39 @@ describe('fetchViaPty', () => {
     )
   })
 
+  it('injects the configured proxy into the hidden PTY spawn env', async () => {
+    const term = makeMockTerm()
+    spawnMock.mockReturnValue(term)
+
+    const resultPromise = fetchViaPty({
+      networkProxySettings: { httpProxyUrl: 'http://127.0.0.1:7890' }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(spawnMock).toHaveBeenCalled()
+    const spawnEnv = spawnMock.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(spawnEnv.HTTPS_PROXY).toBe('http://127.0.0.1:7890')
+    expect(spawnEnv.HTTP_PROXY).toBe('http://127.0.0.1:7890')
+
+    term.emitExit()
+    await resultPromise
+  })
+
+  it('leaves the spawn env proxy untouched when no proxy is configured', async () => {
+    const term = makeMockTerm()
+    spawnMock.mockReturnValue(term)
+    const inheritedHttpsProxy = process.env.HTTPS_PROXY
+
+    const resultPromise = fetchViaPty()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const spawnEnv = spawnMock.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(spawnEnv.HTTPS_PROXY).toBe(inheritedHttpsProxy)
+
+    term.emitExit()
+    await resultPromise
+  })
+
   it('clears the startup delay timer when the hidden PTY exits early', async () => {
     const term = makeMockTerm()
     spawnMock.mockReturnValue(term)

--- a/src/main/rate-limits/claude-pty.test.ts
+++ b/src/main/rate-limits/claude-pty.test.ts
@@ -112,6 +112,36 @@ describe('fetchViaPty', () => {
     await resultPromise
   })
 
+  it('exports the configured proxy inside the WSL launch command', async () => {
+    // Why: Windows-side spawn env does not cross into the distro, so the proxy
+    // must be exported in the bash command for the inner claude to see it.
+    const term = makeMockTerm()
+    spawnMock.mockReturnValue(term)
+
+    const resultPromise = fetchViaPty({
+      networkProxySettings: { httpProxyUrl: 'http://127.0.0.1:7890' },
+      authPreparation: {
+        configDir: '/home/u/.claude',
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu',
+        wslLinuxConfigDir: '/home/u/.claude',
+        envPatch: { CLAUDE_CONFIG_DIR: '/home/u/.claude' },
+        stripAuthEnv: false,
+        provenance: 'system'
+      }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const [spawnFile, spawnArgs] = spawnMock.mock.calls[0] as [string, string[]]
+    expect(spawnFile).toBe('wsl.exe')
+    const bashCommand = spawnArgs.at(-1) as string
+    expect(bashCommand).toContain("export HTTPS_PROXY='http://127.0.0.1:7890'")
+    expect(bashCommand).toContain('exec claude')
+
+    term.emitExit()
+    await resultPromise
+  })
+
   it('clears the startup delay timer when the hidden PTY exits early', async () => {
     const term = makeMockTerm()
     spawnMock.mockReturnValue(term)

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -2,6 +2,7 @@
 driving, parser, timers, and teardown in one state machine; splitting it would
 make the lifecycle harder to audit. */
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+import { buildConfiguredProxyEnv, type NetworkProxySettings } from '../../shared/network-proxy'
 import { resolveClaudeCommand } from '../codex-cli/command'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import { applyClaudeEnvPatch } from '../claude-accounts/environment'
@@ -204,6 +205,7 @@ function describeClaudeUsageFailure(output: string): string {
 
 export async function fetchViaPty(options?: {
   authPreparation?: ClaudeRuntimeAuthPreparation
+  networkProxySettings?: NetworkProxySettings
 }): Promise<ProviderRateLimits> {
   const pty = await import('node-pty')
 
@@ -228,6 +230,11 @@ export async function fetchViaPty(options?: {
       options?.authPreparation?.envPatch ?? {},
       { stripAuthEnv: options?.authPreparation?.stripAuthEnv ?? false }
     )
+    // Why: this hidden usage PTY spawns `claude` directly, not the user's shell
+    // wrapper, so without the configured proxy it would reach api.anthropic.com
+    // from the app's own IP — bypassing the proxy the user set for Claude and
+    // risking rate-limit/geo signals on the account. Falls back to {} when unset.
+    Object.assign(spawnEnv, buildConfiguredProxyEnv(options?.networkProxySettings))
     const authPreparation = options?.authPreparation
     const wslConfig =
       authPreparation?.runtime === 'wsl' &&

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -234,7 +234,8 @@ export async function fetchViaPty(options?: {
     // wrapper, so without the configured proxy it would reach api.anthropic.com
     // from the app's own IP — bypassing the proxy the user set for Claude and
     // risking rate-limit/geo signals on the account. Falls back to {} when unset.
-    Object.assign(spawnEnv, buildConfiguredProxyEnv(options?.networkProxySettings))
+    const proxyEnv = buildConfiguredProxyEnv(options?.networkProxySettings)
+    Object.assign(spawnEnv, proxyEnv)
     const authPreparation = options?.authPreparation
     const wslConfig =
       authPreparation?.runtime === 'wsl' &&
@@ -253,7 +254,13 @@ export async function fetchViaPty(options?: {
           '--',
           'bash',
           '-lc',
-          `export CLAUDE_CONFIG_DIR=${shellQuote(wslConfig.linuxConfigDir)}; exec claude`
+          // Why: Windows-side env does not cross into the distro without WSLENV,
+          // so export the configured proxy inside the command for the inner claude.
+          [
+            `export CLAUDE_CONFIG_DIR=${shellQuote(wslConfig.linuxConfigDir)}`,
+            ...Object.entries(proxyEnv).map(([key, value]) => `export ${key}=${shellQuote(value)}`),
+            'exec claude'
+          ].join('; ')
         ]
       : isWin32
         ? ['/c', `"${claudeCommand}"`]

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -13,6 +13,7 @@ import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetche
 import type { InactiveClaudeAccountInfo } from './claude-fetcher'
 import { consumeCodexRateLimitResetCredit, fetchCodexRateLimits } from './codex-fetcher'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
+import type { NetworkProxySettings } from '../../shared/network-proxy'
 import {
   normalizeClaudeAccountSelectionTarget,
   type ClaudeAccountSelectionTarget,
@@ -121,6 +122,7 @@ export class RateLimitService {
   private geminiCliOAuthEnabledResolver: GeminiCliOAuthEnabledResolver | null = null
   private inactiveClaudeAccountsResolver: (() => InactiveClaudeAccountInfo[]) | null = null
   private inactiveCodexAccountsResolver: (() => InactiveCodexAccountInfo[]) | null = null
+  private networkProxySettingsResolver: (() => NetworkProxySettings) | null = null
   private inactiveClaudeCache = new Map<string, ProviderRateLimits>()
   private inactiveCodexCache = new Map<string, ProviderRateLimits>()
   private inactiveClaudeFetching = new Set<string>()
@@ -162,6 +164,10 @@ export class RateLimitService {
 
   setGeminiCliOAuthEnabledResolver(resolver: GeminiCliOAuthEnabledResolver): void {
     this.geminiCliOAuthEnabledResolver = resolver
+  }
+
+  setNetworkProxySettingsResolver(resolver: () => NetworkProxySettings): void {
+    this.networkProxySettingsResolver = resolver
   }
 
   setInactiveClaudeAccountsResolver(resolver: () => InactiveClaudeAccountInfo[]): void {
@@ -383,7 +389,8 @@ export class RateLimitService {
       }
       try {
         const fresh = await fetchManagedAccountUsage(account, {
-          allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement()
+          allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+          networkProxySettings: this.networkProxySettingsResolver?.()
         })
         if (
           fetchGeneration !== this.inactiveClaudeAccountsGeneration ||
@@ -890,7 +897,8 @@ export class RateLimitService {
         fetchClaudeRateLimits({
           authPreparation: claudeAuthPreparation,
           allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-          allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement()
+          allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+          networkProxySettings: this.networkProxySettingsResolver?.()
         }),
         missingWslCodexHome ??
           fetchCodexRateLimits({
@@ -1066,7 +1074,8 @@ export class RateLimitService {
     const claude = await fetchClaudeRateLimits({
       authPreparation: claudeAuthPreparation,
       allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-      allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement()
+      allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+      networkProxySettings: this.networkProxySettingsResolver?.()
     }).catch(
       (err): ProviderRateLimits => ({
         provider: 'claude',


### PR DESCRIPTION
## Problem

The Claude usage indicator has a hidden PTY fallback (`fetchViaPty` in `rate-limits/claude-pty.ts`) that spawns `claude` directly to scrape the `/usage` panel. It built the child env from `process.env` only — unlike the interactive terminal PTY (`ipc/pty.ts`), it never injected the proxy configured in **Advanced → Network** settings.

Consequence: when Orca is launched from the GUI (Dock / Finder / Spotlight), the app process doesn't inherit the shell's `HTTPS_PROXY`, so this background `claude` reached `api.anthropic.com` **directly from the machine's real IP** — bypassing both the Orca-configured proxy and any shell-level proxy wrapper the user relies on for the CLI. For users who must route Claude through a proxy (e.g. restricted regions), this leaks the real IP on a recurring poll and risks rate-limit / geo signals on the account. The managed / multi-account supplement path triggers this most often.

Worth noting: `claude` is a Node binary that only reads `HTTPS_PROXY` / `HTTP_PROXY` from its environment — it does **not** follow the OS system proxy — so a system-proxy-only setup does not cover this spawn.

## Fix

Thread the configured `NetworkProxySettings` from `RateLimitService` down through `fetchClaudeRateLimits` / `fetchManagedAccountUsage` to `fetchViaPty`, and inject it into the spawn env via `buildConfiguredProxyEnv` — the same helper the interactive terminal PTY already uses. Falls back to a clean no-op when no proxy is configured, so behavior is unchanged for users without a configured proxy.

## Testing

- `vitest run` for `claude-pty` + `claude-fetcher` — **42 passed**, including 2 new tests asserting the hidden PTY spawn env gets the configured proxy (and is left untouched when none is set).
- `tsgo --noEmit` (node project) — clean.
- `oxlint` on changed files — clean.
