### PR TITLE
Plugin system: out-of-process host, panel bridge, permissioned actions, first-run consent

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -121,6 +121,7 @@ module.exports = {
     'out/main/hermes/**',
     'out/main/win32-utils.js',
     'out/main/daemon-entry.js',
+    'out/main/plugin-host-entry.js',
     'out/main/computer-sidecar.js',
     'out/main/parcel-watcher-process-entry.js',
     'out/main/chunks/**',

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -179,6 +179,7 @@ export default defineConfig({
         input: {
           index: resolve('src/main/index.ts'),
           'daemon-entry': resolve('src/main/daemon/daemon-entry.ts'),
+          'plugin-host-entry': resolve('src/main/plugins/plugin-host-entry.ts'),
           'computer-sidecar': resolve('src/main/computer/sidecar-entry.ts'),
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),
           'warp-theme-parser-worker': resolve('src/main/warp-themes/warp-theme-parser-worker.ts'),

--- a/examples/plugins/hello-orca/main.js
+++ b/examples/plugins/hello-orca/main.js
@@ -16,10 +16,14 @@ async function collectFiles(dir, root, results) {
     return
   }
   for (const entry of entries) {
-    if (results.length >= MAX_RESULTS) return
+    if (results.length >= MAX_RESULTS) {
+      return
+    }
     const full = join(dir, entry.name)
     if (entry.isDirectory()) {
-      if (!SKIP_DIRS.has(entry.name)) await collectFiles(full, root, results)
+      if (!SKIP_DIRS.has(entry.name)) {
+        await collectFiles(full, root, results)
+      }
     } else if (SCAN_EXTENSIONS.has(entry.name.slice(entry.name.lastIndexOf('.')))) {
       results.push(full)
     }
@@ -32,7 +36,9 @@ async function scanTodos(query, context) {
   const symbols = []
   const needle = query.toLowerCase()
   for (const file of files) {
-    if (symbols.length >= MAX_RESULTS) break
+    if (symbols.length >= MAX_RESULTS) {
+      break
+    }
     let text
     try {
       text = await readFile(file, 'utf8')
@@ -42,9 +48,13 @@ async function scanTodos(query, context) {
     const lines = text.split('\n')
     for (let i = 0; i < lines.length; i++) {
       const match = lines[i].match(/(?:TODO|FIXME)[:\s](.*)/)
-      if (!match) continue
+      if (!match) {
+        continue
+      }
       const detail = match[1].trim()
-      if (needle && !detail.toLowerCase().includes(needle)) continue
+      if (needle && !detail.toLowerCase().includes(needle)) {
+        continue
+      }
       symbols.push({
         name: detail.slice(0, 80) || 'TODO',
         kind: 'todo',

--- a/examples/plugins/hello-orca/main.js
+++ b/examples/plugins/hello-orca/main.js
@@ -1,0 +1,64 @@
+// Sample Orca plugin entry. Runs inside the out-of-process plugin host
+// (plain Node, no Electron). The default export receives the `orca` API and
+// registers implementations for the extension points declared in the manifest.
+import { readdir, readFile } from 'node:fs/promises'
+import { join, relative } from 'node:path'
+
+const SCAN_EXTENSIONS = new Set(['.js', '.ts', '.tsx', '.jsx', '.py', '.go', '.rs', '.java', '.md'])
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'out', 'build'])
+const MAX_RESULTS = 200
+
+async function collectFiles(dir, root, results) {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (results.length >= MAX_RESULTS) return
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) await collectFiles(full, root, results)
+    } else if (SCAN_EXTENSIONS.has(entry.name.slice(entry.name.lastIndexOf('.')))) {
+      results.push(full)
+    }
+  }
+}
+
+async function scanTodos(query, context) {
+  const files = []
+  await collectFiles(context.workspaceRoot, context.workspaceRoot, files)
+  const symbols = []
+  const needle = query.toLowerCase()
+  for (const file of files) {
+    if (symbols.length >= MAX_RESULTS) break
+    let text
+    try {
+      text = await readFile(file, 'utf8')
+    } catch {
+      continue
+    }
+    const lines = text.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const match = lines[i].match(/(?:TODO|FIXME)[:\s](.*)/)
+      if (!match) continue
+      const detail = match[1].trim()
+      if (needle && !detail.toLowerCase().includes(needle)) continue
+      symbols.push({
+        name: detail.slice(0, 80) || 'TODO',
+        kind: 'todo',
+        file: relative(context.workspaceRoot, file),
+        line: i + 1
+      })
+    }
+  }
+  return symbols
+}
+
+export default function activate(orca) {
+  orca.registerCodeProvider({
+    id: 'todo-scanner',
+    searchSymbols: scanTodos
+  })
+}

--- a/examples/plugins/hello-orca/orca-plugin.json
+++ b/examples/plugins/hello-orca/orca-plugin.json
@@ -1,0 +1,16 @@
+{
+  "id": "hello-orca",
+  "name": "Hello Orca",
+  "version": "1.0.0",
+  "description": "Sample plugin: a TODO-scanning CodeProvider and a right-sidebar panel.",
+  "engines": { "orca": ">=1.4.0" },
+  "main": "main.js",
+  "contributes": {
+    "codeProviders": [
+      { "id": "todo-scanner", "displayName": "TODO Scanner", "languages": ["*"] }
+    ],
+    "panels": [
+      { "id": "hello", "title": "Hello Orca", "icon": "plug", "entry": "panel.html" }
+    ]
+  }
+}

--- a/examples/plugins/hello-orca/panel.html
+++ b/examples/plugins/hello-orca/panel.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      /* Panel UI runs in an opaque-origin sandboxed iframe: self-contained
+         styles only, no access to the host app's DOM or tokens. */
+      body {
+        margin: 0;
+        padding: 12px;
+        font-family: system-ui, sans-serif;
+        font-size: 13px;
+        color: #ddd;
+        background: transparent;
+      }
+      h1 {
+        font-size: 14px;
+        margin: 0 0 8px;
+      }
+      p {
+        color: #999;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Hello Orca 👋</h1>
+    <p>
+      This panel is contributed by the <code>hello-orca</code> sample plugin and rendered in a
+      sandboxed frame. Build your own by dropping a directory with an
+      <code>orca-plugin.json</code> into the Orca plugins folder.
+    </p>
+  </body>
+</html>

--- a/examples/plugins/model-shift/orca-plugin.json
+++ b/examples/plugins/model-shift/orca-plugin.json
@@ -8,6 +8,6 @@
     "panels": [
       { "id": "gear-shifter", "title": "ModelShift", "icon": "gauge", "entry": "panel.html" }
     ],
-    "permissions": ["terminal.sendText"]
+    "permissions": ["terminal.sendText", "workspace.readContext"]
   }
 }

--- a/examples/plugins/model-shift/orca-plugin.json
+++ b/examples/plugins/model-shift/orca-plugin.json
@@ -1,0 +1,13 @@
+{
+  "id": "model-shift",
+  "name": "ModelShift",
+  "version": "1.0.0",
+  "description": "Gear-shifter panel that switches the Claude Code model in the active terminal.",
+  "engines": { "orca": ">=1.4.0" },
+  "contributes": {
+    "panels": [
+      { "id": "gear-shifter", "title": "ModelShift", "icon": "gauge", "entry": "panel.html" }
+    ],
+    "permissions": ["terminal.sendText"]
+  }
+}

--- a/examples/plugins/model-shift/panel.html
+++ b/examples/plugins/model-shift/panel.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      /* Panel UI runs in an opaque-origin sandboxed iframe: self-contained
+         styles only, no access to the host app's DOM or tokens. */
+      body {
+        margin: 0;
+        padding: 14px;
+        font-family: system-ui, sans-serif;
+        font-size: 13px;
+        color: #ddd;
+        background: transparent;
+        user-select: none;
+      }
+      h1 {
+        font-size: 14px;
+        margin: 0 0 2px;
+      }
+      .hint {
+        color: #999;
+        margin: 0 0 12px;
+      }
+      .gate {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 8px;
+        max-width: 240px;
+      }
+      .gear {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+        padding: 10px 4px;
+        border: 1px solid #555;
+        border-radius: 8px;
+        background: #2a2a2a;
+        color: #ddd;
+        cursor: pointer;
+        font: inherit;
+      }
+      .gear:hover {
+        border-color: #888;
+      }
+      .gear.engaged {
+        border-color: #7bd88f;
+        background: #23372a;
+      }
+      .gear .num {
+        font-size: 16px;
+        font-weight: 700;
+      }
+      .gear .label {
+        font-size: 10px;
+        color: #aaa;
+      }
+      .status {
+        margin-top: 12px;
+        min-height: 1.4em;
+        color: #999;
+      }
+      .status.err {
+        color: #e07a7a;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>ModelShift</h1>
+    <p class="hint">Shift the Claude Code model in the active terminal.</p>
+    <div class="gate" id="gate"></div>
+    <p class="status" id="status"></p>
+    <script>
+      'use strict'
+      // Gear order mimics an H-pattern shifter: R(everse to default), then 1-5.
+      var GEARS = [
+        { gear: 'R', label: 'Default', model: 'default' },
+        { gear: '1', label: 'Haiku', model: 'haiku' },
+        { gear: '2', label: 'Sonnet', model: 'sonnet' },
+        { gear: '3', label: 'Sonnet 1M', model: 'sonnet[1m]' },
+        { gear: '4', label: 'Opus', model: 'opus' },
+        { gear: '5', label: 'Fable', model: 'fable' }
+      ]
+      var statusEl = document.getElementById('status')
+      var gateEl = document.getElementById('gate')
+      var seq = 0
+      var pending = {}
+
+      GEARS.forEach(function (entry) {
+        var button = document.createElement('button')
+        button.className = 'gear'
+        button.innerHTML =
+          '<span class="num">' +
+          entry.gear +
+          '</span><span class="label">' +
+          entry.label +
+          '</span>'
+        button.addEventListener('click', function () {
+          shift(entry, button)
+        })
+        gateEl.appendChild(button)
+      })
+
+      function shift(entry, button) {
+        var requestId = 'shift-' + ++seq
+        pending[requestId] = { entry: entry, button: button }
+        statusEl.className = 'status'
+        statusEl.textContent = 'Shifting to ' + entry.label + '…'
+        // The panel frame is an opaque origin, so '*' is the only usable
+        // targetOrigin; the host verifies the sending window instead.
+        window.parent.postMessage(
+          {
+            type: 'orca-panel-action',
+            requestId: requestId,
+            action: 'terminal.sendText',
+            params: { text: '/model ' + entry.model, enter: true }
+          },
+          '*'
+        )
+      }
+
+      window.addEventListener('message', function (event) {
+        var data = event.data
+        if (!data || data.type !== 'orca-panel-action-result') return
+        var request = pending[data.requestId]
+        if (!request) return
+        delete pending[data.requestId]
+        if (data.ok && data.value && data.value.accepted) {
+          statusEl.className = 'status'
+          statusEl.textContent = 'Engaged ' + request.entry.label
+          Array.prototype.forEach.call(document.querySelectorAll('.gear'), function (el) {
+            el.classList.remove('engaged')
+          })
+          request.button.classList.add('engaged')
+        } else {
+          statusEl.className = 'status err'
+          statusEl.textContent =
+            'Shift failed: ' +
+            (data.error || (data.ok ? 'terminal rejected input' : 'unknown error'))
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/examples/plugins/model-shift/panel.html
+++ b/examples/plugins/model-shift/panel.html
@@ -68,7 +68,7 @@
   </head>
   <body>
     <h1>ModelShift</h1>
-    <p class="hint">Shift the Claude Code model in the active terminal.</p>
+    <p class="hint" id="hint">Shift the Claude Code model in the active terminal.</p>
     <div class="gate" id="gate"></div>
     <p class="status" id="status"></p>
     <script>
@@ -120,9 +120,22 @@
         )
       }
 
+      // workspace.readContext demo: show which worktree the shifter targets.
+      window.parent.postMessage(
+        { type: 'orca-panel-action', requestId: 'ctx-1', action: 'workspace.readContext' },
+        '*'
+      )
+
       window.addEventListener('message', function (event) {
         var data = event.data
         if (!data || data.type !== 'orca-panel-action-result') return
+        if (data.requestId === 'ctx-1') {
+          if (data.ok && data.value && data.value.branch) {
+            document.getElementById('hint').textContent =
+              'Shift the Claude Code model on ' + data.value.branch + '.'
+          }
+          return
+        }
         var request = pending[data.requestId]
         if (!request) return
         delete pending[data.requestId]

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -117,6 +117,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     defaultTuiAgent: null,
     disabledTuiAgents: [],
     disabledPlugins: [],
+    approvedPlugins: [],
     skipDeleteWorktreeConfirm: false,
     skipCloseTerminalWithRunningProcessConfirm: false,
     skipDeleteAutomationConfirm: false,

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -116,6 +116,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalScopeHistoryByWorktree: true,
     defaultTuiAgent: null,
     disabledTuiAgents: [],
+    disabledPlugins: [],
     skipDeleteWorktreeConfirm: false,
     skipCloseTerminalWithRunningProcessConfirm: false,
     skipDeleteAutomationConfirm: false,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -122,6 +122,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     defaultTuiAgent: null,
     disabledTuiAgents: [],
     disabledPlugins: [],
+    approvedPlugins: [],
     skipDeleteWorktreeConfirm: false,
     skipCloseTerminalWithRunningProcessConfirm: false,
     skipDeleteAutomationConfirm: false,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -121,6 +121,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalScopeHistoryByWorktree: true,
     defaultTuiAgent: null,
     disabledTuiAgents: [],
+    disabledPlugins: [],
     skipDeleteWorktreeConfirm: false,
     skipCloseTerminalWithRunningProcessConfirm: false,
     skipDeleteAutomationConfirm: false,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2243,9 +2243,11 @@ app.on('will-quit', (e) => {
   starNag?.stop()
   automations?.stop()
   // Why: plugin hosts are forked children; dispose sends shutdown and
-  // escalates to SIGKILL so they cannot outlive the app.
+  // escalates to SIGKILL so they cannot outlive the app. The promise joins
+  // the allSettled barrier below — quitting before it resolves would let
+  // Electron exit first and orphan the hosts.
   setPluginServiceForRpc(null)
-  void pluginService?.dispose()
+  const pluginHostShutdown = pluginService?.dispose() ?? Promise.resolve()
   pluginService = null
   setUnreadDockBadgeCount(0)
   agentHookServer.stop()
@@ -2287,7 +2289,13 @@ app.on('will-quit', (e) => {
     // Why: telemetry flush folds in before app.quit() (bounded 2s); catch defensively so a flush failure can't cancel the quit chain.
     // Why: normal quits keep the detached daemon for warm reattach, but a dead dev parent leaves the temp/dev profile ownerless.
     const daemonTeardown = isDevParentShutdownRequested() ? shutdownDaemon() : disconnectDaemon()
-    Promise.allSettled([daemonTeardown, rpcStopAndClear, watcherShutdown, emulatorShutdown])
+    Promise.allSettled([
+      daemonTeardown,
+      rpcStopAndClear,
+      watcherShutdown,
+      emulatorShutdown,
+      pluginHostShutdown
+    ])
       .then(() => shutdownTelemetry())
       .then(() => shutdownObservability())
       .catch(() => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -173,8 +173,10 @@ import { AgentAwakeService } from './agent-awake-service'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { PluginService } from './plugins/plugin-service'
 import { resolvePluginHostEntryPath } from './plugins/plugin-host-process'
+import { applyPluginEnablement } from './plugins/plugin-enablement'
+import { promptForPendingPlugins } from './plugins/plugin-first-run-consent'
 import { setPluginServiceForRpc } from './runtime/rpc/methods/plugins'
-import { normalizeDisabledPlugins } from '../shared/plugins/plugin-extension-registry'
+import { normalizePluginIdList } from '../shared/plugins/plugin-extension-registry'
 import {
   recordCoalescedCrashBreadcrumb,
   recordCrashBreadcrumb
@@ -1907,17 +1909,34 @@ app.whenReady().then(async () => {
   })
   pluginService = new PluginService({
     userDataPath: app.getPath('userData'),
-    getDisabledPlugins: () => normalizeDisabledPlugins(store?.getSettings().disabledPlugins),
+    getDisabledPlugins: () => normalizePluginIdList(store?.getSettings().disabledPlugins),
+    getApprovedPlugins: () => normalizePluginIdList(store?.getSettings().approvedPlugins),
     hostEntryPath: resolvePluginHostEntryPath(app.getAppPath(), app.isPackaged)
   })
+  const applyEnablement = (pluginId: string, enabled: boolean) =>
+    applyPluginEnablement({ store: store!, pluginService: pluginService!, pluginId, enabled })
   // Why: headless `orca serve` clients reach plugins through the runtime RPC
   // methods, which resolve the service via this module-level setter.
-  setPluginServiceForRpc(pluginService)
+  setPluginServiceForRpc(pluginService, applyEnablement)
   // Why: plugin host startup forks child processes; it must not block window
   // startup, and a broken plugin surfaces via listPlugins() status instead.
-  void pluginService.initialize().catch((error) => {
-    console.warn('[plugins] failed to initialize plugin service:', error)
-  })
+  void pluginService
+    .initialize()
+    .then(() => {
+      // Why: serve mode has no display for a consent dialog; pending plugins
+      // stay inert there until an explicit plugins.setEnabled RPC call.
+      if (isServeMode) {
+        return
+      }
+      return promptForPendingPlugins({
+        pluginService: pluginService!,
+        showMessageBox: (options) => dialog.showMessageBox(options),
+        applyEnablement
+      })
+    })
+    .catch((error) => {
+      console.warn('[plugins] failed to initialize plugin service:', error)
+    })
   starNag = new StarNagService(store, stats)
   starNag.start()
   starNag.registerIpcHandlers()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -171,6 +171,10 @@ import { createHeadlessAutomationOutputSnapshotBuffer } from './automations/head
 import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headless-workspace-create'
 import { AgentAwakeService } from './agent-awake-service'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
+import { PluginService } from './plugins/plugin-service'
+import { resolvePluginHostEntryPath } from './plugins/plugin-host-process'
+import { setPluginServiceForRpc } from './runtime/rpc/methods/plugins'
+import { normalizeDisabledPlugins } from '../shared/plugins/plugin-extension-registry'
 import {
   recordCoalescedCrashBreadcrumb,
   recordCrashBreadcrumb
@@ -238,6 +242,7 @@ let unsubscribeSystemResumeBroadcast: (() => void) | null = null
 let watcherShutdownPromise: Promise<void> | null = null
 let watcherShutdownDone = false
 let automations: AutomationService | null = null
+let pluginService: PluginService | null = null
 let keybindings: KeybindingService | null = null
 // Why: a reload intent must not leak to a later load; the recovery reload re-fires did-finish-load, so its flag spares live PTYs from the orphan sweep (#5787).
 const expectedRendererReload = createWebContentsTimedFlag()
@@ -971,7 +976,8 @@ function openMainWindow(): BrowserWindow {
       },
       onOrcaProfileAuthMutation: () => desktopRelayService?.authMutated(),
       onBeforeOrcaProfileSignOut: () => desktopRelayService?.fenceAndCloseNow()
-    }
+    },
+    pluginService ?? undefined
   )
   automations.setWebContents(window.webContents)
   automations.start()
@@ -1899,6 +1905,19 @@ app.whenReady().then(async () => {
     prepareForCodexLaunch: prepareCodexRuntimeHomeForLaunch,
     prepareForClaudeLaunch: (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target)
   })
+  pluginService = new PluginService({
+    userDataPath: app.getPath('userData'),
+    getDisabledPlugins: () => normalizeDisabledPlugins(store?.getSettings().disabledPlugins),
+    hostEntryPath: resolvePluginHostEntryPath(app.getAppPath(), app.isPackaged)
+  })
+  // Why: headless `orca serve` clients reach plugins through the runtime RPC
+  // methods, which resolve the service via this module-level setter.
+  setPluginServiceForRpc(pluginService)
+  // Why: plugin host startup forks child processes; it must not block window
+  // startup, and a broken plugin surfaces via listPlugins() status instead.
+  void pluginService.initialize().catch((error) => {
+    console.warn('[plugins] failed to initialize plugin service:', error)
+  })
   starNag = new StarNagService(store, stats)
   starNag.start()
   starNag.registerIpcHandlers()
@@ -2204,6 +2223,11 @@ app.on('will-quit', (e) => {
   // Why: stats.flush() must precede killAllPty() so still-running agents emit synthetic agent_stop events (killAllPty skips runtime.onPtyExit()).
   starNag?.stop()
   automations?.stop()
+  // Why: plugin hosts are forked children; dispose sends shutdown and
+  // escalates to SIGKILL so they cannot outlive the app.
+  setPluginServiceForRpc(null)
+  void pluginService?.dispose()
+  pluginService = null
   setUnreadDockBadgeCount(0)
   agentHookServer.stop()
   // Why: cancels relay restart/reinstall timers and kills wsl.exe children deterministically, not via stdio-pipe teardown.

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -2,48 +2,42 @@ import { readFile } from 'node:fs/promises'
 import { ipcMain } from 'electron'
 import type { Store } from '../persistence'
 import { isCodeProviderMethod } from '../../shared/plugins/code-provider'
-import {
-  CODE_PROVIDER_EXTENSION_POINT,
-  normalizeDisabledPlugins
-} from '../../shared/plugins/plugin-extension-registry'
+import { CODE_PROVIDER_EXTENSION_POINT } from '../../shared/plugins/plugin-extension-registry'
+import { applyPluginEnablement } from '../plugins/plugin-enablement'
 import {
   panelActionCallSchema,
   type PluginPanelActionOutcome
 } from '../../shared/plugins/plugin-panel-bridge'
-import {
-  executePluginPanelAction,
-  type PanelActionTerminalRuntime
-} from '../plugins/plugin-panel-actions'
+import { executePluginPanelAction, type PanelActionRuntime } from '../plugins/plugin-panel-actions'
 import type { PluginService } from '../plugins/plugin-service'
 
 export function registerPluginHandlers(
   store: Store,
   pluginService: PluginService,
-  runtime: PanelActionTerminalRuntime | null
+  runtime: PanelActionRuntime | null
 ): void {
-  ipcMain.handle('plugins:list', () => {
+  // Why: startup discovery is fire-and-forget; every handler awaits it so an
+  // early renderer fetch can't observe the empty pre-discovery list.
+  ipcMain.handle('plugins:list', async () => {
+    await pluginService.whenReady()
     return pluginService.listPlugins()
   })
 
   ipcMain.handle(
     'plugins:setEnabled',
     async (event, args: { pluginId: string; enabled: boolean }) => {
+      await pluginService.whenReady()
       const { pluginId, enabled } = args
       if (typeof pluginId !== 'string' || pluginId.length === 0) {
         throw new Error('plugins:setEnabled requires a pluginId')
       }
-      const disabled = new Set(normalizeDisabledPlugins(store.getSettings().disabledPlugins))
-      if (enabled) {
-        disabled.delete(pluginId)
-      } else {
-        disabled.add(pluginId)
-      }
-      store.updateSettings(
-        { disabledPlugins: [...disabled] },
-        { notifyListeners: true, originWebContentsId: event.sender.id }
-      )
-      await pluginService.setPluginEnabled(pluginId, enabled === true)
-      return pluginService.listPlugins()
+      return applyPluginEnablement({
+        store,
+        pluginService,
+        pluginId,
+        enabled: enabled === true,
+        originWebContentsId: event.sender.id
+      })
     }
   )
 
@@ -52,6 +46,7 @@ export function registerPluginHandlers(
   ipcMain.handle(
     'plugins:readPanelEntry',
     async (_event, args: { pluginId: string; panelId: string }) => {
+      await pluginService.whenReady()
       const entryPath = pluginService.getPanelEntryPath(args.pluginId, args.panelId)
       if (!entryPath) {
         return null
@@ -69,11 +64,13 @@ export function registerPluginHandlers(
   ipcMain.handle(
     'plugins:panelAction',
     async (_event, args: unknown): Promise<PluginPanelActionOutcome> => {
+      await pluginService.whenReady()
       const call = panelActionCallSchema.safeParse(args)
       if (!call.success) {
         return { ok: false, code: 'invalid_request', error: 'malformed panel action call' }
       }
       return executePluginPanelAction({
+        pluginId: call.data.pluginId,
         action: call.data.action,
         params: call.data.params,
         grantedPermissions: pluginService.getGrantedPermissions(call.data.pluginId),
@@ -84,12 +81,19 @@ export function registerPluginHandlers(
 
   ipcMain.handle(
     'plugins:invokeCodeProvider',
-    async (_event, args: { pluginId: string; method: string; args: unknown[] }) => {
+    async (
+      _event,
+      args: { pluginId: string; providerId?: string; method: string; args: unknown[] }
+    ) => {
+      await pluginService.whenReady()
       const { pluginId, method } = args
       if (!isCodeProviderMethod(method)) {
         throw new Error(`unknown code provider method: ${method}`)
       }
-      const provider = pluginService.getRegistry().resolve(CODE_PROVIDER_EXTENSION_POINT, pluginId)
+      const providerId = typeof args.providerId === 'string' ? args.providerId : undefined
+      const provider = pluginService
+        .getRegistry()
+        .resolve(CODE_PROVIDER_EXTENSION_POINT, pluginId, providerId)
       const implementation = provider?.[method]
       if (!provider || typeof implementation !== 'function') {
         throw new Error(`plugin ${pluginId} does not provide ${method}`)

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -6,9 +6,21 @@ import {
   CODE_PROVIDER_EXTENSION_POINT,
   normalizeDisabledPlugins
 } from '../../shared/plugins/plugin-extension-registry'
+import {
+  panelActionCallSchema,
+  type PluginPanelActionOutcome
+} from '../../shared/plugins/plugin-panel-bridge'
+import {
+  executePluginPanelAction,
+  type PanelActionTerminalRuntime
+} from '../plugins/plugin-panel-actions'
 import type { PluginService } from '../plugins/plugin-service'
 
-export function registerPluginHandlers(store: Store, pluginService: PluginService): void {
+export function registerPluginHandlers(
+  store: Store,
+  pluginService: PluginService,
+  runtime: PanelActionTerminalRuntime | null
+): void {
   ipcMain.handle('plugins:list', () => {
     return pluginService.listPlugins()
   })
@@ -49,6 +61,24 @@ export function registerPluginHandlers(store: Store, pluginService: PluginServic
       } catch {
         return null
       }
+    }
+  )
+
+  // Panel-originated actions relayed by PluginPanel's postMessage bridge.
+  // Permission enforcement happens here (main), never in the renderer.
+  ipcMain.handle(
+    'plugins:panelAction',
+    async (_event, args: unknown): Promise<PluginPanelActionOutcome> => {
+      const call = panelActionCallSchema.safeParse(args)
+      if (!call.success) {
+        return { ok: false, code: 'invalid_request', error: 'malformed panel action call' }
+      }
+      return executePluginPanelAction({
+        action: call.data.action,
+        params: call.data.params,
+        grantedPermissions: pluginService.getGrantedPermissions(call.data.pluginId),
+        runtime
+      })
     }
   )
 

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -1,0 +1,71 @@
+import { readFile } from 'node:fs/promises'
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import { isCodeProviderMethod } from '../../shared/plugins/code-provider'
+import {
+  CODE_PROVIDER_EXTENSION_POINT,
+  normalizeDisabledPlugins
+} from '../../shared/plugins/plugin-extension-registry'
+import type { PluginService } from '../plugins/plugin-service'
+
+export function registerPluginHandlers(store: Store, pluginService: PluginService): void {
+  ipcMain.handle('plugins:list', () => {
+    return pluginService.listPlugins()
+  })
+
+  ipcMain.handle(
+    'plugins:setEnabled',
+    async (event, args: { pluginId: string; enabled: boolean }) => {
+      const { pluginId, enabled } = args
+      if (typeof pluginId !== 'string' || pluginId.length === 0) {
+        throw new Error('plugins:setEnabled requires a pluginId')
+      }
+      const disabled = new Set(normalizeDisabledPlugins(store.getSettings().disabledPlugins))
+      if (enabled) {
+        disabled.delete(pluginId)
+      } else {
+        disabled.add(pluginId)
+      }
+      store.updateSettings(
+        { disabledPlugins: [...disabled] },
+        { notifyListeners: true, originWebContentsId: event.sender.id }
+      )
+      await pluginService.setPluginEnabled(pluginId, enabled === true)
+      return pluginService.listPlugins()
+    }
+  )
+
+  // Why: the renderer renders panel HTML via a sandboxed iframe srcdoc, so it
+  // needs file contents — never a file:// path — across the IPC boundary.
+  ipcMain.handle(
+    'plugins:readPanelEntry',
+    async (_event, args: { pluginId: string; panelId: string }) => {
+      const entryPath = pluginService.getPanelEntryPath(args.pluginId, args.panelId)
+      if (!entryPath) {
+        return null
+      }
+      try {
+        return { html: await readFile(entryPath, 'utf8') }
+      } catch {
+        return null
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'plugins:invokeCodeProvider',
+    async (_event, args: { pluginId: string; method: string; args: unknown[] }) => {
+      const { pluginId, method } = args
+      if (!isCodeProviderMethod(method)) {
+        throw new Error(`unknown code provider method: ${method}`)
+      }
+      const provider = pluginService.getRegistry().resolve(CODE_PROVIDER_EXTENSION_POINT, pluginId)
+      const implementation = provider?.[method]
+      if (!provider || typeof implementation !== 'function') {
+        throw new Error(`plugin ${pluginId} does not provide ${method}`)
+      }
+      const callArgs = Array.isArray(args.args) ? args.args : []
+      return await (implementation as (...callArgs: unknown[]) => unknown).apply(provider, callArgs)
+    }
+  )
+}

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -167,7 +167,7 @@ export function registerCoreHandlers(
     registerKeybindingHandlers(keybindings)
   }
   if (pluginService) {
-    registerPluginHandlers(store, pluginService)
+    registerPluginHandlers(store, pluginService, runtime)
   }
   registerTelemetryHandlers(store)
   registerOrcaProfileHandlers(store, {

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -46,6 +46,7 @@ import { registerTelemetryHandlers } from './telemetry'
 import { registerBrowserHandlers } from './browser'
 import { registerShellHandlers } from './shell'
 import { registerPetHandlers } from './pet'
+import { registerPluginHandlers } from './plugins'
 import { registerUIHandlers, setTrustedUIRendererWebContentsId } from './ui'
 import { registerEmulatorFrameStreamHandlers } from './emulator-frame-stream'
 import { registerEmulatorVideoStreamHandlers } from './emulator-video-stream'
@@ -78,6 +79,7 @@ import {
   getSavedRuntimeAiVaultHostInfos,
   scanRuntimeAiVaultSessions
 } from '../ai-vault/runtime-session-scanner'
+import type { PluginService } from '../plugins/plugin-service'
 
 let registered = false
 
@@ -104,7 +106,8 @@ export function registerCoreHandlers(
   agentAwakeService?: AgentAwakeService,
   crashReports?: CrashReportStore,
   keybindings?: KeybindingService,
-  lifecycleOptions: CoreHandlerLifecycleOptions = {}
+  lifecycleOptions: CoreHandlerLifecycleOptions = {},
+  pluginService?: PluginService
 ): void {
   // Why: on macOS the app can stay alive after all windows close, then
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
@@ -162,6 +165,9 @@ export function registerCoreHandlers(
   }
   if (keybindings) {
     registerKeybindingHandlers(keybindings)
+  }
+  if (pluginService) {
+    registerPluginHandlers(store, pluginService)
   }
   registerTelemetryHandlers(store)
   registerOrcaProfileHandlers(store, {

--- a/src/main/persistence-right-sidebar-tab.test.ts
+++ b/src/main/persistence-right-sidebar-tab.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Why: persistence.ts touches electron at import time; a minimal stub keeps
+// this normalizer test focused instead of booting the full Store fixture.
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-persistence-right-sidebar-tab-test'
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (plaintext: string) => Buffer.from(plaintext, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8')
+  }
+}))
+
+import { normalizeRightSidebarTab } from './persistence'
+
+describe('normalizeRightSidebarTab', () => {
+  it.each(['explorer', 'search', 'vault', 'workspaces', 'source-control', 'checks', 'ports'])(
+    'preserves the built-in %s tab',
+    (tab) => {
+      expect(normalizeRightSidebarTab(tab)).toBe(tab)
+    }
+  )
+
+  // Regression: pr-checks was missing from the allow-list, so the folder
+  // PR Checks tab silently reset to Explorer on every app restart.
+  it('preserves the folder-only pr-checks tab across restarts', () => {
+    expect(normalizeRightSidebarTab('pr-checks')).toBe('pr-checks')
+  })
+
+  it('preserves well-formed plugin panel tabs', () => {
+    expect(normalizeRightSidebarTab('plugin:my-plugin/dashboard')).toBe(
+      'plugin:my-plugin/dashboard'
+    )
+  })
+
+  it('normalizes malformed plugin tabs to the default tab', () => {
+    expect(normalizeRightSidebarTab('plugin:my-plugin')).toBe('explorer')
+    expect(normalizeRightSidebarTab('plugin:my-plugin/panel/extra')).toBe('explorer')
+    expect(normalizeRightSidebarTab('plugin:My_Plugin/Panel!')).toBe('explorer')
+  })
+
+  it('normalizes unknown values to the default tab', () => {
+    expect(normalizeRightSidebarTab('bogus')).toBe('explorer')
+    expect(normalizeRightSidebarTab(undefined)).toBe('explorer')
+    expect(normalizeRightSidebarTab(42)).toBe('explorer')
+  })
+})

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -70,6 +70,7 @@ import {
   normalizeProjectRuntimePreference
 } from '../shared/project-execution-runtime'
 import { projectHostSetupProjectionFromRepos } from '../shared/project-host-setup-projection'
+import { isPluginPanelTabKey } from '../shared/plugins/plugin-manifest'
 import type { GitRemoteIdentity } from '../shared/git-remote-identity'
 import {
   buildTaskSourceContextFromRepo,
@@ -768,16 +769,22 @@ function normalizeProjectOrderBy(projectOrderBy: unknown): PersistedState['ui'][
   return getDefaultUIState().projectOrderBy
 }
 
-function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['rightSidebarTab'] {
+export function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['rightSidebarTab'] {
   if (
     tab === 'explorer' ||
     tab === 'search' ||
     tab === 'vault' ||
     tab === 'workspaces' ||
+    tab === 'pr-checks' ||
     tab === 'source-control' ||
     tab === 'checks' ||
     tab === 'ports'
   ) {
+    return tab
+  }
+  // Why: plugin tabs are open-ended `plugin:<id>/<panel>` keys; validate the
+  // shape so a persisted plugin tab doesn't reset to Explorer on restart.
+  if (typeof tab === 'string' && isPluginPanelTabKey(tab)) {
     return tab
   }
   return getDefaultUIState().rightSidebarTab

--- a/src/main/plugins/example-plugin-probe.test.ts
+++ b/src/main/plugins/example-plugin-probe.test.ts
@@ -61,7 +61,7 @@ describe('shipped hello-orca example plugin', () => {
 })
 
 describe('shipped model-shift example plugin', () => {
-  it('has a valid manifest granting only terminal.sendText to its panel', async () => {
+  it('has a valid manifest granting only panel-bridge permissions', async () => {
     const manifestRaw = await import('node:fs/promises').then((fs) =>
       fs.readFile(join(MODEL_SHIFT_ROOT, 'orca-plugin.json'), 'utf8')
     )
@@ -71,7 +71,10 @@ describe('shipped model-shift example plugin', () => {
       return
     }
     expect(parsed.manifest.id).toBe('model-shift')
-    expect(parsed.manifest.contributes.permissions).toEqual(['terminal.sendText'])
+    expect(parsed.manifest.contributes.permissions).toEqual([
+      'terminal.sendText',
+      'workspace.readContext'
+    ])
     expect(parsed.manifest.contributes.panels).toEqual([
       { id: 'gear-shifter', title: 'ModelShift', icon: 'gauge', entry: 'panel.html' }
     ])

--- a/src/main/plugins/example-plugin-probe.test.ts
+++ b/src/main/plugins/example-plugin-probe.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parsePluginManifest } from '../../shared/plugins/plugin-manifest'
+import type { PluginHostChildMessage } from '../../shared/plugins/plugin-host-protocol'
+import { createPluginHostRuntime } from './plugin-host-runtime'
+
+const EXAMPLE_ROOT = resolve(__dirname, '../../../examples/plugins/hello-orca')
+
+describe('shipped hello-orca example plugin', () => {
+  it('activates through the real host runtime and answers searchSymbols', async () => {
+    const manifestRaw = await import('node:fs/promises').then((fs) =>
+      fs.readFile(join(EXAMPLE_ROOT, 'orca-plugin.json'), 'utf8')
+    )
+    const parsed = parsePluginManifest(JSON.parse(manifestRaw))
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+
+    const messages: PluginHostChildMessage[] = []
+    const runtime = createPluginHostRuntime({ send: (m) => messages.push(m) })
+    await runtime.handleMessage({
+      type: 'init',
+      pluginRoot: EXAMPLE_ROOT,
+      mainEntry: parsed.manifest.main!,
+      pluginId: parsed.manifest.id
+    })
+    const ready = messages.find((m) => m.type === 'ready')
+    expect(ready).toBeTruthy()
+    if (ready?.type !== 'ready') return
+    expect(ready.registrations[0]).toMatchObject({
+      extensionPoint: 'codeProvider',
+      providerId: 'todo-scanner',
+      methods: ['searchSymbols']
+    })
+
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'orca-plugin-probe-'))
+    writeFileSync(join(workspaceRoot, 'sample.ts'), '// TODO: probe the plugin system\n')
+    await runtime.handleMessage({
+      type: 'invoke',
+      callId: 1,
+      extensionPoint: 'codeProvider',
+      providerId: 'todo-scanner',
+      method: 'searchSymbols',
+      args: ['probe', { workspaceRoot }]
+    })
+    const result = messages.find((m) => m.type === 'result')
+    expect(result).toMatchObject({ ok: true })
+    if (result?.type !== 'result') return
+    expect(result.value).toEqual([
+      { name: 'probe the plugin system', kind: 'todo', file: 'sample.ts', line: 1 }
+    ])
+  })
+})

--- a/src/main/plugins/example-plugin-probe.test.ts
+++ b/src/main/plugins/example-plugin-probe.test.ts
@@ -7,6 +7,7 @@ import type { PluginHostChildMessage } from '../../shared/plugins/plugin-host-pr
 import { createPluginHostRuntime } from './plugin-host-runtime'
 
 const EXAMPLE_ROOT = resolve(__dirname, '../../../examples/plugins/hello-orca')
+const MODEL_SHIFT_ROOT = resolve(__dirname, '../../../examples/plugins/model-shift')
 
 describe('shipped hello-orca example plugin', () => {
   it('activates through the real host runtime and answers searchSymbols', async () => {
@@ -15,7 +16,9 @@ describe('shipped hello-orca example plugin', () => {
     )
     const parsed = parsePluginManifest(JSON.parse(manifestRaw))
     expect(parsed.ok).toBe(true)
-    if (!parsed.ok) return
+    if (!parsed.ok) {
+      return
+    }
 
     const messages: PluginHostChildMessage[] = []
     const runtime = createPluginHostRuntime({ send: (m) => messages.push(m) })
@@ -27,7 +30,9 @@ describe('shipped hello-orca example plugin', () => {
     })
     const ready = messages.find((m) => m.type === 'ready')
     expect(ready).toBeTruthy()
-    if (ready?.type !== 'ready') return
+    if (ready?.type !== 'ready') {
+      return
+    }
     expect(ready.registrations[0]).toMatchObject({
       extensionPoint: 'codeProvider',
       providerId: 'todo-scanner',
@@ -46,9 +51,31 @@ describe('shipped hello-orca example plugin', () => {
     })
     const result = messages.find((m) => m.type === 'result')
     expect(result).toMatchObject({ ok: true })
-    if (result?.type !== 'result') return
+    if (result?.type !== 'result') {
+      return
+    }
     expect(result.value).toEqual([
       { name: 'probe the plugin system', kind: 'todo', file: 'sample.ts', line: 1 }
     ])
+  })
+})
+
+describe('shipped model-shift example plugin', () => {
+  it('has a valid manifest granting only terminal.sendText to its panel', async () => {
+    const manifestRaw = await import('node:fs/promises').then((fs) =>
+      fs.readFile(join(MODEL_SHIFT_ROOT, 'orca-plugin.json'), 'utf8')
+    )
+    const parsed = parsePluginManifest(JSON.parse(manifestRaw))
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) {
+      return
+    }
+    expect(parsed.manifest.id).toBe('model-shift')
+    expect(parsed.manifest.contributes.permissions).toEqual(['terminal.sendText'])
+    expect(parsed.manifest.contributes.panels).toEqual([
+      { id: 'gear-shifter', title: 'ModelShift', icon: 'gauge', entry: 'panel.html' }
+    ])
+    // Panel-only plugin: no host process should ever be spawned for it.
+    expect(parsed.manifest.main).toBeUndefined()
   })
 })

--- a/src/main/plugins/plugin-code-provider-proxy.test.ts
+++ b/src/main/plugins/plugin-code-provider-proxy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PluginHostRegistration } from '../../shared/plugins/plugin-host-protocol'
+import type { PluginHostHandle } from './plugin-host-process'
+import { createCodeProviderProxy } from './plugin-code-provider-proxy'
+
+const CONTEXT = { workspaceRoot: '/ws' }
+
+function createHost(result: unknown): PluginHostHandle & { invoke: ReturnType<typeof vi.fn> } {
+  return {
+    registrations: [],
+    invoke: vi.fn(async () => result),
+    dispose: async () => undefined,
+    onExit: () => undefined
+  }
+}
+
+function registration(methods: string[]): PluginHostRegistration {
+  return {
+    extensionPoint: 'codeProvider',
+    providerId: 'prov',
+    methods: methods as PluginHostRegistration['methods']
+  }
+}
+
+describe('createCodeProviderProxy', () => {
+  it('attaches only registered methods and forwards calls to the host', async () => {
+    const symbols = [{ name: 'foo', kind: 'function', file: 'a.ts', line: 3 }]
+    const host = createHost(symbols)
+    const proxy = createCodeProviderProxy(host, registration(['searchSymbols']))
+
+    expect(proxy.provideHover).toBeUndefined()
+    expect(proxy.provideDefinition).toBeUndefined()
+    await expect(proxy.searchSymbols!('foo', CONTEXT)).resolves.toEqual(symbols)
+    expect(host.invoke).toHaveBeenCalledWith('codeProvider', 'prov', 'searchSymbols', [
+      'foo',
+      CONTEXT
+    ])
+  })
+
+  it('rejects malformed results at the fork boundary instead of passing them through', async () => {
+    const host = createHost({ echoed: 'not-a-symbol-array' })
+    const proxy = createCodeProviderProxy(
+      host,
+      registration(['searchSymbols', 'provideDefinition'])
+    )
+
+    await expect(proxy.searchSymbols!('foo', CONTEXT)).rejects.toThrow(
+      'malformed searchSymbols result'
+    )
+    await expect(proxy.provideDefinition!('a.ts', 1, 1, CONTEXT)).rejects.toThrow(
+      'malformed provideDefinition result'
+    )
+  })
+
+  it('normalizes nullish hover results to null and validates real ones', async () => {
+    const proxy = (result: unknown) =>
+      createCodeProviderProxy(createHost(result), registration(['provideHover']))
+
+    await expect(proxy(undefined).provideHover!('a.ts', 1, 1, CONTEXT)).resolves.toBeNull()
+    await expect(proxy(null).provideHover!('a.ts', 1, 1, CONTEXT)).resolves.toBeNull()
+    await expect(proxy({ contents: 'docs' }).provideHover!('a.ts', 1, 1, CONTEXT)).resolves.toEqual(
+      { contents: 'docs' }
+    )
+    await expect(proxy({ contents: 42 }).provideHover!('a.ts', 1, 1, CONTEXT)).rejects.toThrow(
+      'malformed provideHover result'
+    )
+  })
+})

--- a/src/main/plugins/plugin-code-provider-proxy.ts
+++ b/src/main/plugins/plugin-code-provider-proxy.ts
@@ -1,0 +1,49 @@
+import type {
+  CodeHover,
+  CodeLocation,
+  CodeProvider,
+  CodeProviderContext,
+  CodeSymbol
+} from '../../shared/plugins/code-provider'
+import { CODE_PROVIDER_EXTENSION_POINT } from '../../shared/plugins/plugin-extension-registry'
+import type { PluginHostRegistration } from '../../shared/plugins/plugin-host-protocol'
+import type { PluginHostHandle } from './plugin-host-process'
+
+/**
+ * Builds an in-process CodeProvider whose methods forward to the plugin host
+ * child process. Methods are attached only when the registration listed them,
+ * so `supportsCodeProviderMethod` capability probing keeps working across the
+ * process boundary.
+ */
+export function createCodeProviderProxy(
+  host: PluginHostHandle,
+  registration: PluginHostRegistration
+): CodeProvider {
+  const forward = (method: string, args: unknown[]): Promise<unknown> =>
+    host.invoke(CODE_PROVIDER_EXTENSION_POINT.key, registration.providerId, method, args)
+
+  const provider: CodeProvider = { id: registration.providerId }
+  // Why: results crossed the fork IPC boundary as structured-clone data; the
+  // protocol treats them as opaque, so the casts assert the contract shape.
+  if (registration.methods.includes('searchSymbols')) {
+    provider.searchSymbols = (query: string, context: CodeProviderContext) =>
+      forward('searchSymbols', [query, context]) as Promise<CodeSymbol[]>
+  }
+  if (registration.methods.includes('provideHover')) {
+    provider.provideHover = (
+      file: string,
+      line: number,
+      column: number,
+      context: CodeProviderContext
+    ) => forward('provideHover', [file, line, column, context]) as Promise<CodeHover | null>
+  }
+  if (registration.methods.includes('provideDefinition')) {
+    provider.provideDefinition = (
+      file: string,
+      line: number,
+      column: number,
+      context: CodeProviderContext
+    ) => forward('provideDefinition', [file, line, column, context]) as Promise<CodeLocation[]>
+  }
+  return provider
+}

--- a/src/main/plugins/plugin-code-provider-proxy.ts
+++ b/src/main/plugins/plugin-code-provider-proxy.ts
@@ -29,7 +29,7 @@ export function createCodeProviderProxy(
   const decode = <T>(method: string, schema: z.ZodType<T>, value: unknown): T => {
     const parsed = schema.safeParse(value)
     if (!parsed.success) {
-      throw new Error(`plugin returned a malformed ${method} result`)
+      throw new Error(`plugin returned a malformed ${method} result`, { cause: parsed.error })
     }
     return parsed.data
   }

--- a/src/main/plugins/plugin-code-provider-proxy.ts
+++ b/src/main/plugins/plugin-code-provider-proxy.ts
@@ -1,9 +1,10 @@
-import type {
-  CodeHover,
-  CodeLocation,
-  CodeProvider,
-  CodeProviderContext,
-  CodeSymbol
+import { z } from 'zod'
+import {
+  codeHoverSchema,
+  codeLocationSchema,
+  codeSymbolSchema,
+  type CodeProvider,
+  type CodeProviderContext
 } from '../../shared/plugins/code-provider'
 import { CODE_PROVIDER_EXTENSION_POINT } from '../../shared/plugins/plugin-extension-registry'
 import type { PluginHostRegistration } from '../../shared/plugins/plugin-host-protocol'
@@ -22,28 +23,52 @@ export function createCodeProviderProxy(
   const forward = (method: string, args: unknown[]): Promise<unknown> =>
     host.invoke(CODE_PROVIDER_EXTENSION_POINT.key, registration.providerId, method, args)
 
+  // Why: results crossed the fork IPC boundary as structured-clone data from
+  // code Orca does not control — decode instead of casting so a malformed
+  // plugin response fails here, not in a hover/symbol consumer.
+  const decode = <T>(method: string, schema: z.ZodType<T>, value: unknown): T => {
+    const parsed = schema.safeParse(value)
+    if (!parsed.success) {
+      throw new Error(`plugin returned a malformed ${method} result`)
+    }
+    return parsed.data
+  }
+
   const provider: CodeProvider = { id: registration.providerId }
-  // Why: results crossed the fork IPC boundary as structured-clone data; the
-  // protocol treats them as opaque, so the casts assert the contract shape.
   if (registration.methods.includes('searchSymbols')) {
-    provider.searchSymbols = (query: string, context: CodeProviderContext) =>
-      forward('searchSymbols', [query, context]) as Promise<CodeSymbol[]>
+    provider.searchSymbols = async (query: string, context: CodeProviderContext) =>
+      decode(
+        'searchSymbols',
+        z.array(codeSymbolSchema),
+        await forward('searchSymbols', [query, context])
+      )
   }
   if (registration.methods.includes('provideHover')) {
-    provider.provideHover = (
+    provider.provideHover = async (
       file: string,
       line: number,
       column: number,
       context: CodeProviderContext
-    ) => forward('provideHover', [file, line, column, context]) as Promise<CodeHover | null>
+    ) =>
+      decode(
+        'provideHover',
+        // Plugins may resolve undefined for "no hover"; normalize to null.
+        codeHoverSchema.nullish().transform((value) => value ?? null),
+        await forward('provideHover', [file, line, column, context])
+      )
   }
   if (registration.methods.includes('provideDefinition')) {
-    provider.provideDefinition = (
+    provider.provideDefinition = async (
       file: string,
       line: number,
       column: number,
       context: CodeProviderContext
-    ) => forward('provideDefinition', [file, line, column, context]) as Promise<CodeLocation[]>
+    ) =>
+      decode(
+        'provideDefinition',
+        z.array(codeLocationSchema),
+        await forward('provideDefinition', [file, line, column, context])
+      )
   }
   return provider
 }

--- a/src/main/plugins/plugin-discovery.test.ts
+++ b/src/main/plugins/plugin-discovery.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { PLUGIN_MANIFEST_FILENAME } from '../../shared/plugins/plugin-manifest'
+import { discoverPlugins, getUserPluginsDir, isInvalidDiscoveredPlugin } from './plugin-discovery'
+
+function validManifest(id: string): string {
+  return JSON.stringify({
+    id,
+    name: `Plugin ${id}`,
+    version: '1.0.0',
+    engines: { orca: '>=1.0.0' },
+    main: 'index.js',
+    contributes: {
+      panels: [{ id: 'panel', title: 'Panel', entry: 'panel/index.html' }]
+    }
+  })
+}
+
+describe('plugin-discovery', () => {
+  let pluginsDir: string
+
+  beforeEach(async () => {
+    pluginsDir = await mkdtemp(join(tmpdir(), 'orca-plugins-'))
+  })
+
+  afterEach(async () => {
+    await rm(pluginsDir, { recursive: true, force: true })
+  })
+
+  async function writePlugin(dirName: string, manifestText: string): Promise<void> {
+    const dir = join(pluginsDir, dirName)
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, PLUGIN_MANIFEST_FILENAME), manifestText)
+  }
+
+  it('discovers a valid plugin with its parsed manifest', async () => {
+    await writePlugin('alpha', validManifest('alpha'))
+    const discovered = await discoverPlugins(pluginsDir)
+    expect(discovered).toHaveLength(1)
+    const plugin = discovered[0]!
+    expect(isInvalidDiscoveredPlugin(plugin)).toBe(false)
+    if (!isInvalidDiscoveredPlugin(plugin)) {
+      expect(plugin.pluginId).toBe('alpha')
+      expect(plugin.rootDir).toBe(join(pluginsDir, 'alpha'))
+      expect(plugin.manifest.name).toBe('Plugin alpha')
+      expect(plugin.manifest.contributes.panels).toHaveLength(1)
+    }
+  })
+
+  it('records invalid JSON as an error entry', async () => {
+    await writePlugin('broken', '{ not json')
+    const discovered = await discoverPlugins(pluginsDir)
+    expect(discovered).toHaveLength(1)
+    const plugin = discovered[0]!
+    expect(isInvalidDiscoveredPlugin(plugin)).toBe(true)
+    if (isInvalidDiscoveredPlugin(plugin)) {
+      expect(plugin.error).toContain('invalid JSON')
+      expect(plugin.pluginId).toBeUndefined()
+    }
+  })
+
+  it('records a schema-invalid manifest as an error entry', async () => {
+    await writePlugin('bad-schema', JSON.stringify({ id: 'bad-schema', name: 'x' }))
+    const discovered = await discoverPlugins(pluginsDir)
+    expect(discovered).toHaveLength(1)
+    expect(isInvalidDiscoveredPlugin(discovered[0]!)).toBe(true)
+  })
+
+  it('records a directory/manifest id mismatch as an error entry', async () => {
+    await writePlugin('wrong-dir', validManifest('other-id'))
+    const discovered = await discoverPlugins(pluginsDir)
+    expect(discovered).toHaveLength(1)
+    const plugin = discovered[0]!
+    expect(isInvalidDiscoveredPlugin(plugin)).toBe(true)
+    if (isInvalidDiscoveredPlugin(plugin)) {
+      expect(plugin.pluginId).toBe('other-id')
+      expect(plugin.error).toContain('does not match directory name')
+    }
+  })
+
+  it('records a directory without a manifest as an error entry', async () => {
+    await mkdir(join(pluginsDir, 'empty-dir'))
+    const discovered = await discoverPlugins(pluginsDir)
+    expect(discovered).toHaveLength(1)
+    const plugin = discovered[0]!
+    expect(isInvalidDiscoveredPlugin(plugin)).toBe(true)
+    if (isInvalidDiscoveredPlugin(plugin)) {
+      expect(plugin.error).toContain(PLUGIN_MANIFEST_FILENAME)
+    }
+  })
+
+  it('skips loose files and dot-directories', async () => {
+    await writeFile(join(pluginsDir, 'stray.txt'), 'not a plugin')
+    await mkdir(join(pluginsDir, '.hidden'))
+    await writePlugin('alpha', validManifest('alpha'))
+    const discovered = await discoverPlugins(pluginsDir)
+    expect(discovered).toHaveLength(1)
+  })
+
+  it('returns an empty list for a missing plugins dir', async () => {
+    const discovered = await discoverPlugins(join(pluginsDir, 'does-not-exist'))
+    expect(discovered).toEqual([])
+  })
+
+  it('getUserPluginsDir joins userData with plugins', () => {
+    expect(getUserPluginsDir('/data')).toBe(join('/data', 'plugins'))
+  })
+})

--- a/src/main/plugins/plugin-discovery.ts
+++ b/src/main/plugins/plugin-discovery.ts
@@ -1,0 +1,82 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  PLUGIN_MANIFEST_FILENAME,
+  parsePluginManifest,
+  type PluginManifest
+} from '../../shared/plugins/plugin-manifest'
+
+export type ValidDiscoveredPlugin = {
+  pluginId: string
+  rootDir: string
+  manifest: PluginManifest
+}
+
+export type InvalidDiscoveredPlugin = {
+  pluginId?: string
+  rootDir: string
+  error: string
+}
+
+export type DiscoveredPlugin = ValidDiscoveredPlugin | InvalidDiscoveredPlugin
+
+export function isInvalidDiscoveredPlugin(
+  plugin: DiscoveredPlugin
+): plugin is InvalidDiscoveredPlugin {
+  return 'error' in plugin
+}
+
+export function getUserPluginsDir(userDataPath: string): string {
+  return join(userDataPath, 'plugins')
+}
+
+async function readPluginDir(rootDir: string, dirName: string): Promise<DiscoveredPlugin> {
+  const manifestPath = join(rootDir, PLUGIN_MANIFEST_FILENAME)
+  let rawText: string
+  try {
+    rawText = await readFile(manifestPath, 'utf8')
+  } catch {
+    return { rootDir, error: `missing ${PLUGIN_MANIFEST_FILENAME}` }
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(rawText)
+  } catch (error) {
+    return {
+      rootDir,
+      error: `invalid JSON in ${PLUGIN_MANIFEST_FILENAME}: ${error instanceof Error ? error.message : String(error)}`
+    }
+  }
+  const parsed = parsePluginManifest(raw)
+  if (!parsed.ok) {
+    return { rootDir, error: `invalid manifest: ${parsed.error}` }
+  }
+  // Why: the directory name is the install key (and future uninstall target);
+  // a mismatched manifest id would let two directories claim the same plugin.
+  if (parsed.manifest.id !== dirName) {
+    return {
+      pluginId: parsed.manifest.id,
+      rootDir,
+      error: `manifest id "${parsed.manifest.id}" does not match directory name "${dirName}"`
+    }
+  }
+  return { pluginId: parsed.manifest.id, rootDir, manifest: parsed.manifest }
+}
+
+export async function discoverPlugins(pluginsDir: string): Promise<DiscoveredPlugin[]> {
+  let entries
+  try {
+    entries = await readdir(pluginsDir, { withFileTypes: true })
+  } catch {
+    // A missing plugins dir just means no plugins are installed yet.
+    return []
+  }
+  const discovered: DiscoveredPlugin[] = []
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.startsWith('.')) {
+      continue
+    }
+    discovered.push(await readPluginDir(join(pluginsDir, entry.name), entry.name))
+  }
+  return discovered
+}

--- a/src/main/plugins/plugin-enablement.test.ts
+++ b/src/main/plugins/plugin-enablement.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import { applyPluginEnablement } from './plugin-enablement'
+import type { PluginListEntry, PluginService } from './plugin-service'
+
+function makeFixture(initial: { disabled?: string[]; approved?: string[] } = {}): {
+  store: Store
+  pluginService: PluginService
+  updateSettings: ReturnType<typeof vi.fn>
+  setPluginEnabled: ReturnType<typeof vi.fn>
+  listed: PluginListEntry[]
+} {
+  const settings = {
+    disabledPlugins: initial.disabled ?? [],
+    approvedPlugins: initial.approved ?? []
+  }
+  const updateSettings = vi.fn((updates: Partial<typeof settings>) => {
+    Object.assign(settings, updates)
+    return settings
+  })
+  const setPluginEnabled = vi.fn().mockResolvedValue(undefined)
+  const listed: PluginListEntry[] = [
+    { pluginId: 'model-shift', name: 'ModelShift', version: '1.0.0', status: 'active', panels: [] }
+  ]
+  return {
+    store: { getSettings: () => settings, updateSettings } as unknown as Store,
+    pluginService: { setPluginEnabled, listPlugins: () => listed } as unknown as PluginService,
+    updateSettings,
+    setPluginEnabled,
+    listed
+  }
+}
+
+describe('applyPluginEnablement', () => {
+  it('enable records consent and un-disables before starting the plugin', async () => {
+    const fixture = makeFixture({ disabled: ['model-shift'] })
+    const result = await applyPluginEnablement({
+      store: fixture.store,
+      pluginService: fixture.pluginService,
+      pluginId: 'model-shift',
+      enabled: true
+    })
+
+    expect(fixture.updateSettings).toHaveBeenCalledWith(
+      { disabledPlugins: [], approvedPlugins: ['model-shift'] },
+      { notifyListeners: true, originWebContentsId: undefined }
+    )
+    // Settings persist before the service starts the host, so the service's
+    // own consent check sees the approval.
+    expect(fixture.updateSettings.mock.invocationCallOrder[0]).toBeLessThan(
+      fixture.setPluginEnabled.mock.invocationCallOrder[0]!
+    )
+    expect(fixture.setPluginEnabled).toHaveBeenCalledWith('model-shift', true)
+    expect(result).toBe(fixture.listed)
+  })
+
+  it('disable keeps the prior approval so re-enabling never re-prompts', async () => {
+    const fixture = makeFixture({ approved: ['model-shift'] })
+    await applyPluginEnablement({
+      store: fixture.store,
+      pluginService: fixture.pluginService,
+      pluginId: 'model-shift',
+      enabled: false
+    })
+
+    expect(fixture.updateSettings).toHaveBeenCalledWith(
+      { disabledPlugins: ['model-shift'], approvedPlugins: ['model-shift'] },
+      { notifyListeners: true, originWebContentsId: undefined }
+    )
+    expect(fixture.setPluginEnabled).toHaveBeenCalledWith('model-shift', false)
+  })
+})

--- a/src/main/plugins/plugin-enablement.ts
+++ b/src/main/plugins/plugin-enablement.ts
@@ -1,0 +1,31 @@
+import { normalizePluginIdList } from '../../shared/plugins/plugin-extension-registry'
+import type { Store } from '../persistence'
+import type { PluginListEntry, PluginService } from './plugin-service'
+
+/** Single write path for enabling/disabling a plugin. Enabling also records
+ *  consent (approvedPlugins), so the desktop IPC handler, the headless RPC
+ *  method, and the first-run consent prompt all behave identically. */
+export async function applyPluginEnablement(input: {
+  store: Store
+  pluginService: PluginService
+  pluginId: string
+  enabled: boolean
+  originWebContentsId?: number
+}): Promise<PluginListEntry[]> {
+  const { store, pluginService, pluginId, enabled } = input
+  const settings = store.getSettings()
+  const disabled = new Set(normalizePluginIdList(settings.disabledPlugins))
+  const approved = new Set(normalizePluginIdList(settings.approvedPlugins))
+  if (enabled) {
+    disabled.delete(pluginId)
+    approved.add(pluginId)
+  } else {
+    disabled.add(pluginId)
+  }
+  store.updateSettings(
+    { disabledPlugins: [...disabled], approvedPlugins: [...approved] },
+    { notifyListeners: true, originWebContentsId: input.originWebContentsId }
+  )
+  await pluginService.setPluginEnabled(pluginId, enabled)
+  return pluginService.listPlugins()
+}

--- a/src/main/plugins/plugin-first-run-consent.test.ts
+++ b/src/main/plugins/plugin-first-run-consent.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { promptForPendingPlugins } from './plugin-first-run-consent'
+import type { PluginListEntry, PluginService } from './plugin-service'
+
+function entry(pluginId: string, status: PluginListEntry['status']): PluginListEntry {
+  return { pluginId, name: `Plugin ${pluginId}`, version: '1.0.0', status, panels: [] }
+}
+
+function stubService(entries: PluginListEntry[]): PluginService {
+  return {
+    whenReady: async () => undefined,
+    listPlugins: () => entries
+  } as unknown as PluginService
+}
+
+describe('promptForPendingPlugins', () => {
+  it('prompts only for pending plugins and applies each answer', async () => {
+    const showMessageBox = vi
+      .fn()
+      .mockResolvedValueOnce({ response: 0 })
+      .mockResolvedValueOnce({ response: 1 })
+    const applyEnablement = vi.fn().mockResolvedValue(undefined)
+
+    await promptForPendingPlugins({
+      pluginService: stubService([
+        entry('already-active', 'active'),
+        entry('new-one', 'pending'),
+        entry('was-disabled', 'disabled'),
+        entry('new-two', 'pending'),
+        entry('broken', 'error')
+      ]),
+      showMessageBox,
+      applyEnablement
+    })
+
+    expect(showMessageBox).toHaveBeenCalledTimes(2)
+    expect(applyEnablement).toHaveBeenNthCalledWith(1, 'new-one', true)
+    expect(applyEnablement).toHaveBeenNthCalledWith(2, 'new-two', false)
+  })
+
+  it('defaults the dialog to the safe answer and warns about system access', async () => {
+    const showMessageBox = vi.fn().mockResolvedValue({ response: 1 })
+    await promptForPendingPlugins({
+      pluginService: stubService([entry('new-one', 'pending')]),
+      showMessageBox,
+      applyEnablement: vi.fn().mockResolvedValue(undefined)
+    })
+
+    const options = showMessageBox.mock.calls[0]![0]
+    expect(options.defaultId).toBe(1)
+    expect(options.cancelId).toBe(1)
+    expect(options.buttons[0]).toBe('Enable Plugin')
+    expect(options.detail).toContain('same system access as Orca')
+  })
+
+  it('does nothing when no plugin is pending', async () => {
+    const showMessageBox = vi.fn()
+    await promptForPendingPlugins({
+      pluginService: stubService([entry('already-active', 'active')]),
+      showMessageBox,
+      applyEnablement: vi.fn()
+    })
+    expect(showMessageBox).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/plugins/plugin-first-run-consent.ts
+++ b/src/main/plugins/plugin-first-run-consent.ts
@@ -1,0 +1,42 @@
+import type { PluginService } from './plugin-service'
+
+/** Subset of Electron's dialog.showMessageBox, injected so this module stays
+ *  Electron-free and the prompt flow is testable without a display. */
+export type PluginConsentMessageBox = (options: {
+  type: 'question'
+  buttons: string[]
+  defaultId: number
+  cancelId: number
+  title: string
+  message: string
+  detail: string
+}) => Promise<{ response: number }>
+
+/** Asks the user once per newly discovered plugin whether to enable it.
+ *  Desktop-only: headless serve keeps pending plugins inert until an explicit
+ *  plugins.setEnabled RPC call. Either answer is persisted, so the prompt
+ *  never nags on later launches. */
+export async function promptForPendingPlugins(input: {
+  pluginService: PluginService
+  showMessageBox: PluginConsentMessageBox
+  applyEnablement: (pluginId: string, enabled: boolean) => Promise<unknown>
+}): Promise<void> {
+  await input.pluginService.whenReady()
+  const pending = input.pluginService.listPlugins().filter((plugin) => plugin.status === 'pending')
+  for (const plugin of pending) {
+    const { response } = await input.showMessageBox({
+      type: 'question',
+      buttons: ['Enable Plugin', 'Keep Disabled'],
+      // Why: enabling runs third-party code with full system access, so the
+      // safe answer (and Esc) must be the default.
+      defaultId: 1,
+      cancelId: 1,
+      title: 'New Orca plugin found',
+      message: `Enable plugin "${plugin.name}"?`,
+      detail:
+        `Version ${plugin.version} (${plugin.pluginId}) was found in your plugins folder. ` +
+        'Plugins run with the same system access as Orca itself — only enable plugins you trust.'
+    })
+    await input.applyEnablement(plugin.pluginId, response === 0)
+  }
+}

--- a/src/main/plugins/plugin-host-entry.ts
+++ b/src/main/plugins/plugin-host-entry.ts
@@ -1,0 +1,41 @@
+/**
+ * Child-process entry for the out-of-process plugin host. Forked with
+ * ELECTRON_RUN_AS_NODE, so this file must stay plain Node — no electron
+ * imports (directly or transitively). All logic lives in
+ * `plugin-host-runtime.ts`; this file only wires the fork IPC channel.
+ */
+import { createPluginHostRuntime } from './plugin-host-runtime'
+import type { PluginHostChildMessage } from '../../shared/plugins/plugin-host-protocol'
+
+function sendToParent(message: PluginHostChildMessage): void {
+  process.send?.(message)
+}
+
+const runtime = createPluginHostRuntime({ send: sendToParent })
+
+process.on('message', (raw: unknown) => {
+  void runtime.handleMessage(raw)
+})
+
+// Why: third-party plugin code runs here; an escaped rejection must not leave
+// a zombie host. Report the crash so the parent can mark the plugin errored.
+function dieFatally(error: unknown): void {
+  try {
+    sendToParent({
+      type: 'fatal',
+      error: error instanceof Error ? (error.stack ?? error.message) : String(error)
+    })
+  } catch {
+    // Channel already gone; nothing left to report to.
+  }
+  process.exit(1)
+}
+
+process.on('uncaughtException', dieFatally)
+process.on('unhandledRejection', dieFatally)
+
+// Why: if the parent dies without sending shutdown, the IPC channel closes;
+// exit instead of lingering as an orphaned Node process.
+process.on('disconnect', () => {
+  process.exit(0)
+})

--- a/src/main/plugins/plugin-host-process.test.ts
+++ b/src/main/plugins/plugin-host-process.test.ts
@@ -1,0 +1,121 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { startPluginHost, resolvePluginHostEntryPath } from './plugin-host-process'
+
+// Speaks the parent/child protocol like plugin-host-entry.js would; the real
+// entry's logic is covered by plugin-host-runtime.test.ts without forking.
+const ECHO_HOST_FIXTURE = `
+process.on('message', (message) => {
+  if (message.type === 'init') {
+    process.send({
+      type: 'ready',
+      registrations: [
+        {
+          extensionPoint: 'codeProvider',
+          providerId: message.pluginId + '-provider',
+          methods: ['searchSymbols']
+        }
+      ]
+    })
+  } else if (message.type === 'invoke') {
+    if (message.method === 'searchSymbols') {
+      process.send({ type: 'result', callId: message.callId, ok: true, value: message.args })
+    } else {
+      process.send({ type: 'result', callId: message.callId, ok: false, error: 'echo: boom' })
+    }
+  } else if (message.type === 'shutdown') {
+    process.exit(0)
+  }
+})
+`
+
+const SILENT_HOST_FIXTURE = `
+setInterval(() => {}, 1000)
+process.on('message', () => {})
+`
+
+const EXITING_HOST_FIXTURE = `
+process.exit(3)
+`
+
+describe('plugin-host-process', () => {
+  let fixtureDir: string
+  let echoEntryPath: string
+  let silentEntryPath: string
+  let exitingEntryPath: string
+
+  beforeAll(async () => {
+    fixtureDir = await mkdtemp(join(tmpdir(), 'orca-plugin-host-fixture-'))
+    echoEntryPath = join(fixtureDir, 'echo-host.cjs')
+    silentEntryPath = join(fixtureDir, 'silent-host.cjs')
+    exitingEntryPath = join(fixtureDir, 'exiting-host.cjs')
+    await writeFile(echoEntryPath, ECHO_HOST_FIXTURE)
+    await writeFile(silentEntryPath, SILENT_HOST_FIXTURE)
+    await writeFile(exitingEntryPath, EXITING_HOST_FIXTURE)
+  })
+
+  afterAll(async () => {
+    await rm(fixtureDir, { recursive: true, force: true })
+  })
+
+  it('starts a host, receives registrations, invokes, and disposes', async () => {
+    const host = await startPluginHost({
+      pluginId: 'alpha',
+      rootDir: '/plugin/alpha',
+      mainEntry: 'index.js',
+      entryPath: echoEntryPath
+    })
+    expect(host.registrations).toEqual([
+      { extensionPoint: 'codeProvider', providerId: 'alpha-provider', methods: ['searchSymbols'] }
+    ])
+
+    const echoed = await host.invoke('codeProvider', 'alpha-provider', 'searchSymbols', [
+      'query',
+      { workspaceRoot: '/ws' }
+    ])
+    expect(echoed).toEqual(['query', { workspaceRoot: '/ws' }])
+
+    await expect(host.invoke('codeProvider', 'alpha-provider', 'provideHover', [])).rejects.toThrow(
+      'echo: boom'
+    )
+
+    const exitCode = new Promise<number | null>((resolve) => host.onExit(resolve))
+    await host.dispose()
+    expect(await exitCode).toBe(0)
+    await expect(
+      host.invoke('codeProvider', 'alpha-provider', 'searchSymbols', [])
+    ).rejects.toThrow('not running')
+  })
+
+  it('rejects with a ready timeout when the child never replies', async () => {
+    await expect(
+      startPluginHost({
+        pluginId: 'silent',
+        rootDir: '/plugin/silent',
+        mainEntry: 'index.js',
+        entryPath: silentEntryPath,
+        readyTimeoutMs: 400
+      })
+    ).rejects.toThrow('did not become ready')
+  })
+
+  it('rejects when the child exits before signalling ready', async () => {
+    await expect(
+      startPluginHost({
+        pluginId: 'exiting',
+        rootDir: '/plugin/exiting',
+        mainEntry: 'index.js',
+        entryPath: exitingEntryPath
+      })
+    ).rejects.toThrow('exited before ready')
+  })
+
+  it('resolvePluginHostEntryPath redirects packaged asar paths to the unpacked copy', () => {
+    const packaged = resolvePluginHostEntryPath(join('/apps', 'app.asar'), true)
+    expect(packaged).toBe(join('/apps', 'app.asar.unpacked', 'out', 'main', 'plugin-host-entry.js'))
+    const dev = resolvePluginHostEntryPath('/repo', false)
+    expect(dev).toBe(join('/repo', 'out', 'main', 'plugin-host-entry.js'))
+  })
+})

--- a/src/main/plugins/plugin-host-process.ts
+++ b/src/main/plugins/plugin-host-process.ts
@@ -135,7 +135,14 @@ export async function startPluginHost(options: StartPluginHostOptions): Promise<
         reject(error)
       }
     }
-    child.on('error', (error) => fail(new Error(`${tag} failed to start host: ${error.message}`)))
+    child.on('error', (error) => {
+      const failure = new Error(`${tag} host process error: ${error.message}`)
+      fail(failure)
+      // Why: fail() no-ops once ready; a post-ready error (e.g. IPC channel
+      // fault) must still reject in-flight invokes instead of letting each
+      // one sit until its own timeout.
+      rejectAllPending(failure.message)
+    })
     child.on('exit', (code) => fail(new Error(`${tag} host exited before ready (code ${code})`)))
     child.on('message', (raw) => {
       const parsed = pluginHostChildMessageSchema.safeParse(raw)

--- a/src/main/plugins/plugin-host-process.ts
+++ b/src/main/plugins/plugin-host-process.ts
@@ -1,0 +1,218 @@
+import { fork, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Readable } from 'node:stream'
+import {
+  PLUGIN_HOST_INVOKE_TIMEOUT_MS,
+  PLUGIN_HOST_READY_TIMEOUT_MS,
+  pluginHostChildMessageSchema,
+  type PluginHostParentMessage,
+  type PluginHostRegistration
+} from '../../shared/plugins/plugin-host-protocol'
+
+// Grace between the shutdown message and SIGKILL: long enough for plugin
+// cleanup, short enough that disable/quit never feels stuck.
+const PLUGIN_HOST_SHUTDOWN_GRACE_MS = 2_000
+
+export type PluginHostHandle = {
+  registrations: PluginHostRegistration[]
+  invoke(
+    extensionPoint: string,
+    providerId: string,
+    method: string,
+    args: unknown[]
+  ): Promise<unknown>
+  dispose(): Promise<void>
+  onExit(callback: (code: number | null) => void): void
+}
+
+export type StartPluginHostOptions = {
+  pluginId: string
+  rootDir: string
+  mainEntry: string
+  /** Absolute path to the compiled plugin-host-entry.js, resolved by the caller. */
+  entryPath: string
+  readyTimeoutMs?: number
+  invokeTimeoutMs?: number
+}
+
+/**
+ * Resolves the compiled child entry from the app path. Mirrors
+ * getDaemonEntryPath(): packaged apps must fork the asar-unpacked copy
+ * because fork() cannot execute scripts from inside app.asar.
+ */
+export function resolvePluginHostEntryPath(appPath: string, isPackaged: boolean): string {
+  const basePath = isPackaged ? appPath.replace('app.asar', 'app.asar.unpacked') : appPath
+  const directEntryPath = join(basePath, 'plugin-host-entry.js')
+  if (existsSync(directEntryPath)) {
+    return directEntryPath
+  }
+  return join(basePath, 'out', 'main', 'plugin-host-entry.js')
+}
+
+function pipeChildOutputLines(stream: Readable | null, tag: string): void {
+  if (!stream) {
+    return
+  }
+  let buffered = ''
+  stream.setEncoding('utf8')
+  stream.on('data', (chunk: string) => {
+    buffered += chunk
+    const lines = buffered.split('\n')
+    buffered = lines.pop() ?? ''
+    for (const line of lines) {
+      if (line.trim().length > 0) {
+        console.warn(`${tag} ${line}`)
+      }
+    }
+  })
+  stream.on('end', () => {
+    if (buffered.trim().length > 0) {
+      console.warn(`${tag} ${buffered}`)
+    }
+  })
+}
+
+type PendingInvoke = {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+export async function startPluginHost(options: StartPluginHostOptions): Promise<PluginHostHandle> {
+  const { pluginId, rootDir, mainEntry, entryPath } = options
+  const readyTimeoutMs = options.readyTimeoutMs ?? PLUGIN_HOST_READY_TIMEOUT_MS
+  const invokeTimeoutMs = options.invokeTimeoutMs ?? PLUGIN_HOST_INVOKE_TIMEOUT_MS
+  const tag = `[plugin:${pluginId}]`
+
+  const child: ChildProcess = fork(entryPath, [], {
+    // Why: ELECTRON_RUN_AS_NODE makes the forked Electron binary behave as
+    // plain Node — same pattern as the terminal daemon (daemon-init.ts).
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc']
+  })
+  pipeChildOutputLines(child.stdout, tag)
+  pipeChildOutputLines(child.stderr, tag)
+
+  const pending = new Map<number, PendingInvoke>()
+  const exitCallbacks: ((code: number | null) => void)[] = []
+  let nextCallId = 0
+  let exited = false
+  let disposed = false
+
+  function sendToChild(message: PluginHostParentMessage): void {
+    if (child.connected) {
+      child.send(message)
+    }
+  }
+
+  function rejectAllPending(reason: string): void {
+    for (const [callId, entry] of pending) {
+      clearTimeout(entry.timer)
+      pending.delete(callId)
+      entry.reject(new Error(reason))
+    }
+  }
+
+  child.on('exit', (code) => {
+    exited = true
+    rejectAllPending(`${tag} host exited before responding`)
+    for (const callback of exitCallbacks) {
+      callback(code)
+    }
+  })
+
+  const registrations = await new Promise<PluginHostRegistration[]>((resolve, reject) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      fail(new Error(`${tag} host did not become ready within ${readyTimeoutMs}ms`))
+      child.kill('SIGKILL')
+    }, readyTimeoutMs)
+    function fail(error: Error): void {
+      if (!settled) {
+        settled = true
+        clearTimeout(timer)
+        reject(error)
+      }
+    }
+    child.on('error', (error) => fail(new Error(`${tag} failed to start host: ${error.message}`)))
+    child.on('exit', (code) => fail(new Error(`${tag} host exited before ready (code ${code})`)))
+    child.on('message', (raw) => {
+      const parsed = pluginHostChildMessageSchema.safeParse(raw)
+      if (!parsed.success) {
+        console.warn(`${tag} ignoring malformed host message`)
+        return
+      }
+      const message = parsed.data
+      if (message.type === 'ready') {
+        if (!settled) {
+          settled = true
+          clearTimeout(timer)
+          resolve(message.registrations)
+        }
+      } else if (message.type === 'result') {
+        const entry = pending.get(message.callId)
+        if (!entry) {
+          return
+        }
+        clearTimeout(entry.timer)
+        pending.delete(message.callId)
+        if (message.ok) {
+          entry.resolve(message.value)
+        } else {
+          entry.reject(new Error(message.error ?? 'plugin invocation failed'))
+        }
+      } else if (message.type === 'log') {
+        console.warn(`${tag} ${message.message}`)
+      } else {
+        fail(new Error(`${tag} host crashed: ${message.error}`))
+        rejectAllPending(`${tag} host crashed: ${message.error}`)
+      }
+    })
+    sendToChild({ type: 'init', pluginRoot: rootDir, mainEntry, pluginId })
+  })
+
+  return {
+    registrations,
+    invoke(extensionPoint, providerId, method, args) {
+      if (exited || disposed) {
+        return Promise.reject(new Error(`${tag} host is not running`))
+      }
+      const callId = nextCallId++
+      return new Promise<unknown>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(callId)
+          reject(new Error(`${tag} ${method} timed out after ${invokeTimeoutMs}ms`))
+        }, invokeTimeoutMs)
+        pending.set(callId, { resolve, reject, timer })
+        sendToChild({ type: 'invoke', callId, extensionPoint, providerId, method, args })
+      })
+    },
+    async dispose() {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      if (exited) {
+        return
+      }
+      sendToChild({ type: 'shutdown' })
+      await new Promise<void>((resolve) => {
+        const killTimer = setTimeout(() => {
+          child.kill('SIGKILL')
+        }, PLUGIN_HOST_SHUTDOWN_GRACE_MS)
+        child.once('exit', () => {
+          clearTimeout(killTimer)
+          resolve()
+        })
+        if (exited) {
+          clearTimeout(killTimer)
+          resolve()
+        }
+      })
+    },
+    onExit(callback) {
+      exitCallbacks.push(callback)
+    }
+  }
+}

--- a/src/main/plugins/plugin-host-runtime.test.ts
+++ b/src/main/plugins/plugin-host-runtime.test.ts
@@ -1,0 +1,176 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  CodeProvider,
+  CodeProviderContext,
+  CodeSymbol
+} from '../../shared/plugins/code-provider'
+import type { PluginHostChildMessage } from '../../shared/plugins/plugin-host-protocol'
+import { createPluginHostRuntime, type PluginHostOrcaApi } from './plugin-host-runtime'
+
+type SentMessages = PluginHostChildMessage[]
+
+function createHarness(activate: unknown): {
+  sent: SentMessages
+  exit: ReturnType<typeof vi.fn>
+  handleMessage: (raw: unknown) => Promise<void>
+} {
+  const sent: SentMessages = []
+  const exit = vi.fn()
+  const runtime = createPluginHostRuntime({
+    send: (message) => sent.push(message),
+    importModule: async () => ({ default: activate }),
+    exit
+  })
+  return { sent, exit, handleMessage: runtime.handleMessage }
+}
+
+const INIT = { type: 'init', pluginRoot: '/plugin', mainEntry: 'index.js', pluginId: 'alpha' }
+
+function activateWithProvider(provider: CodeProvider) {
+  return (orca: PluginHostOrcaApi) => {
+    orca.registerCodeProvider(provider)
+  }
+}
+
+describe('plugin-host-runtime', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  it('replies ready with the implemented method names', async () => {
+    const { sent, handleMessage } = createHarness(
+      activateWithProvider({ id: 'alpha-provider', searchSymbols: async () => [] })
+    )
+    await handleMessage(INIT)
+    expect(sent).toEqual([
+      {
+        type: 'ready',
+        registrations: [
+          {
+            extensionPoint: 'codeProvider',
+            providerId: 'alpha-provider',
+            methods: ['searchSymbols']
+          }
+        ]
+      }
+    ])
+  })
+
+  it('invokes a provider method and replies with the result', async () => {
+    const searchSymbols = vi.fn(
+      async (query: string, _context: CodeProviderContext): Promise<CodeSymbol[]> => [
+        { name: query, kind: 'function', file: 'a.ts', line: 1 }
+      ]
+    )
+    const { sent, handleMessage } = createHarness(
+      activateWithProvider({ id: 'alpha-provider', searchSymbols })
+    )
+    await handleMessage(INIT)
+    await handleMessage({
+      type: 'invoke',
+      callId: 7,
+      extensionPoint: 'codeProvider',
+      providerId: 'alpha-provider',
+      method: 'searchSymbols',
+      args: ['foo', { workspaceRoot: '/ws' }]
+    })
+    expect(searchSymbols).toHaveBeenCalledWith('foo', { workspaceRoot: '/ws' })
+    expect(sent[1]).toEqual({
+      type: 'result',
+      callId: 7,
+      ok: true,
+      value: [{ name: 'foo', kind: 'function', file: 'a.ts', line: 1 }]
+    })
+  })
+
+  it('replies with an error result for unknown providers, methods, and thrown errors', async () => {
+    const { sent, handleMessage } = createHarness(
+      activateWithProvider({
+        id: 'alpha-provider',
+        searchSymbols: async () => {
+          throw new Error('provider blew up')
+        }
+      })
+    )
+    await handleMessage(INIT)
+    const invoke = {
+      type: 'invoke',
+      extensionPoint: 'codeProvider',
+      providerId: 'alpha-provider',
+      method: 'searchSymbols',
+      args: []
+    }
+    await handleMessage({ ...invoke, callId: 1, providerId: 'nobody' })
+    await handleMessage({ ...invoke, callId: 2, method: 'notAMethod' })
+    await handleMessage({ ...invoke, callId: 3, method: 'provideHover' })
+    await handleMessage({ ...invoke, callId: 4 })
+    const results = sent.filter((message) => message.type === 'result')
+    expect(results.map((message) => message.ok)).toEqual([false, false, false, false])
+    expect(results[0]!.error).toContain('unknown provider')
+    expect(results[1]!.error).toContain('unknown code provider method')
+    expect(results[2]!.error).toContain('does not implement')
+    expect(results[3]!.error).toContain('provider blew up')
+  })
+
+  it('sends fatal and exits(1) when activation fails', async () => {
+    const { sent, exit, handleMessage } = createHarness(() => {
+      throw new Error('activation failed')
+    })
+    await handleMessage(INIT)
+    expect(sent[0]?.type).toBe('fatal')
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  it('sends fatal and exits(1) when the entry has no activate function', async () => {
+    const { sent, exit, handleMessage } = createHarness(undefined)
+    await handleMessage(INIT)
+    expect(sent[0]?.type).toBe('fatal')
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  it('exits(0) on shutdown and warns on malformed messages', async () => {
+    const { sent, exit, handleMessage } = createHarness(activateWithProvider({ id: 'p' }))
+    await handleMessage({ type: 'not-a-real-type' })
+    expect(sent[0]).toMatchObject({ type: 'log', level: 'warn' })
+    await handleMessage({ type: 'shutdown' })
+    expect(exit).toHaveBeenCalledWith(0)
+  })
+
+  it('imports a real plugin module from disk via the default importer', async () => {
+    const pluginRoot = await mkdtemp(join(tmpdir(), 'orca-plugin-host-'))
+    tempDirs.push(pluginRoot)
+    await writeFile(
+      join(pluginRoot, 'index.mjs'),
+      `export default function activate(orca) {
+        orca.registerCodeProvider({
+          id: 'disk-provider',
+          provideHover: async () => ({ contents: 'hi' })
+        })
+      }`
+    )
+    const sent: SentMessages = []
+    const runtime = createPluginHostRuntime({
+      send: (message) => sent.push(message),
+      exit: vi.fn()
+    })
+    await runtime.handleMessage({
+      type: 'init',
+      pluginRoot,
+      mainEntry: 'index.mjs',
+      pluginId: 'disk'
+    })
+    expect(sent).toEqual([
+      {
+        type: 'ready',
+        registrations: [
+          { extensionPoint: 'codeProvider', providerId: 'disk-provider', methods: ['provideHover'] }
+        ]
+      }
+    ])
+  })
+})

--- a/src/main/plugins/plugin-host-runtime.ts
+++ b/src/main/plugins/plugin-host-runtime.ts
@@ -1,0 +1,131 @@
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  CODE_PROVIDER_METHODS,
+  isCodeProviderMethod,
+  type CodeProvider
+} from '../../shared/plugins/code-provider'
+import { CODE_PROVIDER_EXTENSION_POINT } from '../../shared/plugins/plugin-extension-registry'
+import {
+  pluginHostParentMessageSchema,
+  type PluginHostChildMessage,
+  type PluginHostRegistration
+} from '../../shared/plugins/plugin-host-protocol'
+
+/**
+ * Message-loop core of the out-of-process plugin host. Electron-free and
+ * side-effect-free (send/import/exit are injected) so it unit-tests without
+ * forking a real child process; `plugin-host-entry.ts` wires it to the fork
+ * IPC channel.
+ */
+
+/** API surface handed to a plugin's `activate(orca)` export. */
+export type PluginHostOrcaApi = {
+  registerCodeProvider(provider: CodeProvider): void
+}
+
+export type PluginHostRuntimeOptions = {
+  send: (message: PluginHostChildMessage) => void
+  importModule?: (specifier: string) => Promise<unknown>
+  exit?: (code: number) => void
+}
+
+export type PluginHostRuntime = {
+  handleMessage(raw: unknown): Promise<void>
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? (error.stack ?? error.message) : String(error)
+}
+
+export function createPluginHostRuntime(options: PluginHostRuntimeOptions): PluginHostRuntime {
+  const send = options.send
+  const importModule = options.importModule ?? ((specifier: string) => import(specifier))
+  const exit = options.exit ?? ((code: number) => process.exit(code))
+  const providers = new Map<string, CodeProvider>()
+  let initialized = false
+
+  async function handleInit(pluginRoot: string, mainEntry: string): Promise<void> {
+    if (initialized) {
+      send({ type: 'log', level: 'warn', message: 'ignoring duplicate init message' })
+      return
+    }
+    initialized = true
+    // Why: file URL import keeps ESM plugin entries working on Windows paths.
+    const entryUrl = pathToFileURL(join(pluginRoot, mainEntry)).href
+    const module = (await importModule(entryUrl)) as { default?: unknown }
+    const activate = module?.default
+    if (typeof activate !== 'function') {
+      throw new Error(`plugin entry ${mainEntry} has no default-exported activate function`)
+    }
+    const orca: PluginHostOrcaApi = {
+      registerCodeProvider(provider) {
+        providers.set(provider.id, provider)
+      }
+    }
+    await activate(orca)
+    const registrations: PluginHostRegistration[] = [...providers.values()].map((provider) => ({
+      extensionPoint: CODE_PROVIDER_EXTENSION_POINT.key,
+      providerId: provider.id,
+      methods: CODE_PROVIDER_METHODS.filter((method) => typeof provider[method] === 'function')
+    }))
+    send({ type: 'ready', registrations })
+  }
+
+  async function handleInvoke(message: {
+    callId: number
+    extensionPoint: string
+    providerId: string
+    method: string
+    args: unknown[]
+  }): Promise<void> {
+    try {
+      if (message.extensionPoint !== CODE_PROVIDER_EXTENSION_POINT.key) {
+        throw new Error(`unknown extension point: ${message.extensionPoint}`)
+      }
+      const provider = providers.get(message.providerId)
+      if (!provider) {
+        throw new Error(`unknown provider: ${message.providerId}`)
+      }
+      if (!isCodeProviderMethod(message.method)) {
+        throw new Error(`unknown code provider method: ${message.method}`)
+      }
+      const implementation = provider[message.method]
+      if (typeof implementation !== 'function') {
+        throw new Error(`provider ${message.providerId} does not implement ${message.method}`)
+      }
+      const value = await (implementation as (...args: unknown[]) => unknown).apply(
+        provider,
+        message.args
+      )
+      send({ type: 'result', callId: message.callId, ok: true, value })
+    } catch (error) {
+      send({ type: 'result', callId: message.callId, ok: false, error: toErrorMessage(error) })
+    }
+  }
+
+  return {
+    async handleMessage(raw) {
+      const parsed = pluginHostParentMessageSchema.safeParse(raw)
+      if (!parsed.success) {
+        send({ type: 'log', level: 'warn', message: 'ignoring malformed parent message' })
+        return
+      }
+      const message = parsed.data
+      try {
+        if (message.type === 'init') {
+          await handleInit(message.pluginRoot, message.mainEntry)
+        } else if (message.type === 'invoke') {
+          await handleInvoke(message)
+        } else {
+          exit(0)
+        }
+      } catch (error) {
+        // Why: an init/activation failure leaves the host useless; report and
+        // die so the parent can surface the error instead of hanging on ready.
+        send({ type: 'fatal', error: toErrorMessage(error) })
+        exit(1)
+      }
+    }
+  }
+}

--- a/src/main/plugins/plugin-panel-actions.test.ts
+++ b/src/main/plugins/plugin-panel-actions.test.ts
@@ -1,19 +1,36 @@
 import { describe, expect, it, vi } from 'vitest'
-import { executePluginPanelAction, type PanelActionTerminalRuntime } from './plugin-panel-actions'
+import { executePluginPanelAction, type PanelActionRuntime } from './plugin-panel-actions'
 
-function createRuntime(overrides: Partial<PanelActionTerminalRuntime> = {}): {
-  runtime: PanelActionTerminalRuntime
+function createRuntime(overrides: Partial<PanelActionRuntime> = {}): {
+  runtime: PanelActionRuntime
   resolveActiveTerminal: ReturnType<typeof vi.fn>
   sendTerminal: ReturnType<typeof vi.fn>
+  resolveActiveWorktreeContext: ReturnType<typeof vi.fn>
+  dispatchPluginNotification: ReturnType<typeof vi.fn>
 } {
   const resolveActiveTerminal = vi.fn().mockResolvedValue('term-1')
   const sendTerminal = vi
     .fn()
     .mockResolvedValue({ handle: 'term-1', accepted: true, bytesWritten: 12 })
+  const resolveActiveWorktreeContext = vi.fn().mockResolvedValue({
+    worktreeId: 'repo::/w/feature',
+    path: '/w/feature',
+    branch: 'feature/x',
+    displayName: 'feature'
+  })
+  const dispatchPluginNotification = vi.fn().mockResolvedValue({ delivered: true })
   return {
-    runtime: { resolveActiveTerminal, sendTerminal, ...overrides },
+    runtime: {
+      resolveActiveTerminal,
+      sendTerminal,
+      resolveActiveWorktreeContext,
+      dispatchPluginNotification,
+      ...overrides
+    },
     resolveActiveTerminal,
-    sendTerminal
+    sendTerminal,
+    resolveActiveWorktreeContext,
+    dispatchPluginNotification
   }
 }
 
@@ -21,6 +38,7 @@ describe('executePluginPanelAction permission enforcement', () => {
   it('denies an action the manifest does not grant and never touches the runtime', async () => {
     const { runtime, sendTerminal } = createRuntime()
     const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
       action: 'terminal.sendText',
       params: { text: '/model opus', enter: true },
       grantedPermissions: [],
@@ -37,6 +55,7 @@ describe('executePluginPanelAction permission enforcement', () => {
   it('denies uniformly when the plugin is unknown or disabled (null grants)', async () => {
     const { runtime, sendTerminal } = createRuntime()
     const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
       action: 'terminal.sendText',
       params: { text: 'hi' },
       grantedPermissions: null,
@@ -53,6 +72,7 @@ describe('executePluginPanelAction permission enforcement', () => {
   it('rejects unknown actions before consulting permissions', async () => {
     const { runtime } = createRuntime()
     const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
       action: 'fs.readFile',
       params: {},
       grantedPermissions: ['terminal.sendText'],
@@ -70,6 +90,7 @@ describe('executePluginPanelAction terminal.sendText relay', () => {
   it('types text into the active terminal and reports acceptance', async () => {
     const { runtime, resolveActiveTerminal, sendTerminal } = createRuntime()
     const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
       action: 'terminal.sendText',
       params: { text: '/model sonnet[1m]', enter: true },
       grantedPermissions: ['terminal.sendText'],
@@ -86,6 +107,7 @@ describe('executePluginPanelAction terminal.sendText relay', () => {
   it('defaults enter to false when omitted', async () => {
     const { runtime, sendTerminal } = createRuntime()
     await executePluginPanelAction({
+      pluginId: 'model-shift',
       action: 'terminal.sendText',
       params: { text: 'plain text' },
       grantedPermissions: ['terminal.sendText'],
@@ -98,6 +120,7 @@ describe('executePluginPanelAction terminal.sendText relay', () => {
     const { runtime, sendTerminal } = createRuntime()
     for (const params of [{}, { text: '' }, { text: 42 }, { text: 'ok', enter: 'yes' }, null]) {
       const outcome = await executePluginPanelAction({
+        pluginId: 'model-shift',
         action: 'terminal.sendText',
         params,
         grantedPermissions: ['terminal.sendText'],
@@ -114,6 +137,7 @@ describe('executePluginPanelAction terminal.sendText relay', () => {
 
   it('reports unavailable when no terminal runtime is wired (e.g. early startup)', async () => {
     const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
       action: 'terminal.sendText',
       params: { text: 'hi' },
       grantedPermissions: ['terminal.sendText'],
@@ -130,6 +154,7 @@ describe('executePluginPanelAction terminal.sendText relay', () => {
     const { runtime, resolveActiveTerminal } = createRuntime()
     resolveActiveTerminal.mockRejectedValue(new Error('no_active_terminal'))
     const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
       action: 'terminal.sendText',
       params: { text: 'hi' },
       grantedPermissions: ['terminal.sendText'],
@@ -142,11 +167,110 @@ describe('executePluginPanelAction terminal.sendText relay', () => {
     const { runtime, sendTerminal } = createRuntime()
     sendTerminal.mockResolvedValue({ handle: 'term-1', accepted: false, bytesWritten: 0 })
     const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
       action: 'terminal.sendText',
       params: { text: 'hi' },
       grantedPermissions: ['terminal.sendText'],
       runtime
     })
     expect(outcome).toEqual({ ok: true, value: { accepted: false } })
+  })
+})
+
+describe('executePluginPanelAction workspace.readContext', () => {
+  it('returns the focused worktree context and requires its own permission', async () => {
+    const { runtime, resolveActiveWorktreeContext } = createRuntime()
+    const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
+      action: 'workspace.readContext',
+      params: undefined,
+      grantedPermissions: ['workspace.readContext'],
+      runtime
+    })
+    expect(resolveActiveWorktreeContext).toHaveBeenCalledTimes(1)
+    expect(outcome).toEqual({
+      ok: true,
+      value: {
+        worktreeId: 'repo::/w/feature',
+        path: '/w/feature',
+        branch: 'feature/x',
+        displayName: 'feature'
+      }
+    })
+
+    // terminal.sendText alone must not grant the read.
+    const denied = await executePluginPanelAction({
+      pluginId: 'model-shift',
+      action: 'workspace.readContext',
+      params: undefined,
+      grantedPermissions: ['terminal.sendText'],
+      runtime
+    })
+    expect(denied.ok).toBe(false)
+    if (!denied.ok) {
+      expect(denied.code).toBe('permission_denied')
+    }
+  })
+
+  it('returns null (not an error) when nothing is focused, rejects junk params', async () => {
+    const { runtime, resolveActiveWorktreeContext } = createRuntime()
+    resolveActiveWorktreeContext.mockResolvedValue(null)
+    const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
+      action: 'workspace.readContext',
+      params: undefined,
+      grantedPermissions: ['workspace.readContext'],
+      runtime
+    })
+    expect(outcome).toEqual({ ok: true, value: null })
+
+    const junk = await executePluginPanelAction({
+      pluginId: 'model-shift',
+      action: 'workspace.readContext',
+      params: { give: 'everything' },
+      grantedPermissions: ['workspace.readContext'],
+      runtime
+    })
+    expect(junk.ok).toBe(false)
+    if (!junk.ok) {
+      expect(junk.code).toBe('invalid_params')
+    }
+  })
+})
+
+describe('executePluginPanelAction notifications.show', () => {
+  it('dispatches an attributed notification', async () => {
+    const { runtime, dispatchPluginNotification } = createRuntime()
+    const outcome = await executePluginPanelAction({
+      pluginId: 'model-shift',
+      action: 'notifications.show',
+      params: { title: 'Shift done', body: 'Now on opus' },
+      grantedPermissions: ['notifications.show'],
+      runtime
+    })
+    expect(dispatchPluginNotification).toHaveBeenCalledWith({
+      pluginId: 'model-shift',
+      title: 'Shift done',
+      body: 'Now on opus'
+    })
+    expect(outcome).toEqual({ ok: true, value: { delivered: true } })
+  })
+
+  it('rejects an empty or oversized title', async () => {
+    const { runtime, dispatchPluginNotification } = createRuntime()
+    for (const params of [{ title: '' }, { title: 'x'.repeat(121) }, {}]) {
+      const outcome = await executePluginPanelAction({
+        pluginId: 'model-shift',
+        action: 'notifications.show',
+        params,
+        grantedPermissions: ['notifications.show'],
+        runtime
+      })
+      expect(outcome.ok).toBe(false)
+      if (!outcome.ok) {
+        expect(outcome.code).toBe('invalid_params')
+      }
+    }
+    expect(dispatchPluginNotification).not.toHaveBeenCalled()
   })
 })

--- a/src/main/plugins/plugin-panel-actions.test.ts
+++ b/src/main/plugins/plugin-panel-actions.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest'
+import { executePluginPanelAction, type PanelActionTerminalRuntime } from './plugin-panel-actions'
+
+function createRuntime(overrides: Partial<PanelActionTerminalRuntime> = {}): {
+  runtime: PanelActionTerminalRuntime
+  resolveActiveTerminal: ReturnType<typeof vi.fn>
+  sendTerminal: ReturnType<typeof vi.fn>
+} {
+  const resolveActiveTerminal = vi.fn().mockResolvedValue('term-1')
+  const sendTerminal = vi
+    .fn()
+    .mockResolvedValue({ handle: 'term-1', accepted: true, bytesWritten: 12 })
+  return {
+    runtime: { resolveActiveTerminal, sendTerminal, ...overrides },
+    resolveActiveTerminal,
+    sendTerminal
+  }
+}
+
+describe('executePluginPanelAction permission enforcement', () => {
+  it('denies an action the manifest does not grant and never touches the runtime', async () => {
+    const { runtime, sendTerminal } = createRuntime()
+    const outcome = await executePluginPanelAction({
+      action: 'terminal.sendText',
+      params: { text: '/model opus', enter: true },
+      grantedPermissions: [],
+      runtime
+    })
+    expect(outcome).toEqual({
+      ok: false,
+      code: 'permission_denied',
+      error: 'plugin does not have the "terminal.sendText" permission'
+    })
+    expect(sendTerminal).not.toHaveBeenCalled()
+  })
+
+  it('denies uniformly when the plugin is unknown or disabled (null grants)', async () => {
+    const { runtime, sendTerminal } = createRuntime()
+    const outcome = await executePluginPanelAction({
+      action: 'terminal.sendText',
+      params: { text: 'hi' },
+      grantedPermissions: null,
+      runtime
+    })
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) {
+      return
+    }
+    expect(outcome.code).toBe('permission_denied')
+    expect(sendTerminal).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown actions before consulting permissions', async () => {
+    const { runtime } = createRuntime()
+    const outcome = await executePluginPanelAction({
+      action: 'fs.readFile',
+      params: {},
+      grantedPermissions: ['terminal.sendText'],
+      runtime
+    })
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) {
+      return
+    }
+    expect(outcome.code).toBe('unknown_action')
+  })
+})
+
+describe('executePluginPanelAction terminal.sendText relay', () => {
+  it('types text into the active terminal and reports acceptance', async () => {
+    const { runtime, resolveActiveTerminal, sendTerminal } = createRuntime()
+    const outcome = await executePluginPanelAction({
+      action: 'terminal.sendText',
+      params: { text: '/model sonnet[1m]', enter: true },
+      grantedPermissions: ['terminal.sendText'],
+      runtime
+    })
+    expect(resolveActiveTerminal).toHaveBeenCalledWith()
+    expect(sendTerminal).toHaveBeenCalledWith('term-1', {
+      text: '/model sonnet[1m]',
+      enter: true
+    })
+    expect(outcome).toEqual({ ok: true, value: { accepted: true } })
+  })
+
+  it('defaults enter to false when omitted', async () => {
+    const { runtime, sendTerminal } = createRuntime()
+    await executePluginPanelAction({
+      action: 'terminal.sendText',
+      params: { text: 'plain text' },
+      grantedPermissions: ['terminal.sendText'],
+      runtime
+    })
+    expect(sendTerminal).toHaveBeenCalledWith('term-1', { text: 'plain text', enter: false })
+  })
+
+  it('rejects invalid params without touching the runtime', async () => {
+    const { runtime, sendTerminal } = createRuntime()
+    for (const params of [{}, { text: '' }, { text: 42 }, { text: 'ok', enter: 'yes' }, null]) {
+      const outcome = await executePluginPanelAction({
+        action: 'terminal.sendText',
+        params,
+        grantedPermissions: ['terminal.sendText'],
+        runtime
+      })
+      expect(outcome.ok).toBe(false)
+      if (outcome.ok) {
+        return
+      }
+      expect(outcome.code).toBe('invalid_params')
+    }
+    expect(sendTerminal).not.toHaveBeenCalled()
+  })
+
+  it('reports unavailable when no terminal runtime is wired (e.g. early startup)', async () => {
+    const outcome = await executePluginPanelAction({
+      action: 'terminal.sendText',
+      params: { text: 'hi' },
+      grantedPermissions: ['terminal.sendText'],
+      runtime: null
+    })
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) {
+      return
+    }
+    expect(outcome.code).toBe('unavailable')
+  })
+
+  it('maps runtime failures (no active terminal) to action_failed', async () => {
+    const { runtime, resolveActiveTerminal } = createRuntime()
+    resolveActiveTerminal.mockRejectedValue(new Error('no_active_terminal'))
+    const outcome = await executePluginPanelAction({
+      action: 'terminal.sendText',
+      params: { text: 'hi' },
+      grantedPermissions: ['terminal.sendText'],
+      runtime
+    })
+    expect(outcome).toEqual({ ok: false, code: 'action_failed', error: 'no_active_terminal' })
+  })
+
+  it('propagates a rejected write as accepted: false', async () => {
+    const { runtime, sendTerminal } = createRuntime()
+    sendTerminal.mockResolvedValue({ handle: 'term-1', accepted: false, bytesWritten: 0 })
+    const outcome = await executePluginPanelAction({
+      action: 'terminal.sendText',
+      params: { text: 'hi' },
+      grantedPermissions: ['terminal.sendText'],
+      runtime
+    })
+    expect(outcome).toEqual({ ok: true, value: { accepted: false } })
+  })
+})

--- a/src/main/plugins/plugin-panel-actions.ts
+++ b/src/main/plugins/plugin-panel-actions.ts
@@ -1,0 +1,96 @@
+import {
+  PANEL_ACTION_PARAM_SCHEMAS,
+  PLUGIN_PANEL_ACTIONS,
+  type PluginPanelAction,
+  type PluginPanelActionOutcome
+} from '../../shared/plugins/plugin-panel-bridge'
+
+/**
+ * Executes a panel-originated plugin action after enforcing the plugin's
+ * manifest permissions. Shared by the desktop IPC handler
+ * (`plugins:panelAction`) and the runtime RPC method (`plugins.panelAction`)
+ * so both surfaces enforce identical rules (SSH/headless parity).
+ */
+
+// Structural subset of OrcaRuntimeService so tests and the RPC layer can
+// supply lightweight fakes without importing the runtime module.
+export type PanelActionTerminalRuntime = {
+  resolveActiveTerminal(worktreeSelector?: string): Promise<string>
+  sendTerminal(
+    handle: string,
+    action: { text?: string; enter?: boolean; interrupt?: boolean }
+  ): Promise<{ handle: string; accepted: boolean; bytesWritten: number }>
+}
+
+export type ExecutePanelActionInput = {
+  action: string
+  params: unknown
+  /** Manifest-granted permissions; `null` means the plugin is unknown,
+   *  invalid, or disabled. */
+  grantedPermissions: readonly string[] | null
+  runtime: PanelActionTerminalRuntime | null
+}
+
+function isKnownAction(action: string): action is PluginPanelAction {
+  return (PLUGIN_PANEL_ACTIONS as readonly string[]).includes(action)
+}
+
+async function runTerminalSendText(
+  runtime: PanelActionTerminalRuntime,
+  params: { text: string; enter: boolean }
+): Promise<unknown> {
+  // Active terminal, not a plugin-chosen one: panels may only type where the
+  // user is already looking, never into arbitrary background terminals.
+  const handle = await runtime.resolveActiveTerminal()
+  const result = await runtime.sendTerminal(handle, { text: params.text, enter: params.enter })
+  return { accepted: result.accepted }
+}
+
+export async function executePluginPanelAction(
+  input: ExecutePanelActionInput
+): Promise<PluginPanelActionOutcome> {
+  const { action, grantedPermissions, runtime } = input
+  if (!isKnownAction(action)) {
+    return { ok: false, code: 'unknown_action', error: `unknown panel action: ${action}` }
+  }
+  // Why: a disabled/uninstalled plugin must fail exactly like an ungranted
+  // permission — no probe-able distinction for panel code.
+  if (!grantedPermissions || !grantedPermissions.includes(action)) {
+    return {
+      ok: false,
+      code: 'permission_denied',
+      error: `plugin does not have the "${action}" permission`
+    }
+  }
+  const parsedParams = PANEL_ACTION_PARAM_SCHEMAS[action].safeParse(input.params)
+  if (!parsedParams.success) {
+    const issue = parsedParams.error.issues[0]
+    const path = issue?.path.join('.') || '(root)'
+    return {
+      ok: false,
+      code: 'invalid_params',
+      error: `${path}: ${issue?.message ?? 'invalid action params'}`
+    }
+  }
+  if (!runtime) {
+    return { ok: false, code: 'unavailable', error: 'terminal runtime is not available' }
+  }
+  try {
+    switch (action) {
+      case 'terminal.sendText': {
+        const value = await runTerminalSendText(
+          runtime,
+          parsedParams.data as { text: string; enter: boolean }
+        )
+        return { ok: true, value }
+      }
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'action_failed',
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+  return { ok: false, code: 'unknown_action', error: `unhandled panel action: ${action}` }
+}

--- a/src/main/plugins/plugin-panel-actions.ts
+++ b/src/main/plugins/plugin-panel-actions.ts
@@ -14,21 +14,34 @@ import {
 
 // Structural subset of OrcaRuntimeService so tests and the RPC layer can
 // supply lightweight fakes without importing the runtime module.
-export type PanelActionTerminalRuntime = {
+export type PanelActionRuntime = {
   resolveActiveTerminal(worktreeSelector?: string): Promise<string>
   sendTerminal(
     handle: string,
     action: { text?: string; enter?: boolean; interrupt?: boolean }
   ): Promise<{ handle: string; accepted: boolean; bytesWritten: number }>
+  resolveActiveWorktreeContext(): Promise<{
+    worktreeId: string
+    path: string
+    branch: string
+    displayName: string
+  } | null>
+  dispatchPluginNotification(input: {
+    pluginId: string
+    title: string
+    body?: string
+  }): Promise<{ delivered: boolean }>
 }
 
 export type ExecutePanelActionInput = {
+  /** Attributed to notifications and logs; already validated by the caller. */
+  pluginId: string
   action: string
   params: unknown
   /** Manifest-granted permissions; `null` means the plugin is unknown,
-   *  invalid, or disabled. */
+   *  invalid, pending, or disabled. */
   grantedPermissions: readonly string[] | null
-  runtime: PanelActionTerminalRuntime | null
+  runtime: PanelActionRuntime | null
 }
 
 function isKnownAction(action: string): action is PluginPanelAction {
@@ -36,7 +49,7 @@ function isKnownAction(action: string): action is PluginPanelAction {
 }
 
 async function runTerminalSendText(
-  runtime: PanelActionTerminalRuntime,
+  runtime: PanelActionRuntime,
   params: { text: string; enter: boolean }
 ): Promise<unknown> {
   // Active terminal, not a plugin-chosen one: panels may only type where the
@@ -73,7 +86,7 @@ export async function executePluginPanelAction(
     }
   }
   if (!runtime) {
-    return { ok: false, code: 'unavailable', error: 'terminal runtime is not available' }
+    return { ok: false, code: 'unavailable', error: 'runtime is not available' }
   }
   try {
     switch (action) {
@@ -82,6 +95,20 @@ export async function executePluginPanelAction(
           runtime,
           parsedParams.data as { text: string; enter: boolean }
         )
+        return { ok: true, value }
+      }
+      case 'workspace.readContext': {
+        // Read-only: worktree id/path/branch of the user's focused workspace,
+        // or null when nothing is focused — never an error.
+        return { ok: true, value: await runtime.resolveActiveWorktreeContext() }
+      }
+      case 'notifications.show': {
+        const params = parsedParams.data as { title: string; body?: string }
+        const value = await runtime.dispatchPluginNotification({
+          pluginId: input.pluginId,
+          title: params.title,
+          body: params.body
+        })
         return { ok: true, value }
       }
     }

--- a/src/main/plugins/plugin-service.test.ts
+++ b/src/main/plugins/plugin-service.test.ts
@@ -1,0 +1,207 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CODE_PROVIDER_EXTENSION_POINT } from '../../shared/plugins/plugin-extension-registry'
+import { PLUGIN_MANIFEST_FILENAME } from '../../shared/plugins/plugin-manifest'
+import type { PluginHostHandle } from './plugin-host-process'
+import { PluginService, type PluginHostFactory } from './plugin-service'
+
+type StubHost = PluginHostHandle & {
+  exitCallbacks: ((code: number | null) => void)[]
+}
+
+function createStubHost(providerId: string): StubHost {
+  const exitCallbacks: ((code: number | null) => void)[] = []
+  return {
+    registrations: [{ extensionPoint: 'codeProvider', providerId, methods: ['searchSymbols'] }],
+    invoke: vi.fn(async (...args: unknown[]) => ({ echoed: args })),
+    dispose: vi.fn(async () => undefined),
+    onExit: (callback) => exitCallbacks.push(callback),
+    exitCallbacks
+  }
+}
+
+function manifestJson(id: string, overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    id,
+    name: `Plugin ${id}`,
+    version: '1.0.0',
+    engines: { orca: '>=1.0.0' },
+    main: 'index.js',
+    contributes: {
+      codeProviders: [{ id: `${id}-provider`, displayName: `${id} provider` }],
+      panels: [{ id: 'panel', title: 'Panel', icon: 'puzzle', entry: 'panel/index.html' }]
+    },
+    ...overrides
+  })
+}
+
+describe('PluginService', () => {
+  let userDataPath: string
+  let disabledPlugins: string[]
+  let hosts: Map<string, StubHost>
+  let hostFactory: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    userDataPath = await mkdtemp(join(tmpdir(), 'orca-plugin-service-'))
+    disabledPlugins = []
+    hosts = new Map()
+    hostFactory = vi.fn(async (options: { pluginId: string }) => {
+      const host = createStubHost(`${options.pluginId}-provider`)
+      hosts.set(options.pluginId, host)
+      return host
+    })
+  })
+
+  afterEach(async () => {
+    await rm(userDataPath, { recursive: true, force: true })
+  })
+
+  async function writePlugin(id: string, manifestText: string = manifestJson(id)): Promise<void> {
+    const dir = join(userDataPath, 'plugins', id)
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, PLUGIN_MANIFEST_FILENAME), manifestText)
+  }
+
+  function createService(): PluginService {
+    return new PluginService({
+      userDataPath,
+      getDisabledPlugins: () => disabledPlugins,
+      hostFactory: hostFactory as unknown as PluginHostFactory
+    })
+  }
+
+  it('activates enabled plugins with a main entry and populates the registry', async () => {
+    await writePlugin('alpha')
+    const service = createService()
+    await service.initialize()
+
+    expect(hostFactory).toHaveBeenCalledTimes(1)
+    expect(hostFactory.mock.calls[0]![0]).toMatchObject({
+      pluginId: 'alpha',
+      mainEntry: 'index.js'
+    })
+
+    const provider = service.getRegistry().resolve(CODE_PROVIDER_EXTENSION_POINT, 'alpha')
+    expect(provider?.id).toBe('alpha-provider')
+    // Capability probing: only registered methods exist on the proxy.
+    expect(typeof provider?.searchSymbols).toBe('function')
+    expect(provider?.provideHover).toBeUndefined()
+
+    await provider!.searchSymbols!('foo', { workspaceRoot: '/ws' })
+    expect(hosts.get('alpha')!.invoke).toHaveBeenCalledWith(
+      'codeProvider',
+      'alpha-provider',
+      'searchSymbols',
+      ['foo', { workspaceRoot: '/ws' }]
+    )
+  })
+
+  it('does not activate disabled plugins or plugins without main', async () => {
+    await writePlugin('alpha')
+    await writePlugin('beta', manifestJson('beta', { main: undefined }))
+    disabledPlugins = ['alpha']
+    const service = createService()
+    await service.initialize()
+    expect(hostFactory).not.toHaveBeenCalled()
+    const entries = service.listPlugins()
+    expect(entries.find((entry) => entry.pluginId === 'alpha')?.status).toBe('disabled')
+    expect(entries.find((entry) => entry.pluginId === 'beta')?.status).toBe('active')
+  })
+
+  it('lists plugins with panel tab keys and invalid manifests as errors', async () => {
+    await writePlugin('alpha')
+    await writePlugin('broken', '{ nope')
+    const service = createService()
+    await service.initialize()
+    const entries = service.listPlugins()
+    expect(entries).toHaveLength(2)
+    const alpha = entries.find((entry) => entry.pluginId === 'alpha')!
+    expect(alpha.status).toBe('active')
+    expect(alpha.name).toBe('Plugin alpha')
+    expect(alpha.version).toBe('1.0.0')
+    expect(alpha.panels).toEqual([
+      { id: 'panel', title: 'Panel', icon: 'puzzle', tabKey: 'plugin:alpha/panel' }
+    ])
+    // Unreadable manifests fall back to the directory name as the id.
+    const broken = entries.find((entry) => entry.pluginId === 'broken')!
+    expect(broken.status).toBe('error')
+    expect(broken.error).toContain('invalid JSON')
+    expect(broken.panels).toEqual([])
+  })
+
+  it('disable stops the host and clears the registry; enable restarts it', async () => {
+    await writePlugin('alpha')
+    const service = createService()
+    await service.initialize()
+    const firstHost = hosts.get('alpha')!
+
+    disabledPlugins = ['alpha']
+    await service.setPluginEnabled('alpha', false)
+    expect(firstHost.dispose).toHaveBeenCalledTimes(1)
+    expect(service.getRegistry().resolve(CODE_PROVIDER_EXTENSION_POINT, 'alpha')).toBeNull()
+    expect(service.listPlugins()[0]!.status).toBe('disabled')
+
+    disabledPlugins = []
+    await service.setPluginEnabled('alpha', true)
+    expect(hostFactory).toHaveBeenCalledTimes(2)
+    expect(service.getRegistry().resolve(CODE_PROVIDER_EXTENSION_POINT, 'alpha')).not.toBeNull()
+    expect(service.listPlugins()[0]!.status).toBe('active')
+  })
+
+  it('marks a plugin errored and clears its registrations when the host crashes', async () => {
+    await writePlugin('alpha')
+    const service = createService()
+    await service.initialize()
+    for (const callback of hosts.get('alpha')!.exitCallbacks) {
+      callback(1)
+    }
+    expect(service.listPlugins()[0]!.status).toBe('error')
+    expect(service.listPlugins()[0]!.error).toContain('exited unexpectedly')
+    expect(service.getRegistry().resolve(CODE_PROVIDER_EXTENSION_POINT, 'alpha')).toBeNull()
+  })
+
+  it('marks a plugin errored when the host fails to start', async () => {
+    await writePlugin('alpha')
+    hostFactory.mockRejectedValueOnce(new Error('spawn failed'))
+    const service = createService()
+    await service.initialize()
+    expect(service.listPlugins()[0]!).toMatchObject({ status: 'error', error: 'spawn failed' })
+  })
+
+  it('resolves panel entry paths and returns null for unknown ids', async () => {
+    await writePlugin('alpha')
+    const service = createService()
+    await service.initialize()
+    expect(service.getPanelEntryPath('alpha', 'panel')).toBe(
+      join(userDataPath, 'plugins', 'alpha', 'panel', 'index.html')
+    )
+    expect(service.getPanelEntryPath('alpha', 'nope')).toBeNull()
+    expect(service.getPanelEntryPath('ghost', 'panel')).toBeNull()
+  })
+
+  it('rejects traversal panel entries at the manifest boundary', async () => {
+    await writePlugin(
+      'sneaky',
+      manifestJson('sneaky', {
+        contributes: { panels: [{ id: 'panel', title: 'Panel', entry: '../../outside.html' }] }
+      })
+    )
+    const service = createService()
+    await service.initialize()
+    // Traversal entries fail manifest validation, so the plugin never loads.
+    expect(service.listPlugins()[0]!.status).toBe('error')
+    expect(service.getPanelEntryPath('sneaky', 'panel')).toBeNull()
+  })
+
+  it('dispose shuts down all hosts', async () => {
+    await writePlugin('alpha')
+    await writePlugin('beta')
+    const service = createService()
+    await service.initialize()
+    await service.dispose()
+    expect(hosts.get('alpha')!.dispose).toHaveBeenCalledTimes(1)
+    expect(hosts.get('beta')!.dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/plugins/plugin-service.test.ts
+++ b/src/main/plugins/plugin-service.test.ts
@@ -40,12 +40,16 @@ function manifestJson(id: string, overrides: Record<string, unknown> = {}): stri
 describe('PluginService', () => {
   let userDataPath: string
   let disabledPlugins: string[]
+  let approvedPlugins: string[]
   let hosts: Map<string, StubHost>
   let hostFactory: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
     userDataPath = await mkdtemp(join(tmpdir(), 'orca-plugin-service-'))
     disabledPlugins = []
+    // Tests exercise post-consent behavior by default; consent-specific tests
+    // clear this list.
+    approvedPlugins = ['alpha', 'beta', 'sneaky']
     hosts = new Map()
     hostFactory = vi.fn(async (options: { pluginId: string }) => {
       const host = createStubHost(`${options.pluginId}-provider`)
@@ -68,6 +72,7 @@ describe('PluginService', () => {
     return new PluginService({
       userDataPath,
       getDisabledPlugins: () => disabledPlugins,
+      getApprovedPlugins: () => approvedPlugins,
       hostFactory: hostFactory as unknown as PluginHostFactory
     })
   }
@@ -187,6 +192,44 @@ describe('PluginService', () => {
 
     disabledPlugins = ['alpha']
     expect(service.getGrantedPermissions('alpha')).toBeNull()
+
+    // Pending (never-approved) plugins are denied like disabled ones.
+    disabledPlugins = []
+    approvedPlugins = []
+    expect(service.getGrantedPermissions('alpha')).toBeNull()
+  })
+
+  it('keeps unapproved plugins pending and inert until consent', async () => {
+    await writePlugin('alpha')
+    approvedPlugins = []
+    const service = createService()
+    await service.initialize()
+
+    expect(hostFactory).not.toHaveBeenCalled()
+    expect(service.listPlugins()[0]!.status).toBe('pending')
+    expect(service.getGrantedPermissions('alpha')).toBeNull()
+    expect(service.getPanelEntryPath('alpha', 'panel')).toBeNull()
+
+    // setPluginEnabled(true) without persisted approval must refuse to start.
+    await service.setPluginEnabled('alpha', true)
+    expect(hostFactory).not.toHaveBeenCalled()
+    expect(service.listPlugins()[0]!.status).toBe('pending')
+
+    // Approval recorded (as applyPluginEnablement does) → enable works.
+    approvedPlugins = ['alpha']
+    await service.setPluginEnabled('alpha', true)
+    expect(hostFactory).toHaveBeenCalledTimes(1)
+    expect(service.listPlugins()[0]!.status).toBe('active')
+  })
+
+  it('whenReady resolves once startup discovery finished', async () => {
+    await writePlugin('alpha')
+    const service = createService()
+    // Simulates the composition root: fire-and-forget initialize, then an
+    // early plugins:list awaiting whenReady must see the discovered plugin.
+    void service.initialize()
+    await service.whenReady()
+    expect(service.listPlugins()).toHaveLength(1)
   })
 
   it('resolves panel entry paths and returns null for unknown ids', async () => {

--- a/src/main/plugins/plugin-service.test.ts
+++ b/src/main/plugins/plugin-service.test.ts
@@ -170,6 +170,25 @@ describe('PluginService', () => {
     expect(service.listPlugins()[0]!).toMatchObject({ status: 'error', error: 'spawn failed' })
   })
 
+  it('grants manifest permissions only while the plugin is valid and enabled', async () => {
+    await writePlugin(
+      'alpha',
+      manifestJson('alpha', { contributes: { permissions: ['terminal.sendText'] } })
+    )
+    await writePlugin('beta')
+    await writePlugin('broken', '{ not json')
+    const service = createService()
+    await service.initialize()
+
+    expect(service.getGrantedPermissions('alpha')).toEqual(['terminal.sendText'])
+    expect(service.getGrantedPermissions('beta')).toEqual([])
+    expect(service.getGrantedPermissions('broken')).toBeNull()
+    expect(service.getGrantedPermissions('missing')).toBeNull()
+
+    disabledPlugins = ['alpha']
+    expect(service.getGrantedPermissions('alpha')).toBeNull()
+  })
+
   it('resolves panel entry paths and returns null for unknown ids', async () => {
     await writePlugin('alpha')
     const service = createService()

--- a/src/main/plugins/plugin-service.test.ts
+++ b/src/main/plugins/plugin-service.test.ts
@@ -15,7 +15,9 @@ function createStubHost(providerId: string): StubHost {
   const exitCallbacks: ((code: number | null) => void)[] = []
   return {
     registrations: [{ extensionPoint: 'codeProvider', providerId, methods: ['searchSymbols'] }],
-    invoke: vi.fn(async (...args: unknown[]) => ({ echoed: args })),
+    // Why: the proxy decodes results against the CodeProvider schemas, so the
+    // stub must answer with a valid (empty) symbol list, not an echo object.
+    invoke: vi.fn(async () => []),
     dispose: vi.fn(async () => undefined),
     onExit: (callback) => exitCallbacks.push(callback),
     exitCallbacks
@@ -105,7 +107,14 @@ describe('PluginService', () => {
 
   it('does not activate disabled plugins or plugins without main', async () => {
     await writePlugin('alpha')
-    await writePlugin('beta', manifestJson('beta', { main: undefined }))
+    // Panel-only plugin: no main is only valid without codeProviders.
+    await writePlugin(
+      'beta',
+      manifestJson('beta', {
+        main: undefined,
+        contributes: { panels: [{ id: 'panel', title: 'Panel', entry: 'panel/index.html' }] }
+      })
+    )
     disabledPlugins = ['alpha']
     const service = createService()
     await service.initialize()
@@ -153,6 +162,64 @@ describe('PluginService', () => {
     expect(hostFactory).toHaveBeenCalledTimes(2)
     expect(service.getRegistry().resolve(CODE_PROVIDER_EXTENSION_POINT, 'alpha')).not.toBeNull()
     expect(service.listPlugins()[0]!.status).toBe('active')
+  })
+
+  it('de-dupes concurrent activations so only one host is forked', async () => {
+    await writePlugin('alpha')
+    disabledPlugins = ['alpha']
+    const service = createService()
+    await service.initialize()
+    disabledPlugins = []
+
+    let releaseFactory!: () => void
+    const gate = new Promise<void>((resolve) => {
+      releaseFactory = resolve
+    })
+    hostFactory.mockImplementation(async (options: { pluginId: string }) => {
+      await gate
+      const host = createStubHost(`${options.pluginId}-provider`)
+      hosts.set(options.pluginId, host)
+      return host
+    })
+
+    // Both enables pass the hosts.has guard before the factory resolves.
+    const first = service.setPluginEnabled('alpha', true)
+    const second = service.setPluginEnabled('alpha', true)
+    releaseFactory()
+    await Promise.all([first, second])
+
+    expect(hostFactory).toHaveBeenCalledTimes(1)
+    expect(service.listPlugins()[0]!.status).toBe('active')
+  })
+
+  it('disable racing an in-flight enable waits and stops the new host', async () => {
+    await writePlugin('alpha')
+    disabledPlugins = ['alpha']
+    const service = createService()
+    await service.initialize()
+    disabledPlugins = []
+
+    let releaseFactory!: () => void
+    const gate = new Promise<void>((resolve) => {
+      releaseFactory = resolve
+    })
+    hostFactory.mockImplementation(async (options: { pluginId: string }) => {
+      await gate
+      const host = createStubHost(`${options.pluginId}-provider`)
+      hosts.set(options.pluginId, host)
+      return host
+    })
+
+    const enabling = service.setPluginEnabled('alpha', true)
+    disabledPlugins = ['alpha']
+    const disabling = service.setPluginEnabled('alpha', false)
+    releaseFactory()
+    await Promise.all([enabling, disabling])
+
+    // Without awaiting the in-flight activation, disable would no-op and
+    // leave the freshly forked host running while settings say disabled.
+    expect(hosts.get('alpha')!.dispose).toHaveBeenCalledTimes(1)
+    expect(service.listPlugins()[0]!.status).toBe('disabled')
   })
 
   it('marks a plugin errored and clears its registrations when the host crashes', async () => {

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -139,6 +139,16 @@ export class PluginService {
     return this.registry
   }
 
+  /** Manifest permissions for an *active* plugin; `null` when the plugin is
+   *  unknown, invalid, or disabled so callers deny uniformly. */
+  getGrantedPermissions(pluginId: string): string[] | null {
+    const plugin = this.findValidPlugin(pluginId)
+    if (!plugin || !isPluginEnabled(pluginId, this.options.getDisabledPlugins())) {
+      return null
+    }
+    return plugin.manifest.contributes.permissions
+  }
+
   getPanelEntryPath(pluginId: string, panelId: string): string | null {
     const plugin = this.findValidPlugin(pluginId)
     const panel = plugin?.manifest.contributes.panels.find((entry) => entry.id === panelId)

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -1,0 +1,226 @@
+import { basename, resolve, sep } from 'node:path'
+import { pluginPanelTabKey } from '../../shared/plugins/plugin-manifest'
+import {
+  CODE_PROVIDER_EXTENSION_POINT,
+  createPluginExtensionRegistry,
+  isPluginEnabled,
+  type PluginExtensionRegistry
+} from '../../shared/plugins/plugin-extension-registry'
+import {
+  discoverPlugins,
+  getUserPluginsDir,
+  isInvalidDiscoveredPlugin,
+  type DiscoveredPlugin,
+  type ValidDiscoveredPlugin
+} from './plugin-discovery'
+import { createCodeProviderProxy } from './plugin-code-provider-proxy'
+import { startPluginHost, type PluginHostHandle } from './plugin-host-process'
+
+// Why: this is the wire shape of plugins:list / plugins.list — it must stay
+// assignable to the renderer's PluginHostListEntry (preload/api-types.ts).
+export type PluginPanelListEntry = {
+  id: string
+  title: string
+  icon?: string
+  /** Right-sidebar tab key (`plugin:<pluginId>/<panelId>`). */
+  tabKey: `plugin:${string}`
+}
+
+export type PluginListEntry = {
+  pluginId: string
+  name: string
+  version: string
+  status: 'active' | 'disabled' | 'error'
+  error?: string
+  panels: PluginPanelListEntry[]
+}
+
+export type PluginHostFactory = (options: {
+  pluginId: string
+  rootDir: string
+  mainEntry: string
+  entryPath: string
+}) => Promise<PluginHostHandle>
+
+export type PluginServiceOptions = {
+  userDataPath: string
+  getDisabledPlugins: () => string[]
+  /** Absolute path to the compiled plugin-host-entry.js. Unused with a custom hostFactory. */
+  hostEntryPath?: string
+  hostFactory?: PluginHostFactory
+}
+
+export class PluginService {
+  private readonly options: PluginServiceOptions
+  private readonly hostFactory: PluginHostFactory
+  private readonly registry: PluginExtensionRegistry = createPluginExtensionRegistry()
+  private readonly hosts = new Map<string, PluginHostHandle>()
+  private readonly runtimeErrors = new Map<string, string>()
+  private discovered: DiscoveredPlugin[] = []
+  private disposed = false
+
+  constructor(options: PluginServiceOptions) {
+    this.options = options
+    this.hostFactory =
+      options.hostFactory ??
+      ((hostOptions) => {
+        if (!hostOptions.entryPath) {
+          throw new Error('PluginService requires hostEntryPath when no hostFactory is provided')
+        }
+        return startPluginHost(hostOptions)
+      })
+  }
+
+  async initialize(): Promise<void> {
+    this.discovered = await discoverPlugins(getUserPluginsDir(this.options.userDataPath))
+    const disabledPlugins = this.options.getDisabledPlugins()
+    for (const plugin of this.discovered) {
+      if (isInvalidDiscoveredPlugin(plugin) || !isPluginEnabled(plugin.pluginId, disabledPlugins)) {
+        continue
+      }
+      await this.activatePlugin(plugin)
+    }
+  }
+
+  listPlugins(): PluginListEntry[] {
+    const disabledPlugins = this.options.getDisabledPlugins()
+    return this.discovered.map((plugin) => {
+      if (isInvalidDiscoveredPlugin(plugin)) {
+        // The directory name stands in for the id/name when the manifest is
+        // unreadable, so the entry stays addressable in the plugins UI.
+        const fallbackId = plugin.pluginId ?? basename(plugin.rootDir)
+        return {
+          pluginId: fallbackId,
+          name: fallbackId,
+          version: '0.0.0',
+          status: 'error' as const,
+          error: plugin.error,
+          panels: []
+        }
+      }
+      const runtimeError = this.runtimeErrors.get(plugin.pluginId)
+      const status = !isPluginEnabled(plugin.pluginId, disabledPlugins)
+        ? ('disabled' as const)
+        : runtimeError
+          ? ('error' as const)
+          : ('active' as const)
+      return {
+        pluginId: plugin.pluginId,
+        name: plugin.manifest.name,
+        version: plugin.manifest.version,
+        status,
+        ...(status === 'error' ? { error: runtimeError } : {}),
+        panels: plugin.manifest.contributes.panels.map((panel) => ({
+          id: panel.id,
+          title: panel.title,
+          ...(panel.icon ? { icon: panel.icon } : {}),
+          tabKey: pluginPanelTabKey(plugin.pluginId, panel.id)
+        }))
+      }
+    })
+  }
+
+  /** Starts/stops the host for `pluginId`. The caller persists the setting. */
+  async setPluginEnabled(pluginId: string, enabled: boolean): Promise<void> {
+    const plugin = this.findValidPlugin(pluginId)
+    if (!plugin) {
+      return
+    }
+    if (enabled) {
+      this.runtimeErrors.delete(pluginId)
+      await this.activatePlugin(plugin)
+    } else {
+      await this.deactivatePlugin(pluginId)
+      this.runtimeErrors.delete(pluginId)
+    }
+  }
+
+  getRegistry(): PluginExtensionRegistry {
+    return this.registry
+  }
+
+  getPanelEntryPath(pluginId: string, panelId: string): string | null {
+    const plugin = this.findValidPlugin(pluginId)
+    const panel = plugin?.manifest.contributes.panels.find((entry) => entry.id === panelId)
+    if (!plugin || !panel) {
+      return null
+    }
+    const rootDir = resolve(plugin.rootDir)
+    const entryPath = resolve(rootDir, panel.entry)
+    // Why: the manifest schema already rejects traversal, but this path is
+    // handed to file reads — keep a containment check as defense in depth.
+    if (!entryPath.startsWith(rootDir + sep)) {
+      return null
+    }
+    return entryPath
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true
+    const hosts = [...this.hosts.values()]
+    this.hosts.clear()
+    await Promise.all(hosts.map((host) => host.dispose().catch(() => undefined)))
+  }
+
+  private findValidPlugin(pluginId: string): ValidDiscoveredPlugin | null {
+    for (const plugin of this.discovered) {
+      if (!isInvalidDiscoveredPlugin(plugin) && plugin.pluginId === pluginId) {
+        return plugin
+      }
+    }
+    return null
+  }
+
+  private async activatePlugin(plugin: ValidDiscoveredPlugin): Promise<void> {
+    const { pluginId, rootDir, manifest } = plugin
+    // Panels/commands need no host process; only `main` runs code.
+    if (!manifest.main || this.hosts.has(pluginId) || this.disposed) {
+      return
+    }
+    let host: PluginHostHandle
+    try {
+      host = await this.hostFactory({
+        pluginId,
+        rootDir,
+        mainEntry: manifest.main,
+        entryPath: this.options.hostEntryPath ?? ''
+      })
+    } catch (error) {
+      this.runtimeErrors.set(pluginId, error instanceof Error ? error.message : String(error))
+      return
+    }
+    if (this.disposed) {
+      void host.dispose()
+      return
+    }
+    this.hosts.set(pluginId, host)
+    for (const registration of host.registrations) {
+      if (registration.extensionPoint === CODE_PROVIDER_EXTENSION_POINT.key) {
+        this.registry.register(
+          CODE_PROVIDER_EXTENSION_POINT,
+          pluginId,
+          createCodeProviderProxy(host, registration)
+        )
+      }
+    }
+    host.onExit(() => {
+      // Why: identity check distinguishes a crash from an intentional
+      // deactivate, which removes the host from the map before disposing.
+      if (this.hosts.get(pluginId) === host) {
+        this.hosts.delete(pluginId)
+        this.registry.clearPlugin(pluginId)
+        this.runtimeErrors.set(pluginId, 'plugin host exited unexpectedly')
+      }
+    })
+  }
+
+  private async deactivatePlugin(pluginId: string): Promise<void> {
+    const host = this.hosts.get(pluginId)
+    if (!host) {
+      return
+    }
+    this.hosts.delete(pluginId)
+    this.registry.clearPlugin(pluginId)
+    await host.dispose()
+  }
+}

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -59,6 +59,7 @@ export class PluginService {
   private readonly hostFactory: PluginHostFactory
   private readonly registry: PluginExtensionRegistry = createPluginExtensionRegistry()
   private readonly hosts = new Map<string, PluginHostHandle>()
+  private readonly activating = new Map<string, Promise<void>>()
   private readonly runtimeErrors = new Map<string, string>()
   private discovered: DiscoveredPlugin[] = []
   private initPromise: Promise<void> | null = null
@@ -220,7 +221,21 @@ export class PluginService {
     return null
   }
 
-  private async activatePlugin(plugin: ValidDiscoveredPlugin): Promise<void> {
+  private activatePlugin(plugin: ValidDiscoveredPlugin): Promise<void> {
+    // Why: the hosts.has guard below runs before an await; two concurrent
+    // enables would otherwise both fork a host and orphan the untracked one.
+    const inFlight = this.activating.get(plugin.pluginId)
+    if (inFlight) {
+      return inFlight
+    }
+    const task = this.doActivatePlugin(plugin).finally(() => {
+      this.activating.delete(plugin.pluginId)
+    })
+    this.activating.set(plugin.pluginId, task)
+    return task
+  }
+
+  private async doActivatePlugin(plugin: ValidDiscoveredPlugin): Promise<void> {
     const { pluginId, rootDir, manifest } = plugin
     // Panels/commands need no host process; only `main` runs code.
     if (!manifest.main || this.hosts.has(pluginId) || this.disposed) {
@@ -265,6 +280,9 @@ export class PluginService {
   }
 
   private async deactivatePlugin(pluginId: string): Promise<void> {
+    // Why: a disable racing an in-flight enable must wait for the host to
+    // land in the map; otherwise it no-ops and leaves the host running.
+    await this.activating.get(pluginId)
     const host = this.hosts.get(pluginId)
     if (!host) {
       return

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -3,7 +3,8 @@ import { pluginPanelTabKey } from '../../shared/plugins/plugin-manifest'
 import {
   CODE_PROVIDER_EXTENSION_POINT,
   createPluginExtensionRegistry,
-  isPluginEnabled,
+  getPluginActivationState,
+  type PluginActivationState,
   type PluginExtensionRegistry
 } from '../../shared/plugins/plugin-extension-registry'
 import {
@@ -30,7 +31,8 @@ export type PluginListEntry = {
   pluginId: string
   name: string
   version: string
-  status: 'active' | 'disabled' | 'error'
+  /** `pending` = discovered but never approved by the user; nothing ran. */
+  status: 'active' | 'pending' | 'disabled' | 'error'
   error?: string
   panels: PluginPanelListEntry[]
 }
@@ -45,6 +47,8 @@ export type PluginHostFactory = (options: {
 export type PluginServiceOptions = {
   userDataPath: string
   getDisabledPlugins: () => string[]
+  /** Plugin ids the user consented to. Anything else stays pending/inert. */
+  getApprovedPlugins: () => string[]
   /** Absolute path to the compiled plugin-host-entry.js. Unused with a custom hostFactory. */
   hostEntryPath?: string
   hostFactory?: PluginHostFactory
@@ -57,6 +61,7 @@ export class PluginService {
   private readonly hosts = new Map<string, PluginHostHandle>()
   private readonly runtimeErrors = new Map<string, string>()
   private discovered: DiscoveredPlugin[] = []
+  private initPromise: Promise<void> | null = null
   private disposed = false
 
   constructor(options: PluginServiceOptions) {
@@ -72,18 +77,43 @@ export class PluginService {
   }
 
   async initialize(): Promise<void> {
+    this.initPromise ??= this.runInitialize()
+    return this.initPromise
+  }
+
+  /** Resolves once startup discovery settled (even if it failed). IPC/RPC
+   *  handlers await this so an early plugins:list can't observe the empty
+   *  pre-discovery state and leave the sidebar permanently pluginless. */
+  async whenReady(): Promise<void> {
+    try {
+      await (this.initPromise ?? Promise.resolve())
+    } catch {
+      // initialize() failures are logged by its caller; readiness only means
+      // discovery is no longer in flight.
+    }
+  }
+
+  private async runInitialize(): Promise<void> {
     this.discovered = await discoverPlugins(getUserPluginsDir(this.options.userDataPath))
-    const disabledPlugins = this.options.getDisabledPlugins()
     for (const plugin of this.discovered) {
-      if (isInvalidDiscoveredPlugin(plugin) || !isPluginEnabled(plugin.pluginId, disabledPlugins)) {
+      if (isInvalidDiscoveredPlugin(plugin)) {
+        continue
+      }
+      if (this.getActivationState(plugin.pluginId) !== 'approved') {
         continue
       }
       await this.activatePlugin(plugin)
     }
   }
 
+  private getActivationState(pluginId: string): PluginActivationState {
+    return getPluginActivationState(pluginId, {
+      approvedPlugins: this.options.getApprovedPlugins(),
+      disabledPlugins: this.options.getDisabledPlugins()
+    })
+  }
+
   listPlugins(): PluginListEntry[] {
-    const disabledPlugins = this.options.getDisabledPlugins()
     return this.discovered.map((plugin) => {
       if (isInvalidDiscoveredPlugin(plugin)) {
         // The directory name stands in for the id/name when the manifest is
@@ -99,11 +129,15 @@ export class PluginService {
         }
       }
       const runtimeError = this.runtimeErrors.get(plugin.pluginId)
-      const status = !isPluginEnabled(plugin.pluginId, disabledPlugins)
-        ? ('disabled' as const)
-        : runtimeError
-          ? ('error' as const)
-          : ('active' as const)
+      const activation = this.getActivationState(plugin.pluginId)
+      const status =
+        activation !== 'approved'
+          ? activation === 'disabled'
+            ? ('disabled' as const)
+            : ('pending' as const)
+          : runtimeError
+            ? ('error' as const)
+            : ('active' as const)
       return {
         pluginId: plugin.pluginId,
         name: plugin.manifest.name,
@@ -127,6 +161,11 @@ export class PluginService {
       return
     }
     if (enabled) {
+      // Consent invariant: callers persist approval before enabling; refuse to
+      // start a host for a plugin the user never approved.
+      if (this.getActivationState(pluginId) !== 'approved') {
+        return
+      }
       this.runtimeErrors.delete(pluginId)
       await this.activatePlugin(plugin)
     } else {
@@ -139,11 +178,11 @@ export class PluginService {
     return this.registry
   }
 
-  /** Manifest permissions for an *active* plugin; `null` when the plugin is
-   *  unknown, invalid, or disabled so callers deny uniformly. */
+  /** Manifest permissions for an *approved* plugin; `null` when the plugin is
+   *  unknown, invalid, pending, or disabled so callers deny uniformly. */
   getGrantedPermissions(pluginId: string): string[] | null {
     const plugin = this.findValidPlugin(pluginId)
-    if (!plugin || !isPluginEnabled(pluginId, this.options.getDisabledPlugins())) {
+    if (!plugin || this.getActivationState(pluginId) !== 'approved') {
       return null
     }
     return plugin.manifest.contributes.permissions
@@ -152,7 +191,7 @@ export class PluginService {
   getPanelEntryPath(pluginId: string, panelId: string): string | null {
     const plugin = this.findValidPlugin(pluginId)
     const panel = plugin?.manifest.contributes.panels.find((entry) => entry.id === panelId)
-    if (!plugin || !panel) {
+    if (!plugin || !panel || this.getActivationState(pluginId) !== 'approved') {
       return null
     }
     const rootDir = resolve(plugin.rootDir)
@@ -209,7 +248,8 @@ export class PluginService {
         this.registry.register(
           CODE_PROVIDER_EXTENSION_POINT,
           pluginId,
-          createCodeProviderProxy(host, registration)
+          createCodeProviderProxy(host, registration),
+          registration.providerId
         )
       }
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -378,7 +378,7 @@ import {
 } from '../../shared/claude-agent-teams-tmux-compat'
 import { joinWorktreeRelativePath } from './runtime-relative-paths'
 import { collectMemorySnapshot } from '../memory/collector'
-import { BrowserWindow, ipcMain } from 'electron'
+import { BrowserWindow, ipcMain, Notification } from 'electron'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
 import type { BrowserBackend } from '../browser/browser-backend'
 import { BrowserError } from '../browser/cdp-bridge'
@@ -2135,7 +2135,7 @@ type ResolvedWorktreeInFlight = {
 // events after it — idempotent, no duplicate local pushes.
 export type MobileNotificationDispatchEvent = {
   type: 'notification'
-  source: 'agent-task-complete' | 'terminal-bell' | 'test'
+  source: 'agent-task-complete' | 'terminal-bell' | 'test' | 'plugin'
   title: string
   body: string
   worktreeId?: string
@@ -8509,6 +8509,31 @@ export class OrcaRuntimeService {
     this.dispatchMobileNotification({ type: 'dismiss', notificationId })
   }
 
+  /** Plugin panel action notifications.show. Native on desktop, relayed to
+   *  paired mobile clients either way (mirrors notifications:dispatch). */
+  async dispatchPluginNotification(input: {
+    pluginId: string
+    title: string
+    body?: string
+  }): Promise<{ delivered: boolean }> {
+    // Why: prefix with the plugin id so a plugin cannot spoof an Orca system
+    // notification or impersonate another plugin.
+    const title = `${input.pluginId}: ${input.title}`
+    const body = input.body ?? ''
+    let delivered = false
+    try {
+      if (Notification.isSupported()) {
+        new Notification({ title, body }).show()
+        delivered = true
+      }
+    } catch {
+      // Headless serve has no notification display; the mobile relay below
+      // still runs.
+    }
+    this.dispatchMobileNotification({ type: 'notification', source: 'plugin', title, body })
+    return { delivered }
+  }
+
   // ─── Account Services (mobile RPC bridge) ─────────────────────
 
   setAccountServices(services: RuntimeAccountServices): void {
@@ -11392,6 +11417,41 @@ export class OrcaRuntimeService {
   // dispatch still works for handles without a resolvable pane.
   getTerminalPaneKey(handle: string): string | null {
     return this.getPaneKeyForTerminalHandle(handle)
+  }
+
+  /** Read-only context of the worktree the user is focused on, for plugin
+   *  panels (workspace.readContext). Prefers the persisted session focus and
+   *  falls back to the last-focused pane's worktree; null when neither
+   *  resolves so panels degrade instead of erroring. */
+  async resolveActiveWorktreeContext(): Promise<{
+    worktreeId: string
+    path: string
+    branch: string
+    displayName: string
+  } | null> {
+    let worktreeId = this.store?.getWorkspaceSession?.()?.activeWorktreeId ?? null
+    if (!worktreeId && this.graphStatus === 'ready') {
+      for (const tab of this.tabs.values()) {
+        if (tab.activeLeafId && tab.worktreeId) {
+          worktreeId = tab.worktreeId
+          break
+        }
+      }
+    }
+    if (!worktreeId) {
+      return null
+    }
+    try {
+      const resolved = await this.resolveWorktreeSelector(`id:${worktreeId}`)
+      return {
+        worktreeId: resolved.id,
+        path: resolved.git.path,
+        branch: resolved.git.branch,
+        displayName: resolved.displayName
+      }
+    } catch {
+      return null
+    }
   }
 
   resolveTerminalPane(paneKey: string): RuntimeTerminalResolvePane {

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -30,6 +30,7 @@ import { SPEECH_METHODS } from './speech'
 import { CLIENT_UI_METHODS } from './client-ui'
 import { CLIENT_EVENT_METHODS } from './client-events'
 import { WORKSPACE_PORT_METHODS } from './workspace-ports'
+import { PLUGIN_METHODS } from './plugins'
 import { SKILL_METHODS } from './skills'
 import { CLIPBOARD_METHODS } from './clipboard'
 import { HOST_CAPABILITY_METHODS } from './host-capabilities'
@@ -69,6 +70,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...SSH_METHODS,
   ...SPEECH_METHODS,
   ...WORKSPACE_PORT_METHODS,
+  ...PLUGIN_METHODS,
   ...SKILL_METHODS,
   ...CLIPBOARD_METHODS,
   ...HOST_CAPABILITY_METHODS,

--- a/src/main/runtime/rpc/methods/plugins.test.ts
+++ b/src/main/runtime/rpc/methods/plugins.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RpcContext, RpcMethod } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { PluginService } from '../../../plugins/plugin-service'
+import { PLUGIN_METHODS, setPluginServiceForRpc } from './plugins'
+
+// Why: importing RpcDispatcher would transitively load orca-runtime and its
+// node-pty native module; parsing with the method's own schema exercises the
+// same validation the dispatcher applies without the native dependency.
+function callMethod(
+  method: RpcMethod,
+  params: unknown,
+  runtime: OrcaRuntimeService
+): Promise<unknown> | unknown {
+  const parsed = method.params ? method.params.parse(params) : undefined
+  return method.handler(parsed, { runtime } as RpcContext)
+}
+
+function getPanelActionMethod(): RpcMethod {
+  const method = PLUGIN_METHODS.find((entry) => entry.name === 'plugins.panelAction')
+  if (!method) {
+    throw new Error('plugins.panelAction method is not registered')
+  }
+  return method
+}
+
+function makeRuntime(): { runtime: OrcaRuntimeService; sendTerminal: ReturnType<typeof vi.fn> } {
+  const sendTerminal = vi
+    .fn()
+    .mockResolvedValue({ handle: 'term-1', accepted: true, bytesWritten: 10 })
+  const runtime = {
+    resolveActiveTerminal: vi.fn().mockResolvedValue('term-1'),
+    sendTerminal
+  } as unknown as OrcaRuntimeService
+  return { runtime, sendTerminal }
+}
+
+function stubPluginService(permissions: string[] | null): PluginService {
+  return { getGrantedPermissions: () => permissions } as unknown as PluginService
+}
+
+afterEach(() => {
+  setPluginServiceForRpc(null)
+})
+
+describe('plugins.panelAction RPC method', () => {
+  it('relays a permitted terminal.sendText action to the runtime pty path', async () => {
+    setPluginServiceForRpc(stubPluginService(['terminal.sendText']))
+    const { runtime, sendTerminal } = makeRuntime()
+
+    const result = await callMethod(
+      getPanelActionMethod(),
+      {
+        pluginId: 'model-shift',
+        panelId: 'gear-shifter',
+        action: 'terminal.sendText',
+        params: { text: '/model opus', enter: true }
+      },
+      runtime
+    )
+
+    expect(result).toEqual({ outcome: { ok: true, value: { accepted: true } } })
+    expect(sendTerminal).toHaveBeenCalledWith('term-1', { text: '/model opus', enter: true })
+  })
+
+  it('denies the action when the manifest grants no permission', async () => {
+    setPluginServiceForRpc(stubPluginService([]))
+    const { runtime, sendTerminal } = makeRuntime()
+
+    const result = await callMethod(
+      getPanelActionMethod(),
+      {
+        pluginId: 'model-shift',
+        action: 'terminal.sendText',
+        params: { text: '/model opus', enter: true }
+      },
+      runtime
+    )
+
+    expect(result).toMatchObject({ outcome: { ok: false, code: 'permission_denied' } })
+    expect(sendTerminal).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed call params at the schema boundary', () => {
+    const method = getPanelActionMethod()
+    expect(() => method.params?.parse({ action: 'terminal.sendText' })).toThrow()
+    expect(() => method.params?.parse({ pluginId: '', action: 'terminal.sendText' })).toThrow()
+  })
+
+  it('errors when no plugin service is wired on this runtime', async () => {
+    const { runtime } = makeRuntime()
+
+    await expect(
+      Promise.resolve(
+        callMethod(
+          getPanelActionMethod(),
+          { pluginId: 'model-shift', action: 'terminal.sendText', params: { text: 'hi' } },
+          runtime
+        )
+      )
+    ).rejects.toThrow('Plugin service is not available')
+  })
+})

--- a/src/main/runtime/rpc/methods/plugins.test.ts
+++ b/src/main/runtime/rpc/methods/plugins.test.ts
@@ -36,7 +36,19 @@ function makeRuntime(): { runtime: OrcaRuntimeService; sendTerminal: ReturnType<
 }
 
 function stubPluginService(permissions: string[] | null): PluginService {
-  return { getGrantedPermissions: () => permissions } as unknown as PluginService
+  return {
+    getGrantedPermissions: () => permissions,
+    whenReady: async () => undefined,
+    listPlugins: () => []
+  } as unknown as PluginService
+}
+
+function getMethod(name: string): RpcMethod {
+  const method = PLUGIN_METHODS.find((entry) => entry.name === name)
+  if (!method) {
+    throw new Error(`${name} method is not registered`)
+  }
+  return method
 }
 
 afterEach(() => {
@@ -99,5 +111,39 @@ describe('plugins.panelAction RPC method', () => {
         )
       )
     ).rejects.toThrow('Plugin service is not available')
+  })
+})
+
+describe('plugins.setEnabled RPC method', () => {
+  it('routes through the injected enablement closure (headless consent path)', async () => {
+    const applyEnablement = vi.fn().mockResolvedValue([{ pluginId: 'model-shift' }])
+    setPluginServiceForRpc(stubPluginService([]), applyEnablement)
+    const { runtime } = makeRuntime()
+
+    const result = await callMethod(
+      getMethod('plugins.setEnabled'),
+      { pluginId: 'model-shift', enabled: true },
+      runtime
+    )
+
+    expect(applyEnablement).toHaveBeenCalledWith('model-shift', true)
+    expect(result).toEqual([{ pluginId: 'model-shift' }])
+  })
+
+  it('errors when enablement is not wired', async () => {
+    setPluginServiceForRpc(stubPluginService([]))
+    const { runtime } = makeRuntime()
+
+    await expect(
+      Promise.resolve(
+        callMethod(getMethod('plugins.setEnabled'), { pluginId: 'x', enabled: false }, runtime)
+      )
+    ).rejects.toThrow('Plugin enablement is not available')
+  })
+
+  it('rejects malformed params at the schema boundary', () => {
+    const method = getMethod('plugins.setEnabled')
+    expect(() => method.params?.parse({ pluginId: 'x' })).toThrow()
+    expect(() => method.params?.parse({ pluginId: '', enabled: true })).toThrow()
   })
 })

--- a/src/main/runtime/rpc/methods/plugins.ts
+++ b/src/main/runtime/rpc/methods/plugins.ts
@@ -5,15 +5,24 @@ import { isCodeProviderMethod } from '../../../../shared/plugins/code-provider'
 import { CODE_PROVIDER_EXTENSION_POINT } from '../../../../shared/plugins/plugin-extension-registry'
 import { panelActionCallSchema } from '../../../../shared/plugins/plugin-panel-bridge'
 import { executePluginPanelAction } from '../../../plugins/plugin-panel-actions'
-import type { PluginService } from '../../../plugins/plugin-service'
+import type { PluginListEntry, PluginService } from '../../../plugins/plugin-service'
 
 // Why: RpcContext only carries the OrcaRuntimeService, and plugins are a
 // separate composition-root service — inject it via module setter the way the
 // desktop entry wires it, instead of widening the shared RPC context type.
 let pluginServiceForRpc: PluginService | null = null
+// Enablement needs the settings Store too, so the entry injects a bound
+// closure instead of the store itself.
+let pluginEnablementForRpc:
+  | ((pluginId: string, enabled: boolean) => Promise<PluginListEntry[]>)
+  | null = null
 
-export function setPluginServiceForRpc(service: PluginService | null): void {
+export function setPluginServiceForRpc(
+  service: PluginService | null,
+  applyEnablement?: (pluginId: string, enabled: boolean) => Promise<PluginListEntry[]>
+): void {
   pluginServiceForRpc = service
+  pluginEnablementForRpc = applyEnablement ?? null
 }
 
 function requirePluginService(): PluginService {
@@ -25,6 +34,8 @@ function requirePluginService(): PluginService {
 
 const PluginInvokeCodeProviderParams = z.object({
   pluginId: z.string().min(1),
+  /** Required to reach the second+ provider of a multi-provider plugin. */
+  providerId: z.string().min(1).optional(),
   method: z.string().min(1),
   args: z.array(z.unknown()).default([])
 })
@@ -34,11 +45,36 @@ const PluginReadPanelEntryParams = z.object({
   panelId: z.string().min(1)
 })
 
+const PluginSetEnabledParams = z.object({
+  pluginId: z.string().min(1),
+  enabled: z.boolean()
+})
+
 export const PLUGIN_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'plugins.list',
     params: null,
-    handler: () => requirePluginService().listPlugins()
+    handler: async () => {
+      // Why: startup discovery is fire-and-forget; await it so an early call
+      // can't observe the empty pre-discovery list.
+      const service = requirePluginService()
+      await service.whenReady()
+      return service.listPlugins()
+    }
+  }),
+  defineMethod({
+    // Why: headless serve has no consent dialog — an explicit enable call is
+    // the only way a pending (never-approved) plugin starts on a server.
+    name: 'plugins.setEnabled',
+    params: PluginSetEnabledParams,
+    handler: async (params) => {
+      const service = requirePluginService()
+      await service.whenReady()
+      if (!pluginEnablementForRpc) {
+        throw new Error('Plugin enablement is not available on this runtime')
+      }
+      return pluginEnablementForRpc(params.pluginId, params.enabled)
+    }
   }),
   defineMethod({
     name: 'plugins.invokeCodeProvider',
@@ -47,9 +83,11 @@ export const PLUGIN_METHODS: RpcMethod[] = [
       if (!isCodeProviderMethod(params.method)) {
         throw new Error(`unknown code provider method: ${params.method}`)
       }
-      const provider = requirePluginService()
+      const service = requirePluginService()
+      await service.whenReady()
+      const provider = service
         .getRegistry()
-        .resolve(CODE_PROVIDER_EXTENSION_POINT, params.pluginId)
+        .resolve(CODE_PROVIDER_EXTENSION_POINT, params.pluginId, params.providerId)
       const implementation = provider?.[params.method]
       if (!provider || typeof implementation !== 'function') {
         throw new Error(`plugin ${params.pluginId} does not provide ${params.method}`)
@@ -63,20 +101,27 @@ export const PLUGIN_METHODS: RpcMethod[] = [
     // the desktop IPC handler.
     name: 'plugins.panelAction',
     params: panelActionCallSchema,
-    handler: async (params, { runtime }) => ({
-      outcome: await executePluginPanelAction({
-        action: params.action,
-        params: params.params,
-        grantedPermissions: requirePluginService().getGrantedPermissions(params.pluginId),
-        runtime
-      })
-    })
+    handler: async (params, { runtime }) => {
+      const service = requirePluginService()
+      await service.whenReady()
+      return {
+        outcome: await executePluginPanelAction({
+          pluginId: params.pluginId,
+          action: params.action,
+          params: params.params,
+          grantedPermissions: service.getGrantedPermissions(params.pluginId),
+          runtime
+        })
+      }
+    }
   }),
   defineMethod({
     name: 'plugins.readPanelEntry',
     params: PluginReadPanelEntryParams,
     handler: async (params) => {
-      const entryPath = requirePluginService().getPanelEntryPath(params.pluginId, params.panelId)
+      const service = requirePluginService()
+      await service.whenReady()
+      const entryPath = service.getPanelEntryPath(params.pluginId, params.panelId)
       if (!entryPath) {
         return null
       }

--- a/src/main/runtime/rpc/methods/plugins.ts
+++ b/src/main/runtime/rpc/methods/plugins.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { isCodeProviderMethod } from '../../../../shared/plugins/code-provider'
 import { CODE_PROVIDER_EXTENSION_POINT } from '../../../../shared/plugins/plugin-extension-registry'
+import { panelActionCallSchema } from '../../../../shared/plugins/plugin-panel-bridge'
+import { executePluginPanelAction } from '../../../plugins/plugin-panel-actions'
 import type { PluginService } from '../../../plugins/plugin-service'
 
 // Why: RpcContext only carries the OrcaRuntimeService, and plugins are a
@@ -54,6 +56,21 @@ export const PLUGIN_METHODS: RpcMethod[] = [
       }
       return await (implementation as (...args: unknown[]) => unknown).apply(provider, params.args)
     }
+  }),
+  defineMethod({
+    // Why: headless serve clients relay panel bridge requests over RPC, so
+    // permission enforcement must live behind this method too, not only in
+    // the desktop IPC handler.
+    name: 'plugins.panelAction',
+    params: panelActionCallSchema,
+    handler: async (params, { runtime }) => ({
+      outcome: await executePluginPanelAction({
+        action: params.action,
+        params: params.params,
+        grantedPermissions: requirePluginService().getGrantedPermissions(params.pluginId),
+        runtime
+      })
+    })
   }),
   defineMethod({
     name: 'plugins.readPanelEntry',

--- a/src/main/runtime/rpc/methods/plugins.ts
+++ b/src/main/runtime/rpc/methods/plugins.ts
@@ -1,0 +1,73 @@
+import { readFile } from 'node:fs/promises'
+import { z } from 'zod'
+import { defineMethod, type RpcMethod } from '../core'
+import { isCodeProviderMethod } from '../../../../shared/plugins/code-provider'
+import { CODE_PROVIDER_EXTENSION_POINT } from '../../../../shared/plugins/plugin-extension-registry'
+import type { PluginService } from '../../../plugins/plugin-service'
+
+// Why: RpcContext only carries the OrcaRuntimeService, and plugins are a
+// separate composition-root service — inject it via module setter the way the
+// desktop entry wires it, instead of widening the shared RPC context type.
+let pluginServiceForRpc: PluginService | null = null
+
+export function setPluginServiceForRpc(service: PluginService | null): void {
+  pluginServiceForRpc = service
+}
+
+function requirePluginService(): PluginService {
+  if (!pluginServiceForRpc) {
+    throw new Error('Plugin service is not available on this runtime')
+  }
+  return pluginServiceForRpc
+}
+
+const PluginInvokeCodeProviderParams = z.object({
+  pluginId: z.string().min(1),
+  method: z.string().min(1),
+  args: z.array(z.unknown()).default([])
+})
+
+const PluginReadPanelEntryParams = z.object({
+  pluginId: z.string().min(1),
+  panelId: z.string().min(1)
+})
+
+export const PLUGIN_METHODS: RpcMethod[] = [
+  defineMethod({
+    name: 'plugins.list',
+    params: null,
+    handler: () => requirePluginService().listPlugins()
+  }),
+  defineMethod({
+    name: 'plugins.invokeCodeProvider',
+    params: PluginInvokeCodeProviderParams,
+    handler: async (params) => {
+      if (!isCodeProviderMethod(params.method)) {
+        throw new Error(`unknown code provider method: ${params.method}`)
+      }
+      const provider = requirePluginService()
+        .getRegistry()
+        .resolve(CODE_PROVIDER_EXTENSION_POINT, params.pluginId)
+      const implementation = provider?.[params.method]
+      if (!provider || typeof implementation !== 'function') {
+        throw new Error(`plugin ${params.pluginId} does not provide ${params.method}`)
+      }
+      return await (implementation as (...args: unknown[]) => unknown).apply(provider, params.args)
+    }
+  }),
+  defineMethod({
+    name: 'plugins.readPanelEntry',
+    params: PluginReadPanelEntryParams,
+    handler: async (params) => {
+      const entryPath = requirePluginService().getPanelEntryPath(params.pluginId, params.panelId)
+      if (!entryPath) {
+        return null
+      }
+      try {
+        return { html: await readFile(entryPath, 'utf8') }
+      } catch {
+        return null
+      }
+    }
+  })
+]

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -952,7 +952,8 @@ export type PluginHostPanel = {
   tabKey: `plugin:${string}`
 }
 
-export type PluginHostStatus = 'active' | 'disabled' | 'error'
+/** `pending` = discovered but not yet user-approved; the plugin never ran. */
+export type PluginHostStatus = 'active' | 'pending' | 'disabled' | 'error'
 
 export type PluginHostListEntry = {
   pluginId: string
@@ -3169,11 +3170,16 @@ export type PreloadApi = {
     setEnabled: (args: { pluginId: string; enabled: boolean }) => Promise<PluginHostListEntry[]>
     /** Returns the panel's HTML entry contents, or null when the plugin or
      *  panel is missing/disabled. Rendered only inside a sandboxed iframe. */
-    readPanelEntry: (args: { pluginId: string; panelId: string }) => Promise<{ html: string } | null>
+    readPanelEntry: (args: {
+      pluginId: string
+      panelId: string
+    }) => Promise<{ html: string } | null>
     invokeCodeProvider: (args: {
       pluginId: string
+      /** Required to reach the second+ provider of a multi-provider plugin. */
+      providerId?: string
       method: string
-      args?: unknown
+      args?: unknown[]
     }) => Promise<unknown>
     /** Relays a sandboxed panel's bridge request to main, which enforces the
      *  plugin's manifest permissions before executing. */

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -942,6 +942,26 @@ export type AppApi = {
   ) => Promise<WriteTerminalRenderDesyncEvidenceResult>
 }
 
+/** Panel contribution as surfaced by the main-process plugin host. */
+export type PluginHostPanel = {
+  id: string
+  title: string
+  /** Lucide icon name declared in the plugin manifest. */
+  icon?: string
+  tabKey: `plugin:${string}`
+}
+
+export type PluginHostStatus = 'active' | 'disabled' | 'error'
+
+export type PluginHostListEntry = {
+  pluginId: string
+  name: string
+  version: string
+  status: PluginHostStatus
+  error?: string
+  panels: PluginHostPanel[]
+}
+
 export type PreloadApi = {
   app: AppApi
   orcaProfiles: {
@@ -3142,6 +3162,18 @@ export type PreloadApi = {
   }
   gitBash: {
     isAvailable: () => Promise<boolean>
+  }
+  plugins: {
+    list: () => Promise<PluginHostListEntry[]>
+    setEnabled: (args: { pluginId: string; enabled: boolean }) => Promise<PluginHostListEntry[]>
+    /** Returns the panel's HTML entry contents, or null when the plugin or
+     *  panel is missing/disabled. Rendered only inside a sandboxed iframe. */
+    readPanelEntry: (args: { pluginId: string; panelId: string }) => Promise<{ html: string } | null>
+    invokeCodeProvider: (args: {
+      pluginId: string
+      method: string
+      args?: unknown
+    }) => Promise<unknown>
   }
   agentStatus: {
     /** Listen for agent status updates forwarded from native hook receivers. */

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -59,6 +59,7 @@ import type { LinearIssueAttributeFilter } from '../shared/linear-issue-attribut
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 import type { StartupCommandDelivery } from '../shared/codex-startup-delivery'
 import type { SleepingAgentLaunchConfig } from '../shared/agent-session-resume'
+import type { PluginPanelActionOutcome } from '../shared/plugins/plugin-panel-bridge'
 import type {
   LocalhostWorktreeLabelResult,
   LocalhostWorktreeLabelRoute
@@ -3174,6 +3175,14 @@ export type PreloadApi = {
       method: string
       args?: unknown
     }) => Promise<unknown>
+    /** Relays a sandboxed panel's bridge request to main, which enforces the
+     *  plugin's manifest permissions before executing. */
+    panelAction: (args: {
+      pluginId: string
+      panelId?: string
+      action: string
+      params?: unknown
+    }) => Promise<PluginPanelActionOutcome>
   }
   agentStatus: {
     /** Listen for agent status updates forwarded from native hook receivers. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -222,7 +222,7 @@ import type {
   ReactErrorBoundaryReportArgs,
   ReactErrorBoundaryReportResult
 } from '../shared/crash-reporting'
-import type { PreloadApi } from './api-types'
+import type { PluginHostListEntry, PreloadApi } from './api-types'
 import {
   createUpdaterQuitAbortRelay,
   prepareRendererForAppRestart
@@ -501,6 +501,21 @@ const api = {
   gitBash: {
     isAvailable: (): Promise<boolean> => ipcRenderer.invoke('gitBash:isAvailable')
   },
+
+  plugins: {
+    list: (): Promise<PluginHostListEntry[]> => ipcRenderer.invoke('plugins:list'),
+    setEnabled: (args: { pluginId: string; enabled: boolean }): Promise<PluginHostListEntry[]> =>
+      ipcRenderer.invoke('plugins:setEnabled', args),
+    readPanelEntry: (args: {
+      pluginId: string
+      panelId: string
+    }): Promise<{ html: string } | null> => ipcRenderer.invoke('plugins:readPanelEntry', args),
+    invokeCodeProvider: (args: {
+      pluginId: string
+      method: string
+      args?: unknown
+    }): Promise<unknown> => ipcRenderer.invoke('plugins:invokeCodeProvider', args)
+  } satisfies PreloadApi['plugins'],
 
   repos: {
     list: () => ipcRenderer.invoke('repos:list'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -513,8 +513,9 @@ const api = {
     }): Promise<{ html: string } | null> => ipcRenderer.invoke('plugins:readPanelEntry', args),
     invokeCodeProvider: (args: {
       pluginId: string
+      providerId?: string
       method: string
-      args?: unknown
+      args?: unknown[]
     }): Promise<unknown> => ipcRenderer.invoke('plugins:invokeCodeProvider', args),
     panelAction: (args: {
       pluginId: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,7 @@ import type { StartupCommandDelivery } from '../shared/codex-startup-delivery'
 import type { SleepingAgentLaunchConfig } from '../shared/agent-session-resume'
 import type { MobileRelayStatus } from '../shared/mobile-relay-status'
 import type { MobilePairingConnectionMode } from '../shared/mobile-pairing-connection-mode'
+import type { PluginPanelActionOutcome } from '../shared/plugins/plugin-panel-bridge'
 import type {
   BaseRefSearchResult,
   BaseRefDefaultResult,
@@ -514,7 +515,13 @@ const api = {
       pluginId: string
       method: string
       args?: unknown
-    }): Promise<unknown> => ipcRenderer.invoke('plugins:invokeCodeProvider', args)
+    }): Promise<unknown> => ipcRenderer.invoke('plugins:invokeCodeProvider', args),
+    panelAction: (args: {
+      pluginId: string
+      panelId?: string
+      action: string
+      params?: unknown
+    }): Promise<PluginPanelActionOutcome> => ipcRenderer.invoke('plugins:panelAction', args)
   } satisfies PreloadApi['plugins'],
 
   repos: {

--- a/src/renderer/src/components/right-sidebar/PluginPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PluginPanel.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ActivePluginPanel } from '@/store/plugin-panels'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+const { usePluginPanelsMock } = vi.hoisted(() => ({
+  usePluginPanelsMock: vi.fn<() => ActivePluginPanel[]>(() => [])
+}))
+
+vi.mock('@/store/plugin-panels', () => ({
+  usePluginPanels: usePluginPanelsMock
+}))
+
+import PluginPanel from './PluginPanel'
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true
+
+const dashboardPanel: ActivePluginPanel = {
+  id: 'dashboard',
+  title: 'Dashboard',
+  icon: 'gauge',
+  tabKey: 'plugin:my-plugin/dashboard',
+  pluginId: 'my-plugin',
+  pluginName: 'My Plugin'
+}
+
+let container: HTMLDivElement
+let root: Root
+const readPanelEntryMock = vi.fn()
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  readPanelEntryMock.mockReset()
+  usePluginPanelsMock.mockReturnValue([dashboardPanel])
+  globalThis.window.api = {
+    plugins: { readPanelEntry: readPanelEntryMock }
+  } as unknown as Window['api']
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+async function renderPanel(tabKey: string): Promise<void> {
+  await act(async () => {
+    root.render(<PluginPanel tabKey={tabKey} />)
+  })
+}
+
+describe('PluginPanel', () => {
+  it('renders the panel HTML in a scripts-only sandboxed iframe', async () => {
+    readPanelEntryMock.mockResolvedValue({ html: '<h1>Hello plugin</h1>' })
+
+    await renderPanel('plugin:my-plugin/dashboard')
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+    expect(readPanelEntryMock).toHaveBeenCalledWith({ pluginId: 'my-plugin', panelId: 'dashboard' })
+    expect(iframe?.getAttribute('srcdoc')).toContain('<h1>Hello plugin</h1>')
+    expect(iframe?.getAttribute('title')).toBe('Dashboard')
+    // Why: allow-same-origin would let plugin HTML reach the app DOM/storage;
+    // the sandbox must stay scripts-only.
+    expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts')
+  })
+
+  it('shows an error state when the panel entry cannot be read', async () => {
+    readPanelEntryMock.mockResolvedValue(null)
+
+    await renderPanel('plugin:my-plugin/dashboard')
+
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(container.textContent).toContain('The plugin panel could not be loaded.')
+  })
+
+  it('shows an unavailable state for a tab whose plugin is gone', async () => {
+    usePluginPanelsMock.mockReturnValue([])
+
+    await renderPanel('plugin:removed-plugin/dashboard')
+
+    expect(readPanelEntryMock).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('This plugin panel is no longer available.')
+  })
+
+  it('treats a malformed plugin tab key as unavailable', async () => {
+    await renderPanel('plugin:not-a-valid-key')
+
+    expect(readPanelEntryMock).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('This plugin panel is no longer available.')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/PluginPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PluginPanel.tsx
@@ -1,5 +1,9 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
+import {
+  callPanelActionViaPreload,
+  createPanelBridgeMessageHandler
+} from './plugin-panel-bridge-host'
 import { usePluginPanels } from '@/store/plugin-panels'
 import { translate } from '@/i18n/i18n'
 
@@ -26,9 +30,26 @@ function PluginPanel({ tabKey }: PluginPanelProps): React.JSX.Element {
     ? (panels.find((entry) => entry.tabKey === tabKey) ?? null)
     : null
   const [entryState, setEntryState] = useState<PluginPanelEntryState>({ status: 'loading' })
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
   const pluginId = panel?.pluginId ?? null
   const panelId = panel?.id ?? null
+
+  useEffect(() => {
+    if (!pluginId || !panelId || entryState.status !== 'ready') {
+      return
+    }
+    const handler = createPanelBridgeMessageHandler({
+      pluginId,
+      panelId,
+      getPanelWindow: () => iframeRef.current?.contentWindow ?? null,
+      callPanelAction: callPanelActionViaPreload
+    })
+    window.addEventListener('message', handler)
+    return () => {
+      window.removeEventListener('message', handler)
+    }
+  }, [pluginId, panelId, entryState.status])
 
   useEffect(() => {
     if (!pluginId || !panelId) {
@@ -92,6 +113,7 @@ function PluginPanel({ tabKey }: PluginPanelProps): React.JSX.Element {
 
   return (
     <iframe
+      ref={iframeRef}
       // SECURITY: never add allow-same-origin — the srcdoc frame must stay an
       // opaque origin so plugin UI cannot reach the app DOM, storage, or IPC.
       sandbox="allow-scripts"

--- a/src/renderer/src/components/right-sidebar/PluginPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PluginPanel.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from 'react'
+import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
+import { usePluginPanels } from '@/store/plugin-panels'
+import { translate } from '@/i18n/i18n'
+
+type PluginPanelProps = {
+  tabKey: string
+}
+
+type PluginPanelEntryState =
+  | { status: 'loading' }
+  | { status: 'error' }
+  | { status: 'ready'; html: string }
+
+function PluginPanelMessage({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+function PluginPanel({ tabKey }: PluginPanelProps): React.JSX.Element {
+  const panels = usePluginPanels()
+  const panel = isPluginPanelTabKey(tabKey)
+    ? (panels.find((entry) => entry.tabKey === tabKey) ?? null)
+    : null
+  const [entryState, setEntryState] = useState<PluginPanelEntryState>({ status: 'loading' })
+
+  const pluginId = panel?.pluginId ?? null
+  const panelId = panel?.id ?? null
+
+  useEffect(() => {
+    if (!pluginId || !panelId) {
+      return
+    }
+    let cancelled = false
+    setEntryState({ status: 'loading' })
+    const pluginsApi = window.api?.plugins
+    if (!pluginsApi) {
+      setEntryState({ status: 'error' })
+      return
+    }
+    pluginsApi
+      .readPanelEntry({ pluginId, panelId })
+      .then((entry) => {
+        if (!cancelled) {
+          setEntryState(entry ? { status: 'ready', html: entry.html } : { status: 'error' })
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setEntryState({ status: 'error' })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [pluginId, panelId])
+
+  // Persisted plugin tabs can outlive their plugin (uninstalled/disabled);
+  // render a graceful empty state instead of a broken frame.
+  if (!panel) {
+    return (
+      <PluginPanelMessage>
+        {translate(
+          'auto.components.right.sidebar.PluginPanel.unavailable',
+          'This plugin panel is no longer available.'
+        )}
+      </PluginPanelMessage>
+    )
+  }
+
+  if (entryState.status === 'loading') {
+    return (
+      <PluginPanelMessage>
+        {translate('auto.components.right.sidebar.PluginPanel.loading', 'Loading plugin panel...')}
+      </PluginPanelMessage>
+    )
+  }
+
+  if (entryState.status === 'error') {
+    return (
+      <PluginPanelMessage>
+        {translate(
+          'auto.components.right.sidebar.PluginPanel.loadFailed',
+          'The plugin panel could not be loaded.'
+        )}
+      </PluginPanelMessage>
+    )
+  }
+
+  return (
+    <iframe
+      // SECURITY: never add allow-same-origin — the srcdoc frame must stay an
+      // opaque origin so plugin UI cannot reach the app DOM, storage, or IPC.
+      sandbox="allow-scripts"
+      srcDoc={entryState.html}
+      title={panel.title}
+      className="h-full w-full flex-1 border-0 bg-background"
+    />
+  )
+}
+
+export default PluginPanel

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -26,6 +26,8 @@ import {
 } from './activity-bar-buttons'
 import { getActiveChecksStatus } from './active-checks-status'
 import { getVisibleRightSidebarActivityItems } from './right-sidebar-activity-visibility'
+import { getPluginPanelActivityItems } from './plugin-panel-activity-items'
+import { usePluginPanels } from '@/store/plugin-panels'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import {
   RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME,
@@ -84,6 +86,7 @@ function RightSidebarInner(): React.JSX.Element {
   const isFolderWorkspace = activeWorkspaceScope?.type === 'folder'
   const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
   const isSshRepo = Boolean(activeRepo?.connectionId)
+  const pluginPanels = usePluginPanels()
 
   const activityItems = useMemo<ActivityBarItem[]>(
     () => [
@@ -136,9 +139,12 @@ function RightSidebarInner(): React.JSX.Element {
         title: translate('auto.components.right.sidebar.index.441733b630', 'Ports'),
         shortcut: portsShortcut === 'Unassigned' ? '' : portsShortcut,
         sshOnly: true
-      }
+      },
+      // Why: plugin panels append after the built-in tabs so core navigation
+      // keeps stable positions regardless of which plugins are installed.
+      ...getPluginPanelActivityItems(pluginPanels)
     ],
-    [checksShortcut, explorerShortcut, portsShortcut, sourceControlShortcut]
+    [checksShortcut, explorerShortcut, portsShortcut, sourceControlShortcut, pluginPanels]
   )
 
   const visibleItems = useMemo(

--- a/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.ts
@@ -1,0 +1,86 @@
+import {
+  Activity,
+  BarChart3,
+  Bell,
+  Blocks,
+  Book,
+  Bot,
+  Bug,
+  Calendar,
+  Cloud,
+  Code,
+  Database,
+  FileText,
+  Flag,
+  Folder,
+  Gauge,
+  Globe,
+  Hammer,
+  Layers,
+  Lightbulb,
+  Package,
+  Plug,
+  Puzzle,
+  Rocket,
+  Star,
+  Terminal,
+  Wrench,
+  Zap
+} from 'lucide-react'
+import type { ActivePluginPanel } from '@/store/plugin-panels'
+import type { ActivityBarItem } from './activity-bar-buttons'
+
+type PluginPanelIcon = ActivityBarItem['icon']
+
+// Why: importing lucide's full `icons` map would bundle every icon and defeat
+// tree-shaking, so plugin manifests pick from this curated set (fallback: Plug).
+const PLUGIN_PANEL_ICONS: Record<string, PluginPanelIcon> = {
+  activity: Activity,
+  barchart3: BarChart3,
+  bell: Bell,
+  blocks: Blocks,
+  book: Book,
+  bot: Bot,
+  bug: Bug,
+  calendar: Calendar,
+  cloud: Cloud,
+  code: Code,
+  database: Database,
+  filetext: FileText,
+  flag: Flag,
+  folder: Folder,
+  gauge: Gauge,
+  globe: Globe,
+  hammer: Hammer,
+  layers: Layers,
+  lightbulb: Lightbulb,
+  package: Package,
+  plug: Plug,
+  puzzle: Puzzle,
+  rocket: Rocket,
+  star: Star,
+  terminal: Terminal,
+  wrench: Wrench,
+  zap: Zap
+}
+
+export function resolvePluginPanelIcon(iconName: string | undefined): PluginPanelIcon {
+  if (!iconName) {
+    return Plug
+  }
+  // Accept both lucide naming styles ('file-text' and 'FileText').
+  const normalized = iconName.replaceAll('-', '').toLowerCase()
+  return PLUGIN_PANEL_ICONS[normalized] ?? Plug
+}
+
+/** Maps active plugin panel contributions onto right-sidebar activity items. */
+export function getPluginPanelActivityItems(panels: ActivePluginPanel[]): ActivityBarItem[] {
+  return panels.map((panel) => ({
+    id: panel.tabKey,
+    icon: resolvePluginPanelIcon(panel.icon),
+    // Why: panel titles come from plugin manifests, not the app catalog, so
+    // they render untranslated by design.
+    title: panel.title,
+    shortcut: ''
+  }))
+}

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PluginPanelActionOutcome } from '../../../../shared/plugins/plugin-panel-bridge'
+import { createPanelBridgeMessageHandler } from './plugin-panel-bridge-host'
+
+type FakePanelWindow = Window & { postMessage: ReturnType<typeof vi.fn> }
+
+function createFakePanelWindow(): FakePanelWindow {
+  return { postMessage: vi.fn() } as unknown as FakePanelWindow
+}
+
+function messageEvent(data: unknown, source: unknown): MessageEvent {
+  // The handler only reads .data and .source, so a plain object stands in for
+  // a real MessageEvent without needing a DOM environment.
+  return { data, source } as unknown as MessageEvent
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+const VALID_DATA = {
+  type: 'orca-panel-action',
+  requestId: 'req-1',
+  action: 'terminal.sendText',
+  params: { text: '/model haiku', enter: true }
+}
+
+function createHandler(
+  panelWindow: FakePanelWindow,
+  outcome: PluginPanelActionOutcome = { ok: true, value: { accepted: true } }
+): { handler: (event: MessageEvent) => void; callPanelAction: ReturnType<typeof vi.fn> } {
+  const callPanelAction = vi.fn().mockResolvedValue(outcome)
+  const handler = createPanelBridgeMessageHandler({
+    pluginId: 'model-shift',
+    panelId: 'gear-shifter',
+    getPanelWindow: () => panelWindow,
+    callPanelAction
+  })
+  return { handler, callPanelAction }
+}
+
+describe('createPanelBridgeMessageHandler', () => {
+  it('relays a valid request and posts the success result back into the panel', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow)
+
+    handler(messageEvent(VALID_DATA, panelWindow))
+    await flush()
+
+    expect(callPanelAction).toHaveBeenCalledWith({
+      pluginId: 'model-shift',
+      panelId: 'gear-shifter',
+      action: 'terminal.sendText',
+      params: { text: '/model haiku', enter: true }
+    })
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: 'orca-panel-action-result',
+        requestId: 'req-1',
+        ok: true,
+        value: { accepted: true }
+      },
+      '*'
+    )
+  })
+
+  it('ignores messages whose source is not the panel iframe window', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow)
+
+    handler(messageEvent(VALID_DATA, createFakePanelWindow()))
+    handler(messageEvent(VALID_DATA, null))
+    await flush()
+
+    expect(callPanelAction).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('ignores unrelated window messages without replying', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow)
+
+    handler(messageEvent({ type: 'react-devtools-bridge' }, panelWindow))
+    handler(messageEvent('plain string', panelWindow))
+    await flush()
+
+    expect(callPanelAction).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('answers a malformed bridge request with invalid_request instead of relaying it', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow)
+
+    handler(messageEvent({ ...VALID_DATA, action: 'fs.readFile' }, panelWindow))
+    await flush()
+
+    expect(callPanelAction).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'orca-panel-action-result',
+        requestId: 'req-1',
+        ok: false,
+        errorCode: 'invalid_request'
+      }),
+      '*'
+    )
+  })
+
+  it('relays a denial outcome (missing manifest permission) back to the panel', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler } = createHandler(panelWindow, {
+      ok: false,
+      code: 'permission_denied',
+      error: 'plugin does not have the "terminal.sendText" permission'
+    })
+
+    handler(messageEvent(VALID_DATA, panelWindow))
+    await flush()
+
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: 'orca-panel-action-result',
+        requestId: 'req-1',
+        ok: false,
+        errorCode: 'permission_denied',
+        error: 'plugin does not have the "terminal.sendText" permission'
+      },
+      '*'
+    )
+  })
+
+  it('reports a rejected relay call as action_failed', async () => {
+    const panelWindow = createFakePanelWindow()
+    const callPanelAction = vi.fn().mockRejectedValue(new Error('ipc broke'))
+    const handler = createPanelBridgeMessageHandler({
+      pluginId: 'model-shift',
+      panelId: 'gear-shifter',
+      getPanelWindow: () => panelWindow,
+      callPanelAction
+    })
+
+    handler(messageEvent(VALID_DATA, panelWindow))
+    await flush()
+
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, errorCode: 'action_failed', error: 'ipc broke' }),
+      '*'
+    )
+  })
+})

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
@@ -1,0 +1,104 @@
+import {
+  PANEL_ACTION_RESULT_TYPE,
+  looksLikePanelActionRequest,
+  parsePanelActionRequest,
+  type PluginPanelActionOutcome,
+  type PluginPanelActionResultMessage
+} from '../../../../shared/plugins/plugin-panel-bridge'
+
+/**
+ * Host side of the plugin panel postMessage bridge. Framework-free so message
+ * validation and relay behavior are directly unit-testable; PluginPanel wires
+ * the returned listener to `window` while the panel iframe is mounted.
+ */
+
+export type PanelActionCall = {
+  pluginId: string
+  panelId: string
+  action: string
+  params?: unknown
+}
+
+export type PanelBridgeHostOptions = {
+  pluginId: string
+  panelId: string
+  /** The mounted panel iframe's contentWindow, or null when unmounted. */
+  getPanelWindow: () => Window | null
+  callPanelAction: (call: PanelActionCall) => Promise<PluginPanelActionOutcome>
+}
+
+/** Relays a bridge call through the preload API, degrading to a bridge-level
+ *  error when the preload predates the plugins.panelAction surface. */
+export function callPanelActionViaPreload(
+  call: PanelActionCall
+): Promise<PluginPanelActionOutcome> {
+  const panelAction = window.api?.plugins?.panelAction
+  if (!panelAction) {
+    return Promise.resolve({
+      ok: false,
+      code: 'unavailable',
+      error: 'plugin actions are not available in this client'
+    })
+  }
+  return panelAction(call)
+}
+
+export function createPanelBridgeMessageHandler(
+  options: PanelBridgeHostOptions
+): (event: MessageEvent) => void {
+  return (event: MessageEvent): void => {
+    const panelWindow = options.getPanelWindow()
+    // Why: the sandboxed srcdoc frame has an opaque origin ("null"), so the
+    // sending window's identity — not event.origin — is the only trustworthy
+    // check that this message came from our panel and not another frame.
+    if (!panelWindow || event.source !== panelWindow) {
+      return
+    }
+    if (!looksLikePanelActionRequest(event.data)) {
+      return
+    }
+    const respond = (message: PluginPanelActionResultMessage): void => {
+      // Why: targetOrigin must be '*' — an opaque origin never matches a
+      // concrete origin, so anything stricter would silently drop the reply.
+      options.getPanelWindow()?.postMessage(message, '*')
+    }
+    const parsed = parsePanelActionRequest(event.data)
+    if (!parsed.ok) {
+      if (parsed.requestId) {
+        respond({
+          type: PANEL_ACTION_RESULT_TYPE,
+          requestId: parsed.requestId,
+          ok: false,
+          errorCode: 'invalid_request',
+          error: parsed.error
+        })
+      }
+      return
+    }
+    const { requestId, action, params } = parsed.request
+    options
+      .callPanelAction({ pluginId: options.pluginId, panelId: options.panelId, action, params })
+      .then((outcome) => {
+        respond(
+          outcome.ok
+            ? { type: PANEL_ACTION_RESULT_TYPE, requestId, ok: true, value: outcome.value }
+            : {
+                type: PANEL_ACTION_RESULT_TYPE,
+                requestId,
+                ok: false,
+                errorCode: outcome.code,
+                error: outcome.error
+              }
+        )
+      })
+      .catch((error: unknown) => {
+        respond({
+          type: PANEL_ACTION_RESULT_TYPE,
+          requestId,
+          ok: false,
+          errorCode: 'action_failed',
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
+  }
+}

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
@@ -26,7 +26,9 @@ const items: ActivityBarItem[] = [
     shortcut: '',
     gitOnly: true
   },
-  { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true }
+  { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true },
+  // Plugin panels carry no visibility flags, so they show in every context.
+  { id: 'plugin:my-plugin/dashboard', icon: Files, title: 'Dashboard', shortcut: '' }
 ]
 
 describe('getVisibleRightSidebarActivityItems', () => {
@@ -37,7 +39,7 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: false,
         isSshRepo: false
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'source-control'])
+    ).toEqual(['explorer', 'source-control', 'plugin:my-plugin/dashboard'])
 
     expect(
       getVisibleRightSidebarActivityItems(items, {
@@ -45,7 +47,7 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: false,
         isSshRepo: true
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'source-control', 'ports'])
+    ).toEqual(['explorer', 'source-control', 'ports', 'plugin:my-plugin/dashboard'])
   })
 
   it('shows Workspaces only for folder workspaces and hides git tabs for all folder scopes', () => {
@@ -55,7 +57,7 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: true,
         isSshRepo: true
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'workspaces', 'pr-checks', 'ports'])
+    ).toEqual(['explorer', 'workspaces', 'pr-checks', 'ports', 'plugin:my-plugin/dashboard'])
 
     expect(
       getVisibleRightSidebarActivityItems(items, {
@@ -63,6 +65,6 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: false,
         isSshRepo: true
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'ports'])
+    ).toEqual(['explorer', 'ports', 'plugin:my-plugin/dashboard'])
   })
 })

--- a/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts
@@ -72,6 +72,28 @@ describe('resolveRightSidebarEffectiveTab', () => {
     ).toBe('explorer')
   })
 
+  it('keeps a plugin tab active while its panel is still contributed', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'plugin:my-plugin/dashboard',
+        visibleItems: [...gitVisibleItems, { id: 'plugin:my-plugin/dashboard' }],
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: null
+      })
+    ).toBe('plugin:my-plugin/dashboard')
+  })
+
+  it('falls back to the first visible item when a plugin tab was uninstalled', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'plugin:my-plugin/dashboard',
+        visibleItems: gitVisibleItems,
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: null
+      })
+    ).toBe('explorer')
+  })
+
   it('treats empty visible items as an invariant failure', () => {
     expect(() =>
       resolveRightSidebarEffectiveTab({

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -41,8 +41,13 @@ export function RightSidebarPanelContent({
           />
         )}
         {/* Plugin-contributed tabs route by key prefix; the panel itself
-            handles plugins that have since been uninstalled or disabled. */}
-        {isPluginPanelTabKey(effectiveTab) && <PluginPanel tabKey={effectiveTab} />}
+            handles plugins that have since been uninstalled or disabled.
+            Why key: switching plugin tabs must remount the sandboxed iframe —
+            a reused frame could keep posting messages while the bridge is
+            rebound under the next plugin's identity. */}
+        {isPluginPanelTabKey(effectiveTab) && (
+          <PluginPanel key={effectiveTab} tabKey={effectiveTab} />
+        )}
       </Suspense>
     </div>
   )

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
 
 const FileExplorer = lazy(() => import('./FileExplorer'))
 const SourceControl = lazy(() => import('./SourceControl'))
@@ -9,6 +10,7 @@ const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
+const PluginPanel = lazy(() => import('./PluginPanel'))
 
 type RightSidebarPanelContentProps = {
   effectiveTab: ActiveRightSidebarTab
@@ -38,6 +40,9 @@ export function RightSidebarPanelContent({
             isVisible={rightSidebarOpen && effectiveTab === 'pr-checks'}
           />
         )}
+        {/* Plugin-contributed tabs route by key prefix; the panel itself
+            handles plugins that have since been uninstalled or disabled. */}
+        {isPluginPanelTabKey(effectiveTab) && <PluginPanel tabKey={effectiveTab} />}
       </Suspense>
     </div>
   )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10094,6 +10094,11 @@
             "folderWorkspaces": "Attached worktrees",
             "parentPrChecks": "PR Checks"
           },
+          "PluginPanel": {
+            "loading": "Loading plugin panel...",
+            "unavailable": "This plugin panel is no longer available.",
+            "loadFailed": "The plugin panel could not be loaded."
+          },
           "right": {
             "panel": {
               "comment": {

--- a/src/renderer/src/store/plugin-panels.ts
+++ b/src/renderer/src/store/plugin-panels.ts
@@ -1,0 +1,78 @@
+import { useEffect, useMemo } from 'react'
+import { create } from 'zustand'
+import type { PluginHostListEntry, PluginHostPanel } from '../../../preload/api-types'
+
+/** A panel contribution from an active plugin, flattened for sidebar use. */
+export type ActivePluginPanel = PluginHostPanel & {
+  pluginId: string
+  pluginName: string
+}
+
+type PluginPanelsFetchStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+type PluginPanelsState = {
+  plugins: PluginHostListEntry[]
+  fetchStatus: PluginPanelsFetchStatus
+  fetchPlugins: () => Promise<void>
+  setPluginEnabled: (pluginId: string, enabled: boolean) => Promise<void>
+}
+
+export const usePluginPanelsStore = create<PluginPanelsState>()((set) => ({
+  plugins: [],
+  fetchStatus: 'idle',
+  fetchPlugins: async () => {
+    // Why: preload may predate the plugins namespace (web client pairing an
+    // older desktop build); treat a missing bridge as "no plugins" fail-soft.
+    const pluginsApi = window.api?.plugins
+    if (!pluginsApi) {
+      set({ fetchStatus: 'ready', plugins: [] })
+      return
+    }
+    set({ fetchStatus: 'loading' })
+    try {
+      const plugins = await pluginsApi.list()
+      set({ plugins, fetchStatus: 'ready' })
+    } catch {
+      set({ fetchStatus: 'error' })
+    }
+  },
+  setPluginEnabled: async (pluginId, enabled) => {
+    const pluginsApi = window.api?.plugins
+    if (!pluginsApi) {
+      return
+    }
+    const plugins = await pluginsApi.setEnabled({ pluginId, enabled })
+    set({ plugins, fetchStatus: 'ready' })
+  }
+}))
+
+/** Kicks off the one-shot startup fetch; safe to call repeatedly. */
+export function ensurePluginPanelsLoaded(): void {
+  const { fetchStatus, fetchPlugins } = usePluginPanelsStore.getState()
+  if (fetchStatus === 'idle') {
+    void fetchPlugins()
+  }
+}
+
+export function collectActivePluginPanels(plugins: PluginHostListEntry[]): ActivePluginPanel[] {
+  return plugins
+    .filter((plugin) => plugin.status === 'active')
+    .flatMap((plugin) =>
+      plugin.panels.map((panel) => ({
+        ...panel,
+        pluginId: plugin.pluginId,
+        pluginName: plugin.name
+      }))
+    )
+}
+
+/** Panel contributions of active plugins, loading the list on first use. */
+export function usePluginPanels(): ActivePluginPanel[] {
+  const plugins = usePluginPanelsStore((s) => s.plugins)
+  useEffect(() => {
+    ensurePluginPanelsLoaded()
+  }, [])
+  // Why: derive in useMemo (not the selector) so the store snapshot stays
+  // referentially stable and doesn't retrigger useSyncExternalStore loops.
+  return useMemo(() => collectActivePluginPanels(plugins), [plugins])
+}

--- a/src/renderer/src/store/right-sidebar-route.test.ts
+++ b/src/renderer/src/store/right-sidebar-route.test.ts
@@ -15,4 +15,26 @@ describe('normalizeRightSidebarRoute', () => {
       rightSidebarExplorerView: 'files'
     })
   })
+
+  it('preserves well-formed plugin panel tabs', () => {
+    expect(normalizeRightSidebarRoute('plugin:my-plugin/dashboard')).toEqual({
+      rightSidebarTab: 'plugin:my-plugin/dashboard',
+      rightSidebarExplorerView: 'files'
+    })
+  })
+
+  it('normalizes malformed plugin tabs to Explorer files', () => {
+    expect(normalizeRightSidebarRoute('plugin:my-plugin')).toEqual({
+      rightSidebarTab: 'explorer',
+      rightSidebarExplorerView: 'files'
+    })
+    expect(normalizeRightSidebarRoute('plugin:my-plugin/panel/extra')).toEqual({
+      rightSidebarTab: 'explorer',
+      rightSidebarExplorerView: 'files'
+    })
+    expect(normalizeRightSidebarRoute('plugin:My_Plugin/Panel!')).toEqual({
+      rightSidebarTab: 'explorer',
+      rightSidebarExplorerView: 'files'
+    })
+  })
 })

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -1,4 +1,5 @@
 import type { ActiveRightSidebarTab, RightSidebarExplorerView } from '../../../shared/types'
+import { isPluginPanelTabKey } from '../../../shared/plugins/plugin-manifest'
 
 export type RightSidebarRoute = {
   rightSidebarTab: ActiveRightSidebarTab
@@ -16,6 +17,12 @@ export function normalizeRightSidebarRoute(
   // Why: older builds persisted Search as a standalone activity tab.
   if (tab === 'search') {
     return { rightSidebarTab: 'explorer', rightSidebarExplorerView: 'search' }
+  }
+  // Why: plugin tabs are open-ended keys; validate their shape so a persisted
+  // plugin tab isn't reset to Explorer. Uninstalled plugins still fall back at
+  // render time via resolveRightSidebarEffectiveTab.
+  if (typeof tab === 'string' && isPluginPanelTabKey(tab)) {
+    return { rightSidebarTab: tab, rightSidebarExplorerView: 'files' }
   }
   if (
     tab === 'explorer' ||

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -296,6 +296,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     defaultTuiAgent: null,
     disabledTuiAgents: [...DEFAULT_DISABLED_TUI_AGENTS],
     disabledPlugins: [],
+    approvedPlugins: [],
     claudeAgentTeamsDefaultDisabledMigrated: true,
     skipDeleteWorktreeConfirm: false,
     skipCloseTerminalWithRunningProcessConfirm: false,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -295,6 +295,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalModelQueryAuthority: true,
     defaultTuiAgent: null,
     disabledTuiAgents: [...DEFAULT_DISABLED_TUI_AGENTS],
+    disabledPlugins: [],
     claudeAgentTeamsDefaultDisabledMigrated: true,
     skipDeleteWorktreeConfirm: false,
     skipCloseTerminalWithRunningProcessConfirm: false,

--- a/src/shared/plugins/code-provider.ts
+++ b/src/shared/plugins/code-provider.ts
@@ -8,41 +8,53 @@
  * and the headless `orca serve` runtime.
  */
 
+import { z } from 'zod'
+
 export type CodeProviderContext = {
   /** Absolute root of the workspace/worktree the request is scoped to. */
   workspaceRoot: string
 }
 
-export type CodeSymbolKind =
-  | 'file'
-  | 'class'
-  | 'function'
-  | 'variable'
-  | 'constant'
-  | 'interface'
-  | 'todo'
-  | 'other'
+export const CODE_SYMBOL_KINDS = [
+  'file',
+  'class',
+  'function',
+  'variable',
+  'constant',
+  'interface',
+  'todo',
+  'other'
+] as const
 
-export type CodeSymbol = {
-  name: string
-  kind: CodeSymbolKind
+export type CodeSymbolKind = (typeof CODE_SYMBOL_KINDS)[number]
+
+// Why: method results cross the plugin-host fork boundary as structured-clone
+// data; proxies decode with these schemas so a malformed plugin response
+// fails loudly at the boundary instead of reaching consumers untyped.
+export const codeSymbolSchema = z.object({
+  name: z.string().min(1),
+  kind: z.enum(CODE_SYMBOL_KINDS),
   /** Path relative to the workspace root. */
-  file: string
+  file: z.string(),
   /** 1-based line number. */
-  line: number
-  detail?: string
-}
+  line: z.number(),
+  detail: z.string().optional()
+})
 
-export type CodeHover = {
+export const codeHoverSchema = z.object({
   /** Markdown contents shown in the hover widget. */
-  contents: string
-}
+  contents: z.string()
+})
 
-export type CodeLocation = {
-  file: string
-  line: number
-  column: number
-}
+export const codeLocationSchema = z.object({
+  file: z.string(),
+  line: z.number(),
+  column: z.number()
+})
+
+export type CodeSymbol = z.infer<typeof codeSymbolSchema>
+export type CodeHover = z.infer<typeof codeHoverSchema>
+export type CodeLocation = z.infer<typeof codeLocationSchema>
 
 /**
  * All methods are optional so a provider can implement exactly the surface it

--- a/src/shared/plugins/code-provider.ts
+++ b/src/shared/plugins/code-provider.ts
@@ -1,0 +1,81 @@
+/**
+ * CodeProvider contract — the first Go-style plugin interface. A plugin
+ * implements any subset of the optional methods; Orca dispatches through the
+ * extension registry without knowing which plugin (or process) answers.
+ *
+ * Electron-free on purpose: implementations run in the out-of-process plugin
+ * host, and proxies for them are constructed in both the desktop main process
+ * and the headless `orca serve` runtime.
+ */
+
+export type CodeProviderContext = {
+  /** Absolute root of the workspace/worktree the request is scoped to. */
+  workspaceRoot: string
+}
+
+export type CodeSymbolKind =
+  | 'file'
+  | 'class'
+  | 'function'
+  | 'variable'
+  | 'constant'
+  | 'interface'
+  | 'todo'
+  | 'other'
+
+export type CodeSymbol = {
+  name: string
+  kind: CodeSymbolKind
+  /** Path relative to the workspace root. */
+  file: string
+  /** 1-based line number. */
+  line: number
+  detail?: string
+}
+
+export type CodeHover = {
+  /** Markdown contents shown in the hover widget. */
+  contents: string
+}
+
+export type CodeLocation = {
+  file: string
+  line: number
+  column: number
+}
+
+/**
+ * All methods are optional so a provider can implement exactly the surface it
+ * supports — callers probe with `supportsCodeProviderMethod` before invoking.
+ */
+export type CodeProvider = {
+  readonly id: string
+  searchSymbols?(query: string, context: CodeProviderContext): Promise<CodeSymbol[]>
+  provideHover?(
+    file: string,
+    line: number,
+    column: number,
+    context: CodeProviderContext
+  ): Promise<CodeHover | null>
+  provideDefinition?(
+    file: string,
+    line: number,
+    column: number,
+    context: CodeProviderContext
+  ): Promise<CodeLocation[]>
+}
+
+export const CODE_PROVIDER_METHODS = ['searchSymbols', 'provideHover', 'provideDefinition'] as const
+
+export type CodeProviderMethod = (typeof CODE_PROVIDER_METHODS)[number]
+
+export function isCodeProviderMethod(value: string): value is CodeProviderMethod {
+  return (CODE_PROVIDER_METHODS as readonly string[]).includes(value)
+}
+
+export function supportsCodeProviderMethod(
+  provider: CodeProvider,
+  method: CodeProviderMethod
+): boolean {
+  return typeof provider[method] === 'function'
+}

--- a/src/shared/plugins/plugin-extension-registry.test.ts
+++ b/src/shared/plugins/plugin-extension-registry.test.ts
@@ -4,8 +4,9 @@ import { supportsCodeProviderMethod } from './code-provider'
 import {
   CODE_PROVIDER_EXTENSION_POINT,
   createPluginExtensionRegistry,
+  getPluginActivationState,
   isPluginEnabled,
-  normalizeDisabledPlugins
+  normalizePluginIdList
 } from './plugin-extension-registry'
 
 const provider = (id: string): CodeProvider => ({
@@ -28,6 +29,18 @@ describe('createPluginExtensionRegistry', () => {
     unregister()
     expect(registry.resolve(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a')).toBeNull()
     expect(registry.resolveAll(CODE_PROVIDER_EXTENSION_POINT)).toHaveLength(1)
+  })
+
+  it('addresses each provider of a multi-provider plugin by providerId', () => {
+    const registry = createPluginExtensionRegistry()
+    registry.register(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a', provider('first'), 'first')
+    registry.register(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a', provider('second'), 'second')
+
+    expect(registry.resolve(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a', 'second')?.id).toBe('second')
+    expect(registry.resolve(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a', 'first')?.id).toBe('first')
+    // Without a providerId the first registration wins (single-provider path).
+    expect(registry.resolve(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a')?.id).toBe('first')
+    expect(registry.resolve(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a', 'ghost')).toBeNull()
   })
 
   it('clears every registration owned by a plugin', () => {
@@ -59,7 +72,17 @@ describe('plugin enablement', () => {
   })
 
   it('normalizes persisted disabled lists defensively', () => {
-    expect(normalizeDisabledPlugins(['a', 'a', '', 42, null, 'b'])).toEqual(['a', 'b'])
-    expect(normalizeDisabledPlugins('not-an-array')).toEqual([])
+    expect(normalizePluginIdList(['a', 'a', '', 42, null, 'b'])).toEqual(['a', 'b'])
+    expect(normalizePluginIdList('not-an-array')).toEqual([])
+  })
+
+  it('derives the consent state: disabled beats approved, unknown is pending', () => {
+    const lists = { approvedPlugins: ['a'], disabledPlugins: ['b', 'a'] }
+    expect(getPluginActivationState('a', lists)).toBe('disabled')
+    expect(getPluginActivationState('b', lists)).toBe('disabled')
+    expect(getPluginActivationState('new', lists)).toBe('pending')
+    expect(getPluginActivationState('a', { approvedPlugins: ['a'], disabledPlugins: [] })).toBe(
+      'approved'
+    )
   })
 })

--- a/src/shared/plugins/plugin-extension-registry.test.ts
+++ b/src/shared/plugins/plugin-extension-registry.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import type { CodeProvider } from './code-provider'
+import { supportsCodeProviderMethod } from './code-provider'
+import {
+  CODE_PROVIDER_EXTENSION_POINT,
+  createPluginExtensionRegistry,
+  isPluginEnabled,
+  normalizeDisabledPlugins
+} from './plugin-extension-registry'
+
+const provider = (id: string): CodeProvider => ({
+  id,
+  searchSymbols: async () => []
+})
+
+describe('createPluginExtensionRegistry', () => {
+  it('registers, resolves, and unregisters implementations per point', () => {
+    const registry = createPluginExtensionRegistry()
+    const unregister = registry.register(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a', provider('a'))
+    registry.register(CODE_PROVIDER_EXTENSION_POINT, 'plugin-b', provider('b'))
+
+    expect(registry.resolveAll(CODE_PROVIDER_EXTENSION_POINT).map((r) => r.pluginId)).toEqual([
+      'plugin-a',
+      'plugin-b'
+    ])
+    expect(registry.resolve(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a')?.id).toBe('a')
+
+    unregister()
+    expect(registry.resolve(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a')).toBeNull()
+    expect(registry.resolveAll(CODE_PROVIDER_EXTENSION_POINT)).toHaveLength(1)
+  })
+
+  it('clears every registration owned by a plugin', () => {
+    const registry = createPluginExtensionRegistry()
+    registry.register(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a', provider('a1'))
+    registry.register(CODE_PROVIDER_EXTENSION_POINT, 'plugin-a', provider('a2'))
+    registry.register(CODE_PROVIDER_EXTENSION_POINT, 'plugin-b', provider('b'))
+
+    registry.clearPlugin('plugin-a')
+    expect(registry.resolveAll(CODE_PROVIDER_EXTENSION_POINT).map((r) => r.pluginId)).toEqual([
+      'plugin-b'
+    ])
+  })
+})
+
+describe('code provider capability probing', () => {
+  it('reports only implemented methods', () => {
+    const p = provider('a')
+    expect(supportsCodeProviderMethod(p, 'searchSymbols')).toBe(true)
+    expect(supportsCodeProviderMethod(p, 'provideHover')).toBe(false)
+  })
+})
+
+describe('plugin enablement', () => {
+  it('treats unlisted plugins as enabled', () => {
+    expect(isPluginEnabled('a', [])).toBe(true)
+    expect(isPluginEnabled('a', ['b'])).toBe(true)
+    expect(isPluginEnabled('a', ['a'])).toBe(false)
+  })
+
+  it('normalizes persisted disabled lists defensively', () => {
+    expect(normalizeDisabledPlugins(['a', 'a', '', 42, null, 'b'])).toEqual(['a', 'b'])
+    expect(normalizeDisabledPlugins('not-an-array')).toEqual([])
+  })
+})

--- a/src/shared/plugins/plugin-extension-registry.ts
+++ b/src/shared/plugins/plugin-extension-registry.ts
@@ -1,0 +1,81 @@
+import type { CodeProvider } from './code-provider'
+
+/**
+ * Typed extension-point registry. An extension point is a named, typed slot
+ * (like a Go interface value); plugins register implementations and hosts
+ * resolve them without compile-time knowledge of the implementor. Follows the
+ * `FORGE_PROVIDERS` registry shape but with runtime registration because
+ * plugins load dynamically.
+ */
+
+declare const extensionPointBrand: unique symbol
+
+export type PluginExtensionPoint<T> = {
+  readonly key: string
+  // Why: phantom field carries T so register/resolve stay type-safe per point
+  // even though the runtime value is just `{ key }`.
+  readonly [extensionPointBrand]?: T
+}
+
+export function definePluginExtensionPoint<T>(key: string): PluginExtensionPoint<T> {
+  return { key }
+}
+
+export const CODE_PROVIDER_EXTENSION_POINT = definePluginExtensionPoint<CodeProvider>('codeProvider')
+
+export type PluginExtensionRegistration<T> = {
+  pluginId: string
+  implementation: T
+}
+
+export type PluginExtensionRegistry = {
+  register<T>(point: PluginExtensionPoint<T>, pluginId: string, implementation: T): () => void
+  resolveAll<T>(point: PluginExtensionPoint<T>): PluginExtensionRegistration<T>[]
+  resolve<T>(point: PluginExtensionPoint<T>, pluginId: string): T | null
+  clearPlugin(pluginId: string): void
+}
+
+export function createPluginExtensionRegistry(): PluginExtensionRegistry {
+  const byPoint = new Map<string, PluginExtensionRegistration<unknown>[]>()
+
+  return {
+    register(point, pluginId, implementation) {
+      const registrations = byPoint.get(point.key) ?? []
+      const entry = { pluginId, implementation }
+      byPoint.set(point.key, [...registrations, entry])
+      return () => {
+        const current = byPoint.get(point.key) ?? []
+        byPoint.set(
+          point.key,
+          current.filter((registration) => registration !== entry)
+        )
+      }
+    },
+    resolveAll<T>(point: PluginExtensionPoint<T>) {
+      return (byPoint.get(point.key) ?? []) as PluginExtensionRegistration<T>[]
+    },
+    resolve<T>(point: PluginExtensionPoint<T>, pluginId: string) {
+      const registrations = (byPoint.get(point.key) ?? []) as PluginExtensionRegistration<T>[]
+      return registrations.find((registration) => registration.pluginId === pluginId)?.implementation ?? null
+    },
+    clearPlugin(pluginId) {
+      for (const [key, registrations] of byPoint) {
+        byPoint.set(
+          key,
+          registrations.filter((registration) => registration.pluginId !== pluginId)
+        )
+      }
+    }
+  }
+}
+
+export function isPluginEnabled(pluginId: string, disabledPlugins: readonly string[]): boolean {
+  return !disabledPlugins.includes(pluginId)
+}
+
+export function normalizeDisabledPlugins(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return [...new Set(value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0))]
+}

--- a/src/shared/plugins/plugin-extension-registry.ts
+++ b/src/shared/plugins/plugin-extension-registry.ts
@@ -21,17 +21,25 @@ export function definePluginExtensionPoint<T>(key: string): PluginExtensionPoint
   return { key }
 }
 
-export const CODE_PROVIDER_EXTENSION_POINT = definePluginExtensionPoint<CodeProvider>('codeProvider')
+export const CODE_PROVIDER_EXTENSION_POINT =
+  definePluginExtensionPoint<CodeProvider>('codeProvider')
 
 export type PluginExtensionRegistration<T> = {
   pluginId: string
+  /** Contribution id within the plugin; addresses one of several providers. */
+  providerId?: string
   implementation: T
 }
 
 export type PluginExtensionRegistry = {
-  register<T>(point: PluginExtensionPoint<T>, pluginId: string, implementation: T): () => void
+  register<T>(
+    point: PluginExtensionPoint<T>,
+    pluginId: string,
+    implementation: T,
+    providerId?: string
+  ): () => void
   resolveAll<T>(point: PluginExtensionPoint<T>): PluginExtensionRegistration<T>[]
-  resolve<T>(point: PluginExtensionPoint<T>, pluginId: string): T | null
+  resolve<T>(point: PluginExtensionPoint<T>, pluginId: string, providerId?: string): T | null
   clearPlugin(pluginId: string): void
 }
 
@@ -39,9 +47,9 @@ export function createPluginExtensionRegistry(): PluginExtensionRegistry {
   const byPoint = new Map<string, PluginExtensionRegistration<unknown>[]>()
 
   return {
-    register(point, pluginId, implementation) {
+    register(point, pluginId, implementation, providerId) {
       const registrations = byPoint.get(point.key) ?? []
-      const entry = { pluginId, implementation }
+      const entry = { pluginId, providerId, implementation }
       byPoint.set(point.key, [...registrations, entry])
       return () => {
         const current = byPoint.get(point.key) ?? []
@@ -54,9 +62,16 @@ export function createPluginExtensionRegistry(): PluginExtensionRegistry {
     resolveAll<T>(point: PluginExtensionPoint<T>) {
       return (byPoint.get(point.key) ?? []) as PluginExtensionRegistration<T>[]
     },
-    resolve<T>(point: PluginExtensionPoint<T>, pluginId: string) {
+    resolve<T>(point: PluginExtensionPoint<T>, pluginId: string, providerId?: string) {
       const registrations = (byPoint.get(point.key) ?? []) as PluginExtensionRegistration<T>[]
-      return registrations.find((registration) => registration.pluginId === pluginId)?.implementation ?? null
+      // Why: without a providerId the first registration wins — only safe for
+      // single-provider plugins; multi-provider callers must address by id.
+      const match = registrations.find(
+        (registration) =>
+          registration.pluginId === pluginId &&
+          (providerId === undefined || registration.providerId === providerId)
+      )
+      return match?.implementation ?? null
     },
     clearPlugin(pluginId) {
       for (const [key, registrations] of byPoint) {
@@ -73,9 +88,28 @@ export function isPluginEnabled(pluginId: string, disabledPlugins: readonly stri
   return !disabledPlugins.includes(pluginId)
 }
 
-export function normalizeDisabledPlugins(value: unknown): string[] {
+export type PluginActivationState = 'approved' | 'pending' | 'disabled'
+
+/** Consent gate: a plugin runs only after the user approved it once. A
+ *  discovered plugin in neither list stays inert — dropping a folder into the
+ *  plugins directory must never execute code silently. */
+export function getPluginActivationState(
+  pluginId: string,
+  lists: { approvedPlugins: readonly string[]; disabledPlugins: readonly string[] }
+): PluginActivationState {
+  if (lists.disabledPlugins.includes(pluginId)) {
+    return 'disabled'
+  }
+  return lists.approvedPlugins.includes(pluginId) ? 'approved' : 'pending'
+}
+
+export function normalizePluginIdList(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return []
   }
-  return [...new Set(value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0))]
+  return [
+    ...new Set(
+      value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+    )
+  ]
 }

--- a/src/shared/plugins/plugin-host-protocol.ts
+++ b/src/shared/plugins/plugin-host-protocol.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod'
+
+/**
+ * Message protocol between the Orca process and the out-of-process plugin
+ * host (child_process.fork channel). Zod-validated on both sides because the
+ * child runs third-party code — nothing it sends is trusted structurally.
+ */
+
+export const pluginHostInitSchema = z.object({
+  type: z.literal('init'),
+  pluginRoot: z.string().min(1),
+  mainEntry: z.string().min(1),
+  pluginId: z.string().min(1)
+})
+
+export const pluginHostInvokeSchema = z.object({
+  type: z.literal('invoke'),
+  callId: z.number().int().nonnegative(),
+  extensionPoint: z.string().min(1),
+  providerId: z.string().min(1),
+  method: z.string().min(1),
+  args: z.array(z.unknown())
+})
+
+export const pluginHostShutdownSchema = z.object({ type: z.literal('shutdown') })
+
+export const pluginHostParentMessageSchema = z.discriminatedUnion('type', [
+  pluginHostInitSchema,
+  pluginHostInvokeSchema,
+  pluginHostShutdownSchema
+])
+
+const registrationSchema = z.object({
+  extensionPoint: z.string().min(1),
+  providerId: z.string().min(1),
+  methods: z.array(z.string().min(1))
+})
+
+export const pluginHostReadySchema = z.object({
+  type: z.literal('ready'),
+  registrations: z.array(registrationSchema)
+})
+
+export const pluginHostResultSchema = z.object({
+  type: z.literal('result'),
+  callId: z.number().int().nonnegative(),
+  ok: z.boolean(),
+  // Why: value crosses a fork() IPC boundary, so it is structured-clone data
+  // by construction; zod treats it as opaque and callers re-validate shape.
+  value: z.unknown().optional(),
+  error: z.string().optional()
+})
+
+export const pluginHostLogSchema = z.object({
+  type: z.literal('log'),
+  level: z.enum(['info', 'warn', 'error']),
+  message: z.string()
+})
+
+export const pluginHostFatalSchema = z.object({
+  type: z.literal('fatal'),
+  error: z.string()
+})
+
+export const pluginHostChildMessageSchema = z.discriminatedUnion('type', [
+  pluginHostReadySchema,
+  pluginHostResultSchema,
+  pluginHostLogSchema,
+  pluginHostFatalSchema
+])
+
+export type PluginHostParentMessage = z.infer<typeof pluginHostParentMessageSchema>
+export type PluginHostChildMessage = z.infer<typeof pluginHostChildMessageSchema>
+export type PluginHostRegistration = z.infer<typeof registrationSchema>
+
+export const PLUGIN_HOST_READY_TIMEOUT_MS = 10_000
+export const PLUGIN_HOST_INVOKE_TIMEOUT_MS = 30_000

--- a/src/shared/plugins/plugin-manifest.test.ts
+++ b/src/shared/plugins/plugin-manifest.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isPluginPanelTabKey,
+  parsePluginManifest,
+  pluginPanelTabKey
+} from './plugin-manifest'
+
+const VALID = {
+  id: 'hello-orca',
+  name: 'Hello Orca',
+  version: '1.0.0',
+  engines: { orca: '>=1.4.0' },
+  main: 'main.js',
+  contributes: {
+    codeProviders: [{ id: 'todo-scanner', displayName: 'TODO Scanner' }],
+    panels: [{ id: 'hello', title: 'Hello', entry: 'panel.html' }]
+  }
+}
+
+describe('parsePluginManifest', () => {
+  it('accepts a valid manifest and applies defaults', () => {
+    const result = parsePluginManifest(VALID)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.manifest.contributes.commands).toEqual([])
+    expect(result.manifest.contributes.codeProviders[0].languages).toEqual(['*'])
+  })
+
+  it('rejects non-kebab-case ids', () => {
+    const result = parsePluginManifest({ ...VALID, id: 'Hello_Orca' })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('id')
+  })
+
+  it('rejects entry paths that escape the plugin directory', () => {
+    for (const entry of ['../evil.html', '/etc/passwd', 'C:\\evil.html', 'a/../../b.html']) {
+      const manifest = {
+        ...VALID,
+        contributes: { panels: [{ id: 'p', title: 'P', entry }] }
+      }
+      expect(parsePluginManifest(manifest).ok).toBe(false)
+    }
+  })
+
+  it('rejects non-semver versions and missing engines', () => {
+    expect(parsePluginManifest({ ...VALID, version: 'v1' }).ok).toBe(false)
+    expect(parsePluginManifest({ ...VALID, engines: undefined }).ok).toBe(false)
+  })
+})
+
+describe('plugin panel tab keys', () => {
+  it('round-trips through the key builder', () => {
+    const key = pluginPanelTabKey('hello-orca', 'hello')
+    expect(key).toBe('plugin:hello-orca/hello')
+    expect(isPluginPanelTabKey(key)).toBe(true)
+  })
+
+  it('rejects malformed keys', () => {
+    expect(isPluginPanelTabKey('plugin:')).toBe(false)
+    expect(isPluginPanelTabKey('plugin:only-plugin-id')).toBe(false)
+    expect(isPluginPanelTabKey('plugin:a/b/c')).toBe(false)
+    expect(isPluginPanelTabKey('plugin:Bad_Id/panel')).toBe(false)
+    expect(isPluginPanelTabKey('explorer')).toBe(false)
+  })
+})

--- a/src/shared/plugins/plugin-manifest.test.ts
+++ b/src/shared/plugins/plugin-manifest.test.ts
@@ -43,6 +43,23 @@ describe('parsePluginManifest', () => {
     }
   })
 
+  it('rejects codeProviders without a main entry (providers register from main)', () => {
+    const inert = parsePluginManifest({ ...VALID, main: undefined })
+    expect(inert.ok).toBe(false)
+    if (inert.ok) {
+      return
+    }
+    expect(inert.error).toContain('main')
+
+    // Panel-only manifests stay valid without main.
+    const panelOnly = parsePluginManifest({
+      ...VALID,
+      main: undefined,
+      contributes: { panels: VALID.contributes.panels }
+    })
+    expect(panelOnly.ok).toBe(true)
+  })
+
   it('rejects non-semver versions and missing engines', () => {
     expect(parsePluginManifest({ ...VALID, version: 'v1' }).ok).toBe(false)
     expect(parsePluginManifest({ ...VALID, engines: undefined }).ok).toBe(false)

--- a/src/shared/plugins/plugin-manifest.test.ts
+++ b/src/shared/plugins/plugin-manifest.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  isPluginPanelTabKey,
-  parsePluginManifest,
-  pluginPanelTabKey
-} from './plugin-manifest'
+import { isPluginPanelTabKey, parsePluginManifest, pluginPanelTabKey } from './plugin-manifest'
 
 const VALID = {
   id: 'hello-orca',
@@ -64,11 +60,18 @@ describe('parsePluginManifest', () => {
   it('accepts known permissions and rejects unknown ones', () => {
     const granted = parsePluginManifest({
       ...VALID,
-      contributes: { ...VALID.contributes, permissions: ['terminal.sendText'] }
+      contributes: {
+        ...VALID.contributes,
+        permissions: ['terminal.sendText', 'workspace.readContext', 'notifications.show']
+      }
     })
     expect(granted.ok).toBe(true)
     if (granted.ok) {
-      expect(granted.manifest.contributes.permissions).toEqual(['terminal.sendText'])
+      expect(granted.manifest.contributes.permissions).toEqual([
+        'terminal.sendText',
+        'workspace.readContext',
+        'notifications.show'
+      ])
     }
     const unknown = parsePluginManifest({
       ...VALID,

--- a/src/shared/plugins/plugin-manifest.test.ts
+++ b/src/shared/plugins/plugin-manifest.test.ts
@@ -21,7 +21,9 @@ describe('parsePluginManifest', () => {
   it('accepts a valid manifest and applies defaults', () => {
     const result = parsePluginManifest(VALID)
     expect(result.ok).toBe(true)
-    if (!result.ok) return
+    if (!result.ok) {
+      return
+    }
     expect(result.manifest.contributes.commands).toEqual([])
     expect(result.manifest.contributes.codeProviders[0].languages).toEqual(['*'])
   })
@@ -29,7 +31,9 @@ describe('parsePluginManifest', () => {
   it('rejects non-kebab-case ids', () => {
     const result = parsePluginManifest({ ...VALID, id: 'Hello_Orca' })
     expect(result.ok).toBe(false)
-    if (result.ok) return
+    if (result.ok) {
+      return
+    }
     expect(result.error).toContain('id')
   })
 
@@ -46,6 +50,35 @@ describe('parsePluginManifest', () => {
   it('rejects non-semver versions and missing engines', () => {
     expect(parsePluginManifest({ ...VALID, version: 'v1' }).ok).toBe(false)
     expect(parsePluginManifest({ ...VALID, engines: undefined }).ok).toBe(false)
+  })
+
+  it('defaults contributes.permissions to an empty grant', () => {
+    const result = parsePluginManifest(VALID)
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.manifest.contributes.permissions).toEqual([])
+  })
+
+  it('accepts known permissions and rejects unknown ones', () => {
+    const granted = parsePluginManifest({
+      ...VALID,
+      contributes: { ...VALID.contributes, permissions: ['terminal.sendText'] }
+    })
+    expect(granted.ok).toBe(true)
+    if (granted.ok) {
+      expect(granted.manifest.contributes.permissions).toEqual(['terminal.sendText'])
+    }
+    const unknown = parsePluginManifest({
+      ...VALID,
+      contributes: { ...VALID.contributes, permissions: ['fs.readFile'] }
+    })
+    expect(unknown.ok).toBe(false)
+    if (unknown.ok) {
+      return
+    }
+    expect(unknown.error).toContain('permissions')
   })
 })
 

--- a/src/shared/plugins/plugin-manifest.ts
+++ b/src/shared/plugins/plugin-manifest.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod'
+
+/**
+ * Plugin manifest (`orca-plugin.json` at the plugin root). The `contributes`
+ * key names deliberately mirror VS Code manifest conventions so a future
+ * adapter can map VS Code extension manifests onto Orca extension points.
+ *
+ * Lives in `shared` so the desktop app, the headless `orca serve` runtime,
+ * and the CLI validate manifests identically (SSH/remote parity).
+ */
+
+// Why: ids become filesystem paths, IPC channel fragments, and sidebar tab
+// keys — restrict to kebab-case so they never need escaping downstream.
+const PLUGIN_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+const pluginIdSchema = z.string().regex(PLUGIN_ID_RE, 'must be kebab-case (a-z, 0-9, dashes)')
+
+// Why: entry paths are resolved against the plugin root; reject absolute
+// paths and traversal so a manifest cannot point outside its own directory.
+const relativeEntrySchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) =>
+      !value.startsWith('/') && !value.startsWith('\\') && !/^[a-zA-Z]:/.test(value) && !value.split(/[\\/]/).includes('..'),
+    'must be a relative path inside the plugin directory'
+  )
+
+const codeProviderContributionSchema = z.object({
+  id: pluginIdSchema,
+  displayName: z.string().min(1),
+  /** Language ids the provider serves; `['*']` means all languages. */
+  languages: z.array(z.string().min(1)).nonempty().default(['*'])
+})
+
+const panelContributionSchema = z.object({
+  id: pluginIdSchema,
+  title: z.string().min(1),
+  /** Lucide icon name rendered in the right-sidebar activity bar. */
+  icon: z.string().min(1).optional(),
+  /** HTML entry rendered inside a sandboxed panel frame. */
+  entry: relativeEntrySchema
+})
+
+const commandContributionSchema = z.object({
+  id: pluginIdSchema,
+  title: z.string().min(1)
+})
+
+export const pluginManifestSchema = z.object({
+  id: pluginIdSchema,
+  name: z.string().min(1),
+  version: z.string().regex(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/, 'must be semver'),
+  description: z.string().optional(),
+  engines: z.object({ orca: z.string().min(1) }),
+  /** Node entry executed inside the out-of-process plugin host. */
+  main: relativeEntrySchema.optional(),
+  contributes: z
+    .object({
+      codeProviders: z.array(codeProviderContributionSchema).default([]),
+      panels: z.array(panelContributionSchema).default([]),
+      commands: z.array(commandContributionSchema).default([])
+    })
+    .default({ codeProviders: [], panels: [], commands: [] })
+})
+
+export type PluginManifest = z.infer<typeof pluginManifestSchema>
+export type PluginCodeProviderContribution = z.infer<typeof codeProviderContributionSchema>
+export type PluginPanelContribution = z.infer<typeof panelContributionSchema>
+export type PluginCommandContribution = z.infer<typeof commandContributionSchema>
+
+export const PLUGIN_MANIFEST_FILENAME = 'orca-plugin.json'
+
+export type PluginManifestParseResult =
+  | { ok: true; manifest: PluginManifest }
+  | { ok: false; error: string }
+
+export function parsePluginManifest(raw: unknown): PluginManifestParseResult {
+  const parsed = pluginManifestSchema.safeParse(raw)
+  if (parsed.success) {
+    return { ok: true, manifest: parsed.data }
+  }
+  const issue = parsed.error.issues[0]
+  const path = issue?.path.join('.') || '(root)'
+  return { ok: false, error: `${path}: ${issue?.message ?? 'invalid manifest'}` }
+}
+
+/** Sidebar tab key for a plugin panel: `plugin:<pluginId>/<panelId>`. */
+export function pluginPanelTabKey(pluginId: string, panelId: string): `plugin:${string}` {
+  return `plugin:${pluginId}/${panelId}`
+}
+
+export function isPluginPanelTabKey(tab: string): tab is `plugin:${string}` {
+  if (!tab.startsWith('plugin:')) {
+    return false
+  }
+  const rest = tab.slice('plugin:'.length)
+  const [pluginId, panelId, ...extra] = rest.split('/')
+  return (
+    extra.length === 0 &&
+    !!pluginId &&
+    !!panelId &&
+    PLUGIN_ID_RE.test(pluginId) &&
+    PLUGIN_ID_RE.test(panelId)
+  )
+}

--- a/src/shared/plugins/plugin-manifest.ts
+++ b/src/shared/plugins/plugin-manifest.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { PLUGIN_PANEL_ACTIONS } from './plugin-panel-bridge'
 
 /**
  * Plugin manifest (`orca-plugin.json` at the plugin root). The `contributes`
@@ -59,9 +60,13 @@ export const pluginManifestSchema = z.object({
     .object({
       codeProviders: z.array(codeProviderContributionSchema).default([]),
       panels: z.array(panelContributionSchema).default([]),
-      commands: z.array(commandContributionSchema).default([])
+      commands: z.array(commandContributionSchema).default([]),
+      // Why: permission ids are a closed enum so a typo (or a permission from
+      // a newer Orca) fails manifest validation instead of silently granting
+      // nothing at action time.
+      permissions: z.array(z.enum(PLUGIN_PANEL_ACTIONS)).default([])
     })
-    .default({ codeProviders: [], panels: [], commands: [] })
+    .default({ codeProviders: [], panels: [], commands: [], permissions: [] })
 })
 
 export type PluginManifest = z.infer<typeof pluginManifestSchema>

--- a/src/shared/plugins/plugin-manifest.ts
+++ b/src/shared/plugins/plugin-manifest.ts
@@ -23,7 +23,10 @@ const relativeEntrySchema = z
   .min(1)
   .refine(
     (value) =>
-      !value.startsWith('/') && !value.startsWith('\\') && !/^[a-zA-Z]:/.test(value) && !value.split(/[\\/]/).includes('..'),
+      !value.startsWith('/') &&
+      !value.startsWith('\\') &&
+      !/^[a-zA-Z]:/.test(value) &&
+      !value.split(/[\\/]/).includes('..'),
     'must be a relative path inside the plugin directory'
   )
 
@@ -48,26 +51,39 @@ const commandContributionSchema = z.object({
   title: z.string().min(1)
 })
 
-export const pluginManifestSchema = z.object({
-  id: pluginIdSchema,
-  name: z.string().min(1),
-  version: z.string().regex(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/, 'must be semver'),
-  description: z.string().optional(),
-  engines: z.object({ orca: z.string().min(1) }),
-  /** Node entry executed inside the out-of-process plugin host. */
-  main: relativeEntrySchema.optional(),
-  contributes: z
-    .object({
-      codeProviders: z.array(codeProviderContributionSchema).default([]),
-      panels: z.array(panelContributionSchema).default([]),
-      commands: z.array(commandContributionSchema).default([]),
-      // Why: permission ids are a closed enum so a typo (or a permission from
-      // a newer Orca) fails manifest validation instead of silently granting
-      // nothing at action time.
-      permissions: z.array(z.enum(PLUGIN_PANEL_ACTIONS)).default([])
-    })
-    .default({ codeProviders: [], panels: [], commands: [], permissions: [] })
-})
+export const pluginManifestSchema = z
+  .object({
+    id: pluginIdSchema,
+    name: z.string().min(1),
+    version: z.string().regex(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/, 'must be semver'),
+    description: z.string().optional(),
+    engines: z.object({ orca: z.string().min(1) }),
+    /** Node entry executed inside the out-of-process plugin host. */
+    main: relativeEntrySchema.optional(),
+    contributes: z
+      .object({
+        codeProviders: z.array(codeProviderContributionSchema).default([]),
+        panels: z.array(panelContributionSchema).default([]),
+        commands: z.array(commandContributionSchema).default([]),
+        // Why: permission ids are a closed enum so a typo (or a permission from
+        // a newer Orca) fails manifest validation instead of silently granting
+        // nothing at action time.
+        permissions: z.array(z.enum(PLUGIN_PANEL_ACTIONS)).default([])
+      })
+      .default({ codeProviders: [], panels: [], commands: [], permissions: [] })
+  })
+  // Why: providers register from the main entry's activate() export, so a
+  // manifest declaring codeProviders without `main` is inert — fail at parse
+  // time instead of silently never registering.
+  .superRefine((manifest, ctx) => {
+    if (manifest.contributes.codeProviders.length > 0 && !manifest.main) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['main'],
+        message: 'required when contributes.codeProviders is non-empty'
+      })
+    }
+  })
 
 export type PluginManifest = z.infer<typeof pluginManifestSchema>
 export type PluginCodeProviderContribution = z.infer<typeof codeProviderContributionSchema>

--- a/src/shared/plugins/plugin-panel-bridge.test.ts
+++ b/src/shared/plugins/plugin-panel-bridge.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PANEL_ACTION_TEXT_MAX_LENGTH,
+  looksLikePanelActionRequest,
+  parsePanelActionRequest,
+  terminalSendTextParamsSchema
+} from './plugin-panel-bridge'
+
+const VALID_REQUEST = {
+  type: 'orca-panel-action',
+  requestId: 'req-1',
+  action: 'terminal.sendText',
+  params: { text: '/model opus', enter: true }
+}
+
+describe('parsePanelActionRequest', () => {
+  it('accepts a well-formed bridge request', () => {
+    const result = parsePanelActionRequest(VALID_REQUEST)
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.request.requestId).toBe('req-1')
+    expect(result.request.action).toBe('terminal.sendText')
+  })
+
+  it('rejects payloads with the wrong envelope type', () => {
+    expect(parsePanelActionRequest({ ...VALID_REQUEST, type: 'other' }).ok).toBe(false)
+    expect(parsePanelActionRequest(null).ok).toBe(false)
+    expect(parsePanelActionRequest('orca-panel-action').ok).toBe(false)
+  })
+
+  it('rejects unknown actions', () => {
+    const result = parsePanelActionRequest({ ...VALID_REQUEST, action: 'fs.readFile' })
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+    expect(result.error).toContain('action')
+  })
+
+  it('rejects a missing or oversized requestId', () => {
+    expect(parsePanelActionRequest({ ...VALID_REQUEST, requestId: undefined }).ok).toBe(false)
+    expect(parsePanelActionRequest({ ...VALID_REQUEST, requestId: '' }).ok).toBe(false)
+    expect(parsePanelActionRequest({ ...VALID_REQUEST, requestId: 'x'.repeat(129) }).ok).toBe(false)
+  })
+
+  it('surfaces a usable requestId from an invalid request so the host can reply', () => {
+    const result = parsePanelActionRequest({ ...VALID_REQUEST, action: 'nope' })
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+    expect(result.requestId).toBe('req-1')
+  })
+
+  it('does not echo back a malformed requestId', () => {
+    const result = parsePanelActionRequest({
+      ...VALID_REQUEST,
+      action: 'nope',
+      requestId: 'x'.repeat(200)
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+    expect(result.requestId).toBeNull()
+  })
+})
+
+describe('terminalSendTextParamsSchema', () => {
+  it('accepts text with an optional enter flag', () => {
+    const parsed = terminalSendTextParamsSchema.safeParse({ text: '/model haiku' })
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) {
+      return
+    }
+    expect(parsed.data.enter).toBe(false)
+  })
+
+  it('rejects empty, missing, and oversized text', () => {
+    expect(terminalSendTextParamsSchema.safeParse({ text: '' }).success).toBe(false)
+    expect(terminalSendTextParamsSchema.safeParse({}).success).toBe(false)
+    expect(
+      terminalSendTextParamsSchema.safeParse({
+        text: 'x'.repeat(PANEL_ACTION_TEXT_MAX_LENGTH + 1)
+      }).success
+    ).toBe(false)
+  })
+
+  it('rejects non-boolean enter values', () => {
+    expect(terminalSendTextParamsSchema.safeParse({ text: 'hi', enter: 'yes' }).success).toBe(false)
+  })
+})
+
+describe('looksLikePanelActionRequest', () => {
+  it('matches only the bridge envelope type', () => {
+    expect(looksLikePanelActionRequest(VALID_REQUEST)).toBe(true)
+    expect(looksLikePanelActionRequest({ type: 'orca-panel-action' })).toBe(true)
+    expect(looksLikePanelActionRequest({ type: 'orca-panel-action-result' })).toBe(false)
+    expect(looksLikePanelActionRequest(undefined)).toBe(false)
+  })
+})

--- a/src/shared/plugins/plugin-panel-bridge.ts
+++ b/src/shared/plugins/plugin-panel-bridge.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod'
+
+/**
+ * postMessage protocol between a sandboxed plugin panel iframe and the host
+ * renderer, plus the action call shape relayed to main. The frame has an
+ * opaque origin (sandbox="allow-scripts"), so neither side can use origins
+ * for trust: the host verifies the sending window's identity and re-validates
+ * every payload here; main re-checks permissions before executing.
+ */
+
+/** Panel actions a plugin may call; each doubles as the manifest permission
+ *  id (`contributes.permissions`) that must grant it. */
+export const PLUGIN_PANEL_ACTIONS = ['terminal.sendText'] as const
+
+export type PluginPanelAction = (typeof PLUGIN_PANEL_ACTIONS)[number]
+
+export const PANEL_ACTION_REQUEST_TYPE = 'orca-panel-action'
+export const PANEL_ACTION_RESULT_TYPE = 'orca-panel-action-result'
+
+// Why: text is typed into a live pty; cap it so a plugin cannot flood the
+// terminal (mirrors the runtime's own terminal-send input limit intent).
+export const PANEL_ACTION_TEXT_MAX_LENGTH = 4096
+
+export const terminalSendTextParamsSchema = z.object({
+  text: z.string().min(1).max(PANEL_ACTION_TEXT_MAX_LENGTH),
+  enter: z.boolean().default(false)
+})
+
+export const PANEL_ACTION_PARAM_SCHEMAS: Record<PluginPanelAction, z.ZodTypeAny> = {
+  'terminal.sendText': terminalSendTextParamsSchema
+}
+
+export const panelActionRequestSchema = z.object({
+  type: z.literal(PANEL_ACTION_REQUEST_TYPE),
+  /** Plugin-chosen correlation id echoed back on the result message. */
+  requestId: z.string().min(1).max(128),
+  action: z.enum(PLUGIN_PANEL_ACTIONS),
+  params: z.unknown().optional()
+})
+
+export type PluginPanelActionRequest = z.infer<typeof panelActionRequestSchema>
+
+export type PluginPanelActionErrorCode =
+  | 'invalid_request'
+  | 'unknown_action'
+  | 'permission_denied'
+  | 'invalid_params'
+  | 'unavailable'
+  | 'action_failed'
+
+/** Result message posted back into the panel iframe. */
+export type PluginPanelActionResultMessage = {
+  type: typeof PANEL_ACTION_RESULT_TYPE
+  requestId: string
+  ok: boolean
+  value?: unknown
+  errorCode?: PluginPanelActionErrorCode
+  error?: string
+}
+
+/** Outcome of executing a panel action in main (wire shape of
+ *  `plugins:panelAction` / `plugins.panelAction`). */
+export type PluginPanelActionOutcome =
+  | { ok: true; value: unknown }
+  | { ok: false; code: PluginPanelActionErrorCode; error: string }
+
+/** Call shape the renderer relays to main for a panel-originated action. */
+export const panelActionCallSchema = z.object({
+  pluginId: z.string().min(1),
+  /** Panel that originated the request; informational (permissions are
+   *  plugin-scoped), kept for logging and future per-panel scoping. */
+  panelId: z.string().min(1).optional(),
+  action: z.string().min(1),
+  params: z.unknown().optional()
+})
+
+export type PluginPanelActionCall = z.infer<typeof panelActionCallSchema>
+
+export type PanelActionRequestParseResult =
+  | { ok: true; request: PluginPanelActionRequest }
+  | { ok: false; requestId: string | null; error: string }
+
+/** Validates a raw `message` event payload from the panel iframe. On failure
+ *  still surfaces a best-effort requestId so the host can answer with an
+ *  error instead of silently dropping the request. */
+export function parsePanelActionRequest(data: unknown): PanelActionRequestParseResult {
+  const parsed = panelActionRequestSchema.safeParse(data)
+  if (parsed.success) {
+    return { ok: true, request: parsed.data }
+  }
+  let requestId: string | null = null
+  if (typeof data === 'object' && data !== null && 'requestId' in data) {
+    const raw = (data as { requestId?: unknown }).requestId
+    if (typeof raw === 'string' && raw.length > 0 && raw.length <= 128) {
+      requestId = raw
+    }
+  }
+  const issue = parsed.error.issues[0]
+  const path = issue?.path.join('.') || '(root)'
+  return {
+    ok: false,
+    requestId,
+    error: `${path}: ${issue?.message ?? 'invalid panel action request'}`
+  }
+}
+
+/** True when `data` even looks like a bridge request (right `type`). Used to
+ *  ignore unrelated window messages without replying to them. */
+export function looksLikePanelActionRequest(data: unknown): boolean {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { type?: unknown }).type === PANEL_ACTION_REQUEST_TYPE
+  )
+}

--- a/src/shared/plugins/plugin-panel-bridge.ts
+++ b/src/shared/plugins/plugin-panel-bridge.ts
@@ -10,7 +10,11 @@ import { z } from 'zod'
 
 /** Panel actions a plugin may call; each doubles as the manifest permission
  *  id (`contributes.permissions`) that must grant it. */
-export const PLUGIN_PANEL_ACTIONS = ['terminal.sendText'] as const
+export const PLUGIN_PANEL_ACTIONS = [
+  'terminal.sendText',
+  'workspace.readContext',
+  'notifications.show'
+] as const
 
 export type PluginPanelAction = (typeof PLUGIN_PANEL_ACTIONS)[number]
 
@@ -26,8 +30,19 @@ export const terminalSendTextParamsSchema = z.object({
   enter: z.boolean().default(false)
 })
 
+/** No params; strict so a panel passing junk gets invalid_params, not
+ *  silently ignored input. */
+export const workspaceReadContextParamsSchema = z.object({}).strict().optional()
+
+export const notificationsShowParamsSchema = z.object({
+  title: z.string().min(1).max(120),
+  body: z.string().max(1000).optional()
+})
+
 export const PANEL_ACTION_PARAM_SCHEMAS: Record<PluginPanelAction, z.ZodTypeAny> = {
-  'terminal.sendText': terminalSendTextParamsSchema
+  'terminal.sendText': terminalSendTextParamsSchema,
+  'workspace.readContext': workspaceReadContextParamsSchema,
+  'notifications.show': notificationsShowParamsSchema
 }
 
 export const panelActionRequestSchema = z.object({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2768,6 +2768,10 @@ export type GlobalSettings = {
   /** Plugin ids the user disabled. Discovered plugins stay listed but are not
    *  activated, mirroring the disabledTuiAgents model. */
   disabledPlugins: string[]
+  /** Plugin ids the user explicitly approved. A discovered plugin that is in
+   *  neither list is pending: dropping a folder into the plugins directory
+   *  must never execute code without consent. */
+  approvedPlugins: string[]
   /** One-shot guard: start Claude Agent Teams hidden for existing profiles without overriding later opt-ins. */
   claudeAgentTeamsDefaultDisabledMigrated?: boolean
   /** Why: worktree deletion is destructive (rm -rf of the working dir), so confirm by default. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2765,6 +2765,9 @@ export type GlobalSettings = {
   defaultTuiAgent: TuiAgent | 'blank' | null
   /** Agents hidden from picker/auto-launch; detection stays a raw PATH snapshot. */
   disabledTuiAgents: TuiAgent[]
+  /** Plugin ids the user disabled. Discovered plugins stay listed but are not
+   *  activated, mirroring the disabledTuiAgents model. */
+  disabledPlugins: string[]
   /** One-shot guard: start Claude Agent Teams hidden for existing profiles without overriding later opt-ins. */
   claudeAgentTeamsDefaultDisabledMigrated?: boolean
   /** Why: worktree deletion is destructive (rm -rf of the working dir), so confirm by default. */
@@ -3119,6 +3122,9 @@ export type RightSidebarTab =
   | 'source-control'
   | 'checks'
   | 'ports'
+  // Plugin-contributed panels are keyed `plugin:<pluginId>/<panelId>` so the
+  // static union stays closed while plugin tabs remain type-representable.
+  | `plugin:${string}`
 export type ActiveRightSidebarTab = Exclude<RightSidebarTab, 'search'>
 export type RightSidebarExplorerView = 'files' | 'search'
 


### PR DESCRIPTION
## Summary

Adds an extensible plugin system to Orca, built in three layers across four commits:

1. **Shared core** (`32024dcff`) — manifest schema (zod), typed extension-point registry, plugin contracts. `CodeProvider` is the first extension point.
2. **Out-of-process host + panels** (`7677759ef`) — each plugin's `main` runs in a forked Node child (`ELECTRON_RUN_AS_NODE=1`) for crash/lifecycle isolation; plugins can contribute right-sidebar panels rendered as sandboxed iframes (`allow-scripts` only, opaque origin, `srcdoc` — never `file://`).
3. **Panel action bridge** (`c0890263c`) — panels call back into Orca via a validated postMessage bridge. Action id == permission id, declared in the manifest, enforced **in the main process only** (never renderer). First action: `terminal.sendText`. Example plugin: ModelShift (one-click Claude Code model switch).
4. **Hardening** (`0ff8bb066`) — review-driven fixes:
   - **First-run consent**: discovered plugins start `pending` and are fully inert (no host process, no panel HTML, no permissions) until the user approves. Desktop shows a one-time dialog (safe default = Keep Disabled, both answers persisted); headless serve default-denies with a `plugins.setEnabled` RPC for explicit approval. Dropping a folder into `<userData>/plugins/` can no longer execute code silently.
   - **Startup race fix**: `PluginService.whenReady()` awaited in every IPC/RPC handler, so an early renderer fetch can't lock in an empty plugin list.
   - **Multi-provider addressing**: registrations carry an optional `providerId`; `invokeCodeProvider` can address one of several providers in a plugin.
   - **New panel actions**: `workspace.readContext` (read-only focused-worktree metadata) and `notifications.show` (plugin-id-prefixed titles to prevent notification spoofing, native + mobile relay).

## Trust model (documented in docs/PLUGINS.md)

- Plugin **panel** HTML is sandboxed (opaque-origin iframe, permissioned bridge, param schemas, main-process enforcement).
- Plugin **main** code has full system access once approved — the host process gives crash isolation like VS Code extensions, not a security sandbox. Consent gate + docs make this explicit.

## Test plan

- 1171 unit tests green (Node 24), incl. new suites: consent flow, enablement coordination, activation states, panel action executor (permission denial, junk params, cross-action denial), RPC methods.
- Typecheck clean on node/CLI/web tsconfigs; oxlint 0 errors; oxfmt applied.
- Manual E2E on desktop: model-shift panel → bridge → IPC → permission check → pty; `/model sonnet` typed into live terminal.
- Headless/SSH: RPC paths mirror IPC (`plugins.list/setEnabled/panelAction/invokeCodeProvider`), consent default-deny verified by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Adds an out-of-process plugin system with panels, permissioned actions, and first-run consent. Plugins run isolated and can contribute sandboxed sidebar UI.
