### PR TITLE
refactor(net): use AbortSignal.timeout for fetch timeouts; fix fork-sync clobbered cancel

### DIFF
--- a/src/main/azure-devops/azure-devops-api-request.ts
+++ b/src/main/azure-devops/azure-devops-api-request.ts
@@ -75,15 +75,13 @@ export async function requestAzureDevOpsJsonAtBase<T>(
   options: AzureDevOpsRequestOptions = {}
 ): Promise<T | null> {
   const config = getAzureDevOpsAuthConfig()
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
   try {
     const response = await fetch(apiUrl(baseUrl, path, options.searchParams), {
       headers: {
         Accept: 'application/json',
         ...authHeaders(config)
       },
-      signal: controller.signal
+      signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
     })
     if (!response.ok) {
       return null
@@ -91,8 +89,6 @@ export async function requestAzureDevOpsJsonAtBase<T>(
     return (await response.json()) as T
   } catch {
     return null
-  } finally {
-    clearTimeout(timeout)
   }
 }
 

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -88,15 +88,13 @@ function apiUrl(path: string, searchParams?: RequestOptions['searchParams']): st
 
 async function requestJson<T>(path: string, options: RequestOptions = {}): Promise<T | null> {
   const config = getAuthConfig()
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
   try {
     const response = await fetch(apiUrl(path, options.searchParams), {
       headers: {
         Accept: 'application/json',
         ...authHeaders(config)
       },
-      signal: controller.signal
+      signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
     })
     if (!response.ok) {
       return null
@@ -104,8 +102,6 @@ async function requestJson<T>(path: string, options: RequestOptions = {}): Promi
     return (await response.json()) as T
   } catch {
     return null
-  } finally {
-    clearTimeout(timeout)
   }
 }
 

--- a/src/main/claude-accounts/oauth-refresh.ts
+++ b/src/main/claude-accounts/oauth-refresh.ts
@@ -135,8 +135,6 @@ export async function refreshClaudeOauthCredentials(
     probeUrl: OAUTH_TOKEN_URL
   }).catch(() => {})
 
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS)
   try {
     // Why: the `claude` CLI posts grant_type=refresh_token as
     // application/x-www-form-urlencoded with the public client id. net.fetch
@@ -149,7 +147,7 @@ export async function refreshClaudeOauthCredentials(
         refresh_token: refreshToken,
         client_id: OAUTH_CLIENT_ID
       }).toString(),
-      signal: controller.signal
+      signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS)
     })
     if (!res.ok) {
       // Why: surface the status (never the token) so a throttle (429) or a
@@ -168,7 +166,5 @@ export async function refreshClaudeOauthCredentials(
       error instanceof Error ? error.message : error
     )
     return null
-  } finally {
-    clearTimeout(timer)
   }
 }

--- a/src/main/git/fork-sync.ts
+++ b/src/main/git/fork-sync.ts
@@ -13,21 +13,22 @@ export async function gitSyncForkDefaultBranch(
   expectedUpstream: GitForkSyncExpectedUpstream,
   options: GitRuntimeOptions = {}
 ): Promise<GitForkSyncResult> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 60_000)
+  // Compose the caller's cancel signal with the 60s timeout so neither is lost —
+  // the caller's signal was previously clobbered by the timeout controller.
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, AbortSignal.timeout(60_000)])
+    : AbortSignal.timeout(60_000)
   try {
     return await syncForkDefaultBranch(
       (args) =>
         gitExecFileAsync(args, {
           ...gitOptionsForWorktree(worktreePath, options),
           timeout: 60_000,
-          signal: controller.signal
+          signal
         }),
       { expectedUpstream }
     )
   } catch (error) {
     throw new Error(normalizeGitErrorMessage(error, 'push'))
-  } finally {
-    clearTimeout(timeout)
   }
 }

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -75,15 +75,13 @@ async function requestJsonAtBase<T>(
   options: RequestOptions = {}
 ): Promise<T | null> {
   const config = getAuthConfig()
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
   try {
     const response = await fetch(apiUrl(baseUrl, path, options.searchParams), {
       headers: {
         Accept: 'application/json',
         ...authHeaders(config)
       },
-      signal: controller.signal
+      signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
     })
     if (!response.ok) {
       return null
@@ -91,8 +89,6 @@ async function requestJsonAtBase<T>(
     return (await response.json()) as T
   } catch {
     return null
-  } finally {
-    clearTimeout(timeout)
   }
 }
 

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -409,12 +409,11 @@ async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<Provi
     return abortedClaudeRateLimitResult()
   }
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
-  const abortFromExternalSignal = (): void => {
-    controller.abort()
-  }
-  signal?.addEventListener('abort', abortFromExternalSignal, { once: true })
+  // Compose the caller's cancel signal with the request timeout so a timeout
+  // and an external cancel both abort the fetch.
+  const requestSignal = signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(API_TIMEOUT_MS)])
+    : AbortSignal.timeout(API_TIMEOUT_MS)
 
   try {
     // Why: net.fetch uses Chromium's networking stack which respects OS proxy
@@ -427,7 +426,7 @@ async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<Provi
         // matching the CLI user-agent keeps Orca aligned with that contract.
         'User-Agent': CLAUDE_CODE_USER_AGENT
       },
