### PR TITLE
[codex] Add Whisper Large v3 STT language support

### DIFF
--- a/src/main/ipc/speech.ts
+++ b/src/main/ipc/speech.ts
@@ -178,7 +178,8 @@ export function registerSpeechHandlers(store: Store): void {
             }
           },
           resolvedHotwordsPath,
-          owner
+          owner,
+          store.getSettings().voice?.language
         )
         if (resolvedHotwordsPath) {
           unlink(resolvedHotwordsPath).catch(() => {})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6490,7 +6490,8 @@ export class OrcaRuntimeService {
           }
         },
         undefined,
-        owner
+        owner,
+        voice.language
       )
       if (this.mobileDictation?.id !== params.dictationId) {
         throw new Error('dictation_canceled')

--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -138,6 +138,40 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     streaming: false
   },
   {
+    id: 'whisper-large-v3-turbo',
+    label: 'Whisper Large v3 Turbo',
+    description:
+      '90+ languages with near large-v3 accuracy at a fraction of the cost. Best local choice for non-English dictation (e.g. Turkish).',
+    type: 'whisper',
+    provider: 'local',
+    language: 'multilingual',
+    sizeBytes: 563_790_207,
+    downloadUrl:
+      'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-turbo.tar.bz2',
+    archiveSha256: 'b11acbbcd660b44a8e0df33724feb5aaa709cf65668f2823d59f656312544f22',
+    archiveFormat: 'tar.bz2',
+    files: ['turbo-encoder.int8.onnx', 'turbo-decoder.int8.onnx', 'turbo-tokens.txt'],
+    sampleRate: 16000,
+    streaming: false
+  },
+  {
+    id: 'whisper-large-v3',
+    label: 'Whisper Large v3',
+    description:
+      '90+ languages, highest whisper accuracy. Large download and slow on CPU — prefer Turbo unless accuracy is critical.',
+    type: 'whisper',
+    provider: 'local',
+    language: 'multilingual',
+    sizeBytes: 1_068_482_488,
+    downloadUrl:
+      'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-large-v3.tar.bz2',
+    archiveSha256: '2d0e134b3b5fc4a0533baf24a0c9d473b629aa47f030af0a165a05f461df7a03',
+    archiveFormat: 'tar.bz2',
+    files: ['large-v3-encoder.int8.onnx', 'large-v3-decoder.int8.onnx', 'large-v3-tokens.txt'],
+    sampleRate: 16000,
+    streaming: false
+  },
+  {
     id: 'openai-gpt-4o-mini-transcribe',
     label: 'GPT-4o mini Transcribe',
     description:

--- a/src/main/speech/openai-transcription-client.ts
+++ b/src/main/speech/openai-transcription-client.ts
@@ -112,6 +112,8 @@ export class OpenAiTranscriptionSession {
     const form = new FormData()
     form.append('model', apiModel)
     form.append('response_format', 'json')
+    // Why: 'auto' (or unset) means the user wants automatic language detection,
+    // so omit the field rather than forcing detection off.
     if (this.language && this.language !== 'auto') {
       form.append('language', this.language)
     }

--- a/src/main/speech/openai-transcription-client.ts
+++ b/src/main/speech/openai-transcription-client.ts
@@ -83,7 +83,8 @@ export class OpenAiTranscriptionSession {
 
   constructor(
     private readonly modelId: string,
-    private readonly readApiKey: () => string
+    private readonly readApiKey: () => string,
+    private readonly language?: string
   ) {}
 
   feedAudio(samples: Float32Array, sampleRate: number): void {
@@ -111,6 +112,9 @@ export class OpenAiTranscriptionSession {
     const form = new FormData()
     form.append('model', apiModel)
     form.append('response_format', 'json')
+    if (this.language && this.language !== 'auto') {
+      form.append('language', this.language)
+    }
     // Why: OpenAI's transcription endpoint expects a multipart file object;
     // a named WAV blob avoids filesystem temp files and works in packaged apps.
     form.append('file', new Blob([new Uint8Array(wav)], { type: 'audio/wav' }), 'dictation.wav')

--- a/src/main/speech/stt-service.test.ts
+++ b/src/main/speech/stt-service.test.ts
@@ -173,6 +173,22 @@ describe('SttService', () => {
     expect(getCreatedWorkerCount()).toBe(1)
   })
 
+  it('passes the dictation language to the worker and replaces the warm worker when it changes', async () => {
+    const service = new SttService({
+      getModelState: vi.fn().mockResolvedValue({ id: 'model-a', status: 'ready' }),
+      getModelDir: vi.fn().mockReturnValue('/tmp/model-a')
+    } as never)
+
+    await service.startDictation('model-a', vi.fn(), undefined, 'desktop', 'tr')
+    expect(getLastWorker()!.messages[0]).toMatchObject({ type: 'init', language: 'tr' })
+
+    await service.stopDictation('desktop')
+    await service.startDictation('model-a', vi.fn(), undefined, 'desktop', 'en')
+
+    expect(getCreatedWorkerCount()).toBe(2)
+    expect(getLastWorker()!.messages[0]).toMatchObject({ type: 'init', language: 'en' })
+  })
+
   it('keeps an idle worker warm for an hour', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/speech/stt-service.test.ts
+++ b/src/main/speech/stt-service.test.ts
@@ -79,7 +79,8 @@ const {
 
     constructor(
       readonly modelId: string,
-      readonly readApiKey: () => string
+      readonly readApiKey: () => string,
+      readonly language?: string
     ) {
       HoistedMockOpenAiTranscriptionSession.instances.push(this)
     }
@@ -326,12 +327,13 @@ describe('SttService', () => {
       getModelDir: vi.fn().mockReturnValue('/tmp/model-a')
     } as never)
 
-    await service.startDictation('openai-model', sink, undefined, 'desktop')
+    await service.startDictation('openai-model', sink, undefined, 'desktop', 'tr')
     service.feedAudio(new Float32Array([0.25, -0.25]), 48000, 'desktop')
     await service.stopDictation('desktop')
 
     expect(getCreatedWorkerCount()).toBe(0)
     expect(getCloudSessions()).toHaveLength(1)
+    expect(getCloudSessions()[0].language).toBe('tr')
     expect(getCloudSessions()[0].feedCalls).toHaveLength(1)
     expect(sink).toHaveBeenCalledWith({ type: 'ready' })
     expect(sink).toHaveBeenCalledWith({

--- a/src/main/speech/stt-service.ts
+++ b/src/main/speech/stt-service.ts
@@ -28,6 +28,7 @@ export class SttService {
   private modelManager: ModelManager
   private activeModelId: string | null = null
   private activeHotwordsFilePath: string | undefined
+  private activeLanguage: string | undefined
   private activeOwner: string | null = null
   private startingOwner: string | null = null
   private startingModelId: string | null = null
@@ -47,7 +48,8 @@ export class SttService {
     modelId: string,
     sink: SttEventSink,
     hotwordsFilePath?: string,
-    owner = 'desktop'
+    owner = 'desktop',
+    language?: string
   ): Promise<void> {
     if (this.starting) {
       if (this.startingOwner !== owner) {
@@ -64,7 +66,7 @@ export class SttService {
     this.clearIdleTeardownTimer()
 
     try {
-      await this._startDictation(modelId, sink, hotwordsFilePath, owner)
+      await this._startDictation(modelId, sink, hotwordsFilePath, owner, language)
       if (this.canceledOwners.delete(owner)) {
         await this.stopDictation(owner, { cancelStarting: false })
         throw new Error('dictation_canceled')
@@ -82,7 +84,8 @@ export class SttService {
     modelId: string,
     sink: SttEventSink,
     hotwordsFilePath?: string,
-    owner = 'desktop'
+    owner = 'desktop',
+    language?: string
   ): Promise<void> {
     const manifest = getCatalogModel(modelId)
     if (!manifest) {
@@ -100,7 +103,7 @@ export class SttService {
         throw new Error(`Model not ready: ${modelState.status}`)
       }
 
-      this.cloudSession = new OpenAiTranscriptionSession(modelId, readOpenAiSpeechApiKey)
+      this.cloudSession = new OpenAiTranscriptionSession(modelId, readOpenAiSpeechApiKey, language)
       this.activeModelId = modelId
       this.activeHotwordsFilePath = undefined
       this.eventSink = sink
@@ -115,7 +118,8 @@ export class SttService {
     if (
       this.worker &&
       this.activeModelId === modelId &&
-      this.activeHotwordsFilePath === hotwordsFilePath
+      this.activeHotwordsFilePath === hotwordsFilePath &&
+      this.activeLanguage === language
     ) {
       this.eventSink = sink
       sink({ type: 'ready' })
@@ -142,6 +146,7 @@ export class SttService {
 
     this.activeModelId = modelId
     this.activeHotwordsFilePath = hotwordsFilePath
+    this.activeLanguage = language
     this.eventSink = sink
 
     const readyPromise = new Promise<void>((resolve, reject) => {
@@ -204,6 +209,7 @@ export class SttService {
         this.worker = null
         this.activeModelId = null
         this.activeHotwordsFilePath = undefined
+        this.activeLanguage = undefined
         this.activeOwner = null
         this.eventSink = null
       }
@@ -215,6 +221,7 @@ export class SttService {
         this.worker = null
         this.activeModelId = null
         this.activeHotwordsFilePath = undefined
+        this.activeLanguage = undefined
         this.activeOwner = null
         this.eventSink = null
       }
@@ -238,7 +245,8 @@ export class SttService {
       sampleRate: manifest.sampleRate,
       files: manifest.files ?? [],
       hotwordsFilePath,
-      modelingUnit: manifest.modelingUnit
+      modelingUnit: manifest.modelingUnit,
+      language
     })
 
     try {
@@ -251,6 +259,7 @@ export class SttService {
         this.worker = null
         this.activeModelId = null
         this.activeHotwordsFilePath = undefined
+        this.activeLanguage = undefined
         this.activeOwner = null
         this.eventSink = null
       }
@@ -305,6 +314,7 @@ export class SttService {
         this.eventSink?.({ type: 'stopped' })
         this.activeModelId = null
         this.activeHotwordsFilePath = undefined
+        this.activeLanguage = undefined
         this.activeOwner = null
         this.eventSink = null
       }
@@ -367,6 +377,7 @@ export class SttService {
         this.worker = null
         this.activeModelId = null
         this.activeHotwordsFilePath = undefined
+        this.activeLanguage = undefined
         this.activeOwner = null
         this.eventSink = null
       } else {
@@ -444,6 +455,7 @@ export class SttService {
       this.worker = null
       this.activeModelId = null
       this.activeHotwordsFilePath = undefined
+      this.activeLanguage = undefined
       this.eventSink = null
     }
   }

--- a/src/main/speech/stt-service.ts
+++ b/src/main/speech/stt-service.ts
@@ -106,6 +106,7 @@ export class SttService {
       this.cloudSession = new OpenAiTranscriptionSession(modelId, readOpenAiSpeechApiKey, language)
       this.activeModelId = modelId
       this.activeHotwordsFilePath = undefined
+      this.activeLanguage = language
       this.eventSink = sink
       sink({ type: 'ready' })
       return

--- a/src/main/speech/stt-worker.ts
+++ b/src/main/speech/stt-worker.ts
@@ -13,6 +13,7 @@ type WorkerMessage =
       files: string[]
       hotwordsFilePath?: string
       modelingUnit?: string
+      language?: string
     }
   | { type: 'feed'; samples: Float32Array; sampleRate: number }
   | { type: 'stop' }
@@ -161,12 +162,18 @@ function handleInit(msg: Extract<WorkerMessage, { type: 'init' }>): void {
       recognizer = sherpa.createOnlineRecognizer(config)
       stream = sherpa.createOnlineStream(recognizer)
     } else if (modelType === 'whisper') {
+      // Why: whisper auto-detects language from the first 30s window, which
+      // often misidentifies short dictations. An explicit language from
+      // settings ('auto' or empty keeps detection) fixes e.g. Turkish input.
+      const whisperLanguage = msg.language && msg.language !== 'auto' ? msg.language : ''
       const config = {
         featConfig: { sampleRate, featureDim: 80 },
         modelConfig: {
           whisper: {
             encoder: resolveFile(files, 'encoder', modelDir),
-            decoder: resolveFile(files, 'decoder', modelDir)
+            decoder: resolveFile(files, 'decoder', modelDir),
+            language: whisperLanguage,
+            task: 'transcribe'
           },
           tokens,
           numThreads: 2,

--- a/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
+++ b/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
@@ -1,8 +1,27 @@
 import type { VoiceSettings } from '../../../../shared/speech-types'
 import { Label } from '../ui/label'
 import { Separator } from '../ui/separator'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
+
+// Why: whisper needs an ISO 639-1 code to skip auto-detection; 'auto' keeps
+// model-side detection. Labels are native names, so they are not translated.
+const DICTATION_LANGUAGES: { code: string; label: string }[] = [
+  { code: 'auto', label: 'Auto-detect' },
+  { code: 'en', label: 'English' },
+  { code: 'tr', label: 'Türkçe' },
+  { code: 'de', label: 'Deutsch' },
+  { code: 'es', label: 'Español' },
+  { code: 'fr', label: 'Français' },
+  { code: 'it', label: 'Italiano' },
+  { code: 'pt', label: 'Português' },
+  { code: 'ru', label: 'Русский' },
+  { code: 'zh', label: '中文' },
+  { code: 'ja', label: '日本語' },
+  { code: 'ko', label: '한국어' },
+  { code: 'ar', label: 'العربية' }
+]
 
 type VoiceDictationSettingsSectionProps = {
   voiceSettings: VoiceSettings
@@ -91,6 +110,41 @@ export function VoiceDictationSettingsSection({
             </button>
           ))}
         </div>
+      </div>
+
+      <Separator />
+
+      <div className="flex items-center justify-between gap-4 py-2">
+        <div className="space-y-0.5">
+          <Label>
+            {translate(
+              'auto.components.settings.VoicePane.dictationLanguage',
+              'Dictation Language'
+            )}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.VoicePane.dictationLanguageHint',
+              'Spoken language for transcription. Applies to Whisper and OpenAI models.'
+            )}
+          </p>
+        </div>
+        <Select
+          value={voiceSettings.language || 'auto'}
+          onValueChange={(value) => onUpdateVoiceSettings({ language: value })}
+          disabled={!voiceSettings.enabled}
+        >
+          <SelectTrigger className="w-40 shrink-0">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {DICTATION_LANGUAGES.map((lang) => (
+              <SelectItem key={lang.code} value={lang.code}>
+                {lang.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <Separator />

--- a/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
+++ b/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
@@ -117,14 +117,11 @@ export function VoiceDictationSettingsSection({
       <div className="flex items-center justify-between gap-4 py-2">
         <div className="space-y-0.5">
           <Label>
-            {translate(
-              'auto.components.settings.VoicePane.dictationLanguage',
-              'Dictation Language'
-            )}
+            {translate('auto.components.settings.VoicePane.00ab56a6c0', 'Dictation Language')}
           </Label>
           <p className="text-xs text-muted-foreground">
             {translate(
-              'auto.components.settings.VoicePane.dictationLanguageHint',
+              'auto.components.settings.VoicePane.90c0cbd280',
               'Spoken language for transcription. Applies to Whisper and OpenAI models.'
             )}
           </p>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6758,8 +6758,8 @@
           "f9a9cf6928": "Microphone permission is required before enabling voice dictation.",
           "1eac933202": "Opened macOS Privacy & Security. Enable dictation again after granting access.",
           "cd9fe37556": "Microphone permission granted",
-          "dictationLanguage": "Dictation Language",
-          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
+          "00ab56a6c0": "Dictation Language",
+          "90c0cbd280": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "Remove {{value0}}",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6757,7 +6757,9 @@
           "ad5d036ecc": "Could not request microphone permission. Voice dictation was not enabled.",
           "f9a9cf6928": "Microphone permission is required before enabling voice dictation.",
           "1eac933202": "Opened macOS Privacy & Security. Enable dictation again after granting access.",
-          "cd9fe37556": "Microphone permission granted"
+          "cd9fe37556": "Microphone permission granted",
+          "dictationLanguage": "Dictation Language",
+          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "Remove {{value0}}",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6720,7 +6720,9 @@
           "f9a9cf6928": "Se requiere permiso del micrófono antes de habilitar el dictado de voz.",
           "1eac933202": "Se abrió Privacidad y seguridad de macOS. Vuelve a habilitar el dictado después de otorgar acceso.",
           "cd9fe37556": "Permiso de micrófono concedido",
-          "6fa734ed95": "Eliminar {{value0}}"
+          "6fa734ed95": "Eliminar {{value0}}",
+          "dictationLanguage": "Dictation Language",
+          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "Quitar {{value0}}",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6721,8 +6721,8 @@
           "1eac933202": "Se abrió Privacidad y seguridad de macOS. Vuelve a habilitar el dictado después de otorgar acceso.",
           "cd9fe37556": "Permiso de micrófono concedido",
           "6fa734ed95": "Eliminar {{value0}}",
-          "dictationLanguage": "Dictation Language",
-          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
+          "00ab56a6c0": "Dictation Language",
+          "90c0cbd280": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "Quitar {{value0}}",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6742,7 +6742,9 @@
           "f9a9cf6928": "音声ディクテーションを有効にする前に、マイクの許可が必要です。",
           "1eac933202": "macOS のプライバシーとセキュリティを開きました。アクセスを許可した後、ディクテーションを再度有効にします。",
           "cd9fe37556": "マイクの許可が与えられました",
-          "6fa734ed95": "{{value0}} を削除"
+          "6fa734ed95": "{{value0}} を削除",
+          "dictationLanguage": "Dictation Language",
+          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "{{value0}} を削除",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6743,8 +6743,8 @@
           "1eac933202": "macOS のプライバシーとセキュリティを開きました。アクセスを許可した後、ディクテーションを再度有効にします。",
           "cd9fe37556": "マイクの許可が与えられました",
           "6fa734ed95": "{{value0}} を削除",
-          "dictationLanguage": "Dictation Language",
-          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
+          "00ab56a6c0": "Dictation Language",
+          "90c0cbd280": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "{{value0}} を削除",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6706,8 +6706,8 @@
           "1eac933202": "macOS 개인 정보 보호 및 보안을 열었습니다. 액세스 권한을 부여한 후 받아쓰기를 다시 활성화하세요.",
           "cd9fe37556": "마이크 권한이 부여되었습니다.",
           "6fa734ed95": "{{value0}} 삭제",
-          "dictationLanguage": "Dictation Language",
-          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
+          "00ab56a6c0": "Dictation Language",
+          "90c0cbd280": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "{{value0}} 제거",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6705,7 +6705,9 @@
           "f9a9cf6928": "음성 받아쓰기를 활성화하려면 마이크 권한이 필요합니다.",
           "1eac933202": "macOS 개인 정보 보호 및 보안을 열었습니다. 액세스 권한을 부여한 후 받아쓰기를 다시 활성화하세요.",
           "cd9fe37556": "마이크 권한이 부여되었습니다.",
-          "6fa734ed95": "{{value0}} 삭제"
+          "6fa734ed95": "{{value0}} 삭제",
+          "dictationLanguage": "Dictation Language",
+          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "{{value0}} 제거",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6705,7 +6705,9 @@
           "f9a9cf6928": "启用语音听写之前需要麦克风许可。",
           "1eac933202": "打开 macOS 隐私和安全。授予访问权限后再次启用听写。",
           "cd9fe37556": "已授予麦克风权限",
-          "6fa734ed95": "删除 {{value0}}"
+          "6fa734ed95": "删除 {{value0}}",
+          "dictationLanguage": "Dictation Language",
+          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "删除 {{value0}}",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6706,8 +6706,8 @@
           "1eac933202": "打开 macOS 隐私和安全。授予访问权限后再次启用听写。",
           "cd9fe37556": "已授予麦克风权限",
           "6fa734ed95": "删除 {{value0}}",
-          "dictationLanguage": "Dictation Language",
-          "dictationLanguageHint": "Spoken language for transcription. Applies to Whisper and OpenAI models."
+          "00ab56a6c0": "Dictation Language",
+          "90c0cbd280": "Spoken language for transcription. Applies to Whisper and OpenAI models."
         },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "删除 {{value0}}",


### PR DESCRIPTION
## Summary
- Add Whisper Large v3 and Whisper Large v3 Turbo local STT model entries.
- Thread the configured dictation language through local Whisper decoding and OpenAI transcription requests.
- Add a voice settings language selector and test coverage for STT language propagation.

## Impact
This improves Turkish dictation by avoiding per-utterance language auto-detection for configured voice input.

## Screenshots
- Captured with Playwright: `/tmp/orca-pr-7426-voice-language-selector.png`
- Note: `pnpm run dev:web` requires Electron preload APIs for the full app shell, so the screenshot uses an isolated Playwright fixture of the changed Voice Dictation settings control.

## AI Review Report
- Addressed CodeRabbit feedback in follow-up commit `4e71bfb`.
- Added a why-comment for the OpenAI `auto` language sentinel.
- Switched the new VoicePane localization keys to hash-based keys and synced locale catalog parity.
- Preserved `activeLanguage` for the OpenAI/cloud dictation branch.
- Added cloud path coverage asserting the configured language reaches `OpenAiTranscriptionSession`.

## Security Audit
- No new secrets, network endpoints, permissions, or credential storage paths are introduced.
- The OpenAI transcription request only includes `language` when the user selects an explicit language; `auto` remains omitted to preserve provider-side detection.
- Local model catalog additions reference download metadata only and do not change execution privileges.

## Validation
- `corepack pnpm run verify:localization-catalog`
- `corepack pnpm exec vitest run --config config/vitest.config.ts src/main/speech/stt-service.test.ts`
- Playwright screenshot generated at `/tmp/orca-pr-7426-voice-language-selector.png`

## Notes
- `pnpm-lock.yaml` is intentionally not part of this PR update; it remains a local dirty file from the package manager version mismatch.

## ELI5

Local Whisper Large v3 models and a dictation language setting improve speech-to-text. Configured languages avoid wrong auto-detect, especially for languages like Turkish.
