### PR TITLE
perf: overlap sidebar-scope loads with worktree scan at startup (#7225)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -878,19 +878,28 @@ function App(): React.JSX.Element {
         // active one) so a cold start that restored a remote workspace doesn't
         // hide local repos. The sidebar "All hosts" scope then shows them all.
         await timeRendererStartupStep('fetch-repos', () => actions.fetchReposForAllHosts())
-        await timeRendererStartupStep('fetch-project-groups', () =>
-          actions.fetchProjectGroupsForAllHosts()
-        )
-        await timeRendererStartupStep('fetch-folder-workspaces', () =>
-          actions.fetchFolderWorkspacesForAllHosts()
-        )
-        // Why: both of these fan out `git worktree list` per repo on the main
-        // process. Running them concurrently lets the main process share one
+        // Why: project-groups/folder-workspaces read neither the repos store nor
+        // worktrees, so once repos land they can overlap the per-repo
+        // `git worktree list` fan-out (#7225) instead of queuing ahead of it — a
+        // slow remote host's 15s scope RPCs no longer block the scan. folders
+        // still follow project-groups (they read projectGroups); all settle
+        // before the hydrate steps below.
+        const projectScopeChain = (async () => {
+          await timeRendererStartupStep('fetch-project-groups', () =>
+            actions.fetchProjectGroupsForAllHosts()
+          )
+          await timeRendererStartupStep('fetch-folder-workspaces', () =>
+            actions.fetchFolderWorkspacesForAllHosts()
+          )
+        })()
+        // Why: worktrees + lineage both fan out `git worktree list` per repo on
+        // the main process. Running them concurrently lets it share one
         // in-flight scan per repo instead of paying the process-spawn fan-out
         // twice back-to-back — the dominant renderer-chain cost on Windows
         // (issue #7225). Lineage only reads settings + its own slice, so it
         // does not depend on the worktrees fetch having landed.
         await Promise.all([
+          projectScopeChain,
           timeRendererStartupStep('fetch-worktrees', () => actions.fetchAllWorktrees()),
           timeRendererStartupStep('fetch-worktree-lineage', () => actions.fetchWorktreeLineage())
         ])

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -6,15 +6,38 @@ describe('renderer startup runtime routing', () => {
   it('loads settings before repo and worktree hydration', () => {
     const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
     const startupBlockStart = source.indexOf('void (async () => {')
-    const startupBlockEnd = source.indexOf(
-      "const persistedUI = await timeRendererStartupStep('ui-get'"
-    )
+    const startupBlockEnd = source.indexOf('const persistedUI = await uiGetPromise')
     const startupBlock = source.slice(startupBlockStart, startupBlockEnd)
 
     const settingsIndex = startupBlock.indexOf('actions.fetchSettings()')
     expect(settingsIndex).toBeGreaterThanOrEqual(0)
     expect(settingsIndex).toBeLessThan(startupBlock.indexOf('actions.fetchReposForAllHosts()'))
     expect(settingsIndex).toBeLessThan(startupBlock.indexOf('actions.fetchAllWorktrees()'))
+  })
+
+  it('overlaps sidebar scope loads with worktree hydration before session hydration', () => {
+    const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
+    const startupBlockStart = source.indexOf('void (async () => {')
+    const startupBlockEnd = source.indexOf('const persistedUI = await uiGetPromise')
+    const startupBlock = source.slice(startupBlockStart, startupBlockEnd)
+
+    const reposIndex = startupBlock.indexOf('actions.fetchReposForAllHosts()')
+    const scopeChainIndex = startupBlock.indexOf('const projectScopeChain = (async () => {')
+    const projectGroupsIndex = startupBlock.indexOf('actions.fetchProjectGroupsForAllHosts()')
+    const folderWorkspacesIndex = startupBlock.indexOf('actions.fetchFolderWorkspacesForAllHosts()')
+    const promiseAllIndex = startupBlock.indexOf('await Promise.all([')
+    const awaitedScopeChainIndex = startupBlock.indexOf('projectScopeChain', promiseAllIndex)
+    const worktreesIndex = startupBlock.indexOf('actions.fetchAllWorktrees()')
+    const lineageIndex = startupBlock.indexOf('actions.fetchWorktreeLineage()')
+
+    expect(reposIndex).toBeGreaterThanOrEqual(0)
+    expect(scopeChainIndex).toBeGreaterThan(reposIndex)
+    expect(projectGroupsIndex).toBeGreaterThan(scopeChainIndex)
+    expect(folderWorkspacesIndex).toBeGreaterThan(projectGroupsIndex)
+    expect(promiseAllIndex).toBeGreaterThan(scopeChainIndex)
+    expect(awaitedScopeChainIndex).toBeGreaterThan(promiseAllIndex)
+    expect(worktreesIndex).toBeGreaterThan(promiseAllIndex)
+    expect(lineageIndex).toBeGreaterThan(promiseAllIndex)
   })
 
   it('waits for first-window startup services before terminal reconnect', () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -91,6 +91,7 @@ const mockApi = {
 globalThis.window = { api: mockApi }
 
 import {
+  WORKTREE_REFRESH_CONCURRENCY,
   createWorktreeSlice,
   getHostedReviewLinkMutationGenerationForTests,
   getHostedReviewLinkWorktreeAliasCountForTests,
@@ -5648,7 +5649,7 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
 
   it('bounds concurrent repo scans during hydration-time refresh', async () => {
     const store = createTestStore()
-    const repos = Array.from({ length: 7 }, (_, index) => ({
+    const repos = Array.from({ length: WORKTREE_REFRESH_CONCURRENCY + 2 }, (_, index) => ({
       id: `repo-${index}`,
       path: `/repos/${index}`,
       displayName: `repo-${index}`,
@@ -5670,14 +5671,14 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
 
     await store.getState().fetchAllWorktrees()
 
-    expect(maxActiveScans).toBeLessThanOrEqual(5)
+    expect(maxActiveScans).toBeLessThanOrEqual(WORKTREE_REFRESH_CONCURRENCY)
     expect(mockApi.worktrees.list).toHaveBeenCalledTimes(repos.length)
     expect(store.getState().hasHydratedWorktreePurge).toBe(true)
   })
 
   it('bounds concurrent repo scans after the hydration purge has run', async () => {
     const store = createTestStore()
-    const repos = Array.from({ length: 7 }, (_, index) => ({
+    const repos = Array.from({ length: WORKTREE_REFRESH_CONCURRENCY + 2 }, (_, index) => ({
       id: `repo-${index}`,
       path: `/repos/${index}`,
       displayName: `repo-${index}`,
@@ -5702,7 +5703,7 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
 
     await store.getState().fetchAllWorktrees()
 
-    expect(maxActiveScans).toBeLessThanOrEqual(5)
+    expect(maxActiveScans).toBeLessThanOrEqual(WORKTREE_REFRESH_CONCURRENCY)
     expect(mockApi.worktrees.list).toHaveBeenCalledTimes(repos.length)
     expect(store.getState().hasHydratedWorktreePurge).toBe(true)
   })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -72,7 +72,10 @@ const REMOTE_WORKTREE_LIST_PARITY_LIMIT = 10_000
 const ACTIVE_WORKTREE_TERMINAL_PREP_DELAY_MS = 300
 const ACTIVE_WORKTREE_TERMINAL_PREP_INPUT_QUIET_MS = 450
 const ACTIVE_WORKTREE_TERMINAL_PREP_IDLE_TIMEOUT_MS = 180
-const WORKTREE_REFRESH_CONCURRENCY = 5
+// Why: each repo's `git worktree list` is an independent main-process child, so
+// a higher ceiling cuts startup scan batches (#7225) while staying bounded so
+// one UI moment can't launch every git probe at once.
+export const WORKTREE_REFRESH_CONCURRENCY = 8
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -73,8 +73,8 @@ const ACTIVE_WORKTREE_TERMINAL_PREP_DELAY_MS = 300
 const ACTIVE_WORKTREE_TERMINAL_PREP_INPUT_QUIET_MS = 450
 const ACTIVE_WORKTREE_TERMINAL_PREP_IDLE_TIMEOUT_MS = 180
 // Why: each repo's `git worktree list` is an independent main-process child, so
-// a higher ceiling cuts startup scan batches (#7225) while staying bounded so
-// one UI moment can't launch every git probe at once.
+// a higher ceiling cuts startup scan batches while staying bounded so
+// one UI moment can't launch every git probe at once. That's why we chose 8 over a previous 5.
 export const WORKTREE_REFRESH_CONCURRENCY = 8
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -73,8 +73,8 @@ const ACTIVE_WORKTREE_TERMINAL_PREP_DELAY_MS = 300
 const ACTIVE_WORKTREE_TERMINAL_PREP_INPUT_QUIET_MS = 450
 const ACTIVE_WORKTREE_TERMINAL_PREP_IDLE_TIMEOUT_MS = 180
 // Why: each repo's `git worktree list` is an independent main-process child, so
-// a higher ceiling cuts startup scan batches while staying bounded so
-// one UI moment can't launch every git probe at once. That's why we chose 8 over a previous 5.
+// a higher ceiling cuts startup scan batches (#7225) while staying bounded so
+// one UI moment can't launch every git probe at once.
 export const WORKTREE_REFRESH_CONCURRENCY = 8
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()


### PR DESCRIPTION
## Summary

Continues the renderer startup-chain parallelization proposed in #7225 (proposal 2), on top of the merged #7266 (which fixed the main-process blocking — proposal 1). Two small changes to the renderer startup effect (`App.tsx`) and the worktree slice:

1. **Overlap the sidebar-scope loads with the worktree scan.** `fetchProjectGroupsForAllHosts` → `fetchFolderWorkspacesForAllHosts` previously ran *serially before* the per-repo `git worktree list` fan-out. They enumerate hosts via `runtimeEnvironments.list` and read neither the repos store nor worktrees, so once repos have landed they are independent of the scan. They now run concurrently with the worktree/lineage `Promise.all`, so a slow/unreachable remote host's scope RPCs (up to 15s each) no longer queue ahead of the scan. Ordering (`folder-workspaces` reads `projectGroups`) and the "all settle before hydrate" invariant are preserved.
2. **Raise worktree refresh concurrency 5 → 8.** Each repo's `git worktree list` is an independent main-process child, so a higher ceiling runs fewer sequential scan batches at startup on multi-core machines — the dominant renderer-chain cost from #7225. Still bounded so one UI moment can't launch every git probe at once.

User-visible effect: faster startup, most noticeably for users with many repos and/or a configured-but-unreachable remote host. No behavior or UI change otherwise.

## Screenshots

No visual change. Verified via the `ORCA_STARTUP_DIAGNOSTICS=1` startup timeline instead:

```
renderer-fetch-repos-done            durationMs=87
renderer-fetch-worktrees-done        durationMs=1     ← now overlapped with:
renderer-fetch-project-groups-done   durationMs=25
renderer-fetch-folder-workspaces-done durationMs=2
```
The four fetches complete within the same window (t≈2980–3000) instead of serializing.

## Testing

- [x] `pnpm lint` — oxlint clean on the changed files (`App.tsx`, `worktrees.ts`, `worktrees.test.ts`)
- [x] `pnpm typecheck` — changed files type-clean (the 5 pre-existing `TS6307` project-reference errors are also present on unmodified `main`, unrelated to this PR)
- [x] `pnpm test` — ran the affected suites green: `worktrees.test.ts` (204 tests, incl. the two "bounds concurrent repo scans" tests now asserting against the exported `WORKTREE_REFRESH_CONCURRENCY`) and `app-startup-routing.test.ts` (14 tests)
- [ ] `pnpm build` — not run (renderer-only logic change, no build-surface impact)
- [x] Updated the two concurrency-bound tests to reference the exported constant and use `CONCURRENCY + 2` repos so the bound is still exercised (10 > 8)

## AI Review Report

Reviewed with the AI agent; main risks checked:

- **Store-write races**: the two overlapped branches write disjoint keys (`projectGroups`/`folderWorkspaces` vs `worktreesByRepo`/`detectedWorktreesByRepo`/`sortEpoch`). Zustand `set()` stays atomic per key on the single-threaded event loop, so concurrency cannot cause a lost update. ✅
- **Session/reconnect correctness**: mapped the dependency graph — `folderWorkspaces` (consumed by session hydration + terminal reconnect to build `validWorktreeIds`/`pendingReconnectWorktreeIds`) and `worktreesByRepo` are both still fully awaited before the hydrate steps, so no persisted tab/terminal/editor state is dropped. `fetchAllWorktrees` reads only `repos`/`settings`/`projectHostSetups` (already loaded), not `projectGroups`/`folderWorkspaces`. ✅
- **Error handling / unhandled rejections**: the concurrent `projectScopeChain` promise is created and passed into `Promise.all` in the same synchronous tick (handler attached before any microtask can reject), and a rejection still propagates to the existing outer startup `catch`. Terminal behavior unchanged. ✅
- **Concurrency change**: affects parallelism only, not scan results (each repo scanned exactly once); still bounded.
- **Cross-platform (macOS / Linux / Windows)**: no keyboard shortcuts, UI labels, file paths, or shell invocations touched. Both changes are platform-agnostic (JS promise ordering + a bound on main-process git child processes). #7225 is Windows-focused and this reduces its scan-batch count there. No Electron platform-specific surface touched.

## Security Audit

Low surface. No new IPC handlers, command construction, path handling, auth, secrets, or dependency changes. The concurrency constant only bounds how many existing `git worktree list` child processes run in parallel (raised 5 → 8, still capped — no unbounded spawn). Reordering is pure in-renderer promise scheduling. No user input flows through the changed code. No follow-up required.

## Notes

- Scoped deliberately to proposal 2 of #7225. Proposal 3 (lazy-loading non-critical IPC handlers) is the remaining lever and is not included here.
- SSH / remote-host use case is the primary beneficiary: an unreachable runtime host's 15s scope RPCs now overlap the worktree scan rather than blocking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)