### PR TITLE
feat(ssh): collect remote host resource metrics over the relay

### DIFF
--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -15,6 +15,7 @@ import type {
   SshConnectionStatus,
   SshConnectionState
 } from '../../shared/ssh-types'
+import type { HostMetricsResult } from '../../shared/host-resource-metrics-types'
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../shared/constants'
 import { isRuntimeOwnedSshTargetId } from '../../shared/execution-host'
 import { isAuthError } from '../ssh/ssh-connection-utils'
@@ -1176,6 +1177,19 @@ export function registerSshHandlers(
     const ports = session?.getPortScanner()?.getDetectedPorts(args.targetId) ?? []
     return enrichDetected(args.targetId, ports)
   })
+
+  ipcMain.handle(
+    'ssh:getHostMetrics',
+    async (_event, args: { targetId: string }): Promise<HostMetricsResult> => {
+      const mux = getActiveMultiplexer(args.targetId)
+      if (!mux || mux.isDisposed()) {
+        // Why: metrics are passive polling; a disconnected host has none until
+        // reconnect and should not raise an IPC error.
+        return { metrics: null }
+      }
+      return (await mux.request('host.metrics')) as HostMetricsResult
+    }
+  )
 
   return { connectionManager, sshStore }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -344,6 +344,7 @@ import type {
   WorkspacePortScanRequest,
   WorkspacePortScanResult
 } from '../shared/workspace-ports'
