### PR TITLE
Keep the wake hint when hibernating a completed agent

### DIFF
--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -3064,6 +3064,58 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(store.getState().lastKnownRelayPtyIdByTabId['tab-1']).toBeUndefined()
   })
 
+  it('preserves the wake hint so a hibernated sole completed-agent tab stays cold-restorable', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex', ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: targetLeaf },
+          activeLeafId: targetLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-agent'] }
+    })
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'resume target', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'target-session' } }
+      )
+
+    await store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+      paneKey: targetPaneKey,
+      tabId: 'tab-1',
+      leafId: targetLeaf,
+      ptyId: 'pty-agent'
+    })
+
+    // Worktree is now sleeping: the sole pane's live PTY is gone.
+    expect(store.getState().ptyIdsByTabId['tab-1']).toEqual([])
+    // Core of the fix: the hibernated session id survives as the tab's wake hint
+    // (mirroring manual worktree-sleep) instead of being nulled to orphan the tab.
+    expect(store.getState().tabsByWorktree[wt]?.[0]?.ptyId).toBe('pty-agent')
+    // Because the wake hint survived, the tab is not an orphan, so reactivation
+    // cold-restores the finished transcript instead of dropping to a blank
+    // terminal. A null wake hint would make reconcile report 0 renderable tabs.
+    expect(store.getState().reconcileWorktreeTabModel(wt).renderableTabCount).toBe(1)
+  })
+
   it('does not retain stale completion evidence when pane status changes during hibernation', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/store-sleep-pane-hibernation.test.ts
+++ b/src/renderer/src/store/slices/store-sleep-pane-hibernation.test.ts
@@ -519,6 +519,58 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(mockApi.pty.kill).not.toHaveBeenCalled()
   })
 
+  it('preserves the wake hint so a hibernated sole completed-agent tab stays cold-restorable', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex', ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: targetLeaf },
+          activeLeafId: targetLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-agent'] }
+    })
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'resume target', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'target-session' } }
+      )
+
+    await store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+      paneKey: targetPaneKey,
+      tabId: 'tab-1',
+      leafId: targetLeaf,
+      ptyId: 'pty-agent'
+    })
+
+    // Worktree is now sleeping: the sole pane's live PTY is gone.
+    expect(store.getState().ptyIdsByTabId['tab-1']).toEqual([])
+    // Core of the fix: the hibernated session id survives as the tab's wake hint
+    // (mirroring manual worktree-sleep) instead of being nulled to orphan the tab.
+    expect(store.getState().tabsByWorktree[wt]?.[0]?.ptyId).toBe('pty-agent')
+    // Because the wake hint survived, the tab is not an orphan, so reactivation
+    // cold-restores the finished transcript instead of dropping to a blank
+    // terminal. A null wake hint would make reconcile report 0 renderable tabs.
+    expect(store.getState().reconcileWorktreeTabModel(wt).renderableTabCount).toBe(1)
+  })
+
   it('clears stale relay wake hints when pane hibernation leaves no live PTYs in the tab', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2795,7 +2795,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         const nextTabs = [...tabs]
         nextTabs[tabIndex] = {
           ...nextTabs[tabIndex],
-          ptyId: remainingPtyIds.at(-1) ?? null
+          // Why: a completed agent hibernated as the tab's sole pane must keep
+          // its session id as the wake hint (like manual worktree-sleep does),
+          // not null. Nulling it orphans the tab, so reactivation deletes the
+          // layout wake-hint and cold-restores nothing — a blank terminal
+          // instead of the finished transcript. Multi-pane tabs still fall back
+          // to the last surviving live pty.
+          ptyId: remainingPtyIds.at(-1) ?? opts.ptyId
         }
         nextTabsByWorktree[worktreeId] = nextTabs
       }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1929,7 +1929,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         const nextTabs = [...tabs]
         nextTabs[tabIndex] = {
           ...nextTabs[tabIndex],
-          ptyId: remainingPtyIds.at(-1) ?? null
+          // Why: a completed agent hibernated as the tab's sole pane must keep
+          // its session id as the wake hint (like manual worktree-sleep does),
+          // not null. Nulling it orphans the tab, so reactivation deletes the
+          // layout wake-hint and cold-restores nothing — a blank terminal
+          // instead of the finished transcript. Multi-pane tabs still fall back
+          // to the last surviving live pty.
+          ptyId: remainingPtyIds.at(-1) ?? opts.ptyId
         }
         nextTabsByWorktree[worktreeId] = nextTabs
       }


