### PR TITLE
perf(renderer): gate the jump palette's status-map subscriptions while closed

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1,5 +1,6 @@
 /* oxlint-disable max-lines */
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import {
@@ -14,6 +15,7 @@ import {
 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { getRepoMapFromState, useAllWorktrees } from '@/store/selectors'
+import { selectPaletteStatusInputs } from './worktree-jump-palette-status-inputs'
 import {
   CommandDialog,
   CommandInput,
@@ -193,6 +195,10 @@ type PaletteListEntry = PaletteItem | CreateWorktreePaletteItem | SectionHeader 
 
 const CREATE_WORKSPACE_QUICK_ACTION_ITEM_ID = `quick-action:${CREATE_WORKSPACE_QUICK_ACTION_ID}`
 
+// Why: comfortably outlast the CommandDialog close animation (~150–200ms) so the
+// gated status maps stay live until the fading rows are gone from the DOM.
+const PALETTE_STATUS_INPUTS_LINGER_MS = 300
+
 function getComposerPrefetchRepoId(
   state: ReturnType<typeof useAppStore.getState>,
   initialRepoId?: string
@@ -337,21 +343,44 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const projectHostSetups = useAppStore((s) => s.projectHostSetups)
   const detectedWorktreesByRepo = useAppStore((s) => s.detectedWorktreesByRepo)
   const pendingWorktreeCreations = useAppStore((s) => s.pendingWorktreeCreations)
-  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  // Why: getWorktreeStatus needs per-pane titles so split-pane tabs with a
-  // working agent in a non-focused pane still surface as 'working' in the
-  // jump palette. Without this, clicking between panes would desync the
-  // palette's spinner from the sidebar's spinner.
-  const runtimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
-  // Why: ptyIdsByTabId is the live-pty source of truth — without it,
-  // getWorktreeStatus would treat slept tabs as live (their preserved
-  // tab.ptyId is a wake-hint sessionId, not a liveness signal) and the jump
-  // palette dot would lie green even though the sidebar dot is correctly grey.
-  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
-  const terminalLayoutsByTabId = useAppStore((s) => s.terminalLayoutsByTabId)
+  // Why: keep the (very hot) status maps subscribed through the dialog's close
+  // animation. `visible` flips false synchronously on close, but the CommandDialog
+  // content stays mounted while it fades/zooms out — dropping the maps to empty
+  // there would flash the switcher rows empty/reordered mid-animation. Linger a
+  // beat past close, then let the gate drop the subscription.
+  const [statusInputsLingering, setStatusInputsLingering] = useState(false)
+  useEffect(() => {
+    if (visible) {
+      setStatusInputsLingering(true)
+      return
+    }
+    const timer = window.setTimeout(
+      () => setStatusInputsLingering(false),
+      PALETTE_STATUS_INPUTS_LINGER_MS
+    )
+    return () => window.clearTimeout(timer)
+  }, [visible])
+  // Why: these five status maps drive per-worktree live/working dots and the
+  // switcher sort, but only matter while the palette is active. Two of them
+  // (agentStatusByPaneKey, runtimePaneTitlesByTabId) get a new identity on every
+  // agent-status / pane-title write app-wide, so subscribing to them while the
+  // always-mounted palette is closed re-rendered it on unrelated terminals. Gate
+  // the subscription on active-or-still-closing: a shared frozen constant while
+  // inactive keeps useShallow referentially equal across the churn, and the live
+  // maps flow through the instant the palette opens.
+  // - runtimePaneTitlesByTabId: split-pane tabs with a working agent in a
+  //   non-focused pane still surface as 'working' (matches the sidebar spinner).
+  // - ptyIdsByTabId: the live-pty source of truth — slept tabs keep a wake-hint
+  //   sessionId in tab.ptyId, so without it the palette dot would lie green.
+  const {
+    agentStatusByPaneKey,
+    runtimePaneTitlesByTabId,
+    ptyIdsByTabId,
+    terminalLayoutsByTabId,
+    tabsByWorktree
+  } = useAppStore(useShallow((s) => selectPaletteStatusInputs(s, visible || statusInputsLingering)))
   const prCache = useAppStore((s) => s.prCache)
   const issueCache = useAppStore((s) => s.issueCache)
-  const agentStatusByPaneKey = useAppStore((s) => s.agentStatusByPaneKey)
   const migrationUnsupportedByPtyId = useAppStore((s) => s.migrationUnsupportedByPtyId)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const activeTabType = useAppStore((s) => s.activeTabType)

--- a/src/renderer/src/components/worktree-jump-palette-status-inputs.test.ts
+++ b/src/renderer/src/components/worktree-jump-palette-status-inputs.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { shallow } from 'zustand/shallow'
+import {
+  EMPTY_PALETTE_STATUS_INPUTS,
+  selectPaletteStatusInputs,
+  type PaletteStatusInputsState
+} from './worktree-jump-palette-status-inputs'
+
+const BASE: PaletteStatusInputsState = {
+  agentStatusByPaneKey: {},
+  runtimePaneTitlesByTabId: {},
+  ptyIdsByTabId: {},
+  terminalLayoutsByTabId: {},
+  tabsByWorktree: {}
+}
+
+describe('selectPaletteStatusInputs', () => {
+  it('returns the shared frozen constant while inactive', () => {
+    const inactive = selectPaletteStatusInputs(BASE, false)
+    expect(inactive).toBe(EMPTY_PALETTE_STATUS_INPUTS)
+
+    // Churning the hottest maps while inactive must NOT change the selected
+    // reference, so a useShallow subscription skips the re-render.
+    const churned: PaletteStatusInputsState = {
+      ...BASE,
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: 'claude' } },
+      agentStatusByPaneKey: { 'tab-1:leaf-1': {} as never }
+    }
+    const afterChurn = selectPaletteStatusInputs(churned, false)
+    expect(afterChurn).toBe(EMPTY_PALETTE_STATUS_INPUTS)
+    expect(shallow(inactive, afterChurn)).toBe(true)
+  })
+
+  it('exposes the live maps the instant it becomes active', () => {
+    const titles = { 'tab-1': { 0: 'claude' } }
+    const state: PaletteStatusInputsState = { ...BASE, runtimePaneTitlesByTabId: titles }
+    const active = selectPaletteStatusInputs(state, true)
+    // Live map references pass straight through so status/sort derive correctly.
+    expect(active.runtimePaneTitlesByTabId).toBe(titles)
+    expect(active).not.toBe(EMPTY_PALETTE_STATUS_INPUTS)
+  })
+
+  it('keeps the live maps during the close linger (active stays true while animating)', () => {
+    // The component holds `active` true through the close animation, so churn is
+    // still reflected — no empty-row flash while the dialog fades out.
+    const titles = { 'tab-1': { 0: 'claude' } }
+    const closing = selectPaletteStatusInputs({ ...BASE, runtimePaneTitlesByTabId: titles }, true)
+    expect(closing.runtimePaneTitlesByTabId).toBe(titles)
+  })
+
+  it('shallow-changes only when a subscribed map reference actually changes while active', () => {
+    const titles = { 'tab-1': { 0: 'claude' } }
+    const s1: PaletteStatusInputsState = { ...BASE, runtimePaneTitlesByTabId: titles }
+    const r1 = selectPaletteStatusInputs(s1, true)
+
+    // Same underlying map refs -> shallow-equal -> no re-render.
+    expect(shallow(r1, selectPaletteStatusInputs(s1, true))).toBe(true)
+
+    // A real pane-title write replaces the map ref -> shallow-unequal -> the
+    // open palette re-derives status/order, exactly as before this change.
+    const s2: PaletteStatusInputsState = {
+      ...s1,
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: 'codex' } }
+    }
+    expect(shallow(r1, selectPaletteStatusInputs(s2, true))).toBe(false)
+  })
+})

