### PR TITLE
Reduce Linux file-watcher load on large codebases by excluding nested build/dependency dirs

### DIFF
--- a/src/main/ipc/filesystem-watcher-ignore.test.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.test.ts
@@ -32,8 +32,18 @@ describe('buildParcelWatcherIgnoreOption', () => {
     }
   })
 
-  it('passes the plain list through on other platforms', () => {
-    setPlatform('linux')
-    expect(buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS)).toEqual(WATCHER_IGNORE_DIRS)
+  it('expands to nested globs on Linux/Windows so nested node_modules/.git are excluded', () => {
+    for (const platform of ['linux', 'win32'] as const) {
+      setPlatform(platform)
+      const option = buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS)
+      // @parcel/watcher resolves plain names to top-level-only absolute paths on
+      // these platforms, so nested dirs must be matched via depth-agnostic globs.
+      for (const dir of WATCHER_IGNORE_DIRS) {
+        expect(option).toContain(`**/${dir}`)
+        expect(option).toContain(`**/${dir}/**`)
+      }
+      // No plain (glob-free) entries — those would only exclude the top level.
+      expect(option.every((entry) => entry.includes('*'))).toBe(true)
+    }
   })
 })

--- a/src/main/ipc/filesystem-watcher-ignore.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.ts
@@ -25,7 +25,12 @@ export const MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT = 8
 
 export function buildParcelWatcherIgnoreOption(ignoreDirs: readonly string[]): string[] {
   if (process.platform !== 'darwin') {
-    return [...ignoreDirs]
+    // Linux/Windows: @parcel/watcher resolves plain names to top-level-only
+    // absolute paths, so nested node_modules/.git/build/etc. (monorepos) get
+    // fully watched — on Linux that means one inotify watch per nested dir,
+    // exhausting fs.inotify.max_user_watches. Nested globs match at any depth
+    // (and **/dir still matches the top-level dir), pruning those subtrees.
+    return ignoreDirs.flatMap((dir) => [`**/${dir}`, `**/${dir}/**`])
   }
   return [
     ...ignoreDirs.slice(0, MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT),

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -29,6 +29,10 @@ import { RelayStreamRegistry } from './fs-stream-registry'
 import { scanWorkspaceSpaceDirectory } from './workspace-space-scan'
 import { buildRelayCommandEnv } from './relay-command-env'
 import { assertNoClobberRenameDestinationAvailable } from '../shared/filesystem-rename-collision'
+import {
+  WATCHER_IGNORE_DIRS,
+  buildParcelWatcherIgnoreOption
+} from '../main/ipc/filesystem-watcher-ignore'
 
 type WatchState = {
   rootPath: string
@@ -408,7 +412,9 @@ export class FsHandler {
           }))
           this.dispatcher.notify('fs.changed', { events: mapped })
         },