+import type { HostMetricsResult } from '../shared/host-resource-metrics-types'
 import type { GhAuthDiagnostic } from '../shared/github-auth-types'
 import type {
   SshConnectionState,
@@ -2836,6 +2837,7 @@ export type PreloadApi = {
     removePortForward: (args: { id: string }) => Promise<PortForwardEntry | null>
     listPortForwards: (args?: { targetId?: string }) => Promise<PortForwardEntry[]>
     listDetectedPorts: (args: { targetId: string }) => Promise<EnrichedDetectedPort[]>
+    getHostMetrics: (args: { targetId: string }) => Promise<HostMetricsResult>
     onPortForwardsChanged: (
       callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -123,6 +123,7 @@ import type {
   PortForwardEntry,
   EnrichedDetectedPort
 } from '../shared/ssh-types'
+import type { HostMetricsResult } from '../shared/host-resource-metrics-types'
 import type {
   AgentStatusIpcPayload,
   MigrationUnsupportedPtyEntry
@@ -3880,6 +3881,9 @@ const api = {
 
     listDetectedPorts: (args: { targetId: string }): Promise<EnrichedDetectedPort[]> =>
       ipcRenderer.invoke('ssh:listDetectedPorts', args),
+
+    getHostMetrics: (args: { targetId: string }): Promise<HostMetricsResult> =>
+      ipcRenderer.invoke('ssh:getHostMetrics', args),
 
     onPortForwardsChanged: (
       callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void

--- a/src/relay/host-metrics-handler.test.ts
+++ b/src/relay/host-metrics-handler.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { buildHostResourceMetrics } from './host-metrics-handler'
+
+describe('buildHostResourceMetrics', () => {
+  it('computes used memory and usage percent', () => {
+    const m = buildHostResourceMetrics({
+      totalMemory: 16_000_000_000,
+      freeMemory: 4_000_000_000,
+      cpuCoreCount: 8,
+      loadAverage: [1.5, 2.5, 3.5],
+      uptimeSeconds: 3600,
+      platform: 'linux'
+    })
+    expect(m.usedMemory).toBe(12_000_000_000)
+    expect(m.memoryUsagePercent).toBeCloseTo(75)
+    expect(m).toMatchObject({
+      cpuCoreCount: 8,
+      loadAverage1m: 1.5,
+      loadAverage5m: 2.5,
+      loadAverage15m: 3.5,
+      uptimeSeconds: 3600,
+      platform: 'linux'
+    })
+  })
+
+  it('clamps NaN/negative os values to safe numbers', () => {
+    const m = buildHostResourceMetrics({
+      totalMemory: Number.NaN,
+      freeMemory: -1,
+      cpuCoreCount: 0,
+      loadAverage: [Number.NaN, undefined as unknown as number, -2],
+      uptimeSeconds: -5,
+      platform: 'linux'
+    })
+    expect(m.totalMemory).toBe(0)
+    expect(m.freeMemory).toBe(0)
+    expect(m.usedMemory).toBe(0)
+    expect(m.memoryUsagePercent).toBe(0)
+    // cpuCoreCount floors at 1 so a renderer never divides by zero cores.
+    expect(m.cpuCoreCount).toBe(1)
+    expect(m.loadAverage1m).toBe(0)
+    expect(m.loadAverage5m).toBe(0)
+    expect(m.loadAverage15m).toBe(0)
+    expect(m.uptimeSeconds).toBe(0)
+  })
+
+  it('never reports free memory above total (guards inconsistent reads)', () => {
+    const m = buildHostResourceMetrics({
+      totalMemory: 1000,
+      freeMemory: 5000,
+      cpuCoreCount: 2,
+      loadAverage: [0, 0, 0],
+      uptimeSeconds: 1,
+      platform: 'darwin'
+    })
+    expect(m.freeMemory).toBe(1000)
+    expect(m.usedMemory).toBe(0)
+    expect(m.memoryUsagePercent).toBe(0)
+  })
+
+  it('reports zero load on Windows-style [0,0,0]', () => {
+    const m = buildHostResourceMetrics({
+      totalMemory: 8_000_000_000,
+      freeMemory: 8_000_000_000,
+      cpuCoreCount: 4,
+      loadAverage: [0, 0, 0],
+      uptimeSeconds: 100,
+      platform: 'win32'
+    })
+    expect(m.loadAverage1m).toBe(0)
+    expect(m.platform).toBe('win32')
+  })
+})

--- a/src/relay/host-metrics-handler.ts
+++ b/src/relay/host-metrics-handler.ts
@@ -1,0 +1,67 @@
+import os from 'node:os'
+import type { RelayDispatcher } from './dispatcher'
+// Keep in sync with src/shared/host-resource-metrics-types.ts — HostResourceMetrics.
+import type { HostMetricsResult, HostResourceMetrics } from '../shared/host-resource-metrics-types'
+
+export type HostMetricsInput = {
+  totalMemory: number
+  freeMemory: number
+  cpuCoreCount: number
+  loadAverage: number[]
+  uptimeSeconds: number
+  platform: NodeJS.Platform
+}
+
+export class HostMetricsHandler {
+  constructor(dispatcher: RelayDispatcher) {
+    // Why: the relay executes on the target host, so os.* here reflects the remote
+    // machine's CPU/memory/load — the metric a client-side prober cannot read.
+    dispatcher.onRequest('host.metrics', async () => this.collect())
+  }
+
+  private async collect(): Promise<HostMetricsResult> {
+    try {
+      return {
+        metrics: buildHostResourceMetrics({
+          totalMemory: os.totalmem(),
+          freeMemory: os.freemem(),
+          cpuCoreCount: os.cpus().length,
+          loadAverage: os.loadavg(),
+          uptimeSeconds: os.uptime(),
+          platform: process.platform
+        })
+      }
+    } catch {
+      // os.* is effectively infallible, but guard so a probe never rejects.
+      return { metrics: null }
+    }
+  }
+}
+
+// Why: os.* can return NaN/negative/undefined on exotic platforms; clamp every
+// numeric field so the renderer can render without defensive checks.
+function clampNumber(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0
+  }
+  return Math.max(0, value)
+}
+
+export function buildHostResourceMetrics(input: HostMetricsInput): HostResourceMetrics {
+  const totalMemory = clampNumber(input.totalMemory)
+  const freeMemory = Math.min(clampNumber(input.freeMemory), totalMemory)
+  const usedMemory = Math.max(0, totalMemory - freeMemory)
+  const load = input.loadAverage
+  return {
+    totalMemory,
+    freeMemory,
+    usedMemory,
+    memoryUsagePercent: totalMemory > 0 ? (usedMemory / totalMemory) * 100 : 0,
+    cpuCoreCount: Math.max(1, clampNumber(input.cpuCoreCount)),
+    loadAverage1m: clampNumber(load[0]),
+    loadAverage5m: clampNumber(load[1]),
+    loadAverage15m: clampNumber(load[2]),
+    uptimeSeconds: clampNumber(input.uptimeSeconds),
+    platform: input.platform
+  }
+}

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -41,6 +41,7 @@ import { GitHandler } from './git-handler'
 import { PreflightHandler } from './preflight-handler'
 import { ExternalAutomationsHandler } from './external-automations-handler'
 import { PortScanHandler } from './port-scan-handler'
+import { HostMetricsHandler } from './host-metrics-handler'
 import { AgentExecHandler } from './agent-exec-handler'
 import { WorkspaceSessionHandler } from './workspace-session-handler'
 import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
@@ -436,6 +437,9 @@ async function main(): Promise<void> {
 
   const _portScanHandler = new PortScanHandler(dispatcher)
   void _portScanHandler
+
+  const _hostMetricsHandler = new HostMetricsHandler(dispatcher)
+  void _hostMetricsHandler
 
   const _agentExecHandler = new AgentExecHandler(dispatcher)
   void _agentExecHandler

--- a/src/shared/host-resource-metrics-types.ts
+++ b/src/shared/host-resource-metrics-types.ts
@@ -1,0 +1,21 @@
+// Resource metrics for an SSH execution host. Collected by the relay, which runs
+// ON the remote machine, so these describe the remote box — not the local Orca
+// process (that is covered by MemorySnapshot / HostMemory in ./types).
+
+export type HostResourceMetrics = {
+  totalMemory: number
+  freeMemory: number
+  usedMemory: number
+  memoryUsagePercent: number
+  cpuCoreCount: number
+  /** 1/5/15-minute load averages. On Windows os.loadavg() is [0,0,0]. */
+  loadAverage1m: number
+  loadAverage5m: number
+  loadAverage15m: number
+  uptimeSeconds: number
+  platform: NodeJS.Platform
+}
+
+export type HostMetricsResult = {
+  metrics: HostResourceMetrics | null
+}


### PR DESCRIPTION
## What

Adds a relay-side `host.metrics` probe that reports the **SSH host's own** resource usage: total/free/used memory, memory usage percent, CPU core count, 1/5/15-minute load averages, and uptime.

New API: `orca.ssh.getHostMetrics({ targetId }) → { metrics | null }`.

## Why

Orca's existing resource-usage surface reflects the **local** machine (`os.*` in the Electron main process). When agents run on an SSH execution host, the remote box's CPU/memory/load was previously unobservable. Because the relay executes **on that host**, `os.*` there reads the remote machine directly — no extra SSH round-trip.

## How

- **`src/relay/host-metrics-handler.ts`** — registers `host.metrics`; collection is a pure, unit-tested `buildHostResourceMetrics()` fed from `node:os`.
- **`src/main/ipc/ssh.ts`** — `ssh:getHostMetrics` forwards through the active multiplexer; disconnected host → `{ metrics: null }`.
- **`src/shared/host-resource-metrics-types.ts`** — `HostResourceMetrics` / `HostMetricsResult` (field names aligned with the existing `HostMemory`).
- **preload** — exposes `ssh.getHostMetrics`.

## Robustness / cross-platform

Every numeric field is clamped: NaN/negative/undefined → safe values, free memory never exceeds total, core count floors at 1 (renderers can divide by cores safely). Windows hosts report `[0,0,0]` load without special-casing. Satisfies the `SSH use case` + `Cross-Platform` requirements in AGENTS.md.

## Scope

Backend only; the status-bar / panel surface that renders remote metrics for the active SSH execution host is a follow-up.

## Test plan

- [x] `vitest` — 4 unit tests (usage math, NaN/negative clamping, free>total guard, Windows-style zero load)
- [x] `typecheck` (node + cli + web) clean
- [x] `oxlint` clean on changed files
- [ ] Manual: connect an SSH host, call `getHostMetrics`, confirm remote load/memory match `uptime` / `free -b` on that box

## ELI5

SSH hosts report their own CPU, memory, load, and uptime through the relay. Remote resource usage is no longer a black box compared to the local machine.
