### PR TITLE
Fix main typecheck: pin printToPDF mock Buffer generic

### DIFF
--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -647,10 +647,10 @@ describe('CdpWsProxy', () => {
   })
 
   it('does not register a PDF stream when the client disconnects mid-print', async () => {
-    let resolvePrint: (buf: Buffer) => void = () => {}
+    let resolvePrint: (buf: Buffer<ArrayBuffer>) => void = () => {}
     mock.webContents.printToPDF.mockImplementationOnce(
       () =>
-        new Promise<Buffer>((resolve) => {
+        new Promise<Buffer<ArrayBuffer>>((resolve) => {
           resolvePrint = resolve
         })
     )


### PR DESCRIPTION
Main's `typecheck:node` is red since #7044: the Page.printToPDF disconnect test's `new Promise<Buffer>` resolves `Buffer<ArrayBufferLike>`, but the `printToPDF` mock expects `Promise<Buffer<ArrayBuffer>>`:

```
src/main/browser/cdp-ws-proxy.test.ts(653,9): error TS2322: Type 'Promise<Buffer<ArrayBufferLike>>' is not assignable to type 'Promise<Buffer<ArrayBuffer>>'.
```

This fails the `verify` check for **every open PR** (first seen on PR #7003's run: https://github.com/stablyai/orca/actions/runs/28681817566).

Fix: pin the mock's promise and resolver to `Buffer<ArrayBuffer>` — which is what `Buffer.from` returns, so the test body is unchanged.

Verified: `pnpm run typecheck:node` green, all 30 `cdp-ws-proxy.test.ts` tests pass.

Made with [Orca](https://github.com/stablyai/orca) 🐋
