### PR TITLE
Include Claude Fable reset countdown

### DIFF
--- a/src/main/rate-limits/claude-pty-reset-parser.ts
+++ b/src/main/rate-limits/claude-pty-reset-parser.ts
@@ -1,0 +1,258 @@
+import type { RateLimitWindow } from '../../shared/rate-limit-types'
+import { buildWallClockTimestamp } from './time-zone-wall-clock'
+
+const RESET_LINE_RE = /resets?\s+(?:at\s+|in\s+)?(.+)/i
+const MONTH_PATTERN =
+  'jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?'
+const MONTH_DAY_COMPACT_RE = new RegExp(
+  `\\b(${MONTH_PATTERN})(\\d{1,2})(?=\\s*at\\s*\\d|\\D|$)`,
+  'i'
+)
+const MONTH_DAY_TIME_RE = new RegExp(
+  `\\b(${MONTH_PATTERN})\\.?\\s+(\\d{1,2})(?:,?\\s*(?:at\\s+)?)?(\\d{1,2})(?::(\\d{2}))?\\s*(am|pm)\\b`,
+  'i'
+)
+const WEEKDAY_TIME_RE =
+  /\b(sun(?:day)?|mon(?:day)?|tue(?:sday)?|wed(?:nesday)?|thu(?:rsday)?|fri(?:day)?|sat(?:urday)?)\.?\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b/i
+const TIME_ONLY_RE = /\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b/i
+const RELATIVE_RESET_RE = /^(?:\s*\d+\s*(?:d(?:ays?)?|h(?:ours?|rs?)?|m(?:in(?:ute)?s?)?)\s*)+$/i
+const RELATIVE_RESET_TOKEN_RE = /(\d+)\s*(d(?:ays?)?|h(?:ours?|rs?)?|m(?:in(?:ute)?s?)?)/gi
+const IANA_TIME_ZONE_RE = /\(([^()]*)\)?\s*$/
+
+export type ClaudePtyResetMetadata = Pick<RateLimitWindow, 'resetsAt' | 'resetDescription'>
+
+const MONTH_INDEX_BY_NAME: Record<string, number> = {
+  jan: 0,
+  january: 0,
+  feb: 1,
+  february: 1,
+  mar: 2,
+  march: 2,
+  apr: 3,
+  april: 3,
+  may: 4,
+  jun: 5,
+  june: 5,
+  jul: 6,
+  july: 6,
+  aug: 7,
+  august: 7,
+  sep: 8,
+  sept: 8,
+  september: 8,
+  oct: 9,
+  october: 9,
+  nov: 10,
+  november: 10,
+  dec: 11,
+  december: 11
+}
+
+const WEEKDAY_INDEX_BY_NAME: Record<string, number> = {
+  sun: 0,
+  sunday: 0,
+  mon: 1,
+  monday: 1,
+  tue: 2,
+  tuesday: 2,
+  wed: 3,
+  wednesday: 3,
+  thu: 4,
+  thursday: 4,
+  fri: 5,
+  friday: 5,
+  sat: 6,
+  saturday: 6
+}
+
+export function extractClaudePtyResetMetadata(
+  lines: string[],
+  matchesLabel: (line: string) => boolean,
+  isSectionLabel: (line: string) => boolean
+): ClaudePtyResetMetadata {
+  for (let i = 0; i < lines.length; i++) {
+    if (!matchesLabel(lines[i])) {
+      continue
+    }
+    for (let j = i; j < Math.min(i + 14, lines.length); j++) {
+      if (j > i && isSectionLabel(lines[j])) {
+        break
+      }
+      const m = RESET_LINE_RE.exec(lines[j])
+      if (m) {
+        const resetDescription = normalizeResetDescription(m[1])
+        return {
+          resetsAt: parseResetTimestamp(resetDescription),
+          resetDescription
+        }
+      }
+    }
+  }
+  return { resetsAt: null, resetDescription: null }
+}
+
+function normalizeResetDescription(raw: string): string {
+  // Why: Claude's TUI occasionally drops spaces around the Fable reset date
+  // when copied from the PTY buffer, but the value still encodes a real reset.
+  return raw
+    .trim()
+    .replace(/[)]+$/, '')
+    .replace(/\s+/g, ' ')
+    .replace(MONTH_DAY_COMPACT_RE, '$1 $2')
+    .replace(/(\d{1,2})\s*at\s*(\d{1,2}(?::\d{2})?\s*(?:am|pm))/i, '$1 at $2')
+    .replace(/(\d)(am|pm)\(/gi, '$1$2 (')
+}
+
+function parseResetTimestamp(resetDescription: string | null): number | null {
+  if (!resetDescription) {
+    return null
+  }
+
+  return (
+    parseRelativeResetTimestamp(resetDescription) ??
+    parseMonthDayResetTimestamp(resetDescription) ??
+    parseWeekdayResetTimestamp(resetDescription) ??
+    parseTimeOnlyResetTimestamp(resetDescription)
+  )
+}
+
+function parseRelativeResetTimestamp(resetDescription: string): number | null {
+  if (!RELATIVE_RESET_RE.test(resetDescription)) {
+    return null
+  }
+
+  let durationMs = 0
+  for (const match of resetDescription.matchAll(RELATIVE_RESET_TOKEN_RE)) {
+    const amount = Number(match[1])
+    const unit = match[2].toLowerCase()[0]
+    if (!Number.isFinite(amount)) {
+      continue
+    }
+    if (unit === 'd') {
+      durationMs += amount * 24 * 60 * 60_000
+    } else if (unit === 'h') {
+      durationMs += amount * 60 * 60_000
+    } else if (unit === 'm') {
+      durationMs += amount * 60_000
+    }
+  }
+  return durationMs > 0 ? Date.now() + durationMs : null
+}
+
+function parseMonthDayResetTimestamp(resetDescription: string): number | null {
+  const resetText = stripResetTimeZone(resetDescription)
+  const match = MONTH_DAY_TIME_RE.exec(resetText)
+  if (!match) {
+    return null
+  }
+
+  const monthIndex = MONTH_INDEX_BY_NAME[match[1].toLowerCase()]
+  if (monthIndex === undefined) {
+    return null
+  }
+
+  const day = Number(match[2])
+  const hour = parseHour(match[3], match[5])
+  const minute = Number(match[4] ?? 0)
+  if (!isValidClockTime(hour, minute)) {
+    return null
+  }
+
+  const now = new Date()
+  const timeZone = extractResetTimeZone(resetDescription)
+  let timestamp = buildWallClockTimestamp(
+    { year: now.getFullYear(), monthIndex, day, hour, minute },
+    timeZone
+  )
+  if (timestamp !== null && timestamp <= Date.now()) {
+    timestamp = buildWallClockTimestamp(
+      { year: now.getFullYear() + 1, monthIndex, day, hour, minute },
+      timeZone
+    )
+  }
+  return timestamp
+}
+
+function parseWeekdayResetTimestamp(resetDescription: string): number | null {
+  const resetText = stripResetTimeZone(resetDescription)
+  const match = WEEKDAY_TIME_RE.exec(resetText)
+  if (!match) {
+    return null
+  }
+
+  const weekdayIndex = WEEKDAY_INDEX_BY_NAME[match[1].toLowerCase()]
+  if (weekdayIndex === undefined) {
+    return null
+  }
+
+  const now = new Date()
+  const hour = parseHour(match[2], match[4])
+  const minute = Number(match[3] ?? 0)
+  if (!isValidClockTime(hour, minute)) {
+    return null
+  }
+
+  const candidate = new Date(now)
+  const daysUntil = (weekdayIndex - now.getDay() + 7) % 7
+  candidate.setDate(now.getDate() + daysUntil)
+  candidate.setHours(hour, minute, 0, 0)
+  if (candidate.getTime() <= Date.now()) {
+    candidate.setDate(candidate.getDate() + 7)
+  }
+  return candidate.getTime()
+}
+
+function parseTimeOnlyResetTimestamp(resetDescription: string): number | null {
+  const resetText = stripResetTimeZone(resetDescription)
+  const match = TIME_ONLY_RE.exec(resetText)
+  if (!match) {
+    return null
+  }
+
+  const hour = parseHour(match[1], match[3])
+  const minute = Number(match[2] ?? 0)
+  if (!isValidClockTime(hour, minute)) {
+    return null
+  }
+
+  const candidate = new Date()
+  candidate.setHours(hour, minute, 0, 0)
+  if (candidate.getTime() <= Date.now()) {
+    candidate.setDate(candidate.getDate() + 1)
+  }
+  return candidate.getTime()
+}
+
+function parseHour(hourText: string, periodText: string): number {
+  const hour = Number(hourText)
+  const period = periodText.toLowerCase()
+  if (hour < 1 || hour > 12) {
+    return Number.NaN
+  }
+  if (period === 'am') {
+    return hour === 12 ? 0 : hour
+  }
+  return hour === 12 ? 12 : hour + 12
+}
+
+function isValidClockTime(hour: number, minute: number): boolean {
+  return Number.isInteger(hour) && hour >= 0 && hour < 24 && minute >= 0 && minute < 60
+}
+
+function stripResetTimeZone(resetDescription: string): string {
+  return resetDescription.replace(/\s*\([^)]*\)?\s*$/, '').trim()
+}
+
+function extractResetTimeZone(resetDescription: string): string | null {
+  const match = IANA_TIME_ZONE_RE.exec(resetDescription)
+  if (!match?.[1]) {
+    return null
+  }
+  const timeZone = match[1].trim()
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone })
+    return timeZone
+  } catch {
+    return null
+  }
+}

