### PR TITLE
Add daemon stream backpressure contracts and register the reliability gate

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1560,14 +1560,16 @@
             "later stream data queues behind a backpressured socket until drain",
             "interactive session output is prioritized over unrelated backpressured backlog on drain",
             "queued stream data stays bounded while a socket remains backpressured",
-            "global cleanup clears clients that only have backpressured stream writes"
+            "global cleanup clears clients that only have backpressured stream writes",
+            "writes aimed at a destroyed socket are dropped without clearing the live queue or leaking drain listeners"
           ]
         },
         {
           "file": "src/main/daemon/daemon-server.test.ts",
           "assertions": [
             "exit events do not overtake backpressured stream output; the exit frame is written after the drained tail",
-            "interactive bypass and exit-flush ordering hold at the daemon-server seam"
+            "interactive bypass and exit-flush ordering hold at the daemon-server seam",
+            "exit for sessions attached before a same-clientId reconnect is delivered to the current stream socket, not the stale captured one"
           ]
         }
       ],
@@ -1578,8 +1580,8 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-server.test.ts",
           "result": "passed",
-          "durationSeconds": 0.6,
-          "summary": "2 test files passed, 32 tests passed; queue contracts plus the daemon-server exit-ordering regression test added after the adversarial review round."
+          "durationSeconds": 0.7,
+          "summary": "2 test files passed, 34 tests passed; queue contracts, exit-ordering, stale-socket reconnect exit routing, and destroyed-socket guard — the latter two red-proven from the Fable review round."
         }
       ],
       "runtimeBudget": {
@@ -1592,7 +1594,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The exit-ordering regression test was proven red against the pre-fix branch (exit frame written directly while output sat in the backpressure queue) and green after routing exit through writeEventLine. The five queue contracts were developed red-first on the reliability stack."
+        "evidence": "The exit-ordering regression test was proven red against the pre-fix branch (exit frame written directly while output sat in the backpressure queue) and green after routing exit through writeEventLine. The five queue contracts were developed red-first on the reliability stack. A second (Fable) review round red-proved two more: a stale onExit client reference could wipe the live queue via clear-on-mismatch after a same-clientId reconnect, and destroyed-socket writes leaked never-draining pending entries."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1516,7 +1516,7 @@
       "id": "terminal-performance.daemon-stream-backpressure",
       "title": "Daemon terminal streams respect socket backpressure under output floods",
       "maturity": "experimental",
-      "protection": "none",
+      "protection": "partial",
       "owner": "terminal-performance",
       "layer": "daemon-provider-contract",
       "surfaces": [
@@ -1534,19 +1534,46 @@
       "providers": [
         "daemon"
       ],
-      "coveredPlatforms": [],
+      "coveredPlatforms": [
+        "macos"
+      ],
       "coveredProviders": [],
-      "coverageNotes": "Registered gap on main. The daemon batcher write(false)/drain contracts exist only on the pending reliability stack. It registers here with its owning split PR.",
+      "coverageNotes": "Deterministic daemon socket write/drain contracts with a fake socket; local macOS evidence. Live hidden-output floods, active key latency artifacts, and the renderer ACK slice remain gaps (pending perf slice B).",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6836",
         "https://github.com/stablyai/orca/pull/6858"
       ],
       "invariant": "Daemon terminal output floods must pause when socket writes return false, resume on drain, keep buffered bytes bounded, and not starve focused input.",
       "oracle": "The current executable slice injects a slow socket and asserts write(false)/drain ordering, bounded queued daemon stream bytes, close/error listener cleanup, newest-tail preservation under sustained pressure, and flush-immediate cross-session priority ahead of unrelated background backlog on drain. Active input latency remains part of the broader perf gate.",
-      "commands": [],
-      "testFiles": [],
-      "assertionRefs": [],
-      "evidenceRuns": [],
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts"
+      ],
+      "testFiles": [
+        "src/main/daemon/daemon-stream-data-batcher.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/daemon/daemon-stream-data-batcher.test.ts",
+          "assertions": [
+            "stream writes pause when the socket applies backpressure and resume on drain",
+            "later stream data queues behind a backpressured socket until drain",
+            "interactive session output is prioritized over unrelated backpressured backlog on drain",
+            "queued stream data stays bounded while a socket remains backpressured",
+            "global cleanup clears clients that only have backpressured stream writes"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-03",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.2,
+          "summary": "1 test file passed, 10 tests passed; write/drain pause, queue-until-drain, interactive drain priority, bounded queued bytes, and backpressure-only cleanup contracts."
+        }
+      ],
       "runtimeBudget": {
         "p95Seconds": 60,
         "scope": "daemon provider-contract gate"
@@ -1569,9 +1596,8 @@
         "Pair with the broader output-backpressure budget before blocking."
       ],
       "knownGaps": [
-        "No executable coverage on main yet; the slice lives on the pending fix-terminal-reliability stack.",
-        "Current command is daemon batcher contract coverage, not live daemon/Electron perf.",
-        "Active input latency is not proven in live daemon/Electron perf."
+        "No live flood or latency metric artifact yet; deterministic byte-accounting only.",
+        "The renderer/main ACK and pending-cap extensions arrive with the second perf slice (pty.ts / pty-connection.ts hunks)."
       ],
       "demotionRule": "Cannot promote if backpressure is inferred only from renderer output success."
     },
@@ -1834,7 +1860,7 @@
         "macos"
       ],
       "coveredProviders": [],
-      "coverageNotes": "Local macOS evidence over the runtime-RPC stream budgets on main@1282f5c2d. The pending stack adds byte-exact 512KB/2MB/256KB/48KB budget assertions; legacy JSON subscribe parity remains undecided.",
+      "coverageNotes": "Local macOS evidence over the runtime-RPC stream budgets on main@1282f5c2d. The 512KB mobile initial-snapshot budget is now byte-exact; remaining byte-exact 2MB/256KB/48KB assertions arrive with the pending stack; legacy JSON subscribe parity remains undecided.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6951",
         "https://github.com/stablyai/orca/pull/6955",
@@ -1856,7 +1882,8 @@
           "assertions": [
             "legacy binary output queued during initial snapshot serialization stays bounded",
             "stale mobile resize re-stream completions are dropped for legacy binary streams",
-            "aborted stream signals do not register stale listeners"
+            "aborted stream signals do not register stale listeners",
+            "mobile initial snapshots downgrade until they fit the 512KB byte budget"
           ]
         },
         {
@@ -1884,6 +1911,15 @@
           "result": "passed",
           "durationSeconds": 3.8,
           "summary": "3 test file(s) passed, 28 tests passed on main@1282f5c2d in a clean checkout."
+        },
+        {
+          "date": "2026-07-03",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/rpc/terminal-output-batching.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts",
+          "result": "passed",
+          "durationSeconds": 3.3,
+          "summary": "3 test files passed, 29 tests passed, including the new byte-exact 512KB mobile initial-snapshot budget test."
         }
       ],
       "runtimeBudget": {

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1538,7 +1538,7 @@
         "macos"
       ],
       "coveredProviders": [],
-      "coverageNotes": "Deterministic daemon socket write/drain contracts with a fake socket; local macOS evidence. Live hidden-output floods, active key latency artifacts, and the renderer ACK slice remain gaps (pending perf slice B).",
+      "coverageNotes": "Deterministic daemon socket write/drain contracts with a fake socket; local macOS evidence. The queue byte bound is soft by one frame: the sole remaining line is never dropped, so the effective cap is maxQueuedBytes plus one frame (<= the NDJSON line cap). Live hidden-output floods, active key latency artifacts, and the renderer ACK slice remain gaps (pending perf slice B).",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6836",
         "https://github.com/stablyai/orca/pull/6858"
@@ -1546,10 +1546,11 @@
       "invariant": "Daemon terminal output floods must pause when socket writes return false, resume on drain, keep buffered bytes bounded, and not starve focused input.",
       "oracle": "The current executable slice injects a slow socket and asserts write(false)/drain ordering, bounded queued daemon stream bytes, close/error listener cleanup, newest-tail preservation under sustained pressure, and flush-immediate cross-session priority ahead of unrelated background backlog on drain. Active input latency remains part of the broader perf gate.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-server.test.ts"
       ],
       "testFiles": [
-        "src/main/daemon/daemon-stream-data-batcher.test.ts"
+        "src/main/daemon/daemon-stream-data-batcher.test.ts",
+        "src/main/daemon/daemon-server.test.ts"
       ],
       "assertionRefs": [
         {
@@ -1561,17 +1562,24 @@
             "queued stream data stays bounded while a socket remains backpressured",
             "global cleanup clears clients that only have backpressured stream writes"
           ]
+        },
+        {
+          "file": "src/main/daemon/daemon-server.test.ts",
+          "assertions": [
+            "exit events do not overtake backpressured stream output; the exit frame is written after the drained tail",
+            "interactive bypass and exit-flush ordering hold at the daemon-server seam"
+          ]
         }
       ],
       "evidenceRuns": [
         {
-          "date": "2026-07-03",
+          "date": "2026-07-05",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-server.test.ts",
           "result": "passed",
-          "durationSeconds": 0.2,
-          "summary": "1 test file passed, 10 tests passed; write/drain pause, queue-until-drain, interactive drain priority, bounded queued bytes, and backpressure-only cleanup contracts."
+          "durationSeconds": 0.6,
+          "summary": "2 test files passed, 32 tests passed; queue contracts plus the daemon-server exit-ordering regression test added after the adversarial review round."
         }
       ],
       "runtimeBudget": {
@@ -1584,7 +1592,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Tests assert daemon stream writes pause after socket write(false), later stream data queues behind the pressured socket, flush-immediate output from another session is prioritized ahead of unrelated queued background backlog on drain while preserving per-session order, queued lines resume on drain, global cleanup and close/error clear pending drain listeners, and queued bytes are bounded by preserving priority output plus the newest tail. Needs intentional-break artifact plus active-input latency proof before promotion."
+        "evidence": "The exit-ordering regression test was proven red against the pre-fix branch (exit frame written directly while output sat in the backpressure queue) and green after routing exit through writeEventLine. The five queue contracts were developed red-first on the reliability stack."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1538,7 +1538,7 @@
         "macos"
       ],
       "coveredProviders": [],
