### PR TITLE
fix: coalesce fetchReposForAllHosts so stale all-host loads can't resurrect removed projects (#7020)

### DIFF
--- a/src/renderer/src/store/slices/repos-all-hosts-stale-fetch.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts-stale-fetch.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 // could resolve out of order and resurrect removed projects (#7020). The
 // single-flight coalescing must keep the sidebar on the final persisted state.
 describe('fetchReposForAllHosts stale-fetch race (#7020)', () => {
-  it('coalesces a burst into one trailing reload that reads the final state', async () => {
+  it('coalesces a burst into one trailing reload and makes every caller await it', async () => {
     const store = createTestStore()
     let resolveLeading!: (repos: Repo[]) => void
     const leadingPromise = new Promise<Repo[]>((resolve) => {
@@ -58,21 +58,32 @@ describe('fetchReposForAllHosts stale-fetch race (#7020)', () => {
     const leading = store.getState().fetchReposForAllHosts()
     // Further burst events while the leading load is in flight collapse into a
     // single pending trailing reload rather than starting overlapping loads.
-    const coalescedA = store.getState().fetchReposForAllHosts()
-    const coalescedB = store.getState().fetchReposForAllHosts()
-    await coalescedA
-    await coalescedB
+    let coalescedResolved = false
+    const coalesced = Promise.all([
+      store.getState().fetchReposForAllHosts(),
+      store.getState().fetchReposForAllHosts()
+    ]).then(() => {
+      coalescedResolved = true
+    })
+
+    // Flush pending microtasks: the leading load is still stuck on leadingPromise.
+    await Promise.resolve()
     // Only the leading load has hit the network so far; the burst was absorbed.
     expect(reposList).toHaveBeenCalledTimes(1)
+    // Overlapping callers must NOT resolve before the refresh their event
+    // triggered lands — they await the same in-flight cycle.
+    expect(coalescedResolved).toBe(false)
 
     resolveLeading([localRepo, remoteRepo])
-    await leading
+    await Promise.all([leading, coalesced])
 
+    // The overlapping callers only settled once the cycle drained.
+    expect(coalescedResolved).toBe(true)
     // Leading (both repos) + exactly one trailing reload — not one load per event.
     expect(reposList).toHaveBeenCalledTimes(2)
     // The trailing reload's post-removal read wins, so the removed project is gone.
     expect(store.getState().repos.map((repo) => repo.id)).toEqual(['local-repo'])
-    expect(store.getState().reposAllHostsLoadInFlight).toBe(false)
+    expect(store.getState().reposAllHostsLoadCyclePromise).toBeNull()
     expect(store.getState().reposAllHostsReloadRequested).toBe(false)
   })
 
@@ -84,6 +95,6 @@ describe('fetchReposForAllHosts stale-fetch race (#7020)', () => {
 
     expect(reposList).toHaveBeenCalledTimes(1)
     expect(store.getState().repos.map((repo) => repo.id)).toEqual(['local-repo'])
-    expect(store.getState().reposAllHostsLoadInFlight).toBe(false)
+    expect(store.getState().reposAllHostsLoadCyclePromise).toBeNull()
   })
 })

--- a/src/renderer/src/store/slices/repos-all-hosts-stale-fetch.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts-stale-fetch.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import type { Repo } from '../../../../shared/types'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+
+const localRepo: Repo = {
+  id: 'local-repo',
+  path: '/local',
+  displayName: 'Local',
+  badgeColor: '#000',
+  addedAt: 1
+}
+
+const remoteRepo: Repo = {
+  id: 'remote-repo',
+  path: '/remote',
+  displayName: 'Remote',
+  badgeColor: '#111',
+  addedAt: 2
+}
+
+const reposList = vi.fn()
+const runtimeEnvironmentsList = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposList.mockReset()
+  runtimeEnvironmentsList.mockReset()
+  // No runtime environments configured, so the all-host load only exercises the
+  // local slice. Only repos.list is stubbed — the missing projects API makes
+  // fetchProjectHostSetupCompatibility fall back to deriving from repos.
+  runtimeEnvironmentsList.mockResolvedValue([])
+  vi.stubGlobal('window', {
+    api: {
+      repos: { list: reposList },
+      runtimeEnvironments: { list: runtimeEnvironmentsList }
+    }
+  })
+})
+
+// The runtime-active sidebar refreshes via fetchReposForAllHosts, and a
+// repos:changed burst (deleting a project group with contained projects) fires
+// it N+1 times. Unlike fetchRepos, this path had no stale-fetch guard (#7024
+// scoped its generation guard to fetchRepos), so overlapping all-host loads
+// could resolve out of order and resurrect removed projects (#7020). The
+// single-flight coalescing must keep the sidebar on the final persisted state.
+describe('fetchReposForAllHosts stale-fetch race (#7020)', () => {
+  it('coalesces a burst into one trailing reload that reads the final state', async () => {
+    const store = createTestStore()
+    let resolveLeading!: (repos: Repo[]) => void
+    const leadingPromise = new Promise<Repo[]>((resolve) => {
+      resolveLeading = resolve
+    })
+    // Why: the leading load reads pre-removal state (both repos) but resolves
+    // LAST; the single trailing reload reads post-removal state (remoteRepo gone).
+    reposList.mockReturnValueOnce(leadingPromise).mockResolvedValueOnce([localRepo])
+
+    const leading = store.getState().fetchReposForAllHosts()
+    // Further burst events while the leading load is in flight collapse into a
+    // single pending trailing reload rather than starting overlapping loads.
+    const coalescedA = store.getState().fetchReposForAllHosts()
+    const coalescedB = store.getState().fetchReposForAllHosts()
+    await coalescedA
+    await coalescedB
+    // Only the leading load has hit the network so far; the burst was absorbed.
+    expect(reposList).toHaveBeenCalledTimes(1)
+
+    resolveLeading([localRepo, remoteRepo])
+    await leading
+
+    // Leading (both repos) + exactly one trailing reload — not one load per event.
+    expect(reposList).toHaveBeenCalledTimes(2)
+    // The trailing reload's post-removal read wins, so the removed project is gone.
+    expect(store.getState().repos.map((repo) => repo.id)).toEqual(['local-repo'])
+    expect(store.getState().reposAllHostsLoadInFlight).toBe(false)
+    expect(store.getState().reposAllHostsReloadRequested).toBe(false)
+  })
+
+  it('runs immediately for an isolated event', async () => {
+    const store = createTestStore()
+    reposList.mockResolvedValueOnce([localRepo])
+
+    await store.getState().fetchReposForAllHosts()
+
+    expect(reposList).toHaveBeenCalledTimes(1)
+    expect(store.getState().repos.map((repo) => repo.id)).toEqual(['local-repo'])
+    expect(store.getState().reposAllHostsLoadInFlight).toBe(false)
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1156,7 +1156,9 @@ export type RepoSlice = {
   reposFetchGeneration: number
   // Single-flight gate for fetchReposForAllHosts: a repos:changed burst coalesces
   // into one trailing all-host reload instead of racing overlapping loads (#7020).
-  reposAllHostsLoadInFlight: boolean
+  // Holds the in-flight cycle promise so overlapping callers await the same
+  // refresh (null when idle); a component never selects it, so no extra renders.
+  reposAllHostsLoadCyclePromise: Promise<void> | null
   reposAllHostsReloadRequested: boolean
   fetchRepos: () => Promise<void>
   fetchReposForAllHosts: () => Promise<void>
@@ -1277,7 +1279,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   folderWorkspacePathStatuses: {},
   activeRepoId: null,
   reposFetchGeneration: 0,
-  reposAllHostsLoadInFlight: false,
+  reposAllHostsLoadCyclePromise: null,
   reposAllHostsReloadRequested: false,
 
   fetchRepos: async () => {
@@ -1448,19 +1450,27 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     // run exactly one trailing reload afterwards. The trailing reload reads at or
     // after the final mutation, so the sidebar settles on the final persisted
     // state; the burst's O(N²) host fetches also collapse to ~1 trailing reload.
-    if (get().reposAllHostsLoadInFlight) {
+    const activeCycle = get().reposAllHostsLoadCyclePromise
+    if (activeCycle) {
+      // Await the SAME in-flight cycle so callers don't continue before the
+      // trailing reload their event requested lands (e.g. cold-start metrics /
+      // dependent fetches that read repos right after awaiting this).
       set({ reposAllHostsReloadRequested: true })
+      await activeCycle
       return
     }
-    set({ reposAllHostsLoadInFlight: true })
-    try {
-      do {
-        set({ reposAllHostsReloadRequested: false })
-        await loadReposForAllHosts()
-      } while (get().reposAllHostsReloadRequested)
-    } finally {
-      set({ reposAllHostsLoadInFlight: false })
-    }
+    const cycle = (async () => {
+      try {
+        do {
+          set({ reposAllHostsReloadRequested: false })
+          await loadReposForAllHosts()
+        } while (get().reposAllHostsReloadRequested)
+      } finally {
+        set({ reposAllHostsLoadCyclePromise: null })
+      }
+    })()
+    set({ reposAllHostsLoadCyclePromise: cycle })
+    await cycle
   },
 
   fetchProjectGroups: async () => {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1154,6 +1154,10 @@ export type RepoSlice = {
   activeRepoId: string | null
   // Monotonic sequence so an overlapping fetchRepos can drop its own stale result (#7020).
   reposFetchGeneration: number
+  // Single-flight gate for fetchReposForAllHosts: a repos:changed burst coalesces
+  // into one trailing all-host reload instead of racing overlapping loads (#7020).
+  reposAllHostsLoadInFlight: boolean
+  reposAllHostsReloadRequested: boolean
   fetchRepos: () => Promise<void>
   fetchReposForAllHosts: () => Promise<void>
   fetchRuntimeEnvironmentRepos: (environmentId: string) => Promise<Repo[]>
@@ -1273,6 +1277,8 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   folderWorkspacePathStatuses: {},
   activeRepoId: null,
   reposFetchGeneration: 0,
+  reposAllHostsLoadInFlight: false,
+  reposAllHostsReloadRequested: false,
 
   fetchRepos: async () => {
     // Why: overlapping repos:changed fetches can resolve out of order; an earlier
@@ -1374,60 +1380,86 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     // sidebar "All hosts" scope shows them together regardless of which
     // environment is active. Each host fails soft: an unreachable/disconnected
     // host is skipped without blocking the others.
-    const applyResult = (result: Awaited<ReturnType<typeof fetchReposForTarget>>): void => {
-      const validRepoIds = new Set(result.repos.map((repo) => repo.id))
-      set((s) => {
-        const mergedProjectCompatibility = mergeFetchedProjectCompatibilityForHost({
-          previous: {
-            projects: s.projects,
-            projectHostSetups: s.projectHostSetups
-          },
-          fetched: result.projectCompatibility,
-          repos: result.repos,
-          hostId: result.hostId
+    const loadReposForAllHosts = async (): Promise<void> => {
+      const applyResult = (result: Awaited<ReturnType<typeof fetchReposForTarget>>): void => {
+        const validRepoIds = new Set(result.repos.map((repo) => repo.id))
+        set((s) => {
+          const mergedProjectCompatibility = mergeFetchedProjectCompatibilityForHost({
+            previous: {
+              projects: s.projects,
+              projectHostSetups: s.projectHostSetups
+            },
+            fetched: result.projectCompatibility,
+            repos: result.repos,
+            hostId: result.hostId
+          })
+          return {
+            repos: result.repos,
+            ...mergedProjectCompatibility,
+            folderWorkspacePathStatuses: {},
+            activeRepoId:
+              s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
+            filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+            setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
+              s.setupScriptPromptDismissedRepoIds,
+              validRepoIds
+            )
+          }
         })
-        return {
-          repos: result.repos,
-          ...mergedProjectCompatibility,
-          folderWorkspacePathStatuses: {},
-          activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
-          setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
-            s.setupScriptPromptDismissedRepoIds,
-            validRepoIds
-          )
-        }
-      })
-      // Why: preserve the safe-auto fork sync that fetchRepos /
-      // fetchRuntimeEnvironmentRepos schedule after merging each host, so
-      // cold-start (which now routes through here) keeps updating safe-auto forks.
-      scheduleSafeAutoForkSync(
-        get,
-        result.repos.filter((repo) => getRepoExecutionHostId(repo) === result.hostId)
-      )
-    }
-
-    // Local first so local repos are present even if a remote fetch stalls.
-    try {
-      applyResult(await fetchReposForTarget({ kind: 'local' }, get().repos))
-    } catch (err) {
-      console.error('Failed to fetch local repos for all-host load:', err)
-    }
-
-    const environments = await listRuntimeEnvironmentsForAllHostLoad()
-
-    // Sequential to avoid concurrent set() races on the merged repos array.
-    for (const environment of environments) {
-      try {
-        applyResult(
-          await fetchReposForTarget(
-            { kind: 'environment', environmentId: environment.id },
-            get().repos
-          )
+        // Why: preserve the safe-auto fork sync that fetchRepos /
+        // fetchRuntimeEnvironmentRepos schedule after merging each host, so
+        // cold-start (which now routes through here) keeps updating safe-auto forks.
+        scheduleSafeAutoForkSync(
+          get,
+          result.repos.filter((repo) => getRepoExecutionHostId(repo) === result.hostId)
         )
-      } catch (err) {
-        console.warn(`Skipped repos for runtime environment ${environment.id}:`, err)
       }
+
+      // Local first so local repos are present even if a remote fetch stalls.
+      try {
+        applyResult(await fetchReposForTarget({ kind: 'local' }, get().repos))
+      } catch (err) {
+        console.error('Failed to fetch local repos for all-host load:', err)
+      }
+
+      const environments = await listRuntimeEnvironmentsForAllHostLoad()
+
+      // Sequential to avoid concurrent set() races on the merged repos array.
+      for (const environment of environments) {
+        try {
+          applyResult(
+            await fetchReposForTarget(
+              { kind: 'environment', environmentId: environment.id },
+              get().repos
+            )
+          )
+        } catch (err) {
+          console.warn(`Skipped repos for runtime environment ${environment.id}:`, err)
+        }
+      }
+    }
+
+    // Why: repos:changed fires once per persisted mutation, so deleting a project
+    // group with contained projects emits an N+1 burst. Without coalescing, each
+    // event starts an overlapping all-host load and an earlier one that read
+    // pre-removal state can resolve last and resurrect the removed projects
+    // (#7020 — #7024 guards fetchRepos but left this all-host path unprotected).
+    // Single-flight it: run one load at a time and, when events arrive mid-load,
+    // run exactly one trailing reload afterwards. The trailing reload reads at or
+    // after the final mutation, so the sidebar settles on the final persisted
+    // state; the burst's O(N²) host fetches also collapse to ~1 trailing reload.
+    if (get().reposAllHostsLoadInFlight) {
+      set({ reposAllHostsReloadRequested: true })
+      return
+    }
+    set({ reposAllHostsLoadInFlight: true })
+    try {
+      do {
+        set({ reposAllHostsReloadRequested: false })
+        await loadReposForAllHosts()
+      } while (get().reposAllHostsReloadRequested)
+    } finally {
+      set({ reposAllHostsLoadInFlight: false })
     }
   },
 


### PR DESCRIPTION
## Summary

Follow-up to #7024, closing the all-host gap it deliberately left open.

Deleting a Project Group with **"Remove contained projects"** could leave the removed projects as stale, unusable sidebar rows until restart (#7020). `repos:changed` is broadcast **once per persisted mutation**, so a group delete that also removes N contained projects emits an **N+1** burst.

#7024 fixed the default path by scoping a monotonic generation guard to `fetchRepos` only — deliberately, because a *shared* counter let an unrelated `fetchRepos` bump the generation and abort an in-flight all-host load, dropping every host's repos. That left the **runtime-active** sidebar path, which refreshes via **`fetchReposForAllHosts`**, unguarded: an N+1 burst starts N+1 overlapping all-host loads, and an earlier one that read *pre-removal* state can resolve **last** and resurrect the removed projects.

## Fix

Single-flight `fetchReposForAllHosts`:

- Runs **one load at a time**; events arriving mid-load collapse into a **single trailing reload**.
- The trailing reload's read happens **at or after the final mutation**, so the sidebar settles on the final persisted state.
- Method-local (no shared counter, no cross-call interference), so it avoids the exact trap #7024 called out.
- As a bonus, the burst's O(N²) per-host fetches collapse to ~1 trailing reload.

**Scope:** only the repos all-host path (the reported symptom is project ghost rows). The equivalent `fetchProjectGroupsForAllHosts` / `fetchFolderWorkspacesForAllHosts` out-of-order refresh is known but deferred.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (oxlint + react-doctor) on changed files
- [x] web `tsgo` typecheck (`config/tsconfig.tc.web.json`)
- [x] New `repos-all-hosts-stale-fetch.test.ts` — burst coalesces into one trailing reload that reads the final state; isolated event runs immediately
- [x] Existing `repos-stale-fetch.test.ts` (2) and `repos.test.ts` (22) pass unchanged
- [ ] Full `pnpm test` / `pnpm build` — left to CI

## AI Review Report

Reviewed with Claude Code. Checks:
- **Cross-platform:** pure renderer store logic, no OS/path/shortcut/shell surface — identical on macOS/Linux/Windows.
- **SSH/remote/local:** the all-host load already fans out to local + every runtime environment and fails soft per host; this change only serializes when those loads run, so remote/SSH hosts behave as before.
- **Provider/agent:** no source-control or integration-specific code touched; provider-neutral.
- **Performance:** strictly reduces work — an N+1 `repos:changed` burst goes from N+1 overlapping all-host loads (O(N²) host fetches) to ~2 loads. Single-flight state is plain booleans no component selects, so no extra renders.
- **Security:** no input handling, command execution, path handling, auth, secrets, or IPC surface changed.

## Notes

Method-local single-flight (chosen over extending #7024's generation guard to avoid the shared-counter cross-cancellation it documented). Supersedes the broader #7083 for the all-host slice; #7083 left open for now.

X: [@mark86202384100](https://x.com/mark86202384100)
