### PR TITLE
Seed WSL Codex runtime config through the fresh-mirror preparation

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -1385,6 +1385,25 @@ describe('CodexRuntimeHomeService', () => {
     }
   })
 
+  it('anchors WSL seed rewrites to the Linux-side home parsed from the UNC source', async () => {
+    const { prepareWslRuntimeSeedConfig } = await import('./runtime-home-service')
+
+    // Why: real UNC sources cannot back live fs operations in tests, so pin
+    // the UNC -> Linux-side anchor translation on the extracted seed function.
+    expect(
+      prepareWslRuntimeSeedConfig(
+        'model_instructions_file = "instructions.md"\n',
+        '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex'
+      )
+    ).toContain("model_instructions_file = '/home/alice/.codex/instructions.md'")
+    expect(
+      prepareWslRuntimeSeedConfig(
+        'model_instructions_file = "instructions.md"\n',
+        '\\\\wsl$\\Ubuntu\\home\\alice\\.codex'
+      )
+    ).toContain("model_instructions_file = '/home/alice/.codex/instructions.md'")
+  })
+
   it('switches WSL accounts by rewriting one stable WSL runtime home', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -1324,6 +1324,67 @@ describe('CodexRuntimeHomeService', () => {
     }
   })
 
+  it('seeds the WSL runtime config with rewritten paths and no system hook trust', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const systemCodexHomePath = join(wslHome, '.codex')
+    mkdirSync(systemCodexHomePath, { recursive: true })
+    writeFileSync(
+      join(systemCodexHomePath, 'config.toml'),
+      [
+        'model_instructions_file = "instructions.md"',
+        '',
+        '[hooks.state."system-hooks:stop:0:0"]',
+        'enabled = true',
+        '',
+        '[projects."/home/alice/repo"]',
+        'trust_level = "trusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+    const store = createStore(createSettings())
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const wslRuntimeHomePath = join(
+        wslHome,
+        '.local',
+        'share',
+        'orca',
+        'codex-runtime-home',
+        'home'
+      )
+
+      expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
+        wslRuntimeHomePath
+      )
+      const runtimeConfigPath = join(wslRuntimeHomePath, 'config.toml')
+      const runtimeConfig = readFileSync(runtimeConfigPath, 'utf-8')
+      expect(runtimeConfig).toContain(
+        `model_instructions_file = '${join(systemCodexHomePath, 'instructions.md')}'`
+      )
+      expect(runtimeConfig).toContain('[projects."/home/alice/repo"]')
+      expect(runtimeConfig).not.toContain('[hooks.state.')
+
+      // Why: WSL runtime configs are seeded once; Codex writes trust into them
+      // afterwards, so a relaunch must not clobber the seeded file.
+      writeFileSync(runtimeConfigPath, `${runtimeConfig}\n[projects."/tmp/x"]\n`, 'utf-8')
+      service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+      expect(readFileSync(runtimeConfigPath, 'utf-8')).toContain('[projects."/tmp/x"]')
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
   it('switches WSL accounts by rewriting one stable WSL runtime home', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -40,7 +40,10 @@ import {
   syncSystemCodexResourcesIntoManagedHome
 } from '../codex/codex-home-paths'
 import { startSystemCodexSessionBridgeInBackground } from '../codex/codex-session-bridge'
-import { syncSystemConfigIntoManagedCodexHome } from '../codex/codex-config-mirror'
+import {
+  prepareSystemConfigForFreshRuntimeMirror,
+  syncSystemConfigIntoManagedCodexHome
+} from '../codex/codex-config-mirror'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   getWslSelectionKey,
@@ -705,7 +708,17 @@ export class CodexRuntimeHomeService {
     for (const homePath of candidateHomes) {
       const configPath = join(homePath, 'config.toml')
       if (existsSync(configPath)) {
-        copyFileSync(configPath, runtimeConfigPath)
+        // Why: the seed config is read over UNC but consumed by Codex inside
+        // WSL, so relative path-valued settings must anchor to the Linux-side
+        // source home; a verbatim copy breaks Codex config load (os error 2).
+        const sourceConfigDir = parseWslUncPath(homePath)?.linuxPath ?? homePath
+        writeFileAtomically(
+          runtimeConfigPath,
+          prepareSystemConfigForFreshRuntimeMirror(
+            readFileSync(configPath, 'utf-8'),
+            sourceConfigDir
+          )
+        )
         return
       }
     }

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -708,16 +708,9 @@ export class CodexRuntimeHomeService {
     for (const homePath of candidateHomes) {
       const configPath = join(homePath, 'config.toml')
       if (existsSync(configPath)) {
-        // Why: the seed config is read over UNC but consumed by Codex inside
-        // WSL, so relative path-valued settings must anchor to the Linux-side
-        // source home; a verbatim copy breaks Codex config load (os error 2).
-        const sourceConfigDir = parseWslUncPath(homePath)?.linuxPath ?? homePath
         writeFileAtomically(
           runtimeConfigPath,
-          prepareSystemConfigForFreshRuntimeMirror(
-            readFileSync(configPath, 'utf-8'),
-            sourceConfigDir
-          )
+          prepareWslRuntimeSeedConfig(readFileSync(configPath, 'utf-8'), homePath)
         )
         return
       }
@@ -1574,4 +1567,17 @@ export class CodexRuntimeHomeService {
   clearSystemDefaultSnapshot(): void {
     rmSync(this.getSystemDefaultSnapshotPath(), { force: true })
   }
+}
+
+// Why: the seed config is read over UNC but consumed by Codex inside WSL, so
+// relative path-valued settings must anchor to the Linux-side source home; a
+// verbatim copy breaks Codex config load (os error 2).
+export function prepareWslRuntimeSeedConfig(
+  configContents: string,
+  sourceHomePath: string
+): string {
+  return prepareSystemConfigForFreshRuntimeMirror(
+    configContents,
+    parseWslUncPath(sourceHomePath)?.linuxPath ?? sourceHomePath
+  )
 }

--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -23,7 +23,10 @@ vi.mock('node:os', async () => {
   }
 })
 
-import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+import {
+  prepareSystemConfigForFreshRuntimeMirror,
+  syncSystemConfigIntoManagedCodexHome
+} from './codex-config-mirror'
 
 let fakeHomeDir: string
 let userDataDir: string
@@ -395,5 +398,34 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     syncSystemConfigIntoManagedCodexHome()
 
     expect(existsSync(getRuntimeConfigPath())).toBe(false)
+  })
+})
+
+describe('prepareSystemConfigForFreshRuntimeMirror', () => {
+  it('rewrites relative paths against a Linux-side home and strips hook trust', () => {
+    const prepared = prepareSystemConfigForFreshRuntimeMirror(
+      [
+        'model_instructions_file = "instructions.md"',
+        '',
+        '[features]',
+        'codex_hooks = true',
+        '',
+        '[hooks.state."system-hooks:stop:0:0"]',
+        'enabled = true',
+        '',
+        '[projects."/home/alice/repo"]',
+        'trust_level = "trusted"',
+        ''
+      ].join('\r\n'),
+      '/home/alice/.codex'
+    )
+
+    // Why: WSL configs are consumed inside the distro, so rewrites must use
+    // posix join semantics regardless of the host platform.
+    expect(prepared).toContain("model_instructions_file = '/home/alice/.codex/instructions.md'")
+    expect(prepared).toContain('hooks = true')
+    expect(prepared).not.toContain('codex_hooks')
+    expect(prepared).toContain('[projects."/home/alice/repo"]')
+    expect(prepared).not.toContain('[hooks.state."system-hooks:stop:0:0"]')
   })
 })

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -35,17 +35,19 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
     return
   }
 