-      "coverageNotes": "Deterministic daemon socket write/drain contracts with a fake socket; local macOS evidence. The queue byte bound is soft by one frame: the sole remaining line is never dropped, so the effective cap is maxQueuedBytes plus one frame (<= the NDJSON line cap). Live hidden-output floods, active key latency artifacts, and the renderer ACK slice remain gaps (pending perf slice B).",
+      "coverageNotes": "Deterministic daemon socket write/drain contracts with a fake socket, plus live-socket contracts against a real DaemonServer on a real unix socket with a genuinely stalled reader (kernel-level write(false)/drain). The queue byte bound is soft by one frame: the sole remaining line is never dropped, so the effective cap is maxQueuedBytes plus one frame (<= the NDJSON line cap). Active key latency artifacts and the renderer ACK slice remain gaps (pending perf slice B); Windows named-pipe drain semantics are unexercised in the live regime.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6836",
         "https://github.com/stablyai/orca/pull/6858"
@@ -1546,11 +1546,13 @@
       "invariant": "Daemon terminal output floods must pause when socket writes return false, resume on drain, keep buffered bytes bounded, and not starve focused input.",
       "oracle": "The current executable slice injects a slow socket and asserts write(false)/drain ordering, bounded queued daemon stream bytes, close/error listener cleanup, newest-tail preservation under sustained pressure, and flush-immediate cross-session priority ahead of unrelated background backlog on drain. Active input latency remains part of the broader perf gate.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-server.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-server.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-server.test.ts src/main/daemon/daemon-server.live-socket.test.ts"
       ],
       "testFiles": [
         "src/main/daemon/daemon-stream-data-batcher.test.ts",
-        "src/main/daemon/daemon-server.test.ts"
+        "src/main/daemon/daemon-server.test.ts",
+        "src/main/daemon/daemon-server.live-socket.test.ts"
       ],
       "assertionRefs": [
         {
@@ -1571,6 +1573,17 @@
             "interactive bypass and exit-flush ordering hold at the daemon-server seam",
             "exit for sessions attached before a same-clientId reconnect is delivered to the current stream socket, not the stale captured one"
           ]
+        },
+        {
+          "file": "src/main/daemon/daemon-server.live-socket.test.ts",
+          "assertions": [
+            "queued stream bytes stay bounded against a stalled real socket (kernel-level backpressure)",
+            "the stream is lossless and ordered after drain when the backlog stays under the queue bound",
+            "the newest contiguous tail survives when the backlog exceeds the bound (single gap, tail intact)",
+            "a session's exit frame stays behind its drained output tail on a real socket",
+            "interactive echo jumps unrelated queued backlog on drain",
+            "exit routes through the current stream socket after a same-clientId reconnect, behind the new socket's queued tail"
+          ]
         }
       ],
       "evidenceRuns": [
@@ -1582,6 +1595,15 @@
           "result": "passed",
           "durationSeconds": 0.7,
           "summary": "2 test files passed, 34 tests passed; queue contracts, exit-ordering, stale-socket reconnect exit routing, and destroyed-socket guard — the latter two red-proven from the Fable review round."
+        },
+        {
+          "date": "2026-07-06",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-server.test.ts src/main/daemon/daemon-server.live-socket.test.ts",
+          "result": "passed",
+          "durationSeconds": 5.2,
+          "summary": "34 unit contracts plus 6 live-socket contracts against a real unix socket with a genuinely stalled reader; live rig red-proven three ways (direct exit write, stale captured client, 64KB queue bound each tripped exactly the expected tests). Real-PTY flood probe on the same day: daemon-side buffered bytes 69.4MB unbounded on the merge-base vs 8.4MB bounded on this branch under the same stalled-reader seq flood."
         }
       ],
       "runtimeBudget": {
@@ -1589,8 +1611,8 @@
         "scope": "daemon provider-contract gate"
       },
       "flakeHistory": {
-        "status": "unknown",
-        "evidence": "Focused daemon stream backpressure contract runs locally; needs soak history before promotion."
+        "status": "soaking",
+        "evidence": "100/100 consecutive local green runs of the gate command on 2026-07-06 (macOS, 124s total); needs aggregated CI history before promotion."
       },
       "redGreenEvidence": {
         "status": "partial",
@@ -1606,7 +1628,8 @@
         "Pair with the broader output-backpressure budget before blocking."
       ],
       "knownGaps": [
-        "No live flood or latency metric artifact yet; deterministic byte-accounting only.",
+        "No active-input key latency metric artifact yet.",
+        "Windows named-pipe drain semantics are unexercised in the live regime (unit contracts are platform-neutral; live rig evidence is unix-socket macOS).",
         "The renderer/main ACK and pending-cap extensions arrive with the second perf slice (pty.ts / pty-connection.ts hunks)."
       ],
       "demotionRule": "Cannot promote if backpressure is inferred only from renderer output success."

