### PR TITLE
perf(runtime): memoize onPtyData tail wait scan to halve per-chunk work

### DIFF
--- a/src/main/runtime/orca-runtime-tail-wait-memo.test.ts
+++ b/src/main/runtime/orca-runtime-tail-wait-memo.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendNormalizedToTailBuffer,
+  buildPreview,
+  computeTerminalTailWaitState,
+  tailGainedNewerBlockedReason,
+  type TerminalTailWaitState
+} from './orca-runtime'
+
+// These tests pin the onPtyData wait-detection memoization: caching the
+// post-append wait state and reusing it as the next chunk's pre-append state
+// must produce byte-for-byte the same waitBlockedAt stamping as recomputing the
+// full-tail scan on both sides of every chunk (the pre-memoization behavior),
+// while doing roughly half the full-tail work.
+
+type RedrawCursor = ReturnType<typeof appendNormalizedToTailBuffer>['redrawCursor']
+
+type TailSim = {
+  tailBuffer: string[]
+  tailPartialLine: string
+  tailRedrawCursor: RedrawCursor
+  preview: string
+  waitBlockedAt: number | null
+  tailWaitState?: TerminalTailWaitState
+}
+
+function newSim(): TailSim {
+  return {
+    tailBuffer: [],
+    tailPartialLine: '',
+    tailRedrawCursor: null,
+    preview: '',
+    waitBlockedAt: null
+  }
+}
+
+type Compute = typeof computeTerminalTailWaitState
+
+// Mirrors the memoized onPtyData tail loop: reuse the cached tail-derived state
+// as the previous state; only recompute it on a preview-fallback (empty tail).
+function stepMemoized(sim: TailSim, chunk: string, at: number, compute: Compute): void {
+  const previousWaitState =
+    sim.tailWaitState?.fromTail === true
+      ? sim.tailWaitState
+      : compute(sim.tailBuffer, sim.tailPartialLine, sim.preview)
+  const nextTail = appendNormalizedToTailBuffer(
+    sim.tailBuffer,
+    sim.tailPartialLine,
+    chunk,
+    sim.tailRedrawCursor
+  )
+  const nextWaitState = compute(nextTail.lines, nextTail.partialLine, sim.preview)
+  if (tailGainedNewerBlockedReason(previousWaitState, nextWaitState, chunk)) {
+    sim.waitBlockedAt = at
+  }
+  sim.tailWaitState = nextWaitState
+  sim.tailBuffer = nextTail.lines
+  sim.tailPartialLine = nextTail.partialLine
+  sim.tailRedrawCursor = nextTail.redrawCursor
+  sim.preview = buildPreview(nextTail.lines, nextTail.partialLine)
+}
+
+// Reference: the pre-memoization behavior — recompute the previous state fresh
+// from the current tail on every chunk (no cache).
+function stepReference(sim: TailSim, chunk: string, at: number, compute: Compute): void {
+  const previousWaitState = compute(sim.tailBuffer, sim.tailPartialLine, sim.preview)
+  const nextTail = appendNormalizedToTailBuffer(
+    sim.tailBuffer,
+    sim.tailPartialLine,
+    chunk,
+    sim.tailRedrawCursor
+  )
+  const nextWaitState = compute(nextTail.lines, nextTail.partialLine, sim.preview)
+  if (tailGainedNewerBlockedReason(previousWaitState, nextWaitState, chunk)) {
+    sim.waitBlockedAt = at
+  }
+  sim.tailBuffer = nextTail.lines
+  sim.tailPartialLine = nextTail.partialLine
+  sim.tailRedrawCursor = nextTail.redrawCursor
+  sim.preview = buildPreview(nextTail.lines, nextTail.partialLine)
+}
+
+function runBoth(chunks: string[]): { memoized: (number | null)[]; reference: (number | null)[] } {
+  const memoSim = newSim()
+  const refSim = newSim()
+  const memoized: (number | null)[] = []
+  const reference: (number | null)[] = []
+  chunks.forEach((chunk, index) => {
+    const at = index + 1
+    stepMemoized(memoSim, chunk, at, computeTerminalTailWaitState)
+    stepReference(refSim, chunk, at, computeTerminalTailWaitState)
+    memoized.push(memoSim.waitBlockedAt)
+    reference.push(refSim.waitBlockedAt)
+  })
+  return { memoized, reference }
+}
+
+const SCENARIOS: Record<string, string[]> = {
+  'plain output never blocks': ['building...\n', 'compiled ok\n', 'watching for changes\n'],
+  'blocked prompt in one chunk': ['Update available! Press Enter to continue.\n'],
+  'blocked prompt split across chunks': ['Update available!\n', 'Press Enter to continue.\n'],
+  'blocked then plain output stays blocked': [
+    'Update available! Press Enter to continue.\n',
+    'still here\n',
+    'more logs\n'
+  ],
+  'partial lines without newline then completion': [
+    'Update ava',
+    'ilable! Press Enter ',
+    'to continue.\n'
+  ],
+  'empty and whitespace chunks': ['', '   ', '\n', 'ok\n', ''],
+  'ready header after stale blocked prompt': [
+    'Update available! Press Enter to continue.\n',
+    'OpenAI Codex\n',
+    'model: gpt\n',
+    'directory: /repo\n'
+  ]
+}
+
+describe('onPtyData tail wait memoization', () => {
+  it('computeTerminalTailWaitState reports fromTail and blocked signals', () => {
+    const empty = computeTerminalTailWaitState([], '', '')
+    expect(empty.fromTail).toBe(false)
+    expect(empty.signal).toBeNull()
+
+    const previewOnly = computeTerminalTailWaitState([], '', 'short preview')
+    expect(previewOnly.fromTail).toBe(false)
+    expect(previewOnly.waitText).toBe('short preview')
+
+    const blocked = computeTerminalTailWaitState(
+      ['Update available! Press Enter to continue.'],
+      '',
+      ''
+    )
+    expect(blocked.fromTail).toBe(true)
+    expect(blocked.signal?.reason).toBe('codex-update-prompt')
+  })
+
+  for (const [name, chunks] of Object.entries(SCENARIOS)) {
+    it(`memoized stamping matches recompute reference: ${name}`, () => {
+      const { memoized, reference } = runBoth(chunks)
+      expect(memoized).toEqual(reference)
+    })
+  }
+
+  it('stays equivalent across tail eviction beyond the retained cap', () => {
+    const chunks: string[] = []
+    for (let i = 0; i < 2600; i += 1) {
+      chunks.push(`line ${i} of streaming build output that keeps the tail busy\n`)
+    }
+    // Introduce a real blocked prompt well past the eviction boundary.
+    chunks.push('Update available! Press Enter to continue.\n')
+    chunks.push('trailing log after prompt\n')
+    const { memoized, reference } = runBoth(chunks)
+    expect(memoized).toEqual(reference)
+    // The prompt must actually be detected (guards against a vacuous match).
+    expect(memoized.at(-1)).not.toBeNull()
+  })
+
+  it('does roughly half the full-tail wait scans of the recompute reference', () => {
+    const chunks: string[] = []
+    for (let i = 0; i < 500; i += 1) {
+      chunks.push(`streaming line ${i}\n`)
+    }
+
+    let memoCalls = 0
+    const countingMemo: Compute = (lines, partial, preview) => {
+      memoCalls += 1
+      return computeTerminalTailWaitState(lines, partial, preview)
+    }
+    let refCalls = 0
+    const countingRef: Compute = (lines, partial, preview) => {
+      refCalls += 1
+      return computeTerminalTailWaitState(lines, partial, preview)
+    }
+
+    const memoSim = newSim()
+    const refSim = newSim()
+    chunks.forEach((chunk, index) => {
+      stepMemoized(memoSim, chunk, index + 1, countingMemo)
+      stepReference(refSim, chunk, index + 1, countingRef)
+    })
+
+    // Reference recomputes both sides every chunk: 2 per chunk.
+    expect(refCalls).toBe(chunks.length * 2)
+    // Memoized reuses the cached previous state on every non-empty-tail chunk:
+    // 1 per chunk plus a single first-chunk cold miss.
+    expect(memoCalls).toBe(chunks.length + 1)
+  })
+})

