### PR TITLE
fix(ssh): stop deleted ~/.ssh/config hosts from reappearing on sync

### DIFF
--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -714,8 +714,8 @@ export function registerSshHandlers(
     await removeRegisteredSshTarget(args.id)
   })
 
-  ipcMain.handle('ssh:importConfig', () => {
-    return sshStore!.importFromSshConfig()
+  ipcMain.handle('ssh:importConfig', (_event, args?: { reAdopt?: boolean }) => {
+    return sshStore!.importFromSshConfig(args)
   })
 
   // ── Connection lifecycle ───────────────────────────────────────────

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3339,6 +3339,11 @@ export class Store {
             defaults.workspaceSession
           ),
           sshTargets: (parsed.sshTargets ?? []).map(normalizeSshTarget),
+          deletedSshConfigAliases: Array.isArray(parsed.deletedSshConfigAliases)
+            ? parsed.deletedSshConfigAliases.filter(
+                (alias): alias is string => typeof alias === 'string'
+              )
+            : [],
           sshRemotePtyLeases: (parsed.sshRemotePtyLeases ?? [])
             .map(normalizeSshRemotePtyLease)
             .filter((lease): lease is SshRemotePtyLease => lease !== null),
@@ -5971,6 +5976,34 @@ export class Store {
     }
     this.state.claudeLivePtySessionIds = ids.filter((id) => id !== sessionId)
     this.scheduleSave()
+  }
+
+  getDeletedSshConfigAliases(): string[] {
+    return [...(this.state.deletedSshConfigAliases ?? [])]
+  }
+
+  addDeletedSshConfigAlias(alias: string): void {
+    this.state.deletedSshConfigAliases ??= []
+    if (!this.state.deletedSshConfigAliases.includes(alias)) {
+      this.state.deletedSshConfigAliases.push(alias)
+      this.scheduleSave()
+    }
+  }
+
+  removeDeletedSshConfigAlias(alias: string): void {
+    const current = this.state.deletedSshConfigAliases
+    if (!current || !current.includes(alias)) {
+      return
+    }
+    this.state.deletedSshConfigAliases = current.filter((entry) => entry !== alias)
+    this.scheduleSave()
+  }
+
+  clearDeletedSshConfigAliases(): void {
+    if (this.state.deletedSshConfigAliases && this.state.deletedSshConfigAliases.length > 0) {
+      this.state.deletedSshConfigAliases = []
+      this.scheduleSave()
+    }
   }
 
   // ── SSH Remote PTY Leases ──────────────────────────────────────────

--- a/src/main/ssh/ssh-connection-store.test.ts
+++ b/src/main/ssh/ssh-connection-store.test.ts
@@ -14,6 +14,7 @@ vi.mock('./ssh-config-parser', () => ({
 
 function createMockStore() {
   const targets: SshTarget[] = []
+  let deletedAliases: string[] = []
 
   return {
     getSshTargets: vi.fn(() => [...targets]),
@@ -32,6 +33,18 @@ function createMockStore() {
       if (idx !== -1) {
         targets.splice(idx, 1)
       }
+    }),
+    getDeletedSshConfigAliases: vi.fn(() => [...deletedAliases]),
+    addDeletedSshConfigAlias: vi.fn((alias: string) => {
+      if (!deletedAliases.includes(alias)) {
+        deletedAliases.push(alias)
+      }
+    }),
+    removeDeletedSshConfigAlias: vi.fn((alias: string) => {
+      deletedAliases = deletedAliases.filter((entry) => entry !== alias)
+    }),
+    clearDeletedSshConfigAliases: vi.fn(() => {
+      deletedAliases = []
     })
   }
 }
@@ -322,6 +335,108 @@ describe('SshConnectionStore', () => {
 
       const result = sshStore.importFromSshConfig()
       expect(result).toEqual([])
+    })
+  })
+
+  describe('deleted config host tombstones', () => {
+    function candidate(overrides: Partial<SshTarget> & { configHost: string }): SshTarget {
+      return {
+        id: `tmp-${overrides.configHost}`,
+        label: overrides.configHost,
+        host: `${overrides.configHost}.example.com`,
+        port: 22,
+        username: '',
+        ...overrides
+      }
+    }
+
+    // PRIMARY regression: deleting a config-sourced host must not let the next
+    // ~/.ssh/config sync resurrect it.
+    it('tombstones a deleted config-sourced host so re-import skips it', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-1',
+        label: 'mini',
+        configHost: 'mini',
+        host: 'mini.example.com',
+        port: 22,
+        username: 'ping',
+        source: 'ssh-config'
+      })
+
+      sshStore.removeTarget('ssh-1')
+      expect(mockStore.addDeletedSshConfigAlias).toHaveBeenCalledWith('mini')
+
+      loadUserSshConfigMock.mockReturnValue([{ host: 'mini' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([candidate({ configHost: 'mini' })])
+
+      const result = sshStore.importFromSshConfig()
+
+      expect(mockStore.addSshTarget).toHaveBeenCalledTimes(1) // only the seed insert
+      expect(result).toEqual([])
+    })
+
+    it('does not tombstone a manual target on delete', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-1',
+        label: 'mini',
+        configHost: 'mini',
+        host: 'mini.example.com',
+        port: 22,
+        username: 'ping',
+        source: 'manual'
+      })
+
+      sshStore.removeTarget('ssh-1')
+      expect(mockStore.addDeletedSshConfigAlias).not.toHaveBeenCalled()
+    })
+
+    it('re-adding a deleted host reclaims its alias so sync stops suppressing it', () => {
+      mockStore.addDeletedSshConfigAlias('mini')
+
+      sshStore.addTarget({
+        label: 'mini',
+        configHost: 'mini',
+        host: '10.0.0.2',
+        port: 22,
+        username: 'ping'
+      })
+      expect(mockStore.removeDeletedSshConfigAlias).toHaveBeenCalledWith('mini')
+
+      loadUserSshConfigMock.mockReturnValue([{ host: 'mini' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([candidate({ configHost: 'mini' })])
+      // Alias reclaimed, but it is now a manual target — still not re-inserted.
+      const result = sshStore.importFromSshConfig()
+      expect(result).toEqual([])
+    })
+
+    it('editing a target reclaims its alias from the deleted set', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-1',
+        label: 'mini',
+        configHost: 'mini',
+        host: 'mini.example.com',
+        port: 22,
+        username: 'ping',
+        source: 'ssh-config'
+      })
+      mockStore.addDeletedSshConfigAlias('mini')
+
+      sshStore.updateTarget('ssh-1', { port: 2222, source: 'manual' })
+      expect(mockStore.removeDeletedSshConfigAlias).toHaveBeenCalledWith('mini')
+    })
+
+    it('reAdopt clears all tombstones and re-imports the deleted host', () => {
+      mockStore.addDeletedSshConfigAlias('mini')
+      loadUserSshConfigMock.mockReturnValue([{ host: 'mini' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([candidate({ configHost: 'mini' })])
+
+      const result = sshStore.importFromSshConfig({ reAdopt: true })
+
+      expect(mockStore.clearDeletedSshConfigAliases).toHaveBeenCalled()
+      expect(mockStore.addSshTarget).toHaveBeenCalledWith(
+        expect.objectContaining({ configHost: 'mini', source: 'ssh-config' })
+      )
+      expect(result).toHaveLength(1)
     })
   })
 })

