### PR TITLE
fix(terminal): clear PTY-side buffers on Ctrl+K so the prompt stops repainting at a stale row

### DIFF
--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -172,6 +172,23 @@ export class HeadlessEmulator {
     return this.terminal.buffer.active.type === 'alternate'
   }
 
+  /** Why: PSReadLine's Ctrl+L repaint is only safe at an empty prompt — with
+   *  pending input it re-renders at a cached buffer row that ConPTY's fixed
+   *  viewport doesn't track, painting the input well below the prompt. The
+   *  cursor line counts as an empty prompt when everything before the cursor
+   *  ends with a single '>' and nothing follows it ('>>' is PowerShell's
+   *  continuation prompt, i.e. a multiline edit in flight). */
+  isCursorOnEmptyPromptLine(): boolean {
+    const buffer = this.terminal.buffer.active
+    const line = buffer.getLine(buffer.baseY + buffer.cursorY)
+    if (!line) {
+      return false
+    }
+    const upToCursor = line.translateToString(true, 0, buffer.cursorX).trimEnd()
+    const fullLine = line.translateToString(true).trimEnd()
+    return fullLine === upToCursor && upToCursor.endsWith('>') && !upToCursor.endsWith('>>')
+  }
+
   getVisibleLines(): string[] {
     const buffer = this.terminal.buffer.active
     const lines: string[] = []

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -1030,6 +1030,16 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         dead = true
       }
     },
