### PR TITLE
Fix main typecheck: pin Buffer<ArrayBuffer> in cdp-ws-proxy mid-print test

### DIFF
--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -647,10 +647,10 @@ describe('CdpWsProxy', () => {
   })
 
   it('does not register a PDF stream when the client disconnects mid-print', async () => {
-    let resolvePrint: (buf: Buffer) => void = () => {}
+    let resolvePrint: (buf: Buffer<ArrayBuffer>) => void = () => {}
     mock.webContents.printToPDF.mockImplementationOnce(
       () =>
-        new Promise<Buffer>((resolve) => {
+        new Promise<Buffer<ArrayBuffer>>((resolve) => {
           resolvePrint = resolve
         })
     )


### PR DESCRIPTION
## Summary
- `pnpm typecheck` fails on current main: `src/main/browser/cdp-ws-proxy.test.ts(653,9)` resolves `new Promise<Buffer>` to `Buffer<ArrayBufferLike>`, which no longer satisfies the mocked `printToPDF` return type `Promise<Buffer<ArrayBuffer>>` (introduced by the mid-print disconnect test in `#7044`; the break only appears against current main's typings, so its own PR checks were green).
- Pin the deferred-resolve promise and resolver parameter to `Buffer<ArrayBuffer>`. Type-only change.
- This is currently failing the `PR Checks / verify` job on every open PR based on main (e.g. #7261, #7262).

## Verification
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json` → clean
- `pnpm vitest run src/main/browser/cdp-ws-proxy.test.ts` → 30 passed

Made with [Orca](https://github.com/stablyai/orca) 🐋