--- a/src/main/ssh/ssh-connection-store.ts
+++ b/src/main/ssh/ssh-connection-store.ts
@@ -23,6 +23,9 @@ export class SshConnectionStore {
       source: target.source ?? 'manual',
       id: `ssh-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     }
+    // Why: re-adding a host the user previously deleted is an explicit intent to
+    // keep it — lift any tombstone so config sync stops suppressing this alias.
+    this.reclaimAlias(full.configHost ?? full.label)
     this.store.addSshTarget(full)
     return full
   }
@@ -51,11 +54,34 @@ export class SshConnectionStore {
   }
 
   updateTarget(id: string, updates: Partial<Omit<SshTarget, 'id'>>): SshTarget | null {
-    return this.store.updateSshTarget(id, updates)
+    const updated = this.store.updateSshTarget(id, updates)
+    if (updated) {
+      // Why: actively editing a target reclaims its alias from the deleted set,
+      // so an edit can never leave the host tombstoned.
+      this.reclaimAlias(updated.configHost ?? updated.label)
+    }
+    return updated
   }
 
   removeTarget(id: string): void {
+    const target = this.store.getSshTarget(id)
+    // Why: deleting a config-managed target must record a tombstone; otherwise
+    // the next ~/.ssh/config sync re-inserts it verbatim (the config entry still
+    // exists on disk) and the host reappears. Manual targets need no tombstone —
+    // sync never re-adds them.
+    if (target && isConfigManagedTarget(target)) {
+      const alias = target.configHost ?? target.label
+      if (alias) {
+        this.store.addDeletedSshConfigAlias(alias)
+      }
+    }
     this.store.removeSshTarget(id)
+  }
+
+  private reclaimAlias(alias: string | undefined): void {
+    if (alias) {
+      this.store.removeDeletedSshConfigAlias(alias)
+    }
   }
 
   /**
@@ -63,7 +89,14 @@ export class SshConnectionStore {
    * config-sourced ones in place (so a rotated port takes effect), never touch
    * manual targets. Returns the inserted and updated targets.
    */
-  importFromSshConfig(): SshTarget[] {
+  importFromSshConfig(options?: { reAdopt?: boolean }): SshTarget[] {
+    // Why: the explicit Import action re-adopts every config host, so it clears
+    // all tombstones first. The passive on-open sync passes no flag and keeps
+    // deleted hosts suppressed.
+    if (options?.reAdopt) {
+      this.store.clearDeletedSshConfigAliases()
+    }
+    const deletedAliases = new Set(this.store.getDeletedSshConfigAliases())
     const configHosts = loadUserSshConfig()
     const existingTargets = this.store.getSshTargets()
     // Map config-managed targets (and legacy targets that strongly look like
@@ -100,6 +133,11 @@ export class SshConnectionStore {
       const alias = candidate.configHost ?? candidate.label
       if (manualAliases.has(alias)) {
         // A manual target owns this alias — never clobber it.
+        continue
+      }
+      if (deletedAliases.has(alias)) {
+        // The user deleted this config host — stay deleted until they re-add it
+        // or re-adopt config explicitly.
         continue
       }
       if (processedAliases.has(alias)) {
@@ -154,6 +192,16 @@ export function getRuntimeOwnedSshTargetId(runtimeId: string): string {
 
 export function isRuntimeOwnedSshTarget(target: SshTarget): boolean {
   return target.owner?.type === 'on-demand-runtime'
+}
+
+function isConfigManagedTarget(target: SshTarget): boolean {
+  // Why: a target is subject to config sync (and therefore needs a tombstone on
+  // delete) when it is explicitly config-sourced, or a legacy import that sync
+  // still adopts. Manual targets are excluded — sync never re-adds them.
+  return (
+    target.source === 'ssh-config' ||
+    (target.source === undefined && isLegacyConfigImportTarget(target))
+  )
 }
 
 function isLegacyConfigImportTarget(target: SshTarget): boolean {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2814,7 +2814,7 @@ export type PreloadApi = {
       updates: Partial<Omit<SshTarget, 'id'>>
     }) => Promise<SshTarget>
     removeTarget: (args: { id: string }) => Promise<void>
-    importConfig: () => Promise<SshTarget[]>
+    importConfig: (args?: { reAdopt?: boolean }) => Promise<SshTarget[]>
     connect: (args: { targetId: string }) => Promise<SshConnectionState | null>
     disconnect: (args: { targetId: string }) => Promise<void>
     terminateSessions: (args: { targetId: string }) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3837,7 +3837,8 @@ const api = {
     removeTarget: (args: { id: string }): Promise<void> =>
       ipcRenderer.invoke('ssh:removeTarget', args),
 
-    importConfig: (): Promise<SshTarget[]> => ipcRenderer.invoke('ssh:importConfig'),
+    importConfig: (args?: { reAdopt?: boolean }): Promise<SshTarget[]> =>
+      ipcRenderer.invoke('ssh:importConfig', args),
 
     connect: (args: { targetId: string }): Promise<SshConnectionState | null> =>
       ipcRenderer.invoke('ssh:connect', args),

--- a/src/renderer/src/components/settings/SshPane.tsx
+++ b/src/renderer/src/components/settings/SshPane.tsx
@@ -254,7 +254,10 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
 
   const handleImport = async (): Promise<void> => {
     try {
-      const synced = (await window.api.ssh.importConfig()) as SshTarget[]
+      // Why: the explicit Import action re-adopts every ~/.ssh/config host,
+      // including ones the user previously deleted — clear tombstones so a
+      // deliberate re-import can bring them back.
+      const synced = (await window.api.ssh.importConfig({ reAdopt: true })) as SshTarget[]
       recordFeatureInteraction('ssh')
       if (mountedRef.current) {
         if (synced.length === 0) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -436,6 +436,7 @@ export function getDefaultPersistedState(homedir: string): PersistedState {
     workspaceSession: getDefaultWorkspaceSession(),
     workspaceSessionsByHostId: {},
     sshTargets: [],
+    deletedSshConfigAliases: [],
     sshRemotePtyLeases: [],
     claudeLivePtySessionIds: [],
     migrationUnsupportedPtyEntries: [],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3498,6 +3498,10 @@ export type PersistedState = {
    *  pre-partition builds keep working. Optional/absent on legacy files. */
   workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
   sshTargets: SshTarget[]
+  /** SSH config aliases the user explicitly deleted. Suppresses re-import of the
+   *  matching ~/.ssh/config host on the next sync so a deleted host does not
+   *  reappear. Cleared for an alias when the user re-adds it or re-adopts config. */
+  deletedSshConfigAliases: string[]
   sshRemotePtyLeases: SshRemotePtyLease[]
   /** Daemon session ids of live local Claude launches. Seeds the Claude
    *  live-PTY gate on startup so an early OAuth refresh cannot rotate the


### PR DESCRIPTION
## Bug

Deleting an SSH target that came from `~/.ssh/config` doesn't stick — the host reappears after reopening the Manage-SSH pane (or after a restart, since opening the pane re-imports config).

## Root cause

`SshPane` re-imports `~/.ssh/config` every time the pane mounts (`SshPane.tsx` `useEffect` → `ssh:importConfig`). `SshConnectionStore.importFromSshConfig()` is a pure upsert: for any config alias not currently in the store it **inserts** a fresh `ssh-config` target (`ssh-connection-store.ts`, the `else` branch). Deletion (`removeTarget` → `persistence.removeSshTarget`) is a plain array filter with **no record of what was deleted**, and there is no tombstone anywhere in the SSH path. So the deleted host — still present in `~/.ssh/config` on disk — is re-inserted on the next sync.

## Fix

Persist a `deletedSshConfigAliases` tombstone set (`PersistedState` + defaults + load-parse):

- **Delete** a config-managed target (`source: 'ssh-config'`, or an adopted legacy import) → record its alias. Manual targets are not tombstoned (sync never re-adds them anyway).
- **Sync** (passive, on pane open) → skip tombstoned aliases; a deleted host stays deleted.
- **Re-add / edit** a target → reclaim its alias from the set (covers the "edit changed the alias → old alias resurrected" case too).
- **Import button** (explicit) → `reAdopt: true` clears all tombstones, so a deliberate re-import can bring deleted hosts back.

## Test plan

- [x] `vitest src/main/ssh/ssh-connection-store.test.ts` — 21 pass, incl. 5 new: delete tombstones + sync skips; manual delete not tombstoned; re-add reclaims; edit reclaims; `reAdopt` clears + re-imports
- [x] `typecheck` (node + cli + web) clean
- [x] `oxlint` clean on changed files
- [ ] Manual: with `Host mini` in `~/.ssh/config`, delete it in Manage SSH, reopen the pane → stays gone; click **Import** → comes back