### PR TITLE
Run automations after a repo's project identity changes

### DIFF
--- a/src/main/automations/run-target-resolution.test.ts
+++ b/src/main/automations/run-target-resolution.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import type { Store } from '../persistence'
+import type { Automation } from '../../shared/automations-types'
+import type { WorkspaceRunContext } from '../../shared/task-source-context'
+import type { ProjectHostSetup, Repo } from '../../shared/types'
+import { resolveAutomationRunTarget } from './run-target-resolution'
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#fff',
+    addedAt: 1,
+    kind: 'git',
+    ...overrides
+  }
+}
+
+function makeSetup(overrides: Partial<ProjectHostSetup> = {}): ProjectHostSetup {
+  return {
+    id: 'setup-1',
+    projectId: 'github:o/r',
+    hostId: 'local',
+    repoId: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeRunContext(overrides: Partial<WorkspaceRunContext> = {}): WorkspaceRunContext {
+  return {
+    kind: 'workspace-run',
+    projectId: 'repo:repo-1',
+    hostId: 'local',
+    projectHostSetupId: 'setup-1',
+    repoId: 'repo-1',
+    path: '/repo',
+    ...overrides
+  }
+}
+
+function makeAutomation(runContext: WorkspaceRunContext): Automation {
+  return {
+    id: 'automation-1',
+    name: 'Nightly',
+    prompt: 'Run checks',
+    precheck: null,
+    agentId: 'codex',
+    projectId: 'repo-1',
+    executionTargetType: 'local',
+    executionTargetId: 'local',
+    schedulerOwner: 'local_host_service',
+    workspaceMode: 'new_per_run',
+    baseBranch: null,
+    reuseSession: false,
+    timezone: 'UTC',
+    rrule: 'FREQ=DAILY',
+    dtstart: 1,
+    enabled: true,
+    nextRunAt: 2,
+    missedRunPolicy: 'run_once_within_grace',
+    missedRunGraceMinutes: 720,
+    createdAt: 1,
+    updatedAt: 1,
+    runContext
+  } as Automation
+}
+
+function makeStore(setups: ProjectHostSetup[], repos: Repo[]): Store {
+  return {
+    getProjectHostSetups: () => setups,
+    getRepo: (id: string) => repos.find((repo) => repo.id === id)
+  } as unknown as Store
+}
+
+describe('resolveAutomationRunTarget projectId drift', () => {
+  it('resolves when only the derived projectId tier differs (repo: snapshot vs github: setup)', () => {
+    const store = makeStore([makeSetup()], [makeRepo()])
+    const automation = makeAutomation(makeRunContext({ projectId: 'repo:repo-1' }))
+
+    const result = resolveAutomationRunTarget(store, automation)
+
+    expect(result).toMatchObject({ ok: true, cwd: '/repo' })
+  })
+
+  it('resolves when the snapshot is at the git: tier and the setup climbed to github:', () => {
+    const store = makeStore([makeSetup()], [makeRepo()])
+    const automation = makeAutomation(makeRunContext({ projectId: 'git:github.com/o/r' }))
+
+    const result = resolveAutomationRunTarget(store, automation)
+
+    expect(result).toMatchObject({ ok: true, cwd: '/repo' })
+  })
+
+  it('still blocks when the repoId no longer matches the setup', () => {
+    const store = makeStore([makeSetup({ repoId: 'repo-2' })], [makeRepo()])
+    const automation = makeAutomation(makeRunContext({ repoId: 'repo-1' }))
+
+    const result = resolveAutomationRunTarget(store, automation)
+
+    expect(result).toMatchObject({ ok: false })
+  })
+
+  it('still blocks when the hostId no longer matches the setup', () => {
+    // Guard returns at the setup hostId/repoId check before any repo lookup, so
+    // the repo's execution host is irrelevant here — assert the guard's own error.
+    const store = makeStore([makeSetup({ hostId: 'ssh:devbox' })], [makeRepo()])
+    const automation = makeAutomation(makeRunContext({ hostId: 'local' }))
+
+    const result = resolveAutomationRunTarget(store, automation)
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: 'Automation run target no longer matches the selected project host setup.'
+    })
+  })
+
+  it("still blocks when the repo's execution host drifted off the automation host", () => {
+    // Setup/context hostId agree, but the repo itself now executes on another host —
+    // pins the repo-execution-host check that lives past the setup-match guard.
+    const store = makeStore([makeSetup()], [makeRepo({ executionHostId: 'ssh:devbox' })])
+    const automation = makeAutomation(makeRunContext())
+
+    const result = resolveAutomationRunTarget(store, automation)
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: 'Repository is no longer attached to the selected automation host.'
+    })
+  })
+
+  it('still blocks when the path no longer matches the setup', () => {
+    const store = makeStore([makeSetup({ path: '/repo/new' })], [makeRepo({ path: '/repo/new' })])
+    const automation = makeAutomation(makeRunContext({ path: '/repo/old' }))
+
+    const result = resolveAutomationRunTarget(store, automation)
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: 'Project path for the selected automation host has changed.'
+    })
+  })
+})

