### PR TITLE
fix: prefer Claude-generated titles in AI Vault

### DIFF
--- a/src/main/ai-vault/session-scanner-claude-title.test.ts
+++ b/src/main/ai-vault/session-scanner-claude-title.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { scanAiVaultSessions } from './session-scanner'
+import { isolatedScanRoots, writeJsonlFile } from './session-scanner-test-fixtures'
+
+let tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+describe('scanAiVaultSessions Claude title selection', () => {
+  it('prefers the generated ai-title over the first user prompt, but a custom-title wins over both', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-ai-title-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const projectDir = join(roots.claudeProjectsDir, 'project')
+
+    await writeJsonlFile(join(projectDir, 'generated.jsonl'), [
+      {
+        type: 'user',
+        sessionId: 'generated',
+        timestamp: '2026-05-01T10:00:00.000Z',
+        cwd: '/tmp/claude',
+        message: { role: 'user', content: 'First user prompt' }
+      },
+      {
+        type: 'ai-title',
+        sessionId: 'generated',
+        timestamp: '2026-05-01T10:01:00.000Z',
+        aiTitle: 'Understanding karma and moral accountability'
+      }
+    ])
+    await writeJsonlFile(join(projectDir, 'custom.jsonl'), [
+      {
+        type: 'user',
+        sessionId: 'custom',
+        timestamp: '2026-05-01T11:00:00.000Z',
+        cwd: '/tmp/claude',
+        message: { role: 'user', content: 'First user prompt' }
+      },
+      {
+        type: 'ai-title',
+        sessionId: 'custom',
+        timestamp: '2026-05-01T11:01:00.000Z',
+        aiTitle: 'Generated title that must lose'
+      },
+      {
+        type: 'custom-title',
+        sessionId: 'custom',
+        timestamp: '2026-05-01T11:02:00.000Z',
+        customTitle: 'User set title'
+      }
+    ])
+
+    const result = await scanAiVaultSessions({ ...roots, platform: 'darwin' })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.title).sort()).toEqual([
+      'Understanding karma and moral accountability',
+      'User set title'
+    ])
+  })
+
+  it('excludes Claude Task subagent transcripts from the session list', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-subagents-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const sessionDir = join(roots.claudeProjectsDir, 'project', 'claude-session')
+
+    await writeJsonlFile(join(roots.claudeProjectsDir, 'project', 'claude-session.jsonl'), [
+      {
+        type: 'user',
+        sessionId: 'claude-session',
+        timestamp: '2026-05-01T10:00:00.000Z',
+        cwd: '/tmp/claude',
+        message: { role: 'user', content: 'Parent session prompt' }
+      }
+    ])
+    await writeJsonlFile(join(sessionDir, 'subagents', 'agent-abc123.jsonl'), [
+      {
+        type: 'user',
+        sessionId: 'claude-session',
+        timestamp: '2026-05-01T10:00:05.000Z',
+        cwd: '/tmp/claude',
+        message: { role: 'user', content: 'Subagent task prompt' }
+      }
+    ])
+
+    const result = await scanAiVaultSessions({ ...roots, platform: 'darwin' })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.title)).toEqual(['Parent session prompt'])
+  })
+})

