### PR TITLE
feat(status-bar): remote host metrics + sessions segment

### DIFF
--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -15,6 +15,7 @@ import type {
   SshConnectionStatus,
   SshConnectionState
 } from '../../shared/ssh-types'
+import type { HostSessionsResult } from '../../shared/host-session-types'
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../shared/constants'
 import { isRuntimeOwnedSshTargetId } from '../../shared/execution-host'
 import { isAuthError } from '../ssh/ssh-connection-utils'
@@ -1176,6 +1177,19 @@ export function registerSshHandlers(
     const ports = session?.getPortScanner()?.getDetectedPorts(args.targetId) ?? []
     return enrichDetected(args.targetId, ports)
   })
+
+  ipcMain.handle(
+    'ssh:discoverHostSessions',
+    async (_event, args: { targetId: string }): Promise<HostSessionsResult> => {
+      const mux = getActiveMultiplexer(args.targetId)
+      if (!mux || mux.isDisposed()) {
+        // Why: discovery is passive UI polling. A disconnected host has nothing to
+        // observe until reconnect and should not surface an IPC error.
+        return { sessions: [], tmuxAvailable: false }
+      }
+      return (await mux.request('host.discoverSessions')) as HostSessionsResult
+    }
+  )
 
   return { connectionManager, sshStore }
 }

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -15,6 +15,7 @@ import type {
   SshConnectionStatus,
   SshConnectionState
 } from '../../shared/ssh-types'
+import type { HostMetricsResult } from '../../shared/host-resource-metrics-types'
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../shared/constants'
 import { isRuntimeOwnedSshTargetId } from '../../shared/execution-host'
 import { isAuthError } from '../ssh/ssh-connection-utils'
@@ -1176,6 +1177,19 @@ export function registerSshHandlers(
     const ports = session?.getPortScanner()?.getDetectedPorts(args.targetId) ?? []
     return enrichDetected(args.targetId, ports)
   })
+
+  ipcMain.handle(
+    'ssh:getHostMetrics',
+    async (_event, args: { targetId: string }): Promise<HostMetricsResult> => {
+      const mux = getActiveMultiplexer(args.targetId)
+      if (!mux || mux.isDisposed()) {
+        // Why: metrics are passive polling; a disconnected host has none until
+        // reconnect and should not raise an IPC error.
+        return { metrics: null }
+      }
+      return (await mux.request('host.metrics')) as HostMetricsResult
+    }
+  )
 
   return { connectionManager, sshStore }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -344,6 +344,7 @@ import type {
   WorkspacePortScanRequest,
   WorkspacePortScanResult
 } from '../shared/workspace-ports'
