### PR TITLE
Fix worktree removal blocked by populated submodules (local and SSH paths)

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -272,6 +272,117 @@ branch refs/heads/main
     expect(getGitCalls()).toContain('git worktree remove --force /repo-feature')
   })
 
+  it('retries with --force after re-verifying cleanliness when only a populated submodule blocks removal', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree remove /repo-feature': {
+        error: new Error('fatal: working trees containing submodules cannot be moved or removed')
+      },
+      'git status --porcelain --untracked-files=all --ignore-submodules=none': {
+        stdout: ''
+      },
+      'git worktree remove --force /repo-feature': {
+        stdout: ''
+      }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
+
+    expect(getGitCalls()).toEqual([
+      'git worktree list --porcelain -z',
+      'git worktree remove /repo-feature',
+      'git status --porcelain --untracked-files=all --ignore-submodules=none',
+      'git worktree remove --force /repo-feature',
+      'git branch -d -- feature/test'
+    ])
+  })
+
+  it('does not auto-force when the submodule-blocked worktree is also dirty', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree remove /repo-feature': {
+        error: new Error('fatal: working trees containing submodules cannot be moved or removed')
+      },
+      'git status --porcelain --untracked-files=all --ignore-submodules=none': {
+        stdout: '?? scratch.txt\n'
+      }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature')).rejects.toMatchObject({
+      message: 'Worktree has uncommitted or untracked changes.',
+      stdout: '?? scratch.txt\n'
+    })
+
+    const calls = getGitCalls()
+    expect(calls).toEqual([
+      'git worktree list --porcelain -z',
+      'git worktree remove /repo-feature',
+      'git status --porcelain --untracked-files=all --ignore-submodules=none'
+    ])
+    expect(calls).not.toContain('git worktree remove --force /repo-feature')
+    expect(calls).not.toContain('git branch -d -- feature/test')
+  })
+
+  it('still runs branch cleanup after an auto-force submodule retry, preserving an unmerged branch', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree remove /repo-feature': {
+        error: new Error('fatal: working trees containing submodules cannot be moved or removed')
+      },
+      'git status --porcelain --untracked-files=all --ignore-submodules=none': {
+        stdout: ''
+      },
+      'git worktree remove --force /repo-feature': {
+        stdout: ''
+      },
+      'git branch -d -- feature/test': {
+        error: new Error('branch delete failed'),
+        stderr: 'error: the branch feature/test is not fully merged'
+      }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({
+      preservedBranch: { branchName: 'feature/test', head: 'def456' }
+    })
+
+    const calls = getGitCalls()
+    expect(calls).toContain('git worktree remove --force /repo-feature')
+    expect(calls).toContain('git branch -d -- feature/test')
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[git] Preserved local branch "feature/test" after removing worktree (not fully merged)',
+      expect.any(Error)
+    )
+    warnSpy.mockRestore()
+  })
+
   it('matches Windows worktree paths before deleting the branch', async () => {
     mockGitCommands({
       'git worktree list --porcelain': {
@@ -719,6 +830,28 @@ describe('assertWorktreeCleanForRemoval', () => {
     gitExecFileAsyncMock.mockRejectedValueOnce(error)
 
     await expect(assertWorktreeCleanForRemoval('/repo-feature')).rejects.toBe(error)
+  })
+
+  it('does not add --ignore-submodules when no statusOptions are given (default preflight unchanged)', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await assertWorktreeCleanForRemoval('/repo-feature')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['status', '--porcelain', '--untracked-files=all'],
+      { cwd: '/repo-feature' }
+    )
+  })
+
+  it('appends --ignore-submodules=none when the stricter re-assert is requested', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await assertWorktreeCleanForRemoval('/repo-feature', false, {}, { ignoreSubmodules: 'none' })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['status', '--porcelain', '--untracked-files=all', '--ignore-submodules=none'],
+      { cwd: '/repo-feature' }
+    )
   })
 })
 

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1019,9 +1019,11 @@ export async function removeWorktree(
     // cleanliness ourselves with the stricter `--ignore-submodules=none`
     // status check (which config like submodule.*.ignore or
     // diff.ignoreSubmodules cannot defeat) before retrying with --force, so
-    // this auto-recovery can never discard uncommitted or untracked work —
-    // it only routes around git's blanket submodule refusal for a worktree
-    // we independently re-confirmed is clean immediately beforehand.
+    // this auto-recovery does not discard uncommitted or untracked work that
+    // exists at check time — it only routes around git's blanket submodule
+    // refusal for a worktree we independently re-confirmed clean immediately
+    // beforehand. A concurrent write in the narrow window between that check
+    // and the forced removal is the only residual, as with any check-then-act.
     console.debug(
       `[git] worktree remove blocked only by populated submodules; re-verifying cleanliness before retrying with --force: ${worktreePath}`
     )

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -121,6 +121,24 @@ function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
   )
 }
 
