### PR TITLE
test(windows): guard PowerShell setup-runner encoded delivery (#7236)

### DIFF
--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -7,6 +7,7 @@ import {
   buildWslInteractiveLoginShellCommand,
   escapeWslShCommandForWindows
 } from '../../shared/wsl-login-shell-command'
+import { resolveSetupRunnerCommand } from '../../shared/setup-runner-command'
 import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
 
 function expectedWslArgs(linuxCwd: string, distro?: string): string[] {
@@ -298,5 +299,44 @@ describe('resolveWindowsShellLaunchArgs', () => {
       '-EncodedCommand',
       encodePowerShellCommand(getPowerShellOsc133Bootstrap())
     ])
+  })
+})
+
+// Regression guard for issue #7236: a worktree Setup Script runs through a
+// generated `.cmd` runner invoked as `cmd.exe /c "<runner>"`. When PowerShell
+// received that command as raw typed stdin, a dropped/unbalanced quote surfaced
+// as a "missing terminator" parser error. Delivering it via -EncodedCommand
+// (base64 UTF-16) keeps the quotes balanced and the text verbatim, so it can
+// never be re-parsed as an open string.
+describe('issue #7236: PowerShell setup-runner command delivery', () => {
+  // git rev-parse hands back a forward-slash Windows-absolute path for the runner.
+  const runnerPath = 'C:/Users/alice/repo/.git/orca/setup-runner.cmd'
+
+  it('wraps the setup runner in balanced double quotes', () => {
+    const { command } = resolveSetupRunnerCommand(runnerPath, 'windows')
+    expect(command).toBe(`cmd.exe /c "${runnerPath}"`)
+    expect((command.match(/"/g) ?? []).length % 2).toBe(0)
+  })
+
+  it('delivers the setup-runner command through -EncodedCommand, never raw stdin', () => {
+    const { command } = resolveSetupRunnerCommand(runnerPath, 'windows')
+    const result = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice\\repo',
+      'C:\\Users\\alice',
+      undefined,
+      command
+    )
+
+    // The flag tells the daemon/provider NOT to also type the command over
+    // stdin — raw stdin delivery is the pre-encoded path that broke in #7236.
+    expect(result.startupCommandDeliveredInShellArgs).toBe(true)
+    expect(result.shellArgs.slice(0, 3)).toEqual(['-NoLogo', '-NoExit', '-EncodedCommand'])
+
+    const decoded = Buffer.from(result.shellArgs[3] ?? '', 'base64').toString('utf16le')
+    expect(decoded).toContain(`\n${command}`)
+    expect(decoded.trimEnd().endsWith(command)).toBe(true)
+    // Quotes survive encoding intact, so PowerShell parses one balanced string.
+    expect((decoded.slice(decoded.lastIndexOf(command)).match(/"/g) ?? []).length % 2).toBe(0)
   })
 })


### PR DESCRIPTION
## What & why

Regression guard for #7236 — *"Setup script (worktree hook) fails with PowerShell 'missing terminator' error regardless of content."*

**Root cause (already fixed):** On Windows, a worktree Setup Script runs through a generated `.cmd` runner invoked as `cmd.exe /c "<runner>"`. In pre-encoded builds that command was *typed into PowerShell as raw stdin*. Over ConPTY that delivery is fragile — a dropped/unbalanced `"` gets re-parsed as an open string, producing the `missing terminator` parser error for **any** non-empty script (empty scripts sent nothing, so they worked — matching the report exactly).

Commit f80704cc6 ("[perf] Speed up CLI launch through Orca", first released in **v1.4.81**) fixed this by delivering the startup command through `-EncodedCommand` (base64 UTF-16) — a quote-safe shell argument — instead of raw stdin. Verified on real PowerShell 5.1 (ConPTY/node-pty) with the production OSC 133 bootstrap: the setup runner now executes cleanly with a healthy prompt and no parser error.

## Change

Adds two tests to `windows-shell-args.test.ts` tying `resolveSetupRunnerCommand` → `resolveWindowsShellLaunchArgs`, asserting the **real** setup-runner command:

- is wrapped in balanced double quotes, and
- reaches PowerShell via `-EncodedCommand` (`startupCommandDeliveredInShellArgs === true`) — **never** raw stdin — with its quotes preserved verbatim through encoding.

Neither module's existing tests cover this cross-module contract, so a future change that reintroduces raw-stdin delivery for setup scripts (the #7236 failure mode) would now fail CI.

## Verification

- `vitest run src/main/providers/windows-shell-args.test.ts` — 22 passed
- `typecheck` (node + cli) — clean
- `oxlint` / `oxfmt` — clean (ran via pre-commit)

No production code changes — test-only.