### PR TITLE
Add RC / perf-RC update channels with modifier opt-in

### DIFF
--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -139,7 +139,7 @@ describe('registerAppMenu', () => {
     expect(options.onBeforeReload).toHaveBeenCalledWith({ ignoreCache: true, webContentsId: 102 })
   })
 
-  it('includes prereleases when Check for Updates is clicked with shift held', () => {
+  it('maps Check for Updates modifiers to the RC and perf-RC channels', () => {
     const options = buildMenuOptions()
     registerAppMenu(options)
 
@@ -150,21 +150,30 @@ describe('registerAppMenu', () => {
     const item = getSubmenu(getTemplate(), parentLabel).find(
       (entry) => entry.label === 'Check for Updates...'
     )
+    const click = (event: Electron.KeyboardEvent): void => {
+      item?.click?.({} as never, undefined as never, event)
+    }
 
-    item?.click?.({} as never, undefined as never, { shiftKey: true } as Electron.KeyboardEvent)
-    item?.click?.(
-      {} as never,
-      undefined as never,
-      { metaKey: true, shiftKey: true } as Electron.KeyboardEvent
-    )
-    item?.click?.({} as never, undefined as never, {} as Electron.KeyboardEvent)
-    item?.click?.({} as never, undefined as never, { metaKey: true } as Electron.KeyboardEvent)
+    // Why: Shift opts into the RC channel; adding Cmd (macOS) / Ctrl
+    // (Win/Linux) escalates to perf-RC. Accelerator-triggered clicks carry no
+    // real modifier state, so they must fall back to a plain stable check.
+    const perfModifier = isMac ? { metaKey: true } : { ctrlKey: true }
+    click({ shiftKey: true } as Electron.KeyboardEvent)
+    click({ shiftKey: true, ...perfModifier } as Electron.KeyboardEvent)
+    click({} as Electron.KeyboardEvent)
+    click(perfModifier as Electron.KeyboardEvent)
+    click({
+      shiftKey: true,
+      ...perfModifier,
+      triggeredByAccelerator: true
+    } as Electron.KeyboardEvent)
 
     expect(options.onCheckForUpdates.mock.calls).toEqual([
-      [{ includePrerelease: true }],
-      [{ includePrerelease: true }],
-      [{ includePrerelease: false }],
-      [{ includePrerelease: false }]
+      [{ includePrerelease: true, includePerfPrerelease: false }],
+      [{ includePrerelease: true, includePerfPrerelease: true }],
+      [{ includePrerelease: false, includePerfPrerelease: false }],
+      [{ includePrerelease: false, includePerfPrerelease: false }],
+      [{ includePrerelease: false, includePerfPrerelease: false }]
     ])
   })
 

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -5,6 +5,7 @@ import {
   type KeybindingActionId,
   type KeybindingOverrides
 } from '../../shared/keybindings'
+import type { UpdateCheckOptions } from '../../shared/types'
 import { translateMain } from '../i18n/main-i18n'
 
 export type AppearanceMenuState = {
@@ -26,7 +27,7 @@ type RegisterAppMenuOptions = {
   onOpenSetupGuide: (window?: Electron.BaseWindow | null) => void
   onOpenFeatureTour: (window?: Electron.BaseWindow | null) => void
   onOpenCrashReport: (window?: Electron.BaseWindow | null) => void
-  onCheckForUpdates: (options: { includePrerelease: boolean }) => void
+  onCheckForUpdates: (options: UpdateCheckOptions) => void
   onBeforeReload?: (options: { ignoreCache: boolean; webContentsId: number }) => void
   onZoomIn: () => void
   onZoomOut: () => void
@@ -83,16 +84,22 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     webContents.reload()
   }
 
-  // Why: holding Shift while clicking Check for Updates opts this check into
-  // the release-candidate channel. Extracted so both the macOS app-menu entry
-  // and the Windows/Linux Help-menu entry share the exact same behavior.
+  // Why: holding Shift while clicking Check for Updates opts this check into the
+  // release-candidate channel; adding Cmd (macOS) / Ctrl (Win/Linux) escalates
+  // to the perf-RC channel. Accelerator-triggered invocations carry no real
+  // modifier state, so treat those as a plain stable check. Extracted so the
+  // macOS app-menu entry and the Windows/Linux Help-menu entry share behavior.
   const checkForUpdatesClick: Electron.MenuItemConstructorOptions['click'] = (
     _menuItem,
     _window,
     event
   ) => {
-    const includePrerelease = !event.triggeredByAccelerator && event.shiftKey === true
-    onCheckForUpdates({ includePrerelease })
+    const shiftHeld = !event.triggeredByAccelerator && event.shiftKey === true
+    const perfModifierHeld = shiftHeld && (isMac ? event.metaKey === true : event.ctrlKey === true)
+    onCheckForUpdates({
+      includePrerelease: shiftHeld,
+      includePerfPrerelease: perfModifierHeld
+    })
   }
 
   const checkForUpdatesItem: Electron.MenuItemConstructorOptions = {

--- a/src/main/updater-fallback.ts
+++ b/src/main/updater-fallback.ts
@@ -125,6 +125,21 @@ export function isPrereleaseVersion(value: string): boolean {
   return parsed !== null && parsed.prerelease.length > 0
 }
 
+export type ReleaseChannel = 'stable' | 'rc' | 'perf-rc'
+
+// Why: Orca ships three release tracks — stable (1.4.122), release candidates
+// (1.4.122-rc.3), and perf release candidates (1.4.122-rc.3.perf). The updater
+// gates which tracks a running build is offered, so it must classify a version
+// by track. Perf RCs append the `perf` identifier to an rc tag, so it's the
+// presence of `perf` — not its position — that marks the perf track.
+export function getReleaseChannel(value: string): ReleaseChannel {
+  const parsed = parseVersion(value)
+  if (!parsed || parsed.prerelease.length === 0) {
+    return 'stable'
+  }
+  return parsed.prerelease.includes('perf') ? 'perf-rc' : 'rc'
+}
+
 function compareIdentifiers(left: string, right: string): number {
   const leftNumeric = /^\d+$/.test(left)
   const rightNumeric = /^\d+$/.test(right)

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -257,14 +257,16 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
 
     await expect(
-      fetchNewerReleaseTagsWithReadiness('1.4.27-rc.1', 1, { includePrerelease: true })
+      fetchNewerReleaseTagsWithReadiness('1.4.27-rc.1', 1, {
+        eligibleChannels: ['stable', 'rc']
+      })
     ).resolves.toEqual({
       tags: [],
       state: 'not-ready',
       lastGoodTag: 'v1.4.27-rc.1'
     })
     await expect(
-      fetchNewerReleaseTagsWithReadiness('1.4.26', 1, { includePrerelease: false })
+      fetchNewerReleaseTagsWithReadiness('1.4.26', 1, { eligibleChannels: ['stable'] })
     ).resolves.toEqual({
       tags: [],
       state: 'no-newer'

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -99,7 +99,7 @@ describe('fetchNewerReleaseTag', () => {
   it('can exclude prerelease tags for stable-channel checks', async () => {
     respondWithAtom(['v1.4.1-rc.0', 'v1.4.0', 'v1.3.52-rc.3', 'v1.3.51'])
     const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
-    expect(await fetchNewerReleaseTag('1.3.51', { includePrerelease: false })).toBe('v1.4.0')
+    expect(await fetchNewerReleaseTag('1.3.51', { eligibleChannels: ['stable'] })).toBe('v1.4.0')
   })
 
   it.each([
@@ -153,7 +153,39 @@ describe('fetchNewerReleaseTag', () => {
   it('returns null for stable-channel checks when only prereleases are newer', async () => {
     respondWithAtom(['v1.4.1-rc.0', 'v1.3.52-rc.3', 'v1.3.51'])
     const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
-    expect(await fetchNewerReleaseTag('1.3.51', { includePrerelease: false })).toBe(null)
+    expect(await fetchNewerReleaseTag('1.3.51', { eligibleChannels: ['stable'] })).toBe(null)
+  })
+
+  it('offers RC tags but hides perf-RC tags for a stable+rc check', async () => {
+    // Why: Shift-click puts a stable user on the {stable, rc} tracks — a
+    // perf-RC (even though it is the semver-newest) must stay hidden.
+    respondWithAtom(['v1.4.2-rc.1.perf', 'v1.4.2-rc.1', 'v1.4.1', 'v1.4.0'])
+    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+    expect(await fetchNewerReleaseTag('1.4.0', { eligibleChannels: ['stable', 'rc'] })).toBe(
+      'v1.4.2-rc.1'
+    )
+  })
+
+  it('offers perf-RC tags but hides plain RC tags for a stable+perf-rc check', async () => {
+    // Why: a perf-RC user (or Cmd/Ctrl+Shift) is on the {stable, perf-rc}
+    // tracks — a newer plain RC must stay hidden.
+    respondWithAtom(['v1.4.2-rc.2', 'v1.4.2-rc.1.perf', 'v1.4.1', 'v1.4.0'])
+    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+    expect(await fetchNewerReleaseTag('1.4.0', { eligibleChannels: ['stable', 'perf-rc'] })).toBe(
+      'v1.4.2-rc.1.perf'
+    )
+  })
+
+  it('picks the semver-newest across all tracks when every channel is eligible', async () => {
+    // Why: Cmd/Ctrl+Shift on an RC user opens {stable, rc, perf-rc}; perf-RC
+    // outranks the same-numbered plain RC by semver precedence.
+    respondWithAtom(['v1.4.2-rc.1.perf', 'v1.4.2-rc.1', 'v1.4.1'])
+    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+    expect(
+      await fetchNewerReleaseTag('1.4.2-rc.1', {
+        eligibleChannels: ['stable', 'rc', 'perf-rc']
+      })
+    ).toBe('v1.4.2-rc.1.perf')
   })
 
   it('returns null when nothing in the feed is newer than the current version', async () => {

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -1,6 +1,11 @@
 import { net } from 'electron'
 import { parse } from 'yaml'
-import { compareVersions, isPrereleaseVersion, isValidVersion } from './updater-fallback'
+import {
+  compareVersions,
+  getReleaseChannel,
+  isValidVersion,
+  type ReleaseChannel
+} from './updater-fallback'
 
 const ATOM_FEED_URL = 'https://github.com/stablyai/orca/releases.atom'
 const RELEASES_DOWNLOAD_BASE = 'https://github.com/stablyai/orca/releases/download'
@@ -154,8 +159,13 @@ async function hasReadyPlatformManifest(tag: string): Promise<boolean> {
  * Returns null if the fetch fails, the feed has no parseable tags, or
  * nothing in the feed is newer than `currentVersion`.
  */
+// Why: the caller passes the exact set of release tracks the running build is
+// eligible for (stable plus any Shift / Cmd-Shift opt-ins). Omitting it means
+// "any channel", preserving the historical include-everything default.
+const ALL_RELEASE_CHANNELS: ReleaseChannel[] = ['stable', 'rc', 'perf-rc']
+
 type FetchNewerReleaseTagOptions = {
-  includePrerelease?: boolean
+  eligibleChannels?: ReleaseChannel[]
 }
 
 export type FetchNewerReleaseTagsResult = {
@@ -184,15 +194,15 @@ export async function fetchNewerReleaseTagsWithReadiness(
   maxTags: number,
   options: FetchNewerReleaseTagOptions = {}
 ): Promise<FetchNewerReleaseTagsResult> {
-  const includePrerelease = options.includePrerelease ?? true
+  const eligibleChannels = options.eligibleChannels ?? ALL_RELEASE_CHANNELS
   const tags = await fetchReleaseFeedTags()
   if (!tags || maxTags <= 0) {
     return { tags: [], state: 'unavailable' }
   }
 
-  const candidates = includePrerelease
-    ? tags
-    : tags.filter(({ version }) => !isPrereleaseVersion(version))
+  const candidates = tags.filter(({ version }) =>
+    eligibleChannels.includes(getReleaseChannel(version))
+  )
   const newestNewerIndex = candidates.findIndex(
     ({ version }) => compareVersions(version, currentVersion) > 0
   )

--- a/src/main/updater.fallback.test.ts
+++ b/src/main/updater.fallback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   compareVersions,
+  getReleaseChannel,
   isBenignCheckFailure,
   isMissingUpdateManifestFailure,
   isReleaseAssetsPublishingFailure,
@@ -29,6 +30,27 @@ describe('isPrereleaseVersion', () => {
     expect(isPrereleaseVersion('v1.3.17')).toBe(false)
     expect(isPrereleaseVersion('1.3.17+build.5')).toBe(false)
     expect(isPrereleaseVersion('not-a-version')).toBe(false)
+  })
+})
+
+describe('getReleaseChannel', () => {
+  it('classifies stable, rc, and perf-rc tracks', () => {
+    expect(getReleaseChannel('1.4.122')).toBe('stable')
+    expect(getReleaseChannel('v1.4.122')).toBe('stable')
+    expect(getReleaseChannel('1.4.122+build.5')).toBe('stable')
+    expect(getReleaseChannel('1.4.122-rc.3')).toBe('rc')
+    expect(getReleaseChannel('v1.4.122-rc.3')).toBe('rc')
+    expect(getReleaseChannel('1.4.122-rc.3.perf')).toBe('perf-rc')
+    expect(getReleaseChannel('v1.4.122-rc.3.perf')).toBe('perf-rc')
+  })
+
+  it('treats non-perf prereleases as the rc track and unparseable values as stable', () => {
+    expect(getReleaseChannel('1.0.0-beta.5')).toBe('rc')
+    expect(getReleaseChannel('2.1.0-alpha')).toBe('rc')
+    // Why: a perf identifier anywhere in the prerelease marks the perf track,
+    // even without a numeric suffix.
+    expect(getReleaseChannel('1.4.122-rc.3.perf.1')).toBe('perf-rc')
+    expect(getReleaseChannel('not-a-version')).toBe('stable')
   })
 })
 

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -886,7 +886,7 @@ describe('updater', () => {
 
     await vi.waitFor(() => {
       expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.35', 2, {
-        includePrerelease: true
+        eligibleChannels: ['stable', 'rc']
       })
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
     })
@@ -1000,7 +1000,7 @@ describe('updater', () => {
 
     await vi.waitFor(() => {
       expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17', 2, {
-        includePrerelease: true
+        eligibleChannels: ['stable', 'rc']
       })
       expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
         provider: 'generic',
@@ -1010,6 +1010,86 @@ describe('updater', () => {
     })
     expect(autoUpdaterMock.allowPrerelease).toBe(true)
     expect(autoUpdaterMock.setFeedURL.mock.calls.length).toBe(setupFeedUrlCalls + 1)
+  })
+
+  it('opts into the perf-RC channel when checkForUpdatesFromMenu is called with includePerfPrerelease', async () => {
+    appMock.getVersion.mockReturnValue('1.3.17')
+    fetchNewerReleaseTagsMock.mockResolvedValue(['v1.3.18-rc.1.perf'])
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    // Why: Cmd/Ctrl+Shift-click always carries Shift too, so both opt-ins fire.
+    checkForUpdatesFromMenu({ includePrerelease: true, includePerfPrerelease: true })
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17', 2, {
+        eligibleChannels: ['stable', 'rc', 'perf-rc']
+      })
+      expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+        provider: 'generic',
+        url: 'https://github.com/stablyai/orca/releases/download/v1.3.18-rc.1.perf'
+      })
+    })
+    expect(autoUpdaterMock.allowPrerelease).toBe(true)
+  })
+
+  it('offers stable and perf-RC tracks to a perf-RC user without any modifier', async () => {
+    appMock.getVersion.mockReturnValue('1.4.27-rc.3.perf')
+    fetchNewerReleaseTagsMock.mockResolvedValue(['v1.4.27-rc.4.perf'])
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    // Why: a perf-RC build must see stable + perf-RC but never plain RC unless
+    // it explicitly Shift-clicks.
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.27-rc.3.perf', 2, {
+        eligibleChannels: ['stable', 'perf-rc']
+      })
+    })
+  })
+
+  it('adds the plain RC track for a perf-RC user who Shift-clicks', async () => {
+    appMock.getVersion.mockReturnValue('1.4.27-rc.3.perf')
+    fetchNewerReleaseTagsMock.mockResolvedValue(['v1.4.28-rc.1'])
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    checkForUpdatesFromMenu({ includePrerelease: true })
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.27-rc.3.perf', 2, {
+        eligibleChannels: ['stable', 'rc', 'perf-rc']
+      })
+    })
+  })
+
+  it('adds the perf-RC track for an RC user who Cmd/Ctrl+Shift-clicks', async () => {
+    appMock.getVersion.mockReturnValue('1.3.17-rc.1')
+    fetchNewerReleaseTagsMock.mockResolvedValue(['v1.3.17-rc.1.perf'])
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    checkForUpdatesFromMenu({ includePrerelease: true, includePerfPrerelease: true })
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17-rc.1', 2, {
+        eligibleChannels: ['stable', 'rc', 'perf-rc']
+      })
+    })
   })
 
   it('leaves the feed URL alone for a normal user-initiated check', async () => {
@@ -1736,7 +1816,7 @@ describe('updater', () => {
 
     await vi.waitFor(() => {
       expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17-rc.1', 2, {
-        includePrerelease: true
+        eligibleChannels: ['stable', 'rc']
       })
       expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
         provider: 'generic',
@@ -2886,7 +2966,7 @@ describe('updater', () => {
 
     await vi.waitFor(() => {
       expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17', 1, {
-        includePrerelease: false
+        eligibleChannels: ['stable']
       })
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
     })
@@ -2913,7 +2993,7 @@ describe('updater', () => {
 
     await vi.waitFor(() => {
       expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.3.17', 2, {
-        includePrerelease: true
+        eligibleChannels: ['stable', 'rc']
       })
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
     })

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -2,7 +2,7 @@
 import { app, BrowserWindow, powerMonitor } from 'electron'
 import type { NsisUpdater } from 'electron-updater'
 import { is } from '@electron-toolkit/utils'
-import type { UpdateStatus } from '../shared/types'
+import type { UpdateCheckOptions, UpdateStatus } from '../shared/types'
 import { killAllPty } from './ipc/pty'
 import { withUpdaterSpan } from './observability/instrumentation'
 import { loadElectronAutoUpdater, type ElectronAutoUpdater } from './electron-updater-loader'
@@ -14,11 +14,12 @@ import {
 import { registerAutoUpdaterHandlers } from './updater-events'
 import {
   compareVersions,
+  getReleaseChannel,
   isBenignCheckFailure,
   isMissingUpdateManifestFailure,
-  isPrereleaseVersion,
   isReleaseAssetsPublishingFailure,
-  statusesEqual
+  statusesEqual,
+  type ReleaseChannel
 } from './updater-fallback'
 import {
   fetchNewerReleaseTagsWithReadiness,
@@ -45,9 +46,12 @@ let userInitiatedCheck = false
 let onBeforeQuitCleanup: (() => void | Promise<void>) | null = null
 let autoUpdaterInitialized = false
 // Why: Shift-clicking "Check for Updates" opts the user into the RC release
-// channel for the rest of this process. The generic feed still gets pinned to
+// channel for the rest of this process; Cmd/Ctrl+Shift adds the perf-RC
+// channel. Both opt-ins are sticky so a later background check keeps offering
+// the same track until the user installs. The generic feed still gets pinned to
 // a concrete tag on every check so cancelled RCs without manifests are skipped.
 let includePrereleaseActive = false
+let includePerfPrereleaseActive = false
 let availableVersion: string | null = null
 let availableReleaseUrl: string | null = null
 let pendingCheckFailureKey: string | null = null
@@ -775,21 +779,24 @@ async function pinDefaultReleaseFeed(): Promise<void> {
   // check and the later manual download click. Pinning to the concrete tag
   // keeps the manifest and ZIP asset on the same release.
   //
-  // Prerelease users still need any-channel resolution so they can move to a
-  // newer RC or the next stable. Stable users should only resolve stable tags.
+  // Prerelease users still need cross-channel resolution so they can move to a
+  // newer build or the next stable. Stable users should only resolve stable
+  // tags. The eligible tracks combine the running build's own channel with any
+  // sticky Shift / Cmd-Shift opt-ins (see resolveEligibleReleaseChannels).
   const currentVersion = app.getVersion()
-  const includePrerelease = includePrereleaseActive || isPrereleaseVersion(currentVersion)
+  const eligibleChannels = resolveEligibleReleaseChannels(currentVersion)
+  const includesPrerelease = eligibleChannels.length > 1
   const releaseTagsResult = await fetchNewerReleaseTagsWithReadiness(
     currentVersion,
-    includePrerelease ? 2 : 1,
+    includesPrerelease ? 2 : 1,
     {
-      includePrerelease
+      eligibleChannels
     }
   )
   const newerTag = releaseTagsResult.tags[0] ?? null
-  const fallbackTag = includePrerelease ? (releaseTagsResult.tags[1] ?? null) : null
+  const fallbackTag = includesPrerelease ? (releaseTagsResult.tags[1] ?? null) : null
   pendingPrereleaseFallback =
-    includePrerelease && newerTag && fallbackTag
+    includesPrerelease && newerTag && fallbackTag
       ? {
           primaryTag: newerTag,
           fallbackTag,
@@ -811,7 +818,7 @@ async function pinDefaultReleaseFeed(): Promise<void> {
     clearPublishingWindowLastGoodCheck()
     const url = getReleaseDownloadUrl(newerTag)
     console.info(
-      `[updater] release feed pinned: current=${currentVersion} includePrerelease=${includePrerelease} → ${url}`
+      `[updater] release feed pinned: current=${currentVersion} channels=${eligibleChannels.join('+')} → ${url}`
     )
     autoUpdater.setFeedURL({ provider: 'generic', url })
   } else if (releaseTagsResult.state === 'not-ready') {
@@ -821,7 +828,7 @@ async function pinDefaultReleaseFeed(): Promise<void> {
       // last-good concrete feed lets electron-updater emit a real result.
       const url = getReleaseDownloadUrl(releaseTagsResult.lastGoodTag)
       console.info(
-        `[updater] release feed pinned to last-good: current=${currentVersion} includePrerelease=${includePrerelease} → ${url}`
+        `[updater] release feed pinned to last-good: current=${currentVersion} channels=${eligibleChannels.join('+')} → ${url}`
       )
       publishingWindowLastGoodCheck = { lastGoodTag: releaseTagsResult.lastGoodTag }
       autoUpdater.setFeedURL({ provider: 'generic', url })
@@ -829,7 +836,7 @@ async function pinDefaultReleaseFeed(): Promise<void> {
     }
     clearPublishingWindowLastGoodCheck()
     console.info(
-      `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are still publishing`
+      `[updater] release feed deferred: current=${currentVersion} channels=${eligibleChannels.join('+')}; newest release assets are still publishing`
     )
     throw new Error('Latest release assets are still publishing')
   } else {
@@ -837,10 +844,29 @@ async function pinDefaultReleaseFeed(): Promise<void> {
     clearPublishingWindowLastGoodCheck()
     const url = 'https://github.com/stablyai/orca/releases/latest/download'
     console.info(
-      `[updater] release feed fallback: current=${currentVersion} includePrerelease=${includePrerelease} → ${url}`
+      `[updater] release feed fallback: current=${currentVersion} channels=${eligibleChannels.join('+')} → ${url}`
     )
     autoUpdater.setFeedURL({ provider: 'generic', url })
   }
+}
+
+// Why: a running build is always offered stable plus its own track. A sticky
+// Shift opt-in (includePrereleaseActive) adds the RC track and a sticky
+// Cmd/Ctrl+Shift opt-in (includePerfPrereleaseActive) adds the perf-RC track.
+// Returned in canonical stable→rc→perf-rc order so feed pinning and tests read
+// deterministically. "Update to latest" then picks the newest eligible tag.
+function resolveEligibleReleaseChannels(currentVersion: string): ReleaseChannel[] {
+  const currentChannel = getReleaseChannel(currentVersion)
+  const includeRc = currentChannel === 'rc' || includePrereleaseActive
+  const includePerfRc = currentChannel === 'perf-rc' || includePerfPrereleaseActive
+  const channels: ReleaseChannel[] = ['stable']
+  if (includeRc) {
+    channels.push('rc')
+  }
+  if (includePerfRc) {
+    channels.push('perf-rc')
+  }
+  return channels
 }
 
 function retryPrereleaseFallbackAfterMissingManifest(
@@ -972,28 +998,38 @@ export function checkForUpdates(): void {
   })
 }
 
-function enableIncludePrerelease(): void {
-  if (includePrereleaseActive) {
+function enablePrereleaseChannels(options: { rc: boolean; perfRc: boolean }): void {
+  if (!options.rc && !options.perfRc) {
     return
   }
   // Why: generic-provider checks still need this flag so electron-updater will
-  // accept a prerelease manifest for users who intentionally Shift-clicked.
-  // We keep using the manifest-probed generic feed instead of the native
-  // GitHub provider because cancelled RC releases can appear without assets.
+  // accept a prerelease manifest (RC or perf-RC) for users who intentionally
+  // Shift / Cmd-Shift-clicked. We keep using the manifest-probed generic feed
+  // instead of the native GitHub provider because cancelled RC releases can
+  // appear without assets.
   getAutoUpdater().allowPrerelease = true
-  includePrereleaseActive = true
+  if (options.rc) {
+    includePrereleaseActive = true
+  }
+  if (options.perfRc) {
+    includePerfPrereleaseActive = true
+  }
 }
 
 /** Menu-triggered check — delegates feedback to renderer toasts via userInitiated flag */
-export function checkForUpdatesFromMenu(options?: { includePrerelease?: boolean }): void {
+export function checkForUpdatesFromMenu(options?: UpdateCheckOptions): void {
   if (!app.isPackaged || is.dev) {
     sendStatus({ state: 'not-available', userInitiated: true })
     return
   }
 
-  if (options?.includePrerelease) {
+  const wantsPrereleaseOptIn = Boolean(options?.includePrerelease || options?.includePerfPrerelease)
+  if (wantsPrereleaseOptIn) {
     clearPrereleaseFallbackContext()
-    enableIncludePrerelease()
+    enablePrereleaseChannels({
+      rc: Boolean(options?.includePrerelease),
+      perfRc: Boolean(options?.includePerfPrerelease)
+    })
   }
 
   const checkAlreadyInFlight = backgroundCheckLaunchPending || currentStatus.state === 'checking'
@@ -1009,9 +1045,10 @@ export function checkForUpdatesFromMenu(options?: { includePrerelease?: boolean 
   if (checkAlreadyInFlight) {
     backgroundCheckPromotedToUserInitiated = true
     rearmActiveUpdateCheckStallTimer()
-    if (options?.includePrerelease) {
-      // Why: the in-flight check may have already pinned the stable feed.
-      // Queue a fresh RC check so Shift-click doesn't inherit a stable result.
+    if (wantsPrereleaseOptIn) {
+      // Why: the in-flight check may have already pinned the stable feed. Queue
+      // a fresh prerelease check so Shift / Cmd-Shift-click doesn't inherit a
+      // stable result; the sticky opt-in flags carry the exact channel.
       pendingPrereleaseUserInitiatedCheckAfterInFlight = true
     }
     return

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -4,7 +4,11 @@ import { randomUUID } from 'node:crypto'
 import { app, ipcMain } from 'electron'
 import type { BrowserWindow } from 'electron'
 import type { Store } from '../persistence'
-import type { CreateWorktreeResult, WorktreeStartupLaunch } from '../../shared/types'
+import type {
+  CreateWorktreeResult,
+  UpdateCheckOptions,
+  WorktreeStartupLaunch
+} from '../../shared/types'
 import { registerRepoHandlers } from '../ipc/repos'
 import { registerWorktreeHandlers } from '../ipc/worktrees'
 import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
@@ -448,7 +452,7 @@ export function registerUpdaterHandlers(_store: Store): void {
 
   ipcMain.handle('updater:getStatus', () => getUpdateStatus())
   ipcMain.handle('updater:getVersion', () => app.getVersion())
-  ipcMain.handle('updater:check', (_event, options?: { includePrerelease?: boolean }) => {
+  ipcMain.handle('updater:check', (_event, options?: UpdateCheckOptions) => {
     ensureAutoUpdaterConfigured()
     return checkForUpdatesFromMenu(options)
   })

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -162,6 +162,7 @@ import type {
   StatsSummary,
   MemorySnapshot,
   TuiAgent,
+  UpdateCheckOptions,
   UpdateStatus,
   Worktree,
   WorktreeBaseStatusEvent,
@@ -2159,7 +2160,7 @@ export type PreloadApi = {
   updater: {
     getVersion: () => Promise<string>
     getStatus: () => Promise<UpdateStatus>
-    check: (options?: { includePrerelease?: boolean }) => Promise<void>
+    check: (options?: UpdateCheckOptions) => Promise<void>
     download: () => Promise<void>
     quitAndInstall: () => Promise<void>
     dismissNudge: () => Promise<void>

--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -88,13 +88,16 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
             variant="outline"
             size="sm"
             // Why: Shift-click opts this check into the release-candidate
-            // channel. Keep the affordance hidden; it's a power-user
+            // channel; Cmd (macOS) / Ctrl (Win/Linux) with Shift escalates to
+            // the perf-RC channel. Keep the affordance hidden; it's a power-user
             // shortcut, not a discoverable toggle.
-            onClick={(event) =>
-              window.api.updater.check({
-                includePrerelease: event.shiftKey
+            onClick={(event) => {
+              const isMac = navigator.userAgent.includes('Mac')
+              void window.api.updater.check({
+                includePrerelease: event.shiftKey,
+                includePerfPrerelease: event.shiftKey && (isMac ? event.metaKey : event.ctrlKey)
               })
-            }
+            }}
             disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
             className="gap-2"
           >

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
@@ -58,8 +58,21 @@ vi.mock('../setup-guide/SetupGuideProgressRing', () => ({
 vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
   DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuItem: ({ children, onSelect }: { children: ReactNode; onSelect?: () => void }) => (
-    <button data-testid="menu-item" onClick={onSelect}>
+  // Why: the real Radix item composes props.onClick (a real MouseEvent) before
+  // its own select/close, and its onSelect fires with a modifier-less
+  // CustomEvent. Mirror that: forward onClick when present, else onSelect.
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    onClick,
+    disabled
+  }: {
+    children: ReactNode
+    onSelect?: () => void
+    onClick?: (event: React.MouseEvent) => void
+    disabled?: boolean
+  }) => (
+    <button data-testid="menu-item" disabled={disabled} onClick={onClick ?? onSelect}>
       {children}
     </button>
   ),
@@ -250,6 +263,29 @@ describe('SidebarSettingsHelpMenu', () => {
   it('renders Check for Updates menu item', () => {
     const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
     expect(html).toContain('Check for Updates')
+  })
+
+  it('routes Check for Updates modifiers to the RC and perf-RC channels', async () => {
+    const container = await renderMenu()
+    const item = findMenuItem(container, 'Check for Updates')
+    // Why: Cmd (macOS) / Ctrl (Win/Linux) with Shift is the perf-RC escalation.
+    const perfModifier = navigator.userAgent.includes('Mac') ? { metaKey: true } : { ctrlKey: true }
+
+    const clickWith = async (init: MouseEventInit): Promise<void> => {
+      await act(async () => {
+        item.dispatchEvent(new MouseEvent('click', { bubbles: true, ...init }))
+      })
+    }
+
+    await clickWith({})
+    await clickWith({ shiftKey: true })
+    await clickWith({ shiftKey: true, ...perfModifier })
+
+    expect(mocks.updaterCheck.mock.calls).toEqual([
+      [{ includePrerelease: false, includePerfPrerelease: false }],
+      [{ includePrerelease: true, includePerfPrerelease: false }],
+      [{ includePrerelease: true, includePerfPrerelease: true }]
+    ])
   })
 
   it('renders shortcut keys in the settings tooltip', () => {

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -147,9 +147,19 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
     openSettingsPage()
   }
 
-  const handleCheckForUpdates = (event: Event): void => {
-    const shiftKey = (event as PointerEvent).shiftKey
-    void window.api.updater.check({ includePrerelease: shiftKey })
+  // Why: wired to the menu item's onClick (not Radix onSelect) so it receives a
+  // real MouseEvent — Radix's onSelect delivers a synthetic CustomEvent with no
+  // modifier state. Shift opts into the RC channel; Cmd (macOS) / Ctrl
+  // (Win/Linux) with Shift escalates to perf-RC — a power-user shortcut, not a
+  // discoverable toggle. Keyboard activation dispatches a modifier-less click,
+  // so it correctly falls back to a plain stable check.
+  const handleCheckForUpdates = (event: React.MouseEvent): void => {
+    const isMac = navigator.userAgent.includes('Mac')
+    const shiftKey = event.shiftKey
+    void window.api.updater.check({
+      includePrerelease: shiftKey,
+      includePerfPrerelease: shiftKey && (isMac ? event.metaKey : event.ctrlKey)
+    })
   }
 
   const openMilestones = (): void => {
@@ -299,7 +309,7 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
             <DropdownMenuSeparator />
             <DropdownMenuItem
               disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
-              onSelect={handleCheckForUpdates}
+              onClick={handleCheckForUpdates}
             >
               {updateStatus.state === 'checking' ? (
                 <Loader2 className="size-3.5 animate-spin" />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2214,6 +2214,15 @@ export type UpdateStatus =
   | { state: 'downloaded'; version: string; releaseUrl?: string; activeNudgeId?: string }
   | { state: 'error'; message: string; userInitiated?: boolean; activeNudgeId?: string }
 
+// Why: Shift-click on "Check for Updates" opts a manual check into the RC
+// channel; holding Cmd (macOS) / Ctrl (Win/Linux) with Shift escalates to the
+// perf-RC channel. Both flags are additive on top of the running build's own
+// track, so a stable user can reach RCs and an RC user can reach perf-RCs.
+export type UpdateCheckOptions = {
+  includePrerelease?: boolean
+  includePerfPrerelease?: boolean
+}
+
 // ─── Settings ────────────────────────────────────────────────────────
 export type NotificationSettings = {
   enabled: boolean


### PR DESCRIPTION
## What

Reworks the updater into a **three-channel model** so power users can steer which release track they're offered, keyed off modifier keys on **Check for Updates**.

Release tracks (classified by the new `getReleaseChannel`):

| Track | Example tag |
|---|---|
| stable | `v1.4.122` |
| rc | `v1.4.122-rc.3` |
| perf-rc | `v1.4.122-rc.3.perf` |

## Behavior

A running build is always offered **stable + its own track**. Modifier keys additively opt into higher tracks for that check:

- **Shift** → also offer the **rc** track (a stable user reaches the latest RC).
- **Cmd (macOS) / Ctrl (Win/Linux) + Shift** → also offer the **perf-rc** track (reach the latest perf-RC).

Which matches the requested rules:

- **On an RC build** → stable + rcs, but **not** perf-rcs *unless* Cmd/Ctrl+Shift is held.
- **On a perf-RC build** → stable + perf-rcs, but **not** rcs *unless* Shift is held.
- **Background / auto checks** (no modifier) → only the running build's own track + stable.

"Update to latest" then pins the generic feed to the newest eligible tag (perf-rc outranks the same-numbered plain rc by semver precedence).

## How

- `getReleaseChannel(version)` in `updater-fallback.ts` classifies a version by track (`perf` identifier ⇒ perf-rc, other prerelease ⇒ rc, else stable).
- `resolveEligibleReleaseChannels()` in `updater.ts` combines the running build's channel with sticky Shift / Cmd-Shift opt-ins into a canonical `stable → rc → perf-rc` set.
- The feed resolver (`fetchNewerReleaseTagsWithReadiness`) now takes `eligibleChannels` and filters candidate tags by track instead of a binary `includePrerelease`.
- New shared `UpdateCheckOptions` (`{ includePrerelease?, includePerfPrerelease? }`) is threaded through the native menu, both Settings "Check for Updates" surfaces, and the `updater:check` IPC. Modifier detection is platform-correct (`metaKey` on macOS, `ctrlKey` elsewhere).
- Opt-ins stay sticky for the process, mirroring the prior RC flag, so a later background check keeps offering the same track until install.

## Sidebar fix (from review)

The sidebar `…` Help-menu "Check for Updates" item was wired to Radix's `onSelect`, which delivers a synthetic `CustomEvent` with **no** modifier state — so `Shift` / `Cmd-Shift` never registered there (the RC half was a pre-existing bug on `main`). Switched it to `onClick`, which Radix composes with a **real** `MouseEvent` before its own select/close, and which keyboard activation also dispatches (as a modifier-less click → plain stable check). The native menu and Settings-section button already received real events and were unaffected.

## Tests

- New `getReleaseChannel` unit tests + channel-filtering feed tests (rc-only hides perf, perf-only hides rc, all-tracks picks semver-newest).
- New `updater.ts` integration tests for all four modifier / current-version combinations.
- New sidebar test that clicks the menu item with `Shift` and `Cmd/Ctrl+Shift` and asserts the emitted `UpdateCheckOptions`.
- Menu test rewritten to be platform-robust and assert the new `{ includePrerelease, includePerfPrerelease }` shape.
- Migrated existing feed/updater assertions from `includePrerelease` to `eligibleChannels`.

All updater/menu/sidebar suites (188 tests), `typecheck`, `oxlint`, and `oxfmt` pass. Adversarially reviewed end-to-end against the four rules via a multi-lens workflow; it surfaced one real defect (the sidebar Radix `onSelect` issue above), which is fixed and covered by a test.

## Notes

- Packaged-only path (real update checks require a signed/packaged build), so not exercised in a dev Electron run.
- Web/mobile `updater.check` remains a no-op stub — the widened options type is compatible.
