### PR TITLE
perf(renderer): gate CodexRestartChip's store subscriptions on restart-notice existence

### DIFF
--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAppStore } from '../store'
+import { selectCodexRestartInputs } from './codex-restart-chip-inputs'
 import { translate } from '@/i18n/i18n'
 import { shouldFocusMobileDriverAction } from './terminal-pane/mobile-driver-overlay-focus'
 import {
@@ -73,8 +75,14 @@ export default function CodexRestartChip({
   worktreeId: string
 }): React.JSX.Element | null {
   const tabs = useAppStore((s) => s.tabsByWorktree[worktreeId] ?? EMPTY_TABS)
-  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
-  const codexRestartNoticeByPtyId = useAppStore((s) => s.codexRestartNoticeByPtyId)
+  // Why: both of these maps churn on unrelated pty lifecycle events (ptyIdsByTabId
+  // on attach/detach; codexRestartNoticeByPtyId is re-spread even when empty on
+  // pty teardown), so subscribe to them only while a restart notice actually
+  // exists. Otherwise this per-worktree chip re-rendered on every pty event to
+  // compute "no notice → render nothing". See codex-restart-chip-inputs.
+  const { ptyIdsByTabId, codexRestartNoticeByPtyId } = useAppStore(
+    useShallow(selectCodexRestartInputs)
+  )
   const staleWorktreePtyIds = useMemo(
     () =>
       collectStalePtyIdsForTabs({

--- a/src/renderer/src/components/codex-restart-chip-inputs.test.ts
+++ b/src/renderer/src/components/codex-restart-chip-inputs.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { shallow } from 'zustand/shallow'
+import {
+  EMPTY_CODEX_RESTART_INPUTS,
+  selectCodexRestartInputs,
+  type CodexRestartInputsState
+} from './codex-restart-chip-inputs'
+
+describe('selectCodexRestartInputs', () => {
+  it('returns the frozen empty bundle while no restart notice exists', () => {
+    const state: CodexRestartInputsState = {
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      codexRestartNoticeByPtyId: {}
+    }
+    expect(selectCodexRestartInputs(state)).toBe(EMPTY_CODEX_RESTART_INPUTS)
+
+    // Churning EITHER map while no notice exists must NOT change the selected
+    // reference, so a useShallow subscription skips the re-render. This covers
+    // the pty-teardown path that re-spreads codexRestartNoticeByPtyId even empty.
+    const churnedPty: CodexRestartInputsState = {
+      ...state,
+      ptyIdsByTabId: { 'tab-1': ['pty-2'], 'tab-2': ['pty-3'] }
+    }
+    const churnedNotice: CodexRestartInputsState = {
+      ptyIdsByTabId: state.ptyIdsByTabId,
+      codexRestartNoticeByPtyId: {} // fresh empty object, same as a teardown re-spread
+    }
+    expect(selectCodexRestartInputs(churnedPty)).toBe(EMPTY_CODEX_RESTART_INPUTS)
+    expect(selectCodexRestartInputs(churnedNotice)).toBe(EMPTY_CODEX_RESTART_INPUTS)
+    expect(shallow(selectCodexRestartInputs(state), selectCodexRestartInputs(churnedNotice))).toBe(
+      true
+    )
+  })
+
+  it('exposes both live maps the instant a restart notice exists', () => {
+    const ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+    const codexRestartNoticeByPtyId = { 'pty-1': {} as never }
+    const state: CodexRestartInputsState = { ptyIdsByTabId, codexRestartNoticeByPtyId }
+    const selected = selectCodexRestartInputs(state)
+    // Live references pass straight through so the stale-pty memo + notice lookup derive fully.
+    expect(selected.ptyIdsByTabId).toBe(ptyIdsByTabId)
+    expect(selected.codexRestartNoticeByPtyId).toBe(codexRestartNoticeByPtyId)
+    expect(selected).not.toBe(EMPTY_CODEX_RESTART_INPUTS)
+  })
+
+  it('shallow-changes only when a live map reference changes while a notice exists', () => {
+    const ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+    const s1: CodexRestartInputsState = {
+      ptyIdsByTabId,
+      codexRestartNoticeByPtyId: { 'pty-1': {} as never }
+    }
+    const r1 = selectCodexRestartInputs(s1)
+    expect(shallow(r1, selectCodexRestartInputs(s1))).toBe(true)
+
+    const s2: CodexRestartInputsState = { ...s1, ptyIdsByTabId: { 'tab-1': ['pty-9'] } }
+    expect(shallow(r1, selectCodexRestartInputs(s2))).toBe(false)
+  })
+})

--- a/src/renderer/src/components/codex-restart-chip-inputs.ts
+++ b/src/renderer/src/components/codex-restart-chip-inputs.ts
@@ -1,0 +1,37 @@
+import type { AppState } from '@/store/types'
+
+export type CodexRestartInputsState = Pick<AppState, 'ptyIdsByTabId' | 'codexRestartNoticeByPtyId'>
+
+export type CodexRestartInputs = CodexRestartInputsState
+
+// Why: shared frozen bundle returned while no Codex restart notice exists — the
+// overwhelmingly common case. CodexRestartChip is mounted once per worktree
+// Terminal (visible AND hidden-measurable) and once per split group, and reads
+// these two maps only to find panes carrying a restart notice, which appear only
+// on a Codex account switch. BOTH churn on unrelated pty lifecycle:
+// ptyIdsByTabId gets a fresh identity on every pty register/attach/detach, and
+// codexRestartNoticeByPtyId is re-spread into a new object even when empty on the
+// pty exit/teardown path (terminals.ts clearTabPtyId). Subscribing to either
+// re-rendered every mounted chip on that churn. Gate both behind notice-existence
+// so idle chips keep the same reference and stop reacting; behavior is identical
+// (no notice -> [] stale ids -> null render). Frozen so the singleton can't be
+// mutated.
+export const EMPTY_CODEX_RESTART_INPUTS: CodexRestartInputs = Object.freeze({
+  ptyIdsByTabId: {},
+  codexRestartNoticeByPtyId: {}
+})
+
+/**
+ * Expose the pty and restart-notice maps to the chip only while at least one
+ * Codex restart notice is live; otherwise return a stable frozen bundle so a
+ * `useShallow` subscription skips re-renders on unrelated pty-lifecycle churn.
+ */
+export function selectCodexRestartInputs(s: CodexRestartInputsState): CodexRestartInputs {
+  if (Object.keys(s.codexRestartNoticeByPtyId).length === 0) {
+    return EMPTY_CODEX_RESTART_INPUTS
+  }
+  return {
+    ptyIdsByTabId: s.ptyIdsByTabId,
+    codexRestartNoticeByPtyId: s.codexRestartNoticeByPtyId
+  }
+}


### PR DESCRIPTION
Follow-up scan for more #7545-class wins. Adversarially verified as a genuine, behavior-preserving win, then an independent review caught a partial-win gap (a sibling subscription still churned) which this final version closes. Honestly **low magnitude** (the wasted re-render resolves to a `null` render), so it's a small, clean, standalone PR you can weigh on its own.

## 1. Description
`CodexRestartChip` is mounted once per worktree `Terminal` (visible *and* hidden-measurable) and once per split group, so many instances can be live. It subscribed to two whole maps — `ptyIdsByTabId` and `codexRestartNoticeByPtyId` — to find panes in **this** worktree carrying a Codex restart notice. Those notices are created only on a **Codex account switch** (rare), so in the common case there are none and the component renders `null`.

Both subscriptions churn on unrelated pty lifecycle:
- `ptyIdsByTabId` gets a new top-level reference on every pty register / attach / detach.
- `codexRestartNoticeByPtyId` is re-spread into a **new object even when empty** on the pty exit/teardown path (`clearTabPtyId` in `terminals.ts`).

So every mounted chip re-rendered (and recomputed its stale-pty `useMemo`) on all that churn just to compute "no notice → render nothing".

Fix (same shape as #7545): one `useShallow` selector (`selectCodexRestartInputs`) returns a **shared frozen bundle** of both maps unless at least one restart notice exists, and the live maps only when one does. Idle chips then stay referentially equal across pty churn — on both the attach *and* the teardown paths — and stop re-rendering; the live maps flow through the instant a notice appears so Restart/Dismiss keep working.

## 2. Undeniable evidence + measurable improvement
- **Deterministic unit proof** (`codex-restart-chip-inputs.test.ts`, red→green): with no notice the selector returns the *same* `EMPTY_CODEX_RESTART_INPUTS` reference even after **either** map churns — explicitly covering the pty-teardown re-spread of the notice map; the instant a notice exists it exposes both live maps; and it shallow-changes only when a live map ref actually changes while a notice is open.
- **Behavioral preservation**: identical output in the common path — no notice → `collectStalePtyIdsForTabs(tabs, {}, {})` → `[]` → `null`, exactly as before. Existing `CodexRestartChip` tests pass; typecheck + oxlint clean.
- **Metric**: renders-per-pty-lifecycle-event (attach **and** detach/teardown) for every mounted chip drops from **1 → 0** whenever no Codex restart notice is outstanding (i.e. almost always).

## 3. ELI5
Each worktree had a hidden "your Codex account changed — restart?" chip that woke up and recomputed every time *any* terminal anywhere started, stopped, or moved — even though it only has anything to show in the rare moment right after you switch Codex accounts. Now it stays fully asleep until such a notice actually exists.

## 4. Trade-offs that regress the end experience
None — the `null`-render path is byte-for-byte identical, and both live maps are restored the moment a notice exists (including notices on other worktrees, kept conservative on purpose so cross-worktree behavior is unchanged). The per-worktree `tabsByWorktree[worktreeId]` subscription is untouched.

Made with [Orca](https://github.com/stablyai/orca) 🐋