-        { ignore: ['.git', 'node_modules', 'dist', 'build', '.next', '.cache', '__pycache__'] }
+        // Why: align remote-Linux watchers with the shared nested-glob exclusion
+        // so nested node_modules/.git don't exhaust inotify on large codebases.
+        { ignore: buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS) }
       )
       watchState.unwatchFn = () => {
         void subscription.unsubscribe()


### PR DESCRIPTION
## What changes

On Linux, Orca's file explorer/watcher (`@parcel/watcher`, inotify backend) installs **one inotify watch per directory** across the whole worktree. The shared ignore list (`node_modules`, `.git`, `dist`, `build`, `target`, `.next`, `.cache`, `.venv`, `__pycache__`) was only expanded into nested-matching globs **on macOS**. On Linux/Windows it passed plain directory names, which `@parcel/watcher` resolves to **top-level-only** absolute ignore paths — so every **nested** copy of those dirs (`packages/*/node_modules`, per-package `build`/`dist`, vendored `.git`, `__pycache__`) was fully recursively watched.

On a large codebase the inotify watch count and CPU therefore scale with total generated/vendored directory count, and can exhaust `fs.inotify.max_user_watches`; once that happens the explorer silently marks the root unwatchable and stops auto-refreshing. This is the primary Linux large-codebase lag/CPU source reported in STA-1350.

**Fix:** emit `**/dir` + `**/dir/**` globs on non-darwin platforms (the globstar also matches the top-level dir, so top-level exclusion is preserved). Also route the SSH/remote relay watcher — which runs on the remote (usually Linux) host — through the same shared helper instead of a hardcoded plain-name subset.

**What does not change:** macOS is untouched (it already used globs past the FSEvents 8-path cap). This does not add graceful fallback for already-exhausted inotify, and does not touch the (cross-platform, already-gated) git-status poll cost — see non-goals below.

## Design approach & review

Root cause was traced through Orca and the `@parcel/watcher` library source: the wrapper resolves plain names to top-level-only `ignorePaths` (absolute prefix match) while globs go to `ignoreGlobs` (matched against the **relative** path); during the crawl an ignored path triggers `fts_set(FTS_SKIP)`, pruning the subtree so it never receives inotify watches. Design review converged clean (no P0/P1); it added a confidence-calibration note (the fix explains CPU lag and the silent-refresh-stop, but a hard UI freeze can have separate GPU/compositor causes) and required a before/after Linux measurement as a merge gate.

## Implementation & completeness

Three files: `src/main/ipc/filesystem-watcher-ignore.ts` (non-darwin branch → nested globs), its test (asserts nested globs on linux+win32, macOS test intact), and `src/relay/fs-handler.ts` (shared helper; also picks up previously-missing `target`/`.venv`). Completeness verification (PASS): all four `watcher.subscribe` call sites checked — the explorer and runtime-worker watchers already used the shared helper; the git-common-metadata watcher is intentionally scoped; the WSL watcher uses `find -prune` at any depth and was never affected.

## Headline behavior: **implemented**

The changed code path is the exact mechanism measured below. No scope narrowing.

## Broad app consistency

Source-of-truth = macOS behavior (nested-glob exclusion). Linux/Windows now match it via the shared `buildParcelWatcherIgnoreOption`, and the relay watcher no longer diverges with its own hardcoded list. macOS unchanged.

## Perf audit

Touched hot paths: `buildParcelWatcherIgnoreOption` and the three subscribe callers. No regression — the added per-entry/per-event picomatch work (regexes compiled once per subscribe) runs on a strictly **smaller** set of entries/events, since ignored subtrees are pruned from the watch tree. Improvement is bounded by the watch/entry-count drop measured below.

## Validation (measured on real Linux, Docker)

120-package synthetic monorepo (top-level `node_modules` + per-package nested `node_modules`/`build`/`.git`/`__pycache__`), measuring process inotify watches via `/proc/<pid>/fdinfo`:

| ignore mode | inotify watches |
| --- | --- |
| plain names (before) | **8042** |
| nested globs (after) | **722** (~91% fewer) |

Functional event test on Linux with the shipped glob list: editing a real source file **fires** a watch event; editing/creating files in a nested `node_modules` fires **none**. So source changes still refresh the explorer while nested dep/build churn stays ignored.

- Unit: `filesystem-watcher-ignore.test.ts` (2) + `filesystem-watcher.test.ts` (11) pass.
- Relay bundle rebuilt for all 6 platforms; the shipped `relay.js` contains the nested-glob expansion; `process.platform` correctly reflects the remote host.
- Code review: clean, no actionable findings.

## Risks, ambiguities, non-goals

- The report is an unreproduced third-party tweet. The mechanism above is the most defensible **Linux-specific** scaling cost and is source-verified + measured, but a hard UI freeze specifically could have a separate cause (GPU/compositor software-render, or a large synchronous initial crawl) this fix does not address.
- **Non-goal:** graceful degradation when inotify is already exhausted (fallback to polling / user surface).
- **Non-goal:** the cross-platform `git status` poll cost (already gated by a huge-repo cutoff and O(1) in worktree count).
- **Windows:** semantics tighten to match macOS — editing nested `dist`/`build` no longer triggers an explorer refresh (parity with the documented ignore intent), and the native recursive backend is otherwise unchanged.

## Cross-platform / SSH

Linux is the primary target; Windows gets aligned event filtering; macOS untouched; the relay fix covers remote-Linux hosts over SSH.

Made with [Orca](https://github.com/stablyai/orca) 🐋
