### PR TITLE
Prepare mobile 0.0.24

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.22",
+    "version": "0.0.24",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 4
+      "versionCode": 5
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
Bumps the mobile marketing version `0.0.22 → 0.0.24` and Android `versionCode 4 → 5`.

## Why
`app.json` was stuck at 0.0.22 because prior version bumps were applied only inside the release workflow and never committed back. As a result the Jul 6 mobile builds that carry the show-all-worktrees fix (#7500) shipped with the wrong version:

- **iOS**: went out as **0.0.22 (1)** — *below* the pre-fix **0.0.23** already on TestFlight, so testers never saw it as an update. (Re-released as 0.0.24 via the workflow's version override.)
- **Android**: went out as **0.0.22 / versionCode 4** — identical to the pre-fix APK, so no upgrade signal.

Committing the bump makes `app.json` authoritative again so 0.0.24 cleanly supersedes both platforms and future default releases don't regress.

## After merge
Dispatch `Mobile Android Release` from `main` → produces `0.0.24 / versionCode 5` with a fresh `mobile-android-v0.0.24` tag. iOS 0.0.24 is already building.

Made with [Orca](https://github.com/stablyai/orca) 🐋
