### PR TITLE
Relocate node-pty ConPTY runtime outside the Windows install dir (fixes update-time terminal loss)

### DIFF
--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -384,3 +384,27 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
    }
  }
  #endif
+diff --git a/lib/utils.js b/lib/utils.js
+--- a/lib/utils.js
++++ b/lib/utils.js
+@@ -19,7 +19,20 @@ function loadNativeModule(name) {
+     var dirs = ['build/Release', 'build/Debug', "prebuilds/" + process.platform + "-" + process.arch];
+     // Check relative to the parent dir for unbundled and then the current dir for bundled
+     var relative = ['..', '.'];
+     var lastError;
++    // Why (Orca): the Windows updater force-closes every process whose image
++    // lives under the app install dir; this env var relocates the native
++    // binaries (conpty.dll spawns OpenConsole.exe from beside itself) so PTY
++    // console hosts run outside it and survive updates.
++    var overrideDir = process.env.ORCA_NODE_PTY_NATIVE_DIR;
++    if (overrideDir) {
++        try {
++            return { dir: overrideDir, module: require(overrideDir + "/" + name + ".node") };
++        }
++        catch (e) {
++            lastError = e;
++        }
++    }
+     for (var _i = 0, dirs_1 = dirs; _i < dirs_1.length; _i++) {
+         var d = dirs_1[_i];
+         for (var _a = 0, relative_1 = relative; _a < relative_1.length; _a++) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: 296e716bb67c0aa3d4ff47d493b9fd9ba9518b7e9f6597005fd680ac04274145
     path: config/patches/@xterm__addon-webgl@0.20.0-beta.286.patch
   node-pty@1.1.0:
-    hash: 407ae07e1e0e2ff2e8b58696449c54c31e51d87535bc6aa4a7a7b0b561407282
+    hash: b354dc2fd021578ac4829e77a2666ff192a517ba3a8428337a70ecea930aea88
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -54,7 +54,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=407ae07e1e0e2ff2e8b58696449c54c31e51d87535bc6aa4a7a7b0b561407282)
+        version: 1.1.0(patch_hash=b354dc2fd021578ac4829e77a2666ff192a517ba3a8428337a70ecea930aea88)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -11747,7 +11747,7 @@ snapshots:
       undici: 6.27.0
       which: 6.0.1
 
-  node-pty@1.1.0(patch_hash=407ae07e1e0e2ff2e8b58696449c54c31e51d87535bc6aa4a7a7b0b561407282):
+  node-pty@1.1.0(patch_hash=b354dc2fd021578ac4829e77a2666ff192a517ba3a8428337a70ecea930aea88):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,7 @@ import { ClaudeUsageStore, initClaudeUsagePath } from './claude-usage/store'
 import { CodexUsageStore, initCodexUsagePath } from './codex-usage/store'
 import { OpenCodeUsageStore, initOpenCodeUsagePath } from './opencode-usage/store'
 import { killAllPty } from './ipc/pty'
+import { installRelocatedNodePtyNativeRuntime } from './pty/node-pty-runtime-relocation'
 import { initDaemonPtyProvider, disconnectDaemon, shutdownDaemon } from './daemon/daemon-init'
 import { closeAllWatchers } from './ipc/filesystem-watcher'
 import { disposeWorktreeBaseDirectoryWatchers } from './ipc/worktree-base-directory-watcher'
@@ -575,6 +576,9 @@ if (hasSingleInstanceLock) {
   initClaudeUsagePath()
   initCodexUsagePath()
   initOpenCodeUsagePath()
+  // Why: must run before anything loads node-pty (first PTY spawn) so main
+  // and the daemon it forks both pick up ORCA_NODE_PTY_NATIVE_DIR.
+  installRelocatedNodePtyNativeRuntime()
   crashReports = CrashReportStore.fromUserData()
   recordCrashBreadcrumb('app_started', {
     packaged: app.isPackaged,

--- a/src/main/pty/node-pty-runtime-relocation.test.ts
+++ b/src/main/pty/node-pty-runtime-relocation.test.ts
@@ -144,6 +144,7 @@ describe.runIf(process.platform === 'win32')('patched node-pty loader override',
     })
     expect(destDir).not.toBeNull()
 
+    const previousNativeDir = process.env.ORCA_NODE_PTY_NATIVE_DIR
     process.env.ORCA_NODE_PTY_NATIVE_DIR = destDir!
     try {
       const utils = requireFromHere('node-pty/lib/utils.js')
@@ -151,7 +152,11 @@ describe.runIf(process.platform === 'win32')('patched node-pty loader override',
       expect(loaded.dir).toBe(destDir)
       expect(typeof loaded.module.startProcess).toBe('function')
     } finally {
-      delete process.env.ORCA_NODE_PTY_NATIVE_DIR
+      if (previousNativeDir === undefined) {
+        delete process.env.ORCA_NODE_PTY_NATIVE_DIR
+      } else {
+        process.env.ORCA_NODE_PTY_NATIVE_DIR = previousNativeDir
+      }
     }
   })
 })

