### PR TITLE
Keep Claude live-PTY refresh gate closed across restarts; recover wiped runtime credentials (STA-1246)

### DIFF
--- a/src/main/claude-accounts/live-pty-gate.test.ts
+++ b/src/main/claude-accounts/live-pty-gate.test.ts
@@ -1,15 +1,23 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  attachClaudeLivePtyPersistence,
   beginClaudeAuthSwitch,
+  confirmSeededClaudeLivePtys,
   endClaudeAuthSwitch,
+  hasLiveClaudePtys,
   isClaudeAuthSwitchInProgress,
   markClaudePtyExited,
-  markClaudePtySpawned
+  markClaudePtySpawned,
+  seedLiveClaudePtysFromPersistence
 } from './live-pty-gate'
 
 describe('Claude live PTY gate', () => {
   afterEach(() => {
     markClaudePtyExited('live-claude-pty')
+    markClaudePtyExited('seeded-pty-1')
+    markClaudePtyExited('seeded-pty-2')
+    confirmSeededClaudeLivePtys([])
+    attachClaudeLivePtyPersistence(null)
     endClaudeAuthSwitch()
   })
 
@@ -25,5 +33,62 @@ describe('Claude live PTY gate', () => {
     beginClaudeAuthSwitch()
 
     expect(() => beginClaudeAuthSwitch()).toThrow('already in progress')
+  })
+
+  it('counts seeded session ids as live until confirmed dead', () => {
+    seedLiveClaudePtysFromPersistence(['seeded-pty-1', 'seeded-pty-2'])
+
+    expect(hasLiveClaudePtys()).toBe(true)
+
+    confirmSeededClaudeLivePtys(['seeded-pty-1'])
+
+    expect(hasLiveClaudePtys()).toBe(true)
+
+    confirmSeededClaudeLivePtys([])
+
+    expect(hasLiveClaudePtys()).toBe(true)
+
+    markClaudePtyExited('seeded-pty-1')
+
+    expect(hasLiveClaudePtys()).toBe(false)
+  })
+
+  it('releases seeded ids the daemon no longer knows', () => {
+    const removeClaudeLivePtySessionId = vi.fn()
+    attachClaudeLivePtyPersistence({
+      addClaudeLivePtySessionId: vi.fn(),
+      removeClaudeLivePtySessionId
+    })
+    seedLiveClaudePtysFromPersistence(['seeded-pty-1', 'seeded-pty-2'])
+
+    confirmSeededClaudeLivePtys(['seeded-pty-2'])
+
+    expect(hasLiveClaudePtys()).toBe(true)
+    expect(removeClaudeLivePtySessionId).toHaveBeenCalledWith('seeded-pty-1')
+    expect(removeClaudeLivePtySessionId).not.toHaveBeenCalledWith('seeded-pty-2')
+  })
+
+  it('keeps a seeded id confirmed by a real spawn out of later pruning', () => {
+    seedLiveClaudePtysFromPersistence(['seeded-pty-1'])
+    markClaudePtySpawned('seeded-pty-1')
+
+    confirmSeededClaudeLivePtys([])
+
+    expect(hasLiveClaudePtys()).toBe(true)
+  })
+
+  it('persists spawns and exits when persistence is attached', () => {
+    const addClaudeLivePtySessionId = vi.fn()
+    const removeClaudeLivePtySessionId = vi.fn()
+    attachClaudeLivePtyPersistence({
+      addClaudeLivePtySessionId,
+      removeClaudeLivePtySessionId
+    })
+
+    markClaudePtySpawned('live-claude-pty')
+    expect(addClaudeLivePtySessionId).toHaveBeenCalledWith('live-claude-pty')
+
+    markClaudePtyExited('live-claude-pty')
+    expect(removeClaudeLivePtySessionId).toHaveBeenCalledWith('live-claude-pty')
   })
 })

--- a/src/main/claude-accounts/live-pty-gate.ts
+++ b/src/main/claude-accounts/live-pty-gate.ts
@@ -24,6 +24,10 @@ export function seedLiveClaudePtysFromPersistence(sessionIds: readonly string[])
   }
 }
 
