### PR TITLE
fix(checks): stop Checks tab flip-flopping between 'Branch not published' and 'PR status unavailable'

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel-empty-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-empty-state.test.ts
@@ -179,6 +179,63 @@ describe('getChecksPanelEmptyStateCopy', () => {
       }).title
     ).toBe('Pull request status unavailable')
   })
+
+  // Regression: a local-only branch with an ambiguous GitHub hosted-review card
+  // flip-flopped between "Branch not published" (during an active PR refresh) and
+  // "Pull request status unavailable" (while idle) as background refreshes cycled
+  // the status. The ambiguous copy must stay stable across the whole lifecycle.
+  it('keeps stable ambiguous copy while a PR refresh is queued on an unpublished branch', () => {
+    expect(
+      getChecksPanelEmptyStateCopy({
+        operationLabel: null,
+        prRefreshStatus: 'queued',
+        hostedReviewBlockedReason: 'no_upstream',
+        hasUpstream: false,
+        hasAmbiguousGitHubHostedReview: true
+      }).title
+    ).toBe('Pull request status unavailable')
+  })
+
+  it('keeps stable ambiguous copy while a PR refresh is in-flight on an unpublished branch', () => {
+    expect(
+      getChecksPanelEmptyStateCopy({
+        operationLabel: null,
+        prRefreshStatus: 'in-flight',
+        hostedReviewBlockedReason: undefined,
+        hasUpstream: false,
+        hasAmbiguousGitHubHostedReview: true
+      }).title
+    ).toBe('Pull request status unavailable')
+  })
+
+  it('does not fall back to unpublished-branch copy on refresh error for ambiguous data', () => {
+    expect(
+      getChecksPanelEmptyStateCopy({
+        operationLabel: null,
+        prRefreshStatus: 'error',
+        hostedReviewBlockedReason: 'no_upstream',
+        hasUpstream: false,
+        hasAmbiguousGitHubHostedReview: true
+      }).title
+    ).toBe('Could not refresh pull request')
+  })
+
+  it('renders a single stable title across a full ambiguous refresh cycle', () => {
+    const cycle = ['queued', 'in-flight', undefined, 'skipped', 'paused'] as const
+    const titles = new Set(
+      cycle.map(
+        (prRefreshStatus) =>
+          getChecksPanelEmptyStateCopy({
+            operationLabel: null,
+            prRefreshStatus,
+            hostedReviewBlockedReason: 'no_upstream',
+            hasUpstream: false,
+            hasAmbiguousGitHubHostedReview: true
+          }).title
+      )
+    )
+    expect([...titles]).toEqual(['Pull request status unavailable'])
+  })
 })
 
 describe('shouldShowChecksPanelPublishBranchAction', () => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-empty-state.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-empty-state.ts
@@ -43,14 +43,26 @@ export function getChecksPanelEmptyStateCopy(
   }
 
   const blockedReason = input.hostedReviewBlockedReason
-  // Why: hosted-review metadata with missing PR cache data is ambiguous, so
-  // avoid showing "no PR" or publish guidance until GitHub status is refreshed.
-  if (
-    input.hasAmbiguousGitHubHostedReview === true &&
-    (input.prRefreshStatus === 'paused' ||
-      input.prRefreshStatus === 'skipped' ||
-      input.prRefreshStatus === undefined)
-  ) {
+  // Why: a GitHub hosted-review card with no cached PR is ambiguous. Resolve the
+  // whole empty state here so the copy stays stable across a background PR
+  // refresh's lifecycle (idle/queued/in-flight/paused/skipped). Previously only
+  // the idle statuses were handled and active ones fell through to the
+  // publish-branch branch, so the panel flip-flopped between "Branch not
+  // published" and "Pull request status unavailable" as refreshes cycled. Only a
+  // hard refresh error still surfaces a distinct — but equally stable — message.
+  if (input.hasAmbiguousGitHubHostedReview === true) {
+    if (input.prRefreshStatus === 'error') {
+      return {
+        title: translate(
+          'auto.components.right.sidebar.checks.panel.empty.state.5f478ab3d3',
+          'Could not refresh pull request'
+        ),
+        description: translate(
+          'auto.components.right.sidebar.checks.panel.empty.state.2bdd7aaf2d',
+          'GitHub status could not be refreshed. Existing cached data was preserved.'
+        )
+      }
+    }
     return {
       title: translate(
         'auto.components.right.sidebar.checks.panel.empty.state.3322603418',


### PR DESCRIPTION
## What & why

The **Checks** tab rapidly flip-flopped between **"Branch not published"** and **"Pull request status unavailable"** for a worktree (reported on Windows).

Both strings come from the same function — `getChecksPanelEmptyStateCopy` in `checks-panel-empty-state.ts`. For the affected worktree two inputs are steady:

- `hasAmbiguousGitHubHostedReview === true` — a GitHub hosted-review **card** exists in cache, but the branch-scoped **PR cache is empty**. This is a legitimate transient state (e.g. a card left from a prior/merged PR whose head moved, with no open PR for the current branch). The hosted-review cache and PR cache are populated by different flows, so they can disagree.
- `hasUpstream === false` — the branch is local-only. (Derived from a one-shot git-status snapshot; the 3s poller only runs for SSH runtimes, so it's stable for a local repo.)

The **only** oscillating input is `prRefreshStatus`, which cycles as the background SWR PR refresh polls a branch that has no PR:

| refresh status | branch taken (old code) | message shown |
| --- | --- | --- |
| `undefined` / `paused` / `skipped` (idle) | ambiguous guard | **Pull request status unavailable** |
| `queued` / `in-flight` / `error` (active) | guard skipped → publish-branch branch (fires on `hasUpstream === false`) | **Branch not published** |

The old ambiguous guard only covered the **idle** statuses. When a refresh went **active**, it fell through to the publish-branch branch and rendered "Branch not published". The PR-refresh coordinator re-drains roughly every 2.5–60s, so every poll cycle flipped the copy.

**Why it showed up on Windows:** the logic is platform-agnostic — Windows just surfaces it. Local `git`/`gh` subprocess latency is higher there, which widens the `queued`/`in-flight` window so the contradictory "Branch not published" frame lingers and the switching becomes obvious.

## The fix

Resolve the **entire** empty state inside the ambiguous guard so the copy is stable across the whole refresh lifecycle:

- `error` → **"Could not refresh pull request"**
- every other status (`undefined`/`queued`/`in-flight`/`paused`/`skipped`) → **"Pull request status unavailable"**

The ambiguous state can no longer fall through to publish / needs-push / no-PR copy, so "Branch not published" is never shown while the hosted-review state is ambiguous. This matches the guard's original design intent ("avoid showing publish guidance until GitHub status is refreshed") and is strictly stronger than only guarding the non-error statuses — it also removes the residual `error` ↔ idle flicker on a no-upstream branch.

Presentation-only change (pure function). No cache, refresh-scheduling, or IPC behavior is touched; existing i18n keys are reused (no catalog sync needed).

## Evidence of fix

**Red → green** — the 4 new regression tests run against the *old* code reproduce the flip-flop, then pass with the fix:

```
=== RED: new regression tests vs OLD (unfixed) code ===
 ❯ checks-panel-empty-state.test.ts (21 tests | 4 failed)
   × keeps stable ambiguous copy while a PR refresh is queued on an unpublished branch
   × keeps stable ambiguous copy while a PR refresh is in-flight on an unpublished branch
   × does not fall back to unpublished-branch copy on refresh error for ambiguous data
   × renders a single stable title across a full ambiguous refresh cycle

AssertionError: expected 'Branch not published' to be 'Pull request status unavailable'
AssertionError: expected 'Branch not published' to be 'Could not refresh pull request'
AssertionError: expected [ 'Branch not published', 'Pull request status unavailable' ]
              to deeply equal [ 'Pull request status unavailable' ]      <-- the flip-flop, captured

=== GREEN: with the fix ===
 Test Files  2 passed (2)
      Tests  25 passed (25)
```

The `renders a single stable title across a full ambiguous refresh cycle` test walks the whole `queued → in-flight → undefined → skipped → paused` cycle and asserts the title set collapses to exactly one value — a direct regression lock on the flip-flop.

**Wider validation**

- All right-sidebar tests: **135 files / 1130 tests pass**.
- `typecheck` (tsgo web project) and `oxlint` clean on the changed files.
- No other consumers of these strings (only the empty-state module + its test; e2e/snapshots reference neither).

> Note: I did not run an Electron/manual repro. Reproducing this needs a specific ambiguous cache state plus live refresh churn, which headless Electron can't reliably stage — the pure-function unit tests (exercising every status in the cycle) are the honest harness here.

## ELI5

The Checks tab has a little status message. For a branch that isn't pushed yet but still had a leftover GitHub "review card", the app quietly re-checks GitHub every few seconds to see if there's a pull request. While it was checking it said **"Branch not published"**, and the instant it finished checking it said **"Pull request status unavailable"** — then it started checking again. So the message strobed back and forth between two different sentences and looked broken. Now the app picks **one** calm message and sticks with it the whole time it's checking, so the text stops flickering.

## User-facing trade-offs

- **Trade-off:** in the ambiguous state, while a refresh is actively running, the panel now shows the steady **"Pull request status unavailable"** instead of briefly flashing **"Checking for pull request…"**. We intentionally give up that transient "checking" wording in this one edge case to get a stable, non-flickering message. The manual **Refresh** button and (when applicable) the **Publish Branch** button are unaffected.
- **Behavior change on error:** an ambiguous, no-upstream branch whose refresh *errors* now shows **"Could not refresh pull request"** instead of **"Branch not published"** — more accurate, and it removes the last path that could show contradictory publish guidance.
- **No change** to normal cases: a real unpublished branch (no hosted-review card) still shows "Branch not published"; branches with an open PR, unpushed commits, or no PR are all unchanged.

Made with [Orca](https://github.com/stablyai/orca) 🐋
