### PR TITLE
[codex] Repaint terminal panes after stable observed fit

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
@@ -44,7 +44,8 @@ function createPane(
     stablePaneId: leafId,
     terminal: {
       cols: 79,
-      rows: 24
+      rows: 24,
+      refresh: vi.fn()
     } as never,
     container: { dataset: {} } as never,
     xtermContainer: {
@@ -122,6 +123,30 @@ describe('attachPaneFitResizeObserver', () => {
     expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
   })
 
+  it('repaints the terminal after a stable observed fit', () => {
+    const webglAddon = { clearTextureAtlas: vi.fn() }
+    const pane = createPane()
+    pane.webglAddon = webglAddon as never
+
+    attachPaneFitResizeObserver(pane)
+    mockResizeObservers[0]?.trigger()
+    flushAnimationFrames()
+
+    expect(webglAddon.clearTextureAtlas).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('refreshes DOM-rendered terminals after a stable observed fit', () => {
+    const pane = createPane()
+
+    attachPaneFitResizeObserver(pane)
+    mockResizeObservers[0]?.trigger()
+    flushAnimationFrames()
+
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
   it('waits through a transient grid wobble before fitting', () => {
     const proposed = [
       { cols: 80, rows: 24 },
@@ -172,6 +197,7 @@ describe('attachPaneFitResizeObserver', () => {
 
     expect(pane.fitAddon.fit).not.toHaveBeenCalled()
     expect(onSettled).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
   })
 
   it('skips observer fits while the terminal has no visible geometry', () => {

--- a/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.ts
@@ -1,5 +1,6 @@
 import type { ManagedPane, ManagedPaneInternal } from './pane-manager-types'
 import { safeFit } from './pane-tree-ops'
+import { resetWebglTextureAtlas } from './pane-webgl-renderer'
 
 type ProposedDimensions = {
   cols: number
@@ -78,6 +79,11 @@ function finishStableFit(pane: StableFitPane, shouldFit: boolean): void {
   setPendingObservedFitRafId(pane, null)
   if (shouldFit) {
     safeFit(pane)
+    // Why: a stable ResizeObserver fit can resize the terminal without going
+    // through tab/window reveal recovery. Repaint from the buffer after fit so
+    // WebGL and DOM renderers do not keep compositing stale cells or blank
+    // canvas regions until the next user-driven redraw.
+    resetWebglTextureAtlas(pane)
   }
   flushStableFitCallbacks(pane)
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -1,5 +1,5 @@
 import { WebglAddon } from '@xterm/addon-webgl'
-import type { ManagedPaneInternal } from './pane-manager-types'
+import type { ManagedPane, ManagedPaneInternal } from './pane-manager-types'
 import {
   getTerminalWebglAutoDecision,
   resetTerminalWebglAutoDecision
@@ -24,6 +24,9 @@ type XtermWebglAddonInternals = {
     _canvas?: HTMLCanvasElement
   }
 }
+
+type TerminalRepaintPane = ManagedPane &
+  Partial<Pick<ManagedPaneInternal, 'webglAddon' | 'webglDisabledAfterContextLoss'>>
 
 export function resetTerminalWebglSuggestion(): void {
   // Why: toggling GPU settings should let "auto" retry WebGL after an earlier
@@ -117,7 +120,7 @@ export function markComplexScriptOutput(pane: ManagedPaneInternal): void {
   pane.hasComplexScriptOutput = true
 }
 
-export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
+export function resetWebglTextureAtlas(pane: TerminalRepaintPane): void {
   if (pane.webglDisabledAfterContextLoss) {
     return
   }


### PR DESCRIPTION
## Summary

- repaint a pane from its terminal buffer after a coalesced stable ResizeObserver fit
- reuse the existing WebGL atlas reset helper so WebGL and DOM-rendered panes both refresh
- narrow the repaint helper input type to the pane shape it actually needs, avoiding a full-internal-pane cast in the stable-fit path
- add regression coverage for WebGL repaint, DOM-rendered terminal refresh, and the already-matching-grid no-refresh path

## Why

Terminal reveal/window-wake recovery already clears the WebGL atlas after layout settles, but stable pane fits from ResizeObserver can happen outside that recovery path. When a terminal pane is resized after multiple sessions/panes are visible, the renderer can keep compositing stale cells or blank canvas regions until the next user-driven redraw.

This keeps the fix scoped to the existing stable-fit path rather than repainting on every raw ResizeObserver callback or every global synchronous fit.

Refs https://github.com/stablyai/orca/issues/7550
Related: https://github.com/stablyai/orca/issues/5345, https://github.com/stablyai/orca/issues/7240

## Validation

- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-fit-resize-observer.ts src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/pane-manager/pane-fit-resize-observer.ts src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-column-desync-repro.spec.ts --config tests/playwright.config.ts --project electron-headless -g 'PTY columns stay in sync with xterm across a visible resize'`

## Notes

I did not attach the original screenshot because it contains private local workspace details.

I also tried the `terminal-tab-switch-visual-restore` e2e smoke locally, but that Playwright process exited with SIGTERM before assertions. I am not treating that run as passing evidence.
