### PR TITLE
fix(security): include TLS fingerprint in pairing offer for future cert pinning

### DIFF
--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -20,6 +20,7 @@ import type { WebSocket } from 'ws'
 import { DeviceRegistry, type DeviceScope } from './device-registry'
 import { loadOrCreateE2EEKeypair, type E2EEKeypair } from './e2ee-keypair'
 import { E2EEChannel } from './rpc/e2ee-channel'
+import { loadOrCreateTlsCertificate } from './tls-certificate'
 import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../../shared/pairing'
 import {
   decodeTerminalStreamFrame,
@@ -516,7 +517,8 @@ export class OrcaRuntimeRpcServer {
       endpoint,
       deviceToken: device.token,
       publicKeyB64,
-      scope
+      scope,
+      tlsFingerprint: this.tlsFingerprint ?? undefined
     })
     return {
       available: true,
@@ -695,6 +697,23 @@ export class OrcaRuntimeRpcServer {
       try {
         this.deviceRegistry = new DeviceRegistry(this.userDataPath)
         this.e2eeKeypair = loadOrCreateE2EEKeypair(this.userDataPath)
+
+        // Why: load the self-signed TLS certificate so its fingerprint is
+        // available for the pairing offer. The cert is generated once on first
+        // run and reused across restarts (see tls-certificate.ts). TLS is not
+        // enabled on the transport yet because React Native's WebSocket cannot
+        // pin self-signed certs; E2EE (tweetnacl) provides payload
+        // confidentiality over plain ws:// in the meantime. The fingerprint
+        // lets future clients verify server identity once they support pinning.
+        try {
+          const tls = loadOrCreateTlsCertificate(this.userDataPath)
+          this.tlsFingerprint = tls.fingerprint
+        } catch (error) {
+          // Why: cert generation shells out to OpenSSL, which may be missing
+          // (notably on Windows without Git in PATH). Continue without TLS —
+          // E2EE still protects the payload.
+          console.error('[runtime] Failed to load TLS certificate:', error)
+        }
 
         const wsTransport = new WebSocketTransport({
           host: '0.0.0.0',

--- a/src/shared/pairing.test.ts
+++ b/src/shared/pairing.test.ts
@@ -27,6 +27,16 @@ describe('pairing offer', () => {
     expect(decodePairingOffer(encodePairingOffer(scopedOffer))).toEqual(scopedOffer)
   })
 
+  it('preserves optional TLS fingerprint metadata', () => {
+    const offerWithTls: PairingOffer = { ...offer, tlsFingerprint: 'sha256:abcdef1234567890' }
+    expect(decodePairingOffer(encodePairingOffer(offerWithTls))).toEqual(offerWithTls)
+  })
+
+  it('omits tlsFingerprint when not provided (backward compatibility)', () => {
+    const decoded = decodePairingOffer(encodePairingOffer(offer))
+    expect(decoded.tlsFingerprint).toBeUndefined()
+  })
+
   it('encoded URL uses base64url (no +, /, or = characters)', () => {
     const url = encodePairingOffer(offer)
     const code = new URLSearchParams(url.slice(url.indexOf('?') + 1)).get('code')!

--- a/src/shared/pairing.ts
+++ b/src/shared/pairing.ts
@@ -12,7 +12,12 @@ export const PairingOfferSchema = z.object({
   publicKeyB64: z.string().min(1),
   // Why: advisory UI metadata lets the web client reject phone-QR offers before
   // opening a socket; the runtime still authorizes solely from deviceToken.
-  scope: PairingScopeSchema.optional()
+  scope: PairingScopeSchema.optional(),
+  // Why: SHA-256 fingerprint of the runtime's self-signed TLS certificate
+  // (sha256:<hex>). Clients can pin this to verify the WebSocket server
+  // identity and detect MITM attacks. Optional for backward compatibility —
+  // older clients that don't know the field simply ignore it.
+  tlsFingerprint: z.string().optional()
 })
 
 export type PairingOffer = z.infer<typeof PairingOfferSchema>


### PR DESCRIPTION
## Summary

Wires up the existing self-signed TLS certificate infrastructure so the certificate fingerprint is included in mobile/web pairing offers, enabling future client-side certificate pinning to protect against MITM attacks on shared WiFi networks.

## The vulnerability

The WebSocket transport (`src/main/runtime/rpc/ws-transport.ts`) binds to `0.0.0.0` (required for mobile devices to connect from the network) and falls back to plain `ws://` — no transport-layer encryption. While E2EE (tweetnacl) encrypts the RPC payload, the transport layer has no server-identity verification, leaving it vulnerable to:

- **Passive metadata leakage** on shared WiFi (network-level traffic analysis)
- **MITM attacks** where an attacker substitutes their own E2EE public key

The TLS infrastructure was already built but never connected:
- `src/main/runtime/tls-certificate.ts` — generates and caches a self-signed EC cert (✅ exists)
- `WebSocketTransport` — supports `tlsCert`/`tlsKey` options (✅ exists)
- `ws-transport.test.ts` — already tests with `wss://` + `rejectUnauthorized: false` (✅ exists)
- `OrcaRuntimeRpcServer.getTlsFingerprint()` — **dead code**, always returned `null` (❌ never wired up)

## The fix

1. **Load the TLS certificate at WebSocket transport startup** — calls `loadOrCreateTlsCertificate()` so `getTlsFingerprint()` returns the real SHA-256 fingerprint instead of `null`
2. **Add `tlsFingerprint` to `PairingOfferSchema`** — optional field (`sha256:<hex>`) so clients receive the fingerprint via the QR pairing flow
3. **Include the fingerprint in every `createPairingOffer()` response** — both mobile and runtime scope offers carry it
4. **Handle OpenSSL-missing gracefully** — cert generation shells out to OpenSSL which may be absent (notably Windows without Git in PATH); the runtime continues with E2EE-only protection if generation fails

## Why not enable wss:// end-to-end now?

React Native's `WebSocket` API cannot pin self-signed certificates — it uses the platform's native TLS stack which rejects untrusted CAs by default, with no `rejectUnauthorized: false` equivalent. Enabling `wss://` on the transport without a mobile client update would break mobile pairing.

This change is the **first step**: making the fingerprint available in the pairing offer so future mobile/web clients can verify the server's identity. The endpoint protocol stays `ws://` until client-side cert pinning is implemented.

## Backward compatibility

`tlsFingerprint` is an optional field in the Zod schema. Existing clients that don't know the field parse the pairing offer unchanged — verified by a dedicated backward-compatibility test.

## No visual change

This is a security infrastructure change with no UI or interaction behavior change.

## Code review summary

- **Cross-platform compatibility:** `loadOrCreateTlsCertificate` already handles Windows (resolves OpenSSL from Git's installation directory) and Unix (`openssl` from PATH). The graceful `catch` block ensures the runtime continues if OpenSSL is missing on any platform. No new platform-specific code.
- **SSH/remote/local compatibility:** The WebSocket transport is local-only (mobile pairing to the desktop). SSH relay paths do not use this transport. No SSH impact.
- **Agent/integration compatibility:** No change to any agent, CLI, or integration surface. The pairing offer gains an optional field; existing consumers ignore unknown fields.
- **Performance risk:** Negligible. `loadOrCreateTlsCertificate` runs once at startup (cert is cached on disk after first generation). The fingerprint is a string read from the cached cert — no per-request cost.
- **Security risk:** This change *reduces* security risk. The fingerprint is now available for future cert pinning, closing the gap between the existing TLS infrastructure and the runtime server. The graceful failure path ensures no regression if OpenSSL is unavailable.

## Testing

```
npx vitest run src/shared/pairing.test.ts                  # 18/18 passed (16 existing + 2 new)
npx vitest run src/main/runtime/rpc/ws-transport.test.ts   # 16/16 passed (TLS cert integration)
npx tsgo --noEmit -p config/tsconfig.node.json             # no errors
npx oxlint <changed files>                                  # 0 warnings, 0 errors
```

New tests:
- `preserves optional TLS fingerprint metadata` — round-trip test with `tlsFingerprint: 'sha256:abcdef1234567890'`
- `omits tlsFingerprint when not provided (backward compatibility)` — verifies existing offers decode without the field

## ELI5

Pairing offers now include the TLS certificate fingerprint for future client pinning. Groundwork against MITM on open Wi‑Fi when clients start enforcing pins.
