### PR TITLE
Keep long-lived multi-agent workspaces fast with experimental terminal pane eviction (opt-in)

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -1,1 +1,0 @@
-VITE_EXPOSE_STORE=true

--- a/.env.e2e
+++ b/.env.e2e
@@ -1,0 +1,1 @@
+VITE_EXPOSE_STORE=true

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -8818,5 +8818,43 @@ describe('registerPtyHandlers', () => {
         source: 'headless'
       })
     })
+
+    // STA-1282 gate #5 (xterm-addon.boundary-containment): the eviction remount
+    // fail-open counter must tell a structural replay failure from a nil mirror.
+    // The old handler swallowed serialization errors to null, collapsing both
+    // cases; these pin the corrected contract through the real IPC handler shape.
+    it('rejects (does not swallow to null) when serialization throws, so a structural failure is distinguishable', async () => {
+      const runtime = {
+        setPtyController: vi.fn(),
+        serializeHiddenOutputRecoveryBuffer: vi.fn().mockRejectedValue(new Error('mirror boom'))
+      }
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, runtime as never)
+
+      await expect(
+        handlers.get('pty:getMainBufferSnapshot')!(null, { id: 'pty-1' })
+      ).rejects.toThrow('mirror boom')
+    })
+
+    it('resolves null (nil mirror, not a failure) when there is no runtime', async () => {
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never)
+
+      await expect(
+        handlers.get('pty:getMainBufferSnapshot')!(null, { id: 'pty-1' })
+      ).resolves.toBeNull()
+    })
+
+    it('resolves null without serializing for an empty/invalid id (nil mirror, not an error)', async () => {
+      const runtime = {
+        setPtyController: vi.fn(),
+        serializeHiddenOutputRecoveryBuffer: vi.fn()
+      }
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, runtime as never)
+
+      await expect(handlers.get('pty:getMainBufferSnapshot')!(null, { id: '' })).resolves.toBeNull()
+      expect(runtime.serializeHiddenOutputRecoveryBuffer).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -19,6 +19,7 @@ import type { Store } from '../persistence'
 import type { GlobalSettings, TuiAgent } from '../../shared/types'
 import type { SleepingAgentLaunchConfig } from '../../shared/agent-session-resume'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
+import type { PtyMainBufferSnapshotPayload } from '../../shared/pty-main-buffer-snapshot'
 import {
   isWslShellName,
   resolveLocalWindowsTerminalRuntimeOptions
@@ -2605,26 +2606,17 @@ export function registerPtyHandlers(
     async (
       _event,
       args: { id?: unknown; opts?: { scrollbackRows?: unknown } }
-    ): Promise<{
-      data: string
-      cols: number
-      rows: number
-      cwd?: string | null
-      lastTitle?: string
-      seq?: number
-      source?: 'headless' | 'renderer'
-      alternateScreen?: boolean
-      pendingEscapeTailAnsi?: string
-    } | null> => {
+    ): Promise<PtyMainBufferSnapshotPayload | null> => {
       if (!runtime || typeof args?.id !== 'string' || args.id.length === 0) {
+        // Why: no runtime / bad id is a nil mirror, not a failure — resolves null
+        // so the STA-1282 eviction remount fail-open counter is not charged.
         return null
       }
       const scrollbackRows = normalizeSnapshotScrollbackRows(args.opts?.scrollbackRows)
-      try {
-        return await runtime.serializeHiddenOutputRecoveryBuffer(args.id, { scrollbackRows })
-      } catch {
-        return null
-      }
+      // Why: STA-1282 gate #5 — do NOT swallow serialization/RPC errors to null.
+      // A real error must REJECT so the renderer can tell a structural replay
+      // failure from a nil mirror; the old try/catch made both indistinguishable.
+      return await runtime.serializeHiddenOutputRecoveryBuffer(args.id, { scrollbackRows })
     }
   )
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1505,6 +1505,28 @@ describe('OrcaRuntimeService', () => {
     expect(shown.ptyId).toBe('pty-1')
   })
 
+  it('stamps the main-buffer snapshot seq from the same counter as pty:data delivery (STA-1282 trim contract)', async () => {
+    const runtime = createRuntime()
+    const ptyId = 'pty-1'
+    // The renderer trims the reattach live-tail overlap by comparing the mirror
+    // snapshot seq against pty:data meta.seq. pty:data meta.seq is the cumulative
+    // byte count onPtyData returns (and stores in ptyOutputSequenceById); the
+    // mirror snapshot seq must share that exact domain or the trim would corrupt.
+    const firstChunk = 'seq-1\r\n'
+    const secondChunk = 'seq-2\r\nseq-3\r\n'
+    const seqAfterFirst = runtime.onPtyData(ptyId, firstChunk, 1)
+    const seqAfterSecond = runtime.onPtyData(ptyId, secondChunk, 2)
+    const cumulativeBytes = firstChunk.length + secondChunk.length
+
+    expect(seqAfterFirst).toBe(firstChunk.length)
+    expect(seqAfterSecond).toBe(cumulativeBytes)
+    expect(runtime.getPtyOutputSequence(ptyId)).toBe(cumulativeBytes)
+
+    const snapshot = await runtime.serializeMainTerminalBuffer(ptyId)
+    expect(snapshot?.seq).toBe(cumulativeBytes)
+    expect(snapshot?.seq).toBe(runtime.getPtyOutputSequence(ptyId))
+  })
+
   it('surfaces stale terminal handles for stranded panes and recovers after same-pane wake', async () => {
     const runtime = new OrcaRuntimeService(store)
     const tabId = 'tab-1'

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -10,6 +10,7 @@ import type {
 } from '../shared/hosted-review'
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
 import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
+import type { PtyMainBufferSnapshotPayload } from '../shared/pty-main-buffer-snapshot'
 import type { AppIdentity } from '../shared/app-identity'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { TaskSourceContext } from '../shared/task-source-context'
@@ -1166,16 +1167,7 @@ export type PreloadApi = {
     getMainBufferSnapshot: (
       id: string,
       opts?: { scrollbackRows?: number }
-    ) => Promise<{
-      data: string
-      cols: number
-      rows: number
-      cwd?: string | null
-      seq?: number
-      source?: 'headless' | 'renderer'
-      alternateScreen?: boolean
-      pendingEscapeTailAnsi?: string
-    } | null>
+    ) => Promise<PtyMainBufferSnapshotPayload | null>
     getRendererDeliveryDebugSnapshot: () => Promise<{
       pendingPtyCount: number
       pendingChars: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,6 +6,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
+import type { PtyMainBufferSnapshotPayload } from '../shared/pty-main-buffer-snapshot'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
@@ -842,16 +843,8 @@ const api = {
     getMainBufferSnapshot: (
       id: string,
       opts?: { scrollbackRows?: number }
-    ): Promise<{
-      data: string
-      cols: number
-      rows: number
-      cwd?: string | null
-      seq?: number
-      source?: 'headless' | 'renderer'
-      alternateScreen?: boolean
-      pendingEscapeTailAnsi?: string
-    } | null> => ipcRenderer.invoke('pty:getMainBufferSnapshot', { id, opts }),
+    ): Promise<PtyMainBufferSnapshotPayload | null> =>
+      ipcRenderer.invoke('pty:getMainBufferSnapshot', { id, opts }),
 
     getRendererDeliveryDebugSnapshot: (): Promise<{
       pendingPtyCount: number

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/constants/terminal'
 import { useAppStore } from '../store'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { isTerminalPaneEvictionEnabled } from '../../../shared/terminal-pane-eviction-settings'
 import { useAllWorktrees } from '../store/selectors'
 import { getConnectionId } from '../lib/connection-context'
 import { basename } from '../lib/path'
@@ -223,6 +224,8 @@ function Terminal(): React.JSX.Element | null {
   const renderedActiveWorktreeId = activeWorktreeId
   const activeView = useAppStore((s) => s.activeView)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const terminalPaneMountByTabId = useAppStore((s) => s.terminalPaneMountByTabId)
+  const terminalPaneEvictionEnabled = useAppStore((s) => isTerminalPaneEvictionEnabled(s.settings))
   const activeTabId = useAppStore((s) => s.activeTabId)
   const activeTabIdByWorktree = useAppStore((s) => s.activeTabIdByWorktree)
   const createTab = useAppStore((s) => s.createTab)
@@ -773,15 +776,42 @@ function Terminal(): React.JSX.Element | null {
   // Without this gate, Phase 1 (hydrateWorkspaceSession) sets activeWorktreeId
   // with ptyId: null, and TerminalPane would call connectPanePty → pty:spawn,
   // creating a duplicate PTY for the same tab.
-  if (renderedActiveWorktreeId && workspaceSessionReady) {
-    mountedWorktreeIdsRef.current.add(renderedActiveWorktreeId)
-  }
   // Prune IDs of worktrees that no longer exist (deleted/removed)
   const allWorktreeIds = new Set(workspaceSurfaces.map((workspace) => workspace.id))
-  for (const id of mountedWorktreeIdsRef.current) {
-    if (!allWorktreeIds.has(id)) {
-      mountedWorktreeIdsRef.current.delete(id)
+  // STA-1282 worktree-dimension gate. Flag-OFF inertness: with eviction disabled
+  // (default) keep the pre-eviction MONOTONIC set — add the active worktree, prune
+  // only deleted ones — so switching away never unmounts a visited worktree's pane
+  // tree (byte-identical to today). With eviction ON the set is no longer
+  // monotonic: a worktree stays mounted only while it is active OR still has at
+  // least one policy-mounted (visible/warm/parked) terminal pane, so a fully
+  // aged-out worktree drops its whole pane tree (overlay layers included).
+  if (!terminalPaneEvictionEnabled) {
+    if (renderedActiveWorktreeId && workspaceSessionReady) {
+      mountedWorktreeIdsRef.current.add(renderedActiveWorktreeId)
     }
+    for (const id of mountedWorktreeIdsRef.current) {
+      if (!allWorktreeIds.has(id)) {
+        mountedWorktreeIdsRef.current.delete(id)
+      }
+    }
+  } else {
+    const nextMountedWorktreeIds = new Set<string>()
+    if (renderedActiveWorktreeId && workspaceSessionReady) {
+      nextMountedWorktreeIds.add(renderedActiveWorktreeId)
+    }
+    for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+      if (allWorktreeIds.has(worktreeId) && tabs.some((tab) => terminalPaneMountByTabId[tab.id])) {
+        nextMountedWorktreeIds.add(worktreeId)
+      }
+    }
+    // Preserve the background-measurement set so transient layout measurement
+    // still mounts its worktree.
+    for (const id of measurableBackgroundWorktreeIdsRef.current) {
+      if (allWorktreeIds.has(id)) {
+        nextMountedWorktreeIds.add(id)
+      }
+    }
+    mountedWorktreeIdsRef.current = nextMountedWorktreeIds
   }
   const anyMountedWorktreeHasLayout = computeAnyMountedWorktreeHasLayout(
     workspaceSurfaces.map((workspace) => workspace.id),

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -811,6 +811,15 @@ function Terminal(): React.JSX.Element | null {
         nextMountedWorktreeIds.add(id)
       }
     }
+    // Why: an Activity-page terminal portal shows a pane whose worktree may be
+    // fully aged-out (no policy-mounted tab). Its worktree must stay mounted so
+    // the overlay layer exists to host the portal — otherwise a terminal the user
+    // is viewing on the Activity page would render nothing (Tier 0 violation).
+    for (const portal of activityTerminalPortals) {
+      if (allWorktreeIds.has(portal.worktreeId)) {
+        nextMountedWorktreeIds.add(portal.worktreeId)
+      }
+    }
     mountedWorktreeIdsRef.current = nextMountedWorktreeIds
   }
   const anyMountedWorktreeHasLayout = computeAnyMountedWorktreeHasLayout(

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -14,6 +14,7 @@ import {
   MIN_AGENT_HIBERNATION_IDLE_MS,
   getEffectiveAgentHibernationIdleMs
 } from '@/lib/agent-hibernation-planner'
+import { TerminalPaneEvictionExperimentalSetting } from './TerminalPaneEvictionExperimentalSetting'
 
 export { getExperimentalPaneSearchEntries }
 
@@ -276,6 +277,11 @@ export function ExperimentalPane({
           ) : null}
         </SearchableSetting>
       ) : null}
+
+      <TerminalPaneEvictionExperimentalSetting
+        settings={settings}
+        updateSettings={updateSettings}
+      />
 
       {showNewWorktreeCardStyle ? (
         <SearchableSetting

--- a/src/renderer/src/components/settings/TerminalPaneEvictionExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/TerminalPaneEvictionExperimentalSetting.tsx
@@ -1,0 +1,112 @@
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+import { NumberField, SettingsSwitch } from './SettingsFormControls'
+import { getExperimentalSearchEntry } from './experimental-search'
+import {
+  isTerminalPaneEvictionEnabled,
+  resolveTerminalPaneEvictionAfterMs,
+  resolveTerminalPaneEvictionWarmBudget,
+  TERMINAL_PANE_EVICTION_AFTER_MINUTES_MAX,
+  TERMINAL_PANE_EVICTION_AFTER_MINUTES_MIN,
+  TERMINAL_PANE_EVICTION_WARM_BUDGET_MAX,
+  TERMINAL_PANE_EVICTION_WARM_BUDGET_MIN
+} from '../../../../shared/terminal-pane-eviction-settings'
+
+const MS_PER_MINUTE = 60 * 1000
+
+type TerminalPaneEvictionExperimentalSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+/** STA-1282: experimental, opt-in, default OFF terminal pane eviction — under
+ *  Settings → Experimental, agent-hibernation precedent. */
+export function TerminalPaneEvictionExperimentalSetting({
+  settings,
+  updateSettings
+}: TerminalPaneEvictionExperimentalSettingProps): React.JSX.Element {
+  const enabled = isTerminalPaneEvictionEnabled(settings)
+  const warmBudget = resolveTerminalPaneEvictionWarmBudget(settings)
+  const afterMinutes = Math.round(resolveTerminalPaneEvictionAfterMs(settings) / MS_PER_MINUTE)
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.ExperimentalPane.terminalPaneEviction.title',
+        'Free memory from hidden terminals'
+      )}
+      description={translate(
+        'auto.components.settings.ExperimentalPane.terminalPaneEviction.description',
+        'Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast.'
+      )}
+      keywords={getExperimentalSearchEntry().terminalPaneEviction.keywords}
+      className="space-y-3 py-2"
+      id="experimental-terminal-pane-eviction"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 shrink space-y-0.5">
+          <Label>
+            {translate(
+              'auto.components.settings.ExperimentalPane.terminalPaneEviction.title',
+              'Free memory from hidden terminals'
+            )}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.ExperimentalPane.terminalPaneEviction.copy',
+              'Unmounts terminal panes you have not viewed recently so a busy multi-agent workspace stays fast. Their processes keep running and the pane restores from the live mirror when you open it again. Experimental while we tune restore fidelity for panes with a running agent.'
+            )}
+          </p>
+        </div>
+        <SettingsSwitch
+          checked={enabled}
+          ariaLabel={translate(
+            'auto.components.settings.ExperimentalPane.terminalPaneEviction.toggleLabel',
+            'Toggle free memory from hidden terminals'
+          )}
+          onChange={() => updateSettings({ experimentalTerminalPaneEviction: !enabled })}
+        />
+      </div>
+      {enabled ? (
+        <>
+          <NumberField
+            label={translate(
+              'auto.components.settings.ExperimentalPane.terminalPaneEviction.warmBudgetLabel',
+              'Terminals kept ready'
+            )}
+            description={translate(
+              'auto.components.settings.ExperimentalPane.terminalPaneEviction.warmBudgetDescription',
+              'How many recently-viewed hidden terminals stay mounted before older ones are unmounted.'
+            )}
+            value={warmBudget}
+            min={TERMINAL_PANE_EVICTION_WARM_BUDGET_MIN}
+            max={TERMINAL_PANE_EVICTION_WARM_BUDGET_MAX}
+            step={1}
+            onChange={(value) => updateSettings({ terminalPaneEvictionWarmBudget: value })}
+          />
+          <NumberField
+            label={translate(
+              'auto.components.settings.ExperimentalPane.terminalPaneEviction.afterMinutesLabel',
+              'Unmount after'
+            )}
+            description={translate(
+              'auto.components.settings.ExperimentalPane.terminalPaneEviction.afterMinutesDescription',
+              'A hidden terminal is unmounted once it has been out of view for this long.'
+            )}
+            value={afterMinutes}
+            min={TERMINAL_PANE_EVICTION_AFTER_MINUTES_MIN}
+            max={TERMINAL_PANE_EVICTION_AFTER_MINUTES_MAX}
+            step={1}
+            suffix={translate(
+              'auto.components.settings.ExperimentalPane.terminalPaneEviction.afterMinutesSuffix',
+              'minutes'
+            )}
+            onChange={(minutes) => updateSettings({ terminalPaneEvictionAfterMinutes: minutes })}
+          />
+        </>
+      ) : null}
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/TerminalPaneEvictionExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/TerminalPaneEvictionExperimentalSetting.tsx
@@ -4,6 +4,7 @@ import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
 import { NumberField, SettingsSwitch } from './SettingsFormControls'
 import { getExperimentalSearchEntry } from './experimental-search'
+import { seedTerminalPaneEvictionWarmSetOnEnable } from '../terminal-pane/terminal-pane-eviction-coordinator'
 import {
   isTerminalPaneEvictionEnabled,
   resolveTerminalPaneEvictionAfterMs,
@@ -66,7 +67,15 @@ export function TerminalPaneEvictionExperimentalSetting({
             'auto.components.settings.ExperimentalPane.terminalPaneEviction.toggleLabel',
             'Toggle free memory from hidden terminals'
           )}
-          onChange={() => updateSettings({ experimentalTerminalPaneEviction: !enabled })}
+          onChange={() => {
+            if (!enabled) {
+              // Why: seed BEFORE the enabling settings write — with an empty warm
+              // map the mount gate would mass-detach every hidden pane in the
+              // enable render instead of parking it (STA-1282 enable-time seam).
+              seedTerminalPaneEvictionWarmSetOnEnable()
+            }
+            updateSettings({ experimentalTerminalPaneEviction: !enabled })
+          }}
         />
       </div>
       {enabled ? (

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -3,6 +3,7 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getNewWorktreeCardStyleSearchEntry } from './new-worktree-card-style-search-entry'
+import { getTerminalPaneEvictionExperimentalSearchEntry } from './terminal-pane-eviction-experimental-search-entry'
 import { getNativeChatExperimentalSearchEntry } from './native-chat-experimental-search-entry'
 import { getEphemeralVmsSearchEntry } from './ephemeral-vms-search'
 
@@ -184,6 +185,7 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
         )
       ]
     },
+    getTerminalPaneEvictionExperimentalSearchEntry(),
     getNewWorktreeCardStyleSearchEntry(),
     {
       title: translate(
@@ -265,6 +267,12 @@ export function getExperimentalSearchEntry() {
       translate(
         'auto.components.settings.experimental.search.agentHibernation.title',
         'Agent sleep'
+      )
+    ),
+    terminalPaneEviction: findEntry(
+      translate(
+        'auto.components.settings.experimental.search.terminalPaneEviction.title',
+        'Free memory from hidden terminals'
       )
     ),
     newWorktreeCardStyle: findEntry(

--- a/src/renderer/src/components/settings/terminal-pane-eviction-experimental-search-entry.ts
+++ b/src/renderer/src/components/settings/terminal-pane-eviction-experimental-search-entry.ts
@@ -1,0 +1,42 @@
+import type { SettingsSearchEntry } from './settings-search'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getTerminalPaneEvictionExperimentalSearchEntry(): SettingsSearchEntry {
+  return {
+    title: translate(
+      'auto.components.settings.experimental.search.terminalPaneEviction.title',
+      'Free memory from hidden terminals'
+    ),
+    description: translate(
+      'auto.components.settings.experimental.search.terminalPaneEviction.description',
+      'Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast. Their processes keep running.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.0d24759f14',
+        'experimental'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.terminalPaneEviction.terminal',
+        'terminal'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.terminalPaneEviction.pane',
+        'pane'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.terminalPaneEviction.memory',
+        'memory'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.terminalPaneEviction.performance',
+        'performance'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.terminalPaneEviction.evict',
+        'evict'
+      )
+    ]
+  }
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useShallow } from 'zustand/react/shallow'
 import type { Tab, TabGroup, TerminalTab } from '../../../../shared/types'
@@ -12,6 +12,10 @@ import {
 import TerminalPane from './TerminalPane'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { useNativeChatToggleShortcut } from '../native-chat/use-native-chat-toggle-shortcut'
+import { noteTerminalPaneVisibility } from './terminal-pane-eviction-coordinator'
+import { shouldMountTerminalPaneNow } from './pane-mount-policy'
+import { isTabParked } from './evicted-pane-registry'
+import { isTerminalPaneEvictionEnabled } from '../../../../shared/terminal-pane-eviction-settings'
 
 type TerminalOverlayAssignment = {
   unifiedTabId: string
@@ -55,6 +59,7 @@ type TerminalOverlaySlotProps = {
   isWorktreeActive: boolean
   isVisible: boolean
   isActive: boolean
+  evictionEnabled: boolean
   activityTerminalPortal: ActivityTerminalPortalTarget | null
   onFocusOwningGroup: ((groupId: string) => void) | undefined
   consumeSuppressedPtyExit: (ptyId: string) => boolean
@@ -72,6 +77,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   isWorktreeActive,
   isVisible,
   isActive,
+  evictionEnabled,
   activityTerminalPortal,
   onFocusOwningGroup,
   consumeSuppressedPtyExit,
@@ -80,6 +86,20 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
 }: TerminalOverlaySlotProps): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
   const overlayRef = useRef<HTMLDivElement | null>(null)
+  // Why: STA-1282 — report this mounted pane's visibility to the eviction
+  // coordinator. A pane that goes hidden becomes a warm candidate; going visible
+  // re-warms it and invalidates any queued teardown. An Activity-portaled pane
+  // counts as visible (Tier 0) so it is never evicted out from under the user.
+  // Flag-OFF inertness: with eviction disabled we do NOT report — no timestamps,
+  // no coordinator subscription (byte-identical to the pre-eviction app). The
+  // effect re-runs on flip so enabling at runtime activates the coordinator.
+  const effectiveVisibleForEviction = isVisible || activityTerminalPortal !== null
+  useEffect(() => {
+    if (!evictionEnabled) {
+      return
+    }
+    noteTerminalPaneVisibility(terminalTabId, worktreeId, effectiveVisibleForEviction)
+  }, [evictionEnabled, effectiveVisibleForEviction, terminalTabId, worktreeId])
   const [measuredFallbackRect, setMeasuredFallbackRect] = useState<MeasuredFallbackRect | null>(
     null
   )
@@ -293,6 +313,8 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
       activeGroupId: state.activeGroupIdByWorktree[worktreeId]
     }))
   )
+  const mountByTabId = useAppStore((state) => state.terminalPaneMountByTabId)
+  const evictionEnabled = useAppStore((state) => isTerminalPaneEvictionEnabled(state.settings))
   const focusGroup = useAppStore((state) => state.focusGroup)
   const consumeSuppressedPtyExit = useAppStore((state) => state.consumeSuppressedPtyExit)
   const closeTab = useAppStore((state) => state.closeTab)
@@ -360,6 +382,22 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
           worktreeId,
           tabId: terminalTab.id
         })
+        // STA-1282 tab-dimension gate: a pane mounts iff it is visible now (incl.
+        // Activity portal) OR the eviction coordinator keeps it warm/exempt.
+        // Evicted (Tier 2) and never-visited hidden tabs render no TerminalPane —
+        // this is the mount-storm fix. Flag-OFF: mount every non-parked tab so
+        // behavior is byte-identical to the pre-eviction app (parked panes stay
+        // claimable-on-demand rather than force-remounting on a runtime flip-OFF).
+        const shouldMount = shouldMountTerminalPaneNow({
+          evictionEnabled,
+          isVisible,
+          hasActivityPortal: activityTerminalPortal !== null,
+          isWarm: mountByTabId[terminalTab.id] === true,
+          isParked: evictionEnabled ? false : isTabParked(terminalTab.id)
+        })
+        if (!shouldMount) {
+          return null
+        }
         return (
           <TerminalOverlaySlot
             key={terminalTab.id}
@@ -372,6 +410,7 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
             isWorktreeActive={isWorktreeActive}
             isVisible={isVisible}
             isActive={isActive}
+            evictionEnabled={evictionEnabled}
             activityTerminalPortal={activityTerminalPortal}
             onFocusOwningGroup={focusOwningGroup}
             consumeSuppressedPtyExit={consumeSuppressedPtyExit}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useShallow } from 'zustand/react/shallow'
 import type { Tab, TabGroup, TerminalTab } from '../../../../shared/types'
@@ -12,7 +12,7 @@ import {
 import TerminalPane from './TerminalPane'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { useNativeChatToggleShortcut } from '../native-chat/use-native-chat-toggle-shortcut'
-import { noteTerminalPaneVisibility } from './terminal-pane-eviction-coordinator'
+import { TerminalPaneVisibilityReporter } from './terminal-pane-visibility-reporter'
 import { shouldMountTerminalPaneNow } from './pane-mount-policy'
 import { isTabParked } from './evicted-pane-registry'
 import { isTerminalPaneEvictionEnabled } from '../../../../shared/terminal-pane-eviction-settings'
@@ -59,7 +59,6 @@ type TerminalOverlaySlotProps = {
   isWorktreeActive: boolean
   isVisible: boolean
   isActive: boolean
-  evictionEnabled: boolean
   activityTerminalPortal: ActivityTerminalPortalTarget | null
   onFocusOwningGroup: ((groupId: string) => void) | undefined
   consumeSuppressedPtyExit: (ptyId: string) => boolean
@@ -77,7 +76,6 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   isWorktreeActive,
   isVisible,
   isActive,
-  evictionEnabled,
   activityTerminalPortal,
   onFocusOwningGroup,
   consumeSuppressedPtyExit,
@@ -86,20 +84,11 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
 }: TerminalOverlaySlotProps): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
   const overlayRef = useRef<HTMLDivElement | null>(null)
-  // Why: STA-1282 — report this mounted pane's visibility to the eviction
-  // coordinator. A pane that goes hidden becomes a warm candidate; going visible
-  // re-warms it and invalidates any queued teardown. An Activity-portaled pane
-  // counts as visible (Tier 0) so it is never evicted out from under the user.
-  // Flag-OFF inertness: with eviction disabled we do NOT report — no timestamps,
-  // no coordinator subscription (byte-identical to the pre-eviction app). The
-  // effect re-runs on flip so enabling at runtime activates the coordinator.
-  const effectiveVisibleForEviction = isVisible || activityTerminalPortal !== null
-  useEffect(() => {
-    if (!evictionEnabled) {
-      return
-    }
-    noteTerminalPaneVisibility(terminalTabId, worktreeId, effectiveVisibleForEviction)
-  }, [evictionEnabled, effectiveVisibleForEviction, terminalTabId, worktreeId])
+  // Visibility reporting is NOT done here: this slot is unmounted by the mount
+  // gate the instant a pane goes hidden-and-not-yet-warm, so its effect could
+  // never report the visible->hidden transition (an unmounting slot runs only
+  // its previous cleanup). The report is owned by TerminalPaneVisibilityReporter,
+  // which the parent renders for every tab regardless of the gate.
   const [measuredFallbackRect, setMeasuredFallbackRect] = useState<MeasuredFallbackRect | null>(
     null
   )
@@ -395,28 +384,39 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
           isWarm: mountByTabId[terminalTab.id] === true,
           isParked: evictionEnabled ? false : isTabParked(terminalTab.id)
         })
-        if (!shouldMount) {
-          return null
-        }
+        // The reporter is rendered for EVERY tab (even one the gate unmounts) so
+        // the visible->hidden transition is always reported; the gated slot below
+        // is what actually mounts the pane. Flag-OFF renders neither an extra
+        // reporter nor a changed tree — byte-identical to the pre-eviction app.
         return (
-          <TerminalOverlaySlot
-            key={terminalTab.id}
-            terminalTabId={terminalTab.id}
-            terminalGeneration={terminalTab.generation}
-            worktreeId={worktreeId}
-            worktreePath={worktreePath}
-            startupCwd={terminalTab.startupCwd}
-            groupId={assignment?.groupId}
-            isWorktreeActive={isWorktreeActive}
-            isVisible={isVisible}
-            isActive={isActive}
-            evictionEnabled={evictionEnabled}
-            activityTerminalPortal={activityTerminalPortal}
-            onFocusOwningGroup={focusOwningGroup}
-            consumeSuppressedPtyExit={consumeSuppressedPtyExit}
-            closeTab={closeTab}
-            leaveWorktreeIfEmpty={leaveWorktreeIfEmpty}
-          />
+          <Fragment key={terminalTab.id}>
+            {evictionEnabled ? (
+              <TerminalPaneVisibilityReporter
+                terminalTabId={terminalTab.id}
+                worktreeId={worktreeId}
+                effectiveVisible={isVisible || activityTerminalPortal !== null}
+                evictionEnabled={evictionEnabled}
+              />
+            ) : null}
+            {shouldMount ? (
+              <TerminalOverlaySlot
+                terminalTabId={terminalTab.id}
+                terminalGeneration={terminalTab.generation}
+                worktreeId={worktreeId}
+                worktreePath={worktreePath}
+                startupCwd={terminalTab.startupCwd}
+                groupId={assignment?.groupId}
+                isWorktreeActive={isWorktreeActive}
+                isVisible={isVisible}
+                isActive={isActive}
+                activityTerminalPortal={activityTerminalPortal}
+                onFocusOwningGroup={focusOwningGroup}
+                consumeSuppressedPtyExit={consumeSuppressedPtyExit}
+                closeTab={closeTab}
+                leaveWorktreeIfEmpty={leaveWorktreeIfEmpty}
+              />
+            ) : null}
+          </Fragment>
         )
       })}
     </>

--- a/src/renderer/src/components/terminal-pane/cancelable-idle-callback.ts
+++ b/src/renderer/src/components/terminal-pane/cancelable-idle-callback.ts
@@ -1,0 +1,19 @@
+/** Schedule `callback` on an idle callback (setTimeout fallback), returning a
+ *  canceler. */
+export function scheduleCancelableIdleCallback(callback: () => void): () => void {
+  // Why: requestIdleCallback is this-sensitive — an extracted unbound reference
+  // throws "Illegal invocation" in Chromium, so always invoke as a method.
+  const target = globalThis as {
+    requestIdleCallback?: (cb: () => void) => number
+    cancelIdleCallback?: (id: number) => void
+  }
+  if (
+    typeof target.requestIdleCallback === 'function' &&
+    typeof target.cancelIdleCallback === 'function'
+  ) {
+    const id = target.requestIdleCallback(callback)
+    return () => target.cancelIdleCallback?.(id)
+  }
+  const timer = setTimeout(callback, 0)
+  return () => clearTimeout(timer)
+}

