### PR TITLE
fix(worktrees): fall back from stale default base refs

### DIFF
--- a/src/main/git/repo.test.ts
+++ b/src/main/git/repo.test.ts
@@ -10,6 +10,7 @@ import {
   getBranchConflictKind,
   getRemoteCount,
   parseAndFilterSearchRefDetails,
+  resolveDefaultBaseRefViaExec,
   searchBaseRefDetails,
   searchBaseRefs
 } from './repo'
@@ -493,6 +494,26 @@ describe('getDefaultBaseRef (regression — unchanged behavior)', () => {
     expect(result).toBe('origin/main')
   })
 
+  it('falls through from a stale origin/HEAD target to an existing primary ref', () => {
+    const sha = getHeadSha(tmpDir)
+    createRemoteRef(tmpDir, 'origin/main', sha)
+    git(tmpDir, ['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/master'])
+
+    const result = getDefaultBaseRef(tmpDir)
+
+    expect(result).toBe('origin/main')
+  })
+
+  it('falls through from a stale origin/HEAD primary target to another existing default ref', () => {
+    const sha = getHeadSha(tmpDir)
+    createRemoteRef(tmpDir, 'origin/master', sha)
+    git(tmpDir, ['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/main'])
+
+    const result = getDefaultBaseRef(tmpDir)
+
+    expect(result).toBe('origin/master')
+  })
+
   it('does NOT fall through to upstream/main when origin/* is absent', () => {
     // Why: this is the explicit design decision — the default probe order
     // is origin-only. upstream-aware defaulting is deferred work.
@@ -505,6 +526,53 @@ describe('getDefaultBaseRef (regression — unchanged behavior)', () => {
     // we expect the local `main` — NOT `upstream/main`.
     expect(result).toBe('main')
     expect(result).not.toBe('upstream/main')
+  })
+})
+
+describe('resolveDefaultBaseRefViaExec', () => {
+  it('falls through from a stale origin/HEAD target to the probe list', async () => {
+    const calls: string[][] = []
+    const exec = async (argv: string[]): Promise<{ stdout: string }> => {
+      calls.push(argv)
+      if (argv[0] === 'symbolic-ref') {
+        return { stdout: 'refs/remotes/origin/master\n' }
+      }
+      if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/remotes/origin/main') {
+        return { stdout: 'main-sha\n' }
+      }
+      throw new Error('missing ref')
+    }
+
+    await expect(resolveDefaultBaseRefViaExec(exec)).resolves.toBe('origin/main')
+
+    expect(calls).toEqual([
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/master'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main']
+    ])
+  })
+
+  it('verifies origin/HEAD even when it points at origin/main', async () => {
+    const calls: string[][] = []
+    const exec = async (argv: string[]): Promise<{ stdout: string }> => {
+      calls.push(argv)
+      if (argv[0] === 'symbolic-ref') {
+        return { stdout: 'refs/remotes/origin/main\n' }
+      }
+      if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/remotes/origin/master') {
+        return { stdout: 'master-sha\n' }
+      }
+      throw new Error('missing ref')
+    }
+
+    await expect(resolveDefaultBaseRefViaExec(exec)).resolves.toBe('origin/master')
+
+    expect(calls).toEqual([
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/master']
+    ])
   })
 })
 

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -467,6 +467,24 @@ function hasGitRef(path: string, ref: string): boolean {
   }
 }
 
