### PR TITLE
perf(renderer): LRU-bound the native-chat composer scope caches

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-composer-scope-cache.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-scope-cache.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import {
+  NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX,
+  setBoundedScopeCacheEntry
+} from './native-chat-composer-scope-cache'
+
+describe('setBoundedScopeCacheEntry', () => {
+  it('bounds the cache with LRU eviction, keeping re-set keys', () => {
+    const cache = new Map<string, number>()
+    setBoundedScopeCacheEntry(cache, 'keep', 1)
+
+    const total = NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX + 20
+    for (let i = 0; i < total; i += 1) {
+      setBoundedScopeCacheEntry(cache, `scope-${i}`, i)
+      if (i % 10 === 0) {
+        setBoundedScopeCacheEntry(cache, 'keep', 1)
+      }
+    }
+
+    expect(cache.size).toBe(NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX)
+    expect(cache.has('scope-0')).toBe(false) // oldest untouched entry evicted
+    expect(cache.has('keep')).toBe(true) // periodically re-set → retained
+    expect(cache.has(`scope-${total - 1}`)).toBe(true) // most recent retained
+  })
+
+  it('moves a re-set key to most-recent and updates its value', () => {
+    const cache = new Map<string, number>()
+    setBoundedScopeCacheEntry(cache, 'a', 1)
+    setBoundedScopeCacheEntry(cache, 'b', 2)
+    setBoundedScopeCacheEntry(cache, 'a', 3)
+
+    expect([...cache.keys()]).toEqual(['b', 'a'])
+    expect(cache.get('a')).toBe(3)
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-composer-scope-cache.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-scope-cache.ts
@@ -1,0 +1,24 @@
+// Shared LRU bound for the native-chat composer's per-scope caches (draft text
+// and image attachments), both keyed by `targetPtyId ?? terminalTabId`. The
+// caches exist so an in-progress message survives the composer unmounting on a
+// TUI/GUI toggle, but a scope key for a permanently-removed pane is never
+// revisited, so without a bound its unsent entry would linger for the renderer's
+// whole session. delete-then-set keeps the actively-edited scope most-recent so
+// eviction only sheds the oldest untouched scopes.
+export const NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX = 128
+
+export function setBoundedScopeCacheEntry<T>(
+  cache: Map<string, T>,
+  scopeKey: string,
+  value: T
+): void {
+  cache.delete(scopeKey)
+  cache.set(scopeKey, value)
+  while (cache.size > NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX) {
+    const oldest = cache.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    cache.delete(oldest)
+  }
+}

--- a/src/renderer/src/components/native-chat/native-chat-draft-cache.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-draft-cache.test.ts
@@ -4,6 +4,7 @@ import {
   readNativeChatDraftCache,
   writeNativeChatDraftCache
 } from './native-chat-draft-cache'
+import { NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX } from './native-chat-composer-scope-cache'
 
 afterEach(() => {
   clearNativeChatDraftCacheForTests()
@@ -25,5 +26,22 @@ describe('native-chat draft cache', () => {
     writeNativeChatDraftCache('pty-1', 'hello')
     writeNativeChatDraftCache('pty-1', '')
     expect(readNativeChatDraftCache('pty-1')).toBe('')
+  })
+
+  it('bounds the cache so unsent drafts for removed panes cannot accumulate', () => {
+    writeNativeChatDraftCache('keep', 'hot')
+
+    const total = NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX + 40
+    for (let i = 0; i < total; i += 1) {
+      writeNativeChatDraftCache(`scope-${i}`, `draft-${i}`)
+      if (i % 20 === 0) {
+        writeNativeChatDraftCache('keep', 'hot')
+      }
+    }
+
+    // Oldest untouched draft evicted; the actively-edited and most-recent survive.
+    expect(readNativeChatDraftCache('scope-0')).toBe('')
+    expect(readNativeChatDraftCache('keep')).toBe('hot')
+    expect(readNativeChatDraftCache(`scope-${total - 1}`)).toBe(`draft-${total - 1}`)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-draft-cache.ts
+++ b/src/renderer/src/components/native-chat/native-chat-draft-cache.ts
@@ -4,6 +4,8 @@
 // the typed-but-unsent draft would be lost on every TUI/GUI round-trip. Mirrors
 // the attachment cache so both halves of an unsent message survive the toggle.
 
+import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+
 const draftCache = new Map<string, string>()
 
 export function readNativeChatDraftCache(scopeKey: string): string {
@@ -17,7 +19,8 @@ export function writeNativeChatDraftCache(scopeKey: string, draft: string): void
     draftCache.delete(scopeKey)
     return
   }
-  draftCache.set(scopeKey, draft)
+  // LRU-bounded so unsent drafts for permanently-removed panes can't accumulate.
+  setBoundedScopeCacheEntry(draftCache, scopeKey, draft)
 }
 
 export function clearNativeChatDraftCacheForTests(): void {

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
@@ -7,6 +7,7 @@ import {
   type NativeChatResolvedTarget
 } from './native-chat-composer-target'
 import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
+import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
 
 export type UseNativeChatComposerAttachmentsArgs = {
   attachmentScopeKey: string
@@ -153,7 +154,8 @@ function writeNativeChatAttachmentCache(
     attachmentCache.delete(scopeKey)
     return
   }
-  attachmentCache.set(scopeKey, [...attachments])
+  // LRU-bounded so pending attachments for permanently-removed panes can't accumulate.
+  setBoundedScopeCacheEntry(attachmentCache, scopeKey, [...attachments])
 }
 
 export function clearNativeChatAttachmentCacheForTests(): void {


### PR DESCRIPTION
Part of a full-codebase memory-leak audit — final PR (2 leaks, same subsystem/mechanism).

## Description
The native-chat composer keeps two module-level caches so a typed-but-unsent message survives the composer unmounting on a TUI/GUI toggle:
- `draftCache` (`native-chat-draft-cache.ts`) — the in-progress draft text.
- `attachmentCache` (`use-native-chat-composer-attachments.ts`) — pending image-attachment paths.

Both are keyed by `targetPtyId ?? terminalTabId`. When a pane/tab is **permanently** removed while holding an unsent draft/attachment, its scope key is never revisited, so the entry lingered for the renderer's whole session (keys are never reused).

Fix: a shared `setBoundedScopeCacheEntry` helper (delete-then-set LRU, cap **128**) that both write paths route through.

## Evidence
- `native-chat-draft-cache.ts`: `writeNativeChatDraftCache` only `.delete`d on empty draft, else `.set()` — no bound.
- `use-native-chat-composer-attachments.ts`: `writeNativeChatAttachmentCache` same shape.
- Scope key `targetPtyId ?? terminalTabId` is a fresh, never-reused id, so a removed pane's entry is unreachable and permanent.

## Proof of fix
- New `native-chat-composer-scope-cache.test.ts`: the shared helper caps at the limit, evicts the oldest untouched key, keeps re-set keys, and moves a re-set key to most-recent.
- New draft-cache test: flooding past the cap evicts the oldest draft while the actively-edited and most-recent drafts survive.

```
Test Files  3 passed (3)   ← incl. existing attachment-cache suite
      Tests  9 passed (9)
```
Typecheck (web) + oxlint clean.

## ELI5
When you start typing a message to an agent but flip back to the terminal, the app stashes your half-written note so it's still there when you flip back. If you *closed* that pane for good, the stashed note was kept forever. Now the stash holds at most ~128 notes and forgets the oldest untouched ones — and the note you're actively typing is always kept.

## Trade-offs
- **User-facing behavior:** none in practice. The cap (128) is vastly larger than the handful of panes anyone has unsent drafts in at once, and `delete-then-set` keeps the pane you're actively typing in most-recent so it's never the one evicted.
- **Why a cap instead of purge-on-removal:** a precise purge would require the store to import native-chat component modules — a coupling this codebase deliberately avoids (no `store → components/native-chat` imports exist). The bound is self-contained in the native-chat layer and matches the codebase's existing FIFO/LRU convention (`rememberUnwatchableRoot`).
- **Pathological case:** >128 panes each holding a distinct unsent draft/attachment would drop the least-recently-touched draft — astronomically unlikely, and the dropped value is convenience state only. Target: 0 regression.

Made with [Orca](https://github.com/stablyai/orca) 🐋