+// Why: unlike getErrorText (message + stderr only, shared by the classifiers
+// above), this also checks stdout — git can emit this fatal there depending
+// on how the caller's exec wrapper buckets streams — so it is a standalone
+// check rather than a getErrorText-based one.
+function isSubmoduleWorktreeRemovalError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+  const parts: string[] = []
+  for (const key of ['message', 'stderr', 'stdout'] as const) {
+    const value = (error as Record<string, unknown>)[key]
+    if (typeof value === 'string') {
+      parts.push(value)
+    }
+  }
+  return /working trees? containing submodules cannot be moved or removed/i.test(parts.join('\n'))
+}
+
 function normalizeLocalBranchRef(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
@@ -982,7 +1000,37 @@ export async function removeWorktree(
     args.push('--force')
   }
   args.push(worktreePath)
-  await gitExecFileAsync(args, gitExecOptions(repoPath, options))
+  try {
+    await gitExecFileAsync(args, {
+      ...gitExecOptions(repoPath, options),
+      // Why: git localizes this fatal via gettext, and the classifier below
+      // matches its English text. Pin the locale for just this invocation so
+      // a non-English LC_ALL/LC_MESSAGES on the host cannot silently defeat
+      // the match and skip the recovery below.
+      env: { ...process.env, LC_ALL: 'C', LC_MESSAGES: 'C' }
+    })
+  } catch (error) {
+    if (force || !isSubmoduleWorktreeRemovalError(error)) {
+      throw error
+    }
+    // Why: `git worktree remove` (builtin/worktree.c) refuses removal outright
+    // when the worktree has ANY populated submodule, even if it is otherwise
+    // clean — only `--force` bypasses that hardcoded check. Re-verify
+    // cleanliness ourselves with the stricter `--ignore-submodules=none`
+    // status check (which config like submodule.*.ignore or
+    // diff.ignoreSubmodules cannot defeat) before retrying with --force, so
+    // this auto-recovery can never discard uncommitted or untracked work —
+    // it only routes around git's blanket submodule refusal for a worktree
+    // we independently re-confirmed is clean immediately beforehand.
+    console.debug(
+      `[git] worktree remove blocked only by populated submodules; re-verifying cleanliness before retrying with --force: ${worktreePath}`
+    )
+    await assertWorktreeCleanForRemoval(worktreePath, false, options, { ignoreSubmodules: 'none' })
+    await gitExecFileAsync(
+      ['worktree', 'remove', '--force', worktreePath],
+      gitExecOptions(repoPath, options)
+    )
+  }
 
   if (!branchName) {
     return {}
@@ -1173,13 +1221,24 @@ async function isLocalBranchCheckedOut(
 export async function assertWorktreeCleanForRemoval(
   worktreePath: string,
   force = false,
-  options: GitWorktreeExecOptions = {}
+  options: GitWorktreeExecOptions = {},
+  // Why: the default (no ignoreSubmodules) preflight can be defeated by
+  // submodule.*.ignore / diff.ignoreSubmodules config reporting a dirty
+  // submodule as clean. The auto-force retry in removeWorktree opts into the
+  // stricter `--ignore-submodules=none` re-assert immediately before forcing,
+  // since that path is about to bypass git's own safety check entirely.
+  statusOptions: { ignoreSubmodules?: 'none' } = {}
 ): Promise<void> {
   if (force) {
     return
   }
 
-  const { stdout } = await gitExecFileAsync(['status', '--porcelain', '--untracked-files=all'], {
+  const statusArgs = ['status', '--porcelain', '--untracked-files=all']
+  if (statusOptions.ignoreSubmodules) {
+    statusArgs.push(`--ignore-submodules=${statusOptions.ignoreSubmodules}`)
+  }
+
+  const { stdout } = await gitExecFileAsync(statusArgs, {
     ...gitExecOptions(worktreePath, options)
   })
   if (!stdout.trim()) {

--- a/src/relay/git-handler-worktree-remove-populated-submodules.test.ts
+++ b/src/relay/git-handler-worktree-remove-populated-submodules.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as path from 'node:path'
+import type { GitExec } from './git-handler-ops'
+import { removeWorktreeOp } from './git-handler-worktree-ops'
+
+const SUBMODULE_FATAL = 'fatal: working trees containing submodules cannot be moved or removed'
+
+function worktreeList(...entries: { path: string; branch?: string }[]): string {
+  return entries
+    .map((entry, index) =>
+      [
+        `worktree ${entry.path}`,
+        `HEAD ${index}`,
+        ...(entry.branch ? [`branch refs/heads/${entry.branch}`] : [])
+      ].join('\n')
+    )
+    .join('\n\n')
+}
+
+function resolvedRepoPath(): string {
+  return path.posix.resolve('/repo-feature', '/repo/.git', '..')
+}
+
+function commandText(args: string[], cwd: string): string {
+  return `${cwd}$ ${args.join(' ')}`
+}
+
+describe('removeWorktreeOp populated submodule retry', () => {
+  it('retries with force after a strict clean status check when populated submodules block removal', async () => {
+    const calls: string[] = []
+    const git = vi.fn<GitExec>(async (args, cwd) => {
+      calls.push(commandText(args, cwd))
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove' && !args.includes('--force')) {
+        throw new Error(SUBMODULE_FATAL)
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await removeWorktreeOp(git, { worktreePath: '/repo-feature', deleteBranch: false })
+
+    expect(calls).toEqual([
+      '/repo-feature$ rev-parse --git-common-dir',
+      `${resolvedRepoPath()}$ worktree list --porcelain -z`,
+      `${resolvedRepoPath()}$ worktree remove /repo-feature`,
+      '/repo-feature$ status --porcelain --untracked-files=all --ignore-submodules=none',
+      `${resolvedRepoPath()}$ worktree remove --force /repo-feature`
+    ])
+  })
+
+  it('does not force retry when strict status shows hidden dirty submodule content', async () => {
+    const removalError = new Error(SUBMODULE_FATAL)
+    const calls: string[] = []
+    const git = vi.fn<GitExec>(async (args, cwd) => {
+      calls.push(commandText(args, cwd))
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList({ path: '/repo-feature', branch: 'feature/test' }),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove') {
+        throw removalError
+      }
+      if (args[0] === 'status') {
+        return { stdout: ' m submodule\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(removeWorktreeOp(git, { worktreePath: '/repo-feature' })).rejects.toBe(
+      removalError
+    )
+
+    expect(calls).toEqual([
+      '/repo-feature$ rev-parse --git-common-dir',
+      `${resolvedRepoPath()}$ worktree list --porcelain -z`,
+      `${resolvedRepoPath()}$ worktree remove /repo-feature`,
+      '/repo-feature$ status --porcelain --untracked-files=all --ignore-submodules=none'
+    ])
+    expect(calls).not.toContain(`${resolvedRepoPath()}$ worktree remove --force /repo-feature`)
+  })
+
+  it('rethrows unrelated remove errors without status check or force retry', async () => {
+    const unrelatedError = new Error('fatal: /repo-feature is a main working tree')
+    const calls: string[] = []
+    const git = vi.fn<GitExec>(async (args, cwd) => {
+      calls.push(commandText(args, cwd))
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList({ path: '/repo-feature', branch: 'feature/test' }),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove') {
+        throw unrelatedError
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(removeWorktreeOp(git, { worktreePath: '/repo-feature' })).rejects.toBe(
+      unrelatedError
+    )
+
+    expect(calls).toEqual([
+      '/repo-feature$ rev-parse --git-common-dir',
+      `${resolvedRepoPath()}$ worktree list --porcelain -z`,
+      `${resolvedRepoPath()}$ worktree remove /repo-feature`
+    ])
+  })
+
+  it('continues into branch cleanup after the populated submodule force retry succeeds', async () => {
+    const calls: string[] = []
+    const git = vi.fn<GitExec>(async (args, cwd) => {
+      calls.push(commandText(args, cwd))
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove' && !args.includes('--force')) {
+        throw new Error(SUBMODULE_FATAL)
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await removeWorktreeOp(git, { worktreePath: '/repo-feature' })
+
+    expect(calls).toEqual([
+      '/repo-feature$ rev-parse --git-common-dir',
+      `${resolvedRepoPath()}$ worktree list --porcelain -z`,
+      `${resolvedRepoPath()}$ worktree remove /repo-feature`,
+      '/repo-feature$ status --porcelain --untracked-files=all --ignore-submodules=none',
+      `${resolvedRepoPath()}$ worktree remove --force /repo-feature`,
+      `${resolvedRepoPath()}$ branch -d -- feature/test`
+    ])
+  })
+})

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -33,6 +33,23 @@ function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
   )
 }
 
+function isSubmoduleWorktreeRemovalError(error: unknown): boolean {
+  return /working trees? containing submodules cannot be moved or removed/i.test(
+    getErrorText(error)
+  )
+}
+
+async function isRelayWorktreeCleanIgnoringSubmodules(
+  git: GitExec,
+  worktreePath: string
+): Promise<boolean> {
+  const { stdout } = await git(
+    ['status', '--porcelain', '--untracked-files=all', '--ignore-submodules=none'],
+    worktreePath
+  )
+  return stdout.trim().length === 0
+}
+
 function normalizeLocalBranchRef(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
@@ -178,7 +195,22 @@ export async function removeWorktreeOp(
     args.push('--force')
   }
   args.push(worktreePath)
-  await git(args, repoPath)
+  try {
+    await git(args, repoPath)
+  } catch (error) {
+    // Why: `git worktree remove` refuses a worktree with ANY populated
+    // submodule even when clean; only --force bypasses that specific check.
+    // Re-check with --ignore-submodules=none so auto-force never discards work.
+    // Relay GitExec has no env option, so this fatal-text match depends on the
+    // SSH host locale; the renderer's force-retry classifier is the fallback.
+    if (force || !isSubmoduleWorktreeRemovalError(error)) {
+      throw error
+    }
+    if (!(await isRelayWorktreeCleanIgnoringSubmodules(git, worktreePath))) {
+      throw error
+    }
+    await git(['worktree', 'remove', '--force', worktreePath], repoPath)
+  }
 
   if (!branchName) {
     return {}

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -200,7 +200,9 @@ export async function removeWorktreeOp(
   } catch (error) {
     // Why: `git worktree remove` refuses a worktree with ANY populated
     // submodule even when clean; only --force bypasses that specific check.
-    // Re-check with --ignore-submodules=none so auto-force never discards work.
+    // Re-check with --ignore-submodules=none so auto-force does not discard
+    // work present at check time (a concurrent write before the forced remove
+    // is the only residual, as with any check-then-act removal).
     // Relay GitExec has no env option, so this fatal-text match depends on the
     // SSH host locale; the renderer's force-retry classifier is the fallback.
     if (force || !isSubmoduleWorktreeRemovalError(error)) {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -4083,6 +4083,29 @@ describe('worktree remote runtime mutations', () => {
     expect(store.getState().worktreesByRepo['repo-ssh']).toEqual([])
   })
 
+  it('flags a populated-submodule removal failure as force-retryable', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    mockApi.worktrees.remove.mockRejectedValueOnce(
+      new Error('fatal: working trees containing submodules cannot be moved or removed')
+    )
+    store.setState({
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    const result = await store.getState().removeWorktree(wt.id)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'fatal: working trees containing submodules cannot be moved or removed'
+    })
+    expect(store.getState().deleteStateByWorktreeId[wt.id]).toEqual({
+      isDeleting: false,
+      error: 'fatal: working trees containing submodules cannot be moved or removed',
+      canForceDelete: true
+    })
+  })
+
   it('persists worktree metadata through the active remote runtime environment', async () => {
     const store = createTestStore()
     const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -293,6 +293,14 @@ const FORCE_RETRYABLE_WORKTREE_REMOVAL_MESSAGES = [
 const FORMATTED_DIRTY_WORKTREE_REMOVAL_PATTERN =
   /Failed to delete worktree at [^\n]*\.\s*(?:(?:[MADRCUT][ MADRCUT]| [MADRCUT]|\?\?)\s+\S)/
 
+// Why: git's own worktree-remove refusal for a populated submodule (raw,
+// unformatted fatal — e.g. surfaced through a path that does not go through
+// the local auto-force recovery, such as the SSH/relay provider) is also
+// safe to retry with force: it fires even on an otherwise-clean worktree, so
+// force here does not risk discarding uncommitted work.
+const SUBMODULE_WORKTREE_REMOVAL_PATTERN =
+  /working trees? containing submodules cannot be moved or removed/i
+
 function canRetryWorktreeRemovalWithForce(error: string, force: boolean | undefined): boolean {
   if (force) {
     return false
@@ -301,7 +309,8 @@ function canRetryWorktreeRemovalWithForce(error: string, force: boolean | undefi
   // retry with user confirmation; transport/provider errors need recovery first.
   return (
     FORCE_RETRYABLE_WORKTREE_REMOVAL_MESSAGES.some((message) => error.includes(message)) ||
-    FORMATTED_DIRTY_WORKTREE_REMOVAL_PATTERN.test(error)
+    FORMATTED_DIRTY_WORKTREE_REMOVAL_PATTERN.test(error) ||
+    SUBMODULE_WORKTREE_REMOVAL_PATTERN.test(error)
   )
 }
 


### PR DESCRIPTION
## Summary

Deleting an Orca worktree of a repository that contains **populated** (initialized) git submodules fails outright, because `git worktree remove` refuses without `--force`. This PR makes worktree removal auto-recover from that specific refusal on **both** the local and the relay/SSH-host code paths, and surfaces the existing "Force Delete" retry affordance for the same error in the UI.

## Why

`git worktree remove <path>` refuses with `fatal: working trees containing submodules cannot be moved or removed` whenever the worktree contains any populated submodule — even when the worktree is otherwise clean. Orca invokes this command without `--force` by default, so removal fails outright:

```
Error invoking remote method 'worktrees:remove': Error: Failed to delete worktree at <path>.
fatal: working trees containing submodules cannot be moved or removed
```

Submodule-containing worktrees are common (any repo that vendors dependencies as submodules), so deletion must work.

**Root cause:** `git worktree remove` runs `check_clean_worktree()` → `validate_no_submodules()` only when `force == 0` (`builtin/worktree.c`). A single `--force` bypasses **only** the submodule guard (unlike `git worktree move`, where `--force` does not). Orca always invokes the non-force form by default, so any populated submodule blocks removal regardless of cleanliness.

## What

Three code paths changed:

1. **Local** (`src/main/git/worktree.ts`) — `removeWorktree()` gains a try/catch auto-force recovery; `assertWorktreeCleanForRemoval()` gains an optional stricter `--ignore-submodules=none` status check. The matched invocation pins `LC_ALL=C`/`LC_MESSAGES=C` because git localizes the fatal via gettext.
2. **Relay / SSH host** (`src/relay/git-handler-worktree-remove.ts`) — `removeWorktreeOp()` gains the same auto-force recovery so SSH/remote worktree removal behaves identically to local (satisfies the "must work against local repositories, remote servers, and SSH worktrees" requirement).
3. **Renderer** (`src/renderer/src/store/slices/worktrees.ts`) — the raw submodule fatal is added to `FORCE_RETRYABLE_WORKTREE_REMOVAL_MESSAGES`, so the "Force Delete" retry button appears for this error (defense-in-depth, and the manual path for the relay locale-miss case in R2).

New tests: `src/relay/git-handler-worktree-remove-populated-submodules.test.ts`, plus additions to `src/main/git/remove-worktree.test.ts` and `src/renderer/src/store/slices/worktrees.test.ts`.

## How

On the initial non-force `git worktree remove` failure, if the error is the submodule-refusal fatal and the worktree is independently re-verified clean, retry once with `--force`. The re-verification uses `git status --porcelain --untracked-files=all --ignore-submodules=none`, whose command-line `--ignore-submodules=none` overrides `submodule.*.ignore` / `diff.ignoreSubmodules` config — so the auto-force path does not discard uncommitted or untracked work that exists at check time. It only routes around git's blanket submodule refusal for a worktree confirmed clean immediately beforehand. If the re-check finds the worktree dirty, the original error is rethrown rather than forcing (covered by a dedicated data-loss-guard test).

The relay executor (`GitExec`) has no `env` option, so the locale cannot be pinned there; the relay fatal-text match is therefore locale-dependent on the SSH host, with the renderer force-retry classifier as the fallback (see Residual risk R2).

## Screenshots

No new UI. The only user-visible change: the common case now succeeds without any prompt, and the existing "Force Delete" retry affordance appears for the submodule-refusal error (previously it matched no retryable pattern).

## Test plan

- [x] `pnpm typecheck` — exit 0 (all three projects: `tsconfig.node.json`, `tsconfig.tc.cli.json`, `tsconfig.tc.web.json`).
- [x] `pnpm exec oxlint` on all changed files — exit 0, no warnings.
- [x] `pnpm test` (full vitest suite) — **22,349 passed**, 27 skipped. 108 failures across 34 suites are **pre-existing and environment-driven**, all in suites that do **not** import any file changed here (keychain/`runtime-auth-service` fail with `Unexpected Claude config dir` on a multi-profile dev box; `browser-cookie-import`, `pty-subprocess`/`local-pty-provider`, `orca-runtime-browser` screencast, `remote-runtime-client` socket). Every git / worktree / relay / renderer-worktrees suite passes, including the added tests.
- [x] Added high-quality tests — relay: force retry after strict clean check; **no** retry when a hidden dirty submodule is present (data-loss guard); unrelated-error passthrough; fall-through into branch cleanup.
- [ ] `pnpm lint` — exit 1 **only** from a pre-existing `verify:localization-catalog` error (`WorktreeList.tsx:2620` references key `auto.components.sidebar.WorktreeList.failedUnnestWorkspace`, absent from `en.json` on clean `origin/main`; unrelated to this PR — none of the 6 changed files touch `WorktreeList.tsx` or `en.json`). The oxlint stage passes; the localization-catalog check fails identically on `origin/main`.
- [ ] `pnpm build` — full native/electron build not run locally (heavy, requires the native toolchain); deferred to CI. Local proxy `pnpm typecheck` (all three projects) is green; changes are limited to TypeScript in `src/main`, `src/relay`, `src/renderer` with no new deps.

## AI Review Report

Independent review (Codex, gpt-5.5) of `origin/main..HEAD`. Verdict: **APPROVE-WITH-NITS, no MUST-FIX**.

- **Cross-platform (macOS / Linux / Windows):** PASS. Command construction uses argv arrays and existing cwd/path handling; no new hardcoded separators or shell syntax. Local locale pin preserves `process.env` and existing WSL/abort options.
- **SSH / remote / local compatibility:** PASS with a documented gap. The relay path now mirrors local behavior (strict status re-check, then `--force`). Gap: the relay cannot pin locale, so non-English SSH hosts may miss the auto-recovery and fall back to the renderer force-retry UX (R2).
- **Supported agents & integrations:** PASS. No provider-specific assumptions; plain git worktree behavior.
- **Performance:** PASS. Adds at most one `git status` and one retry, only on the narrow submodule-fatal path. No hot-path/polling impact.
- **UI quality:** PASS. The renderer classifier is narrow — it only makes the raw submodule fatal force-retryable and does not broaden generic force-retry behavior.
- **Security:** PASS. Commands are argv arrays, not shell strings; worktree paths are passed as argv/cwd values. No command injection introduced.
- Nit (addressed): the "never discard work" comments were softened to note the residual TOCTOU window between the status check and the forced removal.

## Security Audit

- **Input handling:** the worktree path is caller-supplied and passed as an argv element / cwd value, never interpolated into a shell string.
- **Command execution:** only git subcommands via the existing `execFile`/`GitExec` executors (no shell); the added calls are `git status …` and `git worktree remove --force <path>`.
- **Path handling:** unchanged; reuses existing relay POSIX/Windows path resolution and the local exec options.
- **Auth / secrets:** none touched; the local locale-pin call spreads `process.env` without adding or logging credentials.
- **Dependencies:** none added.
- **IPC risks:** no new IPC surface; the change is inside existing `worktrees:remove` / relay `removeWorktreeOp` handlers.
- **Data-loss:** the force retry is gated on an independent `--ignore-submodules=none` cleanliness re-check that config cannot defeat; a hidden dirty submodule causes the original error to be rethrown rather than a forced removal (covered by a dedicated test).

## Residual risks

- **R1** — the auto-force re-check trusts a `git status --ignore-submodules=none` snapshot taken immediately before the forced removal; a concurrent write into a nested submodule in that narrow window is the residual (same shape as any check-then-act removal).
- **R2** — the fatal-text classifier matches git's English message. The local path pins `LC_ALL=C` to defeat gettext localization; the relay path cannot (its `GitExec` has no `env` option), so on a non-English SSH host the relay auto-recovery may not fire — the manual "Force Delete" classifier is the fallback. A future `GitExec` env passthrough would let the relay pin the locale like the local path.

X handle: @soichisumi

## ELI5

Deleting a worktree with populated submodules failed on local and SSH. Orca recovers from that git refusal and offers Force Delete when needed.
