### PR TITLE
perf(linear): fetch issue comments in one request, not N+1

### DIFF
--- a/src/main/linear/issues.test.ts
+++ b/src/main/linear/issues.test.ts
@@ -120,6 +120,68 @@ describe('Linear issue queries', () => {
     expect(rawRequest.mock.calls[0][0]).toContain('estimate')
   })
 
+  it('fetches issue comments with one request (no per-comment user N+1)', async () => {
+    rawRequest.mockResolvedValueOnce({
+      data: {
+        issue: {
+          comments: {
+            nodes: [
+              {
+                id: 'comment-1',
+                body: 'First',
+                createdAt: '2026-01-02T03:04:05.000Z',
+                user: { displayName: 'Ada', avatarUrl: 'https://example.com/a.png' }
+              },
+              {
+                id: 'comment-2',
+                body: 'Second',
+                createdAt: '2026-01-02T03:05:05.000Z',
+                user: { displayName: 'Grace', avatarUrl: null }
+              },
+              {
+                id: 'comment-3',
+                body: 'Third',
+                createdAt: '2026-01-02T03:06:05.000Z',
+                user: null
+              }
+            ]
+          }
+        }
+      }
+    })
+    const { getIssueComments } = await import('./issues')
+
+    await expect(getIssueComments('issue-uuid', 'workspace-1')).resolves.toEqual([
+      {
+        id: 'comment-1',
+        body: 'First',
+        createdAt: '2026-01-02T03:04:05.000Z',
+        user: { displayName: 'Ada', avatarUrl: 'https://example.com/a.png' }
+      },
+      {
+        id: 'comment-2',
+        body: 'Second',
+        createdAt: '2026-01-02T03:05:05.000Z',
+        user: { displayName: 'Grace', avatarUrl: undefined }
+      },
+      { id: 'comment-3', body: 'Third', createdAt: '2026-01-02T03:06:05.000Z', user: undefined }
+    ])
+
+    // The point of the fix: one request regardless of comment count.
+    expect(rawRequest).toHaveBeenCalledTimes(1)
+    expect(rawRequest.mock.calls[0][0]).toContain('query OrcaLinearIssueComments')
+    expect(rawRequest.mock.calls[0][0]).toContain('user {')
+    expect(rawRequest.mock.calls[0][1]).toEqual({ id: 'issue-uuid' })
+  })
+
+  it('returns an empty comment list when no Linear client is configured', async () => {
+    getClients.mockReturnValue([])
+    const { getIssueComments } = await import('./issues')
+
+    await expect(getIssueComments('issue-uuid', 'workspace-1')).resolves.toEqual([])
+    expect(rawRequest).not.toHaveBeenCalled()
+  })
+
   it('passes team filters into Linear before list pagination', async () => {
     rawRequest.mockResolvedValueOnce({
       data: { issues: { nodes: [rawIssue('LIN-1')], pageInfo: { hasNextPage: false } } }

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -283,6 +283,29 @@ const ATTACHMENT_BY_UUID_QUERY = `
   }
 `
 
+// Why: fetch comments with their author in a single request. Accessing
+// `.user` on the SDK's Comment model lazily issues one user(id) query per
+// comment, so the previous loop was an N+1 (issue + comments + N user
+// fetches, all sequential while holding a shared Linear concurrency slot).
+// first: 50 matches the SDK default page size the previous code relied on.
+const ISSUE_COMMENTS_QUERY = `
+  query OrcaLinearIssueComments($id: String!) {
+    issue(id: $id) {
+      comments(first: 50) {
+        nodes {
+          id
+          body
+          createdAt
+          user {
+            displayName
+            avatarUrl
+          }
+        }
+      }
+    }
+  }
+`
+
 type LinearIssueByUuidResponse = {
   issue?:
     | (Omit<LinearIssueWriteRecord, 'labels'> & {
@@ -307,6 +330,21 @@ type LinearAttachmentByUuidResponse = {
     title?: string | null
     url?: string | null
     issue?: { id?: string | null; identifier?: string | null; url?: string | null } | null
+  } | null
+}
+
+type LinearIssueCommentsResponse = {
+  issue?: {
+    comments?: {
+      nodes?:
+        | {
+            id: string
+            body?: string | null
+            createdAt?: string | null
+            user?: { displayName?: string | null; avatarUrl?: string | null } | null
+          }[]
+        | null
+    } | null
   } | null
 }
 
@@ -1446,21 +1484,24 @@ export async function getIssueComments(
 
   await acquire()
   try {
-    const issue = await entry.client.issue(issueId)
-    const comments = await issue.comments()
-    const results: LinearComment[] = []
-    for (const c of comments.nodes) {
-      const user = await c.user
-      results.push({
-        id: c.id,
-        body: c.body,
-        createdAt: c.createdAt.toISOString(),
-        user: user
-          ? { displayName: user.displayName, avatarUrl: user.avatarUrl ?? undefined }
-          : undefined
-      })
-    }
-    return results
+    const result = await entry.client.client.rawRequest<
+      LinearIssueCommentsResponse,
+      LinearRawVariables
+    >(ISSUE_COMMENTS_QUERY, { id: issueId })
+    const nodes = result.data?.issue?.comments?.nodes ?? []
+    return nodes.map((node) => ({
+      id: node.id,
+      body: node.body ?? '',
+      // Why: rawRequest returns createdAt as an ISO string already; do not
+      // re-serialize (the SDK model path used .toISOString() on a parsed Date).
+      createdAt: node.createdAt ?? '',
+      user: node.user
+        ? {
+            displayName: node.user.displayName ?? '',
+            avatarUrl: node.user.avatarUrl ?? undefined
+          }
+        : undefined
+    }))
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.workspace.id)


### PR DESCRIPTION
## Problem

`getIssueComments` did:

```ts
const issue = await entry.client.issue(issueId)     // query 1
const comments = await issue.comments()             // query 2
for (const c of comments.nodes) {
  const user = await c.user                          // query per comment
  ...
}
```

Accessing `.user` on the Linear SDK's `Comment` model **lazily issues a fresh `user(id)` GraphQL query** (verified in `@linear/sdk`: `Comment.get user()` → `new UserQuery(...).fetch(this._user?.id)`). Because it's `await`ed inside the loop, a comment-heavy issue does **issue + comments + N sequential user round-trips**.

Impact: a visible multi-second stall when opening an issue's comments; it burns Linear's complexity-based rate limit; and it holds one of only **4 shared** Linear concurrency slots (`acquire`/`release`) for the whole `N × latency` window, serializing other Linear operations.

## Fix

Replace the SDK loop with a single `rawRequest` that fetches each comment's author inline — the same `client.client.rawRequest(...)` pattern the rest of this file already uses (`readAttachmentWriteRecord`, `readCommentWriteRecord`, `listIssues`):

```graphql
query OrcaLinearIssueComments($id: String!) {
  issue(id: $id) { comments(first: 50) { nodes { id body createdAt user { displayName avatarUrl } } } }
}
```

Output shape is unchanged:
- `first: 50` matches the SDK's default page size the previous code relied on (it only read the first page).
- `createdAt` is passed through as the ISO string `rawRequest` already returns — **not** re-serialized (the old SDK path called `.toISOString()` on a parsed `Date`; the raw value is already canonical ISO).
- null `avatarUrl` is normalized to `undefined`, and absent `user` stays `undefined`.

## Evidence

New tests in `issues.test.ts`:
- **One request regardless of comment count** (the N+1 is gone) — asserts `rawRequest` called exactly once and the query/vars are correct.
- Correct author mapping across present-user, null-avatar, and absent-user comments.
- Empty list when no Linear client is configured (no request made).

26 `linear/issues` tests + 3 `ipc/linear` tests pass. Typecheck + lint clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋



---

## Description

`getIssueComments` in `src/main/linear/issues.ts` previously loaded the issue, then its comments, then awaited `c.user` inside a `for` loop. Accessing `.user` on the Linear SDK's `Comment` model lazily fires a fresh `user(id)` GraphQL query per comment, so opening a comment-heavy issue fanned out into `issue` + `comments` + N sequential author round-trips. This PR replaces that with a single `rawRequest` GraphQL query (`OrcaLinearIssueComments`) that selects each comment's author (`displayName`, `avatarUrl`) inline, using `first: 50` to preserve the page size the old `issue.comments()` call relied on (50 is the Linear API's default connection size when `first` is omitted). `createdAt` is passed through as the ISO string `rawRequest` already returns (no re-serialization through a `Date`), null `avatarUrl` maps to `undefined`, and the returned `LinearComment[]` shape is unchanged.

## Undeniable evidence + measured improvement

**Measured improvement (network round-trips, not a CPU benchmark):**

- A 30-comment issue: **32 -> 1** request (`issue` + `comments` + 30 lazy per-comment `user` fetches collapse into one query).
- Scales from **N+2 -> 1**: **-86%** at 5 comments, **-97%** at 30, **-98%** at 50.
- Beyond raw count: those N `user` fetches ran sequentially while holding one of only 4 shared Linear concurrency slots (`MAX_CONCURRENT = 4` in `client.ts`; `getIssueComments` calls `acquire()` once and `release()` in `finally`, so the single slot is held for the entire N+2-request window). The old path therefore also burned the complexity-based rate limit and blocked other Linear calls for the whole `N * latency` window. One request removes that hold.

**Correctness proof (tests in the diff, `src/main/linear/issues.test.ts`):**

- `"fetches issue comments with one request (no per-comment user N+1)"` mocks `rawRequest` with three comments and asserts the exact mapped output, covering the tricky cases: a normal author, `avatarUrl: null -> undefined`, and `user: null -> undefined`. It then asserts the core invariant: `expect(rawRequest).toHaveBeenCalledTimes(1)`, that the query is `OrcaLinearIssueComments` and selects `user {`, and that variables are `{ id: 'issue-uuid' }`. (The mock uses three comments; the single-request guarantee is structural — the query fetches all comments in one call regardless of count.)
- `"returns an empty comment list when no Linear client is configured"` asserts `[]` is returned and `rawRequest` is never called when no workspace client exists.

## ELI5

Imagine asking a librarian for the comments on a page. The old way: the librarian hands you the list of comments, but each comment only has a name-tag number instead of a name — so for every single comment you have to walk back to the desk and ask "who is number 7?", one at a time, waiting in the same short line each trip. On a busy page with 30 comments that's 32 separate trips, and while you're doing it nobody else can use that line. The new way asks one question that already includes each commenter's name, so it's a single trip. Same information comes back; you just stop making the librarian answer the same kind of question thirty times in a row.

## Trade-offs that could regress the end experience

I looked hard; the honest items are minor and mostly pre-existing:

1. **`createdAt` is now the raw GraphQL string instead of `Date.toISOString()`.** Linear's GraphQL `DateTime` scalar already returns canonical ISO 8601 (the test uses `2026-01-02T03:04:05.000Z`), so in practice the value is identical. It is still a real behavior change: if Linear ever returned a differently-formatted timestamp, any consumer that assumed strict `toISOString()` normalization would see that raw form instead. Verified the actual consumers (`formatLinearIssueRelativeTime`, `Date.parse(comment.createdAt)` in `linear-issue-context-snapshot.ts`) parse the value tolerantly, so this stays low risk — but worth naming.

2. **The 50-comment cap is unchanged, not newly introduced.** The old `issue.comments()` returned only the first page (Linear's API defaults to 50 nodes when `first` is omitted), and `first: 50` preserves exactly that. Issues with >50 comments were already truncated and still are — this PR does not regress (or fix) that; no history is newly lost.

3. **Empty-string fallbacks (`body ?? ''`, `createdAt ?? ''`, `displayName ?? ''`).** If a field came back null/undefined, the value is now `''` rather than throwing or being null. This is actually more defensive than before (the old code would have thrown on a null `createdAt` via `.toISOString()`), but it is a subtle value change in a degenerate case.

4. **No latency or retention downside.** The change is strictly fewer round-trips on the open path, the output type is identical, and error/auth handling (clear token on auth error, `[]` on other failures) is preserved unchanged in the diff. Comments authored by non-user actors (bots/integrations) still surface `user: undefined`, exactly as before — the raw query does not select `botActor`/`externalUser`, but neither did the old path, so there is no new information loss.
