### PR TITLE
Serve worktree-colored favicons from the localhost label proxy

### DIFF
--- a/src/main/localhost-worktree-favicon.test.ts
+++ b/src/main/localhost-worktree-favicon.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getLocalhostWorktreeFaviconHue,
+  getLocalhostWorktreeFaviconIco,
+  getLocalhostWorktreeFaviconSvg
+} from './localhost-worktree-favicon'
+
+describe('localhost worktree favicon', () => {
+  it('derives a stable hue from the label', () => {
+    const first = getLocalhostWorktreeFaviconHue('analytics')
+    const second = getLocalhostWorktreeFaviconHue('analytics')
+
+    expect(first).toBe(second)
+    expect(first).toBeGreaterThanOrEqual(0)
+    expect(first).toBeLessThan(360)
+    expect(first % 30).toBe(0)
+  })
+
+  it('gives different labels different hues', () => {
+    // Deterministic sanity check: these known labels land on distinct wheel slots.
+    expect(getLocalhostWorktreeFaviconHue('analytics')).not.toBe(
+      getLocalhostWorktreeFaviconHue('snapstudio-main')
+    )
+  })
+
+  it('renders an svg disc with the uppercased label initial', () => {
+    const svg = getLocalhostWorktreeFaviconSvg('analytics')
+
+    expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
+    expect(svg).toContain('<circle')
+    expect(svg).toContain('>A</text>')
+    expect(svg).toContain(`hsl(${getLocalhostWorktreeFaviconHue('analytics')} 68% 46%)`)
+  })
+
+  it('builds a structurally valid deterministic 32x32 ico', () => {
+    const ico = getLocalhostWorktreeFaviconIco('analytics')
+
+    expect(ico.equals(getLocalhostWorktreeFaviconIco('analytics'))).toBe(true)
+    expect(ico.readUInt16LE(0)).toBe(0) // reserved
+    expect(ico.readUInt16LE(2)).toBe(1) // icon type
+    expect(ico.readUInt16LE(4)).toBe(1) // image count
+    expect(ico.readUInt8(6)).toBe(32) // width
+    expect(ico.readUInt8(7)).toBe(32) // height
+    expect(ico.readUInt16LE(12)).toBe(32) // bits per pixel
+    expect(ico.readUInt32LE(18)).toBe(22) // bitmap offset
+    expect(ico.readUInt32LE(22)).toBe(40) // BITMAPINFOHEADER size
+    expect(ico.readInt32LE(30)).toBe(64) // doubled height (color + AND mask)
+    // Total size = headers + declared bitmap byte count.
+    expect(ico.length).toBe(22 + ico.readUInt32LE(14))
+  })
+
+  it('fills the disc center opaque and the corners transparent', () => {
+    const ico = getLocalhostWorktreeFaviconIco('analytics')
+    const pixelStart = 22 + 40
+    const alphaAt = (x: number, y: number): number =>
+      ico.readUInt8(pixelStart + ((31 - y) * 32 + x) * 4 + 3)
+
+    expect(alphaAt(16, 16)).toBe(255)
+    expect(alphaAt(0, 0)).toBe(0)
+    expect(alphaAt(31, 31)).toBe(0)
+  })
+})

--- a/src/main/localhost-worktree-favicon.test.ts
+++ b/src/main/localhost-worktree-favicon.test.ts
@@ -1,35 +1,18 @@
 import { describe, expect, it } from 'vitest'