--- a/src/main/daemon/daemon-server.live-socket.test.ts
+++ b/src/main/daemon/daemon-server.live-socket.test.ts
@@ -1,0 +1,521 @@
+// Live-socket rig for the daemon stream backpressure queue: a real DaemonServer
+// on a real unix socket with a client whose stream reader stalls, so Node's
+// write(false)/drain signals come from actual kernel socket buffers instead of
+// fake sockets. Complements the unit contracts in daemon-stream-data-batcher.test.ts.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { connect, type Socket } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { StringDecoder } from 'node:string_decoder'
+import { DaemonServer } from './daemon-server'
+import { encodeNdjson, createNdjsonParser } from './ndjson'
+import { PROTOCOL_VERSION } from './types'
+import type { SubprocessHandle } from './session'
+import { getDaemonSocketPath } from './daemon-spawner'
+
+const MAX_BACKPRESSURED_BYTES = 8 * 1024 * 1024
+
+type ScriptedSubprocess = SubprocessHandle & {
+  _emitData: (data: string) => void
+  _emitExit: (code: number) => void
+}
+
+function createScriptedSubprocess(onWrite?: (data: string) => void): ScriptedSubprocess {
+  let onDataCb: ((data: string) => void) | null = null
+  let onExitCb: ((code: number) => void) | null = null
+  return {
+    pid: 44444,
+    getForegroundProcess: () => null,
+    write(data: string) {
+      onWrite?.(data)
+    },
+    resize() {},
+    kill() {
+      setTimeout(() => onExitCb?.(0), 5)
+    },
+    forceKill() {},
+    signal() {},
+    onData(cb) {
+      onDataCb = cb
+    },
+    onExit(cb) {
+      onExitCb = cb
+    },
+    dispose() {},
+    _emitData(data: string) {
+      onDataCb?.(data)
+    },
+    _emitExit(code: number) {
+      onExitCb?.(code)
+    }
+  }
+}
+
+type QueuedLine = { sessionId: string; line: string; priority?: boolean }
+type BackpressureEntry = { socket: Socket; lines: QueuedLine[]; queuedBytes: number }
+type DaemonInternals = {
+  clients: Map<string, { clientId: string; streamSocket: Socket | null }>
+  streamDataBatcher: {
+    pendingByClient: Map<string, unknown>
+    backpressureQueue: { byClient: Map<string, BackpressureEntry> }
+  }
+}
+
+type StreamFrame = {
+  type: string
+  event?: string
+  sessionId?: string
+  payload?: { data?: string; code?: number }
+}
+
+type RigStream = {
+  socket: Socket
+  frames: StreamFrame[]
+  parseErrors: number
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 15_000): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate() && Date.now() - startedAt < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  expect(predicate()).toBe(true)
+}
+
+describe('DaemonServer live-socket backpressure', () => {
+  let dir: string
+  let socketPath: string
+  let tokenPath: string
+  let server: DaemonServer | null = null
+  let openSockets: Socket[] = []
+  const subprocesses = new Map<string, ScriptedSubprocess>()
+  const echoOnWrite = new Map<string, (data: string) => void>()
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-live-rig-'))
+    socketPath = getDaemonSocketPath(dir)
+    tokenPath = join(dir, 'rig.token')
+    subprocesses.clear()
+    echoOnWrite.clear()
+  })
+
+  afterEach(async () => {
+    for (const socket of openSockets) {
+      socket.destroy()
+    }
+    openSockets = []
+    await server?.shutdown()
+    server = null
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  async function startServer(): Promise<DaemonInternals> {
+    server = new DaemonServer({
+      socketPath,
+      tokenPath,
+      spawnSubprocess: (opts) => {
+        const subprocess = createScriptedSubprocess((data) =>
+          echoOnWrite.get(opts.sessionId)?.(data)
+        )
+        subprocesses.set(opts.sessionId, subprocess)
+        return subprocess
+      }
+    })
+    await server.start()
+    return server as unknown as DaemonInternals
+  }
+
+  async function connectRawHello(role: 'control' | 'stream', clientId: string): Promise<Socket> {
+    const socket = connect(socketPath)
+    openSockets.push(socket)
+    socket.on('error', () => {})
+    await new Promise<void>((resolve) => socket.once('connect', resolve))
+    socket.write(
+      encodeNdjson({
+        type: 'hello',
+        version: PROTOCOL_VERSION,
+        token: readFileSync(tokenPath, 'utf-8').trim(),
+        clientId,
+        role
+      })
+    )
+    await new Promise<void>((resolve, reject) => {
+      socket.once('data', (data: Buffer) => {
+        const parsed = JSON.parse(data.toString().trim()) as { ok?: boolean; error?: string }
+        if (parsed.ok) {
+          resolve()
+        } else {
+          reject(new Error(parsed.error ?? 'hello rejected'))
+        }
+      })
+    })
+    return socket
+  }
+
+  function attachStreamParser(socket: Socket): RigStream {
+    const stream: RigStream = { socket, frames: [], parseErrors: 0 }
+    const decoder = new StringDecoder('utf8')
+    const parser = createNdjsonParser(
+      (msg) => stream.frames.push(msg as StreamFrame),
+      () => {
+        stream.parseErrors += 1
+      }
+    )
+    socket.on('data', (chunk: Buffer) => parser.feed(decoder.write(chunk)))
+    return stream
+  }
+
+  type RigControl = {
+    request: (type: string, payload: Record<string, unknown>) => Promise<unknown>
+  }
+
+  function attachControl(socket: Socket): RigControl {
+    const pending = new Map<string, (response: { ok: boolean; error?: string }) => void>()
+    const decoder = new StringDecoder('utf8')
+    const parser = createNdjsonParser(
+      (msg) => {
+        const response = msg as { id?: string; ok: boolean; error?: string }
+        if (response.id && pending.has(response.id)) {
+          const resolve = pending.get(response.id)!
+          pending.delete(response.id)
+          resolve(response)
+        }
+      },
+      () => {}
+    )
+    socket.on('data', (chunk: Buffer) => parser.feed(decoder.write(chunk)))
+    let nextId = 0
+    return {
+      request: (type, payload) => {
+        const id = `rig-${nextId++}`
+        return new Promise((resolve, reject) => {
+          pending.set(id, (response) => {
+            if (response.ok) {
+              resolve(response)
+            } else {
+              reject(new Error(response.error ?? `request ${type} failed`))
+            }
+          })
+          socket.write(encodeNdjson({ id, type, payload }))
+        })
+      }
+    }
+  }
+
+  function dataText(stream: RigStream, sessionId: string): string {
+    return stream.frames
+      .filter((frame) => frame.event === 'data' && frame.sessionId === sessionId)
+      .map((frame) => frame.payload?.data ?? '')
+      .join('')
+  }
+
+  function receivedCounters(stream: RigStream, sessionId: string): number[] {
+    const counters: number[] = []
+    for (const match of dataText(stream, sessionId).matchAll(/C(\d{8})\n/g)) {
+      counters.push(Number(match[1]))
+    }
+    return counters
+  }
+
+  // Counter-tagged flood lines: ~64 bytes each so a 4096-line chunk is ~256KB.
+  function floodChunk(firstCounter: number, lines: number): { data: string; next: number } {
+    let data = ''
+    for (let index = 0; index < lines; index += 1) {
+      data += `${'x'.repeat(54)}C${String(firstCounter + index).padStart(8, '0')}\n`
+    }
+    return { data, next: firstCounter + lines }
+  }
+
+  function queueEntry(daemon: DaemonInternals, clientId: string): BackpressureEntry | undefined {
+    return daemon.streamDataBatcher.backpressureQueue.byClient.get(clientId)
+  }
+
+  async function waitForFlush(daemon: DaemonInternals, clientId: string): Promise<void> {
+    await waitFor(() => !daemon.streamDataBatcher.pendingByClient.has(clientId))
+  }
+
+  // Pumps counter-tagged chunks through the real batcher (8ms timer flushes)
+  // until the server's stream write has genuinely deferred on write(false).
+  async function floodUntilBackpressured(
+    daemon: DaemonInternals,
+    clientId: string,
+    sessionId: string,
+    firstCounter: number
+  ): Promise<number> {
+    let counter = firstCounter
+    await waitFor(() => subprocesses.has(sessionId))
+    const subprocess = subprocesses.get(sessionId)!
+    for (let round = 0; round < 64 && !queueEntry(daemon, clientId); round += 1) {
+      const chunk = floodChunk(counter, 4096)
+      counter = chunk.next
+      subprocess._emitData(chunk.data)
+      await waitForFlush(daemon, clientId)
+    }
+    expect(queueEntry(daemon, clientId)).toBeDefined()
+    return counter
+  }
+
+  async function pumpChunks(
+    daemon: DaemonInternals,
+    clientId: string,
+    sessionId: string,
+    firstCounter: number,
+    rounds: number
+  ): Promise<number> {
+    let counter = firstCounter
+    const subprocess = subprocesses.get(sessionId)!
+    for (let round = 0; round < rounds; round += 1) {
+      const chunk = floodChunk(counter, 4096)
+      counter = chunk.next
+      subprocess._emitData(chunk.data)
+      await waitForFlush(daemon, clientId)
+    }
+    return counter
+  }
+
+  async function setupClient(
+    clientId: string
+  ): Promise<{ control: RigControl; stream: RigStream }> {
+    const controlSocket = await connectRawHello('control', clientId)
+    const control = attachControl(controlSocket)
+    const streamSocket = await connectRawHello('stream', clientId)
+    const stream = attachStreamParser(streamSocket)
+    return { control, stream }
+  }
+
+  it(
+    'keeps queued stream bytes bounded against a stalled real socket',
+    { timeout: 90_000 },
+    async () => {
+      const daemon = await startServer()
+      const clientId = 'client-live-bounded'
+      const { control, stream } = await setupClient(clientId)
+      await control.request('createOrAttach', { sessionId: 'sess-flood', cols: 80, rows: 24 })
+
+      stream.socket.pause()
+      let counter = await floodUntilBackpressured(daemon, clientId, 'sess-flood', 0)
+      // Push far past the 8MB bound (~20MB more) in paced ~256KB flushes.
+      counter = await pumpChunks(daemon, clientId, 'sess-flood', counter, 80)
+
+      const entry = queueEntry(daemon, clientId)
+      expect(entry).toBeDefined()
+      // Soft bound: maxQueuedBytes plus at most one frame; paced flushes keep frames ~256KB.
+      expect(entry!.queuedBytes).toBeLessThanOrEqual(MAX_BACKPRESSURED_BYTES + 1024 * 1024)
+      // The deferred writer must not keep stuffing Node's userspace socket buffer.
+      const serverSocket = daemon.clients.get(clientId)!.streamSocket!
+      expect(serverSocket.writableLength).toBeLessThanOrEqual(2 * 1024 * 1024)
+    }
+  )
+
+  it(
+    'delivers a lossless ordered stream after drain when the backlog stays under the bound',
+    { timeout: 90_000 },
+    async () => {
+      const daemon = await startServer()
+      const clientId = 'client-live-lossless'
+      const { control, stream } = await setupClient(clientId)
+      await control.request('createOrAttach', { sessionId: 'sess-lossless', cols: 80, rows: 24 })
+
+      stream.socket.pause()
+      let counter = await floodUntilBackpressured(daemon, clientId, 'sess-lossless', 0)
+      // Stay well under the 8MB queue bound so nothing may legally be trimmed.
+      counter = await pumpChunks(daemon, clientId, 'sess-lossless', counter, 12)
+
+      stream.socket.resume()
+      await waitFor(() => receivedCounters(stream, 'sess-lossless').at(-1) === counter - 1)
+
+      const counters = receivedCounters(stream, 'sess-lossless')
+      expect(stream.parseErrors).toBe(0)
+      expect(counters.length).toBe(counter)
+      expect(counters).toEqual(Array.from({ length: counter }, (_, index) => index))
+    }
+  )
+
+  it(
+    'preserves the newest contiguous tail when the backlog exceeds the bound',
+    { timeout: 90_000 },
+    async () => {
+      const daemon = await startServer()
+      const clientId = 'client-live-tail'
+      const { control, stream } = await setupClient(clientId)
+      await control.request('createOrAttach', { sessionId: 'sess-tail', cols: 80, rows: 24 })
+
+      stream.socket.pause()
+      let counter = await floodUntilBackpressured(daemon, clientId, 'sess-tail', 0)
+      // ~20MB past the bound forces bounded-queue trimming of the oldest backlog.
+      counter = await pumpChunks(daemon, clientId, 'sess-tail', counter, 80)
+
+      stream.socket.resume()
+      await waitFor(() => receivedCounters(stream, 'sess-tail').at(-1) === counter - 1)
+
+      const counters = receivedCounters(stream, 'sess-tail')
+      expect(stream.parseErrors).toBe(0)
+      let monotonic = true
+      let gapCount = 0
+      for (let index = 1; index < counters.length; index += 1) {
+        if (counters[index] <= counters[index - 1]) {
+          monotonic = false
+        }
+        if (counters[index] > counters[index - 1] + 1) {
+          gapCount += 1
+        }
+      }
+      expect(monotonic).toBe(true)
+      // Trims only ever drop the oldest queued lines, so the delivered stream is
+      // an intact prefix plus an intact newest tail: exactly one gap.
+      expect(gapCount).toBe(1)
+      expect(counters.length).toBeLessThan(counter)
+      expect(counters.at(-1)).toBe(counter - 1)
+    }
+  )
+
+  it(
+    'keeps a session exit frame behind its drained output tail on a real socket',
+    { timeout: 90_000 },
+    async () => {
+      const daemon = await startServer()
+      const clientId = 'client-live-exit'
+      const { control, stream } = await setupClient(clientId)
+      await control.request('createOrAttach', { sessionId: 'sess-exit', cols: 80, rows: 24 })
+
+      stream.socket.pause()
+      let counter = await floodUntilBackpressured(daemon, clientId, 'sess-exit', 0)
+      counter = await pumpChunks(daemon, clientId, 'sess-exit', counter, 8)
+
+      subprocesses.get('sess-exit')!._emitExit(0)
+      stream.socket.resume()
+      await waitFor(() =>
+        stream.frames.some((frame) => frame.event === 'exit' && frame.sessionId === 'sess-exit')
+      )
+
+      const exitIndex = stream.frames.findIndex(
+        (frame) => frame.event === 'exit' && frame.sessionId === 'sess-exit'
+      )
+      let lastDataIndex = -1
+      for (let index = 0; index < stream.frames.length; index += 1) {
+        const frame = stream.frames[index]
+        if (frame.event === 'data' && frame.sessionId === 'sess-exit') {
+          lastDataIndex = index
+        }
+      }
+      expect(lastDataIndex).toBeGreaterThan(-1)
+      expect(exitIndex).toBeGreaterThan(lastDataIndex)
+      expect(stream.frames[exitIndex].payload?.code).toBe(0)
+      // Under-bound backlog: the full tail must precede the exit frame.
+      expect(receivedCounters(stream, 'sess-exit').at(-1)).toBe(counter - 1)
+      expect(stream.parseErrors).toBe(0)
+    }
+  )
+
+  it(
+    'delivers interactive echo ahead of unrelated queued backlog on drain',
+    { timeout: 90_000 },
+    async () => {
+      const daemon = await startServer()
+      const clientId = 'client-live-priority'
+      const { control, stream } = await setupClient(clientId)
+      await control.request('createOrAttach', { sessionId: 'sess-bg', cols: 80, rows: 24 })
+      await control.request('createOrAttach', { sessionId: 'sess-fg', cols: 80, rows: 24 })
+      echoOnWrite.set('sess-fg', (data) => subprocesses.get('sess-fg')!._emitData(`echo:${data}`))
+
+      stream.socket.pause()
+      let counter = await floodUntilBackpressured(daemon, clientId, 'sess-bg', 0)
+      counter = await pumpChunks(daemon, clientId, 'sess-bg', counter, 8)
+
+      const entry = queueEntry(daemon, clientId)!
+      const firstQueuedLine = entry.lines.find((line) => line.sessionId === 'sess-bg')
+      const firstQueuedCounter = Number(firstQueuedLine!.line.match(/C(\d{8})/)![1])
+
+      await control.request('write', { sessionId: 'sess-fg', data: 'k' })
+      await waitFor(() => entry.lines.some((line) => line.sessionId === 'sess-fg'))
+
+      stream.socket.resume()
+      await waitFor(() => receivedCounters(stream, 'sess-bg').at(-1) === counter - 1)
+      await waitFor(() => dataText(stream, 'sess-fg').includes('echo:k'))
+
+      const fgIndex = stream.frames.findIndex(
+        (frame) => frame.event === 'data' && frame.sessionId === 'sess-fg'
+      )
+      const firstQueuedTag = `C${String(firstQueuedCounter).padStart(8, '0')}`
+      const bgQueuedIndex = stream.frames.findIndex(
+        (frame) =>
+          frame.event === 'data' &&
+          frame.sessionId === 'sess-bg' &&
+          (frame.payload?.data ?? '').includes(firstQueuedTag)
+      )
+      expect(fgIndex).toBeGreaterThan(-1)
+      expect(bgQueuedIndex).toBeGreaterThan(-1)
+      // The interactive echo must jump the queued (not yet written) backlog.
+      expect(fgIndex).toBeLessThan(bgQueuedIndex)
+      expect(stream.parseErrors).toBe(0)
+    }
+  )
+
+  it(
+    'routes exit through the current stream socket after a same-clientId reconnect, behind its queued tail',
+    { timeout: 90_000 },
+    async () => {
+      const daemon = await startServer()
+      const clientId = 'client-live-reconnect'
+      const { control, stream } = await setupClient(clientId)
+      await control.request('createOrAttach', { sessionId: 'sess-reconnect', cols: 80, rows: 24 })
+
+      stream.socket.pause()
+      await floodUntilBackpressured(daemon, clientId, 'sess-reconnect', 0)
+      const oldStream = stream
+      const oldServerStreamSocket = daemon.clients.get(clientId)!.streamSocket!
+
+      // Same-clientId reconnect: the server installs a new client pair and
+      // destroys the old sockets; the old backpressured queue is dropped.
+      // (The old client-side socket stays paused, so it never reads the FIN —
+      // observe the replacement on the server side instead.)
+      const newControlSocket = await connectRawHello('control', clientId)
+      const newControl = attachControl(newControlSocket)
+      const newStreamSocket = await connectRawHello('stream', clientId)
+      const newStream = attachStreamParser(newStreamSocket)
+      await waitFor(() => {
+        const current = daemon.clients.get(clientId)?.streamSocket
+        return current != null && current !== oldServerStreamSocket
+      })
+      await waitFor(() => oldServerStreamSocket.destroyed)
+      await waitFor(() => queueEntry(daemon, clientId) === undefined)
+
+      // Backpressure the NEW stream socket with fresh output, then exit the
+      // session that was attached before the reconnect (the stale-closure case).
+      newStream.socket.pause()
+      const tailStart = 10_000_000
+      let counter = await floodUntilBackpressured(daemon, clientId, 'sess-reconnect', tailStart)
+      counter = await pumpChunks(daemon, clientId, 'sess-reconnect', counter, 4)
+
+      subprocesses.get('sess-reconnect')!._emitExit(5)
+      newStream.socket.resume()
+      await waitFor(() =>
+        newStream.frames.some(
+          (frame) => frame.event === 'exit' && frame.sessionId === 'sess-reconnect'
+        )
+      )
+
+      const exitIndex = newStream.frames.findIndex(
+        (frame) => frame.event === 'exit' && frame.sessionId === 'sess-reconnect'
+      )
+      expect(newStream.frames[exitIndex].payload?.code).toBe(5)
+      let lastDataIndex = -1
+      for (let index = 0; index < newStream.frames.length; index += 1) {
+        const frame = newStream.frames[index]
+        if (frame.event === 'data' && frame.sessionId === 'sess-reconnect') {
+          lastDataIndex = index
+        }
+      }
+      expect(lastDataIndex).toBeGreaterThan(-1)
+      expect(exitIndex).toBeGreaterThan(lastDataIndex)
+      // The new socket's own queued tail drained intact ahead of the exit.
+      expect(receivedCounters(newStream, 'sess-reconnect').at(-1)).toBe(counter - 1)
+      // The pre-reconnect socket never saw the exit.
+      expect(oldStream.frames.some((frame) => frame.event === 'exit')).toBe(false)
+      // The daemon stayed healthy across the reconnect + exit.
+      await newControl.request('ping', {})
+      expect(newStream.parseErrors).toBe(0)
+    }
+  )
+})

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -363,6 +363,66 @@ describe('DaemonServer', () => {
       }
     })
 
