### PR TITLE
fix(wsl): honor WSL default runtime for preflight checks and folder picking

### DIFF
--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -7,6 +7,11 @@ import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { z } from 'zod'
 import type { Store } from '../persistence'
+import { getWslHomeAsync } from '../wsl'
+import {
+  buildWslPickerDefaultPath,
+  getWslPickerDefaultDistro
+} from '../../shared/wsl-picker-default-path'
 import type {
   BaseRefSearchResult,
   Project,
@@ -2145,8 +2150,24 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     notifySparsePresetsChanged(mainWindow, args.repoId)
   })
 
+  // Why: when WSL is the default project runtime, seed the folder dialog with
+  // the distro's $HOME so "add project" browses WSL folders instead of stranding
+  // the user on the Windows drive. Resolves to undefined (OS default) otherwise.
+  const resolvePickerDefaultPath = async (): Promise<string | undefined> => {
+    const distro = getWslPickerDefaultDistro(
+      store.getSettings().localWindowsRuntimeDefault,
+      process.platform
+    )
+    if (!distro) {
+      return undefined
+    }
+    return buildWslPickerDefaultPath(distro, await getWslHomeAsync(distro))
+  }
+
   ipcMain.handle('repos:pickFolder', async () => {
+    const defaultPath = await resolvePickerDefaultPath()
     const result = await dialog.showOpenDialog(mainWindow, {
+      ...(defaultPath ? { defaultPath } : {}),
       properties: ['openDirectory']
     })
     if (result.canceled || result.filePaths.length === 0) {
@@ -2156,7 +2177,9 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   })
 
   ipcMain.handle('repos:pickFolders', async () => {
+    const defaultPath = await resolvePickerDefaultPath()
     const result = await dialog.showOpenDialog(mainWindow, {
+      ...(defaultPath ? { defaultPath } : {}),
       properties: ['openDirectory', 'multiSelections']
     })
     if (result.canceled || result.filePaths.length === 0) {
@@ -2169,7 +2192,9 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   // pickFolder which is specifically the "add project" flow. Clone needs a
   // destination directory that may not be a git repo yet.
   ipcMain.handle('repos:pickDirectory', async () => {
+    const defaultPath = await resolvePickerDefaultPath()
     const result = await dialog.showOpenDialog(mainWindow, {
+      ...(defaultPath ? { defaultPath } : {}),
       // Why: macOS can materialize typed partial paths when directory creation
       // is enabled; clone/create actions already create the final path on submit.
       properties: ['openDirectory']

--- a/src/renderer/src/lib/local-preflight-context-cache.ts
+++ b/src/renderer/src/lib/local-preflight-context-cache.ts
@@ -1,0 +1,56 @@
+import type { ProjectExecutionRuntimeResolution } from '../../../shared/project-execution-runtime'
+
+export type LocalPreflightContext =
+  | {
+      wslDistro?: string | null
+      wslDefault?: boolean
+      runtimeContextKey?: string
+      projectRuntime?: ProjectExecutionRuntimeResolution
+    }
+  | undefined
+
+// Why: React/Zustand selectors compare by reference, so preflight contexts must
+// be memoized snapshots. Returning a fresh object per read triggers a
+// useSyncExternalStore update loop when Settings observes WSL repos.
+const wslPreflightContextsByDistro = new Map<string, NonNullable<LocalPreflightContext>>()
+const projectRuntimePreflightContextsByKey = new Map<string, NonNullable<LocalPreflightContext>>()
+
+export function getWslPreflightContext(wslDistro: string): NonNullable<LocalPreflightContext> {
+  const cached = wslPreflightContextsByDistro.get(wslDistro)
+  if (cached) {
+    return cached
+  }
+  const context = Object.freeze({ wslDistro })
+  wslPreflightContextsByDistro.set(wslDistro, context)
+  return context
+}
+
+function getProjectRuntimeContextObjectCacheKey(
+  resolution: ProjectExecutionRuntimeResolution
+): string {
+  if (resolution.status === 'resolved') {
+    return `${resolution.runtime.cacheKey}:${resolution.runtime.reason}`
+  }
+  return `${resolution.repair.cacheKey}:${resolution.repair.source}`
+}
+
+export function getProjectRuntimePreflightContext(
+  resolution: ProjectExecutionRuntimeResolution
+): NonNullable<LocalPreflightContext> {
+  const cacheKey = getProjectRuntimeContextObjectCacheKey(resolution)
+  const cached = projectRuntimePreflightContextsByKey.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const wslDistro =
+    resolution.status === 'resolved' && resolution.runtime.kind === 'wsl'
+      ? resolution.runtime.distro
+      : undefined
+  const context = Object.freeze({
+    ...(wslDistro ? { wslDistro } : {}),
+    projectRuntime: resolution
+  })
+  projectRuntimePreflightContextsByKey.set(cacheKey, context)
+  return context
+}

--- a/src/renderer/src/lib/local-preflight-context.test.ts
+++ b/src/renderer/src/lib/local-preflight-context.test.ts
@@ -190,6 +190,74 @@ describe('local preflight context', () => {
     expect(localPreflightContextKey(context)).toBe('repo-1:repair:wsl-distro-missing:Ubuntu')
   })
 
+  it('uses the global WSL runtime for the git/gh preflight without an active project', () => {
+    const state = {
+      ...makeState({ repoPath: undefined }),
+      activeRepoId: null,
+      activeWorktreeId: null,
+      settings: {
+        localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+      }
+    } as unknown as AppState
+
+    const context = getLocalPreflightContext(state, 'win32')
+
+    expect(context).toEqual({
+      wslDistro: 'Ubuntu',
+      projectRuntime: {
+        status: 'resolved',
+        runtime: {
+          kind: 'wsl',
+          hostPlatform: 'wsl',
+          projectId: 'local-project',
+          distro: 'Ubuntu',
+          reason: 'global-default',
+          cacheKey: 'local-project:wsl:Ubuntu'
+        }
+      }
+    })
+    expect(localPreflightContextKey(context)).toBe('local-project:wsl:Ubuntu')
+  })
+
+  it('keeps the git/gh preflight on the Windows host when that is the default runtime', () => {
+    const state = {
+      ...makeState({ repoPath: undefined }),
+      activeRepoId: null,
+      activeWorktreeId: null,
+      settings: {
+        localWindowsRuntimeDefault: { kind: 'windows-host' }
+      }
+    } as unknown as AppState
+
+    const context = getLocalPreflightContext(state, 'win32')
+
+    expect(context).toEqual({
+      projectRuntime: {
+        status: 'resolved',
+        runtime: {
+          kind: 'windows-host',
+          hostPlatform: 'win32',
+          projectId: 'local-project',
+          reason: 'global-default',
+          cacheKey: 'local-project:windows-host'
+        }
+      }
+    })
+    expect(localPreflightContextKey(context)).toBe('local-project:windows-host')
+  })
+
+  it('leaves the git/gh preflight on the host when no runtime default is set', () => {
+    const state = {
+      ...makeState({ repoPath: undefined }),
+      activeRepoId: null,
+      activeWorktreeId: null,
+      settings: {}
+    } as unknown as AppState
+
+    expect(getLocalPreflightContext(state, 'win32')).toBeUndefined()
+    expect(localPreflightContextKey(getLocalPreflightContext(state, 'win32'))).toBe('host')
+  })
+
   it('uses the migrated WSL runtime for local agent checks when WSL is the default shell', () => {
     const state = {
       ...makeState({ repoPath: 'C:\\Users\\alice\\repo' }),

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -10,11 +10,17 @@ import type { Repo, Worktree } from '../../../shared/types'
 import { getProviderRuntimeContextKey } from './provider-runtime-context'
 import { getRendererAppPlatform } from './renderer-app-platform'
 import {
+  getProjectRuntimePreflightContext,
+  getWslPreflightContext,
+  type LocalPreflightContext
+} from './local-preflight-context-cache'
+import {
   getCachedWindowsTerminalCapabilities,
   hasCachedWindowsTerminalCapabilities
 } from './windows-terminal-capabilities'
 
 export { localPreflightContextKey } from './local-preflight-context-key'
+export type { LocalPreflightContext } from './local-preflight-context-cache'
 
 type LocalProjectRuntimeState = Pick<
   AppState,
@@ -26,65 +32,8 @@ type LocalProjectRuntimeWslContext = {
   availableWslDistros?: readonly string[] | null
 }
 
-export type LocalPreflightContext =
-  | {
-      wslDistro?: string | null
-      wslDefault?: boolean
-      runtimeContextKey?: string
-      projectRuntime?: ProjectExecutionRuntimeResolution
-    }
-  | undefined
-
-const wslPreflightContextsByDistro = new Map<string, NonNullable<LocalPreflightContext>>()
-const projectRuntimePreflightContextsByKey = new Map<string, NonNullable<LocalPreflightContext>>()
-
 export function getWslDistroFromPath(path?: string | null): string | null {
   return path ? (parseWslUncPath(path)?.distro ?? null) : null
-}
-
-function getWslPreflightContext(wslDistro: string): NonNullable<LocalPreflightContext> {
-  const cached = wslPreflightContextsByDistro.get(wslDistro)
-  if (cached) {
-    return cached
-  }
-
-  // Why: React/Zustand selectors must return a cached snapshot. A fresh object
-  // here triggers a useSyncExternalStore loop when Settings observes WSL repos.
-  const context = Object.freeze({ wslDistro })
-  wslPreflightContextsByDistro.set(wslDistro, context)
-  return context
-}
-
-function getProjectRuntimeContextObjectCacheKey(
-  resolution: ProjectExecutionRuntimeResolution
-): string {
-  if (resolution.status === 'resolved') {
-    return `${resolution.runtime.cacheKey}:${resolution.runtime.reason}`
-  }
-  return `${resolution.repair.cacheKey}:${resolution.repair.source}`
-}
-
-function getProjectRuntimePreflightContext(
-  resolution: ProjectExecutionRuntimeResolution
-): NonNullable<LocalPreflightContext> {
-  const cacheKey = getProjectRuntimeContextObjectCacheKey(resolution)
-  const cached = projectRuntimePreflightContextsByKey.get(cacheKey)
-  if (cached) {
-    return cached
-  }
-
-  const wslDistro =
-    resolution.status === 'resolved' && resolution.runtime.kind === 'wsl'
-      ? resolution.runtime.distro
-      : undefined
-  // Why: selectors compare by reference; cache each resolved runtime context so
-  // adding projectRuntime does not reintroduce useSyncExternalStore churn.
-  const context = Object.freeze({
-    ...(wslDistro ? { wslDistro } : {}),
-    projectRuntime: resolution
-  })
-  projectRuntimePreflightContextsByKey.set(cacheKey, context)
-  return context
 }
 
 export function getLocalProjectExecutionRuntimeContext(
@@ -155,6 +104,33 @@ export function getLocalRepoProjectExecutionRuntimeContext(
   })
 }
 
+// Why: Settings, onboarding, and Landing run the git/gh preflight before any
+// project is active. Without this, a Windows user whose default runtime is WSL
+// would see gh/git checked on the Windows host, not inside their distro.
+function getGlobalDefaultRuntimePreflightContext(
+  state: AppState,
+  appPlatform: NodeJS.Platform,
+  wslContext: LocalProjectRuntimeWslContext
+): NonNullable<LocalPreflightContext> | undefined {
+  if (
+    appPlatform !== 'win32' ||
+    state.activeRepoId ||
+    state.activeWorktreeId ||
+    !state.settings?.localWindowsRuntimeDefault
+  ) {
+    return undefined
+  }
+  return getProjectRuntimePreflightContext(
+    resolveProjectExecutionRuntime({
+      appPlatform: 'win32',
+      projectId: getLocalPreflightProjectId(state),
+      projectRuntimePreference: { kind: 'inherit-global' },
+      globalWindowsRuntimeDefault: state.settings.localWindowsRuntimeDefault,
+      ...wslContext
+    })
+  )
+}
+
 export function getLocalPreflightContext(
   state: AppState,
   appPlatform: NodeJS.Platform = getRendererAppPlatform(),
@@ -171,6 +147,10 @@ export function getLocalPreflightContext(
   )
   if (projectRuntime) {
     return getProjectRuntimePreflightContext(projectRuntime)
+  }
+  const globalDefault = getGlobalDefaultRuntimePreflightContext(state, appPlatform, wslContext)
+  if (globalDefault) {
+    return globalDefault
   }
   const wslDistro = getLocalPreflightWslDistro(state)
   return wslDistro ? getWslPreflightContext(wslDistro) : undefined
@@ -191,23 +171,11 @@ export function getLocalAgentPreflightContext(
     return getProjectRuntimePreflightContext(projectRuntime)
   }
 
-  if (
-    appPlatform === 'win32' &&
-    !state.activeRepoId &&
-    !state.activeWorktreeId &&
-    state.settings?.localWindowsRuntimeDefault
-  ) {
-    // Why: Settings -> Agents is global and can mount before any project is
-    // active; still respect the Windows/WSL runtime default for PATH detection.
-    return getProjectRuntimePreflightContext(
-      resolveProjectExecutionRuntime({
-        appPlatform: 'win32',
-        projectId: getLocalPreflightProjectId(state),
-        projectRuntimePreference: { kind: 'inherit-global' },
-        globalWindowsRuntimeDefault: state.settings.localWindowsRuntimeDefault,
-        ...wslContext
-      })
-    )
+  // Why: Settings -> Agents is global and can mount before any project is
+  // active; still respect the Windows/WSL runtime default for PATH detection.
+  const globalDefault = getGlobalDefaultRuntimePreflightContext(state, appPlatform, wslContext)
+  if (globalDefault) {
+    return globalDefault
   }
 
   const explicitAgentRuntime = appPlatform === 'win32' ? state.settings?.localAgentRuntime : null

--- a/src/shared/wsl-picker-default-path.test.ts
+++ b/src/shared/wsl-picker-default-path.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { buildWslPickerDefaultPath, getWslPickerDefaultDistro } from './wsl-picker-default-path'
+
+describe('getWslPickerDefaultDistro', () => {
+  it('returns the distro when WSL is the default runtime on Windows', () => {
+    expect(getWslPickerDefaultDistro({ kind: 'wsl', distro: 'Ubuntu' }, 'win32')).toBe('Ubuntu')
+  })
+
+  it('returns null when the default runtime is the Windows host', () => {
+    expect(getWslPickerDefaultDistro({ kind: 'windows-host' }, 'win32')).toBeNull()
+  })
+
+  it('returns null when the WSL default has no concrete distro selected', () => {
+    expect(getWslPickerDefaultDistro({ kind: 'wsl', distro: null }, 'win32')).toBeNull()
+  })
+
+  it('never targets WSL off Windows even when a WSL default is persisted', () => {
+    expect(getWslPickerDefaultDistro({ kind: 'wsl', distro: 'Ubuntu' }, 'darwin')).toBeNull()
+    expect(getWslPickerDefaultDistro({ kind: 'wsl', distro: 'Ubuntu' }, 'linux')).toBeNull()
+  })
+
+  it('treats malformed persisted settings as the Windows host default', () => {
+    expect(getWslPickerDefaultDistro(undefined, 'win32')).toBeNull()
+    expect(getWslPickerDefaultDistro({}, 'win32')).toBeNull()
+    expect(getWslPickerDefaultDistro('wsl', 'win32')).toBeNull()
+  })
+})
+
+describe('buildWslPickerDefaultPath', () => {
+  it('prefers the resolved WSL home UNC path', () => {
+    expect(buildWslPickerDefaultPath('Ubuntu', String.raw`\\wsl.localhost\Ubuntu\home\alice`)).toBe(
+      String.raw`\\wsl.localhost\Ubuntu\home\alice`
+    )
+  })
+
+  it('falls back to the distro root when home cannot be resolved', () => {
+    expect(buildWslPickerDefaultPath('Ubuntu', null)).toBe(String.raw`\\wsl.localhost\Ubuntu`)
+  })
+})

--- a/src/shared/wsl-picker-default-path.ts
+++ b/src/shared/wsl-picker-default-path.ts
@@ -1,0 +1,30 @@
+import { normalizeGlobalWindowsRuntimeDefault } from './project-execution-runtime'
+
+/**
+ * Distro whose filesystem the folder picker should open in, or null when the
+ * OS default location is correct (non-Windows, Windows-host default, or a WSL
+ * default that has not selected a concrete distro yet).
+ *
+ * Why: when WSL is the default project runtime, "add project" should browse the
+ * distro's Linux filesystem instead of stranding the user on C:\ with no hint
+ * that they can reach WSL folders at all.
+ */
+export function getWslPickerDefaultDistro(
+  runtimeDefault: unknown,
+  platform: string
+): string | null {
+  if (platform !== 'win32') {
+    return null
+  }
+  const normalized = normalizeGlobalWindowsRuntimeDefault(runtimeDefault)
+  return normalized.kind === 'wsl' && normalized.distro ? normalized.distro : null
+}
+
+/**
+ * UNC path to seed the native folder dialog's `defaultPath` with. Prefers the
+ * distro's resolved $HOME; falls back to the distro root when $HOME can't be
+ * resolved so the picker still lands inside WSL rather than on the Windows host.
+ */
+export function buildWslPickerDefaultPath(distro: string, wslHomeUncPath: string | null): string {
+  return wslHomeUncPath ?? `\\\\wsl.localhost\\${distro}`
+}


### PR DESCRIPTION
## Problem

Windows users who choose WSL as their default project runtime still hit friction that pushes them back onto the Windows host:

1. **The gh/git preflight only checked the Windows host.** When no project was active (Settings, onboarding, Landing, the Agents pane), the preflight probed `gh`/`git` on the Windows side even though the user's default runtime is WSL. A WSL-only setup — `gh` and `git` installed inside the distro, not on Windows — was reported as "missing," blocking the flow.
2. **The "add project" folder picker was Windows-only.** The native directory dialog opened on the Windows drive with no obvious path to WSL folders, so a user running everything in WSL couldn't easily register a project living under their distro.

The intent is that a Windows user can opt into running **everything** through WSL and have the app behave accordingly.

## Changes

- **Preflight follows the resolved runtime.** When WSL is the default runtime and no project is active, the global-default preflight now resolves through `resolveProjectExecutionRuntime` and routes the `gh`/`git`/`glab` checks *inside* the distro. This mirrors the behavior that already existed for active projects and for agent detection — the global (no-project) path was the one gap. The shared branch is extracted into `getGlobalDefaultRuntimePreflightContext` and used by both `getLocalPreflightContext` and `getLocalAgentPreflightContext` so they stay symmetric.
- **Folder pickers seed the WSL home.** `repos:pickFolder`, `repos:pickFolders`, and `repos:pickDirectory` now open at the distro's `$HOME` (`\\wsl.localhost\<distro>\...`, falling back to the distro root) when WSL is the default runtime, so browsing/adding WSL projects works out of the box. Path selection itself already accepted UNC paths downstream; the picker default was the missing piece.
- **New pure helper** `getWslPickerDefaultDistro` / `buildWslPickerDefaultPath` (`src/shared/wsl-picker-default-path.ts`) computes the picker default and is fully unit-tested.
- **Refactor:** the preflight-context memoization cache moved into `local-preflight-context-cache.ts` to keep the selector module within the `max-lines` budget (no lint disable added).

## Safety / scope

Both behaviors are gated on `win32` **and** a persisted WSL default. Windows-host defaults, non-Windows platforms, and the SSH execution path are unchanged. The picker default resolves to `undefined` (OS default) whenever WSL isn't the default runtime.

## Tests

- New: `src/shared/wsl-picker-default-path.test.ts` — distro selection (WSL default, windows-host, null distro, non-win32, malformed settings) and path building (home preferred, distro-root fallback).
- Extended: `src/renderer/src/lib/local-preflight-context.test.ts` — global WSL runtime without an active project resolves the preflight into the distro; windows-host default stays on the host; no runtime default leaves the host untouched.
- Full suite green: 37 targeted tests pass; `typecheck:node` / `:cli` / `:web` (both tsgo and the tsc explicit-file-list config) exit 0; oxlint clean.
