### PR TITLE
feat(checks): let users pick agent for PR comment resolution

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -60,7 +60,8 @@ import type {
   PRInfo,
   PRCheckDetail,
   PRCheckRunDetails,
-  PRComment
+  PRComment,
+  TuiAgent
 } from '../../../../shared/types'
 import { getConnectionId } from '@/lib/connection-context'
 import {
@@ -129,7 +130,12 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-cl
 import { gitLabPipelineJobsToPRChecks } from '../../../../shared/gitlab-pipeline-checks'
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { SourceControlAgentActionDialog } from './SourceControlAgentActionDialog'
-import { readSourceControlLaunchRecipeAgentId } from '@/lib/source-control-launch-agent-selection'
+import { getAgentCatalog } from '@/lib/agent-catalog'
+import {
+  pickSourceControlLaunchAgent,
+  readSourceControlLaunchRecipeAgentId
+} from '@/lib/source-control-launch-agent-selection'
+import { filterEnabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import {
   DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS,
   resolveSourceControlActionRecipe,
@@ -455,6 +461,8 @@ export default function ChecksPanel(): React.JSX.Element {
   const [agentComposerState, setAgentComposerState] = useState<ChecksAgentComposerState | null>(
     null
   )
+  const [resolveCommentsPreferredAgent, setResolveCommentsPreferredAgent] =
+    useState<TuiAgent | null>(null)
   const [hostedReviewCreationSnapshot, setHostedReviewCreationSnapshot] =
     useState<HostedReviewCreationSnapshot | null>(null)
   const [gitStatusSnapshot, setGitStatusSnapshot] = useState<ChecksPanelGitStatusSnapshot | null>(
@@ -2564,6 +2572,42 @@ export default function ChecksPanel(): React.JSX.Element {
             : activeReview.provider === 'gitlab' && !activeGitLabReview
               ? 'Open a GitLab MR before resolving comments.'
               : undefined
+  const resolveCommentsLaunchAgent = useMemo(
+    () =>
+      pickSourceControlLaunchAgent({
+        savedAgent: readSourceControlLaunchRecipeAgentId(
+          resolveSourceControlActionRecipe({
+            settings,
+            repo,
+            actionId: 'resolveComments'
+          })
+        ),
+        defaultAgent: settings?.defaultTuiAgent,
+        detectedAgents: detectedAgentsForAI ?? [],
+        disabledAgents: settings?.disabledTuiAgents
+      }),
+    [detectedAgentsForAI, repo, settings]
+  )
+  const resolveCommentsAgentOptions = useMemo(
+    () =>
+      getAgentCatalog().filter((entry) => {
+        const detected = detectedAgentsForAI ?? []
+        const enabled = filterEnabledTuiAgents(detected, settings?.disabledTuiAgents)
+        return enabled.includes(entry.id) || entry.id === resolveCommentsPreferredAgent
+      }),
+    [detectedAgentsForAI, resolveCommentsPreferredAgent, settings?.disabledTuiAgents]
+  )
+  const resolveCommentsReviewKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (resolveCommentsReviewKeyRef.current === stateRequestKey) {
+      return
+    }
+    resolveCommentsReviewKeyRef.current = stateRequestKey
+    setResolveCommentsPreferredAgent(resolveCommentsLaunchAgent)
+  }, [resolveCommentsLaunchAgent, stateRequestKey])
+  useEffect(() => {
+    setResolveCommentsPreferredAgent((current) => current ?? resolveCommentsLaunchAgent)
+  }, [resolveCommentsLaunchAgent])
 
   const handleAddPRComment = useCallback(
     async (body: string) => {
@@ -3805,6 +3849,11 @@ export default function ChecksPanel(): React.JSX.Element {
         selectionClearRequest={commentsSelectionClearRequest}
         resolveCommentsWithAIDisabled={Boolean(resolveCommentsWithAIDisabledReason)}
         resolveCommentsWithAIDisabledReason={resolveCommentsWithAIDisabledReason}
+        resolveCommentsAgentOptions={
+          sourceControlAiActionsVisible ? resolveCommentsAgentOptions : undefined
+        }
+        resolveCommentsAgent={resolveCommentsPreferredAgent}
+        onResolveCommentsAgentChange={setResolveCommentsPreferredAgent}
         onAddComment={pr ? handleAddPRComment : undefined}
         onResolveSelectedCommentsWithAI={
           sourceControlAiActionsVisible ? handleResolveCommentsWithAI : undefined
@@ -3835,6 +3884,10 @@ export default function ChecksPanel(): React.JSX.Element {
         promptDelivery="submit-after-ready"
         launchPlatform={activeSourceControlLaunchPlatform}
         launchSource={agentComposerState?.launchSource ?? 'task_page'}
+        disableSavedRecipeAutoStart={agentComposerState?.actionId === 'resolveComments'}
+        preferredAgentId={
+          agentComposerState?.actionId === 'resolveComments' ? resolveCommentsPreferredAgent : null
+        }
         savedAgentId={
           agentComposerState
             ? readSourceControlLaunchRecipeAgentId(

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -2598,6 +2598,8 @@ export default function ChecksPanel(): React.JSX.Element {
     [detectedAgentsForAI, resolveCommentsPreferredAgent, settings?.disabledTuiAgents]
   )
   const resolveCommentsReviewKeyRef = useRef<string | null>(null)
+  // Why: review switches reset the inline picker, while late agent detection
+  // should only fill a null choice so a per-PR pick is not overwritten.
   useEffect(() => {
     if (resolveCommentsReviewKeyRef.current === stateRequestKey) {
       return

--- a/src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.test.tsx
@@ -207,6 +207,19 @@ describe('SourceControlAgentActionDialog', () => {
     expect(mocks.onStart).not.toHaveBeenCalled()
     expect(container.textContent).toContain('Launch agent')
   })
+  it('pre-selects preferredAgentId over savedAgentId when the dialog opens', async () => {
+    mocks.ensureDetectedAgents.mockResolvedValue(['codex', 'claude'])
+    renderControlledDialog({
+      savedAgentId: 'codex',
+      preferredAgentId: 'claude',
+      disableSavedRecipeAutoStart: true
+    })
+    await vi.waitFor(() => expect(mocks.ensureDetectedAgents).toHaveBeenCalledTimes(1))
+    await flushEffects()
+    expect(container.querySelector('[data-agent-value]')?.getAttribute('data-agent-value')).toBe(
+      'claude'
+    )
+  })
 
   it('hides the dialog and auto-starts once when the saved repo launch recipe matches', async () => {
     resetStore(

--- a/src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.test.tsx
@@ -200,6 +200,14 @@ describe('SourceControlAgentActionDialog', () => {
     expect(mocks.onSaveAgentDefault).not.toHaveBeenCalled()
     expect(container.textContent).not.toContain('Launch agent')
   })
+  it('renders the form and does not auto-start when saved recipe auto-start is disabled', async () => {
+    renderControlledDialog({ disableSavedRecipeAutoStart: true })
+    await vi.waitFor(() => expect(mocks.ensureDetectedAgents).toHaveBeenCalledTimes(1))
+    await flushEffects()
+    expect(mocks.onStart).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Launch agent')
+  })
+
   it('hides the dialog and auto-starts once when the saved repo launch recipe matches', async () => {
     resetStore(
       settingsWithGlobalRecipe({ agentId: 'claude', commandInputTemplate: '{basePrompt}' }),

--- a/src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.tsx
@@ -33,6 +33,10 @@ export type SourceControlAgentActionDialogProps = {
   launchPlatform?: NodeJS.Platform
   launchSource: LaunchSource
   savedAgentId?: TuiAgent | null
+  /** Overrides the saved recipe agent for this launch only (dialog pre-selection). */
+  preferredAgentId?: TuiAgent | null
+  /** When true, always show the dialog instead of auto-starting from a saved recipe. */
+  disableSavedRecipeAutoStart?: boolean
   onSaveAgentDefault?: (
     target: SourceControlAiWriteTarget,
     actionId: SourceControlLaunchActionId,

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -27,6 +27,8 @@ import {
   X
 } from 'lucide-react'
 import { ExternalLink } from 'lucide-react'
+import AgentCombobox from '@/components/agent/AgentCombobox'
+import type { AgentCatalogEntry } from '@/lib/agent-catalog'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -87,7 +89,8 @@ import type {
   PRCheckRunDetails,
   PRComment,
   PRConflictSummary,
-  PRMergeableState
+  PRMergeableState,
+  TuiAgent
 } from '../../../../shared/types'
 import { useCheckDetailsResize } from './check-details-resize'
 import {
@@ -2177,6 +2180,9 @@ export function PRCommentsList({
   selectionClearRequest,
   resolveCommentsWithAIDisabled,
   resolveCommentsWithAIDisabledReason,
+  resolveCommentsAgentOptions,
+  resolveCommentsAgent,
+  onResolveCommentsAgentChange,
   onAddComment,
   onResolveSelectedCommentsWithAI,
   onReply,
@@ -2193,6 +2199,9 @@ export function PRCommentsList({
   selectionClearRequest?: PRCommentsListSelectionClearRequest | null
   resolveCommentsWithAIDisabled?: boolean
   resolveCommentsWithAIDisabledReason?: string
+  resolveCommentsAgentOptions?: AgentCatalogEntry[]
+  resolveCommentsAgent?: TuiAgent | null
+  onResolveCommentsAgentChange?: (agent: TuiAgent | null) => void
   onAddComment?: (body: string) => Promise<RightPanelCommentSubmitResult>
   onResolveSelectedCommentsWithAI?: (groups: PRCommentGroup[]) => void
   onReply?: (comment: PRComment, body: string) => Promise<RightPanelCommentSubmitResult>
@@ -2370,6 +2379,15 @@ export function PRCommentsList({
           <div className="-mr-1 ml-auto flex items-center gap-0.5">
             {canShowResolveWithAI && (
               <>
+                {resolveCommentsAgentOptions && resolveCommentsAgentOptions.length > 0 ? (
+                  <AgentCombobox
+                    agents={resolveCommentsAgentOptions}
+                    value={resolveCommentsAgent ?? null}
+                    onValueChange={(agent) => onResolveCommentsAgentChange?.(agent)}
+                    allowNarrowTrigger
+                    triggerClassName="h-6 w-[6.75rem] min-w-0 px-1.5 text-[11px]"
+                  />
+                ) : null}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button

--- a/src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-agent-action-dialog-support.ts
@@ -1,9 +1,11 @@
 import { getAgentCatalog } from '@/lib/agent-catalog'
+import type { SourceControlLaunchAgentScope } from '@/lib/source-control-launch-agent-selection'
 import { isTuiAgentEnabled } from '../../../../shared/tui-agent-selection'
 import type { TuiAgent } from '../../../../shared/types'
 import type { SourceControlAiWriteTarget } from '../../../../shared/source-control-ai-recipe-save'
 import { translate } from '@/i18n/i18n'
 import type { SourceControlAgentActionDeliveryPlanState } from './SourceControlAgentActionDialogForm'
+import type { SourceControlAgentScopeNote } from './source-control-agent-action-dialog-result'
 
 export function isSourceControlAgentDetectedAndEnabled(
   agent: TuiAgent | null,
@@ -72,6 +74,21 @@ export function resolveSourceControlAgentSaveTarget(
     return { type: 'global' }
   }
   return null
+}
+
+export function buildSourceControlAgentScopeNote(
+  launchAgentScope: SourceControlLaunchAgentScope
+): SourceControlAgentScopeNote | null {
+  if (!launchAgentScope.overridesGlobalAgent) {
+    return null
+  }
+  const catalog = getAgentCatalog()
+  const labelFor = (agentId: TuiAgent | null): string =>
+    catalog.find((entry) => entry.id === agentId)?.label ?? agentId ?? ''
+  return {
+    effectiveAgentLabel: labelFor(launchAgentScope.effectiveAgentId),
+    globalAgentLabel: labelFor(launchAgentScope.globalAgentId)
+  }
 }
 
 export function buildSourceControlAgentStatusCopy(args: {

--- a/src/renderer/src/components/right-sidebar/useSavedSourceControlAgentActionAutoStart.ts
+++ b/src/renderer/src/components/right-sidebar/useSavedSourceControlAgentActionAutoStart.ts
@@ -32,6 +32,8 @@ type UseSavedSourceControlAgentActionAutoStartArgs = {
   isStarting: boolean
   detectedAgents: TuiAgent[]
   disabledAgents: TuiAgent[] | undefined
+  /** Why: per-PR comment resolution should always confirm agent choice in the dialog. */
+  disableSavedRecipeAutoStart?: boolean
   onAutoStart: (args: {
     detectedAgents: TuiAgent[]
     saveTargetValue: SavedSourceControlAgentActionTargetValue
@@ -146,6 +148,7 @@ export function useSavedSourceControlAgentActionAutoStart({
   isStarting,
   detectedAgents,
   disabledAgents,
+  disableSavedRecipeAutoStart = false,
   onAutoStart
 }: UseSavedSourceControlAgentActionAutoStartArgs): SavedSourceControlAgentActionAutoStartResult {
   const autoStartedOpenCycleRef = useRef(0)
@@ -203,6 +206,7 @@ export function useSavedSourceControlAgentActionAutoStart({
     currentReceiptState && receiptKey && currentReceiptState.receiptKey !== receiptKey
   )
   const autoLaunchPending = Boolean(
+    !disableSavedRecipeAutoStart &&
     open &&
     matchedSavedReceiptTargetValue &&
     receiptKey &&
@@ -223,7 +227,12 @@ export function useSavedSourceControlAgentActionAutoStart({
         revealed: !receiptKey
       })
     }
-    if (!matchedSavedReceiptTargetValue || !receiptKey || !savedAgentId) {
+    if (
+      disableSavedRecipeAutoStart ||
+      !matchedSavedReceiptTargetValue ||
+      !receiptKey ||
+      !savedAgentId
+    ) {
       return
     }
     if (receiptState?.openCycle === openCycle && receiptState.receiptKey !== receiptKey) {
@@ -268,6 +277,7 @@ export function useSavedSourceControlAgentActionAutoStart({
     detectedAgents,
     detectionReady,
     detecting,
+    disableSavedRecipeAutoStart,
     disabledAgents,
     isStarting,
     matchedSavedReceiptTargetValue,

--- a/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialog.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialog.ts
@@ -1,9 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { getAgentCatalog } from '@/lib/agent-catalog'
-import {
-  pickSourceControlLaunchAgent,
-  resolveSourceControlLaunchAgentScope
-} from '@/lib/source-control-launch-agent-selection'
+import { resolveSourceControlLaunchAgentScope } from '@/lib/source-control-launch-agent-selection'
 import { useAppStore } from '@/store'
 import { useRepoById } from '@/store/selectors'
 import { renderSourceControlActionCommandTemplate } from '../../../../shared/source-control-ai-actions'
@@ -14,9 +11,11 @@ import type { UseSourceControlAgentActionDialogResult } from './source-control-a
 import { useSavedSourceControlAgentActionAutoStart } from './useSavedSourceControlAgentActionAutoStart'
 import {
   buildSourceControlAgentSaveTargets,
+  buildSourceControlAgentScopeNote,
   buildSourceControlAgentStatusCopy,
   isSourceControlAgentDetectedAndEnabled
 } from './source-control-agent-action-dialog-support'
+import { useSourceControlAgentActionDialogOpenSync } from './useSourceControlAgentActionDialogOpenSync'
 import { useSourceControlAgentActionStart } from './useSourceControlAgentActionStart'
 
 const DEFAULT_SAVE_TARGET_VALUE = 'global'
@@ -36,6 +35,8 @@ export function useSourceControlAgentActionDialog({
   launchPlatform,
   launchSource,
   savedAgentId,
+  preferredAgentId,
+  disableSavedRecipeAutoStart = false,
   onSaveAgentDefault,
   onLaunched,
   onStart
@@ -57,13 +58,11 @@ export function useSourceControlAgentActionDialog({
     savedCommandInputTemplate ?? '{basePrompt}'
   )
   const [agentArgs, setAgentArgs] = useState(savedAgentArgs ?? '')
-  const [selectedAgent, setSelectedAgent] = useState<TuiAgent | null>(savedAgentId ?? null)
+  const [selectedAgent, setSelectedAgent] = useState<TuiAgent | null>(
+    preferredAgentId ?? savedAgentId ?? null
+  )
   const [detectedAgents, setDetectedAgents] = useState<TuiAgent[]>([])
   const [detecting, setDetecting] = useState(false)
-  const openCycleRef = useRef(0)
-  const wasOpenRef = useRef(false)
-  const [openCycle, setOpenCycle] = useState(0)
-  const [detectedOpenCycle, setDetectedOpenCycle] = useState<number | null>(null)
   const saveTargets = useMemo(() => buildSourceControlAgentSaveTargets(repoId), [repoId])
   const [saveLaunchRecipe, setSaveLaunchRecipe] = useState(true)
   const [saveTargetValue, setSaveTargetValue] = useState(defaultSaveTargetValue)
@@ -90,54 +89,22 @@ export function useSourceControlAgentActionDialog({
     }
   }, [connectionId, connectionUnavailable, ensureDetectedAgents, ensureRemoteDetectedAgents])
 
-  useEffect(() => {
-    if (!open) {
-      wasOpenRef.current = false
-      return
-    }
-    const cycle = wasOpenRef.current ? openCycleRef.current : openCycleRef.current + 1
-    if (!wasOpenRef.current) {
-      openCycleRef.current = cycle
-      setOpenCycle(cycle)
-    }
-    wasOpenRef.current = true
-    setDetectedOpenCycle(null)
-    setCommandTemplate(savedCommandInputTemplate ?? '{basePrompt}')
-    setAgentArgs(savedAgentArgs ?? '')
-    setSelectedAgent(savedAgentId ?? null)
-    setSaveLaunchRecipe(true)
-    setSaveTargetValue(defaultSaveTargetValue)
-    let stale = false
-    void refreshDetectedAgents().then((nextAgents) => {
-      if (stale || openCycleRef.current !== cycle) {
-        return
-      }
-      setSelectedAgent(
-        (current) =>
-          current ??
-          pickSourceControlLaunchAgent({
-            savedAgent: savedAgentId,
-            defaultAgent: settings?.defaultTuiAgent,
-            detectedAgents: nextAgents,
-            disabledAgents
-          })
-      )
-      setDetectedOpenCycle(cycle)
-    })
-    return () => {
-      stale = true
-    }
-  }, [
-    defaultSaveTargetValue,
-    disabledAgents,
+  const { openCycle, detectedOpenCycle } = useSourceControlAgentActionDialogOpenSync({
     open,
-    refreshDetectedAgents,
+    preferredAgentId,
     savedAgentId,
     savedAgentArgs,
     savedCommandInputTemplate,
-    repoId,
-    settings?.defaultTuiAgent
-  ])
+    defaultSaveTargetValue,
+    disabledAgents,
+    settings,
+    refreshDetectedAgents,
+    setCommandTemplate,
+    setAgentArgs,
+    setSelectedAgent,
+    setSaveLaunchRecipe,
+    setSaveTargetValue
+  })
 
   const closeDialog = useCallback(() => onOpenChange(false), [onOpenChange])
 
@@ -232,6 +199,7 @@ export function useSourceControlAgentActionDialog({
     isStarting,
     detectedAgents,
     disabledAgents,
+    disableSavedRecipeAutoStart,
     onAutoStart: ({ detectedAgents: agentsForLaunch, saveTargetValue: matchedTargetValue }) =>
       startWithDetectedAgents({
         detectedAgents: agentsForLaunch,
@@ -276,18 +244,10 @@ export function useSourceControlAgentActionDialog({
     [resetDeliveryPlan]
   )
 
-  const agentScopeNote = useMemo(() => {
-    if (!launchAgentScope.overridesGlobalAgent) {
-      return null
-    }
-    const catalog = getAgentCatalog()
-    const labelFor = (agentId: TuiAgent | null): string =>
-      catalog.find((entry) => entry.id === agentId)?.label ?? agentId ?? ''
-    return {
-      effectiveAgentLabel: labelFor(launchAgentScope.effectiveAgentId),
-      globalAgentLabel: labelFor(launchAgentScope.globalAgentId)
-    }
-  }, [launchAgentScope])
+  const agentScopeNote = useMemo(
+    () => buildSourceControlAgentScopeNote(launchAgentScope),
+    [launchAgentScope]
+  )
 
   return {
     handleOpenChange,

--- a/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialogOpenSync.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialogOpenSync.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { pickSourceControlLaunchAgent } from '@/lib/source-control-launch-agent-selection'
+import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
+
+type UseSourceControlAgentActionDialogOpenSyncArgs = {
+  open: boolean
+  preferredAgentId?: TuiAgent | null
+  savedAgentId?: TuiAgent | null
+  savedAgentArgs?: string | null
+  savedCommandInputTemplate?: string | null
+  defaultSaveTargetValue: string
+  disabledAgents: TuiAgent[] | undefined
+  settings: Pick<GlobalSettings, 'defaultTuiAgent'> | null | undefined
+  refreshDetectedAgents: () => Promise<TuiAgent[]>
+  setCommandTemplate: (value: string) => void
+  setAgentArgs: (value: string) => void
+  setSelectedAgent: Dispatch<SetStateAction<TuiAgent | null>>
+  setSaveLaunchRecipe: (value: boolean) => void
+  setSaveTargetValue: (value: string) => void
+}
+
+export function useSourceControlAgentActionDialogOpenSync({
+  open,
+  preferredAgentId,
+  savedAgentId,
+  savedAgentArgs,
+  savedCommandInputTemplate,
+  defaultSaveTargetValue,
+  disabledAgents,
+  settings,
+  refreshDetectedAgents,
+  setCommandTemplate,
+  setAgentArgs,
+  setSelectedAgent,
+  setSaveLaunchRecipe,
+  setSaveTargetValue
+}: UseSourceControlAgentActionDialogOpenSyncArgs): {
+  openCycle: number
+  detectedOpenCycle: number | null
+} {
+  const openCycleRef = useRef(0)
+  const wasOpenRef = useRef(false)
+  const [openCycle, setOpenCycle] = useState(0)
+  const [detectedOpenCycle, setDetectedOpenCycle] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!open) {
+      wasOpenRef.current = false
+      return
+    }
+    const cycle = wasOpenRef.current ? openCycleRef.current : openCycleRef.current + 1
+    if (!wasOpenRef.current) {
+      openCycleRef.current = cycle
+      setOpenCycle(cycle)
+    }
+    wasOpenRef.current = true
+    setDetectedOpenCycle(null)
+    setCommandTemplate(savedCommandInputTemplate ?? '{basePrompt}')
+    setAgentArgs(savedAgentArgs ?? '')
+    setSelectedAgent(preferredAgentId ?? savedAgentId ?? null)
+    setSaveLaunchRecipe(true)
+    setSaveTargetValue(defaultSaveTargetValue)
+    let stale = false
+    void refreshDetectedAgents().then((nextAgents) => {
+      if (stale || openCycleRef.current !== cycle) {
+        return
+      }
+      setSelectedAgent(
+        (current) =>
+          current ??
+          pickSourceControlLaunchAgent({
+            savedAgent: preferredAgentId ?? savedAgentId,
+            defaultAgent: settings?.defaultTuiAgent,
+            detectedAgents: nextAgents,
+            disabledAgents
+          })
+      )
+      setDetectedOpenCycle(cycle)
+    })
+    return () => {
+      stale = true
+    }
+  }, [
+    defaultSaveTargetValue,
+    disabledAgents,
+    open,
+    preferredAgentId,
+    refreshDetectedAgents,
+    savedAgentArgs,
+    savedAgentId,
+    savedCommandInputTemplate,
+    setAgentArgs,
+    setCommandTemplate,
+    setSaveLaunchRecipe,
+    setSaveTargetValue,
+    setSelectedAgent,
+    settings?.defaultTuiAgent
+  ])
+
+  return { openCycle, detectedOpenCycle }
+}

--- a/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialogOpenSync.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialogOpenSync.ts
@@ -48,6 +48,9 @@ export function useSourceControlAgentActionDialogOpenSync({
       wasOpenRef.current = false
       return
     }
+    // Why: bump openCycle only on the rising edge of open so saved-receipt
+    // auto-start resets per dialog session; dependency churn while already
+    // open reuses the current cycle instead of silently re-arming a launch.
     const cycle = wasOpenRef.current ? openCycleRef.current : openCycleRef.current + 1
     if (!wasOpenRef.current) {
       openCycleRef.current = cycle
@@ -61,22 +64,31 @@ export function useSourceControlAgentActionDialogOpenSync({
     setSaveLaunchRecipe(true)
     setSaveTargetValue(defaultSaveTargetValue)
     let stale = false
-    void refreshDetectedAgents().then((nextAgents) => {
-      if (stale || openCycleRef.current !== cycle) {
-        return
-      }
-      setSelectedAgent(
-        (current) =>
-          current ??
-          pickSourceControlLaunchAgent({
-            savedAgent: preferredAgentId ?? savedAgentId,
-            defaultAgent: settings?.defaultTuiAgent,
-            detectedAgents: nextAgents,
-            disabledAgents
-          })
-      )
-      setDetectedOpenCycle(cycle)
-    })
+    void refreshDetectedAgents()
+      .then((nextAgents) => {
+        if (stale || openCycleRef.current !== cycle) {
+          return
+        }
+        setSelectedAgent(
+          (current) =>
+            current ??
+            pickSourceControlLaunchAgent({
+              savedAgent: preferredAgentId ?? savedAgentId,
+              defaultAgent: settings?.defaultTuiAgent,
+              detectedAgents: nextAgents,
+              disabledAgents
+            })
+        )
+        setDetectedOpenCycle(cycle)
+      })
+      .catch(() => {
+        if (stale || openCycleRef.current !== cycle) {
+          return
+        }
+        // Why: still mark detection complete so the dialog can surface status
+        // copy instead of staying blocked behind a pending auto-start receipt.
+        setDetectedOpenCycle(cycle)
+      })
     return () => {
       stale = true
     }


### PR DESCRIPTION
Fixes #7465

## Summary

When sending unresolved PR/MR comments to an AI agent, users can now choose which agent to use per review instead of always relying on the configured default or a saved launch recipe that auto-starts in the background.

## Changes

- Add an inline agent combobox in the PR comments header (next to the sparkles/send actions)
- Pass the selected agent into the launch dialog as the preferred agent
- Disable saved-recipe auto-start for `resolveComments` so the confirmation dialog always appears and agent choice is visible

## How to verify

1. Open a worktree with an active PR/MR that has unresolved comments
2. In the Checks panel Comments section, pick an agent from the new dropdown
3. Click the sparkles button or send queued comments
4. Confirm the launch dialog opens with the selected agent (even if a saved launch recipe exists)

## Testing

- Added coverage for `disableSavedRecipeAutoStart` in `SourceControlAgentActionDialog.test.tsx`
- Full test suite passed locally

## ELI5

When sending PR comments to an agent, you can pick which agent to use per review. Saved recipes no longer auto-start so the confirmation dialog can respect your choice.
