### PR TITLE
perf(main): bound authorized-external-path set with LRU eviction

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -8,8 +8,11 @@ import type * as RepoWorktrees from '../repo-worktrees'
 import { listRepoWorktrees } from '../repo-worktrees'
 import type { FolderWorkspace, GitWorktreeInfo, ProjectGroup, Repo } from '../../shared/types'
 import {
+  AUTHORIZED_EXTERNAL_PATHS_MAX,
+  authorizeExternalPath,
   invalidateAuthorizedRootsCache,
   isDescendantOrEqual,
+  isPathAllowed,
   rebuildAuthorizedRootsCache,
   resolveAuthorizedPath,
   resolveRegisteredWorktreePath,
@@ -334,5 +337,44 @@ describe('filesystem-auth path containment', () => {
       vi.doUnmock('../repo-worktrees')
       vi.resetModules()
     }
+  })
+})
+
+describe('filesystem-auth authorized external path bound', () => {
+  // Empty allow-list store, so a path is allowed only if it (or an ancestor) is
+  // in the session-authorized external-path set.
+  const emptyStore = makeStore([])
+  const flood = (n: number): string =>
+    resolve(`/leak-audit-ext/flood-${String(n).padStart(6, '0')}`)
+
+  it('bounds the authorized external path set with LRU eviction', () => {
+    const keep = resolve('/leak-audit-ext/keep')
+    authorizeExternalPath(keep)
+
+    // Flood past the cap with distinct external paths, re-authorizing `keep`
+    // periodically so LRU keeps it hot.
+    const total = AUTHORIZED_EXTERNAL_PATHS_MAX + 200
+    for (let i = 0; i < total; i += 1) {
+      authorizeExternalPath(flood(i))
+      if (i % 250 === 0) {
+        authorizeExternalPath(keep)
+      }
+    }
+
+    // The oldest never-re-touched entries fell out of the bounded set...
+    expect(isPathAllowed(flood(0), emptyStore)).toBe(false)
+    // ...while the periodically re-authorized path and the most recent survive.
+    expect(isPathAllowed(keep, emptyStore)).toBe(true)
+    expect(isPathAllowed(flood(total - 1), emptyStore)).toBe(true)
+  })
+
+  it('re-authorizes an evicted path on next use (self-healing)', () => {
+    const path = resolve('/leak-audit-ext/evicted-then-reused')
+    for (let i = 0; i < AUTHORIZED_EXTERNAL_PATHS_MAX + 50; i += 1) {
+      authorizeExternalPath(flood(100_000 + i))
+    }
+    expect(isPathAllowed(path, emptyStore)).toBe(false)
+    authorizeExternalPath(path)
+    expect(isPathAllowed(path, emptyStore)).toBe(true)
   })
 })

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -13,6 +13,14 @@ import type { FolderWorkspace, ProjectGroup, Repo } from '../../shared/types'
 
 export const PATH_ACCESS_DENIED_MESSAGE =
   'Access denied: path resolves outside allowed directories. If this blocks a legitimate workflow, please file a GitHub issue.'
+// Why: authorized external paths accumulate for the whole session (file drops,
+// terminal link opens, editor/composer/notebook opens). Bound the set with LRU
+// eviction — mirrors rememberUnwatchableRoot in filesystem-watcher.ts — so a long
+// session touching many distinct external files cannot grow it (or the O(n) auth
+// scan in isPathAllowed) without limit. Every caller re-authorizes a path right
+// before operating on it, so evicting a stale entry is self-healing and does not
+// weaken the security boundary.
+export const AUTHORIZED_EXTERNAL_PATHS_MAX = 4096
 const authorizedExternalPaths = new Set<string>()
 const registeredWorktreeRoots = new Set<string>()
 const registeredWorktreeRootsByRepo = new Map<string, Set<string>>()
@@ -23,12 +31,26 @@ const AUTHORIZED_ROOTS_REBUILD_CONCURRENCY = 8
 type FolderScopeStore = Pick<Store, 'getRepos'> &
   Partial<Pick<Store, 'getProjectGroups' | 'getFolderWorkspaces'>>
 
