### PR TITLE
fix(terminal): fall back from stale local startup cwd

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4086,6 +4086,70 @@ describe('registerPtyHandlers', () => {
     })
   })
 
+  it('falls back to the worktree root for stale local renderer cwd values', async () => {
+    registerPtyHandlers(mainWindow as never)
+
+    await handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+      cols: 80,
+      rows: 24,
+      cwd: '/var/tmp/orca-stale',
+      cwdFallback: 'worktree',
+      worktreeId: 'repo-1::/repo/app'
+    })
+
+    const spawnCall = spawnMock.mock.calls.at(-1)
+    expect(spawnCall?.[2]).toMatchObject({ cwd: '/repo/app' })
+  })
+
+  it('rejects stale renderer cwd values without the fallback flag', async () => {
+    registerPtyHandlers(mainWindow as never)
+
+    await expect(
+      handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+        cols: 80,
+        rows: 24,
+        cwd: '/var/tmp/orca-stale',
+        worktreeId: 'repo-1::/repo/app'
+      })
+    ).rejects.toThrow('Terminal cwd must be inside the selected worktree.')
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps renderer PTY cwd strict when a connectionId is present', async () => {
+    registerPtyHandlers(mainWindow as never)
+
+    await expect(
+      handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+        cols: 80,
+        rows: 24,
+        cwd: '/var/tmp/orca-stale',
+        cwdFallback: 'worktree',
+        connectionId: 'ssh-1',
+        worktreeId: 'repo-1::/repo/app'
+      })
+    ).rejects.toThrow('Terminal cwd must be inside the selected worktree.')
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps renderer PTY cwd strict when a sessionId is present', async () => {
+    registerPtyHandlers(mainWindow as never)
+
+    await expect(
+      handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+        cols: 80,
+        rows: 24,
+        cwd: '/var/tmp/orca-stale',
+        cwdFallback: 'worktree',
+        sessionId: 'session-1',
+        worktreeId: 'repo-1::/repo/app'
+      })
+    ).rejects.toThrow('Terminal cwd must be inside the selected worktree.')
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
   it('does not echo launch config for provider reattach results', async () => {
     const spawn = vi.fn(async () => ({ id: 'ssh-reattach', isReattach: true }))
     registerSshPtyProvider('ssh-reattach-1', {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1963,11 +1963,13 @@ export function registerPtyHandlers(
 
   const resolveGuardedPtySpawnCwd = (
     worktreeId: string | undefined,
-    cwd: string | undefined
+    cwd: string | undefined,
+    outsideWorktreeCwd?: 'throw' | 'fallback-to-worktree'
   ): string | undefined =>
     resolveTerminalStartupCwdForWorkspace({
       workspaceId: worktreeId,
       requestedCwd: cwd,
+      outsideWorktreeCwd,
       resolveFolderWorkspacePath: (folderWorkspaceId) =>
         store?.getFolderWorkspace(folderWorkspaceId)?.folderPath
     })
@@ -2535,6 +2537,7 @@ export function registerPtyHandlers(
           foreground?: unknown
           background?: unknown
         }
+        cwdFallback?: 'worktree'
         // Why: closes the SIGKILL race documented in INVESTIGATION.md by
         // letting main patch + sync-flush the (worktreeId, tabId, leafId →
         // ptyId) binding before pty:spawn returns. Only the renderer's
@@ -2562,7 +2565,13 @@ export function registerPtyHandlers(
         await startupPromise
       }
       await assertFolderWorkspacePtyPathUsable(args.worktreeId)
-      const cwd = resolveGuardedPtySpawnCwd(args.worktreeId, args.cwd)
+      const cwd = resolveGuardedPtySpawnCwd(
+        args.worktreeId,
+        args.cwd,
+        !args.connectionId && !args.sessionId && args.cwdFallback === 'worktree'
+          ? 'fallback-to-worktree'
+          : undefined
+      )
       spawnTiming.mark('preflight')
       const provider = getProvider(args.connectionId)
       const isClaudeLaunch = !args.connectionId && isClaudeLaunchCommand(args.command)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1108,6 +1108,7 @@ export type PreloadApi = {
       cols: number
       rows: number
       cwd?: string
+      cwdFallback?: 'worktree'
       env?: Record<string, string>
       command?: string
       launchConfig?: SleepingAgentLaunchConfig

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -752,6 +752,7 @@ const api = {
       cols: number
       rows: number
       cwd?: string
+      cwdFallback?: 'worktree'
       env?: Record<string, string>
       command?: string
       launchConfig?: SleepingAgentLaunchConfig

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -11073,6 +11073,7 @@ describe('connectPanePty', () => {
       'owner-runtime',
       expect.any(Object)
     )
+    expect(createdTransportOptions[0]?.cwdFallback).toBeUndefined()
     expect(transport.connect).toHaveBeenCalled()
   })
 
@@ -11110,6 +11111,7 @@ describe('connectPanePty', () => {
 
     expect(createRemoteRuntimePtyTransport).not.toHaveBeenCalled()
     expect(createIpcPtyTransport).toHaveBeenCalled()
+    expect(createdTransportOptions[0]?.cwdFallback).toBe('worktree')
     expect(transport.connect).toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2601,6 +2601,7 @@ export function connectPanePty(
     : undefined
   const transportOptions = {
     cwd: deps.cwd,
+    ...(runtimeEnvironmentId === null && !connectionId ? { cwdFallback: 'worktree' as const } : {}),
     env: paneEnv,
     command: shouldDeliverStartupViaTerminalPaste ? undefined : paneStartup?.command,
     startupCommandDelivery: shouldDeliverStartupViaTerminalPaste

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -85,6 +85,7 @@ export type PtyTransport = {
 
 export type IpcPtyTransportOptions = {
   cwd?: string
+  cwdFallback?: 'worktree'
   env?: Record<string, string>
   command?: string
   launchConfig?: SleepingAgentLaunchConfig

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -163,6 +163,51 @@ describe('createIpcPtyTransport', () => {
     expect(sshTransport.getLocalSessionMetadata?.()).toBeNull()
   })
 
+  it('sends the local startup cwd fallback flag only for local IPC spawns', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+
+    const transport = createIpcPtyTransport({ cwdFallback: 'worktree' })
+    await transport.connect({ url: '', callbacks: {} })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwdFallback: 'worktree'
+      })
+    )
+    transport.disconnect()
+  })
+
+  it('omits the local startup cwd fallback flag when the IPC transport is SSH-tagged', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+
+    const transport = createIpcPtyTransport({ connectionId: 'ssh-1', cwdFallback: 'worktree' })
+    await transport.connect({ url: '', callbacks: {} })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        cwdFallback: 'worktree'
+      })
+    )
+    transport.disconnect()
+  })
+
+  it('omits the local startup cwd fallback flag for session reattach spawns', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+
+    const transport = createIpcPtyTransport({ cwdFallback: 'worktree' })
+    await transport.connect({ url: '', callbacks: {}, sessionId: 'session-1' })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        cwdFallback: 'worktree'
+      })
+    )
+    transport.disconnect()
+  })
+
   it('defers title side effects until after terminal data is delivered', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const onTitleChange = vi.fn()

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -433,6 +433,7 @@ export function createPtyOutputProcessor({
 export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTransport {
   const {
     cwd,
+    cwdFallback,
     env,
     command,
     launchConfig,
@@ -600,10 +601,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       }
 
       try {
+        const shouldSendLocalCwdFallback =
+          cwdFallback === 'worktree' && !connectionId && !options.sessionId
         const result = await window.api.pty.spawn({
           cols: options.cols ?? 80,
           rows: options.rows ?? 24,
           cwd,
+          ...(shouldSendLocalCwdFallback ? { cwdFallback } : {}),
           env: options.env ?? env,
           command: options.command ?? command,
           ...((options.launchConfig ?? launchConfig)

--- a/src/shared/terminal-startup-cwd.test.ts
+++ b/src/shared/terminal-startup-cwd.test.ts
@@ -28,6 +28,26 @@ describe('resolveTerminalStartupCwd', () => {
     )
   })
 
+  it('returns undefined for blank cwd input', () => {
+    expect(resolveTerminalStartupCwd('/repo/app', '   ')).toBeUndefined()
+  })
+
+  it('falls back to the worktree root for an outside cwd when requested', () => {
+    expect(
+      resolveTerminalStartupCwd('/repo/app', '/var/tmp/orca-stale', {
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app')
+  })
+
+  it('keeps nested cwd resolution unchanged with fallback enabled', () => {
+    expect(
+      resolveTerminalStartupCwd('/repo/app', '/repo/app/packages/web', {
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app/packages/web')
+  })
+
   it('handles Windows path containment without case drift', () => {
     expect(resolveTerminalStartupCwd('C:\\Repo\\App', 'packages\\web')).toBe(
       'C:/Repo/App/packages/web'
@@ -52,6 +72,16 @@ describe('resolveTerminalStartupCwd', () => {
     ).toThrow('Terminal cwd must be inside the selected worktree.')
   })
 
+  it('falls back to the raw worktree root for stale renderer cwd values', () => {
+    expect(
+      resolveTerminalStartupCwdForWorkspace({
+        workspaceId: 'repo-1::/repo/app',
+        requestedCwd: '/var/tmp/orca-stale',
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app')
+  })
+
   it('validates renderer PTY cwd values against folder workspace keys', () => {
     expect(
       resolveTerminalStartupCwdForWorkspace({
@@ -67,5 +97,16 @@ describe('resolveTerminalStartupCwd', () => {
         resolveFolderWorkspacePath: (id) => (id === 'folder-1' ? '/repo/app' : null)
       })
     ).toThrow('Terminal cwd must be inside the selected worktree.')
+  })
+
+  it('falls back to a resolved folder workspace root for stale cwd values', () => {
+    expect(
+      resolveTerminalStartupCwdForWorkspace({
+        workspaceId: folderWorkspaceKey('folder-1'),
+        requestedCwd: '../other',
+        resolveFolderWorkspacePath: (id) => (id === 'folder-1' ? '/repo/app' : null),
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app')
   })
 })

--- a/src/shared/terminal-startup-cwd.ts
+++ b/src/shared/terminal-startup-cwd.ts
@@ -2,15 +2,21 @@ import { isPathInsideOrEqual, resolveRuntimePath } from './cross-platform-path'
 import { parseWorkspaceKey } from './workspace-scope'
 import { splitWorktreeIdForFilesystem } from './worktree-id'
 
+type OutsideWorktreeCwdPolicy = 'throw' | 'fallback-to-worktree'
+
 export function resolveTerminalStartupCwd(
   worktreePath: string,
-  requestedCwd?: string | null
+  requestedCwd?: string | null,
+  options?: { outsideWorktreeCwd?: OutsideWorktreeCwdPolicy }
 ): string | undefined {
   if (!requestedCwd || requestedCwd.trim().length === 0) {
     return undefined
   }
   const resolvedCwd = resolveRuntimePath(worktreePath, requestedCwd)
   if (!isPathInsideOrEqual(worktreePath, resolvedCwd)) {
+    if (options?.outsideWorktreeCwd === 'fallback-to-worktree') {
+      return worktreePath
+    }
     // Why: remote/session clients can request terminal cwd; never let that
     // become a shell outside the selected workspace.
     throw new Error('Terminal cwd must be inside the selected worktree.')
@@ -22,6 +28,7 @@ export function resolveTerminalStartupCwdForWorkspace(args: {
   workspaceId?: string
   requestedCwd?: string | null
   resolveFolderWorkspacePath?: (folderWorkspaceId: string) => string | null | undefined
+  outsideWorktreeCwd?: OutsideWorktreeCwdPolicy
 }): string | undefined {
   if (!args.requestedCwd || args.requestedCwd.trim().length === 0) {
     return undefined
@@ -33,7 +40,9 @@ export function resolveTerminalStartupCwdForWorkspace(args: {
   if (!workspacePath) {
     return args.requestedCwd
   }
-  return resolveTerminalStartupCwd(workspacePath, args.requestedCwd)
+  return resolveTerminalStartupCwd(workspacePath, args.requestedCwd, {
+    outsideWorktreeCwd: args.outsideWorktreeCwd
+  })
 }
 
 function resolveTerminalWorkspacePath(


### PR DESCRIPTION
## Summary

- Fall back to the selected worktree root when local UI terminal creation receives a stale startup cwd outside that worktree.
- Keep the terminal cwd guard strict by default for remote, session, runtime, mobile, and API callers, with the fallback available only through an explicit local UI spawn opt-in.

Closes #7239.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts` - passed; covers strict default behavior, stale-path fallback, and nested-path preservation.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts -t "stale local renderer cwd values|renderer cwd values without the fallback flag|connectionId is present|sessionId is present"` - passed; covers local fallback and strict no-flag, connection-backed, or session-reattach rejection.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "cwdFallback|explicitly local worktrees while a runtime is focused|owner runtime when focus differs"` - passed; covers local-only transport routing and remote omission.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts -t "startup cwd fallback|SSH-tagged|session reattach"` - passed; covers preload spawn payload routing for local IPC versus SSH-tagged and session-reattach inputs.
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts src/main/ipc/pty.test.ts -t "fallback|stale renderer cwd values|stale local UI cwd|raw worktree root|resolved folder workspace root|sessionId is present"` - passed; covers the combined shared-helper and main-IPC fallback compatibility row.
- `pnpm run typecheck:node` - passed; covers main, preload, and shared type plumbing.
- `pnpm run typecheck:web` - passed; covers renderer and preload type plumbing.
- Broader command run during validation: `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts` - failed in pre-existing `src/main/ipc/pty.test.ts` attribution-path assertions; the new cwd fallback tests passed.

## AI Review Report

Reviewed against the implemented diff after two review passes and fixed a CodeRabbit finding about session reattach spawns. The change keeps the containment guard strict by default, scopes the fallback to new local IPC terminal creation, preserves SSH, session reattach, and remote-runtime rejection, and keeps the shared helper as the single owner of cwd policy. Cross-platform path normalization, macOS/Linux/Windows behavior, local versus remote routing, SSH-tagged payloads, IPC shape, performance, and UI quality were covered by source review and focused tests.

## Security Audit

The change keeps the terminal cwd containment guard strict by default and never permits a shell outside the selected worktree. The only new fallback rewrites a stale local UI cwd to the already selected worktree root, and remote/session/API callers must remain unable to opt into it implicitly.

## Notes

No UI or Electron rendering changes. The fallback is local-only, explicit, and opt-in through the renderer-to-main spawn payload. If PR #7184 lands first, rebase the helper changes so the deleted in-worktree directory fallback and this outside-worktree stale cwd fallback share the same terminal startup cwd authority without widening strict callers.
