### PR TITLE
fix(ai-vault): use runtime Codex sessions as history source

### DIFF
--- a/src/main/ai-vault/remote-codex-runtime-paths.ts
+++ b/src/main/ai-vault/remote-codex-runtime-paths.ts
@@ -1,0 +1,24 @@
+import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { joinRemotePath } from '../ssh/ssh-remote-platform'
+
+export function remoteOrcaManagedCodexHome(
+  remoteHome: string,
+  hostPlatform: RemoteHostPlatform
+): string {
+  return joinRemotePath(
+    hostPlatform,
+    remoteOrcaUserDataPath(remoteHome, hostPlatform),
+    'codex-runtime-home',
+    'home'
+  )
+}
+
+function remoteOrcaUserDataPath(remoteHome: string, hostPlatform: RemoteHostPlatform): string {
+  if (hostPlatform.os === 'darwin') {
+    return joinRemotePath(hostPlatform, remoteHome, 'Library', 'Application Support', 'orca')
+  }
+  if (hostPlatform.os === 'win32') {
+    return joinRemotePath(hostPlatform, remoteHome, 'AppData', 'Roaming', 'orca')
+  }
+  return joinRemotePath(hostPlatform, remoteHome, '.config', 'orca')
+}

--- a/src/main/ai-vault/remote-session-scanner-sources.ts
+++ b/src/main/ai-vault/remote-session-scanner-sources.ts
@@ -17,6 +17,7 @@ import {
 import type { FileWithMtime } from './session-scanner-types'
 import { normalizePiSessionsDir } from './session-scanner-values'
 import { remoteCodexIndexTitles } from './remote-session-scanner-codex-index'
+import { remoteOrcaManagedCodexHome } from './remote-codex-runtime-paths'
 import type {
   RemoteParserOptions,
   RemoteScannerContext,
@@ -135,40 +136,32 @@ function remoteCodexSources(
   remoteHome: string,
   hostPlatform: RemoteHostPlatform
 ): RemoteSessionSource[] {
+  const codexHome = remoteOrcaManagedCodexHome(remoteHome, hostPlatform)
   return [
-    joinRemotePath(hostPlatform, remoteHome, '.codex'),
-    joinRemotePath(
-      hostPlatform,
-      remoteHome,
-      '.local',
-      'share',
-      'orca',
-      'codex-runtime-home',
-      'home'
-    )
-  ].map((codexHome) => ({
-    agent: 'codex',
-    rootDir: joinRemotePath(hostPlatform, codexHome, 'sessions'),
-    extensions: ['.jsonl'],
-    parse: (file, content, context) =>
-      parseCodexSessionContent({
-        file,
-        content,
-        platform: context.hostPlatform.os,
-        codexHome,
-        executionHostId: context.executionHostId,
-        executionHostPlatform: context.hostPlatform.os,
-        readIndexedTitle: async (sessionId) =>
-          (
-            await remoteCodexIndexTitles({
-              provider: context.provider,
-              codexHome,
-              hostPlatform,
-              titleCaches: context.titleCaches
-            })
-          ).get(sessionId) ?? null
-      })
-  }))
+    {
+      agent: 'codex',
+      rootDir: joinRemotePath(hostPlatform, codexHome, 'sessions'),
+      extensions: ['.jsonl'],
+      parse: (file, content, context) =>
+        parseCodexSessionContent({
+          file,
+          content,
+          platform: context.hostPlatform.os,
+          codexHome,
+          executionHostId: context.executionHostId,
+          executionHostPlatform: context.hostPlatform.os,
+          readIndexedTitle: async (sessionId) =>
+            (
+              await remoteCodexIndexTitles({
+                provider: context.provider,
+                codexHome,
+                hostPlatform,
+                titleCaches: context.titleCaches
+              })
+            ).get(sessionId) ?? null
+        })
+    }
+  ]
 }
 
 function remoteOpenClawSources(

--- a/src/main/ai-vault/remote-session-scanner.test.ts
+++ b/src/main/ai-vault/remote-session-scanner.test.ts
@@ -81,12 +81,32 @@ function jsonLines(records: unknown[]): string {
 }
 
 describe('scanRemoteAiVaultSessions', () => {
-  it('parses remote default and Orca-managed Codex homes with SSH host ids', async () => {
+  it('parses remote Orca-managed Codex homes with SSH host ids', async () => {
     const provider = new MemoryRemoteProvider()
     provider.addFile(
-      '/home/ada/.codex/session_index.jsonl',
-      jsonLines([{ id: 'default-session', thread_name: 'Indexed remote title' }]),
+      '/home/ada/.config/orca/codex-runtime-home/home/session_index.jsonl',
+      jsonLines([{ id: 'runtime-session', thread_name: 'Indexed runtime title' }]),
       1
+    )
+    provider.addFile(
+      '/home/ada/.config/orca/codex-runtime-home/home/sessions/runtime.jsonl',
+      jsonLines([
+        {
+          timestamp: '2026-07-04T02:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'runtime-session', cwd: '/home/ada/runtime-repo' }
+        },
+        {
+          timestamp: '2026-07-04T02:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: 'Managed remote title' }]
+          }
+        }
+      ]),
+      20
     )
     provider.addFile(
       '/home/ada/.codex/sessions/2026/07/04/default.jsonl',
@@ -108,25 +128,51 @@ describe('scanRemoteAiVaultSessions', () => {
       ]),
       10
     )
-    provider.addFile(
-      '/home/ada/.local/share/orca/codex-runtime-home/home/sessions/runtime.jsonl',
-      jsonLines([
-        {
-          timestamp: '2026-07-04T02:00:00.000Z',
-          type: 'session_meta',
-          payload: { id: 'runtime-session', cwd: '/home/ada/runtime-repo' }
-        },
-        {
-          timestamp: '2026-07-04T02:00:01.000Z',
-          type: 'response_item',
-          payload: {
-            type: 'message',
-            role: 'user',
-            content: [{ type: 'text', text: 'Managed remote title' }]
-          }
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.title)).toEqual(['Indexed runtime title'])
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions.every((session) => session.executionHostId === 'ssh:dev-box')).toBe(true)
+    expect(result.sessions.every((session) => session.executionHostPlatform === 'linux')).toBe(true)
+    expect(
+      result.sessions.find((session) => session.sessionId === 'runtime-session')
+    ).toMatchObject({
+      codexHome: '/home/ada/.config/orca/codex-runtime-home/home',
+      resumeCommand:
+        "cd '/home/ada/runtime-repo' && CODEX_HOME='/home/ada/.config/orca/codex-runtime-home/home' codex resume 'runtime-session'"
+    })
+  })
+
+  it('ignores remote system Codex sessions as a display source', async () => {
+    const provider = new MemoryRemoteProvider()
+    const sessionContent = jsonLines([
+      {
+        timestamp: '2026-07-06T03:17:18.000Z',
+        type: 'session_meta',
+        payload: { id: 'remote-duplicated-session', cwd: '/home/ada/repo' }
+      },
+      {
+        timestamp: '2026-07-06T03:17:19.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'text', text: 'Remote duplicate title' }]
         }
-      ]),
-      20
+      }
+    ])
+    provider.addFile('/home/ada/.codex/sessions/2026/07/06/duplicate.jsonl', sessionContent, 10)
+    provider.addFile(
+      '/home/ada/.config/orca/codex-runtime-home/home/sessions/2026/07/06/duplicate.jsonl',
+      sessionContent,
+      10
     )
 
     const result = await scanRemoteAiVaultSessions({
@@ -137,26 +183,18 @@ describe('scanRemoteAiVaultSessions', () => {
     })
 
     expect(result.issues).toEqual([])
-    expect(result.sessions.map((session) => session.title)).toEqual([
-      'Managed remote title',
-      'Indexed remote title'
-    ])
-    expect(new Set(result.sessions.map((session) => session.id)).size).toBe(2)
-    expect(result.sessions.every((session) => session.executionHostId === 'ssh:dev-box')).toBe(true)
-    expect(result.sessions.every((session) => session.executionHostPlatform === 'linux')).toBe(true)
-    expect(
-      result.sessions.find((session) => session.sessionId === 'default-session')
-    ).toMatchObject({
-      codexHome: '/home/ada/.codex',
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      executionHostId: 'ssh:dev-box',
+      agent: 'codex',
+      sessionId: 'remote-duplicated-session',
+      title: 'Remote duplicate title',
+      cwd: '/home/ada/repo',
+      filePath:
+        '/home/ada/.config/orca/codex-runtime-home/home/sessions/2026/07/06/duplicate.jsonl',
+      codexHome: '/home/ada/.config/orca/codex-runtime-home/home',
       resumeCommand:
-        "cd '/home/ada/repo' && CODEX_HOME='/home/ada/.codex' codex resume 'default-session'"
-    })
-    expect(
-      result.sessions.find((session) => session.sessionId === 'runtime-session')
-    ).toMatchObject({
-      codexHome: '/home/ada/.local/share/orca/codex-runtime-home/home',
-      resumeCommand:
-        "cd '/home/ada/runtime-repo' && CODEX_HOME='/home/ada/.local/share/orca/codex-runtime-home/home' codex resume 'runtime-session'"
+        "cd '/home/ada/repo' && CODEX_HOME='/home/ada/.config/orca/codex-runtime-home/home' codex resume 'remote-duplicated-session'"
     })
   })
 
@@ -204,7 +242,7 @@ describe('scanRemoteAiVaultSessions', () => {
   it('builds resume commands with the remote host platform', async () => {
     const provider = new MemoryRemoteProvider()
     provider.addFile(
-      'C:/Users/Ada/.codex/sessions/win.jsonl',
+      'C:/Users/Ada/AppData/Roaming/orca/codex-runtime-home/home/sessions/win.jsonl',
       jsonLines([
         {
           timestamp: '2026-07-04T03:00:00.000Z',
@@ -234,14 +272,53 @@ describe('scanRemoteAiVaultSessions', () => {
     expect(result.issues).toEqual([])
     expect(result.sessions[0]?.executionHostPlatform).toBe('win32')
     expect(result.sessions[0]?.resumeCommand).toBe(
-      'cmd /d /s /c "cd /d ""C:/repo/app"" && set ""CODEX_HOME=C:/Users/Ada/.codex"" && codex resume ""win-session"""'
+      'cmd /d /s /c "cd /d ""C:/repo/app"" && set ""CODEX_HOME=C:/Users/Ada/AppData/Roaming/orca/codex-runtime-home/home"" && codex resume ""win-session"""'
     )
+  })
+
+  it('uses the macOS Orca runtime home for remote Codex sessions', async () => {
+    const provider = new MemoryRemoteProvider()
+    provider.addFile(
+      '/Users/ada/Library/Application Support/orca/codex-runtime-home/home/sessions/mac.jsonl',
+      jsonLines([
+        {
+          timestamp: '2026-07-04T03:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'mac-session', cwd: '/Users/ada/repo/app' }
+        },
+        {
+          timestamp: '2026-07-04T03:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: 'macOS remote title' }]
+          }
+        }
+      ]),
+      30
+    )
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:mac-box',
+      remoteHome: '/Users/ada',
+      hostPlatform: getRemoteHostPlatform('darwin-arm64')
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions[0]).toMatchObject({
+      executionHostPlatform: 'darwin',
+      codexHome: '/Users/ada/Library/Application Support/orca/codex-runtime-home/home',
+      resumeCommand:
+        "cd '/Users/ada/repo/app' && CODEX_HOME='/Users/ada/Library/Application Support/orca/codex-runtime-home/home' codex resume 'mac-session'"
+    })
   })
 
   it('continues past skipped candidates to fill the remote scan limit', async () => {
     const provider = new MemoryRemoteProvider()
     provider.addFile(
-      '/home/ada/.codex/sessions/worker.jsonl',
+      '/home/ada/.config/orca/codex-runtime-home/home/sessions/worker.jsonl',
       codexTranscript({
         sessionId: 'worker-session',
         title: 'Internal worker',
@@ -252,7 +329,7 @@ describe('scanRemoteAiVaultSessions', () => {
       40
     )
     provider.addFile(
-      '/home/ada/.codex/sessions/user.jsonl',
+      '/home/ada/.config/orca/codex-runtime-home/home/sessions/user.jsonl',
       codexTranscript({
         sessionId: 'user-session',
         title: 'Visible user session',
@@ -277,7 +354,7 @@ describe('scanRemoteAiVaultSessions', () => {
   it('keeps scoped remote sessions even when they are older than the recency cap', async () => {
     const provider = new MemoryRemoteProvider()
     provider.addFile(
-      '/home/ada/.codex/sessions/other.jsonl',
+      '/home/ada/.config/orca/codex-runtime-home/home/sessions/other.jsonl',
       codexTranscript({
         sessionId: 'other-session',
         title: 'Other workspace',
@@ -287,7 +364,7 @@ describe('scanRemoteAiVaultSessions', () => {
       50
     )
     provider.addFile(
-      '/home/ada/.codex/sessions/scoped.jsonl',
+      '/home/ada/.config/orca/codex-runtime-home/home/sessions/scoped.jsonl',
       codexTranscript({
         sessionId: 'scoped-session',
         title: 'Scoped workspace',

--- a/src/main/ai-vault/session-scanner-codex-bridge.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-bridge.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+let tempRoots: string[] = []
+
+afterEach(async () => {
+  vi.resetModules()
+  vi.restoreAllMocks()
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+function isolatedNonCodexScanRoots(root: string) {
+  return {
+    claudeProjectsDir: join(root, 'claude-projects'),
+    geminiSessionsDir: join(root, 'gemini-sessions'),
+    copilotSessionsDir: join(root, 'copilot-sessions'),
+    cursorProjectsDir: join(root, 'cursor-projects'),
+    opencodeStorageDir: join(root, 'opencode-storage'),
+    opencodeDbPaths: [] as readonly string[],
+    grokSessionsDir: join(root, 'grok-sessions'),
+    devinTranscriptsDir: join(root, 'devin-transcripts'),
+    hermesSessionsDir: join(root, 'hermes-sessions'),
+    rovoSessionsDir: join(root, 'rovo-sessions'),
+    openclawStateDir: join(root, 'openclaw-state'),
+    openclawLegacyStateDir: join(root, 'openclaw-legacy-state'),
+    piSessionsDir: join(root, 'pi-sessions'),
+    droidSessionsDir: join(root, 'droid-sessions'),
+    droidProjectsDir: join(root, 'droid-projects'),
+    kimiSessionsDir: join(root, 'kimi-sessions')
+  }
+}
+
+function jsonLines(records: unknown[]): string {
+  return records.map((record) => JSON.stringify(record)).join('\n')
+}
+
+describe('Codex runtime home scanning', () => {
+  it('uses the Orca runtime home as the default Codex display source', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-codex-runtime-source-'))
+    tempRoots.push(root)
+    const systemHome = join(root, 'system-codex')
+    const runtimeHome = join(root, 'orca', 'codex-runtime-home', 'home')
+    const sessionPath = join('2026', '07', '06', 'rollout-runtime-codex-session.jsonl')
+    await mkdir(join(systemHome, 'sessions', '2026', '07', '06'), { recursive: true })
+    await mkdir(join(runtimeHome, 'sessions', '2026', '07', '06'), { recursive: true })
+    await writeFile(
+      join(systemHome, 'sessions', sessionPath),
+      codexTranscript({
+        id: 'system-session',
+        cwd: '/Users/ada/system-repo',
+        title: 'System Codex session'
+      })
+    )
+    await writeFile(
+      join(runtimeHome, 'sessions', sessionPath),
+      codexTranscript({
+        id: 'runtime-session',
+        cwd: '/Users/ada/runtime-repo',
+        title: 'Runtime Codex session'
+      })
+    )
+
+    vi.doMock('../codex/codex-home-paths', () => ({
+      getSystemCodexHomePath: () => systemHome,
+      getOrcaManagedCodexHomePath: () => runtimeHome
+    }))
+    const { scanAiVaultSessions } = await import('./session-scanner')
+
+    const result = await scanAiVaultSessions({
+      ...isolatedNonCodexScanRoots(root),
+      platform: 'darwin'
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      agent: 'codex',
+      sessionId: 'runtime-session',
+      title: 'Runtime Codex session',
+      cwd: '/Users/ada/runtime-repo',
+      filePath: join(runtimeHome, 'sessions', sessionPath),
+      codexHome: runtimeHome,
+      resumeCommand: `cd '/Users/ada/runtime-repo' && CODEX_HOME='${runtimeHome}' codex resume 'runtime-session'`
+    })
+  })
+})
+
+function codexTranscript(args: { id: string; cwd: string; title: string }): string {
+  return jsonLines([
+    {
+      timestamp: '2026-07-06T02:49:35.000Z',
+      type: 'session_meta',
+      payload: {
+        id: args.id,
+        cwd: args.cwd
+      }
+    },
+    {
+      timestamp: '2026-07-06T02:49:36.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'text', text: args.title }]
+      }
+    }
+  ])
+}

--- a/src/main/ai-vault/session-scanner-source-discovery.ts
+++ b/src/main/ai-vault/session-scanner-source-discovery.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { uniqueCodexSessionsDirs } from './session-scanner-codex-paths'
 import { discoverFiles, discoverOpenClawFiles } from './session-scanner-discovery'
 import { droidDiscoveries, kimiDiscoveries } from './session-scanner-droid-kimi-sources'
@@ -9,9 +10,7 @@ import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner
 import { normalizePiSessionsDir } from './session-scanner-values'
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects')
-export const DEFAULT_CODEX_HOME_DIR = join(homedir(), '.codex')
-const CODEX_HOME_DIR = process.env.CODEX_HOME?.trim() || DEFAULT_CODEX_HOME_DIR
-const CODEX_SESSIONS_DIR = join(CODEX_HOME_DIR, 'sessions')
+export const DEFAULT_CODEX_HOME_DIR = getSystemCodexHomePath()
 const GEMINI_SESSIONS_DIR = join(homedir(), '.gemini', 'tmp')
 const COPILOT_SESSIONS_DIR = join(
   process.env.COPILOT_HOME?.trim() || join(homedir(), '.copilot'),
@@ -42,8 +41,9 @@ export async function discoverAiVaultSessionSources(args: {
   const { options, limitPerAgent, issues } = args
   const wslHomeDirs = normalizedWslHomeDirs(options.wslHomeDirs)
   const codexSessionsDirs = uniqueCodexSessionsDirs([
-    options.codexSessionsDir ?? CODEX_SESSIONS_DIR,
-    ...wslHomeDirs.map((homeDir) => join(homeDir, '.codex', 'sessions')),
+    // Why: AI Vault displays Orca's runtime CODEX_HOME. The user's ~/.codex
+    // sessions are imported into this tree instead of scanned as a second source.
+    options.codexSessionsDir ?? join(getOrcaManagedCodexHomePath(), 'sessions'),
     // Why: Orca-launched WSL Codex sessions use an Orca-owned CODEX_HOME,
     // not the user's default ~/.codex history root.
     ...wslHomeDirs.map((homeDir) =>

--- a/src/main/ipc/ai-vault.test.ts
+++ b/src/main/ipc/ai-vault.test.ts
@@ -9,7 +9,8 @@ const mocks = vi.hoisted(() => ({
   getAiVaultWslHomeDirs: vi.fn(),
   getSshFilesystemProvider: vi.fn(),
   getActiveSshAiVaultHostInfo: vi.fn(),
-  getActiveSshAiVaultHostInfos: vi.fn()
+  getActiveSshAiVaultHostInfos: vi.fn(),
+  syncSystemCodexSessionsIntoManagedHomeIncrementally: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -23,6 +24,11 @@ vi.mock('../ai-vault/session-scanner', () => ({
 
 vi.mock('../ai-vault/remote-session-scanner', () => ({
   scanRemoteAiVaultSessions: mocks.scanRemoteAiVaultSessions
+}))
+
+vi.mock('../codex/codex-session-bridge', () => ({
+  syncSystemCodexSessionsIntoManagedHomeIncrementally:
+    mocks.syncSystemCodexSessionsIntoManagedHomeIncrementally
 }))
 
 vi.mock('../wsl', () => ({
@@ -120,6 +126,28 @@ describe('listAiVaultSessions host routing', () => {
 
     expect(mocks.scanAiVaultSessions).toHaveBeenCalledTimes(1)
     expect(mocks.scanRemoteAiVaultSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('bridges system Codex sessions before a forced local scan', async () => {
+    await _internals.listAiVaultSessions({ executionHostScope: 'local', force: true })
+
+    expect(mocks.syncSystemCodexSessionsIntoManagedHomeIncrementally).toHaveBeenCalledTimes(1)
+    expect(mocks.scanAiVaultSessions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionHostId: 'local'
+      })
+    )
+  })
+
+  it('does not request a remote copy bridge on forced SSH scans', async () => {
+    await _internals.listAiVaultSessions({ executionHostScope: 'ssh:dev-box', force: true })
+
+    expect(mocks.syncSystemCodexSessionsIntoManagedHomeIncrementally).not.toHaveBeenCalled()
+    expect(mocks.scanRemoteAiVaultSessions).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        bridgeSystemCodexSessions: expect.anything()
+      })
+    )
   })
 })
 

--- a/src/main/ipc/ai-vault.ts
+++ b/src/main/ipc/ai-vault.ts
@@ -1,5 +1,6 @@
 import { app, ipcMain } from 'electron'
 import { join } from 'node:path'
+import { syncSystemCodexSessionsIntoManagedHomeIncrementally } from '../codex/codex-session-bridge'
 import { scanRemoteAiVaultSessions } from '../ai-vault/remote-session-scanner'
 import { scanAiVaultSessions } from '../ai-vault/session-scanner'
 import { sessionSortTime } from '../ai-vault/session-scanner-accumulator'
@@ -120,6 +121,9 @@ async function scanAiVaultSessionsByHostScope(
 }
 
 async function scanLocalAiVaultSessions(args?: AiVaultListArgs): Promise<AiVaultListResult> {
+  if (args?.force === true) {
+    await syncSystemCodexSessionsIntoManagedHomeIncrementally()
+  }
   const additionalCodexSessionsDirs =
     handlerOptions.getAdditionalCodexHomePaths?.().map((homePath) => join(homePath, 'sessions')) ??
     []

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -41,7 +41,10 @@ import { translate } from '@/i18n/i18n'
 import { AiVaultPanelHeader } from './AiVaultPanelHeader'
 import { AiVaultSessionVirtualList } from './AiVaultSessionVirtualList'
 import { useAiVaultSessionRefresh } from './ai-vault-session-refresh'
-import { useAiVaultExecutionHostScope } from './ai-vault-host-scope'
+import {
+  getAiVaultScanExecutionHostScope,
+  useAiVaultExecutionHostScope
+} from './ai-vault-host-scope'
 
 export default function AiVaultPanel(): React.JSX.Element {
   const activeWorktreeId = useActiveWorktreeId()
@@ -78,11 +81,15 @@ export default function AiVaultPanel(): React.JSX.Element {
       'runtime',
     [activeWorktreeId, resumeTargetState]
   )
-  const { executionHostScope, activeSshExecutionHostScope, onExecutionHostScopeChange } =
-    useAiVaultExecutionHostScope({
-      activeWorktreeId: activeWorktreeId ?? null,
-      resumeTargetState
-    })
+  const {
+    executionHostScope,
+    workspaceExecutionHostScope,
+    activeSshExecutionHostScope,
+    onExecutionHostScopeChange
+  } = useAiVaultExecutionHostScope({
+    activeWorktreeId: activeWorktreeId ?? null,
+    resumeTargetState
+  })
   const activeWorktreePath = activeWorktree?.path ?? null
   // Why: AI Vault ownership is cwd-based, so we must consider live worktrees across all repos.
   const activeWorktreePaths = useMemo(
@@ -112,9 +119,14 @@ export default function AiVaultPanel(): React.JSX.Element {
       }),
     [activeProjectKey, activeWorktree, allWorktrees, projectHostSetupProjection]
   )
+  const scanExecutionHostScope = getAiVaultScanExecutionHostScope({
+    scope,
+    executionHostScope,
+    workspaceExecutionHostScope
+  })
   const { error, loading, refresh, scanResult, sessions } = useAiVaultSessionRefresh(
     scopePaths,
-    executionHostScope
+    scanExecutionHostScope
   )
   const sessionProjectById = useMemo(
     () =>

--- a/src/renderer/src/components/right-sidebar/AiVaultPanelHeader.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanelHeader.tsx
@@ -106,11 +106,13 @@ export function AiVaultPanelHeader({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1 @max-[300px]/ai-vault:gap-0.5">
-          <VaultHostScopeMenu
-            executionHostScope={executionHostScope}
-            activeSshExecutionHostScope={activeSshExecutionHostScope}
-            onExecutionHostScopeChange={onExecutionHostScopeChange}
-          />
+          {scope === 'all' ? (
+            <VaultHostScopeMenu
+              executionHostScope={executionHostScope}
+              activeSshExecutionHostScope={activeSshExecutionHostScope}
+              onExecutionHostScopeChange={onExecutionHostScopeChange}
+            />
+          ) : null}
           <VaultViewMenu
             agents={agents}
             sort={sort}

--- a/src/renderer/src/components/right-sidebar/ai-vault-host-scope.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-host-scope.test.ts
@@ -5,7 +5,10 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { AppState } from '@/store/types'
 import type { AiVaultSessionResumeTargetState } from './ai-vault-session-resume'
-import { useAiVaultExecutionHostScope } from './ai-vault-host-scope'
+import {
+  getAiVaultScanExecutionHostScope,
+  useAiVaultExecutionHostScope
+} from './ai-vault-host-scope'
 
 type HostScopeResult = ReturnType<typeof useAiVaultExecutionHostScope>
 
@@ -83,6 +86,7 @@ describe('useAiVaultExecutionHostScope', () => {
     })
 
     expect(latest?.executionHostScope).toBe('ssh:dev-box')
+    expect(latest?.workspaceExecutionHostScope).toBe('ssh:dev-box')
     expect(latest?.activeSshExecutionHostScope).toBe('ssh:dev-box')
   })
 
@@ -96,6 +100,7 @@ describe('useAiVaultExecutionHostScope', () => {
     })
 
     expect(latest?.executionHostScope).toBe('local')
+    expect(latest?.workspaceExecutionHostScope).toBe('local')
     expect(latest?.activeSshExecutionHostScope).toBeNull()
   })
 
@@ -116,5 +121,32 @@ describe('useAiVaultExecutionHostScope', () => {
     await renderHook({ ...props, resumeTargetState: { ...props.resumeTargetState } })
 
     expect(latest?.executionHostScope).toBe('all')
+    expect(latest?.workspaceExecutionHostScope).toBe('ssh:dev-box')
+  })
+
+  it('uses the selected host scope only for all-session scans', () => {
+    expect(
+      getAiVaultScanExecutionHostScope({
+        scope: 'all',
+        executionHostScope: 'all',
+        workspaceExecutionHostScope: 'ssh:dev-box'
+      })
+    ).toBe('all')
+
+    expect(
+      getAiVaultScanExecutionHostScope({
+        scope: 'workspace',
+        executionHostScope: 'all',
+        workspaceExecutionHostScope: 'ssh:dev-box'
+      })
+    ).toBe('ssh:dev-box')
+
+    expect(
+      getAiVaultScanExecutionHostScope({
+        scope: 'project',
+        executionHostScope: 'local',
+        workspaceExecutionHostScope: 'ssh:dev-box'
+      })
+    ).toBe('ssh:dev-box')
   })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-host-scope.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-host-scope.ts
@@ -6,6 +6,7 @@ import {
   parseExecutionHostId,
   type ExecutionHostScope
 } from '../../../../shared/execution-host'
+import type { AiVaultScope } from '../../../../shared/ai-vault-types'
 import type { AiVaultSessionResumeTargetState } from './ai-vault-session-resume'
 
 export function useAiVaultExecutionHostScope(args: {
@@ -13,6 +14,7 @@ export function useAiVaultExecutionHostScope(args: {
   resumeTargetState: AiVaultSessionResumeTargetState
 }): {
   executionHostScope: ExecutionHostScope
+  workspaceExecutionHostScope: ExecutionHostScope
   activeSshExecutionHostScope: ExecutionHostScope | null
   onExecutionHostScopeChange: (scope: ExecutionHostScope) => void
 } {
@@ -58,7 +60,16 @@ export function useAiVaultExecutionHostScope(args: {
 
   return {
     executionHostScope,
+    workspaceExecutionHostScope: defaultExecutionHostScope,
     activeSshExecutionHostScope,
     onExecutionHostScopeChange: handleExecutionHostScopeChange
   }
+}
+
+export function getAiVaultScanExecutionHostScope(args: {
+  scope: AiVaultScope
+  executionHostScope: ExecutionHostScope
+  workspaceExecutionHostScope: ExecutionHostScope
+}): ExecutionHostScope {
+  return args.scope === 'all' ? args.executionHostScope : args.workspaceExecutionHostScope
 }


### PR DESCRIPTION
## Summary

  Fixes #7521.

  Codex session history in AI Vault now uses Orca’s Codex runtime home as the single display source instead of scanning both `~/.codex/sessions` and Orca runtime sessions. Workspace/Project views now scan
  the workspace execution host, so an SSH workspace does not scan the local client machine for that workspace’s history.

  ## Screenshots

  No visual change.

  ## Testing

  - [ ] `pnpm lint`
  - [x] `pnpm exec oxlint src/main/ipc/ai-vault.ts src/main/ipc/ai-vault.test.ts`
  - [ ] `pnpm typecheck`
  - [x] `pnpm run typecheck:node`
  - [x] `pnpm run typecheck:web`
  - [ ] `pnpm test`
  - [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ai-vault/session-scanner-codex-bridge.test.ts src/main/ai-vault/remote-session-scanner.test.ts src/main/ipc/ai-vault.test.ts src/
  renderer/src/components/right-sidebar/ai-vault-host-scope.test.ts`
  - [ ] `pnpm build`
  - [x] Added or updated high-quality tests that would catch regressions, covering runtime-home-only Codex scanning, ignored system Codex session roots, OS-specific remote runtime paths, forced local
  bridge behavior, and Workspace/Project host-scope routing.

  ## AI Review Report

  Reviewed the change with an AI coding agent focused on the root cause from #7521: duplicate Codex sessions caused by scanning both system and Orca-managed Codex session roots.

  Main risks checked:
  - AI Vault no longer treats `~/.codex/sessions` as a parallel Codex display source.
  - Local forced refresh bridges system Codex sessions into runtime home before scanning.
  - The local bridge uses the existing incremental bridge path to avoid synchronous full-history directory walks during refresh.
  - SSH scanning resolves the remote host’s Orca runtime home instead of the client machine’s local history.
  - Workspace/Project views use the workspace execution host; the host selector remains scoped to All sessions.
  - The fix avoids transcript-level de-duping as the primary solution and instead uses a single authoritative Codex display source.

  The review explicitly checked cross-platform compatibility for macOS, Linux, and Windows:
  - macOS remote runtime path: `~/Library/Application Support/orca/codex-runtime-home/home`
  - Linux remote runtime path: `~/.config/orca/codex-runtime-home/home`
  - Windows remote runtime path: `~/AppData/Roaming/orca/codex-runtime-home/home`
  - Existing platform-aware remote path joining and Codex resume command behavior are preserved.
  - No keyboard shortcuts, shortcut labels, shell wrappers, or Electron platform behavior were changed.

  ## Security Audit

  Reviewed basic security impact with an AI coding agent.

  Security-relevant areas checked:
  - Path handling: new remote runtime paths are built through existing `joinRemotePath` platform-aware utilities.
  - IPC: no new IPC channel was added; existing `aiVault:listSessions` routing is preserved.
  - Command execution: no new shell command execution was introduced.
  - Auth/secrets: no Codex credentials are copied between local and SSH hosts.
  - Dependencies: no new dependencies were added.
  - Remote SSH behavior: remote hardlink/copy bridging was intentionally not added because the current SSH filesystem provider does not expose a hardlink operation, and copying transcript files would
  weaken the intended single-source history model.

  No immediate security follow-up is required for this PR.

  ## Notes

  This PR intentionally does not implement SSH launch-time `CODEX_HOME` injection or remote hardlink bridging. Those should be handled separately so SSH-launched Codex sessions write directly to the remote
  host’s Orca runtime home without copying client credentials or duplicating transcript sources.

  Related: #7367

## ELI5

Codex history in AI Vault mixed local and runtime homes and could scan the wrong machine over SSH. It now uses Orca’s Codex runtime home on the workspace’s execution host.
