### PR TITLE
Load PR details in forked repositories

### DIFF
--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -5,14 +5,14 @@ import { readFile } from 'node:fs/promises'
 
 const {
   ghExecFileAsyncMock,
-  getOwnerRepoMock,
+  getOriginOwnerRepoMock,
   extractExecErrorMock,
   acquireMock,
   releaseMock,
   getSshFilesystemProviderMock
 } = vi.hoisted(() => ({
   ghExecFileAsyncMock: vi.fn(),
-  getOwnerRepoMock: vi.fn(),
+  getOriginOwnerRepoMock: vi.fn(),
   extractExecErrorMock: vi.fn((error: unknown) => {
     const value = error as { stderr?: string; stdout?: string; message?: string }
     return {
@@ -32,7 +32,7 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 vi.mock('./gh-utils', () => ({
   execFileAsync: vi.fn(),
   ghExecFileAsync: ghExecFileAsyncMock,
-  getOwnerRepo: getOwnerRepoMock,
+  getOriginOwnerRepo: getOriginOwnerRepoMock,
   getIssueOwnerRepo: vi.fn(),
   getOwnerRepoForRemote: vi.fn(),
   githubRepoContext: vi.fn((repoPath: string, connectionId?: string | null) => ({
@@ -59,7 +59,7 @@ import { createGitHubPullRequest } from './client'
 describe('createGitHubPullRequest', () => {
   beforeEach(() => {
     ghExecFileAsyncMock.mockReset()
-    getOwnerRepoMock.mockReset()
+    getOriginOwnerRepoMock.mockReset()
     extractExecErrorMock.mockClear()
     acquireMock.mockReset()
     releaseMock.mockReset()
@@ -68,7 +68,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('creates a GitHub pull request with normalized refs and a body file', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 42,
@@ -118,7 +118,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('runs local WSL project pull request creation through the selected distro', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 43,
@@ -154,7 +154,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('creates SSH-backed pull requests without using the remote path as a local cwd', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 45,
@@ -179,7 +179,7 @@ describe('createGitHubPullRequest', () => {
       url: 'https://github.com/acme/widgets/pull/45'
     })
 
-    expect(getOwnerRepoMock).toHaveBeenCalledWith('/remote/repo-root', 'ssh-1')
+    expect(getOriginOwnerRepoMock).toHaveBeenCalledWith('/remote/repo-root', 'ssh-1')
     const [args, options] = ghExecFileAsyncMock.mock.calls[0]
     expect(args).toEqual(
       expect.arrayContaining([
@@ -231,7 +231,7 @@ describe('createGitHubPullRequest', () => {
         throw new Error('missing template')
       })
       getSshFilesystemProviderMock.mockReturnValue({ readFile: readRemoteFile })
-      getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+      getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
       const writtenBodies: string[] = []
       ghExecFileAsyncMock.mockImplementationOnce(async (args: string[]) => {
         const bodyPath = args[args.indexOf('--body-file') + 1]
@@ -271,7 +271,7 @@ describe('createGitHubPullRequest', () => {
   )
 
   it('falls back to parsing the PR URL for older gh output', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: 'https://github.com/acme/widgets/pull/43\n'
     })
@@ -291,7 +291,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('returns the existing PR when gh reports an already-open pull request', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
       .mockRejectedValueOnce({ stderr: 'a pull request already exists for feature/existing' })
       .mockResolvedValueOnce({
@@ -342,7 +342,7 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('validates base, head, and title before invoking gh', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
 
     await expect(
       createGitHubPullRequest('/repo-root', {

--- a/src/main/github/client-issue-source.test.ts
+++ b/src/main/github/client-issue-source.test.ts
@@ -36,6 +36,10 @@ vi.mock('./gh-utils', async () => {
     execFileAsync: execFileAsyncMock,
     ghExecFileAsync: ghExecFileAsyncMock,
     getOwnerRepo: getOwnerRepoMock,
+    // Why: resolvePrWorkItemSource resolves the raw origin candidate via
+    // getOriginOwnerRepo; map it to the same mock these tests use for the
+    // origin PR repo.
+    getOriginOwnerRepo: getOwnerRepoMock,
     getIssueOwnerRepo: getIssueOwnerRepoMock,
     getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
     resolveIssueSource: resolveIssueSourceMock,

--- a/src/main/github/client-issue-source.test.ts
+++ b/src/main/github/client-issue-source.test.ts
@@ -9,6 +9,7 @@ const {
   execFileAsyncMock,
   ghExecFileAsyncMock,
   getOwnerRepoMock,
+  getOriginOwnerRepoMock,
   getIssueOwnerRepoMock,
   getOwnerRepoForRemoteMock,
   resolveIssueSourceMock,
@@ -20,6 +21,7 @@ const {
   execFileAsyncMock: vi.fn(),
   ghExecFileAsyncMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
+  getOriginOwnerRepoMock: vi.fn(),
   getIssueOwnerRepoMock: vi.fn(),
   getOwnerRepoForRemoteMock: vi.fn(),
   resolveIssueSourceMock: vi.fn(),
@@ -37,9 +39,11 @@ vi.mock('./gh-utils', async () => {
     ghExecFileAsync: ghExecFileAsyncMock,
     getOwnerRepo: getOwnerRepoMock,
     // Why: resolvePrWorkItemSource resolves the raw origin candidate via
-    // getOriginOwnerRepo; map it to the same mock these tests use for the
-    // origin PR repo.
-    getOriginOwnerRepo: getOwnerRepoMock,
+    // getOriginOwnerRepo (distinct from upstream-first getOwnerRepo). Keep it a
+    // separate mock so a regression that collapses originCandidate back onto
+    // getOwnerRepo is observable; it delegates to getOwnerRepoMock by default
+    // (see beforeEach) so existing origin-candidate setups keep working.
+    getOriginOwnerRepo: getOriginOwnerRepoMock,
     getIssueOwnerRepo: getIssueOwnerRepoMock,
     getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
     resolveIssueSource: resolveIssueSourceMock,
@@ -61,6 +65,7 @@ describe('GitHub issue source split', () => {
     execFileAsyncMock.mockReset()
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
+    getOriginOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()
     getOwnerRepoForRemoteMock.mockReset()
     resolveIssueSourceMock.mockReset()
@@ -79,6 +84,13 @@ describe('GitHub issue source split', () => {
       source: await getIssueOwnerRepoMock(),
       fellBack: false
     }))
+    // Why: originCandidate is resolved via getOriginOwnerRepo. Delegate to
+    // getOwnerRepoMock by default so the many existing tests that queue the
+    // origin PR repo on getOwnerRepoMock keep working unchanged; tests that
+    // must distinguish the two (the revert-guard below) override it.
+    getOriginOwnerRepoMock.mockImplementation((...args: unknown[]) =>
+      (getOwnerRepoMock as (...a: unknown[]) => Promise<unknown>)(...args)
+    )
     // Default the upstream-candidate lookup to null so existing tests that
     // only mock `getIssueOwnerRepo` + `getOwnerRepo` don't need to think
     // about it. Tests that care set it explicitly.
@@ -688,6 +700,29 @@ describe('GitHub issue source split', () => {
         originCandidate: { owner: 'fork', repo: 'orca' },
         upstreamCandidate: { owner: 'stablyai', repo: 'orca' }
       })
+    })
+
+    it('resolves originCandidate via raw origin, not upstream-first getOwnerRepo', async () => {
+      // Why: regression guard for the fork toggle. originCandidate must be the
+      // raw `origin` remote so the renderer's IssueSourceSelector keeps
+      // rendering (it gates on originCandidate && upstreamCandidate && distinct).
+      // If this collapses back onto upstream-first getOwnerRepo, originCandidate
+      // would equal upstreamCandidate and the toggle vanishes for every fork.
+      resolveIssueSourceMock.mockResolvedValueOnce({
+        source: { owner: 'stablyai', repo: 'orca' },
+        fellBack: false
+      })
+      getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
+      // What upstream-first getOwnerRepo would return — must NOT reach originCandidate.
+      getOwnerRepoMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+      getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+      ghExecFileAsyncMock.mockResolvedValue({ stdout: '[]' })
+
+      const result = await listWorkItems('/repo-root', 10, 'is:pr', undefined, 'upstream')
+
+      expect(result.sources.originCandidate).toEqual({ owner: 'fork', repo: 'orca' })
+      expect(result.sources.upstreamCandidate).toEqual({ owner: 'stablyai', repo: 'orca' })
+      expect(getOriginOwnerRepoMock).toHaveBeenCalled()
     })
   })
 })

--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -50,6 +50,9 @@ vi.mock('./gh-utils', () => ({
       ? {}
       : { cwd: context.repoPath, ...(context.wslDistro ? { wslDistro: context.wslDistro } : {}) },
   getOwnerRepo: getOwnerRepoMock,
+  // Why: resolvePrWorkItemSource resolves the raw origin candidate via
+  // getOriginOwnerRepo; map it to the same mock these tests use for origin.
+  getOriginOwnerRepo: getOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
   getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
   resolveIssueSource: resolveIssueSourceMock,

--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -7,6 +7,7 @@ const {
   execFileAsyncMock,
   ghExecFileAsyncMock,
   getOwnerRepoMock,
+  getOriginOwnerRepoMock,
   getIssueOwnerRepoMock,
   getOwnerRepoForRemoteMock,
   resolveIssueSourceMock,
@@ -19,6 +20,7 @@ const {
   execFileAsyncMock: vi.fn(),
   ghExecFileAsyncMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
+  getOriginOwnerRepoMock: vi.fn(),
   getIssueOwnerRepoMock: vi.fn(),
   getOwnerRepoForRemoteMock: vi.fn(),
   resolveIssueSourceMock: vi.fn(),
@@ -51,8 +53,10 @@ vi.mock('./gh-utils', () => ({
       : { cwd: context.repoPath, ...(context.wslDistro ? { wslDistro: context.wslDistro } : {}) },
   getOwnerRepo: getOwnerRepoMock,
   // Why: resolvePrWorkItemSource resolves the raw origin candidate via
-  // getOriginOwnerRepo; map it to the same mock these tests use for origin.
-  getOriginOwnerRepo: getOwnerRepoMock,
+  // getOriginOwnerRepo (distinct from upstream-first getOwnerRepo). Keep a
+  // separate mock; it delegates to getOwnerRepoMock by default (see beforeEach)
+  // so existing origin-candidate setups keep working.
+  getOriginOwnerRepo: getOriginOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
   getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
   resolveIssueSource: resolveIssueSourceMock,
@@ -85,6 +89,7 @@ describe('listWorkItems', () => {
     execFileAsyncMock.mockReset()
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
+    getOriginOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()
     getOwnerRepoForRemoteMock.mockReset()
     resolveIssueSourceMock.mockReset()
@@ -102,6 +107,12 @@ describe('listWorkItems', () => {
       source: await getIssueOwnerRepoMock(),
       fellBack: false
     }))
+    // Why: originCandidate is resolved via getOriginOwnerRepo. Delegate to
+    // getOwnerRepoMock by default so existing tests that queue the origin PR
+    // repo on getOwnerRepoMock keep working unchanged.
+    getOriginOwnerRepoMock.mockImplementation((...args: unknown[]) =>
+      (getOwnerRepoMock as (...a: unknown[]) => Promise<unknown>)(...args)
+    )
     getOwnerRepoForRemoteMock.mockResolvedValue(null)
     _resetOwnerRepoCache()
     _resetMergeQueueCacheForTests()

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -10,6 +10,7 @@ const {
   ghExecFileAsyncMock,
   getOwnerRepoMock,
   getIssueOwnerRepoMock,
+  getOriginOwnerRepoMock,
   getOwnerRepoForRemoteMock,
   resolvePRRepositoryCandidatesMock,
   getRemoteUrlForRepoMock,
@@ -28,6 +29,7 @@ const {
   ghExecFileAsyncMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
   getIssueOwnerRepoMock: vi.fn(),
+  getOriginOwnerRepoMock: vi.fn(),
   getOwnerRepoForRemoteMock: vi.fn(),
   resolvePRRepositoryCandidatesMock: vi.fn(),
   getRemoteUrlForRepoMock: vi.fn(),
@@ -58,6 +60,7 @@ vi.mock('./gh-utils', () => ({
   execFileAsync: execFileAsyncMock,
   ghExecFileAsync: ghExecFileAsyncMock,
   getOwnerRepo: getOwnerRepoMock,
+  getOriginOwnerRepo: getOriginOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
   getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
   resolvePRRepositoryCandidates: resolvePRRepositoryCandidatesMock,
@@ -2975,7 +2978,7 @@ describe('getPRForBranch', () => {
   })
 
   it('resolves a distinct upstream remote as the repo upstream', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
     getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
 
     await expect(getRepoUpstream('/repo-root')).resolves.toEqual({
@@ -2987,7 +2990,7 @@ describe('getPRForBranch', () => {
   })
 
   it('does not treat a same-repository upstream remote as a fork', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'StablyAI', repo: 'Orca' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'StablyAI', repo: 'Orca' })
     getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({ isFork: false, parent: null })
@@ -3002,7 +3005,7 @@ describe('getPRForBranch', () => {
   })
 
   it('does not mark an upstream-only GitHub remote as a fork', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce(null)
+    getOriginOwnerRepoMock.mockResolvedValueOnce(null)
 
     await expect(getRepoUpstream('/repo-root')).resolves.toBeNull()
 
@@ -3011,7 +3014,7 @@ describe('getPRForBranch', () => {
   })
 
   it('falls back to the GitHub parent when no upstream remote is configured', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
+    getOriginOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
     getOwnerRepoForRemoteMock.mockResolvedValueOnce(null)
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -169,6 +169,7 @@ describe('getPRForBranch', () => {
     execFileAsyncMock.mockReset()
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
+    getOriginOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()
     getOwnerRepoForRemoteMock.mockReset()
     resolvePRRepositoryCandidatesMock.mockReset()
@@ -3107,6 +3108,7 @@ describe('updatePRState', () => {
   beforeEach(() => {
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
+    getOriginOwnerRepoMock.mockReset()
     ghRepoExecOptionsMock.mockClear()
     githubRepoContextMock.mockClear()
     acquireMock.mockReset()
@@ -3167,6 +3169,7 @@ describe('GitHub GraphQL rate-limit guard', () => {
     execFileAsyncMock.mockReset()
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
+    getOriginOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()
     getOwnerRepoForRemoteMock.mockReset()
     resolvePRRepositoryCandidatesMock.mockReset()

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -51,6 +51,7 @@ import {
   release,
   getOwnerRepo,
   getIssueOwnerRepo,
+  getOriginOwnerRepo,
   getOwnerRepoForRemote,
   resolvePRRepositoryCandidates,
   resolveIssueSource,
@@ -1540,7 +1541,7 @@ export async function getRepoUpstream(
 ): Promise<OwnerRepo | null> {
   const localGitArgs = hostedReviewLocalGitOptionArgs(options)
   const localGitOptions = localGitArgs[0] ?? {}
-  const origin = await getOwnerRepo(repoPath, connectionId, ...localGitArgs)
+  const origin = await getOriginOwnerRepo(repoPath, connectionId, ...localGitArgs)
   if (!origin) {
     return null
   }
@@ -1737,7 +1738,7 @@ export async function createGitHubPullRequest(
     }
   }
 
-  const ownerRepo = await getOwnerRepo(
+  const ownerRepo = await getOriginOwnerRepo(
     repoPath,
     connectionId,
     ...hostedReviewLocalGitOptionArgs(options)

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -993,8 +993,12 @@ async function resolvePrWorkItemSource(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ResolvedPrWorkItemSource> {
+  // Why: originCandidate must stay the raw `origin` remote (not upstream-first),
+  // so the renderer can compare it against upstream to decide whether to show the
+  // issue-source selector. getOwnerRepo is now upstream-first, so use the
+  // origin-specific resolver here.
   const [originCandidate, upstreamCandidate] = await Promise.all([
-    getOwnerRepo(repoPath, connectionId, localGitOptions),
+    getOriginOwnerRepo(repoPath, connectionId, localGitOptions),
     getOwnerRepoForRemote(repoPath, 'upstream', connectionId, localGitOptions)
   ])
   const source =
@@ -1898,12 +1902,13 @@ export async function getWorkItem(
         return issue
       }
     } catch (err) {
-      // Why: the issue lookup now targets `upstream` while the PR lookup targets `origin`,
-      // so a transient upstream failure (5xx, rate limit, network flake) on issue #N would
-      // silently fall through to origin's PR #N — potentially a completely unrelated item.
-      // Only fall through when the issue genuinely doesn't exist (404); re-throw everything
-      // else so the outer catch returns null and the caller sees a real failure instead of
-      // a wrong item. classifyGhError centralizes the 404/"not found" pattern-matching.
+      // Why: issue and PR lookups both resolve upstream-first, so a transient
+      // upstream failure (5xx, rate limit, network flake) on issue #N would
+      // silently fall through to PR #N — a different item that happens to share
+      // the number. Only fall through when the issue genuinely doesn't exist
+      // (404); re-throw everything else so the outer catch returns null and the
+      // caller sees a real failure instead of a wrong item. classifyGhError
+      // centralizes the 404/"not found" pattern-matching.
       const stderr = err instanceof Error ? err.message : String(err)
       if (classifyGhError(stderr).type !== 'not_found') {
         throw err

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -89,24 +89,31 @@ describe('github owner/repo resolution', () => {
     expect(parseGitHubOwnerRepo('https://ghe.acme.internal/acme/orca.git')).toBeNull()
   })
 
-  it('keeps getOwnerRepo origin-based', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: 'git@github.com:fork/orca.git\n'
-    })
+  it('resolves getOwnerRepo upstream-first', async () => {
+    // upstream missing → falls back to origin
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: 'git@github.com:fork/orca.git\n' })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'upstream'], {
+      cwd: '/repo'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['remote', 'get-url', 'origin'], {
       cwd: '/repo'
     })
   })
 
-  it('resolves GitHub HTTPS origin remotes with user info and a default port', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: 'https://alice@github.com:443/acme/widgets.git\n'
-    })
+  it('resolves GitHub HTTPS origin remotes through upstream-first fallback', async () => {
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: 'https://alice@github.com:443/acme/widgets.git\n' })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'acme', repo: 'widgets' })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'upstream'], {
+      cwd: '/repo'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['remote', 'get-url', 'origin'], {
       cwd: '/repo'
     })
   })
@@ -137,11 +144,12 @@ describe('github owner/repo resolution', () => {
   })
 
   it('does not mix origin and upstream cache entries for the same repo path', async () => {
+    // getOwnerRepo and getIssueOwnerRepo both resolve upstream-first now
     gitExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: 'git@github.com:fork/orca.git\n' })
+      .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n' })
       .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n' })
 
-    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
+    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
     await expect(getIssueOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
   })
 
@@ -171,7 +179,10 @@ describe('github owner/repo resolution', () => {
 
   it('resolves SSH repo remotes through the registered SSH git provider', async () => {
     const sshProvider = {
-      exec: vi.fn().mockResolvedValue({ stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' })
+      exec: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' })
     }
     getSshGitProviderMock.mockReturnValue(sshProvider)
 
@@ -182,7 +193,13 @@ describe('github owner/repo resolution', () => {
 
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
     expect(getSshGitProviderMock).toHaveBeenCalledWith('openclaw-2')
-    expect(sshProvider.exec).toHaveBeenCalledWith(
+    expect(sshProvider.exec).toHaveBeenNthCalledWith(
+      1,
+      ['remote', 'get-url', 'upstream'],
+      '/home/user/orca'
+    )
+    expect(sshProvider.exec).toHaveBeenNthCalledWith(
+      2,
       ['remote', 'get-url', 'origin'],
       '/home/user/orca'
     )
@@ -200,8 +217,11 @@ describe('github owner/repo resolution', () => {
   })
 
   it('keeps local host and local WSL owner/repo cache entries separate for the same path', async () => {
+    // upstream-first: each getOwnerRepo call tries upstream then origin
     gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('not found'))
       .mockResolvedValueOnce({ stdout: 'git@github.com:host/orca.git\n' })
+      .mockRejectedValueOnce(new Error('not found'))
       .mockResolvedValueOnce({ stdout: 'git@github.com:wsl/orca.git\n' })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'host', repo: 'orca' })
@@ -209,16 +229,23 @@ describe('github owner/repo resolution', () => {
       owner: 'wsl',
       repo: 'orca'
     })
+    // cached hit
     await expect(getOwnerRepo('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toEqual({
       owner: 'wsl',
       repo: 'orca'
     })
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
-    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'origin'], {
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'upstream'], {
       cwd: '/repo'
     })
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['remote', 'get-url', 'origin'], {
+      cwd: '/repo'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(3, ['remote', 'get-url', 'upstream'], {
+      cwd: '/repo',
+      wslDistro: 'Ubuntu'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(4, ['remote', 'get-url', 'origin'], {
       cwd: '/repo',
       wslDistro: 'Ubuntu'
     })

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -221,11 +221,15 @@ describe('github owner/repo resolution', () => {
   })
 
   it('keeps local host and local WSL owner/repo cache entries separate for the same path', async () => {
-    // upstream-first: each getOwnerRepo call tries upstream then origin
+    // upstream-first: each getOwnerRepo call tries upstream then origin.
+    // Why: use the real "No such remote" wording so the upstream miss takes the
+    // stable-missing negative-cache path (isStableMissingGitRemoteError). That
+    // lets the third call hit cache with zero probes, which the call-count pin
+    // below asserts — guarding against git-process churn (issue #6381 class).
     gitExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('not found'))
+      .mockRejectedValueOnce(new Error("fatal: No such remote 'upstream'"))
       .mockResolvedValueOnce({ stdout: 'git@github.com:host/orca.git\n' })
-      .mockRejectedValueOnce(new Error('not found'))
+      .mockRejectedValueOnce(new Error("fatal: No such remote 'upstream'"))
       .mockResolvedValueOnce({ stdout: 'git@github.com:wsl/orca.git\n' })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'host', repo: 'orca' })
@@ -253,6 +257,8 @@ describe('github owner/repo resolution', () => {
       cwd: '/repo',
       wslDistro: 'Ubuntu'
     })
+    // The third (cached) lookup must not re-probe: 2 remotes x 2 distinct runtimes.
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(4)
   })
 
   it('prunes expired distinct owner/repo cache entries on later lookups', async () => {

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -23,6 +23,7 @@ import {
   classifyGhError,
   classifyListIssuesError,
   getIssueOwnerRepo,
+  getOriginOwnerRepo,
   getOwnerRepo,
   getOwnerRepoForRemote,
   parseGitHubRemoteIdentity,
@@ -144,12 +145,15 @@ describe('github owner/repo resolution', () => {
   })
 
   it('does not mix origin and upstream cache entries for the same repo path', async () => {
-    // getOwnerRepo and getIssueOwnerRepo both resolve upstream-first now
+    // Why: getOriginOwnerRepo probes only `origin`; getIssueOwnerRepo is
+    // upstream-first. Distinct owner/repo values per remote prove the cache
+    // keys stay separate — a mixing regression would return `fork/orca` for
+    // the upstream lookup. Also gives getOriginOwnerRepo direct coverage.
     gitExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n' })
+      .mockResolvedValueOnce({ stdout: 'git@github.com:fork/orca.git\n' })
       .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n' })
 
-    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
+    await expect(getOriginOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
     await expect(getIssueOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
   })
 

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -11,6 +11,7 @@ export {
   _getOwnerRepoCacheSize,
   _resetOwnerRepoCache,
   getIssueOwnerRepo,
+  getOriginOwnerRepo,
   getOwnerRepo,
   getOwnerRepoForRemote,
   getRemoteUrlForRepo,

--- a/src/main/github/github-repository-identity.ts
+++ b/src/main/github/github-repository-identity.ts
@@ -208,19 +208,31 @@ export async function getOwnerRepo(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<OwnerRepo | null> {
-  return getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions)
-}
-
-export async function getIssueOwnerRepo(
-  repoPath: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): Promise<OwnerRepo | null> {
   const upstream = await getOwnerRepoForRemote(repoPath, 'upstream', connectionId, localGitOptions)
   if (upstream) {
     return upstream
   }
   return getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions)
+}
+
+// Why: a few callers (createGitHubPullRequest, getRepoUpstream) specifically
+// need the fork's origin remote, not the upstream canonical repo.
+export async function getOriginOwnerRepo(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<OwnerRepo | null> {
+  return getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions)
+}
+
+// Why: kept for backwards compatibility; behaviour is identical to getOwnerRepo
+// since both now resolve upstream-first.
+export async function getIssueOwnerRepo(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<OwnerRepo | null> {
+  return getOwnerRepo(repoPath, connectionId, localGitOptions)
 }
 
 export type PRRepositoryCandidates = {

--- a/src/main/github/work-item-details.ts
+++ b/src/main/github/work-item-details.ts
@@ -801,9 +801,9 @@ async function getWorkItemParticipants(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<GitHubAssignableUser[]> {
-  // Why: issues in a fork live on the upstream remote, so participants must be
-  // resolved via getIssueOwnerRepo to stay consistent with getIssueBodyAndComments.
-  // PRs remain tied to origin via getOwnerRepo.
+  // Why: both issues and PRs in a fork live on the upstream remote, so
+  // participants are resolved via getIssueOwnerRepo/getOwnerRepo, which both
+  // resolve upstream-first, staying consistent with getIssueBodyAndComments.
   const ownerRepo =
     item.type === 'issue'
       ? await getIssueOwnerRepo(repoPath, connectionId, ...localGitOptionArgs(localGitOptions))


### PR DESCRIPTION
## What changes

PR details now load in forked repositories. Previously, opening a PR in a repo where `origin` points to a fork and `upstream` points to the canonical repo showed **"Unable to load details for this GitHub item."**

Root cause: `getOwnerRepo()` resolved only the `origin` remote, so PR lookups queried the fork (where the PR does not exist) instead of `upstream` (where fork-contribution PRs live). Issue lookups already resolved `upstream`-first, which is why issues worked but PRs did not.

This builds on and hardens community PR #7332 (by @fsdwen) — that PR is left open and unmodified; this one carries its commit plus review fixes so it can be considered as a reviewed, test-hardened unit.

## Approach

- `getOwnerRepo()` now resolves `upstream`-first and falls back to `origin`, matching the existing `getIssueOwnerRepo()` behavior. All ~20 PR-detail call sites that use `getOwnerRepo()` benefit automatically.
- New `getOriginOwnerRepo()` for the callers that genuinely need the fork's `origin`: `createGitHubPullRequest` (head repo is the fork), `getRepoUpstream` (fork detection), and `resolvePrWorkItemSource` (raw origin candidate).
- `getIssueOwnerRepo()` retained as a backwards-compatible alias.

## Takeover review — what was wrong and what this fixes

The original PR switched only two callers to the origin-specific resolver and missed one, plus left stale comments and thin test coverage. This PR adds:

1. **Regression fix (renderer):** `resolvePrWorkItemSource` resolved its `originCandidate` via the now-`upstream`-first `getOwnerRepo`. For a fork that collapsed `originCandidate === upstreamCandidate`, and the renderer's fork detection (`!sameGitHubOwnerRepo(originCandidate, upstreamCandidate)`) then **hid the issue-source (origin/upstream) selector** on fork repos. Now resolved via `getOriginOwnerRepo`, preserving the type contract that `originCandidate` is the raw `origin` remote.
2. **Comment accuracy:** refreshed two comments (`work-item-details.ts`, `client.ts`) that still claimed PR lookups target `origin`.
3. **Test coverage:** gave `getOriginOwnerRepo` a dedicated mock (distinct from `getOwnerRepo`) plus a regression test that fails if the `originCandidate` fix is reverted; distinct origin/upstream values in the cache-separation test; realistic missing-remote error wording so the negative-cache path is exercised and the git-spawn-count guard restored; and `getOriginOwnerRepoMock` resets.

## Completeness & headline behavior

- Headline behavior (fork PR details load): **implemented** at the resolution seam that the details dialog (`gh:workItemDetails`) actually uses.
- Broad consistency: PR detail, participants, checks, and list-source paths all now resolve fork-aware; the renderer fork toggle is preserved (regression #1).

## Known tradeoff (conscious decision for the reviewer)

The `upstream`-first flip is a global heuristic. It fixes the common fork-contribution case (PR lives on `upstream`) but introduces a mirror-image edge case: because the details dialog re-derives a PR's repo **by number**, a fork-*internal* PR whose number also exists on `upstream` would now resolve to the upstream item. The root-cause-correct fix is to thread the already-known PR owner/repo through the details IPC + runtime RPC + detail helpers so PR details never re-guess by number — a cross-cutting change beyond this bug fix. Net effect here is still positive (common case fixed, rare collision regressed). Flagging so this is merged as a conscious decision; the `prRepo`-threading follow-up can be tracked separately.

## Validation

- `npx vitest run src/main/github` → **296 passed** (22 files; +1 regression test).
- `npx tsgo --noEmit -p config/tsconfig.node.json` → clean.
- Two-round-clean adversarial code review; performance checked — the added `upstream` probe is bounded by the existing per-runtime/path/remote owner-repo cache (30s positive / 5min negative TTL) with in-flight coalescing, so non-fork repos add negligible git churn.
- SSH/remote and WSL paths flow through the same `connectionId`/`localGitOptions` plumbing (unchanged); GitLab/other providers are untouched (GitHub-remote-resolution only).

Not merged.

Fixes #7331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