-  const systemConfig = prepareSystemConfigForRuntimeMirror(
-    systemConfigExists ? readFileSync(systemConfigPath, 'utf-8') : '',
-    dirname(systemConfigPath)
-  )
+  const rawSystemConfig = systemConfigExists ? readFileSync(systemConfigPath, 'utf-8') : ''
   if (!runtimeConfigExists) {
-    // Why: trust blocks reference a hooks.json path, so system-home hook trust
-    // entries are not valid in Orca's runtime CODEX_HOME until install remaps them.
-    writeFileAtomically(runtimeConfigPath, stripRuntimeOwnedTomlSections(systemConfig))
+    writeFileAtomically(
+      runtimeConfigPath,
+      prepareSystemConfigForFreshRuntimeMirror(rawSystemConfig, dirname(systemConfigPath))
+    )
     return
   }
 
+  const systemConfig = prepareSystemConfigForRuntimeMirror(
+    rawSystemConfig,
+    dirname(systemConfigPath)
+  )
   const runtimeConfig = readFileSync(runtimeConfigPath, 'utf-8')
   const mergedConfig = mergeSystemCodexConfigIntoRuntime(runtimeConfig, systemConfig)
   if (mergedConfig !== runtimeConfig) {
@@ -60,6 +62,17 @@ function prepareSystemConfigForRuntimeMirror(config: string, systemConfigDir: st
   )
 }
 
