### PR TITLE
docs(runtime): fix stale ps-snapshot factory comment after #7518

### DIFF
--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -63,8 +63,8 @@ type ProcessTableSnapshotReaderDeps<T> = {
  * near-simultaneous scans behind a single in-flight promise + short TTL.
  * Exposed as a factory so tests can inject the scan and clock; production code
  * uses the shared `getProcessTableSnapshot` instance below. Generic over the
- * scan result so the Windows path can cache parsed rows while POSIX caches the
- * raw `ps` stdout string (the default).
+ * scan result so both the POSIX and Windows readers cache already-parsed rows,
+ * letting a burst of panes share one parse per TTL window.
  */
 export function createProcessTableSnapshotReader<T = string>(
   deps: ProcessTableSnapshotReaderDeps<T>


### PR DESCRIPTION
Follow-up to #7518. The factory doc comment on `createProcessTableSnapshotReader` still said *"POSIX caches the raw `ps` stdout string (the default)"* — but #7518 changed the POSIX default reader to cache already-parsed `ProcessTableRow[]` (mirroring the Windows reader). Reword the comment to match the code. Pure comment change; no behavior change (typecheck EXIT 0, 8/8 snapshot tests pass).

Made with [Orca](https://github.com/stablyai/orca) 🐋