--- a/src/main/automations/run-target-resolution.ts
+++ b/src/main/automations/run-target-resolution.ts
@@ -64,11 +64,10 @@ export function resolveAutomationRunTarget(
       error: `Project setup on the selected automation host is ${setup.setupState}.`
     }
   }
-  if (
-    setup.projectId !== context.projectId ||
-    setup.hostId !== context.hostId ||
-    setup.repoId !== context.repoId
-  ) {
+  // Why: projectId is a derived identity that upgrades over time (repo:→git:→github:);
+  // matching on it strands automations created before their repo's identity resolved.
+  // Anchor on repoId/hostId/path instead — the durable, stable target identity.
+  if (setup.hostId !== context.hostId || setup.repoId !== context.repoId) {
     return {
       ok: false,
       error: 'Automation run target no longer matches the selected project host setup.'

--- a/src/renderer/src/components/automations/automation-target-availability.test.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.test.ts
@@ -140,6 +140,72 @@ describe('automation target availability', () => {
     ).toBe('host-mismatch')
   })
 
+  it('allows a run context whose derived projectId tier drifted but repo/host/path still match', () => {
+    expect(
+      getAutomationTargetAvailability({
+        automation: makeAutomation({
+          runContext: {
+            kind: 'workspace-run',
+            // Snapshotted at the repo: tier before the setup climbed to github:.
+            projectId: 'repo:repo-1',
+            hostId: 'local',
+            projectHostSetupId: 'setup-1',
+            repoId: 'repo-1',
+            path: '/repo'
+          }
+        }),
+        repo: makeRepo(),
+        workspace: makeWorkspace(),
+        projectHostSetups: [makeProjectHostSetup({ projectId: 'github:o/r' })],
+        sshConnectionStates: new Map()
+      })
+    ).toEqual({ canRunNow: true, reason: 'available', message: null })
+  })
+
+  it('still blocks a run context whose repoId no longer matches despite projectId drift', () => {
+    expect(
+      getAutomationTargetAvailability({
+        automation: makeAutomation({
+          runContext: {
+            kind: 'workspace-run',
+            projectId: 'repo:repo-2',
+            hostId: 'local',
+            projectHostSetupId: 'setup-1',
+            repoId: 'repo-2',
+            path: '/repo'
+          }
+        }),
+        repo: makeRepo(),
+        workspace: makeWorkspace(),
+        projectHostSetups: [makeProjectHostSetup({ projectId: 'github:o/r', repoId: 'repo-2' })],
+        sshConnectionStates: new Map()
+      }).reason
+    ).toBe('host-mismatch')
+  })
+
+  it('still blocks when the setup repoId drifts even though the live repo still matches', () => {
+    // Live repo matches runContext.repoId (repoMatchesContext passes), so this
+    // isolates the setup-side repoId clause that survives the projectId removal.
+    expect(
+      getAutomationTargetAvailability({
+        automation: makeAutomation({
+          runContext: {
+            kind: 'workspace-run',
+            projectId: 'repo:repo-1',
+            hostId: 'local',
+            projectHostSetupId: 'setup-1',
+            repoId: 'repo-1',
+            path: '/repo'
+          }
+        }),
+        repo: makeRepo(),
+        workspace: makeWorkspace(),
+        projectHostSetups: [makeProjectHostSetup({ projectId: 'github:o/r', repoId: 'repo-2' })],
+        sshConnectionStates: new Map()
+      }).reason
+    ).toBe('host-mismatch')
+  })
+
   it('allows remote-listed SSH automations whose repo is projected through a runtime server', () => {
     expect(
       getAutomationTargetAvailability({

--- a/src/renderer/src/components/automations/automation-target-availability.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.ts
@@ -96,8 +96,10 @@ export function getAutomationTargetAvailability({
         `Project setup on the selected automation host is ${setup.setupState}.`
       )
     }
+    // Why: projectId is a derived identity that upgrades over time (repo:→git:→github:);
+    // matching on it strands automations created before their repo's identity resolved.
+    // Anchor on repoId/path/host instead — the durable, stable target identity.
     const setupMatchesContext =
-      setup.projectId === automation.runContext.projectId &&
       setup.repoId === automation.runContext.repoId &&
       setup.path === automation.runContext.path &&
       setupHostMatchesRunContext(setup.hostId, automation.runContext.hostId, automationHostTarget)


### PR DESCRIPTION
## What changes

Automations that were created before their repo's project identity finished resolving now run again — both the manual **Run Now** button (previously disabled / a silent no-op) and scheduled runs (previously marked `skipped_unavailable`).

**What does not change:** an automation whose target genuinely moved — different repo, host, or path — is still correctly blocked. This only stops blocking on a *label* change to the same repo at the same path on the same host.

## Root cause

An automation snapshots `runContext.projectId` when it is created. But `projectId` is a **derived** identity that upgrades through tiers as a repo's provider identity resolves (`getProjectIdentityKey`): `repo:<uuid>` → `git:<canonicalKey>` → `github:<owner>/<repo>`. The project-host-setup's `projectId` tracks the current top tier, while the automation keeps its older snapshot.

Both run-target checks required exact string equality between the snapshot and the setup's live `projectId`:
- `src/main/automations/run-target-resolution.ts` — the resolver behind scheduled dispatch, manual `runNow`, precheck, and the CLI `automation.runNow` RPC. Mismatch → `skipped_unavailable` ("Automation run target no longer matches the selected project host setup").
- `src/renderer/src/components/automations/automation-target-availability.ts` — `getAutomationTargetAvailability`, whose `canRunNow` disables the Run Now button and context-menu item and short-circuits `runNow` before the IPC (so no run record is even created — "not running at all").

So every automation created before its repo climbed to the `github:` tier was stranded, even though `repoId` + `hostId` + `path` still pointed at the exact same target. (Observed in the wild: of six automations on one machine, only the one created most recently — after the repo reached the `github:` tier — still ran; the rest were silently blocked, which is why they "seemed to be running.")

## Approach

Drop the volatile `projectId` clause from the setup-match in **both** sites and anchor on the durable identity that is already checked there: `repoId` + `hostId` + `path`. `repoId` is the store's stable per-repo id and the setup is already selected by its unique `projectHostSetupId`, so removing `projectId` loses no real protection — it only removes the false-negative source. No data migration is needed; matching resumes immediately.

Rejected alternatives: re-deriving/normalizing `projectId` (the snapshot has no repo handle to re-derive from), and migrating stored `runContext.projectId` (repairs current data but leaves the brittle equality to break again on the next identity-tier change).

## Design review

Reviewed via Brennan's PR process. A parallel Claude + Codex design review confirmed the direction and corrected one doc inaccuracy (remote/`remote_host_service`-scheduled automations fall through the same clause and are fixed identically, not early-returned). No blocking findings; no scope narrowing — manual, scheduled, and CLI are all unblocked.

## Implementation & deviations

Two 1-clause removals plus a short "why" comment at each site, and regression tests. The optional shared-predicate extraction was intentionally skipped: the two sites have genuinely different host-match semantics (main uses direct `hostId` equality + a downstream repo-execution-host check; the renderer uses runtime-target-aware host matching), so a shared predicate would add scope/risk. Kept the two edits parallel and identical in intent.

## Completeness verification

A read-only verification pass traced the full manual chain (enabled button → `runNow` → `automations:runNow` IPC → `service.runNow` creates a `manual` run → `requestDispatch` → resolver now `ok` → `automations:dispatchRequested` → agent launch) and confirmed no other downstream gate re-blocks drifted automations for either `new_per_run` or `existing` workspace modes. Scheduled + CLI share the same resolver. A repo-wide sweep found no other `projectId`-equality gate that strands automations.

## Headline behavior status

**Implemented.** The manual Run Now path is unblocked end-to-end, and scheduled + CLI runs are fixed through the same resolver.

## Broad app consistency

Source-of-truth behavior ("an automation is runnable when its saved target still exists and is ready") is exposed by: the Run Now button (`AutomationDetail`), the Run Now context-menu item (`AutomationsPage`), scheduled evaluation, precheck, and the CLI `automation.runNow` RPC — all now consistent via the two shared chokepoints. Mobile has no automation-run surface (no parity gap). The renderer gate and main resolver previously duplicated the same faulty clause; both are fixed so they agree on the identity-drift case.

## Risks, ambiguities, non-goals

- **Risk (low, disclosed):** dropping `projectId` also allows a run when a repo's upstream is re-pointed to a different project but its `repoId`/`path`/`host` are unchanged. That is the same repo at the same working tree on the same host — the intended target — so this is considered correct, but it is a deliberate loosening worth noting.
- **Non-goals:** no migration of existing `runContext.projectId` snapshots (unnecessary); no change to the identity-derivation tiers themselves; no change to the legacy no-`runContext` path or the disallowed remote-scheduling early return.

## Perf

Touched hot paths: `resolveAutomationRunTarget` (scheduler tick per due automation, plus manual/precheck/CLI) and `getAutomationTargetAvailability` (renderer render, per automation row). The change **removes** one string comparison from each — no new work, allocation, polling, fanout, or subscribers; net micro-improvement. Thundering-herd checked: the scheduler's due-automation tick population is unchanged (drifted automations already reached the check and rescheduled via `advanceAutomationNextRun`); only the per-automation outcome flips from skip to dispatch, which is the intended restoration, within existing sequential-dispatch semantics. No regression.

## Code review

Three independent reviews (two reviewer sessions plus a high-effort workflow review with an adversarial verify pass) returned no surviving correctness findings. One reviewer ran a pin-revert check confirming the tests fail when the `projectId` clause is restored. The only actionable items were two test-quality gaps — a misleading host-mismatch test whose repo-execution-host override was dead setup, and a renderer negative test that didn't independently pin the setup-side `repoId` clause. Both were fixed by tightening assertions and adding a dedicated repo-execution-host test.

## Validation

- Targeted `vitest` on both changed modules: **19/19 pass** (positive drift at `repo:` and `git:` tiers → runnable; negatives for `repoId`/`hostId`/repo-execution-host/`path` still block, on both the resolver and the renderer gate). Tests pin the fix — they fail if the `projectId` clause returns.
- `oxlint` clean on all four files; pre-commit `oxlint`/`oxfmt` clean; `git diff --check` clean.
- Merge-confidence pass verdict: **land**.

## Live UI validation (completed)

Validated in a real Electron build of this branch, in an isolated dev instance (separate userData, throwaway repo — no production data touched). Seeded two automations against a ready `github:`-tier project-host-setup:
- **Drifted** — `runContext.projectId` snapshotted at the `repo:` tier (identity-drift case).
- **Moved** — same repo but a genuinely different `path` (real target move).

A/B via hot-reload on the same running instance:
- **With the fix** (clause removed): the drifted automation's **Run Now is enabled** and its "host no longer matches" banner is gone.
- **Reverting the fix** (clause restored): the *same* drifted automation's **Run Now greys out** with *"The saved run host no longer matches this project setup."* — the exact reported bug.
- **Targeting:** the genuinely-**moved** automation stays **disabled** in both builds, confirming the loosening only forgives identity-tier drift, not a real target move.

Screenshots captured (drifted-enabled, drifted-disabled-pre-fix, moved-disabled). Not committed.

Fixes STA-1371.
