### PR TITLE
fix(lint): remove redundant default case from exhaustive override-field switch

### DIFF
--- a/src/renderer/src/components/settings/SourceControlActionRepoOverrideNote.tsx
+++ b/src/renderer/src/components/settings/SourceControlActionRepoOverrideNote.tsx
@@ -32,11 +32,6 @@ function getRecipeOverrideFieldLabel(field: SourceControlActionRecipeOverrideFie
         'auto.components.settings.SourceControlActionRepoOverrideNote.commandTemplate',
         'Command template'
       )
-    default: {
-      // Fail at compile time if the override-field union grows a new variant.
-      const _exhaustive: never = field
-      return _exhaustive
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

`pnpm lint` currently fails on `main`:

```
src/renderer/src/components/settings/SourceControlActionRepoOverrideNote.tsx:35:5: error typescript(switch-exhaustiveness-check): The switch statement is exhaustive, so the default case is unnecessary.
```

Introduced by #7386. The switch in `getRecipeOverrideFieldLabel` covers every variant of `SourceControlActionRecipeOverrideField`, and `config/oxlint-switch-exhaustiveness.json` sets `allowDefaultCaseForExhaustiveSwitch: false`, so the hand-rolled `never`-guard default case is rejected.

This PR removes the default case. The dedicated `lint:switch-exhaustiveness` rule already fails the build if the union grows a new variant, so the compile-time guard it replaced is redundant — this matches the convention everywhere else in the renderer (no other component uses the `_exhaustive` pattern). No user-visible change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (fails on `main`, passes on this branch)
- [x] `pnpm typecheck`
- [x] `pnpm test` (24,518 passed / 32 skipped)
- [x] `pnpm build`
- [x] Existing coverage: `SourceControlActionRepoOverrideNote.test.tsx` (5/5 passing) exercises all three override-field labels; the `switch-exhaustiveness-check` lint rule itself is the regression guard if the union grows a new variant, so no new tests were needed for a dead-code removal.

## AI Review Report

Reviewed with Claude Code. Main risks checked: (1) whether removing the default case could introduce an implicit-`undefined` return path — it cannot, TypeScript proves the switch exhaustive over the union and `tsgo --noEmit` passes on all three tsconfigs; (2) whether the exhaustiveness safety net is weakened — it is not, `typescript/switch-exhaustiveness-check` (type-aware, `allowDefaultCaseForExhaustiveSwitch: false`) errors at lint time if `SourceControlActionRecipeOverrideField` gains a variant this switch does not handle; (3) convention alignment — no other renderer component uses the `_exhaustive` never-guard pattern. Cross-platform compatibility (macOS, Linux, Windows) was explicitly considered: the change is pure TypeScript control flow with no shortcuts, labels, paths, shell behavior, or Electron platform differences involved.

## Security Audit

No security surface touched: the change removes an unreachable dead-code branch from a pure label-mapping function in the renderer. No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. No follow-up needed.

## Notes

No platform-specific behavior. Zero runtime behavior change — the removed branch was unreachable for every value of the union type.
