### PR TITLE
Stop terminal flicker during active Claude Code sessions

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -20,8 +20,11 @@ vi.mock('./pane-helpers', () => ({
   fitPanes: vi.fn(),
   focusActivePane: vi.fn()
 }))
+const scheduleTabRevealWebglAtlasRecovery = vi.fn()
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery: vi.fn()
+  // Why: the light-tab reveal must recover the atlas immediately, decoupled from
+  // the terminal-output debounce (which a background stream could otherwise defer).
+  scheduleTabRevealWebglAtlasRecovery: () => scheduleTabRevealWebglAtlasRecovery()
 }))
 
 type FakeManager = {
@@ -63,6 +66,9 @@ describe('resumeTerminalVisibility reveal repaint', () => {
 
     expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
     expect(manager.resumeRendering).not.toHaveBeenCalled()
+    // Reveal recovery is immediate (not the terminal-output debounce), so a
+    // background stream in another pane cannot defer this tab's atlas rebuild.
+    expect(scheduleTabRevealWebglAtlasRecovery).toHaveBeenCalledTimes(1)
   })
 
   it('schedules the repaint after rendering resumes on a heavy reveal', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -7,7 +7,7 @@ import {
 } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { enforceTerminalCurrentScrollIntent } from '@/lib/pane-manager/terminal-scroll-intent'
 import { fitAndFocusPanes, fitPanes, focusActivePane } from './pane-helpers'
-import { scheduleTerminalWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
+import { scheduleTabRevealWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
 const WINDOW_WAKE_FLUSH_CHARS = 64 * 1024
@@ -62,7 +62,10 @@ export function resumeTerminalVisibility({
       // overlay's delayed geometry fit. Still request hidden-output recovery:
       // agent TUIs can suppress hidden bytes until the pane is foregrounded.
       requestLightTabBacklogRecovery(manager)
-      scheduleTerminalWebglAtlasRecovery()
+      // Why: reveal recovery must be immediate, not the terminal-output debounce
+      // — a background agent streaming in another pane must not defer this tab's
+      // atlas rebuild.
+      scheduleTabRevealWebglAtlasRecovery()
       if (isActive) {
         focusActivePane(manager)
       }

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
@@ -5,7 +5,9 @@ import {
 } from '@/lib/pane-manager/pane-manager-registry'
 import {
   scheduleImagePasteWebglAtlasRecovery,
-  scheduleTerminalWebglAtlasRecovery
+  scheduleTabRevealWebglAtlasRecovery,
+  scheduleTerminalWebglAtlasRecovery,
+  TERMINAL_OUTPUT_RECOVERY_QUIET_MS
 } from './terminal-webgl-atlas-recovery'
 
 describe('terminal WebGL atlas recovery', () => {
@@ -28,6 +30,10 @@ describe('terminal WebGL atlas recovery', () => {
     for (const manager of registeredManagers.splice(0)) {
       unregisterLivePaneManager(manager)
     }
+    // Why: a test can leave the module-global debounce timer armed; clear the
+    // fake-timer queue before restoring real timers so no pending fire leaks
+    // into a later test.
+    vi.clearAllTimers()
     vi.useRealTimers()
     vi.unstubAllGlobals()
   })
@@ -145,7 +151,63 @@ describe('terminal WebGL atlas recovery', () => {
     expect(manager.refreshAllPanes).not.toHaveBeenCalled()
   })
 
-  it('coalesces terminal-output atlas recovery across a redraw burst', () => {
+  it('recovers immediately on a tab reveal, not through the streaming debounce', () => {
+    // Regression guard (STA-1365 review): reveal recovery must stay immediate so a
+    // background agent streaming in another pane cannot defer a revealed tab's
+    // atlas rebuild. It shares the paste path's immediate burst, not the debounce.
+    vi.useFakeTimers()
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return rafCallbacks.length
+      })
+    )
+    const manager = registerManager()
+
+    scheduleTabRevealWebglAtlasRecovery()
+    // First burst leg fires on the next frame — no 200ms debounce wait.
+    rafCallbacks[0]?.(0)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(120)
+    vi.advanceTimersByTime(380)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not recover mid-stream while terminal output keeps arriving', () => {
+    // Regression (STA-1365): an alternate-screen TUI requests atlas recovery on
+    // every redraw frame. Recovering mid-stream clears the shared glyph atlas and
+    // repaints every pane several times a second, which reads as a flicker. The
+    // debounce must swallow a sustained stream entirely until it goes quiet.
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    // Simulate ~1s of continuous streaming: a redraw chunk every 50ms, each
+    // shorter than the quiet window, so the debounce keeps resetting.
+    for (let elapsed = 0; elapsed < 1000; elapsed += 50) {
+      scheduleTerminalWebglAtlasRecovery()
+      vi.advanceTimersByTime(50)
+    }
+
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
+  })
+
+  it('recovers exactly once after terminal output settles, not a 3-stage burst', () => {
+    // Brennan-approved single-recovery decision: the streaming settle fires one
+    // clear+refresh, not the rAF+120+500 burst, so a clear can only ever land
+    // after 200ms of global quiet. Advancing past the burst delays must add no
+    // further fires on the streaming path.
     vi.useFakeTimers()
     vi.stubGlobal(
       'requestAnimationFrame',
@@ -160,22 +222,96 @@ describe('terminal WebGL atlas recovery', () => {
     scheduleTerminalWebglAtlasRecovery()
     scheduleTerminalWebglAtlasRecovery()
 
+    // Still nothing before the quiet window elapses.
+    vi.advanceTimersByTime(199)
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+
+    // Quiet window elapsed → exactly one clear+refresh for the coalesced stream.
+    vi.advanceTimersByTime(1)
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
     expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+
+    // The 120ms/500ms burst legs must NOT fire on the streaming path.
     vi.advanceTimersByTime(120)
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(2)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(2)
-    scheduleTerminalWebglAtlasRecovery()
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(380)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not clear mid-stream when a settle is followed by resumed streaming', () => {
+    // Cancelable invariant (STA-1365): a stream that pauses just over the quiet
+    // window lets the settle fire its single recovery during the gap, but the
+    // resumed chunks must not trigger any further clear while they keep arriving
+    // <200ms apart — the re-arm cancels the only pending handle (the debounce
+    // timer), so no clear lands mid-resumed-stream.
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    // Initial stream, then a gap just over the quiet window → one settle recovery.
+    for (let elapsed = 0; elapsed < 300; elapsed += 50) {
+      scheduleTerminalWebglAtlasRecovery()
+      vi.advanceTimersByTime(50)
+    }
+    vi.advanceTimersByTime(TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+
+    // Resume streaming: fire-count must stay pinned while chunks keep arriving.
+    for (let elapsed = 0; elapsed < 1000; elapsed += 50) {
+      scheduleTerminalWebglAtlasRecovery()
+      vi.advanceTimersByTime(50)
+      expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+      expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it('coalesces the terminal-output callers onto one shared timer while paste stays immediate', () => {
+    // Cross-caller single-timer invariant: the terminal-output re-arm sites
+    // (foreground and hidden-output PTY writes) funnel through
+    // scheduleTerminalWebglAtlasRecovery and re-arm the one module-global debounce
+    // timer, so a single continuous stream (even a hidden one) keeps the recovery
+    // deferred for everyone. Image paste and tab reveal use their own immediate
+    // burst and are not coupled to the shared debounce timer.
+    vi.useFakeTimers()
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return rafCallbacks.length
+      })
+    )
+    const manager = registerManager()
+
+    // The terminal-output re-arm sites (foreground / hidden-output) both funnel
+    // through this one function; none may fire mid-stream.
+    for (let elapsed = 0; elapsed < 600; elapsed += 50) {
+      scheduleTerminalWebglAtlasRecovery()
+      vi.advanceTimersByTime(50)
+    }
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+
+    // Global quiet → exactly one coalesced recovery for the whole shared stream.
+    vi.advanceTimersByTime(TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+
+    // Paste is independent: its own immediate 3-stage burst, not the shared timer.
+    manager.resetWebglTextureAtlases.mockClear()
+    manager.refreshAllPanes.mockClear()
+    scheduleImagePasteWebglAtlasRecovery()
+    rafCallbacks.at(-1)?.(0)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(120)
     vi.advanceTimersByTime(380)
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
     expect(manager.refreshAllPanes).toHaveBeenCalledTimes(3)
-
-    scheduleTerminalWebglAtlasRecovery()
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(4)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(4)
-    vi.advanceTimersByTime(500)
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(6)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(6)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
@@ -2,7 +2,12 @@ import { resetAndRefreshAllTerminalWebglAtlases } from '@/lib/pane-manager/pane-
 
 const ATLAS_RECOVERY_DELAYS_MS = [120, 500]
 
-let terminalOutputRecoveryScheduled = false
+// Why: a streaming TUI requests output atlas recovery every frame; recovering
+// mid-stream clears the shared atlas and repaints every pane, which flickers
+// (STA-1365). Wait for output to go quiet so recovery runs once, on settle.
+export const TERMINAL_OUTPUT_RECOVERY_QUIET_MS = 200
+
+let terminalOutputRecoveryDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
 function scheduleNextFrame(callback: () => void): void {
   if (typeof globalThis.requestAnimationFrame === 'function') {
@@ -22,32 +27,35 @@ function resetAtlasesAndRefreshPanes(): void {
   }
 }
 
-function scheduleAtlasRecoveryBurst(onComplete?: () => void): void {
+function scheduleAtlasRecoveryBurst(): void {
   scheduleNextFrame(() => resetAtlasesAndRefreshPanes())
-  for (const [index, delayMs] of ATLAS_RECOVERY_DELAYS_MS.entries()) {
-    globalThis.setTimeout(() => {
-      resetAtlasesAndRefreshPanes()
-      if (index === ATLAS_RECOVERY_DELAYS_MS.length - 1) {
-        onComplete?.()
-      }
-    }, delayMs)
+  for (const delayMs of ATLAS_RECOVERY_DELAYS_MS) {
+    globalThis.setTimeout(() => resetAtlasesAndRefreshPanes(), delayMs)
   }
 }
 
 export function scheduleImagePasteWebglAtlasRecovery(): void {
   // Why: image chips can redraw after bracketed paste parsing, so cover the
-  // short post-paste paint window with a few cheap atlas rebuilds.
+  // short post-paste paint window with a few cheap atlas rebuilds. Paste is a
+  // one-shot event, so recover immediately rather than debouncing.
+  scheduleAtlasRecoveryBurst()
+}
+
+export function scheduleTabRevealWebglAtlasRecovery(): void {
+  // Why: a tab reveal is one-shot, so recover immediately — decoupled from the
+  // streaming debounce so a background stream can't defer a revealed tab's rebuild.
   scheduleAtlasRecoveryBurst()
 }
 
 export function scheduleTerminalWebglAtlasRecovery(): void {
-  if (terminalOutputRecoveryScheduled) {
-    return
+  // Why: terminal-output recovery (foreground + hidden PTY writes). Trailing-edge
+  // debounce so a clear only ever runs after 200ms of quiet — never mid-stream;
+  // a resumed stream cancels the pending timer, so a pause-then-resume can't leak.
+  if (terminalOutputRecoveryDebounceTimer != null) {
+    globalThis.clearTimeout(terminalOutputRecoveryDebounceTimer)
   }
-  terminalOutputRecoveryScheduled = true
-  // Why: TUI redraw bursts can corrupt xterm's shared WebGL glyph atlas without
-  // a context-loss event; coalesce resets so output storms do not queue timers.
-  scheduleAtlasRecoveryBurst(() => {
-    terminalOutputRecoveryScheduled = false
-  })
+  terminalOutputRecoveryDebounceTimer = globalThis.setTimeout(() => {
+    terminalOutputRecoveryDebounceTimer = null
+    resetAtlasesAndRefreshPanes()
+  }, TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
 }


### PR DESCRIPTION
## What changes

While an agent (Claude Code, or any alternate-screen TUI) streams output inside an Orca terminal, the terminal area no longer flickers. The flash was a real, measurable redraw storm — not a perception issue.

**Root cause:** xterm's WebGL renderer keeps a module-global glyph atlas shared by all same-config terminals. Orca ran a recovery that clears that shared atlas and repaints **every** pane. One caller drove it from terminal output: on every alternate-screen in-place-rewrite chunk (standalone `\r` / `\b` / erase-line) and every CJK/"renderer-risk" chunk, it re-armed a coalescer that fired the global clear+repaint burst repeatedly. A streaming agent emits such a chunk on essentially every frame, so during an active session the whole terminal cleared and repainted several times a second, and stopped the instant output went static — exactly the report.

**Fix:** debounce the terminal-output recovery to the trailing edge. A sustained redraw stream coalesces into a single clear+refresh that runs only after 200 ms of quiet, so **no atlas clear ever lands during visible streaming**. A resumed stream re-arms (and cancels) the one debounce timer, so a pause-then-resume can't leak a clear mid-stream.

**What does NOT change:** tab-reveal recovery keeps its own immediate burst (deliberately decoupled from the streaming debounce so a background stream can't defer a just-revealed tab's atlas rebuild); the image-paste, OS/window-wake, and WebGL context-loss recovery paths are unchanged and still immediate.

## Reproduction / evidence (macOS)

Instrumented the recovery with a fire-timestamp counter and drove a synthetic alternate-screen redraw stream (~20 fps in-place rewrites) in a real Orca terminal:

- **Before:** 39 global atlas-clear + all-pane repaints during ~8.5 s of streaming (median gap 120 ms); 0 once idle.
- **After:** **0** fires during the streaming window; exactly **1** clear+refresh at the settle edge (~200 ms after output stopped). Tab-reveal recovery still fires its immediate burst.

(Flicker is a sub-frame temporal artifact; the fire-count is the authoritative before/after measurement. Screenshots of the streaming state and the settled state are attached to the PR conversation.)

## Design approach & review

Trailing-edge debounce, keeping a single settle-edge recovery (not a 3-stage burst) so a clear can only ever run after global quiet. Design was reviewed through Brennan's PR process (design-review loop → implementation → completeness verify → perf → two-reviewer code-review loop → live validation). The design-review loop raised and resolved: a burst-cancelation hole (eliminated by the single-recovery choice), a hidden-output shared-timer analysis, and a required Windows/CJK validation item.

## Consistency across recovery surfaces

Compared every caller of the shared atlas recovery: streaming output (fixed), light-tab resume (moved to the immediate reveal path so it is NOT debounced), image paste (immediate, unchanged), hidden→visible reveal / OS-wake / context-loss (unchanged). No user-visible surface loses recovery; only the streaming path changed cadence.

## Headline behavior: implemented

The production path (`pty-connection` foreground/hidden write → `scheduleTerminalWebglAtlasRecovery`) is debounced, verified live (0 mid-stream fires).

## Risks / non-goals

- **Accepted residual (approved):** because the debounce timer is module-global, a visible idle pane's *output-driven* stale-glyph cleanup can defer while a sibling or hidden background agent streams. Rare and Orca-specific; every other recovery trigger (reveal/resume/wake/paste/context-loss) stays immediate. Follow-up signal noted if a visible idle pane is ever seen holding a stale glyph while a sibling streams.
- **Non-goal:** the background-transparency re-blend flicker (STA-912, only with opacity < 1) — different mechanism, separate work.
- Isolated (non-streaming) stale-glyph recovery latency goes from ~1 frame to ≤200 ms — imperceptible for a cleanup repaint.

## Provider / platform

The trigger is client-side content analysis in the renderer, so behavior is identical across local / daemon / SSH / remote / WSL / mobile. The Windows CJK variant (STA-1385, `#7475`) funnels through the same debounced scheduler and is covered by this fix; a live Windows/CJK run is being done separately to confirm.

## Validation

- Unit: `terminal-webgl-atlas-recovery.test.ts` (no mid-stream recovery; single recovery at settle; no clear on pause-then-resume; reveal stays immediate; cross-caller single-timer) + `terminal-visibility-resume.test.ts` (reveal recovery immediate). Adjacent suites green: `pty-connection.test.ts` (323), `pane-manager-registry.test.ts`.
- Perf: net reduction in render work (removes the repeated global clear/repaint from the per-chunk hot path); no new polling/IPC/listeners; single self-clearing timer, no leak.
- Code review: two independent reviewers, converged clean (no P0/P1; the one P2 — resume coupling — was fixed by decoupling reveal recovery).
- Live macOS: 39 → 0 mid-stream fires; reveal burst immediate.
- oxlint + web typecheck clean.

Closes STA-1365. Related: STA-1385 / `#7475` (same cause, Windows CJK).

Made with [Orca](https://github.com/stablyai/orca) 🐋