--- a/src/main/ai-vault/session-scanner-claude-title.test.ts
+++ b/src/main/ai-vault/session-scanner-claude-title.test.ts
@@ -13,7 +13,7 @@ afterEach(async () => {
 })
 
 describe('scanAiVaultSessions Claude title selection', () => {
-  it('prefers the generated ai-title over the first user prompt, but a custom-title wins over both', async () => {
+  it('prefers the latest generated ai-title over the first user prompt, but a custom-title wins over both', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-ai-title-'))
     tempRoots.push(root)
     const roots = isolatedScanRoots(root)
@@ -32,6 +32,12 @@ describe('scanAiVaultSessions Claude title selection', () => {
         sessionId: 'generated',
         timestamp: '2026-05-01T10:01:00.000Z',
         aiTitle: 'Understanding karma and moral accountability'
+      },
+      {
+        type: 'ai-title',
+        sessionId: 'generated',
+        timestamp: '2026-05-01T10:02:00.000Z',
+        aiTitle: 'Updated karma discussion title'
       }
     ])
     await writeJsonlFile(join(projectDir, 'custom.jsonl'), [
@@ -60,7 +66,7 @@ describe('scanAiVaultSessions Claude title selection', () => {
 
     expect(result.issues).toEqual([])
     expect(result.sessions.map((session) => session.title).sort()).toEqual([
-      'Understanding karma and moral accountability',
+      'Updated karma discussion title',
       'User set title'
     ])
   })

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -11,10 +11,12 @@ export async function discoverFiles(args: {
   issues: AiVaultScanIssue[]
   extensions: string[]
   filePredicate?: (path: string) => boolean
+  directoryPredicate?: (name: string) => boolean
 }): Promise<SessionFileDiscovery> {
   const paths = await walkSessionFiles(args.rootDir, args.agent, args.issues, {
     extensions: new Set(args.extensions),
-    filePredicate: args.filePredicate
+    filePredicate: args.filePredicate,
+    directoryPredicate: args.directoryPredicate
   })
   const files: FileWithMtime[] = []
   for (const path of paths) {
@@ -67,6 +69,7 @@ export async function walkSessionFiles(
   options: {
     extensions: Set<string>
     filePredicate?: (path: string) => boolean
+    directoryPredicate?: (name: string) => boolean
   }
 ): Promise<string[]> {
   let entries
@@ -80,7 +83,11 @@ export async function walkSessionFiles(
   for (const entry of entries) {
     const fullPath = join(dirPath, entry.name)
     if (entry.isDirectory()) {
-      files.push(...(await walkSessionFiles(fullPath, agent, issues, options)))
+      // Skip whole subtrees an agent never wants (e.g. subagent transcripts),
+      // avoiding the readdir cost of descending into them.
+      if (options.directoryPredicate?.(entry.name) ?? true) {
+        files.push(...(await walkSessionFiles(fullPath, agent, issues, options)))
+      }
       continue
     }
     if (

--- a/src/main/ai-vault/session-scanner-primary-parsers.ts
+++ b/src/main/ai-vault/session-scanner-primary-parsers.ts
@@ -87,7 +87,11 @@ async function parseClaudeSessionLines(args: {
     }
 
     if (record.type === 'ai-title') {
-      generatedTitle ??= normalizeTitleText(extractString(record.aiTitle) ?? '')
+      const title = normalizeTitleText(extractString(record.aiTitle) ?? '')
+      if (title) {
+        // Claude can revise generated names; AI Vault should mirror the current one.
+        generatedTitle = title
+      }
       continue
     }
 

--- a/src/main/ai-vault/session-scanner-primary-parsers.ts
+++ b/src/main/ai-vault/session-scanner-primary-parsers.ts
@@ -67,6 +67,7 @@ async function parseClaudeSessionLines(args: {
   })
   let metaTitle: string | null = null
   let generatedTitle: string | null = null
+  let firstUserTitle: string | null = null
 
   for await (const line of args.lines) {
     const record = parseJsonObject(line)
@@ -99,10 +100,13 @@ async function parseClaudeSessionLines(args: {
       accumulator.messageCount++
       const title = extractMessageText(record.message)
       addPreviewContent(accumulator, 'user', asRecord(record.message)?.content, record.timestamp)
-      if (title && record.isMeta !== true && !accumulator.title) {
-        accumulator.title = title
-      } else if (title && !metaTitle) {
-        metaTitle = title
+      if (title) {
+        // Meta prompts (injected context) only seed the last-resort title.
+        if (record.isMeta === true) {
+          metaTitle ??= title
+        } else {
+          firstUserTitle ??= title
+        }
       }
       continue
     }
@@ -119,7 +123,9 @@ async function parseClaudeSessionLines(args: {
     }
   }
 
-  accumulator.fallbackTitle = generatedTitle ?? metaTitle
+  // Why: a user-set custom-title (accumulator.title) wins, but Claude's generated
+  // session name (ai-title) should outrank the raw first prompt when present.
+  accumulator.fallbackTitle = generatedTitle ?? firstUserTitle ?? metaTitle
   return finalizeSession(accumulator, args.platform, args.options)
 }
 

--- a/src/main/ai-vault/session-scanner-source-discovery.ts
+++ b/src/main/ai-vault/session-scanner-source-discovery.ts
@@ -76,7 +76,17 @@ function claudeDiscoveries(
     options.claudeProjectsDir ?? CLAUDE_PROJECTS_DIR,
     ...wslHomeDirs.map((homeDir) => join(homeDir, '.claude', 'projects'))
   ].map((rootDir) =>
-    discoverFiles({ rootDir, limit, agent: 'claude', issues, extensions: ['.jsonl'] })
+    discoverFiles({
+      rootDir,
+      limit,
+      agent: 'claude',
+      issues,
+      extensions: ['.jsonl'],
+      // Why: Task subagent transcripts under `<session>/subagents/` share the parent
+      // sessionId and aren't independently resumable, so they'd just duplicate the
+      // parent as untitled rows; prune the subtree instead of indexing it.
+      directoryPredicate: (name) => name !== 'subagents'
+    })
   )
 }
 

--- a/src/main/ai-vault/session-scanner-test-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-test-fixtures.ts
@@ -1,0 +1,35 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+export function isolatedScanRoots(root: string) {
+  return {
+    claudeProjectsDir: join(root, 'claude-projects'),
+    codexSessionsDir: join(root, 'codex-sessions'),
+    geminiSessionsDir: join(root, 'gemini-sessions'),
+    copilotSessionsDir: join(root, 'copilot-sessions'),
+    cursorProjectsDir: join(root, 'cursor-projects'),
+    opencodeStorageDir: join(root, 'opencode-storage'),
+    // Why: prevent the SQLite scanner from picking up the real
+    // ~/.local/share/opencode/opencode.db during tests.
+    opencodeDbPaths: [] as readonly string[],
+    grokSessionsDir: join(root, 'grok-sessions'),
+    devinTranscriptsDir: join(root, 'devin-transcripts'),
+    hermesSessionsDir: join(root, 'hermes-sessions'),
+    rovoSessionsDir: join(root, 'rovo-sessions'),
+    openclawStateDir: join(root, 'openclaw-state'),
+    openclawLegacyStateDir: join(root, 'openclaw-legacy-state'),
+    piSessionsDir: join(root, 'pi-sessions'),
+    droidSessionsDir: join(root, 'droid-sessions'),
+    droidProjectsDir: join(root, 'droid-projects'),
+    kimiSessionsDir: join(root, 'kimi-sessions')
+  }
+}
+
+export function jsonLines(records: unknown[]): string {
+  return records.map((record) => JSON.stringify(record)).join('\n')
+}
+
+export async function writeJsonlFile(filePath: string, records: unknown[]): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, jsonLines(records))
+}

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AI_VAULT_AGENTS, buildAiVaultResumeCommand } from '../../shared/ai-vault-types'
 import { scanAiVaultSessions } from './session-scanner'
+import { isolatedScanRoots, jsonLines } from './session-scanner-test-fixtures'
 
 let tempRoots: string[] = []
 
@@ -12,34 +13,6 @@ afterEach(async () => {
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
 })
-
-function isolatedScanRoots(root: string) {
-  return {
-    claudeProjectsDir: join(root, 'claude-projects'),
-    codexSessionsDir: join(root, 'codex-sessions'),
-    geminiSessionsDir: join(root, 'gemini-sessions'),
-    copilotSessionsDir: join(root, 'copilot-sessions'),
-    cursorProjectsDir: join(root, 'cursor-projects'),
-    opencodeStorageDir: join(root, 'opencode-storage'),
-    // Why: prevent the SQLite scanner from picking up the real
-    // ~/.local/share/opencode/opencode.db during tests.
-    opencodeDbPaths: [] as readonly string[],
-    grokSessionsDir: join(root, 'grok-sessions'),
-    devinTranscriptsDir: join(root, 'devin-transcripts'),
-    hermesSessionsDir: join(root, 'hermes-sessions'),
-    rovoSessionsDir: join(root, 'rovo-sessions'),
-    openclawStateDir: join(root, 'openclaw-state'),
-    openclawLegacyStateDir: join(root, 'openclaw-legacy-state'),
-    piSessionsDir: join(root, 'pi-sessions'),
-    droidSessionsDir: join(root, 'droid-sessions'),
-    droidProjectsDir: join(root, 'droid-projects'),
-    kimiSessionsDir: join(root, 'kimi-sessions')
-  }
-}
-
-function jsonLines(records: unknown[]): string {
-  return records.map((record) => JSON.stringify(record)).join('\n')
-}
 
 describe('scanAiVaultSessions', () => {
   it('indexes Claude and Codex transcripts with resume commands', async () => {


### PR DESCRIPTION
## Summary

I fixed Agent Session History so Claude Code sessions use the Claude-generated `ai-title` when one exists, matching `/status` and the terminal tab title.

The title priority is now: user-set `custom-title` > Claude-generated `ai-title` > first user prompt > injected/meta text > agent/id default. New sessions still fall back to the first prompt until Claude writes the generated title.

I also stopped indexing Claude Task subagent transcripts as separate history rows by pruning `<session>/subagents/` during discovery.

## Screenshots

Same session, before and after (a Claude session with 350 messages).

**Before** — the AI Vault side panel labeled the session with a truncated copy of the first user prompt (`in orc can see that they are not actually using the session generate…`), even though Claude had already generated a name for it.
<img width="1008" height="232" alt="image" src="https://github.com/user-attachments/assets/71562053-2eb4-49c9-aac3-5f310b265018" />


**After** — the session shows its generated name, `Investigate Orca session title generation bug`, matching what `/status` and the tab title show. Other sessions likewise show their generated names (e.g. `Understanding karma and moral accountability`).
<img width="888" height="472" alt="image" src="https://github.com/user-attachments/assets/d393a0de-2b07-4cc5-8128-1dd8bf66e51a" />


<!-- Drag the before/after images here (attached in the PR conversation). -->

## Testing

- [x] Targeted AI Vault scanner tests: `pnpm test`, 53 tests across 13 files passing on Node 24, including the two new Claude title/subagent tests.
- [x] Typecheck is clean for all changed files via `tsgo -p config/tsconfig.node.json`; there is one pre-existing unrelated error in `src/main/browser/cdp-ws-proxy.test.ts`.
- [x] `oxlint` is clean on the changed files.
- [x] Ran the dev app with `pnpm dev` and confirmed Agent Session History now shows Claude-generated titles and no longer shows subagent noise rows.
- [ ] Full repo-wide `pnpm test` not yet run end to end in this environment.
- [ ] Full `pnpm build` not yet run end to end in this environment.

## AI Review Report

Before finalizing, I ran a layered AI review. Three Opus high-reasoning agents first codified Orca's actual codebase conventions for production TypeScript, vitest scanner tests, and scanner performance contracts. I then handed that context to a separate Codex/GPT-class reviewer focused on correctness and optimization.

The main review catch was that my first cut filtered subagents per file, which still walked and allocated over the full `subagents/` subtree. I changed that to a directory-level `directoryPredicate` prune, so the subtree is never `readdir`'d. I also added the requested mapped-array assertions and the explicit test proving `custom-title` beats `ai-title`.

The review explicitly checked cross-platform behavior for macOS, Linux, and Windows: path handling uses Node path APIs and directory entry name comparison, not separator-dependent string matching. There are no keyboard shortcuts, shortcut labels, shell invocations, or Electron platform differences introduced by this change. It also covered SSH/remote behavior since the scanner can index remote and WSL homes, and the performance angle because this path can scan thousands of JSONL transcript files.

## Security Audit

No new input parsing was added beyond records the scanner already reads. `ai-title` and `custom-title` values continue through the existing `normalizeTitleText` path.

Path handling is limited to comparing a directory entry name against `subagents`; it does not construct or trust paths from transcript input, so this does not introduce traversal risk.

There is no command execution, no new IPC surface, no secrets handling, no auth change, no network calls, and no new dependencies. This remains read-only session-history indexing.

## Notes

All changed code is in the main process scanner path. There are no renderer or UI code changes, though the result is visible in the AI Vault side panel.

The subagent filtering is Claude-specific and scoped to Claude discovery. It does not change generic scanner behavior or other agent providers. The filter is intentionally applied during directory traversal for performance and for Windows-safe path handling.

CI should still confirm the full repo-wide test and build jobs.
