### PR TITLE
Throttle WebGL glyph-atlas recovery during sustained CJK terminal output

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -10200,6 +10200,39 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('skips WebGL atlas recovery for CJK keystroke echoes right after terminal input', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const refresh = vi.fn()
+    const terminal = pane.terminal as typeof pane.terminal & {
+      _core?: { refresh: typeof refresh }
+    }
+    terminal._core = { refresh }
+    terminal.write = vi.fn((_data: string, callback?: () => void) => {
+      callback?.()
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks(6)
+    sendTerminalInputThroughPane(pane, '日本語の入力')
+
+    capturedDataCallback.current?.('\x1b[2K\x1b[G> 日本語の入力')
+
+    // Why: the echo still repaints stale cells, but rebuilding the shared
+    // glyph atlas per keystroke would jank IME typing (the prompt line keeps
+    // containing CJK on every subsequent keypress).
+    expect(refresh).toHaveBeenCalledWith(0, 39, true)
+    expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
+  })
+
   it('does not schedule WebGL atlas recovery for plain synchronized foreground frames', async () => {
     const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
     try {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -39,6 +39,7 @@ import { createPtySizeReassertion } from './pty-size-reassertion'
 import { isPaneReplaying, replayIntoTerminal, replayIntoTerminalAsync } from './replay-guard'
 import {
   nativeWindowsRewriteNeedsFollowupRenderRefresh,
+  rendererRiskOutputPrefersAtlasRecovery,
   terminalOutputPrefersRenderRefresh,
   terminalRewriteOutputRenderRefreshDecision,
   terminalRewriteOutputPrefersRenderRefresh,
@@ -4119,7 +4120,13 @@ export function connectPanePty(
         return {
           refresh: true,
           inPlaceRewrite: rewriteOutputPrefersRenderRefresh,
-          recoverWebglAtlasAfterParse: true
+          // Why: see rendererRiskOutputPrefersAtlasRecovery — a shared-atlas
+          // rebuild per keystroke echo janks CJK/IME typing; the forced
+          // viewport refresh above still repaints stale cells.
+          recoverWebglAtlasAfterParse: rendererRiskOutputPrefersAtlasRecovery(data, {
+            hadRecentInput: recentInput,
+            maxInteractiveRedrawChars: FOREGROUND_INTERACTIVE_REDRAW_CHARS
+          })
         }
       }
       if (rewriteOutputPrefersRenderRefresh) {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -21,7 +21,7 @@ vi.mock('./pane-helpers', () => ({
   focusActivePane: vi.fn()
 }))
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery: vi.fn()
+  scheduleTerminalRevealWebglAtlasRecovery: vi.fn()
 }))
 
 type FakeManager = {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -7,7 +7,7 @@ import {
 } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { enforceTerminalCurrentScrollIntent } from '@/lib/pane-manager/terminal-scroll-intent'
 import { fitAndFocusPanes, fitPanes, focusActivePane } from './pane-helpers'
-import { scheduleTerminalWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
+import { scheduleTerminalRevealWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
 const WINDOW_WAKE_FLUSH_CHARS = 64 * 1024
@@ -62,7 +62,9 @@ export function resumeTerminalVisibility({
       // overlay's delayed geometry fit. Still request hidden-output recovery:
       // agent TUIs can suppress hidden bytes until the pane is foregrounded.
       requestLightTabBacklogRecovery(manager)
-      scheduleTerminalWebglAtlasRecovery()
+      // Why: reveal must repaint immediately even while output-driven recovery
+      // is in its cooldown window — a stale revealed pane reads as corruption.
+      scheduleTerminalRevealWebglAtlasRecovery()
       if (isActive) {
         focusActivePane(manager)
       }

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
@@ -225,6 +225,28 @@ describe('terminal WebGL atlas recovery', () => {
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(4)
   })
 
+  it('skips tab-reveal recovery while an output burst is already in flight', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    scheduleTerminalWebglAtlasRecovery()
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+
+    // The burst's pending resets already repaint a pane revealed mid-burst.
+    scheduleTerminalRevealWebglAtlasRecovery()
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+  })
+
   it('lets tab-reveal recovery bypass the terminal-output cooldown', () => {
     vi.useFakeTimers()
     vi.stubGlobal(

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
@@ -4,7 +4,9 @@ import {
   unregisterLivePaneManager
 } from '@/lib/pane-manager/pane-manager-registry'
 import {
+  _resetTerminalWebglAtlasRecoveryForTests,
   scheduleImagePasteWebglAtlasRecovery,
+  scheduleTerminalRevealWebglAtlasRecovery,
   scheduleTerminalWebglAtlasRecovery
 } from './terminal-webgl-atlas-recovery'
 
@@ -28,6 +30,9 @@ describe('terminal WebGL atlas recovery', () => {
     for (const manager of registeredManagers.splice(0)) {
       unregisterLivePaneManager(manager)
     }
+    // Why: the cooldown latch survives discarded fake timers; reset it so one
+    // test's in-flight recovery cannot swallow the next test's first burst.
+    _resetTerminalWebglAtlasRecoveryForTests()
     vi.useRealTimers()
     vi.unstubAllGlobals()
   })
@@ -165,17 +170,78 @@ describe('terminal WebGL atlas recovery', () => {
     vi.advanceTimersByTime(120)
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(2)
     expect(manager.refreshAllPanes).toHaveBeenCalledTimes(2)
-    scheduleTerminalWebglAtlasRecovery()
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(2)
     vi.advanceTimersByTime(380)
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
     expect(manager.refreshAllPanes).toHaveBeenCalledTimes(3)
+  })
+
+  it('defers repeat terminal-output recovery to one trailing burst after the cooldown', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    scheduleTerminalWebglAtlasRecovery()
+    vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+
+    // Requests landing during the cooldown must not start an immediate burst…
+    scheduleTerminalWebglAtlasRecovery()
+    scheduleTerminalWebglAtlasRecovery()
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+
+    // …but the last risky chunk still gets recovered once the cooldown ends.
+    vi.advanceTimersByTime(3000)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(4)
+    vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(6)
+  })
+
+  it('runs terminal-output recovery immediately again after an idle cooldown', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    scheduleTerminalWebglAtlasRecovery()
+    vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+
+    // No request arrived while active, so the cooldown expires back to idle.
+    vi.advanceTimersByTime(3000)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
 
     scheduleTerminalWebglAtlasRecovery()
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(4)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(4)
+  })
+
+  it('lets tab-reveal recovery bypass the terminal-output cooldown', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    scheduleTerminalWebglAtlasRecovery()
     vi.advanceTimersByTime(500)
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(6)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(6)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+
+    // Why: a revealed pane must repaint now, not after the output cooldown.
+    scheduleTerminalRevealWebglAtlasRecovery()
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(4)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
@@ -67,6 +67,12 @@ export function scheduleTerminalRevealWebglAtlasRecovery(): void {
   // Why: tab reveal is a discrete user action whose repaint must not wait out
   // an output-driven recovery cooldown — a just-revealed pane showing stale
   // pixels for seconds reads as a rendering bug.
+  if (terminalOutputRecoveryPhase === 'burst') {
+    // The in-flight burst's pending resets repaint the revealed pane too:
+    // resets enumerate live pane managers at execution time, and the phase
+    // only leaves 'burst' after its final reset has run.
+    return
+  }
   scheduleAtlasRecoveryBurst()
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
@@ -1,8 +1,17 @@
 import { resetAndRefreshAllTerminalWebglAtlases } from '@/lib/pane-manager/pane-manager-registry'
 
 const ATLAS_RECOVERY_DELAYS_MS = [120, 500]
+// Why: sustained CJK/TUI output (agent responses, spinner redraws over a CJK
+// prompt line) can request recovery on nearly every chunk, and each burst
+// re-rasterizes every visible glyph across all panes — felt as typing jank.
+// Space bursts out with a cooldown instead of dropping requests, so the last
+// risky chunk still gets a trailing recovery once the cooldown expires.
+const ATLAS_RECOVERY_COOLDOWN_MS = 3000
 
-let terminalOutputRecoveryScheduled = false
+type TerminalOutputRecoveryPhase = 'idle' | 'burst' | 'cooldown'
+let terminalOutputRecoveryPhase: TerminalOutputRecoveryPhase = 'idle'
+let terminalOutputRecoveryRequestedDuringCooldown = false
+let terminalOutputRecoveryCooldownTimer: ReturnType<typeof setTimeout> | null = null
 
 function scheduleNextFrame(callback: () => void): void {
   if (typeof globalThis.requestAnimationFrame === 'function') {
@@ -34,20 +43,53 @@ function scheduleAtlasRecoveryBurst(onComplete?: () => void): void {
   }
 }
 
+function startTerminalOutputRecoveryCooldown(): void {
+  terminalOutputRecoveryPhase = 'cooldown'
+  terminalOutputRecoveryCooldownTimer = globalThis.setTimeout(() => {
+    terminalOutputRecoveryCooldownTimer = null
+    if (terminalOutputRecoveryRequestedDuringCooldown) {
+      terminalOutputRecoveryRequestedDuringCooldown = false
+      terminalOutputRecoveryPhase = 'burst'
+      scheduleAtlasRecoveryBurst(startTerminalOutputRecoveryCooldown)
+      return
+    }
+    terminalOutputRecoveryPhase = 'idle'
+  }, ATLAS_RECOVERY_COOLDOWN_MS)
+}
+
 export function scheduleImagePasteWebglAtlasRecovery(): void {
   // Why: image chips can redraw after bracketed paste parsing, so cover the
   // short post-paste paint window with a few cheap atlas rebuilds.
   scheduleAtlasRecoveryBurst()
 }
 
+export function scheduleTerminalRevealWebglAtlasRecovery(): void {
+  // Why: tab reveal is a discrete user action whose repaint must not wait out
+  // an output-driven recovery cooldown — a just-revealed pane showing stale
+  // pixels for seconds reads as a rendering bug.
+  scheduleAtlasRecoveryBurst()
+}
+
 export function scheduleTerminalWebglAtlasRecovery(): void {
-  if (terminalOutputRecoveryScheduled) {
-    return
-  }
-  terminalOutputRecoveryScheduled = true
   // Why: TUI redraw bursts can corrupt xterm's shared WebGL glyph atlas without
   // a context-loss event; coalesce resets so output storms do not queue timers.
-  scheduleAtlasRecoveryBurst(() => {
-    terminalOutputRecoveryScheduled = false
-  })
+  if (terminalOutputRecoveryPhase === 'burst') {
+    // The in-flight burst's remaining resets already repaint this chunk.
+    return
+  }
+  if (terminalOutputRecoveryPhase === 'cooldown') {
+    terminalOutputRecoveryRequestedDuringCooldown = true
+    return
+  }
+  terminalOutputRecoveryPhase = 'burst'
+  scheduleAtlasRecoveryBurst(startTerminalOutputRecoveryCooldown)
+}
+
+export function _resetTerminalWebglAtlasRecoveryForTests(): void {
+  if (terminalOutputRecoveryCooldownTimer !== null) {
+    clearTimeout(terminalOutputRecoveryCooldownTimer)
+    terminalOutputRecoveryCooldownTimer = null
+  }
+  terminalOutputRecoveryPhase = 'idle'
+  terminalOutputRecoveryRequestedDuringCooldown = false
 }

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   nativeWindowsRewriteNeedsFollowupRenderRefresh,
+  rendererRiskOutputPrefersAtlasRecovery,
   terminalOutputContainsEastAsianRendererRisk,
   terminalOutputPrefersRenderRefresh,
   terminalRewriteOutputRenderRefreshDecision,
@@ -402,5 +403,36 @@ describe('nativeWindowsRewriteNeedsFollowupRenderRefresh', () => {
         isInPlaceRewrite: true
       })
     ).toBe(false)
+  })
+})
+
+describe('rendererRiskOutputPrefersAtlasRecovery', () => {
+  const maxInteractiveRedrawChars = 128 * 1024
+
+  it('skips atlas recovery for keystroke-echo redraws right after terminal input', () => {
+    expect(
+      rendererRiskOutputPrefersAtlasRecovery('\x1b[2K\x1b[G> 日本語のプロンプト', {
+        hadRecentInput: true,
+        maxInteractiveRedrawChars
+      })
+    ).toBe(false)
+  })
+
+  it('keeps atlas recovery for CJK output without recent terminal input', () => {
+    expect(
+      rendererRiskOutputPrefersAtlasRecovery('エージェントからの日本語ストリーム出力\r\n', {
+        hadRecentInput: false,
+        maxInteractiveRedrawChars
+      })
+    ).toBe(true)
+  })
+
+  it('keeps atlas recovery for oversized chunks even during the interactive window', () => {
+    expect(
+      rendererRiskOutputPrefersAtlasRecovery('あ'.repeat(maxInteractiveRedrawChars + 1), {
+        hadRecentInput: true,
+        maxInteractiveRedrawChars
+      })
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
@@ -266,6 +266,28 @@ export function terminalOutputPrefersRenderRefresh(data: string): boolean {
   return false
 }
 
+export type RendererRiskAtlasRecoveryState = {
+  hadRecentInput: boolean
+  maxInteractiveRedrawChars: number
+}
+
+/**
+ * Whether renderer-risk foreground output should ALSO rebuild the shared WebGL
+ * glyph atlas after parsing, on top of the forced viewport refresh.
+ *
+ * Why: once CJK text sits on a TUI prompt line, every keystroke echoes a redraw
+ * containing it, and a shared-atlas rebuild re-rasterizes every visible glyph
+ * across all panes — felt as continuous IME typing jank. Keystroke echoes keep
+ * the viewport refresh (stale cells still repaint) and leave atlas recovery to
+ * the non-interactive chunks that follow (spinner frames, agent output).
+ */
+export function rendererRiskOutputPrefersAtlasRecovery(
+  data: string,
+  state: RendererRiskAtlasRecoveryState
+): boolean {
+  return !(state.hadRecentInput && data.length <= state.maxInteractiveRedrawChars)
+}
+
 export function terminalOutputContainsEastAsianRendererRisk(data: string): boolean {
   for (let i = 0; i < data.length; i += 1) {
     const codePoint = data.codePointAt(i)


### PR DESCRIPTION
## Summary

Reduces renderer/GPU churn while CJK text flows through a terminal. Today, renderer-risk recovery (#6949) schedules a full shared-glyph-atlas rebuild across **all** panes (3 resets per burst: next frame, +120 ms, +500 ms) for every foreground chunk containing CJK codepoints. Once CJK text sits on a TUI prompt line (Claude Code, Codex, …), every keystroke echo and every spinner frame re-triggers the burst, so sustained Japanese/Chinese/Korean sessions rebuild every visible glyph across every pane roughly 5 times per second — pure waste in the common case where the atlas is not corrupted.

Two targeted changes, preserving the recovery guarantee:

1. **Interactive keystroke echoes skip atlas recovery.** Chunks that land within the existing interactive-input window (`FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS` after a keystroke, size-capped by `FOREGROUND_INTERACTIVE_REDRAW_CHARS`) keep the forced viewport refresh — stale cells still repaint — but no longer rebuild the shared atlas. Non-interactive chunks (agent output storms, spinner frames) keep full recovery, so any corruption that does occur is still repaired moments later.
2. **Output-driven recovery bursts get a cooldown (3 s) with a trailing burst.** Requests that arrive during the cooldown are coalesced into one burst when it expires, so the *last* risky chunk is always recovered. Sustained CJK output settles into one burst per ~3.6 s instead of back-to-back bursts. Tab reveal gets its own immediate entry point (`scheduleTerminalRevealWebglAtlasRecovery`) so a just-revealed pane never waits out the output cooldown to repaint.

Trade-off, stated plainly: if the WebGL glyph atlas does corrupt mid-stream (the rare event #5031/#5130 recovery exists for), garbled glyphs can now stay visible for up to ~3.6 s instead of ~0.6 s. In exchange, the steady-state cost during CJK-heavy sessions drops from ~15 atlas resets/s×panes to ~0.8/s.

Found while profiling Japanese-IME typing jank (the jank itself turned out to be an Electron autofill issue, addressed separately); this change removes the secondary rendering churn the investigation surfaced.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New/updated tests: the interactive-echo predicate (`rendererRiskOutputPrefersAtlasRecovery`) unit tests including the size cap; cooldown behavior (defer-to-trailing-burst, return-to-immediate after idle, tab-reveal bypass); and a pty-connection integration test asserting CJK keystroke echoes right after terminal input refresh the viewport without scheduling atlas recovery. All 331 pre-existing tests in the touched areas pass.

## AI Review Report

Reviewed with Claude Code:

- **Cross-platform:** platform-neutral scheduling logic; the Windows-specific East-Asian refresh paths are untouched and still run. No shortcuts/labels/paths.
- **SSH/remote/local:** decisions are made per PTY output chunk in the renderer regardless of transport; SSH panes behave identically.
- **Agent compatibility:** interactive-echo detection reuses the existing `lastTerminalInputAt` plumbing that already gates interactive redraw handling for agent CLIs; spinner/output frames from agents keep full recovery.
- **Performance:** strictly removes work from the hottest CJK output path; adds one timer per recovery cycle.
- **Security:** no input handling, IPC, or process changes.
- **Risks flagged:** the recovery-latency trade-off above; reveal-path behavior was split into its own entry point specifically so tab switches keep today's immediate repaint.

## Security Audit

No security-relevant surface: pure render-scheduling changes, no new input parsing, IPC, or process execution.

## Notes

- The 3 s cooldown constant is a judgment call — happy to tune it or gate the interactive-echo skip further if you have corruption-prone scenarios in mind; you own the original recovery design (#6949) and know its failure modes best.
- No platform-, SSH-, agent-, or provider-specific behavior beyond what is described.

X: [@hiro3_ngsw](https://x.com/hiro3_ngsw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
