### PR TITLE
feat: add Linux system tray support

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -829,7 +829,7 @@ function quitFromSystemTray(): void {
     showMainWindowFromTray()
   }
   // Why: set the quit latch before app.quit() so the window 'close' handler
-  // proceeds to teardown instead of re-hiding to the Windows tray.
+  // proceeds to teardown instead of re-hiding to the system tray.
   isQuitting = true
   app.quit()
 }
@@ -978,8 +978,10 @@ function openMainWindow(): BrowserWindow {
   })
   recordCrashBreadcrumb('main_window_created')
   logStartupMilestone('window-created')
-  // Why: Windows Tray construction can synchronously block on Shell_NotifyIcon,
-  // so both desktop status-item platforms defer creation to after first paint.
+  // Why: new Tray() can synchronously talk to the desktop shell, so create it
+  // after first paint. The timer fallback covers windows revealed without
+  // ready-to-show ever firing; those can still be hidden to the tray on close,
+  // so the icon must exist by then.
   let trayCreated = false
   const createSystemTrayDeferred = (): void => {
     if (trayCreated || window.isDestroyed() || isQuitting || !store) {

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -311,7 +311,7 @@ export function registerAppHandlers(store: Store, options: RegisterAppHandlersOp
     // Mark shutdown first because app.exit() can bypass the usual quit latch.
     await runBeforeRelaunchCleanup(options.onBeforeRelaunch)
     setTimeout(() => {
-      // Why: app.exit(0) skips before-quit/will-quit, so clean the Windows tray
+      // Why: app.exit(0) skips before-quit/will-quit, so clean the tray
       // explicitly before relaunching to avoid a stale notification-area icon.
       destroySystemTray()
       app.relaunch()

--- a/src/main/tray/system-tray.test.ts
+++ b/src/main/tray/system-tray.test.ts
@@ -224,16 +224,33 @@ describe('createSystemTray', () => {
     expect(warn).toHaveBeenCalledWith('[system-tray] macOS menu bar icon could not be loaded')
   })
 
-  it('is idempotent and remains disabled on Linux', async () => {
+  it('is idempotent on macOS', async () => {
     setPlatform('darwin')
     const { createSystemTray } = await loadModule()
     const options = createOptions()
     expect(createSystemTray(options)).toBe(createSystemTray(options))
     expect(trayInstances).toHaveLength(1)
+  })
 
+  it('keeps the Linux icon, Open/Quit menu, and best-effort click behavior', async () => {
     setPlatform('linux')
-    const linuxModule = await loadModule()
-    expect(linuxModule.createSystemTray(options)).toBeNull()
+    const { createSystemTray } = await loadModule()
+    const options = createOptions()
+
+    createSystemTray(options)
+
+    expect(trayInstances).toHaveLength(1)
+    expect(trayInstances[0].image).toBe(resizedImage)
+    expect(trayInstances[0].setToolTip).toHaveBeenCalledWith('Orca')
+    expect(builtMenuItems().map((item) => item.label)).toEqual(['Open Orca', undefined, 'Quit'])
+    const clickHandler = trayInstances[0].on.mock.calls.find((call) => call[0] === 'click')?.[1]
+    expect(clickHandler).toBeTypeOf('function')
+
+    builtMenuItems()[0].click?.()
+    ;(clickHandler as () => void)()
+    builtMenuItems()[2].click?.()
+    expect(options.onOpen).toHaveBeenCalledTimes(2)
+    expect(options.onQuit).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/main/tray/system-tray.ts
+++ b/src/main/tray/system-tray.ts
@@ -33,8 +33,8 @@ let attentionActive = false
 
 let nativeThemeUpdatedListener: (() => void) | null = null
 
-// Why: on Windows the notification area expects a 16px icon; the app icon PNG
-// is larger, so downscale to avoid a cropped/blurry tray glyph.
+// Why: tray hosts expect a small icon; the app icon PNG is larger, so downscale
+// to avoid a cropped/blurry tray glyph.
 const TRAY_ICON_SIZE = 16
 
 // Why: centralize which image the tray shows so both creation and attention
@@ -151,11 +151,15 @@ function safeMenuAction(action: () => void): () => void {
 }
 
 /**
- * Creates the Windows notification icon or macOS menu bar status item. No-op
- * on Linux. Idempotent: repeated calls never stack duplicate icons.
+ * Creates the Windows/Linux tray icon or macOS menu bar status item.
+ * Idempotent: repeated calls never stack duplicate icons.
  */
 export function createSystemTray(opts: SystemTrayOptions): Tray | null {
-  if (process.platform !== 'win32' && process.platform !== 'darwin') {
+  if (
+    process.platform !== 'win32' &&
+    process.platform !== 'linux' &&
+    process.platform !== 'darwin'
+  ) {
     return null
   }
   if (tray && !tray.isDestroyed()) {
@@ -201,10 +205,10 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
     { label: translateMain('tray.quit', 'Quit'), click: safeMenuAction(() => opts.onQuit()) }
   ])
   tray.setContextMenu(menu)
-  if (process.platform === 'win32') {
+  if (process.platform !== 'darwin') {
     tray.setToolTip('Orca')
-    // Why: a left-click on the tray icon is the conventional Windows gesture to
-    // restore a minimized-to-tray app; macOS opens the attached menu instead.
+    // Why: Windows and Linux expose tray clicks as a best-effort restore gesture;
+    // the Open menu item remains the dependable path on Linux tray hosts.
     tray.on(
       'click',
       safeMenuAction(() => opts.onOpen())
@@ -215,7 +219,7 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
   return tray
 }
 
-/** Applies the persisted macOS visibility preference without affecting Windows. */
+/** Applies the persisted macOS visibility preference without affecting Windows or Linux. */
 export function setMacMenuBarIconVisible(visible: boolean, opts: SystemTrayOptions): Tray | null {
   if (process.platform !== 'darwin') {
     return null
@@ -231,7 +235,7 @@ export function setMacMenuBarIconVisible(visible: boolean, opts: SystemTrayOptio
  * Shows or hides a red/amber attention dot on the tray icon. Call with `true`
  * when a terminal bell or agent completion fires while the window is
  * minimized/hidden, and `false` once the window is shown again. Safe to call
- * before the tray is created or on Linux where no tray is available.
+ * before the tray is created or on an unsupported platform.
  */
 export function setTrayAttention(active: boolean): void {
   if (attentionActive === active) {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -3077,8 +3077,9 @@ describe('createMainWindow', () => {
     })
   })
 
-  describe('minimize to tray on close (win32)', () => {
+  describe('minimize to tray on close (desktop tray platforms)', () => {
     const originalPlatform = process.platform
+    const trayPlatforms = ['win32', 'linux'] as const
 
     function setPlatform(platform: NodeJS.Platform): void {
       Object.defineProperty(process, 'platform', { value: platform, configurable: true })
@@ -3139,24 +3140,44 @@ describe('createMainWindow', () => {
       setPlatform(originalPlatform)
     })
 
-    it('hides to the tray instead of closing when the setting is on', () => {
-      setPlatform('win32')
-      const { windowHandlers, webContents, instance } = setupCloseWindow()
-      const store = makeStore(true, true)
+    it.each(trayPlatforms)(
+      'hides to the tray instead of closing when the setting is on for %s',
+      (platform) => {
+        setPlatform(platform)
+        const { windowHandlers, webContents, instance } = setupCloseWindow()
+        const store = makeStore(true, true)
 
-      createMainWindow(store as never, { getIsQuitting: () => false })
-      const preventDefault = vi.fn()
-      windowHandlers.close({ preventDefault } as never)
+        createMainWindow(store as never, { getIsQuitting: () => false })
+        const preventDefault = vi.fn()
+        windowHandlers.close({ preventDefault } as never)
 
-      expect(preventDefault).toHaveBeenCalled()
-      expect(instance.hide).toHaveBeenCalledTimes(1)
-      expect(webContents.send).not.toHaveBeenCalledWith('window:close-requested', expect.anything())
-      // Notice already shown, so it must not fire again.
-      expect(notificationMock).not.toHaveBeenCalled()
-    })
+        expect(preventDefault).toHaveBeenCalled()
+        expect(instance.hide).toHaveBeenCalledTimes(1)
+        expect(webContents.send).not.toHaveBeenCalledWith(
+          'window:close-requested',
+          expect.anything()
+        )
+        // Notice already shown, so it must not fire again.
+        expect(notificationMock).not.toHaveBeenCalled()
+      }
+    )
 
     it('keeps the normal close flow when the setting is off', () => {
       setPlatform('win32')
+      const { windowHandlers, webContents, instance } = setupCloseWindow()
+      const store = makeStore(false, true)
+
+      createMainWindow(store as never, { getIsQuitting: () => false })
+      windowHandlers.close({ preventDefault: vi.fn() } as never)
+
+      expect(instance.hide).not.toHaveBeenCalled()
+      expect(webContents.send).toHaveBeenCalledWith('window:close-requested', {
+        isQuitting: false
+      })
+    })
+
+    it('keeps the normal close flow when the setting is off on Linux', () => {
+      setPlatform('linux')
       const { windowHandlers, webContents, instance } = setupCloseWindow()
       const store = makeStore(false, true)
 
@@ -3215,7 +3236,7 @@ describe('createMainWindow', () => {
       expect(store.updateUI).toHaveBeenCalledWith({ trayMinimizeNoticeShown: true })
     })
 
-    it('leaves the close handler unchanged off win32', () => {
+    it('leaves the close handler unchanged on macOS', () => {
       setPlatform('darwin')
       const { windowHandlers, webContents, instance } = setupCloseWindow()
       const store = makeStore(true, true)
@@ -3229,7 +3250,7 @@ describe('createMainWindow', () => {
       })
     })
 
-    // Why: on Windows the renderer-drawn X routes through window:request-close,
+    // Why: the renderer-drawn X routes through window:request-close,
     // not the native close event — regression guard for the bug where the app
     // quit instead of hiding because the guard only covered the native event.
     function captureIpcHandlers(): Record<string, (...args: any[]) => void> {
@@ -3241,18 +3262,24 @@ describe('createMainWindow', () => {
       return ipcHandlers
     }
 
-    it('hides to the tray when the renderer-drawn X requests close', () => {
-      setPlatform('win32')
-      const ipcHandlers = captureIpcHandlers()
-      const { webContents, instance } = setupCloseWindow()
-      const store = makeStore(true, true)
+    it.each(trayPlatforms)(
+      'hides to the tray when the renderer-drawn X requests close on %s',
+      (platform) => {
+        setPlatform(platform)
+        const ipcHandlers = captureIpcHandlers()
+        const { webContents, instance } = setupCloseWindow()
+        const store = makeStore(true, true)
 
-      createMainWindow(store as never, { getIsQuitting: () => false })
-      ipcHandlers['window:request-close']?.()
+        createMainWindow(store as never, { getIsQuitting: () => false })
+        ipcHandlers['window:request-close']?.()
 
-      expect(instance.hide).toHaveBeenCalledTimes(1)
-      expect(webContents.send).not.toHaveBeenCalledWith('window:close-requested', expect.anything())
-    })
+        expect(instance.hide).toHaveBeenCalledTimes(1)
+        expect(webContents.send).not.toHaveBeenCalledWith(
+          'window:close-requested',
+          expect.anything()
+        )
+      }
+    )
 
     it('forwards window:request-close to the renderer when the setting is off', () => {
       setPlatform('win32')

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -1024,15 +1024,14 @@ export function createMainWindow(
   let windowCloseConfirmed = false
   const confirmCloseChannel = 'window:confirm-close'
 
-  // Why: Windows minimize-to-tray. Hides the window instead of closing when the
-  // setting is on, this isn't a real quit (Ctrl+Q / tray "Quit" set
-  // getIsQuitting), and the renderer is alive. Returns true when it handled the
-  // close by hiding, so callers skip their normal close path. Shared by BOTH the
-  // renderer-drawn X (window:request-close) and the native close event (Alt+F4).
+  // Why: tray minimize hides the window instead of closing when the setting is
+  // on, this isn't a real quit (Ctrl+Q / tray "Quit" set getIsQuitting), and
+  // the renderer is alive. Shared by BOTH the renderer-drawn X
+  // (window:request-close) and the native close event (Alt+F4).
   const hideToTrayIfEnabled = (): boolean => {
     const isRendererCrashed = mainWindow.webContents.isCrashed?.() ?? false
     if (
-      process.platform !== 'win32' ||
+      (process.platform !== 'win32' && process.platform !== 'linux') ||
       rendererProcessGone ||
       isRendererCrashed ||
       opts?.getIsQuitting?.() === true ||

--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -39,7 +39,7 @@ type AppearanceInterfaceSectionProps = {
   applyTheme: (theme: 'system' | 'dark' | 'light') => void
   fontSuggestions: string[]
   isDesktopMac: boolean
-  isDesktopWindows: boolean
+  isDesktopTraySupported: boolean
   onRequestFontSuggestions?: () => void
   forceVisiblePrimary?: boolean
 }
@@ -50,7 +50,7 @@ export function AppearanceInterfaceSection({
   applyTheme,
   fontSuggestions,
   isDesktopMac,
-  isDesktopWindows,
+  isDesktopTraySupported,
   onRequestFontSuggestions,
   forceVisiblePrimary = false
 }: AppearanceInterfaceSectionProps): React.JSX.Element {
@@ -69,7 +69,7 @@ export function AppearanceInterfaceSection({
   const advancedEntries = [
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),
     ...getTitlebarEntries(),
-    ...getSystemTrayEntries({ showSystemTray: isDesktopWindows }),
+    ...getSystemTrayEntries({ showSystemTray: isDesktopTraySupported }),
     ...getMenuBarIconEntries({ showMenuBarIcon: isDesktopMac })
   ]
   const showAdvanced = !isSearching || matchesSettingsSearch(searchQuery, advancedEntries)
@@ -214,7 +214,7 @@ export function AppearanceInterfaceSection({
               />
             </SearchableSetting>
 
-            {isDesktopWindows ? (
+            {isDesktopTraySupported ? (
               <SearchableSetting
                 title={translate(
                   'auto.components.settings.AppearancePane.2edf606c46',

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -83,9 +83,9 @@ export function AppearancePane({
   )
   const isSearching = normalizeSettingsSearchQuery(searchQuery).length > 0
   const isWebClient = isWebClientLocation()
-  // Why: the system tray behavior is desktop-Electron Windows-only; a Windows
-  // browser web client has no local tray to control.
-  const isDesktopWindows = getRendererAppPlatform() === 'win32' && !isWebClient
+  // Why: system presence settings control desktop Electron surfaces; a browser
+  // client has no local tray or menu bar item to affect.
+  const isDesktopTraySupported = getRendererAppPlatform() !== 'darwin' && !isWebClient
   const isDesktopMac = getRendererAppPlatform() === 'darwin' && !isWebClient
 
   const [manuallyOpenSection, setManuallyOpenSection] = useState<AppearanceSectionKey | null>(
@@ -136,7 +136,7 @@ export function AppearancePane({
     ...getTypographyEntries(),
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),
     ...getTitlebarEntries(),
-    ...getSystemTrayEntries({ showSystemTray: isDesktopWindows }),
+    ...getSystemTrayEntries({ showSystemTray: isDesktopTraySupported }),
     ...getMenuBarIconEntries({ showMenuBarIcon: isDesktopMac })
   ]
   const terminalSearchEntries = [
@@ -211,7 +211,7 @@ export function AppearancePane({
             fontSuggestions={fontSuggestions}
             onRequestFontSuggestions={onRequestFontSuggestions}
             isDesktopMac={isDesktopMac}
-            isDesktopWindows={isDesktopWindows}
+            isDesktopTraySupported={isDesktopTraySupported}
             forceVisiblePrimary={interfaceLabelMatches}
           />
         </AppearanceSection>

--- a/src/renderer/src/components/settings/appearance-system-presence-search.ts
+++ b/src/renderer/src/components/settings/appearance-system-presence-search.ts
@@ -89,8 +89,9 @@ export function getSystemTrayEntries(
 ): SettingsSearchEntry[] {
   const show =
     options.showSystemTray ??
-    // Why: a Windows web client can report win32, but it has no local tray.
-    (getRendererAppPlatform() === 'win32' && !isWebClientLocation())
+    // Why: a browser can report a tray-capable host platform, but it has no
+    // local Electron tray to affect.
+    (getRendererAppPlatform() !== 'darwin' && !isWebClientLocation())
   return show ? getSystemTrayEntryCatalog() : []
 }
 

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -24,6 +24,22 @@ function ids(
   }).map((section) => section.id)
 }
 
+function appearanceSearchTitles(
+  args: { isMac?: boolean; isWindows?: boolean; isWebClient?: boolean; isDev?: boolean } = {}
+): string[] {
+  return (
+    buildSettingsNavigationMetadata({
+      isMac: args.isMac ?? false,
+      isWindows: args.isWindows ?? false,
+      isWebClient: args.isWebClient ?? false,
+      isDev: args.isDev ?? false,
+      repos: [repo]
+    })
+      .find((section) => section.id === 'appearance')
+      ?.searchEntries.map((entry) => entry.title) ?? []
+  )
+}
+
 describe('settings navigation metadata', () => {
   it('puts AI capability panes at the top on desktop', () => {
     expect(ids().slice(0, 10)).toEqual([
@@ -74,6 +90,13 @@ describe('settings navigation metadata', () => {
     expect(webIds).not.toContain('advanced')
     expect(webIds).toContain('servers')
     expect(webIds).toContain('repo-repo-1')
+  })
+
+  it('includes system tray search on Linux and Windows desktop only', () => {
+    expect(appearanceSearchTitles()).toContain('Minimize to Tray on Close')
+    expect(appearanceSearchTitles({ isWindows: true })).toContain('Minimize to Tray on Close')
+    expect(appearanceSearchTitles({ isMac: true })).not.toContain('Minimize to Tray on Close')
+    expect(appearanceSearchTitles({ isWebClient: true })).not.toContain('Minimize to Tray on Close')
   })
 
   it('does not mark installable AI capabilities as beta in the sidebar metadata', () => {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -382,7 +382,7 @@ export function buildSettingsNavigationMetadata({
       icon: Palette,
       searchEntries: getAppearancePaneSearchEntries({
         showWarpImport: showDesktopOnlySettings,
-        showSystemTray: showDesktopOnlySettings && isWindows,
+        showSystemTray: showDesktopOnlySettings && !isMac,
         showMenuBarIcon: showDesktopOnlySettings && isMac
       }),
       group: 'interface'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2623,9 +2623,9 @@ export type GlobalSettings = {
   terminalCursorOpacity?: number
   terminalQuickCommands?: TerminalQuickCommand[]
   windowBackgroundBlur?: boolean
-  /** Why: Windows-only. When on, the close (X) button hides the window to the
-   *  system tray instead of quitting Orca; off keeps the default quit-on-close.
-   *  The tray icon itself is always present on Windows regardless of this flag. */
+  /** Why: tray-supported desktop only. When on, the close (X) button hides the
+   *  window to the system tray instead of quitting Orca; off keeps the default quit-on-close.
+   *  The tray icon itself is always present on Windows/Linux regardless of this flag. */
   minimizeToTrayOnClose?: boolean
   /** Why: macOS keeps Orca running after its last window closes, so this
    *  controls the additive menu-bar entry without changing Dock behavior. */
@@ -3430,8 +3430,8 @@ export type PersistedUIState = {
   /** User-dismissed browser import hint in the browser toolbar. Import remains
    *  available from Settings > Browser and the toolbar overflow menu. */
   browserImportHintHidden?: boolean
-  /** Why: Windows-only. Set once after the window first hides to the system
-   *  tray, so the "Orca is still running" notification shows only on first use. */
+  /** Why: set once after the window first hides to the system tray, so the
+   *  "Orca is still running" notification shows only on first use. */
   trayMinimizeNoticeShown?: boolean
   /** User dismissed the first-run Mobile Emulator intro (Keep, Hide, or close).
    *  Reversible only by re-enabling the feature in Settings. */


### PR DESCRIPTION
## Summary

Adds Linux to the existing system tray flow.

The main behavior is unchanged on macOS and Windows. On Linux, Orca now creates the tray icon, shows the existing Open/Quit tray menu, and honors the `Minimize to Tray on Close` setting. The settings UI and settings search now expose that option on Linux desktop builds.

## Screenshots

Not attached yet. The visual change is Linux-only: the existing system tray setting is now visible in Appearance settings, and the app creates a tray icon at runtime. KDE/manual tray smoke testing is still needed for final visual/runtime confirmation.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted checks run:

- `./node_modules/.bin/vitest run --config config/vitest.config.ts src/main/tray/system-tray.test.ts src/main/window/createMainWindow.test.ts src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts src/renderer/src/components/settings/terminal-search.test.ts`
- `./node_modules/.bin/tsgo --noEmit -p config/tsconfig.node.json`
- `./node_modules/.bin/oxlint src/main/index.ts src/main/ipc/app.ts src/main/tray/system-tray.test.ts src/main/tray/system-tray.ts src/main/window/createMainWindow.test.ts src/main/window/createMainWindow.ts src/renderer/src/components/settings/AppearanceInterfaceSection.tsx src/renderer/src/components/settings/AppearancePane.tsx src/renderer/src/components/settings/appearance-search.ts src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts src/renderer/src/hooks/useSettingsNavigationMetadata.ts src/shared/types.ts`
- `git diff --check`
- `corepack pnpm run build:desktop`
- `corepack pnpm run ensure:electron-runtime && ./node_modules/.bin/electron-builder --config config/electron-builder.config.cjs --linux rpm`

## AI Review Report

Reviewed the change with the coding agent.

Main risks checked:

- Cross-platform behavior: macOS remains no-op for tray; Windows tray behavior is kept; Linux is newly enabled behind runtime platform checks.
- Electron Linux tray behavior: Linux tray activation is desktop-environment dependent, so the code keeps the Open tray-menu item as the dependable restore path. The tray click comment was updated after review so it no longer overstates Linux parity with Windows.
- KDE/Linux support: the implementation uses Electron's existing Linux Tray support and keeps the menu path available for StatusNotifierItem/AppIndicator hosts.
- Scope: no unrelated Linux packaging, titlebar, shortcut, shell, path, SSH, or provider changes were included.
- Tests: existing Windows tray/window-close coverage was parameterized for Linux, and settings search coverage now checks Linux/Windows/macOS/web visibility.

The review explicitly checked macOS, Linux, and Windows behavior for the Electron platform differences touched by this PR. This PR does not change keyboard shortcuts, shortcut labels, filesystem paths, command execution, shell behavior, or SSH flows.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or network behavior is added.

The tray menu only calls existing local app actions: restore/open the main window or quit the app. The close-to-tray behavior is still guarded by the persisted `minimizeToTrayOnClose` boolean setting and falls back to the normal close flow when the platform or runtime state is unsupported. No new IPC channel is introduced in this PR.

## Notes

Electron's Linux tray activation behavior depends on the desktop environment, so the Open tray-menu item is the dependable restore path. KDE/manual tray smoke testing is still worth doing before calling the runtime behavior fully verified.

## ELI5

Linux gets the same system tray Open/Quit flow and “Minimize to Tray on Close” option as other desktops. macOS and Windows behavior stay the same.