--- a/src/main/rate-limits/claude-pty.test.ts
+++ b/src/main/rate-limits/claude-pty.test.ts
@@ -244,6 +244,7 @@ describe('fetchViaPty', () => {
   it('parses the newer Claude weekly limits wording for Fable usage', async () => {
     const term = makeMockTerm()
     spawnMock.mockReturnValue(term)
+    vi.setSystemTime(new Date(2026, 6, 3, 20, 0))
 
     const resultPromise = fetchViaPty()
 
@@ -262,16 +263,20 @@ describe('fetchViaPty', () => {
     `)
     await vi.advanceTimersByTimeAsync(2_000)
 
-    await expect(resultPromise).resolves.toMatchObject({
+    const result = await resultPromise
+
+    expect(result).toMatchObject({
       provider: 'claude',
       status: 'ok',
       session: {
         usedPercent: 82,
+        resetsAt: Date.now() + 2 * 60 * 60_000 + 10 * 60_000,
         resetDescription: '2h 10m'
       },
       weekly: null,
       fableWeekly: {
         usedPercent: 42,
+        resetsAt: Date.now() + 3 * 24 * 60 * 60_000 + 2 * 60 * 60_000,
         resetDescription: '3d 2h'
       },
       error: null
@@ -324,6 +329,7 @@ describe('fetchViaPty', () => {
   it('parses Claude current-week Fable usage as a distinct weekly window', async () => {
     const term = makeMockTerm()
     spawnMock.mockReturnValue(term)
+    vi.setSystemTime(new Date(2026, 6, 3, 20, 0))
 
     const resultPromise = fetchViaPty()
 
@@ -337,11 +343,11 @@ describe('fetchViaPty', () => {
 
       Current week (all models)
       33% used
-      Resets Jul 3 at 12:59pm
+      Resets Jul 10 at 12:59pm
 
       Current week (Fable)
       62% used
-      Resets Jul 3 at 12:59pm
+      Resets Jul10at12:59pm(America/Los_Angeles)
     `)
     await vi.advanceTimersByTimeAsync(2_000)
 
@@ -354,11 +360,13 @@ describe('fetchViaPty', () => {
       },
       weekly: {
         usedPercent: 33,
-        resetDescription: 'Jul 3 at 12:59pm'
+        resetsAt: new Date(2026, 6, 10, 12, 59).getTime(),
+        resetDescription: 'Jul 10 at 12:59pm'
       },
       fableWeekly: {
         usedPercent: 62,
-        resetDescription: 'Jul 3 at 12:59pm'
+        resetsAt: Date.parse('2026-07-10T19:59:00.000Z'),
+        resetDescription: 'Jul 10 at 12:59pm (America/Los_Angeles'
       },
       error: null
     })

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -8,6 +8,7 @@ import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-au
 import { applyClaudeEnvPatch } from '../claude-accounts/environment'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { cleanupHiddenRateLimitPty } from './hidden-pty-cleanup'
+import { extractClaudePtyResetMetadata } from './claude-pty-reset-parser'
 
 const PTY_TIMEOUT_MS = 25_000
 const MAX_OUTPUT_LENGTH = 100_000 // 100KB buffer limit
@@ -26,7 +27,6 @@ const FABLE_LABEL_RE = /^\s*fable\s*$/i
 const FABLE_WEEKLY_LABEL_RE =
   /(?:current\s*week|weekly\s*(?:limits?|usage|rate\s*limits?)|7\s*[- ]?\s*day)\s*(?:\([^)]*\bfable\b[^)]*\)|[-:]?\s*\bfable\b)/i
 const PERCENT_RE = /(\d{1,3})(?:\.\d+)?\s*%\s*(used|consumed|left|remaining|available)/i
-const RESET_LINE_RE = /resets?\s+(?:at\s+|in\s+)?(.+)/i
 const ESC = String.fromCharCode(27)
 const BEL = String.fromCharCode(7)
 const OSC_SEQUENCE_RE = new RegExp(`${ESC}\\][^${BEL}]*(?:${BEL}|${ESC}\\\\)`, 'g')
@@ -83,27 +83,6 @@ function extractPercentAfterLabel(
   return null
 }
 
-function extractResetAfterLabel(
-  lines: string[],
-  matchesLabel: (line: string) => boolean
-): string | null {
-  for (let i = 0; i < lines.length; i++) {
-    if (!matchesLabel(lines[i])) {
-      continue
-    }
-    for (let j = i; j < Math.min(i + 14, lines.length); j++) {
-      if (j > i && isSectionLabel(lines[j])) {
-        break
-      }
-      const m = RESET_LINE_RE.exec(lines[j])
-      if (m) {
-        return m[1].trim().replace(/[)]+$/, '')
-      }
-    }
-  }
-  return null
-}
-
 function parsePtyUsage(output: string): {
   session: RateLimitWindow | null
   weekly: RateLimitWindow | null
@@ -114,14 +93,25 @@ function parsePtyUsage(output: string): {
   const sessionPct = extractPercentAfterLabel(lines, (line) => SESSION_RE.test(line))
   const weeklyPct = extractPercentAfterLabel(lines, matchesWeeklyLabel)
   const fableWeeklyPct = extractPercentAfterLabel(lines, matchesFableUsageLabel)
+  const sessionReset = extractClaudePtyResetMetadata(
+    lines,
+    (line) => SESSION_RE.test(line),
+    isSectionLabel
+  )
+  const weeklyReset = extractClaudePtyResetMetadata(lines, matchesWeeklyLabel, isSectionLabel)
+  const fableWeeklyReset = extractClaudePtyResetMetadata(
+    lines,
+    matchesFableUsageLabel,
+    isSectionLabel
+  )
 
   const session: RateLimitWindow | null =
     sessionPct !== null
       ? {
           usedPercent: Math.min(100, Math.max(0, sessionPct)),
           windowMinutes: 300,
-          resetsAt: null,
-          resetDescription: extractResetAfterLabel(lines, (line) => SESSION_RE.test(line))
+          resetsAt: sessionReset.resetsAt,
+          resetDescription: sessionReset.resetDescription
         }
       : null
 
@@ -130,8 +120,8 @@ function parsePtyUsage(output: string): {
       ? {
           usedPercent: Math.min(100, Math.max(0, weeklyPct)),
           windowMinutes: 10080,
-          resetsAt: null,
-          resetDescription: extractResetAfterLabel(lines, matchesWeeklyLabel)
+          resetsAt: weeklyReset.resetsAt,
+          resetDescription: weeklyReset.resetDescription
         }
       : null
 
@@ -140,8 +130,8 @@ function parsePtyUsage(output: string): {
       ? {
           usedPercent: Math.min(100, Math.max(0, fableWeeklyPct)),
           windowMinutes: 10080,
-          resetsAt: null,
-          resetDescription: extractResetAfterLabel(lines, matchesFableUsageLabel)
+          resetsAt: fableWeeklyReset.resetsAt,
+          resetDescription: fableWeeklyReset.resetDescription
         }
       : null
 

--- a/src/main/rate-limits/time-zone-wall-clock.ts
+++ b/src/main/rate-limits/time-zone-wall-clock.ts
@@ -1,0 +1,86 @@
+export type WallClockDateParts = {
+  year: number
+  monthIndex: number
+  day: number
+  hour: number
+  minute: number
+}
+
+export function buildWallClockTimestamp(
+  parts: WallClockDateParts,
+  timeZone: string | null
+): number | null {
+  if (!timeZone) {
+    const localDate = new Date(parts.year, parts.monthIndex, parts.day, parts.hour, parts.minute)
+    return isMatchingDateParts(localDate, parts) ? localDate.getTime() : null
+  }
+
+  const timestamp = buildTimeZoneTimestamp(parts, timeZone)
+  if (timestamp === null) {
+    return null
+  }
+  const resolvedParts = getTimeZoneDateParts(timestamp, timeZone)
+  return resolvedParts && areMatchingWallClockParts(resolvedParts, parts) ? timestamp : null
+}
+
+function buildTimeZoneTimestamp(parts: WallClockDateParts, timeZone: string): number | null {
+  const utcGuess = Date.UTC(parts.year, parts.monthIndex, parts.day, parts.hour, parts.minute)
+  const firstOffset = getTimeZoneOffsetMs(utcGuess, timeZone)
+  if (firstOffset === null) {
+    return null
+  }
+  const firstTimestamp = utcGuess - firstOffset
+  const secondOffset = getTimeZoneOffsetMs(firstTimestamp, timeZone)
+  return secondOffset === null ? null : utcGuess - secondOffset
+}
+
+function getTimeZoneOffsetMs(timestamp: number, timeZone: string): number | null {
+  const parts = getTimeZoneDateParts(timestamp, timeZone)
+  if (!parts) {
+    return null
+  }
+  return Date.UTC(parts.year, parts.monthIndex, parts.day, parts.hour, parts.minute) - timestamp
+}
+
+function getTimeZoneDateParts(timestamp: number, timeZone: string): WallClockDateParts | null {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+  const parts = Object.fromEntries(
+    formatter.formatToParts(new Date(timestamp)).map((part) => [part.type, part.value])
+  )
+  const year = Number(parts.year)
+  const monthIndex = Number(parts.month) - 1
+  const day = Number(parts.day)
+  const hour = Number(parts.hour)
+  const minute = Number(parts.minute)
+  return [year, monthIndex, day, hour, minute].every(Number.isFinite)
+    ? { year, monthIndex, day, hour, minute }
+    : null
+}
+
+function isMatchingDateParts(date: Date, parts: WallClockDateParts): boolean {
+  return (
+    date.getFullYear() === parts.year &&
+    date.getMonth() === parts.monthIndex &&
+    date.getDate() === parts.day &&
+    date.getHours() === parts.hour &&
+    date.getMinutes() === parts.minute
+  )
+}
+
+function areMatchingWallClockParts(left: WallClockDateParts, right: WallClockDateParts): boolean {
+  return (
+    left.year === right.year &&
+    left.monthIndex === right.monthIndex &&
+    left.day === right.day &&
+    left.hour === right.hour &&
+    left.minute === right.minute
+  )
+}

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 
 vi.mock('@/lib/agent-catalog', () => ({
@@ -20,7 +21,8 @@ import {
   formatResetCountdown,
   getProviderUsageErrorMessage,
   getProviderUsageStatusLabel,
-  getWindowSections
+  getWindowSections,
+  ProviderPanel
 } from './tooltip'
 
 function provider(overrides: Partial<ProviderRateLimits> = {}): ProviderRateLimits {
@@ -376,5 +378,28 @@ describe('getWindowSections', () => {
     expect(sections[0].label).toBe('Pro')
     expect(sections[0].window!.resetsAt).toBe(18000000)
     expect(sections[0].window!.resetDescription).toBe('5:00 PM')
+  })
+})
+
+describe('ProviderPanel reset rendering', () => {
+  it('renders the Fable reset countdown when Claude reports a reset timestamp', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 6, 3, 20, 0))
+    const p = provider({
+      status: 'ok',
+      session: null,
+      weekly: null,
+      fableWeekly: {
+        usedPercent: 62,
+        windowMinutes: 10080,
+        resetsAt: Date.now() + (6 * 24 + 17) * 60 * 60_000,
+        resetDescription: 'Jul 10 at 1:00 PM'
+      }
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).toContain('Fable')
+    expect(markup).toContain('Resets in 6d 17h')
   })
 })


### PR DESCRIPTION
## Summary

- Populate `resetsAt` from the Claude `/usage` PTY fallback instead of carrying only the raw reset text.
- Handle the reset formats Claude currently emits for plan usage: relative durations (`3d 2h`), session times (`9pm`), weekday times, month/day times, and compact Fable text like `Jul10at12:59pm(America/Los_Angeles)`.
- Keep tooltip rendering unchanged and add a renderer regression test proving the Fable row shows `Resets in 6d 17h` once `resetsAt` is present.

## Diagnosis

The Fable usage row was already being parsed and passed through, but the PTY path only filled `resetDescription`. `ProviderPanel` intentionally renders reset copy from `w.resetsAt` via `formatResetCountdown`; when `fableWeekly.resetsAt` was `null`, the Fable row could show usage but not `Resets in ...`.

## Evidence

Live Claude PTY fetch on this branch:

```json
{
  "status": "ok",
  "error": null,
  "weekly": {
    "usedPercent": 20,
    "windowMinutes": 10080,
    "resetsAt": 1783713600000,
    "resetDescription": "Jul 10 at 1pm (America/Los_Angeles"
  },
  "fableWeekly": {
    "usedPercent": 4,
    "windowMinutes": 10080,
    "resetsAt": 1783713600000,
    "resetDescription": "Jul 10 at 1pm (America/Los_Angeles"
  },
  "fableCountdown": "Resets in 6d 17h"
}
```

Local visual evidence was also captured at 4x resolution at `/tmp/orca-fable-reset-evidence-4x.png` and not committed, per repo instructions for PR evidence images.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/claude-pty.test.ts src/main/rate-limits/claude-fetcher.test.ts src/main/rate-limits/service.test.ts src/renderer/src/components/status-bar/tooltip.test.ts src/renderer/src/components/status-bar/inline-usage-bars.test.tsx`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- Live `fetchViaPty()` smoke command shown above
