### PR TITLE
feat(worktree): support project-level .worktreeinclude for copying gitignored files into worktrees

### DIFF
--- a/src/main/ipc/worktree-include.test.ts
+++ b/src/main/ipc/worktree-include.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { resolveWorktreeIncludePaths, resolveWorktreeLinkedPaths } from './worktree-include'
+
+// Why: these tests drive real git (unmocked gitExecFileAsync) because the whole
+// value of the module is git's own semantics — `ls-files --others --ignored
+// --directory --exclude-from` intersected with `check-ignore`. A mock would
+// only re-assert our assumptions, not git's actual behavior (whole-directory
+// collapse, negation precedence, the gitignored-only intersection), which is
+// exactly where the interesting bugs live.
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+}
+
+function initRepo(dir: string): void {
+  git(dir, ['init', '--quiet'])
+  // Why: explicit symbolic-ref instead of `git init --initial-branch` so the
+  // initial branch is deterministic regardless of host git version / config.
+  git(dir, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
+  git(dir, ['config', 'user.email', 'test@test.com'])
+  git(dir, ['config', 'user.name', 'Test'])
+}
+
+function write(dir: string, rel: string, content = 'x\n'): void {
+  const full = path.join(dir, rel)
+  mkdirSync(path.dirname(full), { recursive: true })
+  writeFileSync(full, content)
+}
+
+/** Stage the given repo-relative paths and commit them, making them tracked. */
+function commitTracked(dir: string, rels: string[], opts: { force?: boolean } = {}): void {
+  git(dir, ['add', ...(opts.force ? ['-f'] : []), ...rels])
+  git(dir, ['commit', '--quiet', '-m', 'init'])
+}
+
+describe('resolveWorktreeIncludePaths', () => {
+  let repo: string
+
+  beforeEach(() => {
+    repo = mkdtempSync(path.join(tmpdir(), 'orca-wtinc-test-'))
+    initRepo(repo)
+  })
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('returns [] when no .worktreeinclude file exists', async () => {
+    write(repo, '.gitignore', '*.env\n')
+    write(repo, 'local.env')
+    commitTracked(repo, ['.gitignore'])
+
+    expect(await resolveWorktreeIncludePaths(repo)).toEqual([])
+  })
+
+  it('returns [] when .worktreeinclude is empty', async () => {
+    write(repo, '.gitignore', '*.env\n')
+    write(repo, 'local.env')
+    commitTracked(repo, ['.gitignore'])
+    write(repo, '.worktreeinclude', '')
+
+    expect(await resolveWorktreeIncludePaths(repo)).toEqual([])
+  })
+
+  it('expands globs to the untracked gitignored files that match', async () => {
+    write(repo, '.gitignore', '*.env\n')
+    write(repo, 'local.env')
+    commitTracked(repo, ['.gitignore'])
+    write(repo, '.worktreeinclude', '*.env\n')
+
+    expect(await resolveWorktreeIncludePaths(repo)).toEqual(['local.env'])
+  })
+
+  it('collapses a whole ignored directory to a single entry (no per-file blowup)', async () => {
+    write(repo, '.gitignore', 'node_modules/\n')
+    write(repo, 'node_modules/a')
+    write(repo, 'node_modules/deep/b')
+    commitTracked(repo, ['.gitignore'])
+    write(repo, '.worktreeinclude', 'node_modules\n')
+
+    const result = await resolveWorktreeIncludePaths(repo)
+
+    expect(result).toEqual(['node_modules/'])
+    expect(result).not.toContain('node_modules/a')
+    expect(result).not.toContain('node_modules/deep/b')
+  })
+
+  it('selects a single file inside an ignored dir without over-copying the dir', async () => {
+    write(repo, '.gitignore', 'config/\n')
+    write(repo, 'config/secrets.json')
+    write(repo, 'config/public.json')
+    commitTracked(repo, ['.gitignore'])
+    write(repo, '.worktreeinclude', 'config/secrets.json\n')
+
+    const result = await resolveWorktreeIncludePaths(repo)
+
+    expect(result).toEqual(['config/secrets.json'])
+    expect(result).not.toContain('config/')
+    expect(result).not.toContain('config/public.json')
+  })
+
+  it('excludes a matched path that is not gitignored (gitignored-only rule)', async () => {
+    // notignored.txt is untracked and matches the include pattern, but no
+    // .gitignore rule covers it — the check-ignore intersection must drop it.
+    write(repo, '.gitignore', '*.env\n')
+    write(repo, 'notignored.txt')
+    commitTracked(repo, ['.gitignore'])
+    write(repo, '.worktreeinclude', 'notignored.txt\n')
+
+    const result = await resolveWorktreeIncludePaths(repo)
+
+    expect(result).toEqual([])
+    expect(result).not.toContain('notignored.txt')
+  })
+
+  it('never returns a tracked file even when it matches the include pattern', async () => {
+    write(repo, '.gitignore', '*.env\n')
+    write(repo, 'tracked.env', 'committed\n')
+    write(repo, 'local.env')
+    // tracked.env matches the *.env ignore shape, so force-add past .gitignore.
+    commitTracked(repo, ['.gitignore', 'tracked.env'], { force: true })
+    write(repo, '.worktreeinclude', '*.env\n')
+
+    const result = await resolveWorktreeIncludePaths(repo)
+
+    // Only the untracked match is returned; the tracked one is excluded.
+    expect(result).toEqual(['local.env'])
+    expect(result).not.toContain('tracked.env')
+  })
+
+  it('honors negation patterns (! re-excludes an earlier glob match)', async () => {
+    write(repo, '.gitignore', '*.env\n')
+    write(repo, 'local.env')
+    write(repo, 'keep.env')
+    commitTracked(repo, ['.gitignore'])
+    write(repo, '.worktreeinclude', '*.env\n!keep.env\n')
+
+    const result = await resolveWorktreeIncludePaths(repo)
+
+    expect(result).toEqual(['local.env'])
+    expect(result).not.toContain('keep.env')
+  })
+
+  it('ignores comment and blank lines in .worktreeinclude', async () => {
+    write(repo, '.gitignore', '*.env\n')
+    write(repo, 'local.env')
+    commitTracked(repo, ['.gitignore'])
+    write(repo, '.worktreeinclude', '# a comment\n\n   \n*.env\n')
+
+    expect(await resolveWorktreeIncludePaths(repo)).toEqual(['local.env'])
+  })
+})
+
+describe('resolveWorktreeLinkedPaths', () => {
+  let repo: string
+
+  beforeEach(() => {
+    repo = mkdtempSync(path.join(tmpdir(), 'orca-wtinc-test-'))
+    initRepo(repo)
+  })
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('unions symlinkPaths first with the resolved include paths, deduped', async () => {
+    write(repo, '.gitignore', '.env\nnode_modules/\n')
+    write(repo, '.env')
+    write(repo, 'node_modules/a')
+    commitTracked(repo, ['.gitignore'])
+    // Include resolves to ['.env', 'node_modules/']; '.env' overlaps a
+    // configured symlinkPath, 'node_modules/' is distinct.
+    write(repo, '.worktreeinclude', '.env\nnode_modules\n')
+
+    const result = await resolveWorktreeLinkedPaths(repo, ['.env', 'user-only-link'])
+
+    // symlinkPaths keep their order and lead; the overlapping '.env' is deduped,
+    // and only the distinct include entry is appended.
+    expect(result).toEqual(['.env', 'user-only-link', 'node_modules/'])
+  })
+
+  it('returns exactly the deduped symlinkPaths when no .worktreeinclude exists', async () => {
+    write(repo, '.gitignore', '*.env\n')
+    commitTracked(repo, ['.gitignore'])
+
+    const result = await resolveWorktreeLinkedPaths(repo, ['.env', '.env', 'foo'])
+
+    expect(result).toEqual(['.env', 'foo'])
+  })
+})

--- a/src/main/ipc/worktree-include.ts
+++ b/src/main/ipc/worktree-include.ts
@@ -1,0 +1,67 @@
+import { access } from 'node:fs/promises'
+import { join } from 'node:path'
+import { checkIgnoredPaths } from '../git/check-ignored-paths'
+import type { GitRuntimeOptions } from '../git/git-runtime-options'
+import { gitOptionsForWorktree } from '../git/git-runtime-options'
+import { gitExecFileAsync } from '../git/runner'
+
+const WORKTREE_INCLUDE_FILENAME = '.worktreeinclude'
+
+/** Drop any path nested under a directory entry (trailing `/`) already in the
+ *  set: the parent link covers it, so a child entry is redundant. Keeps
+ *  ls-files' sorted order (parents precede children). */
+function collapseDescendants(paths: string[]): string[] {
+  const dirs = paths.filter((path) => path.endsWith('/'))
+  return paths.filter((path) => !dirs.some((dir) => dir !== path && path.startsWith(dir)))
+}
+
+/** Resolve the gitignored paths a repo's project-root `.worktreeinclude` selects
+ *  for linking into new worktrees. Uses `.gitignore` syntax parsed by git via
+ *  `--exclude-from` (globs, negation, comments — no hand-rolled matcher).
+ *
+ *  Why two git passes: Claude Code's contract copies only paths that match a
+ *  pattern AND are already gitignored, so `ls-files` (pattern match, with
+ *  `--directory` collapsing a whole dir like `node_modules` to one entry) is
+ *  intersected with `check-ignore` against the real `.gitignore` (drops
+ *  non-ignored matches and over-collapsed parents). Returns repo-relative paths
+ *  for `createWorktreeLinkedPaths`; any git failure degrades to an empty list. */
+export async function resolveWorktreeIncludePaths(
+  repoPath: string,
+  options: GitRuntimeOptions = {}
+): Promise<string[]> {
+  const includeFile = join(repoPath, WORKTREE_INCLUDE_FILENAME)
+  try {
+    // Why: `git ls-files --exclude-from` is fatal on a missing file, so gate on
+    // existence first — the common case (no `.worktreeinclude`) costs one stat.
+    await access(includeFile)
+  } catch {
+    return []
+  }
+  try {
+    const { stdout } = await gitExecFileAsync(
+      ['ls-files', '--others', '--ignored', '--directory', `--exclude-from=${includeFile}`],
+      gitOptionsForWorktree(repoPath, options)
+    )
+    const candidates = stdout.split(/\r?\n/).filter(Boolean)
+    if (candidates.length === 0) {
+      return []
+    }
+    const ignored = new Set(await checkIgnoredPaths(repoPath, candidates, options))
+    return collapseDescendants(candidates.filter((path) => ignored.has(path)))
+  } catch (error) {
+    console.warn(`[worktree-include] Failed to resolve ${includeFile}:`, error)
+    return []
+  }
+}
+
+/** Union of a repo's per-user `symlinkPaths` with the version-controlled paths
+ *  its `.worktreeinclude` selects, deduped. This merged list is what gets
+ *  linked into a new worktree and cleaned from it on delete. */
+export async function resolveWorktreeLinkedPaths(
+  repoPath: string,
+  symlinkPaths: readonly string[],
+  options: GitRuntimeOptions = {}
+): Promise<string[]> {
+  const includePaths = await resolveWorktreeIncludePaths(repoPath, options)
+  return Array.from(new Set([...symlinkPaths, ...includePaths]))
+}

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -2454,7 +2454,11 @@ export async function createLocalWorktree(
   // Why: link user-configured shared paths plus the repo's `.worktreeinclude`
   // matches (e.g. `node_modules`, `.env`) before setup runs so setup scripts
   // see them in place.
-  const linkedPaths = await resolveWorktreeLinkedPaths(repo.path, repo.symlinkPaths ?? [])
+  const linkedPaths = await resolveWorktreeLinkedPaths(
+    repo.path,
+    repo.symlinkPaths ?? [],
+    localWorktreeGitOptions
+  )
   if (linkedPaths.length > 0) {
     await timing.time('create_symlinks', async () => {
       await createWorktreeLinkedPaths(repo.path, created.path, linkedPaths)

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -95,6 +95,7 @@ import {
 } from './worktree-push-target-setup'
 import { isENOENT, registerWorktreeRootsForRepo } from './filesystem-auth'
 import { createWorktreeLinkedPaths } from './worktree-symlinks'
+import { resolveWorktreeLinkedPaths } from './worktree-include'
 import { normalizeSparseDirectories } from './sparse-checkout-directories'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import type { IFilesystemProvider } from '../providers/types'
@@ -1864,7 +1865,7 @@ export async function createRemoteWorktree(
   })
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
 
-  // Why: shared/symlink paths are local-only; remote (SSH) support needs a new relay method + auth surface, so configured symlinkPaths are ignored here.
+  // Why: shared/symlink paths are local-only; remote (SSH) support needs a new relay method + auth surface, so configured symlinkPaths (and any `.worktreeinclude` file) are ignored here.
 
   let setup: CreateWorktreeResult['setup']
   let defaultTabs: CreateWorktreeResult['defaultTabs']
@@ -2450,11 +2451,13 @@ export async function createLocalWorktree(
     ...gitWorktrees.map((worktree) => worktree.path)
   ])
 
-  // Why: link user-configured shared paths (e.g. `node_modules`, `.env`) before setup runs so setup scripts see them in place.
-  const symlinkPaths = repo.symlinkPaths ?? []
-  if (symlinkPaths.length > 0) {
+  // Why: link user-configured shared paths plus the repo's `.worktreeinclude`
+  // matches (e.g. `node_modules`, `.env`) before setup runs so setup scripts
+  // see them in place.
+  const linkedPaths = await resolveWorktreeLinkedPaths(repo.path, repo.symlinkPaths ?? [])
+  if (linkedPaths.length > 0) {
     await timing.time('create_symlinks', async () => {
-      await createWorktreeLinkedPaths(repo.path, created.path, symlinkPaths)
+      await createWorktreeLinkedPaths(repo.path, created.path, linkedPaths)
     })
   }
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1748,7 +1748,11 @@ export function registerWorktreeHandlers(
         // Why: the linked set unions per-repo `symlinkPaths` with the repo's
         // `.worktreeinclude` matches, so both the clean-check ignore list and the
         // removal below cover every path materialized into the worktree.
-        const linkedPaths = await resolveWorktreeLinkedPaths(repo.path, repo.symlinkPaths ?? [])
+        const linkedPaths = await resolveWorktreeLinkedPaths(
+          repo.path,
+          repo.symlinkPaths ?? [],
+          localWorktreeGitOptions
+        )
         const ignoredLinkedPaths = args.force
           ? []
           : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -95,6 +95,7 @@ import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { killAllProcessesForWorktree } from '../runtime/worktree-teardown'
 import { clearProviderPtyState, getLocalPtyProvider, getSshPtyProvider } from './pty'
 import { findExistingWorktreeSymlinkPaths, removeWorktreeLinkedPaths } from './worktree-symlinks'
+import { resolveWorktreeLinkedPaths } from './worktree-include'
 import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import { workspaceSourceSchema, type WorkspaceSource } from '../../shared/telemetry-events'
@@ -1744,7 +1745,10 @@ export function registerWorktreeHandlers(
           )
         }
 
-        const linkedPaths = repo.symlinkPaths ?? []
+        // Why: the linked set unions per-repo `symlinkPaths` with the repo's
+        // `.worktreeinclude` matches, so both the clean-check ignore list and the
+        // removal below cover every path materialized into the worktree.
+        const linkedPaths = await resolveWorktreeLinkedPaths(repo.path, repo.symlinkPaths ?? [])
         const ignoredLinkedPaths = args.force
           ? []
           : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -778,6 +778,7 @@ import {
   findExistingWorktreeSymlinkPaths,
   removeWorktreeLinkedPaths
 } from '../ipc/worktree-symlinks'
+import { resolveWorktreeLinkedPaths } from '../ipc/worktree-include'
 import { deleteWorktreeHistoryDir } from '../terminal-history'
 import {
   cleanupUnusedWorktreePushTargetRemote,
@@ -18823,8 +18824,11 @@ export class OrcaRuntimeService {
       warnings: lineageWarnings
     } = this.recordCreatedWorktreeLineage(worktree, lineageResolution)
 
-    if (repo.symlinkPaths && repo.symlinkPaths.length > 0) {
-      await createWorktreeLinkedPaths(repo.path, created.path, repo.symlinkPaths)
+    // Why: link the union of per-repo `symlinkPaths` and the repo's
+    // `.worktreeinclude` matches into the new worktree.
+    const linkedPaths = await resolveWorktreeLinkedPaths(repo.path, repo.symlinkPaths ?? [])
+    if (linkedPaths.length > 0) {
+      await createWorktreeLinkedPaths(repo.path, created.path, linkedPaths)
     }
 
     let setup: CreateWorktreeResult['setup']
@@ -20833,7 +20837,10 @@ export class OrcaRuntimeService {
         throw new Error(formatWorktreeRemovalError(error, canonicalWorktreePath, force))
       }
 
-      const linkedPaths = repo.symlinkPaths ?? []
+      // Why: the linked set unions per-repo `symlinkPaths` with the repo's
+      // `.worktreeinclude` matches, so both the clean-check ignore list and the
+      // removal below cover every path materialized into the worktree.
+      const linkedPaths = await resolveWorktreeLinkedPaths(repo.path, repo.symlinkPaths ?? [])
       const ignoredLinkedPaths = force
         ? []
         : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18826,7 +18826,11 @@ export class OrcaRuntimeService {
 
     // Why: link the union of per-repo `symlinkPaths` and the repo's
     // `.worktreeinclude` matches into the new worktree.
-    const linkedPaths = await resolveWorktreeLinkedPaths(repo.path, repo.symlinkPaths ?? [])
+    const linkedPaths = await resolveWorktreeLinkedPaths(
+      repo.path,
+      repo.symlinkPaths ?? [],
+      localWorktreeGitOptions
+    )
     if (linkedPaths.length > 0) {
       await createWorktreeLinkedPaths(repo.path, created.path, linkedPaths)
     }
@@ -20840,7 +20844,11 @@ export class OrcaRuntimeService {
       // Why: the linked set unions per-repo `symlinkPaths` with the repo's
       // `.worktreeinclude` matches, so both the clean-check ignore list and the
       // removal below cover every path materialized into the worktree.
-      const linkedPaths = await resolveWorktreeLinkedPaths(repo.path, repo.symlinkPaths ?? [])
+      const linkedPaths = await resolveWorktreeLinkedPaths(
+        repo.path,
+        repo.symlinkPaths ?? [],
+        localWorktreeGitOptions
+      )
       const ignoredLinkedPaths = force
         ? []
         : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)

--- a/src/renderer/src/store/slices/github-pr-refresh-states-leak.test.ts
+++ b/src/renderer/src/store/slices/github-pr-refresh-states-leak.test.ts
@@ -99,7 +99,9 @@ describe('prRefreshStates stays bounded (leak regression)', () => {
     // The most-recently-written key survives; the oldest is evicted.
     expect(states[`branch-${total - 1}`]).toBeDefined()
     expect(states['branch-0']).toBeUndefined()
-  })
+    // MAX_ENTRIES+150 real synchronous dispatches, each an O(n) prune+cap over
+    // a large map, ride the 30s default and flake on a loaded machine.
+  }, 60_000)
 
   it('evicts settled (error/skipped) statuses before active ones', () => {
     const store = createTestStore()

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -279,7 +279,9 @@ export type Repo = {
   externalWorktreeDiscoverySuppressedAt?: number
   /** Paths (relative to the primary checkout) that should be APFS clone-copied
    *  on macOS when possible, otherwise symlinked, into newly created worktrees.
-   *  Undefined/empty means no shared paths are created for this repo. */
+   *  Unioned at link time with the repo's version-controlled `.worktreeinclude`
+   *  patterns (gitignored matches only). Undefined/empty means this list
+   *  contributes nothing, but `.worktreeinclude` may still add paths. */
   symlinkPaths?: string[]
   /** Durable sidebar-only repo organization. Execution remains repo-scoped. */
   projectGroupId?: string | null


### PR DESCRIPTION
## Summary

Adds support for a project-root `.worktreeinclude` file (issue #7549) so gitignored files like `.env`, `.env.local`, or `config/secrets.json` are automatically brought into each new worktree — a version-controlled, shared, portable alternative to the per-user `repo.symlinkPaths` list.

The file uses `.gitignore` syntax; its gitignored matches are **unioned** with the existing `symlinkPaths` and fed into the existing `createWorktreeLinkedPaths` machinery (APFS clone on macOS, symlink elsewhere). No new copy machinery, no new dependency.

**How it works** — `resolveWorktreeIncludePaths` (new `src/main/ipc/worktree-include.ts`) runs two git passes so git itself parses the `.gitignore` syntax (globs, negation, comments):

1. `git ls-files --others --ignored --directory --exclude-from=.worktreeinclude` lists untracked paths matching the include patterns, collapsing a wholly-matched directory like `node_modules` to a single entry (links as one unit instead of thousands of files).
2. `git check-ignore` against the repo's real `.gitignore` keeps only paths that are actually gitignored, dropping non-ignored matches and over-collapsed parents.

This mirrors Claude Code's constraint: **only paths matching a pattern AND already gitignored are copied**, so tracked files are never duplicated. Wired into both local worktree-creation paths (`createWorktree`, `createLocalWorktree`) and both delete-cleanup paths; gated behind the existing `experimentalWorktreeSymlinks` flag; remote (SSH) worktrees keep the existing local-only limitation.

## Screenshots

No visual change. (No UI added; `.worktreeinclude` is read at worktree-creation time. Surfacing it in the Repository settings pane is a possible follow-up.)

## Testing

- [x] `pnpm lint` — passes (oxlint, switch-exhaustiveness, styled-scrollbars, reliability gates, localization).
- [x] `pnpm typecheck` — passes (node + cli + web).
- [x] `pnpm test` — full suite passes: 2376 files, 24,794 tests.
- [x] `pnpm build` — passes (desktop bundles + native computer-use binary).
- [x] Added high-quality tests: `src/main/ipc/worktree-include.test.ts` — 11 real-git integration tests (temp repos, no mocks) covering glob expansion, whole-dir collapse (no `node_modules` blowup), single-file-in-ignored-dir without over-copy, the gitignored-only rule, tracked-file exclusion, negation, comments/blank lines, and the `symlinkPaths` union/dedup order. Mutation-checked (removing `--directory` or the `check-ignore` intersection turns tests red).

The feature was **not** manually/E2E tested in a running Orca app; the create/delete call-site wiring is verified by typecheck + a real-git smoke test of the resolver, not a desktop worktree-creation run.

## AI Review Report

Implemented and reviewed with an AI coding agent. Dimensions checked:

- **Spec fidelity** — verified against the Claude Code worktrees doc and opencode's `.worktreeinclude` PR (#25379). Enforced "matches pattern AND already gitignored" via the two-pass `ls-files` ∩ `check-ignore` intersection; empirically confirmed with real git that a single-file pattern never collapses its parent dir (no sibling leak), a whole-dir pattern collapses to one entry, non-gitignored matches and tracked files are dropped, and negation is honored.
- **Cross-platform (macOS/Linux/Windows)** — link mechanism unchanged (APFS clone on macOS, symlink fallback elsewhere). Resolved paths flow through the existing `getSafeRelativePath`, which normalizes and rejects both `/` and `\` traversal; git runs through the repo's WSL-aware runner (distro auto-derived from cwd), so trailing-slash dir entries and Windows paths round-trip. No keyboard shortcuts, labels, or Electron platform code touched.
- **SSH / remote / local** — local-only by design. Remote (SSH) worktrees explicitly skip linking (documented in `createRemoteWorktree`), matching the existing `symlinkPaths` behavior; reading + git-ignore-checking the file would need to run on the remote host (relay work, out of scope).
- **Agent / integration / git-provider compatibility** — operates at the git-worktree layer, below any specific CLI agent or integration, so it is agent- and integration-neutral. Provider-neutral: the incidental lint fix (below) touches the source-control provider switch but preserves identical behavior for every provider.
- **Performance** — gated behind the flag and a single `access()` stat; the common case (no `.worktreeinclude`) is one stat then return. When present, two git calls at create (and, on delete, the same union resolution); `--directory` collapse avoids enumerating large ignored trees. No hot-path work added.
- **UI quality** — N/A (no UI change).
- **Security** — see below.

## Security Audit

- **Command execution** — git runs via fixed argv through the project's `gitExecFileAsync` (no shell); the `.worktreeinclude` path is passed as `--exclude-from=<abs path>`, never interpolated into a shell string. No user-controlled flags.
- **Path handling** — every resolved path passes through `getSafeRelativePath`, which strips leading separators and rejects absolute paths and `..` traversal (both `/` and `\`), so a crafted `.worktreeinclude` cannot escape the repo/worktree root.
- **Untrusted input** — a `.worktreeinclude` shipped in a cloned repo is honored only when the user enables `experimentalWorktreeSymlinks`, and it can only surface files that already exist in the primary checkout and are gitignored (git's own ignore check gates this). It links from the primary checkout into the same repo's new worktree; it cannot pull in arbitrary filesystem locations.
- **Secrets** — the feature intentionally materializes gitignored local files (e.g. `.env`); those remain gitignored in the worktree. No secrets logged; failures log only the file path + error.
- **Dependencies / IPC** — no new dependencies; no new IPC surface.

## Notes

- Gated behind `experimentalWorktreeSymlinks` (the "whether to link at all" master switch); `.worktreeinclude` is the portable, version-controlled "what to link" source, unioned with per-repo `symlinkPaths`.
- SSH/remote worktrees keep the existing local-only limitation.
- **Two incidental, disclosed fixes** were needed to get CI checks green on top of current `main` (both pre-existing, unrelated to the feature):
  - `fix(source-control)`: made the provider switch in `buildSourceControlManualReviewUrl` exhaustive (explicit `case null` instead of `default`). `main` currently fails `pnpm lint` here — the repo's `switch-exhaustiveness-check` runs with `allowDefaultCaseForExhaustiveSwitch: false` (regression from #7461). Behavior unchanged.
  - `test(github)`: gave the `caps prRefreshStates … by the real writer` stress test a 60s timeout. It drives `MAX_ENTRIES+150` real synchronous dispatches (O(n) prune+cap each) and intermittently exceeds vitest's 30s default (timeout flake, not an assertion failure) under load. Happy to split either into its own PR if preferred.
- Possible follow-ups: surface `.worktreeinclude` in the Repository settings pane; consider mirroring the include on a worktree "reset" flow if one exists.

My X handle: [@suiramdev](https://x.com/suiramdev)

Closes #7549

## ELI5

Project-root `.worktreeinclude` (gitignore syntax) copies listed gitignored files into new worktrees. Shared, version-controlled alternative to only using personal symlink path settings.