--- a/src/renderer/src/components/worktree-jump-palette-status-inputs.ts
+++ b/src/renderer/src/components/worktree-jump-palette-status-inputs.ts
@@ -1,0 +1,56 @@
+import type { AppState } from '@/store/types'
+
+export type PaletteStatusInputsState = Pick<
+  AppState,
+  | 'agentStatusByPaneKey'
+  | 'runtimePaneTitlesByTabId'
+  | 'ptyIdsByTabId'
+  | 'terminalLayoutsByTabId'
+  | 'tabsByWorktree'
+>
+
+export type PaletteStatusInputs = PaletteStatusInputsState
+
+// Why: shared frozen bundle returned whenever the Cmd+J jump palette isn't
+// active. The two hottest maps here — agentStatusByPaneKey and
+// runtimePaneTitlesByTabId — get a new top-level identity on every agent-status
+// transition and every terminal pane-title write app-wide. The palette is always
+// mounted (App.tsx renders <CommandDialog open={visible}>) and stays mounted for
+// the whole session once opened, so subscribing to them while it's closed
+// re-rendered the whole palette — and recomputed its per-worktree live/working-dot
+// sort over every worktree — on unrelated terminal chatter. A useShallow
+// subscription keeps this same reference across that churn, so the closed palette
+// stops reacting. Frozen so the shared singleton can't be mutated.
+export const EMPTY_PALETTE_STATUS_INPUTS: PaletteStatusInputs = Object.freeze({
+  agentStatusByPaneKey: {},
+  runtimePaneTitlesByTabId: {},
+  ptyIdsByTabId: {},
+  terminalLayoutsByTabId: {},
+  tabsByWorktree: {}
+})
+
+/**
+ * Select the five status maps the jump palette needs to derive per-worktree
+ * live/working dots and switcher ordering — but only while it's `active` (open,
+ * or still animating closed). While inactive nothing is shown, so return a stable
+ * frozen constant that a `useShallow`-wrapped subscription keeps referentially
+ * equal across the (very hot) agent-status / pane-title writes, skipping the
+ * re-render that would otherwise fire on the always-mounted palette on every
+ * unrelated terminal. The instant it becomes active the live maps flow through
+ * and every derivation recomputes exactly as before.
+ */
+export function selectPaletteStatusInputs(
+  s: PaletteStatusInputsState,
+  active: boolean
+): PaletteStatusInputs {
+  if (!active) {
+    return EMPTY_PALETTE_STATUS_INPUTS
+  }
+  return {
+    agentStatusByPaneKey: s.agentStatusByPaneKey,
+    runtimePaneTitlesByTabId: s.runtimePaneTitlesByTabId,
+    ptyIdsByTabId: s.ptyIdsByTabId,
+    terminalLayoutsByTabId: s.terminalLayoutsByTabId,
+    tabsByWorktree: s.tabsByWorktree
+  }
+}


