### PR TITLE
perf(renderer): project TabBar's agent-status subscription to stable agent types

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -59,6 +59,12 @@ vi.mock('react', async () => {
   }
 })
 
+// The headless React mock above stubs hooks, so zustand's useShallow (which
+// calls useRef) has no dispatcher; make it a pass-through like the store mock.
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (selector: unknown) => selector
+}))
+
 vi.mock('lucide-react', () => ({
   FilePlus: function FilePlus() {
     return null

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -4,6 +4,7 @@
  * branches share little beyond drag data, so consolidating them would cost
  * more clarity than the ~5 lines of bloat is worth. */
 import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { SortableContext } from '@dnd-kit/sortable'
 import {
   ChevronLeft,
@@ -78,7 +79,7 @@ import { useTabStripOverflowNavigation } from './tab-strip-overflow-navigation'
 import { useTabStripDragScrollHandlers } from './tab-strip-drag-scroll'
 import { shouldShowWindowsShellMenu } from './windows-shell-menu-visibility'
 import { canToggleNativeChat } from '../native-chat/native-chat-availability'
-import { findTabAgentEntry } from '../native-chat/native-chat-tab-agent-entry'
+import { selectTabAgentTypesByTabId } from './tab-agent-types-by-tab-id'
 import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
 
 const isWindows = navigator.userAgent.includes('Windows')
@@ -454,7 +455,13 @@ function TabBarInner({
   // eligible when it launched an agent or has a live agent-status entry on any of
   // its panes (paneKey = `${unifiedTabId}:…`), mirroring the toggle button's gate.
   const toggleTabViewMode = useAppStore((s) => s.toggleTabViewMode)
-  const agentStatusByPaneKey = useAppStore((s) => s.agentStatusByPaneKey)
+  // Why: the strip only needs each tab's stable agent identity, but the whole
+  // agentStatusByPaneKey map churns on every working↔idle transition app-wide.
+  // Select a shallow-stable { tabId: agentType } projection so the strip
+  // re-renders only when a tab gains/loses/changes its agent, not on status flips.
+  const tabAgentTypesByTabId = useAppStore(
+    useShallow((s) => selectTabAgentTypesByTabId(s.agentStatusByPaneKey ?? {}))
+  )
   const nativeChatEnabled = useAppStore((s) => s.settings?.experimentalNativeChat === true)
 
   // Why: Electron <webview> elements run in a separate process, so clicking
@@ -1108,8 +1115,7 @@ function TabBarInner({
                 // Key the live-agent lookup by the backing terminal tab id —
                 // agent-status pane keys are `${terminalTab.id}:${leafId}`, and
                 // the unified tab id can differ from it.
-                const detectedAgent =
-                  findTabAgentEntry(agentStatusByPaneKey ?? {}, terminalTab.id)?.agentType ?? null
+                const detectedAgent = tabAgentTypesByTabId[terminalTab.id] ?? null
                 const canToggleViewMode =
                   unifiedTabForItem !== undefined &&
                   canToggleNativeChat({

--- a/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
@@ -123,6 +123,12 @@ vi.mock('react', async () => {
   }
 })
 
+// The headless React mock above stubs hooks, so zustand's useShallow (which
+// calls useRef) has no dispatcher; make it a pass-through like the store mock.
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (selector: unknown) => selector
+}))
+
 vi.mock('lucide-react', () => ({
   FilePlus: function FilePlus() {
     return null

--- a/src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { shallow } from 'zustand/shallow'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { findTabAgentEntry } from '../native-chat/native-chat-tab-agent-entry'
+import { selectTabAgentTypesByTabId } from './tab-agent-types-by-tab-id'
+
+function entry(partial: Partial<AgentStatusEntry>): AgentStatusEntry {
+  return { state: 'working', updatedAt: 0, ...partial } as AgentStatusEntry
+}
+
+describe('selectTabAgentTypesByTabId', () => {
+  it('maps each tab to its first pane agent type, matching findTabAgentEntry', () => {
+    const map: Record<string, AgentStatusEntry> = {
+      'tab-1:leaf-a': entry({ agentType: 'claude' }),
+      'tab-1:leaf-b': entry({ agentType: 'codex' }),
+      'tab-2:leaf-a': entry({ agentType: 'codex' })
+    }
+    const projection = selectTabAgentTypesByTabId(map)
+    expect(projection).toEqual({ 'tab-1': 'claude', 'tab-2': 'codex' })
+
+    // Parity with the lookup it replaces, for every tab.
+    for (const tabId of ['tab-1', 'tab-2', 'tab-missing']) {
+      expect(projection[tabId] ?? null).toBe(findTabAgentEntry(map, tabId)?.agentType ?? null)
+    }
+  })
+
+  it('a first pane without an agentType yields null even if a later pane has one', () => {
+    const map: Record<string, AgentStatusEntry> = {
+      'tab-1:leaf-a': entry({ agentType: undefined }),
+      'tab-1:leaf-b': entry({ agentType: 'claude' })
+    }
+    // First matching pane wins (claims the tab) with no agentType -> null, exactly
+    // like findTabAgentEntry(...)?.agentType ?? null.
+    expect(selectTabAgentTypesByTabId(map)['tab-1'] ?? null).toBe(
+      findTabAgentEntry(map, 'tab-1')?.agentType ?? null
+    )
+  })
+
+  it('stays shallow-equal across a working<->idle status flip (no re-render)', () => {
+    const working: Record<string, AgentStatusEntry> = {
+      'tab-1:leaf-a': entry({ agentType: 'claude', state: 'working' })
+    }
+    // A status write replaces the entry object but not the agentType.
+    const done: Record<string, AgentStatusEntry> = {
+      'tab-1:leaf-a': entry({ agentType: 'claude', state: 'done' })
+    }
+    expect(shallow(selectTabAgentTypesByTabId(working), selectTabAgentTypesByTabId(done))).toBe(
+      true
+    )
+  })
+
+  it('shallow-changes when a tab gains or changes its agent', () => {
+    const before = selectTabAgentTypesByTabId({
+      'tab-1:leaf-a': entry({ agentType: 'claude' })
+    })
+    const gained = selectTabAgentTypesByTabId({
+      'tab-1:leaf-a': entry({ agentType: 'claude' }),
+      'tab-2:leaf-a': entry({ agentType: 'codex' })
+    })
+    expect(shallow(before, gained)).toBe(false)
+  })
+
+  it('ignores malformed pane keys with no tab id', () => {
+    expect(selectTabAgentTypesByTabId({ ':leaf-a': entry({ agentType: 'claude' }) })).toEqual({})
+  })
+})

--- a/src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.ts
@@ -1,0 +1,41 @@
+import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
+
+/**
+ * Project `agentStatusByPaneKey` down to the stable `{ terminalTabId: agentType }`
+ * the tab strip actually reads (to gate the native-chat view-mode toggle).
+ *
+ * Why: agent-status pane keys are `${terminalTab.id}:${leafId}` and the tab strip
+ * only needs each tab's agent *identity* — which is fixed for the life of the
+ * agent. The full `agentStatusByPaneKey` map, however, gets a new top-level
+ * identity on every working↔idle status transition app-wide, so subscribing to it
+ * whole re-rendered every mounted tab strip on unrelated status churn. Selecting
+ * this projection under `useShallow` keeps the result referentially equal across
+ * those transitions, so the strip re-renders only when a tab actually gains, loses,
+ * or changes its agent.
+ *
+ * First matching pane per tab wins, mirroring `findTabAgentEntry` exactly (tab ids
+ * are colon-free by construction, so the substring before the first `:` is the
+ * tab id). A pane whose entry has no `agentType` still claims the tab and yields
+ * `null`, identical to `findTabAgentEntry(...)?.agentType ?? null`.
+ */
+export function selectTabAgentTypesByTabId(
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+): Record<string, AgentType> {
+  const byTabId: Record<string, AgentType> = {}
+  const claimed = new Set<string>()
+  for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
+    const colon = paneKey.indexOf(':')
+    if (colon <= 0) {
+      continue
+    }
+    const tabId = paneKey.slice(0, colon)
+    if (claimed.has(tabId)) {
+      continue
+    }
+    claimed.add(tabId)
+    if (entry.agentType != null) {
+      byTabId[tabId] = entry.agentType
+    }
+  }
+  return byTabId
+}


### PR DESCRIPTION
Follow-up scan for more #7545-class wins — components that re-render on a hot store map they only read a *stable* slice of. Independently surfaced by two finders and adversarially verified; the verifier explicitly endorsed this shallow-projection fix over the narrower gate the finder first proposed, because it eliminates the churn regardless of the native-chat flag.

## 1. Description
`TabBar` (the tab strip) is mounted once per tab group — `TabGroupPanel`, the titlebar fallback in `Terminal`, and each `FloatingTerminalPanel` — so several instances can be live at once. It subscribed to the whole `agentStatusByPaneKey` map:

```ts
const agentStatusByPaneKey = useAppStore((s) => s.agentStatusByPaneKey)
```

but its **only** use is one lookup per rendered tab: `findTabAgentEntry(agentStatusByPaneKey, tab.id)?.agentType` — the tab's agent *identity*, used to gate the native-chat view-mode toggle. `agentStatusByPaneKey` gets a new top-level reference on **every agent-status write app-wide** (working↔idle↔waiting↔done), so every mounted strip re-rendered on every status flip anywhere — even though `agentType` is fixed for the life of the agent and none of those flips change it.

Fix (same family as #7545): subscribe to a **stable `{ tabId: agentType }` projection** via `useShallow` (`selectTabAgentTypesByTabId`, extracted to `tab-agent-types-by-tab-id.ts`) instead of the raw map. Because agent identity is stable across status transitions, the projection is shallow-equal across them, so the strip re-renders only when a tab actually **gains, loses, or changes** its agent — not on every status flip.

The projection reproduces `findTabAgentEntry` exactly: first pane (in `Object.entries` order) whose key starts with `` `${tabId}:` `` wins; a first pane without an `agentType` claims the tab and yields `null` even if a later pane has one; tab ids are colon-free by construction, so the substring before the first `:` is the tab id.

## 2. Undeniable evidence + measurable improvement
- **Deterministic unit proof** (`tab-agent-types-by-tab-id.test.ts`, red→green): asserts parity with `findTabAgentEntry` for present/missing/first-wins tabs, and — the crux — that the projection is **shallow-equal across a working↔idle flip** (no re-render) but shallow-changes when a tab gains/changes its agent.
- **Behavioral preservation**: all existing `TabBar` suites pass (175 tab-bar tests green). The two headless-render tests that mock React's hooks gain a one-line `vi.mock('zustand/react/shallow')` pass-through, matching the existing convention in `ReviewNotesSendMenuContent.test.tsx`.
- **Metric**: renders-per-agent-status-flip for every mounted tab strip drops from **1 → 0** (re-renders now fire only on the rare agent-identity change).

## 3. ELI5
Every tab strip was redrawing itself each time *any* agent anywhere flipped between "working" and "idle", just to re-check which kind of agent each tab holds — a fact that never actually changes while the agent runs. Now it only redraws when a tab genuinely gets or swaps its agent.

## 4. Trade-offs that regress the end experience
None. The native-chat toggle gate reads the same `agentType` it did before, now via a lookup that's provably identical to `findTabAgentEntry`. `agentStatusEpoch` and every other subscription are untouched.

Made with [Orca](https://github.com/stablyai/orca) 🐋
