### PR TITLE
perf(main): drop localhost label routes when a worktree is removed

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -103,6 +103,7 @@ type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
 }
 import { classifyWorkspaceCreateError } from './workspace-create-error-classifier'
 import { advertisedUrlWatcher } from '../ports/advertised-url-watcher'
+import { localhostWorktreeLabelProxy } from '../localhost-worktree-label-proxy'
 import {
   assertWorktreeDoesNotContainRegisteredWorktree,
   canCleanupUnregisteredOrcaLeftoverDirectory,
@@ -161,6 +162,9 @@ function removeWorktreeMetadataAndTransientState(store: Store, worktreeId: strin
   // drop process-local caches before the same ID can point at a new workspace.
   store.removeWorktreeMeta(worktreeId)
   advertisedUrlWatcher.forgetWorktree(worktreeId)
+  // Why: drop this worktree's localhost label routes so they don't accumulate
+  // in the proxy's route maps for the rest of the session.
+  localhostWorktreeLabelProxy.unregisterWorktree(worktreeId)
   deleteWorktreeHistoryDir(worktreeId)
   // Why: release the removed worktree's PR-refresh aliases so coalesced queue
   // entries do not retain it for the rest of the session (memory creep).

--- a/src/main/localhost-worktree-label-proxy.test.ts
+++ b/src/main/localhost-worktree-label-proxy.test.ts
@@ -124,4 +124,33 @@ describe('localhost worktree label proxy', () => {
 
     expect(result.status).toBe(404)
   })
+
+  it('drops a worktree label routes on unregisterWorktree, leaving others intact', async () => {
+    const port = await startUpstream((_request, response) => {
+      response.writeHead(200, { 'content-type': 'text/plain' })
+      response.end('ok')
+    })
+    const proxy = new LocalhostWorktreeLabelProxy()
+    const a = await proxy.registerRoute({
+      targetUrl: `http://localhost:${port}/`,
+      projectName: 'Snap Studio',
+      worktreeName: 'feature-a',
+      worktreeId: 'wt-a'
+    })
+    const b = await proxy.registerRoute({
+      targetUrl: `http://localhost:${port}/`,
+      projectName: 'Snap Studio',
+      worktreeName: 'feature-b',
+      worktreeId: 'wt-b'
+    })
+
+    expect((await fetchThroughProxy(a.url)).status).toBe(200)
+    expect((await fetchThroughProxy(b.url)).status).toBe(200)
+
+    proxy.unregisterWorktree('wt-a')
+
+    // The removed worktree's label no longer routes; the other worktree is unaffected.
+    expect((await fetchThroughProxy(a.url)).status).toBe(404)
+    expect((await fetchThroughProxy(b.url)).status).toBe(200)
+  })
 })

--- a/src/main/localhost-worktree-label-proxy.ts
+++ b/src/main/localhost-worktree-label-proxy.ts
@@ -49,6 +49,18 @@ export class LocalhostWorktreeLabelProxy {
     }
   }
 
+  // Why: routes are added per (worktreeId, targetUrl) but were never removed, so
+  // labels for deleted worktrees accumulated in both maps for the whole session.
+  // Drop them when the worktree is torn down. The shared http.Server stays up.
+  unregisterWorktree(worktreeId: string): void {
+    for (const [label, route] of this.routes) {
+      if (route.worktreeId === worktreeId) {
+        this.routes.delete(label)
+        this.routeKeys.delete(route.routeKey)
+      }
+    }
+  }
+
   private async ensureServer(): Promise<void> {
     if (this.server && this.listenPort !== null) {
       return


### PR DESCRIPTION
Part of a full-codebase memory-leak audit — one never-purged per-entity structure per PR.

## Description
The `localhostWorktreeLabelProxy` singleton (used by the opt-in "labeled localhost" feature that gives a dev server a stable `*.orca.localhost` hostname) keeps two module-level `Map`s: `routes` (label → route) and `routeKeys` (routeKey → label). `registerRoute()` was the only mutator — it only ever `.set()`s. There was **no** removal method on the class, and no worktree-teardown path touched the singleton, so a label route for a deleted worktree (or a since-changed dev-server port) survived in both maps for the entire app session.

Fix: add `unregisterWorktree(worktreeId)` and call it from `removeWorktreeMetadataAndTransientState()` — the single per-worktree main-process teardown function (8 call sites, right next to the existing `advertisedUrlWatcher.forgetWorktree(...)`).

## Evidence
- `src/main/localhost-worktree-label-proxy.ts`: `routes`/`routeKeys` mutated only via `.set()` in `registerRoute` (lines 44–45); grep of the whole class/file showed no `delete`/`clear`/unregister.
- The only IPC surface (`ipc/localhost-worktree-labels.ts`) exposed `register` → `registerRoute` with no unregister counterpart.
- Route key is `worktree:{worktreeId}:{targetUrl}` (`shared/localhost-worktree-labels.ts`), unique per worktree+URL, so a new worktree or a changed port permanently adds 2 entries that outlive worktree teardown.
- Growth driver (with the off-by-default `localhostWorktreeLabelsEnabled` setting on): opening a labeled loopback dev-server link for a not-yet-seen worktree/port; creating and removing many worktrees over a long session accumulates entries.

## Proof of fix
New test in `localhost-worktree-label-proxy.test.ts`: register routes for `wt-a` and `wt-b`, confirm both proxy through (200); `unregisterWorktree('wt-a')`; then `wt-a`'s label returns **404** while `wt-b` still returns **200**.

```
Test Files  1 passed (1)
      Tests  5 passed (5)
```
Typecheck (`tsconfig.node.json`) + oxlint clean.

## ELI5
When you open a dev server with a friendly name, the app remembers "this friendly name points to that server." It remembered forever, even after you deleted the workspace that owned it. Now, when a workspace is removed, its friendly-name entries are thrown away too. The little name-forwarding server itself keeps running for everyone else.

## Trade-offs
- **User-facing behavior:** none. Removing a worktree already tears down its terminals, browser tabs, ports, and PR aliases; its labeled-localhost routes are dead the moment the worktree is gone, so dropping them changes nothing a user can observe.
- **Feature gating:** the labeled-localhost feature is off by default; this path is a no-op when there are no routes for the worktree.
- **Scope:** only routes whose `worktreeId` matches the removed worktree are dropped; routes registered without a `worktreeId` (legacy repo/project-name keys) are untouched — the renderer always supplies `worktreeId`. Target: 0 regression.

Made with [Orca](https://github.com/stablyai/orca) 🐋