--- a/src/main/runtime/orca-runtime-tail-wait-memo.test.ts
+++ b/src/main/runtime/orca-runtime-tail-wait-memo.test.ts
@@ -158,6 +158,42 @@ describe('onPtyData tail wait memoization', () => {
     expect(memoized.at(-1)).not.toBeNull()
   })
 
+  it('recomputes correctly after a transcript prune empties the tail (prune-then-resume)', () => {
+    // pruneDisconnectedPtyTranscript empties the tail AND clears tailWaitState;
+    // model that here and assert the memoized stamping still tracks a fresh
+    // recompute across the reset (a stale cache would desync the first resumed
+    // chunk, since the pre-prune tail held a blocked prompt).
+    const prune = (sim: TailSim): void => {
+      sim.tailBuffer = []
+      sim.tailPartialLine = ''
+      sim.tailRedrawCursor = null
+      sim.preview = ''
+      sim.waitBlockedAt = null
+      sim.tailWaitState = undefined
+    }
+    const memoSim = newSim()
+    const refSim = newSim()
+    const memoOut: (number | null)[] = []
+    const refOut: (number | null)[] = []
+    let at = 0
+    const feed = (chunk: string): void => {
+      at += 1
+      stepMemoized(memoSim, chunk, at, computeTerminalTailWaitState)
+      stepReference(refSim, chunk, at, computeTerminalTailWaitState)
+      memoOut.push(memoSim.waitBlockedAt)
+      refOut.push(refSim.waitBlockedAt)
+    }
+    // Pre-prune: leave a stale blocked prompt in the tail.
+    ;['building\n', 'Update available! Press Enter to continue.\n', 'more log\n'].forEach(feed)
+    prune(memoSim)
+    prune(refSim)
+    // Resume: a fresh blocked prompt must be stamped, not masked by stale cache.
+    ;['fresh start\n', 'Update available! Press Enter to continue.\n', 'after\n'].forEach(feed)
+
+    expect(memoOut).toEqual(refOut)
+    expect(memoSim.waitBlockedAt).not.toBeNull()
+  })
+
   it('does roughly half the full-tail wait scans of the recompute reference', () => {
     const chunks: string[] = []
     for (let i = 0; i < 500; i += 1) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18194,6 +18194,10 @@ export class OrcaRuntimeService {
     pty.tailTruncated = false
     pty.tailLinesTotal = 0
     pty.waitBlockedAt = null
+    // Why: the tail is now empty, so the memoized wait scan must not be reused as
+    // the next chunk's "previous" state — clear it so onPtyData recomputes from
+    // the reset tail if this record resumes output (adoption/reattach).
+    pty.tailWaitState = undefined
   }
 
   private pruneDisconnectedPtyRecords(): void {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -884,6 +884,10 @@ type RuntimeLeafRecord = RuntimeSyncedLeaf & {
   tailLinesTotal: number
   preview: string
   waitBlockedAt: number | null
+  // Why: memoized wait scan of the current retained tail so the next PTY chunk
+  // reuses it as its "previous" state instead of rebuilding + rescanning the
+  // full tail. See computeTerminalTailWaitState.
+  tailWaitState?: TerminalTailWaitState
   lastAgentStatus: AgentStatus | null
   // Why: the most recent OSC title observed on this leaf's PTY data. Used by
   // worktree.ps so daemon-hosted terminals (no renderer pushing pane titles)
@@ -951,6 +955,8 @@ type RuntimePtyWorktreeRecord = {
   tailLinesTotal: number
   preview: string
   waitBlockedAt: number | null
+  // Why: memoized wait scan of the current retained tail (see RuntimeLeafRecord).
+  tailWaitState?: TerminalTailWaitState
 }
 
 type TerminalCreateOptions = {
@@ -5265,26 +5271,28 @@ export class OrcaRuntimeService {
       pty.lastOutputAt = at
       const normalized = normalizeTerminalChunk(data, pty.tailPendingAnsi)
       pty.tailPendingAnsi = normalized.pendingAnsi
-      const previousWaitText = buildTerminalWaitText(
-        pty.tailBuffer,
-        pty.tailPartialLine,
-        pty.preview
-      )
+      // Why: the prior chunk's post-append tail is this chunk's pre-append tail,
+      // so its cached wait scan is exact — reuse it instead of rebuilding and
+      // rescanning the full tail. Only a tail-derived state is safe to reuse.
+      const previousWaitState =
+        pty.tailWaitState?.fromTail === true
+          ? pty.tailWaitState
+          : computeTerminalTailWaitState(pty.tailBuffer, pty.tailPartialLine, pty.preview)
       const nextTail = appendNormalizedToTailBuffer(
         pty.tailBuffer,
         pty.tailPartialLine,
         normalized.text,
         pty.tailRedrawCursor
       )
-      if (
-        nextTailHasNewerBlockedReason(
-          previousWaitText,
-          buildTerminalWaitText(nextTail.lines, nextTail.partialLine, pty.preview),
-          normalized.text
-        )
-      ) {
+      const nextWaitState = computeTerminalTailWaitState(
+        nextTail.lines,
+        nextTail.partialLine,
+        pty.preview
+      )
+      if (tailGainedNewerBlockedReason(previousWaitState, nextWaitState, normalized.text)) {
         pty.waitBlockedAt = at
       }
+      pty.tailWaitState = nextWaitState
       ptyTailAfter = nextTail
       pty.tailBuffer = nextTail.lines
       pty.tailPartialLine = nextTail.partialLine
@@ -5363,29 +5371,30 @@ export class OrcaRuntimeService {
         leaf.tailLinesTotal = pty.tailLinesTotal
         leaf.preview = pty.preview
         leaf.waitBlockedAt = pty.waitBlockedAt
+        // Why: the leaf mirrors the PTY tail here, so share the cached wait scan.
+        leaf.tailWaitState = pty.tailWaitState
       } else {
         const normalized = normalizeTerminalChunk(data, leaf.tailPendingAnsi)
         leaf.tailPendingAnsi = normalized.pendingAnsi
-        const previousWaitText = buildTerminalWaitText(
-          leaf.tailBuffer,
-          leaf.tailPartialLine,
-          leaf.preview
-        )
+        const previousWaitState =
+          leaf.tailWaitState?.fromTail === true
+            ? leaf.tailWaitState
+            : computeTerminalTailWaitState(leaf.tailBuffer, leaf.tailPartialLine, leaf.preview)
         const nextTail = appendNormalizedToTailBuffer(
           leaf.tailBuffer,
           leaf.tailPartialLine,
           normalized.text,
           leaf.tailRedrawCursor
         )
-        if (
-          nextTailHasNewerBlockedReason(
-            previousWaitText,
-            buildTerminalWaitText(nextTail.lines, nextTail.partialLine, leaf.preview),
-            normalized.text
-          )
-        ) {
+        const nextWaitState = computeTerminalTailWaitState(
+          nextTail.lines,
+          nextTail.partialLine,
+          leaf.preview
+        )
+        if (tailGainedNewerBlockedReason(previousWaitState, nextWaitState, normalized.text)) {
           leaf.waitBlockedAt = at
         }
+        leaf.tailWaitState = nextWaitState
         leaf.tailBuffer = nextTail.lines
         leaf.tailPartialLine = nextTail.partialLine
         leaf.tailRedrawCursor = nextTail.redrawCursor
@@ -22974,6 +22983,62 @@ function buildTerminalWaitText(lines: string[], partialLine: string, preview: st
   return waitText.length > 0 ? waitText : preview
 }
 
+export type TerminalTailWaitState = {
+  waitText: string
+  signal: { reason: RuntimeTerminalWaitBlockedReason; index: number } | null
+  // Why: the retained tail is authoritative; `preview` is only a fallback for an
+  // empty tail. A preview-derived state depends on a value that is recomputed
+  // after each append, so it must not be reused as the next chunk's previous
+  // state — reuse is gated on fromTail.
+  fromTail: boolean
+}
+
+// Why: onPtyData runs per raw PTY chunk (hundreds/sec under load). Building the
+// wait text (a full map/trim/filter/join over the up-to-256KB retained tail)
+// and lower-casing + scanning it once per chunk is unavoidable, but the old
+// code did it twice — once for the pre-append tail and once for the post-append
+// tail — every chunk. Caching the post-append state lets the next chunk reuse it
+// as its pre-append state, halving the per-chunk full-tail work.
+export function computeTerminalTailWaitState(
+  lines: string[],
+  partialLine: string,
+  preview: string
+): TerminalTailWaitState {
+  const tailText = buildTailLines(lines, partialLine)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n')
+  const fromTail = tailText.length > 0
+  const waitText = fromTail ? tailText : preview
+  return {
+    waitText,
+    signal: findActionableTerminalWaitBlockedSignal(waitText.toLowerCase()),
+    fromTail
+  }
+}
+
+// Why: equivalent to nextTailHasNewerBlockedReason but consumes precomputed wait
+// states so the full-tail scans are not repeated per chunk.
+export function tailGainedNewerBlockedReason(
+  previous: TerminalTailWaitState,
+  next: TerminalTailWaitState,
+  appendedText: string
+): boolean {
+  if (next.signal === null) {
+    return false
+  }
+  // Why: permission prompts can arrive split across PTY chunks. Stamp when the
+  // accumulated tail first becomes blocked, or when a later prompt appears after
+  // stale blocked text already in the tail.
+  if (previous.signal === null) {
+    return true
+  }
+  const appendCandidateSignal = findActionableTerminalWaitBlockedSignal(
+    `${previous.waitText}${appendedText}`.toLowerCase()
+  )
+  return appendCandidateSignal !== null && appendCandidateSignal.index > previous.signal.index
+}
+
 export function appendNormalizedToTailBuffer(
   previousLines: string[],
   previousPartialLine: string,
@@ -23815,30 +23880,6 @@ function isKnownReadyPromptPreview(preview: string): boolean {
 function detectTerminalWaitBlockedReason(preview: string): RuntimeTerminalWaitBlockedReason | null {
   const normalized = preview.toLowerCase()
   return findActionableTerminalWaitBlockedSignal(normalized)?.reason ?? null
-}
-
-function nextTailHasNewerBlockedReason(
-  previousWaitText: string,
-  nextWaitText: string,
-  appendedText: string
-): boolean {
-  const nextBlockedSignal = findActionableTerminalWaitBlockedSignal(nextWaitText.toLowerCase())
-  if (!nextBlockedSignal) {
-    return false
-  }
-  // Why: permission prompts can arrive split across PTY chunks. Stamp the
-  // blocked signal when the accumulated tail first becomes blocked, or when
-  // a later prompt appears after stale blocked text already in the tail.
-  const previousBlockedSignal = findActionableTerminalWaitBlockedSignal(
-    previousWaitText.toLowerCase()
-  )
-  if (previousBlockedSignal === null) {
-    return true
-  }
-  const appendCandidateSignal = findActionableTerminalWaitBlockedSignal(
-    `${previousWaitText}${appendedText}`.toLowerCase()
-  )
-  return appendCandidateSignal !== null && appendCandidateSignal.index > previousBlockedSignal.index
 }
 
 function findActionableTerminalWaitBlockedSignal(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23021,8 +23021,9 @@ export function computeTerminalTailWaitState(
   }
 }
 
-// Why: equivalent to nextTailHasNewerBlockedReason but consumes precomputed wait
-// states so the full-tail scans are not repeated per chunk.
+// Why: decides whether the appended chunk introduced a newer actionable blocked
+// prompt, consuming precomputed wait states so the full-tail scans are not
+// repeated per chunk (replaces the former inline double full-tail scan).
 export function tailGainedNewerBlockedReason(
   previous: TerminalTailWaitState,
   next: TerminalTailWaitState,

--- a/src/main/runtime/pty-transcript-prune-wait-cache.test.ts
+++ b/src/main/runtime/pty-transcript-prune-wait-cache.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression: pruneDisconnectedPtyTranscript empties a disconnected PTY's
+ * retained tail. The onPtyData wait-scan memoization caches the tail's wait
+ * state on the record (tailWaitState) and reuses it as the next chunk's
+ * "previous" state — so the prune MUST also clear that cache, or a record that
+ * resumes output after adoption/reattach would reuse a stale (pre-prune,
+ * possibly blocked) wait state and mis-stamp waitBlockedAt on its first chunk.
+ */
+import { describe, expect, it } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import type { TerminalTailWaitState } from './orca-runtime'
+
+type PtyRecord = {
+  connected: boolean
+  tailBuffer: string[]
+  tailWaitState?: TerminalTailWaitState
+}
+type RuntimeInternals = {
+  recordPtyWorktree: (p: string, w: string, s?: { connected?: boolean }) => PtyRecord
+  pruneDisconnectedPtyTranscript: (pty: PtyRecord) => void
+}
+
+describe('pruneDisconnectedPtyTranscript clears the wait-scan cache', () => {
+  it('empties the tail and drops tailWaitState so resume recomputes', () => {
+    const runtime = new OrcaRuntimeService()
+    const internals = runtime as unknown as RuntimeInternals
+    const pty = internals.recordPtyWorktree('pty-1', 'wt-1', { connected: true })
+
+    // Simulate an established, blocked tail with a memoized wait state.
+    pty.tailBuffer = ['Update available! Press Enter to continue.']
+    pty.tailWaitState = {
+      waitText: 'update available! press enter to continue.',
+      signal: { reason: 'codex-update-prompt', index: 0 },
+      fromTail: true
+    }
+
+    pty.connected = false
+    internals.pruneDisconnectedPtyTranscript(pty)
+
+    expect(pty.tailBuffer).toEqual([])
+    expect(pty.tailWaitState).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

\`onPtyData\` runs on **every raw PTY chunk** — hundreds per second during verbose builds and agent token streaming (the 8ms IPC batch is strictly downstream; the raw \`node-pty\` \`onData\` → \`onPtyData\` wiring has no coalescing).

For any terminal that has scrolled past the retained-tail cap (\`MAX_TAIL_LINES = 2000\` / \`MAX_TAIL_CHARS = 256KB\`), the wait-blocked-prompt detection did **O(full tail)** work *twice* per chunk:

- `buildTerminalWaitText(...)` for the **pre-append** tail — a `map(trim).filter().join('\n')` over the whole (up to 256KB) retained tail.
- `buildTerminalWaitText(...)` again for the **post-append** tail.
- then `.toLowerCase()` (another full-tail allocation) + ~12 `lastIndexOf` scans over it.

That's ~2 full-tail string builds + a full-tail lowercase + scan **per chunk**, i.e. hundreds of KB of transient allocation per chunk and steady main-process CPU/GC pressure precisely when a terminal is busiest.

This was flagged HIGH severity by a perf audit and independently confirmed against the code.

## Fix

Cache the computed **post-append wait state** (`{ waitText, blocked-signal, fromTail }`) on the pty/leaf record and reuse it as the **next** chunk's pre-append state. The prior chunk's post-append tail *is* this chunk's pre-append tail, so the cached scan is exact.

- Reuse is gated on `fromTail`: the empty-tail `preview` fallback depends on a value that is recomputed *after* append, so a preview-derived state is never reused stale (it's recomputed, which is cheap for an empty tail).
- Per-chunk full-tail wait scans drop from **2N → N+1**.
- `nextTailHasNewerBlockedReason` is replaced by `tailGainedNewerBlockedReason`, a faithful transcription that consumes precomputed states.
- Only the two `onPtyData` hot-path sites change; the many query-time `buildTerminalWaitText` callers (agent-status, wait polling) are untouched.

## Evidence

New `orca-runtime-tail-wait-memo.test.ts`:

- **Equivalence**: memoized `waitBlockedAt` stamping is byte-for-byte identical to a recompute-both-sides reference (the pre-memoization behavior) across plain output, one-chunk prompts, prompts **split across chunks**, partial lines without newline, whitespace/empty chunks, **ready-header-after-stale-blocked demotion**, and **tail eviction past the 2000-line cap**.
- **Count**: over 500 chunks the memoized loop performs `N+1` full-tail scans vs the reference's `2N`.

All 864 related runtime/pty/agent-status tests pass (`orca-runtime`, `runtime-rpc`, `mobile-subscribe-integration`, `pty`, `codex-fetcher*`). Typecheck + lint clean.

## Risk

Low. No behavior change (proven by equivalence test); the security/status-sensitive blocked-prompt semantics are preserved exactly. Does not shorten the retained tail window. A further optimization (a boundary-window pre-gate that skips the remaining post-append scan when the appended text can't introduce a prompt) is deliberately **deferred** — it requires a chunk-boundary token window and couples to the trigger-phrase list, so it's out of scope for this low-risk change.

Made with [Orca](https://github.com/stablyai/orca) 🐋



---

## Description

`onPtyData` runs once per raw PTY chunk (hundreds/sec during builds and agent streaming). For every terminal past the 2000-line / 256KB retained-tail cap it rebuilt the full wait text (a `map`/`trim`/`filter`/`join` over the whole retained tail — an up-to-256KB string plus intermediate arrays) **twice per chunk**: once for the pre-append tail and once for the post-append tail. It then lowercased + scanned the post-append text for a blocked-prompt signal (and scanned the pre-append text too, but only when the post-append text already looked blocked — the pre-append scan was short-circuited otherwise).

This PR adds `computeTerminalTailWaitState` (returns the wait text, the actionable blocked signal, and a `fromTail` flag) and `tailGainedNewerBlockedReason`, and caches the post-append wait state on the pty/leaf record (`tailWaitState`). The next chunk reuses that cached state as its pre-append state instead of rebuilding the tail, so the redundant pre-append full-tail **rebuild** is eliminated every chunk (and its scan too, when the tail is blocked). Reuse is gated on `fromTail === true` so an empty-tail preview-fallback state (which depends on `preview`, recomputed each append) is never reused stale, and `pruneDisconnectedPtyTranscript` clears the cache so a resumed record recomputes cleanly. Only the two `onPtyData` hot-path sites change; all query-time `buildTerminalWaitText` callers are untouched.

## Undeniable evidence + measured improvement

Two things are eliminated per chunk, one deterministically and one measured:

**Deterministic (count test):** full-tail wait-state computations drop from `2N` to `N+1` (one per chunk + a single first-chunk cold miss). `orca-runtime-tail-wait-memo.test.ts` asserts this exactly: `refCalls === chunks.length * 2` vs `memoCalls === chunks.length + 1`. Each eliminated computation is one up-to-256KB string rebuild (plus a 2000-element `map` array and a `filter` array), so on a busy terminal this removes on the order of tens of MB/s of transient allocation — the GC pressure that motivated the fix.

**Measured wall time (isolated tail+wait pipeline, 2000-chunk burst on a 2600-line / ~256KB tail):**

| Scenario | Before | After | Delta |
|---|---|---|---|
| Common case — unblocked output (production-faithful: 2 builds + 1 scan → 1 build + 1 scan) | 834ms | 718ms | **−14%** (0.417 → 0.359 ms/chunk) |
| Blocked-tail / recompute-both reference (2 build+scan → 1 build+scan) | 1454ms | 718ms | **−51%** |

Honest framing: production already short-circuited the *second* scan on unblocked output, so the guaranteed common-case win is the one removed full-tail **build** (**−14%** of this isolated pipeline; a smaller fraction of full `onPtyData`, which also does OSC parsing, agent detection, and the leaf loop). The larger ~50% figure applies specifically when the tail is in a blocked/prompt state, where the redundant scan is also removed. The primary, always-true benefit is the eliminated per-chunk rebuild/allocation.

**Correctness is proven, not asserted.** The suite runs the memoized loop against a `stepReference` loop that reproduces the pre-memoization stamping (recompute both sides fresh) and asserts `waitBlockedAt` is byte-for-byte equal (`expect(memoized).toEqual(reference)`) across: plain output, a one-chunk blocked prompt, a prompt split across chunks, blocked-then-plain, partial lines without newlines, empty/whitespace chunks, a ready-header-after-stale-blocked demotion, tail eviction past the 2000-line cap, and a prune-then-resume sequence. A runtime guard asserts `pruneDisconnectedPtyTranscript` clears the cache. All tests pass.

## ELI5

Imagine a proofreader who checks a long, constantly-growing document for the word "STOP" every time a new sentence is typed. The old way, they re-copied the entire document from the top *twice* for every sentence — once before adding it, once after. That's a mountain of re-copying when sentences arrive hundreds of times a second. This change lets them keep the copy they already made and reuse it for the next sentence's "before" pass, so they copy the document once per sentence instead of twice. They still catch every "STOP" at the exact same moment — the savings is all the wasted re-copying (and the memory it churned through), not any change to what gets caught.

## Trade-offs that could regress the end experience

The equivalence tests rule out behavior change on the normal append path (including tail eviction and prune-then-resume). The honest residual items:

1. **A stale-cache bug was found in review and fixed in this PR.** `pruneDisconnectedPtyTranscript` empties the tail; the first version left `tailWaitState` set, so a pruned-then-resumed PTY could reuse the stale (pre-prune, possibly blocked) state and mis-time the `waitBlockedAt` stamp on its first chunk. The fix clears `tailWaitState` in the prune reset, and both a runtime guard and a sim prune-then-resume equivalence test now lock it. No longer an open risk — called out because it's the kind of edge a memoization introduces.

2. **No speedup for empty-tail terminals (not a regression).** Preview-fallback states are never reused (`fromTail` gating), so an empty retained tail recomputes each chunk as before — but those tails are tiny, so the cost is negligible.

3. **New coupling to maintain.** Wait detection now depends on `tailWaitState` staying in lockstep with `tailBuffer`. A future code path that mutates the tail without updating or clearing the cache would silently desync blocked-prompt detection — a maintenance hazard, not a user-facing regression today. (This is exactly the class of bug #1 was; the prune site was the only existing offender and is fixed.)

No added latency: per-chunk work strictly decreases, and query-time wait readers are unchanged.
