### PR TITLE
fix(ssh): make reconnection prompts non-blocking unless the project is focused

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
@@ -133,7 +133,7 @@ describe('WorktreeCard SSH reconnect prompt', () => {
     worktreeCardProperties = ['status']
   })
 
-  it('opens the reconnect dialog for an active disconnected SSH worktree during render', () => {
+  it('does not auto-open the blocking reconnect dialog for a restored active disconnected SSH worktree', () => {
     sshConnectionStates.set('ssh-target-1', { status: 'disconnected' })
     sshTargetLabels.set('ssh-target-1', 'Remote target')
 
@@ -141,9 +141,11 @@ describe('WorktreeCard SSH reconnect prompt', () => {
       <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={true} />
     )
 
-    expect(markup).toContain('data-ssh-disconnected-dialog="open"')
-    expect(markup).toContain('data-ssh-status="disconnected"')
-    expect(markup).toContain('data-ssh-target-label="Remote target"')
+    // The dialog is blocking, so being the active/restored card must not steal
+    // focus app-wide; it only opens on deliberate click (see handleClick).
+    expect(markup).toContain('data-ssh-disconnected-dialog="closed"')
+    // The disconnected state is still discoverable via the non-blocking card chip.
+    expect(markup).toContain('SSH disconnected')
   })
 
   it('marks a runtime-host worktree disconnected when its environment has no status', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -342,6 +342,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
     return state?.status ?? 'disconnected'
   })
   const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
+  // Why: a terminal view already carries its own in-pane reconnect overlay, so
+  // the blocking dialog would just duplicate it there; reserve the dialog for
+  // views without an in-context prompt. Default to terminal (suppress) for the
+  // ambiguous case so we err toward non-blocking.
+  const activeViewIsTerminal = useAppStore(
+    (s) => (s.activeTabTypeByWorktree?.[worktree.id] ?? 'terminal') === 'terminal'
+  )
 
   // Why: runtime ("Orca server") hosts get the same disconnected treatment as
   // SSH — when the host's runtime environment has no live status, its worktrees
@@ -353,23 +360,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
     }
     return !s.runtimeStatusByEnvironmentId.get(parsed.environmentId)?.status
   })
+  // Why: the reconnect dialog is blocking, so it is never auto-shown for a
+  // disconnected worktree just because it is the active/restored card — that
+  // would steal focus app-wide while the user works elsewhere. The card chip,
+  // status bar, and terminal overlay carry the non-blocking disconnected state;
+  // the dialog only opens on deliberate focus (see handleClick).
   const [showDisconnectedDialog, setShowDisconnectedDialog] = useState(false)
-  const sshDisconnectedPromptKey = isActive && isSshDisconnected ? worktree.id : null
-  const [lastSshDisconnectedPromptKey, setLastSshDisconnectedPromptKey] = useState<string | null>(
-    null
-  )
   const [titleRenaming, setTitleRenaming] = useState(false)
   const [showRenameErrorDialog, setShowRenameErrorDialog] = useState(false)
-
-  // Why: on restart the previously-active worktree is auto-restored without a
-  // click, so the dialog never opens. Auto-show it for the active card when SSH
-  // is disconnected, but keep dismissals sticky until that prompt key changes.
-  if (sshDisconnectedPromptKey !== lastSshDisconnectedPromptKey) {
-    setLastSshDisconnectedPromptKey(sshDisconnectedPromptKey)
-    if (sshDisconnectedPromptKey) {
-      setShowDisconnectedDialog(true)
-    }
-  }
   // Why: read the target label from the store (populated during hydration in
   // useIpcEvents.ts) instead of calling listTargets IPC per card instance.
   const sshTargetLabel = useAppStore((s) =>
@@ -862,7 +860,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
       })
       onImmediateActivate?.(worktree.id, activationRowKey)
       void activateWorktreeFromSidebar(worktree.id)
-      if (isSshDisconnected) {
+      // Why: clicking the card is a deliberate focus of this project, so the
+      // blocking reconnect prompt is appropriate here (unlike auto-restore) —
+      // but skip it when a terminal is active, since that pane already shows the
+      // in-context reconnect overlay and a second prompt would just duplicate it.
+      if (isSshDisconnected && !activeViewIsTerminal) {
         setShowDisconnectedDialog(true)
       }
       onActivate?.()
@@ -875,6 +877,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       isDeleting,
       activationRowKey,
       isSshDisconnected,
+      activeViewIsTerminal,
       onActivate,
       onImmediateActivate,
       onSelectionGesture


### PR DESCRIPTION
Fixes #7314

## Problem

When an SSH-backed project's connection dropped, Orca auto-opened a **modal** reconnect dialog that blocked the entire UI. The worst case is app restart: the previously-active worktree is restored *without any click*, so if its SSH target was down the modal stole focus app-wide — even while the user was working in a different, connected project, inspecting settings, or using another pane.

The culprit was a render-phase auto-open in `WorktreeCard`: whenever a card was `isActive && isSshDisconnected`, it force-opened the blocking `SshDisconnectedDialog`.

## Fix

Reconnection is now scoped to the affected surface, matching the issue's desired behavior:

- **Non-blocking disconnected state** on the worktree card (`ServerOff` chip + dimming) and the status bar (`Connect` per-host) — these already existed and now carry the state on their own.
- **Terminal-local overlay only** inside affected terminal panes (`TerminalSshReconnectOverlay`, pane-scoped, `pointer-events-none` backdrop) — unchanged.
- **The blocking modal opens only on deliberate focus** — clicking the worktree card. It no longer auto-opens for a merely restored/active worktree.
- **No double prompt:** even on a deliberate click, the modal is suppressed when the worktree's active view is a terminal, because that pane already shows the in-context reconnect overlay (goal 2's "terminal-local overlay *only*"). The modal is reserved for views without an in-context prompt (editor/browser/etc.).
- **Connected projects and unrelated UI stay fully usable** while one SSH target is down.

### Code
- `WorktreeCard.tsx`: removed the render-phase auto-open (and its `sshDisconnectedPromptKey` / `lastSshDisconnectedPromptKey` bookkeeping). Gated the click-triggered modal on `!activeViewIsTerminal` using the existing per-worktree `activeTabTypeByWorktree` store field (no new cross-component coupling).
- `WorktreeCard.ssh-reconnect-prompt.test.tsx`: the render test now asserts the dialog stays **closed** for a restored active disconnected worktree while the non-blocking "SSH disconnected" chip still renders.

## Verification
- `typecheck` (web), `oxlint`, and `oxfmt` clean; all **1352** sidebar unit tests pass.
- Adversarial multi-lens review (regression + completeness lenses found no issues; confirmed there is no *other* app-blocking modal on SSH disconnect).
- Driven end-to-end in a dev build via CDP by seeding a disconnected SSH target:
  - Active/restored disconnected worktree → **no modal**, terminal overlay only, sidebar + rest of app usable.
  - Deliberate click, active view = terminal → **modal suppressed** (overlay handles it).
  - Deliberate click, active view = editor → **modal shown** (no in-context prompt).

Screenshots attached in a follow-up comment.

Made with [Orca](https://github.com/stablyai/orca) 🐋