+    clear: () => {
+      if (dead) {
+        return
+      }
+      try {
+        proc.clear()
+      } catch {
+        // Best-effort: a clear on a just-exited PTY must not kill the handle.
+      }
+    },
     kill: () => {
       if (dead) {
         return

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -9,6 +9,7 @@ function createMockSubprocess() {
   let onData: ((data: string) => void) | null = null
   let onExit: ((code: number) => void) | null = null
   let killed = false
+  let clearCalls = 0
   let pid = 12345
 
   return {
@@ -20,13 +21,20 @@ function createMockSubprocess() {
     get pid() {
       return pid
     },
+    foregroundProcess: null as string | null,
     getForegroundProcess(): string | null {
-      return null
+      return this.foregroundProcess
     },
     write(data: string) {
       written.push(data)
     },
     resize(_cols: number, _rows: number) {},
+    get clearCalls() {
+      return clearCalls
+    },
+    clear() {
+      clearCalls++
+    },
     kill() {
       killed = true
       // Simulate async exit
@@ -423,6 +431,58 @@ describe('Session', () => {
       session.signal('SIGINT')
       expect(subprocess.signals).toEqual(['SIGINT'])
       expect(session.isTerminating).toBe(false)
+    })
+  })
+
+  describe('clearScrollback', () => {
+    function withPlatform(platform: NodeJS.Platform, run: () => void): void {
+      const original = process.platform
+      Object.defineProperty(process, 'platform', { value: platform })
+      try {
+        run()
+      } finally {
+        Object.defineProperty(process, 'platform', { value: original })
+      }
+    }
+
+    it('resyncs the native PTY screen state alongside the emulator clear', () => {
+      createSession()
+      session.clearScrollback()
+      // Why: without the subprocess clear, ConPTY keeps a stale cursor row and
+      // the next prompt repaint lands below a blank gap on Windows.
+      expect(subprocess.clearCalls).toBe(1)
+      const take = session.takePendingOutput(false)
+      expect(take?.records).toContainEqual({ kind: 'clear' })
+    })
+
+    it('nudges a Windows PowerShell prompt to repaint with a form feed', () => {
+      createSession()
+      subprocess.foregroundProcess = 'powershell.exe'
+      withPlatform('win32', () => session.clearScrollback())
+      // Why: the ConPTY clear cannot reach PSReadLine's cached cursor row;
+      // Ctrl+L makes PSReadLine repaint the prompt at the true origin.
+      expect(subprocess.written).toEqual(['\x0c'])
+    })
+
+    it('does not send a form feed while a command owns the foreground', () => {
+      createSession()
+      subprocess.foregroundProcess = 'node'
+      withPlatform('win32', () => session.clearScrollback())
+      expect(subprocess.written).toEqual([])
+    })
+
+    it('does not send a form feed on POSIX platforms', () => {
+      createSession()
+      subprocess.foregroundProcess = 'pwsh'
+      withPlatform('linux', () => session.clearScrollback())
+      expect(subprocess.written).toEqual([])
+    })
+
+    it('does not touch the subprocess after dispose', () => {
+      createSession()
+      session.dispose()
+      session.clearScrollback()
+      expect(subprocess.clearCalls).toBe(0)
     })
   })
 

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -477,6 +477,20 @@ describe('Session', () => {
       expect(subprocess.written).toEqual([])
     })
 
+    it('does not send or queue a form feed before shell-ready', async () => {
+      createSession({ shellReadySupported: true })
+      subprocess.foregroundProcess = 'powershell.exe'
+      subprocess.simulateData('PS C:\\Users\\me> ')
+      await vi.advanceTimersByTimeAsync(10)
+      // Why: a queued form feed would flush after the startup command at an
+      // arbitrary later moment, when the prompt gates no longer hold.
+      withPlatform('win32', () => session.clearScrollback())
+      expect(subprocess.written).toEqual([])
+      subprocess.simulateData('\x1b]777;orca-shell-ready\x07\r\nPS C:\\Users\\me> ')
+      await vi.advanceTimersByTimeAsync(10)
+      expect(subprocess.written).toEqual([])
+    })
+
     it('does not send a form feed at a PowerShell continuation prompt', async () => {
       createSession()
       subprocess.foregroundProcess = 'powershell.exe'

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -455,25 +455,51 @@ describe('Session', () => {
       expect(take?.records).toContainEqual({ kind: 'clear' })
     })
 
-    it('nudges a Windows PowerShell prompt to repaint with a form feed', () => {
+    it('nudges a Windows PowerShell prompt to repaint with a form feed', async () => {
       createSession()
       subprocess.foregroundProcess = 'powershell.exe'
+      subprocess.simulateData('PS C:\\Users\\me> ')
+      await vi.advanceTimersByTimeAsync(10)
       withPlatform('win32', () => session.clearScrollback())
       // Why: the ConPTY clear cannot reach PSReadLine's cached cursor row;
       // Ctrl+L makes PSReadLine repaint the prompt at the true origin.
       expect(subprocess.written).toEqual(['\x0c'])
     })
 
-    it('does not send a form feed while a command owns the foreground', () => {
+    it('does not send a form feed while input is pending at the prompt', async () => {
       createSession()
-      subprocess.foregroundProcess = 'node'
+      subprocess.foregroundProcess = 'powershell.exe'
+      subprocess.simulateData('PS C:\\Users\\me> fd')
+      await vi.advanceTimersByTimeAsync(10)
+      // Why: PSReadLine repaints pending input at a stale cached row that
+      // ConPTY's fixed viewport doesn't track, so the nudge must be skipped.
       withPlatform('win32', () => session.clearScrollback())
       expect(subprocess.written).toEqual([])
     })
 
-    it('does not send a form feed on POSIX platforms', () => {
+    it('does not send a form feed at a PowerShell continuation prompt', async () => {
+      createSession()
+      subprocess.foregroundProcess = 'powershell.exe'
+      subprocess.simulateData('PS C:\\Users\\me> {\r\n>> ')
+      await vi.advanceTimersByTimeAsync(10)
+      withPlatform('win32', () => session.clearScrollback())
+      expect(subprocess.written).toEqual([])
+    })
+
+    it('does not send a form feed while a command owns the foreground', async () => {
+      createSession()
+      subprocess.foregroundProcess = 'node'
+      subprocess.simulateData('PS C:\\Users\\me> ')
+      await vi.advanceTimersByTimeAsync(10)
+      withPlatform('win32', () => session.clearScrollback())
+      expect(subprocess.written).toEqual([])
+    })
+
+    it('does not send a form feed on POSIX platforms', async () => {
       createSession()
       subprocess.foregroundProcess = 'pwsh'
+      subprocess.simulateData('PS C:\\Users\\me> ')
+      await vi.advanceTimersByTimeAsync(10)
       withPlatform('linux', () => session.clearScrollback())
       expect(subprocess.written).toEqual([])
     })

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -305,6 +305,13 @@ export class Session {
     if (process.platform !== 'win32') {
       return
     }
+    // Why: before shell-ready, write() would queue the form feed behind the
+    // buffered startup command and deliver it at an arbitrary later moment,
+    // when the foreground/prompt gates below no longer hold. The nudge is
+    // cosmetic — skip it rather than defer it.
+    if (this._shellState === 'pending' || this.postReadyFlushGate.isPending) {
+      return
+    }
     if (!isPowerShellProcess(this.subprocess.getForegroundProcess())) {
       return
     }

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -8,6 +8,7 @@ import {
   scanForShellReady,
   type ShellReadyScanState
 } from '../shell-ready-marker-scanner'
+import { isPowerShellProcess } from '../../shared/shell-process-detection'
 import type {
   PendingOutputRecord,
   SessionState,
@@ -41,6 +42,10 @@ export type SubprocessHandle = {
   startupCommandDeliveredInShellArgs?: boolean
   write(data: string): void
   resize(cols: number, rows: number): void
+  /** Resync the native PTY's own screen state after a frontend clear.
+   *  No-op except on Windows/ConPTY, where a stale ConPTY cursor row makes
+   *  the next prompt repaint land below a blank gap. */
+  clear?(): void
   kill(): void
   forceKill(): void
   signal(sig: string): void
@@ -285,6 +290,23 @@ export class Session {
     }
     this.emulator.clearScrollback()
     this.recordPendingOutput({ kind: 'clear' })
+    this.subprocess.clear?.()
+    this.#nudgePowerShellPromptRepaint()
+  }
+
+  /** Why: ConPTY's buffer clear cannot reach PSReadLine's cached cursor row,
+   *  so PowerShell's first Enter after a clear would still repaint the prompt
+   *  at the stale row, leaving a blank gap. A form feed (Ctrl+L) makes
+   *  PSReadLine itself repaint at the true origin. Gated to a PowerShell
+   *  foreground so a running command or TUI never gets a stray 0x0C. */
+  #nudgePowerShellPromptRepaint(): void {
+    if (process.platform !== 'win32') {
+      return
+    }
+    if (!isPowerShellProcess(this.subprocess.getForegroundProcess())) {
+      return
+    }
+    this.subprocess.write('\x0c')
   }
 
   prepareForFinalSnapshot(): string {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -298,12 +298,17 @@ export class Session {
    *  so PowerShell's first Enter after a clear would still repaint the prompt
    *  at the stale row, leaving a blank gap. A form feed (Ctrl+L) makes
    *  PSReadLine itself repaint at the true origin. Gated to a PowerShell
-   *  foreground so a running command or TUI never gets a stray 0x0C. */
+   *  foreground so a running command or TUI never gets a stray 0x0C, and to
+   *  an empty prompt because PSReadLine repaints pending input at a stale
+   *  cached row that ConPTY's fixed viewport doesn't track. */
   #nudgePowerShellPromptRepaint(): void {
     if (process.platform !== 'win32') {
       return
     }
     if (!isPowerShellProcess(this.subprocess.getForegroundProcess())) {
+      return
+    }
+    if (!this.emulator.isCursorOnEmptyPromptLine()) {
       return
     }
     this.subprocess.write('\x0c')

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3509,6 +3509,17 @@ export function registerPtyHandlers(
       .catch(() => {})
   })
 
+  ipcMain.removeAllListeners('pty:clearBuffer')
+  ipcMain.on('pty:clearBuffer', (_event, args: { id: string }) => {
+    // Why: the renderer already cleared its own xterm buffer. This clears the
+    // PTY-side state (ConPTY screen buffer, daemon emulator, SSH host buffer)
+    // so the next prompt repaint doesn't land at a stale cursor row.
+    tryGetProviderForPty(args.id)
+      ?.clearBuffer(args.id)
+      .catch(() => {})
+    runtime?.clearHeadlessTerminalBuffer(args.id).catch(() => {})
+  })
+
   ipcMain.handle('pty:kill', async (_event, args: { id: string; keepHistory?: boolean }) => {
     const ownedConnectionId = ptyOwnership.get(args.id)
     const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -37,6 +37,7 @@ import {
   STARTUP_COMMAND_READY_MAX_WAIT_MS
 } from './local-pty-shell-ready'
 import type { ShellReadySignal } from './local-pty-shell-ready'
+import { isPowerShellProcess } from '../../shared/shell-process-detection'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
@@ -898,8 +899,26 @@ export class LocalPtyProvider implements IPtyProvider {
   async getInitialCwd(_id: string): Promise<string> {
     return ''
   }
-  async clearBuffer(_id: string): Promise<void> {
-    /* handled client-side in xterm.js */
+  async clearBuffer(id: string): Promise<void> {
+    // Why: xterm.js clear() only resets the renderer. ConPTY keeps its own
+    // screen buffer, so without this its stale cursor row makes the next
+    // prompt repaint land below a blank gap. No-op on POSIX.
+    const proc = ptyProcesses.get(id)
+    if (!proc) {
+      return
+    }
+    try {
+      proc.clear()
+      // Why: the ConPTY clear cannot reach PSReadLine's cached cursor row; a
+      // form feed (Ctrl+L) makes PSReadLine repaint the prompt at the true
+      // origin. Gated to a PowerShell foreground so a running command or TUI
+      // never gets a stray 0x0C.
+      if (process.platform === 'win32' && isPowerShellProcess(proc.process)) {
+        proc.write('\x0c')
+      }
+    } catch {
+      /* PTY may have just exited */
+    }
   }
   acknowledgeDataEvent(_id: string, _charCount: number): void {
     /* no flow control for local */

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -37,7 +37,6 @@ import {
   STARTUP_COMMAND_READY_MAX_WAIT_MS
 } from './local-pty-shell-ready'
 import type { ShellReadySignal } from './local-pty-shell-ready'
-import { isPowerShellProcess } from '../../shared/shell-process-detection'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
@@ -903,19 +902,12 @@ export class LocalPtyProvider implements IPtyProvider {
     // Why: xterm.js clear() only resets the renderer. ConPTY keeps its own
     // screen buffer, so without this its stale cursor row makes the next
     // prompt repaint land below a blank gap. No-op on POSIX.
-    const proc = ptyProcesses.get(id)
-    if (!proc) {
-      return
-    }
+    //
+    // Unlike the daemon session, no PSReadLine form-feed nudge here: it is
+    // only safe at an empty prompt, and without a headless emulator this
+    // provider cannot tell whether input is pending.
     try {
-      proc.clear()
-      // Why: the ConPTY clear cannot reach PSReadLine's cached cursor row; a
-      // form feed (Ctrl+L) makes PSReadLine repaint the prompt at the true
-      // origin. Gated to a PowerShell foreground so a running command or TUI
-      // never gets a stray 0x0C.
-      if (process.platform === 'win32' && isPowerShellProcess(proc.process)) {
-        proc.write('\x0c')
-      }
+      ptyProcesses.get(id)?.clear()
     } catch {
       /* PTY may have just exited */
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5945,7 +5945,9 @@ export class OrcaRuntimeService {
     })
   }
 
-  private async clearHeadlessTerminalBuffer(ptyId: string): Promise<void> {
+  // Public: desktop-initiated clears (ipc/pty.ts) must also drop this mobile
+  // mirror or a resubscribing mobile client resurrects the cleared scrollback.
+  async clearHeadlessTerminalBuffer(ptyId: string): Promise<void> {
     const state = this.headlessTerminals.get(ptyId)
     if (!state) {
       return

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1150,6 +1150,7 @@ export type PreloadApi = {
     resize: (id: string, cols: number, rows: number) => void
     reportGeometry: (id: string, cols: number, rows: number) => void
     signal: (id: string, signal: string) => void
+    clearBuffer: (id: string) => void
     kill: (id: string, opts?: { keepHistory?: boolean }) => Promise<void>
     ackColdRestore: (id: string) => void
     ackData: (id: string, charCount: number) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -812,6 +812,13 @@ const api = {
       ipcRenderer.send('pty:signal', { id, signal })
     },
 
+    /** Why: Cmd/Ctrl+K clears the renderer xterm, but the PTY host (ConPTY,
+     * daemon emulator, SSH host buffer) keeps its own screen state and would
+     * repaint the next prompt at the stale cursor row. */
+    clearBuffer: (id: string): void => {
+      ipcRenderer.send('pty:clearBuffer', { id })
+    },
+
     ackColdRestore: (id: string): void => {
       ipcRenderer.send('pty:ackColdRestore', { id })
     },

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1048,7 +1048,13 @@ export default function TerminalPane({
       // Why: also clear the host buffer for remote-server panes, or the next
       // host snapshot replays the scrollback we just cleared locally.
       const ptyId = paneTransportsRef.current.get(pane.id)?.getPtyId() ?? null
-      clearWebRuntimeTerminalBuffer(ptyId)
+      const clearedRemoteHostBuffer = clearWebRuntimeTerminalBuffer(ptyId)
+      if (!clearedRemoteHostBuffer && ptyId) {
+        // Why: local/daemon/SSH PTYs keep their own screen state (ConPTY on
+        // Windows), and a stale host cursor row makes the next prompt repaint
+        // land below a blank gap after a frontend-only clear.
+        window.api.pty.clearBuffer(ptyId)
+      }
       persistLayoutSnapshot()
     },
     [paneTransportsRef, persistLayoutSnapshot]

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2538,6 +2538,8 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     resize: () => {},
     reportGeometry: () => {},
     signal: () => {},
+    // Web panes clear the host buffer via the terminal.clearBuffer runtime RPC.
+    clearBuffer: () => {},
     kill: () => Promise.resolve(),
     ackColdRestore: () => {},
     ackData: () => {},

--- a/src/shared/shell-process-detection.ts
+++ b/src/shared/shell-process-detection.ts
@@ -21,3 +21,21 @@ export function isShellProcess(processName: string): boolean {
     SHELL_NAMES.has(basenameWithoutWindowsExtension)
   )
 }
+
+// Why: a ConPTY-side buffer clear cannot reach PSReadLine's cached cursor
+// row, so the first Enter after a terminal clear still repaints the prompt at
+// the stale row. Only the PowerShell family binds Ctrl+L (form feed) to a
+// full prompt repaint, so the post-clear nudge must stay scoped to it.
+const POWERSHELL_NAMES = new Set(['powershell', 'pwsh'])
+
+export function isPowerShellProcess(processName: string | null | undefined): boolean {
+  if (!processName) {
+    return false
+  }
+  const normalized = processName
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .toLowerCase()
+  const basename = normalized.split(/[\\/]/).pop() ?? normalized
+  return POWERSHELL_NAMES.has(basename.replace(WINDOWS_PROCESS_EXTENSION_RE, ''))
+}


### PR DESCRIPTION
## Problem

On Windows, pressing Ctrl+K to clear a PowerShell terminal looked fine at first, but the next Enter repainted the prompt several rows down, leaving a blank gap at the top of the pane (screenshot repro: enters → Ctrl+K → Enter).

## Root cause (two layers)

Ctrl+K (`clearPaneScrollback`) only cleared the renderer xterm buffer; nothing told the PTY:

1. **ConPTY keeps its own screen buffer + cursor row.** After a frontend-only clear it still believed the cursor was at row N, so the next prompt repaint emitted `ESC[N;20H` and landed below a blank gap. Captured directly from ConPTY output in a node-pty harness.
2. **PSReadLine caches its cursor row.** Even with the ConPTY buffer cleared, PowerShell's line editor repositions to its cached row on the first Enter, recreating the gap. cmd.exe has no such cache and is fully fixed by the buffer clear alone.

## Fix

- New renderer → main `pty:clearBuffer` channel, called from `clearPaneScrollback` for non-remote panes (remote-web panes keep the existing `terminal.clearBuffer` RPC).
- `LocalPtyProvider.clearBuffer` (previously a no-op) and a new daemon `SubprocessHandle.clear()` invoke node-pty's `clear()`, which resyncs ConPTY's buffer (documented no-op on POSIX, safe everywhere).
- After the ConPTY clear, send a form feed (Ctrl+L) **only when a PowerShell-family process owns the foreground**, so PSReadLine repaints the prompt at the true origin. The foreground gate keeps the `0x0C` away from running commands and TUIs; cmd/WSL/POSIX shells never receive it.
- Desktop-initiated clears also drop the runtime headless mirror so mobile resubscribe snapshots don't resurrect cleared scrollback.

Mobile-initiated clears (`terminal.clearBuffer` RPC) reach the same provider code, so they get the ConPTY resync too, including daemon-hosted terminals on remote Windows SSH hosts.

## Verification

- Headless end-to-end sim (node-pty ConPTY → `@xterm/headless`, exact user key sequence, 80×24):
  - Before: prompt row 1 + 6 blank rows + prompt row 8 (matches the bug report exactly)
  - After (PowerShell, clear + gated FF): prompt row 1, Enter → prompt row 2
  - After (cmd.exe, clear only): prompt row 1, Enter → prompt row 2
- New unit tests: daemon `Session.clearScrollback` resyncs the native PTY, FF nudge fires only on win32 with a PowerShell foreground, never while a command owns the foreground, never after dispose.
- `pnpm typecheck` (node/cli/web) and oxlint clean; daemon/provider/terminal-pane suites pass (remaining failures reproduced on clean main: pre-existing).