+function gitRefToDefaultBaseRef(ref: string): string {
+  return ref.replace(/^refs\/remotes\//, '')
+}
+
+function getVerifiedOriginHeadBaseRef(path: string): string | null {
+  try {
+    const ref = gitExecFileSync(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'], {
+      cwd: path
+    }).trim()
+
+    // Why: origin/HEAD may survive a default-branch rename while pointing at a
+    // deleted ref; verify before trusting it over the probe list.
+    return ref && hasGitRef(path, ref) ? gitRefToDefaultBaseRef(ref) : null
+  } catch {
+    return null
+  }
+}
+
 /**
  * Resolve the default base ref for new worktrees.
  * Prefer the remote primary branch over a potentially stale local branch.
@@ -478,16 +496,9 @@ function hasGitRef(path: string, ref: string): boolean {
  * degrade gracefully for non-creation uses (e.g. hosted URL building).
  */
 export function getDefaultBaseRef(path: string): string | null {
-  try {
-    const ref = gitExecFileSync(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'], {
-      cwd: path
-    }).trim()
-
-    if (ref) {
-      return ref.replace(/^refs\/remotes\//, '')
-    }
-  } catch {
-    // Fall through to explicit remote branch probes.
+  const originHeadBaseRef = getVerifiedOriginHeadBaseRef(path)
+  if (originHeadBaseRef) {
+    return originHeadBaseRef
   }
 
   // Why: walk the shared DEFAULT_BASE_REF_PROBES list so the sync path and the
@@ -595,6 +606,28 @@ export async function getRemoteCount(path: string): Promise<number> {
 /** Callback shape for a git exec function that yields stdout. */
 export type GitExec = (argv: string[]) => Promise<{ stdout: string }>
 
+async function hasGitRefViaExec(exec: GitExec, ref: string): Promise<boolean> {
+  try {
+    await exec(['rev-parse', '--verify', '--quiet', ref])
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function resolveVerifiedOriginHeadBaseRefViaExec(exec: GitExec): Promise<string | null> {
+  try {
+    const { stdout } = await exec(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'])
+    const ref = stdout.trim()
+    if (!ref || !(await hasGitRefViaExec(exec, ref))) {
+      return null
+    }
+    return gitRefToDefaultBaseRef(ref)
+  } catch {
+    return null
+  }
+}
+
 /**
  * Resolve the default base ref given a git exec callback. Prefers
  * origin/HEAD's symbolic-ref target; falls back to DEFAULT_BASE_REF_PROBES.
@@ -609,24 +642,11 @@ export type GitExec = (argv: string[]) => Promise<{ stdout: string }>
  * from a genuine transport failure.
  */
 export async function resolveDefaultBaseRefViaExec(exec: GitExec): Promise<string | null> {
-  try {
-    const { stdout } = await exec(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'])
-    const ref = stdout.trim()
-    if (ref) {
-      return ref.replace(/^refs\/remotes\//, '')
-    }
-  } catch {
-    // symbolic-ref returns non-zero when origin/HEAD is unset — expected.
-    // Fall through to probes.
+  const originHeadBaseRef = await resolveVerifiedOriginHeadBaseRefViaExec(exec)
+  if (originHeadBaseRef) {
+    return originHeadBaseRef
   }
-  return resolveDefaultBaseRefFromProbes(async (ref) => {
-    try {
-      await exec(['rev-parse', '--verify', '--quiet', ref])
-      return true
-    } catch {
-      return false
-    }
-  })
+  return resolveDefaultBaseRefFromProbes((ref) => hasGitRefViaExec(exec, ref))
 }
 
 async function getDefaultBaseRefAsync(

--- a/src/main/git/worktree-base-ref-probe.ts
+++ b/src/main/git/worktree-base-ref-probe.ts
@@ -10,11 +10,14 @@ export async function hasWorktreeBaseCommitRef(
   options: GitExecOptions = {}
 ): Promise<boolean> {
   try {
-    await gitExecFileAsync(['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`], {
-      cwd: repoPath,
-      ...options
-    })
-    return true
+    const { stdout } = await gitExecFileAsync(
+      ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
+      {
+        cwd: repoPath,
+        ...options
+      }
+    )
+    return stdout.trim().length > 0
   } catch {
     return false
   }

--- a/src/main/ipc/ssh-worktree-create-root-registration.ts
+++ b/src/main/ipc/ssh-worktree-create-root-registration.ts
@@ -1,0 +1,50 @@
+import { getActiveMultiplexer } from './ssh'
+
+const SSH_CONNECTION_UNAVAILABLE_MESSAGE =
+  'SSH connection is not available. Please reconnect and try again.'
+
+type SshRootRegistrationMux = {
+  request: (method: 'session.registerRoot', payload: { rootPath: string }) => Promise<unknown>
+  notify: (method: 'session.registerRoot', payload: { rootPath: string }) => void
+}
+
+async function registerSshWorktreeCreateRoots(
+  mux: SshRootRegistrationMux,
+  rootPaths: string[]
+): Promise<void> {
+  try {
+    await Promise.all(
+      rootPaths.map((rootPath) => mux.request('session.registerRoot', { rootPath }))
+    )
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('Method not found')) {
+      for (const rootPath of rootPaths) {
+        mux.notify('session.registerRoot', { rootPath })
+      }
+      return
+    }
+    throw err
+  }
+}
+
+export async function registerOptionalSshWorktreeCreateRoots(
+  connectionId: string,
+  rootPaths: string[]
+): Promise<void> {
+  const mux = getActiveMultiplexer(connectionId)
+  if (!mux) {
+    return
+  }
+  await registerSshWorktreeCreateRoots(mux, rootPaths)
+}
+
+export async function registerRequiredSshWorktreeCreateRoots(
+  connectionId: string,
+  rootPaths: string[]
+): Promise<void> {
+  const mux = getActiveMultiplexer(connectionId)
+  if (!mux) {
+    throw new Error(SSH_CONNECTION_UNAVAILABLE_MESSAGE)
+  }
+  await registerSshWorktreeCreateRoots(mux, rootPaths)
+}

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -30,6 +30,8 @@ import type { AddWorktreeOptions, AddWorktreeResult } from '../git/worktree'
 import { getBranchConflictKind, resolveDefaultBaseRefViaExec } from '../git/repo'
 import { resolveLocalGitUsername } from '../git/git-username'
 import { hasCommitObjectViaGitExec } from '../git/commit-object-ref'
+import { resolveWorktreeCreateBase } from '../worktree-create-base'
+import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
 import type { ForgeProviderId } from '../source-control/forge-provider'
 import { validateGitPushTarget } from '../git/push-target-validation'
@@ -608,6 +610,35 @@ function hasLocalCommitObjectWithOptions(
   )
 }
 
+async function hasLocalWorktreeBaseRefWithOptions(
+  repoPath: string,
+  baseRef: string,
+  gitOptions: { wslDistro?: string }
+): Promise<boolean> {
+  const refExists = async (qualifiedRef: string) => {
+    try {
+      const { stdout } = await gitExecFileAsync(
+        ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
+        {
+          cwd: repoPath,
+          ...gitOptions
+        }
+      )
+      return stdout.trim().length > 0
+    } catch {
+      return false
+    }
+  }
+  const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
+  if (resolvedBaseRef !== baseRef) {
+    return true
+  }
+  if (baseRef.startsWith('refs/')) {
+    return refExists(baseRef)
+  }
+  return hasLocalCommitObjectWithOptions(repoPath, baseRef, gitOptions)
+}
+
 function getLocalGitHubPrForBranch(
   repoPath: string,
   branchName: string,
@@ -624,6 +655,23 @@ function hasRemoteCommitObject(
   ref: string
 ): Promise<boolean> {
   return hasCommitObjectViaGitExec((gitArgs) => provider.exec(gitArgs, repoPath), ref)
+}
+
+async function hasRemoteWorktreeBaseRef(
+  provider: SshGitProvider,
+  repoPath: string,
+  baseRef: string
+): Promise<boolean> {
+  const refExists = (qualifiedRef: string) =>
+    hasRemoteTrackingRefSsh(provider, repoPath, qualifiedRef)
+  const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
+  if (resolvedBaseRef !== baseRef) {
+    return true
+  }
+  if (baseRef.startsWith('refs/')) {
+    return refExists(baseRef)
+  }
+  return hasRemoteCommitObject(provider, repoPath, baseRef)
 }
 
 // Why: hasRemoteCommitObject only resolves full SHAs; a remote-tracking base is
@@ -1218,33 +1266,28 @@ async function resolveRemoteTrackingBaseSsh(
   }
 }
 
-async function resolveRemoteWorktreeCreateBase(
-  provider: SshGitProvider,
-  repo: Repo,
-  requestedBaseBranch: string | undefined
-): Promise<string | null> {
-  let baseBranch = requestedBaseBranch || repo.worktreeBaseRef
-  if (baseBranch) {
-    return baseBranch
-  }
-  try {
-    const { stdout } = await provider.exec(
-      ['symbolic-ref', 'refs/remotes/origin/HEAD', '--short'],
-      repo.path
-    )
-    baseBranch = stdout.trim()
-  } catch {
-    return null
-  }
-  return baseBranch || null
-}
-
 async function resolveRemoteWorktreeCreateBasePlan(
   provider: SshGitProvider,
   repo: Repo,
   requestedBaseBranch: string | undefined
 ): Promise<RemoteWorktreeCreateBasePlan | null> {
-  const baseBranch = await resolveRemoteWorktreeCreateBase(provider, repo, requestedBaseBranch)
+  const baseBranch = await resolveWorktreeCreateBase({
+    requestedBaseBranch,
+    repoWorktreeBaseRef: repo.worktreeBaseRef,
+    resolveDefaultBaseRef: () =>
+      resolveDefaultBaseRefViaExec((argv) => provider.exec(argv, repo.path)),
+    isBaseUsable: async (baseBranchCandidate) => {
+      const remoteTrackingBase = await resolveRemoteTrackingBaseSsh(
+        provider,
+        repo.path,
+        baseBranchCandidate
+      )
+      if (remoteTrackingBase) {
+        return hasRemoteTrackingRefSsh(provider, repo.path, remoteTrackingBase.ref)
+      }
+      return hasRemoteWorktreeBaseRef(provider, repo.path, baseBranchCandidate)
+    }
+  })
   if (!baseBranch) {
     return null
   }
@@ -1288,7 +1331,7 @@ export async function prefetchRemoteWorktreeCreateBase(
     await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, basePlan.remoteTrackingBase)
     return
   }
-  if (await hasRemoteCommitObject(provider, repo.path, basePlan.baseBranch)) {
+  if (await hasRemoteWorktreeBaseRef(provider, repo.path, basePlan.baseBranch)) {
     // Why: PR/MR resolvers already fetched verified SHA start points. A broad
     // remote fetch only updates unrelated refs when the commit object exists.
     return
@@ -1633,7 +1676,7 @@ export async function createRemoteWorktree(
         )
       }
     }
-  } else if (!(await hasRemoteCommitObject(provider, repo.path, baseBranch))) {
+  } else if (!(await hasRemoteWorktreeBaseRef(provider, repo.path, baseBranch))) {
     // Why: local or otherwise non-remote-tracking bases preserve legacy
     // best-effort fetch behavior. Verified PR/MR SHA bases already have the
     // commit object locally, so a broad remote fetch only updates unrelated refs.
@@ -1914,15 +1957,35 @@ export async function createLocalWorktree(
     ? sanitizeWorktreeDisplayName(args.displayName)
     : undefined
 
-  // Why: resolve the base before branch/path selection so remote-tracking bases
-  // can be refreshed before `git worktree add`. Creating first and repairing
-  // later races setup scripts, agents, and user edits.
-  const baseBranch =
-    args.baseBranch ||
-    repo.worktreeBaseRef ||
-    (await resolveDefaultBaseRefViaExec((argv) => gitExecFileAsync(argv, localGitExecOptions)))
+  const baseBranch = await resolveWorktreeCreateBase({
+    requestedBaseBranch: args.baseBranch,
+    repoWorktreeBaseRef: repo.worktreeBaseRef,
+    resolveDefaultBaseRef: () =>
+      resolveDefaultBaseRefViaExec((argv) => gitExecFileAsync(argv, localGitExecOptions)),
+    isBaseUsable: async (baseBranchCandidate) => {
+      if (runtime) {
+        const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
+          repo.path,
+          baseBranchCandidate,
+          ...localWorktreeGitOptionArgs
+        )
+        if (remoteTrackingBase) {
+          return runtime.hasRemoteTrackingRef(
+            repo.path,
+            remoteTrackingBase,
+            ...localWorktreeGitOptionArgs
+          )
+        }
+      }
+      return hasLocalWorktreeBaseRefWithOptions(
+        repo.path,
+        baseBranchCandidate,
+        localGitExecOptions
+      )
+    }
+  })
   if (!baseBranch) {
-    // Why: getDefaultBaseRef may return null when none of origin/HEAD,
+    // Why: resolveDefaultBaseRefViaExec may return null when none of origin/HEAD,
     // origin/main, origin/master, local main, or local master exist. Don't
     // fall back to a hardcoded 'origin/main' — passing a non-existent ref to
     // `git worktree add` produces an opaque error. Fail here with a clear
@@ -1963,7 +2026,7 @@ export async function createLocalWorktree(
         )
       }
     } else if (
-      !(await hasLocalCommitObjectWithOptions(repo.path, baseBranch, localWorktreeGitOptions))
+      !(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))
     ) {
       // Why: when the base branch does not match a configured remote prefix
       // (e.g. plain `main`, `master`, or any local branch), the legacy path
@@ -1976,7 +2039,7 @@ export async function createLocalWorktree(
       emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
     }
   } else {
-    if (!(await hasLocalCommitObjectWithOptions(repo.path, baseBranch, localWorktreeGitOptions))) {
+    if (!(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))) {
       legacyFetchPromise = gitExecFileAsync(['fetch', 'origin'], {
         ...localGitExecOptions,
         timeout: CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -55,12 +55,15 @@ import {
 } from '../hooks'
 import { requireSshGitProvider } from '../providers/ssh-git-dispatch'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
-import { getActiveMultiplexer } from './ssh'
 import type { SshGitProvider } from '../providers/ssh-git-provider'
 import { TUI_AGENT_CONFIG, isTuiAgent } from '../../shared/tui-agent-config'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { getSshGitUsername } from '../git/git-username'
 import { runWorktreeChangeInvalidators } from './worktree-change-invalidators'
+import {
+  registerOptionalSshWorktreeCreateRoots,
+  registerRequiredSshWorktreeCreateRoots
+} from './ssh-worktree-create-root-registration'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -1283,7 +1286,10 @@ async function resolveRemoteWorktreeCreateBasePlan(
         baseBranchCandidate
       )
       if (remoteTrackingBase) {
-        return hasRemoteTrackingRefSsh(provider, repo.path, remoteTrackingBase.ref)
+        if (await hasRemoteTrackingRefSsh(provider, repo.path, remoteTrackingBase.ref)) {
+          return true
+        }
+        return hasRemoteWorktreeBaseRef(provider, repo.path, baseBranchCandidate)
       }
       return hasRemoteWorktreeBaseRef(provider, repo.path, baseBranchCandidate)
     }
@@ -1323,13 +1329,21 @@ export async function prefetchRemoteWorktreeCreateBase(
   repo: Repo,
   args: { baseBranch?: string }
 ): Promise<void> {
+  // Why: the shared base-plan probes use generic git.exec, and some relays
+  // require the repo root to be registered before those probes can see refs.
+  await registerOptionalSshWorktreeCreateRoots(repo.connectionId!, [repo.path])
   const basePlan = await getOrStartRemoteWorktreeCreateBasePlan(provider, repo, args.baseBranch)
   if (!basePlan) {
     return
   }
   if (basePlan.remoteTrackingBase) {
-    await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, basePlan.remoteTrackingBase)
-    return
+    if (
+      (await hasRemoteTrackingRefSsh(provider, repo.path, basePlan.remoteTrackingBase.ref)) ||
+      !(await hasRemoteWorktreeBaseRef(provider, repo.path, basePlan.baseBranch))
+    ) {
+      await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, basePlan.remoteTrackingBase)
+      return
+    }
   }
   if (await hasRemoteWorktreeBaseRef(provider, repo.path, basePlan.baseBranch)) {
     // Why: PR/MR resolvers already fetched verified SHA start points. A broad
@@ -1514,6 +1528,10 @@ export async function createRemoteWorktree(
     ? sanitizeWorktreeDisplayName(args.displayName)
     : undefined
 
+  // Why: resolving the create base can probe repo refs through generic git.exec.
+  // Register the repo root first so relays do not report a valid base as stale.
+  await registerRequiredSshWorktreeCreateRoots(repo.connectionId!, [repo.path])
+
   // Why: SSH targets cannot use the local `gh` account, and git email/name are
   // commit author identity rather than hosted-account usernames.
   const username = await getSshGitUsername(provider, repo.path)
@@ -1531,7 +1549,8 @@ export async function createRemoteWorktree(
       'Could not resolve a default base ref for this repo. Pick a base branch explicitly and try again.'
     )
   }
-  const { baseBranch, remoteTrackingBase } = basePlan
+  const { baseBranch } = basePlan
+  let { remoteTrackingBase } = basePlan
 
   let branchName = ''
   let checkoutExistingBranch = false
@@ -1637,25 +1656,20 @@ export async function createRemoteWorktree(
     }
   }
 
-  const mux = getActiveMultiplexer(repo.connectionId!)
-  if (!mux) {
-    throw new Error('SSH connection is not available. Please reconnect and try again.')
-  }
-  // Why: register before any generic git.exec probe (base-ref existence, the
-  // local-base advisory) as well as addWorktree. Fresh/older relays may gate
-  // generic git.exec on registered roots; probing first would falsely report a
-  // ref missing (and defeat the offline fallback below) even though create works.
-  try {
-    await Promise.all([
-      mux.request('session.registerRoot', { rootPath: repo.path }),
-      mux.request('session.registerRoot', { rootPath: remotePath })
-    ])
-  } catch (err) {
-    if (err instanceof Error && err.message.includes('Method not found')) {
-      mux.notify('session.registerRoot', { rootPath: repo.path })
-      mux.notify('session.registerRoot', { rootPath: remotePath })
-    } else {
-      throw err
+  // Why: addWorktree and setup probes run inside the new worktree path; older
+  // relays need that root registered before accepting git/fs operations there.
+  await registerRequiredSshWorktreeCreateRoots(repo.connectionId!, [remotePath])
+
+  if (remoteTrackingBase) {
+    const hasRemoteTrackingBaseRef = await hasRemoteTrackingRefSsh(
+      provider,
+      repo.path,
+      remoteTrackingBase.ref
+    )
+    const hasLocalBaseRef =
+      hasRemoteTrackingBaseRef || (await hasRemoteWorktreeBaseRef(provider, repo.path, baseBranch))
+    if (!hasRemoteTrackingBaseRef && hasLocalBaseRef) {
+      remoteTrackingBase = null
     }
   }
 
@@ -1970,18 +1984,23 @@ export async function createLocalWorktree(
           ...localWorktreeGitOptionArgs
         )
         if (remoteTrackingBase) {
-          return runtime.hasRemoteTrackingRef(
+          if (
+            await runtime.hasRemoteTrackingRef(
+              repo.path,
+              remoteTrackingBase,
+              ...localWorktreeGitOptionArgs
+            )
+          ) {
+            return true
+          }
+          return hasLocalWorktreeBaseRefWithOptions(
             repo.path,
-            remoteTrackingBase,
-            ...localWorktreeGitOptionArgs
+            baseBranchCandidate,
+            localGitExecOptions
           )
         }
       }
-      return hasLocalWorktreeBaseRefWithOptions(
-        repo.path,
-        baseBranchCandidate,
-        localGitExecOptions
-      )
+      return hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranchCandidate, localGitExecOptions)
     }
   })
   if (!baseBranch) {
@@ -2010,20 +2029,27 @@ export async function createLocalWorktree(
       ...localWorktreeGitOptionArgs
     )
     if (remoteTrackingBase) {
-      const hasLocalBaseRef = await runtime.hasRemoteTrackingRef(
+      const hasRemoteTrackingBaseRef = await runtime.hasRemoteTrackingRef(
         repo.path,
         remoteTrackingBase,
         ...localWorktreeGitOptionArgs
       )
-      emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
-      remoteTrackingRefresh = {
-        base: remoteTrackingBase,
-        hadLocalBaseRef: hasLocalBaseRef,
-        promise: runtime.getOrStartRemoteTrackingBaseRefresh(
-          repo.path,
-          remoteTrackingBase,
-          ...localWorktreeGitOptionArgs
-        )
+      const hasLocalBaseRef =
+        hasRemoteTrackingBaseRef ||
+        (await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localGitExecOptions))
+      if (!hasRemoteTrackingBaseRef && hasLocalBaseRef) {
+        remoteTrackingBase = null
+      } else {
+        emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
+        remoteTrackingRefresh = {
+          base: remoteTrackingBase,
+          hadLocalBaseRef: hasRemoteTrackingBaseRef,
+          promise: runtime.getOrStartRemoteTrackingBaseRefresh(
+            repo.path,
+            remoteTrackingBase,
+            ...localWorktreeGitOptionArgs
+          )
+        }
       }
     } else if (
       !(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))
@@ -2039,7 +2065,9 @@ export async function createLocalWorktree(
       emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
     }
   } else {
-    if (!(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))) {
+    if (
+      !(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))
+    ) {
       legacyFetchPromise = gitExecFileAsync(['fetch', 'origin'], {
         ...localGitExecOptions,
         timeout: CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3812,6 +3812,160 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('keeps a usable SSH persisted local branch base after registering the repo root', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'develop'
+    }
+    let repoRootRegistered = false
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'config') {
+          return { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/heads/develop^{commit}')) {
+          return { stdout: repoRootRegistered ? 'develop-sha\n' : '', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/local-branch-base',
+          head: 'develop-sha',
+          branch: 'refs/heads/local-branch-base',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi
+        .fn()
+        .mockImplementation(async (_method: string, payload: { rootPath: string }) => {
+          if (payload.rootPath === repo.path) {
+            repoRootRegistered = true
+          }
+        }),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'local-branch-base'
+    })
+
+    expect(mux.request).toHaveBeenCalledWith('session.registerRoot', { rootPath: repo.path })
+    expect(provider.fetchRemoteTrackingRef).not.toHaveBeenCalled()
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/repo',
+      'local-branch-base',
+      '/remote/local-branch-base',
+      {
+        base: 'develop'
+      }
+    )
+  })
+
+  it('keeps a usable SSH slash-named local branch base that matches a remote prefix', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'team/feature'
+    }
+    let repoRootRegistered = false
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'config') {
+          return { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'remote') {
+          return { stdout: 'team\norigin\n', stderr: '' }
+        }
+        if (args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main')) {
+          return { stdout: 'main-sha\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/remotes/team/feature^{commit}')) {
+          return { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/heads/team/feature^{commit}')) {
+          return { stdout: repoRootRegistered ? 'team-feature-sha\n' : '', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/slash-local-base',
+          head: 'team-feature-sha',
+          branch: 'refs/heads/slash-local-base',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi
+        .fn()
+        .mockImplementation(async (_method: string, payload: { rootPath: string }) => {
+          if (payload.rootPath === repo.path) {
+            repoRootRegistered = true
+          }
+        }),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'slash-local-base'
+    })
+
+    expect(provider.fetchRemoteTrackingRef).not.toHaveBeenCalledWith(
+      '/remote/repo',
+      'team',
+      'feature',
+      'refs/remotes/team/feature'
+    )
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/repo',
+      'slash-local-base',
+      '/remote/slash-local-base',
+      {
+        base: 'team/feature'
+      }
+    )
+  })
+
   it('reuses a fresh SSH remote-tracking base refresh for repeated creates', async () => {
     const repo = {
       id: 'repo-ssh',
@@ -4012,6 +4166,160 @@ describe('registerWorktreeHandlers', () => {
 
     expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledTimes(1)
     expect(provider.addWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it('registers the SSH repo root before create-base prefetch probes refs', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/master'
+    }
+    const registeredRoots = new Set<string>()
+    const events: string[] = []
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        events.push(`exec:${args[0]}:${registeredRoots.has('/remote/repo')}`)
+        if (!registeredRoots.has('/remote/repo')) {
+          throw new Error('root not registered')
+        }
+        if (args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+        }
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/master^{commit}')) {
+          throw new Error('missing stale base')
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
+          return { stdout: 'main-sha\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/prefetched-worktree',
+          head: 'abc123',
+          branch: 'refs/heads/prefetched-worktree',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi
+        .fn()
+        .mockImplementation(async (_method: string, payload: { rootPath: string }) => {
+          events.push(`register:${payload.rootPath}`)
+          registeredRoots.add(payload.rootPath)
+        }),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-ssh'
+    })
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'prefetched-worktree'
+    })
+
+    expect(events[0]).toBe('register:/remote/repo')
+    expect(events).not.toContain('exec:symbolic-ref:false')
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/repo',
+      'prefetched-worktree',
+      '/remote/prefetched-worktree',
+      {
+        base: 'origin/main'
+      }
+    )
+  })
+
+  it('does not let SSH prefetch turn a persisted slash-named local branch into a remote-tracking base', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'team/feature'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+        }
+        if (args[0] === 'remote') {
+          return { stdout: 'team\norigin\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main')) {
+          return { stdout: 'main-sha\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/remotes/team/feature^{commit}')) {
+          throw new Error('missing remote-tracking ref')
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/heads/team/feature^{commit}')) {
+          return { stdout: 'team-feature-sha\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/slash-local-base',
+          head: 'team-feature-sha',
+          branch: 'refs/heads/slash-local-base',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-ssh'
+    })
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'slash-local-base'
+    })
+
+    expect(provider.fetchRemoteTrackingRef).not.toHaveBeenCalledWith(
+      '/remote/repo',
+      'team',
+      'feature',
+      'refs/remotes/team/feature'
+    )
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/repo',
+      'slash-local-base',
+      '/remote/slash-local-base',
+      {
+        base: 'team/feature'
+      }
+    )
   })
 
   it('shares in-flight SSH create-base resolution with create', async () => {
@@ -4418,6 +4726,64 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/improve-dashboard',
       'improve-dashboard',
       'develop',
+      false
+    )
+  })
+
+  it('keeps a usable persisted slash-named local branch base that matches a remote prefix', async () => {
+    const remoteBase = {
+      remote: 'team',
+      branch: 'feature',
+      ref: 'refs/remotes/team/feature',
+      base: 'team/feature'
+    }
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: 'team/feature'
+    })
+    runtimeStub.resolveRemoteTrackingBase.mockImplementation(async (_repoPath, baseBranch) =>
+      baseBranch === 'team/feature' ? remoteBase : null
+    )
+    runtimeStub.hasRemoteTrackingRef.mockResolvedValue(false)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/slash-local-base',
+        head: 'created-sha',
+        branch: 'slash-local-base',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/team/feature^{commit}')) {
+        throw new Error('missing remote-tracking ref')
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/heads/team/feature^{commit}')) {
+        return { stdout: 'team-feature-sha\n', stderr: '' }
+      }
+      if (args[0] === 'fetch') {
+        throw new Error('network unavailable')
+      }
+      return { stdout: 'created-sha\n', stderr: '' }
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'slash-local-base'
+      })
+    ).resolves.toEqual(expect.objectContaining({ worktree: expect.any(Object) }))
+
+    expect(runtimeStub.getOrStartRemoteTrackingBaseRefresh).not.toHaveBeenCalled()
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/slash-local-base',
+      'slash-local-base',
+      'team/feature',
       false
     )
   })

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -493,16 +493,32 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('prefetches the local default create base through the runtime refresh cache', async () => {
+    const repo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: 'origin/master'
+    }
     const remoteBase = {
       remote: 'origin',
       branch: 'main',
       ref: 'refs/remotes/origin/main',
       base: 'origin/main'
     }
-    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+    store.getRepo.mockReturnValue(repo)
+    runtimeStub.resolveRemoteTrackingBase.mockImplementation(async (_repoPath, baseBranch) =>
+      baseBranch === 'origin/main' ? remoteBase : null
+    )
+    runtimeStub.hasRemoteTrackingRef.mockResolvedValue(true)
 
     await handlers['worktrees:prefetchCreateBase'](null, { repoId: 'repo-1' })
 
+    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'origin/master'
+    )
     expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledWith(
       '/workspace/repo',
       'origin/main'
@@ -3668,7 +3684,7 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
-  it('does not create an SSH worktree when the refresh fails and no local base ref exists', async () => {
+  it('keeps an explicit SSH base strict when refresh fails and no local base ref exists', async () => {
     const repo = {
       id: 'repo-ssh',
       path: '/remote/repo',
@@ -3679,7 +3695,6 @@ describe('registerWorktreeHandlers', () => {
       worktreeBaseRef: 'origin/main'
     }
     const provider = {
-      // Empty rev-parse stdout -> no local remote-tracking base ref to fall back on.
       exec: vi.fn().mockImplementation(async (args: string[]) => {
         if (args[0] === 'remote') {
           return { stdout: 'origin\n', stderr: '' }
@@ -3705,24 +3720,26 @@ describe('registerWorktreeHandlers', () => {
     await expect(
       handlers['worktrees:create'](null, {
         repoId: 'repo-ssh',
-        name: 'improve-dashboard'
+        name: 'improve-dashboard',
+        baseBranch: 'origin/master'
       })
     ).rejects.toThrow(
-      'Could not refresh base ref "origin/main" from "origin". Check your network and try again.'
+      'Could not refresh base ref "origin/master" from "origin". Check your network and try again.'
     )
 
     expect(provider.addWorktree).not.toHaveBeenCalled()
+    expect(resolveDefaultBaseRefViaExecMock).not.toHaveBeenCalled()
     expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledWith(
       '/remote/repo',
       'origin',
-      'main',
-      'refs/remotes/origin/main'
+      'master',
+      'refs/remotes/origin/master'
     )
   })
 
-  it('creates an SSH worktree from an existing local base ref when the refresh fails', async () => {
-    // Regression: a failed SSH refresh must fall back to an existing local
-    // remote-tracking base ref instead of blocking creation.
+  it('creates an SSH worktree from the detected default base when the persisted base is stale', async () => {
+    // Regression: a stale persisted repo base must fall back to the detected
+    // primary default instead of blocking creation.
     const repo = {
       id: 'repo-ssh',
       path: '/remote/repo',
@@ -3730,20 +3747,25 @@ describe('registerWorktreeHandlers', () => {
       badgeColor: '#000',
       addedAt: 0,
       connectionId: 'conn-1',
-      worktreeBaseRef: 'origin/main'
+      worktreeBaseRef: 'origin/master'
     }
     const provider = {
       exec: vi.fn().mockImplementation(async (args: string[]) => {
         if (args[0] === 'remote') {
           return { stdout: 'origin\n', stderr: '' }
         }
-        // Local remote-tracking base ref resolves -> usable fallback exists.
+        if (args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/master^{commit}')) {
+          return { stdout: '', stderr: '' }
+        }
         if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
           return { stdout: `${'a'.repeat(40)}\n`, stderr: '' }
         }
         return { stdout: '', stderr: '' }
       }),
-      fetchRemoteTrackingRef: vi.fn().mockRejectedValue(new Error('network unavailable')),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
       addWorktree: vi.fn().mockResolvedValue(undefined),
       listWorktrees: vi
         .fn()
@@ -3773,15 +3795,21 @@ describe('registerWorktreeHandlers', () => {
       name: 'improve-dashboard'
     })
 
-    // The refresh must be ATTEMPTED (and fail) before falling back — guards
-    // against a regression that skips the refresh whenever a local ref exists.
+    expect(resolveDefaultBaseRefViaExecMock).toHaveBeenCalled()
     expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledWith(
       '/remote/repo',
       'origin',
       'main',
       'refs/remotes/origin/main'
     )
-    expect(provider.addWorktree).toHaveBeenCalled()
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/repo',
+      'improve-dashboard',
+      '/remote/improve-dashboard',
+      {
+        base: 'origin/main'
+      }
+    )
   })
 
   it('reuses a fresh SSH remote-tracking base refresh for repeated creates', async () => {
@@ -4241,7 +4269,16 @@ describe('registerWorktreeHandlers', () => {
         isMainWorktree: false
       }
     ])
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'created-sha\n', stderr: '' })
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (
+        args[0] === 'rev-parse' &&
+        (args.includes('refs/remotes/origin/master^{commit}') ||
+          args.includes('refs/heads/origin/master^{commit}'))
+      ) {
+        throw new Error('missing ref')
+      }
+      return { stdout: 'created-sha\n', stderr: '' }
+    })
 
     const createPromise = handlers['worktrees:create'](null, {
       repoId: 'repo-1',
@@ -4270,17 +4307,82 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
-  it('creates from an existing local base ref when the pre-create refresh fails', async () => {
-    // Regression: a failed refresh must not block creation when a usable local
-    // remote-tracking base ref already exists.
+  it('creates from the detected default base when the persisted base is stale', async () => {
+    // Regression: a stale persisted repo base must fall back to the detected
+    // primary default instead of blocking creation.
     const remoteBase = {
       remote: 'origin',
       branch: 'main',
       ref: 'refs/remotes/origin/main',
       base: 'origin/main'
     }
-    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: 'origin/master'
+    })
+    runtimeStub.resolveRemoteTrackingBase.mockImplementation(async (_repoPath, baseBranch) =>
+      baseBranch === 'origin/main' ? remoteBase : null
+    )
     runtimeStub.hasRemoteTrackingRef.mockResolvedValue(true)
+    runtimeStub.getOrStartRemoteTrackingBaseRefresh.mockResolvedValue({
+      ok: true,
+      errorKind: 'git_error'
+    })
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'created-sha',
+        branch: 'improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (
+        args[0] === 'rev-parse' &&
+        (args.includes('refs/remotes/origin/master^{commit}') ||
+          args.includes('refs/heads/origin/master^{commit}'))
+      ) {
+        throw new Error('missing ref')
+      }
+      return { stdout: 'created-sha\n', stderr: '' }
+    })
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard'
+    })) as CreateWorktreeResult
+
+    expect(addWorktreeMock).toHaveBeenCalled()
+    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'origin/master'
+    )
+    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'origin/main'
+    )
+    expect(runtimeStub.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(
+      '/workspace/repo',
+      remoteBase
+    )
+    expect(result.worktree.id).toBe('repo-1::/workspace/improve-dashboard')
+  })
+
+  it('keeps a usable persisted local branch base when a detected default exists', async () => {
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: 'develop'
+    })
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(null)
     runtimeStub.getOrStartRemoteTrackingBaseRefresh.mockResolvedValue({
       ok: false,
       errorKind: 'git_error'
@@ -4294,29 +4396,14 @@ describe('registerWorktreeHandlers', () => {
         isMainWorktree: false
       }
     ])
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'created-sha\n', stderr: '' })
-
-    const result = (await handlers['worktrees:create'](null, {
-      repoId: 'repo-1',
-      name: 'improve-dashboard'
-    })) as CreateWorktreeResult
-
-    expect(addWorktreeMock).toHaveBeenCalled()
-    expect(result.worktree.id).toBe('repo-1::/workspace/improve-dashboard')
-  })
-
-  it('does not create when the pre-create refresh fails and no local base ref exists', async () => {
-    const remoteBase = {
-      remote: 'origin',
-      branch: 'main',
-      ref: 'refs/remotes/origin/main',
-      base: 'origin/main'
-    }
-    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
-    runtimeStub.hasRemoteTrackingRef.mockResolvedValue(false)
-    runtimeStub.getOrStartRemoteTrackingBaseRefresh.mockResolvedValue({
-      ok: false,
-      errorKind: 'git_error'
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args.includes('refs/heads/develop^{commit}')) {
+        return { stdout: 'develop-sha\n', stderr: '' }
+      }
+      if (args[0] === 'fetch') {
+        throw new Error('network unavailable')
+      }
+      return { stdout: 'created-sha\n', stderr: '' }
     })
 
     await expect(
@@ -4324,11 +4411,51 @@ describe('registerWorktreeHandlers', () => {
         repoId: 'repo-1',
         name: 'improve-dashboard'
       })
+    ).resolves.toEqual(expect.objectContaining({ worktree: expect.any(Object) }))
+
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/improve-dashboard',
+      'improve-dashboard',
+      'develop',
+      false
+    )
+  })
+
+  it('keeps an explicit base strict when the pre-create refresh fails', async () => {
+    const remoteBase = {
+      remote: 'origin',
+      branch: 'master',
+      ref: 'refs/remotes/origin/master',
+      base: 'origin/master'
+    }
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+    runtimeStub.hasRemoteTrackingRef.mockResolvedValue(false)
+    runtimeStub.getOrStartRemoteTrackingBaseRefresh.mockResolvedValue({
+      ok: false,
+      errorKind: 'git_error'
+    })
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: 'origin/main'
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'improve-dashboard',
+        baseBranch: 'origin/master'
+      })
     ).rejects.toThrow(
-      'Could not refresh base ref "origin/main" from "origin". Check your network and try again.'
+      'Could not refresh base ref "origin/master" from "origin". Check your network and try again.'
     )
 
     expect(addWorktreeMock).not.toHaveBeenCalled()
