### PR TITLE
fix(daemon): preload the windowsHide shim via --require (rc.6 shim was inert)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -178,6 +178,13 @@ export default defineConfig({
         input: {
           index: resolve('src/main/index.ts'),
           'daemon-entry': resolve('src/main/daemon/daemon-entry.ts'),
+          // Why a separate entry: preloaded into the node.exe-hosted daemon via
+          // `--require` before its module graph loads. Inlining it into
+          // daemon-entry does not work — rollup hoists chunk requires above
+          // inlined code, so other modules capture promisify(execFile) first.
+          'windows-hidden-console-children': resolve(
+            'src/main/daemon/windows-hidden-console-children.ts'
+          ),
           'computer-sidecar': resolve('src/main/computer/sidecar-entry.ts'),
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),
           'warp-theme-parser-worker': resolve('src/main/warp-themes/warp-theme-parser-worker.ts'),

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -6,9 +6,12 @@
  * Signals readiness to parent via IPC: { type: 'ready' }
  * Shuts down cleanly on SIGTERM.
  */
-// Why first: patches child_process defaults (windowsHide) before any other
-// module captures bindings like promisify(execFile) at its own import time.
-import './windows-hidden-console-children'
+// Note: the windowsHide child_process shim is NOT imported here. Rollup's CJS
+// chunking hoists chunk requires above inlined module code, so an in-graph
+// "first import" runs AFTER sibling chunks capture promisify(execFile) — the
+// shim silently did nothing in packaged builds. It ships as its own bundle
+// entry and the daemon fork preloads it via `--require` (daemon-init.ts),
+// which Node guarantees runs before any of this graph loads.
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { createPtySubprocess } from './pty-subprocess'
 import { warmWindowsConptyOnce } from './windows-conpty-warmup'

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -6,7 +6,7 @@ it would scatter the "swap the running provider atomically" invariant across
 files with no cleaner ownership seam: restart, replaceDaemonProvider, and the
 module-level spawner/adapter singletons must stay co-located so a future
 change cannot leave them drifting out of sync. */
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { app } from 'electron'
 import { mkdirSync, existsSync, unlinkSync, writeFileSync } from 'node:fs'
 import { fork } from 'node:child_process'
@@ -284,6 +284,13 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
     // absent (dev, non-win32, pre-relocation builds) fall back to the install-dir
     // Electron host run as plain Node via ELECTRON_RUN_AS_NODE.
     const relocatedHostExecPath = getRelocatedDaemonHostExecPath()
+    // Why --require and not an import inside daemon-entry: Electron's Node
+    // defaults windowsHide=true but standalone node.exe does not, and rollup's
+    // CJS chunking hoists chunk requires above inlined code — an in-graph
+    // import runs AFTER sibling modules capture promisify(execFile), so the
+    // shim silently no-ops (shipped broken in rc.6). Preloading guarantees it
+    // runs before the daemon's module graph loads.
+    const consoleShimPath = join(dirname(entryPath), 'windows-hidden-console-children.js')
     // Why: without this span a silent fallback to the install-dir host (back
     // inside the updater kill zone) is indistinguishable from the fixed path
     // in field trace files.
@@ -304,8 +311,11 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
       detached: true,
       stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
       // Why: a standalone node.exe is already plain Node; reset execArgv so the
-      // Electron main process's node flags don't leak into it.
-      ...(relocatedHostExecPath ? { execPath: relocatedHostExecPath, execArgv: [] } : {}),
+      // Electron main process's node flags don't leak into it, then preload
+      // the windowsHide shim ahead of the daemon's module graph.
+      ...(relocatedHostExecPath
+        ? { execPath: relocatedHostExecPath, execArgv: ['--require', consoleShimPath] }
+        : {}),
       env: {
         ...process.env,
         // Why: ELECTRON_RUN_AS_NODE makes the forked Electron binary run as a

--- a/src/main/daemon/windows-hidden-console-children.test.ts
+++ b/src/main/daemon/windows-hidden-console-children.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { withHiddenConsoleDefault } from './windows-hidden-console-children'
+import { promisify } from 'node:util'
+import { wrapChildProcessApi, withHiddenConsoleDefault } from './windows-hidden-console-children'
 
 describe('withHiddenConsoleDefault', () => {
   it('injects windowsHide into an existing options object', () => {
@@ -38,5 +39,30 @@ describe('withHiddenConsoleDefault', () => {
     expect(args[0]).toBe('node')
     expect(args[1]).toEqual(['-v'])
     expect(args[2]).toEqual({ windowsHide: true })
+  })
+})
+
+describe('wrapChildProcessApi', () => {
+  it('injects windowsHide through the direct call', () => {
+    let seen: unknown[] = []
+    const original = (...args: unknown[]): void => {
+      seen = args
+    }
+    wrapChildProcessApi(original)('cmd.exe', ['/c'])
+    expect(seen[2]).toEqual({ windowsHide: true })
+  })
+
+  it('injects windowsHide through util.promisify (the rc.6 bypass)', async () => {
+    let seen: unknown[] = []
+    const original = (..._args: unknown[]): void => {}
+    Object.defineProperty(original, promisify.custom, {
+      value: (...args: unknown[]) => {
+        seen = args
+        return Promise.resolve('done')
+      }
+    })
+    const wrapped = wrapChildProcessApi(original)
+    await expect(promisify(wrapped)('powershell.exe', ['-NoProfile'])).resolves.toBe('done')
+    expect(seen[2]).toEqual({ windowsHide: true })
   })
 })

--- a/src/main/daemon/windows-hidden-console-children.ts
+++ b/src/main/daemon/windows-hidden-console-children.ts
@@ -57,20 +57,39 @@ export function installHiddenConsoleChildDefaults(): void {
   }
   installed = true
   for (const name of PATCHED_APIS) {
-    const original = childProcess[name] as (...args: unknown[]) => unknown
-    const wrapped = (...args: unknown[]): unknown => original(...withHiddenConsoleDefault(args))
-    // Why: exec/execFile carry promisify custom symbols; copy them so
-    // util.promisify keeps returning {stdout, stderr} promises.
-    Object.setPrototypeOf(wrapped, original)
-    for (const sym of Object.getOwnPropertySymbols(original)) {
-      Object.defineProperty(wrapped, sym, Object.getOwnPropertyDescriptor(original, sym)!)
-    }
-    ;(childProcess as Record<string, unknown>)[name] = wrapped
+    ;(childProcess as Record<string, unknown>)[name] = wrapChildProcessApi(
+      childProcess[name] as (...args: unknown[]) => unknown
+    )
   }
 }
 
-// Why install on import (not via an exported call): modules capture bindings
-// like `promisify(execFile)` at their own import time, so the patch must land
-// before ANY other daemon module evaluates. daemon-entry imports this module
-// first for that reason.
+export function wrapChildProcessApi(
+  original: (...args: unknown[]) => unknown
+): (...args: unknown[]) => unknown {
+  const wrapped = (...args: unknown[]): unknown => original(...withHiddenConsoleDefault(args))
+  Object.setPrototypeOf(wrapped, original)
+  // Why: exec/execFile carry a util.promisify.custom implementation that
+  // internally calls the ORIGINAL function — copying the symbol verbatim lets
+  // every `promisify(execFile)` call site bypass the wrapper (rc.6 shipped
+  // this bug: the daemon's CIM probes are promisified and kept flashing).
+  // Wrap each symbol-attached function so the injection applies there too.
+  for (const sym of Object.getOwnPropertySymbols(original)) {
+    const desc = Object.getOwnPropertyDescriptor(original, sym)!
+    if (typeof desc.value === 'function') {
+      const originalCustom = desc.value as (...args: unknown[]) => unknown
+      desc.value = (...args: unknown[]): unknown =>
+        originalCustom(...withHiddenConsoleDefault(args))
+    }
+    Object.defineProperty(wrapped, sym, desc)
+  }
+  return wrapped
+}
+
+// Why install on load: this file is built as its own self-contained bundle
+// entry (electron.vite.config.ts) and preloaded into the daemon via
+// `node --require` (daemon-init.ts). An in-graph import cannot work: rollup's
+// CJS output hoists chunk requires above inlined module code, so sibling
+// chunks capture `promisify(execFile)` before any "first import" executes.
+// --require runs before the whole graph loads, immune to bundler ordering.
+// It must therefore never import anything that could be split into a chunk.
 installHiddenConsoleChildDefaults()


### PR DESCRIPTION
## Problem

The rc.6 windowsHide shim (#7486) ships in the bundle but does nothing — rc.6 daemons still flash a Windows Terminal window every ~3 seconds. Two independent defeats, found by driving the real probe path on a live rc.6 machine:

1. **Bundler ordering defeats the "first import".** Rollup's CJS output hoists chunk `require()` calls above inlined module code. Confirmed in the shipped `daemon-entry.js`: the session chunk (containing `windows-foreground-process-rows.ts`, whose module scope captures `promisify(execFile)`) evaluates at byte 375; the inlined shim installs at byte 1063. The capture wins; the shim patches nothing anyone uses.
2. **`util.promisify.custom` bypasses the wrapper.** Node's `execFile` carries a custom promisify implementation that internally calls the *original* function. The shim copied that symbol verbatim, so `promisify(execFile)` — exactly what the daemon's CIM probes use — returned Node's original, skipping the injection even when the wrapper was reachable.

## Fix

- The shim is now its **own self-contained bundle entry** (`out/main/windows-hidden-console-children.js`, zero chunk requires — verified in the built output) and the daemon fork preloads it with **`node --require`**, which Node guarantees runs before the module graph loads. Immune to bundler ordering by construction. Applied only on the relocated-node.exe host path (Electron hosts already default windowsHide=true).
- `wrapChildProcessApi` now wraps each symbol-attached function (the promisify customs) with the same windowsHide-default injection instead of copying them verbatim.

## Verification (Windows, staged production Node 24 binary)

Ambient rc.6 flashing on the test machine contaminates window-count assertions, so probes set a unique console title (`XVER-FLASH-CANARY`) and trials assert on canary-titled Windows Terminal windows only:

- callback-style `execFile`, no preload: **3/3 trials flash** → with preload: **0/6**
- `promisify(execFile)` (the exact daemon probe shape), no preload: **3/3 flash** → with preload: **0/5**
- `promisify(execFile)` under the preload resolves to the injection wrapper (inspected directly); without it, Node's original
- built daemon + `--require` boots and serves `getForegroundProcess` RPCs end-to-end under a standalone node.exe
- 14 unit tests including a promisify-bypass regression test; daemon suites green; typecheck clean

## Rollout note

Daemons already running from rc.5/rc.6 keep flashing until replaced (they survive updates by design). One `Manage Sessions → Restart Daemon` after this ships — or updating with no terminals open (staleness check then auto-replaces) — clears it permanently.
