### PR TITLE
perf(emulator): stop decoding frames for hidden emulator panes

### DIFF
--- a/src/renderer/src/components/emulator-pane/EmulatorPane.tsx
+++ b/src/renderer/src/components/emulator-pane/EmulatorPane.tsx
@@ -80,6 +80,7 @@ export default function EmulatorPane({ tab, worktreeId, isActive = true }: Emula
             deviceName={displayName}
             loading={loading}
             isLive={isLive}
+            isActive={isActive}
             onTap={(x, y) => void sendTap(x, y)}
             onGesture={(points) => void sendGesture(points)}
           />

--- a/src/renderer/src/components/emulator-pane/emulator-device-frame-visibility.test.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-device-frame-visibility.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EmulatorDeviceFrame } from './emulator-device-frame'
+
+// Why: a backgrounded but still-attached emulator must stop streaming frames.
+// The perf contract is that no frame stream is started (no per-frame IPC / MJPEG
+// blob churn / H.264 decode) while the pane is inactive, and that a running
+// stream is torn down when the pane is hidden — so this asserts the IPC calls,
+// not just the rendered DOM.
+
+type FrameListener = (data: { streamId: string; bytes: ArrayBuffer }) => void
+type ErrorListener = (data: { streamId: string; message: string }) => void
+
+let container: HTMLDivElement
+let root: Root
+let startFrameStream: ReturnType<typeof vi.fn>
+let stopFrameStream: ReturnType<typeof vi.fn>
+let streamCounter: number
+
+beforeEach(() => {
+  ;(
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+  streamCounter = 0
+  startFrameStream = vi.fn(async () => ({ streamId: `stream-${++streamCounter}` }))
+  stopFrameStream = vi.fn(async () => {})
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: vi.fn(() => 'blob:emulator-frame')
+  })
+  Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: vi.fn() })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      emulator: {
+        startFrameStream,
+        stopFrameStream,
+        onFrameStreamFrame: (_listener: FrameListener) => () => {},
+        onFrameStreamError: (_listener: ErrorListener) => () => {}
+      }
+    }
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  delete (URL as Partial<typeof URL>).createObjectURL
+  delete (URL as Partial<typeof URL>).revokeObjectURL
+  delete (window as { api?: unknown }).api
+  vi.restoreAllMocks()
+})
+
+async function renderFrame(isActive: boolean): Promise<void> {
+  await act(async () => {
+    root.render(
+      <EmulatorDeviceFrame
+        previewUrl="http://127.0.0.1:3100/stream.mjpeg"
+        wsUrl="ws://127.0.0.1:3100/ws"
+        loading={false}
+        isLive={true}
+        isActive={isActive}
+        onTap={vi.fn()}
+        onGesture={vi.fn()}
+      />
+    )
+  })
+}
+
+describe('EmulatorDeviceFrame visibility gating', () => {
+  it('streams frames while the pane is active', async () => {
+    await renderFrame(true)
+    expect(startFrameStream).toHaveBeenCalledWith(
+      expect.objectContaining({ streamUrl: 'http://127.0.0.1:3100/stream.mjpeg' })
+    )
+  })
+
+  it('does not start a frame stream while the pane is inactive', async () => {
+    await renderFrame(false)
+    expect(startFrameStream).not.toHaveBeenCalled()
+  })
+
+  it('tears the stream down when the pane becomes inactive and resumes when active again', async () => {
+    await renderFrame(true)
+    expect(startFrameStream).toHaveBeenCalledTimes(1)
+
+    // Parking the pane must stop the stream at the source (no more IPC frames).
+    await renderFrame(false)
+    expect(stopFrameStream).toHaveBeenCalledWith({ streamId: 'stream-1' })
+
+    // Re-showing re-fires the stream; the session was never detached.
+    await renderFrame(true)
+    expect(startFrameStream).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/components/emulator-pane/emulator-device-frame.input.test.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-device-frame.input.test.tsx
@@ -99,6 +99,7 @@ function renderFrame(props?: {
         wsUrl="ws://127.0.0.1:3100/ws"
         loading={false}
         isLive={true}
+        isActive={true}
         onTap={props?.onTap ?? vi.fn()}
         onGesture={props?.onGesture ?? vi.fn()}
       />

--- a/src/renderer/src/components/emulator-pane/emulator-device-frame.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-device-frame.tsx
@@ -39,6 +39,9 @@ type EmulatorDeviceFrameProps = {
   deviceName?: string
   loading: boolean
   isLive: boolean
+  /** False when the pane is backgrounded (hidden tab/worktree). Gates the frame
+   *  stream so a parked emulator stops decoding, matching the pane's visibility. */
+  isActive: boolean
   onTap: (x: number, y: number) => void
   onGesture: (points: EmulatorGesturePoint[]) => void
 }
@@ -65,6 +68,7 @@ export function EmulatorDeviceFrame({
   deviceName,
   loading,
   isLive,
+  isActive,
   onTap,
   onGesture
 }: EmulatorDeviceFrameProps) {
@@ -327,7 +331,13 @@ export function EmulatorDeviceFrame({
     setStreamError(true)
   }, [])
 
-  const showStream = isLive && Boolean(previewUrl)
+  // Why: only decode frames while the pane is visible. A backgrounded but still
+  // attached emulator otherwise keeps running the WebCodecs H.264 decode / MJPEG
+  // blob churn against a hidden canvas, with frames still flowing over IPC (and
+  // the network for paired SSH/remote clients). The session stays attached, so
+  // the stream re-fires within a frame on re-show. Mirrors the browser pane's
+  // park-when-hidden behavior.
+  const showStream = isActive && isLive && Boolean(previewUrl)
   const screenAspectRatio = streamSize ? streamSize.width / streamSize.height : 9 / 19
   const screenAspectRatioStyle = streamSize
     ? `${streamSize.width} / ${streamSize.height}`


### PR DESCRIPTION
## Description

`EmulatorDeviceFrame` computed `showStream = isLive && Boolean(previewUrl)` — **no visibility gate** — so a live emulator on a hidden tab/worktree kept its frame stream fully alive:

- **Android:** decodes every H.264 access unit with WebCodecs and `ctx.drawImage`s it onto a `visibility:hidden` canvas.
- **iOS:** allocates a `Blob` + `createObjectURL` per MJPEG frame and calls `setState`.
- **Both:** frames keep flowing over IPC — **and over the network for paired SSH / remote clients** — to a viewer that can't see them. This stacks per open worktree holding a live emulator.

`EmulatorPane` already computes `isActive` (it uses it for `autoAttachOnMount`) but never passed it to `EmulatorDeviceFrame`. Thread it through and gate the stream: `showStream = isActive && isLive && Boolean(previewUrl)`.

## ELI5

You've got a phone emulator running in a tab. You switch to another tab. The emulator's video kept playing full-speed in the background where nobody could see it — decoding every frame, burning CPU/GPU/battery, and shipping frames over the network to your phone/web client for nothing. Now it pauses when you're not looking and un-pauses when you come back.

## Evidence

New `emulator-device-frame-visibility.test.tsx` asserts the **IPC contract**, not just the DOM:
- active pane → `startFrameStream` is called
- inactive pane → `startFrameStream` is **not** called (no per-frame IPC / decode)
- active → inactive → `stopFrameStream` is called (parks at source); re-show restarts

**Reverting the one-line gate fails 2 of the 3 tests.** Full renderer typecheck + oxlint clean.

```
npx vitest run --config config/vitest.config.ts src/renderer/src/components/emulator-pane/
```

> A live end-to-end repro needs a real attached Android/iOS emulator (not available in headless CI), so the unit test is the reproduction harness.

Why it's safe: the overlay slot (`EmulatorPaneOverlayLayer`) already renders the pane with `visibility: isActive ? 'visible' : 'hidden'`, so `isActive === false` means the pane is **already invisible** — gating on it can never blank a stream the user can see. The session stays **attached** (`autoAttachOnMount` untouched), so the stream re-fires via the existing `enabled` effect. Mirrors the browser pane's park-when-hidden precedent.

## Trade-offs

- **Re-show is no longer instant.** Returning to a parked emulator restarts the stream from scratch — Android requests a fresh scrcpy stream and waits for the next keyframe, so you may see a brief "Connecting emulator…" flash (a fraction of a second, up to ~1s) instead of an already-live picture. Previously instant because it never stopped.
- **Tab-hopping causes stop/start churn.** Flipping rapidly between tabs stops and restarts the stream each time (bounded by how fast you click). This mirrors what the browser pane already does, but is more start/stop work than before — traded for zero decode while parked.
- **Not a full detach.** The emulator session stays attached, so **no state loss** — only the video pipe pauses. A hidden emulator still holds its session + an idle control WebSocket; I intentionally left the control WS alive to avoid a ~750ms reconnect on re-show. So the savings are "stop decoding," not "disconnect everything."

## Scope
Renderer-only, ~4 lines of behavior + tests. No change to attach/detach lifecycle.