+    expect(resolveDefaultBaseRefViaExecMock).not.toHaveBeenCalled()
   })
 
   it('delegates remote-tracking base freshness to the runtime before create', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2370,9 +2370,8 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('creates a runtime local worktree from an existing local base ref when the refresh fails', async () => {
-    // Regression: an offline/auth failure while refreshing the remote-tracking
-    // base must not block creation when a usable local base ref already exists.
+  it('creates a runtime local worktree from the detected default when the persisted base is stale', async () => {
+    // Regression: a stale persisted repo base must fall back to the detected default.
     const runtime = new OrcaRuntimeService(store)
     const createdWorktree = {
       path: '/tmp/workspaces/cli-refresh-fails',
@@ -2381,6 +2380,8 @@ describe('OrcaRuntimeService', () => {
       isBare: false,
       isMainWorktree: false
     }
+    const repo = { ...store.getRepos()[0], worktreeBaseRef: 'origin/master' }
+    const getReposSpy = vi.spyOn(store, 'getRepos').mockReturnValue([repo] as never)
     computeWorktreePathMock.mockReturnValue(createdWorktree.path)
     ensurePathWithinWorkspaceMock.mockReturnValue(createdWorktree.path)
     vi.mocked(addWorktree).mockResolvedValueOnce({})
@@ -2392,8 +2393,10 @@ describe('OrcaRuntimeService', () => {
       if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) {
         return { stdout: '/tmp/repo/.git\n', stderr: '' }
       }
-      // Local remote-tracking base ref resolves -> usable fallback exists.
-      if (args[0] === 'rev-parse' && args[1] === '--verify') {
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/master^{commit}')) {
+        throw new Error('missing ref')
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
         return { stdout: 'base-sha\n', stderr: '' }
       }
       if (args[0] === 'fetch') {
@@ -2409,8 +2412,77 @@ describe('OrcaRuntimeService', () => {
         })
       ).resolves.toBeDefined()
 
-      expect(addWorktree).toHaveBeenCalled()
+      expect(addWorktree).toHaveBeenCalledWith(
+        TEST_REPO_PATH,
+        createdWorktree.path,
+        'cli-refresh-fails',
+        'origin/main',
+        false,
+        false,
+        {
+          remoteTrackingBase: {
+            remote: 'origin',
+            branch: 'main',
+            ref: 'refs/remotes/origin/main',
+            base: 'origin/main'
+          },
+          suggestLocalBaseRefUpdate: true
+        }
+      )
+      expect(getDefaultBaseRef).toHaveBeenCalled()
     } finally {
+      getReposSpy.mockRestore()
+      gitSpy.mockRestore()
+    }
+  })
+
+  it('creates a runtime local worktree from a usable persisted local branch base', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const createdWorktree = {
+      path: '/tmp/workspaces/local-branch-base',
+      head: 'develop-sha',
+      branch: 'local-branch-base',
+      isBare: false,
+      isMainWorktree: false
+    }
+    const repo = { ...store.getRepos()[0], worktreeBaseRef: 'develop' }
+    const getReposSpy = vi.spyOn(store, 'getRepos').mockReturnValue([repo] as never)
+    computeWorktreePathMock.mockReturnValue(createdWorktree.path)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdWorktree.path)
+    vi.mocked(addWorktree).mockResolvedValueOnce({})
+    vi.mocked(listWorktrees).mockResolvedValue([createdWorktree])
+    const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) {
+        return { stdout: '/tmp/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/heads/develop^{commit}')) {
+        return { stdout: 'develop-sha\n', stderr: '' }
+      }
+      if (args[0] === 'fetch') {
+        throw new Error('network unavailable')
+      }
+      return { stdout: '', stderr: '' }
+    })
+    try {
+      await expect(
+        runtime.createManagedWorktree({
+          repoSelector: 'id:repo-1',
+          name: 'local-branch-base'
+        })
+      ).resolves.toBeDefined()
+
+      expect(addWorktree).toHaveBeenCalledWith(
+        TEST_REPO_PATH,
+        createdWorktree.path,
+        'local-branch-base',
+        'develop',
+        false
+      )
+    } finally {
+      getReposSpy.mockRestore()
       gitSpy.mockRestore()
     }
   })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -811,6 +811,16 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 const HEADLESS_LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const HEADLESS_SECOND_LEAF_ID = '22222222-2222-4222-8222-222222222222'
 
