### PR TITLE
Fix notes send targets for manual agents

### DIFF
--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -14,6 +14,7 @@ import {
 const WORKTREE_ID = 'wt-1'
 const STATUS_TAB_ID = 'tab-status'
 const LAUNCH_TAB_ID = 'tab-launch'
+const MANUAL_TAB_ID = 'tab-manual'
 const LEAF_A = '11111111-1111-4111-8111-111111111111'
 const LEAF_B = '22222222-2222-4222-8222-222222222222'
 const NOW = 10_000
@@ -201,6 +202,70 @@ describe('notes send agent targets', () => {
     ])
   })
 
+  it('lists a manual agent tab with a recognized idle pane title and live PTY', () => {
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        tabsByWorktree: {
+          [WORKTREE_ID]: [tab(MANUAL_TAB_ID, { title: 'Terminal 2' })]
+        },
+        terminalLayoutsByTabId: { [MANUAL_TAB_ID]: leafLayout(LEAF_B, 'pty-b') },
+        runtimePaneTitlesByTabId: { [MANUAL_TAB_ID]: { 1: 'Codex ready' } }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toEqual([
+      {
+        paneKey: makePaneKey(MANUAL_TAB_ID, LEAF_B),
+        tabId: MANUAL_TAB_ID,
+        leafId: LEAF_B,
+        agentType: 'codex',
+        tabTitle: 'Terminal 2',
+        status: 'eligible'
+      }
+    ])
+  })
+
+  it('skips a manual agent tab with an unrecognized booting pane title', () => {
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        tabsByWorktree: {
+          [WORKTREE_ID]: [tab(MANUAL_TAB_ID, { title: 'Terminal 2' })]
+        },
+        terminalLayoutsByTabId: { [MANUAL_TAB_ID]: leafLayout(LEAF_B, 'pty-b') },
+        runtimePaneTitlesByTabId: { [MANUAL_TAB_ID]: { 1: 'zsh' } }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toEqual([])
+  })
+
+  it('disables a manual agent tab with a permission pane title', () => {
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        tabsByWorktree: {
+          [WORKTREE_ID]: [tab(MANUAL_TAB_ID, { title: 'Terminal 2' })]
+        },
+        terminalLayoutsByTabId: { [MANUAL_TAB_ID]: leafLayout(LEAF_B, 'pty-b') },
+        runtimePaneTitlesByTabId: { [MANUAL_TAB_ID]: { 1: 'Codex - action required' } }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toEqual([
+      expect.objectContaining({
+        paneKey: makePaneKey(MANUAL_TAB_ID, LEAF_B),
+        agentType: 'codex',
+        status: 'disabled',
+        disabledReason: 'Agent needs permission'
+      })
+    ])
+  })
+
   it('recognizes a launch-agent tab by its explicit ready tab title when no pane title is set', () => {
     const targets = deriveNotesSendAgentTargets(
       state({
@@ -346,6 +411,31 @@ describe('notes send agent targets', () => {
     expect(targets).toHaveLength(1)
     expect(targets[0]).toMatchObject({
       tabId: LAUNCH_TAB_ID,
+      leafId: LEAF_A,
+      status: 'eligible'
+    })
+  })
+
+  it('does not duplicate a status-backed tab with a manual title fallback', () => {
+    const paneKey = makePaneKey(MANUAL_TAB_ID, LEAF_A)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'working') },
+        tabsByWorktree: {
+          [WORKTREE_ID]: [tab(MANUAL_TAB_ID, { title: 'Codex ready' })]
+        },
+        terminalLayoutsByTabId: {
+          [MANUAL_TAB_ID]: splitLayout(LEAF_B, { [LEAF_A]: 'pty-a', [LEAF_B]: 'pty-b' })
+        },
+        runtimePaneTitlesByTabId: { [MANUAL_TAB_ID]: { 2: 'Codex ready' } }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toHaveLength(1)
+    expect(targets[0]).toMatchObject({
+      tabId: MANUAL_TAB_ID,
       leafId: LEAF_A,
       status: 'eligible'
     })
@@ -545,17 +635,22 @@ describe('notes send agent targets', () => {
     expect(targets).toEqual([])
   })
 
-  it('does not list a plain terminal tab without a launch agent or status', () => {
+  it('recognizes a manual agent tab by its explicit ready tab title when no pane title is set', () => {
     const targets = deriveNotesSendAgentTargets(
       state({
-        tabsByWorktree: { [WORKTREE_ID]: [tab(LAUNCH_TAB_ID, { title: 'Codex ready' })] },
-        terminalLayoutsByTabId: { [LAUNCH_TAB_ID]: leafLayout(LEAF_B, 'pty-b') },
-        runtimePaneTitlesByTabId: { [LAUNCH_TAB_ID]: { 1: 'Codex ready' } }
+        tabsByWorktree: { [WORKTREE_ID]: [tab(MANUAL_TAB_ID, { title: 'Codex ready' })] },
+        terminalLayoutsByTabId: { [MANUAL_TAB_ID]: leafLayout(LEAF_B, 'pty-b') }
       }),
       WORKTREE_ID,
       NOW
     )
 
-    expect(targets).toEqual([])
+    expect(targets).toEqual([
+      expect.objectContaining({
+        paneKey: makePaneKey(MANUAL_TAB_ID, LEAF_B),
+        agentType: 'codex',
+        status: 'eligible'
+      })
+    ])
   })
 })

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from '../../../shared/agent-status-types'
 import type { AppState } from '@/store/types'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
+import { resolveTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import type { TerminalTab } from '../../../shared/types'
 import { detectAgentSendTitleStatus } from './agent-send-title-status'
 import {
@@ -25,19 +26,30 @@ export type NotesSendAgentTarget = {
   disabledReason?: string
 }
 
-function detectLaunchAgentPaneStatus(
+type AgentTitleEvidence = {
+  status: NonNullable<ReturnType<typeof detectAgentSendTitleStatus>>
+  title: string
+}
+
+type TitleHintAgentTarget = NotesSendAgentTarget & {
+  source: 'launch-agent' | 'manual-title'
+}
+
+function detectTitleHintPaneEvidence(
   paneTitleResolution: RuntimePaneTitleLeafResolution,
   tabTitle: string
-) {
+): AgentTitleEvidence | null {
   if (paneTitleResolution.title !== null) {
-    return detectAgentSendTitleStatus(paneTitleResolution.title)
+    const status = detectAgentSendTitleStatus(paneTitleResolution.title)
+    return status ? { status, title: paneTitleResolution.title } : null
   }
   // Why: mirror isTerminalRunningAgent — the OSC-enriched tab title only counts
   // when the leaf has no runtime pane title of its own yet.
   if (paneTitleResolution.hasAnyPaneTitle) {
     return null
   }
-  return detectAgentSendTitleStatus(tabTitle)
+  const status = detectAgentSendTitleStatus(tabTitle)
+  return status ? { status, title: tabTitle } : null
 }
 
 /**
@@ -46,11 +58,12 @@ function detectLaunchAgentPaneStatus(
  * Why this exists on top of deriveRunningAgentSendTargets: that derivation only
  * sees panes with a live status entry, so a freshly launched (still idle) agent
  * stays invisible until its first hook event — i.e. until the user talks to it.
- * We augment it with launch-agent tabs whose pane still has a live PTY:
- * TerminalTab.launchAgent records the harness Orca started and is the same
- * pre-hook signal the tab bar already trusts for its provider icon.
+ * We augment it with recognized agent-title tabs whose pane still has a live
+ * PTY. TerminalTab.launchAgent records the harness Orca started; manually typed
+ * CLIs do not have that owner bit, so their runtime title is the only pre-hook
+ * signal available.
  *
- * The launch hint is gated on a recognized agent title (pane or tab) — the same
+ * The title hint is gated on a recognized agent title (pane or tab) — the same
  * signal isTerminalRunningAgent checks — so a freshly spawned tab is only listed
  * once the runtime would actually accept the send. Without that gate, clicking a
  * still-booting pane fails with "not a recognized agent session".
@@ -73,12 +86,12 @@ export function deriveNotesSendAgentTargets(
   )
 
   for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
-    const launchTarget = deriveLaunchAgentTarget(state, tab)
-    if (!launchTarget) {
+    const titleHintTarget = deriveTitleHintAgentTarget(state, tab)
+    if (!titleHintTarget) {
       continue
     }
 
-    mergeLaunchAgentTarget(targets, launchTarget)
+    mergeTitleHintAgentTarget(targets, titleHintTarget)
   }
 
   return targets
@@ -94,14 +107,10 @@ function resolveNotesTargetAgentType(
   return launchAgent ?? entryAgentType
 }
 
-function deriveLaunchAgentTarget(
+function deriveTitleHintAgentTarget(
   state: NotesSendAgentTargetState,
   tab: TerminalTab
-): NotesSendAgentTarget | null {
-  if (!tab.launchAgent) {
-    return null
-  }
-
+): TitleHintAgentTarget | null {
   const layout = state.terminalLayoutsByTabId[tab.id]
   const leafId = layout?.activeLeafId
   if (!leafId || !isTerminalLeafId(leafId)) {
@@ -115,32 +124,40 @@ function deriveLaunchAgentTarget(
 
   const paneTitles = state.runtimePaneTitlesByTabId[tab.id]
   const paneTitleResolution = resolveRuntimePaneTitleLeafResolution(layout, paneTitles, leafId)
-  const launchStatus = detectLaunchAgentPaneStatus(paneTitleResolution, tab.title)
-  if (!launchStatus) {
+  const titleEvidence = detectTitleHintPaneEvidence(paneTitleResolution, tab.title)
+  if (!titleEvidence) {
     // Why: launchAgent is set the instant Orca spawns the tab, but the runtime
-    // only accepts a send once the pane reads as an agent. Skipping until the
-    // title is recognized keeps "listed ⇒ sendable" and avoids the boot-window
-    // "not a recognized agent session" error.
+    // only accepts a send once the pane reads as an agent; manually started
+    // CLIs need the same title proof before appearing in the send menu.
     return null
   }
-  const disabledReason = launchStatus === 'permission' ? 'Agent needs permission' : undefined
+  const disabledReason =
+    titleEvidence.status === 'permission' ? 'Agent needs permission' : undefined
 
   return {
     paneKey: makePaneKey(tab.id, leafId),
     tabId: tab.id,
     leafId,
-    agentType: tab.launchAgent,
+    agentType: tab.launchAgent ?? resolveTerminalTitleAgentType(titleEvidence.title),
     tabTitle: tab.title,
     status: disabledReason ? 'disabled' : 'eligible',
-    ...(disabledReason ? { disabledReason } : {})
+    ...(disabledReason ? { disabledReason } : {}),
+    source: tab.launchAgent ? 'launch-agent' : 'manual-title'
   }
 }
 
-function mergeLaunchAgentTarget(
+function mergeTitleHintAgentTarget(
   targets: NotesSendAgentTarget[],
-  launchTarget: NotesSendAgentTarget
+  titleHintTarget: TitleHintAgentTarget
 ): void {
-  const samePaneIndex = targets.findIndex((target) => target.paneKey === launchTarget.paneKey)
+  if (
+    titleHintTarget.source === 'manual-title' &&
+    targets.some((target) => target.tabId === titleHintTarget.tabId)
+  ) {
+    return
+  }
+
+  const samePaneIndex = targets.findIndex((target) => target.paneKey === titleHintTarget.paneKey)
   if (samePaneIndex !== -1) {
     const existing = targets[samePaneIndex]
     if (existing.status === 'eligible' || existing.disabledReason === 'Agent needs permission') {
@@ -151,12 +168,12 @@ function mergeLaunchAgentTarget(
     // same live launch-agent pane has a fresh title proof, prefer the sendable
     // runtime evidence over the stale retained status row.
     targets[samePaneIndex] = {
-      ...launchTarget,
+      ...stripTitleHintSource(titleHintTarget),
       agentType:
         existing.agentType && existing.agentType !== 'unknown'
           ? existing.agentType
-          : launchTarget.agentType,
-      tabTitle: existing.tabTitle || launchTarget.tabTitle
+          : titleHintTarget.agentType,
+      tabTitle: existing.tabTitle || titleHintTarget.tabTitle
     }
     return
   }
@@ -166,12 +183,24 @@ function mergeLaunchAgentTarget(
   if (
     targets.some(
       (target) =>
-        target.tabId === launchTarget.tabId &&
+        target.tabId === titleHintTarget.tabId &&
         (target.status === 'eligible' || target.disabledReason === 'Agent needs permission')
     )
   ) {
     return
   }
 
-  targets.push(launchTarget)
+  targets.push(stripTitleHintSource(titleHintTarget))
+}
+
+function stripTitleHintSource(target: TitleHintAgentTarget): NotesSendAgentTarget {
+  return {
+    paneKey: target.paneKey,
+    tabId: target.tabId,
+    leafId: target.leafId,
+    agentType: target.agentType,
+    tabTitle: target.tabTitle,
+    status: target.status,
+    ...(target.disabledReason ? { disabledReason: target.disabledReason } : {})
+  }
 }

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -31,10 +31,6 @@ type AgentTitleEvidence = {
   title: string
 }
 
-type TitleHintAgentTarget = NotesSendAgentTarget & {
-  source: 'launch-agent' | 'manual-title'
-}
-
 function detectTitleHintPaneEvidence(
   paneTitleResolution: RuntimePaneTitleLeafResolution,
   tabTitle: string
@@ -91,7 +87,14 @@ export function deriveNotesSendAgentTargets(
       continue
     }
 
-    mergeTitleHintAgentTarget(targets, titleHintTarget)
+    // Why: a launchAgent tab carries an owner bit, so its live title can promote a
+    // stale status row on the same pane. A manually started CLI has no owner bit,
+    // so it only ever adds a row and must not override existing status evidence.
+    if (tab.launchAgent) {
+      mergeLaunchAgentTitleTarget(targets, titleHintTarget)
+    } else {
+      mergeManualAgentTitleTarget(targets, titleHintTarget)
+    }
   }
 
   return targets
@@ -110,7 +113,7 @@ function resolveNotesTargetAgentType(
 function deriveTitleHintAgentTarget(
   state: NotesSendAgentTargetState,
   tab: TerminalTab
-): TitleHintAgentTarget | null {
+): NotesSendAgentTarget | null {
   const layout = state.terminalLayoutsByTabId[tab.id]
   const leafId = layout?.activeLeafId
   if (!leafId || !isTerminalLeafId(leafId)) {
@@ -141,23 +144,27 @@ function deriveTitleHintAgentTarget(
     agentType: tab.launchAgent ?? resolveTerminalTitleAgentType(titleEvidence.title),
     tabTitle: tab.title,
     status: disabledReason ? 'disabled' : 'eligible',
-    ...(disabledReason ? { disabledReason } : {}),
-    source: tab.launchAgent ? 'launch-agent' : 'manual-title'
+    ...(disabledReason ? { disabledReason } : {})
   }
 }
 
-function mergeTitleHintAgentTarget(
+// Why: a manual title hint is the weakest signal, so never duplicate a tab that
+// already has a status-backed or launch-agent row — even a disabled one.
+function mergeManualAgentTitleTarget(
   targets: NotesSendAgentTarget[],
-  titleHintTarget: TitleHintAgentTarget
+  target: NotesSendAgentTarget
 ): void {
-  if (
-    titleHintTarget.source === 'manual-title' &&
-    targets.some((target) => target.tabId === titleHintTarget.tabId)
-  ) {
+  if (targets.some((existing) => existing.tabId === target.tabId)) {
     return
   }
+  targets.push(target)
+}
 
-  const samePaneIndex = targets.findIndex((target) => target.paneKey === titleHintTarget.paneKey)
+function mergeLaunchAgentTitleTarget(
+  targets: NotesSendAgentTarget[],
+  target: NotesSendAgentTarget
+): void {
+  const samePaneIndex = targets.findIndex((existing) => existing.paneKey === target.paneKey)
   if (samePaneIndex !== -1) {
     const existing = targets[samePaneIndex]
     if (existing.status === 'eligible' || existing.disabledReason === 'Agent needs permission') {
@@ -168,12 +175,12 @@ function mergeTitleHintAgentTarget(
     // same live launch-agent pane has a fresh title proof, prefer the sendable
     // runtime evidence over the stale retained status row.
     targets[samePaneIndex] = {
-      ...stripTitleHintSource(titleHintTarget),
+      ...target,
       agentType:
         existing.agentType && existing.agentType !== 'unknown'
           ? existing.agentType
-          : titleHintTarget.agentType,
-      tabTitle: existing.tabTitle || titleHintTarget.tabTitle
+          : target.agentType,
+      tabTitle: existing.tabTitle || target.tabTitle
     }
     return
   }
@@ -182,25 +189,13 @@ function mergeTitleHintAgentTarget(
   // be a split shell pane, which would list a second bogus row for the same tab.
   if (
     targets.some(
-      (target) =>
-        target.tabId === titleHintTarget.tabId &&
-        (target.status === 'eligible' || target.disabledReason === 'Agent needs permission')
+      (existing) =>
+        existing.tabId === target.tabId &&
+        (existing.status === 'eligible' || existing.disabledReason === 'Agent needs permission')
     )
   ) {
     return
   }
 
-  targets.push(stripTitleHintSource(titleHintTarget))
-}
-
-function stripTitleHintSource(target: TitleHintAgentTarget): NotesSendAgentTarget {
-  return {
-    paneKey: target.paneKey,
-    tabId: target.tabId,
-    leafId: target.leafId,
-    agentType: target.agentType,
-    tabTitle: target.tabTitle,
-    status: target.status,
-    ...(target.disabledReason ? { disabledReason: target.disabledReason } : {})
-  }
+  targets.push(target)
 }

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -52,7 +52,7 @@ function isGenericClaudeStatusClaim(title: string, titleAgent: TuiAgent | null):
   )
 }
 
-function resolveTerminalTitleAgentType(title: string): TuiAgent | null {
+export function resolveTerminalTitleAgentType(title: string): TuiAgent | null {
   const label = getAgentLabel(title)
   return label ? (TITLE_LABEL_TO_AGENT[label] ?? null) : null
 }


### PR DESCRIPTION
## Summary
- include manually launched agent panes in review-notes Send targets when their live pane/tab title is recognized and the active PTY is live
- derive manual target agentType from the existing terminal-title label mapping
- keep permission titles disabled and avoid duplicate manual fallback rows for status-backed tabs

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/notes-send-agent-targets.test.ts src/shared/terminal-title-agent-type.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm run lint