--- a/src/main/pty/node-pty-runtime-relocation.test.ts
+++ b/src/main/pty/node-pty-runtime-relocation.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => '/unused'),
+    getVersion: vi.fn(() => '0.0.0-test')
+  }
+}))
+
+import {
+  ensureRelocatedNodePtyNativeRuntime,
+  resolveNodePtyNativeSourceDir
+} from './node-pty-runtime-relocation'
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(os.tmpdir(), 'node-pty-relocation-'))
+})
+
+afterEach(() => {
+  // Why: the loader-override test dlopens conpty.node from tempDir, and a
+  // loaded native module stays image-locked until the process exits.
+  try {
+    rmSync(tempDir, { recursive: true, force: true })
+  } catch {}
+})
+
+function seedSourceDir(dir: string): void {
+  mkdirSync(join(dir, 'conpty'), { recursive: true })
+  writeFileSync(join(dir, 'conpty.node'), 'binding')
+  writeFileSync(join(dir, 'conpty_console_list.node'), 'listing')
+  writeFileSync(join(dir, 'pty.node'), 'winpty-binding')
+  writeFileSync(join(dir, 'winpty-agent.exe'), 'agent')
+  writeFileSync(join(dir, 'conpty.pdb'), 'symbols')
+  writeFileSync(join(dir, 'conpty', 'conpty.dll'), 'dll')
+  writeFileSync(join(dir, 'conpty', 'OpenConsole.exe'), 'console-host')
+}
+
+describe('resolveNodePtyNativeSourceDir', () => {
+  it('prefers the rebuilt build/Release binding over prebuilds', () => {
+    const pkg = join(tempDir, 'node-pty')
+    mkdirSync(join(pkg, 'build', 'Release'), { recursive: true })
+    mkdirSync(join(pkg, 'prebuilds', `win32-${process.arch}`), { recursive: true })
+    writeFileSync(join(pkg, 'build', 'Release', 'conpty.node'), 'x')
+    writeFileSync(join(pkg, 'prebuilds', `win32-${process.arch}`, 'conpty.node'), 'x')
+    expect(resolveNodePtyNativeSourceDir(pkg)).toBe(join(pkg, 'build', 'Release'))
+  })
+
+  it('falls back to the platform prebuild dir', () => {
+    const pkg = join(tempDir, 'node-pty')
+    mkdirSync(join(pkg, 'prebuilds', `win32-${process.arch}`), { recursive: true })
+    writeFileSync(join(pkg, 'prebuilds', `win32-${process.arch}`, 'conpty.node'), 'x')
+    expect(resolveNodePtyNativeSourceDir(pkg)).toBe(join(pkg, 'prebuilds', `win32-${process.arch}`))
+  })
+
+  it('returns null when no conpty binding exists', () => {
+    const pkg = join(tempDir, 'node-pty')
+    mkdirSync(join(pkg, 'build', 'Release'), { recursive: true })
+    expect(resolveNodePtyNativeSourceDir(pkg)).toBeNull()
+  })
+})
+
+describe('ensureRelocatedNodePtyNativeRuntime', () => {
+  it('copies the runtime tree (without symbols) and returns the version dir', () => {
+    const sourceDir = join(tempDir, 'source')
+    seedSourceDir(sourceDir)
+    const destRoot = join(tempDir, 'dest')
+
+    const destDir = ensureRelocatedNodePtyNativeRuntime({ sourceDir, destRoot, version: '1.2.3' })
+
+    expect(destDir).toBe(join(destRoot, '1.2.3'))
+    expect(readFileSync(join(destDir!, 'conpty.node'), 'utf8')).toBe('binding')
+    expect(readFileSync(join(destDir!, 'conpty', 'OpenConsole.exe'), 'utf8')).toBe('console-host')
+    expect(readFileSync(join(destDir!, 'conpty', 'conpty.dll'), 'utf8')).toBe('dll')
+    expect(existsSync(join(destDir!, 'conpty.pdb'))).toBe(false)
+  })
+
+  it('skips recopying once the completion marker exists', () => {
+    const sourceDir = join(tempDir, 'source')
+    seedSourceDir(sourceDir)
+    const destRoot = join(tempDir, 'dest')
+    ensureRelocatedNodePtyNativeRuntime({ sourceDir, destRoot, version: '1.2.3' })
+
+    writeFileSync(join(sourceDir, 'conpty.node'), 'changed-after-first-copy')
+    const destDir = ensureRelocatedNodePtyNativeRuntime({ sourceDir, destRoot, version: '1.2.3' })
+
+    expect(readFileSync(join(destDir!, 'conpty.node'), 'utf8')).toBe('binding')
+  })
+
+  it('redoes an interrupted copy that has no completion marker', () => {
+    const sourceDir = join(tempDir, 'source')
+    seedSourceDir(sourceDir)
+    const destRoot = join(tempDir, 'dest')
+    mkdirSync(join(destRoot, '1.2.3'), { recursive: true })
+    writeFileSync(join(destRoot, '1.2.3', 'conpty.node'), 'torn partial copy')
+
+    const destDir = ensureRelocatedNodePtyNativeRuntime({ sourceDir, destRoot, version: '1.2.3' })
+
+    expect(readFileSync(join(destDir!, 'conpty.node'), 'utf8')).toBe('binding')
+  })
+
+  it('removes stale version dirs but keeps the current one', () => {
+    const sourceDir = join(tempDir, 'source')
+    seedSourceDir(sourceDir)
+    const destRoot = join(tempDir, 'dest')
+    ensureRelocatedNodePtyNativeRuntime({ sourceDir, destRoot, version: '1.0.0' })
+
+    const destDir = ensureRelocatedNodePtyNativeRuntime({ sourceDir, destRoot, version: '2.0.0' })
+
+    expect(destDir).toBe(join(destRoot, '2.0.0'))
+    expect(existsSync(join(destRoot, '1.0.0'))).toBe(false)
+    expect(existsSync(join(destRoot, '2.0.0', 'conpty.node'))).toBe(true)
+  })
+
+  it('fails open when the source dir is missing', () => {
+    expect(
+      ensureRelocatedNodePtyNativeRuntime({
+        sourceDir: join(tempDir, 'does-not-exist'),
+        destRoot: join(tempDir, 'dest'),
+        version: '1.2.3'
+      })
+    ).toBeNull()
+  })
+})
+
+// Loads the real win32 conpty binding, so it cannot run on other platforms.
+describe.runIf(process.platform === 'win32')('patched node-pty loader override', () => {
+  it('loads the conpty binding from ORCA_NODE_PTY_NATIVE_DIR', () => {
+    const requireFromHere = createRequire(import.meta.url)
+    const nodePtyPackageDir = dirname(requireFromHere.resolve('node-pty/package.json'))
+    const sourceDir = resolveNodePtyNativeSourceDir(nodePtyPackageDir)
+    expect(sourceDir).not.toBeNull()
+
+    const destDir = ensureRelocatedNodePtyNativeRuntime({
+      sourceDir: sourceDir!,
+      destRoot: join(tempDir, 'relocated-runtime'),
+      version: 'loader-test'
+    })
+    expect(destDir).not.toBeNull()
+
+    process.env.ORCA_NODE_PTY_NATIVE_DIR = destDir!
+    try {
+      const utils = requireFromHere('node-pty/lib/utils.js')
+      const loaded = utils.loadNativeModule('conpty')
+      expect(loaded.dir).toBe(destDir)
+      expect(typeof loaded.module.startProcess).toBe('function')
+    } finally {
+      delete process.env.ORCA_NODE_PTY_NATIVE_DIR
+    }
+  })
+})

