### PR TITLE
Add full-width split pane toggle

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -261,6 +261,7 @@ function Terminal(): React.JSX.Element | null {
   const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
   const layoutByWorktree = useAppStore((s) => s.layoutByWorktree)
   const activeGroupIdByWorktree = useAppStore((s) => s.activeGroupIdByWorktree)
+  const maximizedGroupIdByWorktree = useAppStore((s) => s.maximizedGroupIdByWorktree)
   const ensureWorktreeRootGroup = useAppStore((s) => s.ensureWorktreeRootGroup)
   const reconcileWorktreeTabModel = useAppStore((s) => s.reconcileWorktreeTabModel)
 
@@ -1794,6 +1795,14 @@ function Terminal(): React.JSX.Element | null {
               if (!layout) {
                 return null
               }
+              const maximizedGroupIdCandidate = maximizedGroupIdByWorktree[workspace.id] ?? null
+              const maximizedGroupId =
+                maximizedGroupIdCandidate &&
+                (groupsByWorktree[workspace.id] ?? []).some(
+                  (group) => group.id === maximizedGroupIdCandidate
+                )
+                  ? maximizedGroupIdCandidate
+                  : null
               // Why: use strict equality with 'terminal' instead of !== 'settings'
               // so the terminal/browser surface hides on the tasks page too.
               const isVisible =
@@ -1807,6 +1816,7 @@ function Terminal(): React.JSX.Element | null {
                   worktreePath={workspace.path}
                   layout={layout}
                   focusedGroupId={activeGroupIdByWorktree[workspace.id]}
+                  maximizedGroupId={maximizedGroupId}
                   isVisible={isVisible}
                   shouldMeasureHiddenWorktree={shouldMeasureHiddenWorktree}
                   activityTerminalPortals={activityTerminalPortals}
@@ -2085,6 +2095,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   worktreePath,
   layout,
   focusedGroupId,
+  maximizedGroupId,
   isVisible,
   shouldMeasureHiddenWorktree,
   activityTerminalPortals
@@ -2093,6 +2104,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   worktreePath: string
   layout: TabGroupLayoutNode
   focusedGroupId?: string
+  maximizedGroupId?: string | null
   isVisible: boolean
   shouldMeasureHiddenWorktree: boolean
   activityTerminalPortals: ActivityTerminalPortalTarget[]
@@ -2129,15 +2141,25 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
         worktreeId={worktreeId}
         focusedGroupId={focusedGroupId}
         isWorktreeActive={isVisible}
+        maximizedGroupId={maximizedGroupId}
       />
       <TerminalPaneOverlayLayer
         worktreeId={worktreeId}
         worktreePath={worktreePath}
         isWorktreeActive={isVisible}
         activityTerminalPortals={activityTerminalPortals}
+        maximizedGroupId={maximizedGroupId}
       />
-      <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
-      <EmulatorPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
+      <BrowserPaneOverlayLayer
+        worktreeId={worktreeId}
+        isWorktreeActive={isVisible}
+        maximizedGroupId={maximizedGroupId}
+      />
+      <EmulatorPaneOverlayLayer
+        worktreeId={worktreeId}
+        isWorktreeActive={isVisible}
+        maximizedGroupId={maximizedGroupId}
+      />
       <AiVaultSessionDropLayer worktreeId={worktreeId} enabled={isVisible} />
     </div>
   )

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -138,10 +138,12 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
 // entirely when its own props are unchanged keeps the fast path fastest.
 const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
   worktreeId,
-  isWorktreeActive
+  isWorktreeActive,
+  maximizedGroupId = null
 }: {
   worktreeId: string
   isWorktreeActive: boolean
+  maximizedGroupId?: string | null
 }): React.JSX.Element {
   const { browserTabs, unifiedTabs, groups } = useAppStore(
     useShallow((state) => ({
@@ -200,7 +202,12 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
     <>
       {browserTabs.map((browserTab) => {
         const assignment = assignments.get(browserTab.id)
-        const isActive = Boolean(isWorktreeActive && assignment && assignment.isActiveInGroup)
+        const isActive = Boolean(
+          isWorktreeActive &&
+            assignment &&
+            assignment.isActiveInGroup &&
+            (maximizedGroupId === null || assignment.groupId === maximizedGroupId)
+        )
         return (
           <BrowserOverlaySlot
             key={browserTab.id}

--- a/src/renderer/src/components/emulator-pane/EmulatorPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/emulator-pane/EmulatorPaneOverlayLayer.tsx
@@ -57,10 +57,12 @@ const SimulatorOverlaySlot = memo(function SimulatorOverlaySlot({
 
 const EmulatorPaneOverlayLayer = memo(function EmulatorPaneOverlayLayer({
   worktreeId,
-  isWorktreeActive
+  isWorktreeActive,
+  maximizedGroupId = null
 }: {
   worktreeId: string
   isWorktreeActive: boolean
+  maximizedGroupId?: string | null
 }): React.JSX.Element {
   const { unifiedTabs, groups } = useAppStore(
     useShallow((state) => ({
@@ -91,7 +93,11 @@ const EmulatorPaneOverlayLayer = memo(function EmulatorPaneOverlayLayer({
     <>
       {simulatorTabs.map((tab) => {
         const isActiveInGroup = groupActiveTabById[tab.groupId] === tab.id
-        const isActive = Boolean(isWorktreeActive && isActiveInGroup)
+        const isActive = Boolean(
+          isWorktreeActive &&
+            isActiveInGroup &&
+            (maximizedGroupId === null || tab.groupId === maximizedGroupId)
+        )
         return (
           <SimulatorOverlaySlot
             key={tab.id}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useMemo } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { useDroppable } from '@dnd-kit/core'
-import { Ellipsis, X } from 'lucide-react'
+import { Ellipsis, Maximize2, Minimize2, X } from 'lucide-react'
 import { useAppStore } from '../../store'
 import {
   DropdownMenu,
@@ -255,6 +255,48 @@ export default function TabGroupPanel({
             <div className={focusedActionChromeClassName}>
               {isFocused ? (
                 <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
+              ) : null}
+              {isFocused && hasSplitGroups ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={
+                        model.isGroupMaximized
+                          ? translate(
+                              'auto.components.tab.group.TabGroupPanel.restoreSplitLayout',
+                              'Restore split layout'
+                            )
+                          : translate(
+                              'auto.components.tab.group.TabGroupPanel.maximizePane',
+                              'Maximize pane'
+                            )
+                      }
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        commands.toggleGroupMaximize()
+                      }}
+                      className={menuButtonClassName}
+                    >
+                      {model.isGroupMaximized ? (
+                        <Minimize2 className="size-4" />
+                      ) : (
+                        <Maximize2 className="size-4" />
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={6}>
+                    {model.isGroupMaximized
+                      ? translate(
+                          'auto.components.tab.group.TabGroupPanel.restoreSplitLayout',
+                          'Restore split layout'
+                        )
+                      : translate(
+                          'auto.components.tab.group.TabGroupPanel.maximizePane',
+                          'Maximize pane'
+                        )}
+                  </TooltipContent>
+                </Tooltip>
               ) : null}
               {isFocused && hasSplitGroups ? (
                 <Tooltip>

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -256,11 +256,14 @@ export default function TabGroupPanel({
               {isFocused ? (
                 <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
               ) : null}
+              {/* Why: maximizing a single-pane group is a no-op; spanning only matters
+                  when there are sibling split panes to hide. */}
               {isFocused && hasSplitGroups ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
                       type="button"
+                      aria-pressed={model.isGroupMaximized}
                       aria-label={
                         model.isGroupMaximized
                           ? translate(
@@ -319,6 +322,26 @@ export default function TabGroupPanel({
                       </DropdownMenuTrigger>
                     </TooltipTrigger>
                     <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
+                      <DropdownMenuItem
+                        onSelect={() => {
+                          commands.toggleGroupMaximize()
+                        }}
+                      >
+                        {model.isGroupMaximized ? (
+                          <Minimize2 className="size-4" />
+                        ) : (
+                          <Maximize2 className="size-4" />
+                        )}
+                        {model.isGroupMaximized
+                          ? translate(
+                              'auto.components.tab.group.TabGroupPanel.restoreSplitLayout',
+                              'Restore split layout'
+                            )
+                          : translate(
+                              'auto.components.tab.group.TabGroupPanel.maximizePane',
+                              'Maximize pane'
+                            )}
+                      </DropdownMenuItem>
                       <DropdownMenuItem
                         variant="destructive"
                         onSelect={() => {

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -206,4 +206,33 @@ describe('TabGroupSplitLayout', () => {
 
     expect(recordFeatureInteractionMock).toHaveBeenCalledWith('terminal-panes')
   })
+
+  it('renders only the maximized group while preserving split affordance context', () => {
+    const element = TabGroupSplitLayout({
+      layout: {
+        type: 'split',
+        direction: 'horizontal',
+        ratio: 0.5,
+        first: { type: 'leaf', groupId: 'left-group' },
+        second: { type: 'leaf', groupId: 'right-group' }
+      },
+      worktreeId: 'wt-1',
+      focusedGroupId: 'right-group',
+      isWorktreeActive: true,
+      maximizedGroupId: 'right-group'
+    })
+
+    const tabGroupPanelElement = asElement(getSplitNodeElement(element))
+
+    expect(tabGroupPanelElement.props).toEqual(
+      expect.objectContaining({
+        groupId: 'right-group',
+        worktreeId: 'wt-1',
+        isFocused: true,
+        hasSplitGroups: true,
+        reserveClosedExplorerToggleSpace: true,
+        reserveCollapsedSidebarHeaderSpace: true
+      })
+    )
+  })
 })

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -11,6 +11,16 @@ import { type HoveredTabInsertion, useTabDragSplit } from './useTabDragSplit'
 const MIN_RATIO = 0.15
 const MAX_RATIO = 0.85
 
+function findLeafForGroup(
+  node: TabGroupLayoutNode,
+  groupId: string
+): Extract<TabGroupLayoutNode, { type: 'leaf' }> | null {
+  if (node.type === 'leaf') {
+    return node.groupId === groupId ? node : null
+  }
+  return findLeafForGroup(node.first, groupId) ?? findLeafForGroup(node.second, groupId)
+}
+
 function ResizeHandle({
   direction,
   onResizeStart,
@@ -213,15 +223,19 @@ export default function TabGroupSplitLayout({
   layout,
   worktreeId,
   focusedGroupId,
-  isWorktreeActive
+  isWorktreeActive,
+  maximizedGroupId
 }: {
   layout: TabGroupLayoutNode
   worktreeId: string
   focusedGroupId?: string
   isWorktreeActive: boolean
+  maximizedGroupId?: string | null
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
   const hasSplits = layout.type === 'split'
+  const maximizedLeaf = maximizedGroupId ? findLeafForGroup(layout, maximizedGroupId) : null
+  const renderedLayout = maximizedLeaf ?? layout
 
   return (
     <TabDragProvider
@@ -266,7 +280,7 @@ export default function TabGroupSplitLayout({
           <div className="h-[4px] shrink-0 bg-card" data-terminal-focus-release-surface="true" />
           <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
             <SplitNode
-              node={layout}
+              node={renderedLayout}
               nodePath=""
               worktreeId={worktreeId}
               focusedGroupId={focusedGroupId}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -234,6 +234,8 @@ export default function TabGroupSplitLayout({
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
   const hasSplits = layout.type === 'split'
+  // Why: split chrome is derived from the full layout while maximize only swaps
+  // the mounted leaf below, so restore affordances and edge borders stay true.
   const maximizedLeaf = maximizedGroupId ? findLeafForGroup(layout, maximizedGroupId) : null
   const renderedLayout = maximizedLeaf ?? layout
 

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -29,7 +29,8 @@ const mocks = vi.hoisted(() => ({
   setActiveTabType: vi.fn(),
   setActiveWorktree: vi.fn(),
   setTabColor: vi.fn(),
-  setTabCustomTitle: vi.fn()
+  setTabCustomTitle: vi.fn(),
+  toggleMaximizedTabGroup: vi.fn()
 }))
 
 const storeBox = vi.hoisted(() => ({
@@ -119,6 +120,7 @@ function resetStore(): void {
     activeWorktreeId: 'wt-1',
     browserTabsByWorktree: {},
     expandedPaneByTabId: {},
+    maximizedGroupIdByWorktree: {},
     groupsByWorktree: {
       'wt-1': [
         {
@@ -156,7 +158,8 @@ function resetStore(): void {
     setActiveTabType: mocks.setActiveTabType,
     setActiveWorktree: mocks.setActiveWorktree,
     setTabColor: mocks.setTabColor,
-    setTabCustomTitle: mocks.setTabCustomTitle
+    setTabCustomTitle: mocks.setTabCustomTitle,
+    toggleMaximizedTabGroup: mocks.toggleMaximizedTabGroup
   }
 }
 

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -70,6 +70,7 @@ export function useTabGroupWorkspaceModel({
       openFiles: state.openFiles,
       browserTabs: state.browserTabsByWorktree[worktreeId] ?? EMPTY_BROWSER_TABS,
       expandedPaneByTabId: state.expandedPaneByTabId,
+      maximizedGroupId: state.maximizedGroupIdByWorktree[worktreeId] ?? null,
       terminalLayoutsByTabId: state.terminalLayoutsByTabId ?? EMPTY_TERMINAL_LAYOUTS_BY_TAB_ID,
       generatedTabTitlesEnabled: state.settings?.tabAutoGenerateTitle === true,
       mobileEmulatorEnabled: state.settings?.mobileEmulatorEnabled !== false
@@ -102,6 +103,7 @@ export function useTabGroupWorkspaceModel({
   const setActiveBrowserTab = useAppStore((state) => state.setActiveBrowserTab)
   const setActiveWorktree = useAppStore((state) => state.setActiveWorktree)
   const createEmptySplitGroup = useAppStore((state) => state.createEmptySplitGroup)
+  const toggleMaximizedTabGroup = useAppStore((state) => state.toggleMaximizedTabGroup)
   const setTabCustomTitle = useAppStore((state) => state.setTabCustomTitle)
   const setTabColor = useAppStore((state) => state.setTabColor)
 
@@ -586,6 +588,7 @@ export function useTabGroupWorkspaceModel({
     tabBarOrder,
     groupTabs,
     expandedPaneByTabId: worktreeState.expandedPaneByTabId,
+    isGroupMaximized: worktreeState.maximizedGroupId === groupId,
     commands: {
       focusGroup: () => {
         focusGroup(worktreeId, groupId)
@@ -599,6 +602,9 @@ export function useTabGroupWorkspaceModel({
       closeOthers,
       closeToRight,
       createSplitGroup,
+      toggleGroupMaximize: () => {
+        toggleMaximizedTabGroup(worktreeId, groupId)
+      },
       newBrowserTab: () => {
         void openNewBrowserTabInActiveWorkspace(groupId)
       },

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -278,12 +278,14 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   worktreeId,
   worktreePath,
   isWorktreeActive,
-  activityTerminalPortals = EMPTY_ACTIVITY_PORTALS
+  activityTerminalPortals = EMPTY_ACTIVITY_PORTALS,
+  maximizedGroupId = null
 }: {
   worktreeId: string
   worktreePath: string
   isWorktreeActive: boolean
   activityTerminalPortals?: ActivityTerminalPortalTarget[]
+  maximizedGroupId?: string | null
 }): React.JSX.Element | null {
   const { terminalTabs, unifiedTabs, groups, activeGroupId } = useAppStore(
     useShallow((state) => ({
@@ -354,7 +356,12 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
     <>
       {terminalTabs.map((terminalTab) => {
         const assignment = assignments.get(terminalTab.id)
-        const isVisible = Boolean(isWorktreeActive && assignment && assignment.isActiveInGroup)
+        const isVisible = Boolean(
+          isWorktreeActive &&
+            assignment &&
+            assignment.isActiveInGroup &&
+            (maximizedGroupId === null || assignment.groupId === maximizedGroupId)
+        )
         const isActive = Boolean(isVisible && assignment && assignment.groupId === activeGroupId)
         const activityTerminalPortal = findActivityTerminalPortal(activityTerminalPortals, {
           worktreeId,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2577,7 +2577,9 @@
             "1ff1c77616": "browser",
             "586d2ac445": "terminal",
             "addSplitPane": "Add split pane",
-            "closePaneColumn": "Close split pane"
+            "closePaneColumn": "Close split pane",
+            "restoreSplitLayout": "Restore split layout",
+            "maximizePane": "Maximize pane"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "Drop onto a terminal pane to resume this session.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2578,8 +2578,8 @@
             "586d2ac445": "terminal",
             "addSplitPane": "Agregar panel dividido",
             "closePaneColumn": "Cerrar panel dividido",
-            "restoreSplitLayout": "Restore split layout",
-            "maximizePane": "Maximize pane"
+            "restoreSplitLayout": "Restaurar diseño dividido",
+            "maximizePane": "Maximizar panel"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "Suelta sobre un panel de terminal para reanudar esta sesión.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2577,7 +2577,9 @@
             "1ff1c77616": "navegador",
             "586d2ac445": "terminal",
             "addSplitPane": "Agregar panel dividido",
-            "closePaneColumn": "Cerrar panel dividido"
+            "closePaneColumn": "Cerrar panel dividido",
+            "restoreSplitLayout": "Restore split layout",
+            "maximizePane": "Maximize pane"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "Suelta sobre un panel de terminal para reanudar esta sesión.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2578,8 +2578,8 @@
             "586d2ac445": "ターミナル",
             "addSplitPane": "分割ペインを追加",
             "closePaneColumn": "分割ペインを閉じる",
-            "restoreSplitLayout": "Restore split layout",
-            "maximizePane": "Maximize pane"
+            "restoreSplitLayout": "分割レイアウトを復元",
+            "maximizePane": "ペインを最大化"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "このセッションを再開するにはターミナルペインにドロップしてください。",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2577,7 +2577,9 @@
             "1ff1c77616": "ブラウザ",
             "586d2ac445": "ターミナル",
             "addSplitPane": "分割ペインを追加",
-            "closePaneColumn": "分割ペインを閉じる"
+            "closePaneColumn": "分割ペインを閉じる",
+            "restoreSplitLayout": "Restore split layout",
+            "maximizePane": "Maximize pane"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "このセッションを再開するにはターミナルペインにドロップしてください。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2578,8 +2578,8 @@
             "586d2ac445": "터미널",
             "addSplitPane": "분할 창 추가",
             "closePaneColumn": "분할 창 닫기",
-            "restoreSplitLayout": "Restore split layout",
-            "maximizePane": "Maximize pane"
+            "restoreSplitLayout": "분할 레이아웃 복원",
+            "maximizePane": "창 최대화"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "이 세션을 재개하려면 terminal 창에 놓으세요.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2577,7 +2577,9 @@
             "1ff1c77616": "브라우저",
             "586d2ac445": "터미널",
             "addSplitPane": "분할 창 추가",
-            "closePaneColumn": "분할 창 닫기"
+            "closePaneColumn": "분할 창 닫기",
+            "restoreSplitLayout": "Restore split layout",
+            "maximizePane": "Maximize pane"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "이 세션을 재개하려면 terminal 창에 놓으세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2577,7 +2577,9 @@
             "1ff1c77616": "浏览器",
             "586d2ac445": "终端",
             "addSplitPane": "添加拆分窗格",
-            "closePaneColumn": "关闭拆分窗格"
+            "closePaneColumn": "关闭拆分窗格",
+            "restoreSplitLayout": "Restore split layout",
+            "maximizePane": "Maximize pane"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "拖放到终端面板以恢复此会话。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2578,8 +2578,8 @@
             "586d2ac445": "终端",
             "addSplitPane": "添加拆分窗格",
             "closePaneColumn": "关闭拆分窗格",
-            "restoreSplitLayout": "Restore split layout",
-            "maximizePane": "Maximize pane"
+            "restoreSplitLayout": "恢复分割布局",
+            "maximizePane": "最大化窗格"
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "拖放到终端面板以恢复此会话。",

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -950,6 +950,43 @@ describe('TabsSlice', () => {
     })
   })
 
+  describe('toggleMaximizedTabGroup', () => {
+    it('toggles a split group into a full-width presentation without changing the layout', () => {
+      store.getState().createUnifiedTab(WT, 'terminal')
+      const groupAId = store.getState().groupsByWorktree[WT][0].id
+      const groupBId = store.getState().createEmptySplitGroup(WT, groupAId, 'right')
+      if (!groupBId) {
+        throw new Error('createEmptySplitGroup returned null')
+      }
+      const layoutBefore = store.getState().layoutByWorktree[WT]
+
+      store.getState().toggleMaximizedTabGroup(WT, groupAId)
+
+      expect(store.getState().maximizedGroupIdByWorktree[WT]).toBe(groupAId)
+      expect(store.getState().activeGroupIdByWorktree[WT]).toBe(groupAId)
+      expect(store.getState().layoutByWorktree[WT]).toBe(layoutBefore)
+
+      store.getState().toggleMaximizedTabGroup(WT, groupAId)
+
+      expect(store.getState().maximizedGroupIdByWorktree[WT]).toBeUndefined()
+      expect(store.getState().layoutByWorktree[WT]).toBe(layoutBefore)
+    })
+
+    it('clears a maximized group when the split pane is closed', () => {
+      store.getState().createUnifiedTab(WT, 'terminal')
+      const groupAId = store.getState().groupsByWorktree[WT][0].id
+      const groupBId = store.getState().createEmptySplitGroup(WT, groupAId, 'right')
+      if (!groupBId) {
+        throw new Error('createEmptySplitGroup returned null')
+      }
+
+      store.getState().toggleMaximizedTabGroup(WT, groupBId)
+      store.getState().closeEmptyGroup(WT, groupBId)
+
+      expect(store.getState().maximizedGroupIdByWorktree[WT]).toBeUndefined()
+    })
+  })
+
   // ─── reorderUnifiedTabs ───────────────────────────────────────────
 
   describe('reorderUnifiedTabs', () => {

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -972,6 +972,30 @@ describe('TabsSlice', () => {
       expect(store.getState().layoutByWorktree[WT]).toBe(layoutBefore)
     })
 
+    it('updates active-surface fields when maximizing another split group', () => {
+      store.setState({ activeWorktreeId: WT })
+      const tabA = store.getState().createUnifiedTab(WT, 'terminal')
+      const groupAId = store.getState().groupsByWorktree[WT][0].id
+      const groupBId = store.getState().createEmptySplitGroup(WT, groupAId, 'right')
+      if (!groupBId) {
+        throw new Error('createEmptySplitGroup returned null')
+      }
+      const tabB = store.getState().createUnifiedTab(WT, 'terminal', { targetGroupId: groupBId })
+
+      store.getState().focusGroup(WT, groupAId)
+      expect(store.getState().activeGroupIdByWorktree[WT]).toBe(groupAId)
+      expect(store.getState().activeTabId).toBe(tabA.id)
+
+      store.getState().setMaximizedTabGroup(WT, groupBId)
+
+      expect(store.getState().maximizedGroupIdByWorktree[WT]).toBe(groupBId)
+      expect(store.getState().activeGroupIdByWorktree[WT]).toBe(groupBId)
+      expect(store.getState().activeTabId).toBe(tabB.id)
+      expect(store.getState().activeTabIdByWorktree[WT]).toBe(tabB.id)
+      expect(store.getState().activeTabType).toBe('terminal')
+      expect(store.getState().activeTabTypeByWorktree[WT]).toBe('terminal')
+    })
+
     it('clears a maximized group when the split pane is closed', () => {
       store.getState().createUnifiedTab(WT, 'terminal')
       const groupAId = store.getState().groupsByWorktree[WT][0].id

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -46,6 +46,7 @@ export type TabsSlice = {
   groupsByWorktree: Record<string, TabGroup[]>
   activeGroupIdByWorktree: Record<string, string>
   layoutByWorktree: Record<string, TabGroupLayoutNode>
+  maximizedGroupIdByWorktree: Record<string, string>
   createUnifiedTab: (
     worktreeId: string,
     contentType: TabContentType,
@@ -130,6 +131,8 @@ export type TabsSlice = {
   closeTabsToRight: (tabId: string) => string[]
   ensureWorktreeRootGroup: (worktreeId: string) => string
   focusGroup: (worktreeId: string, groupId: string) => void
+  toggleMaximizedTabGroup: (worktreeId: string, groupId: string) => void
+  setMaximizedTabGroup: (worktreeId: string, groupId: string | null) => void
   closeEmptyGroup: (worktreeId: string, groupId: string) => boolean
   createEmptySplitGroup: (
     worktreeId: string,
@@ -610,6 +613,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
   groupsByWorktree: {},
   activeGroupIdByWorktree: {},
   layoutByWorktree: {},
+  maximizedGroupIdByWorktree: {},
 
   createUnifiedTab: (worktreeId, contentType, init) => {
     const id = init?.id ?? createBrowserUuid()
@@ -1361,6 +1365,42 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       }
     }),
 
+  setMaximizedTabGroup: (worktreeId, groupId) => {
+    set((state) => {
+      const current = state.maximizedGroupIdByWorktree[worktreeId] ?? null
+      if (groupId === null) {
+        if (current === null) {
+          return {}
+        }
+        const { [worktreeId]: _removed, ...remaining } = state.maximizedGroupIdByWorktree
+        return { maximizedGroupIdByWorktree: remaining }
+      }
+      const groupExists = (state.groupsByWorktree[worktreeId] ?? []).some(
+        (group) => group.id === groupId
+      )
+      if (!groupExists || current === groupId) {
+        return {}
+      }
+      return {
+        maximizedGroupIdByWorktree: {
+          ...state.maximizedGroupIdByWorktree,
+          [worktreeId]: groupId
+        },
+        activeGroupIdByWorktree: {
+          ...state.activeGroupIdByWorktree,
+          [worktreeId]: groupId
+        }
+      }
+    })
+  },
+
+  toggleMaximizedTabGroup: (worktreeId, groupId) => {
+    const state = get()
+    const current = state.maximizedGroupIdByWorktree[worktreeId] ?? null
+    state.setMaximizedTabGroup(worktreeId, current === groupId ? null : groupId)
+    get().recordFeatureInteraction?.('terminal-panes')
+  },
+
   closeEmptyGroup: (worktreeId, groupId) => {
     const state = get()
     const group = (state.groupsByWorktree[worktreeId] ?? []).find(
@@ -1383,11 +1423,21 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       // Why: drop the dead group's recent-quick-command entry so the in-memory
       // map can't grow unbounded as users open/close groups.
       const { [groupId]: _droppedRecent, ...remainingRecent } = current.recentQuickCommandIdByGroup
+      const isMaximizedGroup = current.maximizedGroupIdByWorktree[worktreeId] === groupId
+      const nextMaximizedGroupIdByWorktree = isMaximizedGroup
+        ? (() => {
+            const { [worktreeId]: _removed, ...remaining } = current.maximizedGroupIdByWorktree
+            return remaining
+          })()
+        : current.maximizedGroupIdByWorktree
       return {
         groupsByWorktree: { ...current.groupsByWorktree, [worktreeId]: remainingGroups },
         layoutByWorktree: collapsedState.layoutByWorktree,
         activeGroupIdByWorktree: collapsedState.activeGroupIdByWorktree,
         recentQuickCommandIdByGroup: remainingRecent,
+        ...(nextMaximizedGroupIdByWorktree !== current.maximizedGroupIdByWorktree
+          ? { maximizedGroupIdByWorktree: nextMaximizedGroupIdByWorktree }
+          : {}),
         ...(current.activeWorktreeId === worktreeId
           ? buildActiveSurfacePatch(
               {

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -46,7 +46,7 @@ export type TabsSlice = {
   groupsByWorktree: Record<string, TabGroup[]>
   activeGroupIdByWorktree: Record<string, string>
   layoutByWorktree: Record<string, TabGroupLayoutNode>
-  maximizedGroupIdByWorktree: Record<string, string>
+  maximizedGroupIdByWorktree: Record<string, string | undefined>
   createUnifiedTab: (
     worktreeId: string,
     contentType: TabContentType,

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1381,15 +1381,25 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       if (!groupExists || current === groupId) {
         return {}
       }
+      const nextActiveGroupIdByWorktree = {
+        ...state.activeGroupIdByWorktree,
+        [worktreeId]: groupId
+      }
+      const activeSurfacePatch = buildActiveSurfacePatch(
+        {
+          ...state,
+          activeGroupIdByWorktree: nextActiveGroupIdByWorktree
+        },
+        worktreeId,
+        groupId
+      )
       return {
         maximizedGroupIdByWorktree: {
           ...state.maximizedGroupIdByWorktree,
           [worktreeId]: groupId
         },
-        activeGroupIdByWorktree: {
-          ...state.activeGroupIdByWorktree,
-          [worktreeId]: groupId
-        }
+        activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
+        ...activeSurfacePatch
       }
     })
   },

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -3621,6 +3621,10 @@ describe('removeWorktree state cleanup', () => {
         'repo1::/path/wt1': 'group-1',
         'repo1::/path/wt2': 'group-2'
       },
+      maximizedGroupIdByWorktree: {
+        'repo1::/path/wt1': 'group-1',
+        'repo1::/path/wt2': 'group-2'
+      },
       layoutByWorktree: {
         'repo1::/path/wt1': { type: 'leaf', groupId: 'group-1' },
         'repo1::/path/wt2': { type: 'leaf', groupId: 'group-2' }
@@ -3639,6 +3643,9 @@ describe('removeWorktree state cleanup', () => {
       'repo1::/path/wt2': [{ id: 'group-2', worktreeId: 'repo1::/path/wt2', activeTabId: 'tab-2' }]
     })
     expect(store.getState().activeGroupIdByWorktree).toEqual({
+      'repo1::/path/wt2': 'group-2'
+    })
+    expect(store.getState().maximizedGroupIdByWorktree).toEqual({
       'repo1::/path/wt2': 'group-2'
     })
     expect(store.getState().layoutByWorktree).toEqual({
@@ -6324,6 +6331,7 @@ describe('migrateWorktreeIdentity', () => {
       recentlyClosedBrowserPagesByWorkspace: { browser1: [{ id: 'closed-page', worktreeId: OLD }] },
       unifiedTabsByWorktree: { [OLD]: [{ id: 'unified1', worktreeId: OLD }] },
       groupsByWorktree: { [OLD]: [{ id: 'group1', worktreeId: OLD }] },
+      maximizedGroupIdByWorktree: { [OLD]: 'group1' },
       gitStatusByWorktree: { [OLD]: [{ path: 'a.ts' }] },
       gitStatusHeadByWorktree: { [OLD]: 'head-old' },
       gitBranchCompareRequestStatusHeadByWorktree: { [OLD]: 'head-old' },
@@ -6367,6 +6375,8 @@ describe('migrateWorktreeIdentity', () => {
     expect(s.recentlyClosedBrowserPagesByWorkspace.browser1?.[0]?.worktreeId).toBe(NEW)
     expect(s.unifiedTabsByWorktree[NEW]?.[0]?.worktreeId).toBe(NEW)
     expect(s.groupsByWorktree[NEW]?.[0]?.worktreeId).toBe(NEW)
+    expect(s.maximizedGroupIdByWorktree[OLD]).toBeUndefined()
+    expect(s.maximizedGroupIdByWorktree[NEW]).toBe('group1')
     expect(s.gitStatusByWorktree[NEW]).toEqual([{ path: 'a.ts' }])
     expect(s.gitStatusHeadByWorktree[NEW]).toBe('head-old')
     expect(s.gitBranchCompareRequestStatusHeadByWorktree[NEW]).toBe('head-old')

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1655,6 +1655,7 @@ const WORKTREE_ID_KEYED_MAP_KEYS = [
   'groupsByWorktree',
   'layoutByWorktree',
   'activeGroupIdByWorktree',
+  'maximizedGroupIdByWorktree',
   'gitStatusByWorktree',
   'gitStatusHeadByWorktree',
   'gitIgnoredPathsByWorktree',
@@ -3110,6 +3111,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         delete nextLayoutByWorktree[worktreeId]
         const nextActiveGroupIdByWorktree = { ...s.activeGroupIdByWorktree }
         delete nextActiveGroupIdByWorktree[worktreeId]
+        const nextMaximizedGroupIdByWorktree = { ...s.maximizedGroupIdByWorktree }
+        delete nextMaximizedGroupIdByWorktree[worktreeId]
         // Why: git status / compare caches are keyed by worktree and stop being
         // refreshed once the worktree is deleted. Remove them here so deleted
         // worktrees cannot retain stale conflict badges, branch diffs, or compare
@@ -3259,6 +3262,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           groupsByWorktree: nextGroupsByWorktree,
           layoutByWorktree: nextLayoutByWorktree,
           activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
+          maximizedGroupIdByWorktree: nextMaximizedGroupIdByWorktree,
           editorDrafts: nextEditorDrafts,
           markdownViewMode: nextMarkdownViewMode,
           editorViewMode: nextEditorViewMode,

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2007,6 +2007,7 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     groupsByWorktree: omitByWorktree(s.groupsByWorktree),
     layoutByWorktree: omitByWorktree(s.layoutByWorktree),
     activeGroupIdByWorktree: omitByWorktree(s.activeGroupIdByWorktree),
+    maximizedGroupIdByWorktree: omitByWorktree(s.maximizedGroupIdByWorktree),
     // Git status caches
     gitStatusByWorktree: omitByWorktree(s.gitStatusByWorktree),
     // Why: keyed by worktreeId; re-keyed on rename but missed by both removal


### PR DESCRIPTION
## Summary
- add per-worktree split-group maximize state so a pane can temporarily span the full workspace width
- render only the maximized split group while preserving the underlying split layout tree
- add a direct maximize/restore icon button in focused split pane chrome, plus overlay visibility guards for terminal/browser/simulator panes

Fixes #7244

## Testing
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts src/renderer/src/store/slices/tabs.test.ts src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.test.tsx src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
- pnpm run typecheck
- pnpm run verify:localization-catalog
- local Electron smoke test: maximize/restore browser pane in a two-column workspace via the direct icon button

## ELI5

A split pane can temporarily maximize to full workspace width, then restore. Use the maximize control on the focused split without destroying the layout tree.
