### PR TITLE
Fix cross-worktree chat leak: key native-chat transcript cache by resolved file path

### DIFF
--- a/src/main/native-chat/transcript-read-cache.test.ts
+++ b/src/main/native-chat/transcript-read-cache.test.ts
@@ -89,4 +89,62 @@ describe('readNativeChatTranscriptCached', () => {
     const result = await readNativeChatTranscriptCached('claude', 'absent')
     expect('error' in result && result.error).toBeTruthy()
   })
+
+  // Why: two worktrees can present the SAME (agent, sessionId) via different
+  // transcript files — e.g. the same session resumed/forked into a second
+  // worktree, re-homed under the new cwd's slug. Keying the cache by sessionId
+  // let one worktree's cached parse be served to the other whenever their file
+  // mtimes coincided, leaking A's chat transcript into C's panel (#7326).
+  it('never serves one file’s parse for a different file that shares a sessionId', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-cache-xwt-'))
+    tempRoots.push(root)
+    const fileA = join(root, 'worktree-a.jsonl')
+    const fileC = join(root, 'worktree-c.jsonl')
+    await writeFile(
+      fileA,
+      jsonLines([
+        {
+          type: 'user',
+          uuid: 'a0',
+          timestamp: '2026-06-01T10:00:00.000Z',
+          message: { role: 'user', content: 'from-worktree-A' }
+        }
+      ])
+    )
+    await writeFile(
+      fileC,
+      jsonLines([
+        {
+          type: 'user',
+          uuid: 'c0',
+          timestamp: '2026-06-01T10:00:00.000Z',
+          message: { role: 'user', content: 'from-worktree-C' }
+        }
+      ])
+    )
+    // Force IDENTICAL mtimes so a sessionId-only key's mtime guard cannot rescue
+    // the collision — this is the intermittent, activity-driven case.
+    const when = new Date('2026-06-01T10:00:00.000Z')
+    await utimes(fileA, when, when)
+    await utimes(fileC, when, when)
+
+    const readText = (result: Awaited<ReturnType<typeof readNativeChatTranscriptCached>>): string =>
+      'messages' in result
+        ? result.messages
+            .flatMap((message) => message.blocks)
+            .filter((block) => block.type === 'text')
+            .map((block) => (block.type === 'text' ? block.text : ''))
+            .join(' ')
+        : ''
+
+    // Same sessionId, different transcript files (worktree A resumed into C).
+    const a = await readNativeChatTranscriptCached('claude', 'shared-session', fileA)
+    const c = await readNativeChatTranscriptCached('claude', 'shared-session', fileC)
+
+    expect(readText(a)).toContain('from-worktree-A')
+    expect(readText(c)).toContain('from-worktree-C')
+    expect(readText(c)).not.toContain('from-worktree-A')
+    // Distinct files must not share a cached parse object.
+    expect(c).not.toBe(a)
+  })
 })

--- a/src/main/native-chat/transcript-read-cache.test.ts
+++ b/src/main/native-chat/transcript-read-cache.test.ts
@@ -17,6 +17,7 @@ vi.mock('./transcript-reader', async (importOriginal) => {
   }
 })
 
