### PR TITLE
Fix stale readonly Monaco preview state

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -713,9 +713,10 @@ export default function MonacoEditor({
     }
     editorRef.current.updateOptions({
       fontSize: editorFontSize,
-      fontFamily: settings.terminalFontFamily || 'monospace'
+      fontFamily: settings.terminalFontFamily || 'monospace',
+      readOnly
     })
-  }, [editorFontSize, settings])
+  }, [editorFontSize, readOnly, settings])
 
   useEffect(() => {
     markdownDocLinkDecorationsRef.current?.refresh()


### PR DESCRIPTION
## Summary

Fixes a bug where files opened from the right sidebar Explorer could sometimes stop accepting keyboard input. Explorer preview-tab replacement can reuse a mounted Monaco editor instance, so this keeps Monaco’s internal `readOnly` option synchronized with the active editor tab.

Related Issue: https://github.com/stablyai/orca/issues/7418

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
  - `pnpm lint` did not pass locally. Exact command terminated with `[warn] Linter process terminated abnormally (possibly out of memory)`. Running the underlying lint script surfaced an unrelated upstream `switch-exhaustiveness-check` failure in `SourceControlActionRepoOverrideNote.tsx`.
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Results:

No new test was added because this is a narrow Monaco option synchronization fix. Existing Explorer tests cover the preview-open path, and typecheck/build cover the changed React effect/dependency usage.

## AI Review Report

AI review traced the issue through the right sidebar Explorer open path, editor tab state, and Monaco mounting behavior. It verified that Explorer opens files as `mode: 'edit'`, not as Source Control diff tabs, and identified the likely failure mode as stale Monaco editor options after preview-tab replacement.

Main risk checked: a reused Monaco instance could retain `readOnly: true` even after React props changed to a writable edit tab. The fix updates `editorRef.current.updateOptions(...)` to include `readOnly` and adds `readOnly` to the effect dependency list.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This PR does not touch shortcuts, shortcut labels, shell behavior, path handling, IPC, or Electron platform-specific APIs.

## Security Audit

AI audit found no new input handling, command execution, auth, secrets, dependency, IPC, or path handling changes. The PR only synchronizes an existing boolean editor option inside the renderer’s Monaco editor component.

No security follow-up needed.

## Notes

This is a runtime editor-state fix with no UI changes. Users on an already-running build may need to reload/restart the app to clear stale Monaco editor instances.

`pnpm lint` is currently blocked locally by an unrelated upstream lint issue in `SourceControlActionRepoOverrideNote.tsx`.