### PR TITLE
fix(codex): keep codex_apps startup timeout in runtime config

### DIFF
--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -217,6 +217,13 @@ function createCodexAuthJson(email: string, accountId: string, refreshToken: str
   )}\n`
 }
 
+const managedCodexAppsBlock = [
+  '[mcp_servers.codex_apps]',
+  'command = "codex"',
+  'args = ["app-server", "proxy"]',
+  'startup_timeout_sec = 120'
+].join('\n')
+
 describe('CodexAccountService config sync', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -242,11 +249,12 @@ describe('CodexAccountService config sync', () => {
     const canonicalConfigPath = join(testState.fakeHomeDir, '.codex', 'config.toml')
     const canonicalConfig = 'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n'
     writeFileSync(canonicalConfigPath, canonicalConfig, 'utf-8')
+    const authJson = '{"account":"managed"}\n'
     const managedHomePath = createManagedHome(
       testState.userDataDir,
       'account-1',
       'approval_policy = "on-request"\n',
-      '{"account":"managed"}\n'
+      authJson
     )
     const settings = createSettings({
       codexManagedAccounts: [
@@ -271,10 +279,15 @@ describe('CodexAccountService config sync', () => {
     const { CodexAccountService } = await import('./service')
     new CodexAccountService(store as never, rateLimits as never, runtimeHome as never)
 
-    expect(readFileSync(join(managedHomePath, 'config.toml'), 'utf-8')).toBe(canonicalConfig)
-    expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe(
-      '{"account":"managed"}\n'
-    )
+    const managedConfig = readFileSync(join(managedHomePath, 'config.toml'), 'utf-8')
+    expect(managedConfig).toContain('approval_policy = "never"')
+    expect(managedConfig).toContain('sandbox_mode = "danger-full-access"')
+    expect(managedConfig).toContain('[mcp_servers.codex_apps]')
+    expect(managedConfig).toContain('command = "codex"')
+    expect(managedConfig).toContain('args = ["app-server", "proxy"]')
+    expect(managedConfig).toContain('startup_timeout_sec = 120')
+    expect(managedConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
+    expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe(authJson)
   })
 
   it('rewrites relative path config values when syncing into managed homes', async () => {
@@ -327,7 +340,7 @@ describe('CodexAccountService config sync', () => {
     const managedHomePath = createManagedHome(
       testState.userDataDir,
       'account-1',
-      canonicalConfig,
+      `${canonicalConfig.trimEnd()}\n\n${managedCodexAppsBlock}\n`,
       '{"account":"managed"}\n'
     )
     const managedConfigPath = join(managedHomePath, 'config.toml')
@@ -359,7 +372,7 @@ describe('CodexAccountService config sync', () => {
     expect(statSync(managedConfigPath).mtimeMs).toBeLessThan(Date.now() - 60_000)
   })
 
-  it('does not sync configs when ~/.codex/config.toml is missing', async () => {
+  it('adds managed codex_apps when ~/.codex/config.toml is missing', async () => {
     const firstManagedHomePath = createManagedHome(
       testState.userDataDir,
       'account-1',
@@ -405,12 +418,15 @@ describe('CodexAccountService config sync', () => {
     const { CodexAccountService } = await import('./service')
     new CodexAccountService(store as never, rateLimits as never, runtimeHome as never)
 
-    expect(readFileSync(join(firstManagedHomePath, 'config.toml'), 'utf-8')).toBe(
-      'sandbox_mode = "danger-full-access"\n'
-    )
-    expect(readFileSync(join(secondManagedHomePath, 'config.toml'), 'utf-8')).toBe(
-      'sandbox_mode = "workspace-write"\n'
-    )
+    const firstManagedConfig = readFileSync(join(firstManagedHomePath, 'config.toml'), 'utf-8')
+    expect(firstManagedConfig).toContain('sandbox_mode = "danger-full-access"')
+    expect(firstManagedConfig).toContain(managedCodexAppsBlock)
+    expect(firstManagedConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
+
+    const secondManagedConfig = readFileSync(join(secondManagedHomePath, 'config.toml'), 'utf-8')
+    expect(secondManagedConfig).toContain('sandbox_mode = "workspace-write"')
+    expect(secondManagedConfig).toContain(managedCodexAppsBlock)
+    expect(secondManagedConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
   })
 
   it('re-syncs config when selecting an account', async () => {
@@ -452,7 +468,10 @@ describe('CodexAccountService config sync', () => {
 
     await service.selectAccount('account-1')
 
-    expect(readFileSync(join(managedHomePath, 'config.toml'), 'utf-8')).toBe(canonicalConfig)
+    const managedConfig = readFileSync(join(managedHomePath, 'config.toml'), 'utf-8')
+    expect(managedConfig).toContain(canonicalConfig.trimEnd())
+    expect(managedConfig).toContain(managedCodexAppsBlock)
+    expect(managedConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
     expect(rateLimits.refreshForCodexAccountChange).toHaveBeenCalledTimes(1)
     expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledTimes(1)
   })
@@ -489,9 +508,9 @@ describe('CodexAccountService config sync', () => {
     expect(
       () => new CodexAccountService(store as never, rateLimits as never, runtimeHome as never)
     ).not.toThrow()
-    expect(readFileSync(join(managedHomePath, 'config.toml'), 'utf-8')).toBe(
-      'approval_policy = "on-request"\n'
-    )
+    const managedConfig = readFileSync(join(managedHomePath, 'config.toml'), 'utf-8')
+    expect(managedConfig).toContain('approval_policy = "on-request"')
+    expect(managedConfig).not.toContain('[mcp_servers.codex_apps]')
     expect(warnSpy).toHaveBeenCalled()
   })
 
@@ -515,7 +534,10 @@ describe('CodexAccountService config sync', () => {
 
         const loginHome = options.env.CODEX_HOME
         expect(loginHome).toBeTruthy()
-        expect(readFileSync(join(loginHome!, 'config.toml'), 'utf-8')).toBe(canonicalConfig)
+        const managedConfig = readFileSync(join(loginHome!, 'config.toml'), 'utf-8')
+        expect(managedConfig).toContain(canonicalConfig.trimEnd())
+        expect(managedConfig).toContain(managedCodexAppsBlock)
+        expect(managedConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
 
         const payload = Buffer.from(JSON.stringify({ email: 'user@example.com' })).toString(
           'base64url'
@@ -574,7 +596,10 @@ describe('CodexAccountService config sync', () => {
         const loginHome = options.env.CODEX_HOME
         expect(loginHome).toBeTruthy()
         expect(readFileSync(join(loginHome!, '.orca-managed-home'), 'utf-8')).toBe('account-1\n')
-        expect(readFileSync(join(loginHome!, 'config.toml'), 'utf-8')).toBe(canonicalConfig)
+        const managedConfig = readFileSync(join(loginHome!, 'config.toml'), 'utf-8')
+        expect(managedConfig).toContain(canonicalConfig.trimEnd())
+        expect(managedConfig).toContain(managedCodexAppsBlock)
+        expect(managedConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
 
         const child = new EventEmitter() as EventEmitter & {
           stdout: PassThrough
@@ -780,10 +805,11 @@ describe('CodexAccountService config sync', () => {
       ])
       // Why: codex login runs inside WSL, so the rewritten path must be the
       // Linux-side ~/.codex, not a Windows UNC path.
-      expect(readFileSync(join(wslManagedHomePath, 'config.toml'), 'utf-8')).toBe(
-        'sandbox_mode = "danger-full-access"\n' +
-          "model_instructions_file = '/home/alice/.codex/instructions.md'\n"
-      )
+      const managedConfig = readFileSync(join(wslManagedHomePath, 'config.toml'), 'utf-8')
+      expect(managedConfig).toContain('sandbox_mode = "danger-full-access"')
+      expect(managedConfig).toContain("model_instructions_file = '/home/alice/.codex/instructions.md'")
+      expect(managedConfig).toContain(managedCodexAppsBlock)
+      expect(managedConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
       const child = new EventEmitter() as EventEmitter & {
         stdout: PassThrough
         stderr: PassThrough

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -16,6 +16,7 @@ import type {
 import type { CodexRuntimeHomeService } from './runtime-home-service'
 import { writeFileAtomically } from './fs-utils'
 import { rewriteRelativePathConfigValues } from '../codex/codex-config-path-reference-rewrite'
+import { withManagedCodexAppsMcpServer } from '../codex/codex-config-mirror'
 import { resolveCodexCommand } from '../codex-cli/command'
 import type { Store } from '../persistence'
 import type { RateLimitService } from '../rate-limits/service'
@@ -53,6 +54,7 @@ type CanonicalCodexConfig = {
   /** Home the config was read from, in the path style Codex sees at runtime
    *  (Linux-side for WSL); relative path-valued settings resolve against it. */
   sourceHomePath: string
+  useManagedHomeFallback?: boolean
 }
 
 export type CodexAccountAddTarget = {
@@ -463,9 +465,14 @@ export class CodexAccountService {
     // account while preserving consistent Codex behavior. Managed homes are
     // real CODEX_HOMEs for `codex login`, so relative path-valued settings
     // must keep resolving against the home the config was read from.
+    const sourceConfig = canonicalConfig.useManagedHomeFallback
+      ? this.readExistingManagedConfig(trustedManagedHomePath) ?? ''
+      : canonicalConfig.contents
     this.writeManagedConfig(
       trustedManagedHomePath,
-      rewriteRelativePathConfigValues(canonicalConfig.contents, canonicalConfig.sourceHomePath)
+      withManagedCodexAppsMcpServer(
+        rewriteRelativePathConfigValues(sourceConfig, canonicalConfig.sourceHomePath)
+      )
     )
   }
 
@@ -473,7 +480,7 @@ export class CodexAccountService {
     const sourceHomePath = join(homedir(), '.codex')
     const primaryConfigPath = join(sourceHomePath, 'config.toml')
     if (!existsSync(primaryConfigPath)) {
-      return null
+      return { contents: '', sourceHomePath, useManagedHomeFallback: true }
     }
 
     try {
@@ -498,7 +505,7 @@ export class CodexAccountService {
     const wslHome = wslInfo.linuxPath.slice(0, markerIndex)
     const configPath = toWindowsWslPath(`${wslHome}/.codex/config.toml`, wslInfo.distro)
     if (!existsSync(configPath)) {
-      return null
+      return { contents: '', sourceHomePath: wslInfo.linuxPath, useManagedHomeFallback: true }
     }
 
     try {
@@ -522,6 +529,19 @@ export class CodexAccountService {
       // atomic write path owns Windows ACL repair and persistent error surfacing.
     }
     writeFileAtomically(configPath, contents)
+  }
+
+  private readExistingManagedConfig(managedHomePath: string): string | null {
+    const configPath = join(managedHomePath, 'config.toml')
+    if (!existsSync(configPath)) {
+      return null
+    }
+
+    try {
+      return readFileSync(configPath, 'utf-8')
+    } catch {
+      return null
+    }
   }
 
   private getManagedAccountsRoot(): string {

--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import type * as NodeOs from 'node:os'
 import { join } from 'node:path'
@@ -71,20 +71,10 @@ afterEach(() => {
 })
 
 describe('syncSystemConfigIntoManagedCodexHome', () => {
-  it('seeds a missing runtime config without copying system hook trust', () => {
+  it('seeds a missing runtime config with the managed codex_apps block', () => {
     writeFileSync(
       getSystemConfigPath(),
-      [
-        'model = "system-model"',
-        '',
-        '[hooks.state."system-hooks:stop:0:0"]',
-        'enabled = true',
-        'trusted_hash = "sha256:system"',
-        '',
-        '[projects."/repo"]',
-        'trust_level = "trusted"',
-        ''
-      ].join('\n'),
+      ['model = "system-model"', ''].join('\n'),
       'utf-8'
     )
 
@@ -92,8 +82,54 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
 
     const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
     expect(runtimeConfig).toContain('model = "system-model"')
-    expect(runtimeConfig).toContain('[projects."/repo"]')
-    expect(runtimeConfig).not.toContain('[hooks.state."system-hooks:stop:0:0"]')
+    expect(runtimeConfig).toContain('[mcp_servers.codex_apps]')
+    expect(runtimeConfig).toContain('command = "codex"')
+    expect(runtimeConfig).toContain('args = ["app-server", "proxy"]')
+    expect(runtimeConfig).toContain('startup_timeout_sec = 120')
+    expect(runtimeConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
+  })
+
+  it('replaces invalid codex_apps sections in existing runtime configs idempotently', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [
+        'model = "runtime-model"',
+        '',
+        '[mcp_servers.codex_apps]',
+        'startup_timeout_sec = 30',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      [
+        'model = "system-model"',
+        '',
+        '[mcp_servers.github]',
+        'command = "gh"',
+        'args = ["auth", "status"]',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+    const firstPass = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    syncSystemConfigIntoManagedCodexHome()
+    const secondPass = readFileSync(getRuntimeConfigPath(), 'utf-8')
+
+    expect(firstPass).toBe(secondPass)
+    expect(secondPass).toContain('[mcp_servers.github]')
+    expect(secondPass).toContain('command = "gh"')
+    expect(secondPass).toContain('args = ["auth", "status"]')
+    expect(secondPass).toContain('[mcp_servers.codex_apps]')
+    expect(secondPass).toContain('command = "codex"')
+    expect(secondPass).toContain('args = ["app-server", "proxy"]')
+    expect(secondPass).toContain('startup_timeout_sec = 120')
+    expect(secondPass).not.toContain('startup_timeout_sec = 30')
+    expect(secondPass.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
   })
 
   it('normalizes deprecated codex_hooks feature flag only in runtime config', () => {
@@ -394,10 +430,15 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     expect(runtimeConfig).not.toContain('trusted_hash = "sha256:system"')
   })
 
-  it('does not create a runtime config when neither system nor runtime config exists', () => {
+  it('creates a runtime config with managed codex_apps when neither system nor runtime config exists', () => {
     syncSystemConfigIntoManagedCodexHome()
 
-    expect(existsSync(getRuntimeConfigPath())).toBe(false)
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig).toContain('[mcp_servers.codex_apps]')
+    expect(runtimeConfig).toContain('command = "codex"')
+    expect(runtimeConfig).toContain('args = ["app-server", "proxy"]')
+    expect(runtimeConfig).toContain('startup_timeout_sec = 120')
+    expect(runtimeConfig.match(/\[mcp_servers\.codex_apps\]/g)?.length).toBe(1)
   })
 })
 

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -10,6 +10,13 @@ import {
   updateTomlLineScanState
 } from './config-toml-line-scan'
 
+const MANAGED_CODEX_APPS_MCP_SERVER_BLOCK = [
+  '[mcp_servers.codex_apps]',
+  'command = "codex"',
+  'args = ["app-server", "proxy"]',
+  'startup_timeout_sec = 120'
+].join('\n')
+
 function getRuntimeCodexConfigTomlPath(): string {
   return join(getOrcaManagedCodexHomePath(), 'config.toml')
 }
@@ -31,9 +38,6 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(): void {
   const runtimeConfigPath = getRuntimeCodexConfigTomlPath()
   const systemConfigExists = existsSync(systemConfigPath)
   const runtimeConfigExists = existsSync(runtimeConfigPath)
-  if (!systemConfigExists && !runtimeConfigExists) {
-    return
-  }
 
   const rawSystemConfig = systemConfigExists ? readFileSync(systemConfigPath, 'utf-8') : ''
   if (!runtimeConfigExists) {
@@ -70,7 +74,16 @@ export function prepareSystemConfigForFreshRuntimeMirror(
   config: string,
   systemConfigDir: string
 ): string {
-  return stripRuntimeOwnedTomlSections(prepareSystemConfigForRuntimeMirror(config, systemConfigDir))
+  return withManagedCodexAppsMcpServer(
+    stripRuntimeOwnedTomlSections(prepareSystemConfigForRuntimeMirror(config, systemConfigDir))
+  )
+}
+
+export function withManagedCodexAppsMcpServer(config: string): string {
+  return joinTomlBlocks([
+    stripTomlSections(config, (section) => isManagedCodexAppsTomlSection(section.header)),
+    MANAGED_CODEX_APPS_MCP_SERVER_BLOCK
+  ])
 }
 
 function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
@@ -156,17 +169,19 @@ function mergeSystemCodexConfigIntoRuntime(runtimeConfig: string, systemConfig: 
   // trust and project trust are written under Orca's managed CODEX_HOME and
   // must survive the copy unless the user explicitly revoked project trust in
   // the system config.
-  return joinTomlBlocks([
-    stripRuntimeOwnedTomlSections(systemConfig, runtimeProjectHeaders),
-    ...runtimeSections
-      .filter((section) => isRuntimePreservedTomlSection(section.header))
-      .filter(
-        (section) =>
-          !isRuntimeProjectTomlSection(section.header) ||
-          !systemUntrustedProjectHeaders.has(getTomlSectionHeaderKey(section.header))
-      )
-      .map((section) => section.block)
-  ])
+  return withManagedCodexAppsMcpServer(
+    joinTomlBlocks([
+      stripRuntimeOwnedTomlSections(systemConfig, runtimeProjectHeaders),
+      ...runtimeSections
+        .filter((section) => isRuntimePreservedTomlSection(section.header))
+        .filter(
+          (section) =>
+            !isRuntimeProjectTomlSection(section.header) ||
+            !systemUntrustedProjectHeaders.has(getTomlSectionHeaderKey(section.header))
+        )
+        .map((section) => section.block)
+    ])
+  )
 }
 
 type TomlSection = {
@@ -179,21 +194,29 @@ function stripRuntimeOwnedTomlSections(
   config: string,
   runtimeProjectHeaders = new Set<string>()
 ): string {
+  return stripTomlSections(config, (section) => {
+    if (isRuntimeHookTrustTomlSection(section.header)) {
+      return true
+    }
+    return (
+      isRuntimeProjectTomlSection(section.header) &&
+      runtimeProjectHeaders.has(getTomlSectionHeaderKey(section.header)) &&
+      getProjectTrustLevel(section.block) !== 'untrusted'
+    )
+  })
+}
+
+function stripTomlSections(
+  config: string,
+  shouldStrip: (section: TomlSection) => boolean
+): string {
   const lines = config.split('\n')
   const sections = getTomlSections(config)
   const firstSectionIndex = sections[0]?.start ?? -1
   const preamble = firstSectionIndex === -1 ? config : lines.slice(0, firstSectionIndex).join('\n')
   return joinTomlBlocks([
     preamble,
-    ...sections
-      .filter((section) => !isRuntimeHookTrustTomlSection(section.header))
-      .filter(
-        (section) =>
-          !isRuntimeProjectTomlSection(section.header) ||
-          !runtimeProjectHeaders.has(getTomlSectionHeaderKey(section.header)) ||
-          getProjectTrustLevel(section.block) === 'untrusted'
-      )
-      .map((section) => section.block)
+    ...sections.filter((section) => !shouldStrip(section)).map((section) => section.block)
   ])
 }
 
@@ -234,7 +257,11 @@ function getTomlSections(config: string): TomlSection[] {
 }
 
 function isRuntimePreservedTomlSection(header: string): boolean {
-  return isRuntimeHookTrustTomlSection(header) || isRuntimeProjectTomlSection(header)
+  return (
+    isRuntimeHookTrustTomlSection(header) ||
+    isRuntimeProjectTomlSection(header) ||
+    isManagedCodexAppsTomlSection(header)
+  )
 }
 
 function isRuntimeHookTrustTomlSection(header: string): boolean {
@@ -243,6 +270,10 @@ function isRuntimeHookTrustTomlSection(header: string): boolean {
 
 function isRuntimeProjectTomlSection(header: string): boolean {
   return header.trimStart().startsWith('[projects.')
+}
+
+function isManagedCodexAppsTomlSection(header: string): boolean {
+  return header.trim() === '[mcp_servers.codex_apps]'
 }
 
 function getTomlSectionHeaderKey(header: string): string {


### PR DESCRIPTION
## Summary

- Orca now writes a managed `codex_apps` MCP entry into mirrored Codex configs with `command = "codex"`, `args = ["app-server", "proxy"]`, and `startup_timeout_sec = 120`.
- The mirror strips only the exact `[mcp_servers.codex_apps]` section, keeps unrelated MCP servers, and applies the same managed block in runtime and managed-account sync paths, including first-run homes with no existing canonical config.
- No visual change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-config-mirror.test.ts src/main/codex-accounts/service.test.ts`
- [x] `pnpm run typecheck:node`
- [x] Scratch `CODEX_HOME` parser proof with `codex mcp list`
- [x] Scratch `CODEX_HOME` rejection proof for timeout-only `[mcp_servers.codex_apps]`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`

## AI Review Report

- Reviewed the config-mirror flow for Windows, Linux, and WSL paths. The helper stays string-based and uses the existing TOML scanner, so it does not expand the parser surface.
- Confirmed the change is provider-neutral outside Codex. No new subprocesses, no UI code, no auth flow changes, and no account-selection semantics changed.
- Checked idempotence and boundary handling. Exact `[mcp_servers.codex_apps]` is replaced once, unrelated MCP servers stay mirrored, and repeated syncs stay stable.

## Security Audit

- Managed config writes stay inside Orca-owned `CODEX_HOME` and the existing managed-account storage root checks.
- `auth.json` is unchanged by the new helper. The sync path only rewrites config text.
- The change avoids broad MCP parsing and only touches the exact Codex block that the issue reports.

## Notes

- `rtk pnpm` still could not resolve `pnpm` in this checkout, so validation was rerun directly with `pnpm`.
- The Codex parser proof used throwaway `CODEX_HOME` directories under `D:\Repos\orca-codex-proof-*`; the user’s real Codex config was untouched.

Closes #7349