+import { isTextBlock } from '../../shared/native-chat-types'
 import {
   clearNativeChatTranscriptCache,
   readNativeChatTranscriptCached
@@ -91,10 +92,10 @@ describe('readNativeChatTranscriptCached', () => {
   })
 
   // Why: two worktrees can present the SAME (agent, sessionId) via different
-  // transcript files — e.g. the same session resumed/forked into a second
-  // worktree, re-homed under the new cwd's slug. Keying the cache by sessionId
-  // let one worktree's cached parse be served to the other whenever their file
-  // mtimes coincided, leaking A's chat transcript into C's panel (#7326).
+  // transcript files — e.g. the same session resumed into a second worktree,
+  // which writes a new transcript file. Keying the cache by sessionId let one
+  // worktree's cached parse be served to the other whenever their file mtimes
+  // coincided, leaking A's chat transcript into C's panel (#7326).
   it('never serves one file’s parse for a different file that shares a sessionId', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-cache-xwt-'))
     tempRoots.push(root)
@@ -132,8 +133,8 @@ describe('readNativeChatTranscriptCached', () => {
       'messages' in result
         ? result.messages
             .flatMap((message) => message.blocks)
-            .filter((block) => block.type === 'text')
-            .map((block) => (block.type === 'text' ? block.text : ''))
+            .filter(isTextBlock)
+            .map((block) => block.text)
             .join(' ')
         : ''
 

--- a/src/main/native-chat/transcript-read-cache.ts
+++ b/src/main/native-chat/transcript-read-cache.ts
@@ -10,9 +10,9 @@ import { readNativeChatTranscript, type ReadTranscriptResult } from './transcrip
 // against this runtime's home). Keying by connection instead would defeat the
 // multi-client case this feature targets and multiply memory by the connection
 // count. The key is the resolved file path, NOT `agent:sessionId`: two panes can
-// share one sessionId yet resolve to DIFFERENT files (the same session
-// resumed/forked into a second worktree, re-homed under the new cwd's slug), and
-// a sessionId-only key let one worktree's cached parse be served to another when
+// share one sessionId yet resolve to DIFFERENT files (the same session resumed
+// into a second worktree, which writes a new transcript file), and a
+// sessionId-only key let one worktree's cached parse be served to another when
 // their file mtimes momentarily coincided (#7326). The cache stores ONE
 // canonical, unwindowed parse; windowing and per-surface truncation stay in the
 // callers so the same parse is reused across all `limit` values and every client kind.
@@ -45,8 +45,6 @@ function setCached(key: string, value: CachedTranscript): void {
   }
 }
 
-// Why: key by the resolved file path so two different transcript files can never
-// share a cache entry, even when they resolve from the same (agent, sessionId).
 function cacheKey(agent: AgentType, filePath: string): string {
   return `${agent}:${filePath}`
 }
@@ -91,7 +89,7 @@ export async function readNativeChatTranscriptCached(
   return result
 }
 
-/** Test-only: drop the per-session transcript cache between runs. */
+/** Test-only: drop the transcript parse cache between runs. */
 export function clearNativeChatTranscriptCache(): void {
   cache.clear()
 }

--- a/src/main/native-chat/transcript-read-cache.ts
+++ b/src/main/native-chat/transcript-read-cache.ts
@@ -4,13 +4,18 @@ import { resolveSessionFilePath } from './session-file-resolver'
 import { readNativeChatTranscript, type ReadTranscriptResult } from './transcript-reader'
 
 // Why: both the desktop IPC handler and the runtime RPC handler read the same
-// host-filesystem transcript, so a single process-global cache keyed by
-// agent:sessionId maximizes the hit rate across desktop + every paired
-// web/mobile client. Keying by connection instead would defeat the multi-client
-// case this feature targets and multiply memory by the connection count.
-// The cache stores ONE canonical, unwindowed parse; windowing and per-surface
-// truncation stay in the callers so the same parse is reused across all `limit`
-// values and every client kind.
+// host-filesystem transcript, so a single process-global cache keyed by the
+// RESOLVED transcript file path maximizes the hit rate across desktop + every
+// paired web/mobile client (all clients of one session resolve the same path
+// against this runtime's home). Keying by connection instead would defeat the
+// multi-client case this feature targets and multiply memory by the connection
+// count. The key is the resolved file path, NOT `agent:sessionId`: two panes can
+// share one sessionId yet resolve to DIFFERENT files (the same session
+// resumed/forked into a second worktree, re-homed under the new cwd's slug), and
+// a sessionId-only key let one worktree's cached parse be served to another when
+// their file mtimes momentarily coincided (#7326). The cache stores ONE
+// canonical, unwindowed parse; windowing and per-surface truncation stay in the
+// callers so the same parse is reused across all `limit` values and every client kind.
 
 type CachedTranscript = {
   result: ReadTranscriptResult
@@ -40,8 +45,10 @@ function setCached(key: string, value: CachedTranscript): void {
   }
 }
 
-function cacheKey(agent: AgentType, sessionId: string): string {
-  return `${agent}:${sessionId}`
+// Why: key by the resolved file path so two different transcript files can never
+// share a cache entry, even when they resolve from the same (agent, sessionId).
+function cacheKey(agent: AgentType, filePath: string): string {
+  return `${agent}:${filePath}`
 }
 
 async function fileMtimeMs(filePath: string): Promise<number> {
@@ -68,7 +75,7 @@ export async function readNativeChatTranscriptCached(
     return { error: `No transcript found for ${agent} session ${sessionId}` }
   }
 
-  const key = cacheKey(agent, sessionId)
+  const key = cacheKey(agent, filePath)
   const mtimeMs = await fileMtimeMs(filePath)
   const cached = cache.get(key)
   if (cached && Number.isFinite(mtimeMs) && cached.mtimeMs === mtimeMs) {


### PR DESCRIPTION
## Problem

Fixes #7326 — with 2+ worktrees open and concurrent agent activity, the native-chat ("agent chat/log") panel for one worktree (C) intermittently showed another worktree's (A) transcript content.

## ELI5

Each worktree's chat panel asks one shared cache for its transcript, quoting a **session id**. Normally every session has its own id — no confusion. But if you **resume the same session in a second worktree**, both worktrees quote the *same* id, even though the agent is now writing to a *different* file. The cache was filed by id only, so it handed back whichever file it happened to load first. Worktree C asks for its own chat → gets worktree A's.

The fix files the cache by the **file's actual path** instead of the session id, so two different files can never be mixed up — even when they share a session id.

## Root cause

`src/main/native-chat/transcript-read-cache.ts` keyed its process-global transcript **parse cache** by `` `${agent}:${sessionId}` `` — but resolved the actual file via the hook-reported `transcriptPath`:

```ts
const filePath = await resolveSessionFilePath(agent, sessionId, { transcriptPath }) // real file
const key = cacheKey(agent, sessionId)                                             // ignores it
```

Two worktrees can present the **same `(agent, sessionId)` but different transcript files**, so both collide on the single cache key `<agent>:<session_id>`. The mtime guard (`cached.mtimeMs === mtime(fileC)`) only rescues the collision when the two files' mtimes differ — under **concurrent** agent activity the files get written within the same millisecond bucket, their `mtimeMs` momentarily coincide, the guard passes, and pane C is served pane A's cached parse.

This matches every reported symptom facet: **intermittent** (mtime-equality window), **activity-driven** (concurrent appends align the mtimes and keep the entry hot), **2+ worktrees only** (needs a shared `session_id` across worktrees).

### When do two worktrees share a `session_id`?

The realistic trigger is a **session resumed into a second worktree** (`--resume` preserves the id while the agent writes a *new* transcript file):

- **Codex — most reachable.** Codex's session store is **global** (a single Orca-managed home, not cwd-scoped), and the codex-session-bridge hardlinks/symlinks/copies each session into the managed home — so one session id can resolve to **two paths even without a resume**. `codex resume <id>` in a second worktree also isn't cwd-scoped.
- **Claude.** A user running `claude --resume <id>` in a second worktree's terminal (Claude transcripts nest by cwd project slug, so the resumed session re-homes to a new file while keeping the id).

Ruled out as id-sharing sources: **fork** (builds a text prompt and launches a brand-new session → fresh id), Orca's **automatic** sleeping-agent/worktree-activation resume (always re-launches into `record.worktreeId`, never crosses worktrees), and persisted status-snapshot replay (applied strictly by `paneKey`).

Not a regression — the transcriptPath-blind key shipped with the feature (#6641); the only later touch was a non-behavioral lint autofix (#6841). Fixed forward.

## Fix

Key the cache by the **already-resolved absolute file path** (available before the key is computed), so two distinct files can never share an entry:

```ts
function cacheKey(agent: AgentType, filePath: string): string {
  return `${agent}:${filePath}`
}
...
const key = cacheKey(agent, filePath)
```

The multi-client hit-rate goal is preserved: all clients of one session resolve the **same** path against the same runtime home → same key → one shared parse. `cacheKey` is private; no caller depends on its shape. (The `` `${agent}:${sessionId}` `` `cleanupToken` in the runtime RPC method is a separate subscription-cleanup identity, not this cache — unaffected.)

## Evidence

New regression test: same `sessionId`, two distinct files (`worktree-a.jsonl` / `worktree-c.jsonl`), **forced-identical mtimes** so the mtime guard can't mask the collision. Each pane reads with its own `transcriptPath`; the test asserts C's read never returns A's content.

**Without the fix** (cache keyed by `${agent}:${sessionId}`) — the leak reproduces, and the assertion output *is* the bug: reading worktree C's file returns worktree A's content:

```
× never serves one file's parse for a different file that shares a sessionId
AssertionError: expected 'from-worktree-A' to contain 'from-worktree-C'
Test Files  1 failed (1)
Tests  1 failed | 4 passed (5)
```

**With the fix** (cache keyed by resolved file path):

```
Test Files  1 passed (1)
Tests  5 passed (5)
```

Also green: all native-chat main suites (read-cache, ipc, runtime RPC, session-file-resolver, transcript-watch — 30 tests), node typecheck, oxlint.

## Review

Passed a 3-angle review (correctness / cross-file, cleanup / altitude, conventions / test-quality):
- **Correctness:** clean — `filePath` is guarded non-null before keying; two distinct files can never collide; a same-file key mismatch (verbatim hook path vs glob path) only ever costs a re-parse, never wrong/stale content; no caller depends on the key shape.
- **Altitude:** keying the *file*'s parse by its *path* (which the entry's mtime already guards) is the right depth, not a bandaid.
- **Conventions/tests:** the regression test genuinely fails-old/passes-new and is non-flaky (pinned mtimes, unique temp dirs, cache cleared per test).

Post-review polish commit corrected the rationale comments (fork does *not* share an id; Codex uses a global store, not cwd slugs), dropped a comment that duplicated the module header, and used the exported `isTextBlock` type guard in the test.

## Scope investigated (ruled clean)

Independent multi-agent review verified the rest of the data path keys strictly by the globally-unique `paneKey`/`sessionId` and is **not** a leak source: hook attribution (`agent-hooks/server.ts`, tab-scoped, env `ORCA_PANE_KEY` validated at spawn), the renderer agent-status store (`setAgentStatus` keys by exact `paneKey`; `paneKey`+`providerSession` paired in one IPC envelope), the renderer live-session hook/subscription (per-instance state, airtight `subscriptionId` filter), and worktree surface mount/remount (additive, worktree-keyed — no cross-worktree instance/container/PaneManager reuse). The read cache was the single genuine cross-worktree sharing primitive.

## Known residual (follow-up, not fixed here)

A narrower resolver-level vector survives this fix: when a pane's `transcriptPath` hint is **absent or stale** (file rotated/renamed/deleted, or the provider reported no `transcript_path`), `resolveSessionFilePath` falls through to a `files[0]` glob for `<id>.jsonl` (Claude) / the id-embedding rollout (Codex). For a **shared** session id that `files[0]` can be another worktree's file, so pane C resolves to A's *path* and the (now path-keyed) cache faithfully serves A's content. It requires both a shared session id **and** a stale/absent hint; modern Claude/Codex hooks report `transcript_path`, so each pane resolves its own file in the common case. Tracking separately — the resolver has no per-pane signal beyond the hint to disambiguate two files of one session.
