### PR TITLE
Use official OpenCode SVG icon instead of remote favicon

### DIFF
--- a/src/renderer/src/components/agent/AgentCombobox.test.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.test.tsx
@@ -27,4 +27,14 @@ describe('AgentCombobox', () => {
     expect(markup).not.toContain('https://github.com/Gitlawb.png')
     expect(markup).not.toContain('<svg')
   })
+
+  it('uses the official OpenCode SVG mark instead of a remote favicon', () => {
+    const markup = renderToStaticMarkup(<AgentIcon agent="opencode" />)
+
+    expect(markup).toContain('<svg')
+    expect(markup).toContain('viewBox="0 0 240 300"')
+    expect(markup).not.toContain('/resources/opencode.webp')
+    expect(markup).not.toContain('https://www.google.com/s2/favicons')
+    expect(markup).not.toContain('<img')
+  })
 })

--- a/src/renderer/src/components/agent/AgentCombobox.test.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.test.tsx
@@ -32,7 +32,7 @@ describe('AgentCombobox', () => {
     const markup = renderToStaticMarkup(<AgentIcon agent="opencode" />)
 
     expect(markup).toContain('<svg')
-    expect(markup).toContain('viewBox="0 0 240 300"')
+    expect(markup).toContain('viewBox="0 0 512 512"')
     expect(markup).not.toContain('/resources/opencode.webp')
     expect(markup).not.toContain('https://www.google.com/s2/favicons')
     expect(markup).not.toContain('<img')

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -9,6 +9,7 @@ import {
   CopilotIcon,
   KiloIcon,
   OmpIcon,
+  OpenCodeIcon,
   PiIcon
 } from './agent-icon-glyphs'
 import { translate } from '@/i18n/i18n'
@@ -86,7 +87,6 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     id: 'opencode',
     label: translate('auto.lib.agent.catalog.e7a4ca5103', 'OpenCode'),
     cmd: 'opencode',
-    faviconDomain: 'opencode.ai',
     homepageUrl: 'https://opencode.ai/docs/cli/'
   },
   {
@@ -335,6 +335,9 @@ export function AgentIcon({
   }
   if (agent === 'copilot') {
     return <CopilotIcon size={size} />
+  }
+  if (agent === 'opencode') {
+    return <OpenCodeIcon size={size} />
   }
   const catalogEntry = getAgentCatalog().find((a) => a.id === agent)
   if (catalogEntry?.iconUrl) {

--- a/src/renderer/src/lib/agent-icon-glyphs.tsx
+++ b/src/renderer/src/lib/agent-icon-glyphs.tsx
@@ -113,21 +113,26 @@ export function CopilotIcon({ size = 14 }: { size?: number }): React.JSX.Element
 }
 
 export function OpenCodeIcon({ size = 14 }: { size?: number }): React.JSX.Element {
-  // SVG geometry sourced from opencode.ai/brand's official logo asset.
+  // SVG geometry sourced from opencode.ai/favicon.svg's official 512 canvas.
   // Why: the branded fills are adapted to currentColor so the mark is visible
-  // in both Orca themes and avoids the flaky favicon proxy.
+  // in both Orca themes, and keeping the square viewBox matches sibling glyphs.
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 240 300"
+      viewBox="0 0 512 512"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden
       className="text-current"
     >
-      <path d="M180 240H60V120H180V240Z" fill="currentColor" fillOpacity="0.28" />
-      <path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="currentColor" />
+      <path d="M320 224V352H192V224H320Z" fill="currentColor" fillOpacity="0.28" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z"
+        fill="currentColor"
+      />
     </svg>
   )
 }

--- a/src/renderer/src/lib/agent-icon-glyphs.tsx
+++ b/src/renderer/src/lib/agent-icon-glyphs.tsx
@@ -112,6 +112,26 @@ export function CopilotIcon({ size = 14 }: { size?: number }): React.JSX.Element
   )
 }
 
+export function OpenCodeIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  // SVG geometry sourced from opencode.ai/brand's official logo asset.
+  // Why: the branded fills are adapted to currentColor so the mark is visible
+  // in both Orca themes and avoids the flaky favicon proxy.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 240 300"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      className="text-current"
+    >
+      <path d="M180 240H60V120H180V240Z" fill="currentColor" fillOpacity="0.28" />
+      <path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="currentColor" />
+    </svg>
+  )
+}
+
 export function AgentLetterIcon({
   letter,
   size = 14


### PR DESCRIPTION
Fixes https://github.com/stablyai/orca/issues/7348 

## Summary

Replaces the remote favicon for OpenCode with an official built-in SVG icon (`OpenCodeIcon`) to avoid using a flaky remote favicon proxy. The SVG is configured to use `currentColor` and `fillOpacity` so that it renders beautifully on both dark and light themes.

## Screenshots

- No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the icon rendering path and verified that `<OpenCodeIcon>` respects themes by utilizing `currentColor` values. Cross-platform compatibility (macOS, Linux, and Windows) is unaffected as this is a standard renderer-side SVG element optimization.

## Security Audit

No security risks. This change actually improves privacy and security by removing the remote third-party Google favicon proxy request for the `opencode` agent.

## Notes

None.