### PR TITLE
fix: resolve PR owner repo via upstream-first lookup

### DIFF
--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -5,14 +5,14 @@ import { readFile } from 'node:fs/promises'
 
 const {
   ghExecFileAsyncMock,
-  getOwnerRepoMock,
+  getOriginOwnerRepoMock,
   extractExecErrorMock,
   acquireMock,
   releaseMock,
   getSshFilesystemProviderMock
 } = vi.hoisted(() => ({
   ghExecFileAsyncMock: vi.fn(),
-  getOwnerRepoMock: vi.fn(),
+  getOriginOwnerRepoMock: vi.fn(),
   extractExecErrorMock: vi.fn((error: unknown) => {
     const value = error as { stderr?: string; stdout?: string; message?: string }
     return {
@@ -32,7 +32,7 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 vi.mock('./gh-utils', () => ({
   execFileAsync: vi.fn(),
   ghExecFileAsync: ghExecFileAsyncMock,
-  getOwnerRepo: getOwnerRepoMock,
+  getOriginOwnerRepo: getOriginOwnerRepoMock,
   getIssueOwnerRepo: vi.fn(),
   getOwnerRepoForRemote: vi.fn(),
   githubRepoContext: vi.fn((repoPath: string, connectionId?: string | null) => ({
@@ -59,7 +59,7 @@ import { createGitHubPullRequest } from './client'
 describe('createGitHubPullRequest', () => {
   beforeEach(() => {
     ghExecFileAsyncMock.mockReset()
-    getOwnerRepoMock.mockReset()
+    getOriginOwnerRepoMock.mockReset()
     extractExecErrorMock.mockClear()
     acquireMock.mockReset()
     releaseMock.mockReset()
@@ -68,7 +68,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('creates a GitHub pull request with normalized refs and a body file', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 42,
@@ -118,7 +118,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('runs local WSL project pull request creation through the selected distro', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 43,
@@ -154,7 +154,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('creates SSH-backed pull requests without using the remote path as a local cwd', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 45,
@@ -179,7 +179,7 @@ describe('createGitHubPullRequest', () => {
       url: 'https://github.com/acme/widgets/pull/45'
     })
 
-    expect(getOwnerRepoMock).toHaveBeenCalledWith('/remote/repo-root', 'ssh-1')
+    expect(getOriginOwnerRepoMock).toHaveBeenCalledWith('/remote/repo-root', 'ssh-1')
     const [args, options] = ghExecFileAsyncMock.mock.calls[0]
     expect(args).toEqual(
       expect.arrayContaining([
@@ -231,7 +231,7 @@ describe('createGitHubPullRequest', () => {
         throw new Error('missing template')
       })
       getSshFilesystemProviderMock.mockReturnValue({ readFile: readRemoteFile })
-      getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+      getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
       const writtenBodies: string[] = []
       ghExecFileAsyncMock.mockImplementationOnce(async (args: string[]) => {
         const bodyPath = args[args.indexOf('--body-file') + 1]
@@ -271,7 +271,7 @@ describe('createGitHubPullRequest', () => {
   )
 
   it('falls back to parsing the PR URL for older gh output', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: 'https://github.com/acme/widgets/pull/43\n'
     })
@@ -291,7 +291,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('returns the existing PR when gh reports an already-open pull request', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
       .mockRejectedValueOnce({ stderr: 'a pull request already exists for feature/existing' })
       .mockResolvedValueOnce({
@@ -342,7 +342,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('validates base, head, and title before invoking gh', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
 
     await expect(
       createGitHubPullRequest('/repo-root', {

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -10,6 +10,7 @@ const {
   ghExecFileAsyncMock,
   getOwnerRepoMock,
   getIssueOwnerRepoMock,
+  getOriginOwnerRepoMock,
   getOwnerRepoForRemoteMock,
   resolvePRRepositoryCandidatesMock,
   getRemoteUrlForRepoMock,
@@ -28,6 +29,7 @@ const {
   ghExecFileAsyncMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
   getIssueOwnerRepoMock: vi.fn(),
+  getOriginOwnerRepoMock: vi.fn(),
   getOwnerRepoForRemoteMock: vi.fn(),
   resolvePRRepositoryCandidatesMock: vi.fn(),
   getRemoteUrlForRepoMock: vi.fn(),
@@ -58,6 +60,7 @@ vi.mock('./gh-utils', () => ({
   execFileAsync: execFileAsyncMock,
   ghExecFileAsync: ghExecFileAsyncMock,
   getOwnerRepo: getOwnerRepoMock,
+  getOriginOwnerRepo: getOriginOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
   getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
   resolvePRRepositoryCandidates: resolvePRRepositoryCandidatesMock,
@@ -2975,7 +2978,7 @@ describe('getPRForBranch', () => {
   })
 
   it('resolves a distinct upstream remote as the repo upstream', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
     getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
 
     await expect(getRepoUpstream('/repo-root')).resolves.toEqual({
@@ -2987,7 +2990,7 @@ describe('getPRForBranch', () => {
   })
 
   it('does not treat a same-repository upstream remote as a fork', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'StablyAI', repo: 'Orca' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'StablyAI', repo: 'Orca' })
     getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({ isFork: false, parent: null })
@@ -3002,7 +3005,7 @@ describe('getPRForBranch', () => {
   })
 
   it('does not mark an upstream-only GitHub remote as a fork', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce(null)
+    getOriginOwnerRepoMock.mockResolvedValueOnce(null)
 
     await expect(getRepoUpstream('/repo-root')).resolves.toBeNull()
 
@@ -3011,7 +3014,7 @@ describe('getPRForBranch', () => {
   })
 
   it('falls back to the GitHub parent when no upstream remote is configured', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
     getOwnerRepoForRemoteMock.mockResolvedValueOnce(null)
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -51,6 +51,7 @@ import {
   release,
   getOwnerRepo,
   getIssueOwnerRepo,
+  getOriginOwnerRepo,
   getOwnerRepoForRemote,
   resolvePRRepositoryCandidates,
   resolveIssueSource,
@@ -1540,7 +1541,7 @@ export async function getRepoUpstream(
 ): Promise<OwnerRepo | null> {
   const localGitArgs = hostedReviewLocalGitOptionArgs(options)
   const localGitOptions = localGitArgs[0] ?? {}
-  const origin = await getOwnerRepo(repoPath, connectionId, ...localGitArgs)
+  const origin = await getOriginOwnerRepo(repoPath, connectionId, ...localGitArgs)
   if (!origin) {
     return null
   }
@@ -1737,7 +1738,7 @@ export async function createGitHubPullRequest(
     }
   }
 
-  const ownerRepo = await getOwnerRepo(
+  const ownerRepo = await getOriginOwnerRepo(
     repoPath,
     connectionId,
     ...hostedReviewLocalGitOptionArgs(options)

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -89,24 +89,31 @@ describe('github owner/repo resolution', () => {
     expect(parseGitHubOwnerRepo('https://ghe.acme.internal/acme/orca.git')).toBeNull()
   })
 
-  it('keeps getOwnerRepo origin-based', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: 'git@github.com:fork/orca.git\n'
-    })
+  it('resolves getOwnerRepo upstream-first', async () => {
+    // upstream missing → falls back to origin
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: 'git@github.com:fork/orca.git\n' })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'upstream'], {
+      cwd: '/repo'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['remote', 'get-url', 'origin'], {
       cwd: '/repo'
     })
   })
 
-  it('resolves GitHub HTTPS origin remotes with user info and a default port', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: 'https://alice@github.com:443/acme/widgets.git\n'
-    })
+  it('resolves GitHub HTTPS origin remotes through upstream-first fallback', async () => {
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: 'https://alice@github.com:443/acme/widgets.git\n' })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'acme', repo: 'widgets' })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'upstream'], {
+      cwd: '/repo'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['remote', 'get-url', 'origin'], {
       cwd: '/repo'
     })
   })
@@ -137,11 +144,12 @@ describe('github owner/repo resolution', () => {
   })
 
   it('does not mix origin and upstream cache entries for the same repo path', async () => {
+    // getOwnerRepo and getIssueOwnerRepo both resolve upstream-first now
     gitExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: 'git@github.com:fork/orca.git\n' })
+      .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n' })
       .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n' })
 
-    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
+    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
     await expect(getIssueOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
   })
 
@@ -171,7 +179,10 @@ describe('github owner/repo resolution', () => {
 
   it('resolves SSH repo remotes through the registered SSH git provider', async () => {
     const sshProvider = {
-      exec: vi.fn().mockResolvedValue({ stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' })
+      exec: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' })
     }
     getSshGitProviderMock.mockReturnValue(sshProvider)
 
@@ -182,7 +193,13 @@ describe('github owner/repo resolution', () => {
 
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
     expect(getSshGitProviderMock).toHaveBeenCalledWith('openclaw-2')
-    expect(sshProvider.exec).toHaveBeenCalledWith(
+    expect(sshProvider.exec).toHaveBeenNthCalledWith(
+      1,
+      ['remote', 'get-url', 'upstream'],
+      '/home/user/orca'
+    )
+    expect(sshProvider.exec).toHaveBeenNthCalledWith(
+      2,
       ['remote', 'get-url', 'origin'],
       '/home/user/orca'
     )
@@ -200,8 +217,11 @@ describe('github owner/repo resolution', () => {
   })
 
   it('keeps local host and local WSL owner/repo cache entries separate for the same path', async () => {
+    // upstream-first: each getOwnerRepo call tries upstream then origin
     gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('not found'))
       .mockResolvedValueOnce({ stdout: 'git@github.com:host/orca.git\n' })
+      .mockRejectedValueOnce(new Error('not found'))
       .mockResolvedValueOnce({ stdout: 'git@github.com:wsl/orca.git\n' })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'host', repo: 'orca' })
@@ -209,16 +229,23 @@ describe('github owner/repo resolution', () => {
       owner: 'wsl',
       repo: 'orca'
     })
+    // cached hit
     await expect(getOwnerRepo('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toEqual({
       owner: 'wsl',
       repo: 'orca'
     })
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
-    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'origin'], {
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'upstream'], {
       cwd: '/repo'
     })
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['remote', 'get-url', 'origin'], {
+      cwd: '/repo'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(3, ['remote', 'get-url', 'upstream'], {
+      cwd: '/repo',
+      wslDistro: 'Ubuntu'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(4, ['remote', 'get-url', 'origin'], {
       cwd: '/repo',
       wslDistro: 'Ubuntu'
     })

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -11,6 +11,7 @@ export {
   _getOwnerRepoCacheSize,
   _resetOwnerRepoCache,
   getIssueOwnerRepo,
+  getOriginOwnerRepo,
   getOwnerRepo,
   getOwnerRepoForRemote,
   getRemoteUrlForRepo,

--- a/src/main/github/github-repository-identity.ts
+++ b/src/main/github/github-repository-identity.ts
@@ -208,19 +208,31 @@ export async function getOwnerRepo(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<OwnerRepo | null> {
-  return getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions)
-}
-
-export async function getIssueOwnerRepo(
-  repoPath: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): Promise<OwnerRepo | null> {
   const upstream = await getOwnerRepoForRemote(repoPath, 'upstream', connectionId, localGitOptions)
   if (upstream) {
     return upstream
   }
   return getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions)
+}
+
+// Why: a few callers (createGitHubPullRequest, getRepoUpstream) specifically
+// need the fork's origin remote, not the upstream canonical repo.
+export async function getOriginOwnerRepo(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<OwnerRepo | null> {
+  return getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions)
+}
+
+// Why: kept for backwards compatibility; behaviour is identical to getOwnerRepo
+// since both now resolve upstream-first.
+export async function getIssueOwnerRepo(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<OwnerRepo | null> {
+  return getOwnerRepo(repoPath, connectionId, localGitOptions)
 }
 
 export type PRRepositoryCandidates = {


### PR DESCRIPTION
## Summary

Fixes #7331 — PR details fail to load for fork repositories.

## Root Cause

`getOwnerRepo()` only checked the `origin` remote (the fork), but in fork repos all PR operations — viewing, commenting, merging, checks — operate on the upstream canonical repo where the PR actually lives. This caused `getWorkItem()` and all PR detail functions to return null, showing "Unable to load details for this GitHub item."

Meanwhile `getIssueOwnerRepo()` already had the correct upstream-first-then-origin fallback, which is why issue lookups worked fine in fork repos.

## Fix

**Root fix in `github-repository-identity.ts`:**
- `getOwnerRepo()` now resolves upstream-first (checks `upstream` remote, falls back to `origin`)
- New `getOriginOwnerRepo()` for the two callers that explicitly need the fork origin
- `getIssueOwnerRepo()` kept as a backwards-compatible alias

**Caller updates in `client.ts`:**
- `createGitHubPullRequest` → `getOriginOwnerRepo` (head repo is the fork)
- `getRepoUpstream` → `getOriginOwnerRepo` (fork detection)

**Zero changes to `work-item-details.ts` and other PR detail functions** — all ~10 functions that fetch PR body, comments, files, checks, etc. automatically benefit from the root fix because they all use `getOwnerRepo()`.

## Changes

| File | Change |
|------|--------|
| `github-repository-identity.ts` | `getOwnerRepo` upstream-first + new `getOriginOwnerRepo` |
| `gh-utils.ts` | Export `getOriginOwnerRepo` |
| `client.ts` | 2 origin-specific callers use `getOriginOwnerRepo` |
| `client-create-pr.test.ts` | Update mocks for `createGitHubPullRequest` |
| `client.test.ts` | Add `getOriginOwnerRepo` mock, update 4 `getRepoUpstream` tests |
| `gh-utils.test.ts` | Update 5 tests to expect upstream-first behavior |

## Verification

Test results: **2291 passed**, only 1 pre-existing unrelated failure (`pty-subprocess` WSL test).

Locally verified on a fork repo (`fsdwen/openclaw` with upstream `openclaw/openclaw`):
- Before: PR #94139 → "Unable to load details for this GitHub item."
- After: PR loads correctly with body, comments, files, and checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)