+import { getLocalhostWorktreeCssColor } from '../shared/localhost-worktree-color'
 import {
-  getLocalhostWorktreeFaviconHue,
   getLocalhostWorktreeFaviconIco,
   getLocalhostWorktreeFaviconSvg
 } from './localhost-worktree-favicon'
 
 describe('localhost worktree favicon', () => {
-  it('derives a stable hue from the label', () => {
-    const first = getLocalhostWorktreeFaviconHue('analytics')
-    const second = getLocalhostWorktreeFaviconHue('analytics')
-
-    expect(first).toBe(second)
-    expect(first).toBeGreaterThanOrEqual(0)
-    expect(first).toBeLessThan(360)
-    expect(first % 30).toBe(0)
-  })
-
-  it('gives different labels different hues', () => {
-    // Deterministic sanity check: these known labels land on distinct wheel slots.
-    expect(getLocalhostWorktreeFaviconHue('analytics')).not.toBe(
-      getLocalhostWorktreeFaviconHue('snapstudio-main')
-    )
-  })
-
   it('renders an svg disc with the uppercased label initial', () => {
     const svg = getLocalhostWorktreeFaviconSvg('analytics')
 
     expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
     expect(svg).toContain('<circle')
     expect(svg).toContain('>A</text>')
-    expect(svg).toContain(`hsl(${getLocalhostWorktreeFaviconHue('analytics')} 68% 46%)`)
+    expect(svg).toContain(getLocalhostWorktreeCssColor('analytics'))
   })
 
   it('builds a structurally valid deterministic 32x32 ico', () => {

--- a/src/main/localhost-worktree-favicon.ts
+++ b/src/main/localhost-worktree-favicon.ts
@@ -1,5 +1,11 @@
 import type { IncomingMessage } from 'node:http'
 import { URL } from 'node:url'
+import {
+  LOCALHOST_WORKTREE_COLOR_LIGHTNESS,
+  LOCALHOST_WORKTREE_COLOR_SATURATION,
+  getLocalhostWorktreeCssColor,
+  getLocalhostWorktreeHue
+} from '../shared/localhost-worktree-color'
 
 // Why: favicons are the one response the label proxy substitutes. Serving a
 // worktree-specific icon at the HTTP layer keeps tabs visually
@@ -8,12 +14,6 @@ import { URL } from 'node:url'
 const ICON_SIZE = 32
 const CIRCLE_RADIUS = 15
 const SUPERSAMPLE = 4
-// Why: a fixed 12-hue wheel keeps neighboring labels visually distinct;
-// raw hash-derived hues cluster into near-identical muddy colors.
-const HUE_COUNT = 12
-const HUE_STEP = 360 / HUE_COUNT
-const SATURATION = 0.68
-const LIGHTNESS = 0.46
 
 export type LocalhostWorktreeFavicon = {
   contentType: string
@@ -43,14 +43,9 @@ export function localhostWorktreeFaviconForRequest(
   return null
 }
 
-export function getLocalhostWorktreeFaviconHue(label: string): number {
-  return (fnv1aHash(label) % HUE_COUNT) * HUE_STEP
-}
-
 export function getLocalhostWorktreeFaviconSvg(label: string): string {
-  const hue = getLocalhostWorktreeFaviconHue(label)
   const letter = faviconLetter(label)
-  const fill = `hsl(${hue} ${Math.round(SATURATION * 100)}% ${Math.round(LIGHTNESS * 100)}%)`
+  const fill = getLocalhostWorktreeCssColor(label)
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${ICON_SIZE} ${ICON_SIZE}">` +
     `<circle cx="16" cy="16" r="${CIRCLE_RADIUS}" fill="${fill}"/>` +
@@ -60,7 +55,11 @@ export function getLocalhostWorktreeFaviconSvg(label: string): string {
 }
 
 export function getLocalhostWorktreeFaviconIco(label: string): Buffer {
-  const [red, green, blue] = hslToRgb(getLocalhostWorktreeFaviconHue(label), SATURATION, LIGHTNESS)
+  const [red, green, blue] = hslToRgb(
+    getLocalhostWorktreeHue(label),
+    LOCALHOST_WORKTREE_COLOR_SATURATION,
+    LOCALHOST_WORKTREE_COLOR_LIGHTNESS
+  )
   const pixelBytes = ICON_SIZE * ICON_SIZE * 4
   const maskBytes = (ICON_SIZE / 8) * ICON_SIZE
   const bitmapBytes = 40 + pixelBytes + maskBytes
@@ -88,7 +87,7 @@ export function getLocalhostWorktreeFaviconIco(label: string): Buffer {
   const pixelStart = bitmapStart + 40
   for (let y = 0; y < ICON_SIZE; y += 1) {
     for (let x = 0; x < ICON_SIZE; x += 1) {
-      const alpha = Math.round(circleCoverage(x, y) * 255)
+      const alpha = DISC_ALPHA[y * ICON_SIZE + x] ?? 0
       // Why: ICO pixel rows are stored bottom-up in BGRA order.
       const offset = pixelStart + ((ICON_SIZE - 1 - y) * ICON_SIZE + x) * 4
       buffer.writeUInt8(blue, offset)
@@ -106,6 +105,20 @@ function faviconLetter(label: string): string {
   return (match?.[0] ?? '?').toUpperCase()
 }
 
+// Why: the disc shape is label-independent, so the alpha grid is computed once
+// instead of on every no-store favicon request.
+const DISC_ALPHA = buildDiscAlphaGrid()
+
+function buildDiscAlphaGrid(): Uint8Array {
+  const grid = new Uint8Array(ICON_SIZE * ICON_SIZE)
+  for (let y = 0; y < ICON_SIZE; y += 1) {
+    for (let x = 0; x < ICON_SIZE; x += 1) {
+      grid[y * ICON_SIZE + x] = Math.round(circleCoverage(x, y) * 255)
+    }
+  }
+  return grid
+}
+
 function circleCoverage(x: number, y: number): number {
   const center = ICON_SIZE / 2
   let covered = 0
@@ -120,15 +133,6 @@ function circleCoverage(x: number, y: number): number {
     }
   }
   return covered / (SUPERSAMPLE * SUPERSAMPLE)
-}
-
-function fnv1aHash(value: string): number {
-  let hash = 0x811c9dc5
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index)
-    hash = Math.imul(hash, 0x01000193) >>> 0
-  }
-  return hash
 }
 
 function hslToRgb(hue: number, saturation: number, lightness: number): [number, number, number] {

--- a/src/main/localhost-worktree-favicon.ts
+++ b/src/main/localhost-worktree-favicon.ts
@@ -1,0 +1,153 @@
+import type { IncomingMessage } from 'node:http'
+import { URL } from 'node:url'
+
+// Why: favicons are the one response the label proxy substitutes. Serving a
+// worktree-specific icon at the HTTP layer keeps tabs visually
+// distinguishable without rewriting HTML bodies or touching app headers.
+
+const ICON_SIZE = 32
+const CIRCLE_RADIUS = 15
+const SUPERSAMPLE = 4
+// Why: a fixed 12-hue wheel keeps neighboring labels visually distinct;
+// raw hash-derived hues cluster into near-identical muddy colors.
+const HUE_COUNT = 12
+const HUE_STEP = 360 / HUE_COUNT
+const SATURATION = 0.68
+const LIGHTNESS = 0.46
+
+export type LocalhostWorktreeFavicon = {
+  contentType: string
+  body: Buffer
+}
+
+export function localhostWorktreeFaviconForRequest(
+  label: string,
+  request: IncomingMessage
+): LocalhostWorktreeFavicon | null {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return null
+  }
+  const pathname = new URL(request.url || '/', 'http://localhost').pathname
+  if (pathname === '/favicon.ico') {
+    return {
+      contentType: 'image/x-icon',
+      body: getLocalhostWorktreeFaviconIco(label)
+    }
+  }
+  if (pathname === '/favicon.svg') {
+    return {
+      contentType: 'image/svg+xml; charset=utf-8',
+      body: Buffer.from(getLocalhostWorktreeFaviconSvg(label), 'utf8')
+    }
+  }
+  return null
+}
+
+export function getLocalhostWorktreeFaviconHue(label: string): number {
+  return (fnv1aHash(label) % HUE_COUNT) * HUE_STEP
+}
+
+export function getLocalhostWorktreeFaviconSvg(label: string): string {
+  const hue = getLocalhostWorktreeFaviconHue(label)
+  const letter = faviconLetter(label)
+  const fill = `hsl(${hue} ${Math.round(SATURATION * 100)}% ${Math.round(LIGHTNESS * 100)}%)`
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${ICON_SIZE} ${ICON_SIZE}">` +
+    `<circle cx="16" cy="16" r="${CIRCLE_RADIUS}" fill="${fill}"/>` +
+    `<text x="16" y="22" font-family="system-ui, sans-serif" font-size="17" font-weight="700" ` +
+    `fill="#fff" text-anchor="middle">${letter}</text></svg>`
+  )
+}
+
+export function getLocalhostWorktreeFaviconIco(label: string): Buffer {
+  const [red, green, blue] = hslToRgb(getLocalhostWorktreeFaviconHue(label), SATURATION, LIGHTNESS)
+  const pixelBytes = ICON_SIZE * ICON_SIZE * 4
+  const maskBytes = (ICON_SIZE / 8) * ICON_SIZE
+  const bitmapBytes = 40 + pixelBytes + maskBytes
+  const buffer = Buffer.alloc(6 + 16 + bitmapBytes)
+
+  buffer.writeUInt16LE(0, 0) // reserved
+  buffer.writeUInt16LE(1, 2) // type: icon
+  buffer.writeUInt16LE(1, 4) // image count
+  buffer.writeUInt8(ICON_SIZE, 6)
+  buffer.writeUInt8(ICON_SIZE, 7)
+  buffer.writeUInt16LE(1, 10) // color planes
+  buffer.writeUInt16LE(32, 12) // bits per pixel
+  buffer.writeUInt32LE(bitmapBytes, 14)
+  buffer.writeUInt32LE(22, 18) // bitmap offset
+
+  const bitmapStart = 22
+  buffer.writeUInt32LE(40, bitmapStart) // BITMAPINFOHEADER size
+  buffer.writeInt32LE(ICON_SIZE, bitmapStart + 4)
+  // Why: ICO bitmap height counts both the color plane and the AND mask.
+  buffer.writeInt32LE(ICON_SIZE * 2, bitmapStart + 8)
+  buffer.writeUInt16LE(1, bitmapStart + 12)
+  buffer.writeUInt16LE(32, bitmapStart + 14)
+  buffer.writeUInt32LE(pixelBytes, bitmapStart + 20)
+
+  const pixelStart = bitmapStart + 40
+  for (let y = 0; y < ICON_SIZE; y += 1) {
+    for (let x = 0; x < ICON_SIZE; x += 1) {
+      const alpha = Math.round(circleCoverage(x, y) * 255)
+      // Why: ICO pixel rows are stored bottom-up in BGRA order.
+      const offset = pixelStart + ((ICON_SIZE - 1 - y) * ICON_SIZE + x) * 4
+      buffer.writeUInt8(blue, offset)
+      buffer.writeUInt8(green, offset + 1)
+      buffer.writeUInt8(red, offset + 2)
+      buffer.writeUInt8(alpha, offset + 3)
+    }
+  }
+  // The AND mask stays zeroed: 32-bit icons carry opacity in the alpha channel.
+  return buffer
+}
+
+function faviconLetter(label: string): string {
+  const match = label.match(/[a-z0-9]/i)
+  return (match?.[0] ?? '?').toUpperCase()
+}
+
+function circleCoverage(x: number, y: number): number {
+  const center = ICON_SIZE / 2
+  let covered = 0
+  // Why: supersampling gives the disc a smooth edge without an image library.
+  for (let sy = 0; sy < SUPERSAMPLE; sy += 1) {
+    for (let sx = 0; sx < SUPERSAMPLE; sx += 1) {
+      const sampleX = x + (sx + 0.5) / SUPERSAMPLE - center
+      const sampleY = y + (sy + 0.5) / SUPERSAMPLE - center
+      if (sampleX * sampleX + sampleY * sampleY <= CIRCLE_RADIUS * CIRCLE_RADIUS) {
+        covered += 1
+      }
+    }
+  }
+  return covered / (SUPERSAMPLE * SUPERSAMPLE)
+}
+
+function fnv1aHash(value: string): number {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash
+}
+
+function hslToRgb(hue: number, saturation: number, lightness: number): [number, number, number] {
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation
+  const huePrime = hue / 60
+  const secondary = chroma * (1 - Math.abs((huePrime % 2) - 1))
+  const match = lightness - chroma / 2
+  const sextants: [number, number, number][] = [
+    [chroma, secondary, 0],
+    [secondary, chroma, 0],
+    [0, chroma, secondary],
+    [0, secondary, chroma],
+    [secondary, 0, chroma],
+    [chroma, 0, secondary]
+  ]
+  const rgb = sextants[Math.min(Math.floor(huePrime), 5)] ?? [chroma, secondary, 0]
+  return [
+    Math.round((rgb[0] + match) * 255),
+    Math.round((rgb[1] + match) * 255),
+    Math.round((rgb[2] + match) * 255)
+  ]
+}

--- a/src/main/localhost-worktree-label-proxy.test.ts
+++ b/src/main/localhost-worktree-label-proxy.test.ts
@@ -108,6 +108,77 @@ describe('localhost worktree label proxy', () => {
     expect(result.body).toBe('ok')
   })
 
+  it('serves a generated worktree favicon for /favicon.ico without touching the app', async () => {
+    let upstreamHits = 0
+    const port = await startUpstream((_request, response) => {
+      upstreamHits += 1
+      response.end('app favicon')
+    })
+    const proxy = new LocalhostWorktreeLabelProxy()
+    const { url } = await proxy.registerRoute({
+      targetUrl: `http://localhost:${port}/`,
+      projectName: 'Snap Studio',
+      worktreeName: 'analytics'
+    })
+    const labeled = new URL(url)
+    labeled.pathname = '/favicon.ico'
+    labeled.search = '?v=2'
+
+    const result = await fetchThroughProxy(labeled.toString())
+
+    expect(result.status).toBe(200)
+    expect(result.headers['content-type']).toBe('image/x-icon')
+    expect(result.headers['cache-control']).toBe('no-store')
+    // ICONDIR magic: reserved=0, type=1 little-endian.
+    expect(Buffer.from(result.body, 'utf8').subarray(0, 4)).toEqual(
+      Buffer.from([0, 0, 1, 0])
+    )
+    expect(upstreamHits).toBe(0)
+  })
+
+  it('serves an svg worktree favicon for /favicon.svg', async () => {
+    const port = await startUpstream((_request, response) => {
+      response.end('ok')
+    })
+    const proxy = new LocalhostWorktreeLabelProxy()
+    const { url } = await proxy.registerRoute({
+      targetUrl: `http://localhost:${port}/`,
+      projectName: 'Snap Studio',
+      worktreeName: 'analytics'
+    })
+    const labeled = new URL(url)
+    labeled.pathname = '/favicon.svg'
+
+    const result = await fetchThroughProxy(labeled.toString())
+
+    expect(result.status).toBe(200)
+    expect(result.headers['content-type']).toBe('image/svg+xml; charset=utf-8')
+    expect(result.body).toContain('<svg')
+    expect(result.body).toContain('>A</text>')
+  })
+
+  it('still proxies non-GET favicon requests and non-favicon paths to the app', async () => {
+    const seenPaths: string[] = []
+    const port = await startUpstream((request, response) => {
+      seenPaths.push(`${request.method} ${request.url}`)
+      response.end('from app')
+    })
+    const proxy = new LocalhostWorktreeLabelProxy()
+    const { url } = await proxy.registerRoute({
+      targetUrl: `http://localhost:${port}/`,
+      projectName: 'Snap Studio',
+      worktreeName: 'analytics'
+    })
+    const labeled = new URL(url)
+    labeled.pathname = '/assets/favicon-abc123.png'
+
+    const result = await fetchThroughProxy(labeled.toString())
+
+    expect(result.status).toBe(200)
+    expect(result.body).toBe('from app')
+    expect(seenPaths).toEqual(['GET /assets/favicon-abc123.png'])
+  })
+
   it('returns 404 for unregistered orca.localhost labels', async () => {
     const port = await startUpstream((_request, response) => {
       response.end('ok')

--- a/src/main/localhost-worktree-label-proxy.test.ts
+++ b/src/main/localhost-worktree-label-proxy.test.ts
@@ -1,6 +1,7 @@
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { afterEach, describe, expect, it } from 'vitest'
+import { getLocalhostWorktreeFaviconIco } from './localhost-worktree-favicon'
 import { LocalhostWorktreeLabelProxy } from './localhost-worktree-label-proxy'
 
 const upstreamServers: http.Server[] = []
@@ -23,8 +24,9 @@ async function startUpstream(
 }
 
 function fetchThroughProxy(
-  labeledUrl: string
-): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+  labeledUrl: string,
+  method = 'GET'
+): Promise<{ status: number; body: string; bytes: Buffer; headers: http.IncomingHttpHeaders }> {
   const url = new URL(labeledUrl)
   return new Promise((resolve, reject) => {
     // Why: *.orca.localhost is not resolvable DNS; connect to the proxy on
@@ -34,18 +36,21 @@ function fetchThroughProxy(
         host: '127.0.0.1',
         port: Number(url.port),
         path: `${url.pathname}${url.search}`,
+        method,
         headers: { host: url.host }
       },
       (response) => {
         const chunks: Buffer[] = []
         response.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
-        response.on('end', () =>
+        response.on('end', () => {
+          const bytes = Buffer.concat(chunks)
           resolve({
             status: response.statusCode ?? 0,
-            body: Buffer.concat(chunks).toString('utf8'),
+            body: bytes.toString('utf8'),
+            bytes,
             headers: response.headers
           })
-        )
+        })
       }
     )
     request.on('error', reject)
@@ -129,10 +134,7 @@ describe('localhost worktree label proxy', () => {
     expect(result.status).toBe(200)
     expect(result.headers['content-type']).toBe('image/x-icon')
     expect(result.headers['cache-control']).toBe('no-store')
-    // ICONDIR magic: reserved=0, type=1 little-endian.
-    expect(Buffer.from(result.body, 'utf8').subarray(0, 4)).toEqual(
-      Buffer.from([0, 0, 1, 0])
-    )
+    expect(result.bytes.equals(getLocalhostWorktreeFaviconIco('analytics'))).toBe(true)
     expect(upstreamHits).toBe(0)
   })
 
@@ -176,7 +178,14 @@ describe('localhost worktree label proxy', () => {
 
     expect(result.status).toBe(200)
     expect(result.body).toBe('from app')
-    expect(seenPaths).toEqual(['GET /assets/favicon-abc123.png'])
+
+    const postFavicon = new URL(url)
+    postFavicon.pathname = '/favicon.ico'
+    const postResult = await fetchThroughProxy(postFavicon.toString(), 'POST')
+
+    expect(postResult.status).toBe(200)
+    expect(postResult.body).toBe('from app')
+    expect(seenPaths).toEqual(['GET /assets/favicon-abc123.png', 'POST /favicon.ico'])
   })
 
   it('returns 404 for unregistered orca.localhost labels', async () => {

--- a/src/main/localhost-worktree-label-proxy.ts
+++ b/src/main/localhost-worktree-label-proxy.ts
@@ -12,6 +12,7 @@ import {
   getLocalhostWorktreeHostLabel,
   getLocalhostWorktreeRouteKey
 } from '../shared/localhost-worktree-labels'
+import { localhostWorktreeFaviconForRequest } from './localhost-worktree-favicon'
 
 type RegisteredRoute = LocalhostWorktreeLabelRoute & {
   label: string
@@ -114,6 +115,20 @@ export class LocalhostWorktreeLabelProxy {
     if (!route) {
       response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' })
       response.end('Unknown Orca localhost label.')
+      return
+    }
+
+    // Why: favicon paths are answered by Orca with a worktree-colored icon so
+    // labeled tabs are distinguishable at a glance; every other response still
+    // streams through untouched (no HTML rewriting, no header mutation).
+    const favicon = localhostWorktreeFaviconForRequest(route.label, request)
+    if (favicon) {
+      response.writeHead(200, {
+        'content-type': favicon.contentType,
+        'content-length': favicon.body.byteLength,
+        'cache-control': 'no-store'
+      })
+      response.end(request.method === 'HEAD' ? undefined : favicon.body)
       return
     }
 

--- a/src/main/localhost-worktree-label-proxy.ts
+++ b/src/main/localhost-worktree-label-proxy.ts
@@ -118,9 +118,8 @@ export class LocalhostWorktreeLabelProxy {
       return
     }
 
-    // Why: favicon paths are answered by Orca with a worktree-colored icon so
-    // labeled tabs are distinguishable at a glance; every other response still
-    // streams through untouched (no HTML rewriting, no header mutation).
+    // Why: favicon paths are intercepted here so tabs show a worktree-colored
+    // icon; every other request still streams through untouched.
     const favicon = localhostWorktreeFaviconForRequest(route.label, request)
     if (favicon) {
       response.writeHead(200, {

--- a/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
@@ -17,6 +17,7 @@ import {
   resolvePortOpenInOrcaBrowser
 } from '@/lib/workspace-port-actions'
 import { useLocalhostLabelRouteForPort } from '@/lib/workspace-port-localhost-label-selector'
+import { localhostWorktreeColorForRoute } from '@/lib/workspace-port-worktree-color'
 import { addressForPort } from '@/lib/workspace-port-urls'
 import type { WorkspacePort } from '../../../../shared/workspace-ports'
 import { WORKTREE_NATIVE_CONTEXT_MENU_ATTR } from './WorktreeContextMenu'
@@ -34,6 +35,11 @@ export function WorktreeCardPortsTrigger({
   ports
 }: WorktreeCardPortsProps): React.JSX.Element | null {
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
+  // Why: a worktree card's ports all share one owner, so the first port's
+  // label route carries the card's worktree color.
+  const localhostColor = localhostWorktreeColorForRoute(
+    useLocalhostLabelRouteForPort(ports[0] ?? null)
+  )
 
   if (ports.length === 0) {
     return null
@@ -42,7 +48,7 @@ export function WorktreeCardPortsTrigger({
   return (
     <button
       type="button"
-      className="inline-flex size-3.5 shrink-0 items-center justify-center rounded text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-worktree-sidebar-ring"
+      className="relative inline-flex size-3.5 shrink-0 items-center justify-center rounded text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-worktree-sidebar-ring"
       aria-label={translate(
         'auto.components.sidebar.WorktreeCardPorts.fed49903c9',
         '{{value0}} live {{value1}}',
@@ -54,6 +60,13 @@ export function WorktreeCardPortsTrigger({
       }}
     >
       <Plug className="size-3.5" />
+      {localhostColor ? (
+        <span
+          aria-hidden
+          className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full"
+          style={{ backgroundColor: localhostColor }}
+        />
+      ) : null}
     </button>
   )
 }

--- a/src/renderer/src/components/status-bar/ports-status-popover-rows.tsx
+++ b/src/renderer/src/components/status-bar/ports-status-popover-rows.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/workspace-port-actions'
 import type { WorkspacePortGroup } from '@/lib/workspace-port-groups'
 import { useLocalhostLabelRouteForPort } from '@/lib/workspace-port-localhost-label-selector'
+import { localhostWorktreeColorForRoute } from '@/lib/workspace-port-worktree-color'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { useAppStore } from '@/store'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -278,6 +279,11 @@ export function WorkspaceGroupRows({
   group: WorkspacePortGroup
   activeWorktreeId: string | null
 }): React.JSX.Element {
+  // Why: a group's ports all share one owning worktree, so the first port's
+  // label route carries the group's worktree color.
+  const localhostColor = localhostWorktreeColorForRoute(
+    useLocalhostLabelRouteForPort(group.ports[0] ?? null)
+  )
   const handleGoToWorkspace = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation()
@@ -297,8 +303,17 @@ export function WorkspaceGroupRows({
   return (
     <section className="border-t border-border/40 first:border-t-0">
       <div className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-border/40 bg-popover px-3 py-2">
-        <span className="min-w-0 truncate text-[12px] font-medium text-foreground">
-          {group.displayName}
+        <span className="flex min-w-0 items-center gap-1.5">
+          {localhostColor ? (
+            <span
+              aria-hidden
+              className="size-1.5 shrink-0 rounded-full"
+              style={{ backgroundColor: localhostColor }}
+            />
+          ) : null}
+          <span className="min-w-0 truncate text-[12px] font-medium text-foreground">
+            {group.displayName}
+          </span>
         </span>
         <div className="flex shrink-0 items-center gap-1">
           <PortAction

--- a/src/renderer/src/lib/workspace-port-localhost-label-selector.ts
+++ b/src/renderer/src/lib/workspace-port-localhost-label-selector.ts
@@ -29,12 +29,14 @@ export function resolveLocalhostLabelRouteForPort(
   return localhostWorktreeLabelRouteForPort({ port, repo, project, settings: state.settings })
 }
 
+// Why: accepts null so components can keep the hook unconditional above
+// their empty-ports early returns.
 export function useLocalhostLabelRouteForPort(
-  port: WorkspacePort
+  port: WorkspacePort | null
 ): LocalhostWorktreeLabelRoute | null {
   const settings = useAppStore((s) => s.settings)
-  const portWorktreeId = port.kind === 'workspace' ? port.owner.worktreeId : null
-  const portRepoId = port.kind === 'workspace' ? port.owner.repoId : null
+  const portWorktreeId = port?.kind === 'workspace' ? port.owner.worktreeId : null
+  const portRepoId = port?.kind === 'workspace' ? port.owner.repoId : null
   const repo = useAppStore((s) =>
     portRepoId ? ((s.repos ?? []).find((entry) => entry.id === portRepoId) ?? null) : null
   )
@@ -46,5 +48,8 @@ export function useLocalhostLabelRouteForPort(
       ? ((s.projects ?? []).find((entry) => entry.id === worktree.projectId) ?? null)
       : null
   )
+  if (!port) {
+    return null
+  }
   return localhostWorktreeLabelRouteForPort({ port, repo, project, settings })
 }

--- a/src/renderer/src/lib/workspace-port-worktree-color.test.ts
+++ b/src/renderer/src/lib/workspace-port-worktree-color.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getLocalhostWorktreeCssColor } from '../../../shared/localhost-worktree-color'
+import { getLocalhostWorktreeHostLabel } from '../../../shared/localhost-worktree-labels'
+import { localhostWorktreeColorForRoute } from './workspace-port-worktree-color'
+
+describe('localhostWorktreeColorForRoute', () => {
+  it('returns null without a route (labels disabled or non-workspace port)', () => {
+    expect(localhostWorktreeColorForRoute(null)).toBeNull()
+  })
+
+  it('matches the color the proxy favicon derives for the same label', () => {
+    const route = {
+      targetUrl: 'http://localhost:5182/',
+      projectName: 'Snap Demo',
+      worktreeName: 'checkout-flow',
+      worktreePath: '/repos/snapdemo/checkout-flow'
+    }
+
+    expect(localhostWorktreeColorForRoute(route)).toBe(
+      getLocalhostWorktreeCssColor(getLocalhostWorktreeHostLabel(route))
+    )
+  })
+})

--- a/src/renderer/src/lib/workspace-port-worktree-color.ts
+++ b/src/renderer/src/lib/workspace-port-worktree-color.ts
@@ -1,0 +1,15 @@
+import type { LocalhostWorktreeLabelRoute } from '../../../shared/localhost-worktree-labels'
+import { getLocalhostWorktreeHostLabel } from '../../../shared/localhost-worktree-labels'
+import { getLocalhostWorktreeCssColor } from '../../../shared/localhost-worktree-color'
+
+// Why: port indicators tinted with the favicon's hue let users match a
+// sidebar/status-bar port to its browser tab by color alone. Derived from the
+// base label, so a rare proxy collision suffix (-2) may shift the tab hue.
+export function localhostWorktreeColorForRoute(
+  route: LocalhostWorktreeLabelRoute | null
+): string | null {
+  if (!route) {
+    return null
+  }
+  return getLocalhostWorktreeCssColor(getLocalhostWorktreeHostLabel(route))
+}

--- a/src/shared/localhost-worktree-color.test.ts
+++ b/src/shared/localhost-worktree-color.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getLocalhostWorktreeCssColor,
+  getLocalhostWorktreeHue
+} from './localhost-worktree-color'
+
+describe('localhost worktree color', () => {
+  it('derives a stable hue on the 12-step wheel from the label', () => {
+    const first = getLocalhostWorktreeHue('analytics')
+    const second = getLocalhostWorktreeHue('analytics')
+
+    expect(first).toBe(second)
+    expect(first).toBeGreaterThanOrEqual(0)
+    expect(first).toBeLessThan(360)
+    expect(first % 30).toBe(0)
+  })
+
+  it('gives different labels different hues', () => {
+    // Deterministic sanity check: these known labels land on distinct wheel slots.
+    expect(getLocalhostWorktreeHue('analytics')).not.toBe(getLocalhostWorktreeHue('snapstudio-main'))
+  })
+
+  it('formats the css color from the same hue and fixed saturation/lightness', () => {
+    expect(getLocalhostWorktreeCssColor('analytics')).toBe(
+      `hsl(${getLocalhostWorktreeHue('analytics')} 68% 46%)`
+    )
+  })
+})

--- a/src/shared/localhost-worktree-color.ts
+++ b/src/shared/localhost-worktree-color.ts
@@ -1,0 +1,30 @@
+// Why: the favicon served by the label proxy and the renderer's port
+// indicators must derive the identical color from a label, so a browser tab
+// can be matched to its Orca worktree by color alone.
+
+// Why: a fixed 12-hue wheel keeps neighboring labels visually distinct;
+// raw hash-derived hues cluster into near-identical muddy colors.
+const HUE_COUNT = 12
+const HUE_STEP = 360 / HUE_COUNT
+
+export const LOCALHOST_WORKTREE_COLOR_SATURATION = 0.68
+export const LOCALHOST_WORKTREE_COLOR_LIGHTNESS = 0.46
+
+export function getLocalhostWorktreeHue(label: string): number {
+  return (fnv1aHash(label) % HUE_COUNT) * HUE_STEP
+}
+
+export function getLocalhostWorktreeCssColor(label: string): string {
+  const saturation = Math.round(LOCALHOST_WORKTREE_COLOR_SATURATION * 100)
+  const lightness = Math.round(LOCALHOST_WORKTREE_COLOR_LIGHTNESS * 100)
+  return `hsl(${getLocalhostWorktreeHue(label)} ${saturation}% ${lightness}%)`
+}
+
+function fnv1aHash(value: string): number {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash
+}


### PR DESCRIPTION
## Summary

Follow-up to #6424. When Localhost Worktree Labels are enabled, labeled `*.orca.localhost` tabs now get a **worktree-colored favicon**, so multiple worktrees of the same project are distinguishable at a glance in the tab strip — not just in the address bar.

The idea mirrors a recently viral tip about using different favicons per environment (dev/preview/prod) so you never stare at the wrong tab wondering why your changes didn't apply: https://x.com/dferber90/status/2073027573219549678. The same problem exists between worktrees of one project, where every tab shows the identical app favicon and title.

This is deliberately scoped to respect the constraints established when #6424 was merged:

- **No HTML rewriting.** #6424's merge dropped the title/favicon HTML injection because it required buffering full HTML bodies and stripping CSP headers. This PR does not reintroduce any of that: HTML (and everything else) still streams through the proxy byte-for-byte with headers untouched.
- **No agent/prompt surface.** Purely structural, inside the existing proxy request handler.
- **No new settings or behavior for users who have labels off.** The favicon path only exists inside the label proxy, which only runs behind the existing opt-in toggle (Settings → Browser → Localhost Worktree Labels).

## How It Works

The proxy answers `GET`/`HEAD` requests for exactly `/favicon.ico` and `/favicon.svg` on registered label hosts with a generated icon instead of proxying those two paths; every other request continues to stream through untouched.

- The icon is a colored disc whose hue is derived deterministically from the label slug (FNV-1a hash onto a 12-step hue wheel), so a worktree keeps its color across restarts and the same worktree gets the same color everywhere. No re-plumbing of project icon/badge data was needed.
- `/favicon.ico` serves a hand-assembled 32×32 32-bit ICO (BGRA + alpha, supersampled disc edge) — no image library, no new dependencies, works in every browser including Safari.
- `/favicon.svg` serves an SVG disc with the uppercased label initial (e.g. `A` for `analytics`), for apps that declare an SVG favicon.
- Responses are `cache-control: no-store` so toggling the feature off doesn't leave stale Orca icons cached against the label host.

Coverage notes:

- Apps with no declared icon (browser falls back to `/favicon.ico`) and apps declaring the standard `/favicon.ico` / `/favicon.svg` paths are covered.
- Apps that declare a custom or hashed icon path (e.g. `/assets/icon-abc123.svg`, Vite's default `/vite.svg`) keep their own favicon — those requests pass through untouched. Path-based matching keeps the proxy predictable; sniffing content types to catch these would make passthrough behavior data-dependent.
- Only the favicon changes; tab titles are intentionally left alone (that would require the HTML injection #6424 removed).

## Matching In-App Port Indicators

The second commit closes the loop inside Orca with a restrained accent: a small dot in the favicon's exact color appears as a corner badge on the sidebar worktree-card plug icon and next to each worktree group name in the ports status popover. Scanning "red tab in the browser → red dot in Orca" works in both directions, while icons, port numbers, and text keep their normal neutral styling.

- The hue/color derivation moved to `src/shared/localhost-worktree-color.ts` so the main-process favicon generator and the renderer accent derive from one source; the ICO/SVG output is byte-identical to before.
- The accent is driven by the existing `useLocalhostLabelRouteForPort` selector, so it appears only when Localhost Worktree Labels is enabled and the port has a resolvable worktree route — otherwise nothing changes, and the aggregate status-bar plug (which spans many worktrees) stays neutral.
- No new settings or i18n strings.

## Screenshots

Browser tab strips get a distinct colored disc per worktree instead of N copies of the same app favicon; inside Orca, the sidebar plug badges and the ports popover group dots pick up the same per-worktree colors.

<img width="1472" height="846" alt="Three worktrees with matching favicon colors in the sidebar plug badges and ports popover dots" src="https://github.com/user-attachments/assets/b9f3310a-aa15-47f1-bf08-f55ab3a4c014" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 24,183 passed; 16 failed in 4 renderer test files, all the same pre-existing `window.localStorage` unavailable-under-Node-v26 environment issue (also noted in #6424's testing section). Verified the identical failures occur on a clean `upstream/main` checkout without these commits; none of the failing files import the changed code.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New tests:

- `src/shared/localhost-worktree-color.test.ts`: deterministic hue derivation on the 12-step wheel, distinct hues for distinct labels, CSS color formatting.
- `src/main/localhost-worktree-favicon.test.ts`: SVG structure + initial letter + color parity with the shared module, ICO structural validity (ICONDIR magic, 32×32, 32bpp, doubled mask height, declared vs. actual byte counts), opaque disc center / transparent corners.
- `src/main/localhost-worktree-label-proxy.test.ts`: `/favicon.ico` (with query string) served byte-identical to the generator output without hitting the upstream app, `/favicon.svg` content type and body, and a regression guard that non-favicon paths (hashed icon assets) and non-GET favicon requests (`POST /favicon.ico`) still proxy through to the app verbatim.
- `src/renderer/src/lib/workspace-port-worktree-color.test.ts`: the renderer tint matches the color the proxy favicon derives for the same route; null route (labels off / non-workspace port) yields no tint.

CodeRabbit's four review nitpicks are addressed in the second commit: trimmed the interception comment to two lines, precomputed the label-independent ICO alpha grid at module load, replaced the UTF-8-round-tripped ICO assertion with a raw-byte comparison against the generator, and added real non-GET favicon passthrough coverage.

All pre-existing proxy tests (passthrough with CSP intact, `0.0.0.0` normalization, unknown-label 404, https rejection) still pass unchanged.

## AI Review Report

Reviewed with an AI coding agent for:

- **Cross-platform (macOS / Linux / Windows):** icon bytes are generated in pure JS with explicit little-endian `Buffer` writes — no platform APIs, paths, shells, or Electron surface touched. The ICO container was chosen over SVG-only specifically for cross-browser coverage (Safari does not render SVG favicons).
- **Passthrough integrity:** verified the interception happens before the upstream request is created and only for `GET`/`HEAD` on the two exact favicon pathnames; `POST /favicon.ico`, query-stringed app routes, WebSocket upgrades, and all other traffic take the untouched streaming path (covered by tests).
- **Determinism/stability:** same label → same icon bytes across sessions; label collision suffixes (`-2`) produce a different hue, which is desirable since they are different worktrees.
- **SSH/remote:** unaffected — the label proxy is loopback-only and remote workflows never receive it (unchanged from #6424).
- **Performance:** icons are ~4 KB, generated per request without buffering app traffic; `no-store` trades a trivial local re-fetch for predictable toggle-off behavior.

## Security Audit

- The favicon handler runs only after label-host resolution, so unregistered hosts still 404 and the SSRF-hardened registration path from #6424 is unchanged.
- Request path input is parsed with `new URL(request.url, base)` and compared against exact pathname literals — no user input is reflected into the response.
- The SVG body is built entirely from generated values (hue number, `[A-Z0-9]` initial extracted by regex from the already-slugified label), so no injection vector into the SVG markup.
- No new dependencies, IPC endpoints, settings, or renderer-reachable surface.

## Notes

- If a sub-toggle ("keep app favicons") is preferred rather than bundling this under the existing opt-in, happy to add one — kept the diff minimal for review.
- `apple-touch-icon*.png` is intentionally not intercepted: it is used for bookmarks/home-screen, not tab favicons, and would require PNG encoding for marginal value.

## ELI5

Localhost worktree-label tabs get a worktree-colored favicon in the tab strip. Same project, different worktrees are easy to tell apart at a glance.