+function rememberAuthorizedExternalPath(path: string): void {
+  // Delete-then-add keeps re-authorized (actively used) paths most-recent so
+  // eviction only sheds the oldest never-re-touched entries.
+  authorizedExternalPaths.delete(path)
+  authorizedExternalPaths.add(path)
+  while (authorizedExternalPaths.size > AUTHORIZED_EXTERNAL_PATHS_MAX) {
+    const oldest = authorizedExternalPaths.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    authorizedExternalPaths.delete(oldest)
+  }
+}
+
 export function authorizeExternalPath(targetPath: string): void {
   const resolvedTarget = resolve(targetPath)
-  authorizedExternalPaths.add(resolvedTarget)
+  rememberAuthorizedExternalPath(resolvedTarget)
   try {
     // Why: macOS canonicalizes /tmp to /private/tmp during read authorization.
-    authorizedExternalPaths.add(realpathSync(resolvedTarget))
+    rememberAuthorizedExternalPath(realpathSync(resolvedTarget))
   } catch {}
 }
 


### PR DESCRIPTION
Part of a full-codebase memory-leak audit. Each PR fixes one never-purged, per-entity-accumulating structure. All are low-severity but genuine unbounded growth.

## Description
`authorizeExternalPath()` records session grants for file paths **outside** registered repo/worktree roots into a module-level `Set<string>` (`authorizedExternalPaths`). Entries were only ever **added** — there is no `.delete`/`.clear`/reset anywhere for this Set. Every other cache in the same file (`registeredWorktreeRoots`, `registeredWorktreeRootsByRepo`, `registeredWorktreeRootRepoIds`) is cleared on invalidation, but this one was left untouched, so it grows for the entire main-process session and its entries survive worktree/repo removal.

This bounds the set at **4096** entries with delete-then-add LRU eviction, mirroring the existing `rememberUnwatchableRoot` helper in `filesystem-watcher.ts`.

## Evidence
- `src/main/ipc/filesystem-auth.ts`: `authorizeExternalPath()` did `authorizedExternalPaths.add(resolvedTarget)` + `.add(realpathSync(...))` (1–2 entries per distinct external path) with no eviction path anywhere in the repo.
- Growth driver: the renderer fires `fs:authorizeExternalPath` on file drops (`useGlobalFileDrop`), terminal file-link opens (`terminal-file-open-routing`), editor/composer/notebook opens, sidebar drops, and per-imported-source; each distinct path permanently adds 1–2 entries.
- Secondary cost: `isPathAllowed()` linearly scans the whole Set on every filesystem auth check, so growth also degrades every external-path check to O(n).
- The verifier confirmed no cleanup exists and that the identical FIFO-cap pattern already lives one file over (`filesystem-watcher.ts:42`, `UNWATCHABLE_ROOT_CACHE_MAX = 256`), i.e. this Set was overlooked, not deliberately unbounded.

## Proof of fix
New tests in `filesystem-auth.test.ts`:
- Flooding past the cap (with periodic re-authorization of one path) evicts the oldest never-re-touched entry, keeps the re-authorized path and the most-recent entry. ✅
- An evicted path becomes allowed again the next time it is authorized (self-healing). ✅

```
Test Files  1 passed (1)
      Tests  15 passed (15)
```
Typecheck (`tsconfig.node.json`) and oxlint clean.

## ELI5
The app keeps a list of "extra files you're allowed to touch this session." Every new external file you opened got added to that list forever — the list only grew. Now the list is capped: it remembers your most recent ~4096 and forgets the oldest ones you haven't touched in ages. If you open a forgotten file again, it's simply re-added on the spot.

## Trade-offs
- **User-facing behavior:** none in normal use. The cap (4096) is far above realistic session usage, and eviction only ever drops the oldest *never-re-touched* paths. Because every caller re-authorizes a path immediately before operating on it, a re-touched path is re-added transparently — no denied operation, no prompt.
- **Security boundary:** unchanged. The set only ever *grants*; evicting an entry can never widen access, and the re-authorize-before-use contract means it can't wrongly deny either.
- **Regression risk:** the only way to observe a difference is a pathological session that authorizes >4096 distinct external directories and then relies on descendant-matching to reach a child of an evicted directory *without* re-opening it — astronomically unlikely, and even then the next explicit open re-authorizes it. Target: 0 regression.

Made with [Orca](https://github.com/stablyai/orca) 🐋
