### PR TITLE
fix(mobile): match diff review line height to desktop diff density

### DIFF
--- a/mobile/src/components/MobileDiffReviewLine.tsx
+++ b/mobile/src/components/MobileDiffReviewLine.tsx
@@ -92,9 +92,10 @@ export function MobileDiffReviewLine({
   )
 }
 
+// Row height comes from the 18px code lineHeight alone (no vertical padding or
+// minHeight) so mobile diff density matches the desktop diff editor (STA-1239).
 const styles = StyleSheet.create({
   row: {
-    minHeight: 32,
     flexDirection: 'row',
     alignItems: 'stretch',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -112,25 +113,24 @@ const styles = StyleSheet.create({
   },
   prefix: {
     width: 18,
-    paddingTop: spacing.sm,
     textAlign: 'center',
     color: colors.textMuted,
     fontFamily: typography.monoFamily,
-    fontSize: typography.metaSize
+    fontSize: typography.metaSize,
+    lineHeight: 18
   },
   lineNumber: {
     width: 44,
-    paddingTop: spacing.sm,
     paddingRight: spacing.xs,
     textAlign: 'right',
     color: colors.textMuted,
     fontFamily: typography.monoFamily,
-    fontSize: typography.metaSize
+    fontSize: typography.metaSize,
+    lineHeight: 18
   },
   code: {
     flex: 1,
     minWidth: 0,
-    paddingVertical: spacing.sm,
     paddingHorizontal: spacing.sm
   },
   codePressed: {


### PR DESCRIPTION
Fixes #7151 · Linear: [STA-1239](https://linear.app/stably/issue/STA-1239/bug-mobile-diff-view-line-height-excessive)

## Problem

The mobile diff review screen (Changes → per-file review) rendered every code line roughly **34px tall**: `paddingVertical: 8` + `lineHeight: 18` + `minHeight: 32` on each row. The reporter's estimate that it "could probably almost halve it" was accurate — the desktop Monaco diff renders ~19px rows and the mobile branch-diff preview drawer ~21px.

## Fix

`MobileDiffReviewLine.tsx` only. Row height now comes from the 18px code `lineHeight` alone: removed the vertical padding on the code cell and the 32px row floor, and moved the gutter prefix/line-number cells from `paddingTop` alignment onto the same 18px baseline grid. Result is ~18px rows — desktop diff density.

| surface | before | after |
|---|---|---|
| mobile diff review screen | ~34px/row | **~18px/row** |
| desktop Monaco diff | ~19px/row | unchanged (reference) |
| mobile branch-diff preview drawer | ~21px/row | untouched (was already compact; styles are not shared) |

## Verification

- Reproduced and verified on a physical iPhone 14 (iOS 26.5) via the Expo dev build: opened the review screen for a scratch worktree diff before and after — rows tightened from the reported airy layout to desktop-equivalent density. Comment affordances (per-line add-note press target, note icons on commented lines) still render and rows with notes still grow to fit.
- `mobile` package: tsc clean, vitest 168 files / 1203 tests passed.

## Notes

While setting up the on-device repro we confirmed the two mobile diff surfaces duplicate their line styles rather than share them, so this intentionally does not touch the branch-diff preview drawer.

Made with [Orca](https://github.com/stablyai/orca) 🐋
