### PR TITLE
feat(ssh): discover pre-existing tmux agent sessions on remote hosts

### DIFF
--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -15,6 +15,7 @@ import type {
   SshConnectionStatus,
   SshConnectionState
 } from '../../shared/ssh-types'
+import type { HostSessionsResult } from '../../shared/host-session-types'
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../shared/constants'
 import { isRuntimeOwnedSshTargetId } from '../../shared/execution-host'
 import { isAuthError } from '../ssh/ssh-connection-utils'
@@ -1176,6 +1177,19 @@ export function registerSshHandlers(
     const ports = session?.getPortScanner()?.getDetectedPorts(args.targetId) ?? []
     return enrichDetected(args.targetId, ports)
   })
+
+  ipcMain.handle(
+    'ssh:discoverHostSessions',
+    async (_event, args: { targetId: string }): Promise<HostSessionsResult> => {
+      const mux = getActiveMultiplexer(args.targetId)
+      if (!mux || mux.isDisposed()) {
+        // Why: discovery is passive UI polling. A disconnected host has nothing to
+        // observe until reconnect and should not surface an IPC error.
+        return { sessions: [], tmuxAvailable: false }
+      }
+      return (await mux.request('host.discoverSessions')) as HostSessionsResult
+    }
+  )
 
   return { connectionManager, sshStore }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -344,6 +344,7 @@ import type {
   WorkspacePortScanRequest,
   WorkspacePortScanResult
 } from '../shared/workspace-ports'