### PR DESCRIPTION
Follow-up scan for more #7545-class wins — always-mounted renderer components that subscribe to hot store maps they only need under a narrow condition. Independently surfaced by two finders and adversarially verified (churn confirmed, always-mounted confirmed, gate sound); this was the **highest-value** survivor.

## 1. Description
`WorktreeJumpPalette` (Cmd+J) is **always mounted** — `App.tsx` renders `<CommandDialog open={visible}>`, and once opened it stays mounted for the rest of the session. It opened **five** whole-map Zustand subscriptions:

```
agentStatusByPaneKey, runtimePaneTitlesByTabId, ptyIdsByTabId,
terminalLayoutsByTabId, tabsByWorktree
```

Those five feed **only** the palette's row derivations — `sortWorktreesSmart` over *every* worktree, `isInactiveWorkspace` filtering, `buildSearchableWorkspaceTabs`, and the `getWorktreeStatus` dots — all consumed only inside the open dialog. But two of them, `runtimePaneTitlesByTabId` and `agentStatusByPaneKey`, get their top-level reference replaced on **every terminal pane-title escape sequence and every agent-status transition** — the two hottest maps in the app. So while the palette was closed (virtually always), every such write re-rendered the whole palette and recomputed its per-worktree status sort over the full worktree list.

Fix (same shape as #7545): collapse the five subscriptions into one `useShallow` selector (`selectPaletteStatusInputs`, extracted to `worktree-jump-palette-status-inputs.ts`) that returns a **shared frozen constant** while the palette isn't active. Idle palettes then stay referentially equal across the title/status churn and stop re-rendering; the live maps flow through the instant it opens (same render — `visible` derives from the same store snapshot, so there's no stale first frame).

**Close-animation safety:** `visible` flips false synchronously on close, but the `CommandDialog` content stays mounted while it fades/zooms out. A naive gate would flash the rows empty/reordered mid-animation, so a small `statusInputsLingering` latch keeps the maps live for 300ms past close (comfortably beyond the ~150–200ms animation), after which the gate drops the subscription.

## 2. Undeniable evidence + measurable improvement
- **Deterministic unit proof** (`worktree-jump-palette-status-inputs.test.ts`, red→green — the honest, non-flaky evidence): the selector returns the *same* `EMPTY_PALETTE_STATUS_INPUTS` reference even after `runtimePaneTitlesByTabId`/`agentStatusByPaneKey` churn while inactive (→ `useShallow` skips the render); exposes the live maps the instant it becomes active; keeps them live during the close linger; and shallow-changes **only** when a subscribed map ref actually changes while active (so the open palette re-derives exactly as before).
- **Behavioral preservation**: existing `WorktreeJumpPalette` tests pass unchanged; typecheck + oxlint + react-doctor clean.
- **Metric**: renders-per-unrelated-title/status-write for the closed palette drops from **1 → 0**, and it no longer recomputes a whole-worktree-list status sort on that churn.

## 3. ELI5
The Cmd+J switcher was quietly listening to every terminal in the app renaming its tab or flipping agent status — and redrawing its whole list each time — even while it was closed and invisible. Now it ignores all that chatter until you actually open it (and keeps listening just long enough to fade out cleanly).

## 4. Trade-offs that regress the end experience
None material. The five maps drive only the palette's own rows, which are shown only while it's open; the linger removes the one theoretical close-animation flash. `migrationUnsupportedByPtyId` (identity-preserving on the status path) and every non-status subscription are left exactly as they were.

Made with [Orca](https://github.com/stablyai/orca) 🐋
