### PR TITLE
Add local diagnostics bundle export

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,14 +1,8 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-07-03",
+  "updatedAt": "2026-07-04",
   "policy": {
-    "maturityLevels": [
-      "experimental",
-      "soak",
-      "blocking",
-      "accepted-gap",
-      "deprecated"
-    ],
+    "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
       "minimumSoakRuns": 100,
       "minimumSoakDays": 14,
@@ -23,23 +17,10 @@
       "protection": "partial",
       "owner": "terminal-runtime",
       "layer": "renderer-unit",
-      "surfaces": [
-        "terminal lifecycle",
-        "dead-session reconciliation",
-        "tab creation"
-      ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "surfaces": ["terminal lifecycle", "dead-session reconciliation", "tab creation"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence over the reconcile guards that exist on main@1282f5c2d. Broader targeted-hasPty resume paths, no-hot listing counts, and live Electron survival arrive with the pending reliability stack.",
       "motivatingLinks": [
@@ -119,21 +100,9 @@
         "provider session dedupe",
         "sidebar and mobile identity"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "wsl",
-        "remote-runtime"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence over the ownership/dedupe suite on main@1282f5c2d. Queued/pending resume-claim indexing, same-session and wrong-session hook proofs, and Electron repeat-activation coverage arrive with the pending stack (#7008).",
       "motivatingLinks": [
@@ -147,9 +116,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts"
       ],
-      "testFiles": [
-        "src/renderer/src/lib/resume-sleeping-agent-session.test.ts"
-      ],
+      "testFiles": ["src/renderer/src/lib/resume-sleeping-agent-session.test.ts"],
       "assertionRefs": [
         {
           "file": "src/renderer/src/lib/resume-sleeping-agent-session.test.ts",
@@ -207,26 +174,10 @@
       "protection": "partial",
       "owner": "terminal-rendering",
       "layer": "renderer-provider-contract",
-      "surfaces": [
-        "PTY sizing",
-        "split layout",
-        "restore",
-        "hidden-to-visible transitions"
-      ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "surfaces": ["PTY sizing", "split layout", "restore", "hidden-to-visible transitions"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence on main@1282f5c2d, including #7192's runtime-mirror geometry authority slice. Shell-visible size, SSH/remote geometry, Windows ConPTY readback, and resume-time reassertion coverage arrive with the pending stack and #7006.",
       "motivatingLinks": [
@@ -328,27 +279,10 @@
       "protection": "partial",
       "owner": "terminal-rendering",
       "layer": "renderer-unit",
-      "surfaces": [
-        "terminal search",
-        "links",
-        "WebGL",
-        "decorations",
-        "keyboard navigation"
-      ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "surfaces": ["terminal search", "links", "WebGL", "decorations", "keyboard navigation"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence over the WebGL/link/search containment suites on main@1282f5c2d, adopting the #6949 atlas-recovery rename and #7133's reveal hardening tests. Core addon-load throw containment and live typed-input survival arrive with #7004 and a live follow-up.",
       "motivatingLinks": [
@@ -465,23 +399,9 @@
       "protection": "none",
       "owner": "startup-persistence",
       "layer": "upgrade-fixture",
-      "surfaces": [
-        "startup",
-        "upgrade",
-        "session restore",
-        "daemon restore"
-      ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "wsl"
-      ],
+      "surfaces": ["startup", "upgrade", "session restore", "daemon restore"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "wsl"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
@@ -517,9 +437,7 @@
         "Run second restart after current code writes upgraded state.",
         "Record startup timing and failure artifact."
       ],
-      "knownGaps": [
-        "No fixture corpus or command yet."
-      ],
+      "knownGaps": ["No fixture corpus or command yet."],
       "demotionRule": "Cannot promote without old production fixture provenance."
     },
     {
@@ -538,13 +456,8 @@
         "resize",
         "exit cleanup"
       ],
-      "platforms": [
-        "linux",
-        "macos"
-      ],
-      "providers": [
-        "local"
-      ],
+      "platforms": ["linux", "macos"],
+      "providers": ["local"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap on main. The live Electron Playwright slice exists only on the pending reliability stack. It registers here with its owning split PR.",
@@ -603,14 +516,8 @@
         "CJK repaint",
         "cursor and resize"
       ],
-      "platforms": [
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "wsl"
-      ],
+      "platforms": ["windows"],
+      "providers": ["local", "daemon", "wsl"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
@@ -671,18 +578,8 @@
         "resize",
         "render"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "wsl",
-        "remote-runtime"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap on main. The targeted-hasPty product hardening and no-hot count assertions exist only on the pending reliability stack. It registers here with its owning split PR.",
@@ -728,7 +625,7 @@
       "id": "terminal-observability.lifecycle-breadcrumbs",
       "title": "Terminal lifecycle anomalies enter crash diagnostics as compact breadcrumbs",
       "maturity": "experimental",
-      "protection": "none",
+      "protection": "partial",
       "owner": "terminal-runtime",
       "layer": "renderer-observability",
       "surfaces": [
@@ -738,31 +635,48 @@
         "provider ownership",
         "diagnostics bundle"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "wsl",
-        "remote-runtime"
-      ],
-      "coveredPlatforms": [],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
+      "coveredPlatforms": ["windows"],
       "coveredProviders": [],
-      "coverageNotes": "Registered gap on main. The crash-breadcrumb recording and its test exist only on the pending reliability stack. It registers here with its owning split PR.",
+      "coverageNotes": "Local Windows evidence proves compact terminal lifecycle crash breadcrumbs and diagnostics-bundle export of the breadcrumb trace file; full live provider transition traces remain a follow-up.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6800",
         "https://github.com/stablyai/orca/issues/6773"
       ],
       "invariant": "Terminal lifecycle anomalies around reattach, restore, provider ownership, stale liveness, and fallback routing must leave compact, deduped, privacy-safe breadcrumbs in crash diagnostics so future reports can be attributed from evidence.",
-      "oracle": "The current executable slice calls warnTerminalLifecycleAnomaly with terminal identity, provider, PTY id, binding epoch, and reason, then asserts the existing console warning is preserved and a compact terminal_lifecycle_anomaly crash breadcrumb is recorded once per lifecycle identity. Full pane transition traces and diagnostics-bundle artifact proof remain follow-ups.",
-      "commands": [],
-      "testFiles": [],
-      "assertionRefs": [],
-      "evidenceRuns": [],
+      "oracle": "The executable slice calls warnTerminalLifecycleAnomaly with terminal identity and reason, asserts the existing console warning is preserved, records a compact terminal_lifecycle_anomaly crash breadcrumb without raw worktree or PTY ids, and proves diagnostics-bundle export includes crash/terminal-lifecycle.json. Full pane transition traces remain a follow-up.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.test.ts src/main/diagnostics/diagnostic-bundle-export.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.test.ts",
+        "src/main/diagnostics/diagnostic-bundle-export.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.test.ts",
+          "assertions": ["records a compact crash breadcrumb without raw worktree or pty ids"]
+        },
+        {
+          "file": "src/main/diagnostics/diagnostic-bundle-export.test.ts",
+          "assertions": [
+            "writes a ZIP with manifest and selected diagnostics files",
+            "includes the terminal lifecycle trace in crash/terminal-lifecycle.json"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-04",
+          "runner": "local",
+          "platform": "windows",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.test.ts src/main/diagnostics/diagnostic-bundle-export.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.517,
+          "summary": "2 test file(s) passed, 3 tests passed in the creating-exe-dump worktree."
+        }
+      ],
       "runtimeBudget": {
         "p95Seconds": 10,
         "scope": "renderer observability unit test"
@@ -773,7 +687,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Tests would fail if lifecycle anomalies stopped recording crash breadcrumbs or stopped deduping repeated identities. Needs diagnostics-bundle artifact proof and full transition-trace evidence before promotion."
+        "evidence": "Tests fail if lifecycle anomalies stop recording compact crash breadcrumbs or diagnostics-bundle export drops crash/terminal-lifecycle.json. Full transition-trace evidence is still needed before promotion."
       },
       "performanceBudget": {
         "required": true,
@@ -785,9 +699,7 @@
         "Add forbidden-transition tests for stale close, unknown owner fallback, and stuck zero-size panes."
       ],
       "knownGaps": [
-        "No executable coverage on main yet; the slice lives on the pending fix-terminal-reliability stack.",
         "Current command records anomaly breadcrumbs only, not a full pane lifecycle state-machine trace.",
-        "Current command does not prove crash/diagnostics bundle export includes the breadcrumb.",
         "Current command does not assert forbidden transitions across live Electron/provider flows."
       ],
       "demotionRule": "Cannot promote if diagnostics are console-only, unbounded, or missing from support artifacts."
@@ -806,20 +718,9 @@
         "xterm scheduler",
         "hidden output"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence over the main-process pending-output caps that exist on main@1282f5c2d. Daemon stream write(false)/drain contracts, cross-session drain priority, and bounded queued tails arrive with the pending perf slice; live flood/latency artifacts remain gaps.",
       "motivatingLinks": [
@@ -833,9 +734,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts"
       ],
-      "testFiles": [
-        "src/main/ipc/pty.test.ts"
-      ],
+      "testFiles": ["src/main/ipc/pty.test.ts"],
       "assertionRefs": [
         {
           "file": "src/main/ipc/pty.test.ts",
@@ -899,15 +798,8 @@
         "provider ownership",
         "startup restore"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "daemon",
-        "local"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["daemon", "local"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap on main. The fail-closed degraded-daemon hardening and its contracts exist only on the pending reliability stack. It registers here with its owning split PR.",
@@ -964,16 +856,8 @@
         "reattach",
         "unknown liveness"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "ssh",
-        "remote-runtime",
-        "wsl"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["ssh", "remote-runtime", "wsl"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap on main. The SSH unknown-liveness hardening and deferred-reattach contracts exist only on the pending reliability stack. It registers here with its owning split PR.",
@@ -1035,12 +919,8 @@
         "provider liveness",
         "restore"
       ],
-      "platforms": [
-        "windows"
-      ],
-      "providers": [
-        "wsl"
-      ],
+      "platforms": ["windows"],
+      "providers": ["wsl"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
@@ -1098,17 +978,8 @@
         "metadata-only replay",
         "WebGL recovery"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap on main. The replay FIFO/burst coalescing product change and its tests exist only on the pending reliability stack; main still uses a single pendingReplayData slot. It registers here with its owning split PR.",
@@ -1167,20 +1038,9 @@
         "keyboard bypass",
         "JIS yen"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence on main@1282f5c2d; identical files to the pending stack. Real OS IME automation, Windows ConPTY post-agent reset, and the CJK/Vietnamese/Arabic matrix remain registered gaps.",
       "motivatingLinks": [
@@ -1215,9 +1075,7 @@
         },
         {
           "file": "src/renderer/src/components/terminal-pane/terminal-paste-runtime.test.ts",
-          "assertions": [
-            "paste/runtime forwarding avoids duplicate terminal payloads"
-          ]
+          "assertions": ["paste/runtime forwarding avoids duplicate terminal payloads"]
         }
       ],
       "evidenceRuns": [
@@ -1272,14 +1130,8 @@
         "TUI exit",
         "standard key input"
       ],
-      "platforms": [
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "wsl"
-      ],
+      "platforms": ["windows"],
+      "providers": ["local", "daemon", "wsl"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
@@ -1335,14 +1187,8 @@
         "cursor repaint",
         "rewrite output"
       ],
-      "platforms": [
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "wsl"
-      ],
+      "platforms": ["windows"],
+      "providers": ["local", "daemon", "wsl"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
@@ -1378,10 +1224,7 @@
         "Keep stress cases non-blocking until Windows runtime history is stable.",
         "Fail promotion on silent Windows environment skips."
       ],
-      "knownGaps": [
-        "No manifest command yet.",
-        "No Windows CJK/emoji repaint command is wired."
-      ],
+      "knownGaps": ["No manifest command yet.", "No Windows CJK/emoji repaint command is wired."],
       "demotionRule": "Cannot promote if the oracle is screenshot-only or environment-skipped."
     },
     {
@@ -1399,14 +1242,8 @@
         "local provider",
         "daemon provider"
       ],
-      "platforms": [
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "wsl"
-      ],
+      "platforms": ["windows"],
+      "providers": ["local", "daemon", "wsl"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
@@ -1461,17 +1298,8 @@
         "renderer CPU",
         "resize churn"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
@@ -1519,21 +1347,9 @@
       "protection": "none",
       "owner": "terminal-performance",
       "layer": "daemon-provider-contract",
-      "surfaces": [
-        "daemon stream",
-        "socket write",
-        "drain",
-        "hidden output",
-        "input starvation"
-      ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "daemon"
-      ],
+      "surfaces": ["daemon stream", "socket write", "drain", "hidden output", "input starvation"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["daemon"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap on main. The daemon batcher write(false)/drain contracts exist only on the pending reliability stack. It registers here with its owning split PR.",
@@ -1591,23 +1407,12 @@
         "workspace switch",
         "agent status"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap on main. The boot-hydration counters and their tests exist only on the pending reliability stack. It registers here with its owning split PR.",
-      "motivatingLinks": [
-        "https://github.com/stablyai/orca/pull/7002"
-      ],
+      "motivatingLinks": ["https://github.com/stablyai/orca/pull/7002"],
       "invariant": "Terminal typing, focus, resize, tab/workspace switch, and agent/session restore must not trigger unbounded store projection, git status, provider listing, or per-pane polling work.",
       "oracle": "The current executable slice instruments boot-time local PTY registry hydration with repo counts, local-vs-remote repo skips, worktree enumeration counts, adapter/session listing counts, registration/skipped-session counts, duration, and failure phase. The broader oracle still needs instrumentation that counts store selector recomputes, git status requests, provider listings, and session scans during scripted hot interactions with many worktrees and terminal panes.",
       "commands": [],
@@ -1656,20 +1461,9 @@
         "metadata-only replay",
         "clear semantics"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence over the merged #7133/#7173 restore and hidden-output ordering tests on main@1282f5c2d. The dirty-state exactness contract, normal-buffer clear semantics, and metadata-only replay remain pending-stack work.",
       "motivatingLinks": [
@@ -1684,9 +1478,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts"
       ],
-      "testFiles": [
-        "src/renderer/src/components/terminal-pane/pty-connection.test.ts"
-      ],
+      "testFiles": ["src/renderer/src/components/terminal-pane/pty-connection.test.ts"],
       "assertionRefs": [
         {
           "file": "src/renderer/src/components/terminal-pane/pty-connection.test.ts",
@@ -1754,23 +1546,12 @@
         "renderer stream",
         "terminal colors"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
-      "motivatingLinks": [
-        "https://github.com/stablyai/orca/pull/6949"
-      ],
+      "motivatingLinks": ["https://github.com/stablyai/orca/pull/6949"],
       "invariant": "Startup OSC 10/11 color queries are answered out of band at startup only, never leak into shell/provider output streams, and ordinary runtime OSC color queries remain renderer-handled.",
       "oracle": "A provider-contract fixture records startup query replies, shell-visible bytes, renderer-visible bytes, and later runtime OSC behavior to prove no query leakage or color deadlock.",
       "commands": [],
@@ -1798,10 +1579,7 @@
         "Cover startup-only and runtime OSC paths separately.",
         "Keep screenshot evidence diagnostic only."
       ],
-      "knownGaps": [
-        "No manifest command yet.",
-        "No startup color-query contract is wired."
-      ],
+      "knownGaps": ["No manifest command yet.", "No startup color-query contract is wired."],
       "demotionRule": "Cannot promote if success is based only on absence of visible artifacts."
     },
     {
@@ -1818,21 +1596,9 @@
         "JSON subscribe fallback",
         "snapshot buffering"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows",
-        "mobile"
-      ],
-      "providers": [
-        "remote-runtime",
-        "ssh",
-        "local",
-        "daemon"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "platforms": ["macos", "linux", "windows", "mobile"],
+      "providers": ["remote-runtime", "ssh", "local", "daemon"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence over the runtime-RPC stream budgets on main@1282f5c2d. The pending stack adds byte-exact 512KB/2MB/256KB/48KB budget assertions; legacy JSON subscribe parity remains undecided.",
       "motivatingLinks": [
@@ -1928,20 +1694,9 @@
         "unicode width",
         "parser configuration"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
-      "coveredPlatforms": [
-        "macos"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
       "coveredProviders": [],
       "coverageNotes": "Local macOS evidence over #7148's width-parity oracle on main@1282f5c2d. A broader byte corpus, a shared parser-construction assertion over terminal-unicode-provider.ts/pane-terminal-options.ts, and recorded agent-session corpora remain gaps.",
       "motivatingLinks": [
@@ -1953,9 +1708,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/headless-emulator-unicode-width.test.ts"
       ],
-      "testFiles": [
-        "src/main/daemon/headless-emulator-unicode-width.test.ts"
-      ],
+      "testFiles": ["src/main/daemon/headless-emulator-unicode-width.test.ts"],
       "assertionRefs": [
         {
           "file": "src/main/daemon/headless-emulator-unicode-width.test.ts",
@@ -2012,23 +1765,9 @@
       "protection": "none",
       "owner": "terminal-rendering",
       "layer": "renderer-observability",
-      "surfaces": [
-        "hidden-output restore",
-        "snapshot replay",
-        "anomaly breadcrumbs",
-        "telemetry"
-      ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon",
-        "ssh",
-        "remote-runtime"
-      ],
+      "surfaces": ["hidden-output restore", "snapshot replay", "anomaly breadcrumbs", "telemetry"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; the anomaly-breadcrumb machinery exists in this branch but no convergence probe is implemented.",
@@ -2085,15 +1824,8 @@
         "window wake",
         "render model"
       ],
-      "platforms": [
-        "macos",
-        "linux",
-        "windows"
-      ],
-      "providers": [
-        "local",
-        "daemon"
-      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon"],
       "coveredPlatforms": [],
       "coveredProviders": [],
       "coverageNotes": "Registered gap only; the live repro harness with a refresh-repair oracle exists but is not productized into the release-blocking terminal-rendering-golden suite.",

--- a/docs/reference/native-diagnostic-dumps-implementation-plan.md
+++ b/docs/reference/native-diagnostic-dumps-implementation-plan.md
@@ -1,0 +1,325 @@
+# Native Diagnostic Dumps Implementation Plan
+
+Generated: 2026-07-04
+
+Status: implemented in this branch for local diagnostics export. This file maps
+the research in `docs/reference/native-diagnostic-dumps-research.md` to Orca's
+current code seams and records the remaining deferrals.
+
+## Target Outcome
+
+Orca supports a cross-platform diagnostics export that can be created from the
+packaged CLI and, later, from the app UI:
+
+```text
+orca diagnostics bundle [--output <path>] [--lookback <duration>]
+                        [--include <category>] [--exclude <category>]
+                        [--json] [--open]
+```
+
+The export creates a reviewable ZIP by default. A local, explicit export
+includes all supported categories, including minidumps when available.
+Upload or issue attachment must use a separate consent gate because minidumps
+can contain process memory and cannot be reliably redacted after capture.
+
+## Requirement Matrix
+
+| Requirement                       | Pre-branch state                                                                                                                              | Branch state                                                                                                                                |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Native minidumps                  | No `crashReporter`/Crashpad integration found in source search.                                                                               | Electron `crashReporter` starts early with local-only `uploadToServer: false`, explicit crash-dump directory, and static crash annotations. |
+| Redacted observability spans      | Existing `collectDiagnosticBundle` emits capped NDJSON.                                                                                       | Reuse the existing collector as `diagnostics/observability.ndjson` inside the ZIP.                                                          |
+| Crash report context              | Existing crash-report records include app/platform/Electron/Chrome and process-gone details.                                                  | Include sanitized crash-report records plus links to matching Crashpad minidumps by timestamp/process where possible.                       |
+| Memory snapshot                   | Existing CLI exposes `orca diagnostics memory` through `diagnostics.memory`.                                                                  | Include the current `MemorySnapshot` in every default bundle, and keep the standalone command unchanged.                                    |
+| Windows process memory            | Current collector uses `wmic`.                                                                                                                | Windows process enumeration is CIM-first, with `wmic` retained only as a narrow fallback.                                                   |
+| OS diagnostic info                | Existing bundle header only has app version/platform/arch/OS release/channel.                                                                 | Structured `system/os.json`, `system/resources.json`, and platform-specific summaries are exported.                                         |
+| WSL/shell availability            | Not part of current bundle.                                                                                                                   | Bounded Windows WSL summary and shell availability summaries are exported without raw environment dumps.                                    |
+| Workspace/project/terminal counts | Available through stores/runtime/CLI flows, but not in diagnostics bundle.                                                                    | Count-only runtime summaries are exported; raw names, prompts, branches, and paths stay out by default.                                     |
+| Terminal lifecycle evidence       | `config/reliability-gates.jsonc` records a diagnostics-bundle gap, and `warnTerminalLifecycleAnomaly` currently only emits a console warning. | Compact terminal lifecycle breadcrumbs are recorded to crash diagnostics and bundle export coverage proves the trace file is present.       |
+| CLI export                        | Only `orca diagnostics memory` exists.                                                                                                        | `orca diagnostics bundle` is wired through CLI specs, handlers, runtime RPC, and packaged launcher tests.                                   |
+| Issue/upload integration          | Feedback endpoint accepts JSON or multipart NDJSON diagnostic bundle only.                                                                    | Keep ZIP/minidump upload as a later binary artifact endpoint; issue text should reference artifact IDs, not embed binaries.                 |
+
+## Proposed Files And Responsibilities
+
+Use concrete module names. Do not create `helpers`, `utils`, or generic dumping
+grounds.
+
+### Native Crash Capture
+
+- `src/main/diagnostics/native-crash-dump-directory.ts`
+  - Resolves and creates the Crashpad directory.
+  - Uses app data/logs paths, never the install directory.
+
+- `src/main/diagnostics/native-crash-reporter.ts`
+  - Owns the early `crashReporter.start()` call.
+  - Sets `app.setPath('crashDumps', directory)` before start.
+  - Adds static `globalExtra` annotations.
+  - Starts local-only unless a future user-consented upload path exists.
+
+- `src/main/diagnostics/native-crash-dump-index.ts`
+  - Enumerates recent Crashpad dump files and metadata safe for the bundle
+    manifest.
+  - Does not parse or redact minidump bytes.
+
+### Bundle Archive
+
+- `src/shared/diagnostic-bundle-export-types.ts`
+  - Category names, CLI result shape, manifest schema, skipped/error status.
+
+- `src/main/diagnostics/diagnostic-bundle-category.ts`
+  - Category parsing and include/exclude resolution.
+  - Defaults to all supported local categories.
+
+- `src/main/diagnostics/diagnostic-output-path.ts`
+  - Computes default archive paths under Orca logs/diagnostics.
+  - Normalizes user-provided `--output` while preserving platform path rules.
+
+- `src/main/diagnostics/diagnostic-archive-writer.ts`
+  - Writes a ZIP or directory archive.
+  - Records every file in `manifest.json` with bytes, category, and status.
+
+- `src/main/diagnostics/diagnostic-bundle-export.ts`
+  - Orchestrates all collectors.
+  - Every collector failure becomes a manifest `error` entry unless the core
+    output path itself fails.
+
+### Collectors
+
+- `src/main/diagnostics/app-diagnostic-summary.ts`
+  - App version, channel, Electron/Chrome/Node versions, app paths with redacted
+    or role-only fields.
+
+- `src/main/diagnostics/runtime-diagnostic-counts.ts`
+  - Count-only project/worktree/workspace/terminal/runtime summaries.
+  - No workspace names, branch names, prompts, paths, or repository names.
+
+- `src/main/diagnostics/terminal-lifecycle-diagnostic-trace.ts`
+  - Reads compact terminal lifecycle breadcrumbs/traces once that renderer
+    signal is promoted beyond console warnings.
+  - Satisfies the existing reliability-gate follow-up that diagnostics bundle
+    artifacts prove lifecycle evidence is present.
+
+- `src/main/diagnostics/system-diagnostic-summary.ts`
+  - OS platform/release/version, arch, CPU count/model summary, total/free
+    memory, locale where safe.
+
+- `src/main/diagnostics/windows-event-diagnostic-summary.ts`
+  - Uses `Get-WinEvent` for bounded Application Error/Application Hang records.
+  - Filters to Orca/Electron process names and recent lookback.
+  - Non-admin access failures become skipped/error manifest entries.
+
+- `src/main/diagnostics/windows-wsl-diagnostic-summary.ts`
+  - Captures WSL availability and distro state from bounded `wsl.exe` probes.
+  - No filesystem scans of distributions.
+
+- `src/main/diagnostics/shell-availability-summary.ts`
+  - Reports whether expected shells are resolvable, not raw environment data.
+
+- `src/main/diagnostics/macos-report-diagnostic-index.ts`
+  - Indexes recent Orca-named `.ips`/`.spin` files from accessible diagnostic
+    report directories.
+  - Does not include full sysdiagnose by default.
+
+- `src/main/diagnostics/linux-coredump-diagnostic-summary.ts`
+  - Best-effort `coredumpctl` metadata for Orca/Electron processes.
+  - Missing systemd-coredump or permissions become skipped/error status.
+
+### Windows Memory Refactor
+
+- `src/main/memory/windows-process-working-set.ts`
+  - CIM-first Windows process enumeration.
+  - Parses PowerShell JSON for `ProcessId`, `ParentProcessId`, and
+    `WorkingSetSize`.
+  - Handles singleton object JSON, empty arrays, access denied, timeout, and
+    malformed output.
+
+- `src/main/memory/collector.ts`
+  - Delegates Windows enumeration to the new module.
+  - Keeps existing snapshot shape unchanged.
+
+## CLI And RPC Wiring
+
+Add command spec:
+
+- `src/cli/specs/diagnostics.ts`
+  - Add `path: ['diagnostics', 'bundle']`.
+  - Flags: `--output`, `--lookback`, repeated `--include`, repeated
+    `--exclude`, `--open`, `--json`.
+
+Add handler:
+
+- `src/cli/handlers/diagnostics.ts`
+  - Parse flags.
+  - Call `diagnostics.bundle`.
+  - Print archive path and skipped/error category summary.
+
+Add RPC:
+
+- `src/main/runtime/rpc/methods/diagnostics.ts`
+  - Add `diagnostics.bundle`.
+  - Validate arguments at the boundary.
+
+- `src/main/runtime/rpc/methods/index.ts`
+  - Already imports `DIAGNOSTICS_METHODS`; adding to that array should register
+    the method.
+
+- `src/main/runtime/runtime-rpc.ts`
+  - Add `diagnostics.bundle` to the runtime method allowlist next to
+    `diagnostics.memory`.
+
+Packaged launchers:
+
+- `resources/win32/bin/orca.cmd` should not need behavioral changes for the
+  command itself. The viable comment is already true: the shim runs the unpacked
+  CLI through `Orca.exe` using `ELECTRON_RUN_AS_NODE=1`.
+- Add/extend packaged CLI tests so Windows, macOS, and Linux launchers prove
+  `diagnostics bundle --help` and argument forwarding are available.
+
+## Default Paths
+
+The main process should compute the default path because it has Electron path
+APIs:
+
+```text
+<app.getPath('logs')>/diagnostics/orca-diagnostics-<YYYYMMDD-HHMMSS>.zip
+```
+
+Expected platform defaults after Electron log path resolution:
+
+- macOS: `~/Library/Logs/Orca/diagnostics/...`
+- Windows: inside Orca's per-user app data/logs location
+- Linux: inside Orca's per-user app data/logs location
+
+Do not write under `Program Files`, the `.app` bundle, AppImage mount paths, or
+other install directories.
+
+## Archive Contract
+
+Every archive should include:
+
+```text
+manifest.json
+app/orca.json
+system/os.json
+system/resources.json
+diagnostics/observability.ndjson
+memory/snapshot.json
+crash/orca-crash-reports.json
+```
+
+Include when available:
+
+```text
+app/runtime-counts.json
+crash/minidumps/*.dmp
+windows/events.json
+windows/wsl.json
+windows/shells.json
+macos/reports-index.json
+macos/shells.json
+linux/coredumpctl.json
+linux/journal.json
+linux/shells.json
+```
+
+`manifest.json` should list:
+
+- schema version
+- bundle ID
+- collected timestamp
+- Orca version/channel
+- platform/arch
+- output category statuses
+- file list with category, relative path, byte size, and SHA-256
+- skipped categories with reason codes
+- errors with sanitized reason codes
+
+## Privacy And Permissions Rules
+
+- Main process collects all bytes. Renderer and CLI callers may request
+  categories and output path, but must not supply archive payloads.
+- Native minidumps are sensitive. Local explicit export may include them by
+  default; upload and issue attachment require a separate explicit consent gate.
+- Do not collect raw terminal scrollback by default.
+- Do not collect full env vars by default.
+- Do not collect repository contents by default.
+- Runtime/workspace/project summaries should be count-only unless a future
+  explicit "include names/paths" option is added.
+- Platform collectors must be bounded by lookback, max event count, max byte
+  count, and timeout.
+- Permission failures should be visible in the manifest, not fatal.
+
+## Happy Path Tests
+
+- `orca diagnostics bundle --json` returns archive path, bundle ID, included
+  categories, skipped categories, and byte size.
+- `orca diagnostics bundle --output <tmp.zip> --json` writes a ZIP containing
+  `manifest.json`, app summary, system summary, observability NDJSON, and memory
+  snapshot.
+- Existing `orca diagnostics memory` CLI output and RPC behavior remain
+  unchanged.
+- CrashReporter initializer sets crash dump path before starting Crashpad.
+- Renderer crash test in a controlled Electron harness creates a minidump after
+  crashReporter startup.
+- Terminal lifecycle anomaly test proves the bundle includes recent compact
+  lifecycle breadcrumbs/traces, matching the reliability-gate promotion
+  criteria.
+- Packaged Windows CLI shim forwards `diagnostics bundle --help` through
+  `Orca.exe` with `ELECTRON_RUN_AS_NODE=1`.
+
+## Non-Happy Path Tests
+
+- Output directory unwritable: command fails with a clear error before partial
+  archive success is reported.
+- Invalid `--include`/`--exclude`: command rejects with known category names.
+- No Crashpad dumps: archive succeeds with `native-minidumps` skipped.
+- Diagnostics disabled in Privacy settings: observability category is skipped or
+  rejected according to the final consent policy; native local export policy must
+  be explicit.
+- Windows `Get-WinEvent` access denied: archive succeeds with event category
+  error in manifest.
+- PowerShell missing or CIM malformed: Windows memory collector falls back or
+  records a non-fatal collector failure without breaking existing snapshot
+  shape.
+- Linux without `coredumpctl`: category skipped.
+- macOS without DiagnosticReports access: category skipped.
+- Archive size cap exceeded: category truncates or skips according to manifest
+  policy; command does not silently omit data.
+
+## Validation Gates
+
+Run the narrowest relevant gates for each phase:
+
+```text
+pnpm test -- src/main/memory/collector.test.ts
+pnpm test -- src/main/runtime/rpc/methods/diagnostics.test.ts
+pnpm test -- src/cli/index.test.ts
+pnpm test -- src/main/ipc/diagnostics.test.ts
+pnpm test -- src/main/ipc/crash-reporting.test.ts
+pnpm typecheck
+pnpm lint
+```
+
+For packaging and launcher confidence:
+
+```text
+pnpm test -- src/main/cli/packaged-cli-assets.test.ts
+pnpm test -- src/main/cli/windows-launcher-asset.test.ts
+pnpm run build:win
+```
+
+The Windows build is expensive and platform-specific; it should be required
+before merge for this feature, but not necessarily after every small planning
+edit.
+
+## Explicit Deferrals
+
+- Server-side symbolication pipeline.
+- Binary artifact upload endpoint.
+- Provider-neutral auto issue creation with private diagnostic artifacts.
+- Full heap snapshots.
+- Full macOS sysdiagnose capture.
+- ProcDump bundling or auto-download.
+- WER registry mutation.
+
+These are real requirements for a complete support system, but they should not
+block the first local `orca diagnostics bundle --output` implementation.

--- a/docs/reference/native-diagnostic-dumps-implementation-plan.md
+++ b/docs/reference/native-diagnostic-dumps-implementation-plan.md
@@ -12,7 +12,7 @@ Orca supports a cross-platform diagnostics export that can be created from the
 packaged CLI and, later, from the app UI:
 
 ```text
-orca diagnostics bundle [--output <path>] [--lookback <duration>]
+orca diagnostics bundle [--output <filename-or-subpath>] [--lookback <duration>]
                         [--include <category>] [--exclude <category>]
                         [--json] [--open]
 ```
@@ -71,7 +71,8 @@ grounds.
 
 - `src/main/diagnostics/diagnostic-output-path.ts`
   - Computes default archive paths under Orca logs/diagnostics.
-  - Normalizes user-provided `--output` while preserving platform path rules.
+  - Resolves user-provided `--output` as a filename or subpath under that
+    diagnostics directory.
 
 - `src/main/diagnostics/diagnostic-archive-writer.ts`
   - Writes a ZIP or directory archive.
@@ -252,7 +253,8 @@ linux/shells.json
 
 - `orca diagnostics bundle --json` returns archive path, bundle ID, included
   categories, skipped categories, and byte size.
-- `orca diagnostics bundle --output <tmp.zip> --json` writes a ZIP containing
+- `orca diagnostics bundle --output <tmp.zip> --json` writes a ZIP under
+  Orca logs/diagnostics containing
   `manifest.json`, app summary, system summary, observability NDJSON, and memory
   snapshot.
 - Existing `orca diagnostics memory` CLI output and RPC behavior remain

--- a/docs/reference/native-diagnostic-dumps-implementation-plan.md
+++ b/docs/reference/native-diagnostic-dumps-implementation-plan.md
@@ -234,6 +234,51 @@ linux/shells.json
 - skipped categories with reason codes
 - errors with sanitized reason codes
 
+## Reading And Triage Workflow
+
+Support engineers should treat the exported file as a ZIP diagnostics bundle, not
+as an executable to run. The normal review flow is:
+
+1. Ask the user to run `orca diagnostics bundle --json` or
+   `orca diagnostics bundle --open`.
+2. Open the ZIP with the OS archive tool, 7-Zip, Finder, or `unzip -l`.
+3. Start with `manifest.json` to see the bundle ID, Orca version/channel,
+   platform/arch, effective lookback window, included files, skipped categories,
+   and collector errors.
+4. Read JSON/NDJSON files with any text editor, `jq`, or log tooling. The
+   highest-signal files are usually `app/orca.json`, `system/os.json`,
+   `system/resources.json`, `memory/snapshot.json`, `app/runtime-counts.json`,
+   `diagnostics/observability.ndjson`, and `crash/orca-crash-reports.json`.
+5. If `crash/minidumps/*.dmp` exists, inspect it with native dump tooling such
+   as WinDbg or Visual Studio on Windows, `minidump_stackwalk` with matching
+   symbols, or a future Orca symbolication service. Do not paste minidump bytes
+   into issues or chat.
+
+Expected CLI text output:
+
+```text
+bundleId: <uuid>
+outputPath: <logs>/diagnostics/orca-diagnostics-<timestamp>.zip
+bytes: <archive-byte-size>
+files: <manifest-file-count>
+lookbackMinutes: <effective-lookback>
+includedCategories: app, system, observability, ...
+skippedCategories: native-minidumps (none_found)
+errorCategories: windows-events (<sanitized-reason>)
+```
+
+Expected `--json` output is the same data as a structured
+`DiagnosticBundleExportResult`. The archive itself is the support artifact; the
+CLI output is only the receipt and quick status summary.
+
+This is helpful because it puts crash artifacts and the surrounding runtime
+context in the same time-bounded artifact. A minidump can show the crashing
+thread, loaded modules, and native stack state; the bundle explains whether the
+app was packaged, which Orca/Electron/Chrome/Node versions were running, which
+OS resources were constrained, whether terminal/runtime state was unusual, and
+which platform collectors failed or were unavailable. That combination is much
+more actionable than a standalone `.dmp` file or a screenshot of an error.
+
 ## Privacy And Permissions Rules
 
 - Main process collects all bytes. Renderer and CLI callers may request
@@ -245,6 +290,9 @@ linux/shells.json
 - Do not collect repository contents by default.
 - Runtime/workspace/project summaries should be count-only unless a future
   explicit "include names/paths" option is added.
+- Runtime host summaries must bucket host IDs by kind (`local`, `ssh`,
+  `runtime`, `legacy-local`, or `unknown`) rather than emitting configured host
+  names or target IDs.
 - Platform collectors must be bounded by lookback, max event count, max byte
   count, and timeout.
 - Permission failures should be visible in the manifest, not fatal.
@@ -286,6 +334,26 @@ linux/shells.json
 - macOS without DiagnosticReports access: category skipped.
 - Archive size cap exceeded: category truncates or skips according to manifest
   policy; command does not silently omit data.
+
+## Privacy Regression Coverage
+
+Add broad tests at the bundle boundary, not only at individual collectors:
+
+- Build a fake runtime store containing realistic sensitive values: usernames,
+  Windows and POSIX home paths, repository names, branch names, host target
+  labels, terminal IDs/prompts, and token-like strings.
+- Export the default low-risk categories and parse the stored ZIP entries.
+- Assert the archive text contains expected diagnostic fields such as counts,
+  category statuses, role labels, and host-kind buckets.
+- Assert the archive text does not contain the seeded sensitive strings.
+- Keep direct unit tests for path policy, category sanitizers, shell/platform
+  collectors, and runtime count bucketing so regressions fail close to their
+  source.
+
+Native minidumps require a different test posture because their bytes can contain
+process memory by design. Tests should verify consent/default behavior,
+lookback/size caps, manifest labeling, and local-only export behavior; they
+should not claim minidump contents are redacted.
 
 ## Validation Gates
 

--- a/docs/reference/native-diagnostic-dumps-issue-draft.md
+++ b/docs/reference/native-diagnostic-dumps-issue-draft.md
@@ -1,0 +1,155 @@
+# Issue Draft: Cross-Platform Diagnostic Bundle And Native Crash Dumps
+
+Status: local diagnostics export implemented in this branch. Keep this draft as
+the support-facing summary and as the follow-up issue seed for binary upload,
+symbolication, and full platform smoke coverage.
+
+## Summary
+
+Add an Orca diagnostics export that support and users can create from the
+packaged CLI:
+
+```text
+orca diagnostics bundle --output <path>
+```
+
+The command creates a reviewable ZIP with native crash minidumps when
+available, redacted Orca observability spans, crash report context, memory
+snapshot, OS/resource summaries, shell/WSL availability, platform-specific
+failure evidence, and count-only workspace/project/terminal summaries.
+
+This should build on the current diagnostics and crash-reporting code instead
+of creating a parallel support lane.
+
+## Problem
+
+Before this branch, Orca had useful pieces but no single support artifact:
+
+- Settings can create/upload a redacted NDJSON diagnostics bundle.
+- Crash reports can attach that NDJSON bundle.
+- `orca diagnostics memory` can collect a memory snapshot.
+- Process-gone crash reports record app/platform/Electron/Chrome metadata.
+- Windows memory collection still shelled out to deprecated `wmic`.
+- There was no Electron `crashReporter`/Crashpad native minidump setup.
+- There was no local `orca diagnostics bundle --output` archive command.
+
+When users hit native crashes, renderer crashes, GPU failures, WSL/shell
+problems, or platform-specific launch issues, support has to reconstruct state
+from scattered reports.
+
+## Implemented Solution
+
+The branch implements a two-layer diagnostics system:
+
+1. Native crash capture
+   - Start Electron `crashReporter` early with `uploadToServer: false`.
+   - Set a deterministic Crashpad directory under Orca's per-user
+     logs/diagnostics path.
+   - Add static crash annotations: Orca version, channel, platform, arch, OS
+     release/version, Electron, Chrome, schema version.
+
+2. Diagnostic bundle export
+   - Add `orca diagnostics bundle`.
+   - Write a ZIP under an explicit `--output` path or default
+     `<app.getPath('logs')>/diagnostics/orca-diagnostics-<timestamp>.zip`.
+   - Include low-risk categories by default.
+   - Include local minidumps for explicit local exports when available.
+   - Keep upload/issue attachment behind separate explicit consent because
+     minidumps may contain process memory.
+
+## Proposed Archive Contract
+
+Required files:
+
+```text
+manifest.json
+app/orca.json
+system/os.json
+system/resources.json
+diagnostics/observability.ndjson
+memory/snapshot.json
+crash/orca-crash-reports.json
+```
+
+Conditional files:
+
+```text
+app/runtime-counts.json
+crash/minidumps/*.dmp
+windows/events.json
+windows/wsl.json
+windows/shells.json
+macos/reports-index.json
+macos/shells.json
+linux/coredumpctl.json
+linux/journal.json
+linux/shells.json
+```
+
+`manifest.json` should include bundle ID, schema version, timestamp,
+version/channel/platform, category statuses, file hashes, byte sizes, skipped
+reasons, and sanitized collector errors.
+
+## Acceptance Criteria Covered In This Branch
+
+- `orca diagnostics bundle --json` returns bundle ID, output path, byte size,
+  included categories, skipped categories, and sanitized errors.
+- `orca diagnostics bundle --output <tmp.zip> --json` writes a ZIP containing
+  the required files.
+- Default output path is under Orca's per-user logs/diagnostics directory, not
+  the install directory.
+- Existing `orca diagnostics memory` behavior remains unchanged.
+- Electron Crashpad is initialized before renderer creation and writes dumps to
+  the configured directory.
+- Native minidumps are included in explicit local exports when present.
+- Upload or issue attachment of minidumps requires separate explicit consent.
+- Windows process memory enumeration is CIM-first and no longer depends on
+  `wmic` as the primary path.
+- Windows event-log access failures, missing `coredumpctl`, missing macOS
+  reports, and missing minidumps are recorded as skipped/error categories
+  without failing the whole bundle.
+- Runtime summaries are count-only by default and do not include workspace
+  names, paths, prompts, branch names, terminal scrollback, repository contents,
+  or raw environment variables.
+- The diagnostics bundle includes compact terminal lifecycle breadcrumbs,
+  satisfying the reliability-gate artifact gap for the covered unit slice.
+- Packaged Windows/macOS/Linux CLI launchers forward the new command correctly.
+
+## Remaining Follow-Ups
+
+- Electron smoke test that a controlled renderer crash creates a minidump in a
+  packaged-like harness.
+- Binary artifact upload endpoint and private support artifact retention.
+- Server-side symbolication pipeline.
+- Provider-neutral issue creation that links artifact IDs rather than embedding
+  raw dump contents.
+
+## Non-Goals For First Implementation
+
+- Server-side symbolication pipeline.
+- Binary artifact upload endpoint.
+- Provider-neutral automatic issue creation with private artifact links.
+- Full V8 heap snapshots by default.
+- Full macOS sysdiagnose capture by default.
+- ProcDump bundling or auto-download.
+- WER registry mutation.
+
+## Suggested Test Coverage
+
+- CLI spec/handler tests for `diagnostics bundle`.
+- Runtime RPC test for `diagnostics.bundle`.
+- Bundle writer tests for manifest, category statuses, file hashes, and skipped
+  categories.
+- Redaction tests rejecting raw paths, prompts, branches, env vars, and terminal
+  output in default summaries.
+- Windows CIM parser tests for array JSON, singleton JSON, empty output,
+  malformed output, timeout, and access denied.
+- CrashReporter initializer tests for call order: create directory, set
+  `crashDumps`, then start reporter.
+- Electron smoke test that a controlled renderer crash creates a minidump.
+- Packaged CLI asset tests for Windows/macOS/Linux launcher forwarding.
+
+## Reference Docs
+
+- `docs/reference/native-diagnostic-dumps-research.md`
+- `docs/reference/native-diagnostic-dumps-implementation-plan.md`

--- a/docs/reference/native-diagnostic-dumps-issue-draft.md
+++ b/docs/reference/native-diagnostic-dumps-issue-draft.md
@@ -10,7 +10,7 @@ Add an Orca diagnostics export that support and users can create from the
 packaged CLI:
 
 ```text
-orca diagnostics bundle --output <path>
+orca diagnostics bundle --output <filename-or-subpath>
 ```
 
 The command creates a reviewable ZIP with native crash minidumps when
@@ -50,7 +50,7 @@ The branch implements a two-layer diagnostics system:
 
 2. Diagnostic bundle export
    - Add `orca diagnostics bundle`.
-   - Write a ZIP under an explicit `--output` path or default
+   - Write a ZIP under an explicit diagnostics-relative `--output` subpath or default
      `<app.getPath('logs')>/diagnostics/orca-diagnostics-<timestamp>.zip`.
    - Include low-risk categories by default.
    - Include local minidumps for explicit local exports when available.
@@ -94,7 +94,8 @@ reasons, and sanitized collector errors.
 
 - `orca diagnostics bundle --json` returns bundle ID, output path, byte size,
   included categories, skipped categories, and sanitized errors.
-- `orca diagnostics bundle --output <tmp.zip> --json` writes a ZIP containing
+- `orca diagnostics bundle --output <tmp.zip> --json` writes a ZIP under
+  Orca logs/diagnostics containing
   the required files.
 - Default output path is under Orca's per-user logs/diagnostics directory, not
   the install directory.

--- a/docs/reference/native-diagnostic-dumps-research.md
+++ b/docs/reference/native-diagnostic-dumps-research.md
@@ -168,6 +168,46 @@ linux/journal.json
 linux/shells.json
 ```
 
+### Reading The Output
+
+The exported artifact is a ZIP diagnostics bundle. Support should not run it or
+double-click it as an executable. The expected workflow is to unzip it, inspect
+`manifest.json`, then read the category files named in the manifest.
+
+`manifest.json` is the table of contents and triage starting point. It tells a
+reviewer which Orca build produced the bundle, which OS/arch it came from, which
+lookback window was used after defaulting or clamping, which categories were
+included, and which categories were skipped or errored. JSON files can be read
+with a text editor or `jq`; `diagnostics/observability.ndjson` can be read as
+one JSON object per line.
+
+If the bundle includes `crash/minidumps/*.dmp`, those files are native minidumps.
+They are useful, but they are not self-explanatory. A reviewer needs native dump
+tooling such as WinDbg or Visual Studio on Windows, `minidump_stackwalk` with
+matching symbols, or a future Orca symbolication service. Without symbols, a
+minidump can still show process type, loaded modules, thread state, exception
+codes, and stack shapes, but source-level root cause analysis is limited.
+
+Expected CLI receipt:
+
+```text
+bundleId: <uuid>
+outputPath: <logs>/diagnostics/orca-diagnostics-<timestamp>.zip
+bytes: <archive-byte-size>
+files: <manifest-file-count>
+lookbackMinutes: <effective-lookback>
+includedCategories: app, system, observability, memory, ...
+skippedCategories: native-minidumps (none_found)
+errorCategories: <category> (<sanitized-reason>)
+```
+
+This is particularly helpful for support because a crash dump alone answers
+"what crashed", while the bundle also answers "what environment and runtime state
+surrounded the crash". The app, OS, memory, runtime-count, shell, WSL, event-log,
+observability, and crash-report files let support correlate native failures with
+resource pressure, platform configuration, recent app telemetry, terminal
+lifecycle anomalies, and missing platform facilities.
+
 Default category set:
 
 - Include all low-risk, redacted, bounded categories by default.
@@ -195,6 +235,7 @@ Avoid by default:
 - Full environment variables.
 - Git remotes with embedded credentials.
 - Repository paths, workspace names, branch names, prompts, transcripts, or file contents.
+- Raw SSH/runtime host target names; emit host-kind counts instead.
 - Full heap snapshots.
 - Full sysdiagnose archives.
 
@@ -232,7 +273,9 @@ Unit tests:
 - Crash reporter starts with `uploadToServer: false` unless a consented upload path is enabled.
 - Bundle category selection includes default categories and honors `--include`/`--exclude`.
 - Bundle manifest records every file, byte count, category, and skipped/error category.
-- Redaction rejects raw paths, env variables, prompts, branch names, terminal output, and repo names in default summaries.
+- Redaction rejects raw paths, env variables, prompts, branch names, terminal output, repo names, token-like strings, and SSH/runtime host target names in default summaries.
+- Runtime count summaries bucket host IDs by kind rather than emitting configured host IDs.
+- A bundle-level privacy regression test seeds realistic sensitive values into the fake store, exports low-risk categories, parses the ZIP, and asserts none of those values appear in any default text entry.
 - Windows CIM output parser covers normal JSON, singleton JSON object, empty output, timeout, access denied, and malformed JSON.
 - Existing NDJSON 4 MiB cap remains enforced for current upload path.
 

--- a/docs/reference/native-diagnostic-dumps-research.md
+++ b/docs/reference/native-diagnostic-dumps-research.md
@@ -16,7 +16,7 @@ Orca should treat this as two related systems, not one "exe dump" feature:
 
 Electron Crashpad is the only practical cross-platform native crash-dump layer. Windows WER/ProcDump, macOS `.ips` reports/sysdiagnose, and Linux core dumps are useful adjuncts, but they are platform-specific and should not be the primary Orca-owned contract.
 
-The implemented CLI shape is `orca diagnostics bundle --output <path>`, with a default output directory under Orca's per-user logs/diagnostics directory rather than the installation directory. Installed app directories are often unwritable, code-signed, or replaced by updates.
+The implemented CLI shape is `orca diagnostics bundle --output <filename-or-subpath>`, resolved under Orca's per-user logs/diagnostics directory rather than the installation directory. Installed app directories are often unwritable, code-signed, or replaced by updates.
 
 ## Current Orca Evidence
 
@@ -135,7 +135,7 @@ Recommended crash dump directory:
 Add an archive-oriented collector that can be used from UI, crash reporting, and CLI:
 
 ```text
-orca diagnostics bundle [--output <path>] [--lookback <duration>]
+orca diagnostics bundle [--output <filename-or-subpath>] [--lookback <duration>]
                         [--include <category>] [--exclude <category>]
                         [--json] [--open]
 ```
@@ -238,9 +238,9 @@ Unit tests:
 
 IPC/RPC/CLI tests:
 
-- `orca diagnostics bundle --output <path> --json` routes through a new runtime RPC method.
+- `orca diagnostics bundle --output <filename-or-subpath> --json` routes through a new runtime RPC method.
 - Renderer cannot supply raw bundle bytes; main process collects and writes the archive.
-- Output path is explicit or main-computed; parent directories are created only for the chosen output path.
+- Output path is diagnostics-relative or main-computed; parent directories are created only under Orca logs/diagnostics.
 - Missing main runtime returns a clear partial/offline error or produces an explicitly partial bundle.
 - Existing `orca diagnostics memory` behavior remains unchanged.
 

--- a/docs/reference/native-diagnostic-dumps-research.md
+++ b/docs/reference/native-diagnostic-dumps-research.md
@@ -1,0 +1,300 @@
+# Native Diagnostic Dumps Research
+
+Generated: 2026-07-04
+
+Status: research baseline with branch implementation notes. Local diagnostics
+export, local Crashpad capture, CLI/RPC wiring, and CIM-first Windows process
+memory enumeration are implemented in this branch; binary upload and
+symbolication remain separate future work.
+
+## Executive Summary
+
+Orca should treat this as two related systems, not one "exe dump" feature:
+
+1. Native crash dumps: use Electron's `crashReporter`/Crashpad integration to collect minidumps for main, renderer, GPU, utility, and child-process crashes.
+2. Support diagnostic bundle: create a user-reviewable ZIP that combines minidumps with redacted Orca context, OS summaries, memory snapshots, shell/WSL availability, and bounded event-log evidence.
+
+Electron Crashpad is the only practical cross-platform native crash-dump layer. Windows WER/ProcDump, macOS `.ips` reports/sysdiagnose, and Linux core dumps are useful adjuncts, but they are platform-specific and should not be the primary Orca-owned contract.
+
+The implemented CLI shape is `orca diagnostics bundle --output <path>`, with a default output directory under Orca's per-user logs/diagnostics directory rather than the installation directory. Installed app directories are often unwritable, code-signed, or replaced by updates.
+
+## Current Orca Evidence
+
+Orca already has a redacted diagnostic bundle workflow:
+
+- `src/main/ipc/diagnostics.ts` registers `diagnostics:collectBundle`, retains main-collected payloads, and enforces the privacy/consent boundary before upload.
+- `src/main/observability/bundle.ts` emits NDJSON with a header and redacted span lines, capped at 4 MiB.
+- `src/main/observability/diagnostic-bundle-upload.ts` only uploads `application/x-ndjson`, so it is not ready for binary minidumps or ZIP bundles.
+- `src/main/ipc/crash-reporting.ts` attaches the existing diagnostic bundle to crash reports, using a longer lookback window.
+- `src/shared/crash-reporting.ts` already records app version, platform, OS release, arch, Electron, and Chrome versions for captured process-gone reports.
+
+Orca already has a CLI diagnostics surface, but only for memory:
+
+- `src/cli/specs/diagnostics.ts` exposes `orca diagnostics memory`.
+- `src/cli/handlers/diagnostics.ts` calls runtime RPC method `diagnostics.memory`.
+- `src/main/runtime/rpc/methods/diagnostics.ts` returns `runtime.getMemorySnapshot()`.
+
+The packaged CLI path is viable for the bundle command:
+
+- `resources/win32/bin/orca.cmd` runs the unpacked CLI through `Orca.exe` with `ELECTRON_RUN_AS_NODE=1`.
+- `config/electron-builder.config.cjs` ships that Windows command under `resources/bin/orca.cmd`.
+
+Branch implementation added `diagnostics bundle` coverage for CLI parsing,
+runtime RPC validation, bundle writing, and packaged Windows/macOS/Linux
+launcher forwarding.
+
+The pre-branch memory collector had a Windows gap:
+
+- `src/main/memory/collector.ts` uses `wmic process get ProcessId,ParentProcessId,WorkingSetSize /format:value`.
+- Microsoft marks WMIC deprecated and recommends PowerShell/CIM for WMI work, so the Windows enumerator should move to a PowerShell `Get-CimInstance Win32_Process` path with a narrow fallback.
+
+Branch implementation moved Windows process enumeration to
+`src/main/memory/windows-process-working-set.ts` with CIM JSON as the primary
+path and WMIC retained as fallback.
+
+## External Research Findings
+
+### Electron And Crashpad
+
+Electron's official `crashReporter` module is the app-level mechanism for native crash reports. It uses Crashpad, stores crash reports under the app's user-data `Crashpad` directory by default, and can be redirected with `app.setPath('crashDumps', path)` before the reporter starts. `crashReporter.start()` should run as early as possible, preferably before `app.on('ready')`, because renderers created before initialization are not monitored.
+
+Useful Electron constraints:
+
+- `uploadToServer: false` still collects and stores crash reports locally.
+- `globalExtra` is the right place for static metadata such as app version, channel, platform, arch, and Electron version.
+- `extra`/`addExtraParameter` values are string-only and size-limited.
+- Main-process extra parameters do not automatically apply to renderer/child crashes unless they are in `globalExtra` or set in the crashing process.
+- The upload payload includes `upload_file_minidump`, plus product/version/platform/process metadata.
+- `getLastCrashReport()` and `getUploadedReports()` only describe uploaded reports, not merely local files on disk.
+
+Crashpad's design docs explain why this should be treated as sensitive data. Crashpad snapshots process state out of process, writes minidumps, and can include modules, threads, registers, stack memory, command line, environment, and selected memory referenced from stacks or registers. That is useful for debugging but not redaction-friendly.
+
+Symbolication is a separate requirement. Crashpad/Chromium documentation expects minidumps to be stackwalked and symbolized server-side with symbol files. Without a release-symbol pipeline for Orca, Electron, native modules, and bundled helpers, minidumps may still help with process state and module lists, but root-cause analysis will be much weaker.
+
+### Windows
+
+Windows has three relevant mechanisms:
+
+1. WER LocalDumps can be configured under `HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps` or a per-exe subkey. It is not enabled by default and requires administrator privileges to configure. Microsoft also says applications with their own custom crash reporting are not supported by this WER feature.
+2. Sysinternals ProcDump can create minidumps, full dumps, triage dumps, dumps on exceptions, dumps on hangs, and dumps on performance thresholds. It is useful for support playbooks, but bundling or auto-downloading it creates licensing, trust, and AV-friction questions.
+3. Windows 11 Task Manager can create live user-mode memory dumps manually.
+
+For Orca-owned automation, prefer Electron Crashpad for native app crash dumps. Use Windows Event Log and CIM for supplemental summaries:
+
+- `Get-WinEvent` can read Application/System logs and filter `Application Error`, `Application Hang`, and Orca-related records by time window.
+- `Get-CimInstance Win32_OperatingSystem` can provide OS and memory details.
+- WMIC should not be the default new implementation.
+
+### macOS
+
+macOS Console exposes user and system Crash Reports, Spin Reports, Log Reports, and Diagnostic Reports. Crash report names use `.ips`, spin reports use `.spin`, and diagnostic reports use extensions such as `.diag` or `.dpsub`.
+
+Activity Monitor can generate:
+
+- Sample Process reports.
+- Spindumps for unresponsive apps.
+- System Diagnostics reports.
+- Spotlight Diagnostics reports.
+
+These are valuable when a user is manually working with support, but they are too broad and privacy-heavy for default Orca upload. Orca should collect an index or bounded excerpts by default, and only include raw macOS reports when the user explicitly selects them.
+
+### Linux
+
+Linux crash-dump behavior varies by distribution and configuration:
+
+- `systemd-coredump` can log crash summaries to the journal and store core files under `/var/lib/systemd/coredump/`.
+- `coredumpctl` can retrieve and process saved dumps and metadata.
+- `kernel.core_pattern` controls where kernel-generated core dumps go.
+- `gcore` can create a core file from a running process without terminating it, but it depends on debugger availability and permissions.
+
+For Orca, Linux native collection should still start with Electron Crashpad. A support bundle can optionally include `coredumpctl` metadata for Orca/Electron process names if available, but it must tolerate systems without systemd-coredump, without retained cores, or without permission to read them.
+
+### Node And V8 Diagnostics
+
+Node's `process.report` APIs can generate JSON diagnostic reports with platform, resource, stack, heap, and runtime details. Node/V8 heap snapshots can be useful for memory leaks, but Node documents that generating a heap snapshot can require about twice the heap size and blocks the event loop. Heap snapshots should therefore be opt-in, not part of the default bundle.
+
+## Orca Architecture
+
+### Layer 1: Native Minidump Capture
+
+Add an early main-process crash reporter initializer:
+
+- Create the crash-dump directory before starting Crashpad.
+- Call `app.setPath('crashDumps', crashDumpDirectory)` before `crashReporter.start()`.
+- Start with `uploadToServer: false` so Orca collects local dumps without silently uploading them.
+- Add static `globalExtra` fields: `app_version`, `orca_channel`, `platform`, `arch`, `os_release`, `electron_version`, `chrome_version`, `schema_version`.
+- Keep upload behavior behind the same user-facing privacy/consent setting as diagnostic bundles, with a separate "include native crash dumps" decision.
+
+Recommended crash dump directory:
+
+- Main app path: `path.join(app.getPath('logs'), 'diagnostics', 'crashpad')`, or a dedicated `userData/diagnostics/crashpad` path if the logs path is initialized too late.
+- Do not use the installation directory.
+
+### Layer 2: Diagnostic Bundle Export
+
+Add an archive-oriented collector that can be used from UI, crash reporting, and CLI:
+
+```text
+orca diagnostics bundle [--output <path>] [--lookback <duration>]
+                        [--include <category>] [--exclude <category>]
+                        [--json] [--open]
+```
+
+Default output is computed by the main process:
+
+- macOS: `~/Library/Logs/Orca/diagnostics/orca-diagnostics-<timestamp>.zip`
+- Windows/Linux: Electron's default logs path is inside `userData`, so use `app.getPath('logs')/diagnostics/orca-diagnostics-<timestamp>.zip`
+- CLI fallback, when no main process is reachable, should either launch/connect to Orca or use conservative platform defaults and clearly label the bundle as "offline partial".
+
+Archive layout:
+
+```text
+manifest.json
+app/orca.json
+app/runtime-counts.json
+system/os.json
+system/resources.json
+diagnostics/observability.ndjson
+crash/orca-crash-reports.json
+crash/minidumps/*.dmp
+memory/snapshot.json
+windows/events.json
+windows/wsl.json
+windows/shells.json
+macos/reports-index.json
+macos/shells.json
+linux/coredumpctl.json
+linux/journal.json
+linux/shells.json
+```
+
+Default category set:
+
+- Include all low-risk, redacted, bounded categories by default.
+- Include minidumps in local exports created by explicit user command or explicit UI action.
+- Do not upload minidumps or attach them to auto-created issues without a separate explicit consent gate because minidumps cannot be meaningfully redacted after capture.
+
+### Bundle Data Model
+
+Minimum useful fields:
+
+- App: version, channel, package version, Electron version, Chrome version, Node version, build environment if available.
+- OS: platform, release, `process.getSystemVersion()` where Electron is available, arch, locale, CPU model/core count, total/free memory, load average when meaningful.
+- Runtime counts: number of durable projects, configured project host setups, managed worktrees/workspaces, active terminal tabs/panes, local/SSH/remote runtime breakdowns.
+- Diagnostics: current redacted NDJSON spans via existing `collectDiagnosticBundle`.
+- Crash state: current crash-report store, process-gone details, crash breadcrumbs, recent Crashpad minidumps by timestamp.
+- Memory: current `MemorySnapshot`, including app, host, and managed terminal subtree summaries.
+- Shells: detected shell availability and default shell resolver result, without raw env dumps.
+- Windows: WSL availability/distro summary and recent Application Error/Application Hang events filtered to Orca/Electron process names.
+- macOS: recent `.ips`/`.spin` report index for Orca process names, not broad sysdiagnose by default.
+- Linux: `coredumpctl` metadata for Orca/Electron process names when available, not raw cores by default unless explicitly requested.
+
+Avoid by default:
+
+- Raw terminal scrollback.
+- Full environment variables.
+- Git remotes with embedded credentials.
+- Repository paths, workspace names, branch names, prompts, transcripts, or file contents.
+- Full heap snapshots.
+- Full sysdiagnose archives.
+
+### Windows Memory Refactor
+
+Replace `wmic` as the primary path:
+
+- Add a focused Windows process enumerator module with a concrete name, for example `windows-process-working-set.ts`.
+- Query PowerShell CIM, preferably as JSON:
+
+```powershell
+Get-CimInstance Win32_Process |
+  Select-Object ProcessId, ParentProcessId, WorkingSetSize |
+  ConvertTo-Json -Compress
+```
+
+- Keep timeout, max-buffer, and parse-failure handling non-fatal.
+- Keep `wmic` as a last fallback only if needed for older systems.
+- Remove the need to grow `src/main/memory/collector.ts`; AGENTS.md forbids adding max-lines disables, and this file already has one.
+
+### Issue And Upload Integration
+
+Current Orca feedback/crash submission can include an NDJSON diagnostic bundle, but it does not support binary minidump or ZIP uploads. To attach dumps to support issues later:
+
+- Add a binary attachment/token endpoint, or extend the existing endpoint with an explicit content-type and size policy for ZIP/minidump data.
+- Store uploaded bundles as private support artifacts and include only a ticket/artifact ID in feedback text or provider issues.
+- Keep provider-specific issue creation behind adapters. Do not build this as GitHub-only because Orca supports GitLab and other providers.
+- Avoid `gh-attach`; repo instructions explicitly say not to use it.
+
+## Testing Matrix
+
+Unit tests:
+
+- Crash reporter initializer calls `app.setPath('crashDumps', ...)` before `crashReporter.start()`.
+- Crash reporter starts with `uploadToServer: false` unless a consented upload path is enabled.
+- Bundle category selection includes default categories and honors `--include`/`--exclude`.
+- Bundle manifest records every file, byte count, category, and skipped/error category.
+- Redaction rejects raw paths, env variables, prompts, branch names, terminal output, and repo names in default summaries.
+- Windows CIM output parser covers normal JSON, singleton JSON object, empty output, timeout, access denied, and malformed JSON.
+- Existing NDJSON 4 MiB cap remains enforced for current upload path.
+
+IPC/RPC/CLI tests:
+
+- `orca diagnostics bundle --output <path> --json` routes through a new runtime RPC method.
+- Renderer cannot supply raw bundle bytes; main process collects and writes the archive.
+- Output path is explicit or main-computed; parent directories are created only for the chosen output path.
+- Missing main runtime returns a clear partial/offline error or produces an explicitly partial bundle.
+- Existing `orca diagnostics memory` behavior remains unchanged.
+
+Platform smoke tests:
+
+- Windows packaged CLI creates a ZIP with `system/os.json`, `memory/snapshot.json`, and bounded `windows/events.json` when permissions allow.
+- macOS packaged CLI creates a ZIP and tolerates missing `.ips` reports.
+- Linux packaged CLI creates a ZIP and tolerates missing `coredumpctl`.
+- Non-admin Windows event-log access failure is recorded as a skipped category, not a failed bundle.
+- No minidump directory present is recorded as skipped, not failed.
+
+Crash-path tests:
+
+- `process.crash()` in a test-only app path produces a Crashpad file under the configured dump directory.
+- Renderer `process.crash()` is captured when crashReporter starts before renderer creation.
+- Crash report submission can reference a local diagnostic bundle or uploaded artifact ID without embedding binary data in issue text.
+
+## Recommended Phasing
+
+1. Done in this branch: archive-oriented diagnostic bundle design and schema.
+2. Done in this branch: local-only Electron Crashpad initialization.
+3. Done in this branch: `orca diagnostics bundle --output`, implemented through runtime RPC and main-process archive writing.
+4. Done in this branch: Windows memory enumeration with CIM-first process collection.
+5. Done in this branch: OS adjunct collectors for Windows events/WSL/shells, macOS reports index/shells, and Linux coredumpctl/journal/shells.
+6. Future: binary upload/private artifact support if automatic issue creation or support upload is required.
+7. Future: provider-neutral issue integration that links artifact IDs rather than embedding raw dump contents.
+
+## Key Open Questions
+
+- Where will symbols for release builds, Electron, native modules, and helper executables be stored and resolved?
+- Should local minidump collection be always on after user opt-in, or only active when the diagnostics setting is enabled?
+- Should `orca diagnostics bundle` auto-launch/connect to Orca when no runtime is running, or produce an offline partial bundle?
+- What is the maximum acceptable bundle size for local export, support upload, and issue attachment?
+- Which support system should own binary artifacts: the existing feedback endpoint, a new diagnostics endpoint, or provider-specific private attachments?
+
+## Sources
+
+- Electron `crashReporter`: https://www.electronjs.org/docs/latest/api/crash-reporter
+- Electron `app.getPath`, logs, crashDumps, process-gone events: https://www.electronjs.org/docs/latest/api/app
+- Electron process diagnostics APIs: https://www.electronjs.org/docs/latest/api/process
+- Electron render-process-gone details: https://www.electronjs.org/docs/latest/api/structures/render-process-gone-details
+- Crashpad overview design: https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/doc/overview_design.md
+- Crashpad handler docs: https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/handler/crashpad_handler.md
+- Chromium crash reports and minidump workflow: https://www.chromium.org/developers/crash-reports/
+- Microsoft WER LocalDumps: https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+- Microsoft ProcDump: https://learn.microsoft.com/en-us/sysinternals/downloads/procdump
+- Microsoft Get-WinEvent: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.diagnostics/get-winevent
+- Microsoft Get-CimInstance/WMI samples: https://learn.microsoft.com/en-us/powershell/scripting/samples/getting-wmi-objects--get-ciminstance-?view=powershell-7.6
+- Microsoft WMIC deprecation: https://learn.microsoft.com/en-us/windows/win32/wmisdk/wmic
+- Apple Console reports: https://support.apple.com/guide/console/reports-cnsl664be99a/mac
+- Apple Activity Monitor diagnostics: https://support.apple.com/guide/activity-monitor/run-system-diagnostics-actmntr2225/mac
+- Linux systemd-coredump: https://man7.org/linux/man-pages/man8/systemd-coredump.8.html
+- Linux coredump.conf: https://man7.org/linux/man-pages/man5/coredump.conf.5.html
+- Linux core(5): https://man7.org/linux/man-pages/man5/core.5.html
+- Linux gcore: https://man7.org/linux/man-pages/man1/gcore.1.html
+- Node diagnostic report APIs: https://nodejs.org/api/process.html
+- Node V8 heap snapshots: https://nodejs.org/api/v8.html

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -87,6 +87,23 @@ describe('parseArgs', () => {
     expect(parsed.flags.get('label')).toBe(`Bug${REPEATED_FLAG_SEPARATOR}Regression`)
   })
 
+  it('preserves repeated diagnostics bundle category filters', () => {
+    const parsed = parseArgs([
+      'diagnostics',
+      'bundle',
+      '--include',
+      'app',
+      '--include=memory',
+      '--exclude',
+      'native-minidumps',
+      '--open'
+    ])
+
+    expect(parsed.flags.get('include')).toBe(`app${REPEATED_FLAG_SEPARATOR}memory`)
+    expect(parsed.flags.get('exclude')).toBe('native-minidumps')
+    expect(parsed.flags.get('open')).toBe(true)
+  })
+
   it('does not apply repeated flag encoding to ordinary string flags', () => {
     const parsed = parseArgs(['linear', 'list', '--workspace', 'old', '--workspace', 'new'])
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -38,6 +38,7 @@ export const BOOLEAN_FLAGS = new Set([
   'mobile',
   'mobile-pairing',
   'no-pairing',
+  'open',
   'parent-current',
   'provision',
   'ready',
@@ -57,7 +58,7 @@ export const BOOLEAN_FLAGS = new Set([
 ])
 
 export const REPEATED_FLAG_SEPARATOR = '\u0000'
-const REPEATABLE_STRING_FLAGS = new Set(['label'])
+const REPEATABLE_STRING_FLAGS = new Set(['exclude', 'include', 'label'])
 
 function setFlagValue(flags: Map<string, string | boolean>, name: string, value: string): void {
   const existing = flags.get(name)

--- a/src/cli/diagnostics-format.ts
+++ b/src/cli/diagnostics-format.ts
@@ -6,6 +6,7 @@ export function formatDiagnosticBundleExportResult(result: DiagnosticBundleExpor
     `outputPath: ${result.outputPath}`,
     `bytes: ${result.bytes}`,
     `files: ${result.fileCount}`,
+    `lookbackMinutes: ${result.lookbackMinutes}`,
     `includedCategories: ${result.includedCategories.join(', ') || 'none'}`
   ]
   if (result.skippedCategories.length > 0) {

--- a/src/cli/diagnostics-format.ts
+++ b/src/cli/diagnostics-format.ts
@@ -1,0 +1,26 @@
+import type { DiagnosticBundleExportResult } from '../shared/diagnostic-bundle-export-types'
+
+export function formatDiagnosticBundleExportResult(result: DiagnosticBundleExportResult): string {
+  const lines = [
+    `bundleId: ${result.bundleId}`,
+    `outputPath: ${result.outputPath}`,
+    `bytes: ${result.bytes}`,
+    `files: ${result.fileCount}`,
+    `includedCategories: ${result.includedCategories.join(', ') || 'none'}`
+  ]
+  if (result.skippedCategories.length > 0) {
+    lines.push(
+      `skippedCategories: ${result.skippedCategories
+        .map((entry) => `${entry.category}${entry.reason ? ` (${entry.reason})` : ''}`)
+        .join(', ')}`
+    )
+  }
+  if (result.errorCategories.length > 0) {
+    lines.push(
+      `errorCategories: ${result.errorCategories
+        .map((entry) => `${entry.category}${entry.reason ? ` (${entry.reason})` : ''}`)
+        .join(', ')}`
+    )
+  }
+  return lines.join('\n')
+}

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -22,6 +22,8 @@ export {
   formatListWindows
 } from './computer-format'
 export type { ComputerActionFollowUpTarget } from './computer-format'
+export { formatDiagnosticBundleExportResult } from './diagnostics-format'
+
 export {
   formatProjectHostSetupCreateResult,
   formatProjectHostSetupDeleteResult,

--- a/src/cli/handlers/diagnostics.ts
+++ b/src/cli/handlers/diagnostics.ts
@@ -3,6 +3,10 @@ import {
   MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES,
   type DiagnosticBundleExportResult
 } from '../../shared/diagnostic-bundle-export-types'
+import {
+  DIAGNOSTIC_OUTPUT_PATH_ERROR,
+  isSafeDiagnosticBundleOutputPath
+} from '../../shared/diagnostic-bundle-output-path-policy'
 import type { CommandHandler } from '../dispatch'
 import { formatDiagnosticBundleExportResult, formatMemorySnapshot, printResult } from '../format'
 import { getOptionalStringFlag, getRepeatedStringFlag } from '../flags'
@@ -15,7 +19,7 @@ export const DIAGNOSTICS_HANDLERS: Record<string, CommandHandler> = {
   },
   'diagnostics bundle': async ({ client, flags, json }) => {
     const params = {
-      output: getOptionalStringFlag(flags, 'output'),
+      output: parseOutputPath(getOptionalStringFlag(flags, 'output')),
       lookbackMinutes: parseLookbackMinutes(getOptionalStringFlag(flags, 'lookback')),
       include: optionalArray(getRepeatedStringFlag(flags, 'include')),
       exclude: optionalArray(getRepeatedStringFlag(flags, 'exclude')),
@@ -56,4 +60,14 @@ function parseLookbackMinutes(value: string | undefined): number | undefined {
     )
   }
   return minutes
+}
+
+function parseOutputPath(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+  if (!isSafeDiagnosticBundleOutputPath(value)) {
+    throw new RuntimeClientError('invalid_argument', DIAGNOSTIC_OUTPUT_PATH_ERROR)
+  }
+  return value
 }

--- a/src/cli/handlers/diagnostics.ts
+++ b/src/cli/handlers/diagnostics.ts
@@ -1,10 +1,45 @@
 import type { MemorySnapshot } from '../../shared/types'
+import type { DiagnosticBundleExportResult } from '../../shared/diagnostic-bundle-export-types'
 import type { CommandHandler } from '../dispatch'
-import { formatMemorySnapshot, printResult } from '../format'
+import { formatDiagnosticBundleExportResult, formatMemorySnapshot, printResult } from '../format'
+import { getOptionalStringFlag, getRepeatedStringFlag } from '../flags'
+import { RuntimeClientError } from '../runtime-client'
 
 export const DIAGNOSTICS_HANDLERS: Record<string, CommandHandler> = {
   'diagnostics memory': async ({ client, json }) => {
     const result = await client.call<MemorySnapshot>('diagnostics.memory')
     printResult(result, json, formatMemorySnapshot)
+  },
+  'diagnostics bundle': async ({ client, flags, json }) => {
+    const params = {
+      output: getOptionalStringFlag(flags, 'output'),
+      lookbackMinutes: parseLookbackMinutes(getOptionalStringFlag(flags, 'lookback')),
+      include: optionalArray(getRepeatedStringFlag(flags, 'include')),
+      exclude: optionalArray(getRepeatedStringFlag(flags, 'exclude')),
+      open: flags.get('open') === true ? true : undefined
+    }
+    const result = await client.call<DiagnosticBundleExportResult>('diagnostics.bundle', params)
+    printResult(result, json, formatDiagnosticBundleExportResult)
   }
+}
+
+function optionalArray(values: string[]): string[] | undefined {
+  return values.length > 0 ? values : undefined
+}
+
+function parseLookbackMinutes(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined
+  }
+  const match = /^(\d+)([mhd])?$/.exec(value.trim().toLowerCase())
+  if (!match) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Invalid --lookback value. Use minutes, or suffix with m, h, or d.'
+    )
+  }
+  const amount = Number.parseInt(match[1], 10)
+  const unit = match[2] ?? 'm'
+  const multiplier = unit === 'd' ? 24 * 60 : unit === 'h' ? 60 : 1
+  return amount * multiplier
 }

--- a/src/cli/handlers/diagnostics.ts
+++ b/src/cli/handlers/diagnostics.ts
@@ -1,5 +1,8 @@
 import type { MemorySnapshot } from '../../shared/types'
-import type { DiagnosticBundleExportResult } from '../../shared/diagnostic-bundle-export-types'
+import {
+  MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES,
+  type DiagnosticBundleExportResult
+} from '../../shared/diagnostic-bundle-export-types'
 import type { CommandHandler } from '../dispatch'
 import { formatDiagnosticBundleExportResult, formatMemorySnapshot, printResult } from '../format'
 import { getOptionalStringFlag, getRepeatedStringFlag } from '../flags'
@@ -41,5 +44,16 @@ function parseLookbackMinutes(value: string | undefined): number | undefined {
   const amount = Number.parseInt(match[1], 10)
   const unit = match[2] ?? 'm'
   const multiplier = unit === 'd' ? 24 * 60 : unit === 'h' ? 60 : 1
-  return amount * multiplier
+  const minutes = amount * multiplier
+  if (
+    !Number.isSafeInteger(minutes) ||
+    minutes < 1 ||
+    minutes > MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES
+  ) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Invalid --lookback value. Use a range from 1m through 30d.'
+    )
+  }
+  return minutes
 }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -192,7 +192,7 @@ Common Commands:
   orca open [--json]
   orca serve [--port <port>] [--pairing-address <host>] [--mobile-pairing] [--no-pairing] [--project-root <path>] [--recipe-json] [--json]
   orca status [--json]
-  orca diagnostics bundle [--output <path>] [--lookback <duration>] [--include <category>] [--exclude <category>] [--open] [--json]
+  orca diagnostics bundle [--output <filename-or-subpath>] [--lookback <duration>] [--include <category>] [--exclude <category>] [--open] [--json]
   orca diagnostics memory [--json]
   orca environment add --name <name> --pairing-code <code> [--json]
   orca environment list [--json]
@@ -498,7 +498,7 @@ export function formatFlagHelp(flag: string): string {
     'parent-worktree':
       '--parent-worktree <selector> Parent worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current',
     path: '--path <path>          Path argument for the command',
-    output: '--output <path>        Diagnostics bundle ZIP output path',
+    output: '--output <filename-or-subpath>  ZIP filename/subpath under Orca logs/diagnostics',
     lookback: '--lookback <duration> Minutes to include, or use m/h/d suffix',
     open: '--open                 Reveal the exported diagnostics bundle',
     prompt: '--prompt <text>        Prompt text for agent-backed commands',

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -12,6 +12,7 @@ Startup:
   status                    Show app/runtime/graph readiness
 
 Diagnostics:
+  diagnostics bundle        Export a local diagnostics ZIP with crash, memory, and system context
   diagnostics memory        Collect a memory snapshot for Orca and managed terminals
 
 Environments:
@@ -191,6 +192,7 @@ Common Commands:
   orca open [--json]
   orca serve [--port <port>] [--pairing-address <host>] [--mobile-pairing] [--no-pairing] [--project-root <path>] [--recipe-json] [--json]
   orca status [--json]
+  orca diagnostics bundle [--output <path>] [--lookback <duration>] [--include <category>] [--exclude <category>] [--open] [--json]
   orca diagnostics memory [--json]
   orca environment add --name <name> --pairing-code <code> [--json]
   orca environment list [--json]
@@ -297,6 +299,7 @@ Browser Options:
 Examples:
   $ orca open
   $ orca status --json
+  $ orca diagnostics bundle --json
   $ orca diagnostics memory --json
   $ orca repo list
   $ orca worktree create --name agent-task --agent codex --prompt "hi"
@@ -476,8 +479,10 @@ export function formatFlagHelp(flag: string): string {
     'from-x': '--from-x <x>           Source window-local x coordinate',
     'from-y': '--from-y <y>           Source window-local y coordinate',
     help: '--help                 Show this help message',
+    include: '--include <category>  Include a diagnostics bundle category; repeatable',
     interrupt: '--interrupt            Send as an interrupt-style input when supported',
     id: '--id <id>             Identifier for a target item or permission',
+    exclude: '--exclude <category>  Exclude a diagnostics bundle category; repeatable',
     issue: '--issue <number|null>  Linked GitHub issue number',
     'linear-issue':
       '--linear-issue <id|url|null> Linked Linear issue identifier or URL; null clears on set',
@@ -493,6 +498,9 @@ export function formatFlagHelp(flag: string): string {
     'parent-worktree':
       '--parent-worktree <selector> Parent worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current',
     path: '--path <path>          Path argument for the command',
+    output: '--output <path>        Diagnostics bundle ZIP output path',
+    lookback: '--lookback <duration> Minutes to include, or use m/h/d suffix',
+    open: '--open                 Reveal the exported diagnostics bundle',
     prompt: '--prompt <text>        Prompt text for agent-backed commands',
     query: '--query <text>        Search text for matching refs',
     ref: '--ref <ref>            Base ref to persist for the repo',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3489,7 +3489,8 @@ describe('orca cli worktree awareness', () => {
     callMock.mockResolvedValueOnce(
       okFixture('req_diagnostics_bundle', {
         bundleId: 'bundle-1',
-        outputPath: 'C:\\tmp\\orca-diagnostics.zip',
+        outputPath:
+          'C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\orca-diagnostics.zip',
         bytes: 2048,
         includedCategories: ['app', 'memory'],
         skippedCategories: [],
@@ -3504,7 +3505,7 @@ describe('orca cli worktree awareness', () => {
         'diagnostics',
         'bundle',
         '--output',
-        'C:\\tmp\\orca-diagnostics.zip',
+        'orca-diagnostics.zip',
         '--lookback',
         '2h',
         '--include',
@@ -3519,7 +3520,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenCalledWith('diagnostics.bundle', {
-      output: 'C:\\tmp\\orca-diagnostics.zip',
+      output: 'orca-diagnostics.zip',
       lookbackMinutes: 120,
       include: ['app', 'memory'],
       exclude: ['native-minidumps'],
@@ -3534,6 +3535,15 @@ describe('orca cli worktree awareness', () => {
     for (const lookback of ['soon', '0', '31d']) {
       callMock.mockClear()
       await main(['diagnostics', 'bundle', '--lookback', lookback], '/tmp/repo')
+
+      expect(callMock).not.toHaveBeenCalled()
+    }
+  })
+
+  it('rejects unsafe diagnostics bundle output paths before RPC', async () => {
+    for (const output of ['../orca-diagnostics.zip', 'C:\\tmp\\orca-diagnostics.zip']) {
+      callMock.mockClear()
+      await main(['diagnostics', 'bundle', '--output', output], '/tmp/repo')
 
       expect(callMock).not.toHaveBeenCalled()
     }

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3492,6 +3492,7 @@ describe('orca cli worktree awareness', () => {
         outputPath:
           'C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\orca-diagnostics.zip',
         bytes: 2048,
+        lookbackMinutes: 120,
         includedCategories: ['app', 'memory'],
         skippedCategories: [],
         errorCategories: [],
@@ -3528,6 +3529,7 @@ describe('orca cli worktree awareness', () => {
     })
     const output = logSpy.mock.calls.flat().join('\n')
     expect(output).toContain('bundleId: bundle-1')
+    expect(output).toContain('lookbackMinutes: 120')
     expect(output).toContain('includedCategories: app, memory')
   })
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3485,6 +3485,57 @@ describe('orca cli worktree awareness', () => {
     expect(output).toContain('- feature  1.0 MB  2.5%  1 session')
   })
 
+  it('exports diagnostics bundles with repeated category filters', async () => {
+    callMock.mockResolvedValueOnce(
+      okFixture('req_diagnostics_bundle', {
+        bundleId: 'bundle-1',
+        outputPath: 'C:\\tmp\\orca-diagnostics.zip',
+        bytes: 2048,
+        includedCategories: ['app', 'memory'],
+        skippedCategories: [],
+        errorCategories: [],
+        fileCount: 3
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'diagnostics',
+        'bundle',
+        '--output',
+        'C:\\tmp\\orca-diagnostics.zip',
+        '--lookback',
+        '2h',
+        '--include',
+        'app',
+        '--include',
+        'memory',
+        '--exclude',
+        'native-minidumps',
+        '--open'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith('diagnostics.bundle', {
+      output: 'C:\\tmp\\orca-diagnostics.zip',
+      lookbackMinutes: 120,
+      include: ['app', 'memory'],
+      exclude: ['native-minidumps'],
+      open: true
+    })
+    const output = logSpy.mock.calls.flat().join('\n')
+    expect(output).toContain('bundleId: bundle-1')
+    expect(output).toContain('includedCategories: app, memory')
+  })
+
+  it('rejects invalid diagnostics bundle lookback values before RPC', async () => {
+    await main(['diagnostics', 'bundle', '--lookback', 'soon'], '/tmp/repo')
+
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
   it('exits nonzero when terminal wait returns an unsatisfied blocked result', async () => {
     process.env.ORCA_TERMINAL_HANDLE = 'term_worker'
     callMock.mockResolvedValueOnce({

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3531,9 +3531,12 @@ describe('orca cli worktree awareness', () => {
   })
 
   it('rejects invalid diagnostics bundle lookback values before RPC', async () => {
-    await main(['diagnostics', 'bundle', '--lookback', 'soon'], '/tmp/repo')
+    for (const lookback of ['soon', '0', '31d']) {
+      callMock.mockClear()
+      await main(['diagnostics', 'bundle', '--lookback', lookback], '/tmp/repo')
 
-    expect(callMock).not.toHaveBeenCalled()
+      expect(callMock).not.toHaveBeenCalled()
+    }
   })
 
   it('exits nonzero when terminal wait returns an unsatisfied blocked result', async () => {

--- a/src/cli/specs/diagnostics.ts
+++ b/src/cli/specs/diagnostics.ts
@@ -11,5 +11,21 @@ export const DIAGNOSTICS_COMMAND_SPECS: CommandSpec[] = [
       'Runs the same host process sweep used by the Resource Usage popover, so call it when you need a point-in-time diagnostic rather than a cheap heartbeat.'
     ],
     examples: ['orca diagnostics memory --json']
+  },
+  {
+    path: ['diagnostics', 'bundle'],
+    summary: 'Export a local diagnostics ZIP with crash, memory, and system context',
+    usage:
+      'orca diagnostics bundle [--output <path>] [--lookback <duration>] [--include <category>] [--exclude <category>] [--open] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'output', 'lookback', 'include', 'exclude', 'open'],
+    notes: [
+      'Creates a local ZIP under Orca logs/diagnostics by default. Native minidumps are included only in this explicit local export when present.',
+      'Use repeated --include or --exclude flags to select categories. --lookback accepts minutes or m/h/d suffixes.'
+    ],
+    examples: [
+      'orca diagnostics bundle --json',
+      'orca diagnostics bundle --output ./orca-diagnostics.zip --lookback 2h',
+      'orca diagnostics bundle --exclude native-minidumps'
+    ]
   }
 ]

--- a/src/cli/specs/diagnostics.ts
+++ b/src/cli/specs/diagnostics.ts
@@ -16,7 +16,7 @@ export const DIAGNOSTICS_COMMAND_SPECS: CommandSpec[] = [
     path: ['diagnostics', 'bundle'],
     summary: 'Export a local diagnostics ZIP with crash, memory, and system context',
     usage:
-      'orca diagnostics bundle [--output <path>] [--lookback <duration>] [--include <category>] [--exclude <category>] [--open] [--json]',
+      'orca diagnostics bundle [--output <filename-or-subpath>] [--lookback <duration>] [--include <category>] [--exclude <category>] [--open] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'output', 'lookback', 'include', 'exclude', 'open'],
     notes: [
       'Creates a local ZIP under Orca logs/diagnostics by default. Native minidumps are included only in this explicit local export when present.',
@@ -24,7 +24,7 @@ export const DIAGNOSTICS_COMMAND_SPECS: CommandSpec[] = [
     ],
     examples: [
       'orca diagnostics bundle --json',
-      'orca diagnostics bundle --output ./orca-diagnostics.zip --lookback 2h',
+      'orca diagnostics bundle --output orca-diagnostics.zip --lookback 2h',
       'orca diagnostics bundle --exclude native-minidumps'
     ]
   }

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -15,7 +15,9 @@ const builderConfig = require('../../../config/electron-builder.config.cjs') as 
   linux?: { extraResources?: { from?: string; to?: string }[] }
   win?: { extraResources?: { from?: string; to?: string }[] }
 }
+const darwinLauncherAsset = new URL('../../../resources/darwin/bin/orca', import.meta.url)
 const linuxLauncherAsset = new URL('../../../resources/linux/bin/orca-ide', import.meta.url)
+const diagnosticsHelpArgs = ['diagnostics', 'bundle', '--help']
 
 describe('packaged CLI assets', () => {
   it('copies runtime dependencies used before Electron asar integration is available', () => {
@@ -79,11 +81,13 @@ printf 'arg=%s\\n' "$@"
           { encoding: 'utf8', mode: 0o755 }
         )
 
-        const direct = await execFileAsync(launcherPath, ['--help'])
+        const direct = await execFileAsync(launcherPath, diagnosticsHelpArgs)
         expect(direct.stdout).toContain(`electron=${electronPath}`)
         expect(direct.stdout).toContain('run_as_node=1')
         expect(direct.stdout).toContain(`arg=${cliPath}`)
-        expect(direct.stdout).toContain('arg=--help')
+        for (const arg of diagnosticsHelpArgs) {
+          expect(direct.stdout).toContain(`arg=${arg}`)
+        }
 
         const homeDir = join(root, 'home')
         const commandDir = join(homeDir, '.local', 'bin')
@@ -92,18 +96,62 @@ printf 'arg=%s\\n' "$@"
         await mkdir(join(homeDir, 'orca'), { recursive: true })
         await symlink(launcherPath, commandPath)
 
-        const symlinked = await execFileAsync(commandPath, ['--help'], {
+        const symlinked = await execFileAsync(commandPath, diagnosticsHelpArgs, {
           env: { ...process.env, HOME: homeDir }
         })
         expect(symlinked.stdout).toContain(`electron=${electronPath}`)
         expect(symlinked.stdout).toContain('run_as_node=1')
         expect(symlinked.stdout).toContain(`arg=${cliPath}`)
-        expect(symlinked.stdout).toContain('arg=--help')
+        for (const arg of diagnosticsHelpArgs) {
+          expect(symlinked.stdout).toContain(`arg=${arg}`)
+        }
       } finally {
         await rm(root, { recursive: true, force: true })
       }
     }
   )
+
+  itRunsUnixShell('runs the macOS launcher from its packaged app path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-macos-cli-'))
+    try {
+      const appDir = join(root, 'Orca.app')
+      const contentsDir = join(appDir, 'Contents')
+      const resourcesDir = join(contentsDir, 'Resources')
+      const launcherDir = join(resourcesDir, 'bin')
+      const cliDir = join(resourcesDir, 'app.asar.unpacked', 'out', 'cli')
+      const macosDir = join(contentsDir, 'MacOS')
+      const launcherPath = join(launcherDir, 'orca')
+      const electronPath = join(macosDir, 'Orca')
+      const cliPath = join(cliDir, 'index.js')
+
+      await mkdir(launcherDir, { recursive: true })
+      await mkdir(cliDir, { recursive: true })
+      await mkdir(macosDir, { recursive: true })
+      await copyFile(darwinLauncherAsset, launcherPath)
+      expect((await stat(launcherPath)).mode & 0o111).not.toBe(0)
+      await writeFile(cliPath, '', 'utf8')
+      await writeFile(
+        electronPath,
+        `#!/usr/bin/env bash
+printf 'electron=%s\\n' "$0"
+printf 'run_as_node=%s\\n' "\${ELECTRON_RUN_AS_NODE-}"
+printf 'arg=%s\\n' "$@"
+`,
+        { encoding: 'utf8', mode: 0o755 }
+      )
+
+      const result = await execFileAsync(launcherPath, diagnosticsHelpArgs)
+
+      expect(result.stdout).toContain(`electron=${electronPath}`)
+      expect(result.stdout).toContain('run_as_node=1')
+      expect(result.stdout).toContain(`arg=${cliPath}`)
+      for (const arg of diagnosticsHelpArgs) {
+        expect(result.stdout).toContain(`arg=${arg}`)
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
 
   itRunsUnixShell('runs the AppImage CLI wrapper through APPDIR at runtime', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-appimage-cli-'))

--- a/src/main/cli/windows-launcher-asset.test.ts
+++ b/src/main/cli/windows-launcher-asset.test.ts
@@ -9,5 +9,8 @@ describe('packaged Windows CLI launcher asset', () => {
 
     expect(launcher).toContain('for %%I in ("%RESOURCES_DIR%\\..") do set "APP_DIR=%%~fI"')
     expect(launcher).not.toContain('for %%I in ("%RESOURCES_DIR%..") do set "APP_DIR=%%~fI"')
+    expect(launcher).toContain('set "CLI=%RESOURCES_DIR%\\app.asar.unpacked\\out\\cli\\index.js"')
+    expect(launcher).toContain('set ELECTRON_RUN_AS_NODE=1')
+    expect(launcher).toContain('"%ELECTRON%" "%CLI%" %*')
   })
 })

--- a/src/main/diagnostics/app-diagnostic-summary.ts
+++ b/src/main/diagnostics/app-diagnostic-summary.ts
@@ -1,0 +1,20 @@
+import { app } from 'electron'
+import { resolveDiagnosticOrcaChannel } from '../observability/diagnostic-upload-endpoint'
+
+export function collectAppDiagnosticSummary(): Record<string, unknown> {
+  return {
+    appVersion: app.getVersion(),
+    appName: app.getName(),
+    orcaChannel: resolveDiagnosticOrcaChannel(),
+    packaged: app.isPackaged,
+    electronVersion: process.versions.electron ?? 'unknown',
+    chromeVersion: process.versions.chrome ?? 'unknown',
+    nodeVersion: process.versions.node,
+    v8Version: process.versions.v8,
+    pathRoles: {
+      logs: 'app-logs',
+      userData: 'app-user-data',
+      crashDumps: 'app-crash-dumps'
+    }
+  }
+}

--- a/src/main/diagnostics/app-diagnostic-summary.ts
+++ b/src/main/diagnostics/app-diagnostic-summary.ts
@@ -1,11 +1,12 @@
 import { app } from 'electron'
-import { resolveDiagnosticOrcaChannel } from '../observability/diagnostic-upload-endpoint'
 
-export function collectAppDiagnosticSummary(): Record<string, unknown> {
+export function collectAppDiagnosticSummary(
+  orcaChannel: 'stable' | 'rc' | 'dev'
+): Record<string, unknown> {
   return {
     appVersion: app.getVersion(),
     appName: app.getName(),
-    orcaChannel: resolveDiagnosticOrcaChannel(),
+    orcaChannel,
     packaged: app.isPackaged,
     electronVersion: process.versions.electron ?? 'unknown',
     chromeVersion: process.versions.chrome ?? 'unknown',

--- a/src/main/diagnostics/app-diagnostic-summary.ts
+++ b/src/main/diagnostics/app-diagnostic-summary.ts
@@ -13,6 +13,7 @@ export function collectAppDiagnosticSummary(
     nodeVersion: process.versions.node,
     v8Version: process.versions.v8,
     pathRoles: {
+      // Why: real app paths can include usernames; diagnostics only need role labels.
       logs: 'app-logs',
       userData: 'app-user-data',
       crashDumps: 'app-crash-dumps'

--- a/src/main/diagnostics/diagnostic-archive-writer.ts
+++ b/src/main/diagnostics/diagnostic-archive-writer.ts
@@ -49,19 +49,17 @@ export async function writeDiagnosticArchive(args: {
       ...fileManifest
     ]
   }
-  const manifestContent = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
-  manifest.files[0] = {
-    path: 'manifest.json',
-    category: 'manifest',
-    bytes: manifestContent.byteLength,
-    sha256: null
-  }
-  const finalManifestContent = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
-  manifest.files[0] = {
-    path: 'manifest.json',
-    category: 'manifest',
-    bytes: finalManifestContent.byteLength,
-    sha256: null
+  let finalManifestContent = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+  let previousManifestBytes = -1
+  while (finalManifestContent.byteLength !== previousManifestBytes) {
+    previousManifestBytes = finalManifestContent.byteLength
+    manifest.files[0] = {
+      path: 'manifest.json',
+      category: 'manifest',
+      bytes: previousManifestBytes,
+      sha256: null
+    }
+    finalManifestContent = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
   }
   const manifestEntry: PreparedEntry = {
     category: 'manifest',

--- a/src/main/diagnostics/diagnostic-archive-writer.ts
+++ b/src/main/diagnostics/diagnostic-archive-writer.ts
@@ -1,0 +1,172 @@
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import type {
+  DiagnosticBundleCategory,
+  DiagnosticBundleFileManifest,
+  DiagnosticBundleManifest
+} from '../../shared/diagnostic-bundle-export-types'
+
+export type DiagnosticArchiveEntry = {
+  category: DiagnosticBundleCategory
+  path: string
+  content: Buffer | string
+}
+
+type PreparedEntry = {
+  category: DiagnosticBundleCategory | 'manifest'
+  path: string
+  content: Buffer
+  crc32: number
+  sha256: string
+}
+
+const CRC32_TABLE = new Uint32Array(256)
+for (let i = 0; i < CRC32_TABLE.length; i += 1) {
+  let value = i
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+  }
+  CRC32_TABLE[i] = value >>> 0
+}
+
+export async function writeDiagnosticArchive(args: {
+  outputPath: string
+  manifest: Omit<DiagnosticBundleManifest, 'files'>
+  entries: readonly DiagnosticArchiveEntry[]
+}): Promise<{ bytes: number; manifest: DiagnosticBundleManifest }> {
+  const prepared = args.entries.map(prepareEntry)
+  const fileManifest = prepared.map(toManifestEntry)
+  const manifest: DiagnosticBundleManifest = {
+    ...args.manifest,
+    files: [
+      {
+        path: 'manifest.json',
+        category: 'manifest',
+        bytes: 0,
+        sha256: null
+      },
+      ...fileManifest
+    ]
+  }
+  const manifestContent = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+  manifest.files[0] = {
+    path: 'manifest.json',
+    category: 'manifest',
+    bytes: manifestContent.byteLength,
+    sha256: null
+  }
+  const finalManifestContent = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+  manifest.files[0] = {
+    path: 'manifest.json',
+    category: 'manifest',
+    bytes: finalManifestContent.byteLength,
+    sha256: null
+  }
+  const manifestEntry: PreparedEntry = {
+    category: 'manifest',
+    path: 'manifest.json',
+    content: finalManifestContent,
+    crc32: crc32(finalManifestContent),
+    sha256: createHash('sha256').update(finalManifestContent).digest('hex')
+  }
+  const archiveBytes = buildZip([manifestEntry, ...prepared])
+  await mkdir(dirname(args.outputPath), { recursive: true })
+  await writeFile(args.outputPath, archiveBytes)
+  return { bytes: archiveBytes.byteLength, manifest }
+}
+
+function prepareEntry(entry: DiagnosticArchiveEntry): PreparedEntry {
+  const path = normalizeArchivePath(entry.path)
+  const content = Buffer.isBuffer(entry.content)
+    ? entry.content
+    : Buffer.from(entry.content, 'utf8')
+  return {
+    category: entry.category,
+    path,
+    content,
+    crc32: crc32(content),
+    sha256: createHash('sha256').update(content).digest('hex')
+  }
+}
+
+function toManifestEntry(entry: PreparedEntry): DiagnosticBundleFileManifest {
+  return {
+    path: entry.path,
+    category: entry.category,
+    bytes: entry.content.byteLength,
+    sha256: entry.sha256
+  }
+}
+
+function normalizeArchivePath(path: string): string {
+  const normalized = path.replace(/\\/g, '/').replace(/^\/+/, '')
+  if (!normalized || normalized.includes('../') || normalized.startsWith('..')) {
+    throw new Error(`invalid archive path: ${path}`)
+  }
+  return normalized
+}
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff
+  for (const byte of buffer) {
+    crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+function buildZip(entries: readonly PreparedEntry[]): Buffer {
+  const chunks: Buffer[] = []
+  const centralChunks: Buffer[] = []
+  let offset = 0
+  for (const entry of entries) {
+    const name = Buffer.from(entry.path, 'utf8')
+    const local = Buffer.alloc(30)
+    local.writeUInt32LE(0x04034b50, 0)
+    local.writeUInt16LE(20, 4)
+    local.writeUInt16LE(0, 6)
+    local.writeUInt16LE(0, 8)
+    local.writeUInt16LE(0, 10)
+    local.writeUInt16LE(0, 12)
+    local.writeUInt32LE(entry.crc32, 14)
+    local.writeUInt32LE(entry.content.byteLength, 18)
+    local.writeUInt32LE(entry.content.byteLength, 22)
+    local.writeUInt16LE(name.byteLength, 26)
+    local.writeUInt16LE(0, 28)
+    chunks.push(local, name, entry.content)
+
+    const central = Buffer.alloc(46)
+    central.writeUInt32LE(0x02014b50, 0)
+    central.writeUInt16LE(20, 4)
+    central.writeUInt16LE(20, 6)
+    central.writeUInt16LE(0, 8)
+    central.writeUInt16LE(0, 10)
+    central.writeUInt16LE(0, 12)
+    central.writeUInt16LE(0, 14)
+    central.writeUInt32LE(entry.crc32, 16)
+    central.writeUInt32LE(entry.content.byteLength, 20)
+    central.writeUInt32LE(entry.content.byteLength, 24)
+    central.writeUInt16LE(name.byteLength, 28)
+    central.writeUInt16LE(0, 30)
+    central.writeUInt16LE(0, 32)
+    central.writeUInt16LE(0, 34)
+    central.writeUInt16LE(0, 36)
+    central.writeUInt32LE(0, 38)
+    central.writeUInt32LE(offset, 42)
+    centralChunks.push(central, name)
+
+    offset += local.byteLength + name.byteLength + entry.content.byteLength
+  }
+
+  const centralSize = centralChunks.reduce((sum, chunk) => sum + chunk.byteLength, 0)
+  const end = Buffer.alloc(22)
+  end.writeUInt32LE(0x06054b50, 0)
+  end.writeUInt16LE(0, 4)
+  end.writeUInt16LE(0, 6)
+  end.writeUInt16LE(entries.length, 8)
+  end.writeUInt16LE(entries.length, 10)
+  end.writeUInt32LE(centralSize, 12)
+  end.writeUInt32LE(offset, 16)
+  end.writeUInt16LE(0, 20)
+  return Buffer.concat([...chunks, ...centralChunks, end])
+}

--- a/src/main/diagnostics/diagnostic-bundle-category-collector.ts
+++ b/src/main/diagnostics/diagnostic-bundle-category-collector.ts
@@ -12,7 +12,8 @@ import type { DiagnosticArchiveEntry } from './diagnostic-archive-writer'
 import {
   collectDiagnosticJsonCategory,
   makeDiagnosticJsonContent,
-  sanitizeDiagnosticCategoryError
+  sanitizeDiagnosticCategoryError,
+  sanitizeDiagnosticCategoryReason
 } from './diagnostic-bundle-json-category'
 import { collectSystemDiagnosticSummary } from './system-diagnostic-summary'
 import {
@@ -62,7 +63,7 @@ export async function collectDiagnosticBundleCategory(
   switch (category) {
     case 'app':
       await collectDiagnosticJsonCategory(context.record, addEntry, category, 'app/orca.json', () =>
-        collectAppDiagnosticSummary()
+        collectAppDiagnosticSummary(context.orcaChannel)
       )
       break
     case 'system':
@@ -198,27 +199,21 @@ async function collectSystemCategory(
     const summary = collectSystemDiagnosticSummary()
     const osPath = 'system/os.json'
     const resourcesPath = 'system/resources.json'
-    addEntry(
-      'system',
-      osPath,
-      makeDiagnosticJsonContent({
-        platform: summary.platform,
-        arch: summary.arch,
-        osRelease: summary.osRelease,
-        osVersion: summary.osVersion,
-        systemVersion: summary.systemVersion,
-        locale: summary.locale
-      })
-    )
-    addEntry(
-      'system',
-      resourcesPath,
-      makeDiagnosticJsonContent({
-        cpu: summary.cpu,
-        memory: summary.memory,
-        loadAverage1m: summary.loadAverage1m
-      })
-    )
+    const osContent = makeDiagnosticJsonContent({
+      platform: summary.platform,
+      arch: summary.arch,
+      osRelease: summary.osRelease,
+      osVersion: summary.osVersion,
+      systemVersion: summary.systemVersion,
+      locale: summary.locale
+    })
+    const resourcesContent = makeDiagnosticJsonContent({
+      cpu: summary.cpu,
+      memory: summary.memory,
+      loadAverage1m: summary.loadAverage1m
+    })
+    addEntry('system', osPath, osContent)
+    addEntry('system', resourcesPath, resourcesContent)
     record({ category: 'system', status: 'included', files: [osPath, resourcesPath] })
   } catch (error) {
     record({
@@ -244,7 +239,9 @@ async function collectObservabilityCategory(
       record({
         category,
         status: 'skipped',
-        reason: status.disabledReason ?? 'diagnostics_bundle_disabled',
+        reason: sanitizeDiagnosticCategoryReason(
+          status.disabledReason ?? 'diagnostics_bundle_disabled'
+        ),
         files: []
       })
       return

--- a/src/main/diagnostics/diagnostic-bundle-category-collector.ts
+++ b/src/main/diagnostics/diagnostic-bundle-category-collector.ts
@@ -1,0 +1,265 @@
+import os from 'node:os'
+import { app } from 'electron'
+import type {
+  DiagnosticBundleCategory,
+  DiagnosticBundleCategoryResult
+} from '../../shared/diagnostic-bundle-export-types'
+import { collectMemorySnapshot, type MemorySnapshotStore } from '../memory/collector'
+import { collectDiagnosticBundle, getDiagnosticsStatus } from '../observability'
+import { CrashReportStore } from '../crash-reporting/crash-report-store'
+import { collectAppDiagnosticSummary } from './app-diagnostic-summary'
+import type { DiagnosticArchiveEntry } from './diagnostic-archive-writer'
+import {
+  collectDiagnosticJsonCategory,
+  makeDiagnosticJsonContent,
+  sanitizeDiagnosticCategoryError
+} from './diagnostic-bundle-json-category'
+import { collectSystemDiagnosticSummary } from './system-diagnostic-summary'
+import {
+  collectRuntimeDiagnosticCounts,
+  type DiagnosticRuntimeStore
+} from './runtime-diagnostic-counts'
+import { collectTerminalLifecycleDiagnosticTrace } from './terminal-lifecycle-diagnostic-trace'
+import { collectNativeMinidumpCategory } from './diagnostic-bundle-native-minidumps'
+import { collectWindowsEventDiagnosticSummary } from './windows-event-diagnostic-summary'
+import { collectWindowsWslDiagnosticSummary } from './windows-wsl-diagnostic-summary'
+import { collectShellAvailabilitySummary } from './shell-availability-summary'
+import { collectMacosReportDiagnosticIndex } from './macos-report-diagnostic-index'
+import {
+  collectLinuxCoredumpDiagnosticSummary,
+  collectLinuxJournalDiagnosticSummary
+} from './linux-coredump-diagnostic-summary'
+
+export type DiagnosticBundleRuntimeStore = DiagnosticRuntimeStore & MemorySnapshotStore
+
+type CategoryEntryAdder = (
+  category: DiagnosticBundleCategory,
+  path: string,
+  content: Buffer | string
+) => void
+type CategoryResultRecorder = (result: DiagnosticBundleCategoryResult) => void
+
+type DiagnosticBundleCategoryCollectorContext = {
+  store: DiagnosticBundleRuntimeStore
+  lookbackMinutes: number
+  orcaChannel: 'stable' | 'rc' | 'dev'
+  addEntry: (entry: DiagnosticArchiveEntry) => void
+  record: CategoryResultRecorder
+}
+
+export async function collectDiagnosticBundleCategory(
+  category: DiagnosticBundleCategory,
+  context: DiagnosticBundleCategoryCollectorContext
+): Promise<void> {
+  const addEntry = (
+    entryCategory: DiagnosticBundleCategory,
+    path: string,
+    content: Buffer | string
+  ): void => {
+    context.addEntry({ category: entryCategory, path, content })
+  }
+
+  switch (category) {
+    case 'app':
+      await collectDiagnosticJsonCategory(context.record, addEntry, category, 'app/orca.json', () =>
+        collectAppDiagnosticSummary()
+      )
+      break
+    case 'system':
+      await collectSystemCategory(context.record, addEntry)
+      break
+    case 'observability':
+      await collectObservabilityCategory(
+        context.record,
+        addEntry,
+        context.lookbackMinutes,
+        context.orcaChannel
+      )
+      break
+    case 'memory':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'memory/snapshot.json',
+        () => collectMemorySnapshot(context.store)
+      )
+      break
+    case 'crash-reports':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'crash/orca-crash-reports.json',
+        () => CrashReportStore.fromUserData().listRecent()
+      )
+      break
+    case 'native-minidumps':
+      await collectNativeMinidumpCategory(context.record, addEntry, context.lookbackMinutes)
+      break
+    case 'runtime-counts':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'app/runtime-counts.json',
+        () => collectRuntimeDiagnosticCounts(context.store)
+      )
+      break
+    case 'terminal-lifecycle':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'crash/terminal-lifecycle.json',
+        () => collectTerminalLifecycleDiagnosticTrace()
+      )
+      break
+    case 'windows-events':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'windows/events.json',
+        () => collectWindowsEventDiagnosticSummary(context.lookbackMinutes)
+      )
+      break
+    case 'windows-wsl':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'windows/wsl.json',
+        () => collectWindowsWslDiagnosticSummary()
+      )
+      break
+    case 'windows-shells':
+      await collectShellCategory(context.record, addEntry, category, 'windows/shells.json', 'win32')
+      break
+    case 'macos-reports':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'macos/reports-index.json',
+        () => collectMacosReportDiagnosticIndex(context.lookbackMinutes)
+      )
+      break
+    case 'macos-shells':
+      await collectShellCategory(context.record, addEntry, category, 'macos/shells.json', 'darwin')
+      break
+    case 'linux-coredump':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'linux/coredumpctl.json',
+        () => collectLinuxCoredumpDiagnosticSummary(context.lookbackMinutes)
+      )
+      break
+    case 'linux-journal':
+      await collectDiagnosticJsonCategory(
+        context.record,
+        addEntry,
+        category,
+        'linux/journal.json',
+        () => collectLinuxJournalDiagnosticSummary(context.lookbackMinutes)
+      )
+      break
+    case 'linux-shells':
+      await collectShellCategory(context.record, addEntry, category, 'linux/shells.json', 'linux')
+      break
+  }
+}
+
+async function collectShellCategory(
+  record: CategoryResultRecorder,
+  addEntry: CategoryEntryAdder,
+  category: DiagnosticBundleCategory,
+  path: string,
+  platform: NodeJS.Platform
+): Promise<void> {
+  await collectDiagnosticJsonCategory(record, addEntry, category, path, () =>
+    process.platform === platform
+      ? collectShellAvailabilitySummary(platform)
+      : { supported: false, reason: unsupportedPlatformReason(platform) }
+  )
+}
+
+function unsupportedPlatformReason(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? 'not_windows' : platform === 'darwin' ? 'not_macos' : 'not_linux'
+}
+
+async function collectSystemCategory(
+  record: CategoryResultRecorder,
+  addEntry: CategoryEntryAdder
+): Promise<void> {
+  try {
+    const summary = collectSystemDiagnosticSummary()
+    const osPath = 'system/os.json'
+    const resourcesPath = 'system/resources.json'
+    addEntry(
+      'system',
+      osPath,
+      makeDiagnosticJsonContent({
+        platform: summary.platform,
+        arch: summary.arch,
+        osRelease: summary.osRelease,
+        osVersion: summary.osVersion,
+        systemVersion: summary.systemVersion,
+        locale: summary.locale
+      })
+    )
+    addEntry(
+      'system',
+      resourcesPath,
+      makeDiagnosticJsonContent({
+        cpu: summary.cpu,
+        memory: summary.memory,
+        loadAverage1m: summary.loadAverage1m
+      })
+    )
+    record({ category: 'system', status: 'included', files: [osPath, resourcesPath] })
+  } catch (error) {
+    record({
+      category: 'system',
+      status: 'error',
+      reason: sanitizeDiagnosticCategoryError(error),
+      files: []
+    })
+  }
+}
+
+async function collectObservabilityCategory(
+  record: CategoryResultRecorder,
+  addEntry: CategoryEntryAdder,
+  lookbackMinutes: number,
+  orcaChannel: 'stable' | 'rc' | 'dev'
+): Promise<void> {
+  const category = 'observability'
+  const path = 'diagnostics/observability.ndjson'
+  try {
+    const status = getDiagnosticsStatus()
+    if (!status.bundleEnabled) {
+      record({
+        category,
+        status: 'skipped',
+        reason: status.disabledReason ?? 'diagnostics_bundle_disabled',
+        files: []
+      })
+      return
+    }
+    const bundle = collectDiagnosticBundle({
+      appVersion: app.getVersion(),
+      platform: os.platform(),
+      arch: os.arch(),
+      osRelease: os.release(),
+      orcaChannel,
+      lookbackMinutes
+    })
+    addEntry(category, path, bundle.payload)
+    record({ category, status: 'included', files: [path] })
+  } catch (error) {
+    record({ category, status: 'error', reason: sanitizeDiagnosticCategoryError(error), files: [] })
+  }
+}

--- a/src/main/diagnostics/diagnostic-bundle-category.ts
+++ b/src/main/diagnostics/diagnostic-bundle-category.ts
@@ -1,0 +1,36 @@
+import {
+  DIAGNOSTIC_BUNDLE_CATEGORIES,
+  type DiagnosticBundleCategory
+} from '../../shared/diagnostic-bundle-export-types'
+
+const CATEGORY_SET = new Set<string>(DIAGNOSTIC_BUNDLE_CATEGORIES)
+
+export function isDiagnosticBundleCategory(value: string): value is DiagnosticBundleCategory {
+  return CATEGORY_SET.has(value)
+}
+
+export function parseDiagnosticBundleCategories(
+  values: readonly string[]
+): DiagnosticBundleCategory[] {
+  return values.map((value) => {
+    if (!isDiagnosticBundleCategory(value)) {
+      throw new Error(
+        `Unknown diagnostic bundle category "${value}". Known categories: ${DIAGNOSTIC_BUNDLE_CATEGORIES.join(
+          ', '
+        )}`
+      )
+    }
+    return value
+  })
+}
+
+export function resolveDiagnosticBundleCategories(args: {
+  include?: readonly DiagnosticBundleCategory[]
+  exclude?: readonly DiagnosticBundleCategory[]
+}): DiagnosticBundleCategory[] {
+  const selected = new Set(args.include?.length ? args.include : DIAGNOSTIC_BUNDLE_CATEGORIES)
+  for (const category of args.exclude ?? []) {
+    selected.delete(category)
+  }
+  return DIAGNOSTIC_BUNDLE_CATEGORIES.filter((category) => selected.has(category))
+}

--- a/src/main/diagnostics/diagnostic-bundle-export.test.ts
+++ b/src/main/diagnostics/diagnostic-bundle-export.test.ts
@@ -194,6 +194,36 @@ describe('exportDiagnosticBundle', () => {
     expect(manifest.lookbackMinutes).toBe(MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES)
     expect(result.lookbackMinutes).toBe(MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES)
   })
+
+  it('keeps default runtime and app diagnostics free of raw user identifiers', async () => {
+    const { exportDiagnosticBundle } = await import('./diagnostic-bundle-export')
+    const output = 'bundle-privacy.zip'
+
+    const result = await exportDiagnosticBundle({
+      output,
+      include: ['app', 'runtime-counts'],
+      store: makeSensitiveStore()
+    })
+
+    const entries = readStoredZipEntries(await readFile(result.outputPath))
+    const archiveText = [...entries.values()].map((entry) => entry.toString('utf8')).join('\n')
+    expect(archiveText).toContain('"runtimeHostCounts"')
+    expect(archiveText).toContain('"ssh": 1')
+    expect(archiveText).toContain('"runtime": 1')
+    for (const forbidden of [
+      'alice',
+      'private-xaerus-repo',
+      'secret-branch',
+      'prod-gpu-host',
+      'runtime-owner-machine',
+      'ghp_private_token',
+      'C:/Users/Alice/source/private-xaerus-repo',
+      '/home/alice/private-xaerus-repo',
+      'terminal prompt with customer name'
+    ]) {
+      expect(archiveText).not.toContain(forbidden)
+    }
+  })
 })
 
 function makeStore(): DiagnosticBundleRuntimeStore {
@@ -206,6 +236,48 @@ function makeStore(): DiagnosticBundleRuntimeStore {
     getAllWorktreeMeta: () => ({}),
     getWorktreeMeta: () => undefined,
     getWorkspaceSession: () => ({ tabsByWorktree: {}, terminalLayoutsByTabId: {} })
+  } as unknown as DiagnosticBundleRuntimeStore
+}
+
+function makeSensitiveStore(): DiagnosticBundleRuntimeStore {
+  return {
+    getRepos: () => [
+      {
+        name: 'private-xaerus-repo',
+        path: 'C:/Users/Alice/source/private-xaerus-repo',
+        branch: 'secret-branch'
+      }
+    ],
+    getRepo: () => undefined,
+    getProjects: () => [{ name: 'Alice Customer Project' }],
+    getProjectHostSetups: () => [
+      {
+        displayName: 'prod-gpu-host',
+        path: '/home/alice/private-xaerus-repo',
+        gitUsername: 'alice'
+      }
+    ],
+    getFolderWorkspaces: () => [{ path: 'C:/Users/Alice/source/private-xaerus-repo' }],
+    getAllWorktreeMeta: () => ({
+      'C:/Users/Alice/source/private-xaerus-repo': {
+        hostId: 'ssh:prod-gpu-host',
+        branch: 'secret-branch'
+      },
+      '/home/alice/private-xaerus-repo': {
+        hostId: 'runtime:runtime-owner-machine'
+      }
+    }),
+    getWorktreeMeta: () => undefined,
+    getWorkspaceSession: () => ({
+      tabsByWorktree: {
+        'C:/Users/Alice/source/private-xaerus-repo': [{ id: 'tab-ghp_private_token' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-ghp_private_token': {
+          root: { type: 'leaf', leafId: 'terminal prompt with customer name' }
+        }
+      }
+    })
   } as unknown as DiagnosticBundleRuntimeStore
 }
 

--- a/src/main/diagnostics/diagnostic-bundle-export.test.ts
+++ b/src/main/diagnostics/diagnostic-bundle-export.test.ts
@@ -1,0 +1,207 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiagnosticBundleRuntimeStore } from './diagnostic-bundle-category-collector'
+
+const {
+  collectMemorySnapshotMock,
+  collectDiagnosticBundleMock,
+  getDiagnosticsStatusMock,
+  listNativeCrashDumpsMock,
+  showItemInFolderMock
+} = vi.hoisted(() => ({
+  collectMemorySnapshotMock: vi.fn(),
+  collectDiagnosticBundleMock: vi.fn(),
+  getDiagnosticsStatusMock: vi.fn(),
+  listNativeCrashDumpsMock: vi.fn(),
+  showItemInFolderMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.2.3',
+    getName: () => 'Orca',
+    getLocale: () => 'en-US',
+    getPath: (name: string) => join(tmpdir(), 'orca-test', name),
+    isPackaged: false
+  },
+  shell: {
+    showItemInFolder: showItemInFolderMock
+  }
+}))
+
+vi.mock('../memory/collector', () => ({
+  collectMemorySnapshot: collectMemorySnapshotMock
+}))
+
+vi.mock('../observability', () => ({
+  collectDiagnosticBundle: collectDiagnosticBundleMock,
+  getDiagnosticsStatus: getDiagnosticsStatusMock
+}))
+
+vi.mock('../observability/diagnostic-upload-endpoint', () => ({
+  resolveDiagnosticOrcaChannel: () => 'dev'
+}))
+
+vi.mock('../crash-reporting/crash-report-store', () => ({
+  CrashReportStore: {
+    fromUserData: () => ({
+      listRecent: vi.fn(async () => [{ id: 'crash-1', status: 'pending' }])
+    })
+  }
+}))
+
+vi.mock('./native-crash-dump-index', () => ({
+  listNativeCrashDumps: listNativeCrashDumpsMock
+}))
+
+describe('exportDiagnosticBundle', () => {
+  let tempRoot: string
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), 'orca-diagnostic-bundle-'))
+    collectMemorySnapshotMock.mockResolvedValue({
+      app: {
+        cpu: 0,
+        memory: 0,
+        main: { cpu: 0, memory: 0 },
+        renderer: { cpu: 0, memory: 0 },
+        other: { cpu: 0, memory: 0 },
+        history: []
+      },
+      worktrees: [],
+      host: {
+        totalMemory: 0,
+        freeMemory: 0,
+        usedMemory: 0,
+        memoryUsagePercent: 0,
+        cpuCoreCount: 1,
+        loadAverage1m: 0
+      },
+      totalCpu: 0,
+      totalMemory: 0,
+      collectedAt: 123
+    })
+    collectDiagnosticBundleMock.mockReturnValue({
+      bundleSubmissionId: 'submission-1',
+      payload: '{"type":"bundle-header"}\n',
+      bytes: 25,
+      spanCount: 0
+    })
+    getDiagnosticsStatusMock.mockReturnValue({
+      localFileEnabled: true,
+      bundleEnabled: true,
+      traceFilePath: join(tempRoot, 'trace.ndjson'),
+      traceFamilySize: 0
+    })
+    listNativeCrashDumpsMock.mockResolvedValue([])
+    showItemInFolderMock.mockClear()
+  })
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true })
+  })
+
+  it('writes a ZIP with manifest and selected diagnostics files', async () => {
+    const { exportDiagnosticBundle } = await import('./diagnostic-bundle-export')
+    const output = join(tempRoot, 'bundle.zip')
+
+    const result = await exportDiagnosticBundle({
+      output,
+      include: [
+        'app',
+        'system',
+        'observability',
+        'memory',
+        'crash-reports',
+        'runtime-counts',
+        'terminal-lifecycle',
+        'native-minidumps'
+      ],
+      store: makeStore()
+    })
+
+    const entries = readStoredZipEntries(await readFile(output))
+    expect([...entries.keys()].sort()).toEqual([
+      'app/orca.json',
+      'app/runtime-counts.json',
+      'crash/orca-crash-reports.json',
+      'crash/terminal-lifecycle.json',
+      'diagnostics/observability.ndjson',
+      'manifest.json',
+      'memory/snapshot.json',
+      'system/os.json',
+      'system/resources.json'
+    ])
+    const manifest = JSON.parse(entries.get('manifest.json')!.toString('utf8')) as {
+      categories: { category: string; status: string; reason?: string; files: string[] }[]
+      files: { path: string; bytes: number; sha256: string | null }[]
+    }
+    expect(manifest.categories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ category: 'app', status: 'included' }),
+        expect.objectContaining({
+          category: 'native-minidumps',
+          status: 'skipped',
+          reason: 'none_found'
+        })
+      ])
+    )
+    expect(manifest.files.find((file) => file.path === 'manifest.json')?.sha256).toBeNull()
+    expect(result).toMatchObject({
+      outputPath: output,
+      includedCategories: expect.arrayContaining(['app', 'system', 'memory']),
+      skippedCategories: [expect.objectContaining({ category: 'native-minidumps' })],
+      fileCount: manifest.files.length
+    })
+  })
+
+  it('reveals the bundle when requested', async () => {
+    const { exportDiagnosticBundle } = await import('./diagnostic-bundle-export')
+    const output = join(tempRoot, 'bundle-open.zip')
+
+    await exportDiagnosticBundle({
+      output,
+      include: ['app'],
+      open: true,
+      store: makeStore()
+    })
+
+    expect(showItemInFolderMock).toHaveBeenCalledWith(output)
+  })
+})
+
+function makeStore(): DiagnosticBundleRuntimeStore {
+  return {
+    getRepos: () => [{}],
+    getRepo: () => undefined,
+    getProjects: () => [],
+    getProjectHostSetups: () => [],
+    getFolderWorkspaces: () => [],
+    getAllWorktreeMeta: () => ({}),
+    getWorktreeMeta: () => undefined,
+    getWorkspaceSession: () => ({ tabsByWorktree: {}, terminalLayoutsByTabId: {} })
+  } as unknown as DiagnosticBundleRuntimeStore
+}
+
+function readStoredZipEntries(buffer: Buffer): Map<string, Buffer> {
+  const entries = new Map<string, Buffer>()
+  let offset = 0
+  while (offset < buffer.byteLength) {
+    const signature = buffer.readUInt32LE(offset)
+    if (signature === 0x02014b50 || signature === 0x06054b50) {
+      break
+    }
+    expect(signature).toBe(0x04034b50)
+    const compressedSize = buffer.readUInt32LE(offset + 18)
+    const nameLength = buffer.readUInt16LE(offset + 26)
+    const extraLength = buffer.readUInt16LE(offset + 28)
+    const nameStart = offset + 30
+    const contentStart = nameStart + nameLength + extraLength
+    const name = buffer.subarray(nameStart, nameStart + nameLength).toString('utf8')
+    entries.set(name, buffer.subarray(contentStart, contentStart + compressedSize))
+    offset = contentStart + compressedSize
+  }
+  return entries
+}

--- a/src/main/diagnostics/diagnostic-bundle-export.test.ts
+++ b/src/main/diagnostics/diagnostic-bundle-export.test.ts
@@ -155,6 +155,7 @@ describe('exportDiagnosticBundle', () => {
     expect(manifestFile?.bytes).toBe(entries.get('manifest.json')!.byteLength)
     expect(result).toMatchObject({
       outputPath: join(tmpdir(), 'orca-test', 'logs', 'diagnostics', output),
+      lookbackMinutes: 30,
       includedCategories: expect.arrayContaining(['app', 'system', 'memory']),
       skippedCategories: [expect.objectContaining({ category: 'native-minidumps' })],
       fileCount: manifest.files.length
@@ -191,6 +192,7 @@ describe('exportDiagnosticBundle', () => {
       lookbackMinutes: number
     }
     expect(manifest.lookbackMinutes).toBe(MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES)
+    expect(result.lookbackMinutes).toBe(MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES)
   })
 })
 

--- a/src/main/diagnostics/diagnostic-bundle-export.test.ts
+++ b/src/main/diagnostics/diagnostic-bundle-export.test.ts
@@ -102,11 +102,12 @@ describe('exportDiagnosticBundle', () => {
 
   afterEach(async () => {
     await rm(tempRoot, { recursive: true, force: true })
+    await rm(join(tmpdir(), 'orca-test'), { recursive: true, force: true })
   })
 
   it('writes a ZIP with manifest and selected diagnostics files', async () => {
     const { exportDiagnosticBundle } = await import('./diagnostic-bundle-export')
-    const output = join(tempRoot, 'bundle.zip')
+    const output = 'bundle.zip'
 
     const result = await exportDiagnosticBundle({
       output,
@@ -123,7 +124,7 @@ describe('exportDiagnosticBundle', () => {
       store: makeStore()
     })
 
-    const entries = readStoredZipEntries(await readFile(output))
+    const entries = readStoredZipEntries(await readFile(result.outputPath))
     expect([...entries.keys()].sort()).toEqual([
       'app/orca.json',
       'app/runtime-counts.json',
@@ -149,9 +150,11 @@ describe('exportDiagnosticBundle', () => {
         })
       ])
     )
-    expect(manifest.files.find((file) => file.path === 'manifest.json')?.sha256).toBeNull()
+    const manifestFile = manifest.files.find((file) => file.path === 'manifest.json')
+    expect(manifestFile?.sha256).toBeNull()
+    expect(manifestFile?.bytes).toBe(entries.get('manifest.json')!.byteLength)
     expect(result).toMatchObject({
-      outputPath: output,
+      outputPath: join(tmpdir(), 'orca-test', 'logs', 'diagnostics', output),
       includedCategories: expect.arrayContaining(['app', 'system', 'memory']),
       skippedCategories: [expect.objectContaining({ category: 'native-minidumps' })],
       fileCount: manifest.files.length
@@ -160,30 +163,30 @@ describe('exportDiagnosticBundle', () => {
 
   it('reveals the bundle when requested', async () => {
     const { exportDiagnosticBundle } = await import('./diagnostic-bundle-export')
-    const output = join(tempRoot, 'bundle-open.zip')
+    const output = 'bundle-open.zip'
 
-    await exportDiagnosticBundle({
+    const result = await exportDiagnosticBundle({
       output,
       include: ['app'],
       open: true,
       store: makeStore()
     })
 
-    expect(showItemInFolderMock).toHaveBeenCalledWith(output)
+    expect(showItemInFolderMock).toHaveBeenCalledWith(result.outputPath)
   })
 
   it('caps direct caller lookback windows before running collectors', async () => {
     const { exportDiagnosticBundle } = await import('./diagnostic-bundle-export')
-    const output = join(tempRoot, 'bundle-lookback-cap.zip')
+    const output = 'bundle-lookback-cap.zip'
 
-    await exportDiagnosticBundle({
+    const result = await exportDiagnosticBundle({
       output,
       include: ['app'],
       lookbackMinutes: Number.MAX_SAFE_INTEGER,
       store: makeStore()
     })
 
-    const entries = readStoredZipEntries(await readFile(output))
+    const entries = readStoredZipEntries(await readFile(result.outputPath))
     const manifest = JSON.parse(entries.get('manifest.json')!.toString('utf8')) as {
       lookbackMinutes: number
     }

--- a/src/main/diagnostics/diagnostic-bundle-export.test.ts
+++ b/src/main/diagnostics/diagnostic-bundle-export.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES } from '../../shared/diagnostic-bundle-export-types'
 import type { DiagnosticBundleRuntimeStore } from './diagnostic-bundle-category-collector'
 
 const {
@@ -169,6 +170,24 @@ describe('exportDiagnosticBundle', () => {
     })
 
     expect(showItemInFolderMock).toHaveBeenCalledWith(output)
+  })
+
+  it('caps direct caller lookback windows before running collectors', async () => {
+    const { exportDiagnosticBundle } = await import('./diagnostic-bundle-export')
+    const output = join(tempRoot, 'bundle-lookback-cap.zip')
+
+    await exportDiagnosticBundle({
+      output,
+      include: ['app'],
+      lookbackMinutes: Number.MAX_SAFE_INTEGER,
+      store: makeStore()
+    })
+
+    const entries = readStoredZipEntries(await readFile(output))
+    const manifest = JSON.parse(entries.get('manifest.json')!.toString('utf8')) as {
+      lookbackMinutes: number
+    }
+    expect(manifest.lookbackMinutes).toBe(MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES)
   })
 })
 

--- a/src/main/diagnostics/diagnostic-bundle-export.ts
+++ b/src/main/diagnostics/diagnostic-bundle-export.ts
@@ -6,6 +6,7 @@ import type {
   DiagnosticBundleExportResult,
   DiagnosticBundleManifest
 } from '../../shared/diagnostic-bundle-export-types'
+import { MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES } from '../../shared/diagnostic-bundle-export-types'
 import { resolveDiagnosticOrcaChannel } from '../observability/diagnostic-upload-endpoint'
 import {
   resolveDiagnosticBundleCategories,
@@ -87,5 +88,5 @@ function normalizeLookbackMinutes(value: number | undefined): number {
   if (value === undefined || !Number.isFinite(value) || value <= 0) {
     return DEFAULT_LOOKBACK_MINUTES
   }
-  return Math.max(1, Math.floor(value))
+  return Math.min(MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES, Math.max(1, Math.floor(value)))
 }

--- a/src/main/diagnostics/diagnostic-bundle-export.ts
+++ b/src/main/diagnostics/diagnostic-bundle-export.ts
@@ -75,6 +75,7 @@ export async function exportDiagnosticBundle(
     bundleId,
     outputPath,
     bytes: archive.bytes,
+    lookbackMinutes,
     includedCategories: categoryResults
       .filter((result) => result.status === 'included' || result.status === 'truncated')
       .map((result) => result.category),
@@ -88,5 +89,7 @@ function normalizeLookbackMinutes(value: number | undefined): number {
   if (value === undefined || !Number.isFinite(value) || value <= 0) {
     return DEFAULT_LOOKBACK_MINUTES
   }
+  // Why: crash/event scans are filesystem and OS-log bounded, so direct callers
+  // get the same cap enforced by CLI/RPC validation.
   return Math.min(MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES, Math.max(1, Math.floor(value)))
 }

--- a/src/main/diagnostics/diagnostic-bundle-export.ts
+++ b/src/main/diagnostics/diagnostic-bundle-export.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from 'node:crypto'
+import { app, shell } from 'electron'
+import type {
+  DiagnosticBundleCategoryResult,
+  DiagnosticBundleExportArgs,
+  DiagnosticBundleExportResult,
+  DiagnosticBundleManifest
+} from '../../shared/diagnostic-bundle-export-types'
+import { resolveDiagnosticOrcaChannel } from '../observability/diagnostic-upload-endpoint'
+import {
+  resolveDiagnosticBundleCategories,
+  parseDiagnosticBundleCategories
+} from './diagnostic-bundle-category'
+import {
+  collectDiagnosticBundleCategory,
+  type DiagnosticBundleRuntimeStore
+} from './diagnostic-bundle-category-collector'
+import { resolveDiagnosticBundleOutputPath } from './diagnostic-output-path'
+import { writeDiagnosticArchive, type DiagnosticArchiveEntry } from './diagnostic-archive-writer'
+
+const DEFAULT_LOOKBACK_MINUTES = 30
+
+export async function exportDiagnosticBundle(
+  args: DiagnosticBundleExportArgs & { store: DiagnosticBundleRuntimeStore }
+): Promise<DiagnosticBundleExportResult> {
+  const outputPath = resolveDiagnosticBundleOutputPath(args.output)
+  const lookbackMinutes = normalizeLookbackMinutes(args.lookbackMinutes)
+  const selectedCategories = resolveDiagnosticBundleCategories({
+    include: args.include ? parseDiagnosticBundleCategories(args.include) : undefined,
+    exclude: args.exclude ? parseDiagnosticBundleCategories(args.exclude) : undefined
+  })
+
+  const entries: DiagnosticArchiveEntry[] = []
+  const categoryResults: DiagnosticBundleCategoryResult[] = []
+  const collectedAt = new Date().toISOString()
+  const orcaChannel = resolveDiagnosticOrcaChannel()
+  const bundleId = randomUUID()
+
+  const addEntry = (entry: DiagnosticArchiveEntry): void => {
+    entries.push(entry)
+  }
+  const record = (result: DiagnosticBundleCategoryResult): void => {
+    categoryResults.push(result)
+  }
+
+  for (const category of selectedCategories) {
+    await collectDiagnosticBundleCategory(category, {
+      store: args.store,
+      lookbackMinutes,
+      orcaChannel,
+      addEntry,
+      record
+    })
+  }
+
+  const manifest: Omit<DiagnosticBundleManifest, 'files'> = {
+    schemaVersion: 1,
+    bundleId,
+    collectedAt,
+    appVersion: app.getVersion(),
+    orcaChannel,
+    platform: process.platform,
+    arch: process.arch,
+    lookbackMinutes,
+    categories: categoryResults
+  }
+  const archive = await writeDiagnosticArchive({ outputPath, manifest, entries })
+
+  if (args.open) {
+    shell.showItemInFolder(outputPath)
+  }
+
+  return {
+    bundleId,
+    outputPath,
+    bytes: archive.bytes,
+    includedCategories: categoryResults
+      .filter((result) => result.status === 'included' || result.status === 'truncated')
+      .map((result) => result.category),
+    skippedCategories: categoryResults.filter((result) => result.status === 'skipped'),
+    errorCategories: categoryResults.filter((result) => result.status === 'error'),
+    fileCount: archive.manifest.files.length
+  }
+}
+
+function normalizeLookbackMinutes(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_LOOKBACK_MINUTES
+  }
+  return Math.max(1, Math.floor(value))
+}

--- a/src/main/diagnostics/diagnostic-bundle-json-category.ts
+++ b/src/main/diagnostics/diagnostic-bundle-json-category.ts
@@ -1,0 +1,56 @@
+import type {
+  DiagnosticBundleCategory,
+  DiagnosticBundleCategoryResult
+} from '../../shared/diagnostic-bundle-export-types'
+import { redactString } from '../observability/redactor'
+
+export async function collectDiagnosticJsonCategory(
+  record: (result: DiagnosticBundleCategoryResult) => void,
+  addEntry: (category: DiagnosticBundleCategory, path: string, content: Buffer | string) => void,
+  category: DiagnosticBundleCategory,
+  path: string,
+  collect: () => Promise<unknown> | unknown
+): Promise<void> {
+  try {
+    const value = await collect()
+    if (isUnsupportedSummary(value)) {
+      record({
+        category,
+        status: 'skipped',
+        reason: sanitizeDiagnosticCategoryReason(value.reason),
+        files: []
+      })
+      return
+    }
+    addEntry(category, path, makeDiagnosticJsonContent(value))
+    record({ category, status: 'included', files: [path] })
+  } catch (error) {
+    record({
+      category,
+      status: 'error',
+      reason: sanitizeDiagnosticCategoryError(error),
+      files: []
+    })
+  }
+}
+
+export function makeDiagnosticJsonContent(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+export function sanitizeDiagnosticCategoryError(error: unknown): string {
+  return sanitizeDiagnosticCategoryReason(error instanceof Error ? error.message : String(error))
+}
+
+function isUnsupportedSummary(value: unknown): value is { supported: false; reason?: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { supported?: unknown }).supported === false
+  )
+}
+
+function sanitizeDiagnosticCategoryReason(reason: string | undefined): string {
+  const text = reason && reason.trim().length > 0 ? reason : 'unknown'
+  return redactString(text).slice(0, 500)
+}

--- a/src/main/diagnostics/diagnostic-bundle-json-category.ts
+++ b/src/main/diagnostics/diagnostic-bundle-json-category.ts
@@ -42,15 +42,15 @@ export function sanitizeDiagnosticCategoryError(error: unknown): string {
   return sanitizeDiagnosticCategoryReason(error instanceof Error ? error.message : String(error))
 }
 
+export function sanitizeDiagnosticCategoryReason(reason: string | undefined): string {
+  const text = reason && reason.trim().length > 0 ? reason : 'unknown'
+  return redactString(text).slice(0, 500)
+}
+
 function isUnsupportedSummary(value: unknown): value is { supported: false; reason?: string } {
   return (
     typeof value === 'object' &&
     value !== null &&
     (value as { supported?: unknown }).supported === false
   )
-}
-
-function sanitizeDiagnosticCategoryReason(reason: string | undefined): string {
-  const text = reason && reason.trim().length > 0 ? reason : 'unknown'
-  return redactString(text).slice(0, 500)
 }

--- a/src/main/diagnostics/diagnostic-bundle-native-minidumps.ts
+++ b/src/main/diagnostics/diagnostic-bundle-native-minidumps.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises'
+import type {
+  DiagnosticBundleCategory,
+  DiagnosticBundleCategoryResult
+} from '../../shared/diagnostic-bundle-export-types'
+import { sanitizeDiagnosticCategoryError } from './diagnostic-bundle-json-category'
+import { listNativeCrashDumps } from './native-crash-dump-index'
+
+const MAX_NATIVE_MINIDUMPS = 10
+
+type CategoryEntryAdder = (
+  category: DiagnosticBundleCategory,
+  path: string,
+  content: Buffer | string
+) => void
+type CategoryResultRecorder = (result: DiagnosticBundleCategoryResult) => void
+
+export async function collectNativeMinidumpCategory(
+  record: CategoryResultRecorder,
+  addEntry: CategoryEntryAdder,
+  lookbackMinutes: number
+): Promise<void> {
+  const category = 'native-minidumps'
+  try {
+    const dumps = await listNativeCrashDumps(lookbackMinutes)
+    if (dumps.length === 0) {
+      record({ category, status: 'skipped', reason: 'none_found', files: [] })
+      return
+    }
+    const selected = dumps.slice(0, MAX_NATIVE_MINIDUMPS)
+    const files: string[] = []
+    for (const [index, dump] of selected.entries()) {
+      const path = `crash/minidumps/${String(index + 1).padStart(2, '0')}-${safeArchiveSegment(
+        dump.name
+      )}`
+      addEntry(category, path, await readFile(dump.path))
+      files.push(path)
+    }
+    record({
+      category,
+      status: dumps.length > selected.length ? 'truncated' : 'included',
+      ...(dumps.length > selected.length ? { reason: 'minidump_count_cap' } : {}),
+      files
+    })
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') {
+      record({ category, status: 'skipped', reason: 'missing_directory', files: [] })
+      return
+    }
+    record({ category, status: 'error', reason: sanitizeDiagnosticCategoryError(error), files: [] })
+  }
+}
+
+function safeArchiveSegment(name: string): string {
+  const sanitized = name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^\.+/, '')
+  return sanitized.length > 0 ? sanitized : 'dump.dmp'
+}

--- a/src/main/diagnostics/diagnostic-output-path.test.ts
+++ b/src/main/diagnostics/diagnostic-output-path.test.ts
@@ -1,0 +1,35 @@
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+const { appRoot } = vi.hoisted(() => ({
+  appRoot: 'orca-test-root'
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => `${appRoot}/${name}`
+  }
+}))
+
+describe('resolveDiagnosticBundleOutputPath', () => {
+  it('resolves relative output names under the diagnostics directory', async () => {
+    const { resolveDiagnosticBundleOutputPath } = await import('./diagnostic-output-path')
+
+    const output = resolveDiagnosticBundleOutputPath('support/orca-diagnostics.zip')
+    expect(output).toContain(join(appRoot, 'logs'))
+    expect(output.endsWith(join('diagnostics', 'support', 'orca-diagnostics.zip'))).toBe(true)
+  })
+
+  it('rejects output paths outside the diagnostics directory', async () => {
+    const { DIAGNOSTIC_OUTPUT_PATH_ERROR } =
+      await import('../../shared/diagnostic-bundle-output-path-policy')
+    const { resolveDiagnosticBundleOutputPath } = await import('./diagnostic-output-path')
+
+    expect(() => resolveDiagnosticBundleOutputPath('../orca-diagnostics.zip')).toThrow(
+      DIAGNOSTIC_OUTPUT_PATH_ERROR
+    )
+    expect(() => resolveDiagnosticBundleOutputPath('C:\\tmp\\orca-diagnostics.zip')).toThrow(
+      DIAGNOSTIC_OUTPUT_PATH_ERROR
+    )
+  })
+})

--- a/src/main/diagnostics/diagnostic-output-path.ts
+++ b/src/main/diagnostics/diagnostic-output-path.ts
@@ -1,5 +1,9 @@
 import { app } from 'electron'
-import { isAbsolute, join, resolve } from 'node:path'
+import { join } from 'node:path'
+import {
+  DIAGNOSTIC_OUTPUT_PATH_ERROR,
+  parseSafeDiagnosticBundleOutputPath
+} from '../../shared/diagnostic-bundle-output-path-policy'
 
 export function defaultDiagnosticBundleOutputPath(now = new Date()): string {
   const stamp = now
@@ -7,12 +11,20 @@ export function defaultDiagnosticBundleOutputPath(now = new Date()): string {
     .replace(/[-:]/g, '')
     .replace(/\.\d{3}Z$/, '')
     .replace('T', '-')
-  return join(app.getPath('logs'), 'diagnostics', `orca-diagnostics-${stamp}.zip`)
+  return join(getDiagnosticBundleOutputDirectory(), `orca-diagnostics-${stamp}.zip`)
 }
 
 export function resolveDiagnosticBundleOutputPath(output: string | undefined): string {
   if (!output || output.trim().length === 0) {
     return defaultDiagnosticBundleOutputPath()
   }
-  return isAbsolute(output) ? output : resolve(process.cwd(), output)
+  const segments = parseSafeDiagnosticBundleOutputPath(output)
+  if (!segments) {
+    throw new Error(DIAGNOSTIC_OUTPUT_PATH_ERROR)
+  }
+  return join(getDiagnosticBundleOutputDirectory(), ...segments)
+}
+
+export function getDiagnosticBundleOutputDirectory(): string {
+  return join(app.getPath('logs'), 'diagnostics')
 }

--- a/src/main/diagnostics/diagnostic-output-path.ts
+++ b/src/main/diagnostics/diagnostic-output-path.ts
@@ -1,0 +1,18 @@
+import { app } from 'electron'
+import { isAbsolute, join, resolve } from 'node:path'
+
+export function defaultDiagnosticBundleOutputPath(now = new Date()): string {
+  const stamp = now
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, '')
+    .replace('T', '-')
+  return join(app.getPath('logs'), 'diagnostics', `orca-diagnostics-${stamp}.zip`)
+}
+
+export function resolveDiagnosticBundleOutputPath(output: string | undefined): string {
+  if (!output || output.trim().length === 0) {
+    return defaultDiagnosticBundleOutputPath()
+  }
+  return isAbsolute(output) ? output : resolve(process.cwd(), output)
+}

--- a/src/main/diagnostics/linux-coredump-diagnostic-summary.ts
+++ b/src/main/diagnostics/linux-coredump-diagnostic-summary.ts
@@ -1,0 +1,62 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { redactValue } from '../observability/redactor'
+
+const execFileAsync = promisify(execFile)
+const COREDUMP_TIMEOUT_MS = 4_000
+
+export async function collectLinuxCoredumpDiagnosticSummary(
+  lookbackMinutes: number
+): Promise<Record<string, unknown>> {
+  if (process.platform !== 'linux') {
+    return { supported: false, reason: 'not_linux' }
+  }
+  const since = `${Math.max(1, Math.floor(lookbackMinutes))} minutes ago`
+  const { stdout } = await execFileAsync(
+    'coredumpctl',
+    ['--no-pager', '--json=short', '--since', since, 'list'],
+    { timeout: COREDUMP_TIMEOUT_MS, maxBuffer: 1024 * 1024 }
+  )
+  const rows = parseJsonLines(stdout)
+  return {
+    supported: true,
+    count: rows.length,
+    coredumps: rows
+      .filter((row) => /orca|electron/i.test(JSON.stringify(row)))
+      .slice(0, 20)
+      .map((row) => redactObject(row))
+  }
+}
+
+export async function collectLinuxJournalDiagnosticSummary(
+  lookbackMinutes: number
+): Promise<Record<string, unknown>> {
+  if (process.platform !== 'linux') {
+    return { supported: false, reason: 'not_linux' }
+  }
+  const since = `${Math.max(1, Math.floor(lookbackMinutes))} minutes ago`
+  const { stdout } = await execFileAsync(
+    'journalctl',
+    ['--user', '--no-pager', '-n', '50', '-o', 'json', '--since', since],
+    { timeout: COREDUMP_TIMEOUT_MS, maxBuffer: 1024 * 1024 }
+  )
+  return {
+    supported: true,
+    entries: parseJsonLines(stdout)
+      .filter((row) => /orca|electron/i.test(JSON.stringify(row)))
+      .slice(0, 20)
+      .map((row) => redactObject(row))
+  }
+}
+
+function parseJsonLines(stdout: string): unknown[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as unknown)
+}
+
+function redactObject(value: unknown): unknown {
+  return redactValue(value, 'server')
+}

--- a/src/main/diagnostics/macos-report-diagnostic-index.ts
+++ b/src/main/diagnostics/macos-report-diagnostic-index.ts
@@ -1,0 +1,52 @@
+import { readdir, stat } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import { homedir } from 'node:os'
+
+const REPORT_EXTENSIONS = new Set(['.ips', '.spin', '.diag', '.dpsub'])
+const MAX_REPORTS = 20
+type MacosDiagnosticReport = {
+  name: string
+  bytes: number
+  modifiedAt: string
+}
+
+export async function collectMacosReportDiagnosticIndex(
+  lookbackMinutes: number
+): Promise<Record<string, unknown>> {
+  if (process.platform !== 'darwin') {
+    return { supported: false, reason: 'not_macos' }
+  }
+  const cutoffMs = Date.now() - lookbackMinutes * 60 * 1000
+  const roots = [
+    join(homedir(), 'Library', 'Logs', 'DiagnosticReports'),
+    '/Library/Logs/DiagnosticReports'
+  ]
+  const reports: MacosDiagnosticReport[] = []
+  for (const root of roots) {
+    try {
+      for (const name of await readdir(root)) {
+        const extension = name.slice(name.lastIndexOf('.')).toLowerCase()
+        if (!REPORT_EXTENSIONS.has(extension) || !/orca|electron/i.test(name)) {
+          continue
+        }
+        const fullPath = join(root, name)
+        const info = await stat(fullPath)
+        if (info.mtimeMs < cutoffMs) {
+          continue
+        }
+        reports.push({
+          name: basename(fullPath),
+          bytes: info.size,
+          modifiedAt: info.mtime.toISOString()
+        })
+      }
+    } catch {
+      // Missing or protected diagnostic folders are expected on managed macOS.
+    }
+  }
+  return {
+    supported: true,
+    count: reports.length,
+    reports: reports.sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt)).slice(0, MAX_REPORTS)
+  }
+}

--- a/src/main/diagnostics/native-crash-dump-directory.ts
+++ b/src/main/diagnostics/native-crash-dump-directory.ts
@@ -1,0 +1,13 @@
+import { app } from 'electron'
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+export function getNativeCrashDumpDirectory(): string {
+  return join(app.getPath('logs'), 'diagnostics', 'crashpad')
+}
+
+export function ensureNativeCrashDumpDirectory(): string {
+  const directory = getNativeCrashDumpDirectory()
+  mkdirSync(directory, { recursive: true })
+  return directory
+}

--- a/src/main/diagnostics/native-crash-dump-index.ts
+++ b/src/main/diagnostics/native-crash-dump-index.ts
@@ -1,0 +1,44 @@
+import { readdir, stat } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import { getNativeCrashDumpDirectory } from './native-crash-dump-directory'
+
+export type NativeCrashDumpFile = {
+  path: string
+  name: string
+  bytes: number
+  modifiedAt: string
+}
+
+const MINIDUMP_EXTENSIONS = new Set(['.dmp', '.mdmp'])
+
+export async function listNativeCrashDumps(
+  lookbackMinutes: number
+): Promise<NativeCrashDumpFile[]> {
+  const directory = getNativeCrashDumpDirectory()
+  const cutoffMs = Date.now() - lookbackMinutes * 60 * 1000
+  const entries = await readdir(directory, { recursive: true, withFileTypes: true })
+  const files: NativeCrashDumpFile[] = []
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue
+    }
+    const name = entry.name
+    const dot = name.lastIndexOf('.')
+    const extension = dot >= 0 ? name.slice(dot).toLowerCase() : ''
+    if (!MINIDUMP_EXTENSIONS.has(extension)) {
+      continue
+    }
+    const fullPath = join(entry.parentPath ?? directory, name)
+    const info = await stat(fullPath)
+    if (info.mtimeMs < cutoffMs) {
+      continue
+    }
+    files.push({
+      path: fullPath,
+      name: basename(fullPath),
+      bytes: info.size,
+      modifiedAt: info.mtime.toISOString()
+    })
+  }
+  return files.sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt))
+}

--- a/src/main/diagnostics/native-crash-reporter.test.ts
+++ b/src/main/diagnostics/native-crash-reporter.test.ts
@@ -72,4 +72,23 @@ describe('startNativeCrashReporter', () => {
     expect(second).toBeNull()
     expect(startMock).toHaveBeenCalledTimes(1)
   })
+
+  it('can retry if the crash dump directory cannot be created', async () => {
+    const { startNativeCrashReporter } = await import('./native-crash-reporter')
+    ensureDirectoryMock.mockImplementationOnce(() => {
+      calls.push('ensure')
+      throw new Error('permission denied')
+    })
+
+    expect(() => startNativeCrashReporter()).toThrow('permission denied')
+    ensureDirectoryMock.mockImplementationOnce(() => {
+      calls.push('ensure')
+      return 'C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\crashpad'
+    })
+
+    expect(startNativeCrashReporter()).toBe(
+      'C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\crashpad'
+    )
+    expect(startMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/main/diagnostics/native-crash-reporter.test.ts
+++ b/src/main/diagnostics/native-crash-reporter.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { calls, ensureDirectoryMock, setPathMock, startMock } = vi.hoisted(() => ({
+  calls: [] as string[],
+  ensureDirectoryMock: vi.fn(() => {
+    calls.push('ensure')
+    return 'C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\crashpad'
+  }),
+  setPathMock: vi.fn(() => {
+    calls.push('setPath')
+  }),
+  startMock: vi.fn(() => {
+    calls.push('start')
+  })
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.2.3',
+    setPath: setPathMock
+  },
+  crashReporter: {
+    start: startMock
+  }
+}))
+
+vi.mock('./native-crash-dump-directory', () => ({
+  ensureNativeCrashDumpDirectory: ensureDirectoryMock
+}))
+
+vi.mock('../observability/diagnostic-upload-endpoint', () => ({
+  resolveDiagnosticOrcaChannel: () => 'dev'
+}))
+
+describe('startNativeCrashReporter', () => {
+  beforeEach(async () => {
+    calls.length = 0
+    ensureDirectoryMock.mockClear()
+    setPathMock.mockClear()
+    startMock.mockClear()
+    const reporter = await import('./native-crash-reporter')
+    reporter.resetNativeCrashReporterForTest()
+  })
+
+  it('sets the crash dump path before starting local-only Crashpad capture', async () => {
+    const { startNativeCrashReporter } = await import('./native-crash-reporter')
+
+    const directory = startNativeCrashReporter()
+
+    expect(directory).toBe('C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\crashpad')
+    expect(calls).toEqual(['ensure', 'setPath', 'start'])
+    expect(setPathMock).toHaveBeenCalledWith('crashDumps', directory)
+    expect(startMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploadToServer: false,
+        ignoreSystemCrashHandler: false,
+        globalExtra: expect.objectContaining({
+          app_version: '1.2.3',
+          orca_channel: 'dev',
+          schema_version: '1'
+        })
+      })
+    )
+  })
+
+  it('does not start Crashpad twice in one process', async () => {
+    const { startNativeCrashReporter } = await import('./native-crash-reporter')
+
+    startNativeCrashReporter()
+    const second = startNativeCrashReporter()
+
+    expect(second).toBeNull()
+    expect(startMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/diagnostics/native-crash-reporter.ts
+++ b/src/main/diagnostics/native-crash-reporter.ts
@@ -9,7 +9,6 @@ export function startNativeCrashReporter(): string | null {
   if (started) {
     return null
   }
-  started = true
   const crashDumps = ensureNativeCrashDumpDirectory()
   app.setPath('crashDumps', crashDumps)
   crashReporter.start({
@@ -26,6 +25,7 @@ export function startNativeCrashReporter(): string | null {
       schema_version: '1'
     }
   })
+  started = true
   return crashDumps
 }
 

--- a/src/main/diagnostics/native-crash-reporter.ts
+++ b/src/main/diagnostics/native-crash-reporter.ts
@@ -1,0 +1,34 @@
+import { app, crashReporter } from 'electron'
+import os from 'node:os'
+import { ensureNativeCrashDumpDirectory } from './native-crash-dump-directory'
+import { resolveDiagnosticOrcaChannel } from '../observability/diagnostic-upload-endpoint'
+
+let started = false
+
+export function startNativeCrashReporter(): string | null {
+  if (started) {
+    return null
+  }
+  started = true
+  const crashDumps = ensureNativeCrashDumpDirectory()
+  app.setPath('crashDumps', crashDumps)
+  crashReporter.start({
+    uploadToServer: false,
+    ignoreSystemCrashHandler: false,
+    globalExtra: {
+      app_version: app.getVersion(),
+      orca_channel: resolveDiagnosticOrcaChannel(),
+      platform: os.platform(),
+      arch: os.arch(),
+      os_release: os.release(),
+      electron_version: process.versions.electron ?? 'unknown',
+      chrome_version: process.versions.chrome ?? 'unknown',
+      schema_version: '1'
+    }
+  })
+  return crashDumps
+}
+
+export function resetNativeCrashReporterForTest(): void {
+  started = false
+}

--- a/src/main/diagnostics/runtime-diagnostic-counts.test.ts
+++ b/src/main/diagnostics/runtime-diagnostic-counts.test.ts
@@ -10,8 +10,10 @@ describe('collectRuntimeDiagnosticCounts', () => {
       getRepos: () => [{}, {}],
       getAllWorktreeMeta: () => ({
         one: { hostId: 'local' },
-        two: { hostId: 'ssh' },
-        three: {}
+        two: { hostId: 'ssh:ssh-target-1' },
+        three: {},
+        four: { hostId: 'runtime:gpu-vm' },
+        five: { hostId: 'not-a-host-id' }
       }),
       getProjects: () => [],
       getProjectHostSetups: () => [],
@@ -42,13 +44,15 @@ describe('collectRuntimeDiagnosticCounts', () => {
 
     expect(collectRuntimeDiagnosticCounts(store)).toMatchObject({
       repoCount: 2,
-      worktreeCount: 3,
+      worktreeCount: 5,
       terminalTabCount: 2,
       terminalPaneCount: 4,
       runtimeHostCounts: {
         local: 1,
         ssh: 1,
-        'legacy-local': 1
+        'legacy-local': 1,
+        runtime: 1,
+        unknown: 1
       }
     })
   })

--- a/src/main/diagnostics/runtime-diagnostic-counts.test.ts
+++ b/src/main/diagnostics/runtime-diagnostic-counts.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectRuntimeDiagnosticCounts,
+  type DiagnosticRuntimeStore
+} from './runtime-diagnostic-counts'
+
+describe('collectRuntimeDiagnosticCounts', () => {
+  it('counts terminal panes inside nested split layouts', () => {
+    const store = {
+      getRepos: () => [{}, {}],
+      getAllWorktreeMeta: () => ({
+        one: { hostId: 'local' },
+        two: { hostId: 'ssh' }
+      }),
+      getProjects: () => [],
+      getProjectHostSetups: () => [],
+      getFolderWorkspaces: () => [],
+      getWorkspaceSession: () => ({
+        tabsByWorktree: {
+          one: [{ id: 'tab-1' }],
+          two: [{ id: 'tab-2' }]
+        },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: {
+              type: 'split',
+              first: { type: 'leaf', leafId: 'pane-1' },
+              second: {
+                type: 'split',
+                first: { type: 'leaf', leafId: 'pane-2' },
+                second: { type: 'leaf', leafId: 'pane-3' }
+              }
+            }
+          },
+          'tab-2': {
+            root: { type: 'leaf', leafId: 'pane-4' }
+          }
+        }
+      })
+    } as unknown as DiagnosticRuntimeStore
+
+    expect(collectRuntimeDiagnosticCounts(store)).toMatchObject({
+      repoCount: 2,
+      worktreeCount: 2,
+      terminalTabCount: 2,
+      terminalPaneCount: 4,
+      runtimeHostCounts: {
+        local: 1,
+        ssh: 1
+      }
+    })
+  })
+})

--- a/src/main/diagnostics/runtime-diagnostic-counts.test.ts
+++ b/src/main/diagnostics/runtime-diagnostic-counts.test.ts
@@ -10,7 +10,8 @@ describe('collectRuntimeDiagnosticCounts', () => {
       getRepos: () => [{}, {}],
       getAllWorktreeMeta: () => ({
         one: { hostId: 'local' },
-        two: { hostId: 'ssh' }
+        two: { hostId: 'ssh' },
+        three: {}
       }),
       getProjects: () => [],
       getProjectHostSetups: () => [],
@@ -41,12 +42,13 @@ describe('collectRuntimeDiagnosticCounts', () => {
 
     expect(collectRuntimeDiagnosticCounts(store)).toMatchObject({
       repoCount: 2,
-      worktreeCount: 2,
+      worktreeCount: 3,
       terminalTabCount: 2,
       terminalPaneCount: 4,
       runtimeHostCounts: {
         local: 1,
-        ssh: 1
+        ssh: 1,
+        'legacy-local': 1
       }
     })
   })

--- a/src/main/diagnostics/runtime-diagnostic-counts.ts
+++ b/src/main/diagnostics/runtime-diagnostic-counts.ts
@@ -1,0 +1,50 @@
+import type { Store } from '../persistence'
+
+export type DiagnosticRuntimeStore = Pick<Store, 'getRepos' | 'getAllWorktreeMeta'> & {
+  getProjects?: Store['getProjects']
+  getProjectHostSetups?: Store['getProjectHostSetups']
+  getFolderWorkspaces?: Store['getFolderWorkspaces']
+  getWorkspaceSession?: Store['getWorkspaceSession']
+}
+
+export function collectRuntimeDiagnosticCounts(
+  store: DiagnosticRuntimeStore
+): Record<string, unknown> {
+  const session = store.getWorkspaceSession?.()
+  const tabsByWorktree = session?.tabsByWorktree ?? {}
+  const terminalTabCount = Object.values(tabsByWorktree).reduce((sum, tabs) => sum + tabs.length, 0)
+  const terminalPaneCount = Object.values(session?.terminalLayoutsByTabId ?? {}).reduce(
+    (sum, layout) => sum + countTerminalLeaves(layout.root),
+    0
+  )
+  const worktreeMeta = store.getAllWorktreeMeta()
+  const hostCounts = new Map<string, number>()
+  for (const meta of Object.values(worktreeMeta)) {
+    const hostId = meta.hostId ?? 'legacy-local'
+    hostCounts.set(hostId, (hostCounts.get(hostId) ?? 0) + 1)
+  }
+  return {
+    repoCount: store.getRepos().length,
+    projectCount: store.getProjects?.().length ?? 0,
+    projectHostSetupCount: store.getProjectHostSetups?.().length ?? 0,
+    folderWorkspaceCount: store.getFolderWorkspaces?.().length ?? 0,
+    worktreeCount: Object.keys(worktreeMeta).length,
+    terminalTabCount,
+    terminalPaneCount,
+    runtimeHostCounts: Object.fromEntries(hostCounts)
+  }
+}
+
+function countTerminalLeaves(node: { type: string; children?: unknown[] } | null): number {
+  if (!node) {
+    return 0
+  }
+  if (node.type === 'leaf') {
+    return 1
+  }
+  let count = 0
+  for (const child of node.children ?? []) {
+    count += countTerminalLeaves(child as Parameters<typeof countTerminalLeaves>[0])
+  }
+  return count
+}

--- a/src/main/diagnostics/runtime-diagnostic-counts.ts
+++ b/src/main/diagnostics/runtime-diagnostic-counts.ts
@@ -1,4 +1,5 @@
 import type { Store } from '../persistence'
+import { parseExecutionHostId } from '../../shared/execution-host'
 
 export type DiagnosticRuntimeStore = Pick<Store, 'getRepos' | 'getAllWorktreeMeta'> & {
   getProjects?: Store['getProjects']
@@ -20,8 +21,8 @@ export function collectRuntimeDiagnosticCounts(
   const worktreeMeta = store.getAllWorktreeMeta()
   const hostCounts = new Map<string, number>()
   for (const meta of Object.values(worktreeMeta)) {
-    const hostId = meta.hostId ?? 'legacy-local'
-    hostCounts.set(hostId, (hostCounts.get(hostId) ?? 0) + 1)
+    const hostBucket = getDiagnosticHostBucket(meta.hostId)
+    hostCounts.set(hostBucket, (hostCounts.get(hostBucket) ?? 0) + 1)
   }
   return {
     repoCount: store.getRepos().length,
@@ -33,6 +34,15 @@ export function collectRuntimeDiagnosticCounts(
     terminalPaneCount,
     runtimeHostCounts: Object.fromEntries(hostCounts)
   }
+}
+
+function getDiagnosticHostBucket(hostId: string | null | undefined): string {
+  if (!hostId) {
+    return 'legacy-local'
+  }
+  const parsed = parseExecutionHostId(hostId)
+  // Why: SSH/runtime ids can reveal host labels; diagnostics only need host kind counts.
+  return parsed?.kind ?? 'unknown'
 }
 
 type DiagnosticTerminalLayoutNode = {

--- a/src/main/diagnostics/runtime-diagnostic-counts.ts
+++ b/src/main/diagnostics/runtime-diagnostic-counts.ts
@@ -35,16 +35,21 @@ export function collectRuntimeDiagnosticCounts(
   }
 }
 
-function countTerminalLeaves(node: { type: string; children?: unknown[] } | null): number {
+type DiagnosticTerminalLayoutNode = {
+  type: string
+  first?: DiagnosticTerminalLayoutNode | null
+  second?: DiagnosticTerminalLayoutNode | null
+}
+
+function countTerminalLeaves(node: DiagnosticTerminalLayoutNode | null): number {
   if (!node) {
     return 0
   }
   if (node.type === 'leaf') {
     return 1
   }
-  let count = 0
-  for (const child of node.children ?? []) {
-    count += countTerminalLeaves(child as Parameters<typeof countTerminalLeaves>[0])
+  if (node.type === 'split') {
+    return countTerminalLeaves(node.first ?? null) + countTerminalLeaves(node.second ?? null)
   }
-  return count
+  return 0
 }

--- a/src/main/diagnostics/shell-availability-summary.test.ts
+++ b/src/main/diagnostics/shell-availability-summary.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileAsyncMock } = vi.hoisted(() => ({
+  execFileAsyncMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn()
+}))
+
+vi.mock('node:util', () => ({
+  promisify: () => execFileAsyncMock
+}))
+
+describe('collectShellAvailabilitySummary', () => {
+  beforeEach(() => {
+    execFileAsyncMock.mockReset()
+  })
+
+  it('bounds Windows shell probes and converts probe failures to false', async () => {
+    execFileAsyncMock.mockRejectedValue(new Error('not found'))
+    const { collectShellAvailabilitySummary } = await import('./shell-availability-summary')
+
+    const summary = await collectShellAvailabilitySummary('win32')
+
+    expect(summary).toEqual({
+      platform: 'win32',
+      shells: {
+        'cmd.exe': false,
+        'powershell.exe': false,
+        'pwsh.exe': false,
+        'wsl.exe': false,
+        'bash.exe': false
+      }
+    })
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'where.exe',
+      ['cmd.exe'],
+      expect.objectContaining({ timeout: 2000, maxBuffer: 64 * 1024 })
+    )
+  })
+
+  it('uses a bounded POSIX command lookup for Linux shells', async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+    const { collectShellAvailabilitySummary } = await import('./shell-availability-summary')
+
+    const summary = await collectShellAvailabilitySummary('linux')
+
+    expect(summary).toMatchObject({
+      platform: 'linux',
+      shells: {
+        sh: true,
+        bash: true,
+        zsh: true,
+        fish: true,
+        pwsh: true
+      }
+    })
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'sh',
+      ['-lc', "command -v 'sh' >/dev/null 2>&1"],
+      expect.objectContaining({ timeout: 2000, maxBuffer: 64 * 1024 })
+    )
+  })
+})

--- a/src/main/diagnostics/shell-availability-summary.ts
+++ b/src/main/diagnostics/shell-availability-summary.ts
@@ -1,0 +1,46 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const PROBE_TIMEOUT_MS = 2_000
+const PROBE_MAX_BUFFER = 64 * 1024
+
+export async function collectShellAvailabilitySummary(
+  platform: NodeJS.Platform = process.platform
+): Promise<Record<string, unknown>> {
+  const shells =
+    platform === 'win32'
+      ? ['cmd.exe', 'powershell.exe', 'pwsh.exe', 'wsl.exe', 'bash.exe']
+      : ['sh', 'bash', 'zsh', 'fish', 'pwsh']
+  const result: Record<string, boolean> = {}
+  await Promise.all(
+    shells.map(async (shell) => {
+      result[shell] = await isShellAvailable(shell, platform)
+    })
+  )
+  return {
+    platform,
+    shells: result
+  }
+}
+
+async function isShellAvailable(shell: string, platform: NodeJS.Platform): Promise<boolean> {
+  try {
+    await (platform === 'win32'
+      ? execFileAsync('where.exe', [shell], {
+          timeout: PROBE_TIMEOUT_MS,
+          maxBuffer: PROBE_MAX_BUFFER
+        })
+      : execFileAsync('sh', ['-lc', `command -v ${quoteShellWord(shell)} >/dev/null 2>&1`], {
+          timeout: PROBE_TIMEOUT_MS,
+          maxBuffer: PROBE_MAX_BUFFER
+        }))
+    return true
+  } catch {
+    return false
+  }
+}
+
+function quoteShellWord(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}

--- a/src/main/diagnostics/system-diagnostic-summary.ts
+++ b/src/main/diagnostics/system-diagnostic-summary.ts
@@ -1,0 +1,28 @@
+import { app } from 'electron'
+import os from 'node:os'
+
+export function collectSystemDiagnosticSummary(): Record<string, unknown> {
+  const cpus = os.cpus()
+  const totalMemory = os.totalmem()
+  const freeMemory = os.freemem()
+  return {
+    platform: os.platform(),
+    arch: os.arch(),
+    osRelease: os.release(),
+    osVersion: os.version(),
+    systemVersion:
+      typeof process.getSystemVersion === 'function' ? process.getSystemVersion() : null,
+    locale: app.getLocale(),
+    cpu: {
+      coreCount: Math.max(1, cpus.length),
+      model: cpus[0]?.model ?? 'unknown'
+    },
+    memory: {
+      totalMemory,
+      freeMemory,
+      usedMemory: Math.max(0, totalMemory - freeMemory),
+      memoryUsagePercent: totalMemory > 0 ? ((totalMemory - freeMemory) / totalMemory) * 100 : 0
+    },
+    loadAverage1m: os.loadavg()[0] ?? 0
+  }
+}

--- a/src/main/diagnostics/terminal-lifecycle-diagnostic-trace.ts
+++ b/src/main/diagnostics/terminal-lifecycle-diagnostic-trace.ts
@@ -1,0 +1,10 @@
+import { getCrashBreadcrumbSnapshot } from '../crash-reporting/crash-breadcrumb-store'
+
+export function collectTerminalLifecycleDiagnosticTrace(): Record<string, unknown> {
+  const breadcrumbs = getCrashBreadcrumbSnapshot().filter(
+    (breadcrumb) => breadcrumb.name === 'terminal_lifecycle_anomaly'
+  )
+  return {
+    breadcrumbs
+  }
+}

--- a/src/main/diagnostics/windows-event-diagnostic-summary.test.ts
+++ b/src/main/diagnostics/windows-event-diagnostic-summary.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileAsyncMock } = vi.hoisted(() => ({
+  execFileAsyncMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn()
+}))
+
+vi.mock('node:util', () => ({
+  promisify: () => execFileAsyncMock
+}))
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+describe('collectWindowsEventDiagnosticSummary', () => {
+  beforeEach(() => {
+    execFileAsyncMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  it('skips the event-log probe outside Windows', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    const { collectWindowsEventDiagnosticSummary } =
+      await import('./windows-event-diagnostic-summary')
+
+    await expect(collectWindowsEventDiagnosticSummary(30)).resolves.toEqual({
+      supported: false,
+      reason: 'not_windows'
+    })
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('treats empty event output as a successful empty summary', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    execFileAsyncMock.mockResolvedValue({ stdout: '[]', stderr: '' })
+    const { collectWindowsEventDiagnosticSummary } =
+      await import('./windows-event-diagnostic-summary')
+
+    await expect(collectWindowsEventDiagnosticSummary(30)).resolves.toEqual({
+      supported: true,
+      count: 0,
+      events: []
+    })
+
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'powershell.exe',
+      expect.arrayContaining([
+        expect.stringContaining("if ($_.Exception.Message -match 'No events were found')")
+      ]),
+      expect.objectContaining({ timeout: 5000, maxBuffer: 1024 * 1024 })
+    )
+  })
+})

--- a/src/main/diagnostics/windows-event-diagnostic-summary.test.ts
+++ b/src/main/diagnostics/windows-event-diagnostic-summary.test.ts
@@ -52,7 +52,9 @@ describe('collectWindowsEventDiagnosticSummary', () => {
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'powershell.exe',
       expect.arrayContaining([
-        expect.stringContaining("if ($_.Exception.Message -match 'No events were found')")
+        expect.stringContaining(
+          "$_.FullyQualifiedErrorId -eq 'NoMatchingEventsFound,Microsoft.PowerShell.Commands.GetWinEventCommand'"
+        )
       ]),
       expect.objectContaining({ timeout: 5000, maxBuffer: 1024 * 1024 })
     )

--- a/src/main/diagnostics/windows-event-diagnostic-summary.ts
+++ b/src/main/diagnostics/windows-event-diagnostic-summary.ts
@@ -1,0 +1,63 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { redactString } from '../observability/redactor'
+
+const execFileAsync = promisify(execFile)
+const MAX_EVENTS = 20
+const EVENT_TIMEOUT_MS = 5_000
+
+type WindowsEventRow = {
+  TimeCreated?: string
+  ProviderName?: string
+  Id?: number
+  LevelDisplayName?: string
+  Message?: string
+}
+
+export async function collectWindowsEventDiagnosticSummary(
+  lookbackMinutes: number
+): Promise<Record<string, unknown>> {
+  if (process.platform !== 'win32') {
+    return { supported: false, reason: 'not_windows' }
+  }
+  const boundedLookbackMinutes = Math.max(1, Math.floor(lookbackMinutes))
+  const command = [
+    `$start=(Get-Date).AddMinutes(-${boundedLookbackMinutes});`,
+    `try {`,
+    `$events=@(Get-WinEvent -FilterHashtable @{LogName='Application'; StartTime=$start} -ErrorAction Stop |`,
+    `Where-Object { $_.ProviderName -match 'Application Error|Application Hang|Windows Error Reporting' -or $_.Message -match 'Orca|Orca.exe|Electron' } |`,
+    `Select-Object -First ${MAX_EVENTS} TimeCreated,ProviderName,Id,LevelDisplayName,Message);`,
+    `$events | ConvertTo-Json -Compress`,
+    `} catch {`,
+    `if ($_.Exception.Message -match 'No events were found') { '[]' } else { throw }`,
+    `}`
+  ].join(' ')
+  const { stdout } = await execFileAsync('powershell.exe', ['-NoProfile', '-Command', command], {
+    timeout: EVENT_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024
+  })
+  const parsed = parseWindowsEventJson(stdout)
+  return {
+    supported: true,
+    count: parsed.length,
+    events: parsed.map((event) => ({
+      timeCreated: event.TimeCreated,
+      providerName: event.ProviderName,
+      id: event.Id,
+      level: event.LevelDisplayName,
+      messagePreview: event.Message ? redactString(event.Message).slice(0, 500) : undefined
+    }))
+  }
+}
+
+function parseWindowsEventJson(stdout: string): WindowsEventRow[] {
+  const trimmed = stdout.trim()
+  if (!trimmed) {
+    return []
+  }
+  const parsed = JSON.parse(trimmed) as WindowsEventRow | WindowsEventRow[] | null
+  if (!parsed) {
+    return []
+  }
+  return Array.isArray(parsed) ? parsed : [parsed]
+}

--- a/src/main/diagnostics/windows-event-diagnostic-summary.ts
+++ b/src/main/diagnostics/windows-event-diagnostic-summary.ts
@@ -29,7 +29,7 @@ export async function collectWindowsEventDiagnosticSummary(
     `Select-Object -First ${MAX_EVENTS} TimeCreated,ProviderName,Id,LevelDisplayName,Message);`,
     `$events | ConvertTo-Json -Compress`,
     `} catch {`,
-    `if ($_.Exception.Message -match 'No events were found') { '[]' } else { throw }`,
+    `if ($_.FullyQualifiedErrorId -eq 'NoMatchingEventsFound,Microsoft.PowerShell.Commands.GetWinEventCommand') { '[]' } else { throw }`,
     `}`
   ].join(' ')
   const { stdout } = await execFileAsync('powershell.exe', ['-NoProfile', '-Command', command], {

--- a/src/main/diagnostics/windows-wsl-diagnostic-summary.ts
+++ b/src/main/diagnostics/windows-wsl-diagnostic-summary.ts
@@ -1,0 +1,36 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { redactString } from '../observability/redactor'
+
+const execFileAsync = promisify(execFile)
+const WSL_TIMEOUT_MS = 4_000
+
+export async function collectWindowsWslDiagnosticSummary(): Promise<Record<string, unknown>> {
+  if (process.platform !== 'win32') {
+    return { supported: false, reason: 'not_windows' }
+  }
+  const [status, list] = await Promise.all([runWsl(['--status']), runWsl(['--list', '--verbose'])])
+  return {
+    supported: true,
+    status,
+    distributions: list
+  }
+}
+
+async function runWsl(args: string[]): Promise<{ ok: boolean; output?: string; error?: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync('wsl.exe', args, {
+      timeout: WSL_TIMEOUT_MS,
+      maxBuffer: 256 * 1024
+    })
+    return {
+      ok: true,
+      output: redactString([stdout, stderr].filter(Boolean).join('\n')).slice(0, 4000)
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: redactString(error instanceof Error ? error.message : String(error)).slice(0, 1000)
+    }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -179,6 +179,7 @@ import { preserveAgentAuthBeforeRestart } from './agent-auth-restart-preservatio
 import { CliInstaller } from './cli/cli-installer'
 import { installLinuxBareOrcaDispatcher } from './cli/linux-bare-orca-dispatcher'
 import { selfHealRuntimeEnvironmentFocus } from './runtime-environment-focus-self-heal'
+import { startNativeCrashReporter } from './diagnostics/native-crash-reporter'
 
 let mainWindow: BrowserWindow | null = null
 /** Whether a manual app.quit() (Cmd+Q, etc.) is in progress. Shared with the
@@ -574,6 +575,16 @@ if (hasSingleInstanceLock) {
   initClaudeUsagePath()
   initCodexUsagePath()
   initOpenCodeUsagePath()
+  try {
+    // Why: Crashpad needs a stable per-user path before any renderer exists,
+    // but lock losers must avoid touching userData/logs.
+    startNativeCrashReporter()
+  } catch (error) {
+    console.warn(
+      '[diagnostics] Native crash reporter disabled:',
+      error instanceof Error ? error.message : String(error)
+    )
+  }
   crashReports = CrashReportStore.fromUserData()
   recordCrashBreadcrumb('app_started', {
     packaged: app.isPackaged,

--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -102,6 +102,47 @@ describe('parsePsOutput', () => {
   })
 })
 
+describe('parseWindowsProcessWorkingSetJson', () => {
+  it('parses array JSON from Get-CimInstance', async () => {
+    const { parseWindowsProcessWorkingSetJson } = await import('./windows-process-working-set')
+
+    const rows = parseWindowsProcessWorkingSetJson(
+      JSON.stringify([
+        { ProcessId: 100, ParentProcessId: 1, WorkingSetSize: 2048 },
+        { ProcessId: '200', ParentProcessId: '100', WorkingSetSize: '1024' }
+      ])
+    )
+
+    expect(rows).toEqual([
+      { pid: 100, ppid: 1, cpu: 0, memory: 2048 },
+      { pid: 200, ppid: 100, cpu: 0, memory: 1024 }
+    ])
+  })
+
+  it('parses singleton JSON from Get-CimInstance', async () => {
+    const { parseWindowsProcessWorkingSetJson } = await import('./windows-process-working-set')
+
+    const rows = parseWindowsProcessWorkingSetJson(
+      JSON.stringify({ ProcessId: 100, ParentProcessId: 1, WorkingSetSize: 512 })
+    )
+
+    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 512 }])
+  })
+
+  it('drops rows missing a process id or parent id', async () => {
+    const { parseWindowsProcessWorkingSetJson } = await import('./windows-process-working-set')
+
+    const rows = parseWindowsProcessWorkingSetJson(
+      JSON.stringify([
+        { WorkingSetSize: 2048 },
+        { ProcessId: 100, ParentProcessId: 1, WorkingSetSize: 512 }
+      ])
+    )
+
+    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 512 }])
+  })
+})
+
 describe('parseWmicOutput', () => {
   it('emits one row per blank-line-delimited stanza', async () => {
     const { parseWmicOutput } = await loadCollector()
@@ -217,27 +258,28 @@ describe('collectMemorySnapshot', () => {
   })
 
   function mockPsResponse(stdout: string) {
-    const processStdout = process.platform === 'win32' ? psFixtureToWmic(stdout) : stdout
+    const processStdout = process.platform === 'win32' ? psFixtureToCimJson(stdout) : stdout
     execMock.mockImplementation((_cmd, _opts, cb) =>
       cb(null, { stdout: processStdout, stderr: '' })
     )
   }
 
-  function psFixtureToWmic(stdout: string): string {
-    return stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => {
-        const [pid, ppid, _cpu, rssKb] = line.split(/\s+/, 4)
-        const memory = Number.parseInt(rssKb ?? '', 10)
-        return [
-          `ParentProcessId=${ppid ?? ''}`,
-          `ProcessId=${pid ?? ''}`,
-          `WorkingSetSize=${Number.isFinite(memory) && memory > 0 ? memory * 1024 : 0}`
-        ].join('\r\n')
-      })
-      .join('\r\n\r\n')
+  function psFixtureToCimJson(stdout: string): string {
+    return JSON.stringify(
+      stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const [pid, ppid, _cpu, rssKb] = line.split(/\s+/, 4)
+          const memory = Number.parseInt(rssKb ?? '', 10)
+          return {
+            ParentProcessId: Number.parseInt(ppid ?? '', 10),
+            ProcessId: Number.parseInt(pid ?? '', 10),
+            WorkingSetSize: Number.isFinite(memory) && memory > 0 ? memory * 1024 : 0
+          }
+        })
+    )
   }
 
   it('coalesces concurrent callers onto a single in-flight sweep', async () => {

--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -22,7 +22,13 @@ vi.mock('electron', () => ({
 
 vi.mock('child_process', () => ({
   exec: (cmd: string, opts: unknown, cb: (err: Error | null, out: { stdout: string }) => void) =>
-    execMock(cmd, opts, cb)
+    execMock(cmd, opts, cb),
+  execFile: (
+    cmd: string,
+    args: string[],
+    opts: unknown,
+    cb: (err: Error | null, stdout: string, stderr: string) => void
+  ) => execMock([cmd, ...args].join(' '), opts, cb)
 }))
 
 vi.mock('./pty-registry', () => ({

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: the collector's platform-specific
-   enumeration paths (`ps` on Unix, `wmic` on Windows) plus the history
+   enumeration path (`ps` on Unix, CIM/WMIC on Windows) plus the history
    ring buffer plus the Electron bucketing live together to keep one
    snapshot's worth of code in one place. Splitting them produces extra
    modules whose only consumer is this file. */
@@ -10,7 +10,7 @@
  *   - Orca's own Electron processes, via `app.getAppMetrics()`, bucketed
  *     into main / renderer / other.
  *   - Each registered PTY's process subtree, enumerated once from a host-
- *     wide `ps` sweep (`wmic` on Windows).
+ *     wide `ps` sweep (CIM/WMIC on Windows).
  *
  * Memory samples are held in a per-key ring (one key per worktree, plus
  * a reserved app-total key) so the UI can draw a trend sparkline.
@@ -39,6 +39,13 @@ import type {
 import type { Store } from '../persistence'
 import { ORPHAN_WORKTREE_ID } from '../../shared/constants'
 import { listRegisteredPtys } from './pty-registry'
+import {
+  enumerateWindowsProcessWorkingSet,
+  parseWmicOutput,
+  type WindowsProcessWorkingSetRow
+} from './windows-process-working-set'
+
+export { parseWmicOutput }
 
 export type MemorySnapshotStore = Pick<Store, 'getRepo' | 'getWorktreeMeta'>
 
@@ -74,14 +81,7 @@ const PS_EXEC_TIMEOUT_MS = 5_000
 const PS_MAX_BUFFER = 10 * 1024 * 1024
 
 /** One row from the host-wide process listing. */
-type ProcRow = {
-  pid: number
-  ppid: number
-  /** Percent of one core (may exceed 100 on multi-core). 0 on Windows. */
-  cpu: number
-  /** Resident memory in bytes. */
-  memory: number
-}
+type ProcRow = WindowsProcessWorkingSetRow
 
 /** Indexed view of a single `ps`/`wmic` sweep. */
 type ProcIndex = {
@@ -226,67 +226,7 @@ export function parsePsOutput(stdout: string): ProcRow[] {
 }
 
 async function enumerateWindows(): Promise<ProcRow[]> {
-  // Why: `wmic` ships with stock Windows and emits a plain, tab-separated
-  // table without the CSV-quoting edge cases PowerShell's ConvertTo-Csv
-  // introduces. CPU% would require delta sampling between two queries; for
-  // v1 we report 0% on Windows — memory attribution is the primary signal.
-  try {
-    const { stdout } = await execAsync(
-      'wmic process get ProcessId,ParentProcessId,WorkingSetSize /format:value',
-      { maxBuffer: PS_MAX_BUFFER, timeout: PS_EXEC_TIMEOUT_MS }
-    )
-    return parseWmicOutput(stdout)
-  } catch (err) {
-    console.warn('[memory] wmic enumeration failed', err)
-    return []
-  }
-}
-
-/** Exported for tests: parses `wmic /format:value` stanza output. */
-export function parseWmicOutput(stdout: string): ProcRow[] {
-  // wmic /format:value emits stanzas of `Key=Value` lines separated by blank
-  // lines. We accumulate a record until a blank line, then flush.
-  const rows: ProcRow[] = []
-  let pid = Number.NaN
-  let ppid = Number.NaN
-  let ws = Number.NaN
-
-  const flush = (): void => {
-    if (!Number.isNaN(pid) && !Number.isNaN(ppid)) {
-      rows.push({
-        pid,
-        ppid,
-        cpu: 0,
-        memory: Number.isFinite(ws) && ws > 0 ? ws : 0
-      })
-    }
-    pid = Number.NaN
-    ppid = Number.NaN
-    ws = Number.NaN
-  }
-
-  for (const raw of stdout.split(/\r?\n/)) {
-    const line = raw.trim()
-    if (line.length === 0) {
-      flush()
-      continue
-    }
-    const eq = line.indexOf('=')
-    if (eq < 0) {
-      continue
-    }
-    const key = line.slice(0, eq)
-    const value = line.slice(eq + 1)
-    if (key === 'ProcessId') {
-      pid = Number.parseInt(value, 10)
-    } else if (key === 'ParentProcessId') {
-      ppid = Number.parseInt(value, 10)
-    } else if (key === 'WorkingSetSize') {
-      ws = Number.parseInt(value, 10)
-    }
-  }
-  flush()
-  return rows
+  return enumerateWindowsProcessWorkingSet()
 }
 
 /** Walk every descendant PID of `root`, inclusive. Exported for tests. */

--- a/src/main/memory/windows-process-working-set.ts
+++ b/src/main/memory/windows-process-working-set.ts
@@ -1,7 +1,7 @@
-import { exec } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
-const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 const WINDOWS_PROCESS_TIMEOUT_MS = 5_000
 const WINDOWS_PROCESS_MAX_BUFFER = 10 * 1024 * 1024
 
@@ -22,20 +22,21 @@ type CimProcessRow = {
 
 export async function enumerateWindowsProcessWorkingSet(): Promise<WindowsProcessWorkingSetRow[]> {
   try {
-    const { stdout } = await execAsync(
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
       [
-        'powershell.exe',
         '-NoProfile',
         '-Command',
-        '"Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,WorkingSetSize | ConvertTo-Json -Compress"'
-      ].join(' '),
+        'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,WorkingSetSize | ConvertTo-Json -Compress'
+      ],
       { maxBuffer: WINDOWS_PROCESS_MAX_BUFFER, timeout: WINDOWS_PROCESS_TIMEOUT_MS }
     )
     return parseWindowsProcessWorkingSetJson(stdout)
   } catch (cimError) {
     try {
-      const { stdout } = await execAsync(
-        'wmic process get ProcessId,ParentProcessId,WorkingSetSize /format:value',
+      const { stdout } = await execFileAsync(
+        'wmic',
+        ['process', 'get', 'ProcessId,ParentProcessId,WorkingSetSize', '/format:value'],
         { maxBuffer: WINDOWS_PROCESS_MAX_BUFFER, timeout: WINDOWS_PROCESS_TIMEOUT_MS }
       )
       return parseWmicOutput(stdout)

--- a/src/main/memory/windows-process-working-set.ts
+++ b/src/main/memory/windows-process-working-set.ts
@@ -1,0 +1,138 @@
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execAsync = promisify(exec)
+const WINDOWS_PROCESS_TIMEOUT_MS = 5_000
+const WINDOWS_PROCESS_MAX_BUFFER = 10 * 1024 * 1024
+
+export type WindowsProcessWorkingSetRow = {
+  pid: number
+  ppid: number
+  /** CPU% is unavailable from this bounded single-shot query. */
+  cpu: number
+  /** Resident memory in bytes. */
+  memory: number
+}
+
+type CimProcessRow = {
+  ProcessId?: unknown
+  ParentProcessId?: unknown
+  WorkingSetSize?: unknown
+}
+
+export async function enumerateWindowsProcessWorkingSet(): Promise<WindowsProcessWorkingSetRow[]> {
+  try {
+    const { stdout } = await execAsync(
+      [
+        'powershell.exe',
+        '-NoProfile',
+        '-Command',
+        '"Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,WorkingSetSize | ConvertTo-Json -Compress"'
+      ].join(' '),
+      { maxBuffer: WINDOWS_PROCESS_MAX_BUFFER, timeout: WINDOWS_PROCESS_TIMEOUT_MS }
+    )
+    return parseWindowsProcessWorkingSetJson(stdout)
+  } catch (cimError) {
+    try {
+      const { stdout } = await execAsync(
+        'wmic process get ProcessId,ParentProcessId,WorkingSetSize /format:value',
+        { maxBuffer: WINDOWS_PROCESS_MAX_BUFFER, timeout: WINDOWS_PROCESS_TIMEOUT_MS }
+      )
+      return parseWmicOutput(stdout)
+    } catch (wmicError) {
+      console.warn('[memory] Windows process enumeration failed', {
+        cim: cimError,
+        wmic: wmicError
+      })
+      return []
+    }
+  }
+}
+
+export function parseWindowsProcessWorkingSetJson(stdout: string): WindowsProcessWorkingSetRow[] {
+  const trimmed = stdout.trim()
+  if (!trimmed) {
+    return []
+  }
+  const parsed = JSON.parse(trimmed) as CimProcessRow | CimProcessRow[] | null
+  if (!parsed) {
+    return []
+  }
+  const rows = Array.isArray(parsed) ? parsed : [parsed]
+  return rows.flatMap((row) => {
+    const pid = toInteger(row.ProcessId)
+    const ppid = toInteger(row.ParentProcessId)
+    if (pid === null || ppid === null) {
+      return []
+    }
+    return [
+      {
+        pid,
+        ppid,
+        cpu: 0,
+        memory: toNonNegativeInteger(row.WorkingSetSize) ?? 0
+      }
+    ]
+  })
+}
+
+/** Parses `wmic /format:value` stanza output. Kept as a fallback for older hosts. */
+export function parseWmicOutput(stdout: string): WindowsProcessWorkingSetRow[] {
+  const rows: WindowsProcessWorkingSetRow[] = []
+  let pid = Number.NaN
+  let ppid = Number.NaN
+  let ws = Number.NaN
+
+  const flush = (): void => {
+    if (!Number.isNaN(pid) && !Number.isNaN(ppid)) {
+      rows.push({
+        pid,
+        ppid,
+        cpu: 0,
+        memory: Number.isFinite(ws) && ws > 0 ? ws : 0
+      })
+    }
+    pid = Number.NaN
+    ppid = Number.NaN
+    ws = Number.NaN
+  }
+
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (line.length === 0) {
+      flush()
+      continue
+    }
+    const eq = line.indexOf('=')
+    if (eq < 0) {
+      continue
+    }
+    const key = line.slice(0, eq)
+    const value = line.slice(eq + 1)
+    if (key === 'ProcessId') {
+      pid = Number.parseInt(value, 10)
+    } else if (key === 'ParentProcessId') {
+      ppid = Number.parseInt(value, 10)
+    } else if (key === 'WorkingSetSize') {
+      ws = Number.parseInt(value, 10)
+    }
+  }
+  flush()
+  return rows
+}
+
+function toInteger(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isInteger(parsed) ? parsed : null
+  }
+  return null
+}
+
+function toNonNegativeInteger(value: unknown): number | null {
+  const parsed = toInteger(value)
+  return parsed !== null && parsed > 0 ? parsed : null
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -118,6 +118,10 @@ import type {
   WorkspaceSessionState,
   DirEntry
 } from '../../shared/types'
+import type {
+  DiagnosticBundleExportArgs,
+  DiagnosticBundleExportResult
+} from '../../shared/diagnostic-bundle-export-types'
 import type { SleepingAgentLaunchConfig } from '../../shared/agent-session-resume'
 import type { RuntimeClientEvent } from '../../shared/runtime-client-events'
 import { toRuntimeActivateWorktreeEvent } from '../../shared/runtime-client-events'
@@ -327,6 +331,7 @@ import {
 } from '../../shared/claude-agent-teams-tmux-compat'
 import { joinWorktreeRelativePath } from './runtime-relative-paths'
 import { collectMemorySnapshot } from '../memory/collector'
+import { exportDiagnosticBundle } from '../diagnostics/diagnostic-bundle-export'
 import { BrowserWindow, ipcMain } from 'electron'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
 import type { BrowserBackend } from '../browser/browser-backend'
@@ -2332,6 +2337,15 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     return collectMemorySnapshot(this.store)
+  }
+
+  createDiagnosticBundle(
+    args: DiagnosticBundleExportArgs = {}
+  ): Promise<DiagnosticBundleExportResult> {
+    if (!this.store) {
+      throw new Error('runtime_unavailable')
+    }
+    return exportDiagnosticBundle({ ...args, store: this.store })
   }
 
   getUIState(): PersistedUIState {

--- a/src/main/runtime/rpc/methods/diagnostics.test.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import type { OrcaRuntimeService } from '../../orca-runtime'
+import { MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES } from '../../../../shared/diagnostic-bundle-export-types'
 import { DIAGNOSTICS_METHODS } from './diagnostics'
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
@@ -95,6 +96,28 @@ describe('diagnostics RPC methods', () => {
 
     const response = await dispatcher.dispatch(
       makeRequest('diagnostics.bundle', { include: ['not-a-category'] })
+    )
+
+    expect(runtime.createDiagnosticBundle).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'invalid_argument'
+      }
+    })
+  })
+
+  it('rejects diagnostics bundle lookbacks beyond the shared cap', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      createDiagnosticBundle: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: DIAGNOSTICS_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('diagnostics.bundle', {
+        lookbackMinutes: MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES + 1
+      })
     )
 
     expect(runtime.createDiagnosticBundle).not.toHaveBeenCalled()

--- a/src/main/runtime/rpc/methods/diagnostics.test.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.test.ts
@@ -54,6 +54,7 @@ describe('diagnostics RPC methods', () => {
       outputPath:
         'C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\orca-diagnostics.zip',
       bytes: 1234,
+      lookbackMinutes: 120,
       includedCategories: ['app'],
       skippedCategories: [],
       errorCategories: [],
@@ -127,6 +128,39 @@ describe('diagnostics RPC methods', () => {
       error: {
         code: 'invalid_argument'
       }
+    })
+  })
+
+  it('accepts diagnostics bundle lookbacks at the shared cap', async () => {
+    const bundle = {
+      bundleId: 'bundle-1',
+      outputPath:
+        'C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\orca-diagnostics.zip',
+      bytes: 1234,
+      lookbackMinutes: MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES,
+      includedCategories: ['app'],
+      skippedCategories: [],
+      errorCategories: [],
+      fileCount: 2
+    }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      createDiagnosticBundle: vi.fn().mockResolvedValue(bundle)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: DIAGNOSTICS_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('diagnostics.bundle', {
+        lookbackMinutes: MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES
+      })
+    )
+
+    expect(runtime.createDiagnosticBundle).toHaveBeenCalledWith({
+      lookbackMinutes: MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES
+    })
+    expect(response).toMatchObject({
+      ok: true,
+      result: bundle
     })
   })
 

--- a/src/main/runtime/rpc/methods/diagnostics.test.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.test.ts
@@ -46,4 +46,63 @@ describe('diagnostics RPC methods', () => {
       result: snapshot
     })
   })
+
+  it('exports a diagnostics bundle through the runtime', async () => {
+    const bundle = {
+      bundleId: 'bundle-1',
+      outputPath: 'C:\\tmp\\orca-diagnostics.zip',
+      bytes: 1234,
+      includedCategories: ['app'],
+      skippedCategories: [],
+      errorCategories: [],
+      fileCount: 2
+    }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      createDiagnosticBundle: vi.fn().mockResolvedValue(bundle)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: DIAGNOSTICS_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('diagnostics.bundle', {
+        output: 'C:\\tmp\\orca-diagnostics.zip',
+        lookbackMinutes: 120,
+        include: ['app'],
+        exclude: ['native-minidumps'],
+        open: true
+      })
+    )
+
+    expect(runtime.createDiagnosticBundle).toHaveBeenCalledWith({
+      output: 'C:\\tmp\\orca-diagnostics.zip',
+      lookbackMinutes: 120,
+      include: ['app'],
+      exclude: ['native-minidumps'],
+      open: true
+    })
+    expect(response).toMatchObject({
+      ok: true,
+      result: bundle
+    })
+  })
+
+  it('rejects unknown diagnostic bundle categories', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      createDiagnosticBundle: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: DIAGNOSTICS_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('diagnostics.bundle', { include: ['not-a-category'] })
+    )
+
+    expect(runtime.createDiagnosticBundle).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'invalid_argument'
+      }
+    })
+  })
 })

--- a/src/main/runtime/rpc/methods/diagnostics.test.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.test.ts
@@ -51,7 +51,8 @@ describe('diagnostics RPC methods', () => {
   it('exports a diagnostics bundle through the runtime', async () => {
     const bundle = {
       bundleId: 'bundle-1',
-      outputPath: 'C:\\tmp\\orca-diagnostics.zip',
+      outputPath:
+        'C:\\Users\\example\\AppData\\Local\\Orca\\logs\\diagnostics\\orca-diagnostics.zip',
       bytes: 1234,
       includedCategories: ['app'],
       skippedCategories: [],
@@ -66,7 +67,7 @@ describe('diagnostics RPC methods', () => {
 
     const response = await dispatcher.dispatch(
       makeRequest('diagnostics.bundle', {
-        output: 'C:\\tmp\\orca-diagnostics.zip',
+        output: 'orca-diagnostics.zip',
         lookbackMinutes: 120,
         include: ['app'],
         exclude: ['native-minidumps'],
@@ -75,7 +76,7 @@ describe('diagnostics RPC methods', () => {
     )
 
     expect(runtime.createDiagnosticBundle).toHaveBeenCalledWith({
-      output: 'C:\\tmp\\orca-diagnostics.zip',
+      output: 'orca-diagnostics.zip',
       lookbackMinutes: 120,
       include: ['app'],
       exclude: ['native-minidumps'],
@@ -117,6 +118,28 @@ describe('diagnostics RPC methods', () => {
     const response = await dispatcher.dispatch(
       makeRequest('diagnostics.bundle', {
         lookbackMinutes: MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES + 1
+      })
+    )
+
+    expect(runtime.createDiagnosticBundle).not.toHaveBeenCalled()
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'invalid_argument'
+      }
+    })
+  })
+
+  it('rejects diagnostics bundle output paths outside the diagnostics directory', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      createDiagnosticBundle: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: DIAGNOSTICS_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('diagnostics.bundle', {
+        output: '../orca-diagnostics.zip'
       })
     )
 

--- a/src/main/runtime/rpc/methods/diagnostics.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod'
 import {
   DIAGNOSTIC_BUNDLE_CATEGORIES,
-  MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES,
-  type DiagnosticBundleCategory
+  MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES
 } from '../../../../shared/diagnostic-bundle-export-types'
 import {
   DIAGNOSTIC_OUTPUT_PATH_ERROR,
@@ -43,11 +42,7 @@ export const DIAGNOSTICS_METHODS: RpcMethod[] = [
     name: 'diagnostics.bundle',
     params: DiagnosticBundleParams,
     handler: async (params, { runtime }) => {
-      return await runtime.createDiagnosticBundle({
-        ...params,
-        include: params.include as DiagnosticBundleCategory[] | undefined,
-        exclude: params.exclude as DiagnosticBundleCategory[] | undefined
-      })
+      return await runtime.createDiagnosticBundle(params)
     }
   })
 ]

--- a/src/main/runtime/rpc/methods/diagnostics.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.ts
@@ -4,13 +4,21 @@ import {
   MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES,
   type DiagnosticBundleCategory
 } from '../../../../shared/diagnostic-bundle-export-types'
+import {
+  DIAGNOSTIC_OUTPUT_PATH_ERROR,
+  isSafeDiagnosticBundleOutputPath
+} from '../../../../shared/diagnostic-bundle-output-path-policy'
 import { defineMethod, type RpcMethod } from '../core'
 
 const DiagnosticBundleCategory = z.enum(DIAGNOSTIC_BUNDLE_CATEGORIES)
 
 const DiagnosticBundleParams = z
   .object({
-    output: z.string().min(1).optional(),
+    output: z
+      .string()
+      .min(1)
+      .refine(isSafeDiagnosticBundleOutputPath, DIAGNOSTIC_OUTPUT_PATH_ERROR)
+      .optional(),
     lookbackMinutes: z
       .number()
       .int()

--- a/src/main/runtime/rpc/methods/diagnostics.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import {
   DIAGNOSTIC_BUNDLE_CATEGORIES,
+  MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES,
   type DiagnosticBundleCategory
 } from '../../../../shared/diagnostic-bundle-export-types'
 import { defineMethod, type RpcMethod } from '../core'
@@ -14,7 +15,7 @@ const DiagnosticBundleParams = z
       .number()
       .int()
       .positive()
-      .max(30 * 24 * 60)
+      .max(MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES)
       .optional(),
     include: z.array(DiagnosticBundleCategory).optional(),
     exclude: z.array(DiagnosticBundleCategory).optional(),

--- a/src/main/runtime/rpc/methods/diagnostics.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.ts
@@ -1,4 +1,26 @@
+import { z } from 'zod'
+import {
+  DIAGNOSTIC_BUNDLE_CATEGORIES,
+  type DiagnosticBundleCategory
+} from '../../../../shared/diagnostic-bundle-export-types'
 import { defineMethod, type RpcMethod } from '../core'
+
+const DiagnosticBundleCategory = z.enum(DIAGNOSTIC_BUNDLE_CATEGORIES)
+
+const DiagnosticBundleParams = z
+  .object({
+    output: z.string().min(1).optional(),
+    lookbackMinutes: z
+      .number()
+      .int()
+      .positive()
+      .max(30 * 24 * 60)
+      .optional(),
+    include: z.array(DiagnosticBundleCategory).optional(),
+    exclude: z.array(DiagnosticBundleCategory).optional(),
+    open: z.boolean().optional()
+  })
+  .strict()
 
 export const DIAGNOSTICS_METHODS: RpcMethod[] = [
   defineMethod({
@@ -6,6 +28,17 @@ export const DIAGNOSTICS_METHODS: RpcMethod[] = [
     params: null,
     handler: async (_params, { runtime }) => {
       return await runtime.getMemorySnapshot()
+    }
+  }),
+  defineMethod({
+    name: 'diagnostics.bundle',
+    params: DiagnosticBundleParams,
+    handler: async (params, { runtime }) => {
+      return await runtime.createDiagnosticBundle({
+        ...params,
+        include: params.include as DiagnosticBundleCategory[] | undefined,
+        exclude: params.exclude as DiagnosticBundleCategory[] | undefined
+      })
     }
   })
 ]

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -145,6 +145,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'clipboard.commitImageUpload',
   'clipboard.saveImageAsTempFile',
   'clipboard.startImageUpload',
+  'diagnostics.bundle',
   'diagnostics.memory',
   'files.browseServerDir',
   'files.createFile',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -145,7 +145,6 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'clipboard.commitImageUpload',
   'clipboard.saveImageAsTempFile',
   'clipboard.startImageUpload',
-  'diagnostics.bundle',
   'diagnostics.memory',
   'files.browseServerDir',
   'files.createFile',

--- a/src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { recordRendererCrashBreadcrumbMock } = vi.hoisted(() => ({
+  recordRendererCrashBreadcrumbMock: vi.fn()
+}))
+
+vi.mock('../../lib/crash-diagnostics', () => ({
+  recordRendererCrashBreadcrumb: recordRendererCrashBreadcrumbMock
+}))
+
+describe('warnTerminalLifecycleAnomaly', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    recordRendererCrashBreadcrumbMock.mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('records a compact crash breadcrumb without raw worktree or pty ids', async () => {
+    const { warnTerminalLifecycleAnomaly } = await import('./terminal-lifecycle-diagnostics')
+
+    warnTerminalLifecycleAnomaly('missing-pane', {
+      tabId: 'tab-1',
+      worktreeId: 'repo::C:\\secret\\workspace',
+      leafId: 'leaf-1',
+      paneId: 2,
+      ptyId: 'pty-secret',
+      reason: 'detached-layout'
+    })
+
+    expect(recordRendererCrashBreadcrumbMock).toHaveBeenCalledWith('terminal_lifecycle_anomaly', {
+      event: 'missing-pane',
+      tabId: 'tab-1',
+      leafId: 'leaf-1',
+      paneId: 2,
+      reason: 'detached-layout',
+      hasWorktreeId: true,
+      hasPtyId: true
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.ts
@@ -1,3 +1,5 @@
+import { recordRendererCrashBreadcrumb } from '../../lib/crash-diagnostics'
+
 type TerminalLifecycleDiagnosticDetails = {
   tabId?: string
   worktreeId?: string
@@ -31,4 +33,13 @@ export function warnTerminalLifecycleAnomaly(
   }
   emittedDiagnostics.add(key)
   console.warn(`[terminal-lifecycle] ${event}`, details)
+  recordRendererCrashBreadcrumb('terminal_lifecycle_anomaly', {
+    event,
+    tabId: details.tabId ?? null,
+    leafId: details.leafId ?? null,
+    paneId: details.paneId ?? null,
+    reason: details.reason ?? null,
+    hasWorktreeId: Boolean(details.worktreeId),
+    hasPtyId: Boolean(details.ptyId)
+  })
 }

--- a/src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.ts
@@ -33,6 +33,8 @@ export function warnTerminalLifecycleAnomaly(
   }
   emittedDiagnostics.add(key)
   console.warn(`[terminal-lifecycle] ${event}`, details)
+  // Why: worktree and PTY ids can reveal local path/session details, so crash
+  // breadcrumbs keep only their presence while preserving stable pane ids.
   recordRendererCrashBreadcrumb('terminal_lifecycle_anomaly', {
     event,
     tabId: details.tabId ?? null,

--- a/src/shared/diagnostic-bundle-export-types.ts
+++ b/src/shared/diagnostic-bundle-export-types.ts
@@ -1,0 +1,67 @@
+export const DIAGNOSTIC_BUNDLE_CATEGORIES = [
+  'app',
+  'system',
+  'observability',
+  'memory',
+  'crash-reports',
+  'native-minidumps',
+  'runtime-counts',
+  'terminal-lifecycle',
+  'windows-events',
+  'windows-wsl',
+  'windows-shells',
+  'macos-reports',
+  'macos-shells',
+  'linux-coredump',
+  'linux-journal',
+  'linux-shells'
+] as const
+
+export type DiagnosticBundleCategory = (typeof DIAGNOSTIC_BUNDLE_CATEGORIES)[number]
+
+export type DiagnosticBundleCategoryStatus = 'included' | 'skipped' | 'error' | 'truncated'
+
+export type DiagnosticBundleCategoryResult = {
+  category: DiagnosticBundleCategory
+  status: DiagnosticBundleCategoryStatus
+  reason?: string
+  files: string[]
+}
+
+export type DiagnosticBundleFileManifest = {
+  path: string
+  category: DiagnosticBundleCategory | 'manifest'
+  bytes: number
+  sha256: string | null
+}
+
+export type DiagnosticBundleManifest = {
+  schemaVersion: 1
+  bundleId: string
+  collectedAt: string
+  appVersion: string
+  orcaChannel: 'stable' | 'rc' | 'dev'
+  platform: NodeJS.Platform
+  arch: string
+  lookbackMinutes: number
+  categories: DiagnosticBundleCategoryResult[]
+  files: DiagnosticBundleFileManifest[]
+}
+
+export type DiagnosticBundleExportArgs = {
+  output?: string
+  lookbackMinutes?: number
+  include?: DiagnosticBundleCategory[]
+  exclude?: DiagnosticBundleCategory[]
+  open?: boolean
+}
+
+export type DiagnosticBundleExportResult = {
+  bundleId: string
+  outputPath: string
+  bytes: number
+  includedCategories: DiagnosticBundleCategory[]
+  skippedCategories: DiagnosticBundleCategoryResult[]
+  errorCategories: DiagnosticBundleCategoryResult[]
+  fileCount: number
+}

--- a/src/shared/diagnostic-bundle-export-types.ts
+++ b/src/shared/diagnostic-bundle-export-types.ts
@@ -17,6 +17,8 @@ export const DIAGNOSTIC_BUNDLE_CATEGORIES = [
   'linux-shells'
 ] as const
 
+export const MAX_DIAGNOSTIC_BUNDLE_LOOKBACK_MINUTES = 30 * 24 * 60
+
 export type DiagnosticBundleCategory = (typeof DIAGNOSTIC_BUNDLE_CATEGORIES)[number]
 
 export type DiagnosticBundleCategoryStatus = 'included' | 'skipped' | 'error' | 'truncated'

--- a/src/shared/diagnostic-bundle-export-types.ts
+++ b/src/shared/diagnostic-bundle-export-types.ts
@@ -62,6 +62,7 @@ export type DiagnosticBundleExportResult = {
   bundleId: string
   outputPath: string
   bytes: number
+  lookbackMinutes: number
   includedCategories: DiagnosticBundleCategory[]
   skippedCategories: DiagnosticBundleCategoryResult[]
   errorCategories: DiagnosticBundleCategoryResult[]

--- a/src/shared/diagnostic-bundle-output-path-policy.test.ts
+++ b/src/shared/diagnostic-bundle-output-path-policy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSafeDiagnosticBundleOutputPath,
+  parseSafeDiagnosticBundleOutputPath
+} from './diagnostic-bundle-output-path-policy'
+
+describe('diagnostic bundle output path policy', () => {
+  it('accepts relative filenames and subpaths', () => {
+    expect(parseSafeDiagnosticBundleOutputPath('bundle.zip')).toEqual(['bundle.zip'])
+    expect(parseSafeDiagnosticBundleOutputPath('nested\\bundle.zip')).toEqual([
+      'nested',
+      'bundle.zip'
+    ])
+    expect(parseSafeDiagnosticBundleOutputPath('./nested/bundle.zip')).toEqual([
+      'nested',
+      'bundle.zip'
+    ])
+  })
+
+  it('rejects absolute and traversal paths', () => {
+    for (const output of [
+      '/tmp/bundle.zip',
+      '\\\\server\\share\\bundle.zip',
+      'C:\\tmp\\bundle.zip',
+      '../bundle.zip',
+      'nested/../bundle.zip'
+    ]) {
+      expect(isSafeDiagnosticBundleOutputPath(output)).toBe(false)
+    }
+  })
+
+  it('rejects null bytes and colon-bearing segments', () => {
+    for (const output of ['bundle\0.zip', 'nested/logs:bundle.zip']) {
+      expect(parseSafeDiagnosticBundleOutputPath(output)).toBeNull()
+    }
+  })
+})

--- a/src/shared/diagnostic-bundle-output-path-policy.ts
+++ b/src/shared/diagnostic-bundle-output-path-policy.ts
@@ -1,0 +1,26 @@
+export const DIAGNOSTIC_OUTPUT_PATH_ERROR = 'diagnostic_output_path_outside_diagnostics_directory'
+
+export function isSafeDiagnosticBundleOutputPath(output: string): boolean {
+  return parseSafeDiagnosticBundleOutputPath(output) !== null
+}
+
+export function parseSafeDiagnosticBundleOutputPath(output: string): string[] | null {
+  const normalized = output.trim().replace(/\\/g, '/')
+  if (
+    !normalized ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('//') ||
+    /^[a-zA-Z]:/.test(normalized) ||
+    normalized.includes('\0')
+  ) {
+    return null
+  }
+  const segments = normalized.split('/').filter((segment) => segment && segment !== '.')
+  if (
+    segments.length === 0 ||
+    segments.some((segment) => segment === '..' || segment.includes(':'))
+  ) {
+    return null
+  }
+  return segments
+}


### PR DESCRIPTION
## Summary
- Add a local `orca diagnostics bundle` export that writes a reviewable ZIP with a manifest, app/system/runtime/memory/crash diagnostics, and platform-specific summaries.
- Start local-only Electron Crashpad capture early and include recent native minidumps in explicit local exports when present.
- Replace Windows process memory enumeration with a CIM-first path while retaining WMIC as a fallback.
- Record compact terminal lifecycle breadcrumbs and include them in diagnostics bundle artifacts.
- Document how support should read the ZIP/minidump output, what CLI output to expect, and why the bundle is useful for crash triage.

## Security Audit
- Native minidumps are collected locally with `uploadToServer: false`; this PR does not add a binary upload or issue-attachment path.
- Default runtime summaries are count-only and avoid workspace names, paths, prompts, branches, terminal scrollback, raw environment variables, repository contents, and raw SSH/runtime host labels.
- User-provided bundle output names are constrained to the Orca logs/diagnostics directory and reject absolute, parent-traversal, NUL, drive-prefix, and colon-bearing path segments.
- Platform probes are bounded by timeout/max-buffer behavior and collector failures are recorded as skipped/error categories instead of failing the whole bundle.

## Testing
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm test -- src/shared/diagnostic-bundle-output-path-policy.test.ts src/main/diagnostics/diagnostic-bundle-export.test.ts src/main/diagnostics/diagnostic-output-path.test.ts src/main/diagnostics/native-crash-reporter.test.ts src/main/diagnostics/runtime-diagnostic-counts.test.ts src/main/diagnostics/windows-event-diagnostic-summary.test.ts src/main/diagnostics/shell-availability-summary.test.ts src/main/memory/collector.test.ts src/main/runtime/rpc/methods/diagnostics.test.ts src/main/runtime/mobile-rpc-allowlist.test.ts src/cli/args.test.ts src/cli/index.test.ts src/main/cli/packaged-cli-assets.test.ts src/main/cli/windows-launcher-asset.test.ts src/renderer/src/components/terminal-pane/terminal-lifecycle-diagnostics.test.ts` (201 passed, 7 skipped)

## Screenshots
N/A - CLI and main-process diagnostics workflow.

## AI Review Report
- Review scope covered the CLI/RPC/main-process export path, archive manifest integrity, local Crashpad startup, platform collectors, output-path policy, mobile RPC exposure, redaction boundaries, and support-readability docs.
- Review fixes applied: bounded direct-call lookbacks, constrained output paths, removed mobile access to `diagnostics.bundle`, made Crashpad startup retryable after setup failure, counted nested terminal split panes, bucketed runtime host IDs by kind, hardened Windows event-log empty-result handling, used `execFile` for Windows process probes, surfaced effective lookback minutes, added boundary/path-policy tests, covered legacy host fallback counts, documented path-role privacy redaction, and added a bundle-level privacy regression test with seeded sensitive values.
- Cross-platform compatibility: Windows-only collectors are guarded behind Windows checks, macOS and Linux collectors skip outside their platforms, path resolution uses Node/Electron path APIs, and unsafe Windows/POSIX path forms are rejected before export.

## ELI5

`orca diagnostics bundle` writes a local ZIP of app, system, crash, and terminal breadcrumbs. Handy for support without uploading secrets automatically.
