### PR TITLE
fix(daemon): self-heal write routing for undiscovered legacy sessions

### DIFF
--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -118,6 +118,34 @@ describe('DaemonPtyRouter', () => {
     expect(current.write).toHaveBeenCalledWith(fresh.id, 'new\n')
   })
 
+  it('routes an undiscovered legacy session to its owning daemon, not current', () => {
+    // Reproduces the frozen-input bug: the old daemon still owns the session
+    // (hasPty true, output streaming), but the one-shot discoverLegacySessions()
+    // boot pass never mapped it — so the routing map is empty for this id.
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy', ['orphan-session'])
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+    // Deliberately NO discoverLegacySessions() / reconcile / spawn call.
+    router.write('orphan-session', 'input\n')
+    router.resize('orphan-session', 80, 24)
+
+    expect(legacy.write).toHaveBeenCalledWith('orphan-session', 'input\n')
+    expect(legacy.resize).toHaveBeenCalledWith('orphan-session', 80, 24)
+    expect(current.write).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the current adapter when no adapter owns the session', () => {
+    const current = createAdapter('current')
+    const legacy = createAdapter('legacy')
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+    router.write('unknown-session', 'input\n')
+
+    expect(current.write).toHaveBeenCalledWith('unknown-session', 'input\n')
+    expect(legacy.write).not.toHaveBeenCalled()
+  })
+
   it('drops a legacy mapping after the routed session exits', async () => {
     const current = createAdapter('current')
     const legacy = createAdapter('legacy', ['legacy-session'])

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -250,7 +250,20 @@ export class DaemonPtyRouter implements IPtyProvider {
   }
 
   private adapterFor(sessionId: string): DaemonPtyAdapter {
-    return this.sessionAdapters.get(sessionId) ?? this.current
+    const routed = this.sessionAdapters.get(sessionId)
+    if (routed) {
+      return routed
+    }
+    // Why: reads fan out across all adapters, but this routing map is filled only
+    // by one-shot boot discovery. A legacy session it missed had its writes silently
+    // dropped onto `current`; self-heal by asking who actually owns the pty, then cache.
+    for (const adapter of this.allAdapters()) {
+      if (adapter.hasPty(sessionId)) {
+        this.sessionAdapters.set(sessionId, adapter)
+        return adapter
+      }
+    }
+    return this.current
   }
 
   private allAdapters(): DaemonPtyAdapter[] {


### PR DESCRIPTION
## Problem

After an update that bumps the daemon **protocol version** while a previous-protocol daemon survives (holding live terminal sessions), adopted terminals **stream live output but accept no keyboard input**. Repro'd in production going `v1.4.124-rc.1` (protocol v18) → `v1.4.124-rc.2.perf` (protocol v19): the old v18 daemon kept running with the codex/pwsh PTYs, output continued to stream, but every keystroke vanished.

## Root cause

`DaemonPtyRouter` treats reads and writes asymmetrically:

- **Reads** (`onData`, `hasPty`, `listProcesses`) **fan out** across *all* adapters (current + legacy).
- **Writes/resizes** route through `adapterFor()`, which consulted a `sessionAdapters` map populated **only** by the one-shot boot passes (`discoverLegacySessions()` / `reconcileOnStartup()` / `spawn()`).

When boot discovery misses a legacy-owned session — e.g. a Windows named-pipe / startup-ordering race, widened by the `.perf` startup reordering — `adapterFor()` fell back to `this.current` (the *new* daemon). Result: reads fan out so output still streams and `hasPty`/`writeAccepted` still report healthy, masking that every write was dispatched to the wrong daemon and dropped.

This is why the symptom is specifically *frozen input with live output*, and why it only bites on a protocol-bumping update where an old daemon is adopted as a legacy adapter.

## Fix

Make `adapterFor()` **self-heal** on a routing-map miss: ask each adapter whether it owns the pty (`hasPty`, a synchronous `Set` lookup), cache the winner in `sessionAdapters`, and route there. Current-first precedence preserves the safe default. This mirrors the self-healing `providerFor()` already used by `DegradedDaemonPtyProvider` — the same lesson, back-ported to the router.

Scope is deliberately limited to write/resize routing; `spawn()` is left untouched.

## Verification

- Added a regression test reproducing the exact production shape (legacy adapter owns the session, `discoverLegacySessions()` never ran) — asserts writes/resizes reach the **legacy** adapter, not `current`. Confirmed it **fails** on the unfixed router (`legacy.write` called 0×) and **passes** with the fix.
- Added a no-owner fallback test (routes to `current` when nobody owns the session).
- Full `src/main/daemon` suite: no new failures (3 pre-existing, environment-dependent failures on this Windows checkout — WSL/ConPTY/path-parsing — fail identically on the clean tree).
- `oxlint` clean; `tsgo` typecheck clean (node + cli configs).

## Notes / limitations

- Does **not** recover already-frozen sessions in a running process (the stale map lives in memory) — those still need a relaunch, but with this fix a relaunch reconnects reliably instead of depending on the discovery race.
- Hardens the router against the discovery race rather than eliminating it; a follow-up could add retry/backoff to `discoverLegacySessions`.