+import type { HostSessionsResult } from '../shared/host-session-types'
 import type { GhAuthDiagnostic } from '../shared/github-auth-types'
 import type {
   SshConnectionState,
@@ -2836,6 +2837,7 @@ export type PreloadApi = {
     removePortForward: (args: { id: string }) => Promise<PortForwardEntry | null>
     listPortForwards: (args?: { targetId?: string }) => Promise<PortForwardEntry[]>
     listDetectedPorts: (args: { targetId: string }) => Promise<EnrichedDetectedPort[]>
+    discoverHostSessions: (args: { targetId: string }) => Promise<HostSessionsResult>
     onPortForwardsChanged: (
       callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void
     ) => () => void

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -344,6 +344,7 @@ import type {
   WorkspacePortScanRequest,
   WorkspacePortScanResult
 } from '../shared/workspace-ports'
+import type { HostMetricsResult } from '../shared/host-resource-metrics-types'
 import type { GhAuthDiagnostic } from '../shared/github-auth-types'
 import type {
   SshConnectionState,
@@ -2836,6 +2837,7 @@ export type PreloadApi = {
     removePortForward: (args: { id: string }) => Promise<PortForwardEntry | null>
     listPortForwards: (args?: { targetId?: string }) => Promise<PortForwardEntry[]>
     listDetectedPorts: (args: { targetId: string }) => Promise<EnrichedDetectedPort[]>
+    getHostMetrics: (args: { targetId: string }) => Promise<HostMetricsResult>
     onPortForwardsChanged: (
       callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -123,6 +123,7 @@ import type {
   PortForwardEntry,
   EnrichedDetectedPort
 } from '../shared/ssh-types'
+import type { HostSessionsResult } from '../shared/host-session-types'
 import type {
   AgentStatusIpcPayload,
   MigrationUnsupportedPtyEntry
@@ -3880,6 +3881,9 @@ const api = {
 
     listDetectedPorts: (args: { targetId: string }): Promise<EnrichedDetectedPort[]> =>
       ipcRenderer.invoke('ssh:listDetectedPorts', args),
+
+    discoverHostSessions: (args: { targetId: string }): Promise<HostSessionsResult> =>
+      ipcRenderer.invoke('ssh:discoverHostSessions', args),
 
     onPortForwardsChanged: (
       callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -123,6 +123,7 @@ import type {
   PortForwardEntry,
   EnrichedDetectedPort
 } from '../shared/ssh-types'
+import type { HostMetricsResult } from '../shared/host-resource-metrics-types'
 import type {
   AgentStatusIpcPayload,
   MigrationUnsupportedPtyEntry
@@ -3880,6 +3881,9 @@ const api = {
 
     listDetectedPorts: (args: { targetId: string }): Promise<EnrichedDetectedPort[]> =>
       ipcRenderer.invoke('ssh:listDetectedPorts', args),
+
+    getHostMetrics: (args: { targetId: string }): Promise<HostMetricsResult> =>
+      ipcRenderer.invoke('ssh:getHostMetrics', args),
 
     onPortForwardsChanged: (
       callback: (data: { targetId: string; forwards: PortForwardEntry[] }) => void

--- a/src/relay/host-metrics-handler.test.ts
+++ b/src/relay/host-metrics-handler.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { buildHostResourceMetrics } from './host-metrics-handler'
+
+describe('buildHostResourceMetrics', () => {
+  it('computes used memory and usage percent', () => {
+    const m = buildHostResourceMetrics({
+      totalMemory: 16_000_000_000,
+      freeMemory: 4_000_000_000,
+      cpuCoreCount: 8,
+      loadAverage: [1.5, 2.5, 3.5],
+      uptimeSeconds: 3600,
+      platform: 'linux'
+    })
+    expect(m.usedMemory).toBe(12_000_000_000)
+    expect(m.memoryUsagePercent).toBeCloseTo(75)
+    expect(m).toMatchObject({
+      cpuCoreCount: 8,
+      loadAverage1m: 1.5,
+      loadAverage5m: 2.5,
+      loadAverage15m: 3.5,
+      uptimeSeconds: 3600,
+      platform: 'linux'
+    })
+  })
+
+  it('clamps NaN/negative os values to safe numbers', () => {
+    const m = buildHostResourceMetrics({
+      totalMemory: Number.NaN,
+      freeMemory: -1,
+      cpuCoreCount: 0,
+      loadAverage: [Number.NaN, undefined as unknown as number, -2],
+      uptimeSeconds: -5,
+      platform: 'linux'
+    })
+    expect(m.totalMemory).toBe(0)
+    expect(m.freeMemory).toBe(0)
+    expect(m.usedMemory).toBe(0)
+    expect(m.memoryUsagePercent).toBe(0)
+    // cpuCoreCount floors at 1 so a renderer never divides by zero cores.
+    expect(m.cpuCoreCount).toBe(1)
+    expect(m.loadAverage1m).toBe(0)
+    expect(m.loadAverage5m).toBe(0)
+    expect(m.loadAverage15m).toBe(0)
+    expect(m.uptimeSeconds).toBe(0)
+  })
+
+  it('never reports free memory above total (guards inconsistent reads)', () => {
+    const m = buildHostResourceMetrics({
+      totalMemory: 1000,
+      freeMemory: 5000,
+      cpuCoreCount: 2,
+      loadAverage: [0, 0, 0],
+      uptimeSeconds: 1,
+      platform: 'darwin'
+    })
+    expect(m.freeMemory).toBe(1000)
+    expect(m.usedMemory).toBe(0)
+    expect(m.memoryUsagePercent).toBe(0)
+  })
+
+  it('reports zero load on Windows-style [0,0,0]', () => {
+    const m = buildHostResourceMetrics({
+      totalMemory: 8_000_000_000,
+      freeMemory: 8_000_000_000,
+      cpuCoreCount: 4,
+      loadAverage: [0, 0, 0],
+      uptimeSeconds: 100,
+      platform: 'win32'
+    })
+    expect(m.loadAverage1m).toBe(0)
+    expect(m.platform).toBe('win32')
+  })
+})

--- a/src/relay/host-metrics-handler.ts
+++ b/src/relay/host-metrics-handler.ts
@@ -1,0 +1,67 @@
+import os from 'node:os'
+import type { RelayDispatcher } from './dispatcher'
+// Keep in sync with src/shared/host-resource-metrics-types.ts — HostResourceMetrics.
+import type { HostMetricsResult, HostResourceMetrics } from '../shared/host-resource-metrics-types'
+
+export type HostMetricsInput = {
+  totalMemory: number
+  freeMemory: number
+  cpuCoreCount: number
+  loadAverage: number[]
+  uptimeSeconds: number
+  platform: NodeJS.Platform
+}
+
+export class HostMetricsHandler {
+  constructor(dispatcher: RelayDispatcher) {
+    // Why: the relay executes on the target host, so os.* here reflects the remote
+    // machine's CPU/memory/load — the metric a client-side prober cannot read.
+    dispatcher.onRequest('host.metrics', async () => this.collect())
+  }
+
+  private async collect(): Promise<HostMetricsResult> {
+    try {
+      return {
+        metrics: buildHostResourceMetrics({
+          totalMemory: os.totalmem(),
+          freeMemory: os.freemem(),
+          cpuCoreCount: os.cpus().length,
+          loadAverage: os.loadavg(),
+          uptimeSeconds: os.uptime(),
+          platform: process.platform
+        })
+      }
+    } catch {
+      // os.* is effectively infallible, but guard so a probe never rejects.
+      return { metrics: null }
+    }
+  }
+}
+
+// Why: os.* can return NaN/negative/undefined on exotic platforms; clamp every
+// numeric field so the renderer can render without defensive checks.
+function clampNumber(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0
+  }
+  return Math.max(0, value)
+}
+
+export function buildHostResourceMetrics(input: HostMetricsInput): HostResourceMetrics {
+  const totalMemory = clampNumber(input.totalMemory)
+  const freeMemory = Math.min(clampNumber(input.freeMemory), totalMemory)
+  const usedMemory = Math.max(0, totalMemory - freeMemory)
+  const load = input.loadAverage
+  return {
+    totalMemory,
+    freeMemory,
+    usedMemory,
+    memoryUsagePercent: totalMemory > 0 ? (usedMemory / totalMemory) * 100 : 0,
+    cpuCoreCount: Math.max(1, clampNumber(input.cpuCoreCount)),
+    loadAverage1m: clampNumber(load[0]),
+    loadAverage5m: clampNumber(load[1]),
+    loadAverage15m: clampNumber(load[2]),
+    uptimeSeconds: clampNumber(input.uptimeSeconds),
+    platform: input.platform
+  }
+}

--- a/src/relay/host-sessions-handler.test.ts
+++ b/src/relay/host-sessions-handler.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyAgentFromProcTable,
+  parseProcTable,
+  parseTmuxPaneLine,
+  type ProcEntry
+} from './host-sessions-handler'
+
+const TAB = '\t'
+
+describe('parseTmuxPaneLine', () => {
+  it('parses an attached pane', () => {
+    expect(
+      parseTmuxPaneLine(['api', '/home/ubuntu/code/api', 'node', '1', '4242'].join(TAB))
+    ).toEqual({
+      session: 'api',
+      cwd: '/home/ubuntu/code/api',
+      command: 'node',
+      attached: true,
+      pid: 4242
+    })
+  })
+
+  it('treats a zero client count as detached', () => {
+    expect(
+      parseTmuxPaneLine(['web', '/home/ubuntu/web', 'zsh', '0', '77'].join(TAB))?.attached
+    ).toBe(false)
+  })
+
+  it('treats a client count above one as attached', () => {
+    expect(
+      parseTmuxPaneLine(['web', '/home/ubuntu/web', 'zsh', '2', '77'].join(TAB))?.attached
+    ).toBe(true)
+  })
+
+  it('returns undefined pid when pane_pid is non-numeric', () => {
+    expect(parseTmuxPaneLine(['s', '/tmp', 'sh', '1', ''].join(TAB))?.pid).toBeUndefined()
+  })
+
+  it('returns null when required fields are missing', () => {
+    expect(parseTmuxPaneLine('')).toBeNull()
+    expect(parseTmuxPaneLine(['only-session'].join(TAB))).toBeNull()
+    expect(parseTmuxPaneLine(['', '/tmp', 'sh', '1', '5'].join(TAB))).toBeNull()
+  })
+
+  it('keeps commands that contain spaces intact', () => {
+    expect(
+      parseTmuxPaneLine(['s', '/tmp', 'node dist/server.js', '1', '9'].join(TAB))?.command
+    ).toBe('node dist/server.js')
+  })
+})
+
+describe('parseProcTable', () => {
+  it('parses pid/ppid/comm rows and preserves comms with spaces', () => {
+    const table = parseProcTable(['  100   1 zsh', ' 101 100 node dist/x.js', 'garbage'].join('\n'))
+    expect(table.get(100)).toEqual({ ppid: 1, comm: 'zsh' })
+    expect(table.get(101)).toEqual({ ppid: 100, comm: 'node dist/x.js' })
+    expect(table.size).toBe(2)
+  })
+
+  it('returns an empty map for empty input', () => {
+    expect(parseProcTable('').size).toBe(0)
+  })
+})
+
+describe('classifyAgentFromProcTable', () => {
+  const table = (rows: [number, number, string][]): Map<number, ProcEntry> =>
+    new Map(rows.map(([pid, ppid, comm]) => [pid, { ppid, comm }]))
+
+  it('detects claude nested below the pane shell', () => {
+    // pane_pid 100 (zsh) → 200 (node) → 300 (claude)
+    const procs = table([
+      [100, 1, 'zsh'],
+      [200, 100, 'node'],
+      [300, 200, 'claude']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBe('claude')
+  })
+
+  it('detects codex as a direct child', () => {
+    const procs = table([
+      [100, 1, 'zsh'],
+      [200, 100, 'codex']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBe('codex')
+  })
+
+  it('does not match unrelated commands like claude-code-lookalike suffixes', () => {
+    const procs = table([
+      [100, 1, 'zsh'],
+      [200, 100, 'claudette']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBeNull()
+  })
+
+  it('returns null when the subtree has no agent', () => {
+    const procs = table([
+      [100, 1, 'zsh'],
+      [200, 100, 'vim']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBeNull()
+  })
+
+  it('does not match agents outside the pane subtree', () => {
+    // claude (300) lives under a different root (999), not under pane_pid 100.
+    const procs = table([
+      [100, 1, 'zsh'],
+      [999, 1, 'bash'],
+      [300, 999, 'claude']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBeNull()
+  })
+
+  it('returns null when rootPid is undefined', () => {
+    expect(classifyAgentFromProcTable(undefined, table([[1, 0, 'claude']]))).toBeNull()
+  })
+
+  it('terminates on cyclic ppid references', () => {
+    // Defensive: a malformed table where 100↔200 point at each other must not hang.
+    const procs = table([
+      [100, 200, 'zsh'],
+      [200, 100, 'vim']
+    ])
+    expect(classifyAgentFromProcTable(100, procs)).toBeNull()
+  })
+})

--- a/src/relay/host-sessions-handler.ts
+++ b/src/relay/host-sessions-handler.ts
@@ -1,0 +1,207 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import type { RelayDispatcher, RequestContext } from './dispatcher'
+// Keep in sync with src/shared/host-session-types.ts — HostSession/HostSessionAgent.
+import type {
+  HostSession,
+  HostSessionAgent,
+  HostSessionsResult
+} from '../shared/host-session-types'
+
+const execFileAsync = promisify(execFile)
+
+// tmux -F fields are joined with a literal tab; a real path never contains one.
+const TAB = '\t'
+
+// Why: cap the probe so a host with a runaway number of panes can't produce an
+// unbounded payload or make the git-branch fan-out dominate the response time.
+const MAX_SESSIONS = 100
+
+// Why: match the agent by the leaf command in the pane's process subtree. tmux
+// only reports pane_current_command (the immediate foreground process), but the
+// real agent (claude/codex) is usually a descendant of a shell, so we walk the
+// process tree rather than trusting the foreground command alone.
+const AGENT_PATTERNS: { agent: Exclude<HostSessionAgent, null>; test: RegExp }[] = [
+  { agent: 'claude', test: /(^|\/)claude\b/i },
+  { agent: 'codex', test: /(^|\/)codex\b/i }
+]
+
+const TMUX_PANE_FORMAT = [
+  '#{session_name}',
+  '#{pane_current_path}',
+  '#{pane_current_command}',
+  '#{session_attached}',
+  '#{pane_pid}'
+].join(TAB)
+
+export type RawPane = Pick<HostSession, 'session' | 'cwd' | 'command' | 'attached' | 'pid'>
+
+export type ProcEntry = { ppid: number; comm: string }
+
+export class HostSessionsHandler {
+  constructor(dispatcher: RelayDispatcher) {
+    dispatcher.onRequest('host.discoverSessions', (_params, context: RequestContext) =>
+      this.discover(context)
+    )
+  }
+
+  // Why: the relay already runs ON the target host, so we probe tmux/ps/git
+  // locally — no SSH round-trip per probe like a client-side prober would need.
+  private async discover(context: RequestContext): Promise<HostSessionsResult> {
+    const paneOutput = await this.runTmuxListPanes(context.signal)
+    if (paneOutput === null) {
+      return { sessions: [], tmuxAvailable: false }
+    }
+
+    const panes = paneOutput
+      .split('\n')
+      .map(parseTmuxPaneLine)
+      .filter((pane): pane is RawPane => pane !== null)
+      .slice(0, MAX_SESSIONS)
+
+    if (panes.length === 0) {
+      return { sessions: [], tmuxAvailable: true }
+    }
+
+    const procTable = parseProcTable(await this.runPs(context.signal))
+    const branchByCwd = await this.resolveBranches(panes, context.signal)
+
+    const sessions: HostSession[] = panes.map((pane) => ({
+      ...pane,
+      agent: classifyAgentFromProcTable(pane.pid, procTable),
+      branch: branchByCwd.get(pane.cwd)
+    }))
+
+    return { sessions, tmuxAvailable: true }
+  }
+
+  private async runTmuxListPanes(signal?: AbortSignal): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync('tmux', ['list-panes', '-a', '-F', TMUX_PANE_FORMAT], {
+        signal
+      })
+      return stdout
+    } catch {
+      // tmux missing, or no server running → indistinguishable here and both mean
+      // "nothing to observe". Callers surface this as tmuxAvailable: false.
+      return null
+    }
+  }
+
+  private async runPs(signal?: AbortSignal): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,comm='], { signal })
+      return stdout
+    } catch {
+      // No ps → every pane stays classified as agent: null rather than failing.
+      return ''
+    }
+  }
+
+  private async resolveBranches(
+    panes: RawPane[],
+    signal?: AbortSignal
+  ): Promise<Map<string, string>> {
+    const uniqueCwds = [...new Set(panes.map((pane) => pane.cwd))]
+    const branchByCwd = new Map<string, string>()
+    await Promise.all(
+      uniqueCwds.map(async (cwd) => {
+        const branch = await this.gitBranch(cwd, signal)
+        if (branch) {
+          branchByCwd.set(cwd, branch)
+        }
+      })
+    )
+    return branchByCwd
+  }
+
+  private async gitBranch(cwd: string, signal?: AbortSignal): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', cwd, 'branch', '--show-current'], {
+        signal
+      })
+      return stdout.trim() || undefined
+    } catch {
+      return undefined
+    }
+  }
+}
+
+export function parseTmuxPaneLine(line: string): RawPane | null {
+  if (!line) {
+    return null
+  }
+  const fields = line.split(TAB)
+  if (fields.length < 5) {
+    return null
+  }
+  const [session, cwd, command, attached, pidRaw] = fields
+  if (!session || !cwd) {
+    return null
+  }
+  const pid = Number.parseInt(pidRaw, 10)
+  return {
+    session,
+    cwd,
+    command,
+    // session_attached is a client count ("0" when detached).
+    attached: attached !== '0' && attached !== '',
+    pid: Number.isNaN(pid) ? undefined : pid
+  }
+}
+
+// Why: `ps -axo pid=,ppid=,comm=` emits three space-separated columns with no
+// header (the `=` suffixes suppress it); comm may itself contain spaces, so we
+// anchor on the two leading numeric columns and keep the remainder as comm.
+export function parseProcTable(psStdout: string): Map<number, ProcEntry> {
+  const table = new Map<number, ProcEntry>()
+  for (const line of psStdout.split('\n')) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/)
+    if (!match) {
+      continue
+    }
+    table.set(Number.parseInt(match[1], 10), {
+      ppid: Number.parseInt(match[2], 10),
+      comm: match[3]
+    })
+  }
+  return table
+}
+
+export function classifyAgentFromProcTable(
+  rootPid: number | undefined,
+  table: Map<number, ProcEntry>
+): HostSessionAgent {
+  if (rootPid == null) {
+    return null
+  }
+
+  const childrenByPpid = new Map<number, number[]>()
+  for (const [pid, entry] of table) {
+    const siblings = childrenByPpid.get(entry.ppid) ?? []
+    siblings.push(pid)
+    childrenByPpid.set(entry.ppid, siblings)
+  }
+
+  const queue = [rootPid]
+  const seen = new Set<number>()
+  while (queue.length > 0) {
+    const pid = queue.shift()!
+    if (seen.has(pid)) {
+      continue
+    }
+    seen.add(pid)
+
+    const comm = table.get(pid)?.comm ?? ''
+    const hit = AGENT_PATTERNS.find((pattern) => pattern.test.test(comm))
+    if (hit) {
+      return hit.agent
+    }
+
+    for (const child of childrenByPpid.get(pid) ?? []) {
+      queue.push(child)
+    }
+  }
+
+  return null
+}

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -41,6 +41,7 @@ import { GitHandler } from './git-handler'
 import { PreflightHandler } from './preflight-handler'
 import { ExternalAutomationsHandler } from './external-automations-handler'
 import { PortScanHandler } from './port-scan-handler'
+import { HostMetricsHandler } from './host-metrics-handler'
 import { AgentExecHandler } from './agent-exec-handler'
 import { WorkspaceSessionHandler } from './workspace-session-handler'
 import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
@@ -436,6 +437,9 @@ async function main(): Promise<void> {
 
   const _portScanHandler = new PortScanHandler(dispatcher)
   void _portScanHandler
+
+  const _hostMetricsHandler = new HostMetricsHandler(dispatcher)
+  void _hostMetricsHandler
 
   const _agentExecHandler = new AgentExecHandler(dispatcher)
   void _agentExecHandler

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -41,6 +41,7 @@ import { GitHandler } from './git-handler'
 import { PreflightHandler } from './preflight-handler'
 import { ExternalAutomationsHandler } from './external-automations-handler'
 import { PortScanHandler } from './port-scan-handler'
+import { HostSessionsHandler } from './host-sessions-handler'
 import { AgentExecHandler } from './agent-exec-handler'
 import { WorkspaceSessionHandler } from './workspace-session-handler'
 import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
@@ -436,6 +437,9 @@ async function main(): Promise<void> {
 
   const _portScanHandler = new PortScanHandler(dispatcher)
   void _portScanHandler
+
+  const _hostSessionsHandler = new HostSessionsHandler(dispatcher)
+  void _hostSessionsHandler
 
   const _agentExecHandler = new AgentExecHandler(dispatcher)
   void _agentExecHandler

--- a/src/renderer/src/components/status-bar/HostStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/HostStatusSegment.tsx
@@ -1,0 +1,283 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Gauge, Cpu, MemoryStick, Clock, Server } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useAppStore } from '@/store'
+import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
+import type { HostResourceMetrics } from '../../../../shared/host-resource-metrics-types'
+import type { HostSession } from '../../../../shared/host-session-types'
+import { SelectedTextCopyMenu } from '@/components/SelectedTextCopyMenu'
+import { STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS } from './status-bar-context-menu-policy'
+import {
+  agentDotClass,
+  clampPercent,
+  formatGib,
+  formatLoad,
+  formatUptime
+} from './host-status-format'
+import { translate } from '@/i18n/i18n'
+
+type HostStatusSegmentProps = {
+  compact?: boolean
+  iconOnly: boolean
+}
+
+// Why: metrics are cheap (os.* on the remote), so poll them continuously for the
+// glanceable summary; session discovery walks tmux/ps/git, so only run it while
+// the popover is open to avoid steady load on the host.
+const METRICS_POLL_MS = 12_000
+const SESSIONS_POLL_MS = 5_000
+
+export function HostStatusSegment({ iconOnly }: HostStatusSegmentProps): React.JSX.Element | null {
+  const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
+  const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)
+  const [open, setOpen] = useState(false)
+  const [metrics, setMetrics] = useState<HostResourceMetrics | null>(null)
+  const [sessions, setSessions] = useState<HostSession[]>([])
+  const [tmuxAvailable, setTmuxAvailable] = useState(true)
+
+  // Why: the segment targets the active execution host — the first user-managed
+  // SSH target that is connected. Runtime-owned targets are Orca's own ephemeral
+  // VMs and are hidden from host-facing surfaces.
+  const targetId = useMemo(() => {
+    for (const [id, state] of sshConnectionStates) {
+      if (state.status === 'connected' && !isRuntimeOwnedSshTargetId(id)) {
+        return id
+      }
+    }
+    return null
+  }, [sshConnectionStates])
+
+  const label = targetId ? (sshTargetLabels.get(targetId) ?? targetId) : ''
+
+  const refreshMetrics = useCallback(async (id: string) => {
+    const result = await window.api.ssh.getHostMetrics({ targetId: id })
+    setMetrics(result.metrics)
+  }, [])
+
+  const refreshSessions = useCallback(async (id: string) => {
+    const result = await window.api.ssh.discoverHostSessions({ targetId: id })
+    setSessions(result.sessions)
+    setTmuxAvailable(result.tmuxAvailable)
+  }, [])
+
+  useEffect(() => {
+    if (!targetId) {
+      setMetrics(null)
+      return
+    }
+    void refreshMetrics(targetId).catch(() => setMetrics(null))
+    const timer = setInterval(() => void refreshMetrics(targetId).catch(() => {}), METRICS_POLL_MS)
+    return () => clearInterval(timer)
+  }, [targetId, refreshMetrics])
+
+  useEffect(() => {
+    if (!targetId || !open) {
+      return
+    }
+    void refreshSessions(targetId).catch(() => setSessions([]))
+    const timer = setInterval(
+      () => void refreshSessions(targetId).catch(() => {}),
+      SESSIONS_POLL_MS
+    )
+    return () => clearInterval(timer)
+  }, [targetId, open, refreshSessions])
+
+  if (!targetId) {
+    return null
+  }
+
+  const memoryPercent = metrics ? clampPercent(metrics.memoryUsagePercent) : 0
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label={translate(
+                'auto.components.status.bar.HostStatusSegment.aa85babed1',
+                'Remote host metrics'
+              )}
+              className="inline-flex h-5 items-center gap-1 rounded border border-border bg-secondary px-1.5 text-secondary-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <Gauge className="size-3 shrink-0 text-muted-foreground" />
+              {!iconOnly && metrics && (
+                <span className="text-[11px] font-medium tabular-nums text-muted-foreground">
+                  {formatLoad(metrics.loadAverage1m)} · {memoryPercent}%
+                </span>
+              )}
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          {translate(
+            'auto.components.status.bar.HostStatusSegment.tooltip',
+            'Host {{label}} — load {{load}}, memory {{percent}}%',
+            {
+              label,
+              load: metrics ? formatLoad(metrics.loadAverage1m) : '—',
+              percent: memoryPercent
+            }
+          )}
+        </TooltipContent>
+      </Tooltip>
+
+      <PopoverContent
+        side="top"
+        align="end"
+        sideOffset={8}
+        {...STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS}
+        className="w-[22rem] max-w-[calc(100vw-2rem)] p-0"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <SelectedTextCopyMenu>
+          <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-1.5">
+            <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium text-foreground">
+              <Server className="size-3 shrink-0 text-muted-foreground" />
+              <span className="truncate">{label}</span>
+            </div>
+            <span className="text-[11px] tabular-nums text-muted-foreground">
+              {metrics
+                ? translate(
+                    'auto.components.status.bar.HostStatusSegment.164c53f8d4',
+                    '{{value0}} cores',
+                    { value0: metrics.cpuCoreCount }
+                  )
+                : ''}
+            </span>
+          </div>
+
+          {metrics ? (
+            <div className="grid grid-cols-2 gap-x-3 gap-y-2 px-3 py-2.5 text-[11px]">
+              <MetricRow
+                icon={<Cpu className="size-3 shrink-0 text-muted-foreground" />}
+                label={translate(
+                  'auto.components.status.bar.HostStatusSegment.518f1762a3',
+                  'Load avg'
+                )}
+                value={`${formatLoad(metrics.loadAverage1m)} · ${formatLoad(
+                  metrics.loadAverage5m
+                )} · ${formatLoad(metrics.loadAverage15m)}`}
+              />
+              <MetricRow
+                icon={<Clock className="size-3 shrink-0 text-muted-foreground" />}
+                label={translate(
+                  'auto.components.status.bar.HostStatusSegment.0b550095d7',
+                  'Uptime'
+                )}
+                value={formatUptime(metrics.uptimeSeconds)}
+              />
+              <div className="col-span-2 flex items-center gap-1.5">
+                <MemoryStick className="size-3 shrink-0 text-muted-foreground" />
+                <span className="text-muted-foreground">
+                  {translate('auto.components.status.bar.HostStatusSegment.ae01984a93', 'Memory')}
+                </span>
+                <span className="ml-auto tabular-nums text-foreground">
+                  {translate(
+                    'auto.components.status.bar.HostStatusSegment.memory',
+                    '{{used}} / {{total}} GB · {{percent}}%',
+                    {
+                      used: formatGib(metrics.usedMemory),
+                      total: formatGib(metrics.totalMemory),
+                      percent: memoryPercent
+                    }
+                  )}
+                </span>
+              </div>
+              <div className="col-span-2 h-1.5 overflow-hidden rounded bg-muted">
+                <div className="h-full rounded bg-primary" style={{ width: `${memoryPercent}%` }} />
+              </div>
+            </div>
+          ) : (
+            <div className="px-3 py-3 text-xs text-muted-foreground">
+              {translate(
+                'auto.components.status.bar.HostStatusSegment.b54da3f1ac',
+                'Loading host metrics...'
+              )}
+            </div>
+          )}
+
+          <section className="border-t border-border/60">
+            <div className="flex items-center gap-1.5 border-b border-border/40 px-3 py-2 text-[11px] font-medium uppercase tracking-[0.05em] text-muted-foreground">
+              <span>
+                {translate(
+                  'auto.components.status.bar.HostStatusSegment.0ff2a9cbee',
+                  'Sessions on host'
+                )}
+              </span>
+              <span className="ml-auto font-mono text-[10px]">{sessions.length}</span>
+            </div>
+            <div className="max-h-[16rem] overflow-y-auto scrollbar-sleek">
+              {!tmuxAvailable ? (
+                <div className="px-3 py-3 text-xs text-muted-foreground">
+                  {translate(
+                    'auto.components.status.bar.HostStatusSegment.a08d335b74',
+                    'tmux is not running on this host'
+                  )}
+                </div>
+              ) : sessions.length > 0 ? (
+                sessions.map((session) => (
+                  <HostSessionRow
+                    key={`${session.session}:${session.pid ?? ''}`}
+                    session={session}
+                  />
+                ))
+              ) : (
+                <div className="px-3 py-3 text-xs text-muted-foreground">
+                  {translate(
+                    'auto.components.status.bar.HostStatusSegment.3b6f0532da',
+                    'No sessions detected'
+                  )}
+                </div>
+              )}
+            </div>
+          </section>
+        </SelectedTextCopyMenu>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function MetricRow({
+  icon,
+  label,
+  value
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+}): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-1.5">
+      {icon}
+      <span className="text-muted-foreground">{label}</span>
+      <span className="ml-auto tabular-nums text-foreground">{value}</span>
+    </div>
+  )
+}
+
+function HostSessionRow({ session }: { session: HostSession }): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-accent/50">
+      <span className={`size-1.5 shrink-0 rounded-full ${agentDotClass(session.agent)}`} />
+      <span className="min-w-0 truncate font-medium text-foreground">{session.session}</span>
+      {session.branch && (
+        <span className="min-w-0 truncate font-mono text-[10px] text-muted-foreground">
+          {session.branch}
+        </span>
+      )}
+      <span className="ml-auto flex shrink-0 items-center gap-2">
+        {session.agent && (
+          <span className="text-[10px] text-muted-foreground">{session.agent}</span>
+        )}
+        {session.attached && (
+          <span className="text-[10px] uppercase tracking-wide text-emerald-500">
+            {translate('auto.components.status.bar.HostStatusSegment.6641a07d35', 'attached')}
+          </span>
+        )}
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -11,7 +11,8 @@ import {
   Loader2,
   PanelsTopLeft,
   RefreshCw,
-  Server
+  Server,
+  Gauge
 } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
@@ -90,6 +91,9 @@ const PortsStatusSegment = lazyWithRetry(() =>
 )
 const SshStatusSegment = lazyWithRetry(() =>
   import('./SshStatusSegment').then((module) => ({ default: module.SshStatusSegment }))
+)
+const HostStatusSegment = lazyWithRetry(() =>
+  import('./HostStatusSegment').then((module) => ({ default: module.HostStatusSegment }))
 )
 
 export type CodexStatusRuntimeTarget = {
@@ -1865,6 +1869,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
   const showPorts = statusBarItems.includes('ports')
+  const showHost = statusBarItems.includes('host')
   const showFloatingTerminalToggle =
     floatingTerminalEnabled && floatingTerminalTriggerLocation === 'status-bar'
   const anyVisible =
@@ -1994,6 +1999,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             <ResourceUsageStatusSegment compact={compact} iconOnly={iconOnly} />
           ) : null}
           {showPorts ? <PortsStatusSegment compact={compact} iconOnly={iconOnly} /> : null}
+          {showHost ? <HostStatusSegment compact={compact} iconOnly={iconOnly} /> : null}
           {showSsh ? <SshStatusSegment compact={compact} iconOnly={iconOnly} /> : null}
         </React.Suspense>
         {showFloatingTerminalToggle && (
@@ -2116,6 +2122,15 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
           >
             <Plug className="size-3.5" />
             {translate('auto.components.status.bar.StatusBar.9659e38343', 'Ports')}
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={statusBarItems.includes('host')}
+            onCheckedChange={() => {
+              toggleStatusBarItem('host')
+            }}
+          >
+            <Gauge className="size-3.5" />
+            {translate('auto.components.status.bar.StatusBar.b82b5ecf03', 'Host Metrics')}
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/renderer/src/components/status-bar/host-status-format.test.ts
+++ b/src/renderer/src/components/status-bar/host-status-format.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  agentDotClass,
+  clampPercent,
+  formatGib,
+  formatLoad,
+  formatUptime
+} from './host-status-format'
+
+describe('formatGib', () => {
+  it('formats bytes as gigabytes with one decimal', () => {
+    expect(formatGib(16 * 1024 ** 3)).toBe('16.0')
+    expect(formatGib(9.9 * 1024 ** 3)).toBe('9.9')
+  })
+
+  it('clamps negatives to zero', () => {
+    expect(formatGib(-1)).toBe('0.0')
+  })
+})
+
+describe('formatLoad', () => {
+  it('formats with two decimals', () => {
+    expect(formatLoad(1.2)).toBe('1.20')
+    expect(formatLoad(0)).toBe('0.00')
+  })
+})
+
+describe('formatUptime', () => {
+  it('shows days and hours past a day', () => {
+    expect(formatUptime(3 * 86_400 + 4 * 3_600)).toBe('3d 4h')
+  })
+
+  it('shows hours and minutes under a day', () => {
+    expect(formatUptime(4 * 3_600 + 12 * 60)).toBe('4h 12m')
+  })
+
+  it('shows minutes only under an hour', () => {
+    expect(formatUptime(12 * 60)).toBe('12m')
+    expect(formatUptime(0)).toBe('0m')
+  })
+})
+
+describe('agentDotClass', () => {
+  it('maps each agent to a distinct color and null to muted', () => {
+    expect(agentDotClass('claude')).toContain('orange')
+    expect(agentDotClass('codex')).toContain('emerald')
+    expect(agentDotClass(null)).toContain('muted-foreground')
+  })
+})
+
+describe('clampPercent', () => {
+  it('rounds and clamps to [0, 100]', () => {
+    expect(clampPercent(62.4)).toBe(62)
+    expect(clampPercent(150)).toBe(100)
+    expect(clampPercent(-5)).toBe(0)
+    expect(clampPercent(Number.NaN)).toBe(0)
+  })
+})

--- a/src/renderer/src/components/status-bar/host-status-format.ts
+++ b/src/renderer/src/components/status-bar/host-status-format.ts
@@ -1,0 +1,48 @@
+import type { HostSessionAgent } from '../../../../shared/host-session-types'
+
+const BYTES_PER_GIB = 1024 ** 3
+
+/** Formats a byte count as gigabytes with one decimal (e.g. 9.9). */
+export function formatGib(bytes: number): string {
+  return (Math.max(0, bytes) / BYTES_PER_GIB).toFixed(1)
+}
+
+/** Formats a load average with two decimals, matching uptime(1) conventions. */
+export function formatLoad(value: number): string {
+  return Math.max(0, value).toFixed(2)
+}
+
+/** Compact human uptime: "3d 4h", "4h 12m", or "12m". */
+export function formatUptime(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds))
+  const days = Math.floor(total / 86_400)
+  const hours = Math.floor((total % 86_400) / 3_600)
+  const minutes = Math.floor((total % 3_600) / 60)
+  if (days > 0) {
+    return `${days}d ${hours}h`
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`
+  }
+  return `${minutes}m`
+}
+
+/** Tailwind color class for a session's detected agent, for the status dot. */
+export function agentDotClass(agent: HostSessionAgent): string {
+  switch (agent) {
+    case 'claude':
+      return 'bg-orange-500'
+    case 'codex':
+      return 'bg-emerald-500'
+    case null:
+      return 'bg-muted-foreground/40'
+  }
+}
+
+/** Percent clamped to [0, 100] and rounded, for progress rendering. */
+export function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+  return Math.min(100, Math.max(0, Math.round(value)))
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2935,7 +2935,8 @@
             "972a1ff497": "Reset Codex limits?",
             "6d1042aa6f": "This uses one Codex rate-limit reset credit for the active account and resets any eligible usage windows immediately.",
             "f077f586db": "Don't ask again",
-            "c0e972d726": "Cancel"
+            "c0e972d726": "Cancel",
+            "b82b5ecf03": "Host Metrics"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -3098,6 +3099,24 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"
+          },
+          "HostStatusSegment": {
+            "6641a07d35": "attached",
+            "3b6f0532da": "No sessions detected",
+            "a08d335b74": "tmux is not running on this host",
+            "0ff2a9cbee": "Sessions on host",
+            "b54da3f1ac": "Loading host metrics...",
+            "ac42f3d00f": "GB ·",
+            "ae01984a93": "Memory",
+            "0b550095d7": "Uptime",
+            "518f1762a3": "Load avg",
+            "164c53f8d4": "{{value0}} cores",
+            "63dec15e89": ", memory",
+            "63e5e9dbdf": "— load",
+            "acdc4e06b5": "Host",
+            "aa85babed1": "Remote host metrics",
+            "tooltip": "Host {{label}} — load {{load}}, memory {{percent}}%",
+            "memory": "{{used}} / {{total}} GB · {{percent}}%"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2935,7 +2935,8 @@
             "972a1ff497": "¿Restablecer límites de Codex?",
             "6d1042aa6f": "Esto usa un crédito de restablecimiento de límite de Codex para la cuenta activa y restablece de inmediato las ventanas de uso aptas.",
             "f077f586db": "No volver a preguntar",
-            "c0e972d726": "Cancelar"
+            "c0e972d726": "Cancelar",
+            "b82b5ecf03": "Host Metrics"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",
@@ -3098,6 +3099,24 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "Host SSH"
+          },
+          "HostStatusSegment": {
+            "6641a07d35": "attached",
+            "3b6f0532da": "No sessions detected",
+            "a08d335b74": "tmux is not running on this host",
+            "0ff2a9cbee": "Sessions on host",
+            "b54da3f1ac": "Loading host metrics...",
+            "ac42f3d00f": "GB ·",
+            "ae01984a93": "Memory",
+            "0b550095d7": "Uptime",
+            "518f1762a3": "Load avg",
+            "164c53f8d4": "{{value0}} cores",
+            "63dec15e89": ", memory",
+            "63e5e9dbdf": "— load",
+            "acdc4e06b5": "Host",
+            "aa85babed1": "Remote host metrics",
+            "tooltip": "Host {{label}} — load {{load}}, memory {{percent}}%",
+            "memory": "{{used}} / {{total}} GB · {{percent}}%"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2935,7 +2935,8 @@
             "972a1ff497": "Codex の制限をリセットしますか？",
             "6d1042aa6f": "アクティブなアカウントの Codex レート制限リセット枠を 1 回使用し、対象の使用量ウィンドウを直ちにリセットします。",
             "f077f586db": "今後表示しない",
-            "c0e972d726": "キャンセル"
+            "c0e972d726": "キャンセル",
+            "b82b5ecf03": "Host Metrics"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",
@@ -3098,6 +3099,24 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH ホスト"
+          },
+          "HostStatusSegment": {
+            "6641a07d35": "attached",
+            "3b6f0532da": "No sessions detected",
+            "a08d335b74": "tmux is not running on this host",
+            "0ff2a9cbee": "Sessions on host",
+            "b54da3f1ac": "Loading host metrics...",
+            "ac42f3d00f": "GB ·",
+            "ae01984a93": "Memory",
+            "0b550095d7": "Uptime",
+            "518f1762a3": "Load avg",
+            "164c53f8d4": "{{value0}} cores",
+            "63dec15e89": ", memory",
+            "63e5e9dbdf": "— load",
+            "acdc4e06b5": "Host",
+            "aa85babed1": "Remote host metrics",
+            "tooltip": "Host {{label}} — load {{load}}, memory {{percent}}%",
+            "memory": "{{used}} / {{total}} GB · {{percent}}%"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2935,7 +2935,8 @@
             "972a1ff497": "Codex 한도를 재설정할까요?",
             "6d1042aa6f": "활성 계정의 Codex rate-limit 재설정 크레딧 1회를 사용해 재설정 가능한 사용량 창을 즉시 초기화합니다.",
             "f077f586db": "다시 묻지 않기",
-            "c0e972d726": "취소"
+            "c0e972d726": "취소",
+            "b82b5ecf03": "Host Metrics"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",
@@ -3098,6 +3099,24 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 호스트"
+          },
+          "HostStatusSegment": {
+            "6641a07d35": "attached",
+            "3b6f0532da": "No sessions detected",
+            "a08d335b74": "tmux is not running on this host",
+            "0ff2a9cbee": "Sessions on host",
+            "b54da3f1ac": "Loading host metrics...",
+            "ac42f3d00f": "GB ·",
+            "ae01984a93": "Memory",
+            "0b550095d7": "Uptime",
+            "518f1762a3": "Load avg",
+            "164c53f8d4": "{{value0}} cores",
+            "63dec15e89": ", memory",
+            "63e5e9dbdf": "— load",
+            "acdc4e06b5": "Host",
+            "aa85babed1": "Remote host metrics",
+            "tooltip": "Host {{label}} — load {{load}}, memory {{percent}}%",
+            "memory": "{{used}} / {{total}} GB · {{percent}}%"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2935,7 +2935,8 @@
             "972a1ff497": "重置 Codex 限额？",
             "6d1042aa6f": "这会为当前账户使用一次 Codex 速率限制重置额度，并立即重置所有符合条件的用量窗口。",
             "f077f586db": "不再询问",
-            "c0e972d726": "取消"
+            "c0e972d726": "取消",
+            "b82b5ecf03": "Host Metrics"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",
@@ -3098,6 +3099,24 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 主机"
+          },
+          "HostStatusSegment": {
+            "6641a07d35": "attached",
+            "3b6f0532da": "No sessions detected",
+            "a08d335b74": "tmux is not running on this host",
+            "0ff2a9cbee": "Sessions on host",
+            "b54da3f1ac": "Loading host metrics...",
+            "ac42f3d00f": "GB ·",
+            "ae01984a93": "Memory",
+            "0b550095d7": "Uptime",
+            "518f1762a3": "Load avg",
+            "164c53f8d4": "{{value0}} cores",
+            "63dec15e89": ", memory",
+            "63e5e9dbdf": "— load",
+            "acdc4e06b5": "Host",
+            "aa85babed1": "Remote host metrics",
+            "tooltip": "Host {{label}} — load {{load}}, memory {{percent}}%",
+            "memory": "{{used}} / {{total}} GB · {{percent}}%"
           }
         }
       },

--- a/src/shared/host-resource-metrics-types.ts
+++ b/src/shared/host-resource-metrics-types.ts
@@ -1,0 +1,21 @@
+// Resource metrics for an SSH execution host. Collected by the relay, which runs
+// ON the remote machine, so these describe the remote box — not the local Orca
+// process (that is covered by MemorySnapshot / HostMemory in ./types).
+
+export type HostResourceMetrics = {
+  totalMemory: number
+  freeMemory: number
+  usedMemory: number
+  memoryUsagePercent: number
+  cpuCoreCount: number
+  /** 1/5/15-minute load averages. On Windows os.loadavg() is [0,0,0]. */
+  loadAverage1m: number
+  loadAverage5m: number
+  loadAverage15m: number
+  uptimeSeconds: number
+  platform: NodeJS.Platform
+}
+
+export type HostMetricsResult = {
+  metrics: HostResourceMetrics | null
+}

--- a/src/shared/host-session-types.ts
+++ b/src/shared/host-session-types.ts
@@ -1,0 +1,30 @@
+// Types for host session discovery: enumerating pre-existing terminal
+// multiplexer (tmux) sessions on an SSH host and classifying which coding agent
+// each one is running. Unlike Orca's own workspace sessions, these are sessions
+// Orca does not own — they were started outside Orca (e.g. a bare `tmux` + agent
+// on the remote) and can only be observed by probing the host.
+
+export type HostSessionAgent = 'claude' | 'codex' | null
+
+export type HostSession = {
+  /** tmux session name. */
+  session: string
+  /** pane_current_path — working directory of the pane. */
+  cwd: string
+  /** pane_current_command — foreground command tmux reports for the pane. */
+  command: string
+  /** True when at least one client is attached to the session. */
+  attached: boolean
+  /** Agent detected by walking the pane's process subtree, or null if none. */
+  agent: HostSessionAgent
+  /** git branch at `cwd`, if the path is inside a repository. */
+  branch?: string
+  /** pane_pid — root of the process subtree used for agent classification. */
+  pid?: number
+}
+
+export type HostSessionsResult = {
+  sessions: HostSession[]
+  /** False when tmux is not installed or no server is running on the host. */
+  tmuxAvailable: boolean
+}

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -8,5 +8,6 @@ export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'kimi',
   'ssh',
   'resource-usage',
-  'ports'
+  'ports',
+  'host'
 ]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3104,6 +3104,7 @@ export type StatusBarItem =
   | 'ssh'
   | 'resource-usage'
   | 'ports'
+  | 'host'
 export type FloatingTerminalTriggerLocation = 'floating-button' | 'status-bar'
 
 export type TaskResumeState = {


### PR DESCRIPTION
## What

Adds a **"Host" status-bar segment** that surfaces the active SSH execution host's telemetry:

- **Glanceable trigger** — `1m-load · memory%`.
- **Popover** — load 1/5/15m, memory used/total with a usage bar, CPU cores, uptime, and the list of **external tmux sessions** on the host (name · git branch · detected agent `claude`/`codex` · attached state).

The segment targets the first connected, user-managed SSH target (runtime-owned ephemeral VMs excluded) and renders nothing when no such host is connected. A `host` status-bar item (default-on) is toggleable from the status-bar overflow menu.

## Depends on

- #7284 — `host.discoverSessions` relay probe (sessions list)
- #7286 — `host.metrics` relay probe (resource metrics)

**Merge order:** this should land after #7284 and #7286. This branch is stacked on both, so until they merge the diff here also shows their commits; it narrows to the UI-only diff once they're in.

## Design / behavior

- Follows `PortsStatusSegment` for the popover structure and design tokens (`docs/STYLEGUIDE.md`); no new color/spacing primitives.
- **Polling policy:** metrics poll continuously (cheap `os.*` on the remote); session discovery runs **only while the popover is open**, since it walks `tmux`/`ps`/`git` on the host.
- Data is fetched per-open via `window.api.ssh.getHostMetrics` / `discoverHostSessions`; no store/persistence changes.
- All user-facing strings localized via the catalog (`translate` + `sync:localization-catalog`), parity synced across es/ja/ko/zh.

## Test plan

- [x] `vitest` — pure formatting helpers (`formatGib`/`formatLoad`/`formatUptime`/`clampPercent`/`agentDotClass`)
- [x] `typecheck` (node + cli + web) clean
- [x] `oxlint` clean on changed files
- [x] `verify:localization-catalog` + `verify:localization-coverage` pass
- [ ] Manual: connect an SSH host with a detached `tmux` + `claude`; confirm the segment shows remote load/memory and lists the session with its branch + agent badge

## ELI5

A Host status-bar segment shows SSH host load, memory, and external tmux sessions. Glance at remote health without leaving the workspace.
