### PR TITLE
cleanup(terminal): dedupe pane teardown, reuse platform check, harden shadow-cursor tracking

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1247,14 +1247,9 @@ export function connectPanePty(
     )
     return tab?.defaultTitle?.trim() || 'Terminal'
   }
-  /**
-   * Resolves the authoritative owner agent type for this pane, checking tab launch,
-   * pane startup, typed command ownership, and store state configuration.
-   *
-   * Why: launch ownership wins so Pi-compatible live titles/hooks can't repaint an
-   * OMP-owned pane back to Pi; command ownership covers manually typed `omp`
-   * in generic terminals where launch metadata does not exist.
-   */
+  // Why: infer pane ownership from a manually typed agent command (e.g. `omp`) by
+  // shadowing the shell's current command line, for generic terminals where no
+  // launch metadata exists. Consumed by getAuthoritativePaneAgent below.
   let commandInferredPaneAgent: TuiAgent | null = null
   let pendingShellCommandLine = ''
   let pendingShellCommandCursor = 0
@@ -1355,9 +1350,13 @@ export function connectPanePty(
       return null
     }
     const params = data.slice(index + 2, cursor)
-    if (final === 'D') {
+    // Why: only emulate a bare one-column move. Parameterized/modified cursor keys
+    // (e.g. Ctrl+Left `\x1b[1;5D` = word-jump) move the real cursor by more than
+    // one, so tracking them as ±1 would desync the shadow line — fall through to
+    // reset instead of silently corrupting the sampled command.
+    if (final === 'D' && params === '') {
       movePendingShellCommandCursor(-1)
-    } else if (final === 'C') {
+    } else if (final === 'C' && params === '') {
       movePendingShellCommandCursor(1)
     } else if (final === 'H' || (final === '~' && params === '1')) {
       pendingShellCommandCursor = 0
@@ -1462,6 +1461,14 @@ export function connectPanePty(
       }
     }
   }
+  /**
+   * Resolves the authoritative owner agent type for this pane, checking tab launch,
+   * pane startup, typed command ownership, and store state configuration.
+   *
+   * Why: launch ownership wins so Pi-compatible live titles/hooks can't repaint an
+   * OMP-owned pane back to Pi; command ownership covers manually typed `omp`
+   * in generic terminals where launch metadata does not exist.
+   */
   const getAuthoritativePaneAgent = (): AgentType | undefined => {
     const state = useAppStore.getState()
     const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find(

--- a/src/renderer/src/components/terminal-pane/terminal-link-activation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-activation.ts
@@ -1,6 +1,7 @@
+import { isMacPlatform } from './terminal-link-open-hints'
+
 export function isTerminalLinkActivation(
   event: Pick<MouseEvent, 'metaKey' | 'ctrlKey'> | undefined
 ): boolean {
-  const isMac = navigator.userAgent.includes('Mac')
-  return isMac ? Boolean(event?.metaKey) : Boolean(event?.ctrlKey)
+  return isMacPlatform() ? Boolean(event?.metaKey) : Boolean(event?.ctrlKey)
 }

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -166,7 +166,7 @@ type CloseManagedPaneArgs = {
   setActivePaneId: (paneId: number | null) => void
 }
 
-export function closeManagedPane(args: CloseManagedPaneArgs): void {
+function teardownManagedPane(args: CloseManagedPaneArgs, reason: 'close' | 'detach'): void {
   const pane = args.panes.get(args.paneId)
   if (!pane) {
     return
@@ -183,33 +183,24 @@ export function closeManagedPane(args: CloseManagedPaneArgs): void {
   args.managerOptions.onPaneClosed?.(args.paneId, {
     paneId: args.paneId,
     leafId: closedLeafId,
-    reason: 'close'
+    reason
   })
   args.managerOptions.onLayoutChanged?.()
 }
 
+export function closeManagedPane(args: CloseManagedPaneArgs): void {
+  teardownManagedPane(args, 'close')
+}
+
 export function detachManagedPaneForExternalMove(args: CloseManagedPaneArgs): boolean {
-  const pane = args.panes.get(args.paneId)
-  if (!pane || args.panes.size <= 1) {
+  // Why: refuse to detach the last pane — there is no other pane to fall back to.
+  if (!args.panes.has(args.paneId) || args.panes.size <= 1) {
     return false
   }
-  const closedLeafId = pane.leafId
-  args.releasePaneIdentity(args.paneId)
-  removePaneContainer(args, pane)
-  const nextActivePaneId = activateReplacementPane(args)
-  applyPaneOpacity(args.panes.values(), nextActivePaneId, args.styleOptions)
-  for (const p of args.panes.values()) {
-    safeFit(p)
-  }
-  updateMultiPaneState(args.getDragCallbacks())
   // Why: pane-to-tab detach tears down only this renderer pane; the PTY is
-  // adopted by the new tab, so TerminalPane must skip process-close cleanup.
-  args.managerOptions.onPaneClosed?.(args.paneId, {
-    paneId: args.paneId,
-    leafId: closedLeafId,
-    reason: 'detach'
-  })
-  args.managerOptions.onLayoutChanged?.()
+  // adopted by the new tab, so the 'detach' reason tells TerminalPane to skip
+  // process-close cleanup.
+  teardownManagedPane(args, 'detach')
   return true
 }
 


### PR DESCRIPTION
## Cleanup pass — terminal (1 of 3)

Code-quality follow-ups on **terminal** PRs merged 2026-07-03. Surfaced by an automated multi-agent review of the day's merges; every finding was adversarially verified before fixing. Priority order: elegant → performant → clean → functional (plus real bugs).

| Fix | Kind | Origin PR |
|---|---|---|
| Extract shared `teardownManagedPane` so `closeManagedPane`/`detachManagedPaneForExternalMove` can't drift | elegance | #7215 |
| Reuse the existing `isMacPlatform()` instead of a second inline `navigator.userAgent` copy | clean | terminal URL modifier-click restore |
| Gate shadow-cursor CSI moves on empty params so modified cursor keys reset tracking instead of desyncing | **bug** (robustness) | #6954 |
| Move the `getAuthoritativePaneAgent` JSDoc back onto the function it documents (~215 lines away) | comment | #6954 |

### The one behavior change
`consumeShellCommandCsiSequence` treated any `ESC[…D` / `ESC[…C` as a ±1 shadow-cursor move, ignoring the CSI params. A modified cursor key such as Ctrl+Left (`ESC[1;5D`, word-jump in readline/zsh) moves the *real* cursor by a whole word, so the shadow line desynced and a subsequent edit landed at the wrong offset — garbling the command line sampled to infer a manually typed agent name (`omp`). Parameterized sequences now fall through to the existing reset path (a safe miss), consistent with how app-mode arrow keys already reset tracking.

### Verification
`pnpm run typecheck` · `oxlint` · `oxfmt` · unit suites for `pane-split-close`, `pty-connection`, `terminal-link-handlers` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