--- a/src/renderer/src/components/terminal-pane/evicted-pane-registry.test.ts
+++ b/src/renderer/src/components/terminal-pane/evicted-pane-registry.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetEvictedPaneRegistryForTest,
+  claimEvictedPane,
+  evictedPaneCount,
+  forgetEvictedPaneOnExit,
+  getEvictedPane,
+  isEvictionSelfDisabled,
+  isPaneParked,
+  isTabParked,
+  onEvictionSelfDisable,
+  parkedTabIds,
+  recordEvictionRemountReplayOutcome,
+  reconcileEvictedPanes,
+  registerEvictedPane,
+  type EvictedPaneEntry
+} from './evicted-pane-registry'
+
+afterEach(() => __resetEvictedPaneRegistryForTest())
+
+function entry(overrides: Partial<EvictedPaneEntry> & { paneKey: string }): EvictedPaneEntry {
+  return {
+    tabId: overrides.paneKey,
+    worktreeId: 'wt-1',
+    getPtyId: () => `pty-${overrides.paneKey}`,
+    destroy: vi.fn(),
+    releaseForClaim: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('evicted-pane registry', () => {
+  it('registers and reports parked panes', () => {
+    registerEvictedPane(entry({ paneKey: 'a' }))
+    expect(isPaneParked('a')).toBe(true)
+    expect(isPaneParked('b')).toBe(false)
+  })
+
+  it('reports a tab as parked when any of its leaves is parked', () => {
+    registerEvictedPane(entry({ paneKey: 'tab1:leaf1', tabId: 'tab1' }))
+    registerEvictedPane(entry({ paneKey: 'tab1:leaf2', tabId: 'tab1' }))
+    expect(isTabParked('tab1')).toBe(true)
+    expect(parkedTabIds()).toEqual(new Set(['tab1']))
+  })
+
+  it('disposes a stale entry when a pane is re-parked (no double-parked PTY)', () => {
+    const stale = entry({ paneKey: 'a' })
+    registerEvictedPane(stale)
+    registerEvictedPane(entry({ paneKey: 'a' }))
+    expect(stale.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('claim hands the PTY back without killing it', () => {
+    const e = entry({ paneKey: 'a' })
+    registerEvictedPane(e)
+    expect(claimEvictedPane('a')).toBe(true)
+    expect(e.releaseForClaim).toHaveBeenCalledTimes(1)
+    expect(e.destroy).not.toHaveBeenCalled()
+    expect(isPaneParked('a')).toBe(false)
+  })
+
+  it('claim of an unparked pane returns false', () => {
+    expect(claimEvictedPane('missing')).toBe(false)
+  })
+
+  it('forgets a parked pane whose PTY exited without killing it again', () => {
+    const e = entry({ paneKey: 'a' })
+    registerEvictedPane(e)
+    forgetEvictedPaneOnExit('a')
+    expect(e.destroy).not.toHaveBeenCalled()
+    expect(e.releaseForClaim).toHaveBeenCalledTimes(1)
+    expect(isPaneParked('a')).toBe(false)
+  })
+
+  describe('close-reconcile (gate #8)', () => {
+    it('kills a parked pane whose tab is gone', () => {
+      const e = entry({ paneKey: 'a', tabId: 'tab-a', worktreeId: 'wt-1' })
+      registerEvictedPane(e)
+      reconcileEvictedPanes({ tabIds: new Set(), worktreeIds: new Set(['wt-1']) })
+      expect(e.destroy).toHaveBeenCalledTimes(1)
+      expect(isPaneParked('a')).toBe(false)
+    })
+
+    it('kills a parked pane whose worktree is gone', () => {
+      const e = entry({ paneKey: 'a', tabId: 'tab-a', worktreeId: 'wt-gone' })
+      registerEvictedPane(e)
+      reconcileEvictedPanes({ tabIds: new Set(['tab-a']), worktreeIds: new Set(['wt-1']) })
+      expect(e.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps a parked pane whose tab and worktree both still exist', () => {
+      const e = entry({ paneKey: 'a', tabId: 'tab-a', worktreeId: 'wt-1' })
+      registerEvictedPane(e)
+      reconcileEvictedPanes({ tabIds: new Set(['tab-a']), worktreeIds: new Set(['wt-1']) })
+      expect(e.destroy).not.toHaveBeenCalled()
+      expect(isPaneParked('a')).toBe(true)
+    })
+  })
+
+  describe('fail-open counter (gate #5)', () => {
+    it('self-disables only after N structural failures, not on nil/ok', () => {
+      const listener = vi.fn()
+      onEvictionSelfDisable(listener)
+      recordEvictionRemountReplayOutcome('nil')
+      recordEvictionRemountReplayOutcome('ok')
+      recordEvictionRemountReplayOutcome('nil')
+      expect(isEvictionSelfDisabled()).toBe(false)
+      recordEvictionRemountReplayOutcome('error')
+      recordEvictionRemountReplayOutcome('error')
+      expect(isEvictionSelfDisabled()).toBe(false)
+      recordEvictionRemountReplayOutcome('error')
+      expect(isEvictionSelfDisabled()).toBe(true)
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not miscount a nil mirror as a failure', () => {
+      for (let i = 0; i < 10; i++) {
+        recordEvictionRemountReplayOutcome('nil')
+      }
+      expect(isEvictionSelfDisabled()).toBe(false)
+    })
+  })
+
+  // Perf budget item (d2): the registry is the ONE place parked state lives while
+  // a pane is unmounted. It must stay bounded by the number of evicted live PTYs
+  // (not evict cycles) and must hold no renderer render-state (no xterm, DOM, or
+  // scrollback buffer) — those are exactly what eviction tore down.
+  describe('perf budget d2 (bounded, no renderer render-state)', () => {
+    it('is bounded by the count of distinct evicted live PTYs, not by evict cycles', () => {
+      // A 40-agent workspace parks ~40 entries — the aggregate ceiling the budget
+      // asserts (orders of magnitude below the mounted-xterm cost this removes).
+      for (let i = 0; i < 40; i++) {
+        registerEvictedPane(entry({ paneKey: `pane-${i}`, tabId: `tab-${i}` }))
+      }
+      expect(evictedPaneCount()).toBe(40)
+
+      // Repeated evict cycles of the SAME panes re-park in place (each re-park
+      // disposes the stale entry), so the registry never grows past distinct PTYs.
+      for (let cycle = 0; cycle < 5; cycle++) {
+        for (let i = 0; i < 40; i++) {
+          registerEvictedPane(entry({ paneKey: `pane-${i}`, tabId: `tab-${i}` }))
+        }
+      }
+      expect(evictedPaneCount()).toBe(40)
+    })
+
+    it('holds only bounded metadata per entry — no xterm/DOM/scrollback buffer', () => {
+      registerEvictedPane(entry({ paneKey: 'a' }))
+      const parked = getEvictedPane('a')
+      expect(parked).toBeDefined()
+      // The entry is a tiny constant: ids + lifecycle callbacks.
+      // Anything retaining renderer render-state (an xterm instance, a DOM node,
+      // a scrollback buffer) would violate the d2 budget, so the shape is pinned.
+      expect(new Set(Object.keys(parked as object))).toEqual(
+        new Set(['paneKey', 'tabId', 'worktreeId', 'getPtyId', 'destroy', 'releaseForClaim'])
+      )
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/evicted-pane-registry.ts
+++ b/src/renderer/src/components/terminal-pane/evicted-pane-registry.ts
@@ -1,0 +1,176 @@
+// STA-1282: module-scoped registry of parked (evicted) terminal panes.
+//
+// When a hidden pane is evicted (Tier 1 -> Tier 2), its xterm/DOM/addons are
+// gone but the PTY, its main-side mirror, and a lightweight title/status feed
+// stay alive. The parked transport + coordinator live here (webviewRegistry
+// precedent) so they are not garbage-collected while the pane is unmounted, and
+// so tab/worktree close can reconcile them (gate #8). Only live-PTY panes ever
+// enter, so the registry is bounded by construction.
+//
+// Entries are keyed by paneKey (stable per tab+leaf) because a split tab evicts
+// every leaf; each leaf transport is one entry. Close-reconcile keys off the
+// tab/worktree stored on each entry. This module owns no xterm/DOM/scrollback
+// state (perf budget item d2). It also owns the per-session fail-open counter
+// (gate #5) and self-disable state.
+
+import { TERMINAL_PANE_EVICTION_MAX_REPLAY_FAILURES } from '../../../../shared/terminal-pane-eviction-settings'
+
+export type EvictedPaneEntry = {
+  paneKey: string
+  tabId: string
+  worktreeId: string
+  /** Live PTY id of the parked transport. */
+  getPtyId: () => string | null
+  /** Kill the PTY and dispose the parked transport + coordinator (the pane's
+   *  owning tab/worktree is gone). */
+  destroy: () => void
+  /** Dispose only the parked coordinator/feed and neutralize the transport
+   *  WITHOUT killing the PTY (a fresh pane is remounting and taking over). */
+  releaseForClaim: () => void
+}
+
+const evictedPanes = new Map<string, EvictedPaneEntry>()
+
+let sessionReplayFailureCount = 0
+let sessionSelfDisabled = false
+const selfDisableListeners = new Set<() => void>()
+
+export function registerEvictedPane(entry: EvictedPaneEntry): void {
+  // Why: parking a pane that already has a parked entry (rapid evict cycles)
+  // must dispose the stale one so a single leaf never leaks two parked PTYs.
+  const existing = evictedPanes.get(entry.paneKey)
+  if (existing && existing !== entry) {
+    existing.destroy()
+  }
+  evictedPanes.set(entry.paneKey, entry)
+}
+
+export function getEvictedPane(paneKey: string): EvictedPaneEntry | undefined {
+  return evictedPanes.get(paneKey)
+}
+
+export function isPaneParked(paneKey: string): boolean {
+  return evictedPanes.has(paneKey)
+}
+
+export function isTabParked(tabId: string): boolean {
+  for (const entry of evictedPanes.values()) {
+    if (entry.tabId === tabId) {
+      return true
+    }
+  }
+  return false
+}
+
+/** Distinct tab ids that currently have at least one parked leaf. */
+export function parkedTabIds(): Set<string> {
+  const ids = new Set<string>()
+  for (const entry of evictedPanes.values()) {
+    ids.add(entry.tabId)
+  }
+  return ids
+}
+
+/** Iterate (tabId, worktreeId) owners of currently-parked leaves. Used by the
+ *  coordinator's change signature so a parked tab/worktree closing moves the
+ *  signature and triggers the close-reconcile (gate #8), even though parked
+ *  tabs are not in the coordinator's managed set. Allocation-free on purpose —
+ *  this runs per store tick while anything is parked; duplicate owners
+ *  (multi-leaf split tabs) just repeat a signature part, which is harmless. */
+export function forEachParkedOwner(cb: (tabId: string, worktreeId: string) => void): void {
+  for (const entry of evictedPanes.values()) {
+    cb(entry.tabId, entry.worktreeId)
+  }
+}
+
+export function evictedPaneCount(): number {
+  return evictedPanes.size
+}
+
+/**
+ * A fresh pane is remounting `paneKey`: hand the live PTY back by dropping the
+ * parked entry without killing it. Returns true if an entry was claimed (the
+ * remount is an eviction replay and should charge the fail-open counter).
+ */
+export function claimEvictedPane(paneKey: string): boolean {
+  const entry = evictedPanes.get(paneKey)
+  if (!entry) {
+    return false
+  }
+  evictedPanes.delete(paneKey)
+  entry.releaseForClaim()
+  return true
+}
+
+/** The parked PTY exited on its own (or was hibernation-killed) — drop the entry
+ *  and dispose the parked feed. The PTY is already dead, so no kill. */
+export function forgetEvictedPaneOnExit(paneKey: string): void {
+  const entry = evictedPanes.get(paneKey)
+  if (!entry) {
+    return
+  }
+  evictedPanes.delete(paneKey)
+  entry.releaseForClaim()
+}
+
+/**
+ * Gate #8: close-reconcile. Any parked transport whose owning tab or worktree is
+ * gone is killed (its PTY too) so no parked PTY outlives its tab/worktree.
+ */
+export function reconcileEvictedPanes(live: {
+  tabIds: ReadonlySet<string>
+  worktreeIds: ReadonlySet<string>
+}): void {
+  // Deleting the current entry during Map iteration is safe.
+  for (const [paneKey, entry] of evictedPanes) {
+    if (!live.tabIds.has(entry.tabId) || !live.worktreeIds.has(entry.worktreeId)) {
+      evictedPanes.delete(paneKey)
+      entry.destroy()
+    }
+  }
+}
+
+// --- fail-open counter + self-disable (gate #5) ------------------------------
+
+/**
+ * Record the outcome of an eviction remount replay. Only a structural failure
+ * (RPC error/timeout, malformed snapshot) counts toward self-disable; a nil or
+ * empty mirror is a legitimately blank pane and must not.
+ */
+export function recordEvictionRemountReplayOutcome(outcome: 'ok' | 'nil' | 'error'): void {
+  if (outcome !== 'error') {
+    return
+  }
+  sessionReplayFailureCount += 1
+  if (
+    !sessionSelfDisabled &&
+    sessionReplayFailureCount >= TERMINAL_PANE_EVICTION_MAX_REPLAY_FAILURES
+  ) {
+    sessionSelfDisabled = true
+    for (const listener of selfDisableListeners) {
+      listener()
+    }
+  }
+}
+
+export function isEvictionSelfDisabled(): boolean {
+  return sessionSelfDisabled
+}
+
+/** Fires when the session self-disables (the coordinator cancels pending
+ *  teardowns and stops evicting). */
+export function onEvictionSelfDisable(listener: () => void): () => void {
+  selfDisableListeners.add(listener)
+  return () => selfDisableListeners.delete(listener)
+}
+
+// Test-only reset so per-session counters do not leak across unit tests.
+export function __resetEvictedPaneRegistryForTest(): void {
+  for (const entry of evictedPanes.values()) {
+    entry.destroy()
+  }
+  evictedPanes.clear()
+  sessionReplayFailureCount = 0
+  sessionSelfDisabled = false
+  selfDisableListeners.clear()
+}

--- a/src/renderer/src/components/terminal-pane/pane-mount-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-mount-policy.test.ts
@@ -102,6 +102,28 @@ describe('computePaneMountPolicy', () => {
     expect(result.evictTabIds.size).toBe(0)
   })
 
+  it('parked panes do not consume warm-budget rank slots', () => {
+    // A parked pane is always classified 'evict' regardless of rank, so letting
+    // it into the ranking pool would silently steal a warm slot from a live
+    // hidden pane, evicting it earlier than warmBudget intends.
+    const result = computePaneMountPolicy(
+      policy(
+        [
+          candidate({ tabId: 'parked', isParked: true, lastVisibleAt: NOW - 1_000 }),
+          candidate({ tabId: 'a', lastVisibleAt: NOW - 2_000 }),
+          candidate({ tabId: 'b', lastVisibleAt: NOW - 3_000 }),
+          candidate({ tabId: 'c', lastVisibleAt: NOW - 4_000 })
+        ],
+        { warmBudget: 3 }
+      )
+    )
+    expect(result.classifications.get('parked')).toBe('evict')
+    // All three live hidden panes keep their warm slots.
+    expect(result.classifications.get('a')).toBe('warm')
+    expect(result.classifications.get('b')).toBe('warm')
+    expect(result.classifications.get('c')).toBe('warm')
+  })
+
   it('exempts newborn (unbound), dead, and wake-hint panes', () => {
     const result = computePaneMountPolicy(
       policy(

--- a/src/renderer/src/components/terminal-pane/pane-mount-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-mount-policy.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computePaneMountPolicy,
+  nextDwellExpiryAt,
+  shouldMountTerminalPaneNow,
+  type PaneMountCandidate,
+  type PaneMountPolicyInput
+} from './pane-mount-policy'
+
+const NOW = 1_000_000
+
+function candidate(overrides: Partial<PaneMountCandidate> & { tabId: string }): PaneMountCandidate {
+  return {
+    worktreeId: 'wt-1',
+    isVisible: false,
+    lastVisibleAt: NOW,
+    ptyState: 'live',
+    hasWakeHint: false,
+    isParked: false,
+    ...overrides
+  }
+}
+
+function policy(
+  candidates: PaneMountCandidate[],
+  overrides: Partial<PaneMountPolicyInput> = {}
+): PaneMountPolicyInput {
+  return {
+    candidates,
+    nowMs: NOW,
+    evictionEnabled: true,
+    warmBudget: 12,
+    evictAfterMs: 5 * 60_000,
+    ...overrides
+  }
+}
+
+describe('shouldMountTerminalPaneNow (flag-OFF inertness)', () => {
+  const base = {
+    evictionEnabled: true,
+    isVisible: false,
+    hasActivityPortal: false,
+    isWarm: false,
+    isParked: false
+  }
+
+  it('disabled → mount-everything branch: a hidden, non-warm, non-parked tab still mounts', () => {
+    // Byte-identical to the pre-eviction app, where every hidden tab stayed
+    // mounted regardless of the coordinator (which does not run when disabled).
+    expect(shouldMountTerminalPaneNow({ ...base, evictionEnabled: false })).toBe(true)
+  })
+
+  it('disabled → a parked pane stays unmounted (claimable on demand, no batch remount)', () => {
+    // A runtime flag-OFF must not force-remount the whole parked set; parked
+    // panes remount lazily on next visit (disable reconciliation).
+    expect(shouldMountTerminalPaneNow({ ...base, evictionEnabled: false, isParked: true })).toBe(
+      false
+    )
+  })
+
+  it('disabled → a visible parked pane still mounts (visibility wins)', () => {
+    expect(
+      shouldMountTerminalPaneNow({
+        ...base,
+        evictionEnabled: false,
+        isParked: true,
+        isVisible: true
+      })
+    ).toBe(true)
+  })
+
+  it('enabled → mounts only visible/portal/warm; evicted and never-visited hidden tabs do not', () => {
+    expect(shouldMountTerminalPaneNow({ ...base, isVisible: true })).toBe(true)
+    expect(shouldMountTerminalPaneNow({ ...base, hasActivityPortal: true })).toBe(true)
+    expect(shouldMountTerminalPaneNow({ ...base, isWarm: true })).toBe(true)
+    // Hidden, not warm (evicted or never-visited) → no pane (the mount-storm fix).
+    expect(shouldMountTerminalPaneNow({ ...base })).toBe(false)
+  })
+})
+
+describe('computePaneMountPolicy', () => {
+  it('never evicts a visible pane regardless of budget/dwell', () => {
+    const result = computePaneMountPolicy(
+      policy([candidate({ tabId: 'a', isVisible: true, lastVisibleAt: NOW - 60 * 60_000 })], {
+        warmBudget: 0
+      })
+    )
+    expect(result.classifications.get('a')).toBe('visible')
+    expect(result.mountedTabIds.has('a')).toBe(true)
+  })
+
+  it('treats an Activity-portaled tab as visible input (Tier 0, exempt from eviction)', () => {
+    // The coordinator resolves portal membership into isVisible; a portaled tab
+    // that is otherwise inactive and long-hidden must still classify as visible.
+    const result = computePaneMountPolicy(
+      policy([candidate({ tabId: 'portal', isVisible: true, lastVisibleAt: NOW - 30 * 60_000 })], {
+        warmBudget: 0,
+        evictAfterMs: 1
+      })
+    )
+    expect(result.classifications.get('portal')).toBe('visible')
+    expect(result.evictTabIds.size).toBe(0)
+  })
+
+  it('exempts newborn (unbound), dead, and wake-hint panes', () => {
+    const result = computePaneMountPolicy(
+      policy(
+        [
+          candidate({ tabId: 'newborn', ptyState: 'newborn', lastVisibleAt: null }),
+          candidate({ tabId: 'dead', ptyState: 'dead', lastVisibleAt: NOW - 60 * 60_000 }),
+          candidate({ tabId: 'wake', hasWakeHint: true, lastVisibleAt: NOW - 60 * 60_000 })
+        ],
+        { warmBudget: 0 }
+      )
+    )
+    expect(result.classifications.get('newborn')).toBe('exempt')
+    expect(result.classifications.get('dead')).toBe('exempt')
+    expect(result.classifications.get('wake')).toBe('exempt')
+    expect(result.evictTabIds.size).toBe(0)
+  })
+
+  it('keeps the warmBudget most-recently-visible hidden panes and evicts the rest (LRU)', () => {
+    const candidates = Array.from({ length: 5 }, (_, i) =>
+      candidate({ tabId: `t${i}`, lastVisibleAt: NOW - i * 1000 })
+    )
+    const result = computePaneMountPolicy(policy(candidates, { warmBudget: 3 }))
+    // t0..t2 most recent -> warm; t3,t4 -> evict.
+    expect(result.classifications.get('t0')).toBe('warm')
+    expect(result.classifications.get('t2')).toBe('warm')
+    expect(result.classifications.get('t3')).toBe('evict')
+    expect(result.classifications.get('t4')).toBe('evict')
+  })
+
+  it('evicts a warm pane once it passes the dwell window even within budget', () => {
+    const result = computePaneMountPolicy(
+      policy(
+        [
+          candidate({ tabId: 'fresh', lastVisibleAt: NOW - 1000 }),
+          candidate({ tabId: 'stale', lastVisibleAt: NOW - 6 * 60_000 })
+        ],
+        { warmBudget: 12, evictAfterMs: 5 * 60_000 }
+      )
+    )
+    expect(result.classifications.get('fresh')).toBe('warm')
+    expect(result.classifications.get('stale')).toBe('evict')
+  })
+
+  it('evicts a live hidden pane that has never been visible (null lastVisibleAt)', () => {
+    const result = computePaneMountPolicy(
+      policy([candidate({ tabId: 'bg', lastVisibleAt: null })], { warmBudget: 12 })
+    )
+    expect(result.classifications.get('bg')).toBe('evict')
+  })
+
+  it('sinks null-lastVisibleAt panes below timestamped panes in the LRU ranking', () => {
+    const result = computePaneMountPolicy(
+      policy(
+        [
+          candidate({ tabId: 'timestamped', lastVisibleAt: NOW - 10 * 60_000 }),
+          candidate({ tabId: 'null-a', lastVisibleAt: null }),
+          candidate({ tabId: 'null-b', lastVisibleAt: null })
+        ],
+        { warmBudget: 1, evictAfterMs: 60 * 60_000 }
+      )
+    )
+    // Only 1 warm slot; the timestamped pane ranks above the nulls. It is within
+    // dwell so it stays warm; the nulls are out of budget AND out of dwell.
+    expect(result.classifications.get('timestamped')).toBe('warm')
+    expect(result.classifications.get('null-a')).toBe('evict')
+    expect(result.classifications.get('null-b')).toBe('evict')
+  })
+
+  describe('disabled (kill switch / self-disable)', () => {
+    it('keeps live hidden panes mounted (no new evictions)', () => {
+      const result = computePaneMountPolicy(
+        policy([candidate({ tabId: 'a', lastVisibleAt: NOW - 60 * 60_000 })], {
+          evictionEnabled: false,
+          warmBudget: 0,
+          evictAfterMs: 1
+        })
+      )
+      expect(result.classifications.get('a')).toBe('warm')
+      expect(result.evictTabIds.size).toBe(0)
+    })
+
+    it('leaves already-parked panes parked (claimable on visit, no batch remount)', () => {
+      const result = computePaneMountPolicy(
+        policy([candidate({ tabId: 'parked', isParked: true })], { evictionEnabled: false })
+      )
+      expect(result.classifications.get('parked')).toBe('evict')
+      expect(result.mountedTabIds.has('parked')).toBe(false)
+    })
+  })
+
+  it('remounts a parked pane only when it becomes visible', () => {
+    const parkedHidden = computePaneMountPolicy(
+      policy([candidate({ tabId: 'p', isParked: true, isVisible: false })])
+    )
+    expect(parkedHidden.classifications.get('p')).toBe('evict')
+
+    const parkedVisible = computePaneMountPolicy(
+      policy([candidate({ tabId: 'p', isParked: true, isVisible: true })])
+    )
+    expect(parkedVisible.classifications.get('p')).toBe('visible')
+  })
+})
+
+describe('nextDwellExpiryAt', () => {
+  it('returns the soonest warm-pane dwell boundary', () => {
+    const at = nextDwellExpiryAt(
+      policy(
+        [
+          candidate({ tabId: 'a', lastVisibleAt: NOW - 60_000 }),
+          candidate({ tabId: 'b', lastVisibleAt: NOW - 120_000 })
+        ],
+        { evictAfterMs: 5 * 60_000 }
+      )
+    )
+    // b is older, so its dwell boundary (lastVisibleAt + evictAfterMs) is soonest.
+    expect(at).toBe(NOW - 120_000 + 5 * 60_000)
+  })
+
+  it('returns null when eviction is disabled', () => {
+    expect(
+      nextDwellExpiryAt(policy([candidate({ tabId: 'a' })], { evictionEnabled: false }))
+    ).toBeNull()
+  })
+
+  it('returns null when nothing is warm', () => {
+    expect(nextDwellExpiryAt(policy([candidate({ tabId: 'a', isVisible: true })]))).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pane-mount-policy.ts
+++ b/src/renderer/src/components/terminal-pane/pane-mount-policy.ts
@@ -58,8 +58,16 @@ export type PaneMountPolicyResult = {
 }
 
 function isEvictionEligible(candidate: PaneMountCandidate): boolean {
-  // Only live, hidden, non-wake-hint panes are candidates for the LRU.
-  return !candidate.isVisible && candidate.ptyState === 'live' && !candidate.hasWakeHint
+  // Only live, hidden, non-wake-hint panes are candidates for the LRU. Parked
+  // panes are excluded: they are always classified 'evict' regardless of rank,
+  // so letting them into the ranking pool would silently consume warm-budget
+  // slots and evict live hidden panes earlier than warmBudget intends.
+  return (
+    !candidate.isVisible &&
+    !candidate.isParked &&
+    candidate.ptyState === 'live' &&
+    !candidate.hasWakeHint
+  )
 }
 
 function classifyCandidate(

--- a/src/renderer/src/components/terminal-pane/pane-mount-policy.ts
+++ b/src/renderer/src/components/terminal-pane/pane-mount-policy.ts
@@ -1,0 +1,182 @@
+// STA-1282: pure mount policy for terminal panes. Given the current tab
+// visibility/PTY facts and the eviction settings, decide which terminal tabs
+// stay mounted (Tier 0 visible / Tier 1 warm) and which are evicted (Tier 2).
+//
+// This module is intentionally pure — no store, no timers, no DOM — so the
+// LRU/dwell/budget/exemption logic is unit-testable at the cheapest layer. The
+// event-driven coordinator resolves messy store facts into these clean inputs
+// and applies the idle-deferred teardown; this file only classifies.
+
+/** Per-leaf PTY lifecycle rolled up to the tab (the mount unit). */
+export type PanePtyState =
+  // No PTY has bound yet (spawn in flight) — protects the tab-auto-close TOCTOU.
+  | 'newborn'
+  // At least one leaf owns a bound, non-exited PTY.
+  | 'live'
+  // The tab had PTYs and all of them have exited (dead pane).
+  | 'dead'
+
+export type PaneMountCandidate = {
+  tabId: string
+  worktreeId: string
+  /** Foreground now: active worktree + active-in-group, OR shown via an
+   *  Activity-terminal portal. Visible panes are never evicted. */
+  isVisible: boolean
+  /** Epoch ms of the last visible→ transition, or null if never visible. */
+  lastVisibleAt: number | null
+  ptyState: PanePtyState
+  /** Suppressed-exit wake hint (mid-restart) — never evict. */
+  hasWakeHint: boolean
+  /** The tab's transport is currently parked in the evicted registry. */
+  isParked: boolean
+}
+
+export type PaneMountPolicyInput = {
+  candidates: readonly PaneMountCandidate[]
+  nowMs: number
+  evictionEnabled: boolean
+  warmBudget: number
+  evictAfterMs: number
+}
+
+export type PaneMountClassification =
+  // Foreground — always mounted.
+  | 'visible'
+  // Exempt from eviction (newborn / dead / wake-hint) — always mounted.
+  | 'exempt'
+  // Hidden but retained in the warm LRU (within budget and dwell).
+  | 'warm'
+  // Hidden and evicted (or a parked pane not currently visible).
+  | 'evict'
+
+export type PaneMountPolicyResult = {
+  classifications: Map<string, PaneMountClassification>
+  /** Tabs that must have a mounted TerminalPane right now. */
+  mountedTabIds: Set<string>
+  /** Tabs the policy wants unmounted/parked. */
+  evictTabIds: Set<string>
+}
+
+function isEvictionEligible(candidate: PaneMountCandidate): boolean {
+  // Only live, hidden, non-wake-hint panes are candidates for the LRU.
+  return !candidate.isVisible && candidate.ptyState === 'live' && !candidate.hasWakeHint
+}
+
+function classifyCandidate(
+  candidate: PaneMountCandidate,
+  input: PaneMountPolicyInput,
+  warmRankByTabId: ReadonlyMap<string, number>
+): PaneMountClassification {
+  if (candidate.isVisible) {
+    return 'visible'
+  }
+  // Why: a parked pane only ever remounts on demand (when it becomes visible),
+  // never in a hidden/batch remount — this is what keeps disable-reconcile and
+  // exit-while-parked from recreating the mount storm.
+  if (candidate.isParked) {
+    return 'evict'
+  }
+  if (!isEvictionEligible(candidate)) {
+    // newborn / dead / wake-hint — keep today's mounted behavior.
+    return 'exempt'
+  }
+  if (!input.evictionEnabled) {
+    // Kill switch / self-disable: stop evicting. Live hidden panes stay warm;
+    // already-parked panes (handled above) remain claimable on demand.
+    return 'warm'
+  }
+  const rank = warmRankByTabId.get(candidate.tabId)
+  const withinBudget = rank !== undefined && rank < input.warmBudget
+  const withinDwell =
+    candidate.lastVisibleAt !== null && input.nowMs - candidate.lastVisibleAt <= input.evictAfterMs
+  return withinBudget && withinDwell ? 'warm' : 'evict'
+}
+
+/**
+ * Classify every candidate tab. LRU rank is by last-visible recency (most
+ * recent first); a pane stays warm only while it is within `warmBudget` by
+ * recency AND has been hidden no longer than `evictAfterMs`.
+ */
+export function computePaneMountPolicy(input: PaneMountPolicyInput): PaneMountPolicyResult {
+  const eligible = input.candidates.filter(isEvictionEligible)
+  // Sort by recency, most-recently-visible first. Null (never visible) sinks to
+  // the end so background panes age out first.
+  const rankedTabIds = [...eligible]
+    .sort((a, b) => (b.lastVisibleAt ?? -Infinity) - (a.lastVisibleAt ?? -Infinity))
+    .map((candidate) => candidate.tabId)
+  const warmRankByTabId = new Map<string, number>()
+  rankedTabIds.forEach((tabId, index) => warmRankByTabId.set(tabId, index))
+
+  const classifications = new Map<string, PaneMountClassification>()
+  const mountedTabIds = new Set<string>()
+  const evictTabIds = new Set<string>()
+  for (const candidate of input.candidates) {
+    const classification = classifyCandidate(candidate, input, warmRankByTabId)
+    classifications.set(candidate.tabId, classification)
+    if (classification === 'evict') {
+      evictTabIds.add(candidate.tabId)
+    } else {
+      mountedTabIds.add(candidate.tabId)
+    }
+  }
+  return { classifications, mountedTabIds, evictTabIds }
+}
+
+export type TerminalPaneMountDecisionInput = {
+  /** The `experimentalTerminalPaneEviction` setting (NOT the self-disable flag). */
+  evictionEnabled: boolean
+  /** Foreground now (active worktree + active-in-group, incl. Activity portal). */
+  isVisible: boolean
+  hasActivityPortal: boolean
+  /** The coordinator keeps this hidden pane in the warm set (terminalPaneMountByTabId). */
+  isWarm: boolean
+  /** The pane's transport is currently parked in the evicted registry. */
+  isParked: boolean
+}
+
+/**
+ * STA-1282 render-seam mount decision for one terminal tab (flag-OFF inertness).
+ * With eviction OFF (default) every non-parked tab mounts, byte-identical to the
+ * pre-eviction app where hidden tabs stayed mounted. A parked tab stays unmounted
+ * even when disabled so a runtime flag flip-OFF does not force a batch remount of
+ * the whole parked set — they remain claimable on demand (disable reconciliation).
+ * With eviction ON a tab mounts iff it is visible now or the coordinator keeps it
+ * warm; evicted/never-visited hidden tabs render no pane (the mount-storm fix).
+ */
+export function shouldMountTerminalPaneNow(input: TerminalPaneMountDecisionInput): boolean {
+  if (input.isVisible || input.hasActivityPortal) {
+    return true
+  }
+  if (!input.evictionEnabled) {
+    return !input.isParked
+  }
+  return input.isWarm
+}
+
+/**
+ * Soonest epoch-ms at which some currently-warm pane will cross the dwell
+ * boundary and become evictable, or null when nothing is dwell-bound. The
+ * coordinator arms a single lazy timer at this time instead of polling.
+ */
+export function nextDwellExpiryAt(
+  input: PaneMountPolicyInput,
+  // Why: callers that just ran computePaneMountPolicy on the same input pass
+  // its classifications to avoid recomputing the whole policy per recompute.
+  precomputed?: ReadonlyMap<string, PaneMountClassification>
+): number | null {
+  if (!input.evictionEnabled) {
+    return null
+  }
+  const classifications = precomputed ?? computePaneMountPolicy(input).classifications
+  let soonest: number | null = null
+  for (const candidate of input.candidates) {
+    if (classifications.get(candidate.tabId) !== 'warm' || candidate.lastVisibleAt === null) {
+      continue
+    }
+    const expiresAt = candidate.lastVisibleAt + input.evictAfterMs
+    if (soonest === null || expiresAt < soonest) {
+      soonest = expiresAt
+    }
+  }
+  return soonest
+}

--- a/src/renderer/src/components/terminal-pane/pane-unmount-action.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-unmount-action.test.ts
@@ -80,6 +80,23 @@ describe('resolvePaneUnmountAction', () => {
     ).toBe('destroy')
   })
 
+  it('P0-2: a tab closed mid-eviction (live exclusive PTY) -> destroy, never park', () => {
+    // Guards the orphan-PTY leak: if the user closes a tab while its eviction
+    // teardown is in flight, the tab is gone by unmount time. A closed tab must
+    // reach destroy() (kill the PTY) — parking it would leave a live PTY with no
+    // owning tab and no close-reconcile owner. tabStillExists=false wins over the
+    // eviction park branch precisely so this can never orphan.
+    const action = resolvePaneUnmountAction({
+      isEviction: true,
+      tabStillExists: false,
+      tabId: 't1',
+      ptyId: 'pty-1',
+      worktreeTabs: []
+    })
+    expect(action).toBe('destroy')
+    expect(action).not.toBe('park')
+  })
+
   it('a shared PTY is never parked even under an eviction unmount', () => {
     // Guards against two transports claiming one PTY: if the PTY still belongs to
     // a sibling tab, detach wins over park regardless of the eviction flag.

--- a/src/renderer/src/components/terminal-pane/pane-unmount-action.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-unmount-action.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalTab } from '../../../../shared/types'
+import { resolvePaneUnmountAction } from './use-terminal-pane-lifecycle'
+
+function tab(id: string, ptyId: string | null): TerminalTab {
+  return {
+    id,
+    ptyId,
+    worktreeId: 'wt-1',
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+// STA-1282 gate #1 (terminal-pane-eviction.pty-alive): the unmount decision
+// asserts the OUTCOME (a PTY-alive path vs destroy) across the three cases.
+describe('resolvePaneUnmountAction', () => {
+  it('policy-evicted with a live PTY -> park (PTY stays alive)', () => {
+    expect(
+      resolvePaneUnmountAction({
+        isEviction: true,
+        tabStillExists: true,
+        tabId: 't1',
+        ptyId: 'pty-1',
+        worktreeTabs: [tab('t1', 'pty-1')]
+      })
+    ).toBe('park')
+  })
+
+  it('split-move reparent (tab alive, NOT eviction) -> detach, never park', () => {
+    const action = resolvePaneUnmountAction({
+      isEviction: false,
+      tabStillExists: true,
+      tabId: 't1',
+      ptyId: 'pty-1',
+      worktreeTabs: [tab('t1', 'pty-1')]
+    })
+    expect(action).toBe('detach')
+    expect(action).not.toBe('park')
+  })
+
+  it('web/mobile session-mirror host-surface handoff (tab gone, PTY moved to sibling) -> detach, never park', () => {
+    // The temporary tab is removed but its PTY now belongs to the host-surface
+    // tab, so the PTY must stay alive without parking (the host re-registers it).
+    const action = resolvePaneUnmountAction({
+      isEviction: false,
+      tabStillExists: false,
+      tabId: 'temp-tab',
+      ptyId: 'pty-shared',
+      worktreeTabs: [tab('host-tab', 'pty-shared')]
+    })
+    expect(action).toBe('detach')
+    expect(action).not.toBe('park')
+  })
+
+  it('an eviction can never reach a PTY-alive path when there is no PTY -> destroy', () => {
+    expect(
+      resolvePaneUnmountAction({
+        isEviction: true,
+        tabStillExists: true,
+        tabId: 't1',
+        ptyId: null,
+        worktreeTabs: [tab('t1', null)]
+      })
+    ).toBe('destroy')
+  })
+
+  it('tab and worktree gone (PTY not shared) -> destroy', () => {
+    expect(
+      resolvePaneUnmountAction({
+        isEviction: false,
+        tabStillExists: false,
+        tabId: 't1',
+        ptyId: 'pty-1',
+        worktreeTabs: []
+      })
+    ).toBe('destroy')
+  })
+
+  it('a shared PTY is never parked even under an eviction unmount', () => {
+    // Guards against two transports claiming one PTY: if the PTY still belongs to
+    // a sibling tab, detach wins over park regardless of the eviction flag.
+    expect(
+      resolvePaneUnmountAction({
+        isEviction: true,
+        tabStillExists: true,
+        tabId: 'temp-tab',
+        ptyId: 'pty-shared',
+        worktreeTabs: [tab('temp-tab', 'pty-shared'), tab('host-tab', 'pty-shared')]
+      })
+    ).toBe('detach')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8237,6 +8237,45 @@ describe('connectPanePty', () => {
     __resetEvictedPaneRegistryForTest()
   })
 
+  it('releases the parked claim once the fresh pane adopts the PTY (STA-1282 gate #8)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest, isPaneParked, registerEvictedPane } =
+      await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    const releaseForClaim = vi.fn()
+    registerEvictedPane({
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'pty-id',
+      destroy: vi.fn(),
+      releaseForClaim
+    })
+    const transport = createMockTransport('pty-id')
+    transport.connect.mockImplementation(async () => 'pty-id')
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMainBufferSnapshot.mockResolvedValue(null)
+    const binding = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps() as never
+    )
+    try {
+      await flushAsyncTicks(20)
+      // Adoption ran: the parked entry is released so the stale feed cannot
+      // double-drive and a later re-park cannot destroy() the live PTY.
+      expect(releaseForClaim).toHaveBeenCalledTimes(1)
+      expect(isPaneParked(paneKey)).toBe(false)
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
   it('keeps all visible bytes after a pending hidden ESC becomes non-query output', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3711,12 +3711,17 @@ describe('connectPanePty', () => {
     // replay write grows the buffer and follows to the bottom, as xterm does.
     const remountPane = createPane(1)
     const remountBuffer = remountPane.terminal.buffer.active
+    // Model real xterm: write() queues and parses on a later macrotask (the
+    // WriteBuffer setTimeout path), so buffer state must NOT change until then.
+    // A synchronous mock hides the empty-buffer enforce bug this test pins.
     remountPane.terminal.write = vi.fn((data: string, callback?: () => void) => {
-      if (data.includes('parked-history')) {
-        remountBuffer.baseY = 40
-        remountBuffer.viewportY = 40
-      }
-      callback?.()
+      setTimeout(() => {
+        if (data.includes('parked-history')) {
+          remountBuffer.baseY = 40
+          remountBuffer.viewportY = 40
+        }
+        callback?.()
+      }, 0)
     }) as never
     const remountTracking = attachTerminalScrollIntentTracking(
       remountPane.terminal as never,
@@ -3734,6 +3739,11 @@ describe('connectPanePty', () => {
         'parked-history\r\n',
         expect.any(Function)
       )
+      // Yield real macrotasks so the deferred xterm-style parse callbacks run
+      // (flushAsyncTicks pumps microtasks only), then flush the enforce .then.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      await flushAsyncTicks(10)
       // The empty pre-replay buffer must not be captured as the scroll target:
       // that pins the viewport to row 0 AND overwrites the durable intent to 0.
       expect(remountPane.terminal.scrollToLine).not.toHaveBeenCalledWith(0)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3600,6 +3600,66 @@ describe('connectPanePty', () => {
     expect(remountDeps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'pty-main')
   })
 
+  it('drives the mirror replay for a claimed eviction remount adopting via direct attach (STA-1282 gate #5)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest, registerEvictedPane } =
+      await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    const remountTransport = createMockTransport()
+    transportFactoryQueue.push(remountTransport)
+
+    // A live eager buffer + current-tab ownership routes adoption to the DIRECT
+    // attach branch (eagerLivePtyId), which never passes handleReattachResult —
+    // the codex P1-A path (e.g. a background automation agent's PTY).
+    vi.mocked(getEagerPtyBufferHandle).mockImplementation((ptyId: string) =>
+      ptyId === 'pty-main' ? { flush: () => '', dispose: () => {} } : undefined
+    )
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-main' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-main'] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMainBufferSnapshot.mockResolvedValue({ data: 'parked-history\r\n', cols: 100, rows: 30 })
+
+    // Evicted state: a parked registry entry owns the live PTY.
+    registerEvictedPane({
+      paneKey: makePaneKey('tab-1', LEAF_1),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'pty-main',
+      destroy: vi.fn(),
+      releaseForClaim: vi.fn()
+    })
+
+    // Remount: adopts the live PTY via the DIRECT attach path (no
+    // handleReattachResult). The claimed remount must proactively request the
+    // mirror snapshot even though the PTY emits nothing (silent pane).
+    const remountPane = createPane(1)
+    const remountBinding = connectPanePty(
+      remountPane as never,
+      createManager(2) as never,
+      createDeps() as never
+    )
+    try {
+      await flushAsyncTicks(30)
+      expect(remountTransport.attach).toHaveBeenCalledWith(
+        expect.objectContaining({ existingPtyId: 'pty-main' })
+      )
+      expect(getMainBufferSnapshot).toHaveBeenCalled()
+      expect(remountPane.terminal.write).toHaveBeenCalledWith(
+        'parked-history\r\n',
+        expect.any(Function)
+      )
+    } finally {
+      remountBinding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
   it('binds a fresh spawn that resolves as a daemon reattach', async () => {
     const { connectPanePty } = await import('./pty-connection')
     let currentPtyId: string | null = null
@@ -8269,6 +8329,51 @@ describe('connectPanePty', () => {
       // Adoption ran: the parked entry is released so the stale feed cannot
       // double-drive and a later re-park cannot destroy() the live PTY.
       expect(releaseForClaim).toHaveBeenCalledTimes(1)
+      expect(isPaneParked(paneKey)).toBe(false)
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
+  it('parked exit observer clears tab ptyId + drops the entry when the PTY dies in the claim gap (STA-1282 gate #8)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest, isPaneParked } =
+      await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    // A park-capable transport captures the parked sinks the eviction installs.
+    const transport = createMockTransport('pty-id')
+    const parkedSinks: { current: { onPtyExit?: (ptyId: string) => void } | null } = {
+      current: null
+    }
+    const transportLifecycle = transport as unknown as {
+      park: (sinks: { onPtyExit?: (ptyId: string) => void }) => boolean
+      destroy: () => void
+    }
+    transportLifecycle.park = vi.fn((sinks) => {
+      parkedSinks.current = sinks
+      return true
+    })
+    transportLifecycle.destroy = vi.fn()
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    manager.getActivePane.mockReturnValue({ id: 1, leafId: LEAF_1 })
+    const deps = createDeps()
+    const binding = connectPanePty(createPane(1) as never, manager as never, deps as never)
+    try {
+      await flushAsyncTicks(20)
+      // Evict this pane: the parked transport's onPtyExit is now the ONLY observer
+      // of the live PTY while a fresh pane's remount claim is deferred to adoption.
+      binding.park()
+      expect(isPaneParked(paneKey)).toBe(true)
+      expect(parkedSinks.current?.onPtyExit).toBeTypeOf('function')
+
+      // The PTY dies during that gap: the parked observer must update store/tab
+      // state (clear the stale ptyId) and drop the registry entry so nothing
+      // remounts onto a dead PTY and no parked PTY is orphaned.
+      parkedSinks.current?.onPtyExit?.('pty-id')
+      expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'pty-id')
       expect(isPaneParked(paneKey)).toBe(false)
     } finally {
       binding.dispose()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8095,6 +8095,117 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('charges the fail-open counter when a claimed eviction remount snapshot rejects through the real IPC shape (STA-1282 gate #5)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const {
+      __resetEvictedPaneRegistryForTest,
+      isEvictionSelfDisabled,
+      recordEvictionRemountReplayOutcome,
+      registerEvictedPane
+    } = await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    // Two prior structural failures pre-charged: the third must come from the
+    // real remount snapshot path (rejecting IPC) and trip the self-disable.
+    recordEvictionRemountReplayOutcome('error')
+    recordEvictionRemountReplayOutcome('error')
+    registerEvictedPane({
+      paneKey: makePaneKey('tab-1', LEAF_1),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'pty-id',
+      destroy: vi.fn(),
+      releaseForClaim: vi.fn()
+    })
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMainBufferSnapshot.mockRejectedValue(new Error('mirror boom'))
+
+    const isVisibleRef = { current: false }
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const binding = connectPanePty(
+      pane as never,
+      manager as never,
+      createDeps({ isVisibleRef, startup: { command: 'codex' } }) as never
+    )
+    try {
+      await flushAsyncTicks(6)
+      capturedDataCallback.current?.('\x1b[6')
+      isVisibleRef.current = true
+      capturedDataCallback.current?.('n')
+      await flushAsyncTicks(20)
+
+      expect(getMainBufferSnapshot).toHaveBeenCalled()
+      expect(isEvictionSelfDisabled()).toBe(true)
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
+  it('does not charge the fail-open counter for a nil mirror on a claimed eviction remount (STA-1282 gate #5)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const {
+      __resetEvictedPaneRegistryForTest,
+      isEvictionSelfDisabled,
+      recordEvictionRemountReplayOutcome,
+      registerEvictedPane
+    } = await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    recordEvictionRemountReplayOutcome('error')
+    recordEvictionRemountReplayOutcome('error')
+    registerEvictedPane({
+      paneKey: makePaneKey('tab-1', LEAF_1),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'pty-id',
+      destroy: vi.fn(),
+      releaseForClaim: vi.fn()
+    })
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMainBufferSnapshot.mockResolvedValue(null)
+
+    const isVisibleRef = { current: false }
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const binding = connectPanePty(
+      pane as never,
+      manager as never,
+      createDeps({ isVisibleRef, startup: { command: 'codex' } }) as never
+    )
+    try {
+      await flushAsyncTicks(6)
+      capturedDataCallback.current?.('\x1b[6')
+      isVisibleRef.current = true
+      capturedDataCallback.current?.('n')
+      await flushAsyncTicks(20)
+
+      expect(getMainBufferSnapshot).toHaveBeenCalled()
+      // A nil mirror is a successful blank+live remount, never a failure.
+      expect(isEvictionSelfDisabled()).toBe(false)
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
   it('keeps all visible bytes after a pending hidden ESC becomes non-query output', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3660,6 +3660,92 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('re-applies the durable pinned scroll position on a claimed eviction remount instead of pinning to row 0 (#7472)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest, registerEvictedPane } =
+      await import('./evicted-pane-registry')
+    const { attachTerminalScrollIntentTracking, markTerminalPinnedViewport } =
+      await import('@/lib/pane-manager/terminal-scroll-intent')
+    __resetEvictedPaneRegistryForTest()
+    const remountTransport = createMockTransport()
+    transportFactoryQueue.push(remountTransport)
+    vi.mocked(getEagerPtyBufferHandle).mockImplementation((ptyId: string) =>
+      ptyId === 'pty-main' ? { flush: () => '', dispose: () => {} } : undefined
+    )
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-main' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-main'] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMainBufferSnapshot.mockResolvedValue({ data: 'parked-history\r\n', cols: 100, rows: 30 })
+
+    // Pre-eviction pane: the user scrolled up (viewportY 5 of 40), recording a
+    // durable pinnedViewport intent under the leaf-stable scroll-intent key —
+    // exactly what the real pane lifecycle persists across an unmount.
+    const scrollIntentKey = `evict-scroll-test-${LEAF_1}`
+    const preEvictionPane = createPane(1)
+    preEvictionPane.terminal.buffer.active.baseY = 40
+    preEvictionPane.terminal.buffer.active.viewportY = 5
+    const preEvictionTracking = attachTerminalScrollIntentTracking(
+      preEvictionPane.terminal as never,
+      preEvictionPane.container,
+      scrollIntentKey
+    )
+    markTerminalPinnedViewport(preEvictionPane.terminal as never)
+    preEvictionTracking.dispose()
+
+    registerEvictedPane({
+      paneKey: makePaneKey('tab-1', LEAF_1),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'pty-main',
+      destroy: vi.fn(),
+      releaseForClaim: vi.fn()
+    })
+
+    // Remount into a FRESH xterm (empty buffer, viewportY/baseY 0) whose
+    // replay write grows the buffer and follows to the bottom, as xterm does.
+    const remountPane = createPane(1)
+    const remountBuffer = remountPane.terminal.buffer.active
+    remountPane.terminal.write = vi.fn((data: string, callback?: () => void) => {
+      if (data.includes('parked-history')) {
+        remountBuffer.baseY = 40
+        remountBuffer.viewportY = 40
+      }
+      callback?.()
+    }) as never
+    const remountTracking = attachTerminalScrollIntentTracking(
+      remountPane.terminal as never,
+      remountPane.container,
+      scrollIntentKey
+    )
+    const remountBinding = connectPanePty(
+      remountPane as never,
+      createManager(2) as never,
+      createDeps() as never
+    )
+    try {
+      await flushAsyncTicks(30)
+      expect(remountPane.terminal.write).toHaveBeenCalledWith(
+        'parked-history\r\n',
+        expect.any(Function)
+      )
+      // The empty pre-replay buffer must not be captured as the scroll target:
+      // that pins the viewport to row 0 AND overwrites the durable intent to 0.
+      expect(remountPane.terminal.scrollToLine).not.toHaveBeenCalledWith(0)
+      expect(remountPane.terminal.scrollToLine).toHaveBeenCalledWith(5)
+      expect(remountBuffer.viewportY).toBe(5)
+    } finally {
+      remountTracking.dispose()
+      remountBinding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
   it('restores a claimed eviction remount from the seq-aligned mirror, not the sequence-less daemon reattach snapshot (STA-1282)', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { __resetEvictedPaneRegistryForTest, registerEvictedPane } =
@@ -8436,6 +8522,255 @@ describe('connectPanePty', () => {
       parkedSinks.current?.onPtyExit?.('pty-id')
       expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'pty-id')
       expect(isPaneParked(paneKey)).toBe(false)
+      // Match the live exit path: a dead PTY has no running agent and no
+      // foreground identity — a respawn must not inherit a stale agent icon.
+      expect(mockStoreState.removeAgentStatus).toHaveBeenCalledWith(paneKey)
+      expect(mockStoreState.clearPaneForegroundAgent).toHaveBeenCalledWith(paneKey)
+      // STA-1282: the parked exit must also mirror the live path's remaining store
+      // cleanup — consume the suppressed-exit flag (a hibernation kill suppresses
+      // the exit) and clear the stale runtime title + prompt cache timer, not just
+      // the ptyId/status. Otherwise these leak until the pane is remounted.
+      expect(deps.consumeSuppressedPtyExit).toHaveBeenCalledWith('pty-id')
+      expect(deps.clearRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1)
+      expect(deps.setCacheTimerStartedAt).toHaveBeenCalledWith(paneKey, null)
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
+  it('parked BEL still raises the tab/worktree unread marks (STA-1282)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest, isPaneParked } =
+      await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    const transport = createMockTransport('pty-id')
+    const parkedSinks: { current: { onBell?: () => void } | null } = { current: null }
+    const transportLifecycle = transport as unknown as {
+      park: (sinks: { onBell?: () => void }) => boolean
+      destroy: () => void
+    }
+    transportLifecycle.park = vi.fn((sinks) => {
+      parkedSinks.current = sinks
+      return true
+    })
+    transportLifecycle.destroy = vi.fn()
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    manager.getActivePane.mockReturnValue({ id: 1, leafId: LEAF_1 })
+    const deps = createDeps()
+    const binding = connectPanePty(createPane(1) as never, manager as never, deps as never)
+    try {
+      await flushAsyncTicks(20)
+      binding.park()
+      expect(isPaneParked(paneKey)).toBe(true)
+      deps.markWorktreeUnread.mockClear()
+      deps.markTerminalTabUnread.mockClear()
+      // A hidden mounted pane's BEL raises these marks today; parking (which
+      // only puts the rendering away) must not swallow the attention signal.
+      expect(parkedSinks.current?.onBell).toBeTypeOf('function')
+      parkedSinks.current?.onBell?.()
+      expect(deps.markWorktreeUnread).toHaveBeenCalledWith('wt-1')
+      expect(deps.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
+  it('charges the fail-open counter when a claimed eviction remount reattach rejects (STA-1282 gate #5)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const {
+      __resetEvictedPaneRegistryForTest,
+      isEvictionSelfDisabled,
+      recordEvictionRemountReplayOutcome,
+      registerEvictedPane
+    } = await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    // Two prior structural failures pre-charged: the third must come from the
+    // claimed remount whose deferred reattach REJECTS (the .catch path), a sibling
+    // of the in-handler no-id/expired branches that already charge the counter.
+    recordEvictionRemountReplayOutcome('error')
+    recordEvictionRemountReplayOutcome('error')
+    registerEvictedPane({
+      paneKey: makePaneKey('tab-1', LEAF_1),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'restored-session',
+      destroy: vi.fn(),
+      releaseForClaim: vi.fn()
+    })
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async (opts: { sessionId?: string }) => {
+      if (opts.sessionId) {
+        throw new Error('reattach boom')
+      }
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((ptyId: string) => void)
+        | undefined
+      onPtySpawn?.('fresh-pty')
+      return 'fresh-pty'
+    })
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'restored-session' }
+    })
+    const binding = connectPanePty(pane as never, manager as never, deps as never)
+    try {
+      await flushAsyncTicks(20)
+      expect(transport.connect).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'restored-session' })
+      )
+      // Reverting the .catch charge leaves the counter at 2 → not self-disabled.
+      expect(isEvictionSelfDisabled()).toBe(true)
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
+  it('charges the fail-open counter when a claimed eviction remount SSH-deferred reattach rejects (STA-1282 gate #5)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const {
+      __resetEvictedPaneRegistryForTest,
+      isEvictionSelfDisabled,
+      recordEvictionRemountReplayOutcome,
+      registerEvictedPane
+    } = await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    // Two prior structural failures pre-charged: the third must come from the
+    // SSH-deferred reattach branch (waits for the connection, then reattaches),
+    // a sibling of the direct-deferred branch that also lost its charge before.
+    recordEvictionRemountReplayOutcome('error')
+    recordEvictionRemountReplayOutcome('error')
+    registerEvictedPane({
+      paneKey: makePaneKey('tab-1', LEAF_1),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'leaf-session',
+      destroy: vi.fn(),
+      releaseForClaim: vi.fn()
+    })
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async (opts: { sessionId?: string }) => {
+      if (opts.sessionId) {
+        throw new Error('ssh reattach boom')
+      }
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((ptyId: string) => void)
+        | undefined
+      onPtySpawn?.('fresh-ssh-pty')
+      return 'fresh-ssh-pty'
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': 'tab-level-stale-session' }
+    } as StoreState
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'leaf-session' }
+    })
+    const binding = connectPanePty(pane as never, manager as never, deps as never)
+    try {
+      await flushAsyncTicks(20)
+      expect(transport.connect).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'leaf-session' })
+      )
+      // Reverting the SSH-deferred .catch charge leaves the counter at 2.
+      expect(isEvictionSelfDisabled()).toBe(true)
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
+  it('keeps the runtime pane title fresh while parked so the jump palette does not freeze (STA-1282)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest } = await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    const transport = createMockTransport('pty-id')
+    const parkedSinks: {
+      current: { onTitleChange?: (title: string, rawTitle: string) => void } | null
+    } = { current: null }
+    const transportLifecycle = transport as unknown as {
+      park: (sinks: { onTitleChange?: (title: string, rawTitle: string) => void }) => boolean
+      destroy: () => void
+    }
+    transportLifecycle.park = vi.fn((sinks) => {
+      parkedSinks.current = sinks
+      return true
+    })
+    transportLifecycle.destroy = vi.fn()
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    manager.getActivePane.mockReturnValue({ id: 1, leafId: LEAF_1 })
+    const deps = createDeps()
+    const binding = connectPanePty(createPane(1) as never, manager as never, deps as never)
+    try {
+      await flushAsyncTicks(20)
+      binding.park()
+      expect(parkedSinks.current?.onTitleChange).toBeTypeOf('function')
+      ;(deps.setRuntimePaneTitle as ReturnType<typeof vi.fn>).mockClear()
+      parkedSinks.current?.onTitleChange?.('shell-title', 'shell-title')
+      // Without this, the per-pane runtime title (jump palette / split spinner
+      // 'working' source) freezes at the pre-eviction title until remount.
+      expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'shell-title')
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
+  it('normalizes the parked remote-runtime agent type instead of storing the raw payload (STA-1282)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest } = await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    enableActiveRuntimeEnvironment()
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    const transport = createMockTransport('remote:web-env-1@@pty-parked-omp')
+    const parkedSinks: {
+      current: { onAgentStatus?: (payload: unknown) => void } | null
+    } = { current: null }
+    const transportLifecycle = transport as unknown as {
+      park: (sinks: { onAgentStatus?: (payload: unknown) => void }) => boolean
+      destroy: () => void
+    }
+    transportLifecycle.park = vi.fn((sinks) => {
+      parkedSinks.current = sinks
+      return true
+    })
+    transportLifecycle.destroy = vi.fn()
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const manager = createManager(1, 1)
+    manager.getActivePane.mockReturnValue({ id: 1, leafId: LEAF_1 })
+    const deps = createDeps()
+    const binding = connectPanePty(pane as never, manager as never, deps as never)
+    try {
+      // Establish the pane's authoritative agent as OMP by typing the command,
+      // exactly as the live-handler normalization tests do.
+      sendTerminalInputThroughPane(pane, 'omp\r')
+      await flushAsyncTicks()
+      binding.park()
+      expect(parkedSinks.current?.onAgentStatus).toBeTypeOf('function')
+      // A raw 'pi' status arriving while parked must be normalized to the owner
+      // agent (OMP), not stored verbatim — otherwise a parked remote pane mislabels
+      // its agent (#5270). Reverting the fix stores agentType 'pi'.
+      parkedSinks.current?.onAgentStatus?.({ state: 'done', prompt: '', agentType: 'pi' })
+      expect(mockStoreState.agentStatusByPaneKey[paneKey]).toMatchObject({
+        state: 'done',
+        agentType: 'omp'
+      })
     } finally {
       binding.dispose()
       __resetEvictedPaneRegistryForTest()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8206,6 +8206,37 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('defers the parked claim until adoption: a dispose before attach leaves the entry reapable (STA-1282 gate #8)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest, isPaneParked, registerEvictedPane } =
+      await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    const releaseForClaim = vi.fn()
+    registerEvictedPane({
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'pty-id',
+      destroy: vi.fn(),
+      releaseForClaim
+    })
+    const transport = createMockTransport('pty-id')
+    transportFactoryQueue.push(transport)
+    const binding = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps() as never
+    )
+    // Dispose before the deferred connect adopts the PTY (StrictMode / split-group
+    // remount race). Pre-fix the claim released the entry at bind, orphaning the
+    // still-live PTY; the claim must instead survive to be reaped on close.
+    binding.dispose()
+    expect(isPaneParked(paneKey)).toBe(true)
+    expect(releaseForClaim).not.toHaveBeenCalled()
+    __resetEvictedPaneRegistryForTest()
+  })
+
   it('keeps all visible bytes after a pending hidden ESC becomes non-query output', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3660,6 +3660,67 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('restores a claimed eviction remount from the seq-aligned mirror, not the sequence-less daemon reattach snapshot (STA-1282)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { __resetEvictedPaneRegistryForTest, registerEvictedPane } =
+      await import('./evicted-pane-registry')
+    __resetEvictedPaneRegistryForTest()
+
+    let currentPtyId: string | null = null
+    const transport = createMockTransport()
+    transport.getPtyId.mockImplementation(() => currentPtyId)
+    transport.connect.mockImplementation(async () => {
+      currentPtyId = 'pty-reattach'
+      // A daemon reattach snapshot is a bare string with no sequence — its tail
+      // overlaps the first live chunk and the renderer cannot trim it.
+      return { id: currentPtyId, isReattach: true, snapshot: 'daemon-snapshot-tail\r\n' }
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    }
+
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMainBufferSnapshot.mockResolvedValue({
+      data: 'mirror-history\r\n',
+      cols: 100,
+      rows: 30,
+      seq: 42
+    })
+
+    // A parked registry entry marks this remount as an eviction claim.
+    registerEvictedPane({
+      paneKey: makePaneKey('tab-1', LEAF_1),
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getPtyId: () => 'pty-reattach',
+      destroy: vi.fn(),
+      releaseForClaim: vi.fn()
+    })
+
+    const pane = createPane(1)
+    const binding = connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    try {
+      await flushAsyncTicks(30)
+      // The seq-aligned mirror restores this evicted pane...
+      expect(getMainBufferSnapshot).toHaveBeenCalled()
+      expect(pane.terminal.write).toHaveBeenCalledWith('mirror-history\r\n', expect.any(Function))
+      // ...and the sequence-less daemon reattach snapshot is never painted, so it
+      // cannot duplicate the boundary line when live output resumes.
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        'daemon-snapshot-tail\r\n',
+        expect.any(Function)
+      )
+    } finally {
+      binding.dispose()
+      __resetEvictedPaneRegistryForTest()
+    }
+  })
+
   it('binds a fresh spawn that resolves as a daemon reattach', async () => {
     const { connectPanePty } = await import('./pty-connection')
     let currentPtyId: string | null = null

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -14,7 +14,17 @@ import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-colo
 import { isTerminalQueryReply } from '../../../../shared/terminal-query-reply'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
+import type { ParkedPtySinks } from './pty-transport-types'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
+import {
+  claimEvictedPane,
+  forgetEvictedPaneOnExit,
+  isPaneParked,
+  recordEvictionRemountReplayOutcome,
+  registerEvictedPane
+} from './evicted-pane-registry'
+import { logTerminalPaneEvictionBreadcrumb } from './terminal-pane-eviction-breadcrumbs'
+import { TERMINAL_PANE_EVICTION_REMOUNT_SNAPSHOT_TIMEOUT_MS } from '../../../../shared/terminal-pane-eviction-settings'
 import { getConnectionId } from '@/lib/connection-context'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import {
@@ -489,6 +499,30 @@ function readE2eHiddenSnapshotOverride(ptyId: string): Promise<PtyBufferSnapshot
   })
 }
 
+// STA-1282 gate #5: sentinel returned when the eviction-remount snapshot request
+// exceeds its bounded deadline. Distinct from a resolved snapshot/nil so the
+// caller can charge the fail-open counter and fall open to a live pane.
+const EVICTION_REMOUNT_SNAPSHOT_TIMEOUT = Symbol('eviction-remount-snapshot-timeout')
+
+function awaitEvictionRemountSnapshot(
+  request: Promise<{ snapshot: PtyBufferSnapshot | null; failed: boolean }>
+): Promise<
+  { snapshot: PtyBufferSnapshot | null; failed: boolean } | typeof EVICTION_REMOUNT_SNAPSHOT_TIMEOUT
+> {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const timeout = new Promise<typeof EVICTION_REMOUNT_SNAPSHOT_TIMEOUT>((resolve) => {
+    timer = setTimeout(
+      () => resolve(EVICTION_REMOUNT_SNAPSHOT_TIMEOUT),
+      TERMINAL_PANE_EVICTION_REMOUNT_SNAPSHOT_TIMEOUT_MS
+    )
+  })
+  return Promise.race([request, timeout]).finally(() => {
+    if (timer !== null) {
+      clearTimeout(timer)
+    }
+  })
+}
+
 function shouldKeepHiddenStartupRendererQueriesLive(
   startup: PtyConnectionDeps['startup']
 ): boolean {
@@ -672,6 +706,11 @@ type PanePtyBinding = IDisposable & {
   sampleForegroundAgentOnFocus: () => void
   reconcileIfSessionDead: (liveSessionIds: Set<string>, snapshotRequestedAt?: number) => void
   reconcileIfSessionMissing: (hasPty: HasPty, livenessRequestedAt?: number) => void
+  /** STA-1282: park this pane's transport (Tier 1 -> Tier 2 eviction) instead of
+   *  full dispose — keep the PTY + title/status feed alive in the evicted
+   *  registry, tear down the xterm/DOM. Returns true if a live PTY was parked;
+   *  false means there was nothing to park (caller should dispose/destroy). */
+  park: () => boolean
 }
 
 function isAgentTaskCompleteNotificationEnabled(): boolean {
@@ -1046,6 +1085,13 @@ export function connectPanePty(
 ): PanePtyBinding {
   exposeE2eTerminalPtyOutputDebug()
   let disposed = false
+  // Why: STA-1282 — set on park() so this evicted pane keeps its completion
+  // coordinator alive (isLive checks !parked) even though `disposed` is set to
+  // stop the hidden-output-restore loop that writes to the torn-down xterm.
+  let parked = false
+  // Why: STA-1282 — set when this fresh pane is remounting a parked (evicted)
+  // transport, so the first snapshot outcome charges the fail-open counter.
+  let evictionRemountReplayPending = false
   let connectFrame: number | null = null
   let connectFallbackTimer: ReturnType<typeof setTimeout> | null = null
   let startupGridSettleHandle: TerminalStartupGridSettleHandle | null = null
@@ -1107,6 +1153,16 @@ export function connectPanePty(
   // Why: paneKey crosses PTY env, hook IPC, retained rows, and reload/replay.
   // Use the stable layout leaf UUID, not the renderer-local numeric pane id.
   const cacheKey = makePaneKey(deps.tabId, pane.leafId)
+  // Why: STA-1282 — a fresh pane mounting over a parked (evicted) entry claims
+  // the live PTY back (no new spawn — the store still owns its ptyId) and marks
+  // its first snapshot outcome to charge the fail-open counter. releaseForClaim
+  // disposes the stale parked feed so it never double-drives the store.
+  if (isPaneParked(cacheKey)) {
+    evictionRemountReplayPending = claimEvictedPane(cacheKey)
+    if (evictionRemountReplayPending) {
+      logTerminalPaneEvictionBreadcrumb('remount-claim', { tabId: deps.tabId, paneKey: cacheKey })
+    }
+  }
   const getSleepingRecordForPane = (
     state: ReturnType<typeof useAppStore.getState>
   ): { paneKey: string; record: SleepingAgentSessionRecord } | null => {
@@ -1993,7 +2049,10 @@ export function connectPanePty(
     shouldPollProcessCadence: () =>
       isAgentTaskCompleteTrackingEnabled() && deps.isVisibleRef.current,
     isLive: () => {
-      if (disposed) {
+      // Why: STA-1282 — a parked (evicted) pane keeps this coordinator alive to
+      // drive title-based hookless status while unmounted, so liveness must key
+      // off the PTY, not the `disposed` flag that stops the xterm-write loop.
+      if (disposed && !parked) {
         return false
       }
       if (transport.getPtyId()) {
@@ -2520,7 +2579,10 @@ export function connectPanePty(
       ) {
         return
       }
-      if (disposed) {
+      // Why: STA-1282 — a parked (evicted) pane keeps firing agent-complete
+      // notifications while unmounted (gate #3); only a genuinely disposed,
+      // non-parked pane suppresses them.
+      if (disposed && !parked) {
         return
       }
       // Why: terminal attention is a visual pane affordance, not an OS
@@ -4150,6 +4212,18 @@ export function connectPanePty(
     // can reuse the pane object for a different session before visibility.
     let hiddenOutputRestorePtyId: string | null = null
     let hiddenOutputRestoreGeneration = 0
+    const reportEvictionRemountReplayOutcome = (outcome: 'ok' | 'nil' | 'error'): void => {
+      if (!evictionRemountReplayPending) {
+        return
+      }
+      evictionRemountReplayPending = false
+      // Why: STA-1282 gate #5 — the first definitive snapshot outcome of an
+      // eviction remount resolves the fail-open counter (error → structural
+      // failure; nil/empty/happy → success), then clears so routine
+      // hidden-restores never charge the counter.
+      logTerminalPaneEvictionBreadcrumb('remount-replay', { tabId: deps.tabId, outcome })
+      recordEvictionRemountReplayOutcome(outcome)
+    }
     let foregroundImmediateBudgetChars = 0
     let foregroundImmediateBudgetWindowStart = 0
     let foregroundRewriteChunkEndedWithCarriageReturn = false
@@ -4185,18 +4259,32 @@ export function connectPanePty(
     async function serializeHiddenOutputSnapshot(
       ptyId: string,
       opts: { scrollbackRows?: number }
-    ): Promise<PtyBufferSnapshot | null> {
+    ): Promise<{ snapshot: PtyBufferSnapshot | null; failed: boolean }> {
       const e2eSnapshot = readE2eHiddenSnapshotOverride(ptyId)
       if (e2eSnapshot) {
-        return e2eSnapshot
+        return { snapshot: await e2eSnapshot, failed: false }
       }
       if (canUseMainBufferSnapshot(ptyId)) {
-        return window.api.pty.getMainBufferSnapshot(ptyId, opts)
+        try {
+          // Why: STA-1282 — a resolved value (snapshot or null) is a success; a
+          // null is a nil mirror (blank+live, not a failure). Only a rejection
+          // (RPC error) counts as a structural failure for the fail-open counter
+          // (gate #5). A hung snapshot that never resolves is handled by the
+          // existing foreground-deadline fallback, not this counter.
+          const snapshot = await window.api.pty.getMainBufferSnapshot(ptyId, opts)
+          return { snapshot, failed: false }
+        } catch {
+          return { snapshot: null, failed: true }
+        }
       }
       if (transport.getPtyId() !== ptyId || typeof transport.serializeBuffer !== 'function') {
-        return null
+        return { snapshot: null, failed: false }
       }
-      return transport.serializeBuffer(opts)
+      try {
+        return { snapshot: await transport.serializeBuffer(opts), failed: false }
+      } catch {
+        return { snapshot: null, failed: true }
+      }
     }
 
     function respondToSkippedMode2031Subscribe(data: string): void {
@@ -5133,12 +5221,31 @@ export function connectPanePty(
           const restoreGeneration = hiddenOutputRestoreGeneration
           hiddenOutputRestoreNeeded = false
           let snapshot: PtyBufferSnapshot | null = null
+          let snapshotFailed = false
+          // STA-1282 gate #5: bound ONLY the eviction-claim snapshot request. A
+          // never-resolving getMainBufferSnapshot on an evicted remount would
+          // otherwise leave the pane history-blank forever without charging the
+          // fail-open counter (the foreground deadline arms only when live chunks
+          // queue). The ordinary hidden-restore path keeps its unbounded await so
+          // its existing retry/deadline tests are unperturbed.
+          const evictionRemountSnapshotClaim = evictionRemountReplayPending
+          let evictionRemountSnapshotTimedOut = false
           try {
-            snapshot = await serializeHiddenOutputSnapshot(currentPtyId, {
+            const request = serializeHiddenOutputSnapshot(currentPtyId, {
               scrollbackRows: HIDDEN_OUTPUT_RESTORE_SCROLLBACK_ROWS
             })
+            const result = evictionRemountSnapshotClaim
+              ? await awaitEvictionRemountSnapshot(request)
+              : await request
+            if (result === EVICTION_REMOUNT_SNAPSHOT_TIMEOUT) {
+              evictionRemountSnapshotTimedOut = true
+            } else {
+              snapshot = result.snapshot
+              snapshotFailed = result.failed
+            }
           } catch {
             snapshot = null
+            snapshotFailed = true
           }
           if (disposed) {
             return
@@ -5156,13 +5263,30 @@ export function connectPanePty(
             }
             return
           }
+          if (evictionRemountSnapshotTimedOut) {
+            // Charge the structural failure and fall open to a live pane now,
+            // rather than retrying an already-hung mirror.
+            logTerminalPaneEvictionBreadcrumb('remount-replay', {
+              tabId: deps.tabId,
+              outcome: 'error',
+              reason: 'snapshot-timeout'
+            })
+            reportEvictionRemountReplayOutcome('error')
+            abandonHiddenOutputRestoreAndDrainPendingForeground(currentPtyId)
+            return
+          }
           if (!snapshot) {
+            // Why: a nil mirror (blank/newborn PTY) is a successful remount —
+            // mount blank + live; only a structural error charges the fail-open
+            // counter (gate #5).
+            reportEvictionRemountReplayOutcome(snapshotFailed ? 'error' : 'nil')
             hiddenOutputRestoreNeeded = true
             hiddenOutputRestoreFreshSnapshotNeeded = false
             hiddenOutputRestoreRetryDeferred = true
             scheduleHiddenOutputRestoreDeferredRetry()
             return
           }
+          reportEvictionRemountReplayOutcome('ok')
           hiddenOutputRestoreDeferredRetryAttempts = 0
           applyMainBufferSnapshot(snapshot)
           const needsFreshSnapshot = hiddenOutputRestoreFreshSnapshotNeeded
@@ -5376,6 +5500,10 @@ export function connectPanePty(
         if (staleSessionId) {
           deps.clearTabPtyId(deps.tabId, staleSessionId)
         }
+        // STA-1282 gate #5: a claimed eviction remount whose reattach returns no
+        // PTY lost its parked history (a fresh shell replaces it) — a structural
+        // replay failure for the fail-open counter.
+        reportEvictionRemountReplayOutcome('error')
         startFreshColdRestoreAgentResume(coldRestoreStartup, {
           forceBlankRestoredViewport: true
         })
@@ -5397,6 +5525,9 @@ export function connectPanePty(
         // Why: SSH sleep/reconnect can invalidate the relay-held PTY while
         // leaving the tab mounted. Replace the dead lease in-place instead of
         // stranding the pane behind a stale expired-session overlay.
+        // STA-1282 gate #5: an expired session on a claimed remount lost its
+        // parked history — charge the fail-open counter as a structural failure.
+        reportEvictionRemountReplayOutcome('error')
         startFreshColdRestoreAgentResume(coldRestoreStartup, {
           forceBlankRestoredViewport: true
         })
@@ -5515,6 +5646,24 @@ export function connectPanePty(
         }
         if (didPrepareResume && !coldRestoreStartup) {
           schedulePendingStartupCommandDelivery()
+        }
+      }
+      // STA-1282 gate #5: a painted reattach (daemon snapshot/replay/coldRestore)
+      // resolves the claimed-remount outcome as 'ok'. An UNPAINTED reattach must
+      // NOT consume the claim as 'nil': for providers with no connect-time paint
+      // (in-process local PTYs) the mirror snapshot is the replay source, so we
+      // drive the hidden-output-restore path now and let its outcome
+      // (ok/nil/error/timeout) resolve the fail-open counter — otherwise a
+      // silent evicted pane would remount history-blank and a later mirror
+      // failure could never be charged. Structural reattach failures (no pty /
+      // expired) charge 'error' in the early-return branches above.
+      if (connectResult?.snapshot || connectResult?.replay || connectResult?.coldRestore) {
+        reportEvictionRemountReplayOutcome('ok')
+      } else if (evictionRemountReplayPending) {
+        if (canUseHiddenOutputSnapshot(transport.getPtyId())) {
+          markHiddenOutputRestoreNeeded()
+        } else {
+          reportEvictionRemountReplayOutcome('nil')
         }
       }
       // Why: when a mobile-fit override is active, skip sending desktop dims
@@ -6172,9 +6321,80 @@ export function connectPanePty(
       .catch(() => {})
   }
 
+  // Why: STA-1282 eviction. Keep the PTY + completion coordinator alive and
+  // re-point the renderer-only title/status feed + exit observer to the parked
+  // registry, then let dispose() tear down the xterm/DOM (it skips the
+  // coordinator because `parked` is set). Returns false when there is no live
+  // PTY to park (caller falls back to a normal destroy).
+  const parkTransportForEviction = (): boolean => {
+    const ptyId = transport.getPtyId()
+    if (!ptyId || typeof transport.park !== 'function') {
+      return false
+    }
+    parked = true
+    const parkedSinks: ParkedPtySinks = {
+      onTitleChange: (title, rawTitle) => {
+        const paneTitle = normalizeCompatibleAgentTitleForOwner(title, getAuthoritativePaneAgent())
+        deps.updateTabTitle(deps.tabId, paneTitle)
+        if (syncAgentTaskCompleteTrackingEnabled()) {
+          agentCompletionCoordinator.observeTitle(rawTitle)
+        }
+      },
+      // Remote-runtime status is renderer-owned; retain it while parked.
+      ...(shouldOwnAgentStatusInRenderer
+        ? {
+            onAgentStatus: (payload) => {
+              const state = useAppStore.getState()
+              if (launchToken) {
+                state.setAgentStatus(cacheKey, payload, undefined, undefined, undefined, {
+                  launchToken
+                })
+              } else {
+                state.setAgentStatus(cacheKey, payload)
+              }
+              if (syncAgentTaskCompleteTrackingEnabled()) {
+                agentCompletionCoordinator.observeHookStatus(payload)
+              }
+            }
+          }
+        : {}),
+      onPtyExit: (exitedPtyId) => {
+        // Re-pointed exit observer: a real exit (or hibernation kill) while
+        // parked updates store state and drops the registry entry (gate #8).
+        deps.clearTabPtyId(deps.tabId, exitedPtyId)
+        useAppStore.getState().removeAgentStatus(cacheKey)
+        forgetEvictedPaneOnExit(cacheKey)
+      }
+    }
+    transport.park(parkedSinks)
+    registerEvictedPane({
+      paneKey: cacheKey,
+      tabId: deps.tabId,
+      worktreeId: deps.worktreeId,
+      getPtyId: () => transport.getPtyId(),
+      destroy: () => {
+        transport.destroy?.()
+        agentCompletionCoordinator.dispose()
+      },
+      releaseForClaim: () => {
+        transport.park?.({})
+        agentCompletionCoordinator.dispose()
+      }
+    })
+    logTerminalPaneEvictionBreadcrumb('evict', { tabId: deps.tabId, paneKey: cacheKey, ptyId })
+    return true
+  }
+
   return {
     syncProcessTracking() {
       agentCompletionCoordinator.startProcessTracking()
+    },
+    park() {
+      const parkedOk = parkTransportForEviction()
+      // dispose() runs the xterm/DOM teardown; it skips the coordinator dispose
+      // when `parked` so the parked title/status feed keeps driving the store.
+      this.dispose()
+      return parkedOk
     },
     // Why: called from the lifecycle visibility effect so the visible-resume
     // size readback can repair dropped hidden resizes without refitting against
@@ -6277,7 +6497,13 @@ export function connectPanePty(
       }
       commandLifecycle.dispose()
       paneForegroundAgentTracker.dispose()
-      agentCompletionCoordinator.dispose()
+      // Why: STA-1282 — when parking, the completion coordinator is handed to
+      // the evicted registry (it keeps driving title-based status/notifications
+      // while unmounted). Disposing it here would sever that feed; the registry
+      // entry's destroy()/releaseForClaim() owns its disposal instead.
+      if (!parked) {
+        agentCompletionCoordinator.dispose()
+      }
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1098,6 +1098,11 @@ export function connectPanePty(
   // parked entry live through the deferred-connect window, so a dispose before
   // adoption (StrictMode / split-group remount) can never orphan the PTY (gate #8).
   let pendingEvictionClaimKey: string | null = null
+  // Why: STA-1282 — adoption paths that bind via bindActivePanePty (direct
+  // attach, spawn) never pass handleReattachResult, so they must drive the
+  // mirror replay for a claimed remount themselves. Late-bound because the
+  // restore helpers live in the data-pipeline scope below.
+  let resolveClaimedRemountReplayAfterAdoption: ((ptyId: string) => void) | null = null
   let connectFrame: number | null = null
   let connectFallbackTimer: ReturnType<typeof setTimeout> | null = null
   let startupGridSettleHandle: TerminalStartupGridSettleHandle | null = null
@@ -2459,6 +2464,7 @@ export function connectPanePty(
       sampleVisiblePaneForegroundAgent()
     }
     finalizeEvictionClaim()
+    resolveClaimedRemountReplayAfterAdoption?.(ptyId)
   }
 
   const onPtySpawn = (ptyId: string): void => {
@@ -4246,6 +4252,22 @@ export function connectPanePty(
       // hidden-restores never charge the counter.
       logTerminalPaneEvictionBreadcrumb('remount-replay', { tabId: deps.tabId, outcome })
       recordEvictionRemountReplayOutcome(outcome)
+    }
+    // STA-1282 gate #5 (codex P1-A): a claimed remount that adopts via
+    // bindActivePanePty (direct attach / spawn — paths that never reach
+    // handleReattachResult) must still drive the mirror replay, or a silent
+    // evicted pane remounts history-blank and the claim outcome never resolves.
+    // Exactly-once: reportEvictionRemountReplayOutcome clears the pending flag,
+    // and handleReattachResult binds inline so it never reaches this hook.
+    resolveClaimedRemountReplayAfterAdoption = (adoptedPtyId: string): void => {
+      if (!evictionRemountReplayPending) {
+        return
+      }
+      if (canUseHiddenOutputSnapshot(adoptedPtyId)) {
+        markHiddenOutputRestoreNeeded()
+      } else {
+        reportEvictionRemountReplayOutcome('nil')
+      }
     }
     let foregroundImmediateBudgetChars = 0
     let foregroundImmediateBudgetWindowStart = 0

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2411,6 +2411,19 @@ export function connectPanePty(
     }
     window.api.pty.setRendererPtyVisible?.(ptyId, visible)
   }
+  // Why: STA-1282 — release the parked entry only once this fresh pane has adopted
+  // the PTY. Must be called from EVERY adoption path (bindActivePanePty for
+  // spawn/attach AND the inline daemon/SSH reattach bind in handleReattachResult):
+  // a missed path leaks the claim, so the stale parked feed keeps double-driving
+  // the store and a later re-park's registry-eviction destroy() would kill the
+  // live PTY. Idempotent — safe to call more than once.
+  const finalizeEvictionClaim = (): void => {
+    if (pendingEvictionClaimKey !== null) {
+      claimEvictedPane(pendingEvictionClaimKey)
+      pendingEvictionClaimKey = null
+    }
+  }
+
   const bindActivePanePty = (
     ptyId: string,
     options: {
@@ -2445,14 +2458,7 @@ export function connectPanePty(
     if (options.sampleVisibleForegroundAgent === true) {
       sampleVisiblePaneForegroundAgent()
     }
-    // Why: adoption succeeded — this fresh pane now owns the PTY, so it is safe to
-    // release the parked entry (drops the stale parked feed + removes the registry
-    // entry). Deferring the release to here is what prevents a claim->dispose race
-    // from orphaning the PTY (gate #8).
-    if (pendingEvictionClaimKey !== null) {
-      claimEvictedPane(pendingEvictionClaimKey)
-      pendingEvictionClaimKey = null
-    }
+    finalizeEvictionClaim()
   }
 
   const onPtySpawn = (ptyId: string): void => {
@@ -5556,6 +5562,9 @@ export function connectPanePty(
       deps.updateTabPtyId(deps.tabId, ptyId)
       agentCompletionCoordinator.startProcessTracking()
       sampleVisiblePaneForegroundAgent()
+      // Daemon/SSH reattach binds the PTY inline here (not via bindActivePanePty),
+      // so release the deferred parked claim on this adoption path too (gate #8).
+      finalizeEvictionClaim()
 
       // Why: mobile terminal streaming needs the exact screen state from
       // xterm.js. The shared helper installs both the SerializeAddon-backed
@@ -6412,7 +6421,21 @@ export function connectPanePty(
         agentCompletionCoordinator.dispose()
       },
       releaseForClaim: () => {
-        transport.park?.({})
+        // Release the parked transport's renderer resources without killing the
+        // PTY. Provider-specific: a remote park() intentionally keeps its
+        // per-instance multiplexed stream open (the snapshot channel), so it must
+        // be closed on claim via detach() (closeMultiplexedStream) or the host
+        // subscription + parser leaks on every remote evict/remount — detach()
+        // closes only THIS instance's stream (unique streamId), safe for the
+        // freshly-subscribed pane. Local must stay park({}): its data handler is a
+        // module map keyed by ptyId that the fresh pane's attach already
+        // overwrote, and detach() would unregister that shared handler and sever
+        // the live pane.
+        if (isRemoteRuntimePtyId(transport.getPtyId())) {
+          transport.detach?.()
+        } else {
+          transport.park?.({})
+        }
         agentCompletionCoordinator.dispose()
       }
     })
@@ -6530,6 +6553,12 @@ export function connectPanePty(
         cancelAnimationFrame(pendingGeometryReportRaf)
         pendingGeometryReportRaf = null
       }
+      // STA-1282 accepted gap: OSC-133 command lifecycle + foreground tracking are
+      // fed only from the mounted xterm data handler, so they are NOT retained
+      // while parked (Tier 2). Command boundaries go untracked until remount, when
+      // a fresh lifecycle re-syncs from the mirror. Accepted for the experimental
+      // phase — the pane is not visible, and agent completion/title/status/exit ARE
+      // retained by the parked feed (unlike this, they are gated on !parked below).
       commandLifecycle.dispose()
       paneForegroundAgentTracker.dispose()
       // Why: STA-1282 — when parking, the completion coordinator is handed to

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1092,6 +1092,12 @@ export function connectPanePty(
   // Why: STA-1282 — set when this fresh pane is remounting a parked (evicted)
   // transport, so the first snapshot outcome charges the fail-open counter.
   let evictionRemountReplayPending = false
+  // Why: STA-1282 — a parked entry claim (which releases the old parked feed and
+  // removes the registry entry) must not commit until this fresh pane actually
+  // adopts the PTY. Holding the claim here until bindActivePanePty keeps the
+  // parked entry live through the deferred-connect window, so a dispose before
+  // adoption (StrictMode / split-group remount) can never orphan the PTY (gate #8).
+  let pendingEvictionClaimKey: string | null = null
   let connectFrame: number | null = null
   let connectFallbackTimer: ReturnType<typeof setTimeout> | null = null
   let startupGridSettleHandle: TerminalStartupGridSettleHandle | null = null
@@ -1155,13 +1161,16 @@ export function connectPanePty(
   const cacheKey = makePaneKey(deps.tabId, pane.leafId)
   // Why: STA-1282 — a fresh pane mounting over a parked (evicted) entry claims
   // the live PTY back (no new spawn — the store still owns its ptyId) and marks
-  // its first snapshot outcome to charge the fail-open counter. releaseForClaim
-  // disposes the stale parked feed so it never double-drives the store.
+  // its first snapshot outcome to charge the fail-open counter. The claim's
+  // releaseForClaim (disposing the stale parked feed so it never double-drives the
+  // store) is deferred to adoption so a dispose before attach cannot orphan it.
   if (isPaneParked(cacheKey)) {
-    evictionRemountReplayPending = claimEvictedPane(cacheKey)
-    if (evictionRemountReplayPending) {
-      logTerminalPaneEvictionBreadcrumb('remount-claim', { tabId: deps.tabId, paneKey: cacheKey })
-    }
+    // Enter replay mode now (the main mirror is the snapshot source), but defer
+    // the registry claim/release to adoption (bindActivePanePty) so a dispose
+    // before attach leaves the parked entry intact and reapable (gate #8).
+    evictionRemountReplayPending = true
+    pendingEvictionClaimKey = cacheKey
+    logTerminalPaneEvictionBreadcrumb('remount-claim', { tabId: deps.tabId, paneKey: cacheKey })
   }
   const getSleepingRecordForPane = (
     state: ReturnType<typeof useAppStore.getState>
@@ -2435,6 +2444,14 @@ export function connectPanePty(
     // restored PTYs may already be inside Codex with no new foreground signal.
     if (options.sampleVisibleForegroundAgent === true) {
       sampleVisiblePaneForegroundAgent()
+    }
+    // Why: adoption succeeded — this fresh pane now owns the PTY, so it is safe to
+    // release the parked entry (drops the stale parked feed + removes the registry
+    // entry). Deferring the release to here is what prevents a claim->dispose race
+    // from orphaning the PTY (gate #8).
+    if (pendingEvictionClaimKey !== null) {
+      claimEvictedPane(pendingEvictionClaimKey)
+      pendingEvictionClaimKey = null
     }
   }
 
@@ -6332,10 +6349,28 @@ export function connectPanePty(
       return false
     }
     parked = true
+    // Why: capture whether this leaf drove the tab title at park time. A split tab
+    // parks every leaf, so without this guard two parked feeds would both write the
+    // tab title and flicker it (the live handler gates the same way on the active
+    // pane). The pane is still in the manager here — dispose() runs after park().
+    const drivesTabTitleWhileParked = manager.getActivePane()?.id === pane.id
     const parkedSinks: ParkedPtySinks = {
       onTitleChange: (title, rawTitle) => {
         const paneTitle = normalizeCompatibleAgentTitleForOwner(title, getAuthoritativePaneAgent())
-        deps.updateTabTitle(deps.tabId, paneTitle)
+        // Match the live handler: drop Codex auto-approval synthetic titles so a
+        // parked pane never leaks one to the tab chip.
+        if (
+          shouldSuppressCodexAutoApprovalSyntheticTitle(paneTitle, {
+            paneKey: cacheKey,
+            tabId: deps.tabId,
+            ...(launchToken ? { launchToken } : {})
+          })
+        ) {
+          return
+        }
+        if (drivesTabTitleWhileParked) {
+          deps.updateTabTitle(deps.tabId, paneTitle)
+        }
         if (syncAgentTaskCompleteTrackingEnabled()) {
           agentCompletionCoordinator.observeTitle(rawTitle)
         }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -92,6 +92,7 @@ import { isLocalNativeWindowsConpty } from '@/lib/pane-manager/windows-pty-compa
 import { recordTerminalOutput } from '@/lib/pane-manager/pane-scroll'
 import {
   captureTerminalWriteScrollIntent,
+  enforceTerminalCurrentScrollIntent,
   enforceTerminalWriteScrollIntent
 } from '@/lib/pane-manager/terminal-scroll-intent'
 import { createBrowserUuid } from '@/lib/browser-uuid'
@@ -5112,15 +5113,24 @@ export function connectPanePty(
       })
     }
 
-    function applyMainBufferSnapshot(snapshot: {
-      data: string
-      cols: number
-      rows: number
-      seq?: number
-      alternateScreen?: boolean
-      pendingEscapeTailAnsi?: string
-    }): void {
-      const scrollIntent = captureTerminalWriteScrollIntent(pane.terminal)
+    function applyMainBufferSnapshot(
+      snapshot: {
+        data: string
+        cols: number
+        rows: number
+        seq?: number
+        alternateScreen?: boolean
+        pendingEscapeTailAnsi?: string
+      },
+      opts?: { restoreDurableScrollIntent?: boolean }
+    ): void {
+      // Why: an eviction remount replays into a FRESH xterm whose pre-replay
+      // buffer is empty — capturing it would pin the viewport to row 0 and
+      // overwrite the durable (leaf-keyed) scroll intent the pre-eviction pane
+      // recorded (#7472). Re-apply the durable intent after replay instead.
+      const scrollIntent = opts?.restoreDurableScrollIntent
+        ? null
+        : captureTerminalWriteScrollIntent(pane.terminal)
       const colsBeforeReplay = pane.terminal.cols
       const rowsBeforeReplay = pane.terminal.rows
       const hasSnapshotDimensions =
@@ -5158,7 +5168,21 @@ export function connectPanePty(
         writeReplayData('\x1b[?1049h\x1b[2J\x1b[H')
       }
       writeReplayData(snapshot.data)
-      writeReplayData(POST_REPLAY_LIVE_SNAPSHOT_RESET)
+      if (opts?.restoreDurableScrollIntent) {
+        // Why: xterm parses writes asynchronously — when this function returns
+        // the fresh remounted buffer is still empty, so a synchronous enforce
+        // would clamp the durable viewport to row 0 AND overwrite the durable
+        // (leaf-keyed) intent with that empty-buffer state. Enforce only after
+        // xterm has parsed the full replay (write callbacks are FIFO, so the
+        // reset chunk parsing implies the snapshot body is in the buffer).
+        void writeReplayDataAsync(POST_REPLAY_LIVE_SNAPSHOT_RESET).then(() => {
+          if (!disposed) {
+            enforceTerminalCurrentScrollIntent(pane.terminal)
+          }
+        })
+      } else {
+        writeReplayData(POST_REPLAY_LIVE_SNAPSHOT_RESET)
+      }
       if (snapshot.pendingEscapeTailAnsi) {
         // Why last: the snapshot was serialized while the emulator sat mid-escape;
         // re-arm the dangling sequence as the FINAL replay write (any later ESC —
@@ -5188,7 +5212,10 @@ export function connectPanePty(
       }
       // Why: snapshot replay clears and rebuilds xterm state; re-apply the
       // user's scroll intent once so hidden catch-up cannot repin the viewport.
-      enforceTerminalWriteScrollIntent(pane.terminal, scrollIntent)
+      // (The durable-restore path enforces in the replay parse callback above.)
+      if (!opts?.restoreDurableScrollIntent) {
+        enforceTerminalWriteScrollIntent(pane.terminal, scrollIntent)
+      }
     }
 
     function requestHiddenOutputRestoreIfNeeded(opts?: { bypassScheduler?: boolean }): boolean {
@@ -5333,7 +5360,9 @@ export function connectPanePty(
           }
           reportEvictionRemountReplayOutcome('ok')
           hiddenOutputRestoreDeferredRetryAttempts = 0
-          applyMainBufferSnapshot(snapshot)
+          applyMainBufferSnapshot(snapshot, {
+            restoreDurableScrollIntent: evictionRemountSnapshotClaim
+          })
           const needsFreshSnapshot = hiddenOutputRestoreFreshSnapshotNeeded
           hiddenOutputRestoreFreshSnapshotNeeded = false
           if (drainPendingLiveChunksAfterSnapshot(snapshot.seq) && !needsFreshSnapshot) {
@@ -5982,6 +6011,10 @@ export function connectPanePty(
                   }
                   deps.clearExitedPanePtyLayoutBinding(pane.id, pendingSessionId)
                   deps.clearTabPtyId(deps.tabId, pendingSessionId)
+                  // STA-1282 gate #5: an expired SSH-deferred reattach on a claimed
+                  // remount lost its parked history — charge the fail-open counter,
+                  // matching the direct-deferred and in-handler failure paths.
+                  reportEvictionRemountReplayOutcome('error')
                   startFreshColdRestoreAgentResume(coldRestoreStartup, {
                     forceBlankRestoredViewport: true
                   })
@@ -6004,6 +6037,10 @@ export function connectPanePty(
                 if (disposed) {
                   return
                 }
+                // STA-1282 gate #5: a threw SSH-deferred reattach on a claimed remount
+                // lost its parked history — both fresh-restart branches below replace
+                // the parked PTY, so charge the fail-open counter once.
+                reportEvictionRemountReplayOutcome('error')
                 if (isSshSessionExpiredError(err)) {
                   deps.clearExitedPanePtyLayoutBinding(pane.id, pendingSessionId)
                   deps.clearTabPtyId(deps.tabId, pendingSessionId)
@@ -6157,6 +6194,10 @@ export function connectPanePty(
             }
             deps.clearExitedPanePtyLayoutBinding(pane.id, deferredReattachSessionId)
             deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
+            // STA-1282 gate #5: an expired reattach on a claimed remount lost its
+            // parked history (fresh shell replaces it) — charge the fail-open
+            // counter as a structural failure, matching handleReattachResult.
+            reportEvictionRemountReplayOutcome('error')
             startFreshColdRestoreAgentResume(coldRestoreStartup, {
               forceBlankRestoredViewport: true
             })
@@ -6184,8 +6225,19 @@ export function connectPanePty(
             ptyId: deferredReattachSessionId,
             reason: message
           })
+          // Why: bail on a dispose-before-adoption like the sibling reattach-failure
+          // paths — the deferred claim was never finalized (parked entry intact and
+          // reapable), and a fresh spawn here would orphan a PTY for a torn-down pane
+          // AND drop the parked history while under-counting the fail-open failure.
+          if (disposed) {
+            return
+          }
           deps.clearExitedPanePtyLayoutBinding(pane.id, deferredReattachSessionId)
           deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
+          // STA-1282 gate #5: a reattach that threw on a claimed remount lost its
+          // parked history — both fresh-restart branches below replace the parked
+          // PTY, so charge the fail-open counter once as a structural failure.
+          reportEvictionRemountReplayOutcome('error')
           if (connectionId && isSshSessionExpiredError(err)) {
             startFreshColdRestoreAgentResume(coldRestoreStartup, {
               forceBlankRestoredViewport: true
@@ -6239,6 +6291,10 @@ export function connectPanePty(
       } catch (err) {
         reportError(err instanceof Error ? err.message : String(err))
         deps.clearTabPtyId(deps.tabId, attachPtyId)
+        // STA-1282 gate #5: if a claimed eviction remount adopted this live PTY and
+        // attach threw, the fresh spawn loses the parked history — charge the
+        // fail-open counter (a no-op unless this remount was an eviction claim).
+        reportEvictionRemountReplayOutcome('error')
         startFreshSpawn()
       }
     } else {
@@ -6419,6 +6475,10 @@ export function connectPanePty(
         ) {
           return
         }
+        // Why: keep the per-pane runtime title fresh while parked (the live
+        // handler does the same at bind) so the jump palette / split spinner do
+        // not freeze on a stale title until the pane is remounted (STA-1282).
+        deps.setRuntimePaneTitle(deps.tabId, pane.id, paneTitle)
         if (drivesTabTitleWhileParked) {
           deps.updateTabTitle(deps.tabId, paneTitle)
         }
@@ -6426,20 +6486,68 @@ export function connectPanePty(
           agentCompletionCoordinator.observeTitle(rawTitle)
         }
       },
+      onBell: () => {
+        // Why: BEL is the only attention signal for TUIs without hook
+        // integration (e.g. a permission prompt); a hidden mounted pane raises
+        // these unread marks today, so a parked pane must too. The pane-level
+        // marker and the OS-notification timers are torn down with the pane —
+        // only the durable tab/worktree marks are raised here.
+        deps.markWorktreeUnread(deps.worktreeId)
+        deps.markTerminalTabUnread(deps.tabId)
+      },
       // Remote-runtime status is renderer-owned; retain it while parked.
       ...(shouldOwnAgentStatusInRenderer
         ? {
             onAgentStatus: (payload) => {
+              // Match the live handler: drop Codex auto-approval synthetic status
+              // and normalize the agent type so a parked pane never resurfaces the
+              // suppressed status noise (#6230) or mislabels its agent (#5270).
+              if (
+                shouldSuppressCodexAutoApprovalStatus(payload, {
+                  paneKey: cacheKey,
+                  tabId: deps.tabId,
+                  ...(launchToken ? { launchToken } : {})
+                })
+              ) {
+                return
+              }
               const state = useAppStore.getState()
+              const authoritativePaneAgent = getAuthoritativePaneAgent()
+              const agentType = resolveCompatibleAgentTypeForOwner(
+                payload.agentType,
+                authoritativePaneAgent
+              )
+              const statusPayload =
+                agentType === payload.agentType ? payload : { ...payload, agentType }
+              // Why: pair the status with the current runtime title (kept fresh
+              // while parked, above) exactly like the live handler, so consumers of
+              // the stored terminalTitle (hover/fallback rows, runtime/mobile
+              // projection) do not read a stale title while the pane is parked.
+              const title = state.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
+              const resolvedStatusTitle = resolveAgentStatusTerminalTitle(statusPayload, title)
+              const statusTitle = resolvedStatusTitle
+                ? normalizeCompatibleAgentTitleForOwner(
+                    resolvedStatusTitle,
+                    agentType ?? authoritativePaneAgent
+                  )
+                : resolvedStatusTitle
               if (launchToken) {
-                state.setAgentStatus(cacheKey, payload, undefined, undefined, undefined, {
+                state.setAgentStatus(cacheKey, statusPayload, statusTitle, undefined, undefined, {
                   launchToken
                 })
               } else {
-                state.setAgentStatus(cacheKey, payload)
+                state.setAgentStatus(cacheKey, statusPayload, statusTitle)
               }
               if (syncAgentTaskCompleteTrackingEnabled()) {
-                agentCompletionCoordinator.observeHookStatus(payload)
+                // Why: enrich with the stored stateStartedAt like the live handler so
+                // repeated identical done-snapshots keep a stable completion identity
+                // and cannot double-schedule the quiet-window completion while parked.
+                const storedStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]
+                const notificationPayload =
+                  typeof storedStatus?.stateStartedAt === 'number'
+                    ? { ...statusPayload, stateStartedAt: storedStatus.stateStartedAt }
+                    : statusPayload
+                agentCompletionCoordinator.observeHookStatus(notificationPayload)
               }
             }
           }
@@ -6447,8 +6555,22 @@ export function connectPanePty(
       onPtyExit: (exitedPtyId) => {
         // Re-pointed exit observer: a real exit (or hibernation kill) while
         // parked updates store state and drops the registry entry (gate #8).
+        // Why: mirror the live exit path's store cleanup so a parked exit does not
+        // leak the suppressed-exit flag (hibernation kill) or leave a stale runtime
+        // title / prompt cache timer that only clears on the next remount.
+        deps.consumeSuppressedPtyExit(exitedPtyId)
+        deps.clearRuntimePaneTitle(deps.tabId, pane.id)
         deps.clearTabPtyId(deps.tabId, exitedPtyId)
+        deps.setCacheTimerStartedAt(cacheKey, null)
         useAppStore.getState().removeAgentStatus(cacheKey)
+        // Why: match the live exit path — a dead PTY has no foreground agent.
+        // Without this, a parked pane that exits and later respawns inherits a
+        // stale agent tab icon (the remount probe never clears on a stale agent).
+        useAppStore.getState().clearPaneForegroundAgent(cacheKey)
+        // Why: republish the runtime graph (CLI/mobile terminal bindings) like the
+        // live exit path so it stops advertising this dead PTY immediately instead
+        // of waiting for an unrelated spawn/exit/layout event.
+        scheduleRuntimeGraphSync()
         forgetEvictedPaneOnExit(cacheKey)
       }
     }
@@ -6601,6 +6723,11 @@ export function connectPanePty(
       // a fresh lifecycle re-syncs from the mirror. Accepted for the experimental
       // phase — the pane is not visible, and agent completion/title/status/exit ARE
       // retained by the parked feed (unlike this, they are gated on !parked below).
+      // Known sub-gap: an agent that exits while parked (shell survives) leaves a
+      // stale paneForegroundAgent entry the remount probe cannot clear — clearing
+      // needs 133;D prompt proof, which visible-pty reads deliberately never
+      // supply (a probe can catch an agent's transient tool subshell and would
+      // false-clear a live icon). Self-heals on the next command boundary.
       commandLifecycle.dispose()
       paneForegroundAgentTracker.dispose()
       // Why: STA-1282 — when parking, the completion coordinator is handed to

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5604,7 +5604,22 @@ export function connectPanePty(
       // newer than disk-recorded scrollback. If we ever return all three,
       // the daemon and relay are by definition tracking the same session
       // and only the freshest source belongs on screen.
-      if (connectResult?.snapshot) {
+      //
+      // STA-1282: an eviction remount re-subscribes to a still-live session, so
+      // the daemon/relay reattach payload's tail overlaps the first live chunk.
+      // That payload carries no sequence, so the renderer cannot trim the overlap
+      // and the boundary line duplicates. Restore such remounts from the local
+      // main-buffer mirror instead, whose snapshot seq shares the pty:data
+      // meta.seq domain (both advance from onPtyData's outputSequence), so
+      // drainPendingLiveChunksAfterSnapshot drops the overlap. coldRestore
+      // (fresh shell, no live-tail overlap) and remote relay-replay (not
+      // exercised by eviction yet) keep their existing paint.
+      const preferEvictionMirrorRestore =
+        evictionRemountReplayPending &&
+        !connectResult?.coldRestore &&
+        (Boolean(connectResult?.snapshot) || Boolean(connectResult?.replay)) &&
+        canUseMainBufferSnapshot(transport.getPtyId())
+      if (!preferEvictionMirrorRestore && connectResult?.snapshot) {
         rememberReattachPayloadAgentSignal(connectResult.snapshot, { fullScreenReplay: true })
         // Why: the daemon serializes its grid with soft-wrapped lines as
         // continuous text. Replaying that at a different column count rewraps
@@ -5653,7 +5668,7 @@ export function connectPanePty(
             window.api.pty.ackColdRestore(ptyId)
           }
         }
-      } else if (connectResult?.replay) {
+      } else if (!preferEvictionMirrorRestore && connectResult?.replay) {
         rememberReattachPayloadAgentSignal(connectResult.replay, { fullScreenReplay: true })
         // Relay replay holds the last 100 KB of raw output. The xterm may
         // already hold pre-disconnect content; clear first to avoid
@@ -5705,7 +5720,12 @@ export function connectPanePty(
       // silent evicted pane would remount history-blank and a later mirror
       // failure could never be charged. Structural reattach failures (no pty /
       // expired) charge 'error' in the early-return branches above.
-      if (connectResult?.snapshot || connectResult?.replay || connectResult?.coldRestore) {
+      if (preferEvictionMirrorRestore) {
+        // The sequence-less daemon/relay paint was skipped above; the mirror
+        // snapshot (seq-aligned) restores this evicted pane and its outcome
+        // resolves the fail-open counter, same as the no-paint case below.
+        markHiddenOutputRestoreNeeded()
+      } else if (connectResult?.snapshot || connectResult?.replay || connectResult?.coldRestore) {
         reportEvictionRemountReplayOutcome('ok')
       } else if (evictionRemountReplayPending) {
         if (canUseHiddenOutputSnapshot(transport.getPtyId())) {

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -99,7 +99,22 @@ export type PtyTransport = {
   serializeBuffer?: (opts?: { scrollbackRows?: number }) => Promise<PtyBufferSnapshot | null>
   preserve?: () => void
   detach?: () => void
+  /** STA-1282: keep the PTY + its data/exit handlers alive while the pane's
+   *  xterm is torn down (Tier 1 -> Tier 2 eviction). Re-points title/status/exit
+   *  to a parked feed and stops writing to any xterm (no backlog — the main
+   *  mirror is the replay source). Distinct from detach() (which severs the feed)
+   *  and destroy() (which kills the PTY). */
+  park?: (sinks: ParkedPtySinks) => void
   destroy?: () => void | Promise<void>
+}
+
+/** Parked feed for an evicted pane: renderer-only title/status that has no
+ *  main->renderer push and would otherwise die with the xterm, plus the
+ *  re-pointed exit observer that clears store/registry state on a real exit. */
+export type ParkedPtySinks = {
+  onTitleChange?: (title: string, rawTitle: string) => void
+  onAgentStatus?: (payload: ParsedAgentStatusPayload) => void
+  onPtyExit?: (id: string) => void
 }
 
 export type IpcPtyTransportOptions = {

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -113,6 +113,9 @@ export type PtyTransport = {
  *  re-pointed exit observer that clears store/registry state on a real exit. */
 export type ParkedPtySinks = {
   onTitleChange?: (title: string, rawTitle: string) => void
+  /** BEL is the attention signal for TUIs without hook integration — a parked
+   *  pane must still raise the tab/worktree unread marks. */
+  onBell?: () => void
   onAgentStatus?: (payload: ParsedAgentStatusPayload) => void
   onPtyExit?: (id: string) => void
 }

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -184,6 +184,45 @@ describe('createIpcPtyTransport', () => {
     transport.disconnect()
   })
 
+  it('park() retains the title/exit feed but stops xterm writes (STA-1282 gate #3)', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onTitleChange = vi.fn()
+    const onPtyExit = vi.fn()
+    const onDataCallback = vi.fn()
+    const transport = createIpcPtyTransport({ onTitleChange, onPtyExit })
+
+    await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
+
+    // Pre-park (mounted pane): a title feeds the live feed and data reaches xterm.
+    onData?.({ id: 'pty-1', data: '\x1b]0;live-title\x07body' })
+    expect(onDataCallback).toHaveBeenCalledWith('\x1b]0;live-title\x07body')
+    await flushPtySideEffects()
+    expect(onTitleChange).toHaveBeenCalledWith('live-title', 'live-title')
+    onTitleChange.mockClear()
+    onDataCallback.mockClear()
+
+    // Evict: park re-points title/exit to the parked registry feed. The PTY and
+    // its data handler stay alive (still parsing OSC titles), but nothing writes
+    // to the torn-down xterm anymore (storedCallbacks cleared).
+    const parkedTitle = vi.fn()
+    const parkedExit = vi.fn()
+    transport.park?.({ onTitleChange: parkedTitle, onPtyExit: parkedExit })
+
+    onData?.({ id: 'pty-1', data: '\x1b]0;parked-title\x07more' })
+    expect(onDataCallback).not.toHaveBeenCalled()
+    await flushPtySideEffects()
+    // The renderer-only title feed survives, now driving the parked sink…
+    expect(parkedTitle).toHaveBeenCalledWith('parked-title', 'parked-title')
+    // …and the original (unmounted) pane's feed is silent.
+    expect(onTitleChange).not.toHaveBeenCalled()
+
+    // A real exit while parked routes to the parked exit observer (gate #8 hook),
+    // never the original pane's observer.
+    onExit?.({ id: 'pty-1', code: 0 })
+    expect(parkedExit).toHaveBeenCalledWith('pty-1')
+    expect(onPtyExit).not.toHaveBeenCalled()
+  })
+
   it('does not schedule PTY side-effect drains for ordinary output with no working title', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -188,8 +188,9 @@ describe('createIpcPtyTransport', () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const onTitleChange = vi.fn()
     const onPtyExit = vi.fn()
+    const onBell = vi.fn()
     const onDataCallback = vi.fn()
-    const transport = createIpcPtyTransport({ onTitleChange, onPtyExit })
+    const transport = createIpcPtyTransport({ onTitleChange, onPtyExit, onBell })
 
     await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
 
@@ -201,12 +202,13 @@ describe('createIpcPtyTransport', () => {
     onTitleChange.mockClear()
     onDataCallback.mockClear()
 
-    // Evict: park re-points title/exit to the parked registry feed. The PTY and
-    // its data handler stay alive (still parsing OSC titles), but nothing writes
-    // to the torn-down xterm anymore (storedCallbacks cleared).
+    // Evict: park re-points title/bell/exit to the parked registry feed. The PTY
+    // and its data handler stay alive (still parsing OSC titles), but nothing
+    // writes to the torn-down xterm anymore (storedCallbacks cleared).
     const parkedTitle = vi.fn()
     const parkedExit = vi.fn()
-    transport.park?.({ onTitleChange: parkedTitle, onPtyExit: parkedExit })
+    const parkedBell = vi.fn()
+    transport.park?.({ onTitleChange: parkedTitle, onPtyExit: parkedExit, onBell: parkedBell })
 
     onData?.({ id: 'pty-1', data: '\x1b]0;parked-title\x07more' })
     expect(onDataCallback).not.toHaveBeenCalled()
@@ -215,6 +217,13 @@ describe('createIpcPtyTransport', () => {
     expect(parkedTitle).toHaveBeenCalledWith('parked-title', 'parked-title')
     // …and the original (unmounted) pane's feed is silent.
     expect(onTitleChange).not.toHaveBeenCalled()
+
+    // A standalone BEL while parked is an attention signal (unread marks) and
+    // must route to the parked bell sink, never the original pane's.
+    onData?.({ id: 'pty-1', data: 'ready\x07' })
+    await flushPtySideEffects()
+    expect(parkedBell).toHaveBeenCalled()
+    expect(onBell).not.toHaveBeenCalled()
 
     // A real exit while parked routes to the parked exit observer (gate #8 hook),
     // never the original pane's observer.

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -483,21 +483,37 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   // unread marks, or notifications for unrelated worktrees just because Orca
   // is reconnecting background terminals on launch.
   let suppressAttentionEvents = false
+  // Why: STA-1282 — side-effect callbacks are routed through this mutable holder
+  // so park() can re-point title/status/exit to the parked feed without
+  // rebuilding the outputProcessor. Wrappers are installed only when the
+  // corresponding opt was provided so construction-time gating (e.g. status
+  // ownership) is preserved exactly.
+  const sinks = {
+    onTitleChange,
+    onBell,
+    onAgentBecameIdle,
+    onAgentBecameWorking,
+    onAgentExited,
+    onAgentStatus,
+    onPtyExit
+  }
   const inputWriteQueue = createPtyInputWriteQueue({
     isWritable: (id) => connected && ptyId === id,
     write: (id, data) => window.api.pty.write(id, data)
   })
   const outputProcessor = createPtyOutputProcessor({
-    onTitleChange,
-    onBell,
-    onAgentBecameIdle: (title) => {
-      if (!suppressAttentionEvents) {
-        onAgentBecameIdle?.(title)
-      }
-    },
-    onAgentBecameWorking,
-    onAgentExited,
-    onAgentStatus
+    onTitleChange: onTitleChange ? (title, raw) => sinks.onTitleChange?.(title, raw) : undefined,
+    onBell: onBell ? () => sinks.onBell?.() : undefined,
+    onAgentBecameIdle: onAgentBecameIdle
+      ? (title) => {
+          if (!suppressAttentionEvents) {
+            sinks.onAgentBecameIdle?.(title)
+          }
+        }
+      : undefined,
+    onAgentBecameWorking: onAgentBecameWorking ? () => sinks.onAgentBecameWorking?.() : undefined,
+    onAgentExited: onAgentExited ? () => sinks.onAgentExited?.() : undefined,
+    onAgentStatus: onAgentStatus ? (payload) => sinks.onAgentStatus?.(payload) : undefined
   })
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
 
@@ -595,7 +611,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       unregisterPtyHandlers(id)
       storedCallbacks.onExit?.(code)
       storedCallbacks.onDisconnect?.()
-      onPtyExit?.(id)
+      sinks.onPtyExit?.(id)
     }
     ptyExitHandlers.set(id, exitHandler)
     // Why: shutdownWorktreeTerminals bypasses the transport layer — it
@@ -853,6 +869,24 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       connected = false
       ptyId = null
       storedCallbacks = {}
+    },
+
+    park(parkedSinks) {
+      // Why: STA-1282 eviction. Keep the PTY + its registered data/exit handlers
+      // alive, but stop writing to the torn-down xterm and re-point the
+      // renderer-only title/status feed + exit observer to the parked registry.
+      // No backlog is retained — the main mirror is the replay source of truth.
+      inputWriteQueue.clear()
+      // Drop onData/onReplayData: the data handler still runs (parsing OSC
+      // titles/status for the parked feed) but nothing is written to xterm.
+      storedCallbacks = {}
+      sinks.onTitleChange = parkedSinks.onTitleChange
+      sinks.onBell = undefined
+      sinks.onAgentBecameIdle = undefined
+      sinks.onAgentBecameWorking = undefined
+      sinks.onAgentExited = undefined
+      sinks.onAgentStatus = parkedSinks.onAgentStatus
+      sinks.onPtyExit = parkedSinks.onPtyExit
     },
 
     sendInput(data: string): boolean {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -881,7 +881,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       // titles/status for the parked feed) but nothing is written to xterm.
       storedCallbacks = {}
       sinks.onTitleChange = parkedSinks.onTitleChange
-      sinks.onBell = undefined
+      sinks.onBell = parkedSinks.onBell
       sinks.onAgentBecameIdle = undefined
       sinks.onAgentBecameWorking = undefined
       sinks.onAgentExited = undefined

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -1199,6 +1199,50 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(onBell).toHaveBeenCalledTimes(1)
   })
 
+  it('park() retains the title/exit feed and keeps the multiplexed stream open (STA-1282 gate #3)', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onTitleChange = vi.fn()
+    const onPtyExit = vi.fn()
+    const onDataCallback = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      onTitleChange,
+      onPtyExit
+    })
+
+    await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const { streamId } = latestSubscribePayload()
+
+    // Pre-park (mounted pane): a title feeds the live feed and data reaches xterm.
+    emitOutput(streamId, '\x1b]0;live-title\x07')
+    expect(onDataCallback).toHaveBeenCalledWith(
+      '\x1b]0;live-title\x07',
+      expect.objectContaining({ seq: 1 })
+    )
+    // Title extraction rides the async terminal parser — settle before asserting.
+    await vi.waitFor(() => expect(onTitleChange).toHaveBeenCalledWith('live-title', 'live-title'))
+    onTitleChange.mockClear()
+    onDataCallback.mockClear()
+
+    // Evict. Provider-specific: remote park re-points the renderer-owned title/
+    // exit feed but must NOT close the multiplexed stream (unlike detach) — that
+    // stream is the channel host output and the snapshot ride on. Emitting more
+    // host output after park and seeing the parked feed receive it proves the
+    // stream is still open.
+    const parkedTitle = vi.fn()
+    const parkedExit = vi.fn()
+    transport.park?.({ onTitleChange: parkedTitle, onPtyExit: parkedExit })
+
+    emitOutput(streamId, '\x1b]0;parked-title\x07')
+    // The parked title feed still receives host output (stream still open)…
+    await vi.waitFor(() => expect(parkedTitle).toHaveBeenCalledWith('parked-title', 'parked-title'))
+    // …with no xterm write (storedCallbacks cleared) — the pane's DOM/xterm is gone…
+    expect(onDataCallback).not.toHaveBeenCalled()
+    // …and the original (unmounted) pane's feed is silent.
+    expect(onTitleChange).not.toHaveBeenCalled()
+  })
+
   it('processes binary remote data chunks through the terminal parser', async () => {
     const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
     const onData = vi.fn()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -1265,7 +1265,7 @@ describe('createRemoteRuntimePtyTransport', () => {
     // On remount claim, a remote transport is released via detach() (not another
     // park), which closes the per-instance multiplexed stream. Without this the
     // subscription + parser would leak on every remote evict/remount.
-    transport.detach()
+    transport.detach?.()
     emitOutput(streamId, '\x1b]0;after-release\x07')
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(parkedTitle).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -1243,6 +1243,34 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(onTitleChange).not.toHaveBeenCalled()
   })
 
+  it('detach() releases a parked stream so it stops receiving host output (claim-release: no remote stream/parser leak, STA-1282 gate #8)', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      onTitleChange: vi.fn(),
+      onPtyExit: vi.fn()
+    })
+
+    await transport.connect({ url: '', callbacks: { onData: vi.fn() } })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const { streamId } = latestSubscribePayload()
+
+    // Park keeps the stream open; the parked title feed receives host output.
+    const parkedTitle = vi.fn()
+    transport.park?.({ onTitleChange: parkedTitle })
+    emitOutput(streamId, '\x1b]0;parked-title\x07')
+    await vi.waitFor(() => expect(parkedTitle).toHaveBeenCalledWith('parked-title', 'parked-title'))
+    parkedTitle.mockClear()
+
+    // On remount claim, a remote transport is released via detach() (not another
+    // park), which closes the per-instance multiplexed stream. Without this the
+    // subscription + parser would leak on every remote evict/remount.
+    transport.detach()
+    emitOutput(streamId, '\x1b]0;after-release\x07')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(parkedTitle).not.toHaveBeenCalled()
+  })
+
   it('processes binary remote data chunks through the terminal parser', async () => {
     const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
     const onData = vi.fn()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -89,13 +89,26 @@ export function createRemoteRuntimePtyTransport(
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
   let resubscribing = false
   const clientId = `desktop:${tabId ?? 'tab'}:${leafId ?? 'leaf'}`
-  const outputProcessor = createPtyOutputProcessor({
+  // Why: STA-1282 — route side-effect callbacks through a mutable holder so
+  // park() can re-point the renderer-owned title/status feed (remote-runtime
+  // status is renderer-owned) and the exit observer without rebuilding the
+  // processor. Wrappers installed only where the opt was provided.
+  const sinks = {
     onTitleChange,
     onBell,
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
-    onAgentStatus
+    onAgentStatus,
+    onPtyExit
+  }
+  const outputProcessor = createPtyOutputProcessor({
+    onTitleChange: onTitleChange ? (title, raw) => sinks.onTitleChange?.(title, raw) : undefined,
+    onBell: onBell ? () => sinks.onBell?.() : undefined,
+    onAgentBecameIdle: onAgentBecameIdle ? (title) => sinks.onAgentBecameIdle?.(title) : undefined,
+    onAgentBecameWorking: onAgentBecameWorking ? () => sinks.onAgentBecameWorking?.() : undefined,
+    onAgentExited: onAgentExited ? () => sinks.onAgentExited?.() : undefined,
+    onAgentStatus: onAgentStatus ? (payload) => sinks.onAgentStatus?.(payload) : undefined
   })
 
   function findReadyHostSessionHandle(
@@ -355,7 +368,7 @@ export function createRemoteRuntimePtyTransport(
     remotePtyId = null
     closeMultiplexedStream()
     if (stalePtyId) {
-      onPtyExit?.(stalePtyId)
+      sinks.onPtyExit?.(stalePtyId)
     }
   }
 
@@ -424,7 +437,7 @@ export function createRemoteRuntimePtyTransport(
           storedCallbacks.onExit?.(0)
           storedCallbacks.onDisconnect?.()
           if (subscribedPtyId) {
-            onPtyExit?.(subscribedPtyId)
+            sinks.onPtyExit?.(subscribedPtyId)
           }
         },
         onError: (message) => {
@@ -595,7 +608,7 @@ export function createRemoteRuntimePtyTransport(
       remotePtyId = null
       storedCallbacks.onDisconnect?.()
       if (id) {
-        onPtyExit?.(id)
+        sinks.onPtyExit?.(id)
       }
     },
 
@@ -607,6 +620,25 @@ export function createRemoteRuntimePtyTransport(
       connected = false
       closeMultiplexedStream()
       storedCallbacks = {}
+    },
+
+    park(parkedSinks) {
+      // Why: STA-1282 provider-specific park. Unlike detach(), do NOT close the
+      // multiplexed stream — it is the channel both the renderer-owned
+      // title/status feed AND serializeBuffer() (host-side snapshot) ride on.
+      // Keep connected + handle intact so an evicted remote tab replays host
+      // scrollback/alt-screen on remount instead of coming back blank.
+      inputBatcher.flush()
+      inputBatcher.clear()
+      viewportBatcher.flush()
+      storedCallbacks = {}
+      sinks.onTitleChange = parkedSinks.onTitleChange
+      sinks.onBell = undefined
+      sinks.onAgentBecameIdle = undefined
+      sinks.onAgentBecameWorking = undefined
+      sinks.onAgentExited = undefined
+      sinks.onAgentStatus = parkedSinks.onAgentStatus
+      sinks.onPtyExit = parkedSinks.onPtyExit
     },
 
     sendInput(data: string): boolean {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -633,7 +633,7 @@ export function createRemoteRuntimePtyTransport(
       viewportBatcher.flush()
       storedCallbacks = {}
       sinks.onTitleChange = parkedSinks.onTitleChange
-      sinks.onBell = undefined
+      sinks.onBell = parkedSinks.onBell
       sinks.onAgentBecameIdle = undefined
       sinks.onAgentBecameWorking = undefined
       sinks.onAgentExited = undefined

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-breadcrumbs.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-breadcrumbs.ts
@@ -1,0 +1,21 @@
+// STA-1282 diagnostics. Breadcrumb log lines on evict / remount / replay-failure
+// with the pane id + counts so a future "my terminal came back wrong" report is
+// attributable. Breadcrumbs only (telemetry gate: no PostHog events).
+
+type EvictionBreadcrumbEvent = 'evict' | 'remount-claim' | 'remount-replay' | 'self-disable'
+
+export function logTerminalPaneEvictionBreadcrumb(
+  event: EvictionBreadcrumbEvent,
+  details: {
+    tabId?: string
+    paneKey?: string
+    worktreeId?: string
+    ptyId?: string | null
+    outcome?: 'ok' | 'nil' | 'error'
+    mountedCount?: number
+    parkedCount?: number
+    reason?: string
+  }
+): void {
+  console.debug(`[terminal-pane-eviction] ${event}`, details)
+}

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalTab } from '../../../../shared/types'
+import { useAppStore } from '@/store'
+import {
+  __resetTerminalPaneEvictionCoordinatorForTest,
+  consumeTerminalPaneEviction,
+  noteTerminalPaneVisibility
+} from './terminal-pane-eviction-coordinator'
+import {
+  __resetEvictedPaneRegistryForTest,
+  isPaneParked,
+  recordEvictionRemountReplayOutcome,
+  registerEvictedPane
+} from './evicted-pane-registry'
+
+function makeTab(id: string): TerminalTab {
+  return {
+    id,
+    ptyId: `pty-${id}`,
+    worktreeId: 'wt-1',
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function seedStore(tabIds: string[], overrides: Record<string, unknown> = {}): void {
+  useAppStore.setState({
+    tabsByWorktree: { 'wt-1': tabIds.map(makeTab) },
+    ptyIdsByTabId: Object.fromEntries(tabIds.map((id) => [id, [`pty-${id}`]])),
+    suppressedPtyExitIds: {},
+    settings: {
+      ...useAppStore.getState().settings,
+      experimentalTerminalPaneEviction: true,
+      terminalPaneEvictionWarmBudget: 4,
+      terminalPaneEvictionAfterMinutes: 5,
+      ...overrides
+    } as never,
+    terminalPaneMountByTabId: {}
+  })
+}
+
+async function settle(): Promise<void> {
+  // Flush the microtask recompute, then any idle/setTimeout teardown + dwell.
+  await Promise.resolve()
+  await Promise.resolve()
+  await vi.advanceTimersByTimeAsync(1)
+  await Promise.resolve()
+}
+
+function mountMap(): Record<string, boolean> {
+  return useAppStore.getState().terminalPaneMountByTabId
+}
+
+describe('terminal-pane-eviction coordinator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Force the setTimeout idle fallback so teardowns are timer-controlled.
+    ;(globalThis as { requestIdleCallback?: unknown }).requestIdleCallback = undefined
+    __resetTerminalPaneEvictionCoordinatorForTest()
+    __resetEvictedPaneRegistryForTest()
+  })
+
+  afterEach(() => {
+    __resetTerminalPaneEvictionCoordinatorForTest()
+    __resetEvictedPaneRegistryForTest()
+    vi.useRealTimers()
+  })
+
+  it('keeps a just-hidden pane warm-mounted (does not unmount on the switch)', async () => {
+    seedStore(['a'])
+    noteTerminalPaneVisibility('a', 'wt-1', true)
+    await settle()
+    noteTerminalPaneVisibility('a', 'wt-1', false)
+    // Before the dwell window elapses, the pane stays mounted (Tier 1 warm).
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mountMap()['a']).toBe(true)
+  })
+
+  it('evicts a hidden pane once it passes the dwell window (deferred teardown)', async () => {
+    seedStore(['a'], { terminalPaneEvictionAfterMinutes: 1 })
+    noteTerminalPaneVisibility('a', 'wt-1', false)
+    await settle()
+    expect(mountMap()['a']).toBe(true) // warm within dwell
+
+    // Advance past the 1-minute dwell: the lazy dwell timer fires a recompute,
+    // which schedules and (on the idle callback) runs the deferred teardown.
+    await vi.advanceTimersByTimeAsync(61_000)
+    await settle()
+    expect(consumeTerminalPaneEviction('a')).toBe(true)
+    expect(mountMap()['a']).toBeUndefined()
+  })
+
+  it('gate #9: switching back before the dwell elapses keeps the pane warm (no eviction)', async () => {
+    seedStore(['a'], { terminalPaneEvictionAfterMinutes: 1 })
+    noteTerminalPaneVisibility('a', 'wt-1', false)
+    await settle()
+    await vi.advanceTimersByTimeAsync(30_000) // still within dwell
+    // Switch back to the tab (re-warm / remount claim) — bumps the generation.
+    noteTerminalPaneVisibility('a', 'wt-1', true)
+    await settle()
+    // Advance well past the ORIGINAL dwell boundary; a stale teardown must not fire.
+    await vi.advanceTimersByTimeAsync(120_000)
+    await settle()
+    expect(consumeTerminalPaneEviction('a')).toBe(false)
+  })
+
+  it('disable reconciliation: flipping the kill switch off stops evictions', async () => {
+    seedStore(['a'], { terminalPaneEvictionAfterMinutes: 1 })
+    noteTerminalPaneVisibility('a', 'wt-1', false)
+    await settle()
+    // Turn eviction off, then advance past the dwell window.
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings,
+        experimentalTerminalPaneEviction: false
+      } as never
+    })
+    await settle()
+    await vi.advanceTimersByTimeAsync(120_000)
+    await settle()
+    // No eviction: the pane stays mounted (warm) because eviction is disabled.
+    expect(consumeTerminalPaneEviction('a')).toBe(false)
+    expect(mountMap()['a']).toBe(true)
+  })
+
+  it('gate #5: tripping the fail-open self-disable stops further evictions', async () => {
+    seedStore(['a'], { terminalPaneEvictionAfterMinutes: 1 })
+    noteTerminalPaneVisibility('a', 'wt-1', false)
+    await settle()
+    // Trip the per-session self-disable (3 structural replay failures). The
+    // coordinator's onEvictionSelfDisable listener cancels pending teardowns.
+    recordEvictionRemountReplayOutcome('error')
+    recordEvictionRemountReplayOutcome('error')
+    recordEvictionRemountReplayOutcome('error')
+    await settle()
+    // Even past the dwell window, the pane is not evicted (eviction self-disabled).
+    await vi.advanceTimersByTimeAsync(120_000)
+    await settle()
+    expect(consumeTerminalPaneEviction('a')).toBe(false)
+    expect(mountMap()['a']).toBe(true)
+  })
+
+  describe('gate #8 close-reconcile for a background parked tab (finding #4)', () => {
+    function parkedEntry(tabId: string, destroy: () => void) {
+      return {
+        paneKey: `${tabId}:leaf`,
+        tabId,
+        worktreeId: 'wt-1',
+        getPtyId: () => `pty-${tabId}`,
+        destroy,
+        releaseForClaim: vi.fn()
+      }
+    }
+
+    it('closing a background parked tab (not in managedTabs) destroys its entry + kills its PTY promptly', async () => {
+      // Bring the coordinator online with one managed (hidden) tab so its store
+      // subscription is active, and park a DIFFERENT background tab.
+      seedStore(['a', 'parked'])
+      noteTerminalPaneVisibility('a', 'wt-1', false)
+      await settle()
+
+      const destroy = vi.fn()
+      registerEvictedPane(parkedEntry('parked', destroy))
+      expect(isPaneParked('parked:leaf')).toBe(true)
+
+      // Close the background parked tab: it is NOT in managedTabs, so only the
+      // parked-owner liveness folded into the change signature moves the
+      // signature and triggers the registry close-reconcile.
+      useAppStore.setState({
+        tabsByWorktree: { 'wt-1': [makeTab('a')] }
+      })
+      await settle()
+
+      expect(destroy).toHaveBeenCalledTimes(1) // PTY killed promptly
+      expect(isPaneParked('parked:leaf')).toBe(false)
+    })
+  })
+
+  describe('flag-OFF inertness (finding #1)', () => {
+    function setEvictionSetting(enabled: boolean): void {
+      useAppStore.setState({
+        settings: {
+          ...useAppStore.getState().settings,
+          experimentalTerminalPaneEviction: enabled
+        } as never
+      })
+    }
+
+    it('disabled from start: reporting a pane never subscribes to the store or records state', () => {
+      useAppStore.setState({
+        tabsByWorktree: { 'wt-1': [makeTab('a')] },
+        ptyIdsByTabId: { a: ['pty-a'] },
+        terminalPaneMountByTabId: {},
+        settings: {
+          ...useAppStore.getState().settings,
+          experimentalTerminalPaneEviction: false
+        } as never
+      })
+      const subscribeSpy = vi.spyOn(useAppStore, 'subscribe')
+      // Both a hide and a show report — neither may activate the coordinator.
+      noteTerminalPaneVisibility('a', 'wt-1', false)
+      noteTerminalPaneVisibility('a', 'wt-1', true)
+      expect(subscribeSpy).not.toHaveBeenCalled()
+      // No warm set was written (the overlay mounts everything when disabled).
+      expect(mountMap()['a']).toBeUndefined()
+      subscribeSpy.mockRestore()
+    })
+
+    it('enabling at runtime activates: a reported hidden pane becomes warm then evicts past dwell', async () => {
+      // Seed disabled: reporting is inert.
+      seedStore(['a'], {
+        experimentalTerminalPaneEviction: false,
+        terminalPaneEvictionAfterMinutes: 1
+      })
+      noteTerminalPaneVisibility('a', 'wt-1', false)
+      await settle()
+      expect(mountMap()['a']).toBeUndefined() // inert while disabled
+
+      // Flip ON at runtime, then the overlay reporter re-fires for the pane.
+      setEvictionSetting(true)
+      noteTerminalPaneVisibility('a', 'wt-1', false)
+      await settle()
+      expect(mountMap()['a']).toBe(true) // now warm-mounted (coordinator active)
+
+      await vi.advanceTimersByTimeAsync(61_000)
+      await settle()
+      expect(consumeTerminalPaneEviction('a')).toBe(true) // evicts past dwell
+      expect(mountMap()['a']).toBeUndefined()
+    })
+
+    it('disabling at runtime deactivates and cancels a scheduled teardown', async () => {
+      // Capture idle teardown callbacks so we control exactly when they run.
+      const idleCallbacks = new Map<number, () => void>()
+      let nextIdleId = 1
+      ;(globalThis as { requestIdleCallback?: unknown }).requestIdleCallback = (cb: () => void) => {
+        const id = nextIdleId++
+        idleCallbacks.set(id, cb)
+        return id
+      }
+      ;(globalThis as { cancelIdleCallback?: unknown }).cancelIdleCallback = (id: number) => {
+        idleCallbacks.delete(id)
+      }
+
+      seedStore(['a'], { terminalPaneEvictionAfterMinutes: 1 })
+      noteTerminalPaneVisibility('a', 'wt-1', false)
+      await settle()
+      // Past dwell: the dwell timer fires a recompute that SCHEDULES (does not
+      // run) the idle teardown.
+      await vi.advanceTimersByTimeAsync(61_000)
+      await settle()
+      expect(idleCallbacks.size).toBe(1)
+
+      // Flip OFF before the idle teardown runs: deactivation cancels it.
+      setEvictionSetting(false)
+      await settle()
+      expect(idleCallbacks.size).toBe(0) // canceled — never fires
+
+      // Even running any stragglers, the pane is not evicted and stays mounted.
+      for (const cb of idleCallbacks.values()) {
+        cb()
+      }
+      expect(consumeTerminalPaneEviction('a')).toBe(false)
+      expect(mountMap()['a']).toBe(true)
+
+      ;(globalThis as { requestIdleCallback?: unknown }).requestIdleCallback = undefined
+      ;(globalThis as { cancelIdleCallback?: unknown }).cancelIdleCallback = undefined
+    })
+  })
+
+  describe('hot-path: unrelated store ticks do not churn the warm set (perf)', () => {
+    it('flag ON with a warm pane: a burst of unrelated store ticks triggers zero warm-set writes', async () => {
+      // The coordinator subscribes to the WHOLE store, so every set() app-wide
+      // runs its subscriber (e.g. an active terminal's status/title/git ticks).
+      // The signature short-circuit + the shallowEqual pushMountMap gate must
+      // keep a tick that touches a field eviction never reads from recomputing or
+      // rewriting the warm set. This regresses to per-tick store churn if the
+      // signature is dropped/always-changing or pushMountMap loses its gate.
+      seedStore(['a', 'b'])
+      noteTerminalPaneVisibility('a', 'wt-1', false)
+      await settle()
+      expect(mountMap()['a']).toBe(true) // warm within dwell
+
+      const warmSetBefore = mountMap()
+      let warmSetWrites = 0
+      const unsubscribe = useAppStore.subscribe((state, prev) => {
+        if (state.terminalPaneMountByTabId !== prev.terminalPaneMountByTabId) {
+          warmSetWrites += 1
+        }
+      })
+      for (let i = 0; i < 50; i++) {
+        useAppStore.setState({ __unrelatedHotTick: i } as never)
+      }
+      await settle()
+      unsubscribe()
+
+      expect(warmSetWrites).toBe(0)
+      // Same object identity: the coordinator never rewrote the warm set.
+      expect(mountMap()).toBe(warmSetBefore)
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.test.ts
@@ -80,6 +80,45 @@ describe('terminal-pane-eviction coordinator', () => {
     expect(mountMap()['a']).toBe(true)
   })
 
+  describe('warm-set population across the visible->hidden transition', () => {
+    // Regression: the overlay slot reports a hide only while it is still mounted,
+    // and a slot unmounts in the same commit that flips it hidden UNLESS the store
+    // warm map already keeps it mounted. So a VISIBLE tab must appear in
+    // terminalPaneMountByTabId; otherwise the just-hidden pane unmounts before it
+    // can report the hide and the whole managed/warm/park pipeline never engages.
+    it('a visible tab is present in the warm mount map (survives the hide render)', async () => {
+      seedStore(['a'])
+      noteTerminalPaneVisibility('a', 'wt-1', true)
+      await settle()
+      expect(mountMap()['a']).toBe(true)
+    })
+
+    it('report visible then hidden: the pane is brought under management (warm)', async () => {
+      seedStore(['a'], { terminalPaneEvictionAfterMinutes: 5 })
+      noteTerminalPaneVisibility('a', 'wt-1', true)
+      await settle()
+      expect(mountMap()['a']).toBe(true)
+      // The hide report can only happen because the pane stayed mounted above.
+      noteTerminalPaneVisibility('a', 'wt-1', false)
+      await settle()
+      expect(mountMap()['a']).toBe(true) // warm within dwell
+    })
+
+    it('a tab closed while visible is pruned from the warm map on the next recompute', async () => {
+      seedStore(['a', 'b'])
+      noteTerminalPaneVisibility('a', 'wt-1', true)
+      await settle()
+      expect(mountMap()['a']).toBe(true)
+      // Close tab a while it is visible (it never reports hidden), then drive a
+      // recompute by reporting b hidden. Stale visible ids must not leak.
+      useAppStore.setState({ tabsByWorktree: { 'wt-1': [makeTab('b')] } })
+      noteTerminalPaneVisibility('b', 'wt-1', false)
+      await settle()
+      expect(mountMap()['a']).toBeUndefined()
+      expect(mountMap()['b']).toBe(true)
+    })
+  })
+
   it('evicts a hidden pane once it passes the dwell window (deferred teardown)', async () => {
     seedStore(['a'], { terminalPaneEvictionAfterMinutes: 1 })
     noteTerminalPaneVisibility('a', 'wt-1', false)

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.test.ts
@@ -4,7 +4,8 @@ import { useAppStore } from '@/store'
 import {
   __resetTerminalPaneEvictionCoordinatorForTest,
   consumeTerminalPaneEviction,
-  noteTerminalPaneVisibility
+  noteTerminalPaneVisibility,
+  seedTerminalPaneEvictionWarmSetOnEnable
 } from './terminal-pane-eviction-coordinator'
 import {
   __resetEvictedPaneRegistryForTest,
@@ -116,6 +117,42 @@ describe('terminal-pane-eviction coordinator', () => {
       await settle()
       expect(mountMap()['a']).toBeUndefined()
       expect(mountMap()['b']).toBe(true)
+    })
+  })
+
+  describe('enable-time warm-set seed (runtime flag flip, STA-1282)', () => {
+    it('synchronously seeds every non-parked tab into the warm mount map', () => {
+      // Called by the settings toggle BEFORE the enabling settings write, so it
+      // must work while the flag is still OFF — the mount map must be populated
+      // in the same tick, before the enable render evaluates the mount gate
+      // (otherwise every hidden mounted pane mass-DETACHES instead of parking).
+      seedStore(['a', 'b', 'c'], { experimentalTerminalPaneEviction: false })
+      // A parked tab stays Tier-2 (claimable on demand) — never re-warmed.
+      registerEvictedPane({
+        paneKey: 'tab-c-leaf',
+        tabId: 'c',
+        worktreeId: 'wt-1',
+        getPtyId: () => 'pty-c',
+        destroy: vi.fn(),
+        releaseForClaim: vi.fn()
+      })
+      seedTerminalPaneEvictionWarmSetOnEnable()
+      expect(mountMap()['a']).toBe(true)
+      expect(mountMap()['b']).toBe(true)
+      expect(mountMap()['c']).toBeUndefined()
+    })
+
+    it('seeded panes age out through the normal dwell policy with the park signal', async () => {
+      seedStore(['a', 'b'], { terminalPaneEvictionAfterMinutes: 5 })
+      seedTerminalPaneEvictionWarmSetOnEnable()
+      await settle()
+      expect(mountMap()['a']).toBe(true)
+      // Past the dwell window the seeded panes evict through the ordinary idle
+      // teardown, raising the eviction signal so the lifecycle parks (not detach).
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 5)
+      await settle()
+      expect(mountMap()['a']).toBeUndefined()
+      expect(consumeTerminalPaneEviction('a')).toBe(true)
     })
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
@@ -48,13 +48,18 @@ let selfDisableUnsubscribe: (() => void) | null = null
 let lastInputSignature = ''
 
 function scheduleIdle(callback: () => void): () => void {
-  const idle = (globalThis as { requestIdleCallback?: (cb: () => void) => number })
-    .requestIdleCallback
-  const cancelIdle = (globalThis as { cancelIdleCallback?: (id: number) => void })
-    .cancelIdleCallback
-  if (typeof idle === 'function' && typeof cancelIdle === 'function') {
-    const id = idle(callback)
-    return () => cancelIdle(id)
+  // Why: requestIdleCallback is this-sensitive — an extracted unbound reference
+  // throws "Illegal invocation" in Chromium, so always invoke as a method.
+  const target = globalThis as {
+    requestIdleCallback?: (cb: () => void) => number
+    cancelIdleCallback?: (id: number) => void
+  }
+  if (
+    typeof target.requestIdleCallback === 'function' &&
+    typeof target.cancelIdleCallback === 'function'
+  ) {
+    const id = target.requestIdleCallback(callback)
+    return () => target.cancelIdleCallback?.(id)
   }
   const timer = setTimeout(callback, 0)
   return () => clearTimeout(timer)

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
@@ -260,6 +260,13 @@ function deactivateEvictionAtRuntime(state: StoreState): void {
   // Stop evicting without a full recompute/signature hash: cancel queued
   // teardowns, drop the dwell timer, and keep the parked registry consistent so
   // a parked tab that closes while disabled is still reaped (gate #8).
+  //
+  // Runs on every store tick while disabled (managed warm panes keep the
+  // subscriber alive), so it must stay cheap: skip the O(managed) managed-tab
+  // prune — while disabled the warm mount map is ignored (the overlay mounts
+  // every non-parked tab) so stale managed ids are harmless and get cleaned on
+  // re-enable. Only the parked close-reconcile is load-bearing, and it itself
+  // early-returns when nothing is parked.
   if (pendingTeardowns.size > 0) {
     for (const [, pending] of pendingTeardowns) {
       pending.cancel()
@@ -267,7 +274,6 @@ function deactivateEvictionAtRuntime(state: StoreState): void {
     pendingTeardowns.clear()
   }
   clearDwellTimer()
-  pruneClosedManagedTabs(state)
   reconcileParkedForClose(state)
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
@@ -1,0 +1,356 @@
+// STA-1282: event-driven coordinator for terminal pane eviction.
+//
+// Owns the non-reactive eviction bookkeeping (last-visible timestamps, the
+// currently-visible set, managed hidden panes, in-flight teardown generations,
+// the single lazy dwell timer) and drives the store's reactive warm set
+// (`terminalPaneMountByTabId`). It is deliberately off the React render path.
+//
+// Flow: an overlay slot reports its visibility (noteTerminalPaneVisibility). A
+// pane that goes hidden becomes "managed" (kept warm). Recompute classifies
+// managed panes with the pure policy; panes classified `evict` are torn down on
+// a cancelable idle callback AFTER the switch paints (never in the switch
+// commit), each keyed by a per-pane generation so a queued teardown is a no-op
+// once the pane re-warms or a remount claims it (gate #9). The lifecycle reads
+// the eviction signal (consumeTerminalPaneEviction) to choose park over detach.
+
+import { useAppStore } from '@/store'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { isTerminalPaneEvictionEnabled } from '../../../../shared/terminal-pane-eviction-settings'
+import { computePaneMountPolicy, nextDwellExpiryAt } from './pane-mount-policy'
+import type { PaneMountClassification, PaneMountPolicyInput } from './pane-mount-policy'
+import {
+  evictedPaneCount,
+  onEvictionSelfDisable,
+  reconcileEvictedPanes
+} from './evicted-pane-registry'
+import {
+  buildEvictionPolicyInput,
+  collectLiveTabAndWorktreeIds,
+  computeEvictionInputSignature,
+  shallowEqualBooleanMap
+} from './terminal-pane-eviction-inputs'
+import { logTerminalPaneEvictionBreadcrumb } from './terminal-pane-eviction-breadcrumbs'
+
+type ManagedTab = { worktreeId: string }
+
+const managedTabs = new Map<string, ManagedTab>()
+const lastVisibleAt = new Map<string, number>()
+const visibleTabIds = new Set<string>()
+const generationByTab = new Map<string, number>()
+const pendingTeardowns = new Map<string, { generation: number; cancel: () => void }>()
+const evictingTabIds = new Set<string>()
+
+let dwellTimer: ReturnType<typeof setTimeout> | null = null
+let recomputeScheduled = false
+let initialized = false
+let storeUnsubscribe: (() => void) | null = null
+let selfDisableUnsubscribe: (() => void) | null = null
+let lastInputSignature = ''
+
+function scheduleIdle(callback: () => void): () => void {
+  const idle = (globalThis as { requestIdleCallback?: (cb: () => void) => number })
+    .requestIdleCallback
+  const cancelIdle = (globalThis as { cancelIdleCallback?: (id: number) => void })
+    .cancelIdleCallback
+  if (typeof idle === 'function' && typeof cancelIdle === 'function') {
+    const id = idle(callback)
+    return () => cancelIdle(id)
+  }
+  const timer = setTimeout(callback, 0)
+  return () => clearTimeout(timer)
+}
+
+function bumpGeneration(tabId: string): void {
+  generationByTab.set(tabId, (generationByTab.get(tabId) ?? 0) + 1)
+}
+
+function cancelTeardown(tabId: string): void {
+  const pending = pendingTeardowns.get(tabId)
+  if (pending) {
+    pending.cancel()
+    pendingTeardowns.delete(tabId)
+  }
+}
+
+const coordinatorContext = {
+  managedTabs: managedTabs as ReadonlyMap<string, { worktreeId: string }>,
+  lastVisibleAt: lastVisibleAt as ReadonlyMap<string, number>,
+  visibleTabIds: visibleTabIds as ReadonlySet<string>
+}
+
+type StoreState = ReturnType<typeof useAppStore.getState>
+
+function pushMountMap(): void {
+  const next: Record<string, boolean> = {}
+  for (const tabId of managedTabs.keys()) {
+    next[tabId] = true
+  }
+  const current = useAppStore.getState().terminalPaneMountByTabId
+  // Why: skip the store write when unchanged so our own store subscription does
+  // not re-trigger a recompute (avoids a feedback loop, keeps this off hot ticks).
+  if (!shallowEqualBooleanMap(current, next)) {
+    useAppStore.getState().setTerminalPaneMountByTabId(next)
+  }
+}
+
+function clearDwellTimer(): void {
+  if (dwellTimer !== null) {
+    clearTimeout(dwellTimer)
+    dwellTimer = null
+  }
+}
+
+function currentPolicyInput(state: StoreState): PaneMountPolicyInput {
+  return buildEvictionPolicyInput(state, coordinatorContext)
+}
+
+function pruneClosedManagedTabs(state: StoreState): void {
+  // Deleting the current entry during Map iteration is safe.
+  for (const [tabId, { worktreeId }] of managedTabs) {
+    const worktreeTabs = state.tabsByWorktree[worktreeId]
+    const stillExists = worktreeTabs?.some((tab) => tab.id === tabId)
+    if (!stillExists) {
+      managedTabs.delete(tabId)
+      lastVisibleAt.delete(tabId)
+      visibleTabIds.delete(tabId)
+      cancelTeardown(tabId)
+    }
+  }
+}
+
+function reconcileParkedForClose(state: StoreState): void {
+  if (evictedPaneCount() === 0) {
+    return
+  }
+  reconcileEvictedPanes(collectLiveTabAndWorktreeIds(state))
+}
+
+function armDwellTimer(
+  input: PaneMountPolicyInput,
+  precomputed?: ReadonlyMap<string, PaneMountClassification>
+): void {
+  clearDwellTimer()
+  const expiresAt = nextDwellExpiryAt(input, precomputed)
+  if (expiresAt === null) {
+    return
+  }
+  // Single lazy timer for the soonest warm-pane dwell boundary — no polling.
+  // Fire 1ms PAST the boundary: the dwell check is `now - lastVisibleAt <=
+  // evictAfterMs` (inclusive), so recomputing exactly at the boundary would
+  // still classify the pane warm and re-arm at the same instant (tight loop).
+  const delay = Math.max(0, expiresAt - Date.now()) + 1
+  dwellTimer = setTimeout(() => {
+    dwellTimer = null
+    recompute()
+  }, delay)
+}
+
+function scheduleTeardown(tabId: string): void {
+  if (pendingTeardowns.has(tabId)) {
+    return
+  }
+  const generation = generationByTab.get(tabId) ?? 0
+  const cancel = scheduleIdle(() => {
+    pendingTeardowns.delete(tabId)
+    fireTeardown(tabId, generation)
+  })
+  pendingTeardowns.set(tabId, { generation, cancel })
+}
+
+function fireTeardown(tabId: string, scheduledGeneration: number): void {
+  // Gate #9: a teardown queued for generation N is a no-op once the pane
+  // re-warmed or a remount claimed it (both bump the generation).
+  if ((generationByTab.get(tabId) ?? 0) !== scheduledGeneration) {
+    return
+  }
+  if (!managedTabs.has(tabId) || visibleTabIds.has(tabId)) {
+    return
+  }
+  // Fire-time policy recheck: re-run against CURRENT state, never stale state.
+  const state = useAppStore.getState()
+  const input = currentPolicyInput(state)
+  if (!input.evictionEnabled) {
+    return
+  }
+  const result = computePaneMountPolicy(input)
+  if (result.classifications.get(tabId) !== 'evict') {
+    return
+  }
+  const worktreeId = managedTabs.get(tabId)?.worktreeId
+  // Signal the eviction to the pane lifecycle BEFORE the unmounting store write
+  // so the React cleanup reads it and chooses park() over detach()/destroy().
+  evictingTabIds.add(tabId)
+  managedTabs.delete(tabId)
+  lastVisibleAt.delete(tabId)
+  bumpGeneration(tabId)
+  logTerminalPaneEvictionBreadcrumb('evict', {
+    tabId,
+    worktreeId,
+    mountedCount: managedTabs.size,
+    parkedCount: evictedPaneCount()
+  })
+  pushMountMap()
+  armDwellTimer(currentPolicyInput(useAppStore.getState()))
+}
+
+function recompute(): void {
+  recomputeScheduled = false
+  const state = useAppStore.getState()
+  pruneClosedManagedTabs(state)
+  reconcileParkedForClose(state)
+  if (managedTabs.size === 0) {
+    pushMountMap()
+    clearDwellTimer()
+    return
+  }
+  const input = currentPolicyInput(state)
+  const result = computePaneMountPolicy(input)
+  for (const tabId of managedTabs.keys()) {
+    if (result.classifications.get(tabId) === 'evict') {
+      scheduleTeardown(tabId)
+    } else {
+      cancelTeardown(tabId)
+    }
+  }
+  pushMountMap()
+  armDwellTimer(input, result.classifications)
+}
+
+function scheduleRecompute(): void {
+  if (recomputeScheduled) {
+    return
+  }
+  recomputeScheduled = true
+  queueMicrotask(recompute)
+}
+
+function reconcileDisabled(): void {
+  // Disable reconciliation: cancel all pending teardowns so no further pane is
+  // evicted; already-parked panes stay claimable on demand (no batch remount).
+  for (const [, pending] of pendingTeardowns) {
+    pending.cancel()
+  }
+  pendingTeardowns.clear()
+  clearDwellTimer()
+  scheduleRecompute()
+}
+
+function deactivateEvictionAtRuntime(state: StoreState): void {
+  // The `experimentalTerminalPaneEviction` setting was flipped OFF at runtime.
+  // Stop evicting without a full recompute/signature hash: cancel queued
+  // teardowns, drop the dwell timer, and keep the parked registry consistent so
+  // a parked tab that closes while disabled is still reaped (gate #8).
+  if (pendingTeardowns.size > 0) {
+    for (const [, pending] of pendingTeardowns) {
+      pending.cancel()
+    }
+    pendingTeardowns.clear()
+  }
+  clearDwellTimer()
+  pruneClosedManagedTabs(state)
+  reconcileParkedForClose(state)
+}
+
+function ensureInitialized(): void {
+  if (initialized) {
+    return
+  }
+  initialized = true
+  storeUnsubscribe = useAppStore.subscribe(() => {
+    if (managedTabs.size === 0 && evictedPaneCount() === 0) {
+      // No steady-state work when nothing is hidden or parked.
+      return
+    }
+    const state = useAppStore.getState()
+    if (!isTerminalPaneEvictionEnabled(state.settings)) {
+      // Flag-OFF inertness: the setting was flipped OFF at runtime. Deactivate
+      // eviction (cancel any queued teardown + the dwell timer) and stop hashing
+      // signatures — but keep the parked registry consistent so a closed parked
+      // tab's PTY is still reaped (gate #8). Already-parked panes stay claimable
+      // on demand; warm panes just stay mounted (the overlay mounts everything
+      // non-parked while disabled). Re-enabling reactivates via the overlay
+      // visibility reporter.
+      deactivateEvictionAtRuntime(state)
+      return
+    }
+    const signature = computeEvictionInputSignature(state, managedTabs)
+    if (signature === lastInputSignature) {
+      return
+    }
+    lastInputSignature = signature
+    scheduleRecompute()
+  })
+  selfDisableUnsubscribe = onEvictionSelfDisable(() => {
+    logTerminalPaneEvictionBreadcrumb('self-disable', { parkedCount: evictedPaneCount() })
+    reconcileDisabled()
+  })
+}
+
+/** Report an overlay slot's current visibility. The single entry point that
+ *  brings a pane under eviction management (on visible -> hidden). */
+export function noteTerminalPaneVisibility(
+  tabId: string,
+  worktreeId: string,
+  isVisible: boolean
+): void {
+  // Policy scope excludes the floating quick-terminal (and other ungated
+  // surfaces never reach this reporter).
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return
+  }
+  // Flag-OFF inertness: with eviction disabled the coordinator does no work at
+  // all — it never subscribes, hashes, arms timers, or records timestamps. The
+  // overlay reporter already gates on the setting; this guard keeps the
+  // coordinator self-contained (and makes "disabled → zero subscriptions"
+  // directly assertable). Enabling at runtime reactivates via the reporter.
+  if (!isTerminalPaneEvictionEnabled(useAppStore.getState().settings)) {
+    return
+  }
+  ensureInitialized()
+  const now = Date.now()
+  lastVisibleAt.set(tabId, now)
+  if (isVisible) {
+    visibleTabIds.add(tabId)
+    // Re-warm / remount claim: invalidate any queued teardown (gate #9).
+    bumpGeneration(tabId)
+    cancelTeardown(tabId)
+    managedTabs.delete(tabId)
+  } else {
+    visibleTabIds.delete(tabId)
+    managedTabs.set(tabId, { worktreeId })
+  }
+  scheduleRecompute()
+}
+
+/** Read-and-clear the eviction signal for a tab. The pane lifecycle calls this
+ *  during React cleanup to choose park() over detach()/destroy() (gate #1). */
+export function consumeTerminalPaneEviction(tabId: string): boolean {
+  const wasEvicting = evictingTabIds.has(tabId)
+  evictingTabIds.delete(tabId)
+  return wasEvicting
+}
+
+export function isTerminalPaneEvictionActive(): boolean {
+  return managedTabs.size > 0 || evictedPaneCount() > 0
+}
+
+// Test-only reset.
+export function __resetTerminalPaneEvictionCoordinatorForTest(): void {
+  for (const [, pending] of pendingTeardowns) {
+    pending.cancel()
+  }
+  pendingTeardowns.clear()
+  managedTabs.clear()
+  lastVisibleAt.clear()
+  visibleTabIds.clear()
+  generationByTab.clear()
+  evictingTabIds.clear()
+  clearDwellTimer()
+  recomputeScheduled = false
+  lastInputSignature = ''
+  storeUnsubscribe?.()
+  storeUnsubscribe = null
+  selfDisableUnsubscribe?.()
+  selfDisableUnsubscribe = null
+  initialized = false
+}

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
@@ -31,15 +31,25 @@ import {
   shallowEqualBooleanMap
 } from './terminal-pane-eviction-inputs'
 import { logTerminalPaneEvictionBreadcrumb } from './terminal-pane-eviction-breadcrumbs'
+import { scheduleCancelableIdleCallback } from './cancelable-idle-callback'
+import {
+  __resetTerminalPaneEvictionSignalForTest,
+  bumpTeardownGeneration,
+  clearTabEvictingSignal,
+  markTabEvicting,
+  pruneTabEvictionSignal,
+  teardownGeneration
+} from './terminal-pane-eviction-signal'
+
+// Re-exported so the pane lifecycle keeps its single import site (gate #1).
+export { consumeTerminalPaneEviction } from './terminal-pane-eviction-signal'
 
 type ManagedTab = { worktreeId: string }
 
 const managedTabs = new Map<string, ManagedTab>()
 const lastVisibleAt = new Map<string, number>()
 const visibleTabIds = new Set<string>()
-const generationByTab = new Map<string, number>()
 const pendingTeardowns = new Map<string, { generation: number; cancel: () => void }>()
-const evictingTabIds = new Set<string>()
 
 let dwellTimer: ReturnType<typeof setTimeout> | null = null
 let recomputeScheduled = false
@@ -47,28 +57,6 @@ let initialized = false
 let storeUnsubscribe: (() => void) | null = null
 let selfDisableUnsubscribe: (() => void) | null = null
 let lastInputSignature = ''
-
-function scheduleIdle(callback: () => void): () => void {
-  // Why: requestIdleCallback is this-sensitive — an extracted unbound reference
-  // throws "Illegal invocation" in Chromium, so always invoke as a method.
-  const target = globalThis as {
-    requestIdleCallback?: (cb: () => void) => number
-    cancelIdleCallback?: (id: number) => void
-  }
-  if (
-    typeof target.requestIdleCallback === 'function' &&
-    typeof target.cancelIdleCallback === 'function'
-  ) {
-    const id = target.requestIdleCallback(callback)
-    return () => target.cancelIdleCallback?.(id)
-  }
-  const timer = setTimeout(callback, 0)
-  return () => clearTimeout(timer)
-}
-
-function bumpGeneration(tabId: string): void {
-  generationByTab.set(tabId, (generationByTab.get(tabId) ?? 0) + 1)
-}
 
 function cancelTeardown(tabId: string): void {
   const pending = pendingTeardowns.get(tabId)
@@ -130,8 +118,7 @@ function pruneClosedManagedTabs(state: StoreState): void {
       cancelTeardown(tabId)
       // Why: drop the per-tab generation and any stale eviction signal too, so a
       // closed tab leaves no residual coordinator state for the session.
-      generationByTab.delete(tabId)
-      evictingTabIds.delete(tabId)
+      pruneTabEvictionSignal(tabId)
     }
   }
   // Why: a tab closed while visible never reports hidden, so prune stale visible
@@ -145,8 +132,7 @@ function pruneClosedManagedTabs(state: StoreState): void {
         lastVisibleAt.delete(tabId)
         // Why: a tab closed while visible is never in managedTabs, so drop its
         // generation + eviction-signal here too (the managed loop above cannot).
-        generationByTab.delete(tabId)
-        evictingTabIds.delete(tabId)
+        pruneTabEvictionSignal(tabId)
       }
     }
   }
@@ -183,8 +169,8 @@ function scheduleTeardown(tabId: string): void {
   if (pendingTeardowns.has(tabId)) {
     return
   }
-  const generation = generationByTab.get(tabId) ?? 0
-  const cancel = scheduleIdle(() => {
+  const generation = teardownGeneration(tabId)
+  const cancel = scheduleCancelableIdleCallback(() => {
     pendingTeardowns.delete(tabId)
     fireTeardown(tabId, generation)
   })
@@ -194,7 +180,7 @@ function scheduleTeardown(tabId: string): void {
 function fireTeardown(tabId: string, scheduledGeneration: number): void {
   // Gate #9: a teardown queued for generation N is a no-op once the pane
   // re-warmed or a remount claimed it (both bump the generation).
-  if ((generationByTab.get(tabId) ?? 0) !== scheduledGeneration) {
+  if (teardownGeneration(tabId) !== scheduledGeneration) {
     return
   }
   if (!managedTabs.has(tabId) || visibleTabIds.has(tabId)) {
@@ -213,10 +199,10 @@ function fireTeardown(tabId: string, scheduledGeneration: number): void {
   const worktreeId = managedTabs.get(tabId)?.worktreeId
   // Signal the eviction to the pane lifecycle BEFORE the unmounting store write
   // so the React cleanup reads it and chooses park() over detach()/destroy().
-  evictingTabIds.add(tabId)
+  markTabEvicting(tabId)
   managedTabs.delete(tabId)
   lastVisibleAt.delete(tabId)
-  bumpGeneration(tabId)
+  bumpTeardownGeneration(tabId)
   logTerminalPaneEvictionBreadcrumb('evict', {
     tabId,
     worktreeId,
@@ -352,13 +338,13 @@ export function noteTerminalPaneVisibility(
   if (isVisible) {
     visibleTabIds.add(tabId)
     // Re-warm / remount claim: invalidate any queued teardown (gate #9).
-    bumpGeneration(tabId)
+    bumpTeardownGeneration(tabId)
     cancelTeardown(tabId)
     managedTabs.delete(tabId)
     // Why: a teardown that fired while this tab was already re-revealed can leave a
     // stale eviction signal; clear it on re-warm so a later close/reparent of the
     // tab is not misread as an eviction (park instead of destroy/detach).
-    evictingTabIds.delete(tabId)
+    clearTabEvictingSignal(tabId)
   } else {
     visibleTabIds.delete(tabId)
     managedTabs.set(tabId, { worktreeId })
@@ -396,14 +382,6 @@ export function seedTerminalPaneEvictionWarmSetOnEnable(): void {
   scheduleRecompute()
 }
 
-/** Read-and-clear the eviction signal for a tab. The pane lifecycle calls this
- *  during React cleanup to choose park() over detach()/destroy() (gate #1). */
-export function consumeTerminalPaneEviction(tabId: string): boolean {
-  const wasEvicting = evictingTabIds.has(tabId)
-  evictingTabIds.delete(tabId)
-  return wasEvicting
-}
-
 export function isTerminalPaneEvictionActive(): boolean {
   return managedTabs.size > 0 || evictedPaneCount() > 0
 }
@@ -417,8 +395,7 @@ export function __resetTerminalPaneEvictionCoordinatorForTest(): void {
   managedTabs.clear()
   lastVisibleAt.clear()
   visibleTabIds.clear()
-  generationByTab.clear()
-  evictingTabIds.clear()
+  __resetTerminalPaneEvictionSignalForTest()
   clearDwellTimer()
   recomputeScheduled = false
   lastInputSignature = ''

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
@@ -85,6 +85,14 @@ function pushMountMap(): void {
   for (const tabId of managedTabs.keys()) {
     next[tabId] = true
   }
+  // Why: a visible tab must also be in the warm mount map so the overlay keeps it
+  // mounted through the single render where it flips visible->hidden — that render
+  // is when the slot's effect reports the hide (an unmounting slot never runs its
+  // effect body). Without this the just-hidden pane unmounts in the same commit
+  // and is never brought under management, defeating the warm set entirely.
+  for (const tabId of visibleTabIds) {
+    next[tabId] = true
+  }
   const current = useAppStore.getState().terminalPaneMountByTabId
   // Why: skip the store write when unchanged so our own store subscription does
   // not re-trigger a recompute (avoids a feedback loop, keeps this off hot ticks).
@@ -114,6 +122,18 @@ function pruneClosedManagedTabs(state: StoreState): void {
       lastVisibleAt.delete(tabId)
       visibleTabIds.delete(tabId)
       cancelTeardown(tabId)
+    }
+  }
+  // Why: a tab closed while visible never reports hidden, so prune stale visible
+  // entries here too — otherwise the warm mount map (which now includes visible
+  // tabs) would retain closed-tab ids across recomputes.
+  if (visibleTabIds.size > 0) {
+    const liveTabIds = collectLiveTabAndWorktreeIds(state).tabIds
+    for (const tabId of visibleTabIds) {
+      if (!liveTabIds.has(tabId)) {
+        visibleTabIds.delete(tabId)
+        lastVisibleAt.delete(tabId)
+      }
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-coordinator.ts
@@ -20,6 +20,7 @@ import { computePaneMountPolicy, nextDwellExpiryAt } from './pane-mount-policy'
 import type { PaneMountClassification, PaneMountPolicyInput } from './pane-mount-policy'
 import {
   evictedPaneCount,
+  isTabParked,
   onEvictionSelfDisable,
   reconcileEvictedPanes
 } from './evicted-pane-registry'
@@ -127,6 +128,10 @@ function pruneClosedManagedTabs(state: StoreState): void {
       lastVisibleAt.delete(tabId)
       visibleTabIds.delete(tabId)
       cancelTeardown(tabId)
+      // Why: drop the per-tab generation and any stale eviction signal too, so a
+      // closed tab leaves no residual coordinator state for the session.
+      generationByTab.delete(tabId)
+      evictingTabIds.delete(tabId)
     }
   }
   // Why: a tab closed while visible never reports hidden, so prune stale visible
@@ -138,6 +143,10 @@ function pruneClosedManagedTabs(state: StoreState): void {
       if (!liveTabIds.has(tabId)) {
         visibleTabIds.delete(tabId)
         lastVisibleAt.delete(tabId)
+        // Why: a tab closed while visible is never in managedTabs, so drop its
+        // generation + eviction-signal here too (the managed loop above cannot).
+        generationByTab.delete(tabId)
+        evictingTabIds.delete(tabId)
       }
     }
   }
@@ -346,10 +355,44 @@ export function noteTerminalPaneVisibility(
     bumpGeneration(tabId)
     cancelTeardown(tabId)
     managedTabs.delete(tabId)
+    // Why: a teardown that fired while this tab was already re-revealed can leave a
+    // stale eviction signal; clear it on re-warm so a later close/reparent of the
+    // tab is not misread as an eviction (park instead of destroy/detach).
+    evictingTabIds.delete(tabId)
   } else {
     visibleTabIds.delete(tabId)
     managedTabs.set(tabId, { worktreeId })
   }
+  scheduleRecompute()
+}
+
+/** STA-1282 enable-time seam. Flag-off mounts every pane, so at the instant the
+ *  experiment flips ON the warm map is empty and the mount gate would mass-
+ *  DETACH every hidden mounted pane (status/title/exit feeds dark until each is
+ *  revisited) instead of parking it. The settings toggle calls this just BEFORE
+ *  the enabling settings write: bring every currently-mounted (non-parked) tab
+ *  under management as warm-now and push the mount map synchronously, so the
+ *  enable render never sees an empty warm set. The next recompute then evicts
+ *  beyond-budget panes through the normal idle teardown, which parks them with
+ *  their feeds retained. */
+export function seedTerminalPaneEvictionWarmSetOnEnable(): void {
+  ensureInitialized()
+  const state = useAppStore.getState()
+  const now = Date.now()
+  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    // Same scope exclusion as the visibility reporter path.
+    if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+      continue
+    }
+    for (const tab of tabs) {
+      if (isTabParked(tab.id) || visibleTabIds.has(tab.id) || managedTabs.has(tab.id)) {
+        continue
+      }
+      managedTabs.set(tab.id, { worktreeId })
+      lastVisibleAt.set(tab.id, now)
+    }
+  }
+  pushMountMap()
   scheduleRecompute()
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-inputs.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-inputs.ts
@@ -1,0 +1,118 @@
+// STA-1282: pure-ish store-reading helpers for the eviction coordinator, split
+// out to keep the coordinator focused. These resolve the messy store facts into
+// the clean policy inputs and the change-detection signature.
+
+import type { useAppStore } from '@/store'
+import {
+  isTerminalPaneEvictionEnabled,
+  resolveTerminalPaneEvictionAfterMs,
+  resolveTerminalPaneEvictionWarmBudget
+} from '../../../../shared/terminal-pane-eviction-settings'
+import type { PaneMountCandidate, PaneMountPolicyInput } from './pane-mount-policy'
+import { forEachParkedOwner, isEvictionSelfDisabled, isTabParked } from './evicted-pane-registry'
+
+type StoreState = ReturnType<typeof useAppStore.getState>
+
+export type EvictionCoordinatorContext = {
+  managedTabs: ReadonlyMap<string, { worktreeId: string }>
+  lastVisibleAt: ReadonlyMap<string, number>
+  visibleTabIds: ReadonlySet<string>
+}
+
+export function buildEvictionCandidates(
+  state: StoreState,
+  ctx: EvictionCoordinatorContext
+): PaneMountCandidate[] {
+  const candidates: PaneMountCandidate[] = []
+  for (const [tabId, { worktreeId }] of ctx.managedTabs) {
+    const ptyIds = state.ptyIdsByTabId[tabId] ?? []
+    const hasWakeHint = ptyIds.some((id) => state.suppressedPtyExitIds[id])
+    candidates.push({
+      tabId,
+      worktreeId,
+      isVisible: ctx.visibleTabIds.has(tabId),
+      lastVisibleAt: ctx.lastVisibleAt.get(tabId) ?? null,
+      // No bound PTY yet = newborn/dead (both exempt: keep today's behavior).
+      ptyState: ptyIds.length > 0 ? 'live' : 'newborn',
+      hasWakeHint,
+      isParked: isTabParked(tabId)
+    })
+  }
+  return candidates
+}
+
+export function buildEvictionPolicyInput(
+  state: StoreState,
+  ctx: EvictionCoordinatorContext
+): PaneMountPolicyInput {
+  return {
+    candidates: buildEvictionCandidates(state, ctx),
+    nowMs: Date.now(),
+    evictionEnabled: isTerminalPaneEvictionEnabled(state.settings) && !isEvictionSelfDisabled(),
+    warmBudget: resolveTerminalPaneEvictionWarmBudget(state.settings),
+    evictAfterMs: resolveTerminalPaneEvictionAfterMs(state.settings)
+  }
+}
+
+/**
+ * Cheap change-detector so the store subscription only recomputes when an
+ * eviction input actually moved (selection / PTY bind-exit / wake / settings),
+ * not on every unrelated store tick (e.g. hot PTY output).
+ */
+export function computeEvictionInputSignature(
+  state: StoreState,
+  managedTabs: ReadonlyMap<string, { worktreeId: string }>
+): string {
+  const parts: string[] = [
+    state.activeWorktreeId ?? '',
+    state.activeTabId ?? '',
+    state.activeView ?? ''
+  ]
+  for (const tabId of managedTabs.keys()) {
+    const ptyIds = state.ptyIdsByTabId[tabId] ?? []
+    const wake = ptyIds.some((id) => state.suppressedPtyExitIds[id]) ? '1' : '0'
+    parts.push(`${tabId}:${ptyIds.join(',')}:${wake}`)
+  }
+  // Gate #8: parked (evicted) tabs are not in managedTabs, so a background parked
+  // tab or its worktree closing would otherwise not move the signature and the
+  // registry close-reconcile would only fire on the next unrelated event. Fold
+  // each parked owner's tab/worktree liveness in so the close is detected promptly.
+  forEachParkedOwner((tabId, worktreeId) => {
+    const tabAlive = state.tabsByWorktree[worktreeId]?.some((tab) => tab.id === tabId) ? '1' : '0'
+    const worktreeAlive = state.tabsByWorktree[worktreeId] !== undefined ? '1' : '0'
+    parts.push(`p:${worktreeId}:${tabId}:${tabAlive}${worktreeAlive}`)
+  })
+  const settings = state.settings
+  parts.push(
+    `${settings?.experimentalTerminalPaneEviction ?? ''}:${settings?.terminalPaneEvictionWarmBudget ?? ''}:${settings?.terminalPaneEvictionAfterMinutes ?? ''}`
+  )
+  return parts.join('|')
+}
+
+/** Live tab/worktree ids for the parked-registry close-reconcile (gate #8). */
+export function collectLiveTabAndWorktreeIds(state: StoreState): {
+  tabIds: Set<string>
+  worktreeIds: Set<string>
+} {
+  const tabIds = new Set<string>()
+  const worktreeIds = new Set<string>()
+  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    worktreeIds.add(worktreeId)
+    for (const tab of tabs) {
+      tabIds.add(tab.id)
+    }
+  }
+  return { tabIds, worktreeIds }
+}
+
+export function shallowEqualBooleanMap(
+  a: Record<string, boolean>,
+  b: Record<string, boolean>
+): boolean {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+  return aKeys.every((key) => a[key] === b[key])
+}

--- a/src/renderer/src/components/terminal-pane/terminal-pane-eviction-signal.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-eviction-signal.ts
@@ -1,0 +1,49 @@
+// STA-1282 gate #9 bookkeeping: per-tab teardown-invalidation generations and
+// the evicting signal the pane lifecycle consumes during React cleanup to
+// choose park() over detach()/destroy() (gate #1). A teardown queued for
+// generation N must become a no-op once the pane re-warms or a remount claims
+// it — both bump the generation.
+
+const generationByTab = new Map<string, number>()
+const evictingTabIds = new Set<string>()
+
+export function teardownGeneration(tabId: string): number {
+  return generationByTab.get(tabId) ?? 0
+}
+
+export function bumpTeardownGeneration(tabId: string): void {
+  generationByTab.set(tabId, (generationByTab.get(tabId) ?? 0) + 1)
+}
+
+/** Raised just BEFORE the unmounting store write so the pane lifecycle's
+ *  cleanup reads it and parks instead of detaching/destroying. */
+export function markTabEvicting(tabId: string): void {
+  evictingTabIds.add(tabId)
+}
+
+/** Clear a stale eviction signal without touching the generation (re-warm:
+ *  a teardown that fired while the tab was already re-revealed must not make
+ *  a later close/reparent look like an eviction). */
+export function clearTabEvictingSignal(tabId: string): void {
+  evictingTabIds.delete(tabId)
+}
+
+/** Drop all per-tab signal state (tab closed — leave no session residue). */
+export function pruneTabEvictionSignal(tabId: string): void {
+  generationByTab.delete(tabId)
+  evictingTabIds.delete(tabId)
+}
+
+/** Read-and-clear the eviction signal for a tab. The pane lifecycle calls this
+ *  during React cleanup to choose park() over detach()/destroy() (gate #1). */
+export function consumeTerminalPaneEviction(tabId: string): boolean {
+  const wasEvicting = evictingTabIds.has(tabId)
+  evictingTabIds.delete(tabId)
+  return wasEvicting
+}
+
+// Test-only reset.
+export function __resetTerminalPaneEvictionSignalForTest(): void {
+  generationByTab.clear()
+  evictingTabIds.clear()
+}

--- a/src/renderer/src/components/terminal-pane/terminal-pane-overlay-eviction.integration.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-overlay-eviction.integration.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment happy-dom
+//
+// STA-1282 P0 integration test. The unit tests for the coordinator call
+// noteTerminalPaneVisibility() directly, which BYPASSES the real bug: the
+// visible->hidden report has to survive the render/mount-gate seam. This test
+// renders the real TerminalPaneOverlayLayer (real store + real coordinator, only
+// TerminalPane stubbed) so the visibility reporter runs through React exactly as
+// it does live. It is the regression lock for "warm set stays {} forever".
+
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Tab, TabGroup, TerminalTab } from '../../../../shared/types'
+import { useAppStore } from '@/store'
+import { __resetTerminalPaneEvictionCoordinatorForTest } from './terminal-pane-eviction-coordinator'
+import { __resetEvictedPaneRegistryForTest } from './evicted-pane-registry'
+
+vi.mock('./TerminalPane', () => ({
+  default: ({ tabId }: { tabId: string }) => <div data-testid={`pane-${tabId}`} />
+}))
+// Not under test; its keydown/store effects would only add noise.
+vi.mock('../native-chat/use-native-chat-toggle-shortcut', () => ({
+  useNativeChatToggleShortcut: () => {}
+}))
+
+import TerminalPaneOverlayLayer from './TerminalPaneOverlayLayer'
+
+const WT = 'wt-1'
+
+function terminalTab(id: string): TerminalTab {
+  return {
+    id,
+    ptyId: `pty-${id}`,
+    worktreeId: WT,
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function unifiedTab(entityId: string, sortOrder: number): Tab {
+  return {
+    id: `u-${entityId}`,
+    entityId,
+    groupId: 'g1',
+    worktreeId: WT,
+    contentType: 'terminal',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder + 1
+  }
+}
+
+function group(activeEntityId: string): TabGroup {
+  return {
+    id: 'g1',
+    worktreeId: WT,
+    activeTabId: `u-${activeEntityId}`,
+    tabOrder: ['u-a', 'u-b']
+  }
+}
+
+function seed(activeEntityId: string): void {
+  useAppStore.setState({
+    tabsByWorktree: { [WT]: [terminalTab('a'), terminalTab('b')] },
+    unifiedTabsByWorktree: { [WT]: [unifiedTab('a', 0), unifiedTab('b', 1)] },
+    groupsByWorktree: { [WT]: [group(activeEntityId)] },
+    activeGroupIdByWorktree: { [WT]: 'g1' },
+    ptyIdsByTabId: { a: ['pty-a'], b: ['pty-b'] },
+    suppressedPtyExitIds: {},
+    terminalPaneMountByTabId: {},
+    settings: {
+      ...useAppStore.getState().settings,
+      experimentalTerminalPaneEviction: true,
+      terminalPaneEvictionWarmBudget: 4,
+      terminalPaneEvictionAfterMinutes: 5
+    } as never
+  })
+}
+
+function setActiveEntity(entityId: string): void {
+  act(() => {
+    useAppStore.setState({ groupsByWorktree: { [WT]: [group(entityId)] } })
+  })
+}
+
+async function flush(): Promise<void> {
+  // Let the reporter effect run, then the coordinator's queued recompute +
+  // the pushMountMap store write it triggers, then the resulting re-render.
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function mountMap(): Record<string, boolean> {
+  return useAppStore.getState().terminalPaneMountByTabId
+}
+
+describe('TerminalPaneOverlayLayer eviction seam (P0 integration)', () => {
+  beforeEach(() => {
+    ;(globalThis as { requestIdleCallback?: unknown }).requestIdleCallback = undefined
+    __resetTerminalPaneEvictionCoordinatorForTest()
+    __resetEvictedPaneRegistryForTest()
+    seed('a')
+  })
+
+  afterEach(() => {
+    cleanup()
+    __resetTerminalPaneEvictionCoordinatorForTest()
+    __resetEvictedPaneRegistryForTest()
+    useAppStore.setState({ terminalPaneMountByTabId: {} })
+  })
+
+  function renderOverlay(): ReturnType<typeof render> {
+    return render(
+      <TerminalPaneOverlayLayer worktreeId={WT} worktreePath="/wt-1" isWorktreeActive={true} />
+    )
+  }
+
+  it('P0-1: switching a tab visible->hidden warms it through the real render cycle', async () => {
+    const view = renderOverlay()
+    await flush()
+    // 'a' is visible; 'b' was never visible so it must not mount (no PTY spawn).
+    expect(view.queryByTestId('pane-a')).not.toBeNull()
+    expect(view.queryByTestId('pane-b')).toBeNull()
+
+    // Switch to 'b': 'a' flips visible->hidden. The reporter (not the gated slot)
+    // must report the hide so the coordinator brings 'a' under warm management.
+    setActiveEntity('b')
+    await flush()
+
+    // The core of the live P0-1: 'a' is now warm-mounted. Before the ungated
+    // reporter this stayed {} forever (the slot unmounted before it could report).
+    expect(mountMap().a).toBe(true)
+    // Warm 'a' stays mounted (Tier 1); 'b' is now visible.
+    expect(view.queryByTestId('pane-a')).not.toBeNull()
+    expect(view.queryByTestId('pane-b')).not.toBeNull()
+  })
+
+  it('P0-1: the hide report fires even when the warm map did not retain the tab', async () => {
+    // Reproduce the live deadlock directly: force the warm map empty while 'a' is
+    // still visible (simulating the visible-phase write never landing). On the
+    // hide render the gated slot for 'a' unmounts (isWarm=false) — so a reporter
+    // living inside that slot would never fire the hide. The ungated reporter
+    // still fires it, so 'a' recovers into the warm set instead of deadlocking.
+    const view = renderOverlay()
+    await flush()
+    act(() => {
+      useAppStore.setState({ terminalPaneMountByTabId: {} })
+    })
+
+    setActiveEntity('b')
+    await flush()
+
+    expect(mountMap().a).toBe(true)
+    expect(view.queryByTestId('pane-a')).not.toBeNull()
+  })
+
+  it('P0-1 gate #9: hide then immediately re-show never leaves the tab managed for eviction', async () => {
+    const view = renderOverlay()
+    await flush()
+    setActiveEntity('b') // hide 'a'
+    await flush()
+    setActiveEntity('a') // re-show 'a' before any dwell
+    await flush()
+
+    // 'a' is visible again and still mounted; 'b' went warm on its own hide.
+    expect(view.queryByTestId('pane-a')).not.toBeNull()
+    expect(mountMap().a).toBe(true)
+    expect(mountMap().b).toBe(true)
+  })
+
+  it('P0-2: closing a warm hidden tab unmounts its pane (reaches the destroy teardown)', async () => {
+    const view = renderOverlay()
+    await flush()
+    setActiveEntity('b') // 'a' -> warm hidden
+    await flush()
+    expect(view.queryByTestId('pane-a')).not.toBeNull()
+
+    // Close 'a' while it is hidden+warm: the store drops it and the overlay stops
+    // rendering its slot, so the real TerminalPane unmount teardown runs (destroy
+    // -> pty.kill, asserted directly in pane-unmount-action.test.ts). No orphan.
+    act(() => {
+      useAppStore.setState({
+        tabsByWorktree: { [WT]: [terminalTab('b')] },
+        unifiedTabsByWorktree: { [WT]: [unifiedTab('b', 1)] },
+        groupsByWorktree: { [WT]: [group('b')] }
+      })
+    })
+    await flush()
+    expect(view.queryByTestId('pane-a')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pane-visibility-reporter.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-visibility-reporter.tsx
@@ -1,0 +1,46 @@
+import { memo, useEffect, useRef } from 'react'
+import { noteTerminalPaneVisibility } from './terminal-pane-eviction-coordinator'
+
+// STA-1282: the eviction visibility report MUST come from a component that
+// survives the mount gate. The gated overlay slot unmounts the instant a pane
+// goes hidden-and-not-yet-warm, so reporting from inside it deadlocks (a pane
+// can't warm without reporting hidden, and can't report hidden without staying
+// mounted). This reporter is rendered by the overlay layer for EVERY terminal
+// tab — visible, warm, evicted, or never-visited — so the visible->hidden
+// transition is always reported before/without unmounting anything.
+//
+// It is edge-honest: a tab that has never been visible does NOT report hidden
+// (that would warm every background tab and defeat the mount-storm fix); only a
+// tab that was visible reports the hide. Flag-OFF inertness: with eviction
+// disabled it does nothing (the coordinator also self-guards), so it is
+// byte-identical to the pre-eviction app; enabling at runtime reactivates via
+// the next visible report.
+export const TerminalPaneVisibilityReporter = memo(function TerminalPaneVisibilityReporter({
+  terminalTabId,
+  worktreeId,
+  effectiveVisible,
+  evictionEnabled
+}: {
+  terminalTabId: string
+  worktreeId: string
+  effectiveVisible: boolean
+  evictionEnabled: boolean
+}): null {
+  const hasBeenVisibleRef = useRef(false)
+  useEffect(() => {
+    if (!evictionEnabled) {
+      return
+    }
+    if (effectiveVisible) {
+      hasBeenVisibleRef.current = true
+      noteTerminalPaneVisibility(terminalTabId, worktreeId, true)
+      return
+    }
+    // Only report the visible->hidden transition. A never-visited hidden tab
+    // must stay Tier-2 unmounted (no warm entry, no PTY spawn).
+    if (hasBeenVisibleRef.current) {
+      noteTerminalPaneVisibility(terminalTabId, worktreeId, false)
+    }
+  }, [evictionEnabled, effectiveVisible, terminalTabId, worktreeId])
+  return null
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -89,6 +89,7 @@ import { installMouseHideWhileTyping } from './mouse-hide-while-typing'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { connectPanePty } from './pty-connection'
+import { consumeTerminalPaneEviction } from './terminal-pane-eviction-coordinator'
 import type { PtyTransport } from './pty-transport'
 import {
   reconcileMissingSessions,
@@ -456,6 +457,46 @@ export function shouldDetachPaneTransportOnUnmount(args: {
   return Boolean(
     args.worktreeTabs?.some((tab) => tab.id !== args.tabId && tab.ptyId === args.ptyId)
   )
+}
+
+export type PaneUnmountAction = 'park' | 'detach' | 'destroy'
+
+/**
+ * STA-1282 gate #1: three-way unmount selection at a today-binary seam.
+ * `shouldDetachPaneTransportOnUnmount` is keyed solely on tab existence; a
+ * tab-alive unmount is ambiguous (eviction vs. reparent/host-surface handoff).
+ * The discriminator is *eviction vs. everything-else-tab-alive*:
+ *   - policy-evicted, PTY alive          -> park (keep PTY + title/status feed)
+ *   - reparent / session-mirror handoff  -> detach (fresh pane re-registers now)
+ *   - tab/worktree gone, or no PTY yet    -> destroy
+ * A split-move reparent and a web/mobile host-surface handoff both keep the tab
+ * alive but are NOT evictions, so they take detach() (never park), which is what
+ * stops two transports from ever claiming one PTY.
+ */
+export function resolvePaneUnmountAction(args: {
+  isEviction: boolean
+  tabStillExists: boolean
+  tabId: string
+  ptyId: string | null
+  worktreeTabs: readonly TerminalTab[] | undefined
+}): PaneUnmountAction {
+  if (!args.ptyId) {
+    return 'destroy'
+  }
+  // Another live tab already owns this PTY (host-surface handoff / session
+  // mirror): detach, never park — parking would leave two transports on one PTY.
+  const sharedWithSibling = Boolean(
+    args.worktreeTabs?.some((tab) => tab.id !== args.tabId && tab.ptyId === args.ptyId)
+  )
+  if (sharedWithSibling) {
+    return 'detach'
+  }
+  if (!args.tabStillExists) {
+    return 'destroy'
+  }
+  // Tab alive, PTY exclusive to this tab: eviction parks (keep PTY + feed);
+  // reparent takes plain detach.
+  return args.isEviction ? 'park' : 'detach'
 }
 
 /**
@@ -1704,32 +1745,57 @@ export function useTerminalPaneLifecycle({
         disposable.dispose()
       }
       imeNativeTextForwarderDisposables.clear()
-      for (const transport of paneTransports.values()) {
-        const ptyId = transport.getPtyId()
-        if (
-          shouldDetachPaneTransportOnUnmount({
-            tabStillExists,
-            tabId,
-            ptyId,
-            worktreeTabs: currentWorktreeTabs
-          })
-        ) {
-          // Why: moving a terminal tab between groups currently rehomes the
-          // React subtree, which unmounts this TerminalPane even though the tab
-          // itself is still alive. Web session mirroring can also replace a
-          // temporary local tab with a host surface that owns the same PTY.
-          // Detaching preserves the running PTY so the remounted pane can
-          // reattach without restarting the user's shell.
-          // Transports that have not attached yet still have no PTY ID; those
-          // must be destroyed so any in-flight spawn resolves into a killed PTY
-          // instead of reviving a stale binding after unmount.
+      // STA-1282 three-way unmount selection at a today-binary seam. The React
+      // cleanup reads eviction *policy state* (consumed here so it fires once per
+      // unmount), not just tab existence:
+      //   - policy-evicted        -> park (keep PTY + title/status feed alive)
+      //   - reparent / host-surface handoff (tab alive, not eviction) -> detach
+      //   - tab/worktree gone     -> destroy
+      // consumeTerminalPaneEviction returns true only when the coordinator's
+      // idle teardown is what triggered this unmount, so a split-move reparent or
+      // a session-mirror handoff can never be misread as an eviction (gate #1).
+      const isEvictionUnmount = consumeTerminalPaneEviction(tabId)
+      for (const [paneId, transport] of paneTransports.entries()) {
+        const action = resolvePaneUnmountAction({
+          isEviction: isEvictionUnmount,
+          tabStillExists,
+          tabId,
+          ptyId: transport.getPtyId(),
+          worktreeTabs: currentWorktreeTabs
+        })
+        if (action === 'park') {
+          // park() keeps the PTY + title/status feed alive in the evicted
+          // registry and runs the pane's own DOM/xterm teardown; it returns
+          // false only when there is no live PTY to park (fall back to destroy).
+          const binding = panePtyBindings.get(paneId) as
+            | (IDisposable & { park?: () => boolean })
+            | undefined
+          const parked = binding?.park?.() ?? false
+          if (!parked) {
+            transport.destroy?.()
+            binding?.dispose()
+          }
+        } else if (action === 'detach') {
+          // Why: moving a terminal tab between groups rehomes the React subtree,
+          // unmounting this TerminalPane even though the tab is still alive. Web
+          // session mirroring can also replace a temporary local tab with a host
+          // surface that owns the same PTY. Detaching preserves the running PTY
+          // so the remounted pane reattaches without restarting the shell.
           transport.detach?.()
+          panePtyBindings.get(paneId)?.dispose()
         } else {
+          // Unbound/dead or tab gone: destroy so an in-flight spawn resolves into
+          // a killed PTY instead of reviving a stale binding after unmount.
           transport.destroy?.()
+          panePtyBindings.get(paneId)?.dispose()
         }
       }
-      for (const panePtyBinding of panePtyBindings.values()) {
-        panePtyBinding.dispose()
+      // Dispose any binding without a paired transport (defensive — they are
+      // created together, but never leave a binding undisposed).
+      for (const [paneId, panePtyBinding] of panePtyBindings.entries()) {
+        if (!paneTransports.has(paneId)) {
+          panePtyBinding.dispose()
+        }
       }
       panePtyBindings.clear()
       paneTransports.clear()

--- a/src/renderer/src/components/terminal/split-group-mount.test.ts
+++ b/src/renderer/src/components/terminal/split-group-mount.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { getEffectiveLayoutForWorktree, anyMountedWorktreeHasLayout } from './split-group-mount'
 import type { TabGroup, TabGroupLayoutNode } from '../../../../shared/types'
 
+// STA-1282 boundary note: these assertions pin the mounted-worktree/layout
+// computation for worktrees that still have policy-mounted (Tier 0 visible or
+// Tier 1 warm) panes. Under terminal pane eviction the mounted-worktree set is
+// no longer monotonic — a fully aged-out (Tier 2) worktree drops from it — but
+// that transition is driven by the eviction coordinator, not by this layout
+// helper, so these cases are unchanged.
+
 function makeGroup(id: string, worktreeId: string): TabGroup {
   return { id, worktreeId, activeTabId: null, tabOrder: [] }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5165,6 +5165,17 @@
             "defaultViewLabel": "Default native chat view",
             "defaultViewTerminal": "Terminal chat",
             "defaultViewNative": "Native chat"
+          },
+          "terminalPaneEviction": {
+            "title": "Free memory from hidden terminals",
+            "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast.",
+            "copy": "Unmounts terminal panes you have not viewed recently so a busy multi-agent workspace stays fast. Their processes keep running and the pane restores from the live mirror when you open it again. Experimental while we tune restore fidelity for panes with a running agent.",
+            "toggleLabel": "Toggle free memory from hidden terminals",
+            "warmBudgetLabel": "Terminals kept ready",
+            "warmBudgetDescription": "How many recently-viewed hidden terminals stay mounted before older ones are unmounted.",
+            "afterMinutesLabel": "Unmount after",
+            "afterMinutesDescription": "A hidden terminal is unmounted once it has been out of view for this long.",
+            "afterMinutesSuffix": "minutes"
           }
         },
         "FloatingWorkspacePane": {
@@ -7354,6 +7365,10 @@
             "nativeChat": {
               "title": "Native chat",
               "description": "Preview the desktop chat surface for Claude and Codex terminal sessions."
+            },
+            "terminalPaneEviction": {
+              "title": "Free memory from hidden terminals",
+              "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast. Their processes keep running."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5165,6 +5165,17 @@
             "defaultViewLabel": "Vista predeterminada de chat nativo",
             "defaultViewTerminal": "Chat en terminal",
             "defaultViewNative": "Chat nativo"
+          },
+          "terminalPaneEviction": {
+            "title": "Free memory from hidden terminals",
+            "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast.",
+            "copy": "Unmounts terminal panes you have not viewed recently so a busy multi-agent workspace stays fast. Their processes keep running and the pane restores from the live mirror when you open it again. Experimental while we tune restore fidelity for panes with a running agent.",
+            "toggleLabel": "Toggle free memory from hidden terminals",
+            "warmBudgetLabel": "Terminals kept ready",
+            "warmBudgetDescription": "How many recently-viewed hidden terminals stay mounted before older ones are unmounted.",
+            "afterMinutesLabel": "Unmount after",
+            "afterMinutesDescription": "A hidden terminal is unmounted once it has been out of view for this long.",
+            "afterMinutesSuffix": "minutes"
           }
         },
         "FloatingWorkspacePane": {
@@ -7317,6 +7328,10 @@
             "nativeChat": {
               "title": "Chat nativo",
               "description": "Previsualiza la vista de chat de escritorio para sesiones de terminal de Claude y Codex."
+            },
+            "terminalPaneEviction": {
+              "title": "Free memory from hidden terminals",
+              "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast. Their processes keep running."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5150,6 +5150,17 @@
             "defaultViewLabel": "デフォルトのネイティブ チャット ビュー",
             "defaultViewTerminal": "Terminal チャット",
             "defaultViewNative": "ネイティブチャット"
+          },
+          "terminalPaneEviction": {
+            "title": "Free memory from hidden terminals",
+            "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast.",
+            "copy": "Unmounts terminal panes you have not viewed recently so a busy multi-agent workspace stays fast. Their processes keep running and the pane restores from the live mirror when you open it again. Experimental while we tune restore fidelity for panes with a running agent.",
+            "toggleLabel": "Toggle free memory from hidden terminals",
+            "warmBudgetLabel": "Terminals kept ready",
+            "warmBudgetDescription": "How many recently-viewed hidden terminals stay mounted before older ones are unmounted.",
+            "afterMinutesLabel": "Unmount after",
+            "afterMinutesDescription": "A hidden terminal is unmounted once it has been out of view for this long.",
+            "afterMinutesSuffix": "minutes"
           }
         },
         "FloatingWorkspacePane": {
@@ -7339,6 +7350,10 @@
             "nativeChat": {
               "title": "ネイティブチャット",
               "description": "Claude と Codex の terminal セッションのデスクトップ チャット サーフェスをプレビューします。"
+            },
+            "terminalPaneEviction": {
+              "title": "Free memory from hidden terminals",
+              "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast. Their processes keep running."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5150,6 +5150,17 @@
             "defaultViewLabel": "기본 기본 채팅 보기",
             "defaultViewTerminal": "Terminal 채팅",
             "defaultViewNative": "네이티브 채팅"
+          },
+          "terminalPaneEviction": {
+            "title": "Free memory from hidden terminals",
+            "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast.",
+            "copy": "Unmounts terminal panes you have not viewed recently so a busy multi-agent workspace stays fast. Their processes keep running and the pane restores from the live mirror when you open it again. Experimental while we tune restore fidelity for panes with a running agent.",
+            "toggleLabel": "Toggle free memory from hidden terminals",
+            "warmBudgetLabel": "Terminals kept ready",
+            "warmBudgetDescription": "How many recently-viewed hidden terminals stay mounted before older ones are unmounted.",
+            "afterMinutesLabel": "Unmount after",
+            "afterMinutesDescription": "A hidden terminal is unmounted once it has been out of view for this long.",
+            "afterMinutesSuffix": "minutes"
           }
         },
         "FloatingWorkspacePane": {
@@ -7302,6 +7313,10 @@
             "nativeChat": {
               "title": "네이티브 채팅",
               "description": "Claude 및 Codex terminal 세션에 대한 데스크톱 채팅 화면을 미리 봅니다."
+            },
+            "terminalPaneEviction": {
+              "title": "Free memory from hidden terminals",
+              "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast. Their processes keep running."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5150,6 +5150,17 @@
             "defaultViewLabel": "默认原生聊天视图",
             "defaultViewTerminal": "终端聊天",
             "defaultViewNative": "原生聊天"
+          },
+          "terminalPaneEviction": {
+            "title": "Free memory from hidden terminals",
+            "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast.",
+            "copy": "Unmounts terminal panes you have not viewed recently so a busy multi-agent workspace stays fast. Their processes keep running and the pane restores from the live mirror when you open it again. Experimental while we tune restore fidelity for panes with a running agent.",
+            "toggleLabel": "Toggle free memory from hidden terminals",
+            "warmBudgetLabel": "Terminals kept ready",
+            "warmBudgetDescription": "How many recently-viewed hidden terminals stay mounted before older ones are unmounted.",
+            "afterMinutesLabel": "Unmount after",
+            "afterMinutesDescription": "A hidden terminal is unmounted once it has been out of view for this long.",
+            "afterMinutesSuffix": "minutes"
           }
         },
         "FloatingWorkspacePane": {
@@ -7302,6 +7313,10 @@
             "nativeChat": {
               "title": "原生聊天",
               "description": "预览 Claude 和 Codex 终端会话的桌面聊天界面。"
+            },
+            "terminalPaneEviction": {
+              "title": "Free memory from hidden terminals",
+              "description": "Unmounts terminal panes you have not looked at recently and restores them on demand, keeping heavy multi-agent workspaces fast. Their processes keep running."
             }
           }
         },

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
@@ -253,6 +253,39 @@ describe('terminal scroll intent', () => {
     remountedDisposable.dispose()
   })
 
+  it('enforcing against a transiently-empty remounted buffer neither scrolls nor clobbers the durable pin', () => {
+    vi.stubGlobal('Element', TestElement)
+    const firstTerminal = createTerminal({ viewportY: 76, baseY: 100 })
+    const firstHost = new TestElement() as unknown as HTMLElement
+    const firstDisposable = attachTerminalScrollIntentTracking(firstTerminal, firstHost, 'leaf-2')
+    markTerminalPinnedViewport(firstTerminal)
+
+    const remountedTerminal = createTerminal({ viewportY: 0, baseY: 0 })
+    const remountedHost = new TestElement() as unknown as HTMLElement
+    const remountedDisposable = attachTerminalScrollIntentTracking(
+      remountedTerminal,
+      remountedHost,
+      'leaf-2'
+    )
+
+    // Why: the reveal-path enforce runs BEFORE xterm has parsed the eviction
+    // remount replay, so the buffer is still empty. It must not scrollToLine(0)
+    // and must not overwrite the durable pinned intent with empty-buffer state.
+    enforceTerminalCurrentScrollIntent(remountedTerminal)
+    expect(remountedTerminal.scrollToLine).not.toHaveBeenCalled()
+    expect(remountedTerminal.scrollToBottom).not.toHaveBeenCalled()
+
+    // Once the replay is parsed (full-height buffer), the post-parse enforce
+    // restores the durable position.
+    remountedTerminal.buffer.active.baseY = 100
+    remountedTerminal.buffer.active.viewportY = 100
+    enforceTerminalCurrentScrollIntent(remountedTerminal)
+    expect(remountedTerminal.scrollToLine).toHaveBeenCalledWith(76)
+
+    firstDisposable.dispose()
+    remountedDisposable.dispose()
+  })
+
   it('tracks pointer-driven scrollbar scrolls without using output scroll as intent', () => {
     vi.stubGlobal('Element', TestElement)
     const terminal = createTerminal({ viewportY: 100, baseY: 100 })

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -232,6 +232,15 @@ export function enforceTerminalWriteScrollIntent(
     }
     return
   }
+  // Why: a remounted/replayed terminal briefly reports an empty or shorter
+  // scrollback (xterm parses writes asynchronously). Enforcing a pinned
+  // viewport against that transient would clamp to row 0 AND overwrite the
+  // durable intent with the empty-buffer state — mirror the down-shrink guard
+  // in syncTerminalScrollIntentFromViewport and wait for a full-height buffer.
+  const existing = readStoredIntent(terminal)
+  if (existing?.kind === 'pinnedViewport' && current.baseY < existing.baseY) {
+    return
+  }
   const targetY = clampViewportY(snapshot.viewportY, current.baseY)
   if (current.viewportY !== targetY) {
     safeScrollCall(() => terminal.scrollToLine?.(targetY))

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -34,6 +34,7 @@ import { createRuntimeStatusSlice } from './slices/runtime-status'
 import { createPullRequestGenerationSlice } from './slices/pull-request-generation'
 import { createCommitMessageGenerationSlice } from './slices/commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './slices/pinned-tab-close-confirm'
+import { createTerminalPaneEvictionSlice } from './slices/terminal-pane-eviction'
 import { e2eConfig } from '@/lib/e2e-config'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
@@ -71,7 +72,8 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createRuntimeStatusSlice(...a),
   ...createPullRequestGenerationSlice(...a),
   ...createCommitMessageGenerationSlice(...a),
-  ...createPinnedTabCloseConfirmSlice(...a)
+  ...createPinnedTabCloseConfirmSlice(...a),
+  ...createTerminalPaneEvictionSlice(...a)
 }))
 
 registerHttpLinkStoreAccessor(() => useAppStore.getState())

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -139,6 +139,7 @@ import { createRuntimeStatusSlice } from './runtime-status'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
 import { createCommitMessageGenerationSlice } from './commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './pinned-tab-close-confirm'
+import { createTerminalPaneEvictionSlice } from './terminal-pane-eviction'
 
 function createTestStore() {
   return create<AppState>()((...a) => ({
@@ -175,7 +176,8 @@ function createTestStore() {
     ...createRuntimeStatusSlice(...a),
     ...createPullRequestGenerationSlice(...a),
     ...createCommitMessageGenerationSlice(...a),
-    ...createPinnedTabCloseConfirmSlice(...a)
+    ...createPinnedTabCloseConfirmSlice(...a),
+    ...createTerminalPaneEvictionSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -42,6 +42,7 @@ import { createRuntimeStatusSlice } from './runtime-status'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
 import { createCommitMessageGenerationSlice } from './commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './pinned-tab-close-confirm'
+import { createTerminalPaneEvictionSlice } from './terminal-pane-eviction'
 import { translate } from '@/i18n/i18n'
 
 export const TEST_REPO = {
@@ -87,7 +88,8 @@ export function createTestStore() {
     ...createRuntimeStatusSlice(...a),
     ...createPullRequestGenerationSlice(...a),
     ...createCommitMessageGenerationSlice(...a),
-    ...createPinnedTabCloseConfirmSlice(...a)
+    ...createPinnedTabCloseConfirmSlice(...a),
+    ...createTerminalPaneEvictionSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/terminal-pane-eviction.ts
+++ b/src/renderer/src/store/slices/terminal-pane-eviction.ts
@@ -1,0 +1,28 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+
+// STA-1282. The ONLY reactive state eviction needs in the store is the effective
+// warm set the overlay gate reads. All other eviction bookkeeping (last-visible
+// timestamps, the visible set, in-flight teardown generations, the dwell timer)
+// lives in the coordinator module, which is event-driven and off the React
+// render path so no store subscriber re-scans it on unrelated ticks.
+
+export type TerminalPaneEvictionSlice = {
+  /** tabId -> true for hidden panes the eviction coordinator keeps mounted
+   *  (Tier 1 warm, or exempt: newborn/dead/wake-hint). The overlay gate renders
+   *  a pane iff it is visible now OR this is true. Absent for evicted (Tier 2)
+   *  and never-visited hidden tabs — that absence is the mount-storm fix. */
+  terminalPaneMountByTabId: Record<string, boolean>
+  /** Replace the effective warm set (coordinator-owned). */
+  setTerminalPaneMountByTabId: (next: Record<string, boolean>) => void
+}
+
+export const createTerminalPaneEvictionSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  TerminalPaneEvictionSlice
+> = (set) => ({
+  terminalPaneMountByTabId: {},
+  setTerminalPaneMountByTabId: (next) => set({ terminalPaneMountByTabId: next })
+})

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -32,6 +32,7 @@ import type { RuntimeStatusSlice } from './slices/runtime-status'
 import type { PullRequestGenerationSlice } from './slices/pull-request-generation'
 import type { CommitMessageGenerationSlice } from './slices/commit-message-generation'
 import type { PinnedTabCloseConfirmSlice } from './slices/pinned-tab-close-confirm'
+import type { TerminalPaneEvictionSlice } from './slices/terminal-pane-eviction'
 
 export type AppState = RepoSlice &
   SparsePresetsSlice &
@@ -66,4 +67,5 @@ export type AppState = RepoSlice &
   RuntimeStatusSlice &
   PullRequestGenerationSlice &
   CommitMessageGenerationSlice &
-  PinnedTabCloseConfirmSlice
+  PinnedTabCloseConfirmSlice &
+  TerminalPaneEvictionSlice

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,6 +31,11 @@ import {
 import { DEFAULT_SOURCE_CONTROL_GROUP_ORDER } from './source-control-group-order'
 import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy'
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from './terminal-scrollback-policy'
+import {
+  TERMINAL_PANE_EVICTION_AFTER_MINUTES_DEFAULT,
+  TERMINAL_PANE_EVICTION_DEFAULT_ENABLED,
+  TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT
+} from './terminal-pane-eviction-settings'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -265,6 +270,9 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     claudeAgentTeamsMode: 'off',
     setupScriptLaunchMode: 'new-tab',
     terminalScrollbackRows: DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT,
+    experimentalTerminalPaneEviction: TERMINAL_PANE_EVICTION_DEFAULT_ENABLED,
+    terminalPaneEvictionWarmBudget: TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT,
+    terminalPaneEvictionAfterMinutes: TERMINAL_PANE_EVICTION_AFTER_MINUTES_DEFAULT,
     httpProxyUrl: '',
     httpProxyBypassRules: '',
     electronHttp1CompatibilityMode: false,

--- a/src/shared/pty-main-buffer-snapshot.ts
+++ b/src/shared/pty-main-buffer-snapshot.ts
@@ -1,0 +1,21 @@
+// Payload for the pty:getMainBufferSnapshot IPC.
+//
+// STA-1282 gate #5 requires a real serialization/RPC error to be distinguishable
+// from a nil mirror: the handler resolves `null` for a nil mirror but REJECTS on
+// a genuine error (instead of the old swallow-to-null), so the eviction remount
+// fail-open counter can tell a structural replay failure from a legitimately
+// blank pane.
+
+export type PtyMainBufferSnapshotPayload = {
+  data: string
+  cols: number
+  rows: number
+  cwd?: string | null
+  lastTitle?: string
+  seq?: number
+  source?: 'headless' | 'renderer'
+  alternateScreen?: boolean
+  // #7329: the partial escape-sequence tail split across the snapshot boundary,
+  // replayed after the reset so a mid-escape cut does not corrupt the terminal.
+  pendingEscapeTailAnsi?: string
+}

--- a/src/shared/terminal-pane-eviction-settings.test.ts
+++ b/src/shared/terminal-pane-eviction-settings.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isTerminalPaneEvictionEnabled,
+  resolveTerminalPaneEvictionAfterMs,
+  resolveTerminalPaneEvictionWarmBudget,
+  TERMINAL_PANE_EVICTION_AFTER_MINUTES_DEFAULT,
+  TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT
+} from './terminal-pane-eviction-settings'
+
+// Gate #7 (startup-upgrade.persisted-session-corpus): older persisted settings
+// without the new keys must hydrate to defaults (STA-5082 lesson), and
+// out-of-range persisted values must clamp.
+describe('terminal-pane-eviction settings hydration', () => {
+  it('defaults OFF (experimental, opt-in) when the key is absent (older settings)', () => {
+    expect(isTerminalPaneEvictionEnabled(null)).toBe(false)
+    expect(isTerminalPaneEvictionEnabled({})).toBe(false)
+  })
+
+  it('respects an explicit opt-in', () => {
+    expect(isTerminalPaneEvictionEnabled({ experimentalTerminalPaneEviction: true })).toBe(true)
+    expect(isTerminalPaneEvictionEnabled({ experimentalTerminalPaneEviction: false })).toBe(false)
+  })
+
+  it('defaults the warm budget when absent and clamps out-of-range values', () => {
+    expect(resolveTerminalPaneEvictionWarmBudget(null)).toBe(
+      TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT
+    )
+    expect(resolveTerminalPaneEvictionWarmBudget({ terminalPaneEvictionWarmBudget: 1 })).toBe(4)
+    expect(resolveTerminalPaneEvictionWarmBudget({ terminalPaneEvictionWarmBudget: 999 })).toBe(64)
+    expect(resolveTerminalPaneEvictionWarmBudget({ terminalPaneEvictionWarmBudget: 20 })).toBe(20)
+  })
+
+  it('rejects a non-finite persisted budget and falls back to default', () => {
+    expect(resolveTerminalPaneEvictionWarmBudget({ terminalPaneEvictionWarmBudget: NaN })).toBe(
+      TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT
+    )
+  })
+
+  it('defaults the dwell when absent and clamps minutes 1-120', () => {
+    expect(resolveTerminalPaneEvictionAfterMs(null)).toBe(
+      TERMINAL_PANE_EVICTION_AFTER_MINUTES_DEFAULT * 60_000
+    )
+    expect(resolveTerminalPaneEvictionAfterMs({ terminalPaneEvictionAfterMinutes: 0 })).toBe(
+      1 * 60_000
+    )
+    expect(resolveTerminalPaneEvictionAfterMs({ terminalPaneEvictionAfterMinutes: 9999 })).toBe(
+      120 * 60_000
+    )
+    expect(resolveTerminalPaneEvictionAfterMs({ terminalPaneEvictionAfterMinutes: 5 })).toBe(
+      5 * 60_000
+    )
+  })
+})

--- a/src/shared/terminal-pane-eviction-settings.test.ts
+++ b/src/shared/terminal-pane-eviction-settings.test.ts
@@ -31,9 +31,9 @@ describe('terminal-pane-eviction settings hydration', () => {
   })
 
   it('rejects a non-finite persisted budget and falls back to default', () => {
-    expect(resolveTerminalPaneEvictionWarmBudget({ terminalPaneEvictionWarmBudget: NaN })).toBe(
-      TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT
-    )
+    expect(
+      resolveTerminalPaneEvictionWarmBudget({ terminalPaneEvictionWarmBudget: Number.NaN })
+    ).toBe(TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT)
   })
 
   it('defaults the dwell when absent and clamps minutes 1-120', () => {

--- a/src/shared/terminal-pane-eviction-settings.ts
+++ b/src/shared/terminal-pane-eviction-settings.ts
@@ -37,8 +37,8 @@ function clamp(value: number, min: number, max: number): number {
 
 /**
  * Why: older persisted settings objects predate these keys. `?? default`
- * hydration (STA-5082 lesson) keeps them behaving as default-on rather than
- * disabled, and clamps out-of-range persisted values.
+ * hydration (STA-5082 lesson) keeps them on the documented defaults (eviction
+ * OFF, warm budget 12, dwell 5 min), and clamps out-of-range persisted values.
  */
 export function isTerminalPaneEvictionEnabled(settings: EvictionSettingsInput | null): boolean {
   return settings?.experimentalTerminalPaneEviction ?? TERMINAL_PANE_EVICTION_DEFAULT_ENABLED

--- a/src/shared/terminal-pane-eviction-settings.ts
+++ b/src/shared/terminal-pane-eviction-settings.ts
@@ -1,0 +1,72 @@
+// Settings resolution for STA-1282 terminal pane eviction. Kept as a pure
+// shared module so the renderer policy, the settings UI, and the main/runtime
+// hosts resolve the same defaults and clamps without importing renderer code.
+
+// Experimental, opt-in, default OFF (Brennan, design review: field risk 9/10).
+// Follows the agent-hibernation precedent exactly.
+export const TERMINAL_PANE_EVICTION_DEFAULT_ENABLED = false
+
+export const TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT = 12
+export const TERMINAL_PANE_EVICTION_WARM_BUDGET_MIN = 4
+export const TERMINAL_PANE_EVICTION_WARM_BUDGET_MAX = 64
+
+export const TERMINAL_PANE_EVICTION_AFTER_MINUTES_DEFAULT = 5
+export const TERMINAL_PANE_EVICTION_AFTER_MINUTES_MIN = 1
+export const TERMINAL_PANE_EVICTION_AFTER_MINUTES_MAX = 120
+
+// Why: a self-disable trips after this many *structural* replay failures in a
+// session (RPC error/timeout, malformed snapshot) — never on a legitimately
+// blank/nil mirror. See remount step 5 / gate #5.
+export const TERMINAL_PANE_EVICTION_MAX_REPLAY_FAILURES = 3
+
+// Why: bound the eviction-remount main-buffer snapshot request. A never-resolving
+// getMainBufferSnapshot on an evicted remount would otherwise keep the pane
+// history-blank forever without charging the fail-open counter; on timeout the
+// pane falls open to live and the structural-failure counter is charged (gate #5).
+export const TERMINAL_PANE_EVICTION_REMOUNT_SNAPSHOT_TIMEOUT_MS = 10_000
+
+type EvictionSettingsInput = {
+  experimentalTerminalPaneEviction?: boolean
+  terminalPaneEvictionWarmBudget?: number
+  terminalPaneEvictionAfterMinutes?: number
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Why: older persisted settings objects predate these keys. `?? default`
+ * hydration (STA-5082 lesson) keeps them behaving as default-on rather than
+ * disabled, and clamps out-of-range persisted values.
+ */
+export function isTerminalPaneEvictionEnabled(settings: EvictionSettingsInput | null): boolean {
+  return settings?.experimentalTerminalPaneEviction ?? TERMINAL_PANE_EVICTION_DEFAULT_ENABLED
+}
+
+export function resolveTerminalPaneEvictionWarmBudget(
+  settings: EvictionSettingsInput | null
+): number {
+  const raw = settings?.terminalPaneEvictionWarmBudget
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    return TERMINAL_PANE_EVICTION_WARM_BUDGET_DEFAULT
+  }
+  return clamp(
+    Math.round(raw),
+    TERMINAL_PANE_EVICTION_WARM_BUDGET_MIN,
+    TERMINAL_PANE_EVICTION_WARM_BUDGET_MAX
+  )
+}
+
+export function resolveTerminalPaneEvictionAfterMs(settings: EvictionSettingsInput | null): number {
+  const raw = settings?.terminalPaneEvictionAfterMinutes
+  const minutes =
+    typeof raw === 'number' && Number.isFinite(raw)
+      ? clamp(
+          Math.round(raw),
+          TERMINAL_PANE_EVICTION_AFTER_MINUTES_MIN,
+          TERMINAL_PANE_EVICTION_AFTER_MINUTES_MAX
+        )
+      : TERMINAL_PANE_EVICTION_AFTER_MINUTES_DEFAULT
+  return minutes * 60_000
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2612,6 +2612,17 @@ export type GlobalSettings = {
    *  usable without the setup output crowding the initial pane. */
   setupScriptLaunchMode: SetupScriptLaunchMode
   terminalScrollbackRows: number
+  /** Experimental: bound the number of live-mounted terminal panes: evict hidden
+   *  xterm instances that overflow the warm budget or age past the dwell window,
+   *  keeping their PTY + status feed alive and replaying the main mirror on
+   *  re-show. Opt-in, default OFF. See STA-1282. */
+  experimentalTerminalPaneEviction?: boolean
+  /** Most-recently-visible hidden panes kept mounted (warm) before eviction.
+   *  Clamped 4-64. */
+  terminalPaneEvictionWarmBudget?: number
+  /** Minutes a pane must stay hidden before it is eligible for eviction.
+   *  Clamped 1-120. */
+  terminalPaneEvictionAfterMinutes?: number
   /** Optional app-level proxy for Electron networking and locally spawned PTYs.
    *  Empty preserves system proxy settings plus inherited proxy env behavior. */
   httpProxyUrl?: string

--- a/tests/e2e/terminal-hidden-pane-evict-restore.spec.ts
+++ b/tests/e2e/terminal-hidden-pane-evict-restore.spec.ts
@@ -1,0 +1,289 @@
+/**
+ * STA-1282 E2E: terminal pane eviction (Tier 1 -> Tier 2 -> Tier 0).
+ *
+ * Runs under an AGGRESSIVE policy (small warm budget) set via settings so
+ * eviction is driven by budget overflow rather than the 5-minute dwell, which
+ * real time cannot advance in an E2E run.
+ *
+ * Proves the load-bearing invariants:
+ *  - the mounted-pane count stays bounded as tabs accumulate (the field-report
+ *    metric: DOM/xterm/listener growth is what this ticket removes);
+ *  - re-showing an evicted pane restores its mirror-faithful scrollback and
+ *    accepts live input (gate #2);
+ *  - PRIORITY (Brennan's #1 fear): a pane with a LIVE running process that keeps
+ *    streaming across the whole evict->remount cycle comes back with contiguous
+ *    output — no lost or duplicated bytes at the claim->snapshot->drain window
+ *    (gate #2's claim-window race);
+ *  - switching away then immediately back keeps the pane warm with no replay and
+ *    the PTY intact (gate #9 observable);
+ *  - an evicted pane's alternate-screen TUI frame rehydrates on remount (gate #2);
+ *  - remounting at a different viewport size repaints and stays usable (gate #4).
+ *
+ * The remote-runtime (SSH/relay) evict->remount variant is a skip-marked
+ * scaffold (accepted gap): it needs a live relay/runtime fixture this harness
+ * lacks. Its provider-specific park path (the multiplexed host stream stays open
+ * while evicted) is unit-covered by remote-runtime-pty-transport `park()`. The
+ * agent-completes-while-evicted notification is likewise unit-covered (parked
+ * title/status feed) and validated manually.
+ */
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  discoverActivePtyId,
+  execInTerminal,
+  getTerminalContent,
+  sendToTerminal,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const WARM_BUDGET = 4
+
+async function configureAggressiveEviction(page: Page): Promise<void> {
+  await page.evaluate((warmBudget) => {
+    window.__store?.getState().updateSettings({
+      experimentalTerminalPaneEviction: true,
+      terminalPaneEvictionWarmBudget: warmBudget,
+      // Minimum dwell; eviction in this spec is driven by budget overflow.
+      terminalPaneEvictionAfterMinutes: 1
+    })
+  }, WARM_BUDGET)
+}
+
+async function mountedTabIds(page: Page): Promise<string[]> {
+  return page.evaluate(() => [...(window.__paneManagers?.keys() ?? [])])
+}
+
+/** Create `count` terminal tabs in the active worktree, activating each so its
+ *  PTY spawns and its pane mounts, and return their ids in creation order. */
+async function createTerminalTabs(page: Page, count: number): Promise<string[]> {
+  const worktreeId = await waitForActiveWorktree(page)
+  const ids: string[] = []
+  for (let i = 0; i < count; i++) {
+    const tabId = await page.evaluate((wtId) => {
+      const state = window.__store?.getState()
+      const tab = state?.createTab(wtId, undefined, undefined, { pendingActivationSpawn: true })
+      if (!tab) {
+        throw new Error('createTab failed')
+      }
+      state?.setActiveTab(tab.id)
+      return tab.id
+    }, worktreeId)
+    await waitForActiveTerminalManager(page)
+    await discoverActivePtyId(page)
+    ids.push(tabId)
+  }
+  return ids
+}
+
+async function activateTab(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((id) => window.__store?.getState().setActiveTab(id), tabId)
+  await waitForActiveTerminalManager(page)
+}
+
+test.describe('terminal hidden pane eviction', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForSessionReady(page)
+    await ensureTerminalVisible(page)
+    await configureAggressiveEviction(page)
+  })
+
+  test('mounted-pane count stays bounded while cycling many tabs', async ({ page }) => {
+    const tabIds = await createTerminalTabs(page, WARM_BUDGET + 3)
+    // Cycle through every tab so each becomes hidden-then-revisited.
+    for (const tabId of tabIds) {
+      await activateTab(page, tabId)
+    }
+    // The mounted set must stay bounded by warm budget + the visible tab + a
+    // small margin for panes still awaiting their idle teardown, NOT grow with
+    // the number of tabs visited.
+    await expect
+      .poll(async () => (await mountedTabIds(page)).length, { timeout: 15_000 })
+      .toBeLessThanOrEqual(WARM_BUDGET + 2)
+  })
+
+  test('re-showing an evicted pane restores its scrollback and accepts input', async ({ page }) => {
+    const tabIds = await createTerminalTabs(page, WARM_BUDGET + 3)
+    const firstTab = tabIds[0]
+
+    // Type a unique marker into the first tab.
+    await activateTab(page, firstTab)
+    const marker = `evict-marker-${Date.now()}`
+    const firstPtyId = await discoverActivePtyId(page)
+    await sendToTerminal(page, firstPtyId, `echo ${marker}`)
+    await expect.poll(async () => getTerminalContent(page)).toContain(marker)
+
+    // Push the first tab out of the warm budget by visiting the newer tabs.
+    for (const tabId of tabIds.slice(1)) {
+      await activateTab(page, tabId)
+    }
+    // The first tab is evicted: its pane manager is unmounted.
+    await expect
+      .poll(async () => (await mountedTabIds(page)).includes(firstTab), { timeout: 15_000 })
+      .toBe(false)
+
+    // Re-show it: the mirror snapshot replays the marker and live input echoes.
+    await activateTab(page, firstTab)
+    await expect.poll(async () => getTerminalContent(page)).toContain(marker)
+    const restoredPtyId = await discoverActivePtyId(page)
+    const echo = `after-restore-${Date.now()}`
+    await sendToTerminal(page, restoredPtyId, `echo ${echo}`)
+    await expect.poll(async () => getTerminalContent(page)).toContain(echo)
+  })
+
+  test('a live process streaming across evict->remount restores contiguous output (no lost/dup)', async ({
+    page
+  }) => {
+    // Brennan's #1 fear: how a pane with a live running process appears when you
+    // return to it. A shell loop streams monotonically-increasing lines the whole
+    // time the pane is evicted; on remount the mirror replay + live drain must
+    // reproduce a CONTIGUOUS tail (each parsed number == previous + 1), proving
+    // the claim->snapshot->drain window neither drops nor duplicates output.
+    const tabIds = await createTerminalTabs(page, WARM_BUDGET + 3)
+    const streamTab = tabIds[0]
+
+    await activateTab(page, streamTab)
+    const streamPtyId = await discoverActivePtyId(page)
+    // ~0.05s cadence keeps output flowing across the switch + snapshot round-trip.
+    // execInTerminal appends the carriage return so the loop actually runs.
+    await execInTerminal(
+      page,
+      streamPtyId,
+      'i=0; while [ $i -lt 100000 ]; do i=$((i+1)); echo "seq-$i"; sleep 0.05; done'
+    )
+    await expect.poll(async () => getTerminalContent(page)).toContain('seq-')
+
+    // Evict the streaming tab (it keeps running, feeding the main mirror).
+    for (const tabId of tabIds.slice(1)) {
+      await activateTab(page, tabId)
+    }
+    await expect
+      .poll(async () => (await mountedTabIds(page)).includes(streamTab), { timeout: 15_000 })
+      .toBe(false)
+
+    // Re-show it while it is still streaming.
+    await activateTab(page, streamTab)
+
+    const parseSeq = async (): Promise<number[]> => {
+      const content = await getTerminalContent(page, 8000)
+      return [...content.matchAll(/seq-(\d+)/g)].map((m) => Number(m[1]))
+    }
+    // The restored buffer must contain a run of increasing numbers.
+    await expect.poll(async () => (await parseSeq()).length, { timeout: 20_000 }).toBeGreaterThan(3)
+
+    const numbers = await parseSeq()
+    // Contiguity: every consecutive pair increases by exactly 1 — no gap (lost
+    // output) and no repeat (duplicated output) at the claim window boundary.
+    for (let i = 1; i < numbers.length; i++) {
+      expect(numbers[i]).toBe(numbers[i - 1] + 1)
+    }
+    // And it is genuinely still live: a later number appears after remount.
+    const highBeforeWait = numbers.at(-1) ?? 0
+    await expect
+      .poll(async () => {
+        const seq = await parseSeq()
+        return seq.at(-1) ?? 0
+      })
+      .toBeGreaterThan(highBeforeWait)
+  })
+
+  test('switching away then immediately back keeps the pane warm (no eviction)', async ({
+    page
+  }) => {
+    const tabIds = await createTerminalTabs(page, 2)
+    const [tabA, tabB] = tabIds
+
+    await activateTab(page, tabA)
+    const marker = `warm-marker-${Date.now()}`
+    const ptyId = await discoverActivePtyId(page)
+    await sendToTerminal(page, ptyId, `echo ${marker}`)
+    await expect.poll(async () => getTerminalContent(page)).toContain(marker)
+
+    // Switch away and immediately back — within budget and dwell, so tab A stays
+    // mounted the whole time (Tier 1 warm), never evicted, no replay needed.
+    await activateTab(page, tabB)
+    await activateTab(page, tabA)
+
+    expect(await mountedTabIds(page)).toContain(tabA)
+    // Scrollback is still present (never lost) and the PTY is intact.
+    await expect.poll(async () => getTerminalContent(page)).toContain(marker)
+    expect(await discoverActivePtyId(page)).toBe(ptyId)
+  })
+
+  test('re-showing an evicted pane rehydrates its alternate-screen TUI frame (gate #2)', async ({
+    page
+  }) => {
+    // The main mirror captures the alt buffer unconditionally, so an evicted
+    // pane whose xterm was torn down must restore the alt-screen frame (cursor,
+    // last frame) from that mirror on remount — the most-hardened replay path,
+    // now run on every Tier-2 re-show.
+    const tabIds = await createTerminalTabs(page, WARM_BUDGET + 3)
+    const altTab = tabIds[0]
+
+    await activateTab(page, altTab)
+    const marker = `alt-${Date.now()}`
+    const ptyId = await discoverActivePtyId(page)
+    // Enter the alternate screen and draw a unique marker straight to the PTY.
+    // \033[?1049h = enter alt buffer, \033[2J\033[H = clear + home.
+    await execInTerminal(page, ptyId, `printf '\\033[?1049h\\033[2J\\033[HALT-SCREEN-${marker}'`)
+    await expect.poll(async () => getTerminalContent(page)).toContain(`ALT-SCREEN-${marker}`)
+
+    // Evict the alt-screen tab; its alt buffer lives on in the main mirror.
+    for (const tabId of tabIds.slice(1)) {
+      await activateTab(page, tabId)
+    }
+    await expect
+      .poll(async () => (await mountedTabIds(page)).includes(altTab), { timeout: 15_000 })
+      .toBe(false)
+
+    // Re-show it: the mirror snapshot rehydrates the alternate-screen frame.
+    await activateTab(page, altTab)
+    await expect.poll(async () => getTerminalContent(page)).toContain(`ALT-SCREEN-${marker}`)
+  })
+
+  test('remounting an evicted pane at a different viewport size repaints and stays usable (gate #4)', async ({
+    page
+  }) => {
+    const tabIds = await createTerminalTabs(page, WARM_BUDGET + 3)
+    const sizedTab = tabIds[0]
+
+    await activateTab(page, sizedTab)
+    const marker = `sized-${Date.now()}`
+    const ptyId = await discoverActivePtyId(page)
+    await execInTerminal(page, ptyId, `echo ${marker}`)
+    await expect.poll(async () => getTerminalContent(page)).toContain(marker)
+
+    // Evict the tab (push it out of the warm budget).
+    for (const tabId of tabIds.slice(1)) {
+      await activateTab(page, tabId)
+    }
+    await expect
+      .poll(async () => (await mountedTabIds(page)).includes(sizedTab), { timeout: 15_000 })
+      .toBe(false)
+
+    // Resize the window while the pane is evicted so it remounts at a size that
+    // differs from the frozen PTY size — the SIGWINCH-driven full-repaint path.
+    await page.setViewportSize({ width: 760, height: 800 })
+
+    // Re-show it: history replays AND the PTY reconverges to the new size (never
+    // 0x0), so live input still echoes — a usable, repainted pane.
+    await activateTab(page, sizedTab)
+    await expect.poll(async () => getTerminalContent(page)).toContain(marker)
+    const restoredPtyId = await discoverActivePtyId(page)
+    const echo = `resized-echo-${Date.now()}`
+    await execInTerminal(page, restoredPtyId, `echo ${echo}`)
+    await expect.poll(async () => getTerminalContent(page)).toContain(echo)
+  })
+
+  // Remote-runtime (SSH/relay) evict->remount is a provider-specific park path:
+  // the multiplexed host stream must stay reachable while evicted so host-side
+  // scrollback + alt-screen replay on remount instead of coming back blank. This
+  // harness has no live relay/runtime, so the variant is a skip-marked scaffold
+  // (the accepted gap flagged in the design). The park path itself is unit-covered
+  // by remote-runtime-pty-transport `park()` keeping the multiplexed stream open.
+  test.skip('remote-runtime evict->remount restores non-blank host scrollback + alt-screen (accepted gap)', async () => {
+    // Scaffold: pair a remote runtime, open a remote worktree terminal, drive
+    // host-side scrollback + an alt-screen frame, evict past the warm budget,
+    // remount, and assert the host buffer is non-blank and the alt frame restores.
+  })
+})

--- a/tests/e2e/terminal-hidden-pane-evict-restore.spec.ts
+++ b/tests/e2e/terminal-hidden-pane-evict-restore.spec.ts
@@ -32,7 +32,6 @@ import {
   discoverActivePtyId,
   execInTerminal,
   getTerminalContent,
-  sendToTerminal,
   waitForActiveTerminalManager
 } from './helpers/terminal'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
@@ -82,13 +81,13 @@ async function activateTab(page: Page, tabId: string): Promise<void> {
 }
 
 test.describe('terminal hidden pane eviction', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ orcaPage: page }) => {
     await waitForSessionReady(page)
     await ensureTerminalVisible(page)
     await configureAggressiveEviction(page)
   })
 
-  test('mounted-pane count stays bounded while cycling many tabs', async ({ page }) => {
+  test('mounted-pane count stays bounded while cycling many tabs', async ({ orcaPage: page }) => {
     const tabIds = await createTerminalTabs(page, WARM_BUDGET + 3)
     // Cycle through every tab so each becomes hidden-then-revisited.
     for (const tabId of tabIds) {
@@ -102,7 +101,9 @@ test.describe('terminal hidden pane eviction', () => {
       .toBeLessThanOrEqual(WARM_BUDGET + 2)
   })
 
-  test('re-showing an evicted pane restores its scrollback and accepts input', async ({ page }) => {
+  test('re-showing an evicted pane restores its scrollback and accepts input', async ({
+    orcaPage: page
+  }) => {
     const tabIds = await createTerminalTabs(page, WARM_BUDGET + 3)
     const firstTab = tabIds[0]
 
@@ -110,7 +111,7 @@ test.describe('terminal hidden pane eviction', () => {
     await activateTab(page, firstTab)
     const marker = `evict-marker-${Date.now()}`
     const firstPtyId = await discoverActivePtyId(page)
-    await sendToTerminal(page, firstPtyId, `echo ${marker}`)
+    await execInTerminal(page, firstPtyId, `echo ${marker}`)
     await expect.poll(async () => getTerminalContent(page)).toContain(marker)
 
     // Push the first tab out of the warm budget by visiting the newer tabs.
@@ -127,12 +128,12 @@ test.describe('terminal hidden pane eviction', () => {
     await expect.poll(async () => getTerminalContent(page)).toContain(marker)
     const restoredPtyId = await discoverActivePtyId(page)
     const echo = `after-restore-${Date.now()}`
-    await sendToTerminal(page, restoredPtyId, `echo ${echo}`)
+    await execInTerminal(page, restoredPtyId, `echo ${echo}`)
     await expect.poll(async () => getTerminalContent(page)).toContain(echo)
   })
 
   test('a live process streaming across evict->remount restores contiguous output (no lost/dup)', async ({
-    page
+    orcaPage: page
   }) => {
     // Brennan's #1 fear: how a pane with a live running process appears when you
     // return to it. A shell loop streams monotonically-increasing lines the whole
@@ -188,7 +189,7 @@ test.describe('terminal hidden pane eviction', () => {
   })
 
   test('switching away then immediately back keeps the pane warm (no eviction)', async ({
-    page
+    orcaPage: page
   }) => {
     const tabIds = await createTerminalTabs(page, 2)
     const [tabA, tabB] = tabIds
@@ -196,7 +197,7 @@ test.describe('terminal hidden pane eviction', () => {
     await activateTab(page, tabA)
     const marker = `warm-marker-${Date.now()}`
     const ptyId = await discoverActivePtyId(page)
-    await sendToTerminal(page, ptyId, `echo ${marker}`)
+    await execInTerminal(page, ptyId, `echo ${marker}`)
     await expect.poll(async () => getTerminalContent(page)).toContain(marker)
 
     // Switch away and immediately back — within budget and dwell, so tab A stays
@@ -211,7 +212,7 @@ test.describe('terminal hidden pane eviction', () => {
   })
 
   test('re-showing an evicted pane rehydrates its alternate-screen TUI frame (gate #2)', async ({
-    page
+    orcaPage: page
   }) => {
     // The main mirror captures the alt buffer unconditionally, so an evicted
     // pane whose xterm was torn down must restore the alt-screen frame (cursor,
@@ -242,7 +243,7 @@ test.describe('terminal hidden pane eviction', () => {
   })
 
   test('remounting an evicted pane at a different viewport size repaints and stays usable (gate #4)', async ({
-    page
+    orcaPage: page
   }) => {
     const tabIds = await createTerminalTabs(page, WARM_BUDGET + 3)
     const sizedTab = tabIds[0]

--- a/tests/e2e/terminal-hidden-tui-visual-restore.spec.ts
+++ b/tests/e2e/terminal-hidden-tui-visual-restore.spec.ts
@@ -1,3 +1,9 @@
+// STA-1282 boundary note: this spec pins TIER 1 (hidden-warm) behavior — a
+// hidden pane that stays mounted keeps replaying live hidden output on its xterm.
+// Under terminal pane eviction the default 5-minute dwell means panes only reach
+// Tier 2 (evicted/unmounted) after minutes, so this seconds-timescale spec is
+// unchanged; the evict/restore path is covered by
+// terminal-hidden-pane-evict-restore.spec.ts.
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { randomUUID } from 'node:crypto'
 import { rmSync, writeFileSync } from 'node:fs'


### PR DESCRIPTION
Implements Linear STA-1282 (terminal panes not unmounted when switching away — root cause of the 10s workspace in STA-1280).

> **Status: READY (unmerged per process). 2026-07-07: rebased onto latest main and fully re-reviewed + re-validated — see the Update section at the bottom.** Every pipeline stage is complete and green: all verification findings (2 P0, 3 P1, 1 e2e-proven boundary bug, 1 CodeRabbit-caught budget bug) fixed with regression tests; CI passing; CodeRabbit clean; live re-validation certified all 8 matrix items on the final tip with screenshot evidence; and a live **Windows/ConPTY pass is clean** — flag-off sanity, eviction + restore, streaming Codex TUI restore with no gaps/dupes, resize-while-evicted remount (94x52 -> 14x46), close-while-evicted kills the conhost process, toggle-off with no mass remount. The one Windows non-run: the e2e spec harness (a pre-existing fixture path-separator issue on Windows — test harness, not product; tracked on STA-1372, full Windows report in the PR comments below). Merge when satisfied.

## What this changes

Opt-in experimental feature (`Settings → Experimental → Terminal pane eviction`, **default OFF**): terminal panes that have been hidden for 5+ minutes (beyond the 12 most-recently-viewed, which always stay live) are unmounted from the renderer — their DOM, xterm instance, listeners, and heap are released — and rebuilt from Orca's always-current main-process terminal mirror when you next view them. The shell/agent process is never touched. With the flag off (everyone, by default), behavior is byte-identical to today — verified by dedicated inertness tests.

Fixes the field report behind STA-1280/STA-1282: a multi-day multi-agent workspace accumulated 350k DOM nodes, 122k listeners, and ~1GB renderer heap, making workspace open/tab switch take ~10 seconds.

## ELI5

Orca currently keeps every terminal you've ever opened fully alive in the window, even ones you haven't looked at in days — they just get hidden. After days of multi-agent work that's hundreds of invisible live terminals, and the app slows to a crawl. With this feature turned on, Orca puts terminals to sleep if you haven't looked at them for 5 minutes, and redraws them from its saved copy the moment you click back — like minimizing apps you're not using instead of keeping every window open forever. Your 12 most recently used terminals never sleep, so switching between the things you're actually working on stays instant. The running programs inside the terminals are never stopped — only the picture of them is put away and redrawn. It's off by default; flip it on in Settings → Experimental if your workspaces get slow.

## Risk assessment

**Who is exposed:** nobody, until they opt in. The flag-off path is pinned byte-identical to today by dedicated tests (mount-everything branch, zero new subscriptions/timers). The single highest-severity residual risk in this PR is a gating bug that leaks behavior to flag-off users — which is why flag-off inertness has its own oracle rather than being assumed.

**The core risk (rated 9/10 pre-mitigation): restore fidelity.** The buffer-replay path previously ran roughly once per app launch (restart restore); for opt-in users it now runs on every re-show of an evicted pane — a frequency change, not a new mechanism. What failure looks like, concretely, in worst-to-likely order:

- a TUI (Claude/Codex/vim) redraws with a stale or garbled frame until its next output/keypress;
- a chunk of output is duplicated or missing in scrollback if the agent was streaming at the exact moment of re-show;
- the pane comes back with blank history but alive and typable (this is the deliberate fail-open floor).

What failure structurally cannot look like: a killed agent/shell (eviction can only take PTY-alive paths; the kill branch is unreachable and outcome-tested), a dead/frozen pane (replay failure degrades to live-blank), or any effect on users who haven't opted in.

**Why we believe the replay risk is manageable:** the replay source is the main-process mirror that is fed every byte continuously and never disconnects — fresher than the restart path that already ships; the streaming race is closed by reusing the existing sequence-numbered snapshot/drain machinery (the #7173 fix class), with a dedicated e2e that streams monotonically-numbered lines through the entire evict→re-show cycle and asserts contiguity; alt-screen state (frame, cursor, paste/mouse modes) restores via the same rehydrate sequences used by restart restore; geometry reconverges through the existing spawn-time reconcile (different-size re-show → natural SIGWINCH repaint; 0×0 remains impossible).

**Containment if fidelity problems escape anyway:** per-session 3-strike self-disable (structural replay failures only — an empty terminal is not a failure), a plain kill switch, breadcrumb logs on every evict/re-show/failure so field reports are attributable, and an architectural fallback: the mount-gating/policy/registry machinery is shared with a lower-risk "park the live instance" variant, so if opt-in field evidence demands it, Tier 2 can be downgraded without redoing the feature — trading back the memory win, keeping the speed win.

**Known limitation while the flag is ON (documented, accepted):** tabs never visited this session don't mount at all, so tab titles and title-based (hookless) agent status for those tabs appear on first visit instead of live. Claude/Codex status is main-side and unaffected. Follow-up candidate: a lightweight parked parser for never-visited live PTYs.

**Accepted validation gaps (explicit, not hidden):** live Windows/ConPTY pass pending (a machine is available; unit coverage exists for resize-on-remount and the replay path is platform-neutral renderer code); the remote-runtime park path (stream close on claim, host-snapshot channel) is unit-tested but was not driven against a live relay; the exit-during-claim-gap race is locked by a unit test rather than manual reproduction (it is a single-frame window); measured perf-budget latency oracles partially manual (bounded-count oracles automated; live DOM/mount measurements recorded in validation).

**Secondary risks:** parked-transport leak on close (gate #8: closing an evicted tab kills its PTY promptly — tested); teardown racing a re-show (gate #9: generation-keyed cancel — tested); status/title staleness while evicted (gate #3: parked parser retention — tested); coordinator cost when idle (event-driven, no polling; the only timer is armed when a pane is actually due to age out).

## Process summary (Brennan's PR process)

- **Design**: tiered eviction (hide → GPU-suspend [ships today] → full evict + mirror replay), pure mount-policy module, park transport state, evicted-session registry. Chosen from the three viable strategies for hidden-terminal DOM: full unmount + replay, LRU warm tiers, and lazy mount. Design-review loop: 5 rounds, 15 code-verified findings fixed (park ≠ bare detach — title/status feed is renderer-only; provider-specific park for remote-runtime; snapshot IPC nil≠error contract required for the fail-open counter; Activity-portal visibility; close-while-evicted reconcile; generation-keyed teardown race), converged READY.
- **Decisions (Brennan, explicit)**: option 4 (dispose + replay) over park-live-instance; experimental opt-in DEFAULT OFF (field risk rated 9/10); mirror scrollback unchanged at 5k (zero new standing memory).
- **Implementation**: ~40 files; policy/coordinator/registry/park/remount/settings per the doc. Notable deviations (all documented): reject-on-error snapshot contract instead of a typed union; `lastVisibleAt` in coordinator module state (nothing needs it reactively); registry keyed per-pane leaf.
- **Completeness verification**: complete-with-gaps → all 5 findings fixed, including the top one (flag-OFF was not byte-identical — now pinned inert by dedicated oracles) and a real product gap found while fixing: a claimed remount whose reattach paints nothing (in-process local PTY) now drives the mirror-snapshot restore instead of silently consuming the claim — otherwise a silent evicted pane remounted blank.
- **Headline behavior**: implemented, behind the opt-in flag, both dimensions (inactive worktrees AND hidden tabs of the active worktree).
- **Perf audit**: flag-OFF proven inert (never subscribes, no timers, byte-identical mount path — test-covered); flag-ON bounded: no polling, single lazy dwell timer, idle-deferred teardown, hot-path guard test added (50 unrelated store ticks → zero eviction-map churn). Three minor findings fixed on the spot (allocation-free parked-owner signature fold, halved per-recompute policy computation, dead entry field removed); deferred with named follow-ups: per-tick signature scales with hidden-tab count (µs-scale, guard-tested), remote parked panes keep the host stream open (measured under the SSH accepted gap).
- **Code-review loop**: 3 rounds, two adversarial reviewers per round (independent thinking + reproduction lanes), round 3 both clean. Verification wave findings, all fixed with tests: 2 P0s from live validation (the visibility report fired inside the mount-gated slot, so the warm set never engaged through the real UI and a closing hidden tab could orphan its PTY — root-fixed with a persistent ungated per-tab reporter + integration-seam test); 3 claim-handoff races from an independent codex review (direct-attach remounts never drove the mirror replay; parked-feed release racing the deferred adoption; remote park leaking the host stream on claim — unified into a claim-takeover protocol with deferred release at the adoption chokepoint); 1 e2e-proven boundary bug (a pre-existing seq-less daemon-reattach paint duplicated one line under load when streaming — eviction remounts now paint from the seq-aligned runtime mirror, gated to claimed remounts so non-opt-in reattach behavior is byte-identical); 1 CodeRabbit-caught budget bug (parked panes silently consumed warm-budget rank slots).
- **Validation (brennan-test-changes)**: two live Electron passes. First pass proved restore safety (streaming TUI restored contiguously; 24 mounted xterms → 1 on the repro workspace; DOM 2831 → 1566) and caught the 2 P0s. Certified re-run on the final tip, all 8 items PASS with measured evidence: warm set holds exactly visible+4 under aggressive policy with textbook LRU+dwell eviction timing; evict/claim/replay breadcrumbs fire; closing a parked tab kills its PTY; tab titles/status update while parked; toggle-off causes no remount storm and parked panes restore on demand; warm switch-back does no replay; the headline streaming case restored fully contiguous (TICK_374→422, process never stopped, input echoes); the daemon-mirror boundary case shows zero duplicated lines. Uncropped full-window screenshots retained as run evidence (not committed, per policy).
- **Static checks**: web+cli typecheck 0 errors (node has one pre-existing main error from #7044, untouched file); 1,539 terminal-pane tests + 211 main pty tests + 3,604-test renderer battery green; oxlint/oxfmt clean.
- **Post-PR stabilization**: CI green on the final tip (verify + wayland + golden e2e on earlier commits); CodeRabbit round of 5 comments fully resolved (3 fixed — warm-budget slot theft with regression test, unbound requestIdleCallback, docstring; 2 already addressed by prior commits); zero new comments on the fix commits.

## Update (2026-07-07): full post-rebase re-review — verdict: LAND

Main moved ~100 commits under this PR; the branch was rebased twice (conflicts composed with `#7476` foreground-agent icons, `#7524` revert restoring `forceBlankRestoredViewport`, and this PR's own claim refactor) and the whole feature was re-reviewed and re-validated on the rebased tip.

**Review structure:** a 6-round two-lane adversarial review loop (independent thinking + reproduction lanes, final round both-clean), plus two independent read-only cross-checks against the recently-merged terminal-display work. Cross-check verdicts: #7540 atlas-recovery debounce, #7310 ConPTY viewport blanking, #7514 handle reminting, and #7490 exit-waiter teardown are all SAFE against eviction (evidence chains traced end-to-end); #7472 scroll preservation had a real regression on eviction remounts — found, root-caused, fixed (below).

**Fixes this round (each with a regression test verified to fail when the fix is reverted):**
- **Scroll position restore on eviction remount** (two layers): the durable leaf-keyed scroll intent is now enforced in the replay's post-parse write callback (xterm parses asynchronously — a synchronous enforce saw the empty fresh buffer, pinned to row 0, and overwrote the durable intent), and `enforceTerminalWriteScrollIntent` gained the same transient-shrink guard the sync path had, so the reveal-path enforce cannot clobber the pin either. The remount test mock now models real deferred parsing so CI catches this class.
- **BEL while parked**: parked panes now raise tab/worktree unread marks on BEL (previously swallowed; hidden mounted panes mark unread today). `ParkedPtySinks.onBell`, wired in both transports.
- **Enable-time warm-set seed** (HIGH, found independently by both review lanes): flipping the experiment ON with existing hidden panes used to mass-detach them (feeds dark until revisit). The settings toggle now seeds the warm set synchronously before the enabling write; panes later age out through normal parking.
- **Parked-exit parity**: parked `onPtyExit` now mirrors the live exit path (`clearPaneForegroundAgent`, suppressed-exit consume, runtime title, cache timer, runtime-graph sync) — a respawn no longer inherits a stale agent icon. One adjacent edge (agent exits while parked, shell survives → stale icon until the next command boundary) is deliberately accepted and documented in-code: clearing needs OSC 133;D prompt proof, and a probe could false-clear a live agent's tool subshell.
- **Fail-open completeness**: the remount replay-failure counter is now charged on all 8 reattach-failure sites (including SSH-deferred and catch paths), so a flaky-SSH environment actually trips the self-disable.
- **Parked feed parity**: parked agent status runs the same suppression/normalization/title pairing as the live handler; a dispose-before-adoption race that could spawn an orphan PTY is guarded.
- Housekeeping: coordinator split to meet the new max-lines budget (gate-#9 signal → `terminal-pane-eviction-signal.ts`), localization catalog re-synced (rebases drop the keys), one lint fix.

**Live Electron validation on the rebased tip (fresh profile, real UI):**
- Enable-time flip via the real Settings toggle: all 7 pre-existing panes stayed mounted through the flip (warm map seeded in the same tick), then aged out through normal parking.
- Dwell eviction: hidden panes evicted on schedule; mounted panes dropped 7 → 1 while **all 7 PTYs stayed alive**.
- Remount fidelity: full scrollback + prompt restored, no duplicated/lost lines.
- BEL while parked: bell icon on the tab + `unreadTerminalTabs` store entry, raised while the pane was unmounted.
- Scroll restore: scrolled to rows 179–229, evicted, remounted → viewport restored to **exactly rows 179–229** (screenshot evidence retained, not committed, per policy).

**Static checks on the final tip:** typecheck clean; oxlint clean on all touched files (two pre-existing errors on main in untouched files); `check:max-lines-ratchet` OK; localization verifiers pass; full unit suite green.

**Final integration (2026-07-07/08):** one more rebase onto main composed this PR's named `PtyMainBufferSnapshotPayload` type with #7329's `pendingEscapeTailAnsi` (the tail is the final replay write in both scroll branches; the durable-scroll enforce uses only xterm scroll APIs so it cannot abort the dangling sequence). Branch force-pushed with lease; PR is MERGEABLE/CLEAN with all required checks green (verify, golden e2e linux+mac, wayland terminal input).

**Mergeability confidence: LAND.** Residual gaps, restated honestly: the SSH/remote park path remains unit-tested but never driven against a live relay; the earlier Windows/ConPTY pass predates this rebase (the rebase touched platform-neutral renderer code, so a Windows re-check is optional belt-and-braces); and the agent-exits-while-parked stale-icon edge above is accepted for the experimental phase.


Made with [Orca](https://github.com/stablyai/orca) 🐋







