### PR TITLE
fix(checks): keep a merged PR visible when the worktree sits behind its own PR head

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -821,6 +821,15 @@ describe('getPRForBranch', () => {
     const pr = await getPRForBranch('/repo-root', 'fix-hibernation-wake')
 
     expect(pr).toBeNull()
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(3)
+
+    // A definitive "not part of this PR" answer is immutable for a merged PR:
+    // repeated polls must not re-probe GitHub.
+    mockMergedBranchPRLookupBehindHead()
+    const second = await getPRForBranch('/repo-root', 'fix-hibernation-wake')
+
+    expect(second).toBeNull()
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(5)
   })
 
   it('keeps hiding a merged branch PR when the commit membership probe fails', async () => {

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -33,7 +33,9 @@ const {
   getRemoteUrlForRepoMock: vi.fn(),
   gitExecFileAsyncMock: vi.fn(),
   getRateLimitMock: vi.fn(),
-  rateLimitGuardMock: vi.fn<() => RateLimitGuardResult>(() => ({ blocked: false })),
+  rateLimitGuardMock: vi.fn<(bucket?: string) => RateLimitGuardResult>(() => ({
+    blocked: false
+  })),
   noteRateLimitSpendMock: vi.fn(),
   ghRepoExecOptionsMock: vi.fn((context) =>
     context.connectionId
@@ -121,6 +123,7 @@ import {
   __resetTrackedUpstreamBranchCacheForTests
 } from './client'
 import { __resetPRConflictSummaryGitCapabilityCacheForTests } from './conflict-summary'
+import { resetMergedPRCommitMembershipCacheForTest } from './merged-pr-commit-membership'
 
 describe('checkOrcaStarred', () => {
   beforeEach(() => {
@@ -192,6 +195,7 @@ describe('getPRForBranch', () => {
     _resetMergeQueueCacheForTests()
     __resetTrackedUpstreamBranchCacheForTests()
     __resetPRConflictSummaryGitCapabilityCacheForTests()
+    resetMergedPRCommitMembershipCacheForTest()
   })
 
   it('queries GitHub by head branch when the remote is on github.com', async () => {
@@ -743,6 +747,176 @@ describe('getPRForBranch', () => {
       title: 'Merged current branch PR',
       state: 'merged',
       headSha: 'current-head-oid'
+    })
+  })
+
+  const mockMergedBranchPRLookupBehindHead = (prNumber = 6011): void => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: prNumber,
+            title: 'Merged PR with unpulled final head',
+            state: 'closed',
+            merged_at: '2026-07-03T21:27:36Z',
+            html_url: `https://github.com/acme/widgets/pull/${prNumber}`,
+            updated_at: '2026-07-03T21:27:36Z',
+            draft: false,
+            mergeable_state: 'clean',
+            head: { ref: 'fix-hibernation-wake', sha: 'aaaa1111aaaa1111' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: prNumber,
+          title: 'Merged PR with unpulled final head',
+          state: 'MERGED',
+          url: `https://github.com/acme/widgets/pull/${prNumber}`,
+          statusCheckRollup: [],
+          updatedAt: '2026-07-03T21:27:36Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'fix-hibernation-wake',
+          baseRefOid: 'base-oid',
+          headRefOid: 'aaaa1111aaaa1111'
+        })
+      })
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'bbbb2222bbbb2222\n',
+      stderr: ''
+    })
+  }
+
+  it('shows a merged branch PR when the worktree head is one of its own commits', async () => {
+    mockMergedBranchPRLookupBehindHead()
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([{ number: 6011 }, { number: 42 }])
+    })
+
+    const pr = await getPRForBranch('/repo-root', 'fix-hibernation-wake')
+
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      ['api', 'repos/acme/widgets/commits/bbbb2222bbbb2222/pulls?per_page=100'],
+      expect.anything()
+    )
+    expect(pr).toMatchObject({
+      number: 6011,
+      state: 'merged',
+      headSha: 'aaaa1111aaaa1111',
+      confirmedContainedHeadOid: 'bbbb2222bbbb2222'
+    })
+  })
+
+  it('keeps hiding a merged branch PR when the head belongs to a different PR (reused branch)', async () => {
+    mockMergedBranchPRLookupBehindHead()
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([{ number: 42 }])
+    })
+
+    const pr = await getPRForBranch('/repo-root', 'fix-hibernation-wake')
+
+    expect(pr).toBeNull()
+  })
+
+  it('keeps hiding a merged branch PR when the commit membership probe fails', async () => {
+    mockMergedBranchPRLookupBehindHead()
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 422: No commit found'))
+
+    const pr = await getPRForBranch('/repo-root', 'fix-hibernation-wake')
+
+    expect(pr).toBeNull()
+  })
+
+  it('skips the membership probe while the core rate-limit budget is blocked', async () => {
+    mockMergedBranchPRLookupBehindHead()
+    rateLimitGuardMock.mockImplementation((bucket?: string) =>
+      bucket === 'core'
+        ? { blocked: true, remaining: 0, limit: 5000, resetAt: 0 }
+        : { blocked: false }
+    )
+
+    const pr = await getPRForBranch('/repo-root', 'fix-hibernation-wake')
+
+    expect(pr).toBeNull()
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('reuses the cached membership answer instead of re-querying per poll', async () => {
+    mockMergedBranchPRLookupBehindHead()
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([{ number: 6011 }])
+    })
+    const first = await getPRForBranch('/repo-root', 'fix-hibernation-wake')
+    expect(first).toMatchObject({ number: 6011, confirmedContainedHeadOid: 'bbbb2222bbbb2222' })
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(3)
+
+    mockMergedBranchPRLookupBehindHead()
+    const second = await getPRForBranch('/repo-root', 'fix-hibernation-wake')
+
+    expect(second).toMatchObject({ number: 6011, confirmedContainedHeadOid: 'bbbb2222bbbb2222' })
+    // No fourth membership call: the confirmed answer is immutable and cached.
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(5)
+  })
+
+  it('uses the caller-supplied worktree head for the membership probe without shelling out', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 6012,
+            title: 'Merged PR queried by checks panel',
+            state: 'closed',
+            merged_at: '2026-07-03T21:27:36Z',
+            html_url: 'https://github.com/acme/widgets/pull/6012',
+            updated_at: '2026-07-03T21:27:36Z',
+            draft: false,
+            mergeable_state: 'clean',
+            head: { ref: 'fix-hibernation-wake', sha: 'aaaa1111aaaa1111' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 6012,
+          title: 'Merged PR queried by checks panel',
+          state: 'MERGED',
+          url: 'https://github.com/acme/widgets/pull/6012',
+          statusCheckRollup: [],
+          updatedAt: '2026-07-03T21:27:36Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'fix-hibernation-wake',
+          baseRefOid: 'base-oid',
+          headRefOid: 'aaaa1111aaaa1111'
+        })
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([{ number: 6012 }])
+      })
+
+    const outcome = await getPRForBranchOutcome(
+      '/repo-root',
+      'fix-hibernation-wake',
+      null,
+      null,
+      null,
+      {
+        currentHeadOid: 'cccc3333cccc3333'
+      }
+    )
+
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(outcome).toMatchObject({
+      kind: 'found',
+      pr: { number: 6012, confirmedContainedHeadOid: 'cccc3333cccc3333' }
     })
   })
 

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -62,6 +62,7 @@ import {
   type LocalGitExecOptions,
   type OwnerRepo
 } from './gh-utils'