-      signal: controller.signal
+      signal: requestSignal
     })
 
     if (!res.ok) {
@@ -453,9 +452,6 @@ async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<Provi
       return abortedClaudeRateLimitResult()
     }
     throw err
-  } finally {
-    clearTimeout(timeout)
-    signal?.removeEventListener('abort', abortFromExternalSignal)
   }
 }
 

--- a/src/main/rate-limits/gemini-oauth-sources.ts
+++ b/src/main/rate-limits/gemini-oauth-sources.ts
@@ -94,68 +94,54 @@ export async function refreshAccessToken(
   clientId: string,
   clientSecret: string
 ): Promise<RefreshTokenResult> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+  const res = await net.fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token'
+    }).toString(),
+    signal: AbortSignal.timeout(API_TIMEOUT_MS)
+  })
 
-  try {
-    const res = await net.fetch(GOOGLE_TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        client_id: clientId,
-        client_secret: clientSecret,
-        refresh_token: refreshToken,
-        grant_type: 'refresh_token'
-      }).toString(),
-      signal: controller.signal
-    })
+  if (!res.ok) {
+    return { accessToken: null, newRefreshToken: null }
+  }
 
-    if (!res.ok) {
-      return { accessToken: null, newRefreshToken: null }
-    }
-
-    const data = (await res.json()) as {
-      access_token?: string
-      refresh_token?: string
-      expires_in?: number
-    }
-    return {
-      accessToken: typeof data.access_token === 'string' ? data.access_token : null,
-      newRefreshToken: typeof data.refresh_token === 'string' ? data.refresh_token : null,
-      expiresIn: typeof data.expires_in === 'number' ? data.expires_in : undefined
-    }
-  } finally {
-    clearTimeout(timeout)
+  const data = (await res.json()) as {
+    access_token?: string
+    refresh_token?: string
+    expires_in?: number
+  }
+  return {
+    accessToken: typeof data.access_token === 'string' ? data.access_token : null,
+    newRefreshToken: typeof data.refresh_token === 'string' ? data.refresh_token : null,
+    expiresIn: typeof data.expires_in === 'number' ? data.expires_in : undefined
   }
 }
 
 export async function loadProjectId(accessToken: string): Promise<string> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+  const res = await net.fetch(LOAD_CODE_ASSIST_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`
+    },
+    body: JSON.stringify({ metadata: { ideType: 'GEMINI_CLI', pluginType: 'GEMINI' } }),
+    signal: AbortSignal.timeout(API_TIMEOUT_MS)
+  })
 
-  try {
-    const res = await net.fetch(LOAD_CODE_ASSIST_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`
-      },
-      body: JSON.stringify({ metadata: { ideType: 'GEMINI_CLI', pluginType: 'GEMINI' } }),
-      signal: controller.signal
-    })
-
-    if (!res.ok) {
-      throw new Error(`Failed to load Gemini project ID (HTTP ${res.status})`)
-    }
-
-    const data = (await res.json()) as { cloudaicompanionProject?: string }
-    if (typeof data.cloudaicompanionProject !== 'string') {
-      throw new Error('Gemini project ID not found in API response')
-    }
-    return data.cloudaicompanionProject
-  } finally {
-    clearTimeout(timeout)
+  if (!res.ok) {
+    throw new Error(`Failed to load Gemini project ID (HTTP ${res.status})`)
   }
+
+  const data = (await res.json()) as { cloudaicompanionProject?: string }
+  if (typeof data.cloudaicompanionProject !== 'string') {
+    throw new Error('Gemini project ID not found in API response')
+  }
+  return data.cloudaicompanionProject
 }
 
 // Why: accepts a plain refresh token string so both the oauth_creds.json path

