### PR TITLE
fix(daemon): fix windows-hidden-console-children test typecheck break (main is red)

### DIFF
--- a/src/main/daemon/windows-hidden-console-children.test.ts
+++ b/src/main/daemon/windows-hidden-console-children.test.ts
@@ -62,7 +62,10 @@ describe('wrapChildProcessApi', () => {
       }
     })
     const wrapped = wrapChildProcessApi(original)
-    await expect(promisify(wrapped)('powershell.exe', ['-NoProfile'])).resolves.toBe('done')
+    // wrapChildProcessApi is typed (...args) => unknown, so promisify() can't
+    // infer the runtime-attached [promisify.custom] signature — assert the real one.
+    const promisified = promisify(wrapped) as (command: string, args: string[]) => Promise<string>
+    await expect(promisified('powershell.exe', ['-NoProfile'])).resolves.toBe('done')
     expect(seen[2]).toEqual({ windowsHide: true })
   })
 })


### PR DESCRIPTION
## Problem

`main` is currently **red on the `verify` typecheck step**, blocking every PR:

```
src/main/daemon/windows-hidden-console-children.test.ts(65,37): error TS2554: Expected 0 arguments, but got 2.
```

Introduced by the recent daemon `windowsHide` promisify work (#7486/#7499). `promisify(wrapped)` infers a **0-argument** function (it matches `util.promisify`'s callback-only overload) and is then called with 2 args. `wrapChildProcessApi` is typed `(...args) => unknown`, so `promisify()` cannot see the `[promisify.custom]` implementation that is attached at runtime via `Object.defineProperty`.

## Fix

Assert the promisified function's real call signature at the test call site. **Test-only** — production monkeypatches `child_process` at runtime, so the source typing is correct and unchanged.

## Verification

- `pnpm typecheck` (node + cli + web) all clean.
- `oxlint` clean.
- `windows-hidden-console-children.test.ts` — 9/9 pass.

Made with [Orca](https://github.com/stablyai/orca) 🐋
