### PR TITLE
fix(browser): allow trusted embedded popup windows

### DIFF
--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -161,8 +161,33 @@ describe('browserManager', () => {
 
     const handler = guestSetWindowOpenHandlerMock.mock.calls[0][0] as (details: {
       url: string
+      features?: string
     }) => { action: 'allow' | 'deny' }
-    expect(handler({ url: 'https://example.com/login' })).toEqual({ action: 'allow' })
+    expect(handler({ url: 'about:blank' })).toMatchObject({ action: 'allow' })
+    expect(
+      handler({
+        url: 'https://example.com/login',
+        features: 'alwaysOnTop=yes,frame=no,fullscreen=yes,kiosk=yes,modal=yes,transparent=yes'
+      })
+    ).toEqual({
+      action: 'allow',
+      overrideBrowserWindowOptions: {
+        alwaysOnTop: false,
+        closable: true,
+        focusable: true,
+        frame: true,
+        fullscreen: false,
+        kiosk: false,
+        modal: false,
+        movable: true,
+        opacity: 1,
+        show: true,
+        simpleFullscreen: false,
+        skipTaskbar: false,
+        titleBarStyle: 'default',
+        transparent: false
+      }
+    })
 
     expect(shellOpenExternalMock).not.toHaveBeenCalled()
     expect(rendererSendMock).not.toHaveBeenCalled()
@@ -201,6 +226,9 @@ describe('browserManager', () => {
       url: string
     }) => { action: 'allow' | 'deny' }
     expect(handler({ url: 'javascript:alert(1)' })).toEqual({ action: 'deny' })
+    expect(handler({ url: 'file:///etc/passwd' })).toEqual({ action: 'deny' })
+    expect(handler({ url: 'file:///C:/Users/example/.ssh/id_rsa' })).toEqual({ action: 'deny' })
+    expect(handler({ url: 'file://server/share/private.txt' })).toEqual({ action: 'deny' })
 
     expect(shellOpenExternalMock).not.toHaveBeenCalled()
     expect(rendererSendMock).not.toHaveBeenCalledWith(
@@ -900,6 +928,7 @@ describe('browserManager', () => {
   })
 
   it('attaches guest policies to created popup child windows', () => {
+    const rendererSendMock = vi.fn()
     const childSetBackgroundThrottlingMock = vi.fn()
     const childSetWindowOpenHandlerMock = vi.fn()
     const childOnMock = vi.fn()
@@ -925,9 +954,22 @@ describe('browserManager', () => {
       off: guestOffMock,
       openDevTools: guestOpenDevToolsMock
     }
-    webContentsFromIdMock.mockReturnValue(guest)
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
 
     browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
 
     const didCreateWindowHandler = guestOnMock.mock.calls.find(
       ([event]) => event === 'did-create-window'
@@ -943,6 +985,133 @@ describe('browserManager', () => {
     )
     expect(childOnMock.mock.calls.filter(([event]) => event === 'will-navigate')).toHaveLength(1)
     expect(childOnMock.mock.calls.filter(([event]) => event === 'will-redirect')).toHaveLength(1)
+
+    const childWindowOpenHandler = childSetWindowOpenHandlerMock.mock.calls[0][0] as (details: {
+      url: string
+    }) => { action: 'allow' | 'deny' }
+    expect(childWindowOpenHandler({ url: 'https://identity.example.com/login' })).toMatchObject({
+      action: 'allow'
+    })
+    expect(childWindowOpenHandler({ url: 'file:///etc/passwd' })).toEqual({ action: 'deny' })
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:popup', {
+      browserPageId: 'browser-1',
+      origin: 'null',
+      action: 'blocked'
+    })
+    browserManager.notifyPermissionDenied({
+      guestWebContentsId: childGuest.id,
+      permission: 'notifications',
+      rawUrl: 'https://identity.example.com/login'
+    })
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:permission-denied', {
+      browserPageId: 'browser-1',
+      permission: 'notifications',
+      origin: 'https://identity.example.com'
+    })
+
+    const childDidFailLoadHandler = childOnMock.mock.calls.find(
+      ([event]) => event === 'did-fail-load'
+    )?.[1] as
+      | ((
+          event: Electron.Event,
+          errorCode: number,
+          errorDescription: string,
+          validatedURL: string,
+          isMainFrame: boolean
+        ) => void)
+      | undefined
+    childDidFailLoadHandler?.(
+      {} as Electron.Event,
+      -105,
+      'Name not resolved',
+      'https://identity.example.com/unavailable',
+      true
+    )
+    expect(rendererSendMock).not.toHaveBeenCalledWith(
+      'browser:guest-load-failed',
+      expect.anything()
+    )
+
+    const childDownloadItem = createDownloadItem()
+    browserManager.handleGuestWillDownload({
+      guestWebContentsId: childGuest.id,
+      item: childDownloadItem
+    })
+    expect(rendererSendMock).toHaveBeenCalledWith(
+      'browser:download-requested',
+      expect.objectContaining({ browserPageId: 'browser-1' })
+    )
+    const childDownloadDoneHandler = getDownloadItemEventHandler(childDownloadItem, 'once', 'done')
+    childDownloadDoneHandler?.({} as Electron.Event, 'completed')
+
+    const managerState = browserManager as unknown as {
+      popupOwnerContextByGuestId: Map<number, unknown>
+    }
+    expect(managerState.popupOwnerContextByGuestId.has(childGuest.id)).toBe(true)
+
+    const cleanupChildOnMock = vi.fn()
+    const cleanupChildGuest = {
+      ...childGuest,
+      id: 4041,
+      on: cleanupChildOnMock,
+      off: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      setWindowOpenHandler: vi.fn()
+    }
+    const childDidCreateWindowHandler = childOnMock.mock.calls.find(
+      ([event]) => event === 'did-create-window'
+    )?.[1] as ((window: { webContents: typeof cleanupChildGuest }) => void) | undefined
+    childDidCreateWindowHandler?.({ webContents: cleanupChildGuest })
+    expect(managerState.popupOwnerContextByGuestId.has(cleanupChildGuest.id)).toBe(true)
+    const cleanupChildWindowOpenHandler = cleanupChildGuest.setWindowOpenHandler.mock
+      .calls[0][0] as (details: { url: string }) => { action: 'allow' | 'deny' }
+    expect(
+      cleanupChildWindowOpenHandler({ url: 'https://identity.example.com/continue' })
+    ).toMatchObject({ action: 'allow' })
+    const cleanupChildDestroyedHandler = cleanupChildOnMock.mock.calls.find(
+      ([event]) => event === 'destroyed'
+    )?.[1] as (() => void) | undefined
+    cleanupChildDestroyedHandler?.()
+    expect(managerState.popupOwnerContextByGuestId.has(cleanupChildGuest.id)).toBe(false)
+
+    const replacementGuest = {
+      ...guest,
+      id: 405,
+      on: vi.fn(),
+      off: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      setWindowOpenHandler: vi.fn()
+    }
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === replacementGuest.id) {
+        return replacementGuest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
+    browserManager.attachGuestPolicies(replacementGuest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: replacementGuest.id,
+      rendererWebContentsId
+    })
+
+    expect(childWindowOpenHandler({ url: 'https://identity.example.com/next' })).toEqual({
+      action: 'deny'
+    })
+    expect(shellOpenExternalMock).toHaveBeenCalledWith('https://identity.example.com/next')
+    expect(managerState.popupOwnerContextByGuestId.has(childGuest.id)).toBe(false)
+
+    const childDestroyedHandler = childOnMock.mock.calls.find(
+      ([event]) => event === 'destroyed'
+    )?.[1] as (() => void) | undefined
+    childDestroyedHandler?.()
+    expect(managerState.popupOwnerContextByGuestId.has(childGuest.id)).toBe(false)
 
     browserManager.unregisterAll()
 

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1,4 +1,5 @@
 /* oxlint-disable max-lines */
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -129,7 +130,7 @@ describe('browserManager', () => {
     expect(shellOpenExternalMock).toHaveBeenCalledWith('http://localhost:3000/')
   })
 
-  it('routes safe popup URLs into a new Orca browser tab for the owning renderer', () => {
+  it('allows registered safe popup URLs as Electron child windows', () => {
     const rendererSendMock = vi.fn()
     const guest = {
       id: 103,
@@ -160,18 +161,56 @@ describe('browserManager', () => {
 
     const handler = guestSetWindowOpenHandlerMock.mock.calls[0][0] as (details: {
       url: string
-    }) => { action: 'deny' }
-    expect(handler({ url: 'https://example.com/login' })).toEqual({ action: 'deny' })
+    }) => { action: 'allow' | 'deny' }
+    expect(handler({ url: 'https://example.com/login' })).toEqual({ action: 'allow' })
 
     expect(shellOpenExternalMock).not.toHaveBeenCalled()
-    expect(rendererSendMock).toHaveBeenCalledWith('browser:open-link-in-orca-tab', {
-      browserPageId: 'browser-1',
-      url: 'https://example.com/login'
+    expect(rendererSendMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks unsafe popup URLs for registered guests', () => {
+    const rendererSendMock = vi.fn()
+    const guest = {
+      id: 106,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
     })
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+
+    const handler = guestSetWindowOpenHandlerMock.mock.calls[0][0] as (details: {
+      url: string
+    }) => { action: 'allow' | 'deny' }
+    expect(handler({ url: 'javascript:alert(1)' })).toEqual({ action: 'deny' })
+
+    expect(shellOpenExternalMock).not.toHaveBeenCalled()
+    expect(rendererSendMock).not.toHaveBeenCalledWith(
+      'browser:open-link-in-orca-tab',
+      expect.anything()
+    )
     expect(rendererSendMock).toHaveBeenCalledWith('browser:popup', {
       browserPageId: 'browser-1',
-      origin: 'https://example.com',
-      action: 'opened-in-orca'
+      origin: 'null',
+      action: 'blocked'
     })
   })
 
@@ -855,6 +894,61 @@ describe('browserManager', () => {
     expect(guestSetWindowOpenHandlerMock).toHaveBeenCalledTimes(1)
     expect(guestOnMock.mock.calls.filter(([event]) => event === 'will-navigate')).toHaveLength(1)
     expect(guestOnMock.mock.calls.filter(([event]) => event === 'will-redirect')).toHaveLength(1)
+    expect(guestOnMock.mock.calls.filter(([event]) => event === 'did-create-window')).toHaveLength(
+      1
+    )
+  })
+
+  it('attaches guest policies to created popup child windows', () => {
+    const childSetBackgroundThrottlingMock = vi.fn()
+    const childSetWindowOpenHandlerMock = vi.fn()
+    const childOnMock = vi.fn()
+    const childOffMock = vi.fn()
+    const childOpenDevToolsMock = vi.fn()
+    const childGuest = {
+      id: 4040,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: childSetBackgroundThrottlingMock,
+      setWindowOpenHandler: childSetWindowOpenHandlerMock,
+      on: childOnMock,
+      off: childOffMock,
+      openDevTools: childOpenDevToolsMock
+    }
+    const guest = {
+      id: 404,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+
+    const didCreateWindowHandler = guestOnMock.mock.calls.find(
+      ([event]) => event === 'did-create-window'
+    )?.[1] as ((window: { webContents: typeof childGuest }) => void) | undefined
+    expect(didCreateWindowHandler).toBeTypeOf('function')
+
+    didCreateWindowHandler?.({ webContents: childGuest })
+
+    expect(childSetBackgroundThrottlingMock).toHaveBeenCalledWith(false)
+    expect(childSetWindowOpenHandlerMock).toHaveBeenCalledTimes(1)
+    expect(childOnMock.mock.calls.filter(([event]) => event === 'did-create-window')).toHaveLength(
+      1
+    )
+    expect(childOnMock.mock.calls.filter(([event]) => event === 'will-navigate')).toHaveLength(1)
+    expect(childOnMock.mock.calls.filter(([event]) => event === 'will-redirect')).toHaveLength(1)
+
+    browserManager.unregisterAll()
+
+    expect(childOffMock).toHaveBeenCalledWith('did-create-window', expect.any(Function))
+    expect(childOffMock).toHaveBeenCalledWith('will-navigate', expect.any(Function))
+    expect(childOffMock).toHaveBeenCalledWith('will-redirect', expect.any(Function))
   })
 
   it('cleans attached guest policy state when a guest is destroyed before registration', () => {
@@ -1068,11 +1162,11 @@ describe('browserManager', () => {
         origin: 'https://example.com',
         totalBytes: 2048,
         mimeType: 'text/csv',
-        savePath: '/downloads/report.csv',
+        savePath: join('/downloads', 'report.csv'),
         status: 'downloading'
       })
     )
-    expect(item.setSavePath).toHaveBeenCalledWith('/downloads/report.csv')
+    expect(item.setSavePath).toHaveBeenCalledWith(join('/downloads', 'report.csv'))
   })
 
   it('sets the download save path immediately and reports progress and completion', () => {
@@ -1106,7 +1200,7 @@ describe('browserManager', () => {
     })
     browserManager.handleGuestWillDownload({ guestWebContentsId: guest.id, item })
 
-    expect(item.setSavePath).toHaveBeenCalledWith('/downloads/report.csv')
+    expect(item.setSavePath).toHaveBeenCalledWith(join('/downloads', 'report.csv'))
     expect(item.on).toHaveBeenCalledWith('updated', expect.any(Function))
     expect(item.once).toHaveBeenCalledWith('done', expect.any(Function))
     expect(rendererSendMock).toHaveBeenCalledWith(
@@ -1114,7 +1208,7 @@ describe('browserManager', () => {
       expect.objectContaining({
         browserPageId: 'browser-1',
         filename: 'report.csv',
-        savePath: '/downloads/report.csv',
+        savePath: join('/downloads', 'report.csv'),
         status: 'downloading'
       })
     )
@@ -1139,7 +1233,7 @@ describe('browserManager', () => {
       expect.objectContaining({
         browserPageId: 'browser-1',
         status: 'completed',
-        savePath: '/downloads/report.csv',
+        savePath: join('/downloads', 'report.csv'),
         error: null
       })
     )

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -575,22 +575,17 @@ export class BrowserManager {
     // Orca window is not the focused foreground app. With throttling enabled,
     // the compositor stops producing frames and capturePage() returns empty.
     guest.setBackgroundThrottling(false)
+    const handleDidCreateWindow = (window: Electron.BrowserWindow): void => {
+      this.attachGuestPolicies(window.webContents)
+    }
+    guest.on('did-create-window', handleDidCreateWindow)
     guest.setWindowOpenHandler(({ url }) => {
       const browserTabId = this.resolveBrowserTabIdForGuestWebContentsId(guest.id)
       const browserUrl = normalizeBrowserNavigationUrl(url)
       const externalUrl = normalizeExternalBrowserUrl(url)
 
-      // Why: popup-capable guests are required for OAuth and target=_blank
-      // flows, but Orca still does not host child windows itself. For normal
-      // web URLs, route the request into Orca's own browser-tab model first so
-      // the user stays in the IDE. Only fall back to the system browser when
-      // Orca cannot safely host the destination or when the guest is not yet
-      // associated with a trusted browser tab/renderer.
-      if (browserTabId && browserUrl && this.openLinkInOrcaTab(browserTabId, browserUrl)) {
-        this.forwardOrQueuePopupEvent(guest.id, {
-          origin: safeOrigin(browserUrl),
-          action: 'opened-in-orca'
-        })
+      if (browserTabId && browserUrl) {
+        return { action: 'allow' }
       } else if (externalUrl) {
         // Why: a target=_blank click on a Kagi search result page produces a
         // popup URL that still contains the bearer token; redact before
@@ -671,6 +666,7 @@ export class BrowserManager {
       disposeAntiDetection()
       try {
         guest.off('destroyed', handleDestroyed)
+        guest.off('did-create-window', handleDidCreateWindow)
       } catch {
         // guest may already be destroyed
       }
@@ -1774,25 +1770,6 @@ export class BrowserManager {
     })
   }
 
-  private openLinkInOrcaTab(browserTabId: string, rawUrl: string): boolean {
-    const renderer = this.resolveRendererForBrowserTab(browserTabId)
-    if (!renderer) {
-      return false
-    }
-    const normalizedUrl = normalizeBrowserNavigationUrl(rawUrl)
-    if (!normalizedUrl || normalizedUrl === 'about:blank') {
-      return false
-    }
-    // Why: the guest context menu knows which browser tab the click came from,
-    // but only the renderer owns the worktree/tab model. Forward the validated
-    // URL back to that renderer so it can open a sibling Orca browser tab in
-    // the same worktree without letting the guest process mutate app state.
-    renderer.send('browser:open-link-in-orca-tab', {
-      browserPageId: browserTabId,
-      url: normalizedUrl
-    })
-    return true
-  }
 }
 
 export const browserManager = new BrowserManager()

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -5,6 +5,7 @@ in one file avoids scattering the browser security boundary across modules. */
 import { randomUUID } from 'node:crypto'
 
 import { shell, webContents } from 'electron'
+import { ORCA_BROWSER_BLANK_URL } from '../../shared/constants'
 import {
   normalizeBrowserNavigationUrl,
   normalizeExternalBrowserUrl,
@@ -140,6 +141,27 @@ export type BrowserGuestRegistration = {
 type PendingPermissionEvent = Omit<BrowserPermissionDeniedEvent, 'browserPageId'>
 type PendingPopupEvent = Omit<BrowserPopupEvent, 'browserPageId'>
 type BrowserDownloadDoneState = 'completed' | 'cancelled' | 'interrupted'
+type PopupOwnerContext = {
+  browserTabId: string
+  rootGuestWebContentsId: number
+}
+
+const SAFE_POPUP_WINDOW_OPTIONS = {
+  alwaysOnTop: false,
+  closable: true,
+  focusable: true,
+  frame: true,
+  fullscreen: false,
+  kiosk: false,
+  modal: false,
+  movable: true,
+  opacity: 1,
+  show: true,
+  simpleFullscreen: false,
+  skipTaskbar: false,
+  titleBarStyle: 'default',
+  transparent: false
+} satisfies Electron.BrowserWindowConstructorOptions
 
 type ActiveDownload = {
   downloadId: string
@@ -181,6 +203,7 @@ export class BrowserManager {
   // Why: reverse map enables O(1) guest→tab lookups instead of O(N) linear
   // scans on every mouse event, load failure, permission, and popup event.
   private readonly tabIdByWebContentsId = new Map<number, string>()
+  private readonly popupOwnerContextByGuestId = new Map<number, PopupOwnerContext>()
   // Why: guest registration is keyed by browser page id, but renderer
   // visibility/focus state is keyed by browser workspace id. Screenshot prep
   // has to bridge that mismatch to activate the right tab before capture.
@@ -293,7 +316,23 @@ export class BrowserManager {
   }
 
   private resolveBrowserTabIdForGuestWebContentsId(guestWebContentsId: number): string | null {
-    return this.tabIdByWebContentsId.get(guestWebContentsId) ?? null
+    return this.resolvePopupOwnerContext(guestWebContentsId)?.browserTabId ?? null
+  }
+
+  private resolvePopupOwnerContext(guestWebContentsId: number): PopupOwnerContext | null {
+    const browserTabId = this.tabIdByWebContentsId.get(guestWebContentsId)
+    if (browserTabId) {
+      return { browserTabId, rootGuestWebContentsId: guestWebContentsId }
+    }
+    const inherited = this.popupOwnerContextByGuestId.get(guestWebContentsId)
+    if (
+      inherited &&
+      this.webContentsIdByTabId.get(inherited.browserTabId) === inherited.rootGuestWebContentsId
+    ) {
+      return inherited
+    }
+    this.popupOwnerContextByGuestId.delete(guestWebContentsId)
+    return null
   }
 
   private resolveRendererForBrowserTab(browserTabId: string): Electron.WebContents | null {
@@ -558,11 +597,17 @@ export class BrowserManager {
     }
   }
 
-  attachGuestPolicies(guest: Electron.WebContents): void {
+  attachGuestPolicies(
+    guest: Electron.WebContents,
+    inheritedOwnerContext: PopupOwnerContext | null = null
+  ): void {
     if (this.policyAttachedGuestIds.has(guest.id)) {
       return
     }
     this.policyAttachedGuestIds.add(guest.id)
+    if (inheritedOwnerContext) {
+      this.popupOwnerContextByGuestId.set(guest.id, inheritedOwnerContext)
+    }
 
     // Why: Cloudflare Turnstile and similar bot detectors probe browser APIs
     // (navigator.webdriver, plugins, window.chrome) that differ in Electron
@@ -576,7 +621,9 @@ export class BrowserManager {
     // the compositor stops producing frames and capturePage() returns empty.
     guest.setBackgroundThrottling(false)
     const handleDidCreateWindow = (window: Electron.BrowserWindow): void => {
-      this.attachGuestPolicies(window.webContents)
+      // Why: popup descendants inherit the opener's owner context for routing,
+      // but must not replace its primary guest registration.
+      this.attachGuestPolicies(window.webContents, this.resolvePopupOwnerContext(guest.id))
     }
     guest.on('did-create-window', handleDidCreateWindow)
     guest.setWindowOpenHandler(({ url }) => {
@@ -584,8 +631,13 @@ export class BrowserManager {
       const browserUrl = normalizeBrowserNavigationUrl(url)
       const externalUrl = normalizeExternalBrowserUrl(url)
 
-      if (browserTabId && browserUrl) {
-        return { action: 'allow' }
+      // Why: file URLs are valid for user-opened in-pane previews, but remote
+      // content must not create native child windows targeting local paths.
+      const canOpenAsChild = Boolean(externalUrl || browserUrl === ORCA_BROWSER_BLANK_URL)
+      if (browserTabId && canOpenAsChild) {
+        // Why: OAuth may request ordinary size/position features, but browser
+        // content must not create deceptive or inescapable native chrome.
+        return { action: 'allow', overrideBrowserWindowOptions: SAFE_POPUP_WINDOW_OPTIONS }
       } else if (externalUrl) {
         // Why: a target=_blank click on a Kagi search result page produces a
         // popup URL that still contains the bearer token; redact before
@@ -683,17 +735,28 @@ export class BrowserManager {
     // swaps renderer processes. Late events from the dead guest must stop
     // resolving to the live page, or stale download/popup/permission callbacks
     // can be delivered to the wrong session after the swap.
-    this.tabIdByWebContentsId.delete(previousWebContentsId)
     this.cleanupGuestPolicyAttachment(previousWebContentsId)
+    this.tabIdByWebContentsId.delete(previousWebContentsId)
   }
 
   private cleanupGuestPolicyAttachment(guestWebContentsId: number): void {
+    const isPrimaryGuest = this.tabIdByWebContentsId.has(guestWebContentsId)
     const policyCleanup = this.policyCleanupByGuestId.get(guestWebContentsId)
     if (policyCleanup) {
       policyCleanup()
       this.policyCleanupByGuestId.delete(guestWebContentsId)
     }
     this.policyAttachedGuestIds.delete(guestWebContentsId)
+    this.popupOwnerContextByGuestId.delete(guestWebContentsId)
+    // Why: a popup must stop inheriting authorization as soon as its primary
+    // owner is retired, even if Chromium has not destroyed the child yet.
+    if (isPrimaryGuest) {
+      for (const [popupGuestId, owner] of this.popupOwnerContextByGuestId) {
+        if (owner.rootGuestWebContentsId === guestWebContentsId) {
+          this.popupOwnerContextByGuestId.delete(popupGuestId)
+        }
+      }
+    }
     this.pendingLoadFailuresByGuestId.delete(guestWebContentsId)
     this.pendingPermissionEventsByGuestId.delete(guestWebContentsId)
     this.pendingPopupEventsByGuestId.delete(guestWebContentsId)
@@ -879,6 +942,7 @@ export class BrowserManager {
     }
     this.policyCleanupByGuestId.clear()
     this.tabIdByWebContentsId.clear()
+    this.popupOwnerContextByGuestId.clear()
     this.worktreeIdByTabId.clear()
     this.sessionProfileIdByPageId.clear()
     this.pendingLoadFailuresByGuestId.clear()
@@ -1769,7 +1833,6 @@ export class BrowserManager {
       }
     })
   }
-
 }
 
 export const browserManager = new BrowserManager()


### PR DESCRIPTION
## Summary

- Allow trusted embedded browser popup requests to create real Electron popup windows instead of rerouting them into Orca browser tabs.
- Keep unregistered safe popups on the existing external-browser fallback and keep unsafe popup URLs denied with sanitized metadata only.
- Attach the same BrowserManager guest policy to any child popup `WebContents` that Electron creates.

Closes #7374.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-manager.test.ts -t "allows registered safe popup URLs as Electron child windows"` - passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-manager.test.ts -t "falls back to opening popup URLs externally before a guest is registered"` - passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-manager.test.ts -t "blocks unsafe popup URLs for registered guests"` - passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-manager.test.ts -t "attaches guest policies to created popup child windows"` - passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-manager.test.ts` - passed.
- `pnpm run typecheck:node` - passed.

## AI Review Report

No issues found in the final diff review.
- Platform coverage: popup policy stays in BrowserManager and uses Electron's child-window lifecycle, which is shared across macOS, Linux, and Windows.
- SSH, terminal, provider integration, command execution, filesystem, and visual UI paths are unchanged.
- The allow path only applies to registered guests that normalize to a browser URL.

## Security Audit

No new security issues found.
- Popup URL validation stays centralized through `normalizeBrowserNavigationUrl`.
- Unregistered safe URLs still use the redacted external handoff path.
- Unsafe URLs, including `javascript:alert(1)`, still deny with sanitized origin metadata.
- Child popup `WebContents` inherits BrowserManager navigation guards and anti-detection setup through `attachGuestPolicies`.

## Notes

No visual change. Out of scope: claiming that every OAuth provider accepts Electron embedded browsers. Some providers can still reject embedded user agents independently of popup support.
