### PR TITLE
fix(automations): start scheduler in headless serve mode

### DIFF
--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -348,6 +348,76 @@ describe('AutomationService', () => {
     )
   })
 
+  it('dispatches due scheduled automations headlessly', async () => {
+    const store = await createStore()
+    const runtimeHostId = toRuntimeExecutionHostId('gpu-server')
+    store.addRepo(makeRepo({ executionHostId: runtimeHostId }))
+    const setup = store.getProjectHostSetups()[0]!
+    vi.useRealTimers()
+    const current = new Date()
+    const hour = current.getUTCHours()
+    const minute = current.getUTCMinutes()
+    const automation = store.createAutomation({
+      name: 'Morning check',
+      prompt: 'Check the repo',
+      agentId: 'claude',
+      projectId: 'r1',
+      runContext: {
+        kind: 'workspace-run',
+        projectId: setup.projectId,
+        hostId: runtimeHostId,
+        projectHostSetupId: setup.id,
+        repoId: setup.repoId,
+        path: setup.path
+      },
+      workspaceMode: 'new_per_run',
+      timezone: 'UTC',
+      rrule: `FREQ=DAILY;BYHOUR=${hour};BYMINUTE=${minute}`,
+      dtstart: Date.UTC(
+        current.getUTCFullYear(),
+        current.getUTCMonth(),
+        current.getUTCDate() - 1
+      ),
+      missedRunGraceMinutes: 100_000
+    })
+    const persistedAutomation = (
+      store as unknown as { state: { automations: Array<{ id: string; nextRunAt: number }> } }
+    ).state.automations.find((entry) => entry.id === automation.id)
+    if (!persistedAutomation) {
+      throw new Error('Automation not found in store.')
+    }
+    persistedAutomation.nextRunAt = 0
+
+    const headlessDispatcher = vi.fn().mockResolvedValue({
+      workspaceId: 'wt1',
+      workspaceDisplayName: 'Morning check',
+      terminalSessionId: 'tab-1',
+      terminalPaneKey: 'pane-1',
+      terminalPtyId: 'pty-1'
+    })
+    vi.useRealTimers()
+    const service = new AutomationService(store, {
+      tickMs: 1,
+      allowRemoteHostScheduling: true,
+      headlessDispatcher
+    })
+
+    try {
+      service.start()
+      await vi.waitFor(() => expect(headlessDispatcher).toHaveBeenCalledTimes(1))
+      const run = store.listAutomationRuns(automation.id)[0]
+      expect(run?.status).toBe('dispatched')
+      expect(headlessDispatcher).toHaveBeenCalledWith(
+        expect.objectContaining({ automation: expect.objectContaining({ id: automation.id }) })
+      )
+      expect(store.listAutomations().find((entry) => entry.id === automation.id)?.nextRunAt).toBeGreaterThan(
+        run?.scheduledFor ?? 0
+      )
+    } finally {
+      service.stop()
+    }
+  })
+
   it('attaches provider usage when a completed run can be attributed', async () => {
     vi.setSystemTime(new Date('2026-05-13T10:00:00'))
     const store = await createStore()

--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -349,14 +349,17 @@ describe('AutomationService', () => {
   })
 
   it('dispatches due scheduled automations headlessly', async () => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const beforeRunAt = new Date(2026, 4, 13, 8, 59).getTime()
+    const scheduledRunAt = new Date(2026, 4, 13, 9, 0).getTime()
+    const afterRunAt = new Date(2026, 4, 13, 9, 1).getTime()
+    const nextRunAt = new Date(2026, 4, 14, 9, 0).getTime()
+
+    vi.setSystemTime(beforeRunAt)
     const store = await createStore()
     const runtimeHostId = toRuntimeExecutionHostId('gpu-server')
     store.addRepo(makeRepo({ executionHostId: runtimeHostId }))
     const setup = store.getProjectHostSetups()[0]!
-    vi.useRealTimers()
-    const current = new Date()
-    const hour = current.getUTCHours()
-    const minute = current.getUTCMinutes()
     const automation = store.createAutomation({
       name: 'Morning check',
       prompt: 'Check the repo',
@@ -371,22 +374,10 @@ describe('AutomationService', () => {
         path: setup.path
       },
       workspaceMode: 'new_per_run',
-      timezone: 'UTC',
-      rrule: `FREQ=DAILY;BYHOUR=${hour};BYMINUTE=${minute}`,
-      dtstart: Date.UTC(
-        current.getUTCFullYear(),
-        current.getUTCMonth(),
-        current.getUTCDate() - 1
-      ),
-      missedRunGraceMinutes: 100_000
+      timezone,
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date(2026, 4, 12, 0, 0).getTime()
     })
-    const persistedAutomation = (
-      store as unknown as { state: { automations: Array<{ id: string; nextRunAt: number }> } }
-    ).state.automations.find((entry) => entry.id === automation.id)
-    if (!persistedAutomation) {
-      throw new Error('Automation not found in store.')
-    }
-    persistedAutomation.nextRunAt = 0
 
     const headlessDispatcher = vi.fn().mockResolvedValue({
       workspaceId: 'wt1',
@@ -395,23 +386,26 @@ describe('AutomationService', () => {
       terminalPaneKey: 'pane-1',
       terminalPtyId: 'pty-1'
     })
-    vi.useRealTimers()
     const service = new AutomationService(store, {
-      tickMs: 1,
+      tickMs: 60_000,
       allowRemoteHostScheduling: true,
       headlessDispatcher
     })
 
     try {
+      vi.setSystemTime(afterRunAt)
       service.start()
       await vi.waitFor(() => expect(headlessDispatcher).toHaveBeenCalledTimes(1))
       const run = store.listAutomationRuns(automation.id)[0]
       expect(run?.status).toBe('dispatched')
+      expect(run?.scheduledFor).toBe(scheduledRunAt)
       expect(headlessDispatcher).toHaveBeenCalledWith(
         expect.objectContaining({ automation: expect.objectContaining({ id: automation.id }) })
       )
-      expect(store.listAutomations().find((entry) => entry.id === automation.id)?.nextRunAt).toBeGreaterThan(
-        run?.scheduledFor ?? 0
+      await vi.waitFor(() =>
+        expect(store.listAutomations().find((entry) => entry.id === automation.id)?.nextRunAt).toBe(
+          nextRunAt
+        )
       )
     } finally {
       service.stop()

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -69,7 +69,9 @@ export class AutomationService {
     this.timer = setInterval(() => {
       void this.evaluateDueRuns()
     }, this.tickMs)
-    if (this.rendererReady) {
+    // Why: headless serve never gets a renderer-ready IPC, but due runs still
+    // need the same startup catch-up pass desktop gets after renderer attach.
+    if (this.rendererReady || this.headlessDispatcher) {
       void this.evaluateDueRuns()
     }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2046,6 +2046,8 @@ app.whenReady().then(async () => {
         )
       }
     }
+    // Headless serve never opens a renderer, so arm scheduled automation dispatch here.
+    automations.start()
     await printServeReady(serveOptions)
     return
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2046,7 +2046,7 @@ app.whenReady().then(async () => {
         )
       }
     }
-    // Headless serve never opens a renderer, so arm scheduled automation dispatch here.
+    // Why: headless serve never opens a renderer, so arm scheduled automation dispatch here.
     automations.start()
     await printServeReady(serveOptions)
     return

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -32,4 +32,28 @@ describe('desktop startup ordering', () => {
     expect(attachIndex).toBeGreaterThanOrEqual(0)
     expect(startIndex).toBeGreaterThan(attachIndex)
   })
+
+  it('starts the automation scheduler before headless serve reports ready', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const serveStart = source.indexOf('if (serveOptions) {')
+    const serveReady = source.indexOf('await printServeReady(serveOptions)', serveStart)
+    const serveReturn = source.indexOf('return', serveReady)
+    const runtimeRpcStart = source.indexOf('await runtimeRpc.start()', serveStart)
+    const automationStart = source.indexOf('automations.start()', serveStart)
+    const desktopSetWebContents = source.indexOf('automations.setWebContents(window.webContents)')
+    const desktopAutomationStart = source.indexOf(
+      'automations.start()',
+      desktopSetWebContents + 1
+    )
+
+    expect(serveStart).toBeGreaterThanOrEqual(0)
+    expect(serveReady).toBeGreaterThan(serveStart)
+    expect(serveReturn).toBeGreaterThan(serveReady)
+    expect(runtimeRpcStart).toBeGreaterThan(serveStart)
+    expect(automationStart).toBeGreaterThan(runtimeRpcStart)
+    expect(automationStart).toBeLessThan(serveReady)
+    expect(automationStart).toBeLessThan(serveReturn)
+    expect(desktopSetWebContents).toBeGreaterThanOrEqual(0)
+    expect(desktopAutomationStart).toBeGreaterThan(desktopSetWebContents)
+  })
 })


### PR DESCRIPTION
## Summary

- Start the automation scheduler when Orca runs in headless `orca-ide serve` mode so due scheduled automations can create and dispatch runs without a renderer window.
- Keep the existing desktop scheduler startup and headless dispatcher paths; the fix wires the serve lifecycle to the already-constructed `AutomationService`.

Closes #7270.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/desktop-startup-ordering.test.ts -t "starts the automation scheduler before headless serve reports ready"` - passed; covers the serve startup ordering regression.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/automations/service.test.ts -t "dispatches due scheduled automations headlessly"` - passed; covers headless scheduled dispatch from a started service.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/desktop-startup-ordering.test.ts src/main/automations/service.test.ts` - passed; covers startup ordering and automation service behavior together.
- `pnpm run typecheck:node` - passed; covers main-process TypeScript integration.

## AI Review Report

Reviewed the final diff for lifecycle regressions and reran the focused startup and service tests after review feedback. The change stays in the main-process startup path, starts the existing scheduler only in headless serve mode, leaves desktop window startup unchanged, and preserves the existing headless dispatcher and manual RPC wiring. No macOS, Linux, Windows, SSH, remote/local, provider, performance, or UI quality issue surfaced in the touched code.

## Security Audit

Security risk stays low. The patch only arms an existing in-process scheduler in serve mode, adds no new subprocess construction, auth flow, filesystem path handling, IPC channel, browser surface, or secret handling, and keeps the existing serve startup ordering around RPC, signal handlers, and CLI setup intact.

## Notes

Out of scope: changing automation schedule calculation, missed-run policy, manual `orca automations run`, renderer readiness IPC, remote-host ownership rules, CLI installer behavior, or headless dispatcher implementation.
