### PR TITLE
Keep unread slept workspaces visible under Hide sleeping

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -930,11 +930,14 @@ function WorktreeJumpPaletteContent({
         ) {
           return false
         }
+        // Keep a slept workspace listed while it has a pending notification so
+        // the Hide-sleeping filter can't bury an unread agent completion.
         if (
           !showSleepingWorkspaces &&
           // Why the exemption here too: Cmd+J re-implements the sidebar's
           // filter pass, so the shared predicate is what keeps them in step.
           !isSleepingSweepExemptWorkspace(worktree, alwaysShowDefaultBranchWorkspace) &&
+          !worktree.isUnread &&
           isInactiveWorkspace(
             worktree.id,
             tabsByWorktree,

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -59,7 +59,10 @@ import {
   getPairedDeviceIdsByEnvironment,
   isWorkspaceFromOtherDevice
 } from '@/components/sidebar/workspace-creator-visibility'
-import { getLiveAgentStatusByWorktreeId, isInactiveWorkspace } from '@/lib/worktree-activity-state'
+import {
+  getLiveAgentStatusByWorktreeId,
+  isHiddenBySleepFilter
+} from '@/lib/worktree-activity-state'
 import { orderEmptyQueryWorktrees } from '@/lib/order-empty-query-worktrees'
 import {
   getOpenTabMatchRelevance,
@@ -933,13 +936,12 @@ function WorktreeJumpPaletteContent({
         // Keep a slept workspace listed while it has a pending notification so
         // the Hide-sleeping filter can't bury an unread agent completion.
         if (
-          !showSleepingWorkspaces &&
           // Why the exemption here too: Cmd+J re-implements the sidebar's
           // filter pass, so the shared predicate is what keeps them in step.
           !isSleepingSweepExemptWorkspace(worktree, alwaysShowDefaultBranchWorkspace) &&
-          !worktree.isUnread &&
-          isInactiveWorkspace(
-            worktree.id,
+          isHiddenBySleepFilter(
+            worktree,
+            showSleepingWorkspaces,
             tabsByWorktree,
             ptyIdsByTabId,
             browserTabsByWorktree,

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -30,7 +30,7 @@ import {
   isAutomationGeneratedWorkspace,
   isDefaultBranchWorkspace
 } from '@/components/sidebar/visible-worktrees'
-import { isInactiveWorkspace } from '@/lib/worktree-activity-state'
+import { isHiddenBySleepFilter } from '@/lib/worktree-activity-state'
 import { orderEmptyQueryWorktrees } from '@/lib/order-empty-query-worktrees'
 import StatusIndicator from '@/components/sidebar/StatusIndicator'
 import { cn } from '@/lib/utils'
@@ -454,9 +454,13 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         // Keep a slept workspace listed while it has a pending notification so
         // the Hide-sleeping filter can't bury an unread agent completion.
         if (
-          !showSleepingWorkspaces &&
-          !worktree.isUnread &&
-          isInactiveWorkspace(worktree.id, tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree)
+          isHiddenBySleepFilter(
+            worktree,
+            showSleepingWorkspaces,
+            tabsByWorktree,
+            ptyIdsByTabId,
+            browserTabsByWorktree
+          )
         ) {
           return false
         }

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -451,8 +451,11 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         if (hideAutomationGeneratedWorkspaces && isAutomationGeneratedWorkspace(worktree)) {
           return false
         }
+        // Keep a slept workspace listed while it has a pending notification so
+        // the Hide-sleeping filter can't bury an unread agent completion.
         if (
           !showSleepingWorkspaces &&
+          !worktree.isUnread &&
           isInactiveWorkspace(worktree.id, tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree)
         ) {
           return false

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -185,6 +185,50 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([])
   })
 
+  it('keeps an unread inactive worktree visible when show sleeping is off', () => {
+    const wt = { ...makeWorktree('wt-unread-sleeping'), isUnread: true }
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [wt] },
+      [wt.id],
+      visibleOptions({
+        showSleepingWorkspaces: false
+      })
+    )
+
+    expect(result).toEqual([wt.id])
+  })
+
+  it('hides only the read inactive worktree when show sleeping is off', () => {
+    const unread = { ...makeWorktree('wt-unread'), isUnread: true }
+    const read = makeWorktree('wt-read')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [unread, read] },
+      [unread.id, read.id],
+      visibleOptions({
+        showSleepingWorkspaces: false
+      })
+    )
+
+    expect(result).toEqual([unread.id])
+  })
+
+  it('shows both read and unread inactive worktrees when show sleeping is on', () => {
+    const unread = { ...makeWorktree('wt-unread'), isUnread: true }
+    const read = makeWorktree('wt-read')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [unread, read] },
+      [unread.id, read.id],
+      visibleOptions({
+        showSleepingWorkspaces: true
+      })
+    )
+
+    expect(result).toEqual([unread.id, read.id])
+  })
+
   it('hides automation-created workspaces when the automation filter is enabled', () => {
     const manual = makeWorktree('manual')
     const automationCreated = {

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -133,6 +133,50 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([])
   })
 
+  it('keeps an unread inactive worktree visible when show sleeping is off', () => {
+    const wt = { ...makeWorktree('wt-unread-sleeping'), isUnread: true }
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [wt] },
+      [wt.id],
+      visibleOptions({
+        showSleepingWorkspaces: false
+      })
+    )
+
+    expect(result).toEqual([wt.id])
+  })
+
+  it('hides only the read inactive worktree when show sleeping is off', () => {
+    const unread = { ...makeWorktree('wt-unread'), isUnread: true }
+    const read = makeWorktree('wt-read')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [unread, read] },
+      [unread.id, read.id],
+      visibleOptions({
+        showSleepingWorkspaces: false
+      })
+    )
+
+    expect(result).toEqual([unread.id])
+  })
+
+  it('shows both read and unread inactive worktrees when show sleeping is on', () => {
+    const unread = { ...makeWorktree('wt-unread'), isUnread: true }
+    const read = makeWorktree('wt-read')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [unread, read] },
+      [unread.id, read.id],
+      visibleOptions({
+        showSleepingWorkspaces: true
+      })
+    )
+
+    expect(result).toEqual([unread.id, read.id])
+  })
+
   it('hides automation-created workspaces when the automation filter is enabled', () => {
     const manual = makeWorktree('manual')
     const automationCreated = {

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -264,9 +264,12 @@ export function computeVisibleWorktreeIds(
   if (!opts.showSleepingWorkspaces) {
     // Why no !hideDefaultBranchWorkspace term: that filter already ran above, so
     // an explicit hide still wins over the exemption.
+    // Keep a slept workspace visible while it has a pending notification, so an
+    // unread agent completion isn't silently hidden by the Hide-sleeping filter.
     all = all.filter(
       (w) =>
         isSleepingSweepExemptWorkspace(w, opts.alwaysShowDefaultBranchWorkspace) ||
+        w.isUnread ||
         !isInactiveWorkspace(
           w.id,
           opts.tabsByWorktree,

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -3,7 +3,7 @@ import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
-import { getWorktreeIdsWithLiveAgent, isInactiveWorkspace } from '@/lib/worktree-activity-state'
+import { getWorktreeIdsWithLiveAgent, isHiddenBySleepFilter } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
 import {
   getAllWorktreesFromState,
@@ -269,9 +269,9 @@ export function computeVisibleWorktreeIds(
     all = all.filter(
       (w) =>
         isSleepingSweepExemptWorkspace(w, opts.alwaysShowDefaultBranchWorkspace) ||
-        w.isUnread ||
-        !isInactiveWorkspace(
-          w.id,
+        !isHiddenBySleepFilter(
+          w,
+          opts.showSleepingWorkspaces,
           opts.tabsByWorktree,
           opts.ptyIdsByTabId,
           opts.browserTabsByWorktree,

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -1,6 +1,6 @@
 import type { Worktree, Repo, TerminalTab, WorktreeLineage } from '../../../../shared/types'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
-import { isInactiveWorkspace } from '@/lib/worktree-activity-state'
+import { isHiddenBySleepFilter } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
 import { getAllWorktreesFromState, getRepoMapFromState } from '@/store/selectors'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
@@ -164,20 +164,18 @@ export function computeVisibleWorktreeIds(
     all = all.filter((w) => selectedRepoIds.has(w.repoId))
   }
 
-  if (!opts.showSleepingWorkspaces) {
-    // Keep a slept workspace visible while it has a pending notification, so an
-    // unread agent completion isn't silently hidden by the Hide-sleeping filter.
-    all = all.filter(
-      (w) =>
-        w.isUnread ||
-        !isInactiveWorkspace(
-          w.id,
-          opts.tabsByWorktree,
-          opts.ptyIdsByTabId,
-          opts.browserTabsByWorktree
-        )
-    )
-  }
+  // Keep a slept workspace visible while it has a pending notification, so an
+  // unread agent completion isn't buried by the Hide-sleeping filter.
+  all = all.filter(
+    (w) =>
+      !isHiddenBySleepFilter(
+        w,
+        opts.showSleepingWorkspaces,
+        opts.tabsByWorktree,
+        opts.ptyIdsByTabId,
+        opts.browserTabsByWorktree
+      )
+  )
 
   // Apply cached sort order. Items not yet in the cache (e.g. brand-new
   // worktrees before the next sortEpoch bump) are appended at the end.

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -165,8 +165,11 @@ export function computeVisibleWorktreeIds(
   }
 
   if (!opts.showSleepingWorkspaces) {
+    // Keep a slept workspace visible while it has a pending notification, so an
+    // unread agent completion isn't silently hidden by the Hide-sleeping filter.
     all = all.filter(
       (w) =>
+        w.isUnread ||
         !isInactiveWorkspace(
           w.id,
           opts.tabsByWorktree,

--- a/src/renderer/src/lib/worktree-activity-state.test.ts
+++ b/src/renderer/src/lib/worktree-activity-state.test.ts
@@ -3,12 +3,14 @@ import {
   getLiveAgentStatusByWorktreeId,
   getWorktreeIdsWithLiveAgent,
   hasActiveWorkspaceActivity,
+  isHiddenBySleepFilter,
   isInactiveWorkspace
 } from './worktree-activity-state'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 
 const NOW = 10_000_000
+const NO_LIVE_AGENTS = new Set<string>()
 
 function makeTab(id: string): Pick<TerminalTab, 'id'> {
   return { id }
@@ -222,5 +224,51 @@ describe('getWorktreeIdsWithLiveAgent', () => {
         ['wt-2', 'permission']
       ])
     )
+  })
+})
+
+describe('isHiddenBySleepFilter', () => {
+  it('hides an inactive, read workspace when the sleep filter is on', () => {
+    expect(
+      isHiddenBySleepFilter({ id: 'wt-1', isUnread: false }, false, {}, {}, {}, NO_LIVE_AGENTS)
+    ).toBe(true)
+  })
+
+  it('keeps an inactive workspace visible when it has a pending unread notification', () => {
+    expect(
+      isHiddenBySleepFilter({ id: 'wt-1', isUnread: true }, false, {}, {}, {}, NO_LIVE_AGENTS)
+    ).toBe(false)
+  })
+
+  it('keeps an active workspace (live pty) visible even when read', () => {
+    expect(
+      isHiddenBySleepFilter(
+        { id: 'wt-1', isUnread: false },
+        false,
+        { 'wt-1': [makeTab('tab-1')] },
+        { 'tab-1': ['pty-1'] },
+        {},
+        NO_LIVE_AGENTS
+      )
+    ).toBe(false)
+  })
+
+  it('keeps an active workspace (browser tab) visible even when read', () => {
+    expect(
+      isHiddenBySleepFilter(
+        { id: 'wt-1', isUnread: false },
+        false,
+        { 'wt-1': [makeTab('tab-1')] },
+        { 'tab-1': [] },
+        { 'wt-1': [{ id: 'browser-1' }] },
+        NO_LIVE_AGENTS
+      )
+    ).toBe(false)
+  })
+
+  it('never hides any workspace when the sleep filter is off', () => {
+    expect(
+      isHiddenBySleepFilter({ id: 'wt-1', isUnread: false }, true, {}, {}, {}, NO_LIVE_AGENTS)
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/lib/worktree-activity-state.test.ts
+++ b/src/renderer/src/lib/worktree-activity-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { hasActiveWorkspaceActivity, isInactiveWorkspace } from './worktree-activity-state'
+import {
+  hasActiveWorkspaceActivity,
+  isHiddenBySleepFilter,
+  isInactiveWorkspace
+} from './worktree-activity-state'
 import type { TerminalTab } from '../../../shared/types'
 
 function makeTab(id: string): Pick<TerminalTab, 'id'> {
@@ -62,5 +66,43 @@ describe('worktree activity state', () => {
         { 'wt-1': [{ id: 'browser-1' }] }
       )
     ).toBe(true)
+  })
+})
+
+describe('isHiddenBySleepFilter', () => {
+  it('hides an inactive, read workspace when the sleep filter is on', () => {
+    expect(isHiddenBySleepFilter({ id: 'wt-1', isUnread: false }, false, {}, {}, {})).toBe(true)
+  })
+
+  it('keeps an inactive workspace visible when it has a pending unread notification', () => {
+    expect(isHiddenBySleepFilter({ id: 'wt-1', isUnread: true }, false, {}, {}, {})).toBe(false)
+  })
+
+  it('keeps an active workspace (live pty) visible even when read', () => {
+    expect(
+      isHiddenBySleepFilter(
+        { id: 'wt-1', isUnread: false },
+        false,
+        { 'wt-1': [makeTab('tab-1')] },
+        { 'tab-1': ['pty-1'] },
+        {}
+      )
+    ).toBe(false)
+  })
+
+  it('keeps an active workspace (browser tab) visible even when read', () => {
+    expect(
+      isHiddenBySleepFilter(
+        { id: 'wt-1', isUnread: false },
+        false,
+        { 'wt-1': [makeTab('tab-1')] },
+        { 'tab-1': [] },
+        { 'wt-1': [{ id: 'browser-1' }] }
+      )
+    ).toBe(false)
+  })
+
+  it('never hides any workspace when the sleep filter is off', () => {
+    expect(isHiddenBySleepFilter({ id: 'wt-1', isUnread: false }, true, {}, {}, {})).toBe(false)
   })
 })

--- a/src/renderer/src/lib/worktree-activity-state.ts
+++ b/src/renderer/src/lib/worktree-activity-state.ts
@@ -91,3 +91,27 @@ export function isInactiveWorkspace(
     worktreeIdsWithLiveAgent
   )
 }
+
+/**
+ * Whether "Hide sleeping" hides this workspace. A slept workspace with a pending
+ * notification (isUnread) stays reachable so an agent completion isn't buried.
+ */
+export function isHiddenBySleepFilter(
+  worktree: { id: string; isUnread?: boolean },
+  showSleepingWorkspaces: boolean,
+  tabsByWorktree: TabsByWorktree | null | undefined,
+  ptyIdsByTabId: PtyIdsByTabId | null | undefined,
+  browserTabsByWorktree: BrowserTabsByWorktree | null | undefined,
+  worktreeIdsWithLiveAgent: ReadonlySet<string>
+): boolean {
+  if (showSleepingWorkspaces || worktree.isUnread) {
+    return false
+  }
+  return isInactiveWorkspace(
+    worktree.id,
+    tabsByWorktree,
+    ptyIdsByTabId,
+    browserTabsByWorktree,
+    worktreeIdsWithLiveAgent
+  )
+}

--- a/src/renderer/src/lib/worktree-activity-state.ts
+++ b/src/renderer/src/lib/worktree-activity-state.ts
@@ -34,3 +34,20 @@ export function isInactiveWorkspace(
     browserTabsByWorktree
   )
 }
+
+/**
+ * Whether "Hide sleeping" hides this workspace. A slept workspace with a pending
+ * notification (isUnread) stays reachable so an agent completion isn't buried.
+ */
+export function isHiddenBySleepFilter(
+  worktree: { id: string; isUnread?: boolean },
+  showSleepingWorkspaces: boolean,
+  tabsByWorktree: TabsByWorktree | null | undefined,
+  ptyIdsByTabId: PtyIdsByTabId | null | undefined,
+  browserTabsByWorktree: BrowserTabsByWorktree | null | undefined
+): boolean {
+  if (showSleepingWorkspaces || worktree.isUnread) {
+    return false
+  }
+  return isInactiveWorkspace(worktree.id, tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree)
+}


### PR DESCRIPTION
## Summary

With the **Hide sleeping** sidebar filter on, a workspace was hidden whenever it had no live PTY and no browser tab — activity was judged purely by live sessions (`isInactiveWorkspace`). But a slept/background agent can still finish its job and post a notification, which sets `worktree.isUnread`. That unread workspace stayed hidden, so the only way to find where the notification came from was to toggle **Hide sleeping** off, click through to read it, then toggle it back on.

This change treats a pending notification as a reason to keep the workspace reachable: when sleeping is hidden, a workspace is still shown if `worktree.isUnread` is true. Applied in both places that honor the filter — the sidebar list (`computeVisibleWorktreeIds`) and the worktree jump palette's empty-query list (Search) — via one shared predicate `isHiddenBySleepFilter`. Once the user opens the workspace, the existing `clearWorktreeUnread` path drops the flag and normal sleeping behavior resumes.

## Screenshots

No new visual styling. The change is a visibility/behavioral one: a slept workspace carrying an unread notification badge now remains in the sidebar workspace list and the Search palette instead of disappearing while **Hide sleeping** is on; it drops back out once opened (which marks it read).

## Testing

- [ ] `pnpm lint` — not run in full; `oxlint` + `oxlint --config config/oxlint-react-doctor.json` + `oxfmt` ran via lint-staged on the changed files and passed.
- [x] `pnpm typecheck` — clean (node + cli + web projects).
- [ ] `pnpm test` — full suite not run; ran the affected files: `visible-worktrees.test.ts` and `worktree-activity-state.test.ts` (51 tests pass).
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed.

Tests: `computeVisibleWorktreeIds` gained cases for unread-stays-visible / read-stays-hidden / show-all; the extracted `isHiddenBySleepFilter` gained a full truth-table suite (filter off, unread override, active-via-PTY, active-via-browser, inactive+read hidden). Teeth-verified: removing the `|| worktree.isUnread` short-circuit reddens the unread cases; removing the `showSleepingWorkspaces ||` short-circuit reddens the filter-off case.

## AI Review Report

Reviewed the change with an AI coding agent. Focus areas and findings:
- **Root cause, not symptom**: confirmed the filter fed only `worktree.id` to `isInactiveWorkspace` (live-session check) and never consulted `isUnread`, while `markWorktreeUnread` sets `isUnread`/`lastActivityAt` but no activity signal — so a slept workspace's notification could never lift the filter. Fix targets that gap directly.
- **Callsite parity**: verified both filter sites (sidebar + jump palette) now route through the single `isHiddenBySleepFilter` predicate, eliminating the drift risk flagged in review; `isInactiveWorkspace` remains the pure live-activity check with no behavior change to its other semantics.
- **Cross-platform (macOS / Linux / Windows)**: the change is pure in-memory TypeScript filter logic in the renderer. It touches no keyboard shortcuts, UI shortcut labels, filesystem paths, shell invocation, or Electron main/IPC/platform APIs, so there is no OS-specific behavior to gate. SSH/remote workspaces are unaffected — visibility is derived from the same worktree metadata regardless of execution host.

## Security Audit

No new attack surface. The change adds a boolean predicate over already-in-memory worktree state (`isUnread`, tab/pty/browser maps). No input parsing, no command execution, no path handling, no auth/secrets, no IPC or network calls, and no new dependencies. Nothing to follow up.

## Notes

- Behavioral, non-visual change; no styling added.
- The jump palette memo already depends on `allWorktrees`, whose reference changes when `isUnread` flips, so it recomputes without a new dependency.
- Follow-up: none required. Opening a surfaced workspace clears the unread flag through the existing path, so it does not linger in the list.

## ELI5

With “Hide sleeping” on, unread slept workspaces disappeared after an agent finished. Unread workspaces stay visible so you can find the notification’s source.
