### PR TITLE
perf(renderer): pause the shared useNow clock while the window is hidden

### DIFF
--- a/src/renderer/src/components/dashboard/useNow.test.ts
+++ b/src/renderer/src/components/dashboard/useNow.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createSharedNowClock } from './useNow'
 
 describe('createSharedNowClock', () => {
+  afterEach(() => {
+    // Only the hidden-window test stubs `document`; unstub so it can't leak.
+    vi.unstubAllGlobals()
+  })
+
   it('shares one timer across subscribers and clears it when idle', () => {
     let now = 1_000
     const intervalCallbacks: (() => void)[] = []
@@ -64,5 +69,55 @@ describe('createSharedNowClock', () => {
     expect(clock.getSnapshot()).toBe(61_000)
     expect(second).toHaveBeenCalledTimes(1)
     expect(setIntervalMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not arm the timer while hidden and catches up when the window becomes visible', () => {
+    let visibilityState: DocumentVisibilityState = 'hidden'
+    const documentListeners = new Map<string, () => void>()
+    vi.stubGlobal('document', {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener: vi.fn((event: string, listener: () => void) => {
+        documentListeners.set(event, listener)
+      }),
+      removeEventListener: vi.fn()
+    })
+
+    let now = 1_000
+    const handle = {} as ReturnType<typeof setInterval>
+    const setIntervalMock = vi.fn(() => handle)
+    const clearIntervalMock = vi.fn()
+    const listener = vi.fn()
+    const clock = createSharedNowClock(30_000, {
+      now: () => now,
+      setInterval: setIntervalMock,
+      clearInterval: clearIntervalMock
+    })
+
+    const unsubscribe = clock.subscribe(listener)
+    // Hidden on mount: no timer armed, no forced render, snapshot untouched.
+    expect(setIntervalMock).not.toHaveBeenCalled()
+    expect(listener).not.toHaveBeenCalled()
+    expect(clock.getSnapshot()).toBe(1_000)
+
+    // Becoming visible catches the stale label up and arms the shared timer.
+    now = 90_000
+    visibilityState = 'visible'
+    documentListeners.get('visibilitychange')?.()
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(clock.getSnapshot()).toBe(90_000)
+    expect(setIntervalMock).toHaveBeenCalledTimes(1)
+
+    // Hiding again stops the shared timer so it stops ticking in the background.
+    visibilityState = 'hidden'
+    documentListeners.get('visibilitychange')?.()
+    expect(clearIntervalMock).toHaveBeenCalledWith(handle)
+
+    unsubscribe()
+    expect(document.removeEventListener).toHaveBeenCalledWith(
+      'visibilitychange',
+      documentListeners.get('visibilitychange')
+    )
   })
 })

--- a/src/renderer/src/components/dashboard/useNow.ts
+++ b/src/renderer/src/components/dashboard/useNow.ts
@@ -1,9 +1,13 @@
 import { useSyncExternalStore } from 'react'
+import {
+  installWindowVisibilityInterval,
+  type WindowVisibilityIntervalTimer
+} from '@/lib/window-visibility-interval'
 
 type ClockDeps = {
   now: () => number
-  setInterval: (callback: () => void, intervalMs: number) => ReturnType<typeof setInterval>
-  clearInterval: (handle: ReturnType<typeof setInterval>) => void
+  setInterval: (callback: () => void, intervalMs: number) => WindowVisibilityIntervalTimer
+  clearInterval: (handle: WindowVisibilityIntervalTimer) => void
 }
 
 type SharedNowClock = {
@@ -22,7 +26,7 @@ export function createSharedNowClock(
   }
 ): SharedNowClock {
   let now = deps.now()
-  let timer: ReturnType<typeof setInterval> | null = null
+  let stopInterval: (() => void) | null = null
   const listeners = new Set<() => void>()
 
   const tick = (): void => {
@@ -36,18 +40,24 @@ export function createSharedNowClock(
     getSnapshot: () => now,
     subscribe: (listener) => {
       listeners.add(listener)
-      if (!timer) {
-        // Why: all mounted relative-time labels at the same cadence can share
-        // one timer. Refresh immediately on restart so remounted labels don't
-        // display the stale timestamp left from the previous subscriber set.
-        tick()
-        timer = deps.setInterval(tick, intervalMs)
+      if (!stopInterval) {
+        // Why: all mounted relative-time labels at this cadence share one
+        // visibility-gated timer. installWindowVisibilityInterval runs tick
+        // immediately on (re)start — so remounted or newly-visible labels catch
+        // up at once — and pauses the interval while the window is hidden, so
+        // backgrounded agent rows stop re-rendering for ticks no one can see.
+        stopInterval = installWindowVisibilityInterval({
+          run: tick,
+          intervalMs,
+          setIntervalFn: deps.setInterval,
+          clearIntervalFn: deps.clearInterval
+        })
       }
       return () => {
         listeners.delete(listener)
-        if (listeners.size === 0 && timer) {
-          deps.clearInterval(timer)
-          timer = null
+        if (listeners.size === 0 && stopInterval) {
+          stopInterval()
+          stopInterval = null
         }
       }
     }


### PR DESCRIPTION
Part of a fresh adversarially-verified perf/memory audit (10 finders → 3-skeptic refute-by-default verify → synthesis). Survived 3/3 skeptic votes, safe in-pattern fix.

## 1. Description
`createSharedNowClock()` (backing the `useNow` hook) arms `setInterval(tick, intervalMs)` on the first subscriber and only clears it when the **last** subscriber unmounts — it has no visibility handling. Its sibling clock, `prompt-cache-countdown-clock.ts`, implements the same shared-clock pattern **with** a visibility gate (bails on `!isWindowVisible()`, restarts on `visibilitychange`), which shows the gate was deliberately present there and simply missing here.

The persistent consumer is `WorktreeCardAgents.tsx`'s `useNow(30_000)`, whose inline agent rows live in the always-present sidebar. On macOS, `setBackgroundThrottling(false)` keeps timers firing while the window is hidden, so every 30s the clock re-renders **every mounted `DashboardAgentRow`** to recompute relative-time labels ("3m ago") that nobody can see.

Fix: route the shared clock through the existing `installWindowVisibilityInterval` helper — stop the interval while hidden, and on becoming visible run an immediate catch-up `tick()` (so labels refresh from any staleness accrued while hidden) before re-arming.

## 2. Undeniable evidence + measurable improvement
- **Sibling proof**: `prompt-cache-countdown-clock.ts` already gates the identical pattern; this change makes `useNow` consistent with it and reuses the same shared helper rather than re-implementing.
- **Deterministic unit proof** (committed, red→green): a new test stubs `document.visibilityState` and injects `setInterval`/`clearInterval` mocks, then asserts: mounting while hidden arms **no** timer and forces **no** render; a `visibilitychange → visible` fires exactly one catch-up tick and arms the timer; `→ hidden` clears it; unsubscribe removes the `visibilitychange` listener. The two pre-existing `createSharedNowClock` tests pass unchanged.
- **Metric**: with the window hidden, `tick` firings drop from one every 30s (× every mounted agent row re-rendered) → **0**, plus one catch-up tick on restore.

## 3. ELI5
The little "3m ago" timers on the agent rows kept ticking and redrawing even after you minimized the app, where nobody can see them. We pause that clock when the window is hidden and snap the labels back up to date the instant you return.

## 4. Trade-offs that regress the end experience
Effectively none. Labels are refreshed with an immediate tick the moment the window becomes visible, so you never see a stale timestamp. The only behavioral note: any *future* `useNow` consumer now inherits the same gate — which is the desired behavior. Nothing regresses because hidden output is, by definition, not visible.

Made with [Orca](https://github.com/stablyai/orca) 🐋
