### PR TITLE
Fix Claude managed account OAuth login callback

### DIFF
--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -5,6 +5,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
+import type { ClaudeManagedAccount } from '../../shared/types'
 import {
   deleteActiveClaudeKeychainCredentialsStrict,
   readActiveClaudeKeychainCredentials,
@@ -1052,13 +1053,16 @@ describe('ClaudeAccountService credential capture', () => {
     vi.resetModules()
     vi.useFakeTimers()
     const child = new EventEmitter() as EventEmitter & {
+      stdin: PassThrough
       stdout: PassThrough
       stderr: PassThrough
       kill: () => void
     }
+    child.stdin = new PassThrough()
     child.stdout = new PassThrough()
     child.stderr = new PassThrough()
     child.kill = vi.fn()
+    const destroyStdin = vi.spyOn(child.stdin, 'destroy')
     const spawnMock = vi.fn(() => child)
     vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
 
@@ -1074,13 +1078,15 @@ describe('ClaudeAccountService credential capture', () => {
           runClaudeCommand(
             args: string[],
             configDir: { windowsPath: string; linuxPath: string | null; wslDistro: string | null },
-            timeoutMs: number
+            timeoutMs: number,
+            options?: { keepStdinOpen?: boolean }
           ): Promise<string>
         }
       ).runClaudeCommand(
         ['login'],
         { windowsPath: '/tmp/claude-auth', linuxPath: null, wslDistro: null },
-        1000
+        1000,
+        { keepStdinOpen: true }
       )
       const rejection = expect(commandPromise).rejects.toThrow(
         'Claude sign-in took too long to finish.'
@@ -1090,6 +1096,7 @@ describe('ClaudeAccountService credential capture', () => {
 
       await rejection
       expect(child.kill).toHaveBeenCalledTimes(1)
+      expect(destroyStdin).toHaveBeenCalledTimes(1)
       expect(child.stdout.listenerCount('data')).toBe(0)
       expect(child.stderr.listenerCount('data')).toBe(0)
       expect(child.listenerCount('error')).toBe(0)
@@ -1100,18 +1107,109 @@ describe('ClaudeAccountService credential capture', () => {
     }
   })
 
+  it('pipes stdin only for the explicit Claude account login command', async () => {
+    setPlatform('linux')
+    vi.resetModules()
+    vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValue(null)
+    const loginChild = new EventEmitter() as EventEmitter & {
+      stdin: PassThrough
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: ReturnType<typeof vi.fn>
+    }
+    loginChild.stdin = new PassThrough()
+    loginChild.stdout = new PassThrough()
+    loginChild.stderr = new PassThrough()
+    loginChild.kill = vi.fn()
+    const statusChild = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: ReturnType<typeof vi.fn>
+    }
+    statusChild.stdout = new PassThrough()
+    statusChild.stderr = new PassThrough()
+    statusChild.kill = vi.fn()
+    const spawnMock = vi.fn(
+      (_command: string, args: string[], options: { env: NodeJS.ProcessEnv }) => {
+        if (args[1] === 'login') {
+          writeFileSync(
+            join(options.env.CLAUDE_CONFIG_DIR!, '.credentials.json'),
+            '{"claudeAiOauth":{"email":"user@example.com","accessToken":"token"}}\n',
+            'utf-8'
+          )
+          queueMicrotask(() => loginChild.emit('close', 0))
+          return loginChild
+        }
+        statusChild.stdout.write('{"email":"user@example.com"}\n')
+        queueMicrotask(() => statusChild.emit('close', 0))
+        return statusChild
+      }
+    )
+    vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
+
+    try {
+      const { ClaudeAccountService } = await import('./service')
+      let settings = {
+        claudeManagedAccounts: [] as ClaudeManagedAccount[],
+        activeClaudeManagedAccountId: null,
+        activeClaudeManagedAccountIdsByRuntime: { host: null, wsl: {} }
+      }
+      const store = {
+        getSettings: vi.fn(() => settings),
+        updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+          settings = { ...settings, ...updates }
+          return settings
+        })
+      }
+      const runtimeAuth = {
+        clearLastWrittenCredentialsJson: vi.fn(),
+        forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+      }
+      const rateLimits = {
+        evictInactiveClaudeCache: vi.fn(),
+        refreshForClaudeAccountChange: vi.fn()
+      }
+      const service = new ClaudeAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeAuth as never
+      )
+
+      await service.addAccount()
+
+      expect(spawnMock).toHaveBeenNthCalledWith(
+        1,
+        'claude',
+        ['auth', 'login', '--claudeai'],
+        expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+      )
+      expect(spawnMock).toHaveBeenNthCalledWith(
+        2,
+        'claude',
+        ['auth', 'status', '--json'],
+        expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
+      )
+      expect(settings.claudeManagedAccounts[0]?.email).toBe('user@example.com')
+    } finally {
+      vi.doUnmock('node:child_process')
+    }
+  })
+
   it('rejects immediately when Claude sign-in is denied', async () => {
     vi.resetModules()
     const child = new EventEmitter() as EventEmitter & {
+      stdin: PassThrough
       stdout: PassThrough
       stderr: PassThrough
       kill: ReturnType<typeof vi.fn>
       pid: number
     }
+    child.stdin = new PassThrough()
     child.stdout = new PassThrough()
     child.stderr = new PassThrough()
     child.kill = vi.fn()
     child.pid = 4242
+    const destroyStdin = vi.spyOn(child.stdin, 'destroy')
     const spawnMock = vi.fn(() => child)
     vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
     // Denial must tear down the whole detached login/browser tree (process-group kill on POSIX),
@@ -1130,13 +1228,15 @@ describe('ClaudeAccountService credential capture', () => {
           runClaudeCommand(
             args: string[],
             configDir: { windowsPath: string; linuxPath: string | null; wslDistro: string | null },
-            timeoutMs: number
+            timeoutMs: number,
+            options?: { keepStdinOpen?: boolean }
           ): Promise<string>
         }
       ).runClaudeCommand(
         ['login'],
         { windowsPath: '/tmp/claude-auth', linuxPath: null, wslDistro: null },
-        180_000
+        180_000,
+        { keepStdinOpen: true }
       )
 
       child.stderr.write('OAuth authorization failed: access_denied\n')
@@ -1144,6 +1244,7 @@ describe('ClaudeAccountService credential capture', () => {
       await expect(commandPromise).rejects.toThrow('Claude sign-in was denied. Please try again.')
       expect(killTree).toHaveBeenCalledWith(-child.pid)
       expect(child.kill).not.toHaveBeenCalled()
+      expect(destroyStdin).toHaveBeenCalledTimes(1)
       expect(child.stdout.listenerCount('data')).toBe(0)
       expect(child.stderr.listenerCount('data')).toBe(0)
       expect(child.listenerCount('error')).toBe(0)
@@ -1157,13 +1258,16 @@ describe('ClaudeAccountService credential capture', () => {
   it('cancels an in-flight Claude account add', async () => {
     vi.resetModules()
     const child = new EventEmitter() as EventEmitter & {
+      stdin: PassThrough
       stdout: PassThrough
       stderr: PassThrough
       kill: ReturnType<typeof vi.fn>
     }
+    child.stdin = new PassThrough()
     child.stdout = new PassThrough()
     child.stderr = new PassThrough()
     child.kill = vi.fn()
+    const destroyStdin = vi.spyOn(child.stdin, 'destroy')
     const spawnMock = vi.fn(() => child)
     vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
 
@@ -1203,6 +1307,7 @@ describe('ClaudeAccountService credential capture', () => {
       expect(service.cancelPendingLogin()).toBe(true)
       await expect(addPromise).rejects.toThrow('Claude sign-in was cancelled.')
       expect(child.kill).toHaveBeenCalledTimes(1)
+      expect(destroyStdin).toHaveBeenCalledTimes(1)
       expect(service.cancelPendingLogin()).toBe(false)
       expect(settings.claudeManagedAccounts).toEqual([])
       expect(child.stdout.listenerCount('data')).toBe(0)
@@ -1278,14 +1383,17 @@ describe('ClaudeAccountService credential capture', () => {
     vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValue(null)
     const child = new EventEmitter() as EventEmitter & {
       pid: number
+      stdin: PassThrough
       stdout: PassThrough
       stderr: PassThrough
       kill: ReturnType<typeof vi.fn>
     }
     child.pid = 1234
+    child.stdin = new PassThrough()
     child.stdout = new PassThrough()
     child.stderr = new PassThrough()
     child.kill = vi.fn()
+    const destroyStdin = vi.spyOn(child.stdin, 'destroy')
     const taskkill = new EventEmitter() as EventEmitter & {
       unref: ReturnType<typeof vi.fn>
     }
@@ -1339,6 +1447,7 @@ describe('ClaudeAccountService credential capture', () => {
         expect.objectContaining({ stdio: 'ignore', windowsHide: true })
       )
       expect(taskkill.unref).toHaveBeenCalled()
+      expect(destroyStdin).toHaveBeenCalledTimes(1)
       expect(service.cancelPendingLogin()).toBe(false)
     } finally {
       vi.doUnmock('node:child_process')

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -449,7 +449,8 @@ export class ClaudeAccountService {
         throw new Error('Claude sign-in was cancelled.')
       }
       await this.runClaudeCommand(['auth', 'login', '--claudeai'], tempConfig, LOGIN_TIMEOUT_MS, {
-        signal: loginAbortController.signal
+        signal: loginAbortController.signal,
+        keepStdinOpen: true
       })
       this.cancelPendingClaudeLogin = null
       const status = await this.runClaudeCommand(
@@ -885,7 +886,7 @@ export class ClaudeAccountService {
     args: string[],
     configDir: { windowsPath: string; linuxPath: string | null; wslDistro: string | null },
     timeoutMs: number,
-    options?: { allowFailure?: boolean; signal?: AbortSignal }
+    options?: { allowFailure?: boolean; signal?: AbortSignal; keepStdinOpen?: boolean }
   ): Promise<string> {
     return new Promise((resolvePromise, rejectPromise) => {
       const spawnConfig =
@@ -913,13 +914,26 @@ export class ClaudeAccountService {
               shell: process.platform === 'win32'
             }
       const child = spawn(spawnConfig.command, spawnConfig.args, {
-        stdio: ['ignore', 'pipe', 'pipe'],
+        // Why: Claude's browser auth can bind its callback lifetime to stdin.
+        // Keeping stdin open prevents hidden managed-login runs from tearing down
+        // the local callback server before the browser returns.
+        stdio: [options?.keepStdinOpen ? 'pipe' : 'ignore', 'pipe', 'pipe'],
         shell: spawnConfig.shell,
         env: spawnConfig.env,
         // Why: Claude auth can leave browser/login descendants alive after denial.
         // A process group lets cancellation terminate the whole POSIX login tree.
         detached: process.platform !== 'win32'
       })
+      const stdout = child.stdout
+      const stderr = child.stderr
+      if (!stdout || !stderr) {
+        if (options?.keepStdinOpen) {
+          child.stdin?.destroy()
+        }
+        child.kill()
+        rejectPromise(new Error('Claude command failed to open output streams.'))
+        return
+      }
 
       let settled = false
       let output = ''
@@ -941,11 +955,14 @@ export class ClaudeAccountService {
           clearTimeout(timeout)
           timeout = null
         }
-        child.stdout.off('data', appendOutput)
-        child.stderr.off('data', appendOutput)
+        stdout.off('data', appendOutput)
+        stderr.off('data', appendOutput)
         child.off('error', onError)
         child.off('close', onClose)
         options?.signal?.removeEventListener('abort', onAbort)
+        if (options?.keepStdinOpen) {
+          child.stdin?.destroy()
+        }
       }
       const settle = (callback: () => void): void => {
         if (settled) {
@@ -1006,8 +1023,8 @@ export class ClaudeAccountService {
         })
       }
 
-      child.stdout.on('data', appendOutput)
-      child.stderr.on('data', appendOutput)
+      stdout.on('data', appendOutput)
+      stderr.on('data', appendOutput)
       child.on('error', onError)
       child.on('close', onClose)
       if (options?.signal?.aborted) {


### PR DESCRIPTION
## Summary

Fixes the managed Claude account login flow so the explicit `claude auth login --claudeai` subprocess keeps stdin open while Claude Code completes its browser OAuth callback. The follow-up `auth status --json` command and other non-login commands keep the previous ignored-stdin behavior.

The cleanup path also destroys the opened stdin pipe on timeout, cancellation, OAuth denial, and Windows taskkill cancellation so the login process does not leak file descriptors or linger after Orca rejects the operation.

## Design and regression review

Reviewed the relevant Claude account history before finalizing the fix:

- #6702 cancel flow: preserved `cancelPendingLogin()` and rollback behavior.
- #6653 denial cleanup: preserved whole process-tree cleanup for denial/timeout/cancel.
- #6180 background auth fallback guard: kept this change scoped to explicit managed-account login; background usage refresh does not launch interactive auth.
- #7403 hidden PTY hardening: no hidden PTY or background rate-limit process behavior changed.

A read-only review found no remaining regression risk after the test was moved to the real `addAccount()` flow. A perf/reliability pass found two issues in the first draft: stdin was too broad and was not explicitly destroyed on early exits. Both are fixed here.

## Headline behavior

Implemented. Orca now keeps Claude Code’s browser OAuth login subprocess alive for the callback path while preserving existing cancel, timeout, denial, and Windows cleanup behavior.

## Review-code loop

Formal `review-code-fix-loop` completed after PR creation. Round 1 used two fresh adversarial reviewers. Both returned `No issues found`, so no fix/re-review round was needed. No findings were intentionally left unresolved.

## Validation

- `pnpm vitest run --config config/vitest.config.ts src/main/claude-accounts/service.test.ts`
- `pnpm tsgo --noEmit -p config/tsconfig.node.json`
- `pnpm oxlint src/main/claude-accounts/service.ts src/main/claude-accounts/service.test.ts`
- `git diff --check -- src/main/claude-accounts/service.ts src/main/claude-accounts/service.test.ts design-docs/claude-managed-login-callback.md`
- Live dev-instance OAuth validation with an isolated Orca dev profile:
  - Triggered managed Claude account add through Orca IPC.
  - Confirmed the hidden `claude auth login --claudeai` process stayed alive with a local callback listener.
  - Completed browser OAuth as `delta-eng@stably.ai`.
  - Claude returned `https://platform.claude.com/oauth/code/success?app=claude-code`.
  - Orca captured the managed account successfully.
  - Removed the test managed account and deleted the isolated dev profile afterward.
- PR checks: `verify` passed; `track-community-pr` passed.

## Notes

No UI labels or account-switching semantics changed. No screenshot evidence is attached because the manual validation involved a live OAuth credential flow.

## Tests (validation pass — brennan-test-changes)

Static + focused:
- [x] `pnpm tsgo --noEmit -p config/tsconfig.node.json` — pass
- [x] `pnpm oxlint src/main/claude-accounts/service.ts src/main/claude-accounts/service.test.ts` — pass
- [x] `pnpm vitest run --config config/vitest.config.ts src/main/claude-accounts/service.test.ts` — 23/23 pass
- [x] `git diff --check` — clean

Live in-app flow (Electron launched from this PR worktree; identity verified as `brennanb2025/fix-oauth-callback`):
- [x] Drove the **real** `window.api.claudeAccounts.add()` IPC. Orca spawned `claude auth login --claudeai` in an isolated temp `CLAUDE_CONFIG_DIR` (`orca-claude-login-…`), parented by this worktree's Electron main.
- [x] **Crux of the fix:** `lsof` on the spawned login process showed **fd 0 (stdin) = `unix` socketpair pipe**, not `/dev/null` — proving the `keepStdinOpen` path is active in the real flow (a `CHR /dev/null` would appear if stdin were `ignore`).
- [x] Cancel/cleanup: `cancelPendingLogin()` → `true`, login process-group terminated, `add()` rejected with `Claude sign-in was cancelled.`, accounts list empty, second cancel → `false` (idempotent).
- [x] macOS keychain safety: personal `Claude Code-credentials` item read + restored (net no-op); temp config dir cleaned up.
- [x] Mechanism note: this `claude` build (2.1.201) uses the paste-code OAuth flow (`code=true`, code read back over **stdin**) — exactly why stdin must stay open.

Accepted gap:
- [ ] Completing the real OAuth token capture requires a live managed Claude credential; not reproducible here. Already validated live by the author (`delta-eng@stably.ai`, successful account capture).

Performance: no-regression. Change only flips `stdio[0]` to `pipe` for the single login spawn and adds `child.stdin?.destroy()` on every exit path (timeout/denial/cancel/Windows-taskkill — each asserted once in unit tests). No new polling, fanout, or hot-path work; one fd for the login lifetime, always destroyed.