--- a/src/main/pty/node-pty-runtime-relocation.ts
+++ b/src/main/pty/node-pty-runtime-relocation.ts
@@ -1,0 +1,136 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { app } from 'electron'
+
+/**
+ * Relocates node-pty's Windows native runtime (conpty.node, conpty.dll,
+ * OpenConsole.exe, winpty binaries) from the install directory to userData.
+ *
+ * Why: the NSIS update installer force-closes every process whose image path
+ * is under the install directory before replacing files. conpty.dll spawns
+ * OpenConsole.exe from beside itself, so while these binaries live in the
+ * install dir every live terminal's console host is killed mid-update.
+ * Loading them from userData (via the ORCA_NODE_PTY_NATIVE_DIR override
+ * patched into node-pty's loader) takes them out of the installer's kill
+ * zone, and the detached daemon inherits the env var so its PTYs are covered.
+ */
+export const NODE_PTY_NATIVE_DIR_ENV_VAR = 'ORCA_NODE_PTY_NATIVE_DIR'
+
+const RELOCATION_COMPLETE_MARKER = '.relocation-complete'
+
+export function resolveNodePtyNativeSourceDir(nodePtyPackageDir: string): string | null {
+  // Packaged builds carry the rebuilt binding in build/Release; dev installs
+  // (and the forced-relocation test path) load from prebuilds.
+  const candidates = [
+    join(nodePtyPackageDir, 'build', 'Release'),
+    join(nodePtyPackageDir, 'prebuilds', `win32-${process.arch}`)
+  ]
+  for (const candidate of candidates) {
+    if (existsSync(join(candidate, 'conpty.node'))) {
+      return candidate
+    }
+  }
+  return null
+}
+
+function copyRuntimeTree(sourceDir: string, destDir: string): void {
+  mkdirSync(destDir, { recursive: true })
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = join(sourceDir, entry.name)
+    const destPath = join(destDir, entry.name)
+    if (entry.isDirectory()) {
+      copyRuntimeTree(sourcePath, destPath)
+    } else if (entry.isFile() && !/\.pdb$/i.test(entry.name)) {
+      copyFileSync(sourcePath, destPath)
+    }
+  }
+}
+
+function removeStaleRuntimeVersions(destRoot: string, keepVersion: string): void {
+  let entries
+  try {
+    entries = readdirSync(destRoot, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === keepVersion) {
+      continue
+    }
+    // Why: an adopted daemon from a previous version may still run (or later
+    // respawn) binaries out of its own version dir. Renaming a directory
+    // fails on Windows while anything inside is open, so a successful rename
+    // proves the dir is unused and safe to delete.
+    const doomedPath = join(destRoot, `${entry.name}.stale`)
+    try {
+      renameSync(join(destRoot, entry.name), doomedPath)
+      rmSync(doomedPath, { recursive: true, force: true })
+    } catch {
+      // Still in use (or already being cleaned) — retry on a future launch.
+    }
+  }
+}
+
+export function ensureRelocatedNodePtyNativeRuntime(options: {
+  sourceDir: string
+  destRoot: string
+  version: string
+}): string | null {
+  const { sourceDir, destRoot, version } = options
+  const destDir = join(destRoot, version)
+  try {
+    // Why: the marker is written only after a full copy, so a crash mid-copy
+    // leaves no marker and the next launch redoes the copy from scratch.
+    if (!existsSync(join(destDir, RELOCATION_COMPLETE_MARKER))) {
+      rmSync(destDir, { recursive: true, force: true })
+      copyRuntimeTree(sourceDir, destDir)
+      writeFileSync(join(destDir, RELOCATION_COMPLETE_MARKER), '')
+    }
+    removeStaleRuntimeVersions(destRoot, version)
+    return destDir
+  } catch {
+    // Fail open: node-pty keeps loading from the install dir, which is the
+    // pre-relocation behavior (sessions then don't survive updates).
+    return null
+  }
+}
+
+export function installRelocatedNodePtyNativeRuntime(): void {
+  if (process.platform !== 'win32') {
+    return
+  }
+  if (!app.isPackaged && process.env.ORCA_FORCE_CONPTY_RELOCATION !== '1') {
+    return
+  }
+  if (process.env[NODE_PTY_NATIVE_DIR_ENV_VAR]) {
+    return
+  }
+  let nodePtyPackageDir: string
+  try {
+    const requireFromHere = createRequire(import.meta.url)
+    nodePtyPackageDir = dirname(requireFromHere.resolve('node-pty/package.json'))
+  } catch {
+    return
+  }
+  const sourceDir = resolveNodePtyNativeSourceDir(nodePtyPackageDir)
+  if (!sourceDir) {
+    return
+  }
+  const destDir = ensureRelocatedNodePtyNativeRuntime({
+    sourceDir,
+    destRoot: join(app.getPath('userData'), 'node-pty-runtime'),
+    version: app.getVersion()
+  })
+  if (destDir) {
+    process.env[NODE_PTY_NATIVE_DIR_ENV_VAR] = destDir
+  }
+}

