### PR TITLE
fix(sidebar): drop vertical rule from hovercard title

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -262,7 +262,7 @@ export function WorktreeCardDetailsHover({
       >
         <SelectedTextCopyMenu className="space-y-3">
           {showIdentityHeader && (
-            <div className="min-w-0 border-l border-border/70 pl-2">
+            <div className="min-w-0">
               {/* Why: the closed card no longer carries a branch row; custom-titled
                   worktrees still need their git branch available in the hover. */}
               {identityOrder === 'branch-first' ? branchIdentity : workspaceIdentity}


### PR DESCRIPTION
## What

Removes the left vertical rule (and its indent) from the worktree hovercard's **title / identity header**. The title now sits flush at level 0.

## Why

The vertical rule reads best as a section-body indent marker. On the title it was redundant. The Ports section — and the other detail sections (PR/Review, Issue, Linear, Automation, Notes) that share `WorktreeCardDetailSectionContent` — keep their rule.

## Change

`WorktreeCardMeta.tsx`: identity header `border-l border-border/70 pl-2` → `min-w-0`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
