### PR TITLE
[codex] Add Claude session restart on account switch

### DIFF
--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -32,6 +32,10 @@ import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
 import { matchesSettingsSearch } from './settings-search'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import {
+  getLiveClaudeSessionRestartPlan,
+  markClaudeSessionsForRestart
+} from '@/lib/claude-session-restart'
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -256,6 +260,7 @@ export function AccountsPane({
   const codexRateLimitTarget = useAppStore((s) => s.rateLimits.codexTarget)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const fetchSettings = useAppStore((s) => s.fetchSettings)
+  const queueClaudePaneRestarts = useAppStore((s) => s.queueClaudePaneRestarts)
   const recordedOpenCodeSettingEditsRef = useRef<Set<'cookie' | 'workspaceId'>>(new Set())
   const accountRuntime = getSelectedAccountRuntime(
     settings,
@@ -528,6 +533,7 @@ export function AccountsPane({
     )
     setClaudeAction(action)
     try {
+      const restartPlan = await getLiveClaudeSessionRestartPlan()
       const next = await operation()
       await syncClaudeAccounts(next)
       recordFeatureInteraction('claude-account-switching')
@@ -539,17 +545,53 @@ export function AccountsPane({
           nextActiveAccountId !== null &&
           action === `reauth:${nextActiveAccountId}`)
       if (shouldPromptRestart) {
-        toast.info(
-          translate('auto.components.settings.AccountsPane.f921d32606', 'Claude account updated.'),
+        const isActiveReauth =
+          action.startsWith('reauth:') &&
+          nextActiveAccountId !== null &&
+          action === `reauth:${nextActiveAccountId}`
+        const previousAccountLabel = getClaudeAccountLabel(claudeAccounts, previousActiveAccountId)
+        const nextAccountLabel = getClaudeAccountLabel(next, nextActiveAccountId)
+        markClaudeSessionsForRestart({
+          ptyIds: restartPlan.livePtyIds,
+          previousAccountLabel,
+          nextAccountLabel,
+          forceRestart: isActiveReauth
+        })
+        const stillStalePtyIds = restartPlan.livePtyIds.filter((ptyId) =>
+          Boolean(useAppStore.getState().claudeRestartNoticeByPtyId[ptyId])
+        )
+        queueClaudePaneRestarts(stillStalePtyIds)
+        const hasActiveWork = restartPlan.workInProgressPtyIds.length > 0
+        const notify = hasActiveWork ? toast.warning : toast.info
+        notify(
+          hasActiveWork
+            ? translate(
+                'auto.components.settings.AccountsPane.36a122b91d',
+                'Claude account updated. Restarting active sessions.'
+              )
+            : translate(
+                'auto.components.settings.AccountsPane.f921d32606',
+                'Claude account updated.'
+              ),
           {
-            description: translate(
-              'auto.components.settings.AccountsPane.b15ce90870',
-              '{{value0}} -> {{value1}}. Restart live Claude terminals before continuing old sessions.',
-              {
-                value0: getClaudeAccountLabel(claudeAccounts, previousActiveAccountId),
-                value1: getClaudeAccountLabel(next, nextActiveAccountId)
-              }
-            )
+            description:
+              stillStalePtyIds.length > 0
+                ? translate(
+                    'auto.components.settings.AccountsPane.d129385b6b',
+                    '{{value0}} -> {{value1}}. Live Claude sessions are restarting under the selected account.',
+                    {
+                      value0: previousAccountLabel,
+                      value1: nextAccountLabel
+                    }
+                  )
+                : translate(
+                    'auto.components.settings.AccountsPane.5cd45d5f33',
+                    '{{value0}} -> {{value1}}.',
+                    {
+                      value0: previousAccountLabel,
+                      value1: nextAccountLabel
+                    }
+                  )
           }
         )
       }

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -533,7 +533,7 @@ export function AccountsPane({
     )
     setClaudeAction(action)
     try {
-      const restartPlan = await getLiveClaudeSessionRestartPlan()
+      const restartPlan = await getLiveClaudeSessionRestartPlan({ target: accountRuntime })
       const next = await operation()
       await syncClaudeAccounts(next)
       recordFeatureInteraction('claude-account-switching')
@@ -555,6 +555,8 @@ export function AccountsPane({
           ptyIds: restartPlan.livePtyIds,
           previousAccountLabel,
           nextAccountLabel,
+          previousAccountId: previousActiveAccountId,
+          nextAccountId: nextActiveAccountId,
           forceRestart: isActiveReauth
         })
         const stillStalePtyIds = restartPlan.livePtyIds.filter((ptyId) =>

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -57,6 +57,11 @@ import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { formatWindowLabel } from '@/lib/window-label-formatter'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
+import {
+  getLiveClaudeSessionRestartPlan,
+  markClaudeSessionsForRestart,
+  type LiveClaudeSessionRestartPlan
+} from '@/lib/claude-session-restart'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
@@ -65,7 +70,10 @@ import { shouldOpenStatusBarContextMenu } from './status-bar-context-menu-policy
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { FloatingTerminalIconContextMenu } from '@/components/floating-terminal/FloatingTerminalIconContextMenu'
-import { summarizeCodexRestartStatus } from './codex-restart-status-summary'
+import {
+  summarizeAccountRestartStatus,
+  summarizeCodexRestartStatus
+} from './codex-restart-status-summary'
 import {
   getWindowsTerminalCapabilityOwnerKey,
   useWindowsTerminalCapabilities
@@ -149,6 +157,16 @@ function getCodexAccountLabel(
 
 function getCodexAccountDisplayLabel(account: CodexStatusAccount): string {
   return account.workspaceLabel ? `${account.email} (${account.workspaceLabel})` : account.email
+}
+
+function getClaudeAccountLabel(
+  state: ClaudeRateLimitAccountsState,
+  accountId: string | null | undefined
+): string {
+  if (accountId == null) {
+    return 'System default'
+  }
+  return state.accounts.find((account) => account.id === accountId)?.email ?? 'Claude account'
 }
 
 function getCodexStatusWslKey(wslDistro: string | null | undefined): string {
@@ -574,6 +592,68 @@ function CodexRestartStatusPrompt(): React.JSX.Element | null {
   )
 }
 
+function ClaudeRestartStatusPrompt(): React.JSX.Element | null {
+  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
+  const claudeRestartNoticeByPtyId = useAppStore((s) => s.claudeRestartNoticeByPtyId)
+  const queueClaudePaneRestarts = useAppStore((s) => s.queueClaudePaneRestarts)
+
+  const staleClaudeStatus = useMemo(
+    () =>
+      summarizeAccountRestartStatus({
+        tabsByWorktree,
+        ptyIdsByTabId,
+        restartNoticeByPtyId: claudeRestartNoticeByPtyId
+      }),
+    [claudeRestartNoticeByPtyId, ptyIdsByTabId, tabsByWorktree]
+  )
+
+  if (staleClaudeStatus.staleTabCount === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <div className="px-2 py-2">
+        <div className="text-[11px] text-muted-foreground">
+          {staleClaudeStatus.staleSessionCount === 1
+            ? translate(
+                'auto.components.status.bar.StatusBar.84a41c5fd9',
+                '1 Claude session is still on the old account'
+              )
+            : translate(
+                'auto.components.status.bar.StatusBar.17c96496c6',
+                '{{value0}} Claude sessions are still on the old account.',
+                { value0: staleClaudeStatus.staleSessionCount }
+              )}
+          {staleClaudeStatus.staleWorktreeCount > 1 ? (
+            <span className="mt-0.5 block">
+              {translate(
+                'auto.components.status.bar.StatusBar.5a455b9b43',
+                'Visible sessions restart now. Others restart when their worktree becomes active.'
+              )}
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => queueClaudePaneRestarts(staleClaudeStatus.stalePtyIds)}
+          className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-border/70 px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent/60"
+        >
+          {staleClaudeStatus.staleSessionCount === 1
+            ? translate('auto.components.status.bar.StatusBar.c1f47b86ef', 'Restart Session')
+            : translate(
+                'auto.components.status.bar.StatusBar.463b064b78',
+                'Restart {{value0}} Sessions',
+                { value0: staleClaudeStatus.staleSessionCount }
+              )}
+        </button>
+      </div>
+    </>
+  )
+}
+
 function AccountRuntimeToggle<TGroup extends { key: string; label: string }>({
   groups,
   value,
@@ -631,6 +711,11 @@ function ClaudeSwitcherMenu({
 }): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [accountsExpanded, setAccountsExpanded] = useState(false)
+  const [pendingClaudeSwitch, setPendingClaudeSwitch] = useState<{
+    accountId: string | null
+    target: CodexStatusRuntimeTarget
+    restartPlan: LiveClaudeSessionRestartPlan
+  } | null>(null)
   const [accounts, setAccounts] = useState<ClaudeRateLimitAccountsState>({
     accounts: [],
     activeAccountId: null,
@@ -644,6 +729,7 @@ function ClaudeSwitcherMenu({
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const refreshClaudeRateLimitsForTarget = useAppStore((s) => s.refreshClaudeRateLimitsForTarget)
   const fetchInactiveClaudeAccountUsage = useAppStore((s) => s.fetchInactiveClaudeAccountUsage)
+  const queueClaudePaneRestarts = useAppStore((s) => s.queueClaudePaneRestarts)
   const inactiveClaudeAccounts = useAppStore((s) => s.rateLimits.inactiveClaudeAccounts)
   const claudeTarget = useAppStore((s) => s.rateLimits.claudeTarget)
   const settings = useAppStore((s) => s.settings)
@@ -701,13 +787,15 @@ function ClaudeSwitcherMenu({
     }
   }, [accountsExpanded, fetchInactiveClaudeAccountUsage])
 
-  const handleSelectAccount = async (
+  const performClaudeAccountSwitch = async (
     accountId: string | null,
-    target: CodexStatusRuntimeTarget
+    target: CodexStatusRuntimeTarget,
+    restartPlan: LiveClaudeSessionRestartPlan
   ): Promise<void> => {
     if (isSwitching) {
       return
     }
+    const previousActiveAccountId = getClaudeStatusActiveId(accountState, target)
     setIsSwitching(true)
     try {
       const next = await window.api.claudeAccounts.select({
@@ -720,6 +808,18 @@ function ClaudeSwitcherMenu({
         setAccounts(next)
       }
       await fetchSettings()
+      const nextActiveAccountId = getClaudeStatusActiveId(next, target)
+      if (previousActiveAccountId !== nextActiveAccountId && restartPlan.livePtyIds.length > 0) {
+        markClaudeSessionsForRestart({
+          ptyIds: restartPlan.livePtyIds,
+          previousAccountLabel: getClaudeAccountLabel(accountState, previousActiveAccountId),
+          nextAccountLabel: getClaudeAccountLabel(next, nextActiveAccountId)
+        })
+        const stillStalePtyIds = restartPlan.livePtyIds.filter((ptyId) =>
+          Boolean(useAppStore.getState().claudeRestartNoticeByPtyId[ptyId])
+        )
+        queueClaudePaneRestarts(stillStalePtyIds)
+      }
       if (mountedRef.current) {
         setAccountsExpanded(false)
       }
@@ -730,6 +830,36 @@ function ClaudeSwitcherMenu({
         setIsSwitching(false)
       }
     }
+  }
+
+  const handleSelectAccount = async (
+    accountId: string | null,
+    target: CodexStatusRuntimeTarget
+  ): Promise<void> => {
+    if (isSwitching) {
+      return
+    }
+    try {
+      const restartPlan = await getLiveClaudeSessionRestartPlan()
+      if (restartPlan.livePtyIds.length > 0 && restartPlan.workInProgressPtyIds.length > 0) {
+        setPendingClaudeSwitch({ accountId, target, restartPlan })
+        setAccountsExpanded(false)
+        setOpen(false)
+        return
+      }
+      await performClaudeAccountSwitch(accountId, target, restartPlan)
+    } catch (error) {
+      console.error('Failed to inspect live Claude sessions before account switch:', error)
+    }
+  }
+
+  const handleConfirmPendingClaudeSwitch = (): void => {
+    const pending = pendingClaudeSwitch
+    if (!pending) {
+      return
+    }
+    setPendingClaudeSwitch(null)
+    void performClaudeAccountSwitch(pending.accountId, pending.target, pending.restartPlan)
   }
 
   const handleSelectRuntime = async (group: ClaudeStatusSwitchGroup): Promise<void> => {
@@ -767,118 +897,178 @@ function ClaudeSwitcherMenu({
   const activeTarget = selectedGroup?.targets.find((target) => target.active)
 
   return (
-    <ProviderDetailsMenu
-      provider={claude}
-      compact={compact}
-      iconOnly={iconOnly}
-      ariaLabel={translate(
-        'auto.components.status.bar.StatusBar.3dd7ddfae1',
-        'Open Claude details and account switcher'
-      )}
-      topContent={
-        <AccountRuntimeToggle
-          groups={switchGroups}
-          value={selectedGroup?.key ?? selectedRuntimeKey}
-          onChange={(group) => void handleSelectRuntime(group)}
-          ariaLabel={translate(
-            'auto.components.status.bar.StatusBar.11e2354daf',
-            'Claude usage runtime'
-          )}
-        />
-      }
-      open={open}
-      onOpenChange={handleOpenChange}
-    >
-      <DropdownMenuLabel>
-        {translate('auto.components.status.bar.StatusBar.d450654fa2', 'Claude Account')}
-      </DropdownMenuLabel>
-      <DropdownMenuItem
-        onSelect={(event) => {
-          event.preventDefault()
-          handleAccountsExpandedToggle()
-        }}
-      >
-        <span className="max-w-[180px] truncate text-[12px] text-foreground">
-          {activeTarget?.label ??
-            translate('auto.components.status.bar.StatusBar.c676918adc', 'System default')}
-        </span>
-        {accountsExpanded ? (
-          <ChevronDown className="ml-auto size-3.5 text-muted-foreground/85" />
-        ) : (
-          <ChevronRight className="ml-auto size-3.5 text-muted-foreground/85" />
+    <>
+      <ProviderDetailsMenu
+        provider={claude}
+        compact={compact}
+        iconOnly={iconOnly}
+        ariaLabel={translate(
+          'auto.components.status.bar.StatusBar.3dd7ddfae1',
+          'Open Claude details and account switcher'
         )}
-      </DropdownMenuItem>
-      {accountsExpanded ? (
-        <div className="px-1 pb-1">
-          <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-            {translate('auto.components.status.bar.StatusBar.9332ba8684', 'Switch to')}
-          </div>
-          <div className="max-h-[220px] overflow-y-auto rounded-md border border-border/60 bg-accent/5 p-1 scrollbar-sleek">
-            {selectedGroup?.targets.length === 0 ? (
-              <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
-                {translate('auto.components.status.bar.StatusBar.c98ea88392', 'No other accounts')}
-              </div>
-            ) : null}
-            {selectedGroup?.targets.map((target) => {
-              const inactiveUsage = target.id
-                ? inactiveClaudeAccounts.find((a) => a.accountId === target.id)
-                : null
+        topContent={
+          <AccountRuntimeToggle
+            groups={switchGroups}
+            value={selectedGroup?.key ?? selectedRuntimeKey}
+            onChange={(group) => void handleSelectRuntime(group)}
+            ariaLabel={translate(
+              'auto.components.status.bar.StatusBar.11e2354daf',
+              'Claude usage runtime'
+            )}
+          />
+        }
+        open={open}
+        onOpenChange={handleOpenChange}
+      >
+        <DropdownMenuLabel>
+          {translate('auto.components.status.bar.StatusBar.d450654fa2', 'Claude Account')}
+        </DropdownMenuLabel>
+        <DropdownMenuItem
+          onSelect={(event) => {
+            event.preventDefault()
+            handleAccountsExpandedToggle()
+          }}
+        >
+          <span className="max-w-[180px] truncate text-[12px] text-foreground">
+            {activeTarget?.label ??
+              translate('auto.components.status.bar.StatusBar.c676918adc', 'System default')}
+          </span>
+          {accountsExpanded ? (
+            <ChevronDown className="ml-auto size-3.5 text-muted-foreground/85" />
+          ) : (
+            <ChevronRight className="ml-auto size-3.5 text-muted-foreground/85" />
+          )}
+        </DropdownMenuItem>
+        {accountsExpanded ? (
+          <div className="px-1 pb-1">
+            <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+              {translate('auto.components.status.bar.StatusBar.9332ba8684', 'Switch to')}
+            </div>
+            <div className="max-h-[220px] overflow-y-auto rounded-md border border-border/60 bg-accent/5 p-1 scrollbar-sleek">
+              {selectedGroup?.targets.length === 0 ? (
+                <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+                  {translate(
+                    'auto.components.status.bar.StatusBar.c98ea88392',
+                    'No other accounts'
+                  )}
+                </div>
+              ) : null}
+              {selectedGroup?.targets.map((target) => {
+                const inactiveUsage = target.id
+                  ? inactiveClaudeAccounts.find((a) => a.accountId === target.id)
+                  : null
 
-              return (
-                <DropdownMenuItem
-                  key={`${selectedGroup.key}:${target.id ?? 'system'}`}
-                  disabled={isSwitching || target.active}
-                  onSelect={(event) => {
-                    event.preventDefault()
-                    if (!target.active) {
-                      void handleSelectAccount(target.id, target.runtimeTarget)
-                    }
-                  }}
-                >
-                  <div className="flex w-full flex-col gap-0.5">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <span className="min-w-0 flex-1 truncate">{target.label}</span>
-                      {target.active ? (
-                        <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
-                          {translate('auto.components.status.bar.StatusBar.ff0fbe9311', 'Active')}
-                        </span>
+                return (
+                  <DropdownMenuItem
+                    key={`${selectedGroup.key}:${target.id ?? 'system'}`}
+                    disabled={isSwitching || target.active}
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      if (!target.active) {
+                        void handleSelectAccount(target.id, target.runtimeTarget)
+                      }
+                    }}
+                  >
+                    <div className="flex w-full flex-col gap-0.5">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span className="min-w-0 flex-1 truncate">{target.label}</span>
+                        {target.active ? (
+                          <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
+                            {translate('auto.components.status.bar.StatusBar.ff0fbe9311', 'Active')}
+                          </span>
+                        ) : null}
+                      </div>
+                      {inactiveUsage?.isFetching && !inactiveUsage.rateLimits ? (
+                        <InlineUsageSkeleton />
+                      ) : inactiveUsage?.rateLimits ? (
+                        <InlineUsageBars
+                          limits={inactiveUsage.rateLimits}
+                          isFetching={inactiveUsage.isFetching}
+                        />
                       ) : null}
                     </div>
-                    {inactiveUsage?.isFetching && !inactiveUsage.rateLimits ? (
-                      <InlineUsageSkeleton />
-                    ) : inactiveUsage?.rateLimits ? (
-                      <InlineUsageBars
-                        limits={inactiveUsage.rateLimits}
-                        isFetching={inactiveUsage.isFetching}
-                      />
-                    ) : null}
-                  </div>
-                </DropdownMenuItem>
-              )
-            })}
+                  </DropdownMenuItem>
+                )
+              })}
+            </div>
+            <div className="px-2 py-1.5 text-[10px] leading-4 text-muted-foreground">
+              {translate(
+                'auto.components.status.bar.StatusBar.8295903d17',
+                'Restart live Claude terminals before continuing old conversations after switching.'
+              )}
+            </div>
           </div>
-          <div className="px-2 py-1.5 text-[10px] leading-4 text-muted-foreground">
-            {translate(
-              'auto.components.status.bar.StatusBar.8295903d17',
-              'Restart live Claude terminals before continuing old conversations after switching.'
-            )}
-          </div>
-        </div>
-      ) : null}
-      <DropdownMenuSeparator />
-      <DropdownMenuItem
-        onSelect={() => {
-          openSettingsTarget({
-            pane: 'accounts',
-            repoId: null,
-            sectionId: 'accounts-claude'
-          })
-          openSettingsPage()
+        ) : null}
+        {open ? <ClaudeRestartStatusPrompt /> : null}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={() => {
+            openSettingsTarget({
+              pane: 'accounts',
+              repoId: null,
+              sectionId: 'accounts-claude'
+            })
+            openSettingsPage()
+          }}
+        >
+          {translate('auto.components.status.bar.StatusBar.75ded02687', 'Manage Accounts…')}
+        </DropdownMenuItem>
+      </ProviderDetailsMenu>
+      <Dialog
+        open={pendingClaudeSwitch !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && !isSwitching) {
+            setPendingClaudeSwitch(null)
+          }
         }}
       >
-        {translate('auto.components.status.bar.StatusBar.75ded02687', 'Manage Accounts…')}
-      </DropdownMenuItem>
-    </ProviderDetailsMenu>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="size-4 text-destructive" />
+              {translate(
+                'auto.components.status.bar.StatusBar.df5d2c1384',
+                'Active Claude work is running'
+              )}
+            </DialogTitle>
+            <DialogDescription>
+              {(pendingClaudeSwitch?.restartPlan.workInProgressPtyIds.length ?? 0) === 1
+                ? translate(
+                    'auto.components.status.bar.StatusBar.a0e249e2d2',
+                    '1 Claude session appears to be working or waiting for input. Switching accounts will stop and restart it so the new account is used.'
+                  )
+                : translate(
+                    'auto.components.status.bar.StatusBar.3ca963aa09',
+                    '{{value0}} Claude sessions appear to be working or waiting for input. Switching accounts will stop and restart them so the new account is used.',
+                    {
+                      value0: pendingClaudeSwitch?.restartPlan.workInProgressPtyIds.length ?? 0
+                    }
+                  )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setPendingClaudeSwitch(null)}
+              disabled={isSwitching}
+            >
+              {translate('auto.components.status.bar.StatusBar.625fb26b4b', 'Cancel')}
+            </Button>
+            <Button type="button" onClick={handleConfirmPendingClaudeSwitch} disabled={isSwitching}>
+              {isSwitching ? (
+                <>
+                  <Loader2 className="size-3.5 animate-spin" />
+                  {translate('auto.components.status.bar.StatusBar.c31c67d31f', 'Switching...')}
+                </>
+              ) : (
+                translate('auto.components.status.bar.StatusBar.c15d5d972a', 'Switch and Restart')
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 

--- a/src/renderer/src/components/status-bar/codex-restart-status-summary.ts
+++ b/src/renderer/src/components/status-bar/codex-restart-status-summary.ts
@@ -6,28 +6,36 @@ export type CodexRestartStatusSummaryInput = {
   codexRestartNoticeByPtyId: Record<string, unknown>
 }
 
-export type CodexRestartStatusSummary = {
+export type AccountRestartStatusSummaryInput = {
+  tabsByWorktree: TabLookup
+  ptyIdsByTabId: Record<string, string[]>
+  restartNoticeByPtyId: Record<string, unknown>
+}
+
+export type AccountRestartStatusSummary = {
   stalePtyIds: string[]
   staleSessionCount: number
   staleTabCount: number
   staleWorktreeCount: number
 }
 
-const EMPTY_CODEX_RESTART_STATUS_SUMMARY: CodexRestartStatusSummary = {
+export type CodexRestartStatusSummary = AccountRestartStatusSummary
+
+const EMPTY_ACCOUNT_RESTART_STATUS_SUMMARY: AccountRestartStatusSummary = {
   stalePtyIds: [],
   staleSessionCount: 0,
   staleTabCount: 0,
   staleWorktreeCount: 0
 }
 
-export function summarizeCodexRestartStatus({
+export function summarizeAccountRestartStatus({
   tabsByWorktree,
   ptyIdsByTabId,
-  codexRestartNoticeByPtyId
-}: CodexRestartStatusSummaryInput): CodexRestartStatusSummary {
-  const stalePtyIds = Object.keys(codexRestartNoticeByPtyId)
+  restartNoticeByPtyId
+}: AccountRestartStatusSummaryInput): AccountRestartStatusSummary {
+  const stalePtyIds = Object.keys(restartNoticeByPtyId)
   if (stalePtyIds.length === 0) {
-    return EMPTY_CODEX_RESTART_STATUS_SUMMARY
+    return EMPTY_ACCOUNT_RESTART_STATUS_SUMMARY
   }
 
   const stalePtyIdSet = new Set(stalePtyIds)
@@ -51,4 +59,16 @@ export function summarizeCodexRestartStatus({
     staleTabCount: staleTabIds.size,
     staleWorktreeCount: staleWorktreeIds.size
   }
+}
+
+export function summarizeCodexRestartStatus({
+  tabsByWorktree,
+  ptyIdsByTabId,
+  codexRestartNoticeByPtyId
+}: CodexRestartStatusSummaryInput): CodexRestartStatusSummary {
+  return summarizeAccountRestartStatus({
+    tabsByWorktree,
+    ptyIdsByTabId,
+    restartNoticeByPtyId: codexRestartNoticeByPtyId
+  })
 }

--- a/src/renderer/src/components/status-bar/status-bar-claude-switcher.test.tsx
+++ b/src/renderer/src/components/status-bar/status-bar-claude-switcher.test.tsx
@@ -1,0 +1,307 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { useAppStore, type AppState } from '@/store'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { ClaudeRateLimitAccountsState } from '../../../../shared/types'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import { StatusBar } from './StatusBar'
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string, values?: Record<string, unknown>) => {
+    if (!values) {
+      return fallback
+    }
+    return Object.entries(values).reduce(
+      (text, [key, value]) => text.replace(`{{${key}}}`, String(value)),
+      fallback
+    )
+  }
+}))
+
+vi.mock('./UpdateStatusSegment', () => ({
+  UpdateStatusSegment: () => null
+}))
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+class MockResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+  unobserve(): void {}
+}
+
+function claudeLimits(): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: {
+      usedPercent: 20,
+      windowMinutes: 300,
+      resetsAt: null,
+      resetDescription: null
+    },
+    weekly: null,
+    fableWeekly: null,
+    updatedAt: 1,
+    error: null,
+    status: 'ok'
+  }
+}
+
+function selectedClaudeAccountsState(): ClaudeRateLimitAccountsState {
+  return {
+    accounts: [
+      {
+        id: 'claude-work',
+        email: 'work@example.com',
+        managedAuthRuntime: 'host',
+        wslDistro: null,
+        authMethod: 'subscription-oauth',
+        organizationUuid: null,
+        organizationName: null,
+        createdAt: 1,
+        updatedAt: 1,
+        lastAuthenticatedAt: 1
+      }
+    ],
+    activeAccountId: 'claude-work',
+    activeAccountIdsByRuntime: { host: 'claude-work', wsl: {} }
+  }
+}
+
+function seedStatusBarStore(): void {
+  const settings = {
+    ...getDefaultSettings('/tmp'),
+    claudeManagedAccounts: [
+      {
+        id: 'claude-work',
+        email: 'work@example.com',
+        managedAuthPath: '/tmp/claude-work',
+        managedAuthRuntime: 'host' as const,
+        wslDistro: null,
+        wslLinuxAuthPath: null,
+        authMethod: 'subscription-oauth' as const,
+        organizationUuid: null,
+        organizationName: null,
+        createdAt: 1,
+        updatedAt: 1,
+        lastAuthenticatedAt: 1
+      }
+    ],
+    activeClaudeManagedAccountId: null,
+    activeClaudeManagedAccountIdsByRuntime: { host: null, wsl: {} },
+    floatingTerminalEnabled: false
+  }
+  const paneKey = makePaneKey('tab-1', LEAF_ID)
+  useAppStore.setState({
+    settings,
+    statusBarVisible: true,
+    statusBarItems: ['claude'],
+    detectedAgentIds: ['claude'],
+    rateLimits: {
+      ...useAppStore.getState().rateLimits,
+      claude: claudeLimits(),
+      codex: null,
+      gemini: null,
+      opencodeGo: null,
+      kimi: null,
+      claudeTarget: { runtime: 'host', wslDistro: null },
+      inactiveClaudeAccounts: []
+    },
+    tabsByWorktree: {
+      wt1: [
+        {
+          id: 'tab-1',
+          ptyId: 'pty-1',
+          worktreeId: 'wt1',
+          title: 'Claude',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: { type: 'leaf', leafId: LEAF_ID },
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+      }
+    },
+    runtimePaneTitlesByTabId: {},
+    agentStatusByPaneKey: {
+      [paneKey]: {
+        paneKey,
+        state: 'working',
+        prompt: 'finish account switch',
+        updatedAt: 1,
+        stateStartedAt: 1,
+        agentType: 'claude',
+        stateHistory: []
+      }
+    },
+    pendingClaudePaneRestartIds: {},
+    claudeRestartNoticeByPtyId: {},
+    recordFeatureInteraction: vi.fn(),
+    ensureDetectedAgents: vi.fn().mockResolvedValue(undefined),
+    refreshRateLimits: vi.fn().mockResolvedValue(undefined),
+    refreshDetectedAgents: vi.fn().mockResolvedValue(undefined),
+    fetchSettings: vi.fn().mockResolvedValue(undefined),
+    fetchInactiveClaudeAccountUsage: vi.fn().mockResolvedValue(undefined)
+  })
+}
+
+function getButtonByName(name: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll('button')).find(
+    (candidate) =>
+      candidate.textContent?.trim() === name || candidate.getAttribute('aria-label') === name
+  )
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${name}`)
+  }
+  return button
+}
+
+function getText(text: string): HTMLElement {
+  const element = Array.from(document.body.querySelectorAll<HTMLElement>('*')).find(
+    (candidate) => candidate.textContent?.trim() === text
+  )
+  if (!element) {
+    throw new Error(`Text not found: ${text}`)
+  }
+  return element
+}
+
+function getDialogByName(name: string): HTMLElement {
+  const dialog = Array.from(document.body.querySelectorAll<HTMLElement>('[role="dialog"]')).find(
+    (candidate) => candidate.textContent?.includes(name)
+  )
+  if (!dialog) {
+    throw new Error(`Dialog not found: ${name}`)
+  }
+  return dialog
+}
+
+async function clickElement(element: Element): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }))
+    element.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, button: 0 }))
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }))
+  })
+}
+
+async function waitUntil(assertion: () => void): Promise<void> {
+  const startedAt = Date.now()
+  let lastError: unknown = null
+  while (Date.now() - startedAt < 1_000) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+  if (lastError instanceof Error) {
+    throw lastError
+  }
+  throw new Error('Timed out waiting for assertion')
+}
+
+function unmountRenderedStatusBar(rendered: { root: Root; container: HTMLElement } | null): void {
+  if (!rendered) {
+    return
+  }
+  act(() => {
+    rendered.root.unmount()
+  })
+  rendered.container.remove()
+}
+
+function renderStatusBarSurface(): { root: Root; container: HTMLElement } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <StatusBar floatingTerminalOpen={false} />
+      </TooltipProvider>
+    )
+  })
+  return { root, container }
+}
+
+function renderStatusBar() {
+  return renderStatusBarSurface()
+}
+
+describe('StatusBar Claude account switcher', () => {
+  let initialStoreState: AppState
+  let selectClaudeAccount: ReturnType<typeof vi.fn>
+  let renderedStatusBar: { root: Root; container: HTMLElement } | null
+
+  beforeEach(() => {
+    initialStoreState = useAppStore.getState()
+    renderedStatusBar = null
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    selectClaudeAccount = vi.fn().mockResolvedValue(selectedClaudeAccountsState())
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        claudeAccounts: {
+          list: vi.fn().mockResolvedValue(selectedClaudeAccountsState()),
+          select: selectClaudeAccount
+        },
+        pty: {
+          getForegroundProcess: vi.fn().mockResolvedValue('node'),
+          hasChildProcesses: vi.fn().mockResolvedValue(false)
+        }
+      }
+    })
+    seedStatusBarStore()
+  })
+
+  afterEach(() => {
+    unmountRenderedStatusBar(renderedStatusBar)
+    Reflect.deleteProperty(window, 'api')
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    useAppStore.setState(initialStoreState, true)
+  })
+
+  it('warns before switching accounts when a Claude pane is actively working', async () => {
+    renderedStatusBar = renderStatusBar()
+
+    await clickElement(getButtonByName('Open Claude details and account switcher'))
+    await clickElement(getText('System default'))
+    await clickElement(getText('work@example.com'))
+
+    await waitUntil(() => {
+      expect(selectClaudeAccount).not.toHaveBeenCalled()
+      expect(getDialogByName('Active Claude work is running').textContent).toContain(
+        '1 Claude session appears to be working or waiting for input. Switching accounts will stop and restart it so the new account is used.'
+      )
+    })
+
+    await clickElement(getButtonByName('Switch and Restart'))
+
+    await waitUntil(() => {
+      expect(selectClaudeAccount).toHaveBeenCalledOnce()
+      expect(useAppStore.getState().pendingClaudePaneRestartIds).toEqual({ 'pty-1': true })
+    })
+    expect(selectClaudeAccount).toHaveBeenCalledWith({
+      accountId: 'claude-work',
+      runtime: 'host',
+      wslDistro: null
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -567,6 +567,11 @@ export default function TerminalPane({
     (store) => store.consumePendingCodexPaneRestart
   )
   const clearCodexRestartNotice = useAppStore((store) => store.clearCodexRestartNotice)
+  const pendingClaudePaneRestartIds = useAppStore((store) => store.pendingClaudePaneRestartIds)
+  const consumePendingClaudePaneRestart = useAppStore(
+    (store) => store.consumePendingClaudePaneRestart
+  )
+  const clearClaudeRestartNotice = useAppStore((store) => store.clearClaudeRestartNotice)
   // Why: when this tab is in native chat view the chat surface is the active
   // layer above the still-mounted terminal, so the terminal's own mobile-driver
   // overlay must not render on top of it; the chat composer's guarded canSend
@@ -1565,8 +1570,8 @@ export default function TerminalPane({
     }
   }, [])
 
-  const handleRestartCodexPane = useCallback(
-    (paneId: number) => {
+  const handleRestartAccountPane = useCallback(
+    (paneId: number, command: 'claude' | 'codex', clearRestartNotice: (ptyId: string) => void) => {
       const manager = managerRef.current
       const pane = manager?.getPanes().find((candidate) => candidate.id === paneId)
       if (!manager || !pane) {
@@ -1579,11 +1584,11 @@ export default function TerminalPane({
 
       if (existingPtyId) {
         suppressPtyExit(existingPtyId)
-        clearCodexRestartNotice(existingPtyId)
-        // Why: pane-scoped Codex restarts should preserve the split layout and
-        // replace only the stale session in place. Clearing the PTY binding and
-        // consuming the upcoming suppressed exit keeps the pane mounted while a
-        // fresh PTY reconnects under the newly selected Codex account.
+        clearRestartNotice(existingPtyId)
+        // Why: pane-scoped account restarts should preserve the split layout
+        // and replace only the stale session in place. Clearing the PTY
+        // binding and consuming the upcoming suppressed exit keeps the pane
+        // mounted while a fresh PTY reconnects under the selected account.
         clearTabPtyId(tabId, existingPtyId)
       }
 
@@ -1599,7 +1604,7 @@ export default function TerminalPane({
         tabId,
         worktreeId,
         cwd,
-        startup: { command: 'codex' },
+        startup: { command },
         paneTransportsRef,
         paneMode2031Ref,
         paneLastThemeModeRef,
@@ -1630,7 +1635,6 @@ export default function TerminalPane({
       manager.setActivePane(paneId, { focus: true })
     },
     [
-      clearCodexRestartNotice,
       clearExitedPanePtyLayoutBinding,
       clearRuntimePaneTitle,
       clearTabPtyId,
@@ -1663,17 +1667,29 @@ export default function TerminalPane({
 
     for (const pane of manager.getPanes()) {
       const ptyId = paneTransportsRef.current.get(pane.id)?.getPtyId()
-      if (!ptyId || !pendingCodexPaneRestartIds[ptyId]) {
+      if (!ptyId) {
         continue
       }
-      // Why: the status-bar switcher can request a global restart for stale
-      // Codex sessions, but the actual execution must stay pane scoped so a
-      // split tab does not lose unrelated non-Codex panes.
-      if (consumePendingCodexPaneRestart(ptyId)) {
-        handleRestartCodexPane(pane.id)
+      if (pendingCodexPaneRestartIds[ptyId] && consumePendingCodexPaneRestart(ptyId)) {
+        handleRestartAccountPane(pane.id, 'codex', clearCodexRestartNotice)
+        continue
+      }
+      if (!pendingClaudePaneRestartIds[ptyId]) {
+        continue
+      }
+      if (consumePendingClaudePaneRestart(ptyId)) {
+        handleRestartAccountPane(pane.id, 'claude', clearClaudeRestartNotice)
       }
     }
-  }, [consumePendingCodexPaneRestart, handleRestartCodexPane, pendingCodexPaneRestartIds])
+  }, [
+    clearClaudeRestartNotice,
+    clearCodexRestartNotice,
+    consumePendingClaudePaneRestart,
+    consumePendingCodexPaneRestart,
+    handleRestartAccountPane,
+    pendingClaudePaneRestartIds,
+    pendingCodexPaneRestartIds
+  ])
 
   useTerminalFontZoom({ isActive, containerRef, managerRef, paneFontSizesRef, settingsRef })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -135,6 +135,10 @@ type StoreState = {
     string,
     { previousAccountLabel: string; nextAccountLabel: string }
   >
+  claudeRestartNoticeByPtyId: Record<
+    string,
+    { previousAccountLabel: string; nextAccountLabel: string }
+  >
   deferredSshReconnectTargets: string[]
   deferredSshSessionIdsByTabId: Record<string, string>
   removeDeferredSshReconnectTarget: ReturnType<typeof vi.fn>
@@ -701,6 +705,7 @@ describe('connectPanePty', () => {
       cacheTimerByKey: {},
       settings: { promptCacheTimerEnabled: true, experimentalTerminalAttention: true },
       codexRestartNoticeByPtyId: {},
+      claudeRestartNoticeByPtyId: {},
       deferredSshReconnectTargets: [],
       deferredSshSessionIdsByTabId: {},
       removeDeferredSshReconnectTarget: vi.fn(),
@@ -3196,6 +3201,49 @@ describe('connectPanePty', () => {
         }
       ),
       codexRestartNoticeByPtyId: {
+        'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B' }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).not.toHaveBeenCalled()
+  })
+
+  it('blocks stale Claude fallback input from the current worktree tab without enumerating all worktrees', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport(null)
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: new Proxy(
+        {
+          'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }],
+          'wt-2': [{ id: 'tab-2', ptyId: 'pty-other' }]
+        },
+        {
+          ownKeys() {
+            throw new Error('tabsByWorktree should not be enumerated')
+          }
+        }
+      ),
+      claudeRestartNoticeByPtyId: {
         'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B' }
       }
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -92,7 +92,8 @@ import { e2eConfig } from '@/lib/e2e-config'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry,
-  type AgentType
+  type AgentType,
+  type ParsedAgentStatusPayload
 } from '../../../../shared/agent-status-types'
 import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
 import {
@@ -647,11 +648,16 @@ function isStatefulRendererReplyCsiQuery(sequence: string): boolean {
   return sequence === '\x1b[6n' || (sequence.startsWith('\x1b[?') && sequence.endsWith('$p'))
 }
 
-let codexRestartNoticePresenceSource: Record<
+type AccountRestartNoticesByPtyId = Record<
   string,
   { previousAccountLabel: string; nextAccountLabel: string }
-> | null = null
-let codexRestartNoticePresence = false
+>
+
+let accountRestartNoticePresenceSource: {
+  codex: AccountRestartNoticesByPtyId
+  claude: AccountRestartNoticesByPtyId
+} | null = null
+let accountRestartNoticePresence = false
 let inactiveForegroundImmediateBudgetChars = 0
 let inactiveForegroundImmediateBudgetWindowStart = 0
 
@@ -804,14 +810,22 @@ function consumeInactiveForegroundImmediateBudget(dataLength: number): boolean {
   return true
 }
 
-function hasCodexRestartNotices(
-  noticesByPtyId: Record<string, { previousAccountLabel: string; nextAccountLabel: string }>
+function hasAccountRestartNotices(
+  codexNoticesByPtyId: AccountRestartNoticesByPtyId,
+  claudeNoticesByPtyId: AccountRestartNoticesByPtyId
 ): boolean {
-  if (codexRestartNoticePresenceSource !== noticesByPtyId) {
-    codexRestartNoticePresenceSource = noticesByPtyId
-    codexRestartNoticePresence = Object.keys(noticesByPtyId).length > 0
+  if (
+    accountRestartNoticePresenceSource?.codex !== codexNoticesByPtyId ||
+    accountRestartNoticePresenceSource?.claude !== claudeNoticesByPtyId
+  ) {
+    accountRestartNoticePresenceSource = {
+      codex: codexNoticesByPtyId,
+      claude: claudeNoticesByPtyId
+    }
+    accountRestartNoticePresence =
+      Object.keys(codexNoticesByPtyId).length > 0 || Object.keys(claudeNoticesByPtyId).length > 0
   }
-  return codexRestartNoticePresence
+  return accountRestartNoticePresence
 }
 
 function sshPromptConnectOutcomeForStatus(
@@ -862,22 +876,28 @@ async function waitForSshConnection(connectionId: string): Promise<SshConnectRes
   return promise
 }
 
-function isCodexPaneStale(args: {
+function isAccountSwitchPaneStale(args: {
   tabId: string
   worktreeId: string
   panePtyId: string | null
 }): boolean {
   const state = useAppStore.getState()
-  const { codexRestartNoticeByPtyId } = state
-  if (!hasCodexRestartNotices(codexRestartNoticeByPtyId)) {
+  const { claudeRestartNoticeByPtyId, codexRestartNoticeByPtyId } = state
+  if (!hasAccountRestartNotices(codexRestartNoticeByPtyId, claudeRestartNoticeByPtyId)) {
     return false
   }
-  if (args.panePtyId && codexRestartNoticeByPtyId[args.panePtyId]) {
+  if (
+    args.panePtyId &&
+    (codexRestartNoticeByPtyId[args.panePtyId] || claudeRestartNoticeByPtyId[args.panePtyId])
+  ) {
     return true
   }
 
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)
-  if (tab?.ptyId && codexRestartNoticeByPtyId[tab.ptyId]) {
+  if (
+    tab?.ptyId &&
+    (codexRestartNoticeByPtyId[tab.ptyId] || claudeRestartNoticeByPtyId[tab.ptyId])
+  ) {
     return true
   }
 
@@ -1616,22 +1636,20 @@ export function connectPanePty(
   const interruptInference = createAgentInterruptInference({
     paneKey: cacheKey,
     getStatusEntry: () => useAppStore.getState().agentStatusByPaneKey[cacheKey],
-    inferInterrupt: (request) => {
+    inferInterrupt: async (request) => {
       // Why: the explicit hook row is the authority for an in-flight agent turn.
       // Codex can reset its terminal title while handling Ctrl+C/Escape, so title
       // state must not veto clearing the row's working state.
-      return window.api.agentStatus
-        .inferInterrupt(request)
-        .then((applied) => {
-          if (applied) {
-            clearInferredInterruptWorkingTitle()
-          }
-          return applied
-        })
-        .catch((err) => {
-          console.warn('[agent-interrupt] inferInterrupt failed:', err)
-          return false
-        })
+      try {
+        const applied = await window.api.agentStatus.inferInterrupt(request)
+        if (applied) {
+          clearInferredInterruptWorkingTitle()
+        }
+        return applied
+      } catch (err) {
+        console.warn('[agent-interrupt] inferInterrupt failed:', err)
+        return false
+      }
     }
   })
   const dropCommandFinishedStatusIfSameTurn = (
@@ -2561,7 +2579,7 @@ export function connectPanePty(
     // local main, so the renderer remains their status owner for now.
     ...(shouldOwnAgentStatusInRenderer
       ? {
-          onAgentStatus: (payload) => {
+          onAgentStatus: (payload: ParsedAgentStatusPayload) => {
             if (
               shouldSuppressCodexAutoApprovalStatus(payload, {
                 paneKey: cacheKey,
@@ -2649,14 +2667,14 @@ export function connectPanePty(
       return
     }
     const currentPtyId = transport.getPtyId()
-    // Why: after a Codex account switch, the runtime auth has already moved to
-    // the newly selected account. Stale panes must not keep sending input until
-    // they restart, or work can execute under the wrong account while the UI
-    // still says the pane is stale. Fall back to the tab's persisted PTY ID so
-    // the block still holds during reconnect races before the live transport has
+    // Why: after an account switch, runtime auth has already moved to the newly
+    // selected account. Stale panes must not keep sending input until they
+    // restart, or work can execute under the wrong account while the UI still
+    // says the pane is stale. Fall back to the tab's persisted PTY ID so the
+    // block still holds during reconnect races before the live transport has
     // updated its local PTY binding.
     if (
-      isCodexPaneStale({
+      isAccountSwitchPaneStale({
         tabId: deps.tabId,
         worktreeId: deps.worktreeId,
         panePtyId: currentPtyId

--- a/src/renderer/src/lib/claude-session-restart-target.test.ts
+++ b/src/renderer/src/lib/claude-session-restart-target.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore, type AppState } from '@/store'
+import {
+  getLiveClaudeSessionRestartPlan,
+  markClaudeSessionsForRestart
+} from './claude-session-restart'
+import { toRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
+import { getDefaultSettings } from '../../../shared/constants'
+import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
+import type { Project, Repo, Worktree } from '../../../shared/types'
+
+const ACCOUNT_LABEL = 'same@example.com'
+const HOST_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const WSL_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+
+function makeRepo(args: { id: string; path: string; connectionId?: string | null }): Repo {
+  return {
+    id: args.id,
+    path: args.path,
+    displayName: args.id,
+    badgeColor: '#000000',
+    addedAt: 1,
+    connectionId: args.connectionId ?? null
+  }
+}
+
+function makeProject(args: {
+  id: string
+  repoId: string
+  runtime: Project['localWindowsRuntimePreference']
+}): Project {
+  return {
+    id: args.id,
+    displayName: args.id,
+    badgeColor: '#000000',
+    sourceRepoIds: [args.repoId],
+    localWindowsRuntimePreference: args.runtime,
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+function makeWorktree(args: {
+  id: string
+  repoId: string
+  projectId: string
+  path: string
+}): Worktree {
+  return {
+    id: args.id,
+    repoId: args.repoId,
+    projectId: args.projectId,
+    displayName: args.id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    path: args.path,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: false
+  }
+}
+
+function makeTab(args: {
+  id: string
+  ptyId: string
+  worktreeId: string
+  title?: string
+  launchAgent?: 'claude'
+}): AppState['tabsByWorktree'][string][number] {
+  return {
+    id: args.id,
+    ptyId: args.ptyId,
+    worktreeId: args.worktreeId,
+    title: args.title ?? 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...(args.launchAgent ? { launchAgent: args.launchAgent } : {})
+  }
+}
+
+function makeLayout(leafId: string, ptyId: string): AppState['terminalLayoutsByTabId'][string] {
+  return {
+    root: { type: 'leaf', leafId },
+    activeLeafId: leafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { [leafId]: ptyId }
+  }
+}
+
+describe('Claude session restart targeting', () => {
+  const originalWindow = (globalThis as { window?: typeof window }).window
+
+  beforeEach(() => {
+    useAppStore.setState({
+      settings: getDefaultSettings('/tmp'),
+      tabsByWorktree: {},
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: {},
+      runtimePaneTitlesByTabId: {},
+      agentStatusByPaneKey: {},
+      pendingClaudePaneRestartIds: {},
+      claudeRestartNoticeByPtyId: {}
+    })
+    vi.stubGlobal('window', {
+      ...originalWindow,
+      api: {
+        ...originalWindow?.api,
+        platform: {
+          ...originalWindow?.api?.platform,
+          get: vi.fn(() => ({ platform: 'win32' }))
+        },
+        pty: {
+          ...originalWindow?.api?.pty,
+          getForegroundProcess: vi.fn(),
+          hasChildProcesses: vi.fn().mockResolvedValue(false)
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('scopes WSL account switches to matching local WSL Claude PTYs', async () => {
+    const hostWorktreeId = 'repo-host::C:\\repo'
+    const wslWorktreeId = 'repo-wsl::C:\\repo'
+    const sshWorktreeId = 'repo-ssh::/repo'
+    const sshPtyId = toAppSshPtyId('target-1', 'pty-ssh')
+    const runtimePtyId = toRemoteRuntimePtyId('pty-runtime', 'runtime-env')
+
+    useAppStore.setState({
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        localWindowsRuntimeDefault: { kind: 'windows-host' }
+      },
+      projects: [
+        makeProject({
+          id: 'project-host',
+          repoId: 'repo-host',
+          runtime: { kind: 'windows-host' }
+        }),
+        makeProject({
+          id: 'project-wsl',
+          repoId: 'repo-wsl',
+          runtime: { kind: 'wsl', distro: 'Ubuntu' }
+        })
+      ],
+      repos: [
+        makeRepo({ id: 'repo-host', path: 'C:\\repo' }),
+        makeRepo({ id: 'repo-wsl', path: 'C:\\repo' }),
+        makeRepo({ id: 'repo-ssh', path: '/repo', connectionId: 'target-1' })
+      ],
+      worktreesByRepo: {
+        'repo-host': [
+          makeWorktree({
+            id: hostWorktreeId,
+            repoId: 'repo-host',
+            projectId: 'project-host',
+            path: 'C:\\repo'
+          })
+        ],
+        'repo-wsl': [
+          makeWorktree({
+            id: wslWorktreeId,
+            repoId: 'repo-wsl',
+            projectId: 'project-wsl',
+            path: 'C:\\repo'
+          })
+        ],
+        'repo-ssh': [
+          makeWorktree({
+            id: sshWorktreeId,
+            repoId: 'repo-ssh',
+            projectId: 'project-ssh',
+            path: '/repo'
+          })
+        ]
+      },
+      tabsByWorktree: {
+        [hostWorktreeId]: [
+          makeTab({ id: 'tab-host', ptyId: 'pty-host', worktreeId: hostWorktreeId })
+        ],
+        [wslWorktreeId]: [makeTab({ id: 'tab-wsl', ptyId: 'pty-wsl', worktreeId: wslWorktreeId })],
+        [sshWorktreeId]: [makeTab({ id: 'tab-ssh', ptyId: sshPtyId, worktreeId: sshWorktreeId })]
+      },
+      ptyIdsByTabId: {
+        'tab-host': ['pty-host'],
+        'tab-wsl': ['pty-wsl', runtimePtyId],
+        'tab-ssh': [sshPtyId]
+      },
+      terminalLayoutsByTabId: {
+        'tab-host': makeLayout(HOST_LEAF_ID, 'pty-host'),
+        'tab-wsl': makeLayout(WSL_LEAF_ID, 'pty-wsl'),
+        'tab-ssh': makeLayout(HOST_LEAF_ID, sshPtyId)
+      }
+    })
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('claude')
+
+    await expect(
+      getLiveClaudeSessionRestartPlan({ target: { runtime: 'wsl', wslDistro: 'Ubuntu' } })
+    ).resolves.toEqual({ livePtyIds: ['pty-wsl'], workInProgressPtyIds: [] })
+
+    expect(window.api.pty.getForegroundProcess).toHaveBeenCalledTimes(1)
+    expect(window.api.pty.getForegroundProcess).toHaveBeenCalledWith('pty-wsl')
+  })
+
+  it('does not use stale Claude tab hints when a shell is foregrounded', async () => {
+    useAppStore.setState({
+      tabsByWorktree: {
+        wt1: [
+          makeTab({
+            id: 'tab-1',
+            ptyId: 'pty-1',
+            worktreeId: 'wt1',
+            title: '. write account switcher',
+            launchAgent: 'claude'
+          })
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      terminalLayoutsByTabId: { 'tab-1': makeLayout(HOST_LEAF_ID, 'pty-1') },
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: '. write account switcher' } }
+    })
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('zsh')
+
+    await expect(getLiveClaudeSessionRestartPlan()).resolves.toEqual({
+      livePtyIds: [],
+      workInProgressPtyIds: []
+    })
+  })
+
+  it('keeps same-label Claude accounts stale until the original account id returns', () => {
+    markClaudeSessionsForRestart({
+      ptyIds: ['pty-1'],
+      previousAccountLabel: ACCOUNT_LABEL,
+      nextAccountLabel: ACCOUNT_LABEL,
+      previousAccountId: 'account-org-a',
+      nextAccountId: 'account-org-b'
+    })
+
+    expect(useAppStore.getState().claudeRestartNoticeByPtyId['pty-1']).toMatchObject({
+      previousAccountLabel: ACCOUNT_LABEL,
+      nextAccountLabel: ACCOUNT_LABEL,
+      previousAccountId: 'account-org-a',
+      nextAccountId: 'account-org-b'
+    })
+
+    markClaudeSessionsForRestart({
+      ptyIds: ['pty-1'],
+      previousAccountLabel: ACCOUNT_LABEL,
+      nextAccountLabel: ACCOUNT_LABEL,
+      previousAccountId: 'account-org-b',
+      nextAccountId: 'account-org-a'
+    })
+
+    expect(useAppStore.getState().claudeRestartNoticeByPtyId['pty-1']).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/claude-session-restart-target.ts
+++ b/src/renderer/src/lib/claude-session-restart-target.ts
@@ -1,0 +1,161 @@
+import type { AppState } from '@/store'
+import { getFolderWorkspaceConnectionId } from '@/lib/folder-workspace-connection'
+import {
+  getLocalProjectExecutionRuntimeContext,
+  getWslDistroFromPath
+} from '@/lib/local-preflight-context'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
+import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId
+} from '../../../shared/execution-host'
+import type { ProjectExecutionRuntimeResolution } from '../../../shared/project-execution-runtime'
+import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
+import { parseWorkspaceKey } from '../../../shared/workspace-scope'
+import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../../shared/worktree-id'
+
+export type ClaudeSessionRestartTarget = {
+  runtime: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
+type RestartCandidateTab = AppState['tabsByWorktree'][string][number]
+
+type LocalRuntimeScope =
+  | { runtime: 'host' }
+  | { runtime: 'wsl'; wslDistro: string | null }
+  | { runtime: 'remote' }
+
+function normalizeDistro(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function isRemoteExecutionHost(hostId: string | null | undefined): boolean {
+  const parsed = parseExecutionHostId(hostId ?? LOCAL_EXECUTION_HOST_ID)
+  return parsed?.kind === 'ssh' || parsed?.kind === 'runtime'
+}
+
+function getProjectRuntimeScope(
+  resolution: ProjectExecutionRuntimeResolution | undefined
+): LocalRuntimeScope | null {
+  if (!resolution) {
+    return null
+  }
+  switch (resolution.status) {
+    case 'repair-required':
+      return {
+        runtime: 'wsl',
+        wslDistro: normalizeDistro(resolution.repair.preferredRuntime.distro)
+      }
+    case 'resolved':
+      switch (resolution.runtime.kind) {
+        case 'wsl':
+          return { runtime: 'wsl', wslDistro: resolution.runtime.distro }
+        case 'windows-host':
+        case 'local-host':
+          return { runtime: 'host' }
+      }
+  }
+}
+
+function getFolderWorkspaceRuntimeScope(
+  state: AppState,
+  folderWorkspaceId: string
+): LocalRuntimeScope {
+  const workspace = state.folderWorkspaces.find((entry) => entry.id === folderWorkspaceId)
+  if (!workspace) {
+    return { runtime: 'host' }
+  }
+  const projectGroup = state.projectGroups.find((entry) => entry.id === workspace.projectGroupId)
+  if (isRemoteExecutionHost(projectGroup?.executionHostId)) {
+    return { runtime: 'remote' }
+  }
+
+  const connectionId = getFolderWorkspaceConnectionId(state, folderWorkspaceId)
+  if (connectionId) {
+    return { runtime: 'remote' }
+  }
+
+  const wslDistro = getWslDistroFromPath(workspace.folderPath)
+  return wslDistro ? { runtime: 'wsl', wslDistro } : { runtime: 'host' }
+}
+
+function findWorktree(state: AppState, worktreeId: string) {
+  return (
+    Object.values(state.worktreesByRepo)
+      .flat()
+      .find((entry) => entry.id === worktreeId) ?? null
+  )
+}
+
+function getWorktreeRuntimeScope(state: AppState, worktreeId: string): LocalRuntimeScope {
+  const worktree = findWorktree(state, worktreeId)
+  const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
+  const repo = state.repos.find((entry) => entry.id === repoId) ?? null
+  if (
+    isRemoteExecutionHost(worktree?.hostId) ||
+    (repo && isRemoteExecutionHost(getRepoExecutionHostId(repo)))
+  ) {
+    return { runtime: 'remote' }
+  }
+
+  const projectRuntime = getLocalProjectExecutionRuntimeContext(
+    state,
+    worktreeId,
+    getRendererAppPlatform()
+  )
+  const projectRuntimeScope = getProjectRuntimeScope(projectRuntime)
+  if (projectRuntimeScope) {
+    return projectRuntimeScope
+  }
+
+  const path = worktree?.path ?? splitWorktreeId(worktreeId)?.worktreePath ?? repo?.path
+  const wslDistro = getWslDistroFromPath(path)
+  return wslDistro ? { runtime: 'wsl', wslDistro } : { runtime: 'host' }
+}
+
+function getTabRuntimeScope(state: AppState, tab: RestartCandidateTab): LocalRuntimeScope {
+  const workspaceScope = parseWorkspaceKey(tab.worktreeId)
+  if (workspaceScope?.type === 'folder') {
+    return getFolderWorkspaceRuntimeScope(state, workspaceScope.folderWorkspaceId)
+  }
+  return getWorktreeRuntimeScope(state, tab.worktreeId)
+}
+
+function runtimeScopeMatchesTarget(
+  scope: LocalRuntimeScope,
+  target: ClaudeSessionRestartTarget
+): boolean {
+  if (scope.runtime === 'remote') {
+    return false
+  }
+  if (target.runtime === 'host') {
+    return scope.runtime === 'host'
+  }
+  const targetDistro = normalizeDistro(target.wslDistro)
+  return scope.runtime === 'wsl' && (!targetDistro || scope.wslDistro === targetDistro)
+}
+
+function isLocalPtyId(ptyId: string): boolean {
+  return parseRemoteRuntimePtyId(ptyId) === null && parseAppSshPtyId(ptyId) === null
+}
+
+export function getTargetScopedClaudeRestartPtyIds(
+  state: AppState,
+  tab: RestartCandidateTab,
+  ptyIds: string[],
+  target: ClaudeSessionRestartTarget | null | undefined
+): string[] {
+  if (!target) {
+    return ptyIds
+  }
+  if (!runtimeScopeMatchesTarget(getTabRuntimeScope(state, tab), target)) {
+    return []
+  }
+  // Why: local Claude account switches do not rewrite credentials inside SSH or
+  // runtime-owned terminals, even if stale tab metadata still looks local.
+  return ptyIds.filter(isLocalPtyId)
+}

--- a/src/renderer/src/lib/claude-session-restart.test.ts
+++ b/src/renderer/src/lib/claude-session-restart.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import {
+  getLiveClaudeSessionRestartPlan,
+  markClaudeSessionsForRestart
+} from './claude-session-restart'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '@/runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import { getDefaultSettings } from '../../../shared/constants'
+
+const ACCOUNT_A = 'account-a@example.com'
+const ACCOUNT_B = 'account-b@example.com'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+describe('Claude session restart planning', () => {
+  const originalWindow = (globalThis as { window?: typeof window }).window
+  const runtimeEnvironmentCall = vi.fn()
+  const runtimeEnvironmentTransportCall = vi.fn()
+
+  beforeEach(() => {
+    clearRuntimeCompatibilityCacheForTests()
+    runtimeEnvironmentCall.mockReset()
+    runtimeEnvironmentTransportCall.mockReset()
+    runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+    })
+    useAppStore.setState({
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab-1',
+            ptyId: 'pty-1',
+            worktreeId: 'wt1',
+            title: 'Terminal 1',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1']
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        }
+      },
+      runtimePaneTitlesByTabId: {},
+      agentStatusByPaneKey: {},
+      pendingClaudePaneRestartIds: {},
+      claudeRestartNoticeByPtyId: {}
+    })
+
+    ;(globalThis as { window: typeof window }).window = {
+      ...originalWindow,
+      api: {
+        ...originalWindow?.api,
+        pty: {
+          ...originalWindow?.api?.pty,
+          getForegroundProcess: vi.fn(),
+          hasChildProcesses: vi.fn().mockResolvedValue(false)
+        },
+        runtimeEnvironments: {
+          ...originalWindow?.api?.runtimeEnvironments,
+          call: runtimeEnvironmentTransportCall
+        }
+      }
+    } as unknown as typeof window
+  })
+
+  afterEach(() => {
+    if (originalWindow) {
+      ;(globalThis as { window: typeof window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: typeof window }).window
+    }
+  })
+
+  it('marks a live Claude PTY for restart', async () => {
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('claude')
+
+    const plan = await getLiveClaudeSessionRestartPlan()
+    markClaudeSessionsForRestart({
+      ptyIds: plan.livePtyIds,
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+
+    expect(window.api.pty.getForegroundProcess).toHaveBeenCalledWith('pty-1')
+    expect(plan).toEqual({ livePtyIds: ['pty-1'], workInProgressPtyIds: [] })
+    expect(useAppStore.getState().claudeRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+  })
+
+  it('can force a restart when Claude credentials changed without a label change', async () => {
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('claude')
+
+    const plan = await getLiveClaudeSessionRestartPlan()
+    markClaudeSessionsForRestart({
+      ptyIds: plan.livePtyIds,
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_A,
+      forceRestart: true
+    })
+
+    expect(useAppStore.getState().claudeRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_A
+    })
+  })
+
+  it('treats Claude executable variants as Claude sessions', async () => {
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('claude.exe')
+
+    await expect(getLiveClaudeSessionRestartPlan()).resolves.toEqual({
+      livePtyIds: ['pty-1'],
+      workInProgressPtyIds: []
+    })
+
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('claude-code')
+
+    await expect(getLiveClaudeSessionRestartPlan()).resolves.toEqual({
+      livePtyIds: ['pty-1'],
+      workInProgressPtyIds: []
+    })
+  })
+
+  it('uses Claude hook state to warn about work in progress', async () => {
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('node')
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    useAppStore.setState({
+      agentStatusByPaneKey: {
+        [paneKey]: {
+          paneKey,
+          state: 'working',
+          prompt: 'finish migration',
+          updatedAt: 1,
+          stateStartedAt: 1,
+          agentType: 'claude',
+          stateHistory: []
+        }
+      }
+    })
+
+    await expect(getLiveClaudeSessionRestartPlan()).resolves.toEqual({
+      livePtyIds: ['pty-1'],
+      workInProgressPtyIds: ['pty-1']
+    })
+  })
+
+  it('uses single-pane Claude titles as an active work fallback', async () => {
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('node')
+    useAppStore.setState({
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab-1',
+            ptyId: 'pty-1',
+            worktreeId: 'wt1',
+            title: '. write account switcher',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    })
+
+    await expect(getLiveClaudeSessionRestartPlan()).resolves.toEqual({
+      livePtyIds: ['pty-1'],
+      workInProgressPtyIds: ['pty-1']
+    })
+  })
+
+  it('does not restart split siblings from a tab-wide Claude title alone', async () => {
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('zsh')
+    useAppStore.setState({
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab-1',
+            ptyId: 'pty-2',
+            worktreeId: 'wt1',
+            title: '. write account switcher',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1', 'pty-2']
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        }
+      }
+    })
+
+    await expect(getLiveClaudeSessionRestartPlan()).resolves.toEqual({
+      livePtyIds: [],
+      workInProgressPtyIds: []
+    })
+  })
+
+  it('inspects remote runtime PTYs through the active runtime environment', async () => {
+    useAppStore.setState({
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'env-1' },
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab-1',
+            ptyId: 'remote:term-1',
+            worktreeId: 'wt1',
+            title: 'Terminal 1',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['remote:term-1']
+      }
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: {
+        process: { foregroundProcess: 'claude', hasChildProcesses: true }
+      },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+
+    await expect(getLiveClaudeSessionRestartPlan()).resolves.toEqual({
+      livePtyIds: ['remote:term-1'],
+      workInProgressPtyIds: []
+    })
+
+    expect(window.api.pty.getForegroundProcess).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'terminal.inspectProcess',
+      params: { terminal: 'term-1' },
+      timeoutMs: 15_000
+    })
+  })
+})

--- a/src/renderer/src/lib/claude-session-restart.ts
+++ b/src/renderer/src/lib/claude-session-restart.ts
@@ -1,0 +1,146 @@
+import type { AppState } from '@/store'
+import { useAppStore } from '@/store'
+import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
+import { detectAgentStatusFromTitle, isClaudeAgent } from '@/lib/agent-status'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+
+export type LiveClaudeSessionRestartPlan = {
+  livePtyIds: string[]
+  workInProgressPtyIds: string[]
+}
+
+function normalizeProcessName(processName: string | null): string | null {
+  if (!processName) {
+    return null
+  }
+  return processName.toLowerCase().replace(/\.exe$/, '')
+}
+
+function isClaudeForegroundProcess(processName: string | null): boolean {
+  const normalized = normalizeProcessName(processName)
+  return (
+    normalized === 'claude' ||
+    normalized === 'claude-code' ||
+    normalized?.startsWith('claude-') === true
+  )
+}
+
+type RestartCandidateTab = AppState['tabsByWorktree'][string][number]
+type AgentStatusEntry = AppState['agentStatusByPaneKey'][string]
+
+function getPaneKeyForPtyId(state: AppState, tabId: string, ptyId: string): string | null {
+  const ptyIdsByLeafId = state.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId ?? {}
+  for (const [leafId, leafPtyId] of Object.entries(ptyIdsByLeafId)) {
+    if (leafPtyId === ptyId) {
+      return makePaneKey(tabId, leafId)
+    }
+  }
+  return null
+}
+
+function isClaudeStatusEntry(entry: AgentStatusEntry | undefined): boolean {
+  return entry?.agentType === 'claude'
+}
+
+function isActiveClaudeStatusEntry(entry: AgentStatusEntry | undefined): boolean {
+  return isClaudeStatusEntry(entry) && entry?.state !== 'done'
+}
+
+function titleIndicatesActiveClaudeWork(title: string | null | undefined): boolean {
+  if (!title || !isClaudeAgent(title)) {
+    return false
+  }
+  if (title.startsWith('. ')) {
+    return true
+  }
+  const titleStatus = detectAgentStatusFromTitle(title)
+  return titleStatus === 'working' || titleStatus === 'permission'
+}
+
+function tabHasClaudeIdentityHint(state: AppState, tab: RestartCandidateTab): boolean {
+  if (tab.launchAgent === 'claude' || isClaudeAgent(tab.title)) {
+    return true
+  }
+  return Object.values(state.runtimePaneTitlesByTabId[tab.id] ?? {}).some((title) =>
+    isClaudeAgent(title)
+  )
+}
+
+function tabHasActiveClaudeWorkTitle(state: AppState, tab: RestartCandidateTab): boolean {
+  if (titleIndicatesActiveClaudeWork(tab.title)) {
+    return true
+  }
+  return Object.values(state.runtimePaneTitlesByTabId[tab.id] ?? {}).some((title) =>
+    titleIndicatesActiveClaudeWork(title)
+  )
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort()
+}
+
+export async function getLiveClaudeSessionRestartPlan(
+  state: AppState = useAppStore.getState()
+): Promise<LiveClaudeSessionRestartPlan> {
+  const tabs = Object.values(state.tabsByWorktree).flat()
+  const tabChecks = await Promise.all(
+    tabs.map(async (tab) => {
+      const ptyIds = state.ptyIdsByTabId[tab.id] ?? []
+      if (ptyIds.length === 0) {
+        return { livePtyIds: [], workInProgressPtyIds: [] }
+      }
+
+      const titleHintsClaude = tabHasClaudeIdentityHint(state, tab)
+      const titleHintsActiveWork = tabHasActiveClaudeWorkTitle(state, tab)
+      const foregroundProcesses = await Promise.all(
+        ptyIds.map((ptyId) =>
+          inspectRuntimeTerminalProcess(state.settings, ptyId)
+            .then((inspection) => inspection.foregroundProcess)
+            .catch(() => null)
+        )
+      )
+      const livePtyIds: string[] = []
+      const workInProgressPtyIds: string[] = []
+      for (const [index, ptyId] of ptyIds.entries()) {
+        const paneKey = getPaneKeyForPtyId(state, tab.id, ptyId)
+        const paneStatus = paneKey ? state.agentStatusByPaneKey[paneKey] : undefined
+        const isLiveClaudeSession =
+          isClaudeForegroundProcess(foregroundProcesses[index] ?? null) ||
+          isClaudeStatusEntry(paneStatus) ||
+          (ptyIds.length === 1 && titleHintsClaude)
+        if (!isLiveClaudeSession) {
+          continue
+        }
+        livePtyIds.push(ptyId)
+        if (isActiveClaudeStatusEntry(paneStatus) || titleHintsActiveWork) {
+          workInProgressPtyIds.push(ptyId)
+        }
+      }
+      return { livePtyIds, workInProgressPtyIds }
+    })
+  )
+
+  return {
+    livePtyIds: sortedUnique(tabChecks.flatMap((check) => check.livePtyIds)),
+    workInProgressPtyIds: sortedUnique(tabChecks.flatMap((check) => check.workInProgressPtyIds))
+  }
+}
+
+export function markClaudeSessionsForRestart(args: {
+  ptyIds: string[]
+  previousAccountLabel: string
+  nextAccountLabel: string
+  forceRestart?: boolean
+}): void {
+  if (args.ptyIds.length === 0) {
+    return
+  }
+  useAppStore.getState().markClaudeRestartNotices(
+    args.ptyIds.map((ptyId) => ({
+      ptyId,
+      previousAccountLabel: args.previousAccountLabel,
+      nextAccountLabel: args.nextAccountLabel,
+      forceRestart: args.forceRestart
+    }))
+  )
+}

--- a/src/renderer/src/lib/claude-session-restart.ts
+++ b/src/renderer/src/lib/claude-session-restart.ts
@@ -2,6 +2,10 @@ import type { AppState } from '@/store'
 import { useAppStore } from '@/store'
 import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
 import { detectAgentStatusFromTitle, isClaudeAgent } from '@/lib/agent-status'
+import {
+  getTargetScopedClaudeRestartPtyIds,
+  type ClaudeSessionRestartTarget
+} from './claude-session-restart-target'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 
 export type LiveClaudeSessionRestartPlan = {
@@ -9,11 +13,37 @@ export type LiveClaudeSessionRestartPlan = {
   workInProgressPtyIds: string[]
 }
 
+type LiveClaudeSessionRestartPlanOptions = {
+  state?: AppState
+  target?: ClaudeSessionRestartTarget | null
+}
+
+const SHELL_FOREGROUND_PROCESSES = new Set([
+  'bash',
+  'cmd',
+  'csh',
+  'dash',
+  'fish',
+  'ksh',
+  'powershell',
+  'pwsh',
+  'sh',
+  'tcsh',
+  'wsl',
+  'zsh'
+])
+
 function normalizeProcessName(processName: string | null): string | null {
   if (!processName) {
     return null
   }
-  return processName.toLowerCase().replace(/\.exe$/, '')
+  return (
+    processName
+      .toLowerCase()
+      .replace(/\.exe$/, '')
+      .split(/[\\/]/)
+      .pop() ?? null
+  )
 }
 
 function isClaudeForegroundProcess(processName: string | null): boolean {
@@ -23,6 +53,11 @@ function isClaudeForegroundProcess(processName: string | null): boolean {
     normalized === 'claude-code' ||
     normalized?.startsWith('claude-') === true
   )
+}
+
+function isShellForegroundProcess(processName: string | null): boolean {
+  const normalized = normalizeProcessName(processName)
+  return normalized ? SHELL_FOREGROUND_PROCESSES.has(normalized) : false
 }
 
 type RestartCandidateTab = AppState['tabsByWorktree'][string][number]
@@ -80,12 +115,14 @@ function sortedUnique(values: string[]): string[] {
 }
 
 export async function getLiveClaudeSessionRestartPlan(
-  state: AppState = useAppStore.getState()
+  options: LiveClaudeSessionRestartPlanOptions = {}
 ): Promise<LiveClaudeSessionRestartPlan> {
+  const state = options.state ?? useAppStore.getState()
   const tabs = Object.values(state.tabsByWorktree).flat()
   const tabChecks = await Promise.all(
     tabs.map(async (tab) => {
-      const ptyIds = state.ptyIdsByTabId[tab.id] ?? []
+      const allPtyIds = state.ptyIdsByTabId[tab.id] ?? []
+      const ptyIds = getTargetScopedClaudeRestartPtyIds(state, tab, allPtyIds, options.target)
       if (ptyIds.length === 0) {
         return { livePtyIds: [], workInProgressPtyIds: [] }
       }
@@ -104,10 +141,12 @@ export async function getLiveClaudeSessionRestartPlan(
       for (const [index, ptyId] of ptyIds.entries()) {
         const paneKey = getPaneKeyForPtyId(state, tab.id, ptyId)
         const paneStatus = paneKey ? state.agentStatusByPaneKey[paneKey] : undefined
+        const foregroundProcess = foregroundProcesses[index] ?? null
+        const foregroundIsShell = isShellForegroundProcess(foregroundProcess)
         const isLiveClaudeSession =
-          isClaudeForegroundProcess(foregroundProcesses[index] ?? null) ||
-          isClaudeStatusEntry(paneStatus) ||
-          (ptyIds.length === 1 && titleHintsClaude)
+          isClaudeForegroundProcess(foregroundProcess) ||
+          (!foregroundIsShell &&
+            (isClaudeStatusEntry(paneStatus) || (allPtyIds.length === 1 && titleHintsClaude)))
         if (!isLiveClaudeSession) {
           continue
         }
@@ -130,6 +169,8 @@ export function markClaudeSessionsForRestart(args: {
   ptyIds: string[]
   previousAccountLabel: string
   nextAccountLabel: string
+  previousAccountId?: string | null
+  nextAccountId?: string | null
   forceRestart?: boolean
 }): void {
   if (args.ptyIds.length === 0) {
@@ -140,6 +181,10 @@ export function markClaudeSessionsForRestart(args: {
       ptyId,
       previousAccountLabel: args.previousAccountLabel,
       nextAccountLabel: args.nextAccountLabel,
+      ...(args.previousAccountId !== undefined
+        ? { previousAccountId: args.previousAccountId }
+        : {}),
+      ...(args.nextAccountId !== undefined ? { nextAccountId: args.nextAccountId } : {}),
       forceRestart: args.forceRestart
     }))
   )

--- a/src/renderer/src/store/slices/ssh-target-cleanup.ts
+++ b/src/renderer/src/store/slices/ssh-target-cleanup.ts
@@ -67,12 +67,16 @@ function clearSshTargetTabPtyState(
   | 'lastKnownRelayPtyIdByTabId'
   | 'pendingCodexPaneRestartIds'
   | 'codexRestartNoticeByPtyId'
+  | 'pendingClaudePaneRestartIds'
+  | 'claudeRestartNoticeByPtyId'
 > & { changed: boolean } {
   let nextTabsByWorktree = state.tabsByWorktree
   const nextPtyIdsByTabId = { ...state.ptyIdsByTabId }
   const nextLastKnownRelayPtyIdByTabId = { ...state.lastKnownRelayPtyIdByTabId }
   const nextPendingCodexPaneRestartIds = { ...state.pendingCodexPaneRestartIds }
   const nextCodexRestartNoticeByPtyId = { ...state.codexRestartNoticeByPtyId }
+  const nextPendingClaudePaneRestartIds = { ...state.pendingClaudePaneRestartIds }
+  const nextClaudeRestartNoticeByPtyId = { ...state.claudeRestartNoticeByPtyId }
   let changed = false
 
   for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
@@ -106,6 +110,8 @@ function clearSshTargetTabPtyState(
       for (const ptyId of ptyIds) {
         delete nextPendingCodexPaneRestartIds[ptyId]
         delete nextCodexRestartNoticeByPtyId[ptyId]
+        delete nextPendingClaudePaneRestartIds[ptyId]
+        delete nextClaudeRestartNoticeByPtyId[ptyId]
       }
     }
     if (nextTabs !== tabs) {
@@ -119,7 +125,9 @@ function clearSshTargetTabPtyState(
     ptyIdsByTabId: nextPtyIdsByTabId,
     lastKnownRelayPtyIdByTabId: nextLastKnownRelayPtyIdByTabId,
     pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds,
-    codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId
+    codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId,
+    pendingClaudePaneRestartIds: nextPendingClaudePaneRestartIds,
+    claudeRestartNoticeByPtyId: nextClaudeRestartNoticeByPtyId
   }
 }
 
@@ -196,7 +204,9 @@ export function buildRemovedSshTargetCleanupPatch(
           ptyIdsByTabId: tabPtyState.ptyIdsByTabId,
           lastKnownRelayPtyIdByTabId: tabPtyState.lastKnownRelayPtyIdByTabId,
           pendingCodexPaneRestartIds: tabPtyState.pendingCodexPaneRestartIds,
-          codexRestartNoticeByPtyId: tabPtyState.codexRestartNoticeByPtyId
+          codexRestartNoticeByPtyId: tabPtyState.codexRestartNoticeByPtyId,
+          pendingClaudePaneRestartIds: tabPtyState.pendingClaudePaneRestartIds,
+          claudeRestartNoticeByPtyId: tabPtyState.claudeRestartNoticeByPtyId
         }
       : {}),
     ...(removedCredentialRequest ? { sshCredentialQueue: nextCredentialQueue } : {}),

--- a/src/renderer/src/store/slices/ssh.test.ts
+++ b/src/renderer/src/store/slices/ssh.test.ts
@@ -53,6 +53,17 @@ describe('createSshSlice', () => {
         [removedPtyId]: { previousAccountLabel: 'Old', nextAccountLabel: 'New' },
         [otherPtyId]: { previousAccountLabel: 'Other old', nextAccountLabel: 'Other new' }
       },
+      pendingClaudePaneRestartIds: {
+        [removedPtyId]: true,
+        [otherPtyId]: true
+      },
+      claudeRestartNoticeByPtyId: {
+        [removedPtyId]: { previousAccountLabel: 'Claude old', nextAccountLabel: 'Claude new' },
+        [otherPtyId]: {
+          previousAccountLabel: 'Other Claude old',
+          nextAccountLabel: 'Other Claude new'
+        }
+      },
       sshConnectionStates: new Map([
         [targetId, { targetId, status: 'disconnected', error: null, reconnectAttempt: 0 }],
         [
@@ -126,6 +137,8 @@ describe('createSshSlice', () => {
     expect(state.lastKnownRelayPtyIdByTabId['tab-stale-last-known']).toBeUndefined()
     expect(state.pendingCodexPaneRestartIds[removedPtyId]).toBeUndefined()
     expect(state.codexRestartNoticeByPtyId[removedPtyId]).toBeUndefined()
+    expect(state.pendingClaudePaneRestartIds[removedPtyId]).toBeUndefined()
+    expect(state.claudeRestartNoticeByPtyId[removedPtyId]).toBeUndefined()
 
     expect(state.sshConnectionStates.get(otherTargetId)?.status).toBe('connected')
     expect(state.sshTargetLabels.get(otherTargetId)).toBe('Other target')
@@ -140,6 +153,11 @@ describe('createSshSlice', () => {
     expect(state.codexRestartNoticeByPtyId[otherPtyId]).toEqual({
       previousAccountLabel: 'Other old',
       nextAccountLabel: 'Other new'
+    })
+    expect(state.pendingClaudePaneRestartIds[otherPtyId]).toBe(true)
+    expect(state.claudeRestartNoticeByPtyId[otherPtyId]).toEqual({
+      previousAccountLabel: 'Other Claude old',
+      nextAccountLabel: 'Other Claude new'
     })
   })
 

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -247,6 +247,35 @@ describe('restartCodexTabs', () => {
     expect(state.suppressedPtyExitIds).toEqual({})
     expect(state.tabsByWorktree[wt1][0].generation).toBe(2)
   })
+
+  it('queues pane-scoped Claude restarts without remounting the whole tab', () => {
+    const store = createTestStore()
+    const wt1 = 'repo1::/path/wt1'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt1, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt1]: [makeTab({ id: 'tab1', worktreeId: wt1, title: 'claude', generation: 2 })]
+      },
+      ptyIdsByTabId: {
+        tab1: ['pty-a', 'pty-b']
+      },
+      pendingStartupByTabId: {}
+    })
+
+    store.getState().queueClaudePaneRestarts(['pty-b'])
+    const state = store.getState()
+
+    expect(state.pendingClaudePaneRestartIds).toEqual({ 'pty-b': true })
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(state.suppressedPtyExitIds).toEqual({})
+    expect(state.tabsByWorktree[wt1][0].generation).toBe(2)
+  })
 })
 
 describe('hydrateWorkspaceSession', () => {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -71,6 +71,50 @@ import {
   type AgentStatusWorktreeShutdownReason
 } from './agent-status'
 
+type AccountRestartNotice = {
+  previousAccountLabel: string
+  nextAccountLabel: string
+}
+
+type AccountRestartNoticeInput = AccountRestartNotice & {
+  ptyId: string
+  forceRestart?: boolean
+}
+
+function applyAccountRestartNotices(
+  notices: AccountRestartNoticeInput[],
+  existingNoticesByPtyId: Record<string, AccountRestartNotice>,
+  existingPendingRestartIds: Record<string, true>
+): {
+  restartNoticeByPtyId: Record<string, AccountRestartNotice>
+  pendingPaneRestartIds: Record<string, true>
+} {
+  const next = { ...existingNoticesByPtyId }
+  const nextPendingPaneRestartIds = { ...existingPendingRestartIds }
+  for (const notice of notices) {
+    const existing = next[notice.ptyId]
+    const previousAccountLabel = existing?.previousAccountLabel ?? notice.previousAccountLabel
+
+    // Why: a live pane keeps the account it originally launched with until it
+    // restarts. Repeated switches must preserve that origin so A -> B -> A
+    // clears the stale marker instead of asking for an unnecessary restart.
+    if (!notice.forceRestart && previousAccountLabel === notice.nextAccountLabel) {
+      delete next[notice.ptyId]
+      delete nextPendingPaneRestartIds[notice.ptyId]
+      continue
+    }
+
+    next[notice.ptyId] = {
+      previousAccountLabel,
+      nextAccountLabel: notice.nextAccountLabel
+    }
+  }
+  return {
+    restartNoticeByPtyId: next,
+    pendingPaneRestartIds: nextPendingPaneRestartIds
+  }
+}
+
 function getNextTerminalOrdinal(tabs: TerminalTab[]): number {
   const usedOrdinals = new Set<number>()
   for (const tab of tabs) {
@@ -354,10 +398,9 @@ export type TerminalSlice = {
   unreadAgentCompletionPanes: Record<string, true>
   suppressedPtyExitIds: Record<string, true>
   pendingCodexPaneRestartIds: Record<string, true>
-  codexRestartNoticeByPtyId: Record<
-    string,
-    { previousAccountLabel: string; nextAccountLabel: string }
-  >
+  codexRestartNoticeByPtyId: Record<string, AccountRestartNotice>
+  pendingClaudePaneRestartIds: Record<string, true>
+  claudeRestartNoticeByPtyId: Record<string, AccountRestartNotice>
   expandedPaneByTabId: Record<string, boolean>
   canExpandPaneByTabId: Record<string, boolean>
   terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
@@ -529,10 +572,12 @@ export type TerminalSlice = {
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   queueCodexPaneRestarts: (ptyIds: string[]) => void
   consumePendingCodexPaneRestart: (ptyId: string) => boolean
-  markCodexRestartNotices: (
-    notices: { ptyId: string; previousAccountLabel: string; nextAccountLabel: string }[]
-  ) => void
+  markCodexRestartNotices: (notices: AccountRestartNoticeInput[]) => void
   clearCodexRestartNotice: (ptyId: string) => void
+  queueClaudePaneRestarts: (ptyIds: string[]) => void
+  consumePendingClaudePaneRestart: (ptyId: string) => boolean
+  markClaudeRestartNotices: (notices: AccountRestartNoticeInput[]) => void
+  clearClaudeRestartNotice: (ptyId: string) => void
   setTabPaneExpanded: (tabId: string, expanded: boolean) => void
   setTabCanExpandPane: (tabId: string, canExpand: boolean) => void
   setTabLayout: (tabId: string, layout: TerminalLayoutSnapshot | null) => void
@@ -628,6 +673,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   suppressedPtyExitIds: {},
   pendingCodexPaneRestartIds: {},
   codexRestartNoticeByPtyId: {},
+  pendingClaudePaneRestartIds: {},
+  claudeRestartNoticeByPtyId: {},
   expandedPaneByTabId: {},
   canExpandPaneByTabId: {},
   terminalLayoutsByTabId: {},
@@ -1793,13 +1840,19 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       nextPtyIdsByTabId[tabId] = remainingPtyIds
       const nextPendingCodexPaneRestartIds = { ...s.pendingCodexPaneRestartIds }
       const nextCodexRestartNoticeByPtyId = { ...s.codexRestartNoticeByPtyId }
+      const nextPendingClaudePaneRestartIds = { ...s.pendingClaudePaneRestartIds }
+      const nextClaudeRestartNoticeByPtyId = { ...s.claudeRestartNoticeByPtyId }
       if (ptyId) {
         delete nextPendingCodexPaneRestartIds[ptyId]
         delete nextCodexRestartNoticeByPtyId[ptyId]
+        delete nextPendingClaudePaneRestartIds[ptyId]
+        delete nextClaudeRestartNoticeByPtyId[ptyId]
       } else {
         for (const currentPtyId of s.ptyIdsByTabId[tabId] ?? []) {
           delete nextPendingCodexPaneRestartIds[currentPtyId]
           delete nextCodexRestartNoticeByPtyId[currentPtyId]
+          delete nextPendingClaudePaneRestartIds[currentPtyId]
+          delete nextClaudeRestartNoticeByPtyId[currentPtyId]
         }
       }
       // Why: when a specific ptyId is passed, the PTY actually exited (not
@@ -1817,7 +1870,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ptyIdsByTabId: nextPtyIdsByTabId,
         lastKnownRelayPtyIdByTabId: nextLastKnownRelay,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds,
-        codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId
+        codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId,
+        pendingClaudePaneRestartIds: nextPendingClaudePaneRestartIds,
+        claudeRestartNoticeByPtyId: nextClaudeRestartNoticeByPtyId
       }
     })
 
@@ -1974,8 +2029,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
 
       const nextCodexRestartNoticeByPtyId = { ...s.codexRestartNoticeByPtyId }
+      const nextClaudeRestartNoticeByPtyId = { ...s.claudeRestartNoticeByPtyId }
       for (const ptyId of shutdownPtyIds) {
         delete nextCodexRestartNoticeByPtyId[ptyId]
+        delete nextClaudeRestartNoticeByPtyId[ptyId]
       }
       const nextLastKnownRelay =
         remainingPtyIds.length === 0
@@ -2020,6 +2077,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           ...Object.fromEntries(shutdownPtyIds.map((ptyId) => [ptyId, true] as const))
         },
         codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId,
+        claudeRestartNoticeByPtyId: nextClaudeRestartNoticeByPtyId,
         ...(nextRuntimePaneTitlesByTabId !== s.runtimePaneTitlesByTabId
           ? { runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId }
           : {}),
@@ -2188,20 +2246,26 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ...s.suppressedPtyExitIds,
         ...Object.fromEntries(shutdownPtyIds.map((ptyId) => [ptyId, true] as const))
       }
-      // Why: pendingCodexPaneRestartIds is keyed by ptyId — under sleep we
+      // Why: account restart queues are keyed by ptyId — under sleep we
       // preserve it so a mid-restart marker survives wake against the same
-      // identifier. codexRestartNoticeByPtyId is also keyed by the now-stale
+      // identifier. restart notices are also keyed by the now-stale
       // ptyId; on wake the post-spawn ptyId may differ, so the notice can't
       // be carried forward and is cleared in both cases.
       const nextPendingCodexPaneRestartIds = keepIdentifiers
         ? s.pendingCodexPaneRestartIds
         : { ...s.pendingCodexPaneRestartIds }
       const nextCodexRestartNoticeByPtyId = { ...s.codexRestartNoticeByPtyId }
+      const nextPendingClaudePaneRestartIds = keepIdentifiers
+        ? s.pendingClaudePaneRestartIds
+        : { ...s.pendingClaudePaneRestartIds }
+      const nextClaudeRestartNoticeByPtyId = { ...s.claudeRestartNoticeByPtyId }
       for (const ptyId of shutdownPtyIds) {
         if (!keepIdentifiers) {
           delete nextPendingCodexPaneRestartIds[ptyId]
+          delete nextPendingClaudePaneRestartIds[ptyId]
         }
         delete nextCodexRestartNoticeByPtyId[ptyId]
+        delete nextClaudeRestartNoticeByPtyId[ptyId]
       }
       // Why: setup-split and issue-command-split are transient one-shots that
       // drive new-tab UX. They are not sleep-recovery state; clear in both
@@ -2300,6 +2364,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         suppressedPtyExitIds: nextSuppressedPtyExitIds,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds,
         codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId,
+        pendingClaudePaneRestartIds: nextPendingClaudePaneRestartIds,
+        claudeRestartNoticeByPtyId: nextClaudeRestartNoticeByPtyId,
         pendingSetupSplitByTabId: nextPendingSetupSplitByTabId,
         pendingIssueCommandSplitByTabId: nextPendingIssueCommandSplitByTabId,
         terminalLayoutsByTabId: nextTerminalLayoutsByTabId,
@@ -2422,31 +2488,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       return
     }
     set((s) => {
-      const next = { ...s.codexRestartNoticeByPtyId }
-      const nextPendingCodexPaneRestartIds = { ...s.pendingCodexPaneRestartIds }
-      for (const notice of notices) {
-        const existing = next[notice.ptyId]
-        const previousAccountLabel = existing?.previousAccountLabel ?? notice.previousAccountLabel
-
-        // Why: a live Codex pane stays on the account it originally launched
-        // with until that pane actually restarts. Repeated account switches
-        // must preserve that original pane account; otherwise A -> B -> A
-        // keeps showing a stale restart notice even though the pane never left
-        // account A and no longer needs a restart.
-        if (previousAccountLabel === notice.nextAccountLabel) {
-          delete next[notice.ptyId]
-          delete nextPendingCodexPaneRestartIds[notice.ptyId]
-          continue
-        }
-
-        next[notice.ptyId] = {
-          previousAccountLabel,
-          nextAccountLabel: notice.nextAccountLabel
-        }
-      }
+      const nextState = applyAccountRestartNotices(
+        notices,
+        s.codexRestartNoticeByPtyId,
+        s.pendingCodexPaneRestartIds
+      )
       return {
-        codexRestartNoticeByPtyId: next,
-        pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds
+        codexRestartNoticeByPtyId: nextState.restartNoticeByPtyId,
+        pendingCodexPaneRestartIds: nextState.pendingPaneRestartIds
       }
     })
   },
@@ -2463,6 +2512,65 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       return {
         codexRestartNoticeByPtyId: next,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds
+      }
+    })
+  },
+
+  queueClaudePaneRestarts: (ptyIds) => {
+    if (ptyIds.length === 0) {
+      return
+    }
+    set((s) => ({
+      pendingClaudePaneRestartIds: {
+        ...s.pendingClaudePaneRestartIds,
+        ...Object.fromEntries(ptyIds.map((ptyId) => [ptyId, true] as const))
+      }
+    }))
+  },
+
+  consumePendingClaudePaneRestart: (ptyId) => {
+    let wasQueued = false
+    set((s) => {
+      if (!s.pendingClaudePaneRestartIds[ptyId]) {
+        return {}
+      }
+      wasQueued = true
+      const next = { ...s.pendingClaudePaneRestartIds }
+      delete next[ptyId]
+      return { pendingClaudePaneRestartIds: next }
+    })
+    return wasQueued
+  },
+
+  markClaudeRestartNotices: (notices) => {
+    if (notices.length === 0) {
+      return
+    }
+    set((s) => {
+      const nextState = applyAccountRestartNotices(
+        notices,
+        s.claudeRestartNoticeByPtyId,
+        s.pendingClaudePaneRestartIds
+      )
+      return {
+        claudeRestartNoticeByPtyId: nextState.restartNoticeByPtyId,
+        pendingClaudePaneRestartIds: nextState.pendingPaneRestartIds
+      }
+    })
+  },
+
+  clearClaudeRestartNotice: (ptyId) => {
+    set((s) => {
+      if (!s.claudeRestartNoticeByPtyId[ptyId]) {
+        return {}
+      }
+      const next = { ...s.claudeRestartNoticeByPtyId }
+      const nextPendingClaudePaneRestartIds = { ...s.pendingClaudePaneRestartIds }
+      delete next[ptyId]
+      delete nextPendingClaudePaneRestartIds[ptyId]
+      return {
+        claudeRestartNoticeByPtyId: next,
+        pendingClaudePaneRestartIds: nextPendingClaudePaneRestartIds
       }
     })
   },

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -74,6 +74,8 @@ import {
 type AccountRestartNotice = {
   previousAccountLabel: string
   nextAccountLabel: string
+  previousAccountId?: string | null
+  nextAccountId?: string | null
 }
 
 type AccountRestartNoticeInput = AccountRestartNotice & {
@@ -94,11 +96,19 @@ function applyAccountRestartNotices(
   for (const notice of notices) {
     const existing = next[notice.ptyId]
     const previousAccountLabel = existing?.previousAccountLabel ?? notice.previousAccountLabel
+    const previousAccountId =
+      existing?.previousAccountId !== undefined
+        ? existing.previousAccountId
+        : notice.previousAccountId
 
     // Why: a live pane keeps the account it originally launched with until it
     // restarts. Repeated switches must preserve that origin so A -> B -> A
     // clears the stale marker instead of asking for an unnecessary restart.
-    if (!notice.forceRestart && previousAccountLabel === notice.nextAccountLabel) {
+    const identityMatches =
+      previousAccountId !== undefined || notice.nextAccountId !== undefined
+        ? previousAccountId === notice.nextAccountId
+        : previousAccountLabel === notice.nextAccountLabel
+    if (!notice.forceRestart && identityMatches) {
       delete next[notice.ptyId]
       delete nextPendingPaneRestartIds[notice.ptyId]
       continue
@@ -106,7 +116,9 @@ function applyAccountRestartNotices(
 
     next[notice.ptyId] = {
       previousAccountLabel,
-      nextAccountLabel: notice.nextAccountLabel
+      nextAccountLabel: notice.nextAccountLabel,
+      ...(previousAccountId !== undefined ? { previousAccountId } : {}),
+      ...(notice.nextAccountId !== undefined ? { nextAccountId: notice.nextAccountId } : {})
     }
   }
   return {


### PR DESCRIPTION
## Summary

- Detect live Claude Code sessions before Claude account changes and queue pane-scoped restarts under the newly selected account.
- Warn from the status-bar switcher when active Claude work appears to be running or waiting for input before stopping/restarting sessions.
- Add stale-session state, input blocking, SSH cleanup, settings-account handling, and tests for the restart planner and UI flow.

## Validation

- `pnpm run typecheck:web`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/claude-session-restart.test.ts src/renderer/src/components/status-bar/status-bar-claude-switcher.test.tsx src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts src/renderer/src/components/status-bar/codex-restart-status-summary.test.ts`
- Pre-commit hook: `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --write`

Note: `pnpm run typecheck:web` reports the repo engine warning because this environment is Node v22.22.3 while package.json wants Node 24, but the command exits 0.

## ELI5

Switching Claude accounts can restart live Claude Code panes under the new account. You get a warning if work is still running or waiting before sessions are stopped.