--- a/src/main/pty/node-pty-runtime-relocation.ts
+++ b/src/main/pty/node-pty-runtime-relocation.ts
@@ -111,9 +111,10 @@ export function installRelocatedNodePtyNativeRuntime(): void {
   if (!app.isPackaged && process.env.ORCA_FORCE_CONPTY_RELOCATION !== '1') {
     return
   }
-  if (process.env[NODE_PTY_NATIVE_DIR_ENV_VAR]) {
-    return
-  }
+  // Note: a pre-set env var is deliberately NOT honored here. The update
+  // relaunch chain (old app -> installer -> new app) inherits the previous
+  // version's value, which would pin the new process to stale binaries and
+  // skip copying the current version.
   let nodePtyPackageDir: string
   try {
     const requireFromHere = createRequire(import.meta.url)


### PR DESCRIPTION
## Summary

Windows terminal sessions die on every app update since June 30 because the NSIS update installer force-closes every process running from the install directory — and #6968 moved the ConPTY console hosts into it. This PR relocates node-pty's native runtime (`conpty.node`, `conpty.dll`, `OpenConsole.exe`, winpty binaries) to `userData/node-pty-runtime/<version>/`, taking terminal infrastructure out of the installer's kill zone. Verified end-to-end against the installer's verbatim kill commands.

## Root cause (reproduction-harness verified, not inferred)

electron-builder's NSIS template (`allowOnlyOneInstallerInstance.nsh`, unchanged in this repo since the initial commit) runs `CHECK_APP_RUNNING` during every update install:

```powershell
# FIND: is anything running from the install dir?
if ((Get-CimInstance Win32_Process | ? {$_.Path -and $_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')}).Count -gt 0) { exit 0 } else { exit 1 }
# KILL: Stop-Process each match, then a -Force retry loop
```

Three facts, each demonstrated by running these commands **verbatim** against disposable process topologies (harness output in the PR comments):

1. **A latent single-match blind spot protected the daemon until June 30.** In Windows PowerShell 5.1, a pipeline that matches exactly ONE process returns a bare `CimInstance` whose `.Count` is `$null`, so `-gt 0` is false and the installer concludes "nothing running" and kills **nothing**. Pre-#6968, terminals used the System32 console host, so the detached daemon was the *only* install-dir process → single match → spared on every update. Same-process daemon survival across updates was real — and an accident.
2. **#6968 (June 30) unmasked the sweep.** With `OpenConsole.exe` instances now under `resources/`, there are 2+ matches, `.Count` works, and the sweep kills the daemon **and every console host** mid-install. Killing a console host kills its attached shell (reproduced; matches the `GetConsoleScreenBufferInfo` console-loss crashes Windows Error Reporting captured during the July 4 and July 5 update windows on the incident machine — and at no June update).
3. **Relocated topology survives.** With the native runtime outside the install dir, `OpenConsole.exe` spawns from userData, FIND reports nothing (the daemon is again the sole install-dir process, back under the single-match umbrella), and daemon + shell + console host all survive the sweep.

This also corrects the earlier working theory: the update-relaunch wedge-kill path fixed in #7340 is real and reproducible, but the installer sweep — not that path — is what killed sessions in the July incidents.

## Fix

- **node-pty patch** (`config/patches/node-pty@1.1.0.patch`): `loadNativeModule` honors `ORCA_NODE_PTY_NATIVE_DIR` before its stock search paths, falling through on any failure. The native side already resolves `conpty.dll` (and spawns `OpenConsole.exe`) from `conpty/` **beside the loaded binding**, so relocating the binding relocates the console hosts.
- **`src/main/pty/node-pty-runtime-relocation.ts`**: at startup (win32 + packaged only), copy the binding dir (rebuilt `build/Release`, fallback platform prebuilds; `.pdb` excluded) to `userData/node-pty-runtime/<appVersion>/` and set the env var. Crash-safe via a completion marker (partial copies redone). The forked daemon inherits the env, covering daemon-owned PTYs.
- **Stale version cleanup** uses a rename probe: renaming a directory fails on Windows while anything inside is open, so only provably-unused version dirs are deleted — an adopted previous-version daemon keeps its runtime.
- Fail-open everywhere: any error leaves the env unset and node-pty loads from the install dir exactly as today.

## Verification

- **End-to-end sweep test (this machine):** daemon-analog + patched node-pty package under a fake install dir, `ORCA_NODE_PTY_NATIVE_DIR` pointing at a relocated runtime; real ConPTY session with a live `powershell.exe`. `OpenConsole.exe` verified running from the relocated dir; the verbatim installer FIND/KILL sequence found nothing and **daemon, shell, and console host all survived**. Control legs: pre-fix (July) topology → all killed; pre-#6968 (June) topology → all spared via the single-match blind spot.
- **Unit tests** (`node-pty-runtime-relocation.test.ts`): source-dir resolution order, tree copy without symbols, marker idempotency, interrupted-copy recovery, stale-version cleanup keeping the current version, fail-open on missing source — plus a win32 integration test loading the real conpty binding through the patched loader from a relocated dir.
- Typecheck clean; pty suites green (one pre-existing symlink-privilege failure in `terminal-cwd-realpath.test.ts`, untouched by this change and identical on the base branch).

## Follow-ups (not in this PR)

1. **Daemon image relocation** — the daemon binary is still `INSTDIR\Orca.exe`; today it survives via the single-match blind spot. Moving its image out of the install dir makes survival principled instead of accidental (and is the fix that remains correct if electron-builder ever repairs the `.Count` check upstream).
2. **Upstream report to electron-builder** — the single-match `.Count` bug means the sweep silently skips exactly-one-process cases for every Electron app; conversely apps with detached helpers under the install dir lose them whenever there are 2+.
3. The periodic resume-record capture from #7340 remains the safety net for any path that still loses processes.