+// Why: trust blocks reference a hooks.json path, so system-home hook trust
+// entries are not valid in a fresh runtime CODEX_HOME until install remaps
+// them. Also seeds WSL runtime homes, where systemConfigDir must be the
+// Linux-side ~/.codex the config resolves against inside the distro.
+export function prepareSystemConfigForFreshRuntimeMirror(
+  config: string,
+  systemConfigDir: string
+): string {
+  return stripRuntimeOwnedTomlSections(prepareSystemConfigForRuntimeMirror(config, systemConfigDir))
+}
+
 function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
   if (!config.includes('codex_hooks')) {
     return config
@@ -71,7 +84,9 @@ function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
 
   for (let index = 0; index <= lines.length; index += 1) {
     const line = lines[index]
-    const isHeader = line === undefined || /^[ \t]*\[[^\]]+\][ \t]*(?:#.*)?$/.test(line)
+    // Why: CRLF configs keep a trailing \r after the split, so header anchors
+    // must tolerate it or Windows-shaped configs skip normalization entirely.
+    const isHeader = line === undefined || /^[ \t]*\[[^\]]+\][ \t]*(?:#.*)?\r?$/.test(line)
     if (!isHeader) {
       continue
     }
@@ -80,7 +95,7 @@ function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
       featureSections.push({ start: featureStart, end: index })
       featureStart = null
     }
-    if (line !== undefined && /^[ \t]*\[features\][ \t]*(?:#.*)?$/.test(line)) {
+    if (line !== undefined && /^[ \t]*\[features\][ \t]*(?:#.*)?\r?$/.test(line)) {
       featureStart = index
     }
   }


### PR DESCRIPTION
## Summary
- Follow-up to #7157, which fixed relative path-valued Codex config settings for the host runtime home and managed account homes but explicitly deferred the WSL runtime home seed (`seedWslRuntimeHome`) as a known gap.
- The WSL seed copied `config.toml` verbatim, so a WSL user with e.g. `model_instructions_file = "instructions.md"` hit the exact #7025 failure class inside every Orca WSL terminal: Codex resolves the relative value against the runtime `CODEX_HOME`, misses the file, and aborts config load with `Error loading configuration: ... (os error 2)`.
- The seed now runs the same fresh-mirror preparation the host path uses: deprecated `codex_hooks` feature-flag normalization, relative-path rewrite anchored to the **Linux-side** source home, and system hook-trust section strip.

## ELI5
In plain English: Orca gives Codex a private settings folder so it can manage logins and trust safely, and it copies the user's real settings file into that private folder. Some settings mean "open this file sitting next to my settings file." After the copy moves, Codex looks next to the *copy* — in the private folder — where the file doesn't exist, and it refuses to start at all.

PR #7157 fixed this by rewriting those references in the copy into full paths that point back at the user's real folder. But Orca can also run Codex inside WSL (Linux inside Windows), and the WSL private folder still got a plain, unfixed copy — so WSL users kept hitting "Codex won't start." This PR gives the WSL copy the same treatment, with the paths written the way Linux inside WSL sees them (`/home/alice/.codex/...`), not the way Windows sees them (`\\wsl$\...`).

## What changed
- `src/main/codex/codex-config-mirror.ts` — extracted the existing fresh-write composition (`stripRuntimeOwnedTomlSections` ∘ `prepareSystemConfigForRuntimeMirror`) into an exported `prepareSystemConfigForFreshRuntimeMirror`; the host fresh-mirror branch now calls it, so both consumers share one definition. No host behavior change.
- `src/main/codex-accounts/runtime-home-service.ts` — `seedWslRuntimeHome` reads the seed config, applies the preparation via the extracted pure `prepareWslRuntimeSeedConfig` — anchor derived via `parseWslUncPath(homePath)?.linuxPath` (the config is read over UNC but consumed inside the distro, so join semantics must be posix Linux-side) — and writes with `writeFileAtomically` instead of `copyFileSync`.
- **CRLF bug fix found while testing**: `normalizeDeprecatedCodexHookFeatureFlag`'s header regexes anchored with `$` and `[ \t]*` and did not tolerate the trailing `\r` left by splitting CRLF configs on `\n`, so Windows-shaped configs silently skipped `codex_hooks` → `hooks` normalization. Headers now accept an optional trailing `\r` (the line-scan path already did via `\s*`).

## Verified against openai/codex source
- `codex-rs/config/src/loader/layer_io.rs` (`validate_config_toml_strictly`) sets `AbsolutePathBufGuard::new(base_dir)` with `base_dir = config.toml's parent directory` before deserializing a config layer, so every relative `AbsolutePathBuf` setting resolves against the directory Codex read the config from — i.e. the runtime `CODEX_HOME` after Orca's seed. Anchoring the rewrite to the Linux-side source home is exactly the inverse of this mechanism.
- `codex-rs/core/src/config/mod.rs` reads `model_instructions_file` (profile-level first, then top-level) via `try_read_non_empty_file(...).await?` — a missing target propagates the raw `io::Error` and aborts config load, producing the bare `Error loading configuration: ... (os error 2)` from #7025.

## Behavior notes
- Seed-once semantics are unchanged and now pinned by a test: an existing WSL runtime config is never overwritten (Codex writes project trust into it after seeding). Re-mirroring system config changes into WSL runtime homes remains the deferred follow-up from #7157.
- Stripping `[hooks.state.*]` on WSL seed matches host fresh-mirror semantics: those trust entries hash against a hooks.json path that is not valid in a moved `CODEX_HOME`, so they were dead weight either way. `[projects.*]` trust is preserved.
- The managed-account seed candidate already contains absolute paths (rewritten by `codex-accounts/service.ts` since #7157), so the preparation is a no-op there — the rewrite skips absolute values, making the seed path uniform and idempotent.

## Evidence
- New regression test `seeds the WSL runtime config with rewritten paths and no system hook trust` **fails against the pre-change code** (verbatim copy leaves `model_instructions_file = "instructions.md"` relative and keeps `[hooks.state.*]`) and passes with the fix.
- New unit test for `prepareSystemConfigForFreshRuntimeMirror` covers a CRLF config with a Linux-side anchor, asserting posix join output, hook-trust strip, project-trust preservation, and `codex_hooks` normalization — the CRLF case is what exposed the regex bug.

- New unit test pins the UNC → Linux-side anchor translation on `prepareWslRuntimeSeedConfig` with hardcoded `\\wsl.localhost\...` and `\\wsl$\...` literals (real UNC sources cannot back live fs operations in tests).

## Test plan
- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex src/main/codex-accounts` (301 passed)
- `pnpm exec oxlint src/main/codex src/main/codex-accounts`
- `pnpm typecheck` (all three projects)

## Win/Linux compat
The rewrite anchor uses the Linux-side path parsed from the UNC seed source, so posix join semantics apply inside the distro regardless of host platform; CRLF (Windows-shaped) configs are covered by both new tests. No `config/tsconfig.cli.json` change needed — no new modules, and `codex-config-mirror.ts` is already in the CLI file list.