### PR TITLE
Fall back to local base ref when worktree-create refresh fails

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -623,6 +623,26 @@ function hasRemoteCommitObject(
   return hasCommitObjectViaGitExec((gitArgs) => provider.exec(gitArgs, repoPath), ref)
 }
 
+// Why: hasRemoteCommitObject only resolves full SHAs; a remote-tracking base is
+// a symbolic ref (refs/remotes/origin/main), so detect its presence directly so
+// SSH creates can fall back to an existing local base ref when the refresh
+// fetch fails. Require a resolved object id: a missing ref exits non-zero.
+async function hasRemoteTrackingRefSsh(
+  provider: SshGitProvider,
+  repoPath: string,
+  ref: string
+): Promise<boolean> {
+  try {
+    const { stdout } = await provider.exec(
+      ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`],
+      repoPath
+    )
+    return stdout.trim().length > 0
+  } catch {
+    return false
+  }
+}
+
 async function canCheckoutExistingLocalBranchSsh(
   provider: SshGitProvider,
   repoPath: string,
@@ -1571,32 +1591,14 @@ export async function createRemoteWorktree(
     }
   }
 
-  if (remoteTrackingBase) {
-    try {
-      await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, remoteTrackingBase)
-    } catch {
-      throw new Error(
-        `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
-      )
-    }
-  } else if (!(await hasRemoteCommitObject(provider, repo.path, baseBranch))) {
-    // Why: local or otherwise non-remote-tracking bases preserve legacy
-    // best-effort fetch behavior. Verified PR/MR SHA bases already have the
-    // commit object locally, so a broad remote fetch only updates unrelated refs.
-    try {
-      await fetchRemoteForWorktreeCreate(provider, repo, 'origin')
-    } catch {
-      /* best-effort */
-    }
-  }
-
   const mux = getActiveMultiplexer(repo.connectionId!)
   if (!mux) {
     throw new Error('SSH connection is not available. Please reconnect and try again.')
   }
