### PR TITLE
Fix latent prefer-array-find lint error breaking verify on every PR

### DIFF
--- a/src/shared/linear-inline-media.ts
+++ b/src/shared/linear-inline-media.ts
@@ -94,7 +94,7 @@ function fileNameFromUrl(url: string): string | null {
   }
   try {
     const parsed = new URL(url)
-    const last = parsed.pathname.split('/').filter(Boolean).pop()
+    const last = parsed.pathname.split('/').findLast(Boolean)
     return last ? decodeURIComponent(last) : null
   } catch {
     return null


### PR DESCRIPTION
## Summary

Every open PR currently fails the `verify` check at the Lint step. Two recent main commits crossed: `7b7a21e3c` (Linear inline media) added a `.filter(Boolean).pop()` in `src/shared/linear-inline-media.ts`, and `ce687221d` enabled `unicorn/prefer-array-find`, which flags that pattern. Each PR passed its own checks against the base it was tested on, but their merge is red — and since `verify` only runs on PRs (not on main pushes), the breakage is invisible on main and surfaces as a lint failure on every PR's merge commit.

One-line fix: `.split('/').filter(Boolean).pop()` → `.split('/').findLast(Boolean)` — identical semantics (last non-empty path segment), satisfies the rule.

## Testing

- `pnpm exec oxlint` — 0 errors (was 1)
- `pnpm vitest run src/shared/linear-inline-media.test.ts` — 2 passed

Found while investigating the `verify` failure on `#7460`, whose own files are lint-clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