+export function hasSeededUnconfirmedClaudePtys(): boolean {
+  return seededUnconfirmedPtyIds.size > 0
+}
+
 /**
  * Reconcile seeded ids against the daemon's live session list. Seeded ids the
  * daemon no longer knows are dead — release them so they cannot defer OAuth

--- a/src/main/claude-accounts/live-pty-gate.ts
+++ b/src/main/claude-accounts/live-pty-gate.ts
@@ -1,12 +1,56 @@
 const liveClaudePtyIds = new Set<string>()
+// Why: ids restored from persistence at startup, not yet confirmed against the
+// daemon. They keep the OAuth refresh gate closed so an early managed refresh
+// cannot rotate the single-use refresh token out from under a Claude CLI that
+// survived the app restart inside the daemon.
+const seededUnconfirmedPtyIds = new Set<string>()
 let switchInProgress = false
+
+export type ClaudeLivePtyPersistence = {
+  addClaudeLivePtySessionId(sessionId: string): void
+  removeClaudeLivePtySessionId(sessionId: string): void
+}
+
+let persistence: ClaudeLivePtyPersistence | null = null
+
+export function attachClaudeLivePtyPersistence(target: ClaudeLivePtyPersistence | null): void {
+  persistence = target
+}
+
+export function seedLiveClaudePtysFromPersistence(sessionIds: readonly string[]): void {
+  for (const sessionId of sessionIds) {
+    liveClaudePtyIds.add(sessionId)
+    seededUnconfirmedPtyIds.add(sessionId)
+  }
+}
+
+/**
+ * Reconcile seeded ids against the daemon's live session list. Seeded ids the
+ * daemon no longer knows are dead — release them so they cannot defer OAuth
+ * refresh forever. Seeded ids that are still alive stay in the gate even if
+ * their pane never reattaches: that daemon process still owns the credentials.
+ */
+export function confirmSeededClaudeLivePtys(aliveSessionIds: readonly string[]): void {
+  const alive = new Set(aliveSessionIds)
+  for (const sessionId of seededUnconfirmedPtyIds) {
+    if (!alive.has(sessionId)) {
+      liveClaudePtyIds.delete(sessionId)
+      persistence?.removeClaudeLivePtySessionId(sessionId)
+    }
+  }
+  seededUnconfirmedPtyIds.clear()
+}
 
 export function markClaudePtySpawned(ptyId: string): void {
   liveClaudePtyIds.add(ptyId)
+  seededUnconfirmedPtyIds.delete(ptyId)
+  persistence?.addClaudeLivePtySessionId(ptyId)
 }
 
 export function markClaudePtyExited(ptyId: string): void {
   liveClaudePtyIds.delete(ptyId)
+  seededUnconfirmedPtyIds.delete(ptyId)
+  persistence?.removeClaudeLivePtySessionId(ptyId)
 }
 
 export function hasLiveClaudePtys(): boolean {

--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -1081,6 +1081,53 @@ describe('ClaudeRuntimeAuthService', () => {
     }
   })
 