-  // Why: register before the local-base advisory probe as well as addWorktree.
-  // Fresh/older relays may gate generic git.exec calls on registered roots; if
-  // the probe runs first it degrades to "no suggestion" even though create works.
+  // Why: register before any generic git.exec probe (base-ref existence, the
+  // local-base advisory) as well as addWorktree. Fresh/older relays may gate
+  // generic git.exec on registered roots; probing first would falsely report a
+  // ref missing (and defeat the offline fallback below) even though create works.
   try {
     await Promise.all([
       mux.request('session.registerRoot', { rootPath: repo.path }),
@@ -1608,6 +1610,34 @@ export async function createRemoteWorktree(
       mux.notify('session.registerRoot', { rootPath: remotePath })
     } else {
       throw err
+    }
+  }
+
+  if (remoteTrackingBase) {
+    try {
+      await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, remoteTrackingBase)
+    } catch {
+      // Why: a failed refresh must not block creation when a usable local base
+      // ref already exists — `git worktree add` can still create from that
+      // (possibly stale but valid) ref, so a transient offline/auth failure does
+      // not make the workspace uncreatable. Probe AFTER registerRoot so relays
+      // that gate generic git.exec accept it; only hard-fail when there is no
+      // local ref to fall back on. Drift is reflected by the compare-to-base
+      // view once the remote is reachable again.
+      if (!(await hasRemoteTrackingRefSsh(provider, repo.path, remoteTrackingBase.ref))) {
+        throw new Error(
+          `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
+        )
+      }
+    }
+  } else if (!(await hasRemoteCommitObject(provider, repo.path, baseBranch))) {
+    // Why: local or otherwise non-remote-tracking bases preserve legacy
+    // best-effort fetch behavior. Verified PR/MR SHA bases already have the
+    // commit object locally, so a broad remote fetch only updates unrelated refs.
+    try {
+      await fetchRemoteForWorktreeCreate(provider, repo, 'origin')
+    } catch {
+      /* best-effort */
     }
   }
 
@@ -2135,7 +2165,13 @@ export async function createLocalWorktree(
   if (remoteTrackingRefresh) {
     await timing.time('refresh_base_ref', async () => {
       const result = await remoteTrackingRefresh.promise
-      if (!result.ok) {
+      if (!result.ok && !remoteTrackingRefresh.hadLocalBaseRef) {
+        // Why: only block creation when the refresh failed AND there is no local
+        // base ref to fall back on. An existing local remote-tracking ref lets
+        // `git worktree add` proceed from a possibly stale but valid base, so a
+        // transient offline/auth failure must not make the workspace
+        // uncreatable. The compare-to-base view reflects any drift once the
+        // remote is reachable again.
         throw new Error(
           `Could not refresh base ref "${baseBranch}" from "${remoteTrackingRefresh.base.remote}". Check your network and try again.`
         )

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3668,7 +3668,7 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
-  it('does not create an SSH worktree when remote-tracking base refresh fails', async () => {
+  it('does not create an SSH worktree when the refresh fails and no local base ref exists', async () => {
     const repo = {
       id: 'repo-ssh',
       path: '/remote/repo',
@@ -3679,6 +3679,7 @@ describe('registerWorktreeHandlers', () => {
       worktreeBaseRef: 'origin/main'
     }
     const provider = {
+      // Empty rev-parse stdout -> no local remote-tracking base ref to fall back on.
       exec: vi.fn().mockImplementation(async (args: string[]) => {
         if (args[0] === 'remote') {
           return { stdout: 'origin\n', stderr: '' }
@@ -3717,6 +3718,70 @@ describe('registerWorktreeHandlers', () => {
       'main',
       'refs/remotes/origin/main'
     )
+  })
+
+  it('creates an SSH worktree from an existing local base ref when the refresh fails', async () => {
+    // Regression: a failed SSH refresh must fall back to an existing local
+    // remote-tracking base ref instead of blocking creation.
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        // Local remote-tracking base ref resolves -> usable fallback exists.
+        if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
+          return { stdout: `${'a'.repeat(40)}\n`, stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockRejectedValue(new Error('network unavailable')),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            path: '/remote/improve-dashboard',
+            head: 'abc123',
+            branch: 'refs/heads/improve-dashboard',
+            isBare: false,
+            isMainWorktree: false
+          }
+        ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'improve-dashboard'
+    })
+
+    // The refresh must be ATTEMPTED (and fail) before falling back — guards
+    // against a regression that skips the refresh whenever a local ref exists.
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/remote/repo',
+      'origin',
+      'main',
+      'refs/remotes/origin/main'
+    )
+    expect(provider.addWorktree).toHaveBeenCalled()
   })
 
   it('reuses a fresh SSH remote-tracking base refresh for repeated creates', async () => {
@@ -4205,7 +4270,9 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
-  it('does not create when the pre-create remote-tracking refresh fails', async () => {
+  it('creates from an existing local base ref when the pre-create refresh fails', async () => {
+    // Regression: a failed refresh must not block creation when a usable local
+    // remote-tracking base ref already exists.
     const remoteBase = {
       remote: 'origin',
       branch: 'main',
@@ -4214,6 +4281,39 @@ describe('registerWorktreeHandlers', () => {
     }
     runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
     runtimeStub.hasRemoteTrackingRef.mockResolvedValue(true)
+    runtimeStub.getOrStartRemoteTrackingBaseRefresh.mockResolvedValue({
+      ok: false,
+      errorKind: 'git_error'
+    })
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'created-sha',
+        branch: 'improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'created-sha\n', stderr: '' })
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard'
+    })) as CreateWorktreeResult
+
+    expect(addWorktreeMock).toHaveBeenCalled()
+    expect(result.worktree.id).toBe('repo-1::/workspace/improve-dashboard')
+  })
+
+  it('does not create when the pre-create refresh fails and no local base ref exists', async () => {
+    const remoteBase = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+    runtimeStub.hasRemoteTrackingRef.mockResolvedValue(false)
     runtimeStub.getOrStartRemoteTrackingBaseRefresh.mockResolvedValue({
       ok: false,
       errorKind: 'git_error'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2355,10 +2355,21 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('does not create runtime local worktrees when remote-tracking base refresh fails', async () => {
+  it('creates a runtime local worktree from an existing local base ref when the refresh fails', async () => {
+    // Regression: an offline/auth failure while refreshing the remote-tracking
+    // base must not block creation when a usable local base ref already exists.
     const runtime = new OrcaRuntimeService(store)
-    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/cli-refresh-fails')
-    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/cli-refresh-fails')
+    const createdWorktree = {
+      path: '/tmp/workspaces/cli-refresh-fails',
+      head: 'base-sha',
+      branch: 'cli-refresh-fails',
+      isBare: false,
+      isMainWorktree: false
+    }
+    computeWorktreePathMock.mockReturnValue(createdWorktree.path)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdWorktree.path)
+    vi.mocked(addWorktree).mockResolvedValueOnce({})
+    vi.mocked(listWorktrees).mockResolvedValue([createdWorktree])
     const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
       if (args[0] === 'remote') {
         return { stdout: 'origin\n', stderr: '' }
@@ -2366,6 +2377,7 @@ describe('OrcaRuntimeService', () => {
       if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) {
         return { stdout: '/tmp/repo/.git\n', stderr: '' }
       }
+      // Local remote-tracking base ref resolves -> usable fallback exists.
       if (args[0] === 'rev-parse' && args[1] === '--verify') {
         return { stdout: 'base-sha\n', stderr: '' }
       }
@@ -2379,6 +2391,40 @@ describe('OrcaRuntimeService', () => {
         runtime.createManagedWorktree({
           repoSelector: 'id:repo-1',
           name: 'cli-refresh-fails'
+        })
+      ).resolves.toBeDefined()
+
+      expect(addWorktree).toHaveBeenCalled()
+    } finally {
+      gitSpy.mockRestore()
+    }
+  })
+
+  it('does not create a runtime local worktree when the refresh fails and no local base ref exists', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/cli-refresh-no-local')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/cli-refresh-no-local')
+    const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) {
+        return { stdout: '/tmp/repo/.git\n', stderr: '' }
+      }
+      // No local remote-tracking base ref -> nothing to fall back on.
+      if (args[0] === 'rev-parse' && args[1] === '--verify') {
+        throw new Error('missing ref')
+      }
+      if (args[0] === 'fetch') {
+        throw new Error('network unavailable')
+      }
+      return { stdout: '', stderr: '' }
+    })
+    try {
+      await expect(
+        runtime.createManagedWorktree({
+          repoSelector: 'id:repo-1',
+          name: 'cli-refresh-no-local'
         })
       ).rejects.toThrow(
         'Could not refresh base ref "origin/main" from "origin". Check your network and try again.'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13075,7 +13075,13 @@ export class OrcaRuntimeService {
         remoteTrackingBase,
         ...localWorktreeGitOptionArgs
       )
-      if (!refreshResult.ok) {
+      if (!refreshResult.ok && !hadLocalBaseRef) {
+        // Why: only block creation when the refresh failed AND there is no
+        // usable local base ref to fall back on. If a local remote-tracking ref
+        // already exists, `git worktree add` can create from it — a possibly
+        // stale but valid base — so a transient offline/auth failure must not
+        // make the workspace uncreatable. The compare-to-base view reflects any
+        // drift once the remote is reachable again.
         throw new Error(
           `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
         )


### PR DESCRIPTION
## Summary

Creating a workspace failed with **`Could not refresh base ref "origin/main" from "origin". Check your network and try again.`** whenever the pre‑create `git fetch` of a remote‑tracking base failed — even when a perfectly usable local `origin/main` already existed and `git worktree add` from it would succeed. This makes the workspace *uncreatable* on a transient network/auth hiccup.

Fix: only hard‑fail when the refresh fails **and** there is no usable local base ref to fall back on. Otherwise create from the local ref (a possibly‑stale but valid base).

---

## 1. Where the regression was introduced

**Yes, this is a regression.** Introduced by **#2310 — “Refresh optimistic worktrees after base fetch”** (`5c93579e40`, 2026‑05‑19).

Before #2310, worktree creation did a **best‑effort** `fetchRemoteWithCache` (errors swallowed, `console.warn` only) and then a post‑create `reconcileWorktreeBaseStatus`. #2310 deliberately replaced that with a **hard network gate** — its own commit message says: *“Fail creation before mutating git state when the required base refresh fails or remains missing.”* That traded away availability: any fetch failure now blocks creation outright.

Why it bites Linux users especially: a GUI Electron process launched from a desktop entry often doesn’t inherit `SSH_AUTH_SOCK`, so the base refresh (`git fetch` with `GIT_SSH_COMMAND='ssh -o BatchMode=yes'`) fails to authenticate **even while online**, and the pre‑#2310 best‑effort behavior would have sailed right past it.

---

## 2. Description

The base‑ref refresh is a hard gate at three creation sites:

| Site | Path | Function |
|---|---|---|
| Local (CLI/runtime) | `src/main/runtime/orca-runtime.ts` | `OrcaRuntimeService.createManagedWorktree` |
| Local (desktop IPC) | `src/main/ipc/worktree-remote.ts` | `createLocalWorktree` |
| SSH | `src/main/ipc/worktree-remote.ts` | `createRemoteWorktree` |

At each site the fix computes `hadLocalBaseRef` (does `refs/remotes/<remote>/<branch>` already resolve locally?) and only throws when **`!refresh.ok && !hadLocalBaseRef`**. When a local ref exists, creation proceeds from it — exactly what `git worktree add -b <branch> origin/main` does. The follow‑on “Base ref … was not found after fetching” check is unchanged.

For SSH, a small `hasRemoteTrackingRefSsh` helper does `rev-parse --verify --quiet <ref>^{commit}` (a symbolic ref, which the existing SHA‑only `hasRemoteCommitObject` can’t detect). Following an adversarial review, that probe was moved **after** `session.registerRoot` so relays that gate generic `git.exec` on registered roots don’t false‑negative and defeat the fallback (mirrors the existing local‑base advisory probe).

**Scope check (from review):** all worktree creation funnels through these three functions; every other base‑touching path (prefetch, `refreshLocalBaseRefForWorktreeCreate`, sparse add, folder repos, WSL, non‑GitHub providers) is already best‑effort and cannot block on a transient fetch. No other hard gate remains.

---

## 3. Evidence of fix

**Reproduced at the git level on Linux** (a clone with a valid local `origin/main`, then `origin` pointed at an unreachable URL — mimicking offline/auth failure):

```
=== STEP A: the EXACT fetch Orca runs as its hard network gate ===
  fetch: FAILED (exit 128) -> Orca throws 'Could not refresh base ref'
  git stderr: ssh: connect to host 127.0.0.1 port 1: Connection refused fatal: Could not read from remote repository...

=== STEP B: is the local base ref still usable? ===
  YES - refs/remotes/origin/main resolves to a valid commit

=== STEP C: can git create the worktree from that local ref (what Orca REFUSES to try)? ===
  git worktree add: SUCCEEDED -> workspace creation was possible all along
```

So the fetch fails, but the local base ref is valid and `git worktree add` from it works — Orca was refusing a creation git can perform.

**Code‑level:** the pre‑existing test *“does not create runtime local worktrees when remote‑tracking base refresh fails”* already proved the hard‑fail fired **even with a valid local ref present** (`rev-parse --verify` → a real SHA). It was repurposed, and companion tests added, so each of the three sites now pins **both**:
- refresh fails **+ local ref present → creation proceeds** (and asserts the refresh was still attempted), and
- refresh fails **+ no local ref → still throws** the original error.

**Verification run**
- `worktrees.test.ts` (167) + `orca-runtime.test.ts` (547) → **714 passing**
- `typecheck:node` → clean; `oxlint` + `oxfmt --check` → clean
- Change reviewed by a multi‑lens adversarial review (correctness / completeness / SSH‑helper / tests‑and‑design); all confirmed findings were minor and are addressed here.

---

## 4. ELI5

You ask Orca to make a new workspace based on `main`. To be safe, Orca first phones the server to grab the very latest `main`. If that call doesn’t go through — you’re offline, on a flaky VPN, or your key just isn’t loaded — Orca used to give up entirely and refuse to make the workspace.

But Orca already had a recent copy of `main` sitting on your disk. This change says: if the phone call fails **but we still have a good local copy**, just use that copy and make the workspace. You only get the hard error now if there’s genuinely no copy to build from. You get your workspace and keep working; it quietly catches up to the newest `main` the next time the network is back.

---

## 5. End‑user tradeoffs

- **Freshness vs. availability:** on the failure path we now create from the **local** copy of the base, which may be a few commits behind the server. That copy is a *valid* commit, so the worktree is sound — it’s just not guaranteed to be at the absolute latest tip. This restores the pre‑#2310 behavior; the happy path (network up) still fetches the exact latest base as before.
- **Drift visibility:** there is **no extra creation‑time toast** telling you the base was stale. Staleness surfaces through the normal source‑control **compare‑to‑base** view once the remote is reachable again (the older `reconcileWorktreeBaseStatus` drift‑push path is currently dead code and was *not* relied on — the code comments were corrected to stop claiming it). A dedicated non‑blocking “created from a possibly‑stale base” notice is a reasonable **follow‑up**, intentionally left out here to keep this a focused bug fix (it needs i18n keys + renderer plumbing).
- **No behavior change when online / when there’s no local ref:** if the fetch succeeds you get the freshest base exactly as today; if there’s no local base ref to fall back on, you still get the clear original error.

---

🔁 Regression: #2310 · Fixes the “can’t create workspace — could not refresh base” reports.

Made with [Orca](https://github.com/stablyai/orca) 🐋