+import { isCommitPartOfMergedPR } from './merged-pr-commit-membership'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import {
   hasHostedReviewLocalGitOptions,
@@ -2808,7 +2809,30 @@ export async function getPRForBranchOutcome(
       typeof options.currentHeadOid === 'string' && options.currentHeadOid.trim().length > 0
         ? options.currentHeadOid.trim()
         : null
-    const hideMergedImplicitPR = async (candidate: PullRequestLookupData | null) => {
+    let confirmedContainedHeadOid: string | null = null
+    const mergedPRContainsHead = async (
+      candidate: PullRequestLookupData,
+      candidateRepo: OwnerRepo | null,
+      headOid: string | null
+    ): Promise<boolean> => {
+      if (!candidateRepo || !headOid) {
+        return false
+      }
+      const contained = await isCommitPartOfMergedPR({
+        ownerRepo: candidateRepo,
+        prNumber: candidate.number,
+        commitOid: headOid,
+        ghOptions
+      })
+      if (contained) {
+        confirmedContainedHeadOid = headOid
+      }
+      return contained
+    }
+    const hideMergedImplicitPR = async (
+      candidate: PullRequestLookupData | null,
+      candidateRepo: OwnerRepo | null
+    ) => {
       if (!candidate || !isMergedImplicitPR(candidate, linkedPRNumber)) {
         return false
       }
@@ -2819,7 +2843,18 @@ export async function getPRForBranchOutcome(
         explicitCurrentHeadOid !== null
           ? explicitCurrentHeadOid
           : await getCurrentHeadOid(repoPath, connectionId, localGitOptions)
-      return shouldHideMergedImplicitPR(candidate, linkedPRNumber, currentHeadOidForMergedImplicit)
+      if (!shouldHideMergedImplicitPR(candidate, linkedPRNumber, currentHeadOidForMergedImplicit)) {
+        return false
+      }
+      // Why: a worktree can sit behind its own PR's final head (update-branch
+      // merges, web-committed suggestions). A head that is one of the PR's own
+      // commits is the same line of work, not a reused branch name — keep the
+      // merged PR visible instead of offering "create a pull request".
+      return !(await mergedPRContainsHead(
+        candidate,
+        candidateRepo,
+        currentHeadOidForMergedImplicit
+      ))
     }
 
     if (typeof linkedPRNumber === 'number') {
@@ -2886,7 +2921,7 @@ export async function getPRForBranchOutcome(
       }
     }
     let mergedBranchLookupNumber: number | null = null
-    if (await hideMergedImplicitPR(data)) {
+    if (await hideMergedImplicitPR(data, dataRepo)) {
       mergedBranchLookupNumber = data?.number ?? null
       data = null
       dataRepo = null
@@ -2913,14 +2948,15 @@ export async function getPRForBranchOutcome(
       data.number === fallbackPRNumber
     const explicitHeadHidesMergedImplicitPR =
       explicitCurrentHeadOid !== null &&
-      shouldHideMergedImplicitPR(data, linkedPRNumber, explicitCurrentHeadOid)
+      shouldHideMergedImplicitPR(data, linkedPRNumber, explicitCurrentHeadOid) &&
+      !(await mergedPRContainsHead(data, dataRepo, explicitCurrentHeadOid))
     const shouldPreserveMergedFallback =
       !explicitHeadHidesMergedImplicitPR &&
       (fallbackConfirmedMergedBranch || options.acceptMergedFallbackPR === true)
     // Why: a currently visible PR can be merged outside Orca; when the caller
     // marks the fallback as visible review state, keep its lifecycle fresh even
     // if GitHub no longer reports it by branch (for example deleted heads).
-    if ((await hideMergedImplicitPR(data)) && !shouldPreserveMergedFallback) {
+    if ((await hideMergedImplicitPR(data, dataRepo)) && !shouldPreserveMergedFallback) {
       return { kind: 'no-pr', fetchedAt: Date.now() }
     }
 
@@ -2962,6 +2998,7 @@ export async function getPRForBranchOutcome(
           : {}),
         ...(data.mergeStateStatus !== undefined ? { mergeStateStatus: data.mergeStateStatus } : {}),
         headSha: data.headRefOid,
+        ...(confirmedContainedHeadOid ? { confirmedContainedHeadOid } : {}),
         ...(data.baseRefName ? { baseRefName: data.baseRefName } : {}),
         prRepo: dataRepo ?? undefined,
         headRepo: dataHeadRepo ?? undefined,

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2950,6 +2950,10 @@ export async function getPRForBranchOutcome(
       explicitCurrentHeadOid !== null &&
       shouldHideMergedImplicitPR(data, linkedPRNumber, explicitCurrentHeadOid) &&
       !(await mergedPRContainsHead(data, dataRepo, explicitCurrentHeadOid))
+    // Why no lazy-HEAD re-check on preservation: fallback numbers come from
+    // callers that already gated them on head equality or confirmed
+    // containment; re-hiding against the main-repo HEAD would blank
+    // deleted-head merged PRs that are deliberately kept visible.
     const shouldPreserveMergedFallback =
       !explicitHeadHidesMergedImplicitPR &&
       (fallbackConfirmedMergedBranch || options.acceptMergedFallbackPR === true)

--- a/src/main/github/merged-pr-commit-membership.ts
+++ b/src/main/github/merged-pr-commit-membership.ts
@@ -4,12 +4,13 @@ import type { OwnerRepo } from './github-repository-identity'
 
 type GhExecOptions = Parameters<typeof ghExecFileAsync>[1]
 
-// Why: a merged PR's commit set is immutable, so confirmations never expire in
-// practice; the TTLs only bound memory and let "commit not on GitHub yet"
-// answers retry after a future push.
+// Why: a merged PR's commit set is immutable, so definitive answers — member
+// or not — never change; that TTL only bounds memory. Errors (a commit not on
+// GitHub yet, network) get a short TTL so a future push can flip the answer
+// without the checks-panel poll re-probing every cycle.
 const MEMBERSHIP_CACHE_MAX_ENTRIES = 200
-const MEMBERSHIP_CONFIRMED_TTL_MS = 6 * 60 * 60 * 1000
-const MEMBERSHIP_NEGATIVE_TTL_MS = 5 * 60 * 1000
+const MEMBERSHIP_DEFINITIVE_TTL_MS = 6 * 60 * 60 * 1000
+const MEMBERSHIP_ERROR_TTL_MS = 5 * 60 * 1000
 
 const membershipCache = new Map<string, { value: boolean; expiresAt: number }>()
 
@@ -80,7 +81,7 @@ export async function isCommitPartOfMergedPR(args: {
       )
     membershipCache.set(cacheKey, {
       value,
-      expiresAt: now + (value ? MEMBERSHIP_CONFIRMED_TTL_MS : MEMBERSHIP_NEGATIVE_TTL_MS)
+      expiresAt: now + MEMBERSHIP_DEFINITIVE_TTL_MS
     })
     return value
   } catch {
@@ -88,7 +89,7 @@ export async function isCommitPartOfMergedPR(args: {
     // definitive "new local work" today, but a push can change it; retry later.
     membershipCache.set(cacheKey, {
       value: false,
-      expiresAt: now + MEMBERSHIP_NEGATIVE_TTL_MS
+      expiresAt: now + MEMBERSHIP_ERROR_TTL_MS
     })
     return false
   }

--- a/src/main/github/merged-pr-commit-membership.ts
+++ b/src/main/github/merged-pr-commit-membership.ts
@@ -1,0 +1,95 @@
+import { ghExecFileAsync } from './gh-utils'
+import { noteRateLimitSpend, rateLimitGuard } from './rate-limit'
+import type { OwnerRepo } from './github-repository-identity'
+
+type GhExecOptions = Parameters<typeof ghExecFileAsync>[1]
+
+// Why: a merged PR's commit set is immutable, so confirmations never expire in
+// practice; the TTLs only bound memory and let "commit not on GitHub yet"
+// answers retry after a future push.
+const MEMBERSHIP_CACHE_MAX_ENTRIES = 200
+const MEMBERSHIP_CONFIRMED_TTL_MS = 6 * 60 * 60 * 1000
+const MEMBERSHIP_NEGATIVE_TTL_MS = 5 * 60 * 1000
+
+const membershipCache = new Map<string, { value: boolean; expiresAt: number }>()
+
+function pruneMergedPRCommitMembershipCache(now = Date.now()): void {
+  for (const [cacheKey, cached] of membershipCache) {
+    if (cached.expiresAt <= now) {
+      membershipCache.delete(cacheKey)
+    }
+  }
+  while (membershipCache.size > MEMBERSHIP_CACHE_MAX_ENTRIES) {
+    const oldestKey = membershipCache.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    membershipCache.delete(oldestKey)
+  }
+}
+
+export function resetMergedPRCommitMembershipCacheForTest(): void {
+  membershipCache.clear()
+}
+
+/**
+ * Whether `commitOid` is part of pull request `prNumber` on GitHub — i.e. the
+ * commit belongs to that PR's history rather than merely sharing a branch name.
+ * A worktree sitting on such a commit is on the PR's own line of work (for
+ * example behind web-committed suggestions or an update-branch merge), not a
+ * reused branch name. Conservative on any failure: returns false.
+ */
+export async function isCommitPartOfMergedPR(args: {
+  ownerRepo: OwnerRepo
+  prNumber: number
+  commitOid: string
+  ghOptions: GhExecOptions
+}): Promise<boolean> {
+  const oid = args.commitOid.trim().toLowerCase()
+  if (!/^[0-9a-f]{4,64}$/.test(oid) || !Number.isInteger(args.prNumber)) {
+    return false
+  }
+  const owner = args.ownerRepo.owner
+  const repo = args.ownerRepo.repo
+  const cacheKey = `${owner.toLowerCase()}/${repo.toLowerCase()}#${args.prNumber}@${oid}`
+  const now = Date.now()
+  pruneMergedPRCommitMembershipCache(now)
+  const cached = membershipCache.get(cacheKey)
+  if (cached && cached.expiresAt > now) {
+    return cached.value
+  }
+  // Why blocked → uncached false: keep the merged PR hidden without burning
+  // budget; the next poll re-asks once the rate-limit window recovers.
+  if (rateLimitGuard('core').blocked) {
+    return false
+  }
+  try {
+    noteRateLimitSpend('core')
+    const { stdout } = await ghExecFileAsync(
+      ['api', `repos/${owner}/${repo}/commits/${oid}/pulls?per_page=100`],
+      args.ghOptions
+    )
+    const parsed = JSON.parse(stdout) as unknown
+    const value =
+      Array.isArray(parsed) &&
+      parsed.some(
+        (entry) =>
+          typeof entry === 'object' &&
+          entry !== null &&
+          (entry as { number?: unknown }).number === args.prNumber
+      )
+    membershipCache.set(cacheKey, {
+      value,
+      expiresAt: now + (value ? MEMBERSHIP_CONFIRMED_TTL_MS : MEMBERSHIP_NEGATIVE_TTL_MS)
+    })
+    return value
+  } catch {
+    // Why: the common failure is 422 for a commit never pushed to GitHub —
+    // definitive "new local work" today, but a push can change it; retry later.
+    membershipCache.set(cacheKey, {
+      value: false,
+      expiresAt: now + MEMBERSHIP_NEGATIVE_TTL_MS
+    })
+    return false
+  }
+}

--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -94,6 +94,28 @@ describe('pr-refresh-coordinator', () => {
     vi.useRealTimers()
   })
 
+  it('forwards the candidate worktree head into the branch lookup options', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValueOnce({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    reportVisiblePRRefreshCandidates([makeCandidate({ currentHeadOid: 'worktree-head-oid' })], 1, 1)
+    await vi.runOnlyPendingTimersAsync()
+
+    // Why: without the head, a panel-supplied fallback number preserves a
+    // merged PR head-blind after the branch moves on to new work.
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith(
+      '/repo',
+      'feature/test',
+      null,
+      null,
+      null,
+      expect.objectContaining({ currentHeadOid: 'worktree-head-oid' })
+    )
+  })
+
   it('does not show visible background refreshes as queued', async () => {
     const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
     getPRForBranchOutcomeMock.mockResolvedValueOnce({

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -56,7 +56,7 @@ function hostedReviewOptionArgs(
     options.acceptMergedFallbackPR = true
   }
   if (typeof candidate.currentHeadOid === 'string' && candidate.currentHeadOid.trim().length > 0) {
-    options.currentHeadOid = candidate.currentHeadOid
+    options.currentHeadOid = candidate.currentHeadOid.trim()
   }
   return Object.keys(options).length > 0 ? [options] : []
 }

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -34,7 +34,7 @@ type PRRefreshOutcomeObserver = (
 
 type PRBranchLookupCandidate = Pick<
   GitHubPRRefreshCandidate,
-  'localGitOptions' | 'linkedPRNumber' | 'fallbackPRNumber' | 'fallbackPRSource'
+  'localGitOptions' | 'linkedPRNumber' | 'fallbackPRNumber' | 'fallbackPRSource' | 'currentHeadOid'
 >
 
 function shouldAcceptMergedFallbackPR(candidate: PRBranchLookupCandidate): boolean {
@@ -54,6 +54,9 @@ function hostedReviewOptionArgs(
   }
   if (shouldAcceptMergedFallbackPR(candidate)) {
     options.acceptMergedFallbackPR = true
+  }
+  if (typeof candidate.currentHeadOid === 'string' && candidate.currentHeadOid.trim().length > 0) {
+    options.currentHeadOid = candidate.currentHeadOid
   }
   return Object.keys(options).length > 0 ? [options] : []
 }

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -278,19 +278,27 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         linkedPRNumber?: number | null
         fallbackPRNumber?: number | null
         acceptMergedFallbackPR?: boolean
+        currentHeadOid?: string | null
       }
     ) => {
       const repo = assertRegisteredRepo(args, store)
       const localGitOptions = localGitOptionArgs(store, repo)[0]
       const hostedReviewOptionArgs: [] | [{ localGitExecOptions: { wslDistro?: string } }] =
         localGitOptions ? [{ localGitExecOptions: localGitOptions }] : []
+      const currentHeadOid =
+        typeof args.currentHeadOid === 'string' && args.currentHeadOid.trim().length > 0
+          ? args.currentHeadOid.trim()
+          : null
       const lookupOptions: GitHubPRBranchLookupOptions | undefined = hostedReviewOptionArgs[0]
         ? { ...hostedReviewOptionArgs[0] }
-        : args.acceptMergedFallbackPR === true
+        : args.acceptMergedFallbackPR === true || currentHeadOid !== null
           ? {}
           : undefined
       if (lookupOptions && args.acceptMergedFallbackPR === true) {
         lookupOptions.acceptMergedFallbackPR = true
+      }
+      if (lookupOptions && currentHeadOid !== null) {
+        lookupOptions.currentHeadOid = currentHeadOid
       }
       const lookupOptionArgs: [] | [GitHubPRBranchLookupOptions] = lookupOptions
         ? [lookupOptions]

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10799,13 +10799,17 @@ export class OrcaRuntimeService {
     branch: string,
     linkedPRNumber?: number | null,
     fallbackPRNumber?: number | null,
-    acceptMergedFallbackPR?: boolean
+    acceptMergedFallbackPR?: boolean,
+    currentHeadOid?: string | null
   ): Promise<Awaited<ReturnType<typeof getPRForBranch>>> {
     const repo = await this.resolveRepoSelector(repoSelector)
     const options: GitHubPRBranchLookupOptions = this.getHostedReviewExecutionOptions(repo) ?? {}
     const lookupOptions = { ...options }
     if (acceptMergedFallbackPR === true) {
       lookupOptions.acceptMergedFallbackPR = true
+    }
+    if (typeof currentHeadOid === 'string' && currentHeadOid.trim().length > 0) {
+      lookupOptions.currentHeadOid = currentHeadOid.trim()
     }
     const lookupOptionArgs: [] | [GitHubPRBranchLookupOptions] =
       Object.keys(lookupOptions).length > 0 ? [lookupOptions] : []

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -53,7 +53,8 @@ const PrForBranch = RepoSelector.extend({
   branch: requiredString('Missing branch'),
   linkedPRNumber: z.number().int().positive().nullable().optional(),
   fallbackPRNumber: z.number().int().positive().nullable().optional(),
-  acceptMergedFallbackPR: z.boolean().optional()
+  acceptMergedFallbackPR: z.boolean().optional(),
+  currentHeadOid: z.string().nullable().optional()
 })
 
 const Issue = RepoSelector.extend({
@@ -361,7 +362,8 @@ export const GITHUB_METHODS: RpcMethod[] = [
         params.branch,
         params.linkedPRNumber,
         params.fallbackPRNumber,
-        params.acceptMergedFallbackPR
+        params.acceptMergedFallbackPR,
+        params.currentHeadOid
       )
   }),
   defineMethod({

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1257,6 +1257,7 @@ export type PreloadApi = {
       linkedPRNumber?: number | null
       fallbackPRNumber?: number | null
       acceptMergedFallbackPR?: boolean
+      currentHeadOid?: string | null
     }) => Promise<PRInfo | null>
     refreshPRNow: (args: { candidate: GitHubPRRefreshCandidate }) => Promise<PRRefreshOutcome>
     enqueuePRRefresh: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1026,6 +1026,7 @@ const api = {
       linkedPRNumber?: number | null
       fallbackPRNumber?: number | null
       acceptMergedFallbackPR?: boolean
+      currentHeadOid?: string | null
     }): Promise<unknown> => ipcRenderer.invoke('gh:prForBranch', args),
 
     refreshPRNow: (args: { candidate: GitHubPRRefreshCandidate }): Promise<unknown> =>

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -36,8 +36,7 @@ import type {
   Worktree,
   Repo,
   IssueInfo,
-  LinearIssue,
-  PRInfo
+  LinearIssue
 } from '../../../../shared/types'
 import { CONFLICT_OPERATION_LABELS } from './WorktreeCardHelpers'
 import {
@@ -48,7 +47,10 @@ import {
 } from './WorktreeCardMeta'
 import { WorktreeCardPortsDetails, WorktreeCardPortsTrigger } from './WorktreeCardPorts'
 import { writeWorkspaceDragData } from './workspace-status'
-import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
+import {
+  getWorktreeCardPrDisplay,
+  isCachedMergedBranchPRCurrentForWorktree
+} from './worktree-card-pr-display'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 import {
   coerceWorktreeCardVisibleTitle,
@@ -151,20 +153,6 @@ function formatSparseDirectoryPreview(directories: string[]): string {
 
 function isWebClient(): boolean {
   return Boolean((window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__)
-}
-
-function isCachedMergedBranchPRCurrentForWorktree(
-  cachedPR: PRInfo | null | undefined,
-  worktree: Worktree
-): boolean {
-  return (
-    cachedPR?.state === 'merged' &&
-    typeof cachedPR.headSha === 'string' &&
-    cachedPR.headSha.length > 0 &&
-    typeof worktree.head === 'string' &&
-    worktree.head.length > 0 &&
-    cachedPR.headSha === worktree.head
-  )
 }
 
 function getDirectoryName(folderPath: string): string {

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
-import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
+import type { PRInfo } from '../../../../shared/types'
+import {
+  getWorktreeCardPrDisplay,
+  isCachedMergedBranchPRCurrentForWorktree
+} from './worktree-card-pr-display'
 
 const pr: HostedReviewInfo = {
   provider: 'github',
@@ -102,5 +106,40 @@ describe('getWorktreeCardPrDisplay', () => {
 
   it('preserves branch-discovered hosted reviews for providers without worktree metadata', () => {
     expect(getWorktreeCardPrDisplay(bitbucketReview, null)).toBe(bitbucketReview)
+  })
+})
+
+describe('isCachedMergedBranchPRCurrentForWorktree', () => {
+  const mergedPR: PRInfo = {
+    number: 55,
+    title: 'Merged PR',
+    state: 'merged',
+    url: 'https://github.com/stablyai/orca/pull/55',
+    checksStatus: 'success',
+    updatedAt: '2026-07-03T00:00:00.000Z',
+    mergeable: 'MERGEABLE',
+    headSha: 'final-head'
+  }
+
+  it('matches when the worktree sits exactly on the merged head', () => {
+    expect(isCachedMergedBranchPRCurrentForWorktree(mergedPR, { head: 'final-head' })).toBe(true)
+  })
+
+  it('matches when the worktree head is a confirmed commit of the merged PR', () => {
+    expect(
+      isCachedMergedBranchPRCurrentForWorktree(
+        { ...mergedPR, confirmedContainedHeadOid: 'behind-head' },
+        { head: 'behind-head' }
+      )
+    ).toBe(true)
+  })
+
+  it('rejects a merged PR when the worktree head is neither the final head nor confirmed', () => {
+    expect(
+      isCachedMergedBranchPRCurrentForWorktree(
+        { ...mergedPR, confirmedContainedHeadOid: 'other-head' },
+        { head: 'reused-branch-head' }
+      )
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -1,6 +1,23 @@
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
+import type { PRInfo, Worktree } from '../../../../shared/types'
 
 type LinkedReviewMetadataProvider = Exclude<HostedReviewInfo['provider'], 'unsupported'>
+
+export function isCachedMergedBranchPRCurrentForWorktree(
+  cachedPR: PRInfo | null | undefined,
+  worktree: Pick<Worktree, 'head'>
+): boolean {
+  return (
+    cachedPR?.state === 'merged' &&
+    typeof cachedPR.headSha === 'string' &&
+    cachedPR.headSha.length > 0 &&
+    typeof worktree.head === 'string' &&
+    worktree.head.length > 0 &&
+    // Why: a worktree behind its own merged PR (update-branch/web commits) is
+    // still that PR's line of work; match the main-process visibility rule.
+    (cachedPR.headSha === worktree.head || cachedPR.confirmedContainedHeadOid === worktree.head)
+  )
+}
 
 type LinkedReviewNumbers = {
   linkedPR: number | null

--- a/src/renderer/src/store/slices/github-pr-refresh-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/github-pr-refresh-owner-routing.test.ts
@@ -155,7 +155,7 @@ describe('GitHub PR refresh owner-host routing', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-runtime', branch, linkedPRNumber: null },
+      params: { repo: 'repo-runtime', branch, linkedPRNumber: null, currentHeadOid: 'head-oid' },
       timeoutMs: 30_000
     })
   })
@@ -228,7 +228,7 @@ describe('GitHub PR refresh owner-host routing', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-runtime', branch, linkedPRNumber: null },
+      params: { repo: 'repo-runtime', branch, linkedPRNumber: null, currentHeadOid: 'head-oid' },
       timeoutMs: 30_000
     })
   })
@@ -272,7 +272,12 @@ describe('GitHub PR refresh owner-host routing', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-runtime', branch: 'feature/runtime', linkedPRNumber: null },
+      params: {
+        repo: 'repo-runtime',
+        branch: 'feature/runtime',
+        linkedPRNumber: null,
+        currentHeadOid: 'head-oid'
+      },
       timeoutMs: 30_000
     })
   })

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -3573,7 +3573,12 @@ describe('createGitHubSlice.refreshGitHubForWorktreeIfStale', () => {
     // GitHub stops reporting the deleted head by branch name.
     expect(mockApi.gh.enqueuePRRefresh).toHaveBeenCalledWith(
       expect.objectContaining({
-        candidate: expect.objectContaining({ fallbackPRNumber: 13 })
+        candidate: expect.objectContaining({
+          fallbackPRNumber: 13,
+          // Why: main can only head-gate fallback preservation when the
+          // candidate carries the worktree head it was built for.
+          currentHeadOid: 'behind-head'
+        })
       })
     )
   })
@@ -3960,7 +3965,7 @@ describe('createGitHubSlice.refreshGitHubForWorktreeIfStale', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-1', branch, linkedPRNumber: 12 },
+      params: { repo: 'repo-1', branch, linkedPRNumber: 12, currentHeadOid: null },
       timeoutMs: 30_000
     })
     expect(store.getState().hostedReviewCache[hostedReviewCacheKey]).toMatchObject({
@@ -4010,7 +4015,7 @@ describe('createGitHubSlice.refreshGitHubForWorktreeIfStale', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-runtime', branch, linkedPRNumber: null },
+      params: { repo: 'repo-runtime', branch, linkedPRNumber: null, currentHeadOid: null },
       timeoutMs: 30_000
     })
     expect(store.getState().prCache[`runtime:env-1::repo-runtime::${branch}`]?.data).toMatchObject({
@@ -4247,7 +4252,7 @@ describe('createGitHubSlice.refreshAllGitHub', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-1', branch, linkedPRNumber: null },
+      params: { repo: 'repo-1', branch, linkedPRNumber: null, currentHeadOid: null },
       timeoutMs: 30_000
     })
   })
@@ -4377,7 +4382,7 @@ describe('createGitHubSlice.refreshGitHubForWorktree', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-1', branch, linkedPRNumber: null },
+      params: { repo: 'repo-1', branch, linkedPRNumber: null, currentHeadOid: null },
       timeoutMs: 30_000
     })
   })

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -2264,6 +2264,55 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     expect(mockApi.cache.setGitHub).not.toHaveBeenCalled()
   })
 
+  it('preserves cached merged PR data when the worktree head is a confirmed PR commit', async () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/merged-pr-behind-head'
+    const worktreeId = 'wt-merged-behind-head'
+    const cachedPR = makePR({
+      number: 13,
+      title: 'Merged PR with unpulled final head',
+      state: 'merged',
+      headSha: 'merged-final-head',
+      confirmedContainedHeadOid: 'behind-head'
+    })
+
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        [repoId]: [
+          makePRRefreshWorktree({
+            id: worktreeId,
+            repoId,
+            branch,
+            head: 'behind-head'
+          })
+        ]
+      },
+      prCache: {
+        [`${repoId}::${branch}`]: {
+          data: cachedPR,
+          fetchedAt: 1
+        }
+      }
+    } as unknown as Partial<AppState>)
+    mockApi.gh.refreshPRNow.mockResolvedValueOnce({ kind: 'no-pr', fetchedAt: 2 })
+
+    await expect(
+      store.getState().fetchPRForBranch(repoPath, branch, {
+        force: true,
+        repoId,
+        worktreeId
+      })
+    ).resolves.toEqual(cachedPR)
+    expect(store.getState().prCache[`${repoId}::${branch}`]).toEqual({
+      data: cachedPR,
+      fetchedAt: 1
+    })
+  })
+
   it.each([
     {
       name: 'worktree id is missing',
@@ -3480,6 +3529,53 @@ describe('createGitHubSlice.refreshGitHubForWorktreeIfStale', () => {
 
     expect(mockApi.gh.enqueuePRRefresh).toHaveBeenCalledTimes(1)
     expect(mockApi.gh.prForBranch).not.toHaveBeenCalled()
+  })
+
+  it('keeps a confirmed behind-head merged PR as the refresh fallback number', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/merged-pr-behind-head'
+    const worktreeId = 'wt-merged-behind-fallback'
+    mockApi.gh.enqueuePRRefresh.mockResolvedValueOnce({ kind: 'queued' })
+
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        [repoId]: [
+          makePRRefreshWorktree({
+            id: worktreeId,
+            repoId,
+            branch,
+            head: 'behind-head'
+          })
+        ]
+      },
+      prCache: {
+        [`${repoId}::${branch}`]: {
+          data: makePR({
+            number: 13,
+            title: 'Merged PR with unpulled final head',
+            state: 'merged',
+            headSha: 'merged-final-head',
+            confirmedContainedHeadOid: 'behind-head'
+          }),
+          fetchedAt: 1
+        }
+      }
+    } as unknown as Partial<AppState>)
+
+    store.getState().enqueueGitHubPRRefresh(worktreeId, 'active', 80)
+    await Promise.resolve()
+
+    // Why 13: a merged PR confirmed to contain this worktree head is still the
+    // branch's PR; losing the fallback number would blank the panel whenever
+    // GitHub stops reporting the deleted head by branch name.
+    expect(mockApi.gh.enqueuePRRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidate: expect.objectContaining({ fallbackPRNumber: 13 })
+      })
+    )
   })
 
   it('direct-fetches when enqueue returns an explicit fallback result', async () => {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1038,6 +1038,9 @@ function buildPRRefreshCandidate(
     true
   )
   const cachedFallbackPRNumber = cachedPR?.number ?? null
+  // Why: a merged PR stays a valid fallback when the worktree sits on its head
+  // or on a commit main confirmed as part of the PR; anything else means the
+  // branch moved on and the number must not resurrect the old merged PR.
   const cachedMergedPRMovedPastHead =
     worktree.linkedPR == null &&
     cachedPR?.state === 'merged' &&

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1039,7 +1039,10 @@ function buildPRRefreshCandidate(
   )
   const cachedFallbackPRNumber = cachedPR?.number ?? null
   const cachedMergedPRMovedPastHead =
-    worktree.linkedPR == null && cachedPR?.state === 'merged' && cachedPR.headSha !== worktree.head
+    worktree.linkedPR == null &&
+    cachedPR?.state === 'merged' &&
+    cachedPR.headSha !== worktree.head &&
+    cachedPR.confirmedContainedHeadOid !== worktree.head
   const fallbackPRNumber =
     worktree.linkedPR == null && !cachedMergedPRMovedPastHead
       ? (cachedFallbackPRNumber ?? hostedReviewFallbackPRNumber)
@@ -1264,7 +1267,8 @@ function shouldPreserveExistingPRForFallbackMiss(args: {
   const worktree = args.worktreeId ? findWorktreeById(args.state, args.worktreeId) : null
   const worktreeHead = worktree?.head
   // Why: merged branch PRs are only safe to keep when cached PR metadata still
-  // matches the commit this stored worktree is actually on.
+  // matches the commit this stored worktree is actually on — exactly, or via a
+  // head main confirmed to be part of the merged PR.
   const preservesMergedPRForCurrentHead =
     args.nextPR === null &&
     args.linkedPRNumber == null &&
@@ -1273,7 +1277,8 @@ function shouldPreserveExistingPRForFallbackMiss(args: {
     args.currentPR.headSha.length > 0 &&
     typeof worktreeHead === 'string' &&
     worktreeHead.length > 0 &&
-    args.currentPR.headSha === worktreeHead
+    (args.currentPR.headSha === worktreeHead ||
+      args.currentPR.confirmedContainedHeadOid === worktreeHead)
 
   // Why: fallback PR numbers come from already-visible cache, not durable
   // worktree metadata. A branch/fallback miss is weaker than the current exact

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1066,6 +1066,7 @@ function buildPRRefreshCandidate(
     branch,
     cacheKey,
     worktreeId: worktree.id,
+    currentHeadOid: worktree.head ?? null,
     // Why: persisted linked PR metadata is exact, while PR cache numbers are
     // only fallback hints after branch lookup misses.
     linkedPRNumber: worktree.linkedPR ?? null,
@@ -2949,6 +2950,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const request = (async () => {
       try {
         const runtimeRepo = getRuntimeRepoTarget(get(), repoPath, requestSettings)
+        const candidateWorktree = options?.worktreeId
+          ? findWorktreeById(get(), options.worktreeId)
+          : null
         const outcome = runtimeRepo
           ? await callRuntimeRpc<PRInfo | null>(
               runtimeRepo.target,
@@ -2957,6 +2961,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 repo: runtimeRepo.repo.id,
                 branch,
                 linkedPRNumber,
+                currentHeadOid: candidateWorktree?.head ?? null,
                 ...(fallbackPRNumber !== null
                   ? { fallbackPRNumber, acceptMergedFallbackPR: fallbackPRSource !== null }
                   : {})
@@ -2975,6 +2980,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 branch,
                 cacheKey,
                 worktreeId: options?.worktreeId,
+                currentHeadOid: candidateWorktree?.head ?? null,
                 linkedPRNumber,
                 fallbackPRNumber,
                 fallbackPRSource,
@@ -2996,7 +3002,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                       branch,
                       linkedPRNumber,
                       fallbackPRNumber,
-                      acceptMergedFallbackPR: fallbackPRNumber !== null && fallbackPRSource !== null
+                      acceptMergedFallbackPR:
+                        fallbackPRNumber !== null && fallbackPRSource !== null,
+                      currentHeadOid: candidateWorktree?.head ?? null
                     })
                     .then((pr) =>
                       pr

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -547,6 +547,39 @@ describe('hosted review slice', () => {
     expect(mockApi.hostedReview.forBranch).toHaveBeenCalledTimes(2)
   })
 
+  it('serves a cached merged review whose confirmed contained head matches the worktree', async () => {
+    const mergedBehindHead: HostedReviewInfo = {
+      provider: 'github',
+      number: 7,
+      title: 'Merged with unpulled final head',
+      state: 'merged',
+      url: 'https://github.com/acme/orca/pull/7',
+      status: 'success',
+      updatedAt: '2026-05-10T00:00:00.000Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'aaaaaaa',
+      confirmedContainedHeadOid: 'bbbbbbb'
+    }
+    mockApi.hostedReview.forBranch.mockResolvedValueOnce(mergedBehindHead)
+    const store = makeStore()
+
+    await expect(
+      store.getState().fetchHostedReviewForBranch('/repo', 'feature/merged', {
+        currentHeadOid: 'bbbbbbb'
+      })
+    ).resolves.toEqual(mergedBehindHead)
+
+    // Why one call: a merged review confirmed for this worktree head is not
+    // stale, so the second read must reuse the branch-scoped cache instead of
+    // refetching every poll.
+    await expect(
+      store.getState().fetchHostedReviewForBranch('/repo', 'feature/merged', {
+        currentHeadOid: 'bbbbbbb'
+      })
+    ).resolves.toEqual(mergedBehindHead)
+    expect(mockApi.hostedReview.forBranch).toHaveBeenCalledTimes(1)
+  })
+
   it('does not preserve a merged GitHub review after the worktree moves off its head', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const cacheKey = getHostedReviewCacheKey(

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -100,9 +100,10 @@ function isStaleMergedGitHubReviewForHead(
   cached: CacheEntry<HostedReviewInfo> | undefined,
   currentHeadOid: string | null | undefined
 ): boolean {
-  // Why: a merged GitHub PR is only shown when the worktree sits on its head.
-  // The cache key is branch-scoped, so a worktree that advanced off the merged
-  // head must not reuse (or, on failure, preserve) the now-stale merged review.
+  // Why: a merged GitHub PR is only shown when the worktree sits on its head
+  // or on a commit confirmed to be part of the PR. The cache key is
+  // branch-scoped, so a worktree that advanced off the merged line of work
+  // must not reuse (or, on failure, preserve) the now-stale merged review.
   const head = typeof currentHeadOid === 'string' ? currentHeadOid.trim() : ''
   if (head.length === 0) {
     return false
@@ -113,7 +114,8 @@ function isStaleMergedGitHubReviewForHead(
     data.state === 'merged' &&
     typeof data.headSha === 'string' &&
     data.headSha.length > 0 &&
-    data.headSha !== head
+    data.headSha !== head &&
+    data.confirmedContainedHeadOid !== head
   )
 }
 

--- a/src/shared/hosted-review-github.ts
+++ b/src/shared/hosted-review-github.ts
@@ -120,6 +120,9 @@ export function hostedReviewInfoFromGitHubPRInfo(pr: PRInfo): HostedReviewInfo {
     ...(pr.mergeQueueRequired !== undefined ? { mergeQueueRequired: pr.mergeQueueRequired } : {}),
     ...(pr.mergeStateStatus !== undefined ? { mergeStateStatus: pr.mergeStateStatus } : {}),
     ...(pr.headSha ? { headSha: pr.headSha } : {}),
+    ...(pr.confirmedContainedHeadOid
+      ? { confirmedContainedHeadOid: pr.confirmedContainedHeadOid }
+      : {}),
     ...(pr.conflictSummary ? { conflictSummary: pr.conflictSummary } : {})
   }
 }

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -25,6 +25,9 @@ export type HostedReviewInfo = {
   mergeQueueRequired?: boolean | null
   mergeStateStatus?: string | null
   headSha?: string
+  // Why: mirrors PRInfo.confirmedContainedHeadOid so merged-review staleness
+  // checks accept a worktree head confirmed to be part of the merged PR.
+  confirmedContainedHeadOid?: string
   /** Target branch name for review-created worktree compare-base repair. */
   baseRefName?: string
   conflictSummary?: PRConflictSummary

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1196,6 +1196,10 @@ export type GitHubPRRefreshCandidate = GitHubPRRefreshAlias & {
   cachedMergeable?: PRMergeableState | null
   cachedMergeStateStatus?: string | null
   localGitOptions?: { wslDistro?: string }
+  // Why: merged branch-matched PRs are only visible for heads that belong to
+  // the PR; without the worktree head, a panel-supplied fallback number would
+  // keep a merged PR alive head-blind after the branch moves on.
+  currentHeadOid?: string | null
 }
 
 export type GitHubPRRefreshSkippedReason =

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1133,6 +1133,10 @@ export type PRInfo = {
   // Keeping the head SHA in cached PR metadata lets the checks panel poll the
   // correct commit without re-querying GitHub or guessing from local branch refs.
   headSha?: string
+  // Why: a merged branch-matched PR stays visible when the worktree head is one
+  // of the PR's own commits (behind update-branch/web commits). Cache staleness
+  // checks must honor that confirmation without re-querying GitHub.
+  confirmedContainedHeadOid?: string
   /** Target branch name for PR-created worktree compare-base repair. */
   baseRefName?: string
   prRepo?: GitHubRepositoryIdentity


### PR DESCRIPTION
## Problem

Right after a PR merges, its worktree can show **"No pull request found — Create a pull request to start checks and review."** in the Checks panel, and the sidebar card loses its merged badge. This happens whenever the branch picked up a remote-side commit the local worktree never pulled (an "Update branch" merge, web-committed review suggestions, or a commit pushed from another machine) before merging.

Observed in the wild today on `brennanb2025/fix-agent-hibernation-ghost-wake`: local HEAD `b5bb8c7b8` sat one commit behind merged PR #7145's final head `53a792106`, and the panel offered to *create* a PR for a branch that had just merged.

## Root cause

Merged branch-matched (non-linked) PRs are deliberately hidden to stop reused branch names from resurrecting historical PRs — but the "does this merged PR belong to the current checkout" test is **exact head equality** (`shouldHideMergedImplicitPR`). A worktree sitting *behind its own PR's head* fails it, and every renderer surface (hosted-review staleness, refresh fallback number, no-PR cache preserve, sidebar merged badge) repeats the same exact-match test, so the PR vanishes everywhere with a misleading create-PR call to action.

## Fix

Keep the reused-branch guard, but before hiding a merged branch-matched PR, ask GitHub whether the worktree head is **one of that PR's own commits** (`repos/{owner}/{repo}/commits/{sha}/pulls`, single call):

- A behind-head commit of the same PR ⇒ same line of work ⇒ keep showing the merged PR.
- Old base-branch commits carry no association with the PR ⇒ reused branch names stay hidden (guard intact).
- Commits never pushed to GitHub ⇒ probe 422s ⇒ stay hidden (new local work).

The probe lives in `src/main/github/merged-pr-commit-membership.ts`: bounded cache (membership of a merged PR is immutable — long TTL for confirmations, short TTL for negatives so a later push can flip them), `core` rate-limit-guarded, and fail-safe to the previous hide behavior on any error. Confirmed heads are stamped on `PRInfo`/`HostedReviewInfo` as `confirmedContainedHeadOid`, and the four renderer agreement points accept the stamp so the panel doesn't refetch-loop and the fallback PR number / cache preserve / sidebar badge stay consistent with main.

`getPRForBranchOutcome` is the single chokepoint used by both the PR-cache path and the hosted-review path (all providers' exec options are threaded through, so SSH/WSL lookups run in the same context as today). GitLab and the other forges have no implicit-merged hide rule to mirror — their reviews attach via explicit links.

## Tests

All new behavior is pinned red-green (each test fails with its product hunk reverted):

- main: shows a merged branch PR when the worktree head is one of its own commits; keeps hiding for a different PR's commit (reused branch), on probe failure, and while the core rate-limit budget is blocked (no probe call); reuses the cached membership answer across polls; uses the caller-supplied worktree head without shelling out.
- renderer: hosted-review cache serves a confirmed merged review without refetch-looping; no-PR refresh preserves a confirmed behind-head merged PR; the refresh candidate keeps the confirmed merged PR as its fallback number; sidebar merged-badge predicate extracted to `worktree-card-pr-display.ts` and unit-pinned.

## Live validation follow-up (commit b66e972)

Exercising the real workflow in a dev build caught a loop the unit seams missed: the Checks panel passes its **displayed** PR number as the refresh fallback, and the PR-refresh candidate carried no worktree head, so main preserved a merged branch PR head-blind — the merged view survived new local commits instead of yielding to "No pull request found". Fixed by carrying `currentHeadOid` on `GitHubPRRefreshCandidate`, both renderer candidate builders, the `gh:prForBranch` IPC, and the runtime RPC method (mirroring the hosted-review path), so the explicit-head gate applies to every renderer-driven lookup. True no-context callers keep the designed deleted-head preservation.

## Tests

- [x] `pnpm typecheck` (node/cli/web), full `oxlint` (0 errors), `git diff --check`, full `pnpm lint` incl. localization checks
- [x] 309 tests across the seven touched/adjacent suites; every product hunk pinned red-green (fails with its hunk reverted): membership show/hide/error/rate-limit/cache, hosted-review staleness serve-from-cache, fallback-number gate, preserve-on-miss, sidebar badge predicate, coordinator head forwarding, candidate head presence
- [x] Real-API probes of the association assumption (behind-head commit → its PR; final head → its PR; old base-branch commit → none)
- [x] Live dev-build E2E on a disposable `demo-project` PR (branch → PR → remote-only commit → merge → local worktree one commit behind):
  - Checks panel renders **#N Merged** + title for the behind-head worktree (previously "No pull request found — Create a pull request…"); sidebar card shows the merged badge; `prCache`/hosted entries carry `confirmedContainedHeadOid` = worktree head
  - Control: a new local commit on the same branch flips both surfaces back to "No pull request found" / plain branch card (reused-branch guard intact, no self-sustaining merged view)
  - Cleanup: test worktree/branches (local + remote) removed, isolated app profile deleted
- [x] Live SSH E2E (throwaway Linux Docker SSH target, real `demo-project` clone, disposable merged PR): behind-head worktree on the SSH-hosted repo shows the merged PR in the Checks panel + sidebar with `confirmedContainedHeadOid` = worktree head in both caches; control commit flips it to "No pull request found" and it stays hidden across repeated refreshes; relay deploy/logs clean; full cleanup verified
- [x] Runtime RPC `github.prForBranch` exercised directly with the new `currentHeadOid` param (behind head → merged PR + stamp; new head → null) through `OrcaRuntimeService.getRepoPRForBranch` over the local runtime transport
- [ ] Networked serve-mode runtime-environment transport for the same RPC (same handler code, different transport) — not exercised; plain SSH repos don't use it

