### PR TITLE
Preserve terminal scrollbar position after tab switches

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -459,6 +459,97 @@
       "demotionRule": "Cannot promote while it only checks visual rendering."
     },
     {
+      "id": "terminal-scroll.intent-preservation",
+      "title": "Scrollbar drag intent survives tab and visibility resume",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-rendering",
+      "layer": "renderer-unit",
+      "surfaces": [
+        "terminal lifecycle",
+        "hidden-to-visible resume",
+        "tab switching",
+        "xterm scrollbar DOM",
+        "scrollback"
+      ],
+      "platforms": [
+        "macos",
+        "linux",
+        "windows"
+      ],
+      "providers": [
+        "local",
+        "daemon",
+        "ssh",
+        "wsl",
+        "remote-runtime"
+      ],
+      "coveredPlatforms": [
+        "macos"
+      ],
+      "coveredProviders": [],
+      "coverageNotes": "Renderer-unit coverage proves the shared xterm DOM intent path. Live Electron evidence is PR validation evidence for local macOS only until the flow has stable automation; live SSH, WSL, Linux, and Windows paths remain unproved.",
+      "motivatingLinks": [
+        "STA-1341"
+      ],
+      "invariant": "A user-driven xterm scrollbar thumb or track scroll updates the live terminal scroll intent before tab, visibility, or layout resume enforces intent, so resume preserves the latest dragged viewport instead of an older pinned line.",
+      "oracle": "Pointerdown on .xterm-scrollbar or .xterm-slider followed by xterm viewport movement records the new pinned viewport, and enforcing current intent restores that dragged line instead of stale top intent.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts",
+          "assertions": [
+            "pointer-driven .xterm-scrollbar and .xterm-slider scrolls update terminal scroll intent",
+            "a scrollbar-dragged viewport is restored instead of stale top intent",
+            "terminal body pointer activity is not treated as scrollbar intent"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-05",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.3,
+          "summary": "1 test file(s) passed, 17 tests passed in this worktree."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 10,
+        "scope": "focused renderer unit test"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "New experimental gate; needs soak history before promotion."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The new scrollbar DOM target assertions fail when only .xterm-viewport pointerdown is recognized. Needs saved CI/intentional-break artifact before blocking promotion."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Runtime fix is limited to constant-time class/closest checks on pointerdown. It must not add polling, output parsing, PTY listing, hidden-pane wakeups, resize calls, or startup awaits."
+      },
+      "promotionCriteria": [
+        "Collect stable CI soak history for the renderer-unit gate.",
+        "Add stable live Electron automation for the scrollbar drag plus tab-switch repro.",
+        "Attach red/green evidence for stale intent restoring the wrong viewport."
+      ],
+      "knownGaps": [
+        "Manifest command is deterministic renderer-unit coverage, not a live Electron scrollbar drag.",
+        "Live daemon, SSH, WSL, remote-runtime, Linux, and Windows validation is not covered by this gate.",
+        "Future xterm scrollbar DOM class changes are only caught if they break the currently modeled class contract."
+      ],
+      "demotionRule": "Demote or quarantine if the unit gate flakes without a product bug or harness bug filed to the owner."
+    },
+    {
       "id": "startup-upgrade.persisted-session-corpus",
       "title": "Current Orca preserves or recovers old production persisted sessions",
       "maturity": "experimental",

--- a/src/renderer/src/components/settings/SourceControlActionRepoOverrideNote.tsx
+++ b/src/renderer/src/components/settings/SourceControlActionRepoOverrideNote.tsx
@@ -32,11 +32,6 @@ function getRecipeOverrideFieldLabel(field: SourceControlActionRecipeOverrideFie
         'auto.components.settings.SourceControlActionRepoOverrideNote.commandTemplate',
         'Command template'
       )
-    default: {
-      // Fail at compile time if the override-field union grows a new variant.
-      const _exhaustive: never = field
-      return _exhaustive
-    }
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
@@ -53,12 +53,15 @@ class TestElement extends EventTarget {
   }
 
   closest(selector: string): TestElement | null {
-    if (!selector.startsWith('.')) {
-      return null
-    }
-    const className = selector.slice(1)
-    if (this.classList.contains(className)) {
-      return this
+    for (const candidate of selector.split(',')) {
+      const trimmed = candidate.trim()
+      if (!trimmed.startsWith('.')) {
+        continue
+      }
+      const className = trimmed.slice(1)
+      if (this.classList.contains(className)) {
+        return this
+      }
     }
     return this.parentElement?.closest(selector) ?? null
   }

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
@@ -270,6 +270,56 @@ describe('terminal scroll intent', () => {
     disposable.dispose()
   })
 
+  it.each(['xterm-scrollbar', 'xterm-slider'])(
+    'tracks pointer-driven xterm %s scrolls as user intent',
+    (scrollbarClassName) => {
+      vi.stubGlobal('Element', TestElement)
+      const terminal = createTerminal({ viewportY: 100, baseY: 100 })
+      const hostElement = new TestElement()
+      const scrollbarTarget = new TestElement(scrollbarClassName)
+      const scrollbarChild = new TestElement('xterm-scrollbar-child')
+      hostElement.append(scrollbarTarget)
+      scrollbarTarget.append(scrollbarChild)
+      const host = hostElement as unknown as HTMLElement
+      const disposable = attachTerminalScrollIntentTracking(terminal, host)
+
+      terminal.buffer.active.viewportY = 50
+      host.dispatchEvent(new Event('scroll'))
+      expect(getTerminalScrollIntentKind(terminal)).toBe('followOutput')
+
+      scrollbarChild.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+      scrollbarChild.dispatchEvent(new Event('scroll', { bubbles: true }))
+      expect(getTerminalScrollIntentKind(terminal)).toBe('pinnedViewport')
+
+      disposable.dispose()
+    }
+  )
+
+  it('restores a scrollbar-dragged viewport instead of stale top intent', () => {
+    vi.stubGlobal('Element', TestElement)
+    const terminal = createTerminal({ viewportY: 0, baseY: 600 })
+    const hostElement = new TestElement()
+    const scrollbar = new TestElement('xterm-scrollbar')
+    const slider = new TestElement('xterm-slider')
+    hostElement.append(scrollbar)
+    scrollbar.append(slider)
+    const host = hostElement as unknown as HTMLElement
+    const disposable = attachTerminalScrollIntentTracking(terminal, host, 'terminal-1')
+
+    expect(getTerminalScrollIntentKind(terminal)).toBe('pinnedViewport')
+
+    terminal.buffer.active.viewportY = 572
+    slider.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    slider.dispatchEvent(new Event('scroll', { bubbles: true }))
+
+    terminal.buffer.active.viewportY = 0
+    enforceTerminalCurrentScrollIntent(terminal)
+
+    expect(terminal.scrollToLine).toHaveBeenLastCalledWith(572)
+    expect(terminal.buffer.active.viewportY).toBe(572)
+    disposable.dispose()
+  })
+
   it('does not treat terminal body pointer activity as scrollbar intent', () => {
     vi.stubGlobal('Element', TestElement)
     const terminal = createTerminal({ viewportY: 100, baseY: 100 })

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -47,6 +47,9 @@ const XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES = [
   'xterm-scrollbar',
   'xterm-slider'
 ] as const
+const XTERM_SCROLL_INTENT_POINTER_TARGET_SELECTOR = XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES.map(
+  (className) => `.${className}`
+).join(',')
 
 function readBufferSnapshot(
   terminal: TerminalScrollIntentTarget
@@ -130,9 +133,7 @@ function isTerminalScrollIntentPointerTarget(target: EventTarget | null): target
     return false
   }
   // xterm's custom scrollbar uses separate thumb/track nodes from the viewport.
-  return XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES.some(
-    (className) => target.classList.contains(className) || target.closest(`.${className}`) !== null
-  )
+  return target.closest(XTERM_SCROLL_INTENT_POINTER_TARGET_SELECTOR) !== null
 }
 
 export function markTerminalFollowOutput(terminal: TerminalScrollIntentTarget): void {

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -42,6 +42,11 @@ const terminalScrollIntentKeyByTerminal = new WeakMap<
 const terminalScrollIntentByKey = new Map<TerminalScrollIntentKey, TerminalScrollIntent>()
 
 const BOTTOM_TOLERANCE_ROWS = 1
+const XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES = [
+  'xterm-viewport',
+  'xterm-scrollbar',
+  'xterm-slider'
+] as const
 
 function readBufferSnapshot(
   terminal: TerminalScrollIntentTarget
@@ -118,6 +123,16 @@ function safeScrollCall(fn: () => void): boolean {
     }
     throw err
   }
+}
+
+function isTerminalScrollIntentPointerTarget(target: EventTarget | null): target is Element {
+  if (typeof Element === 'undefined' || !(target instanceof Element)) {
+    return false
+  }
+  // xterm's custom scrollbar uses separate thumb/track nodes from the viewport.
+  return XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES.some(
+    (className) => target.classList.contains(className) || target.closest(`.${className}`) !== null
+  )
 }
 
 export function markTerminalFollowOutput(terminal: TerminalScrollIntentTarget): void {
@@ -255,11 +270,7 @@ export function attachTerminalScrollIntentTracking(
   }
 
   const onPointerDown = (event: PointerEvent): void => {
-    const target = event.target
-    pointerScrollActive =
-      typeof Element !== 'undefined' &&
-      target instanceof Element &&
-      (target.classList.contains('xterm-viewport') || target.closest('.xterm-viewport') !== null)
+    pointerScrollActive = isTerminalScrollIntentPointerTarget(event.target)
   }
 
   const onPointerDone = (): void => {


### PR DESCRIPTION
## Summary

Preserves terminal scroll position after the user drags xterm's scrollbar thumb or track, then switches tabs or returns from visibility/layout resume. This fixes STA-1341's stale-scroll-intent shape: a dragged viewport could snap back to an older pinned line.

This does not change wheel/trackpad scrolling, Codex/TUI mouse-reporting behavior, hidden-output replay, output scheduling, or terminal styling.

## Design Approach

- Treat pointerdown targets on `.xterm-scrollbar` and `.xterm-slider` as user scroll-intent sources, alongside the existing `.xterm-viewport` path.
- Reuse the existing scroll/pointerup synchronization path so xterm remains the source for the settled `viewportY`.
- Add focused regression coverage for scrollbar/slider pointer intent and stale-top restore.
- Register `terminal-scroll.intent-preservation` as an experimental/partial reliability gate.

Design review completed clean after tightening the reliability gate, provider/platform gap language, and Electron validation selector.

## Implementation

- `terminal-scroll-intent.ts` now classifies xterm viewport, scrollbar, and slider pointer targets as scroll-intent targets.
- `terminal-scroll-intent.test.ts` covers scrollbar/slider pointer-driven scroll intent and proves a dragged viewport restores instead of stale top intent.
- `config/reliability-gates.jsonc` adds the experimental/partial `terminal-scroll.intent-preservation` gate.
- `SourceControlActionRepoOverrideNote.tsx` removes an unnecessary exhaustive-switch `default` that blocked repo-wide lint.

No implementation deviations from the reviewed design, except the small unrelated lint cleanup required to get `pnpm run lint` passing.

## Completeness

Headline behavior: implemented.

Independent completeness verification found no blockers. The stale-top regression test would fail under the old `.xterm-viewport`-only classifier because `.xterm-slider` pointerdown would not refresh stored intent.

Broad app consistency: the source-of-truth behavior is terminal scroll intent architecture: user-driven scroll position is authoritative, and tab/workspace visibility changes should not become scroll operations. Desktop terminal panes share the renderer/xterm path; mobile/relay is unaffected by desktop xterm DOM scrollbar pointer events. No header/footer/overflow/command-palette/review/settings actions changed.

## Reliability

Reliability invariant: a user-driven xterm scrollbar thumb or track scroll updates live terminal scroll intent before tab, visibility, or layout resume enforces intent.

Gate: `terminal-scroll.intent-preservation`, experimental/partial.

Correctness evidence:

- Unit oracle records `.xterm-scrollbar` / `.xterm-slider` pointer intent and restores the dragged line instead of stale top intent.
- Electron oracle reproduced the product flow with real mouse input.

Provider/platform coverage:

- Covered live: local macOS Electron; SSH to a throwaway Linux Docker target with a real relay-backed remote PTY; Windows desktop Electron; Windows WSL2-backed terminal.
- Covered by shared renderer-path reasoning/unit gate: daemon, remote-runtime.
- Live-unproved gaps: daemon, remote-runtime, Linux desktop host.
- Mobile/relay: unaffected by this desktop xterm DOM change.

## Performance

Perf audit clean. The runtime change is bounded to three `classList.contains` / `closest` checks on existing `pointerdown` handling. No polling, timers, output parsing, IPC, PTY listing, provider scans, resize churn, startup awaits, hidden-pane wake loops, or listener fanout were added.

## Review

- Design review: clean after fixes.
- Completeness verification: complete, no blockers.
- Perf audit: clean.
- Code-review loop: final four-file diff reviewed by two fresh reviewers in the same round; both returned clean.
- Merge-confidence validation: should land.
- Post-PR stabilization: CodeRabbit quick-win comment addressed; refreshed CodeRabbit sweep reported no actionable comments; PR checks passed.

## Validation

- `pnpm run lint` passed, with existing warnings only.
- `pnpm run typecheck` passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts` passed, 17 tests.
- `pnpm run check:reliability-gates` passed, 28 gates.
- `git diff --check` passed.
- Live Electron validation in this worktree:
  - real xterm scrollbar track moved `top: 0px -> 467px`;
  - after switching `Terminal 2 -> Terminal 3 -> Terminal 2`, it stayed at `top: 467px`.
- Live SSH/Linux validation in this worktree:
  - relay target: throwaway `node:22-bookworm` Docker container, `remotePlatform: linux`;
  - real SSH PTY id: `ssh:ssh-1783310567594-y6qz85@@pty-1`;
  - xterm scrollback `baseY: 652`;
  - scrollbar drag moved `viewportY 0 -> 387` and slider `top: 40px -> 489px`;
  - after switching away and back, `viewportY` stayed `387` and slider `top` stayed `489px`.
- Live Windows validation from Neil's Windows agent report:
  - environment: Windows 11 Pro `10.0.26100`, Node `v24.16.0`, pnpm `10.24.0`, Orca `1.4.123-rc.1` (Electron `42.3.3`, Chrome `148`);
  - CDP identity confirmed branch `brennanb2025/sta-1341-codex-terminal-scroll` at `C:\Users\neil\orca\workspaces\orca\7472`;
  - static checks passed, including typecheck, oxlint on tracked source, switch exhaustiveness, styled scrollbars, reliability gates, localization checks, and focused Vitest `17/17`;
  - real Playwright mouse drag on `.xterm-scrollable-element > .xterm-scrollbar.xterm-vertical > .xterm-slider`;
  - scrollbar drag moved `viewportY 0 -> 296`, `baseY: 651`, and slider `top: 40px -> 390px`;
  - after switching to Terminal 2 and back, `viewportY` stayed `296` and slider `top` stayed `390px`.
- Live WSL2 validation from PR comment:
  - environment: Windows 11 Pro `10.0.26100`, WSL `2.7.8.0`, kernel `6.18.33.1-microsoft-standard-WSL2`, Ubuntu `24.04.4 LTS`, Orca `1.4.123-rc.1`;
  - confirmed genuinely WSL-backed via terminal `uname=Linux`, OS process table showing both PTYs as `wsl.exe` children of `electron.exe`, and workspace path `\\wsl.localhost\Ubuntu-24.04\root\orca-wsl-sta1341`;
  - real Playwright mouse drag on `.xterm-scrollable-element > .xterm-scrollbar.xterm-vertical > .xterm-slider`;
  - scrollbar drag moved `viewportY 0 -> 296`, `baseY: 653`, and slider `top: 40px -> 390px`;
  - after switching to Terminal 2 and back, `viewportY` stayed `296` and slider `top` stayed `390px`.
- Earlier Electron screenshot evidence: `.tmp/validation-evidence/sta-1341-terminal-scrollbar-after-tab-switch.png`, with `viewportY 0 -> 431 -> 431` after tab switch.
- PR checks after the follow-up push:
  - `verify` passed.
  - `golden e2e linux experiment` passed.
  - `golden e2e mac experiment` passed.

## Screenshots

- Manual Electron evidence screenshot: `.tmp/validation-evidence/sta-1341-terminal-scrollbar-after-tab-switch.png`.
- The screenshot shows Terminal 2 preserved around lines 430-480 after the tab switch.
- SSH/Linux remote PTY evidence screenshot: `.tmp/validation-evidence/sta-1341-ssh-linux-lite-terminal-scrollbar-after-tab-switch.png`.
- Windows evidence screenshot from Neil's agent report: `C:\Users\neil\AppData\Local\Temp\orca-sta1341-evidence\terminal1-after-return.png`, showing Terminal 1 preserved around `STA1341_WIN_LINE_0294` through `_0345` after switching away and back.
- WSL2 evidence from PR comment: after-return screenshot showed Terminal 1 preserved around `STA1341_WSL_LINE_0292` through `_0343`, matching `viewportY=296`.

## Testing Checklist

- [x] Focused unit regression test for terminal scrollbar/slider scroll intent.
- [x] Full lint.
- [x] Typecheck.
- [x] Reliability gate manifest check.
- [x] Live Electron local macOS validation.
- [x] Live SSH/Linux remote PTY validation.
- [x] Live Windows desktop Electron validation.
- [x] Live Windows WSL2 terminal validation.
- [x] PR CI checks.

## AI Review Report

- Design review completed clean after edits.
- Perf audit completed clean.
- Code-review loop completed clean with two reviewers in the same round.
- CodeRabbit quick-win comment was addressed; refreshed sweep reported no actionable comments.

## Security Audit

No security-sensitive behavior changes. This PR changes renderer-side xterm DOM event classification, renderer-unit tests, a reliability manifest entry, and an exhaustive-switch lint cleanup. It adds no network calls, filesystem access, shell/process execution, authentication, permission, or provider-identity behavior.

## Notes

The first Linux golden experiment failed once in an unrelated terminal-rendering golden test with `Execution context was destroyed` during setup; the refreshed run after the follow-up push passed.

SSH/Linux validation used a minimal synthetic remote workspace state after establishing a real Orca SSH target and relay-backed PTY. The earlier full `repos:addRemote` harness caused unrelated remote repo watcher/mux churn before reaching the scrollbar assertion; the passing lite harness still exercised the real renderer, xterm, tab switch, SSH target, Linux relay, and remote PTY path for this scroll behavior.

## Risks And Gaps

- Live daemon, remote-runtime, and Linux desktop host validation were not run.
- Future xterm scrollbar DOM class changes could require updating the target classifier and tests.
- Keyboard scroll intent is a documented non-goal for this fix.
- CodeRabbit's description-template warning is non-actionable for this repository PR body; no code-review comments remain actionable after the follow-up push.