### PR DESCRIPTION
## Summary

Reactivating a slept worktree whose agent had **finished** (a completed/`done` agent) opened a **blank terminal** instead of showing the finished transcript.

Root cause: when the auto-hibernation coordinator sleeps a completed agent that is the sole pane in its tab, `shutdownCompletedAgentPaneForHibernation` recomputed the tab's wake hint as `remainingPtyIds.at(-1) ?? null`. With no live PTYs left, that is `null`. A null wake hint (`tab.ptyId`) makes the tab an **orphan** (`getOrphanTerminalIds`), so on reactivation `reconcileWorktreeTabModel` drops it (`renderableTabCount` → 0) and its layout — including the daemon-session pointer needed for cold-restore — is deleted. Because a completed agent is intentionally *passive* (never relaunched via `--resume`), there is nothing left to display, so `ensureWorktreeHasInitialTerminal` mints a fresh blank terminal.

Manual worktree-sleep never hits this: it preserves `tab.ptyId`, which is why ordinary sleep → wake restores fine. A *working* (non-done) hibernated agent also escapes it because it relaunches into a brand-new tab.

The daemon still holds the scrollback on disk (`keepHistory` + the existing alt-screen cold-restore fix) — only the renderer's pointer to it was being discarded.

## Fix

Preserve the hibernated session id as the wake hint (`?? opts.ptyId`), mirroring what manual worktree-sleep already does. The tab stays non-orphaned and cold-restores the completed transcript on reactivation. Multi-pane tabs are unchanged — they still fall back to the last surviving live PTY. Behavior stays "evidence only": the completed agent is shown, not relaunched.

## Screenshots

No new visual styling. Behavioral: reactivating a slept worktree whose sole agent had completed now shows the finished transcript (cold-restore) instead of a blank shell.

## Testing

- [ ] `pnpm lint` — not run in full; `oxlint` + react-doctor + `oxfmt` ran via lint-staged on the changed files and passed.
- [x] `pnpm typecheck` — web project clean.
- [ ] `pnpm test` — full suite not run; ran the affected file `store-cascades.test.ts` (106 tests pass, incl. the new regression).
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed.

New regression test in `store-cascades.test.ts`: hibernating the sole completed-agent pane preserves `tab.ptyId` (the wake hint) and keeps `reconcileWorktreeTabModel(...).renderableTabCount === 1`. Teeth-verified: reverting the fix to `?? null` reddens both the wake-hint and renderability assertions (tab.ptyId null → orphaned → renderableTabCount 0).

## AI Review Report

Traced the sleep→hibernate→reactivate path end to end. Findings:
- Confirmed root cause (null wake hint → orphan → layout deletion → passive completed record not relaunched → blank), and that the daemon-side history survives, so the defect is purely the renderer discarding the pointer.
- Verified the fix mirrors the proven manual-worktree-sleep invariant (`tab.ptyId` preserved as wake hint) and does not alter the multi-pane path (`remainingPtyIds.at(-1)` still wins when live panes remain).
- Confirmed `tab.ptyId` is a wake-hint, not a liveness signal — liveness reads `ptyIdsByTabId` (still `[]` after hibernation), so the worktree remains correctly classified as sleeping/inactive.
- Cross-platform (macOS / Linux / Windows): pure in-memory store logic, no shortcuts, paths, shell, or Electron platform APIs touched. SSH/remote: the captured scrollback buffer (`buffersByLeafId`, already captured for SSH) plus a preserved non-null wake hint keeps the tab renderable there too; the existing relay-hint cleanup test still passes.

## Security Audit

No new surface. The change alters one in-memory field (`tab.ptyId`) during hibernation. No input parsing, command execution, path handling, auth/secrets, IPC, or dependency changes. Nothing to follow up.

## Notes

- Behavioral, non-visual; keeps the intended "completed agents are not relaunched, only shown" policy.
- Surfaced while testing the companion filter fix (#7353), but independent of it.

## ELI5

Waking a slept worktree whose agent had finished opened a blank terminal. The wake hint is kept so you still see the completed transcript after hibernation.