+  it('rematerializes managed credentials over a wiped runtime blob while a Claude terminal is live', async () => {
+    setPlatform('win32')
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const originalCredentials = createClaudeCredentialsJson('user@example.com', 'original', 'org-a')
+    // Why: Claude CLI wipes tokens in place (keeps identity fields) after an
+    // invalid_grant refresh — the exact blob shape this regression guards.
+    const parsedOriginal = JSON.parse(originalCredentials) as {
+      claudeAiOauth: Record<string, unknown>
+    }
+    const wipedCredentials = `${JSON.stringify({
+      claudeAiOauth: {
+        ...parsedOriginal.claudeAiOauth,
+        accessToken: '',
+        refreshToken: '',
+        expiresAt: 0
+      }
+    })}\n`
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      originalCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { organizationUuid: 'org-a' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const { markClaudePtyExited, markClaudePtySpawned } = await import('./live-pty-gate')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    markClaudePtySpawned('live-claude-pty')
+    try {
+      writeFileSync(runtimeCredentialsPath, wipedCredentials, 'utf-8')
+      await service.syncForCurrentSelection()
+
+      expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(originalCredentials)
+      expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(originalCredentials)
+    } finally {
+      markClaudePtyExited('live-claude-pty')
+    }
+  })
+
   it('rejects unverifiable refreshed runtime credentials', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const originalCredentials = createClaudeCredentialsWithoutEmail('original')

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -67,7 +67,12 @@ type ClaudeAuthIdentity = {
 
 type ClaudeReadBackResult =
   | { status: 'unchanged' | 'persisted' }
-  | { status: 'rejected'; runtimeCredentialsChanged: boolean; runtimeCredentialsJson?: string }
+  | {
+      status: 'rejected'
+      runtimeCredentialsChanged: boolean
+      hasValidChangedRuntimeCredentials: boolean
+      runtimeCredentialsJson?: string
+    }
 type ClaudeReadBackMatch =
   | { kind: 'matched'; account: ClaudeManagedAccount; managedCredentialsJson: string }
   | { kind: 'none' | 'ambiguous' }
@@ -378,6 +383,10 @@ export class ClaudeRuntimeAuthService {
         } else if (
           readBackResult.status === 'rejected' &&
           readBackResult.runtimeCredentialsChanged &&
+          // Why: a live Claude that lost a refresh-token race wipes its runtime
+          // blob (empty tokens). Preserving that wreckage would leave every new
+          // session logged out — rematerialize managed credentials instead.
+          readBackResult.hasValidChangedRuntimeCredentials &&
           hasLiveClaudePtys()
         ) {
           if (
@@ -499,10 +508,12 @@ export class ClaudeRuntimeAuthService {
       }[] = []
       const ambiguousCandidates: string[] = []
       let sawAmbiguousCandidate = false
+      let sawValidChangedCandidate = false
       for (const runtimeContents of changedCandidates) {
         if (!this.isValidCredentialsJsonObject(runtimeContents.credentialsJson)) {
           continue
         }
+        sawValidChangedCandidate = true
         const match = await this.findManagedAccountForRuntimeCredentials(
           runtimeContents.credentialsJson,
           runtimeContents.runtimeOauthAccount
@@ -557,6 +568,7 @@ export class ClaudeRuntimeAuthService {
         return {
           status: 'rejected',
           runtimeCredentialsChanged: true,
+          hasValidChangedRuntimeCredentials: sawValidChangedCandidate,
           runtimeCredentialsJson:
             ambiguousCandidates.length === 1 ? ambiguousCandidates[0] : undefined
         }
@@ -582,7 +594,10 @@ export class ClaudeRuntimeAuthService {
       return {
         status: 'rejected',
         runtimeCredentialsChanged:
-          this.runtimeCredentialsChangedSinceLastWrite(baselineCredentialsJson)
+          this.runtimeCredentialsChangedSinceLastWrite(baselineCredentialsJson),
+        // Why: an fs error hides whether a live session's refresh is present,
+        // so err toward preserving runtime state like before.
+        hasValidChangedRuntimeCredentials: true
       }
     }
   }

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -38,6 +38,7 @@ const {
   spawnerInstances,
   ensureRunningOverrides,
   adapterInstances,
+  defaultListSessionsSessions,
   getLocalPtyProviderMock,
   localFallbackProvider,
   setLocalPtyProviderMock,
@@ -103,6 +104,9 @@ const {
   // Same for DaemonPtyAdapter. The test asserts the replacement adapter is a
   // fresh instance whose respawn closure targets the *original* spawner.
   const adapterInstances: MockAdapter[] = []
+  // Why: adapters are constructed inside initDaemonPtyProvider, so tests that
+  // need listSessions to report live sessions set this before calling init.
+  const defaultListSessionsSessions: { sessionId: string }[] = []
 
   const localFallbackProvider = {
     routesFreshSpawnsToLocalProvider: undefined,
@@ -154,6 +158,7 @@ const {
     spawnerInstances,
     ensureRunningOverrides,
     adapterInstances,
+    defaultListSessionsSessions,
     getLocalPtyProviderMock,
     localFallbackProvider,
     setLocalPtyProviderMock,
@@ -303,7 +308,7 @@ vi.mock('./daemon-pty-adapter', () => ({
         this.callOrder.push('fanoutSyntheticExits')
       })
       this.listProcesses = vi.fn(async () => [])
-      this.listSessions = vi.fn(async () => [])
+      this.listSessions = vi.fn(async () => [...defaultListSessionsSessions])
       this.shutdown = vi.fn(async () => {})
       this.dispose = vi.fn()
       this.disconnectOnly = vi.fn(async () => {})
@@ -326,6 +331,7 @@ async function importFresh() {
   spawnerInstances.length = 0
   ensureRunningOverrides.length = 0
   adapterInstances.length = 0
+  defaultListSessionsSessions.length = 0
   getLocalPtyProviderMock.mockClear()
   localFallbackProvider.spawn.mockClear()
   localFallbackProvider.write.mockClear()
@@ -395,6 +401,28 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(rebindLocalProviderListenersMock.mock.invocationCallOrder[0]).toBeGreaterThan(
       setLocalPtyProviderMock.mock.invocationCallOrder[0]
     )
+  })
+
+  it('prunes seeded Claude live-PTY ids against daemon sessions after init', async () => {
+    const mod = await importFresh()
+    // Why: live-pty-gate is intentionally unmocked — import from the same fresh
+    // module registry so the module-level gate state matches daemon-init's.
+    const gate = await import('../claude-accounts/live-pty-gate')
+    defaultListSessionsSessions.push({ sessionId: 'claude-alive' })
+    gate.seedLiveClaudePtysFromPersistence(['claude-alive', 'claude-dead'])
+    try {
+      await mod.initDaemonPtyProvider()
+
+      expect(gate.hasLiveClaudePtys()).toBe(true)
+
+      gate.markClaudePtyExited('claude-alive')
+      // Why: proves 'claude-dead' was released by the daemon reconcile — the
+      // surviving session was the only id still holding the gate.
+      expect(gate.hasLiveClaudePtys()).toBe(false)
+    } finally {
+      gate.markClaudePtyExited('claude-alive')
+      gate.markClaudePtyExited('claude-dead')
+    }
   })
 
   it('does not install a late daemon provider after startup fallback aborts the init attempt', async () => {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -44,7 +44,10 @@ import {
   rebindLocalProviderListeners
 } from '../ipc/pty'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from '../startup/startup-diagnostics'
-import { confirmSeededClaudeLivePtys } from '../claude-accounts/live-pty-gate'
+import {
+  confirmSeededClaudeLivePtys,
+  hasSeededUnconfirmedClaudePtys
+} from '../claude-accounts/live-pty-gate'
 
 // Why: daemon init runs concurrently with window load, so harness-side stderr
 // arrival times are useless — in-process `t` lets the startup benchmark derive
@@ -463,6 +466,9 @@ export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void>
 // Listing failures keep the seeds: over-holding the gate only delays a usage
 // refresh, while releasing it early can rotate a live CLI's refresh token.
 async function reconcileSeededClaudeLivePtys(provider: DaemonProvider): Promise<void> {
+  if (!hasSeededUnconfirmedClaudePtys()) {
+    return
+  }
   try {
     const adapters =
       provider instanceof DaemonPtyRouter || provider instanceof DegradedDaemonPtyProvider

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -44,6 +44,7 @@ import {
   rebindLocalProviderListeners
 } from '../ipc/pty'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from '../startup/startup-diagnostics'
+import { confirmSeededClaudeLivePtys } from '../claude-accounts/live-pty-gate'
 
 // Why: daemon init runs concurrently with window load, so harness-side stderr
 // arrival times are useless — in-process `t` lets the startup benchmark derive
@@ -453,6 +454,35 @@ export async function initDaemonPtyProvider(signal?: AbortSignal): Promise<void>
   // data/exit events through the renderer and runtime listeners.
   rebindLocalProviderListeners()
   logDaemonMilestone('daemon-init-done', { legacyAdapters: legacyAdapters.length })
+  await reconcileSeededClaudeLivePtys(routedAdapter)
+}
+
+// Why: the Claude live-PTY gate is seeded pessimistically from persistence at
+// store load. Once the daemon is up we know which of those sessions actually
+// survived — release dead ids so they cannot defer OAuth refresh forever.
+// Listing failures keep the seeds: over-holding the gate only delays a usage
+// refresh, while releasing it early can rotate a live CLI's refresh token.
+async function reconcileSeededClaudeLivePtys(provider: DaemonProvider): Promise<void> {
+  try {
+    const adapters =
+      provider instanceof DaemonPtyRouter || provider instanceof DegradedDaemonPtyProvider
+        ? provider.getAllAdapters()
+        : [provider]
+    const results = await Promise.allSettled(adapters.map((entry) => entry.listSessions()))
+    if (results.some((result) => result.status === 'rejected')) {
+      console.warn('[daemon] Keeping seeded Claude live-PTY gate — session listing failed')
+      return
+    }
+    confirmSeededClaudeLivePtys(
+      results.flatMap((result) =>
+        result.status === 'fulfilled' ? result.value.map((session) => session.sessionId) : []
+      )
+    )
+  } catch (error) {
+    // Why: gate bookkeeping must never fail daemon init; stale seeds only
+    // defer a usage refresh until the next restart.
+    console.warn('[daemon] Failed to reconcile seeded Claude live-PTY gate:', error)
+  }
 }
 
 // Why: the Manage Sessions IPC handlers need read access to the current

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -120,6 +120,10 @@ import { normalizeClaudeRuntimeSelection } from './claude-accounts/runtime-selec
 import { codexHookService } from './codex/hook-service'
 import { ClaudeAccountService } from './claude-accounts/service'
 import { ClaudeRuntimeAuthService } from './claude-accounts/runtime-auth-service'
+import {
+  attachClaudeLivePtyPersistence,
+  seedLiveClaudePtysFromPersistence
+} from './claude-accounts/live-pty-gate'
 import { StarNagService } from './star-nag/service'
 import { agentHookServer } from './agent-hooks/server'
 import { maybeAutoRenameBranchOnFirstWork } from './agent-hooks/first-work-branch-rename'
@@ -1620,6 +1624,18 @@ app.whenReady().then(async () => {
 
   store = new Store()
   logStartupMilestone('store-loaded')
+  // Why: must run before ClaudeRuntimeAuthService's constructor sync — a Claude
+  // CLI that survived the restart inside the daemon still holds the current
+  // single-use refresh token, and an unguarded early refresh would rotate it
+  // out from under that process (it then shows "Not logged in" mid-session).
+  attachClaudeLivePtyPersistence(store)
+  const persistedClaudePtyIds = store.getClaudeLivePtySessionIds()
+  seedLiveClaudePtysFromPersistence(persistedClaudePtyIds)
+  if (persistedClaudePtyIds.length > 0) {
+    console.log(
+      `[claude-live-pty] Seeded ${persistedClaudePtyIds.length} persisted Claude session id(s) into the refresh gate`
+    )
+  }
   selfHealRuntimeEnvironmentFocus({ store, userDataPath: app.getPath('userData') })
   applyAppIcon(store.getSettings().appIcon)
   if (shouldSuppressDevEducation({ isDev: is.dev })) {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -8446,6 +8446,55 @@ describe('Store', () => {
     expect(store.getWorkspaceLineage(unrelatedLineage.childWorkspaceKey)).toEqual(unrelatedLineage)
   })
 
+  // ── Live Claude PTY session ids (STA-1246) ─────────────────────────
+
+  describe('claudeLivePtySessionIds', () => {
+    it('persists added ids across reloads and removes them durably', async () => {
+      const store = await createStore()
+
+      store.addClaudeLivePtySessionId('claude-session-1')
+      store.addClaudeLivePtySessionId('claude-session-2')
+      store.addClaudeLivePtySessionId('claude-session-1')
+
+      expect(store.getClaudeLivePtySessionIds()).toEqual(['claude-session-1', 'claude-session-2'])
+
+      const reloaded = await createStore()
+      expect(reloaded.getClaudeLivePtySessionIds()).toEqual([
+        'claude-session-1',
+        'claude-session-2'
+      ])
+
+      reloaded.removeClaudeLivePtySessionId('claude-session-1')
+      reloaded.flush()
+
+      const reloadedAgain = await createStore()
+      expect(reloadedAgain.getClaudeLivePtySessionIds()).toEqual(['claude-session-2'])
+    })
+
+    it('drops malformed persisted entries on load', async () => {
+      writeDataFile({
+        schemaVersion: 1,
+        claudeLivePtySessionIds: ['valid-id', '', 42, null, 'valid-id', 'x'.repeat(513)]
+      })
+
+      const store = await createStore()
+
+      expect(store.getClaudeLivePtySessionIds()).toEqual(['valid-id'])
+    })
+
+    it('caps the persisted id list', async () => {
+      const store = await createStore()
+      for (let index = 0; index < 205; index += 1) {
+        store.addClaudeLivePtySessionId(`claude-session-${index}`)
+      }
+
+      const ids = store.getClaudeLivePtySessionIds()
+      expect(ids).toHaveLength(200)
+      expect(ids[0]).toBe('claude-session-5')
+      expect(ids[199]).toBe('claude-session-204')
+    })
+  })
+
   // ── Rolling backups (issue #1158) ──────────────────────────────────
 
   describe('rolling backups', () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -8482,6 +8482,20 @@ describe('Store', () => {
       expect(store.getClaudeLivePtySessionIds()).toEqual(['valid-id'])
     })
 
+    it('keeps the newest ids when an oversized persisted list is loaded', async () => {
+      writeDataFile({
+        schemaVersion: 1,
+        claudeLivePtySessionIds: Array.from({ length: 205 }, (_, index) => `claude-${index}`)
+      })
+
+      const store = await createStore()
+
+      const ids = store.getClaudeLivePtySessionIds()
+      expect(ids).toHaveLength(200)
+      expect(ids[0]).toBe('claude-5')
+      expect(ids[199]).toBe('claude-204')
+    })
+
     it('caps the persisted id list', async () => {
       const store = await createStore()
       for (let index = 0; index < 205; index += 1) {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2177,6 +2177,29 @@ function remapAcknowledgedAgentPaneKeys(
   return { acknowledgements: next, changed }
 }
 
+// Why: bounds a corrupt/bloated persisted list — the gate only ever needs the
+// handful of Claude sessions a daemon can realistically keep alive.
+const MAX_CLAUDE_LIVE_PTY_SESSION_IDS = 200
+
+function normalizeClaudeLivePtySessionIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const ids: string[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'string' || entry.length === 0 || entry.length > 512) {
+      continue
+    }
+    if (!ids.includes(entry)) {
+      ids.push(entry)
+    }
+    if (ids.length >= MAX_CLAUDE_LIVE_PTY_SESSION_IDS) {
+      break
+    }
+  }
+  return ids
+}
+
 function normalizeMigrationUnsupportedPtyEntries(value: unknown): MigrationUnsupportedPtyEntry[] {
   if (!Array.isArray(value)) {
     return []
@@ -3315,6 +3338,7 @@ export class Store {
           sshRemotePtyLeases: (parsed.sshRemotePtyLeases ?? [])
             .map(normalizeSshRemotePtyLease)
             .filter((lease): lease is SshRemotePtyLease => lease !== null),
+          claudeLivePtySessionIds: normalizeClaudeLivePtySessionIds(parsed.claudeLivePtySessionIds),
           migrationUnsupportedPtyEntries: normalizeMigrationUnsupportedPtyEntries(
             parsed.migrationUnsupportedPtyEntries
           ),
@@ -5911,6 +5935,37 @@ export class Store {
       return
     }
     this.state.sshTargets = this.state.sshTargets.filter((t) => t.id !== id)
+    this.scheduleSave()
+  }
+
+  // ── Live Claude PTY sessions ───────────────────────────────────────
+
+  getClaudeLivePtySessionIds(): string[] {
+    return [...(this.state.claudeLivePtySessionIds ?? [])]
+  }
+
+  addClaudeLivePtySessionId(sessionId: string): void {
+    if (sessionId.length === 0 || sessionId.length > 512) {
+      return
+    }
+    const ids = this.state.claudeLivePtySessionIds ?? []
+    if (ids.includes(sessionId)) {
+      return
+    }
+    // Why: drop the oldest entry at the cap — stale ids are pruned against the
+    // daemon at startup anyway, so recency is the only thing worth keeping.
+    this.state.claudeLivePtySessionIds = [...ids, sessionId].slice(-MAX_CLAUDE_LIVE_PTY_SESSION_IDS)
+    // Why: flush synchronously — a force-quit right after a Claude spawn must
+    // still seed the live-PTY gate on the next launch.
+    this.flush()
+  }
+
+  removeClaudeLivePtySessionId(sessionId: string): void {
+    const ids = this.state.claudeLivePtySessionIds ?? []
+    if (!ids.includes(sessionId)) {
+      return
+    }
+    this.state.claudeLivePtySessionIds = ids.filter((id) => id !== sessionId)
     this.scheduleSave()
   }
 

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2185,8 +2185,12 @@ function normalizeClaudeLivePtySessionIds(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return []
   }
+  // Why: scan newest-first so the cap keeps the most recent ids, matching
+  // addClaudeLivePtySessionId's eviction policy while bounding the work done
+  // on an oversized/corrupt list.
   const ids: string[] = []
-  for (const entry of value) {
+  for (let index = value.length - 1; index >= 0; index -= 1) {
+    const entry = value[index]
     if (typeof entry !== 'string' || entry.length === 0 || entry.length > 512) {
       continue
     }
@@ -2197,7 +2201,7 @@ function normalizeClaudeLivePtySessionIds(value: unknown): string[] {
       break
     }
   }
-  return ids
+  return ids.toReversed()
 }
 
 function normalizeMigrationUnsupportedPtyEntries(value: unknown): MigrationUnsupportedPtyEntry[] {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -437,6 +437,7 @@ export function getDefaultPersistedState(homedir: string): PersistedState {
     workspaceSessionsByHostId: {},
     sshTargets: [],
     sshRemotePtyLeases: [],
+    claudeLivePtySessionIds: [],
     migrationUnsupportedPtyEntries: [],
     legacyPaneKeyAliasEntries: [],
     automations: [],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3492,6 +3492,10 @@ export type PersistedState = {
   workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
   sshTargets: SshTarget[]
   sshRemotePtyLeases: SshRemotePtyLease[]
+  /** Daemon session ids of live local Claude launches. Seeds the Claude
+   *  live-PTY gate on startup so an early OAuth refresh cannot rotate the
+   *  single-use refresh token out from under a still-running daemon CLI. */
+  claudeLivePtySessionIds?: string[]
   migrationUnsupportedPtyEntries: MigrationUnsupportedPtyEntry[]
   legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[]
   automations: Automation[]


### PR DESCRIPTION
Fixes STA-1246 — Claude Code shows "Not logged in · Run /login" (and "API Usage Billing") while its Orca-managed session keeps running fine.

## Root cause

Claude.ai OAuth refresh tokens are single-use. Orca already defers its own managed refresh while a live Claude PTY owns the credentials (the `hasLiveClaudePtys()` gate), but the gate is an in-memory set populated only by renderer/runtime spawn handlers. Two holes remained:

1. **Restart-surviving daemon sessions are invisible to the gate.** Claude CLIs keep running inside the PTY daemon across an Orca restart, but until (and unless — panes reattach lazily) the renderer reattaches, the gate reads empty. `ClaudeRuntimeAuthService`'s constructor sync — and the first usage refresh ~1s after startup — can then rotate the refresh token "safely". The surviving CLI's next refresh fails with `invalid_grant`; Claude Code marks its refresh token dead and flips to "Not logged in / API Usage Billing" while continuing to run on its still-valid in-memory access token. This exactly matches the ticket screenshot (running session, red "Not logged in · Run /login", cost footer, and Orca's status bar showing "Waiting for Claude session").
2. **A wiped runtime blob was preserved forever.** When a losing CLI's `invalid_grant` guard fires while the disk blob still holds the dead token, it wipes the blob in place (`accessToken: ""`, `refreshToken: ""`). Orca's read-back rejected the wiped blob as invalid and then "preserved changed runtime credentials while live Claude terminals are running" — so valid managed credentials were never rematerialized until every Claude session exited, and newly launched sessions started logged out.

## Fix

- **Persist + seed the gate (prevention).** Local Claude launches persist their daemon session id (`claudeLivePtySessionIds` in `orca-data.json`, capped, normalized on load). At startup the gate is seeded pessimistically right after store load — before the runtime-auth constructor sync — and once daemon init completes, seeds are reconciled against the daemon's live session list (current + legacy adapters); dead ids are released so stale seeds can't defer refresh forever. Listing failures keep seeds (over-holding only delays a usage refresh; releasing early can strand a live CLI).
- **Recover wiped runtime credentials (self-healing).** Read-back now reports whether any changed runtime candidate was a *valid* credentials object. If everything that changed is invalid (the wiped-blob signature), the preserve-and-return path is skipped and managed credentials are rematerialized over the wreckage, so re-reading live sessions and new launches recover.

## Tests

- `live-pty-gate.test.ts`: seeding counts as live, daemon confirmation prunes only dead seeds, real spawns confirm seeds, persistence add/remove hooks.
- `daemon-init.test.ts`: end-to-end prune of seeded ids against mock daemon `listSessions` during `initDaemonPtyProvider`.
- `persistence.test.ts`: round-trip add/remove across reloads, malformed-entry normalization, list cap.
- `runtime-auth-service.test.ts`: wiped runtime blob is rematerialized from managed credentials while a Claude terminal is live (previously preserved).

`pnpm run typecheck` clean; oxlint clean; touched suites green (735 tests).

## Residual risks (documented, not addressed here)

- A CLI that already marked its refresh token dead in memory keeps showing the banner until that session restarts — Orca cannot fix Claude Code's in-memory state, only stop causing it and repair the disk surface.
- The hidden usage-CLI supplement is already blocked while `managedRefreshDeferredByLivePty` is set (live sessions + token inside the 5-minute expiry buffer, recomputed per fetch). A token that *enters* the buffer mid-probe can still race a live session; this window is seconds-wide and self-corrects via read-back for new sessions.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## Review

Three independent Opus 4.8 adversarial reviewers (correctness/lifecycle, platform/runtime matrix, assumption-violation scenarios) ran against the diff: **zero Critical/High/Medium findings**. All eight candidate failure scenarios (crash-between-spawn-and-persist, stale seeds, id reuse, double-reconcile, account-switch asymmetry, fs-error path, spawn/exit churn, cap eviction) were refuted with file:line evidence. Convergent Low advisories: the unconditional daemon `listSessions` at init tail (fixed in `eb8fe86d9`), a second synchronous store flush per Claude spawn (deliberate, force-quit durability; Claude spawns are user-paced), serve/headless or aborted-init runs never prune seeds (safe direction — defers proactive refresh only, self-heals via CLI rotation and next restart), and a downgrade→upgrade cycle dropping the persisted field once (standard optional-field degradation).

## Tests

- [x] Unit: gate seeding/confirm/prune, persistence round-trip + normalization + cap, daemon-init reconcile, wiped-blob rematerialization (`live-pty-gate`, `persistence`, `daemon-init`, `runtime-auth-service` suites — 735 tests green)
- [x] `pnpm run typecheck`, oxlint on touched files, `git diff --check` clean (`pnpm run lint` fails only on a pre-existing `SourceControlActionRepoOverrideNote.tsx` switch-exhaustiveness error from #7386, untouched by this branch)
- [x] Live Electron (this worktree's dev build, identity verified via CDP): launching a Claude tab persists its daemon session id to `claudeLivePtySessionIds` in `orca-data.json`
- [x] Live restart-survival: quit Electron leaving daemon + Claude CLI running → relaunch logs `[claude-live-pty] Seeded 1 persisted Claude session id(s) into the refresh gate` before any auth sync; daemon reconcile retains the alive id; the surviving session reattaches with a working prompt and **no "Not logged in" banner**
- [x] Live exit path: closing the Claude tab removes the persisted id
- [x] Live prune path: Claude session killed while the app was closed → next launch seeds 1, then daemon reconcile prunes it to `[]`, releasing the refresh gate
- [ ] Not exercised live: a real `invalid_grant` wipe (requires forcing token rotation against production OAuth; covered by the `runtime-auth-service` unit test simulating the CLI's exact wiped-blob shape) and WSL/SSH surfaces (WSL-managed accounts bypass the changed host materialization path entirely; SSH launches can never enter the persisted list — both verified by code trace in review)
