### PR TITLE
Disable auto-merge for unstable GitHub PRs

### DIFF
--- a/mobile/src/components/pr-sidebar/pr-auto-merge-availability.ts
+++ b/mobile/src/components/pr-sidebar/pr-auto-merge-availability.ts
@@ -15,6 +15,10 @@ function isConflicting(item: MobilePRAutoMergeAvailabilityInput): boolean {
   return item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'DIRTY'
 }
 
+function isUnstable(item: MobilePRAutoMergeAvailabilityInput): boolean {
+  return item.mergeStateStatus === 'UNSTABLE'
+}
+
 function hasReviewRequirement(item: MobilePRAutoMergeAvailabilityInput): boolean {
   return item.reviewDecision === 'REVIEW_REQUIRED' || item.reviewDecision === 'CHANGES_REQUESTED'
 }
@@ -27,7 +31,9 @@ function canMergeImmediately(item: MobilePRAutoMergeAvailabilityInput): boolean 
 }
 
 function canRequestWhenReady(item: MobilePRAutoMergeAvailabilityInput): boolean {
-  if (item.state !== 'open' || isConflicting(item)) {
+  // Why: GitHub auto-merge waits on unmet requirements; UNSTABLE is rejected
+  // by the mutation rather than becoming a waitable auto-merge request.
+  if (item.state !== 'open' || isConflicting(item) || isUnstable(item)) {
     return false
   }
   if (item.mergeQueueRequired === true) {

--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -62,6 +62,18 @@ describe('presentGitHubPRMergeState', () => {
     })
   })
 
+  it('does not offer enable auto-merge for GitHub unstable PRs', () => {
+    expect(
+      presentGitHubPRMergeState(
+        pr({
+          mergeable: 'UNKNOWN',
+          mergeStateStatus: 'UNSTABLE',
+          checksSummary: { state: 'failure', total: 1, passed: 0, failed: 1, pending: 0 }
+        })
+      ).autoMergeAction
+    ).toBeNull()
+  })
+
   it('does not offer enable auto-merge on conflicting PRs (GitHub would reject it)', () => {
     expect(
       presentGitHubPRMergeState(pr({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }))

--- a/src/shared/github-pr-auto-merge-availability.test.ts
+++ b/src/shared/github-pr-auto-merge-availability.test.ts
@@ -48,7 +48,7 @@ describe('github PR auto-merge availability', () => {
     expect(canShowGitHubPRAutoMergeControl(pr({ autoMergeEnabled: true }))).toBe(true)
   })
 
-  it('suppresses closed, draft, disallowed, and conflicting PRs', () => {
+  it('suppresses closed, draft, disallowed, conflicting, and unstable PRs', () => {
     expect(
       canShowGitHubPRAutoMergeControl(pr({ state: 'draft', mergeStateStatus: 'BLOCKED' }))
     ).toBe(false)
@@ -62,6 +62,12 @@ describe('github PR auto-merge availability', () => {
     ).toBe(false)
     expect(
       canShowGitHubPRAutoMergeControl(pr({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }))
+    ).toBe(false)
+    expect(
+      canEnableGitHubPRAutoMerge(pr({ mergeable: 'UNKNOWN', mergeStateStatus: 'UNSTABLE' }))
+    ).toBe(false)
+    expect(
+      canShowGitHubPRAutoMergeControl(pr({ mergeable: 'UNKNOWN', mergeStateStatus: 'UNSTABLE' }))
     ).toBe(false)
   })
 })

--- a/src/shared/github-pr-auto-merge-availability.ts
+++ b/src/shared/github-pr-auto-merge-availability.ts
@@ -18,6 +18,10 @@ function isConflicting(item: GitHubPRAutoMergeAvailabilityInput): boolean {
   return item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'DIRTY'
 }
 
+function isUnstable(item: GitHubPRAutoMergeAvailabilityInput): boolean {
+  return item.mergeStateStatus === 'UNSTABLE'
+}
+
 function hasReviewRequirement(item: GitHubPRAutoMergeAvailabilityInput): boolean {
   return item.reviewDecision === 'REVIEW_REQUIRED' || item.reviewDecision === 'CHANGES_REQUESTED'
 }
@@ -30,7 +34,9 @@ function canMergeImmediately(item: GitHubPRAutoMergeAvailabilityInput): boolean 
 }
 
 function canRequestWhenReady(item: GitHubPRAutoMergeAvailabilityInput): boolean {
-  if (!isOpenPR(item) || isConflicting(item)) {
+  // Why: GitHub auto-merge waits on unmet requirements; UNSTABLE is rejected
+  // by the mutation rather than becoming a waitable auto-merge request.
+  if (!isOpenPR(item) || isConflicting(item) || isUnstable(item)) {
     return false
   }
   if (item.mergeQueueRequired === true) {


### PR DESCRIPTION
## Summary

Disables the option to enable auto-merge for GitHub pull requests with an `UNSTABLE` merge state status. This prevents mutation rejection from GitHub when trying to enable auto-merge on unstable PRs.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the auto-merge logic adjustments for mobile and shared components. Checked that `UNSTABLE` status is consistently restricted from requesting auto-merge to avoid GitHub API errors. Confirmed that cross-platform compatibility was checked; these changes are pure TypeScript logic running in shared and mobile environments, with no platform-specific shortcuts, paths, shell, or Electron differences.

## Security Audit

Verified that no new input handling, command execution, path processing, auth, secrets, or IPC risks are introduced. The restriction simply prevents a remote API call that is bound to fail.

## Notes

None