### PR TITLE
Remove stale max-lines lint disables from files under the limit

### DIFF
--- a/mobile/src/hooks/use-mobile-dictation.ts
+++ b/mobile/src/hooks/use-mobile-dictation.ts
@@ -1,6 +1,3 @@
-/* oxlint-disable max-lines -- Why: mobile dictation keeps permission, recording,
- * chunk upload, completion, and cancellation in one hook so native audio state
- * cannot drift from the runtime RPC lifecycle. */
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 // Why: import from 'buffer' (the npm polyfill), not 'node:buffer' — Metro
 // can't resolve Node's builtin in a React Native bundle.

--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: this file groups every CLI browser-command test (page targeting, profiles, waits, viewport) so test-fixture imports and the runtime-client mock stay shared in one place. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const callMock = vi.fn()

--- a/src/cli/handlers/file.test.ts
+++ b/src/cli/handlers/file.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: file CLI coverage shares one mocked runtime setup across command contracts. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const callMock = vi.fn()

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: this fixture verifies the shared remote hook installer fake across every managed agent so SSH regressions are caught together. */
 import { describe, expect, it, vi } from 'vitest'
 import type { SFTPWrapper } from 'ssh2'
 

--- a/src/main/attribution/terminal-attribution.test.ts
+++ b/src/main/attribution/terminal-attribution.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: these tests exercise generated shell wrapper
-scripts end-to-end, and keeping the regression fixtures adjacent makes the
-attribution safety cases easier to audit. */
 import { execFileSync } from 'node:child_process'
 import {
   chmodSync,

--- a/src/main/automations/external-manager.test.ts
+++ b/src/main/automations/external-manager.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: external automation mapping and lifecycle IPC share fixtures. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createExternalAutomation,

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: cookie import tests share import-time Electron mocks plus
-   browser-specific cookie fixtures; splitting would duplicate brittle setup. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { sessionFromPartitionMock, dialogShowOpenDialogMock } = vi.hoisted(() => ({

--- a/src/main/browser/browser-screencast-stream.test.ts
+++ b/src/main/browser/browser-screencast-stream.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: one fixture-backed file covers screencast frame, viewport, dialog, and cleanup behavior together. */
 import { Buffer } from 'node:buffer'
 import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'

--- a/src/main/browser/cdp-bridge-integration.test.ts
+++ b/src/main/browser/cdp-bridge-integration.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: integration test covering the full browser automation pipeline end-to-end. */
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'

--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: scan gating, pricing, and automation
-usage attribution share one stateful Claude usage store fixture. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClaudeUsagePersistedState } from './types'
 

--- a/src/main/cli/wsl-cli-installer.test.ts
+++ b/src/main/cli/wsl-cli-installer.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- WSL CLI tests cover one installer state machine with shared
-   runner fixtures; splitting would duplicate the fake WSL filesystem setup. */
 import type { CliInstallStatus } from '../../shared/cli-install-types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/src/main/codex-usage/scanner-paths.test.ts
+++ b/src/main/codex-usage/scanner-paths.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: path discovery and legacy bridge scan preference cases need shared mocked homes to keep filesystem behavior realistic. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { linkSync, lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'

--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: daemon connection, RPC, event, and disconnect behavior share one socket test harness. */
 import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createServer, type Server, type Socket } from 'node:net'

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: daemon server RPC, auth, stream batching, and shutdown behavior share one socket/client harness; splitting would duplicate setup. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { connect, type Server, type Socket } from 'node:net'
 import { tmpdir } from 'node:os'

--- a/src/main/daemon/reattach-snapshot.test.ts
+++ b/src/main/daemon/reattach-snapshot.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { TerminalHost } from './terminal-host'
 import { HeadlessEmulator } from './headless-emulator'

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: shell-ready wrapper coverage keeps zsh,
-   bash, marker scanning, and env restoration cases in one suite so the
-   generated wrapper contract is reviewed as a unit. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Session, type SubprocessHandle } from './session'
 import { TerminalHost } from './terminal-host'

--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: WSL fallback, retry safety, and glab parity share mocks. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as WslModule from '../wsl'
 

--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: create-PR tests share gh/SSH mocks across
-   template, CLI, and error-path cases; keeping them together prevents drift. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { readFile } from 'node:fs/promises'
 

--- a/src/main/github/client-issue-source.test.ts
+++ b/src/main/github/client-issue-source.test.ts
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines -- Why: the issue-source test suite covers the
-heuristic split (#1076), the partial-failure envelope (feature 1), and the
-three-state preference matrix (feature 2) as one surface so a regression in
-any of them blocks the same merge gate. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as GhUtils from './gh-utils'
 

--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: work-items coverage stays in one file so
-the fan-out mock plumbing (issue + PR gh calls, allSettled handling) does
-not drift across split files. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {

--- a/src/main/github/project-view/internals.ts
+++ b/src/main/github/project-view/internals.ts
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines -- Why: shared infrastructure for project-view —
-slug validation, error classification, runGraphql/runRest, and rate-limit
-synthesis. Co-located so the read and write paths observe identical
-classification semantics. */
 // Why: `ghExecFileAsync` (WSL-aware, retry-enabled) is the single spawn site
 // for gh calls. The legacy plain `execFileAsync` is NOT used here — routing
 // every gh call through the runner gives us transient-5xx retry, WSL path

--- a/src/main/gitlab/issues.test.ts
+++ b/src/main/gitlab/issues.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: GitLab issue mutation/list coverage shares glab mocks across related endpoint cases. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as GlUtils from './gl-utils'
 

--- a/src/main/gitlab/merge-request-creation.test.ts
+++ b/src/main/gitlab/merge-request-creation.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: MR creation tests share glab and SSH filesystem mocks across CLI, template, and duplicate-detection paths. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {

--- a/src/main/ipc/browser.test.ts
+++ b/src/main/ipc/browser.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: browser IPC tests share one mocked trust-boundary handler registry plus registration waiters; splitting would duplicate setup and weaken coverage. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Why: crash-reporting IPC tests share mocked Electron/observability handler setup; splitting would duplicate brittle IPC wiring. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CrashReportRecord } from '../../shared/crash-reporting'
 

--- a/src/main/ipc/diagnostics.test.ts
+++ b/src/main/ipc/diagnostics.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Why: diagnostics IPC tests share mocked Electron handler setup; splitting would duplicate brittle IPC wiring. */
 import { readFileSync, writeFileSync } from 'node:fs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CollectedBundle } from '../observability/bundle'

--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: import tests cover local copy, SSH routing,
-symlink safety, and runtime-upload staging against one shared IPC fixture. */
 import path from 'node:path'
 import { constants } from 'node:fs'
 import { Readable, Writable } from 'node:stream'

--- a/src/main/ipc/filesystem-list-files.test.ts
+++ b/src/main/ipc/filesystem-list-files.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: one Quick Open file-list suite covers both rg and git fallback process lifecycles. */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const {

--- a/src/main/ipc/filesystem-watcher.test.ts
+++ b/src/main/ipc/filesystem-watcher.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: filesystem watcher tests share module-level
-state across local, WSL, and SSH lifecycle paths; keeping them together makes
-closeAllWatchers cleanup regressions visible in one suite. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { handleMock, getSshFilesystemProviderMock } = vi.hoisted(() => ({

--- a/src/main/ipc/pty-management.test.ts
+++ b/src/main/ipc/pty-management.test.ts
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines -- Why: covers every pty:management IPC channel
-against shared mocks (electron, fs, daemon-init, DaemonPtyRouter). Splitting
-across files would duplicate the vi.hoisted setup and the shared helpers,
-with no meaningful ownership seam. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DaemonSessionInfo } from '../daemon/types'
 

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: this test mirrors the complete core IPC handler registry so
-   duplicate-registration coverage stays tied to the one production entry point. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {

--- a/src/main/ipc/remote-workspace-patch-queue.test.ts
+++ b/src/main/ipc/remote-workspace-patch-queue.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Why: queue/cache regression cases share one mocked IPC harness so stale revision sequencing stays visible. */
 import { ipcMain } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: shell IPC path validation, OS opener fallbacks, and launcher lifecycle tests share one mocked Electron/child_process boundary. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { normalize, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'

--- a/src/main/ipc/telemetry.test.ts
+++ b/src/main/ipc/telemetry.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: a single test file pins the IPC boundary behavior for all four telemetry handlers plus the cohort-injection invariants; splitting would fragment the threat-model coverage. */
 // IPC boundary behavior for the telemetry surface. Strict type narrows must
 // drop obviously-malformed calls before they reach the validator (the
 // renderer is in the threat model). Pins the consent-mutation rate limit:

--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: scan and IPC process-liveness tests share
-   hoisted Electron/git provider mocks; splitting would duplicate brittle setup. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ipcMain } from 'electron'
 import type { Store } from '../persistence'

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: these worktree path/name tests share a
-single setup-free pure-logic module, and splitting them would make the related
-edge cases harder to audit together. */
 import { posix, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {

--- a/src/main/observability/bundle.test.ts
+++ b/src/main/observability/bundle.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Why: diagnostics bundle fixtures cover collection, preview deletion, upload URL hardening, and byte caps as one contract surface. Splitting would duplicate the temp-file/server harness and make edge-case coverage harder to audit. */
 // Bundle collection + upload tests. Upload helpers live outside bundle.ts, but
 // this suite keeps the diagnostic bundle contract in one place.
 

--- a/src/main/observability/redactor.test.ts
+++ b/src/main/observability/redactor.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Why: the redactor has intentionally broad fixture coverage across every secret location and key-shape rule; keeping it together makes gaps visible. */
 // Fixture-based test suite for the redactor. Each provider-key shape is
 // exercised in three locations (attribute value, span event message,
 // exit-status `cause`) — that's the contract telemetry-error-tracking.md

--- a/src/main/opencode-usage/scanner.test.ts
+++ b/src/main/opencode-usage/scanner.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: OpenCode scanner tests cover multiple DB schema generations and attribution boundaries together so parser regressions stay auditable. */
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'

--- a/src/main/opencode/hook-service.test.ts
+++ b/src/main/opencode/hook-service.test.ts
@@ -1,8 +1,3 @@
-/* eslint-disable max-lines -- Why: this suite covers four orthogonal regimes
-   (plugin source, id guards, legacy per-PTY round-trip, and overlay mode for
-   user-set OPENCODE_CONFIG_DIR). Splitting them across files would scatter
-   tightly coupled fixtures (userData mock, hooks/overlay roots) and obscure
-   the docs/opencode-config-dir-collision.md regression matrix. */
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   existsSync,

--- a/src/main/project-groups/nested-repo-discovery.test.ts
+++ b/src/main/project-groups/nested-repo-discovery.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: nested scan behavior is intentionally covered in one
-suite so traversal order, ignore rules, cancellation, and filesystem fixtures stay aligned. */
 import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: SSH filesystem provider coverage keeps relay fallback,
-SFTP binary writes, watch fan-out, and provider lifecycle tests together so
-transport parity regressions are visible in one suite. */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { SshFilesystemProvider } from './ssh-filesystem-provider'
 import { JsonRpcErrorCode } from '../ssh/relay-protocol'

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Why: integration tests cover the full mobile subscribe lifecycle across many scenarios; splitting would scatter related assertions. */
 /**
  * Integration tests for the server-authoritative mobile subscribe lifecycle.
  * Tests handleMobileSubscribe, handleMobileUnsubscribe, applyMobileDisplayMode,

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: browser runtime command tests share one
-mocked BrowserManager/agent-browser bridge so page wake and registration
-ordering regressions stay in one boundary-focused suite. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
 import type { RuntimeBrowserCommandHost } from './orca-runtime-browser'

--- a/src/main/runtime/orchestration/coordinator.test.ts
+++ b/src/main/runtime/orchestration/coordinator.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: coordinator tests cover dispatch, DAG ordering, escalation, decision gates, concurrency, and stop — splitting by category would scatter shared setup without improving clarity. */
 import { afterEach, describe, expect, it } from 'vitest'
 import { OrchestrationDb } from './db'
 import { reconcileLifecycleMessage } from './lifecycle-reconciliation'

--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: DB tests cover messages, tasks, dispatch contexts, decision gates, coordinator runs, and lifecycle in one suite to share the createDb() helper and afterEach cleanup. */
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'

--- a/src/main/runtime/rpc/methods/files.test.ts
+++ b/src/main/runtime/rpc/methods/files.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: file RPC routing coverage stays together so
-the dispatcher contract for read, write, mutation, and watch methods is easy to audit. */
 import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: git RPC methods share one dispatcher fixture, and keeping the contract cases together makes method coverage easy to audit. */
 import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'

--- a/src/main/runtime/rpc/methods/github.test.ts
+++ b/src/main/runtime/rpc/methods/github.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: runtime GitHub RPC methods share one dispatcher suite so repo-scoped and Project-scoped contract coverage cannot drift. */
 import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'

--- a/src/main/runtime/rpc/methods/gitlab.test.ts
+++ b/src/main/runtime/rpc/methods/gitlab.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: one routing test exercises the full GitLab RPC surface so provider parity regressions show up in a single contract fixture. */
 import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Why: terminal subscribe buffering tests share a live dispatcher harness; splitting would duplicate stream setup and weaken lifecycle coverage. */
 import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from './dispatcher'
 import type { RpcRequest } from './core'

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: these tests exercise one stateful transport
-   boundary across connection lifecycle, heartbeat, pre-auth timeout, and
-   shutdown behavior; splitting the setup would obscure the shared invariants. */
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: the WebSocket transport owns connection
-   admission, heartbeat, pre-auth timeout, and client-id cleanup together; those
-   invariants are easier to audit in one transport boundary. */
 // Why: the WebSocket transport enables mobile clients to connect to the Orca
 // runtime over the local network. When TLS cert/key are provided it uses wss://
 // to prevent passive sniffing; otherwise it falls back to plain ws://. Per-device

--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: hosted review creation permutations share large mocks; splitting would hide branch-specific expectations. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {

--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -1,5 +1,3 @@
-/* oxlint-disable max-lines -- Why: keeps the mux protocol lifecycle harness
-   together across request, notification, keepalive, and disposal cases. */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { SshChannelMultiplexer, type MultiplexerTransport } from './ssh-channel-multiplexer'
 import { encodeFrame, MessageType, HEADER_LENGTH, encodeKeepAliveFrame } from './relay-protocol'

--- a/src/main/ssh/ssh-config-parser.test.ts
+++ b/src/main/ssh/ssh-config-parser.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: SSH config parsing fixtures cover OpenSSH file parsing and ssh -G output together so import and connection resolution stay aligned. */
 import { describe, expect, it, vi } from 'vitest'
 import { join } from 'node:path'
 import { parseSshConfig, sshConfigHostsToTargets, parseSshGOutput } from './ssh-config-parser'

--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: SSH connection utility tests share mocked filesystem and environment setup across auth, proxy, and retry helpers. */
 import { EventEmitter } from 'node:events'
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest'
 import { join } from 'node:path'

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -1,8 +1,3 @@
-/* eslint-disable max-lines -- Why: pinning every layer that should have
-   caught the original "node-pty not available" bug (chained shell, package
-   ordering, probe shape, channel-failure surfacing, .bashrc-noise immunity,
-   platform-tagged logs) requires keeping these scenarios in one file so the
-   shared mock connection and exec-response fixture stay aligned. */
 // Why: regression coverage for the install-probe contract. The original
 // "node-pty is not available" bug shipped because every layer that should
 // have caught it (chained shell, swallowing catch, dir-only probe) was

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: this integration spec keeps the SSH relay,
-agent-hook server, and replay/interrupt ordering fixtures together so regressions
-cover the full mux-to-main path. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Store } from '../persistence'

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: relay session tests need one shared mocked
-provider/multiplexer harness to cover establish, reconnect, detach, and dispose
-state transitions without duplicating brittle setup. */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { SshRelaySession } from './ssh-relay-session'
 import type { SshConnection } from './ssh-connection'

--- a/src/main/startup/run-electron-vite-dev.test.ts
+++ b/src/main/startup/run-electron-vite-dev.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: this integration-style wrapper suite shares
-   process cleanup and fake Electron CLI fixtures across related regressions. */
 import { existsSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines -- Why: history scoping touches shell detection, env
-injection, fallback patching, WSL translation, cleanup, and GC with a TOCTOU age
-guard — covering each path in one test file keeps assertions co-located with the
-shared mock harness rather than splitting across files. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: attachMainWindowServices centralizes main-window IPC wiring; keeping its integration-style mocks together avoids brittle cross-file setup. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
 

--- a/src/main/workspace-space-analysis.test.ts
+++ b/src/main/workspace-space-analysis.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: scan, cancellation, SSH fallback, and compaction tests share temp-repo fixtures. */
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'

--- a/src/relay/dispatcher.test.ts
+++ b/src/relay/dispatcher.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: dispatcher behavior is stateful across
-   primary, socket, timeout, and cancellation paths; keeping fixtures shared
-   makes regression tests easier to audit. */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { RelayDispatcher } from './dispatcher'
 import {

--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: this suite covers relay filesystem RPCs,
-   Space scans, file watcher lifecycle edges, and cross-platform path behavior together. */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { FsHandler } from './fs-handler'
 import { MAX_TEXT_FILE_SIZE } from './fs-handler-utils'

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable max-lines -- Why: subprocess coverage shares one bundled relay artifact; splitting this file would rebuild the same daemon bundle across suites and make these lifecycle tests slower/flakier. */
 import { afterAll, beforeAll, describe, expect, it, afterEach } from 'vitest'
 import { existsSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { rm } from 'node:fs/promises'

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: the update-card behavior is easiest to verify as one
-   lifecycle-oriented suite because the store caching and visibility rules interact directly. */
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultUIState } from '../../../shared/constants'

--- a/src/renderer/src/components/editor/editor-autosave-controller.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: autosave behavior depends on event wiring,
-   dirty drafts, remote routing, quiesce, and failure cleanup in one harness. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { createEditorSlice } from '@/store/slices/editor'

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: this onboarding step owns the full notification setup surface, including macOS guidance, sound choices, and upload controls. */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { BellRing, FileAudio, Settings, Upload } from 'lucide-react'
 import { toast } from 'sonner'

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: the dropdown priority table is easier to audit when the row-state cases live together. */
 import { describe, expect, it } from 'vitest'
 import { resolveDropdownItems, type DropdownActionInputs } from './source-control-dropdown-items'
 

--- a/src/renderer/src/components/settings/AgentsPane.test.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: Agents pane settings interactions share
-   store-backed queue fixtures that are easier to audit beside the UI helper coverage. */
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
@@ -1,6 +1,3 @@
-/* oxlint-disable max-lines -- Why: TerminalPane tests share a large mocked
-   settings harness; splitting the new Windows-shell cases would duplicate
-   brittle React/store mocks without improving coverage. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockStateValues: unknown[] = []

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: this suite shares a broad mocked sidebar
-   harness across compact/full mode, lineage, and image-note cases. */
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: this component keeps compact/full inline
-   agent rendering and lineage disclosure behavior together; splitting during
-   this bug fix would risk divergent parent-child row behavior. */
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'

--- a/src/renderer/src/components/sidebar/smart-attention.test.ts
+++ b/src/renderer/src/components/sidebar/smart-attention.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { describe, expect, it } from 'vitest'
 import {
   AGENT_STATUS_STALE_AFTER_MS,

--- a/src/renderer/src/components/sidebar/smart-sort.test.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { describe, expect, it } from 'vitest'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import {

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { describe, expect, it } from 'vitest'
 import {
   computeClearFilterActions,

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: this file co-locates tightly-coupled scenario
-   tests for the resource-usage merge function. Splitting them weakens the
-   single-source view of how snapshot + daemon-session inputs combine. */
 import { describe, expect, it } from 'vitest'
 import type { MemorySnapshot, TerminalTab, WorktreeMemory } from '../../../../shared/types'
 import { mergeSnapshotAndSessions, UNATTRIBUTED_REPO_ID } from './mergeSnapshotAndSessions'

--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -1,5 +1,3 @@
-/* oxlint-disable max-lines -- Why: keeping these mocked TabBar wiring cases
- * together avoids duplicating the lightweight renderer harness. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const appStoreSnapshot: {

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: this suite locks the interrupt inference state machine across several agent-specific keyboard semantics. */
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import {

--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -1,5 +1,3 @@
-/* oxlint-disable max-lines -- Why: this test keeps split layout replay fixtures together so
- * stable leaf-id migration regressions are visible in one focused suite. */
 import { describe, expect, it, beforeAll, vi } from 'vitest'
 import type { TerminalPaneLayoutNode } from '../../../../shared/types'
 

--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: fork flow tests share a mocked store and launch harness. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: terminal keyboard policy covers platform
- * readline compatibility, pane management, and Option-as-Alt translation in
- * one pure function; the cases need to stay adjacent. */
 import { describe, expect, it } from 'vitest'
 import {
   resolveTerminalShortcutAction,

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: dispatch guards are interdependent, so these notification liveness and unread regressions stay together with one store mock. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { dispatchTerminalNotification } from './use-notification-dispatch'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: notification edge cases share one module-scoped coordinator, so keeping setup and regression cases together prevents brittle cross-file mock resets. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 import { YOLO_TUI_AGENT_ARGS } from '../../../shared/tui-agent-permissions'

--- a/src/renderer/src/hooks/ipc-tab-switch.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: tab-switch shortcut behavior is shared by
- * renderer and IPC entry points; keeping terminal, sequential, across-type,
- * and MRU cases together makes regressions obvious. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { getStateMock, getActiveTabNavOrderMock } = vi.hoisted(() => ({

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines --
- * Why: agent title detection is intentionally table-driven in one place so the
- * supported title variants stay readable and regressions are easy to compare.
- */
 import { describe, expect, it, test, vi } from 'vitest'
 import {
   detectAgentStatusFromTitle,

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Focus, shortcut, creation, and switching cases share
- * the same floating-workspace DOM/store fixtures. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import type { Tab, TerminalTab } from '../../../shared/types'

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: local/runtime launch tests share a mock harness. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT } from '@/constants/terminal'
 import { createCompatibleRuntimeStatusResponseIfNeeded } from '@/runtime/runtime-compatibility-test-fixture'

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: runtime git routing tests share compatibility-cache and IPC stubs; splitting would hide cross-environment contract drift. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   bulkDiscardRuntimeGitPaths,

--- a/src/renderer/src/runtime/runtime-linear-client.test.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: runtime Linear routing cases stay together
-   so local preload fallback and SSH runtime transport parity are reviewed as one boundary. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   linearCreateIssue,

--- a/src/renderer/src/runtime/sync-runtime-graph-terminal-layout.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-terminal-layout.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: this file keeps terminal session publication
- * fixtures together so split-pane and split-tab parity assertions do not drift. */
 import { describe, expect, it } from 'vitest'
 import { buildMobileSessionTabSnapshots } from './sync-runtime-graph'
 import type { AppState } from '../store/types'

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: this test file owns the diff-comments
-slice's persistence, runtime routing, rollback, and compatibility behavior. */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: hosted-review tests cover runtime routing,
-hinted cache revalidation, provider discovery, and PR cache reconciliation. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'

--- a/src/renderer/src/store/slices/new-markdown.test.ts
+++ b/src/renderer/src/store/slices/new-markdown.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { describe, expect, it } from 'vitest'
 import { createEditorSlice } from './editor'

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: hydration regressions share store setup and session invariants that are easier to audit together. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))

--- a/src/renderer/src/store/slices/workspace-cleanup.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: cleanup store tests share a Zustand store
-   harness and mocked window API; splitting would obscure the state transitions. */
 import { create } from 'zustand'
 import { describe, expect, it, vi } from 'vitest'
 import type { AppState } from '../types'

--- a/src/renderer/src/web/web-runtime-client.test.ts
+++ b/src/renderer/src/web/web-runtime-client.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-lines -- Why: these tests share one mocked browser
-   WebSocket/E2EE transport fixture, and splitting them would obscure the
-   subscription lifecycle regressions they cover. */
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
 import WebSocket, { WebSocketServer } from 'ws'
 import { WebRuntimeClient } from './web-runtime-client'

--- a/src/shared/telemetry-events.test.ts
+++ b/src/shared/telemetry-events.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- Why: telemetry schema tests keep related event
-   invariants together so cross-event payload rules stay easy to audit. */
 // Schema round-trip coverage for the event map. Fail-closed invariants that
 // must hold: agent_error is enum-only (error_message / error_stack rejected
 // by `.strict()`), unknown enum values fail, and any well-formed payload

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines -- Why: this file covers every branch of the
-shortcut policy (letter chords, zoom variants, alt/shift gating, history
-navigation, new-workspace tab routing). Splitting across files would
-fragment the test of a single pure function. */
 import { describe, expect, it } from 'vitest'
 import {
   isRecentTabSwitcherCommitRelease,

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Activity E2E keeps the setup helpers beside the split-pane, split-group, and workspace-card routing assertions they support. */
 import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import {

--- a/tests/e2e/droid-notification.spec.ts
+++ b/tests/e2e/droid-notification.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: this e2e shares one Electron notification spy and hook endpoint setup across related notification regressions. */
 import { test, expect } from './helpers/orca-app'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { getRendererTitleLog, installRendererTitleLog } from './helpers/terminal-title-log'

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: onboarding E2E coverage shares one first-launch wizard fixture and step helpers; splitting this file would make the linear flow harder to audit. */
 /**
  * E2E tests for the first-launch Onboarding flow.
  *

--- a/tests/e2e/setup-guide-sidebar.spec.ts
+++ b/tests/e2e/setup-guide-sidebar.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: this regression spec keeps the deterministic IPC fakes, setup-state seeding, and frame-level flash monitor together so the flicker contract is auditable in one place. */
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import type { SkillDiscoveryResult } from '../../src/shared/skills'
 import { test, expect } from './helpers/orca-app'

--- a/tests/e2e/ssh-localhost.spec.ts
+++ b/tests/e2e/ssh-localhost.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Localhost SSH E2E covers setup, remote PTY, hook relay, and interrupt inference in one expensive app boot. */
 import os from 'node:os'
 
 import type { Page } from '@stablyai/playwright-test'

--- a/tests/e2e/terminal-output-scheduler.spec.ts
+++ b/tests/e2e/terminal-output-scheduler.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Scheduler E2E coverage shares one booted Electron app and debug API. */
 /**
  * E2E repro for terminal output bursts from many background tabs.
  *

--- a/tests/e2e/terminal-restart-persistence.spec.ts
+++ b/tests/e2e/terminal-restart-persistence.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Restart persistence E2E covers separate lifecycle regressions that need real relaunches. */
 /**
  * E2E tests for terminal scrollback persistence across clean app restarts.
  *

--- a/tests/e2e/terminal-shortcuts.spec.ts
+++ b/tests/e2e/terminal-shortcuts.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Terminal shortcut E2E keeps platform keyboard paths beside their shared PTY assertions. */
 /**
  * E2E test for terminal keyboard shortcuts.
  *


### PR DESCRIPTION
## What

Removes **110 stale `max-lines` lint disables** — files that carry an `eslint/oxlint-disable max-lines` directive but are **already under the default budget** (`.ts` 300 / `.tsx` 400 / `.mjs` 600 / `*.test/spec` 800, counted with `skipBlankLines` + `skipComments`). The suppression is dead weight: it silently opts these files out of `max-lines` coverage forever, so if one later balloons, CI won't catch it.

## Why

These came out of a repo-wide audit of files over the line limit. Of 445 files carrying a `max-lines` disable, only 352 are actually over the limit — the other **110 are removable with zero risk**. Deleting them restores real `max-lines` coverage and shrinks the suppression surface.

## Safety

- Every removed directive had **`max-lines` as its only rule** (no compound directives were touched).
- Diff is **pure deletions** (200 lines removed, 0 added) — no code changed, only the directive comments (single-line and multi-line `-- Why:` blocks).
- Verified green by a full `oxlint` run (**0 max-lines violations, 0 new errors**) and by the repo's own pre-commit `lint-staged` gate (oxlint + react-doctor + oxfmt) across all 110 files.

## Not in scope

The 352 genuinely-over-limit files (their disables are load-bearing) and the mobile `mobile/.oxlintrc.json` per-file `max` bumps. Those need real decomposition, tracked separately.

Made with [Orca](https://github.com/stablyai/orca) 🐋
