### PR TITLE
perf(renderer): purge pane-expand maps on worktree removal

### DIFF
--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -3241,6 +3241,29 @@ describe('removeWorktree state cleanup', () => {
     expect(getHostedReviewLinkMutationGenerationForTests(surviving.id)).toBeGreaterThan(0)
   })
 
+  it('cleans up expandedPaneByTabId/canExpandPaneByTabId for removed worktree tabs', async () => {
+    const store = createTestStore()
+    const removed = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    const surviving = makeWorktree({ id: 'repo1::/path/wt2', repoId: 'repo1', path: '/path/wt2' })
+
+    store.setState({
+      worktreesByRepo: { repo1: [removed, surviving] },
+      tabsByWorktree: {
+        [removed.id]: [makeTerminalTab({ id: 'removed-tab', worktreeId: removed.id })],
+        [surviving.id]: [makeTerminalTab({ id: 'surviving-tab', worktreeId: surviving.id })]
+      },
+      // Split panes write these even when false; only closeTab deleted them
+      // before, so removeWorktree used to strand them for the whole session.
+      expandedPaneByTabId: { 'removed-tab': true, 'surviving-tab': false },
+      canExpandPaneByTabId: { 'removed-tab': false, 'surviving-tab': true }
+    } as unknown as Partial<AppState>)
+
+    await store.getState().removeWorktree(removed.id)
+
+    expect(store.getState().expandedPaneByTabId).toEqual({ 'surviving-tab': false })
+    expect(store.getState().canExpandPaneByTabId).toEqual({ 'surviving-tab': true })
+  })
+
   it('cleans up automatic agent resume claims for removed worktree tabs', async () => {
     const store = createTestStore()
     const removed = makeWorktree({
@@ -5849,6 +5872,8 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
         'tab-3': { panes: [] }
       },
       ptyIdsByTabId: { 'tab-1': ['pty-1'], 'tab-2': ['pty-2'], 'tab-3': ['pty-3'] },
+      expandedPaneByTabId: { 'tab-1': true, 'tab-2': false, 'tab-3': true },
+      canExpandPaneByTabId: { 'tab-1': true, 'tab-2': true, 'tab-3': false },
       runtimePaneTitlesByTabId: { 'tab-1': 'claude', 'tab-3': 'bash' },
       automaticAgentResumeClaimsByTabId: {
         'tab-1': {
@@ -5914,6 +5939,8 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
     })
     expect(s.terminalLayoutsByTabId).toEqual({ 'tab-3': { panes: [] } })
     expect(s.ptyIdsByTabId).toEqual({ 'tab-3': ['pty-3'] })
+    expect(s.expandedPaneByTabId).toEqual({ 'tab-3': true })
+    expect(s.canExpandPaneByTabId).toEqual({ 'tab-3': false })
     expect(s.runtimePaneTitlesByTabId).toEqual({ 'tab-3': 'bash' })
     expect(s.automaticAgentResumeClaimsByTabId).toEqual({
       'tab-3': {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1992,6 +1992,10 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     runtimePaneTitlesByTabId: omitByTabId(s.runtimePaneTitlesByTabId),
     automaticAgentResumeClaimsByTabId: omitByTabId(s.automaticAgentResumeClaimsByTabId),
     nativeChatLaunchPromptByTabId: omitByTabId(s.nativeChatLaunchPromptByTabId),
+    // Why: bulk/hydration purge must drop the per-tab pane-expand flags too;
+    // this path never runs terminal teardown, so nothing else evicts them.
+    expandedPaneByTabId: omitByTabId(s.expandedPaneByTabId),
+    canExpandPaneByTabId: omitByTabId(s.canExpandPaneByTabId),
     // Why: these tab/pane-scoped agent-status, unread, and input maps are only
     // cleared on the single removeWorktree path (via shutdownWorktreeTerminals /
     // dropAgentStatusByWorktree / clearPaneForegroundAgentByWorktree, which read
@@ -3098,12 +3102,19 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           ...s.automaticAgentResumeClaimsByTabId
         }
         const nextNativeChatLaunchPromptByTabId = { ...s.nativeChatLaunchPromptByTabId }
+        // Why: closeTab deletes these two per-tab maps but removeWorktree missed
+        // them, so a split pane's expand flags outlived its deleted worktree for
+        // the renderer's whole session. Purge them here to match closeTab.
+        const nextExpandedPaneByTabId = { ...s.expandedPaneByTabId }
+        const nextCanExpandPaneByTabId = { ...s.canExpandPaneByTabId }
         for (const tabId of tabIds) {
           delete nextLayouts[tabId]
           delete nextPtyIdsByTabId[tabId]
           delete nextRuntimePaneTitlesByTabId[tabId]
           delete nextAutomaticAgentResumeClaimsByTabId[tabId]
           delete nextNativeChatLaunchPromptByTabId[tabId]
+          delete nextExpandedPaneByTabId[tabId]
+          delete nextCanExpandPaneByTabId[tabId]
         }
         const nextDeleteState = { ...s.deleteStateByWorktreeId }
         delete nextDeleteState[worktreeId]
@@ -3251,6 +3262,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           automaticAgentResumeClaimsByTabId: nextAutomaticAgentResumeClaimsByTabId,
           nativeChatLaunchPromptByTabId: nextNativeChatLaunchPromptByTabId,
           terminalLayoutsByTabId: nextLayouts,
+          expandedPaneByTabId: nextExpandedPaneByTabId,
+          canExpandPaneByTabId: nextCanExpandPaneByTabId,
           deleteStateByWorktreeId: nextDeleteState,
           baseStatusByWorktreeId: (() => {
             const nextStatus = { ...s.baseStatusByWorktreeId }


### PR DESCRIPTION
Part of a fresh adversarially-verified perf/memory audit (10 finders → 3-skeptic refute-by-default verify → synthesis). This finding survived 3/3 skeptic votes with a safe, in-pattern fix.

## 1. Description
`expandedPaneByTabId` and `canExpandPaneByTabId` are per-tab `Record<string, boolean>` maps that record split-pane expansion state. They're written for **any** split terminal tab (the setters write the key even when the value is `false`), and the single-tab `closeTab` path correctly `delete`s both keys. But `removeWorktree`'s reducer loop — which deletes five other per-tab maps for every tab in the removed worktree — never touched these two, and neither did the bulk `buildWorktreePurgeState` path (used by the authoritative-scan reconcile, remove-project, and hydration-stale purges). Result: every *create worktree → split a pane → delete worktree* cycle stranded up to two boolean entries per split tab, resident for the renderer's entire session. Worktree create/delete is a core, repeated workflow.

The fix mirrors the already-correct `closeTab` cleanup on both removal paths.

## 2. Undeniable evidence + measurable improvement
- **`grep` proof of the omission**: before this change, `expandedPaneByTabId`/`canExpandPaneByTabId` had **zero** references in `worktrees.ts` (the removal file) while appearing in `terminals.ts`'s `closeTab` — an inconsistent omission, not intent.
- **Deterministic unit proof** (committed, red→green): a `removeWorktree` test dispatches create → populate both maps for a removed-worktree tab and a surviving-worktree tab → `removeWorktree`, then asserts the removed tab's keys are gone and the surviving tab's keys remain. The existing bulk-purge test (`purgeWorktreeTerminalState direct`) is extended with the same two maps and assertions. Both **fail before, pass after**.
- **Metric**: entries left in both maps after a create/split/delete cycle drop from `2 × (split tabs)` → `0`.

## 3. ELI5
When you delete a worktree, the app tidies up almost all the little sticky-notes about that worktree's tabs — but it forgot two of them ("was this pane expanded?"). Those two just piled up forever. Now it throws them away too, exactly like closing a single tab already does.

## 4. Trade-offs that regress the end experience
None. The keys belong to tabs that no longer exist after removal, and nothing reads them once the worktree row is gone (the orphan sweep can't reach them either). This is a pure consistency fix aligning the worktree-removal paths with the already-correct `closeTab` path. Magnitude is honestly small (two booleans per split tab) — this is memory-hygiene, not a hot-path CPU win.

Made with [Orca](https://github.com/stablyai/orca) 🐋