--- a/src/main/rate-limits/kimi-fetcher.ts
+++ b/src/main/rate-limits/kimi-fetcher.ts
@@ -242,14 +242,12 @@ export async function fetchKimiRateLimits(): Promise<ProviderRateLimits> {
     return result('error', 'Kimi token expired — open Kimi to refresh')
   }
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
   try {
     const res = await net.fetch(`${KIMI_BASE_URL.replace(/\/$/, '')}/usages`, {
       // Why: identical to the CLI's fetchManagedUsage — bearer token + Accept.
       // No extra User-Agent: the usages endpoint authenticates by token only.
       headers: { Authorization: `Bearer ${creds.access_token}`, Accept: 'application/json' },
-      signal: controller.signal
+      signal: AbortSignal.timeout(API_TIMEOUT_MS)
     })
     if (res.status === 401 || res.status === 403) {
       return result('error', `Kimi usage request unauthorized (HTTP ${res.status})`)
@@ -261,7 +259,5 @@ export async function fetchKimiRateLimits(): Promise<ProviderRateLimits> {
     return mapUsageResponse(typeof data === 'object' && data !== null ? data : {})
   } catch (err) {
     return result('error', err instanceof Error ? err.message : 'Kimi usage request failed')
-  } finally {
-    clearTimeout(timeout)
   }
 }

--- a/src/main/rate-limits/minimax-fetcher.test.ts
+++ b/src/main/rate-limits/minimax-fetcher.test.ts
@@ -135,14 +135,20 @@ describe('fetchMiniMaxRateLimits', () => {
   })
 
   it('aborts a hung fetch after the timeout and classifies it as network', async () => {
+    // AbortSignal.timeout() uses an internal timer that fake timers cannot
+    // advance, so simulate the timeout firing with an already-aborted signal.
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(
+      AbortSignal.abort(new DOMException('The operation timed out.', 'TimeoutError'))
+    )
     netFetchMock.mockImplementation((_url: string, init: { signal: AbortSignal }) => {
       return new Promise((_resolve, reject) => {
         const abort = (): void => {
-          const error = new Error('The operation was aborted')
-          error.name = 'AbortError'
+          const error = new Error('The operation timed out.')
+          error.name = 'TimeoutError'
           reject(error)
         }
-        // The manual-cookie-header fallback receives the already-aborted signal.
+        // Both the session-cookie-jar and manual-cookie-header fetches receive
+        // the already-aborted timeout signal.
         if (init.signal.aborted) {
           abort()
           return
@@ -150,9 +156,7 @@ describe('fetchMiniMaxRateLimits', () => {
         init.signal.addEventListener('abort', abort)
       })
     })
-    const promise = fetchMiniMaxRateLimits({ cookie: FULL_COOKIE })
-    await vi.advanceTimersByTimeAsync(15_000)
-    const result = await promise
+    const result = await fetchMiniMaxRateLimits({ cookie: FULL_COOKIE })
     expect(result.status).toBe('error')
     expect(result.usageMetadata?.failureKind).toBe('network')
   })

--- a/src/main/rate-limits/minimax-fetcher.ts
+++ b/src/main/rate-limits/minimax-fetcher.ts
@@ -231,14 +231,12 @@ export async function fetchMiniMaxRateLimits(
   }
   const groupId =
     options.groupId?.trim() || extractMiniMaxCookieValue(cookie, 'minimax_group_id_v2')
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
   try {
     const fetchResult = await fetchMiniMaxResponse({
       cookie,
       endpoint: options.endpoint ?? MINIMAX_USAGE_ENDPOINT,
       groupId,
-      signal: controller.signal
+      signal: AbortSignal.timeout(API_TIMEOUT_MS)
     })
     const httpError = handleMiniMaxHttpError(fetchResult)
     if (httpError) {
@@ -277,7 +275,5 @@ export async function fetchMiniMaxRateLimits(
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown MiniMax usage error'
     return makeError(redactMiniMaxSecret(message), 'network')
-  } finally {
-    clearTimeout(timeout)
   }
 }

--- a/src/main/rate-limits/opencode-go-usage-fetcher.ts
+++ b/src/main/rate-limits/opencode-go-usage-fetcher.ts
@@ -130,8 +130,6 @@ export async function fetchOpenCodeGoRateLimits(
     }
     ids = [override]
   } else {
-    const workspacesController = new AbortController()
-    const workspacesTimeout = setTimeout(() => workspacesController.abort(), API_TIMEOUT_MS)
     try {
       // The /_server endpoint uses SST server-function protocol: GET with ?id=<hash>
       // and X-Server-Id / X-Server-Instance headers for routing.
@@ -147,7 +145,7 @@ export async function fetchOpenCodeGoRateLimits(
           Origin: OPENCODE_BASE_URL,
           Referer: OPENCODE_BASE_URL
         },
-        signal: workspacesController.signal
+        signal: AbortSignal.timeout(API_TIMEOUT_MS)
       })
 
       if (!workspacesRes.ok) {
@@ -175,8 +173,6 @@ export async function fetchOpenCodeGoRateLimits(
         error: message,
         status: 'error'
       }
-    } finally {
-      clearTimeout(workspacesTimeout)
     }
   }
 
@@ -193,12 +189,10 @@ export async function fetchOpenCodeGoRateLimits(
   }
 
   // Step 2: Robust workspace resolution. Try each candidate ID until one returns 200 OK
-  // and valid usage data. Each candidate gets its own AbortController so a slow or
+  // and valid usage data. Each candidate gets its own timeout so a slow or
   // hung candidate cannot starve the rest.
   let lastError = ''
   for (const candidateId of ids) {
-    const candidateController = new AbortController()
-    const candidateTimeout = setTimeout(() => candidateController.abort(), API_TIMEOUT_MS)
     try {
       const usagePageUrl = `${OPENCODE_BASE_URL}/workspace/${candidateId}/go`
       const pageRes = await net.fetch(usagePageUrl, {
@@ -209,7 +203,7 @@ export async function fetchOpenCodeGoRateLimits(
           Origin: OPENCODE_BASE_URL,
           Referer: OPENCODE_BASE_URL
         },
-        signal: candidateController.signal
+        signal: AbortSignal.timeout(API_TIMEOUT_MS)
       })
 
       if (!pageRes.ok) {
@@ -239,8 +233,6 @@ export async function fetchOpenCodeGoRateLimits(
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
       lastError = message
-    } finally {
-      clearTimeout(candidateTimeout)
     }
   }
 

--- a/src/main/source-control/hosted-review-api-request.ts
+++ b/src/main/source-control/hosted-review-api-request.ts
@@ -23,10 +23,8 @@ export async function requestHostedReviewJson<T>(
   init: Omit<RequestInit, 'signal'>,
   timeoutMs: number
 ): Promise<T> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    const response = await fetch(url, { ...init, signal: controller.signal })
+    const response = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) })
     if (!response.ok) {
       const body = await readResponseText(response)
       throw new HostedReviewApiRequestError(body || response.statusText, {
@@ -38,11 +36,10 @@ export async function requestHostedReviewJson<T>(
     if (error instanceof HostedReviewApiRequestError) {
       throw error
     }
-    if (error instanceof Error && error.name === 'AbortError') {
+    // AbortSignal.timeout() rejects with a TimeoutError, not an AbortError.
+    if (error instanceof Error && error.name === 'TimeoutError') {
       throw new HostedReviewApiRequestError('Request timed out', { timedOut: true })
     }
     throw error
-  } finally {
-    clearTimeout(timeout)
   }
 }

--- a/src/main/updater-changelog.ts
+++ b/src/main/updater-changelog.ts
@@ -42,100 +42,93 @@ export async function fetchChangelog(
   incomingVersion: string,
   localVersion: string
 ): Promise<ChangelogData | null> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 5000)
+  const res = await net.fetch('https://onorca.dev/whats-new/changelog.json', {
+    signal: AbortSignal.timeout(5000)
+  })
+  if (!res.ok) {
+    return null
+  }
+  const json: unknown = await res.json()
 
-  try {
-    const res = await net.fetch('https://onorca.dev/whats-new/changelog.json', {
-      signal: controller.signal
-    })
-    if (!res.ok) {
-      return null
-    }
-    const json: unknown = await res.json()
+  // Why: the JSON endpoint is external and could serve malformed data.
+  // Validate the shape before indexing into it to avoid runtime errors
+  // that would propagate up and delay the 'available' status broadcast.
+  if (!Array.isArray(json)) {
+    return null
+  }
+  const entries = json as ChangelogEntry[]
 
-    // Why: the JSON endpoint is external and could serve malformed data.
-    // Validate the shape before indexing into it to avoid runtime errors
-    // that would propagate up and delay the 'available' status broadcast.
-    if (!Array.isArray(json)) {
-      return null
-    }
-    const entries = json as ChangelogEntry[]
+  const localIndex = entries.findIndex((e) => e.version === localVersion)
 
-    const localIndex = entries.findIndex((e) => e.version === localVersion)
-
-    // ── Try exact match first ────────────────────────────────────────
-    const incomingIndex = entries.findIndex((e) => e.version === incomingVersion)
-    if (incomingIndex !== -1) {
-      const entry = entries[incomingIndex]
-      if (isValidEntry(entry) && hasRichContent(entry)) {
-        const releasesBehind =
-          localIndex === -1
-            ? null
-            : localIndex - incomingIndex > 0
-              ? localIndex - incomingIndex
-              : null
-        const { version: _, ...release } = entry
-        return { release, releasesBehind }
-      }
-    }
-
-    // ── Fallback: find the most recent entry with rich content ────────
-    // Why: releases often ship without rich media/description. Rather than
-    // showing the plain card, we look for the latest entry that does have
-    // rich content. As long as the user's local version is behind that
-    // entry, the demo is still relevant — it highlights something they
-    // haven't seen yet. We swap the release notes URL to the generic
-    // changelog page since the shown content doesn't match the incoming
-    // version.
-    for (let i = 0; i < entries.length; i++) {
-      const candidate = entries[i]
-      if (!isValidEntry(candidate) || !hasRichContent(candidate)) {
-        continue
-      }
-
-      // Only show this entry if the user's local version is at or behind it.
-      // Why: the user hasn't necessarily seen the rich card for their own
-      // version (e.g., they updated silently or dismissed the card), so
-      // entries at the same version as localVersion are still worth showing.
-      // When localIndex === -1 the local version isn't in the JSON at all —
-      // this could mean it's very old OR very new (e.g., a patch release not
-      // yet in the changelog). Fall back to semver comparison to avoid
-      // showing stale content to users who are already ahead.
-      if (localIndex !== -1) {
-        if (localIndex < i) {
-          continue
-        }
-      } else if (compareVersions(localVersion, candidate.version) >= 0) {
-        // localVersion is newer than (or same as) this candidate — user already
-        // passed it. Why >=: compareVersions returns 0 both for genuinely equal
-        // versions and for unparseable strings. In the localIndex === -1 path,
-        // equal means localVersion literally matches the candidate but wasn't
-        // found by findIndex (shouldn't happen), and unparseable means we can't
-        // determine the relationship. Either way, skipping is the safe default
-        // to avoid showing stale content.
-        continue
-      }
-
-      // Why: releasesBehind counts how far behind the user is from the
-      // incoming update, not from the shown content entry. When incomingIndex
-      // is -1, the incoming version is newer than anything in the JSON —
-      // treat it as being at the front (index 0) for counting purposes.
-      const effectiveIncomingIndex = incomingIndex !== -1 ? incomingIndex : 0
+  // ── Try exact match first ────────────────────────────────────────
+  const incomingIndex = entries.findIndex((e) => e.version === incomingVersion)
+  if (incomingIndex !== -1) {
+    const entry = entries[incomingIndex]
+    if (isValidEntry(entry) && hasRichContent(entry)) {
       const releasesBehind =
         localIndex === -1
           ? null
-          : localIndex - effectiveIncomingIndex > 0
-            ? localIndex - effectiveIncomingIndex
+          : localIndex - incomingIndex > 0
+            ? localIndex - incomingIndex
             : null
-      const { version: _, ...release } = candidate
-      // Why: the shown content is from an older entry, not the incoming version.
-      // Point to the generic changelog page so the link doesn't mislead.
-      return { release: { ...release, releaseNotesUrl: CHANGELOG_URL }, releasesBehind }
+      const { version: _, ...release } = entry
+      return { release, releasesBehind }
+    }
+  }
+
+  // ── Fallback: find the most recent entry with rich content ────────
+  // Why: releases often ship without rich media/description. Rather than
+  // showing the plain card, we look for the latest entry that does have
+  // rich content. As long as the user's local version is behind that
+  // entry, the demo is still relevant — it highlights something they
+  // haven't seen yet. We swap the release notes URL to the generic
+  // changelog page since the shown content doesn't match the incoming
+  // version.
+  for (let i = 0; i < entries.length; i++) {
+    const candidate = entries[i]
+    if (!isValidEntry(candidate) || !hasRichContent(candidate)) {
+      continue
     }
 
-    return null
-  } finally {
-    clearTimeout(timeout)
+    // Only show this entry if the user's local version is at or behind it.
+    // Why: the user hasn't necessarily seen the rich card for their own
+    // version (e.g., they updated silently or dismissed the card), so
+    // entries at the same version as localVersion are still worth showing.
+    // When localIndex === -1 the local version isn't in the JSON at all —
+    // this could mean it's very old OR very new (e.g., a patch release not
+    // yet in the changelog). Fall back to semver comparison to avoid
+    // showing stale content to users who are already ahead.
+    if (localIndex !== -1) {
+      if (localIndex < i) {
+        continue
+      }
+    } else if (compareVersions(localVersion, candidate.version) >= 0) {
+      // localVersion is newer than (or same as) this candidate — user already
+      // passed it. Why >=: compareVersions returns 0 both for genuinely equal
+      // versions and for unparseable strings. In the localIndex === -1 path,
+      // equal means localVersion literally matches the candidate but wasn't
+      // found by findIndex (shouldn't happen), and unparseable means we can't
+      // determine the relationship. Either way, skipping is the safe default
+      // to avoid showing stale content.
+      continue
+    }
+
+    // Why: releasesBehind counts how far behind the user is from the
+    // incoming update, not from the shown content entry. When incomingIndex
+    // is -1, the incoming version is newer than anything in the JSON —
+    // treat it as being at the front (index 0) for counting purposes.
+    const effectiveIncomingIndex = incomingIndex !== -1 ? incomingIndex : 0
+    const releasesBehind =
+      localIndex === -1
+        ? null
+        : localIndex - effectiveIncomingIndex > 0
+          ? localIndex - effectiveIncomingIndex
+          : null
+    const { version: _, ...release } = candidate
+    // Why: the shown content is from an older entry, not the incoming version.
+    // Point to the generic changelog page so the link doesn't mislead.
+    return { release: { ...release, releaseNotesUrl: CHANGELOG_URL }, releasesBehind }
   }
+
+  return null
 }

--- a/src/main/updater-nudge.ts
+++ b/src/main/updater-nudge.ts
@@ -8,12 +8,9 @@ export type NudgeConfig = {
 }
 
 export async function fetchNudge(): Promise<NudgeConfig | null> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 5000)
-
   try {
     const res = await net.fetch('https://onorca.dev/whats-new/nudge.json', {
-      signal: controller.signal
+      signal: AbortSignal.timeout(5000)
     })
     if (!res.ok) {
       return null
@@ -60,8 +57,6 @@ export async function fetchNudge(): Promise<NudgeConfig | null> {
     }
   } catch {
     return null
-  } finally {
-    clearTimeout(timeout)
   }
 }
 

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -56,11 +56,8 @@ export function isPerfPrereleaseTag(tag: string): boolean {
 }
 
 async function fetchReleaseFeedTags(): Promise<ReleaseFeedTag[] | null> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-
   try {
-    const res = await net.fetch(ATOM_FEED_URL, { signal: controller.signal })
+    const res = await net.fetch(ATOM_FEED_URL, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
     if (!res.ok) {
       return null
     }
@@ -79,8 +76,6 @@ async function fetchReleaseFeedTags(): Promise<ReleaseFeedTag[] | null> {
     return tags
   } catch {
     return null
-  } finally {
-    clearTimeout(timeout)
   }
 }
 
@@ -109,32 +104,27 @@ function getManifestAssetNames(manifestText: string): string[] {
 }
 
 async function isReleaseAssetAvailable(tag: string, assetName: string): Promise<boolean> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-
   try {
     const assetUrl = assetName.startsWith('http')
       ? assetName
       : getReleaseAssetUrl(tag, assetName.split('/').filter(Boolean).at(-1) ?? assetName)
-    const res = await net.fetch(assetUrl, { method: 'HEAD', signal: controller.signal })
+    const res = await net.fetch(assetUrl, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+    })
     return res.ok
   } catch {
     return false
-  } finally {
-    clearTimeout(timeout)
   }
 }
 
 async function hasReadyPlatformManifest(tag: string): Promise<boolean> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-
   try {
     // Why: cancelled/draft releases can appear in GitHub's atom feed before
     // they have updater manifests or the ZIP/exe/AppImage assets referenced by
     // those manifests. Pinning to those tags makes download clicks 404.
     const manifestUrl = getReleaseManifestUrl(tag)
-    const res = await net.fetch(manifestUrl, { signal: controller.signal })
+    const res = await net.fetch(manifestUrl, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
     if (!res.ok) {
       return false
     }
@@ -148,8 +138,6 @@ async function hasReadyPlatformManifest(tag: string): Promise<boolean> {
     return assetResults.every(Boolean)
   } catch {
     return false
-  } finally {
-    clearTimeout(timeout)
   }
 }
 


### PR DESCRIPTION
## What

Replaces the hand-rolled fetch-timeout pattern

```ts
const controller = new AbortController()
const timeout = setTimeout(() => controller.abort(), MS)
try { await fetch(url, { signal: controller.signal }) } finally { clearTimeout(timeout) }
```

with the modern `AbortSignal.timeout(MS)` across **14 main-process modules** (rate-limit fetchers, updater feeds, and hosted-provider API clients). `AbortSignal.timeout` is Node 17.3+ (Electron main is Node 22+); its timer is self-clearing and, unlike a bare `setTimeout`, does not keep the event loop alive.

**Why:** removes a timer-leak footgun — any early-return/throw path that skips the `finally` leaks the timer — and ~3–4 lines of bookkeeping per site. Net **−72 lines**.

This came out of a broader "outdated patterns" scan; it was the one genuinely non-lintable modernization worth a PR (there were **0** existing uses of `AbortSignal.timeout` and ~16 hand-rolled races).

## Two composed sites (`AbortSignal.any`, Node 20.3+)

- **`git/fork-sync.ts`** — also fixes a **latent bug**: the caller's `options.signal` was spread into the git options and then immediately overridden by `signal: controller.signal` (spread precedes the key), so caller cancellation was silently dropped. `AbortSignal.any([options.signal, AbortSignal.timeout(60_000)])` restores it.
- **`rate-limits/claude-fetcher.ts`** (`fetchViaOAuth`) — composes the caller's external signal with the timeout; the `signal?.aborted` checks that distinguish external-cancel from timeout are preserved.

## Behavioral caveat handled

`AbortSignal.timeout()` rejects with a **`TimeoutError`** DOMException, not `AbortError`. `source-control/hosted-review-api-request.ts` inspected `error.name === 'AbortError'` to set `timedOut`; updated to `'TimeoutError'` (otherwise timeout detection would silently break). No other migrated site inspects the error name.

## Test change

`AbortSignal.timeout`'s internal timer **cannot be advanced by vitest fake timers**. `minimax-fetcher.test.ts`'s "aborts a hung fetch" test drove the abort via `advanceTimersByTimeAsync`; rewritten to fire the timeout with an already-aborted signal (`AbortSignal.abort(new DOMException(..., 'TimeoutError'))`) so it genuinely exercises the abort→classify-as-network path (and runs in ms instead of 15s).

## Deliberately NOT migrated

- **`src/relay/git-handler.ts`** — the relay targets **Node 18** (`build-relay.mjs: target: 'node18'`, `MIN_NODE_MAJOR = 18`). `AbortSignal.any` needs Node 20.3+, and a timeout-only swap would drop the request-context signal. Left on the manual pattern for SSH remote-host compatibility.
- **`ipc/feedback.ts`** — its timeout-driven fallback is verified with fake timers, which can't advance `AbortSignal.timeout`. Migrating would force less-faithful test rewrites for no production benefit. Left on the manual pattern.

## Notes for review

- `updater-changelog.ts` and `gemini-oauth-sources.ts` show large line counts — those functions were `try { … } finally { clearTimeout }` with no `catch`, so removing the timer removes the try wrapper and oxfmt re-indents the body. **View with whitespace hidden** — the logical change is only the timeout swap.

## Verification

- `pnpm typecheck:node` / `typecheck:web` clean (one pre-existing unrelated error in `windows-hidden-console-children.test.ts`, present on `main`).
- `oxlint` clean on all changed files.
- All 10 affected test suites pass (178 tests).

Made with [Orca](https://github.com/stablyai/orca) 🐋