+import type { HostSessionsResult } from '../shared/host-session-types'
 import type { GhAuthDiagnostic } from '../shared/github-auth-types'
 import type {
   SshConnectionState,
@@ -2836,6 +2837,7 @@ export type PreloadApi = {
     removePortForward: (args: { id: string }) => Promise<PortForwardEntry | null>
     listPortForwards: (args?: { targetId?: string }) => Promise<PortForwardEntry[]>
     listDetectedPorts: (args: { targetId: string }) => Promise<EnrichedDetectedPort[]>
+    discoverHostSessions: (args: { targetId: string }) => Promise<HostSessionsResult>
     onPortForwardsChanged: (
       callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -123,6 +123,7 @@ import type {
   PortForwardEntry,
   EnrichedDetectedPort
 } from '../shared/ssh-types'
+import type { HostSessionsResult } from '../shared/host-session-types'
 import type {
   AgentStatusIpcPayload,
   MigrationUnsupportedPtyEntry
@@ -3880,6 +3881,9 @@ const api = {
 
     listDetectedPorts: (args: { targetId: string }): Promise<EnrichedDetectedPort[]> =>
       ipcRenderer.invoke('ssh:listDetectedPorts', args),
+
+    discoverHostSessions: (args: { targetId: string }): Promise<HostSessionsResult> =>
+      ipcRenderer.invoke('ssh:discoverHostSessions', args),
 
     onPortForwardsChanged: (
       callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void

--- a/src/relay/host-sessions-handler.test.ts
+++ b/src/relay/host-sessions-handler.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyAgentFromProcTable,
+  parseProcTable,
+  parseTmuxPaneLine,
+  type ProcEntry
+} from './host-sessions-handler'
+
+const TAB = '\t'
+
+describe('parseTmuxPaneLine', () => {
+  it('parses an attached pane', () => {
+    expect(
+      parseTmuxPaneLine(['api', '/home/ubuntu/code/api', 'node', '1', '4242'].join(TAB))
+    ).toEqual({
+      session: 'api',
+      cwd: '/home/ubuntu/code/api',
+      command: 'node',
+      attached: true,
+      pid: 4242
+    })
+  })
+
+  it('treats a zero client count as detached', () => {
+    expect(
+      parseTmuxPaneLine(['web', '/home/ubuntu/web', 'zsh', '0', '77'].join(TAB))?.attached
+    ).toBe(false)
+  })
+
+  it('treats a client count above one as attached', () => {
+    expect(
+      parseTmuxPaneLine(['web', '/home/ubuntu/web', 'zsh', '2', '77'].join(TAB))?.attached
+    ).toBe(true)
+  })
+
+  it('returns undefined pid when pane_pid is non-numeric', () => {
+    expect(parseTmuxPaneLine(['s', '/tmp', 'sh', '1', ''].join(TAB))?.pid).toBeUndefined()
+  })
+
+  it('returns null when required fields are missing', () => {
+    expect(parseTmuxPaneLine('')).toBeNull()
+    expect(parseTmuxPaneLine(['only-session'].join(TAB))).toBeNull()
+    expect(parseTmuxPaneLine(['', '/tmp', 'sh', '1', '5'].join(TAB))).toBeNull()
+  })
+
+  it('keeps commands that contain spaces intact', () => {
+    expect(
+      parseTmuxPaneLine(['s', '/tmp', 'node dist/server.js', '1', '9'].join(TAB))?.command
+    ).toBe('node dist/server.js')
+  })
+})
+
+describe('parseProcTable', () => {
+  it('parses pid/ppid/comm rows and preserves comms with spaces', () => {
+    const table = parseProcTable(['  100   1 zsh', ' 101 100 node dist/x.js', 'garbage'].join('\n'))
+    expect(table.get(100)).toEqual({ ppid: 1, comm: 'zsh' })
+    expect(table.get(101)).toEqual({ ppid: 100, comm: 'node dist/x.js' })
+    expect(table.size).toBe(2)
+  })
+
+  it('returns an empty map for empty input', () => {
+    expect(parseProcTable('').size).toBe(0)
+  })
+})
+
+describe('classifyAgentFromProcTable', () => {
+  const table = (rows: [number, number, string][]): Map<number, ProcEntry> =>
+    new Map(rows.map(([pid, ppid, comm]) => [pid, { ppid, comm }]))
+
+  it('detects claude nested below the pane shell', () => {
+    // pane_pid 100 (zsh) → 200 (node) → 300 (claude)
+    const procs = table([
+      [100, 1, 'zsh'],
+      [200, 100, 'node'],
+      [300, 200, 'claude']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBe('claude')
+  })
+
+  it('detects codex as a direct child', () => {
+    const procs = table([
+      [100, 1, 'zsh'],
+      [200, 100, 'codex']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBe('codex')
+  })
+
+  it('does not match unrelated commands like claude-code-lookalike suffixes', () => {
+    const procs = table([
+      [100, 1, 'zsh'],
+      [200, 100, 'claudette']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBeNull()
+  })
+
+  it('returns null when the subtree has no agent', () => {
+    const procs = table([
+      [100, 1, 'zsh'],
+      [200, 100, 'vim']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBeNull()
+  })
+
+  it('does not match agents outside the pane subtree', () => {
+    // claude (300) lives under a different root (999), not under pane_pid 100.
+    const procs = table([
+      [100, 1, 'zsh'],
+      [999, 1, 'bash'],
+      [300, 999, 'claude']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBeNull()
+  })
+
+  it('returns null when rootPid is undefined', () => {
+    expect(classifyAgentFromProcTable(undefined, table([[1, 0, 'claude']]))).toBeNull()
+  })
+
+  it('terminates on cyclic ppid references', () => {
+    // Defensive: a malformed table where 100↔200 point at each other must not hang.
+    const procs = table([
+      [100, 200, 'zsh'],
+      [200, 100, 'vim']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBeNull()
+  })
+})

--- a/src/relay/host-sessions-handler.ts
+++ b/src/relay/host-sessions-handler.ts
@@ -1,0 +1,207 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import type { RelayDispatcher, RequestContext } from './dispatcher'
+// Keep in sync with src/shared/host-session-types.ts — HostSession/HostSessionAgent.
+import type {
+  HostSession,
+  HostSessionAgent,
+  HostSessionsResult
+} from '../shared/host-session-types'
+
+const execFileAsync = promisify(execFile)
+
+// tmux -F fields are joined with a literal tab; a real path never contains one.
+const TAB = '\t'
+
+// Why: cap the probe so a host with a runaway number of panes can't produce an
+// unbounded payload or make the git-branch fan-out dominate the response time.
+const MAX_SESSIONS = 100
+
+// Why: match the agent by the leaf command in the pane's process subtree. tmux
+// only reports pane_current_command (the immediate foreground process), but the
+// real agent (claude/codex) is usually a descendant of a shell, so we walk the
+// process tree rather than trusting the foreground command alone.
+const AGENT_PATTERNS: { agent: Exclude<HostSessionAgent, null>; test: RegExp }[] = [
+  { agent: 'claude', test: /(^|\/)claude\b/i },
+  { agent: 'codex', test: /(^|\/)codex\b/i }
+]
+
+const TMUX_PANE_FORMAT = [
+  '#{session_name}',
+  '#{pane_current_path}',
+  '#{pane_current_command}',
+  '#{session_attached}',
+  '#{pane_pid}'
+].join(TAB)
+
+export type RawPane = Pick<HostSession, 'session' | 'cwd' | 'command' | 'attached' | 'pid'>
+
+export type ProcEntry = { ppid: number; comm: string }
+
+export class HostSessionsHandler {
+  constructor(dispatcher: RelayDispatcher) {
+    dispatcher.onRequest('host.discoverSessions', (_params, context: RequestContext) =>
+      this.discover(context)
+    )
+  }
+
+  // Why: the relay already runs ON the target host, so we probe tmux/ps/git
+  // locally — no SSH round-trip per probe like a client-side prober would need.
+  private async discover(context: RequestContext): Promise<HostSessionsResult> {
+    const paneOutput = await this.runTmuxListPanes(context.signal)
+    if (paneOutput === null) {
+      return { sessions: [], tmuxAvailable: false }
+    }
+
+    const panes = paneOutput
+      .split('\n')
+      .map(parseTmuxPaneLine)
+      .filter((pane): pane is RawPane => pane !== null)
+      .slice(0, MAX_SESSIONS)
+
+    if (panes.length === 0) {
+      return { sessions: [], tmuxAvailable: true }
+    }
+
+    const procTable = parseProcTable(await this.runPs(context.signal))
+    const branchByCwd = await this.resolveBranches(panes, context.signal)
+
+    const sessions: HostSession[] = panes.map((pane) => ({
+      ...pane,
+      agent: classifyAgentFromProcTable(pane.pid, procTable),
+      branch: branchByCwd.get(pane.cwd)
+    }))
+
+    return { sessions, tmuxAvailable: true }
+  }
+
+  private async runTmuxListPanes(signal?: AbortSignal): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync('tmux', ['list-panes', '-a', '-F', TMUX_PANE_FORMAT], {
+        signal
+      })
+      return stdout
+    } catch {
+      // tmux missing, or no server running → indistinguishable here and both mean
+      // "nothing to observe". Callers surface this as tmuxAvailable: false.
+      return null
+    }
+  }
+
+  private async runPs(signal?: AbortSignal): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,comm='], { signal })
+      return stdout
+    } catch {
+      // No ps → every pane stays classified as agent: null rather than failing.
+      return ''
+    }
+  }
+
+  private async resolveBranches(
+    panes: RawPane[],
+    signal?: AbortSignal
+  ): Promise<Map<string, string>> {
+    const uniqueCwds = [...new Set(panes.map((pane) => pane.cwd))]
+    const branchByCwd = new Map<string, string>()
+    await Promise.all(
+      uniqueCwds.map(async (cwd) => {
+        const branch = await this.gitBranch(cwd, signal)
+        if (branch) {
+          branchByCwd.set(cwd, branch)
+        }
+      })
+    )
+    return branchByCwd
+  }
+
+  private async gitBranch(cwd: string, signal?: AbortSignal): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', cwd, 'branch', '--show-current'], {
+        signal
+      })
+      return stdout.trim() || undefined
+    } catch {
+      return undefined
+    }
+  }
+}
+
+export function parseTmuxPaneLine(line: string): RawPane | null {
+  if (!line) {
+    return null
+  }
+  const fields = line.split(TAB)
+  if (fields.length < 5) {
+    return null
+  }
+  const [session, cwd, command, attached, pidRaw] = fields
+  if (!session || !cwd) {
+    return null
+  }
+  const pid = Number.parseInt(pidRaw, 10)
+  return {
+    session,
+    cwd,
+    command,
+    // session_attached is a client count ("0" when detached).
+    attached: attached !== '0' && attached !== '',
+    pid: Number.isNaN(pid) ? undefined : pid
+  }
+}
+
+// Why: `ps -axo pid=,ppid=,comm=` emits three space-separated columns with no
+// header (the `=` suffixes suppress it); comm may itself contain spaces, so we
+// anchor on the two leading numeric columns and keep the remainder as comm.
+export function parseProcTable(psStdout: string): Map<number, ProcEntry> {
+  const table = new Map<number, ProcEntry>()
+  for (const line of psStdout.split('\n')) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/)
+    if (!match) {
+      continue
+    }
+    table.set(Number.parseInt(match[1], 10), {
+      ppid: Number.parseInt(match[2], 10),
+      comm: match[3]
+    })
+  }
+  return table
+}
+
+export function classifyAgentFromProcTable(
+  rootPid: number | undefined,
+  table: Map<number, ProcEntry>
+): HostSessionAgent {
+  if (rootPid == null) {
+    return null
+  }
+
+  const childrenByPpid = new Map<number, number[]>()
+  for (const [pid, entry] of table) {
+    const siblings = childrenByPpid.get(entry.ppid) ?? []
+    siblings.push(pid)
+    childrenByPpid.set(entry.ppid, siblings)
+  }
+
+  const queue = [rootPid]
+  const seen = new Set<number>()
+  while (queue.length > 0) {
+    const pid = queue.shift()!
+    if (seen.has(pid)) {
+      continue
+    }
+    seen.add(pid)
+
+    const comm = table.get(pid)?.comm ?? ''
+    const hit = AGENT_PATTERNS.find((pattern) => pattern.test.test(comm))
+    if (hit) {
+      return hit.agent
+    }
+
+    for (const child of childrenByPpid.get(pid) ?? []) {
+      queue.push(child)
+    }
+  }
+
+  return null
+}

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -41,6 +41,7 @@ import { GitHandler } from './git-handler'
 import { PreflightHandler } from './preflight-handler'
 import { ExternalAutomationsHandler } from './external-automations-handler'
 import { PortScanHandler } from './port-scan-handler'
+import { HostSessionsHandler } from './host-sessions-handler'
 import { AgentExecHandler } from './agent-exec-handler'
 import { WorkspaceSessionHandler } from './workspace-session-handler'
 import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
@@ -436,6 +437,9 @@ async function main(): Promise<void> {
 
   const _portScanHandler = new PortScanHandler(dispatcher)
   void _portScanHandler
+
+  const _hostSessionsHandler = new HostSessionsHandler(dispatcher)
+  void _hostSessionsHandler
 
   const _agentExecHandler = new AgentExecHandler(dispatcher)
   void _agentExecHandler

--- a/src/shared/host-session-types.ts
+++ b/src/shared/host-session-types.ts
@@ -1,0 +1,30 @@
+// Types for host session discovery: enumerating pre-existing terminal
+// multiplexer (tmux) sessions on an SSH host and classifying which coding agent
+// each one is running. Unlike Orca's own workspace sessions, these are sessions
+// Orca does not own — they were started outside Orca (e.g. a bare `tmux` + agent
+// on the remote) and can only be observed by probing the host.
+
+export type HostSessionAgent = 'claude' | 'codex' | null
+
+export type HostSession = {
+  /** tmux session name. */
+  session: string
+  /** pane_current_path — working directory of the pane. */
+  cwd: string
+  /** pane_current_command — foreground command tmux reports for the pane. */
+  command: string
+  /** True when at least one client is attached to the session. */
+  attached: boolean
+  /** Agent detected by walking the pane's process subtree, or null if none. */
+  agent: HostSessionAgent
+  /** git branch at `cwd`, if the path is inside a repository. */
+  branch?: string
+  /** pane_pid — root of the process subtree used for agent classification. */
+  pid?: number
+}
+
+export type HostSessionsResult = {
+  sessions: HostSession[]
+  /** False when tmux is not installed or no server is running on the host. */
+  tmuxAvailable: boolean
+}


### PR DESCRIPTION
## What

Adds a relay-side probe that enumerates **tmux sessions already running on an SSH host** — sessions Orca does not own — and, for each pane, reports:

- which coding agent it's running (`claude` / `codex` / none), classified by walking the pane's **process subtree** (tmux only reports the immediate foreground command, so the real agent is usually a descendant of a shell);
- the pane's `cwd` and the **git branch** at that path;
- whether the session is attached.

New API: `orca.ssh.discoverHostSessions({ targetId }) → { sessions, tmuxAvailable }`.

## Why

When you run agents on a remote host, anything started outside Orca (a bare `tmux` + `claude`/`codex` on the box) is invisible to Orca today. This gives Orca a way to *observe* an environment it doesn't own, without taking it over.

## How

- **`src/relay/host-sessions-handler.ts`** — registers `host.discoverSessions`. Because the relay already executes **on the target host**, the probe runs `tmux list-panes` / `ps` / `git` **locally with no per-probe SSH round-trip**, and is cancellable via the request signal. Parsing/classification is factored into pure functions (`parseTmuxPaneLine`, `parseProcTable`, `classifyAgentFromProcTable`) with unit tests.
- **`src/main/ipc/ssh.ts`** — `ssh:discoverHostSessions` resolves the target's active multiplexer and forwards the RPC; a disconnected host returns `{ sessions: [], tmuxAvailable: false }` rather than erroring.
- **`src/shared/host-session-types.ts`** — canonical `HostSession` / `HostSessionsResult`.
- **preload** — exposes `ssh.discoverHostSessions`.

## Cross-platform / degradation

Missing `tmux` → `tmuxAvailable: false`; missing `ps`/`git` → `agent: null` / no branch. No hard failures. Windows hosts (no tmux) return an empty result. Matches the `SSH use case` and `Cross-Platform` requirements in AGENTS.md.

## Scope

Backend pipeline only. The SSH-host **UI surface** (panel + status-bar segment + polling) is intentionally a follow-up so this diff stays reviewable.

## Test plan

- [x] `vitest` — 15 unit tests (agent classification incl. subtree isolation and cyclic-ppid safety, tmux/ps parsing)
- [x] `typecheck` (node + cli + web) clean
- [x] `oxlint` clean on changed files
- [ ] Manual: connect an SSH host running a detached `tmux` + `claude`, call `discoverHostSessions`, confirm the session/agent/branch are reported

## ELI5

Orca can discover tmux sessions already running on an SSH host that it didn’t start. See agent, branch, and attach state for external sessions on that box.
