### PR TITLE
feat(terminal): add `terminal create --parent` for task-free lineage grouping

### DIFF
--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -143,7 +143,12 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       // unless the caller explicitly asks for focus.
       focus,
       ...(focus ? { presentation: 'focused' } : {}),
-      ...(useRendererBackedInteractiveTerminal ? { rendererBacked: true, activate: focus } : {})
+      ...(useRendererBackedInteractiveTerminal ? { rendererBacked: true, activate: focus } : {}),
+      // Why: nest the new terminal under an existing parent in the dashboard,
+      // even across worktrees, without an orchestration task/dispatch.
+      ...(getOptionalStringFlag(flags, 'parent')
+        ? { parentTerminalHandle: getOptionalStringFlag(flags, 'parent') }
+        : {})
     })
     printResult(result, json, formatTerminalCreate)
   },

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -435,6 +435,9 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   if (command === 'linear create' && flag === 'parent-current') {
     return '--parent-current      Use the current linked issue as parent'
   }
+  if (command === 'terminal create' && flag === 'parent') {
+    return '--parent <handle>     Nest the new terminal under this parent terminal handle in the dashboard (works cross-worktree; no orchestration task created)'
+  }
   if (command === 'worktree create' && flag === 'parent-worktree') {
     return '--parent-worktree <selector> Parent selector such as active/current, id:<id>, branch:<branch>, issue:<number>, path:<path>, folder:<id>, or worktree:<id>'
   }

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -220,17 +220,19 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['terminal', 'create'],
     summary: 'Create a terminal session in the current worktree',
     usage:
-      'orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--focus] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'command', 'title', 'focus'],
+      'orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--parent <handle>] [--focus] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'command', 'title', 'parent', 'focus'],
     notes: [
       'Creates a visible terminal tab without switching focus when possible; falls back to a background handle if the UI cannot adopt it. Pass --focus to switch to it.',
-      'Use this, not worktree create, for a fresh agent in the current checkout.'
+      'Use this, not worktree create, for a fresh agent in the current checkout.',
+      'Pass --parent <handle> to nest the new terminal under an existing terminal in the dashboard, even when it lives in a different worktree. This is a lightweight lineage edge — no orchestration task or dispatch is created.'
     ],
     examples: [
       'orca terminal create --json',
       'orca terminal create --worktree active --command "codex" --json',
       'orca terminal create --worktree path:/projects/myapp --title "RUNNER" --command "opencode"',
-      'orca terminal create --worktree path:/projects/myapp --command "opencode" --focus'
+      'orca terminal create --worktree path:/projects/myapp --command "opencode" --focus',
+      'orca terminal create --worktree path:/projects/other --parent term_abc123 --command "claude"'
     ]
   },
   {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -999,6 +999,7 @@ function openMainWindow(): BrowserWindow {
       maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })
       const orchestration = runtime?.getAgentStatusOrchestrationContextForPaneKey(paneKey)
       const terminalHandle = runtime?.getAgentStatusTerminalHandleForPaneKey(paneKey)