+    it('delivers exit for sessions attached before a reconnect to the current stream socket', async () => {
+      vi.useFakeTimers()
+      try {
+        let subprocess: ReturnType<typeof createMockSubprocess>
+        server = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => {
+            subprocess = createMockSubprocess()
+            return subprocess
+          }
+        })
+        const daemon = server as unknown as DaemonServerPrivate
+        const oldControlSocket = { destroy: vi.fn() } as unknown as Socket
+        const oldStreamSocket = {
+          destroyed: false,
+          destroy: vi.fn(),
+          write: vi.fn(() => true)
+        } as unknown as Socket & { write: ReturnType<typeof vi.fn> }
+
+        daemon.clients.set('client-1', {
+          clientId: 'client-1',
+          controlSocket: oldControlSocket,
+          streamSocket: oldStreamSocket
+        })
+
+        await daemon.routeRequest('client-1', {
+          id: 'req-1',
+          type: 'createOrAttach',
+          payload: { sessionId: 'test-session', cols: 80, rows: 24 }
+        })
+
+        // Same-clientId reconnect: a new ConnectedClient replaces the old one and
+        // the old sockets are destroyed, but the createOrAttach closure still
+        // holds the replaced object.
+        const newStreamSocket = {
+          destroyed: false,
+          destroy: vi.fn(),
+          write: vi.fn(() => true)
+        } as unknown as Socket & { write: ReturnType<typeof vi.fn> }
+        daemon.clients.set('client-1', {
+          clientId: 'client-1',
+          controlSocket: { destroy: vi.fn() } as unknown as Socket,
+          streamSocket: newStreamSocket
+        })
+        ;(oldStreamSocket as { destroyed: boolean }).destroyed = true
+
+        subprocess!._simulateExit(7)
+
+        const oldWrites = oldStreamSocket.write.mock.calls.map((c) => String(c[0]))
+        const newWrites = newStreamSocket.write.mock.calls.map((c) => String(c[0]))
+        expect(oldWrites.some((w) => w.includes('"event":"exit"'))).toBe(false)
+        expect(newWrites.some((w) => w.includes('"event":"exit"') && w.includes('"code":7'))).toBe(
+          true
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('keeps the exit event behind backpressured stream output', async () => {
       vi.useFakeTimers()
       try {

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -363,6 +363,71 @@ describe('DaemonServer', () => {
       }
     })
 
+    it('keeps the exit event behind backpressured stream output', async () => {
+      vi.useFakeTimers()
+      try {
+        let subprocess: ReturnType<typeof createMockSubprocess>
+        server = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => {
+            subprocess = createMockSubprocess()
+            return subprocess
+          }
+        })
+        const daemon = server as unknown as DaemonServerPrivate
+        const controlSocket = { destroy: vi.fn() } as unknown as Socket
+        const writes: string[] = []
+        let drainHandler: (() => void) | null = null
+        const streamSocket = {
+          destroyed: false,
+          destroy: vi.fn(),
+          write: vi.fn((line: string) => {
+            writes.push(String(line))
+            // First accepted write signals backpressure; later writes are accepted.
+            return writes.length !== 1
+          }),
+          once: vi.fn((event: string, cb: () => void) => {
+            if (event === 'drain') {
+              drainHandler = cb
+            }
+          }),
+          off: vi.fn()
+        } as unknown as Socket & { write: ReturnType<typeof vi.fn> }
+
+        daemon.clients.set('client-1', {
+          clientId: 'client-1',
+          controlSocket,
+          streamSocket
+        })
+
+        await daemon.routeRequest('client-1', {
+          id: 'req-1',
+          type: 'createOrAttach',
+          payload: { sessionId: 'test-session', cols: 80, rows: 24 }
+        })
+
+        subprocess!._simulateData('first')
+        vi.advanceTimersByTime(8)
+        expect(writes).toHaveLength(1)
+
+        subprocess!._simulateData('final-tail')
+        vi.advanceTimersByTime(8)
+        expect(writes).toHaveLength(1)
+
+        subprocess!._simulateExit(42)
+        expect(writes.some((w) => w.includes('"event":"exit"'))).toBe(false)
+
+        drainHandler!()
+        const tailIndex = writes.findIndex((w) => w.includes('final-tail'))
+        const exitIndex = writes.findIndex((w) => w.includes('"event":"exit"'))
+        expect(tailIndex).toBeGreaterThan(-1)
+        expect(exitIndex).toBeGreaterThan(tailIndex)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('flushes pending batched stream output before the exit event', async () => {
       vi.useFakeTimers()
       try {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -299,12 +299,16 @@ export class DaemonServer {
               // so the last few milliseconds of PTY data are not stranded.
               this.streamDataBatcher.flush(clientId)
               this.lastInputAtBySessionId.delete(p.sessionId)
-              if (client?.streamSocket) {
+              // Why: the client captured at createOrAttach is stale after a
+              // same-clientId reconnect replaces it; resolve the current owner
+              // so exit frames follow the live socket, not a destroyed one.
+              const liveClient = this.clients.get(clientId)
+              if (liveClient?.streamSocket) {
                 // Why: exit must ride the same ordered path as stream data so it
                 // cannot overtake output queued behind a backpressured socket.
                 this.streamDataBatcher.writeEventLine(
                   clientId,
-                  client.streamSocket,
+                  liveClient.streamSocket,
                   p.sessionId,
                   encodeNdjson({
                     type: 'event',

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -300,7 +300,12 @@ export class DaemonServer {
               this.streamDataBatcher.flush(clientId)
               this.lastInputAtBySessionId.delete(p.sessionId)
               if (client?.streamSocket) {
-                client.streamSocket.write(
+                // Why: exit must ride the same ordered path as stream data so it
+                // cannot overtake output queued behind a backpressured socket.
+                this.streamDataBatcher.writeEventLine(
+                  clientId,
+                  client.streamSocket,
+                  p.sessionId,
                   encodeNdjson({
                     type: 'event',
                     event: 'exit',
@@ -422,7 +427,10 @@ export class DaemonServer {
     // Why: write/resize are notification-heavy and intentionally do not wait
     // for replies. If their target session is gone, this synthetic exit is the
     // only signal the renderer gets to clear stale terminal pane bindings.
-    client.streamSocket.write(
+    this.streamDataBatcher.writeEventLine(
+      client.clientId,
+      client.streamSocket,
+      sessionId,
       encodeNdjson({
         type: 'event',
         event: 'exit',

--- a/src/main/daemon/daemon-stream-backpressure-queue.ts
+++ b/src/main/daemon/daemon-stream-backpressure-queue.ts
@@ -1,0 +1,156 @@
+import type { Socket } from 'node:net'
+
+export type BackpressuredStreamLine = {
+  sessionId: string
+  line: string
+  priority?: boolean
+}
+
+type BackpressuredStreamWrites = {
+  socket: Socket
+  lines: BackpressuredStreamLine[]
+  queuedBytes: number
+  onDrain: () => void
+  onClose: () => void
+}
+
+export type WriteStreamLinesOptions = {
+  prioritizeBackpressuredSession?: boolean
+}
+
+export class BackpressuredStreamWriteQueue {
+  private byClient = new Map<string, BackpressuredStreamWrites>()
+  private maxQueuedBytes: number
+
+  constructor(maxQueuedBytes: number) {
+    this.maxQueuedBytes = Math.max(1, maxQueuedBytes)
+  }
+
+  clientIds(): Iterable<string> {
+    return this.byClient.keys()
+  }
+
+  write(
+    clientId: string,
+    streamSocket: Socket,
+    lines: BackpressuredStreamLine[],
+    opts: WriteStreamLinesOptions = {}
+  ): void {
+    const existing = this.byClient.get(clientId)
+    if (existing) {
+      if (existing.socket === streamSocket && !streamSocket.destroyed) {
+        this.appendLines(existing, lines, opts)
+        return
+      }
+      this.clear(clientId)
+    }
+
+    for (let index = 0; index < lines.length; index += 1) {
+      // Why: only Node's explicit `false` return signals backpressure; duck-typed
+      // sockets in tests or wrappers may return undefined and must keep the
+      // legacy direct-write path.
+      if (streamSocket.write(lines[index].line) === false) {
+        this.deferUntilDrain(clientId, streamSocket, lines.slice(index + 1))
+        return
+      }
+    }
+  }
+
+  clear(clientId: string): void {
+    const pending = this.byClient.get(clientId)
+    if (!pending) {
+      return
+    }
+    this.byClient.delete(clientId)
+    pending.socket.off('drain', pending.onDrain)
+    pending.socket.off('close', pending.onClose)
+    pending.socket.off('error', pending.onClose)
+  }
+
+  private deferUntilDrain(
+    clientId: string,
+    streamSocket: Socket,
+    lines: BackpressuredStreamLine[]
+  ): void {
+    const onDrain = (): void => {
+      const pending = this.byClient.get(clientId)
+      if (!pending || pending.socket !== streamSocket) {
+        return
+      }
+      this.byClient.delete(clientId)
+      streamSocket.off('close', pending.onClose)
+      streamSocket.off('error', pending.onClose)
+      if (!streamSocket.destroyed) {
+        this.write(clientId, streamSocket, pending.lines)
+      }
+    }
+    const onClose = (): void => {
+      this.clear(clientId)
+    }
+
+    const pending: BackpressuredStreamWrites = {
+      socket: streamSocket,
+      lines: [],
+      queuedBytes: 0,
+      onDrain,
+      onClose
+    }
+    this.appendLines(pending, lines)
+    this.byClient.set(clientId, pending)
+    streamSocket.once('drain', onDrain)
+    streamSocket.once('close', onClose)
+    streamSocket.once('error', onClose)
+  }
+
+  private appendLines(
+    pending: BackpressuredStreamWrites,
+    lines: BackpressuredStreamLine[],
+    opts: WriteStreamLinesOptions = {}
+  ): void {
+    if (opts.prioritizeBackpressuredSession && lines.length > 0) {
+      // Why: input-triggered daemon output should not sit behind an unrelated
+      // hidden-output flood once the socket drains, but each session's bytes
+      // must still keep their own order.
+      const sessionId = lines[0].sessionId
+      let lastSameSessionIndex = -1
+      for (let index = pending.lines.length - 1; index >= 0; index -= 1) {
+        if (pending.lines[index].sessionId === sessionId) {
+          lastSameSessionIndex = index
+          break
+        }
+      }
+      if (lastSameSessionIndex >= 0) {
+        pending.lines.splice(lastSameSessionIndex + 1, 0, ...lines)
+      } else {
+        const firstNonPriorityIndex = pending.lines.findIndex((line) => !line.priority)
+        pending.lines.splice(
+          firstNonPriorityIndex === -1 ? pending.lines.length : firstNonPriorityIndex,
+          0,
+          ...lines
+        )
+      }
+    } else {
+      pending.lines.push(...lines)
+    }
+    pending.queuedBytes += this.measureLinesBytes(lines)
+    // Why: a wedged stream socket can otherwise retain unbounded hidden-output
+    // floods below the renderer ACK budget. Preserve the newest bounded tail.
+    while (pending.queuedBytes > this.maxQueuedBytes && pending.lines.length > 1) {
+      const dropIndex = pending.lines.findIndex((line) => !line.priority)
+      const [dropped] = pending.lines.splice(dropIndex === -1 ? 0 : dropIndex, 1)
+      pending.queuedBytes -= dropped ? this.measureLineBytes(dropped) : 0
+    }
+  }
+
+  private measureLinesBytes(lines: BackpressuredStreamLine[]): number {
+    let bytes = 0
+    for (const line of lines) {
+      bytes += this.measureLineBytes(line)
+    }
+    return bytes
+  }
+
+  private measureLineBytes(line: BackpressuredStreamLine): number {
+    return Buffer.byteLength(line.line, 'utf8')
+  }
+}

--- a/src/main/daemon/daemon-stream-backpressure-queue.ts
+++ b/src/main/daemon/daemon-stream-backpressure-queue.ts
@@ -36,6 +36,12 @@ export class BackpressuredStreamWriteQueue {
     lines: BackpressuredStreamLine[],
     opts: WriteStreamLinesOptions = {}
   ): void {
+    // Why: a write aimed at a destroyed socket (a stale reference held across a
+    // reconnect) must not clear the live client's queue or register drain
+    // listeners that can never fire; the frame is dropped instead.
+    if (streamSocket.destroyed) {
+      return
+    }
     const existing = this.byClient.get(clientId)
     if (existing) {
       if (existing.socket === streamSocket && !streamSocket.destroyed) {

--- a/src/main/daemon/daemon-stream-backpressure-queue.ts
+++ b/src/main/daemon/daemon-stream-backpressure-queue.ts
@@ -135,6 +135,8 @@ export class BackpressuredStreamWriteQueue {
     pending.queuedBytes += this.measureLinesBytes(lines)
     // Why: a wedged stream socket can otherwise retain unbounded hidden-output
     // floods below the renderer ACK budget. Preserve the newest bounded tail.
+    // The sole remaining line is never dropped, so the effective bound is
+    // maxQueuedBytes plus at most one frame (frames are <= the NDJSON line cap).
     while (pending.queuedBytes > this.maxQueuedBytes && pending.lines.length > 1) {
       const dropIndex = pending.lines.findIndex((line) => !line.priority)
       const [dropped] = pending.lines.splice(dropIndex === -1 ? 0 : dropIndex, 1)

--- a/src/main/daemon/daemon-stream-data-batcher.test.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Socket } from 'node:net'
+import { EventEmitter } from 'node:events'
 import { DaemonStreamDataBatcher } from './daemon-stream-data-batcher'
 import { createNdjsonParser } from './ndjson'
 
 function createBatcher(options?: ConstructorParameters<typeof DaemonStreamDataBatcher>[1]) {
-  const streamSocket = {
+  const streamSocket = Object.assign(new EventEmitter(), {
     destroyed: false,
-    write: vi.fn()
-  } as unknown as Socket & { write: ReturnType<typeof vi.fn> }
+    write: vi.fn(() => true)
+  }) as unknown as Socket & { write: ReturnType<typeof vi.fn> }
   const batcher = new DaemonStreamDataBatcher(() => ({ streamSocket }), options)
   return { batcher, streamSocket }
 }
@@ -125,6 +126,145 @@ describe('DaemonStreamDataBatcher', () => {
           .map(([message]) => (message as { payload?: { data?: string } }).payload?.data ?? '')
           .join('')
       ).toBe(data)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('pauses stream writes when the socket applies backpressure', () => {
+    vi.useFakeTimers()
+    try {
+      const maxLineBytes = 256
+      const { batcher, streamSocket } = createBatcher({ maxLineBytes })
+      streamSocket.write.mockReturnValueOnce(false).mockReturnValue(true)
+
+      batcher.enqueue('client-1', 'session-1', 'x'.repeat(maxLineBytes * 3))
+      vi.advanceTimersByTime(8)
+
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+
+      streamSocket.emit('drain')
+
+      expect(streamSocket.write.mock.calls.length).toBeGreaterThan(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('queues later stream data behind a backpressured socket until drain', () => {
+    vi.useFakeTimers()
+    try {
+      const maxLineBytes = 256
+      const { batcher, streamSocket } = createBatcher({ maxLineBytes })
+      streamSocket.write.mockReturnValueOnce(false).mockReturnValue(true)
+
+      batcher.enqueue('client-1', 'session-1', 'x'.repeat(maxLineBytes * 3))
+      vi.advanceTimersByTime(8)
+      batcher.enqueue('client-1', 'session-2', 'interactive', {
+        flushImmediately: true,
+        flushMaxChars: 1024
+      })
+
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+
+      streamSocket.emit('drain')
+
+      expect(
+        streamSocket.write.mock.calls.some(([line]) =>
+          String(line).includes('"sessionId":"session-2"')
+        )
+      ).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('globally clears clients that only have backpressured stream writes', () => {
+    vi.useFakeTimers()
+    try {
+      const maxLineBytes = 256
+      const { batcher, streamSocket } = createBatcher({ maxLineBytes })
+      streamSocket.write.mockReturnValueOnce(false).mockReturnValue(true)
+
+      batcher.enqueue('client-1', 'session-1', 'x'.repeat(maxLineBytes * 3))
+      vi.advanceTimersByTime(8)
+
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+      expect(streamSocket.listenerCount('drain')).toBe(1)
+
+      batcher.clear()
+      expect(streamSocket.listenerCount('drain')).toBe(0)
+      expect(streamSocket.listenerCount('close')).toBe(0)
+      expect(streamSocket.listenerCount('error')).toBe(0)
+
+      streamSocket.write.mockClear()
+      streamSocket.emit('drain')
+
+      expect(streamSocket.write).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('prioritizes interactive session output over unrelated backpressured backlog on drain', () => {
+    vi.useFakeTimers()
+    try {
+      const maxLineBytes = 256
+      const { batcher, streamSocket } = createBatcher({ maxLineBytes })
+      streamSocket.write.mockReturnValueOnce(false).mockReturnValue(true)
+
+      batcher.enqueue('client-1', 'session-background', 'x'.repeat(maxLineBytes * 3))
+      vi.advanceTimersByTime(8)
+      batcher.enqueue('client-1', 'session-interactive', 'prompt-redraw', {
+        flushImmediately: true,
+        flushMaxChars: 1024
+      })
+
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+      streamSocket.write.mockClear()
+
+      streamSocket.emit('drain')
+
+      expect(String(streamSocket.write.mock.calls[0]?.[0])).toContain(
+        '"sessionId":"session-interactive"'
+      )
+      expect(String(streamSocket.write.mock.calls[0]?.[0])).toContain('"data":"prompt-redraw"')
+      expect(
+        streamSocket.write.mock.calls.some(([line]) =>
+          String(line).includes('"sessionId":"session-background"')
+        )
+      ).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('bounds queued stream data while a socket remains backpressured', () => {
+    vi.useFakeTimers()
+    try {
+      const { batcher, streamSocket } = createBatcher({
+        maxLineBytes: 256,
+        maxBackpressuredBytes: 1
+      })
+      streamSocket.write.mockReturnValueOnce(false).mockReturnValue(true)
+
+      batcher.enqueue('client-1', 'session-old', 'old-output'.repeat(200))
+      vi.advanceTimersByTime(8)
+
+      for (let index = 0; index < 5; index += 1) {
+        batcher.enqueue('client-1', `session-new-${index}`, `new-output-${index}`, {
+          flushImmediately: true,
+          flushMaxChars: 1024
+        })
+      }
+
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+      streamSocket.write.mockClear()
+
+      streamSocket.emit('drain')
+
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+      expect(String(streamSocket.write.mock.calls[0]?.[0])).toContain('"sessionId":"session-new-4"')
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/daemon/daemon-stream-data-batcher.test.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.test.ts
@@ -14,6 +14,43 @@ function createBatcher(options?: ConstructorParameters<typeof DaemonStreamDataBa
 }
 
 describe('DaemonStreamDataBatcher', () => {
+  it('drops event writes aimed at a destroyed socket without clearing the live queue', () => {
+    vi.useFakeTimers()
+    try {
+      const { batcher, streamSocket } = createBatcher()
+      streamSocket.write.mockReturnValueOnce(false)
+      batcher.enqueue('client-1', 'session-1', 'head', {
+        flushImmediately: true,
+        flushMaxChars: 1024
+      })
+      batcher.enqueue('client-1', 'session-1', 'tail', {
+        flushImmediately: true,
+        flushMaxChars: 1024
+      })
+      expect(streamSocket.write).toHaveBeenCalledTimes(1)
+
+      // A stale destroyed socket (captured across a same-clientId reconnect)
+      // must not wipe the live socket's queued output or leak drain listeners.
+      const staleSocket = Object.assign(new EventEmitter(), {
+        destroyed: true,
+        write: vi.fn(() => false)
+      }) as unknown as Socket & { write: ReturnType<typeof vi.fn> }
+      batcher.writeEventLine(
+        'client-1',
+        staleSocket,
+        'session-1',
+        '{"type":"event","event":"exit","sessionId":"session-1","payload":{"code":0}}\n'
+      )
+      expect(staleSocket.write).not.toHaveBeenCalled()
+
+      streamSocket.emit('drain')
+      const writes = streamSocket.write.mock.calls.map((c) => String(c[0]))
+      expect(writes.some((w) => w.includes('"data":"tail"'))).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('coalesces background output before writing daemon stream events', () => {
     vi.useFakeTimers()
     try {

--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -172,7 +172,9 @@ export class DaemonStreamDataBatcher {
   writeEventLine(clientId: string, streamSocket: Socket, sessionId: string, line: string): void {
     // Why: session events (exit) must not overtake this session's queued output
     // on a backpressured socket; the priority path orders the event after the
-    // session's own lines and protects it from bounded-queue trimming.
+    // session's own lines and ahead of unrelated non-priority backlog. Trimming
+    // prefers non-priority lines, so the event is dropped only if the queue
+    // overflows with priority-only frames.
     this.backpressureQueue.write(clientId, streamSocket, [{ sessionId, line, priority: true }], {
       prioritizeBackpressuredSession: true
     })

--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -1,5 +1,7 @@
 import type { Socket } from 'node:net'
-import { encodeNdjson, NDJSON_MAX_LINE_BYTES } from './ndjson'
+import { NDJSON_MAX_LINE_BYTES } from './ndjson'
+import { BackpressuredStreamWriteQueue } from './daemon-stream-backpressure-queue'
+import { encodeStreamDataEvent, splitStreamDataForNdjson } from './daemon-stream-ndjson-frames'
 
 type StreamDataClient = {
   streamSocket: Socket | null
@@ -14,6 +16,7 @@ type PendingStreamDataBatch = {
 // Why: match main-process PTY IPC batching to avoid adding latency while
 // removing daemon socket writes and JSON framing during bursty output.
 const STREAM_DATA_BATCH_INTERVAL_MS = 8
+const DEFAULT_MAX_BACKPRESSURED_STREAM_BYTES = 8 * 1024 * 1024
 
 type EnqueueOptions = {
   flushImmediately?: boolean
@@ -22,88 +25,12 @@ type EnqueueOptions = {
 
 type DaemonStreamDataBatcherOptions = {
   maxLineBytes?: number
-}
-
-function encodeStreamDataEvent(sessionId: string, data: string): string {
-  return encodeNdjson({
-    type: 'event',
-    event: 'data',
-    sessionId,
-    payload: { data }
-  })
-}
-
-function streamDataEventLineBytes(sessionId: string, data: string): number {
-  return Buffer.byteLength(encodeStreamDataEvent(sessionId, data), 'utf8')
-}
-
-function isHighSurrogate(value: number): boolean {
-  return value >= 0xd800 && value <= 0xdbff
-}
-
-function isLowSurrogate(value: number): boolean {
-  return value >= 0xdc00 && value <= 0xdfff
-}
-
-function clampToSafeSplitIndex(value: string, start: number, end: number): number {
-  if (end <= start || end >= value.length) {
-    return end
-  }
-  const prev = value.charCodeAt(end - 1)
-  const next = value.charCodeAt(end)
-  return isHighSurrogate(prev) && isLowSurrogate(next) ? end - 1 : end
-}
-
-function nextSafeSplitIndex(value: string, start: number): number {
-  const next = Math.min(value.length, start + 1)
-  if (
-    next < value.length &&
-    isHighSurrogate(value.charCodeAt(start)) &&
-    isLowSurrogate(value.charCodeAt(next))
-  ) {
-    return next + 1
-  }
-  return next
-}
-
-function splitStreamDataForNdjson(sessionId: string, data: string, maxLineBytes: number): string[] {
-  if (streamDataEventLineBytes(sessionId, data) <= maxLineBytes) {
-    return [data]
-  }
-
-  const chunks: string[] = []
-  let start = 0
-  while (start < data.length) {
-    let low = start + 1
-    let high = data.length
-    let best = start
-
-    while (low <= high) {
-      const rawMid = Math.floor((low + high) / 2)
-      const mid = clampToSafeSplitIndex(data, start, rawMid)
-      if (mid <= start) {
-        low = rawMid + 1
-        continue
-      }
-
-      if (streamDataEventLineBytes(sessionId, data.slice(start, mid)) <= maxLineBytes) {
-        best = mid
-        low = rawMid + 1
-      } else {
-        high = rawMid - 1
-      }
-    }
-
-    const end = best > start ? best : nextSafeSplitIndex(data, start)
-    chunks.push(data.slice(start, end))
-    start = end
-  }
-
-  return chunks
+  maxBackpressuredBytes?: number
 }
 
 export class DaemonStreamDataBatcher {
   private pendingByClient = new Map<string, PendingStreamDataBatch>()
+  private backpressureQueue: BackpressuredStreamWriteQueue
   private getClient: (clientId: string) => StreamDataClient | undefined
   private maxLineBytes: number
 
@@ -113,6 +40,9 @@ export class DaemonStreamDataBatcher {
   ) {
     this.getClient = getClient
     this.maxLineBytes = Math.max(1, options.maxLineBytes ?? NDJSON_MAX_LINE_BYTES)
+    this.backpressureQueue = new BackpressuredStreamWriteQueue(
+      options.maxBackpressuredBytes ?? DEFAULT_MAX_BACKPRESSURED_STREAM_BYTES
+    )
   }
 
   enqueue(clientId: string, sessionId: string, data: string, options: EnqueueOptions = {}): void {
@@ -166,7 +96,7 @@ export class DaemonStreamDataBatcher {
     }
 
     for (const entry of batch.queue) {
-      this.writeStreamDataEvent(client.streamSocket, entry.sessionId, entry.data)
+      this.writeStreamDataEvent(clientId, client.streamSocket, entry.sessionId, entry.data)
     }
   }
 
@@ -217,30 +147,43 @@ export class DaemonStreamDataBatcher {
     }
 
     for (const entry of flushed) {
-      this.writeStreamDataEvent(client.streamSocket, entry.sessionId, entry.data)
+      this.writeStreamDataEvent(clientId, client.streamSocket, entry.sessionId, entry.data, {
+        prioritizeBackpressuredSession: true
+      })
     }
   }
 
   clear(clientId?: string): void {
-    const batches =
+    const clientIds =
       clientId === undefined
-        ? Array.from(this.pendingByClient.entries())
-        : [[clientId, this.pendingByClient.get(clientId)] as const]
+        ? new Set([...this.pendingByClient.keys(), ...this.backpressureQueue.clientIds()])
+        : new Set([clientId])
 
-    for (const [id, batch] of batches) {
+    for (const id of clientIds) {
+      const batch = this.pendingByClient.get(id)
       if (batch?.timer) {
         clearTimeout(batch.timer)
       }
       this.pendingByClient.delete(id)
+      this.backpressureQueue.clear(id)
     }
   }
 
-  private writeStreamDataEvent(streamSocket: Socket, sessionId: string, data: string): void {
+  private writeStreamDataEvent(
+    clientId: string,
+    streamSocket: Socket,
+    sessionId: string,
+    data: string,
+    opts: { prioritizeBackpressuredSession?: boolean } = {}
+  ): void {
     // Why: createNdjsonParser rejects oversized lines. Terminal output can
     // burst faster than the batch interval, so writer-side chunking prevents
     // the daemon from dropping its own stream events at the receiver.
-    for (const chunk of splitStreamDataForNdjson(sessionId, data, this.maxLineBytes)) {
-      streamSocket.write(encodeStreamDataEvent(sessionId, chunk))
-    }
+    const lines = splitStreamDataForNdjson(sessionId, data, this.maxLineBytes).map((chunk) => ({
+      sessionId,
+      line: encodeStreamDataEvent(sessionId, chunk),
+      ...(opts.prioritizeBackpressuredSession ? { priority: true } : {})
+    }))
+    this.backpressureQueue.write(clientId, streamSocket, lines, opts)
   }
 }

--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -169,6 +169,15 @@ export class DaemonStreamDataBatcher {
     }
   }
 
+  writeEventLine(clientId: string, streamSocket: Socket, sessionId: string, line: string): void {
+    // Why: session events (exit) must not overtake this session's queued output
+    // on a backpressured socket; the priority path orders the event after the
+    // session's own lines and protects it from bounded-queue trimming.
+    this.backpressureQueue.write(clientId, streamSocket, [{ sessionId, line, priority: true }], {
+      prioritizeBackpressuredSession: true
+    })
+  }
+
   private writeStreamDataEvent(
     clientId: string,
     streamSocket: Socket,

--- a/src/main/daemon/daemon-stream-ndjson-frames.ts
+++ b/src/main/daemon/daemon-stream-ndjson-frames.ts
@@ -1,0 +1,85 @@
+import { encodeNdjson } from './ndjson'
+
+// NDJSON framing for daemon stream-data events: encoding, byte measurement, and
+// surrogate-safe splitting so oversized chunks never break a UTF-16 pair mid-frame.
+export function encodeStreamDataEvent(sessionId: string, data: string): string {
+  return encodeNdjson({
+    type: 'event',
+    event: 'data',
+    sessionId,
+    payload: { data }
+  })
+}
+
+export function streamDataEventLineBytes(sessionId: string, data: string): number {
+  return Buffer.byteLength(encodeStreamDataEvent(sessionId, data), 'utf8')
+}
+
+function isHighSurrogate(value: number): boolean {
+  return value >= 0xd800 && value <= 0xdbff
+}
+
+function isLowSurrogate(value: number): boolean {
+  return value >= 0xdc00 && value <= 0xdfff
+}
+
+function clampToSafeSplitIndex(value: string, start: number, end: number): number {
+  if (end <= start || end >= value.length) {
+    return end
+  }
+  const prev = value.charCodeAt(end - 1)
+  const next = value.charCodeAt(end)
+  return isHighSurrogate(prev) && isLowSurrogate(next) ? end - 1 : end
+}
+
+function nextSafeSplitIndex(value: string, start: number): number {
+  const next = Math.min(value.length, start + 1)
+  if (
+    next < value.length &&
+    isHighSurrogate(value.charCodeAt(start)) &&
+    isLowSurrogate(value.charCodeAt(next))
+  ) {
+    return next + 1
+  }
+  return next
+}
+
+export function splitStreamDataForNdjson(
+  sessionId: string,
+  data: string,
+  maxLineBytes: number
+): string[] {
+  if (streamDataEventLineBytes(sessionId, data) <= maxLineBytes) {
+    return [data]
+  }
+
+  const chunks: string[] = []
+  let start = 0
+  while (start < data.length) {
+    let low = start + 1
+    let high = data.length
+    let best = start
+
+    while (low <= high) {
+      const rawMid = Math.floor((low + high) / 2)
+      const mid = clampToSafeSplitIndex(data, start, rawMid)
+      if (mid <= start) {
+        low = rawMid + 1
+        continue
+      }
+
+      if (streamDataEventLineBytes(sessionId, data.slice(start, mid)) <= maxLineBytes) {
+        best = mid
+        low = rawMid + 1
+      } else {
+        high = rawMid - 1
+      }
+    }
+
+    const end = best > start ? best : nextSafeSplitIndex(data, start)
+    chunks.push(data.slice(start, end))
+    start = end
+  }
+
+  return chunks
+}

--- a/src/main/runtime/rpc/terminal-output-batching.test.ts
+++ b/src/main/runtime/rpc/terminal-output-batching.test.ts
@@ -246,6 +246,9 @@ describe('terminal output batching', () => {
         .map((frame) => decodeTerminalStreamFrame(frame))
         .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
       expect(outputFrames.length).toBeGreaterThan(1)
+      for (const frame of outputFrames) {
+        expect(frame?.payload.byteLength ?? 0).toBeLessThanOrEqual(48 * 1024)
+      }
       expect(firstOutputEncodeCount).toBe(1)
       expect(
         outputFrames.map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : '')).join('')

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -430,6 +430,88 @@ describe('terminal subscribe buffering', () => {
     }
   })
 
+  it('downgrades mobile initial snapshots until they fit the 512KB byte budget', async () => {
+    const messages: string[] = []
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const cleanups = new Map<string, () => void>()
+    const oversizedSnapshot = 'x'.repeat(600 * 1024)
+    const budgetedSnapshot = 'tail'.repeat(40 * 1024)
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+      serializeTerminalBuffer: vi.fn(async (_ptyId: string, opts?: { scrollbackRows?: number }) => {
+        if ((opts?.scrollbackRows ?? 0) > 250) {
+          return { data: oversizedSnapshot, cols: 100, rows: 30 }
+        }
+        return { data: budgetedSnapshot, cols: 100, rows: 30, seq: 42 }
+      }),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('mobile-fit'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      isTerminalAlternateScreen: vi.fn().mockReturnValue(false),
+      handleMobileSubscribe: vi.fn().mockResolvedValue(undefined),
+      handleMobileUnsubscribe: vi.fn(),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      cleanupSubscription: vi.fn((id: string) => {
+        const cleanup = cleanups.get(id)
+        cleanups.delete(id)
+        cleanup?.()
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+      sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+      updateMobileViewport: vi.fn().mockResolvedValue(false)
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.subscribe', {
+        terminal: 'terminal-1',
+        client: { id: 'phone-1', type: 'mobile' },
+        capabilities: { terminalBinaryStream: 1 }
+      }),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-mobile-budget',
+        sendBinary: (bytes) => binaryFrames.push(bytes)
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+    )
+
+    expect(runtime.serializeTerminalBuffer).toHaveBeenNthCalledWith(1, 'pty-1', {
+      scrollbackRows: 1000
+    })
+    expect(runtime.serializeTerminalBuffer).toHaveBeenNthCalledWith(2, 'pty-1', {
+      scrollbackRows: 500
+    })
+    expect(runtime.serializeTerminalBuffer).toHaveBeenNthCalledWith(3, 'pty-1', {
+      scrollbackRows: 250
+    })
+    const decodedFrames = binaryFrames.map((frame) => decodeTerminalStreamFrame(frame))
+    const snapshotStart = decodedFrames.find(
+      (frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart
+    )
+    expect(snapshotStart && decodeTerminalStreamJson(snapshotStart.payload)).toMatchObject({
+      truncatedByByteBudget: true
+    })
+    const snapshotData = decodedFrames
+      .filter((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotChunk)
+      .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+      .join('')
+    expect(snapshotData).toBe(budgetedSnapshot)
+    expect(Buffer.byteLength(snapshotData, 'utf8')).toBeLessThanOrEqual(512 * 1024)
+
+    runtime.cleanupSubscription('terminal-1:phone-1')
+    await dispatchPromise
+  })
+
   it('drops stale mobile resize re-stream completions for legacy binary streams', async () => {
     const messages: string[] = []
     const binaryFrames: Uint8Array<ArrayBufferLike>[] = []


### PR DESCRIPTION
Stacked on #7295 (retargets to main when it merges). First of two perf slices from the reliability stack — the deterministic regression net around the daemon output hot path, prioritized for in-flight terminal perf work.

## What this does

**Product hardening (`daemon-stream-data-batcher.ts`):** daemon stream writes now respect socket backpressure — `write(false)` pauses further stream writes until `drain`, queued lines stay bounded (8MB default, newest tail preserved, priority lines protected), interactive session output is re-queued ahead of unrelated backpressured backlog on drain, and global cleanup clears clients that only have backpressured writes. Previously a slow/wedged stream socket could accumulate unbounded queued output or starve interactive output behind a hidden-output flood.

**Module split (max-lines):** the backpressured write queue and NDJSON frame helpers are extracted into `daemon-stream-backpressure-queue.ts` and `daemon-stream-ndjson-frames.ts`; the batcher keeps only batching/flush policy. Behavior-preserving — the contracts are the proof.

**Tests:** 5 new deterministic fake-socket contracts (pause, queue-until-drain, drain priority, bounded bytes, backpressure-only cleanup) plus the byte-exact 512KB mobile initial-snapshot budget test.

**Manifest:** re-promotes `terminal-performance.daemon-stream-backpressure` from registered gap to `partial` with fresh evidence; extends `terminal-runtime.mobile-stream-budget` refs and evidence.

## Reliability proof

- **Reliability invariant:** `terminal-performance.daemon-stream-backpressure` — daemon socket writes must respect backpressure under output floods and must not starve active input or grow unbounded queues.
- **Material impact:** protects the freeze/input-lag/memory-growth class where background terminal floods harm the active terminal, at the daemon seam; gives concurrent perf work a regression net on exactly these paths.
- **Product change type:** perf hardening + test-only gate registration.
- **Performance risk inventory:** touches PTY output and hidden-output paths (daemon socket writes). No typing, focus, resize, startup, provider listing, polling, or store paths.
- **No-regression evidence:** no new timers/polling; queue work is O(lines) on the existing write path with constant-time byte accounting; typecheck:node clean; oxlint clean; the 10 batcher contracts + 29 runtime stream tests pass. Full `src/main/{daemon,ipc,runtime}` sweep: 3,541/3,544 relevant tests pass; the only failure is the known pre-existing `pty-subprocess` WSL assertion (fails identically on the untouched base; same known failure noted in `#7192`).
- **Found and fixed by that sweep:** the first cut deferred on any falsy `socket.write()` return, which broke two `daemon-server.test.ts` integration tests whose fake sockets return `undefined`. The queue now defers only on Node's explicit `false` backpressure signal — duck-typed sockets keep the legacy direct-write path. This is exactly the failure mode focused unit contracts miss and cross-module sweeps catch. Before/after terminal perf artifact (`tests/e2e/terminal-typing-latency.spec.ts`, electron-headless, same machine, back-to-back): **before** (v2 base) test body 9.0s, suite 45.5s, passed; **after** (this PR) test body 9.0s, suite 45.2s, passed. The spec's internal echo-latency thresholds held on both runs — no regression signal.
- **Correctness evidence:** `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts` — 10 tests; each backpressure guard was developed red-first on the reliability stack.
- **Provider/platform coverage:** daemon provider path, local macOS evidence; SSH/remote-runtime stream paths unaffected (separate transports). Windows/Linux: no platform-specific code touched.
- **Residual gaps:** live hidden-output flood and key-latency metric artifacts; the renderer/main ACK + pending-cap extensions arrive in perf slice B (`pty.ts`/`pty-connection.ts` hunks reconciled with #7133/#7173).
- **Promotion status:** `partial`/`experimental`; not blocking. Promotion requires aggregated CI history.
- **Rollback/demotion rule:** if the batcher contracts flake or the bounded-queue trim is observed dropping non-flood interactive output, demote the gate and revert the queue bound while keeping the pause/drain contracts.

## Adversarial review round

Per the reliability plan's review discipline, this PR got a deep adversarial pass before merge: a baseline review plus three independent Codex reviewers (`gpt-5.5`, xhigh reasoning, read-only sandbox) with distinct lenses — correctness/lifecycle, environment/consumer matrix, and adversarial scenarios.

**Found and fixed (High, 4/4 independent detections):** exit frames were written directly to the stream socket (`daemon-server.ts` real + synthetic exit sites) and could overtake output held in the backpressure queue, so under socket backpressure the wire order became data-prefix → exit → data-tail. The client tears down session state on exit (`daemon-pty-adapter.ts`, `pty-transport.ts` unregister handlers), so the final output tail could be silently lost — the exact class the original "flush final output first" comment was written to prevent. Both exit sites now route through `writeEventLine` on the same ordered path; the priority splice places the exit after the session's own queued output, ahead of unrelated sessions' backlog, and protects it from bounded-queue trimming. The regression test at the daemon-server seam was proven red against the pre-fix branch.

**Found and documented (Medium):** the queue byte bound is soft by one frame — the sole remaining line is never dropped (dropping it would lose data for no benefit), so the effective cap is `maxQueuedBytes` plus at most one frame (frames are capped at the NDJSON line limit). Now documented in the code and the gate's coverage notes.

**Clean across all lenses:** drain/close/error listener pairing over repeated defer cycles, re-entrant drain writes, socket replacement while deferred, byte-accounting drift, same-session ordering under the priority splice, NDJSON wire-format compatibility (old daemon binaries persist across updates — no wire change), and SSH/remote stream paths.

Post-review validation: 32 daemon-server + batcher tests green (including the new red-proven exit-ordering test), full `src/main/{daemon,ipc,runtime}` sweep 3,530 passed with only the known pre-existing WSL failure, checker green for 27 gates, typecheck clean.

## Second (Fable) review round

A single Fable 5 reviewer then attacked the post-fix state with fresh eyes. It verified the exit-ordering fix's priority-splice compositions safe (session-id reuse after a queued exit, drain re-defer ordering, multiple exits FIFO) and the manifest honest (re-ran both gate commands, checked every assertionRef against a real test) — and found three real issues, now fixed:

- **Medium (fixed, red-proven):** the `onExit` closure holds the `ConnectedClient` captured at `createOrAttach`, which goes stale when a same-clientId reconnect replaces it (a supported, tested path). Routing exit through the queue with that stale destroyed socket tripped the queue's clear-on-mismatch and **wiped the live socket's queued output for every session of the client**, then wrote the exit to the dead socket. `onExit` now resolves the current client; regression test simulates the reconnect. This also fixes the pre-existing sibling bug on main where post-reconnect exit frames were silently written to the dead socket.
- **Low (fixed, red-proven):** writes aimed at an already-destroyed socket deferred into a pending entry whose drain/close can never fire (bounded leak + swallowed frame). The queue now drops destroyed-socket writes without touching the live queue.
- **Low (fixed, docs):** the "priority protects exit from trimming" comment overclaimed — trimming prefers non-priority lines, but an all-priority overflow (>8MB of priority-only frames) can still drop the oldest. Comment corrected; the regime is unreachable in practice (interactive frames are ≤1024 chars).

Post-round validation: 34/34 tests in the touched files (both new tests proven red first), full `src/main/{daemon,ipc,runtime}` sweep green except the known pre-existing WSL failure, checker green for 27 gates, typecheck clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋



