### PR TITLE
Record hibernation activity from real user input and protect typed drafts

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1703,6 +1703,67 @@ describe('connectPanePty', () => {
     expect(transport.connect.mock.calls.length).toBe(connectCallsBeforeExit)
   })
 
+  it('records hibernation activity from the core user-input signal, not synthetic onData replies', async () => {
+    // Regression: xterm auto-replies (focus in/out reports, DA/DSR responses)
+    // arrive through the same onData stream as typing. Recording them as pane
+    // input made the hibernation planner treat a pane hidden after its agent
+    // finished as "input after done" and never hibernate it.
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-pane-2')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps()
+    const pane = createPane(2)
+    let userInputListener: (() => void) | null = null
+    const userInputDispose = vi.fn()
+    ;(pane.terminal as unknown as { _core: unknown })._core = {
+      coreService: {
+        onUserInput: vi.fn((listener: () => void) => {
+          userInputListener = listener
+          return { dispose: userInputDispose }
+        })
+      }
+    }
+
+    const binding = connectPanePty(pane as never, manager as never, deps as never) as unknown as {
+      dispose: () => void
+    }
+    await flushAsyncTicks()
+    expect(userInputListener).toBeTypeOf('function')
+    ;(mockStoreState.recordTerminalInput as ReturnType<typeof vi.fn>).mockClear()
+
+    // A focus-out report forwarded to the PTY must not count as activity.
+    sendTerminalInputThroughPane(pane, '\x1b[O')
+    expect(mockStoreState.recordTerminalInput).not.toHaveBeenCalled()
+    // The reply still reaches the shell; only the activity recording is gated.
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b[O')
+
+    // Real user input fires the core signal and records activity.
+    ;(userInputListener as unknown as () => void)()
+    expect(mockStoreState.recordTerminalInput).toHaveBeenCalledTimes(1)
+
+    binding.dispose()
+    expect(userInputDispose).toHaveBeenCalled()
+  })
+
+  it('falls back to onData hibernation recording when the core user-input signal is unavailable', async () => {
+    // If an xterm upgrade removes the internal signal, activity recording must
+    // degrade to the historical onData behavior — never to no tracking at all.
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-pane-2')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps()
+    const pane = createPane(2)
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks()
+    ;(mockStoreState.recordTerminalInput as ReturnType<typeof vi.fn>).mockClear()
+
+    sendTerminalInputThroughPane(pane, 'x')
+    expect(mockStoreState.recordTerminalInput).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps a fresh split pane mounted when its newborn PTY exits before output or input', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-pane-2')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -67,6 +67,7 @@ import {
   scanMode2031Sequences
 } from '../../../../shared/terminal-color-scheme-protocol'
 import { warnTerminalLifecycleAnomaly } from './terminal-lifecycle-diagnostics'
+import { subscribeToTerminalUserInput } from './terminal-user-input-signal'
 import { registerPtySerializer, registerPtyTitleSource } from './pty-buffer-serializer'
 import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
 import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
@@ -2561,12 +2562,27 @@ export function connectPanePty(
   const markTerminalInputSent = (): void => {
     lastTerminalInputAt = performance.now()
   }
-  const recordAcceptedTerminalInputForHibernation = (): void => {
+  const recordTerminalInputForHibernation = (): void => {
     useAppStore.getState().recordTerminalInput(cacheKey)
+  }
+  // Why: onData mixes real user input with xterm's parser auto-replies (focus
+  // reports, DA/DSR/CPR responses). Recording those replies as activity makes
+  // the hibernation planner treat a pane hidden after its agent finished as
+  // "input after done" forever. The core user-input signal fires only for real
+  // input, so hibernation activity records from it; onData recording remains
+  // solely as the fallback when the internal API is unavailable.
+  const userInputActivityDisposable = subscribeToTerminalUserInput(
+    pane.terminal,
+    recordTerminalInputForHibernation
+  )
+  const recordTerminalInputForHibernationFallback = (): void => {
+    if (userInputActivityDisposable === null) {
+      recordTerminalInputForHibernation()
+    }
   }
   const markAcceptedTerminalInputSent = (): void => {
     markTerminalInputSent()
-    recordAcceptedTerminalInputForHibernation()
+    recordTerminalInputForHibernationFallback()
   }
   const terminalTheme = pane.terminal.options.theme
   const terminalColorQueryReplies = terminalTheme
@@ -2737,7 +2753,7 @@ export function connectPanePty(
         .sendInputAccepted(data)
         .then((accepted) => {
           if (accepted) {
-            recordAcceptedTerminalInputForHibernation()
+            recordTerminalInputForHibernationFallback()
             observeAcceptedShellCommandInput(data)
             observeAcceptedTerminalInput(data, acknowledgedIntent)
             interruptInference.observeInputIntent(acknowledgedIntent)
@@ -5946,6 +5962,7 @@ export function connectPanePty(
         connectFallbackTimer = null
       }
       onDataDisposable.dispose()
+      userInputActivityDisposable?.dispose()
       terminalCapabilityRepliesDisposable.dispose()
       onResizeDisposable.dispose()
       onBufferChangeDisposable?.dispose()

--- a/src/renderer/src/components/terminal-pane/terminal-user-input-signal.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-user-input-signal.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Terminal } from '@xterm/xterm'
+import { subscribeToTerminalUserInput } from './terminal-user-input-signal'
+
+type CoreServiceAccess = {
+  _core: {
+    coreService: {
+      triggerDataEvent: (data: string, wasUserInput?: boolean) => void
+    }
+  }
+}
+
+// These tests run against the real vendored @xterm/xterm build on purpose:
+// the subscription reaches a core-internal API, so an xterm upgrade that
+// removes or reshapes it must fail here loudly instead of silently dropping
+// terminal activity tracking to the onData fallback.
+describe('subscribeToTerminalUserInput', () => {
+  it('fires for real user input and not for parser auto-replies', () => {
+    const terminal = new Terminal({ allowProposedApi: true })
+    const listener = vi.fn()
+    const subscription = subscribeToTerminalUserInput(terminal, listener)
+    expect(subscription).not.toBeNull()
+
+    const coreService = (terminal as unknown as CoreServiceAccess)._core.coreService
+    // Keyboard/IME/paste/mouse paths mark their data as user input.
+    coreService.triggerDataEvent('a', true)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    // Parser-generated replies (focus reports, DA/DSR/CPR responses) are not
+    // user input and must not fire the signal, while still flowing to onData.
+    const onData = vi.fn()
+    terminal.onData(onData)
+    coreService.triggerDataEvent('\x1b[O', false)
+    coreService.triggerDataEvent('\x1b[?1;2c')
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(onData).toHaveBeenCalledTimes(2)
+
+    subscription?.dispose()
+    coreService.triggerDataEvent('b', true)
+    expect(listener).toHaveBeenCalledTimes(1)
+    terminal.dispose()
+  })
+
+  it('returns null when the core signal is unavailable', () => {
+    const listener = vi.fn()
+    expect(subscribeToTerminalUserInput({} as never, listener)).toBeNull()
+    expect(
+      subscribeToTerminalUserInput({ _core: { coreService: {} } } as never, listener)
+    ).toBeNull()
+    expect(
+      subscribeToTerminalUserInput(
+        {
+          _core: {
+            coreService: {
+              onUserInput: () => {
+                throw new Error('unavailable')
+              }
+            }
+          }
+        } as never,
+        listener
+      )
+    ).toBeNull()
+    // A reshaped internal that subscribes but returns no usable disposable
+    // must read as unavailable, so callers keep their onData fallback.
+    expect(
+      subscribeToTerminalUserInput(
+        { _core: { coreService: { onUserInput: () => undefined } } } as never,
+        listener
+      )
+    ).toBeNull()
+    expect(
+      subscribeToTerminalUserInput(
+        { _core: { coreService: { onUserInput: () => ({}) } } } as never,
+        listener
+      )
+    ).toBeNull()
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-user-input-signal.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-user-input-signal.ts
@@ -1,0 +1,45 @@
+import type { Terminal } from '@xterm/xterm'
+
+// Why: xterm's public onData stream mixes real user input (keyboard, IME,
+// paste, mouse reports) with parser-generated auto-replies (focus in/out
+// reports, DA/DSR/CPR query responses). The core service already classifies
+// the two — its onUserInput event fires only for real input — but that
+// classification is not exposed on the public API.
+type TerminalWithCoreUserInput = {
+  _core?: {
+    coreService?: {
+      onUserInput?: (listener: () => void) => { dispose?: unknown } | undefined
+    }
+  }
+}
+
+/**
+ * Subscribe to xterm's core user-input signal. Fires only for real user
+ * input, never for the emulator's synthetic query replies that also flow
+ * through onData.
+ *
+ * Returns null when the internal API is unavailable (e.g. after an xterm
+ * upgrade) so callers can fall back to onData-based recording — degrading to
+ * the historical behavior instead of losing input tracking.
+ */
+export function subscribeToTerminalUserInput(
+  terminal: Terminal,
+  listener: () => void
+): { dispose: () => void } | null {
+  const coreService = (terminal as unknown as TerminalWithCoreUserInput)._core?.coreService
+  if (!coreService || typeof coreService.onUserInput !== 'function') {
+    return null
+  }
+  try {
+    const subscription = coreService.onUserInput(listener)
+    // Why: a reshaped internal that subscribes but returns no disposable must
+    // not be treated as live — callers disable their onData fallback on a
+    // non-null return, and activity tracking would silently disappear.
+    if (subscription && typeof subscription.dispose === 'function') {
+      return subscription as { dispose: () => void }
+    }
+    return null
+  } catch {
+    return null
+  }
+}

--- a/src/renderer/src/lib/agent-hibernation-input-guard.ts
+++ b/src/renderer/src/lib/agent-hibernation-input-guard.ts
@@ -1,0 +1,37 @@
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+
+export function lastInputBlocksHibernation(entry: AgentStatusEntry, inputAt: number): boolean {
+  // Why: attribute the last real input to the state segment it landed in —
+  // stateHistory entries in order, then the current state as the open tail.
+  // Input during any 'working' segment is a draft or queued message, and
+  // input in the open 'done' tail is post-completion engagement; both die
+  // with the PTY, so they block. Input during input-expecting states
+  // ('waiting', 'blocked') or in a done segment that later transitioned
+  // onward was consumed as a submission and must not block — otherwise every
+  // session with a mid-turn permission answer would never hibernate.
+  // Ties (input stamped the same millisecond as a segment start) resolve
+  // toward blocking: when the input could belong to either neighbor, prefer
+  // keeping the pane alive over risking a lost draft.
+  if (inputAt >= entry.stateStartedAt) {
+    if (entry.state === 'working' || entry.state === 'done') {
+      return true
+    }
+    if (inputAt > entry.stateStartedAt) {
+      return false
+    }
+  }
+  for (let i = entry.stateHistory.length - 1; i >= 0; i--) {
+    const past = entry.stateHistory[i]
+    if (!past || inputAt < past.startedAt) {
+      continue
+    }
+    if (past.state === 'working') {
+      return true
+    }
+    if (inputAt > past.startedAt) {
+      return false
+    }
+  }
+  // Input older than all recorded segments predates anything still at risk.
+  return false
+}

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -130,8 +130,118 @@ describe('agent sleep planner', () => {
       plannedWorktrees(snapshot({ lastTerminalInputAtByPaneKey: { [`tab-1:${LEAF}`]: OLD + 1 } }))
     ).toEqual([])
     expect(
-      plannedWorktrees(snapshot({ lastTerminalInputAtByPaneKey: { [`tab-1:${LEAF}`]: OLD } }))
+      plannedWorktrees(snapshot({ lastTerminalInputAtByPaneKey: { [`tab-1:${LEAF}`]: OLD - 1 } }))
     ).toEqual(['wt-bg'])
+    // A millisecond tie between the input stamp and the done transition
+    // resolves toward blocking — the keystroke may be a draft character.
+    expect(
+      plannedWorktrees(snapshot({ lastTerminalInputAtByPaneKey: { [`tab-1:${LEAF}`]: OLD } }))
+    ).toEqual([])
+  })
+
+  it('blocks hibernation when real input arrived after the turn started', () => {
+    // Regression: a draft typed while the agent was still working lands before
+    // the done timestamp, so the old input-after-done compare was blind to it
+    // and the hibernation kill discarded the TUI composer's contents.
+    const turnStartedAt = OLD - 60_000
+    const withTurn = entry({
+      stateHistory: [{ state: 'working', prompt: 'make it so', startedAt: turnStartedAt }]
+    })
+    expect(
+      plannedWorktrees(
+        snapshot({
+          agentStatusByPaneKey: { [withTurn.paneKey]: withTurn },
+          lastTerminalInputAtByPaneKey: { [withTurn.paneKey]: turnStartedAt + 30_000 }
+        })
+      )
+    ).toEqual([])
+    // The submission that started the turn precedes the working transition
+    // and must not block hibernation.
+    expect(
+      plannedWorktrees(
+        snapshot({
+          agentStatusByPaneKey: { [withTurn.paneKey]: withTurn },
+          lastTerminalInputAtByPaneKey: { [withTurn.paneKey]: turnStartedAt - 1_000 }
+        })
+      )
+    ).toEqual(['wt-bg'])
+    // Input after done still blocks, with or without turn history.
+    expect(
+      plannedWorktrees(
+        snapshot({
+          agentStatusByPaneKey: { [withTurn.paneKey]: withTurn },
+          lastTerminalInputAtByPaneKey: { [withTurn.paneKey]: OLD + 1 }
+        })
+      )
+    ).toEqual([])
+  })
+
+  it('attributes input to its state segment across working/waiting cycles', () => {
+    // A turn can pause for permission (working → waiting → working → done). A
+    // draft typed during the FIRST working segment is older than the last
+    // working start, so a last-working-start guard misses it; and a permission
+    // answer typed during the waiting segment must NOT block, or every session
+    // with a mid-turn permission prompt would never hibernate.
+    const multiSegment = entry({
+      stateHistory: [
+        { state: 'working', prompt: 'make it so', startedAt: OLD - 90_000 },
+        { state: 'waiting', prompt: 'make it so', startedAt: OLD - 60_000 },
+        { state: 'working', prompt: 'make it so', startedAt: OLD - 30_000 }
+      ]
+    })
+    // Draft typed during the first working segment: blocked.
+    expect(
+      plannedWorktrees(
+        snapshot({
+          agentStatusByPaneKey: { [multiSegment.paneKey]: multiSegment },
+          lastTerminalInputAtByPaneKey: { [multiSegment.paneKey]: OLD - 75_000 }
+        })
+      )
+    ).toEqual([])
+    // Permission answer typed during the waiting segment: consumed, eligible.
+    expect(
+      plannedWorktrees(
+        snapshot({
+          agentStatusByPaneKey: { [multiSegment.paneKey]: multiSegment },
+          lastTerminalInputAtByPaneKey: { [multiSegment.paneKey]: OLD - 45_000 }
+        })
+      )
+    ).toEqual(['wt-bg'])
+    // A submission typed in a PREVIOUS done segment that already transitioned
+    // onward was consumed and must not block the next completion.
+    const resubmitted = entry({
+      stateHistory: [
+        { state: 'done', prompt: 'earlier turn', startedAt: OLD - 90_000 },
+        { state: 'working', prompt: 'make it so', startedAt: OLD - 30_000 }
+      ]
+    })
+    expect(
+      plannedWorktrees(
+        snapshot({
+          agentStatusByPaneKey: { [resubmitted.paneKey]: resubmitted },
+          lastTerminalInputAtByPaneKey: { [resubmitted.paneKey]: OLD - 45_000 }
+        })
+      )
+    ).toEqual(['wt-bg'])
+    // Boundary ties resolve toward blocking: input stamped exactly at a
+    // working-segment start blocks, and a tie at a waiting-segment start also
+    // blocks because it could belong to the preceding working segment.
+    expect(
+      plannedWorktrees(
+        snapshot({
+          agentStatusByPaneKey: { [multiSegment.paneKey]: multiSegment },
+          lastTerminalInputAtByPaneKey: { [multiSegment.paneKey]: OLD - 30_000 }
+        })
+      )
+    ).toEqual([])
+    expect(
+      plannedWorktrees(
+        snapshot({
+          agentStatusByPaneKey: { [multiSegment.paneKey]: multiSegment },
+          lastTerminalInputAtByPaneKey: { [multiSegment.paneKey]: OLD - 60_000 }
+        })
+      )
+    ).toEqual([])
   })
 
   it('uses foreground terminal tab last-seen as the idle baseline when it is newer', () => {

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -5,6 +5,7 @@ import {
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
+import { lastInputBlocksHibernation } from './agent-hibernation-input-guard'
 import type { GlobalSettings, TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 
@@ -162,7 +163,14 @@ function getEligiblePane(args: {
     return null
   }
   const inputAt = lastTerminalInputAtByPaneKey[entry.paneKey]
-  if (typeof inputAt === 'number' && Number.isFinite(inputAt) && inputAt > entry.updatedAt) {
+  // Why: killing the PTY discards the TUI composer's draft and any queued
+  // messages. The old input-after-done compare missed drafts typed while the
+  // agent was still working — the class that lost a user's draft in prod.
+  if (
+    typeof inputAt === 'number' &&
+    Number.isFinite(inputAt) &&
+    lastInputBlocksHibernation(entry, inputAt)
+  ) {
     return null
   }
   const livePane = getPaneLivePtyId(entry, layout)


### PR DESCRIPTION
## ELI5

Orca can put a finished AI agent's terminal to sleep after 30 idle minutes to free memory, and wake it back up when you come back to it. To know a terminal is idle, Orca watches for typing. The problem: the terminal component sends invisible housekeeping messages (for example "the user switched away") down the same channel as real typing, and Orca counted those as typing. Two things went wrong because of that. Most finished agents never went to sleep, because switching away from one looked like typing in it. And a half-written message you hadn't sent yet could still be destroyed by sleep, because the typing check compared against the wrong point in time — anything typed while the agent was still answering didn't count.

This PR makes Orca count only real typing (the terminal component already knows the difference internally; we now ask it directly), and never sleep a pane you've typed into since the agent's current task began. Sleep now actually happens for finished agents, and it never destroys a draft.

## Symptom

Two agent-hibernation idle-tracking bugs with one root cause — pane activity is recorded from xterm's `onData` stream, which mixes real user input with the emulator's parser auto-replies (focus reports, DA/DSR/CPR query responses):

1. **Hibernation never fires for panes hidden after their agent finished.** Hiding a pane makes xterm emit a focus-out report to the PTY; recording it as pane input trips the planner's input-after-done guard permanently. Measured live on main: hiding a done claude pane bumped `lastTerminalInputAtByPaneKey` to done+73s and the pane never hibernated across 12+ minutes of polling. The only panes that hibernate today are ones hidden *while the agent was still working*.
2. **A draft typed while the agent is working is invisible to the guard.** The guard compared input time against the done timestamp; a mid-turn draft predates done, so the hibernation kill discards the TUI composer's contents and any queued messages. One production occurrence (flagged out-of-scope in `#7145`).

## What changes

- **New `terminal-user-input-signal.ts`**: subscribes to xterm's core user-input classification, which fires only for keyboard/IME/paste/mouse input — never for parser auto-replies. This is a defensive `_core` reach in the codebase's established pattern (`pane-terminal-foreground-render-settle.ts`, `pane-terminal-unicode-provider.ts`): structural optional typing, runtime shape validation including the returned disposable, and `null` on any mismatch so the caller keeps its fallback. A test against the real vendored xterm pins the internal — an xterm upgrade that reshapes it fails CI loudly instead of silently degrading.
- **`pty-connection.ts`** records hibernation activity from that signal; the `onData` recording remains solely as the fallback when the internal is unavailable (degrades to historical behavior, never to no tracking). The local interactive-redraw timestamp and all PTY write forwarding are untouched.
- **Planner (`agent-hibernation-input-guard.ts`)**: the input-after-done compare is replaced with state-segment attribution. The last real input blocks hibernation iff it landed in a `working` segment (draft/queued message) or the open `done` tail (post-completion engagement). Input during `waiting`/`blocked` segments (permission answers) or in a done segment that later transitioned onward (consumed submissions) does not block — otherwise every session with a mid-turn permission prompt would never hibernate. Millisecond boundary ties resolve toward blocking.

Direct input seams (paste paths, drag-drop, quick commands, keybinding sends, remote/mobile driver input) already record via `recordTerminalUserInputForLeaf` and are unchanged. The macOS dictation/native-text forwarder routes through `terminal.input()`, which marks its data as user input — verified against the vendored build.

## Validation (Brennan's PR process)

- **Regression tests**: focused suites green — `terminal-user-input-signal` (real-xterm classification + malformed-internal fallbacks), `pty-connection` (core-signal recording vs synthetic onData replies, fallback mode, disposal), `agent-hibernation-planner` (mid-turn draft blocks, permission answer doesn't, consumed submission doesn't, boundary ties), plus coordinator and store-cascades: **461 passed**. Both headline tests fail against unchanged main code (verified by running them over the pre-change tree). `pnpm run typecheck` clean.
- **Code-review loop**: three rounds. Round 1 found a real hole — a `working → waiting → working → done` turn under-guarded drafts typed in the first working segment — which drove the segment-attribution design; round 2 found the boundary-tie misattribution; round 3 clean. All findings fixed and pinned by tests.
- **Live E2E (dev build, 60s idle setting, real claude sessions)**:
  - *Hide-after-done now hibernates*: hiding the pane did **not** bump the input timestamp (measured directly), and hibernation fired at ~2.5 min — the exact sequence that never fires on main. On reveal, `#7145`'s wake consumed the record and rebound a fresh PTY (the two changes compose).
  - *Draft protection*: an identical hide with a real typed draft observed for 5.5 minutes — no hibernation, agent status intact, and the draft visibly preserved in the composer on reveal.

## How we know it's performant and has no hidden failure modes

**No added typing-path work, by construction.** The change moves one existing bookkeeping write (a per-keystroke timestamp into the store) from one xterm event to another; the write itself and everything on the PTY forwarding path are unchanged. Synthetic reply bursts, which previously triggered that write, now trigger nothing — the steady-state write count strictly decreases. No new timers, no polling, no per-keystroke allocations; exactly one additional event subscription per pane binding, disposed with the binding (disposal is test-pinned).

**Measured on this branch.** The existing terminal typing-latency perf spec (`tests/e2e/terminal-typing-latency.spec.ts`, which fails on visible echo lag) passes on this branch: `1 passed, 8.9s test body`.

**Bounded planner cost.** The draft-guard segment walk is bounded by the capped agent state history and runs only inside the hibernation coordinator's 60-second tick, only for panes that already passed every other eligibility gate — never on typing, focus, render, or tab/workspace-switch paths.

**The one risky dependency fails safe.** The core user-input event is xterm-internal. It is wrapped in shape validation (including the returned disposable); on any mismatch the code returns to today's `onData`-based recording automatically — the failure mode is *the old behavior*, never *no input tracking*. The real-xterm pin test makes an xterm upgrade that reshapes the internal fail CI loudly instead of degrading silently.

**Blast radius and rollback.** Hibernation is opt-in (`experimentalAgentHibernation`, off by default), so the planner change is flag-gated; the recording swap only feeds hibernation state. Post-merge signals that would indicate a problem, in order of severity: a lost-draft report (guard failure), finished agents accumulating without hibernating (recording failure — visible as memory growth for flag users), or the pin test failing on an xterm bump (upgrade drift, caught in CI). Rollback is a single-commit revert; a softer switch is forcing the subscription helper to return `null` (one line), which restores pre-PR recording without touching the planner.

## Provider/platform coverage

Local: covered (unit + live). SSH/remote-runtime/mobile: unaffected — activity recording is renderer-side and transport-agnostic; remote/mobile driver input records through its existing main-side seam. macOS IME/dictation: covered (see above). Windows/Linux: no platform-conditional code.

## Residual gaps

- The core user-input signal is xterm-internal API. Mitigations: shape validation, fallback to historical onData recording, and a real-xterm pin test that fails CI on upgrade drift.
- The live draft scenario exercised a post-done draft (the agent finished before the draft was typed); the mid-turn variant is pinned by unit tests over the same attribution code path.
- Hibernation remains experimental and off by default; these fixes are prerequisites for any future default-on decision.
