### PR TITLE
Fix mobile session snapshot freshness after main-side bumps

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12106,6 +12106,217 @@ describe('OrcaRuntimeService', () => {
     await expect(runtime.isTerminalRunningAgent(terminal.handle)).resolves.toBe(false)
   })
 
+  it('accepts fresh renderer mobile tab structure after main-side live version bumps', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer-epoch',
+          snapshotVersion: 1,
+          activeGroupId: 'group-1',
+          activeTabId: 'tab-1::pane:1',
+          activeTabType: 'terminal',
+          tabGroups: [
+            {
+              id: 'group-1',
+              activeTabId: 'tab-1',
+              tabOrder: ['tab-1']
+            }
+          ],
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'tab-1::pane:1',
+              parentTabId: 'tab-1',
+              leafId: 'pane:1',
+              ptyId: 'pty-1',
+              title: 'Terminal 1',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    const touchSnapshot = runtime as unknown as {
+      touchMobileSessionSnapshotsForPty: (ptyId: string) => void
+    }
+    for (let index = 0; index < 5; index += 1) {
+      touchSnapshot.touchMobileSessionSnapshotsForPty('pty-1')
+    }
+    const bumped = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(bumped.snapshotVersion).toBe(6)
+    expect(bumped.tabs.map((tab) => tab.type === 'terminal' && tab.parentTabId)).toEqual(['tab-1'])
+
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer-epoch',
+          snapshotVersion: 1,
+          activeGroupId: 'group-1',
+          activeTabId: 'tab-1::pane:1',
+          activeTabType: 'terminal',
+          tabGroups: [
+            {
+              id: 'group-1',
+              activeTabId: 'tab-1',
+              tabOrder: ['tab-1']
+            }
+          ],
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'tab-1::pane:1',
+              parentTabId: 'tab-1',
+              leafId: 'pane:1',
+              ptyId: 'pty-1',
+              title: 'Terminal 1',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+    const duplicate = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(duplicate.snapshotVersion).toBe(6)
+    expect(duplicate.tabs.map((tab) => tab.type === 'terminal' && tab.parentTabId)).toEqual([
+      'tab-1'
+    ])
+
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer-epoch',
+          snapshotVersion: 2,
+          activeGroupId: 'group-1',
+          activeTabId: 'tab-2::pane:2',
+          activeTabType: 'terminal',
+          tabGroups: [
+            {
+              id: 'group-1',
+              activeTabId: 'tab-2',
+              tabOrder: ['tab-1', 'tab-2'],
+              recentTabIds: ['tab-1', 'tab-2']
+            }
+          ],
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'tab-1::pane:1',
+              parentTabId: 'tab-1',
+              leafId: 'pane:1',
+              ptyId: 'pty-1',
+              title: 'Terminal 1',
+              isActive: false
+            },
+            {
+              type: 'terminal',
+              id: 'tab-2::pane:2',
+              parentTabId: 'tab-2',
+              leafId: 'pane:2',
+              ptyId: 'pty-2',
+              title: 'Terminal 2',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.publicationEpoch).toBe('renderer-epoch')
+    expect(listed.snapshotVersion).toBe(7)
+    expect(listed.tabs.map((tab) => tab.type === 'terminal' && tab.parentTabId)).toEqual([
+      'tab-1',
+      'tab-2'
+    ])
+    expect(listed.tabGroups?.[0]?.tabOrder).toEqual(['tab-1', 'tab-2'])
+  })
+
+  it('rejects stale renderer mobile tab structure within the same publication epoch', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer-epoch',
+          snapshotVersion: 2,
+          activeGroupId: 'group-1',
+          activeTabId: 'tab-2::pane:2',
+          activeTabType: 'terminal',
+          tabGroups: [{ id: 'group-1', activeTabId: 'tab-2', tabOrder: ['tab-1', 'tab-2'] }],
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'tab-1::pane:1',
+              parentTabId: 'tab-1',
+              leafId: 'pane:1',
+              ptyId: 'pty-1',
+              title: 'Terminal 1',
+              isActive: false
+            },
+            {
+              type: 'terminal',
+              id: 'tab-2::pane:2',
+              parentTabId: 'tab-2',
+              leafId: 'pane:2',
+              ptyId: 'pty-2',
+              title: 'Terminal 2',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer-epoch',
+          snapshotVersion: 1,
+          activeGroupId: 'group-1',
+          activeTabId: 'tab-1::pane:1',
+          activeTabType: 'terminal',
+          tabGroups: [{ id: 'group-1', activeTabId: 'tab-1', tabOrder: ['tab-1'] }],
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'tab-1::pane:1',
+              parentTabId: 'tab-1',
+              leafId: 'pane:1',
+              ptyId: 'pty-1',
+              title: 'Terminal 1',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.tabs.map((tab) => tab.type === 'terminal' && tab.parentTabId)).toEqual([
+      'tab-1',
+      'tab-2'
+    ])
+    expect(listed.tabGroups?.[0]?.tabOrder).toEqual(['tab-1', 'tab-2'])
+  })
+
   it('keeps mobile terminal surfaces visible while their leaf handle is pending', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.attachWindow(1)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1995,6 +1995,10 @@ export class OrcaRuntimeService {
   private authoritativeWindowId: number | null = null
   private tabs = new Map<string, RuntimeSyncedTab>()
   private mobileSessionTabsByWorktree = new Map<string, RuntimeMobileSessionTabsSnapshot>()
+  private rendererMobileSessionSnapshotFreshnessByWorktree = new Map<
+    string,
+    { publicationEpoch: string; snapshotVersion: number }
+  >()
   // Why: idempotency map for mobile terminal creation — a retried create with the
   // same clientMutationId returns the in-flight operation instead of duplicating.
   private mobileTerminalCreateByMutationId = new Map<
@@ -18281,6 +18285,45 @@ export class OrcaRuntimeService {
     }
   }
 
+  private acceptRendererMobileSessionSnapshot(snapshot: RuntimeMobileSessionTabsSnapshot): boolean {
+    // Why (#7400): mobileSessionTabsByWorktree snapshotVersion is also a
+    // main-bumped delivery watermark; keep renderer tab-graph freshness separate
+    // so delivery bumps cannot mask newer renderer-owned structure.
+    const current = this.rendererMobileSessionSnapshotFreshnessByWorktree.get(snapshot.worktree)
+    if (
+      current &&
+      current.publicationEpoch === snapshot.publicationEpoch &&
+      snapshot.snapshotVersion <= current.snapshotVersion
+    ) {
+      return false
+    }
+
+    this.rendererMobileSessionSnapshotFreshnessByWorktree.set(snapshot.worktree, {
+      publicationEpoch: snapshot.publicationEpoch,
+      snapshotVersion: snapshot.snapshotVersion
+    })
+    return true
+  }
+
+  private withMonotonicMobileSessionSnapshotVersion(
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    existing: RuntimeMobileSessionTabsSnapshot | undefined
+  ): RuntimeMobileSessionTabsSnapshot {
+    if (
+      !existing ||
+      snapshot.publicationEpoch !== existing.publicationEpoch ||
+      snapshot.snapshotVersion > existing.snapshotVersion
+    ) {
+      return snapshot
+    }
+
+    // Why: clients still use snapshotVersion as the delivery freshness gate,
+    // but main-side PTY/title touches can bump that delivery version without
+    // changing renderer-owned tab structure. Preserve client monotonicity while
+    // allowing a fresh renderer structural snapshot to replace old content.
+    return { ...snapshot, snapshotVersion: existing.snapshotVersion + 1 }
+  }
+
   private syncMobileSessionTabs(snapshots: RuntimeMobileSessionTabsSnapshot[] | undefined): void {
     if (snapshots === undefined) {
       return
@@ -18294,15 +18337,15 @@ export class OrcaRuntimeService {
     const nextWorktrees = new Set<string>()
     for (const snapshot of snapshots) {
       nextWorktrees.add(snapshot.worktree)
-      const existing = this.mobileSessionTabsByWorktree.get(snapshot.worktree)
-      const nextSnapshot = this.mergePreservedHeadlessMobileSessionTabs(snapshot, existing)
-      if (
-        !existing ||
-        nextSnapshot.publicationEpoch !== existing.publicationEpoch ||
-        nextSnapshot.snapshotVersion >= existing.snapshotVersion
-      ) {
-        this.mobileSessionTabsByWorktree.set(snapshot.worktree, nextSnapshot)
+      if (!this.acceptRendererMobileSessionSnapshot(snapshot)) {
+        continue
       }
+      const existing = this.mobileSessionTabsByWorktree.get(snapshot.worktree)
+      const nextSnapshot = this.withMonotonicMobileSessionSnapshotVersion(
+        this.mergePreservedHeadlessMobileSessionTabs(snapshot, existing),
+        existing
+      )
+      this.mobileSessionTabsByWorktree.set(snapshot.worktree, nextSnapshot)
     }
     for (const [worktreeId, existing] of [...this.mobileSessionTabsByWorktree.entries()]) {
       if (!nextWorktrees.has(worktreeId)) {
@@ -18312,6 +18355,7 @@ export class OrcaRuntimeService {
           nextWorktrees.add(worktreeId)
         } else {
           this.mobileSessionTabsByWorktree.delete(worktreeId)
+          this.rendererMobileSessionSnapshotFreshnessByWorktree.delete(worktreeId)
           this.notifyMobileSessionTabsRemoved(worktreeId)
         }
       }


### PR DESCRIPTION
## Summary

Fixes #7400.

- Track renderer-owned mobile session tab snapshot freshness separately from the client-visible delivery `snapshotVersion` that main can bump for PTY/title/live updates.
- Preserve monotonic client delivery versions when a fresh renderer structural snapshot arrives after main-side bumps.
- Reject stale and duplicate same-version renderer snapshots within the same publication epoch so an old one-tab snapshot cannot overwrite newer tab structure.
- Add regression coverage for the #7400 stale one-tab mobile session scenario.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
  - Attempted on latest `origin/main` (`17d5eff`) and also reproduced on clean `origin/main` without this PR: `src/renderer/src/components/settings/SourceControlActionRepoOverrideNote.tsx:35` fails `typescript(switch-exhaustiveness-check)` because the switch is already exhaustive. Changed-file oxlint passed.
- [x] `pnpm typecheck`
- [ ] `pnpm test`
  - Attempted on the final branch rebased onto `origin/main@17d5eff`; fails in unrelated macOS node-pty / relay subprocess timing tests outside this PR. Targeted #7400 regression tests passed.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed on the final branch after rebasing onto `origin/main@17d5eff`:

```bash
pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts
pnpm exec vitest run src/main/runtime/orca-runtime.test.ts --testNamePattern "renderer mobile tab structure|stale renderer mobile tab structure" --reporter dot
pnpm typecheck
pnpm build
```

Also passed earlier for the complete runtime test file:

```bash
pnpm exec vitest run src/main/runtime/orca-runtime.test.ts --reporter dot
```

Current full-suite notes on the final branch / latest `origin/main@17d5eff`:

```text
pnpm run lint:switch-exhaustiveness
# Fails on clean origin/main at:
# src/renderer/src/components/settings/SourceControlActionRepoOverrideNote.tsx:35

pnpm test
# 2 failed test files / 3 failed tests, all outside this PR:
# src/main/daemon/node-pty-fd-leak.test.ts
# src/relay/subprocess.test.ts
```

## AI Review Report

A read-only AI review checked the final diff in `src/main/runtime/orca-runtime.ts` and `src/main/runtime/orca-runtime.test.ts` for the #7400 failure mode, stale/same-version renderer snapshot handling, client-visible monotonic delivery versions, cross-platform compatibility, SSH/remote/local behavior, provider neutrality, performance, security, and PR scope.

The review found no blocking issues. It confirmed that renderer-owned tab graph freshness is now separate from main-bumped delivery freshness, same-epoch stale and duplicate snapshots are rejected, accepted renderer snapshots remain delivery-monotonic for clients, and the added tests cover stale, duplicate, and fresh-after-main-bump cases. It also explicitly checked macOS/Linux/Windows concerns, shortcuts, labels, paths, shell behavior, and Electron-specific platform differences; this PR does not touch UI, shortcut, accelerator, path, shell, or platform-specific code. The review flagged an unrelated untracked architecture document, which is intentionally excluded from this PR.

## Security Audit

This change only adds in-memory runtime bookkeeping for mobile session snapshot freshness. It does not add IPC methods, command execution, filesystem/path handling, network calls, dependencies, auth handling, secrets handling, or new user-controlled parsing. The extra `Map` is keyed by existing worktree identifiers and bounded by the existing worktree snapshot lifecycle; entries are deleted when snapshots are removed. Security risk is neutral.

## Notes

- No mobile app or protocol change is required; the existing `publicationEpoch`, `snapshotVersion`, tab group, and tab payload shape remains intact.
- Cross-platform / SSH / remote behavior is preserved because the fix is runtime-local snapshot freshness bookkeeping.
- X handle: not provided.

## ELI5

Mobile session tab snapshots could go stale or overwrite newer structure after main-side bumps. Freshness tracking keeps delivery versions monotonic and rejects outdated snapshots.
