### PR TITLE
fix(agent-status): cap retainedAgentsByPaneKey to stop renderer heap OOM on Windows

### DIFF
--- a/src/renderer/src/store/slices/agent-status-retained-leak.test.ts
+++ b/src/renderer/src/store/slices/agent-status-retained-leak.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Memory-leak regression: retainedAgentsByPaneKey must stay bounded.
+ *
+ * `retainedAgentsByPaneKey` is a Record keyed by ephemeral paneKey
+ * (`${tabId}:${leafId}`, where leafId is a fresh UUID minted per pane and never
+ * reused). Every agent that finishes and then vanishes from the live map is
+ * snapshotted here via `retainAgents`. Each snapshot is a full RetainedAgentEntry
+ * — an AgentStatusEntry (which carries an up-to-8KB lastAssistantMessage, an
+ * up-to-16KB interactivePrompt, a prompt, and up to 20 stateHistory rows) plus a
+ * full TerminalTab snapshot.
+ *
+ * Before the fix, `retainAgents` only ever wrote entries and never capped them,
+ * so the map grew monotonically with the number of distinct completed-agent
+ * paneKeys observed. The only removal paths are worktree removal
+ * (`pruneRetainedAgents`) and explicit user dismissal — neither of which runs
+ * while a long-lived worktree stays open. Under a multi-hour multi-agent /
+ * orchestration session (sub-agents complete continuously), this large-payload
+ * accumulator is the dominant driver of the renderer JS-heap OOM seen in the
+ * Windows crash bundles (heap climbing to the 3586 MB old-space limit).
+ *
+ * The fix caps it to MAX_RETAINED_AGENTS, evicting the oldest-retained keys
+ * (insertion order == retention order, so the newest completions survive).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/types'
+import type { RetainedAgentEntry } from './agent-status'
+import { createTestStore } from './store-test-helpers'
+
+// MAX_RETAINED_AGENTS is module-private; mirror its value here.
+const MAX_RETAINED_AGENTS = 500
+
+// Approximate the worst-case per-entry payload the production type permits, so
+// the leak's byte weight (not just entry count) is visible in the assertions.
+const BIG_ASSISTANT_MESSAGE = 'a'.repeat(8 * 1024)
+const BIG_INTERACTIVE_PROMPT = 'q'.repeat(16 * 1024)
+
+function makeRetained(index: number, worktreeId = 'wt-x'): RetainedAgentEntry {
+  const paneKey = `tab-${index}:leaf-${index}`
+  const entry: AgentStatusEntry = {
+    state: 'done',
+    prompt: `prompt ${index}`,
+    updatedAt: index,
+    stateStartedAt: index,
+    paneKey,
+    stateHistory: [],
+    lastAssistantMessage: BIG_ASSISTANT_MESSAGE,
+    interactivePrompt: BIG_INTERACTIVE_PROMPT
+  }
+  return {
+    entry,
+    worktreeId,
+    tab: { id: `tab-${index}`, title: 'claude' } as unknown as TerminalTab,
+    agentType: 'claude',
+    startedAt: index
+  }
+}
+
+describe('retainedAgentsByPaneKey stays bounded (leak regression)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('caps retainedAgentsByPaneKey and keeps the most recently retained keys', () => {
+    const store = createTestStore()
+
+    // Drive the production retention path with more distinct ephemeral paneKeys
+    // than the cap allows — one call per completion, as production does.
+    const total = MAX_RETAINED_AGENTS + 200
+    for (let i = 0; i < total; i++) {
+      store.getState().retainAgents([makeRetained(i)])
+    }
+
+    const retained = store.getState().retainedAgentsByPaneKey
+    // Bounded — not `total`. Without the cap this is MAX_RETAINED_AGENTS + 200.
+    expect(Object.keys(retained)).toHaveLength(MAX_RETAINED_AGENTS)
+
+    // The newest completions survive; the oldest are evicted.
+    expect(retained[`tab-${total - 1}:leaf-${total - 1}`]).toBeDefined()
+    expect(retained['tab-0:leaf-0']).toBeUndefined()
+    // The exact eviction boundary: everything before (total - cap) is gone.
+    expect(
+      retained[`tab-${total - MAX_RETAINED_AGENTS - 1}:leaf-${total - MAX_RETAINED_AGENTS - 1}`]
+    ).toBeUndefined()
+    expect(
+      retained[`tab-${total - MAX_RETAINED_AGENTS}:leaf-${total - MAX_RETAINED_AGENTS}`]
+    ).toBeDefined()
+  })
+
+  it('caps even when many completions are retained in a single batch', () => {
+    const store = createTestStore()
+    const total = MAX_RETAINED_AGENTS + 50
+    const batch = Array.from({ length: total }, (_, i) => makeRetained(i))
+
+    store.getState().retainAgents(batch)
+
+    const retained = store.getState().retainedAgentsByPaneKey
+    expect(Object.keys(retained)).toHaveLength(MAX_RETAINED_AGENTS)
+    expect(retained[`tab-${total - 1}:leaf-${total - 1}`]).toBeDefined()
+    expect(retained['tab-0:leaf-0']).toBeUndefined()
+  })
+
+  it('does not evict anything while under the cap', () => {
+    const store = createTestStore()
+    for (let i = 0; i < MAX_RETAINED_AGENTS; i++) {
+      store.getState().retainAgents([makeRetained(i)])
+    }
+    const retained = store.getState().retainedAgentsByPaneKey
+    expect(Object.keys(retained)).toHaveLength(MAX_RETAINED_AGENTS)
+    expect(retained['tab-0:leaf-0']).toBeDefined()
+  })
+
+  it('re-retaining an existing paneKey overwrites in place and never grows the count', () => {
+    const store = createTestStore()
+    const first = makeRetained(0)
+    store.getState().retainAgents([first])
+    // Same paneKey, fresh snapshot (e.g. a later status update for the same pane).
+    const updated = makeRetained(0)
+    updated.entry.prompt = 'updated'
+    store.getState().retainAgents([updated])
+
+    const retained = store.getState().retainedAgentsByPaneKey
+    expect(Object.keys(retained)).toHaveLength(1)
+    expect(retained['tab-0:leaf-0'].entry.prompt).toBe('updated')
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -215,6 +215,32 @@ export type AgentStatusSlice = {
   clearRetentionSuppressedPaneKeys: (paneKeys: string[]) => void
 }
 
+// Why: retainedAgentsByPaneKey snapshots a completed agent (a full
+// AgentStatusEntry — up to ~24KB of prompt/message text — plus a TerminalTab)
+// per ephemeral paneKey. paneKeys never recur, and the map is pruned only on
+// worktree removal or manual dismissal, so a long-lived worktree in a busy
+// multi-agent session grows it without bound — the dominant driver of the
+// renderer JS-heap OOM. Cap by insertion order (== retention order), evicting
+// the oldest completions first so the newest — the ones a user is most likely
+// to still care about — always survive. Evicted rows just stop showing in the
+// recently-completed overlay.
+const MAX_RETAINED_AGENTS = 500
+
+function capRetainedAgents(
+  retained: Record<string, RetainedAgentEntry>,
+  maxEntries = MAX_RETAINED_AGENTS
+): Record<string, RetainedAgentEntry> {
+  const keys = Object.keys(retained)
+  if (keys.length <= maxEntries) {
+    return retained
+  }
+  const capped: Record<string, RetainedAgentEntry> = {}
+  for (const key of keys.slice(keys.length - maxEntries)) {
+    capped[key] = retained[key]
+  }
+  return capped
+}
+
 function paneKeyMatchesAnyTabPrefix(paneKey: string, tabPrefixes: string[]): boolean {
   for (const prefix of tabPrefixes) {
     if (paneKey.startsWith(prefix)) {
@@ -2147,7 +2173,10 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           next[retained.entry.paneKey] =
             entry === retained.entry ? retained : { ...retained, entry }
         }
-        return { retainedAgentsByPaneKey: next }
+        // Why: bound the map so a long multi-agent session cannot leak the
+        // renderer heap. retainAgents is the only path that grows it, so
+        // capping here is sufficient; evicts oldest-retained first.
+        return { retainedAgentsByPaneKey: capRetainedAgents(next) }
       })
     },
 


### PR DESCRIPTION
## Description

Windows crash bundles from 07-05-2026 show the **renderer process** dying with exit codes `-536870904` (Chromium OOM) and `-36861` (renderer heap-pegged kill). The `renderer_memory` breadcrumbs in the diagnostics ndjson show the V8 JS heap climbing in event-driven bursts toward the **3586 MB old-space limit** during continuous multi-agent / orchestration work, then flat-lining when idle. It is a genuine leak in long-lived sessions, not a spike.

Root cause: **`retainedAgentsByPaneKey`** in the agent-status store slice grows without bound.

- It is a `Record` keyed by an **ephemeral `paneKey`** (`${tabId}:${leafId}`, where `leafId` is a fresh UUID minted per pane and never reused).
- Every agent that finishes and then leaves the live map is **snapshotted** into it by `retainAgents`. Each snapshot is a full `RetainedAgentEntry`: an `AgentStatusEntry` carrying an up-to-8 KB `lastAssistantMessage`, an up-to-16 KB `interactivePrompt`, the prompt, and up to 20 `stateHistory` rows — plus a full `TerminalTab`. Roughly **~24 KB of retained payload per completed agent**.
- The only removal paths are **worktree removal** (`pruneRetainedAgents`) and **explicit user dismissal**. Neither runs while a worktree stays open, so in a busy multi-hour session where sub-agents complete continuously, the map grows monotonically. This is the dominant large-payload accumulator that can plausibly reach multiple GB.

`retainAgents` is the **only** write path that adds new keys — every other write site (`pruneRetainedAgents`, dismissal, drop-by-worktree/tab-prefix) only removes or mutates existing keys — so a single cap at that site fully bounds the structure.

## The fix

Cap `retainedAgentsByPaneKey` at **`MAX_RETAINED_AGENTS = 500`** using insertion-order (== retention-order) FIFO eviction, mirroring the existing `capRecordByInsertionOrder` pattern in `github.ts`. The newest completions always survive; the oldest simply age out of the "recently completed" overlay.

```ts
const MAX_RETAINED_AGENTS = 500

function capRetainedAgents(retained, maxEntries = MAX_RETAINED_AGENTS) {
  const keys = Object.keys(retained)
  if (keys.length <= maxEntries) return retained
  const capped = {}
  for (const key of keys.slice(keys.length - maxEntries)) capped[key] = retained[key]
  return capped
}
// applied in retainAgents:
return { retainedAgentsByPaneKey: capRetainedAgents(next) }
```

## CLEAR, UNDENIABLE fix evidence

A new regression test — `agent-status-retained-leak.test.ts` — drives the **production `retainAgents` path** with more distinct ephemeral paneKeys than the cap allows and asserts the map stays bounded.

**BEFORE the fix** (cap bypassed — the leak reproduced deterministically):

```
❯ agent-status-retained-leak.test.ts (4 tests | 2 failed)
  × caps retainedAgentsByPaneKey and keeps the most recently retained keys
  × caps even when many completions are retained in a single batch

AssertionError: expected [ 'tab-0:leaf-0', …(699) ] to have a length of 500 but got 700
  ❯ agent-status-retained-leak.test.ts:76:35
AssertionError: expected [ 'tab-0:leaf-0', …(549) ] to have a length of 500 but got 550
  ❯ agent-status-retained-leak.test.ts:98:35

Tests  2 failed | 2 passed (4)
```

The map grew to **700** (and **550** in the single-batch case) — unbounded, exactly the OOM mechanism.

**AFTER the fix** (cap in place):

```
Test Files  1 passed (1)
      Tests  4 passed (4)
```

The map is held at 500, newest kept, oldest evicted. Fails-before / passes-after on the real code path is the undeniable proof.

Full suite regression check stayed green: agent-status slice tests + the cascade/activity suites all pass; `oxlint` and the renderer typecheck are clean.

## ELI5

Every time one of your background agents finishes, the app quietly tucks a copy of that agent's final state into a drawer so it can still show it in the "recently completed" list. The problem: it **never threw anything out** of that drawer unless you closed the whole folder. Leave Orca running for hours with lots of agents finishing, and the drawer keeps filling — thousands of fat snapshots — until the app runs out of memory and crashes.

The fix puts a limit on the drawer: it keeps the **500 most recent** finished-agent snapshots and lets the oldest ones fall out. You still see your recent agents; the app stops eating memory forever.

## Trade-offs / negative behavior changes

- **Minor visibility regression:** the "recently completed agents" overlay now shows **at most 500** retained entries per renderer. In a session that completes more than 500 agents without a worktree removal or manual dismissal, the **oldest completed-agent snapshots age off** and are no longer listed. This is invisible to normal usage (500 completed agents in one live session is already extreme) and is strictly better than the alternative — the process crashing and losing *everything*. 500 was chosen to sit far above realistic session volume while still capping worst-case memory at a few MB.
- No change to live agents, active status, or any on-disk/persisted data — only the in-memory retained-snapshot map is bounded.

## Note on other findings (not the OOM cause, recommended follow-ups)

The investigation also surfaced four other genuinely-unbounded-but-tiny accumulators — `recentlyClosedAgentStatusTabIds`, `closedAgentStatusTabIds`, `foregroundTerminalTabLastSeenAtById`, and `consumedAgentStartupDeliveries`. Each stores only small scalars/ids, so none can account for a multi-GB heap; they are worth a cheap cap in a follow-up but are deliberately out of scope here to keep this fix surgical.