+function isOriginMainBaseRefProbe(args: string[]): boolean {
+  return (
+    args[0] === 'rev-parse' &&
+    args[1] === '--verify' &&
+    (args.includes('origin/main') ||
+      args.includes('refs/remotes/origin/main') ||
+      args.includes('refs/remotes/origin/main^{commit}'))
+  )
+}
+
 function antigravityReadyScreen(model = 'Gemini 3.5 Flash (High)'): string {
   return [
     'Antigravity CLI 1.0.3',
@@ -2487,6 +2497,64 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('creates a runtime local worktree from a slash-named local branch matching a remote prefix', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const createdWorktree = {
+      path: '/tmp/workspaces/slash-local-base',
+      head: 'team-feature-sha',
+      branch: 'slash-local-base',
+      isBare: false,
+      isMainWorktree: false
+    }
+    const repo = { ...store.getRepos()[0], worktreeBaseRef: 'team/feature' }
+    const getReposSpy = vi.spyOn(store, 'getRepos').mockReturnValue([repo] as never)
+    computeWorktreePathMock.mockReturnValue(createdWorktree.path)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdWorktree.path)
+    vi.mocked(addWorktree).mockResolvedValueOnce({})
+    vi.mocked(listWorktrees).mockResolvedValue([createdWorktree])
+    const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (args[0] === 'remote') {
+        return { stdout: 'team\norigin\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) {
+        return { stdout: '/tmp/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/team/feature^{commit}')) {
+        throw new Error('missing remote-tracking ref')
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/heads/team/feature^{commit}')) {
+        return { stdout: 'team-feature-sha\n', stderr: '' }
+      }
+      if (args[0] === 'fetch') {
+        throw new Error('network unavailable')
+      }
+      return { stdout: '', stderr: '' }
+    })
+    try {
+      await expect(
+        runtime.createManagedWorktree({
+          repoSelector: 'id:repo-1',
+          name: 'slash-local-base'
+        })
+      ).resolves.toBeDefined()
+
+      expect(addWorktree).toHaveBeenCalledWith(
+        TEST_REPO_PATH,
+        createdWorktree.path,
+        'slash-local-base',
+        'team/feature',
+        false
+      )
+      expect(gitSpy).not.toHaveBeenCalledWith(
+        ['fetch', '--no-tags', 'team', '+refs/heads/feature:refs/remotes/team/feature'],
+        expect.any(Object)
+      )
+    } finally {
+      getReposSpy.mockRestore()
+      gitSpy.mockRestore()
+    }
+  })
+
   it('does not create a runtime local worktree when the refresh fails and no local base ref exists', async () => {
     const runtime = new OrcaRuntimeService(store)
     computeWorktreePathMock.mockReturnValue('/tmp/workspaces/cli-refresh-no-local')
@@ -3212,6 +3280,9 @@ describe('OrcaRuntimeService', () => {
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
         }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
+        }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
         }
@@ -3315,6 +3386,9 @@ describe('OrcaRuntimeService', () => {
         }
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
+        }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
         }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