+      const explicitParent = runtime?.getAgentStatusExplicitParentForPaneKey(paneKey)
       mainWindow?.webContents.send('agentStatus:set', {
         ...payload,
         paneKey,
@@ -1010,7 +1011,11 @@ function openMainWindow(): BrowserWindow {
         receivedAt,
         stateStartedAt,
         ...(providerSession ? { providerSession } : {}),
-        ...(orchestration ? { orchestration } : {})
+        ...(orchestration ? { orchestration } : {}),
+        ...(explicitParent?.parentTerminalHandle
+          ? { parentTerminalHandle: explicitParent.parentTerminalHandle }
+          : {}),
+        ...(explicitParent?.parentPaneKey ? { parentPaneKey: explicitParent.parentPaneKey } : {})
       })
       recordAgentStateCrashBreadcrumb(payload.agentType ?? 'unknown', payload.state)
       // Why: some native OSC titles miss terminal idle/permission frames.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8440,6 +8440,41 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('records an explicit --parent lineage edge and stamps it onto the child pane, with no orchestration state', async () => {
+    let ptyCounter = 0
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      // Why: distinct pty ids per spawn so parent and child map to separate
+      // pty records instead of colliding on a shared id.
+      spawn: vi.fn().mockImplementation(async () => ({ id: `pty-${++ptyCounter}` })),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    const parent = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      presentation: 'background'
+    })
+    const child = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      presentation: 'background',
+      parentTerminalHandle: parent.handle
+    })
+
+    expect(child.paneKey).toBeDefined()
+    expect(runtime.getAgentStatusExplicitParentForPaneKey(child.paneKey!)).toEqual({
+      parentTerminalHandle: parent.handle,
+      parentPaneKey: parent.paneKey
+    })
+    // The parent has no explicit parent of its own.
+    expect(runtime.getAgentStatusExplicitParentForPaneKey(parent.paneKey!)).toBeUndefined()
+    // Grouping is task-free — no orchestration context is fabricated.
+    expect(runtime.getAgentStatusOrchestrationContextForPaneKey(child.paneKey!)).toBeUndefined()
+
+    // Closing the child prunes the edge so a reused handle can't inherit it.
+    await runtime.closeTerminal(child.handle)
+    expect(runtime.getAgentStatusExplicitParentForPaneKey(child.paneKey!)).toBeUndefined()
+  })
+
   it('drops retained PTY transcript memory when a background terminal exits', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -978,6 +978,8 @@ type TerminalCreateOptions = {
   presentation?: RuntimeTerminalPresentation
   tabId?: string
   leafId?: string
+  // Why: explicit lineage parent handle from `terminal create --parent`.
+  parentTerminalHandle?: string
   sessionId?: string
   persistHostSessionBinding?: boolean
   // Why: the headless mobile-session create publishes its own authoritative
@@ -2077,6 +2079,11 @@ export class OrcaRuntimeService {
   // iterates them all. Listeners are cleaned up via subscriptionCleanups.
   private notificationListeners = new Set<(event: MobileNotificationEvent) => void>()
   private ptysById = new Map<string, RuntimePtyWorktreeRecord>()
+  // Why: explicit `terminal create --parent` lineage edges, keyed by the child
+  // terminal handle. Lets the dashboard nest a terminal under a parent without
+  // an orchestration task/dispatch, and covers both background and
+  // renderer-backed creates (leaves and pty records alike). Pruned on close.
+  private explicitParentByChildHandle = new Map<string, string>()
   private titleObservationSequence = 0
   private headlessTerminals = new Map<string, RuntimeHeadlessTerminal>()
   private ptyOutputSequenceById = new Map<string, number>()
@@ -15850,6 +15857,7 @@ export class OrcaRuntimeService {
         pty.launchAgent = launchOpts.launchAgent ?? null
       }
       const handle = pty ? this.issuePtyHandle(pty) : preAllocatedHandle
+      this.recordExplicitParentForChildHandle(handle, launchOpts.parentTerminalHandle)
       if (pty && launchOpts.deferMobileSessionPublish !== true) {
         this.publishPtyBackedMobileSessionTerminal(workspace.id, pty, {
           tabId,
@@ -15963,6 +15971,7 @@ export class OrcaRuntimeService {
     // populates this.leaves may not have arrived yet. Wait for the leaf to
     // appear so we can return a valid handle the caller can use right away.
     const handle = await this.waitForTerminalHandle(reply.tabId)
+    this.recordExplicitParentForChildHandle(handle, launchOpts.parentTerminalHandle)
     return {
       handle,
       tabId: reply.tabId,
@@ -16612,6 +16621,9 @@ export class OrcaRuntimeService {
   async closeTerminal(handle: string): Promise<RuntimeTerminalClose> {
     const pty = this.getLivePtyForHandle(handle)
     this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
+    // Why: drop any explicit-parent lineage edge so a reused handle can't inherit
+    // a stale parent after this terminal is gone.
+    this.explicitParentByChildHandle.delete(handle)
     if (pty) {
       const ptyKilled = this.ptyController?.kill(pty.pty.ptyId) ?? false
       return { handle, tabId: pty.pty.tabId ?? pty.record.tabId, ptyKilled }
@@ -18986,6 +18998,40 @@ export class OrcaRuntimeService {
 
   getAgentStatusTerminalHandleForPaneKey(paneKey: string): string | undefined {
     return this.getTerminalHandleForPaneKey(paneKey) ?? undefined
+  }
+
+  private recordExplicitParentForChildHandle(
+    childHandle: string,
+    parentTerminalHandle: string | undefined
+  ): void {
+    const parent = parentTerminalHandle?.trim()
+    // Why: a terminal cannot be its own lineage parent; ignore self-references
+    // so the dashboard resolver never forms a trivial cycle.
+    if (!parent || parent === childHandle) {
+      return
+    }
+    this.explicitParentByChildHandle.set(childHandle, parent)
+  }
+
+  /**
+   * Explicit lineage parent for a pane, set at `terminal create --parent` time.
+   * Task-free: sourced from the explicitParentByChildHandle map, not the
+   * orchestration DB. Resolves the parent's live pane key when available so the
+   * dashboard can nest without re-deriving it from the handle.
+   */
+  getAgentStatusExplicitParentForPaneKey(
+    paneKey: string
+  ): { parentTerminalHandle: string; parentPaneKey?: string } | undefined {
+    const handle = this.getTerminalHandleForPaneKey(paneKey)
+    const parentTerminalHandle = handle ? this.explicitParentByChildHandle.get(handle) : undefined
+    if (!parentTerminalHandle || parentTerminalHandle === handle) {
+      return undefined
+    }
+    const parentPaneKey = this.getPaneKeyForTerminalHandle(parentTerminalHandle) ?? undefined
+    return {
+      parentTerminalHandle,
+      ...(parentPaneKey && parentPaneKey !== paneKey ? { parentPaneKey } : {})
+    }
   }
 
   getAgentStatusLaunchConfigForPaneKey(

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -669,7 +669,10 @@ const TerminalCreateParams = z.object({
   activate: z.unknown().optional(),
   presentation: z.enum(['background', 'focused']).optional(),
   tabId: OptionalString,
-  leafId: OptionalString
+  leafId: OptionalString,
+  // Why: explicit lineage parent so the new terminal nests under the given
+  // parent handle in the dashboard, without an orchestration task/dispatch.
+  parentTerminalHandle: OptionalString
 })
 
 const TerminalSplit = TerminalHandle.extend({
@@ -1043,7 +1046,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         activate: params.activate === true,
         presentation: params.presentation,
         tabId: params.tabId,
-        leafId: params.leafId
+        leafId: params.leafId,
+        parentTerminalHandle: params.parentTerminalHandle
       })
     })
   }),

--- a/src/renderer/src/components/dashboard/agent-row-lineage-model.test.ts
+++ b/src/renderer/src/components/dashboard/agent-row-lineage-model.test.ts
@@ -24,6 +24,10 @@ function makeRow(
     parentPaneKey?: string
     parentTerminalHandle?: string
     coordinatorHandle?: string
+    /** Explicit, task-free lineage parent set on the entry (from `terminal
+     *  create --parent`), independent of orchestration context. */
+    entryParentPaneKey?: string
+    entryParentTerminalHandle?: string
   } = {}
 ): DashboardAgentRow {
   const orchestration =
@@ -47,6 +51,10 @@ function makeRow(
     stateHistory: [],
     agentType: 'codex',
     ...(options.terminalHandle ? { terminalHandle: options.terminalHandle } : {}),
+    ...(options.entryParentPaneKey ? { parentPaneKey: options.entryParentPaneKey } : {}),
+    ...(options.entryParentTerminalHandle
+      ? { parentTerminalHandle: options.entryParentTerminalHandle }
+      : {}),
     ...(orchestration ? { orchestration } : {})
   }
 
@@ -76,6 +84,34 @@ describe('buildAgentRowLineageTree', () => {
   it('falls back to the parent terminal handle when the parent pane key is absent', () => {
     const parent = makeRow('parent:1', { terminalHandle: 'term-parent' })
     const child = makeRow('child:1', { parentTerminalHandle: 'term-parent' })
+
+    const tree = buildAgentRowLineageTree([parent, child])
+
+    expect(tree.rootRows.map((row) => row.paneKey)).toEqual(['parent:1'])
+    expect(tree.childrenByParentPaneKey.get('parent:1')?.map((row) => row.paneKey)).toEqual([
+      'child:1'
+    ])
+  })
+
+  it('groups by an explicit entry parent pane key without orchestration context', () => {
+    const parent = makeRow('parent:1')
+    const child = makeRow('child:1', { entryParentPaneKey: 'parent:1' })
+
+    expect(child.entry.orchestration).toBeUndefined()
+
+    const tree = buildAgentRowLineageTree([parent, child])
+
+    expect(tree.rootRows.map((row) => row.paneKey)).toEqual(['parent:1'])
+    expect(tree.childrenByParentPaneKey.get('parent:1')?.map((row) => row.paneKey)).toEqual([
+      'child:1'
+    ])
+  })
+
+  it('groups by an explicit entry parent terminal handle without orchestration context', () => {
+    const parent = makeRow('parent:1', { terminalHandle: 'term-parent' })
+    const child = makeRow('child:1', { entryParentTerminalHandle: 'term-parent' })
+
+    expect(child.entry.orchestration).toBeUndefined()
 
     const tree = buildAgentRowLineageTree([parent, child])
 

--- a/src/renderer/src/components/dashboard/agent-row-lineage-model.ts
+++ b/src/renderer/src/components/dashboard/agent-row-lineage-model.ts
@@ -23,7 +23,11 @@ export function resolveAgentRowParentPaneKey<T extends DashboardAgentRow>(
   rowsByPaneKey: ReadonlyMap<string, T>,
   paneKeyByTerminalHandle: ReadonlyMap<string, string>
 ): string | undefined {
-  const explicitParentPaneKey = row.entry.orchestration?.parentPaneKey
+  // Why: an explicit `terminal create --parent` edge (entry.parentPaneKey /
+  // parentTerminalHandle) is a first-class, task-free lineage signal — honor it
+  // ahead of orchestration-derived context so callers can nest a terminal
+  // without creating an orchestration task/dispatch.
+  const explicitParentPaneKey = row.entry.parentPaneKey ?? row.entry.orchestration?.parentPaneKey
   if (
     explicitParentPaneKey &&
     explicitParentPaneKey !== row.paneKey &&
@@ -33,6 +37,7 @@ export function resolveAgentRowParentPaneKey<T extends DashboardAgentRow>(
   }
 
   const parentTerminalHandles = [
+    row.entry.parentTerminalHandle,
     row.entry.orchestration?.parentTerminalHandle,
     row.entry.orchestration?.coordinatorHandle
   ]

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -92,6 +92,16 @@ export type AgentStatusEntry = {
   /** Runtime terminal handle for matching retained parent rows when the parent
    *  pane key cannot be re-derived after terminal teardown. */
   terminalHandle?: string
+  /** Explicit lineage parent set at `terminal create --parent <handle>` time.
+   *  Why: lets a caller nest a terminal under a parent in the dashboard without
+   *  going through the orchestration task/dispatch system. Independent of
+   *  `orchestration` (whose taskId/dispatchId are required); consulted by the
+   *  agent-row lineage resolver as a first-class parent edge. Groups
+   *  cross-worktree because nesting keys on terminal handle, not worktree. */
+  parentTerminalHandle?: string
+  /** Pane key of the explicit lineage parent, resolved by main when the parent
+   *  terminal is live. Preferred over parentTerminalHandle when present. */
+  parentPaneKey?: string
   /** Worktree attribution stamped by main when a hook can be resolved there.
    *  Why: orchestration workers can report status before their terminal tab is
    *  present in a renderer; retaining this lets worktree-level UI still show


### PR DESCRIPTION
## Summary

Adds `orca terminal create --parent <handle>` — a lightweight way to nest a created terminal under an existing **parent terminal** in the dashboard, **even across worktrees**, without any orchestration task/dispatch.

```bash
orca terminal create --worktree path:/projects/other --parent term_abc123 --command "claude"
```

Today the only way to make a child terminal nest under a parent is the orchestration coordinator flow (a task **and** a dispatch per child). That writes to the orchestration DB and surfaces a task label in the UI — heavy when all you want is visual lineage. This adds a first-class, task-free lineage edge instead. Grouping works cross-worktree because dashboard nesting keys on the terminal handle, not the worktree.

**How it works (data flow):**
- **CLI** (`cli/handlers/terminal.ts`, `cli/specs/core.ts`, `cli/help.ts`) — `--parent <handle>` flag, forwarded as `parentTerminalHandle`.
- **RPC** (`rpc/methods/terminal.ts`) — `parentTerminalHandle` added to `TerminalCreateParams`, forwarded to `runtime.createTerminal`.
- **Runtime** (`orca-runtime.ts`) — a new `explicitParentByChildHandle` map records the edge in **both** the background and renderer-backed create paths (interactive agents like `claude` take the renderer path when a window is present), pruned in `closeTerminal`. Exposed via `getAgentStatusExplicitParentForPaneKey`.
- **Main** (`main/index.ts`) — stamps `parentTerminalHandle`/`parentPaneKey` onto the `agentStatus:set` payload alongside orchestration context.
- **Renderer** (`components/dashboard/agent-row-lineage-model.ts`) — `resolveAgentRowParentPaneKey` honors the explicit entry parent ahead of orchestration-derived context.

The edge is independent of `AgentStatusOrchestrationContext` (whose `taskId`/`dispatchId` are required), so it carries no orchestration semantics.

## Screenshots

⚠️ **No recording included** — I developed this without a way to run the Electron UI, so I could not capture the dashboard nesting on screen. The change reuses the existing agent-row lineage rendering (the same nesting path already used for orchestration-parented rows), and both halves are covered by unit tests (see Testing). **A maintainer sanity-check of the visual nesting would be appreciated** — `pnpm dev`, then `orca terminal create --parent <a-live-term-handle> --command claude` and confirm the child nests under the parent in the dashboard.

## Testing

- [x] `pnpm typecheck` — passes (node / cli / web configs)
- [x] `oxlint` + `oxlint --config oxlint-react-doctor` + `oxfmt --check` — clean on all changed files (pre-commit + manual). Note: the full `pnpm lint` meta-script (localization/reliability gates) I left to CI.
- [x] `pnpm test` — 24,765 passed. **18 failures in 4 unrelated files** (`right-sidebar/pr-comment-presentation`, `right-sidebar/pr-comments-list-selection`, `sidebar/LinearAgentSkillSetupPrompt.reminder-toast`, `sidebar/SidebarToolbar`) reproduce **identically on the base commit** (`b41cab1a9`) in my local sandbox — an environmental `localStorage`/jsdom quirk (`--localstorage-file was provided without a valid path`), **not introduced by this PR**. My touched areas are green: `orca-runtime` 558/558, dashboard `agent-row-lineage-model` 6/6, CLI `args`+`index` 148/148.
- [x] `pnpm build:unpack` — passes.
- [x] Added high-quality tests — renderer resolver: two new cases proving grouping by explicit entry parent (pane key + terminal handle) with no orchestration context; runtime: one new case proving `createTerminal --parent` records the edge, `getAgentStatusExplicitParentForPaneKey` returns the parent handle + resolved pane key, no orchestration context is fabricated, and `closeTerminal` prunes it.

## AI Review Report

Reviewed with Claude Code across the required dimensions:

- **Cross-platform (macOS / Linux / Windows):** platform-agnostic. No keyboard shortcuts, no path handling, no shell invocation, no Electron platform branches — just a CLI string flag, an RPC string param, an in-memory `Map` keyed by opaque handles, and a renderer array lookup.
- **SSH / remote / local:** no local-only assumptions. Keyed on runtime terminal handles / pane keys that the runtime already issues uniformly for local, remote, and SSH worktrees; resolution reuses existing `getTerminalHandleForPaneKey` / `getPaneKeyForTerminalHandle`.
- **Agent / integration / git-provider neutral:** no agent-, integration-, or provider-specific logic; grouping is independent of which CLI agent runs in the terminal.
- **Performance:** O(1) `Map` set/get/delete. The getter runs on the existing per-`agentStatus:set` path with two cheap lookups; no new allocation in hot paths, no added polling.
- **UI quality:** no new components or styles — reuses the existing lineage nesting. The explicit edge is consulted ahead of orchestration context, so behavior is unchanged when `--parent` is unset.
- **Correctness / edge cases:** self-parent references are ignored; cycles are already neutralized by `buildAgentRowLineageTree` (participants stay visible as flat roots); stale edges are pruned on `closeTerminal`; an unresolved parent handle simply yields no nesting (the resolver requires the parent row to exist).

## Security Audit

- **Input handling:** `--parent <handle>` is an opaque terminal-handle string — trimmed, compared, and only ever resolved to an existing live pane via existing lookups. No parsing or execution.
- **Command execution / path handling / auth / secrets:** none introduced or touched.
- **IPC:** adds two optional string fields (`parentTerminalHandle`, `parentPaneKey`) to the existing `agentStatus:set` renderer message — no new channel, no privilege change.
- **Dependencies:** none added.
- **Worst case:** a caller passes an arbitrary handle; if it doesn't match a live pane, nothing nests. No cross-worktree data exposure — the edge is purely a display-tree relationship over already-visible agent rows.

## Notes

- **Behavior change:** `terminal create --parent <handle>` nests the new terminal under the given parent in the dashboard, cross-worktree, with no orchestration task/dispatch.
- No platform-, remote/SSH-, agent-, integration-, or git-provider-specific behavior.
- Open verification item: live dashboard nesting was not visually confirmed (see Screenshots) — logic is unit-tested on both the runtime and renderer sides; the `main/index.ts` stamping is a straight passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
