### PR TITLE
Remove Open badge from PR comment actions

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -1609,13 +1609,6 @@ function PRCommentActionBadge({
       </span>
     )
   }
-  if (actionState === 'open') {
-    return (
-      <span className={presentation.statusBadgeOpen}>
-        {translate('auto.components.right.sidebar.checks.panel.content.7c1f0a2b11', 'Open')}
-      </span>
-    )
-  }
   if (actionState === 'resolved') {
     return (
       <span className={presentation.statusBadgeResolved}>

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
@@ -41,7 +41,6 @@ export type PRCommentPresentationClasses = {
   audienceTab: string
   audienceTabActive: string
   sectionTriageLabel: string
-  statusBadgeOpen: string
   statusBadgeResolved: string
   statusBadgeQueued: string
   commentHeaderPrimary: string
@@ -160,8 +159,6 @@ export function getPRCommentPresentationClasses(
         'flex h-7 items-center justify-center gap-1 rounded-md px-1.5 text-[11px] font-medium text-muted-foreground transition-colors',
       audienceTabActive: 'bg-muted text-foreground',
       sectionTriageLabel: cn('px-3 pt-2', RESOLVED_SECTION_LABEL),
-      statusBadgeOpen:
-        'shrink-0 rounded border border-status-success-border bg-status-success-background px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-status-success',
       statusBadgeResolved:
         'shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground',
       statusBadgeQueued:
@@ -211,8 +208,6 @@ export function getPRCommentPresentationClasses(
       'flex h-7 items-center justify-center gap-1 rounded-md px-1.5 text-[11px] font-medium text-muted-foreground transition-colors',
     audienceTabActive: 'bg-muted text-foreground shadow-xs',
     sectionTriageLabel: cn('px-3 pt-1', RESOLVED_SECTION_LABEL),
-    statusBadgeOpen:
-      'shrink-0 rounded border border-status-success-border bg-status-success-background px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-status-success',
     statusBadgeResolved:
       'shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground',
     statusBadgeQueued:


### PR DESCRIPTION
## Summary

Removes the "Open" status badge from PR comment actions.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the removal of the unused `statusBadgeOpen` styling class and its conditional rendering in `PRCommentActionBadge`. No risks of regression identified. Verified that renderer-side React changes do not impact any OS/platform-specific shortcuts, labels, or shell behavior across macOS, Linux, and Windows.

## Security Audit

No security risks. The changes are strictly limited to UI presentation adjustments and contain no IPC, shell commands, secret handling, or input validation logic.

## Notes

No platform-specific behavior or risks.