@@ -3469,6 +3543,9 @@ describe('OrcaRuntimeService', () => {
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
         }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
+        }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
         }
@@ -3579,6 +3656,9 @@ describe('OrcaRuntimeService', () => {
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
         }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
+        }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
         }
@@ -3680,6 +3760,9 @@ describe('OrcaRuntimeService', () => {
         }
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
+        }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
         }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
@@ -3836,6 +3919,9 @@ describe('OrcaRuntimeService', () => {
         }
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
+        }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
         }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
@@ -4911,6 +4997,9 @@ describe('OrcaRuntimeService', () => {
     const asyncGitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
       if (args[0] === 'symbolic-ref') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+      }
+      if (isOriginMainBaseRefProbe(args)) {
+        return { stdout: 'main-sha\n', stderr: '' }
       }
       if (args[0] === 'remote') {
         return { stdout: 'origin\n', stderr: '' }
@@ -22404,6 +22493,9 @@ describe('OrcaRuntimeService', () => {
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
         }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
+        }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
         }
@@ -22496,6 +22588,9 @@ describe('OrcaRuntimeService', () => {
         }
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
+        }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
         }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
@@ -22606,6 +22701,9 @@ describe('OrcaRuntimeService', () => {
         }
         if (args[0] === 'symbolic-ref') {
           return { stdout: 'origin/main\n', stderr: '' }
+        }
+        if (isOriginMainBaseRefProbe(args)) {
+          return { stdout: 'main-sha\n', stderr: '' }
         }
         if (args[0] === 'fetch') {
           return { stdout: '', stderr: '' }
@@ -23287,6 +23385,9 @@ describe('OrcaRuntimeService', () => {
     const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
       if (args[0] === 'symbolic-ref') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+      }
+      if (isOriginMainBaseRefProbe(args)) {
+        return { stdout: 'main-sha\n', stderr: '' }
       }
       if (args[0] === 'config') {
         return { stdout: 'origin\n', stderr: '' }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -46,6 +46,8 @@ import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
 import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
+import { resolveWorktreeCreateBase } from '../worktree-create-base'
+import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
 import { OrchestrationDb } from './orchestration/db'
 import { formatMessagesForInjection } from './orchestration/formatter'
 import type {
@@ -581,7 +583,8 @@ import {
   getRemoteDrift,
   getRecentDriftSubjects
 } from '../git/repo'
-import { hasLocalCommitObject } from '../git/commit-object-ref'
+import { hasCommitObjectViaGitExec } from '../git/commit-object-ref'
+import { hasWorktreeBaseCommitRef } from '../git/worktree-base-ref-probe'
 import { resolveLocalGitUsername } from '../git/git-username'
 import {
   listWorktrees,
@@ -1961,6 +1964,26 @@ type LayoutQueueEntry = {
     target: PtyLayoutTarget
     waiters: ((r: ApplyLayoutResult) => void)[]
   }[]
+}
+
+async function hasLocalWorktreeBaseRef(
+  repoPath: string,
+  baseRef: string,
+  options: { wslDistro?: string } = {}
+): Promise<boolean> {
+  const refExists = (qualifiedRef: string) =>
+    hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+  const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
+  if (resolvedBaseRef !== baseRef) {
+    return true
+  }
+  if (baseRef.startsWith('refs/')) {
+    return refExists(baseRef)
+  }
+  return hasCommitObjectViaGitExec(
+    (gitArgs) => gitExecFileAsync(gitArgs, { cwd: repoPath, ...options }),
+    baseRef
+  )
 }
 
 export class OrcaRuntimeService {
@@ -12992,12 +13015,33 @@ export class OrcaRuntimeService {
     let effectiveSanitizedName = sanitizedName
     const username = await resolveLocalGitUsername(repo.path)
 
-    const baseBranch =
-      args.baseBranch ||
-      repo.worktreeBaseRef ||
-      (hasLocalWorktreeGitOptions
-        ? await resolveDefaultBaseRefViaExec((argv) => gitExecFileAsync(argv, localGitExecOptions))
-        : getDefaultBaseRef(repo.path))
+    const baseBranch = await resolveWorktreeCreateBase({
+      requestedBaseBranch: args.baseBranch,
+      repoWorktreeBaseRef: repo.worktreeBaseRef,
+      resolveDefaultBaseRef: () =>
+        hasLocalWorktreeGitOptions
+          ? resolveDefaultBaseRefViaExec((argv) => gitExecFileAsync(argv, localGitExecOptions))
+          : Promise.resolve(getDefaultBaseRef(repo.path)),
+      isBaseUsable: async (baseBranchCandidate) => {
+        const remoteTrackingBase = await this.resolveRemoteTrackingBase(
+          repo.path,
+          baseBranchCandidate,
+          ...localWorktreeGitOptionArgs
+        )
+        if (remoteTrackingBase) {
+          return this.hasRemoteTrackingRef(
+            repo.path,
+            remoteTrackingBase,
+            ...localWorktreeGitOptionArgs
+          )
+        }
+        return hasLocalWorktreeBaseRef(
+          repo.path,
+          baseBranchCandidate,
+          hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
+        )
+      }
+    })
     if (!baseBranch) {
       // Why: getDefaultBaseRef returns null when no suitable ref exists.
       // Don't fabricate 'origin/main' — passing it to addWorktree would
@@ -13165,7 +13209,13 @@ export class OrcaRuntimeService {
       ) {
         throw new Error(`Base ref "${baseBranch}" was not found after fetching.`)
       }
-    } else if (!(await hasLocalCommitObject(repo.path, baseBranch))) {
+    } else if (
+      !(await hasLocalWorktreeBaseRef(
+        repo.path,
+        baseBranch,
+        hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
+      ))
+    ) {
       // Why: local bases keep legacy best-effort fetch behavior. Verified PR
       // SHA bases already have the commit object needed by `git worktree add`.
       try {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13029,10 +13029,19 @@ export class OrcaRuntimeService {
           ...localWorktreeGitOptionArgs
         )
         if (remoteTrackingBase) {
-          return this.hasRemoteTrackingRef(
+          if (
+            await this.hasRemoteTrackingRef(
+              repo.path,
+              remoteTrackingBase,
+              ...localWorktreeGitOptionArgs
+            )
+          ) {
+            return true
+          }
+          return hasLocalWorktreeBaseRef(
             repo.path,
-            remoteTrackingBase,
-            ...localWorktreeGitOptionArgs
+            baseBranchCandidate,
+            hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
           )
         }
         return hasLocalWorktreeBaseRef(
@@ -13172,42 +13181,53 @@ export class OrcaRuntimeService {
         `Could not find an available worktree path for "${sanitizedName}". Pick a different worktree name.`
       )
     }
-    const remoteTrackingBase = await this.resolveRemoteTrackingBase(
+    let remoteTrackingBase = await this.resolveRemoteTrackingBase(
       repo.path,
       baseBranch,
       ...localWorktreeGitOptionArgs
     )
     if (remoteTrackingBase) {
-      const hadLocalBaseRef = await this.hasRemoteTrackingRef(
+      const hadRemoteTrackingBaseRef = await this.hasRemoteTrackingRef(
         repo.path,
         remoteTrackingBase,
         ...localWorktreeGitOptionArgs
       )
-      const refreshResult = await this.getOrStartRemoteTrackingBaseRefresh(
-        repo.path,
-        remoteTrackingBase,
-        ...localWorktreeGitOptionArgs
-      )
-      if (!refreshResult.ok && !hadLocalBaseRef) {
-        // Why: only block creation when the refresh failed AND there is no
-        // usable local base ref to fall back on. If a local remote-tracking ref
-        // already exists, `git worktree add` can create from it — a possibly
-        // stale but valid base — so a transient offline/auth failure must not
-        // make the workspace uncreatable. The compare-to-base view reflects any
-        // drift once the remote is reachable again.
-        throw new Error(
-          `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
-        )
-      }
-      if (
-        !hadLocalBaseRef &&
-        !(await this.hasRemoteTrackingRef(
+      const hasLocalBaseRef =
+        hadRemoteTrackingBaseRef ||
+        (await hasLocalWorktreeBaseRef(
+          repo.path,
+          baseBranch,
+          hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {}
+        ))
+      if (!hadRemoteTrackingBaseRef && hasLocalBaseRef) {
+        remoteTrackingBase = null
+      } else {
+        const refreshResult = await this.getOrStartRemoteTrackingBaseRefresh(
           repo.path,
           remoteTrackingBase,
           ...localWorktreeGitOptionArgs
-        ))
-      ) {
-        throw new Error(`Base ref "${baseBranch}" was not found after fetching.`)
+        )
+        if (!refreshResult.ok && !hadRemoteTrackingBaseRef) {
+          // Why: only block creation when the refresh failed AND there is no
+          // usable local base ref to fall back on. If a local remote-tracking ref
+          // already exists, `git worktree add` can create from it — a possibly
+          // stale but valid base — so a transient offline/auth failure must not
+          // make the workspace uncreatable. The compare-to-base view reflects any
+          // drift once the remote is reachable again.
+          throw new Error(
+            `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
+          )
+        }
+        if (
+          !hadRemoteTrackingBaseRef &&
+          !(await this.hasRemoteTrackingRef(
+            repo.path,
+            remoteTrackingBase,
+            ...localWorktreeGitOptionArgs
+          ))
+        ) {
+          throw new Error(`Base ref "${baseBranch}" was not found after fetching.`)
+        }
       }
     } else if (
       !(await hasLocalWorktreeBaseRef(

--- a/src/main/worktree-create-base-prefetch.ts
+++ b/src/main/worktree-create-base-prefetch.ts
@@ -20,10 +20,7 @@ type WorktreeCreateBasePrefetchRuntime = {
     repoPath: string,
     baseBranch: string
   ) => Promise<RemoteTrackingBaseForPrefetch | null>
-  hasRemoteTrackingRef: (
-    repoPath: string,
-    base: RemoteTrackingBaseForPrefetch
-  ) => Promise<boolean>
+  hasRemoteTrackingRef: (repoPath: string, base: RemoteTrackingBaseForPrefetch) => Promise<boolean>
   getOrStartRemoteTrackingBaseRefresh: (
     repoPath: string,
     base: RemoteTrackingBaseForPrefetch
@@ -58,7 +55,10 @@ async function prefetchLocalWorktreeCreateBase(
         baseBranchCandidate
       )
       if (remoteTrackingBase) {
-        return runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase)
+        if (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase)) {
+          return true
+        }
+        return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate)
       }
       return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate)
     }
@@ -74,8 +74,13 @@ async function prefetchLocalWorktreeCreateBase(
   }
   const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(repo.path, resolvedBaseBranch)
   if (remoteTrackingBase) {
-    await runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase)
-    return
+    if (
+      (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase)) ||
+      !(await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch))
+    ) {
+      await runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase)
+      return
+    }
   }
   if (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch)) {
     // Why: hosted-review start points and local branch bases are already local; a broad remote fetch cannot make them fresher.

--- a/src/main/worktree-create-base-prefetch.ts
+++ b/src/main/worktree-create-base-prefetch.ts
@@ -1,9 +1,12 @@
 import { isFolderRepo } from '../shared/repo-kind'
 import type { Repo } from '../shared/types'
-import { hasLocalCommitObject } from './git/commit-object-ref'
+import { hasLocalCommitObject, isFullGitObjectId } from './git/commit-object-ref'
+import { hasWorktreeBaseCommitRef } from './git/worktree-base-ref-probe'
 import { getDefaultBaseRef } from './git/repo'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { prefetchRemoteWorktreeCreateBase } from './ipc/worktree-remote'
+import { resolveWorktreeCreateBase } from './worktree-create-base'
+import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
 
 type RemoteTrackingBaseForPrefetch = {
   remote: string
@@ -17,6 +20,10 @@ type WorktreeCreateBasePrefetchRuntime = {
     repoPath: string,
     baseBranch: string
   ) => Promise<RemoteTrackingBaseForPrefetch | null>
+  hasRemoteTrackingRef: (
+    repoPath: string,
+    base: RemoteTrackingBaseForPrefetch
+  ) => Promise<boolean>
   getOrStartRemoteTrackingBaseRefresh: (
     repoPath: string,
     base: RemoteTrackingBaseForPrefetch
@@ -24,23 +31,54 @@ type WorktreeCreateBasePrefetchRuntime = {
   fetchRemoteWithCache: (repoPath: string, remote: string) => Promise<void>
 }
 
+async function hasLocalWorktreeBaseRef(repoPath: string, baseRef: string): Promise<boolean> {
+  const refExists = (qualifiedRef: string) => hasWorktreeBaseCommitRef(repoPath, qualifiedRef)
+  const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
+  if (resolvedBaseRef !== baseRef) {
+    return true
+  }
+  if (baseRef.startsWith('refs/')) {
+    return refExists(baseRef)
+  }
+  return hasLocalCommitObject(repoPath, baseRef)
+}
+
 async function prefetchLocalWorktreeCreateBase(
   repo: Repo,
   baseBranch: string | undefined,
   runtime: WorktreeCreateBasePrefetchRuntime
 ): Promise<void> {
-  const resolvedBaseBranch = baseBranch || repo.worktreeBaseRef || getDefaultBaseRef(repo.path)
+  const resolvedBaseBranch = await resolveWorktreeCreateBase({
+    requestedBaseBranch: baseBranch,
+    repoWorktreeBaseRef: repo.worktreeBaseRef,
+    resolveDefaultBaseRef: async () => getDefaultBaseRef(repo.path),
+    isBaseUsable: async (baseBranchCandidate) => {
+      const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
+        repo.path,
+        baseBranchCandidate
+      )
+      if (remoteTrackingBase) {
+        return runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase)
+      }
+      return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate)
+    }
+  })
   if (!resolvedBaseBranch) {
     return
   }
-  if (await hasLocalCommitObject(repo.path, resolvedBaseBranch)) {
-    // Why: hosted-review start points can be verified commit SHAs; a broad
-    // remote fetch cannot make an already-local object fresher.
+  if (
+    isFullGitObjectId(resolvedBaseBranch) &&
+    (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch))
+  ) {
     return
   }
   const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(repo.path, resolvedBaseBranch)
   if (remoteTrackingBase) {
     await runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase)
+    return
+  }
+  if (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch)) {
+    // Why: hosted-review start points and local branch bases are already local; a broad remote fetch cannot make them fresher.
     return
   }
 

--- a/src/main/worktree-create-base.test.ts
+++ b/src/main/worktree-create-base.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveWorktreeCreateBase } from './worktree-create-base'
+
+describe('resolveWorktreeCreateBase', () => {
+  it('falls back from a stale persisted base to the detected default', async () => {
+    const resolveDefaultBaseRef = vi.fn().mockResolvedValue('origin/main')
+    const isBaseUsable = vi.fn().mockResolvedValue(false)
+
+    await expect(
+      resolveWorktreeCreateBase({
+        repoWorktreeBaseRef: 'origin/master',
+        resolveDefaultBaseRef,
+        isBaseUsable
+      })
+    ).resolves.toBe('origin/main')
+
+    expect(resolveDefaultBaseRef).toHaveBeenCalledTimes(1)
+    expect(isBaseUsable).toHaveBeenCalledWith('origin/master')
+  })
+
+  it('returns an explicit base without probing defaults or usability', async () => {
+    const resolveDefaultBaseRef = vi.fn()
+    const isBaseUsable = vi.fn()
+
+    await expect(
+      resolveWorktreeCreateBase({
+        requestedBaseBranch: 'origin/master',
+        repoWorktreeBaseRef: 'origin/main',
+        resolveDefaultBaseRef,
+        isBaseUsable
+      })
+    ).resolves.toBe('origin/master')
+
+    expect(resolveDefaultBaseRef).not.toHaveBeenCalled()
+    expect(isBaseUsable).not.toHaveBeenCalled()
+  })
+
+  it('keeps a usable persisted base when it is still valid', async () => {
+    const resolveDefaultBaseRef = vi.fn().mockResolvedValue('origin/main')
+    const isBaseUsable = vi.fn().mockResolvedValue(true)
+
+    await expect(
+      resolveWorktreeCreateBase({
+        repoWorktreeBaseRef: 'origin/master',
+        resolveDefaultBaseRef,
+        isBaseUsable
+      })
+    ).resolves.toBe('origin/master')
+
+    expect(resolveDefaultBaseRef).toHaveBeenCalledTimes(1)
+    expect(isBaseUsable).toHaveBeenCalledWith('origin/master')
+  })
+})

--- a/src/main/worktree-create-base.ts
+++ b/src/main/worktree-create-base.ts
@@ -1,0 +1,27 @@
+type ResolveWorktreeCreateBaseArgs = {
+  requestedBaseBranch?: string
+  repoWorktreeBaseRef?: string | null
+  resolveDefaultBaseRef: () => Promise<string | null>
+  isBaseUsable: (baseBranch: string) => Promise<boolean>
+}
+
+export async function resolveWorktreeCreateBase(
+  args: ResolveWorktreeCreateBaseArgs
+): Promise<string | null> {
+  if (args.requestedBaseBranch) {
+    return args.requestedBaseBranch
+  }
+
+  const defaultBaseRef = await args.resolveDefaultBaseRef()
+  const repoWorktreeBaseRef = args.repoWorktreeBaseRef
+  if (!repoWorktreeBaseRef) {
+    return defaultBaseRef
+  }
+  if (!defaultBaseRef) {
+    return (await args.isBaseUsable(repoWorktreeBaseRef)) ? repoWorktreeBaseRef : null
+  }
+  if (repoWorktreeBaseRef === defaultBaseRef) {
+    return repoWorktreeBaseRef
+  }
+  return (await args.isBaseUsable(repoWorktreeBaseRef)) ? repoWorktreeBaseRef : defaultBaseRef
+}

--- a/src/main/worktree-create-base.ts
+++ b/src/main/worktree-create-base.ts
@@ -20,8 +20,10 @@ export async function resolveWorktreeCreateBase(
   if (!defaultBaseRef) {
     return (await args.isBaseUsable(repoWorktreeBaseRef)) ? repoWorktreeBaseRef : null
   }
+  // Resolving the default already proved matching persisted refs exist.
   if (repoWorktreeBaseRef === defaultBaseRef) {
     return repoWorktreeBaseRef
   }
+  // Stale persisted refs fall back to the detected default; usable custom refs stay authoritative.
   return (await args.isBaseUsable(repoWorktreeBaseRef)) ? repoWorktreeBaseRef : defaultBaseRef
 }

--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -512,8 +512,8 @@ describe('useComposerState host-context boundaries', () => {
 
     expect(section).toContain('resolveWorktreeCreateBaseBranch')
     expect(section).toContain('explicitBaseBranch: smartSubmitBaseBranch')
-    expect(section).toContain('repoWorktreeBaseRef: selectedRepo.worktreeBaseRef')
-    expect(section).toContain('getRuntimeRepoBaseRefDefault')
+    expect(section).not.toContain('repoWorktreeBaseRef: selectedRepo.worktreeBaseRef')
+    expect(section).not.toContain('getRuntimeRepoBaseRefDefault')
   })
 
   it('plans new workspace agent startup from the selected repo runtime', () => {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -29,7 +29,6 @@ import {
 import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
-import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
 import { resolveWorktreeCreateBaseBranch } from '@/runtime/worktree-create-base'
 import {
   buildTaskSourceContextFromRepo,
@@ -3971,11 +3970,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         })
         const submitBaseBranch = selectedRepoIsGit
           ? await resolveWorktreeCreateBaseBranch({
-              explicitBaseBranch: smartSubmitBaseBranch,
-              repoWorktreeBaseRef: selectedRepo.worktreeBaseRef,
-              loadDefaultBaseRef: async () =>
-                (await getRuntimeRepoBaseRefDefault(selectedRepoSettings, repoId).catch(() => null))
-                  ?.defaultBaseRef
+              explicitBaseBranch: smartSubmitBaseBranch
             })
           : undefined
         const createDisplayName =

--- a/src/renderer/src/runtime/worktree-create-base.test.ts
+++ b/src/renderer/src/runtime/worktree-create-base.test.ts
@@ -1,42 +1,28 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { resolveWorktreeCreateBaseBranch } from './worktree-create-base'
 
 describe('resolveWorktreeCreateBaseBranch', () => {
-  it('uses an explicit Start-from selection before repo defaults', async () => {
-    const loadDefaultBaseRef = vi.fn().mockResolvedValue('origin/main')
-
+  it('uses an explicit Start-from selection', async () => {
     await expect(
       resolveWorktreeCreateBaseBranch({
-        explicitBaseBranch: 'origin/feature',
-        repoWorktreeBaseRef: 'dev',
-        loadDefaultBaseRef
+        explicitBaseBranch: ' origin/feature '
       })
     ).resolves.toBe('origin/feature')
-
-    expect(loadDefaultBaseRef).not.toHaveBeenCalled()
   })
 
-  it('uses the pinned repo worktree base before resolving the git primary', async () => {
-    const loadDefaultBaseRef = vi.fn().mockResolvedValue('origin/main')
-
+  it('omits repo defaults so backend create owns base selection', async () => {
     await expect(
       resolveWorktreeCreateBaseBranch({
-        explicitBaseBranch: undefined,
-        repoWorktreeBaseRef: ' dev ',
-        loadDefaultBaseRef
+        explicitBaseBranch: undefined
       })
-    ).resolves.toBe('dev')
-
-    expect(loadDefaultBaseRef).not.toHaveBeenCalled()
+    ).resolves.toBeUndefined()
   })
 
-  it('falls back to the git primary when no explicit or pinned base exists', async () => {
+  it('omits blank explicit selections', async () => {
     await expect(
       resolveWorktreeCreateBaseBranch({
-        explicitBaseBranch: undefined,
-        repoWorktreeBaseRef: undefined,
-        loadDefaultBaseRef: vi.fn().mockResolvedValue('origin/main')
+        explicitBaseBranch: '   '
       })
-    ).resolves.toBe('origin/main')
+    ).resolves.toBeUndefined()
   })
 })

--- a/src/renderer/src/runtime/worktree-create-base.ts
+++ b/src/renderer/src/runtime/worktree-create-base.ts
@@ -1,3 +1,4 @@
+// Backend base resolution owns stale-ref fallback, so the renderer only forwards explicit selections.
 export async function resolveWorktreeCreateBaseBranch(args: {
   explicitBaseBranch: string | undefined
 }): Promise<string | undefined> {

--- a/src/renderer/src/runtime/worktree-create-base.ts
+++ b/src/renderer/src/runtime/worktree-create-base.ts
@@ -1,15 +1,5 @@
 export async function resolveWorktreeCreateBaseBranch(args: {
   explicitBaseBranch: string | undefined
-  repoWorktreeBaseRef: string | undefined
-  loadDefaultBaseRef: () => Promise<string | null | undefined>
 }): Promise<string | undefined> {
-  if (args.explicitBaseBranch) {
-    return args.explicitBaseBranch
-  }
-  const pinnedBaseRef = args.repoWorktreeBaseRef?.trim()
-  if (pinnedBaseRef) {
-    return pinnedBaseRef
-  }
-  const defaultBaseRef = (await args.loadDefaultBaseRef())?.trim()
-  return defaultBaseRef || undefined
+  return args.explicitBaseBranch?.trim() || undefined
 }


### PR DESCRIPTION
## Summary

Typed-name, SSH, local IPC, runtime, and prefetch worktree creation now route through one shared base resolver. When the caller leaves `baseBranch` unset and the persisted repo default is stale, the code falls back to the detected primary base instead of trying to refresh the stale ref first. The quick composer now leaves repo defaults unset in the request, so the backend can make that fallback decision instead of treating a stored default as an explicit user choice. Usable persisted local branch defaults still stay authoritative.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions.

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/worktree-create-base.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts` - passed, covers shared resolver behavior, local IPC create, SSH create, runtime create, prefetch base warming, stale persisted remote defaults, explicit base strictness, usable persisted local branch defaults, and SHA base preservation.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/worktree-create-base.test.ts src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts` - passed, covers quick-create request base formation and the renderer boundary that keeps repo defaults backend-owned.
- `pnpm run typecheck:node` - passed.
- `pnpm run typecheck:web` - passed.

## AI Review Report

- Shared base selection now lives in `src/main/worktree-create-base.ts`.
- Quick-create request formation now sends only explicit Start-from selections.
- Explicit caller bases still bypass fallback.
- Persisted local branch defaults are probed through the same qualified branch-ref path used by worktree creation.
- SSH, local IPC, runtime, and prefetch all reuse the same decision point.
- No new subprocesses were added.
- macOS compatibility: no platform-specific path, shell, or shortcut handling changed.
- Linux compatibility: local and SSH git flows keep using the existing git execution paths.
- Windows compatibility: WSL and local git option routing stays in the backend paths that create or prefetch worktrees.

## Security Audit

- No new trust boundary was introduced.
- Existing git exec and fetch paths were reused.
- Explicit base errors still fail hard when the ref cannot be refreshed.

## Notes

- The change only affects unset create-time bases and optimistic prefetch.
- Usable persisted defaults still win.
- Missing-default errors stay intact.

Closes #7312
