### PR TITLE
perf(renderer): purge sparse-preset maps when a repo is removed

### DIFF
--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -49,6 +49,7 @@ import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
 import { reconcileFetchedRepos } from './repo-identity-reconcile'
 import { splitRepoReorderByHost } from './repo-reorder-host-split'
+import { omitSparsePresetsForRepos } from './sparse-presets'
 import {
   findRepoForHost,
   getRepoHostIdentity,
@@ -2251,7 +2252,14 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           repo && !projectHostSetups.some((setup) => setup.projectId === result.project.id)
             ? s.projects.filter((project) => project.id !== result.project.id)
             : s.projects
-        return { repos, projects, projectHostSetups }
+        const survivingRepoIds = new Set(repos.map((r) => r.id))
+        const removedRepoIds = s.repos.filter((r) => !survivingRepoIds.has(r.id)).map((r) => r.id)
+        return {
+          repos,
+          projects,
+          projectHostSetups,
+          ...omitSparsePresetsForRepos(s, removedRepoIds)
+        }
       })
       return { ...result, repo }
     } catch (err) {
@@ -2516,8 +2524,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
             delete nextLastVisitedAtByWorktreeId[id]
           }
         }
+        const survivingRepoIds = new Set(nextRepos.map((r) => r.id))
+        const removedRepoIds = s.repos.filter((r) => !survivingRepoIds.has(r.id)).map((r) => r.id)
         return {
           repos: nextRepos,
+          // Why: drop the removed repos' sparse-preset maps so they don't outlive
+          // the repo for the renderer's whole session.
+          ...omitSparsePresetsForRepos(s, removedRepoIds),
           ...mergeProjectCompatibilityForHostRepoChange({
             previous: { projects: s.projects, projectHostSetups: s.projectHostSetups },
             nextRepos,

--- a/src/renderer/src/store/slices/sparse-presets-repo-removal-purge-leak.test.ts
+++ b/src/renderer/src/store/slices/sparse-presets-repo-removal-purge-leak.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Memory-leak regression: removing a repo must purge its sparse-preset maps.
+ *
+ * The four per-repo maps (`sparsePresetsByRepo`, `sparsePresetsLoadingByRepo`,
+ * `sparsePresetsLoadStatusByRepo`, `sparsePresetsErrorByRepo`) are populated
+ * lazily by `fetchSparsePresets` but were never pruned when a repo was removed,
+ * so orphaned entries accumulated for the renderer's whole session. repoIds are
+ * random UUIDs (never reused), so re-adding a repo cannot reclaim the old keys.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createTestStore, makeWorktree } from './store-test-helpers'
+import type { Repo, SparsePreset } from '../../../../shared/types'
+
+const repo1: Repo = { id: 'repo-1', path: '/r1', displayName: 'R1', badgeColor: '#000', addedAt: 1 }
+const repo2: Repo = { id: 'repo-2', path: '/r2', displayName: 'R2', badgeColor: '#111', addedAt: 2 }
+
+const reposRemove = vi.fn().mockResolvedValue(undefined)
+
+beforeEach(() => {
+  reposRemove.mockReset().mockResolvedValue(undefined)
+  vi.stubGlobal('window', {
+    api: {
+      repos: { remove: reposRemove },
+      pty: { kill: vi.fn() },
+      runtimeEnvironments: { call: vi.fn() }
+    }
+  })
+})
+
+function preset(id: string, repoId: string): SparsePreset {
+  return { id, repoId, name: id, directories: ['src'], createdAt: 1, updatedAt: 1 }
+}
+
+function seed(store: ReturnType<typeof createTestStore>): void {
+  store.setState({
+    repos: [repo1, repo2],
+    worktreesByRepo: {
+      [repo1.id]: [makeWorktree({ id: 'repo-1::/r1/wt1', repoId: repo1.id, path: '/r1/wt1' })],
+      [repo2.id]: [makeWorktree({ id: 'repo-2::/r2/wt1', repoId: repo2.id, path: '/r2/wt1' })]
+    },
+    sparsePresetsByRepo: {
+      [repo1.id]: [preset('p1', repo1.id)],
+      [repo2.id]: [preset('p2', repo2.id)]
+    },
+    sparsePresetsLoadingByRepo: { [repo1.id]: false, [repo2.id]: false },
+    sparsePresetsLoadStatusByRepo: { [repo1.id]: 'loaded', [repo2.id]: 'loaded' },
+    sparsePresetsErrorByRepo: { [repo1.id]: 'stale', [repo2.id]: 'boom' }
+  })
+}
+
+describe('removeProject purges the removed repo sparse-preset maps (leak regression)', () => {
+  it('drops all four sparse-preset maps for the removed repo, keeps the surviving repo', async () => {
+    const store = createTestStore()
+    seed(store)
+
+    await store.getState().removeProject(repo1.id)
+
+    const s = store.getState()
+    // Removed repo: every sparse-preset map key is gone.
+    expect(repo1.id in s.sparsePresetsByRepo).toBe(false)
+    expect(repo1.id in s.sparsePresetsLoadingByRepo).toBe(false)
+    expect(repo1.id in s.sparsePresetsLoadStatusByRepo).toBe(false)
+    expect(repo1.id in s.sparsePresetsErrorByRepo).toBe(false)
+    // Surviving repo: retained (guard over-eviction).
+    expect(s.sparsePresetsByRepo[repo2.id]).toEqual([preset('p2', repo2.id)])
+    expect(s.sparsePresetsLoadingByRepo[repo2.id]).toBe(false)
+    expect(s.sparsePresetsLoadStatusByRepo[repo2.id]).toBe('loaded')
+    expect(s.sparsePresetsErrorByRepo[repo2.id]).toBe('boom')
+  })
+})

--- a/src/renderer/src/store/slices/sparse-presets.ts
+++ b/src/renderer/src/store/slices/sparse-presets.ts
@@ -26,6 +26,58 @@ export type SparsePresetsSlice = {
   removeSparsePreset: (args: { repoId: string; presetId: string }) => Promise<void>
 }
 
+type SparsePresetsMaps = Pick<
+  AppState,
+  | 'sparsePresetsByRepo'
+  | 'sparsePresetsLoadingByRepo'
+  | 'sparsePresetsLoadStatusByRepo'
+  | 'sparsePresetsErrorByRepo'
+>
+
+// Why: the four per-repo sparse-preset maps are populated lazily per repo but
+// were never pruned when a repo was removed, so orphaned entries accumulated for
+// the renderer's whole session. Call this from the repo-removal reducers to drop
+// entries for repos that no longer exist. Returns only the maps that changed so
+// unrelated selectors don't re-run.
+export function omitSparsePresetsForRepos(
+  s: SparsePresetsMaps,
+  removedRepoIds: Iterable<string>
+): Partial<AppState> {
+  const removed = removedRepoIds instanceof Set ? removedRepoIds : new Set(removedRepoIds)
+  if (removed.size === 0) {
+    return {}
+  }
+  const omit = <T>(obj: Record<string, T>): Record<string, T> => {
+    let changed = false
+    const out = { ...obj }
+    for (const id of removed) {
+      if (id in out) {
+        delete out[id]
+        changed = true
+      }
+    }
+    return changed ? out : obj
+  }
+  const result: Partial<AppState> = {}
+  const byRepo = omit(s.sparsePresetsByRepo)
+  if (byRepo !== s.sparsePresetsByRepo) {
+    result.sparsePresetsByRepo = byRepo
+  }
+  const loading = omit(s.sparsePresetsLoadingByRepo)
+  if (loading !== s.sparsePresetsLoadingByRepo) {
+    result.sparsePresetsLoadingByRepo = loading
+  }
+  const status = omit(s.sparsePresetsLoadStatusByRepo)
+  if (status !== s.sparsePresetsLoadStatusByRepo) {
+    result.sparsePresetsLoadStatusByRepo = status
+  }
+  const error = omit(s.sparsePresetsErrorByRepo)
+  if (error !== s.sparsePresetsErrorByRepo) {
+    result.sparsePresetsErrorByRepo = error
+  }
+  return result
+}
+
 export const createSparsePresetsSlice: StateCreator<AppState, [], [], SparsePresetsSlice> = (
   set,
   get


### PR DESCRIPTION
Part of a full-codebase memory-leak audit — one never-purged per-entity structure per PR.

## Description
The sparse-preset feature keeps four per-repo maps in the store — `sparsePresetsByRepo`, `sparsePresetsLoadingByRepo`, `sparsePresetsLoadStatusByRepo`, `sparsePresetsErrorByRepo` — populated lazily by `fetchSparsePresets(repoId)`. None of the repo-removal reducers pruned them, so an entry for every touched-then-removed repo lingered for the renderer's whole session.

Fix: add `omitSparsePresetsForRepos(state, removedRepoIds)` and call it from both repo-removal reducers (`removeProject` and `deleteProjectHostSetup`).

## Evidence
- `store/slices/sparse-presets.ts`: the four maps are only ever written per repoId; the slice has no removal reducer.
- `store/slices/repos.ts`: `removeProject` (`nextRepos = s.repos.filter(...)`) and `deleteProjectHostSetup` shrink `s.repos` but left the sparse-preset maps untouched, unlike the ~30 worktree-scoped maps they already purge.
- repoIds are random UUIDs (never reused), so re-adding the same repo cannot reclaim the orphaned keys.

## Proof of fix
New test `sparse-presets-repo-removal-purge-leak.test.ts` seeds all four maps for two repos, drives the real `removeProject` reducer, and asserts every map key is gone for the removed repo and intact for the surviving one.

```
Test Files  3 passed (3)   ← incl. existing sparse-presets + repo-purge suites
      Tests  12 passed (12)
```
Typecheck (web) + oxlint clean.

## ELI5
Each project could remember a few "sparse checkout presets." When you deleted a project, the app forgot the project but kept its preset notes forever. Now deleting a project also throws away its preset notes — and only that project's, leaving other projects' notes alone.

## Trade-offs
- **User-facing behavior:** none. The entries belong to a repo that's been removed; there's no UI that reads presets for a non-existent repo.
- **Host-duplicate safety:** eviction is scoped to repo ids with **no surviving entry** (`survivingRepoIds`), so removing a repo id on one host while a duplicate id remains on another host keeps the presets. Mirrors the existing `repoIdFullyRemoved` logic in the same reducer.
- **Selector churn:** the helper returns only the maps that actually changed, so unrelated selectors don't re-run. Target: 0 regression.

Made with [Orca](https://github.com/stablyai/orca) 🐋
