### PR TITLE
fix(main): detect CJK input source via cfprefsd on macOS 15

### DIFF
--- a/src/main/ipc/app.test.ts
+++ b/src/main/ipc/app.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -5,7 +6,7 @@ const {
   appExitMock,
   appQuitMock,
   appRelaunchMock,
-  execFileMock,
+  spawnMock,
   destroySystemTrayMock,
   showOpenDialogMock,
   grantFloatingWorkspaceDirectoryMock
@@ -14,15 +15,52 @@ const {
   appExitMock: vi.fn(),
   appQuitMock: vi.fn(),
   appRelaunchMock: vi.fn(),
-  execFileMock: vi.fn(),
+  spawnMock: vi.fn(),
   destroySystemTrayMock: vi.fn(),
   showOpenDialogMock: vi.fn(),
   grantFloatingWorkspaceDirectoryMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({
-  execFile: execFileMock
+  spawn: spawnMock
 }))
+
+// Fakes the detached `spawn` child: a stdout EventEmitter plus close/error
+// events, so tests drive the async command lifecycle readCommandStdout expects.
+function createFakeSpawnChild(options: {
+  stdout?: string
+  code?: number
+  error?: Error
+  pid?: number
+  hang?: boolean
+}): EventEmitter & { pid: number; kill: ReturnType<typeof vi.fn>; stdout: EventEmitter } {
+  const { stdout, code = 0, error, pid = 4242, hang = false } = options
+  const child = new EventEmitter() as EventEmitter & {
+    pid: number
+    kill: ReturnType<typeof vi.fn>
+    stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+  }
+  child.pid = pid
+  child.kill = vi.fn()
+  const stdoutStream = new EventEmitter() as EventEmitter & {
+    setEncoding: ReturnType<typeof vi.fn>
+  }
+  stdoutStream.setEncoding = vi.fn()
+  child.stdout = stdoutStream
+  if (!hang) {
+    queueMicrotask(() => {
+      if (error) {
+        child.emit('error', error)
+        return
+      }
+      if (stdout !== undefined) {
+        stdoutStream.emit('data', stdout)
+      }
+      child.emit('close', code)
+    })
+  }
+  return child
+}
 
 vi.mock('electron', () => ({
   app: {
@@ -63,6 +101,9 @@ import { registerAppHandlers } from './app'
 
 describe('registerAppHandlers', () => {
   const originalPlatform = process.platform
+  // Why: readCommandStdout process-group-kills on timeout; stub the real signal
+  // so a fake child pid can never target a live process group during tests.
+  let processKillSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     vi.useFakeTimers()
@@ -70,14 +111,16 @@ describe('registerAppHandlers', () => {
     appExitMock.mockReset()
     appQuitMock.mockReset()
     appRelaunchMock.mockReset()
-    execFileMock.mockReset()
+    spawnMock.mockReset()
     destroySystemTrayMock.mockReset()
     showOpenDialogMock.mockReset()
     grantFloatingWorkspaceDirectoryMock.mockReset()
+    processKillSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
   })
 
   afterEach(() => {
+    processKillSpy.mockRestore()
     vi.useRealTimers()
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
   })
@@ -177,10 +220,9 @@ describe('registerAppHandlers', () => {
 
   it('returns the selected macOS input mode before the keyboard layout fallback', async () => {
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
-    execFileMock.mockImplementation((_command, _args, _options, callback) => {
-      callback(
-        null,
-        JSON.stringify([
+    spawnMock.mockImplementation(() =>
+      createFakeSpawnChild({
+        stdout: JSON.stringify([
           { 'Bundle ID': 'com.apple.PressAndHold', InputSourceKind: 'Non Keyboard Input Method' },
           {
             'Bundle ID': 'com.apple.inputmethod.SCIM',
@@ -188,68 +230,96 @@ describe('registerAppHandlers', () => {
             InputSourceKind: 'Input Mode'
           }
         ])
-      )
-      return { kill: vi.fn() }
-    })
+      })
+    )
     registerAppHandlers({} as never)
 
     await expect(handlers.get('app:getKeyboardInputSourceId')?.(null)).resolves.toBe(
       'com.apple.inputmethod.SCIM.ITABC'
     )
-    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(spawnMock).toHaveBeenCalledTimes(1)
     // Why: macOS 15's `plutil -extract <key> json` aborts on the input-source
     // array, so the probe reads live cfprefsd via `defaults export` and dodges
     // the bug with an xml1 extract before converting the clean subtree to JSON.
-    expect(execFileMock).toHaveBeenCalledWith(
+    // Pin the exact pipeline (absolute paths, stdin markers) so dropping any
+    // stage silently regressing CJK detection to the fallback fails the test.
+    expect(spawnMock).toHaveBeenCalledWith(
       '/bin/sh',
       [
         '-c',
-        expect.stringMatching(
-          /^defaults export com\.apple\.HIToolbox - \| plutil -extract AppleSelectedInputSources xml1 .+ \| plutil -convert json/
-        )
+        '/usr/bin/defaults export com.apple.HIToolbox - | ' +
+          '/usr/bin/plutil -extract AppleSelectedInputSources xml1 -o - - | ' +
+          '/usr/bin/plutil -convert json -o - -'
       ],
-      expect.any(Object),
-      expect.any(Function)
+      expect.objectContaining({ detached: true, stdio: ['ignore', 'pipe', 'ignore'] })
     )
   })
 
   it('falls back to the keyboard layout when no keyboard input mode is selected', async () => {
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
-    execFileMock
-      .mockImplementationOnce((_command, _args, _options, callback) => {
-        callback(
-          null,
-          JSON.stringify([
+    spawnMock
+      .mockImplementationOnce(() =>
+        createFakeSpawnChild({
+          stdout: JSON.stringify([
             {
               'Bundle ID': 'com.apple.PressAndHold',
               InputSourceKind: 'Non Keyboard Input Method'
             }
           ])
-        )
-        return { kill: vi.fn() }
-      })
-      .mockImplementationOnce((_command, _args, _options, callback) => {
-        callback(null, 'com.apple.keylayout.ABC\n')
-        return { kill: vi.fn() }
-      })
+        })
+      )
+      .mockImplementationOnce(() => createFakeSpawnChild({ stdout: 'com.apple.keylayout.ABC\n' }))
     registerAppHandlers({} as never)
 
     await expect(handlers.get('app:getKeyboardInputSourceId')?.(null)).resolves.toBe(
       'com.apple.keylayout.ABC'
     )
-    expect(execFileMock).toHaveBeenCalledTimes(2)
-    expect(execFileMock).toHaveBeenLastCalledWith(
+    expect(spawnMock).toHaveBeenCalledTimes(2)
+    expect(spawnMock).toHaveBeenLastCalledWith(
       '/usr/bin/defaults',
       ['read', 'com.apple.HIToolbox', 'AppleCurrentKeyboardLayoutInputSourceID'],
-      expect.any(Object),
-      expect.any(Function)
+      expect.objectContaining({ detached: true })
     )
+  })
+
+  it('falls back to the keyboard layout when the selected input source probe exits non-zero', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    // Why: reproduces macOS 15's `plutil` abort — the pipeline exits non-zero, so
+    // the probe rejects on the `close` branch and the handler falls back.
+    spawnMock
+      .mockImplementationOnce(() => createFakeSpawnChild({ code: 1 }))
+      .mockImplementationOnce(() => createFakeSpawnChild({ stdout: 'com.apple.keylayout.ABC\n' }))
+    registerAppHandlers({} as never)
+
+    await expect(handlers.get('app:getKeyboardInputSourceId')?.(null)).resolves.toBe(
+      'com.apple.keylayout.ABC'
+    )
+    expect(spawnMock).toHaveBeenCalledTimes(2)
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      '/usr/bin/defaults',
+      ['read', 'com.apple.HIToolbox', 'AppleCurrentKeyboardLayoutInputSourceID'],
+      expect.objectContaining({ detached: true })
+    )
+  })
+
+  it('falls back to the keyboard layout when the selected input source probe fails to spawn', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    // Why: a spawn-level failure (ENOENT/EACCES) emits 'error'; the handler must
+    // still fall back rather than reject out of the IPC call.
+    spawnMock
+      .mockImplementationOnce(() => createFakeSpawnChild({ error: new Error('spawn ENOENT') }))
+      .mockImplementationOnce(() => createFakeSpawnChild({ stdout: 'com.apple.keylayout.ABC\n' }))
+    registerAppHandlers({} as never)
+
+    await expect(handlers.get('app:getKeyboardInputSourceId')?.(null)).resolves.toBe(
+      'com.apple.keylayout.ABC'
+    )
+    expect(spawnMock).toHaveBeenCalledTimes(2)
   })
 
   it('falls back when macOS keyboard input source probes never report completion', async () => {
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
-    const killMock = vi.fn()
-    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    spawnMock.mockImplementation(() => createFakeSpawnChild({ pid: 4242, hang: true }))
     registerAppHandlers({} as never)
 
     const handler = handlers.get('app:getKeyboardInputSourceId')
@@ -264,7 +334,10 @@ describe('registerAppHandlers', () => {
 
     expect(settled).toBe(true)
     await expect(resultPromise).resolves.toBeNull()
-    expect(killMock).toHaveBeenCalledTimes(2)
+    // Why: both wedged probes get a process-group SIGKILL (negative pid) so the
+    // shell and any orphaned `defaults`/`plutil` stages are reaped on timeout.
+    expect(processKillSpy).toHaveBeenCalledTimes(2)
+    expect(processKillSpy).toHaveBeenCalledWith(-4242, 'SIGKILL')
   })
 
   it('picks an existing floating workspace directory without enabling native directory creation', async () => {

--- a/src/main/ipc/app.test.ts
+++ b/src/main/ipc/app.test.ts
@@ -197,9 +197,17 @@ describe('registerAppHandlers', () => {
       'com.apple.inputmethod.SCIM.ITABC'
     )
     expect(execFileMock).toHaveBeenCalledTimes(1)
+    // Why: macOS 15's `plutil -extract <key> json` aborts on the input-source
+    // array, so the probe reads live cfprefsd via `defaults export` and dodges
+    // the bug with an xml1 extract before converting the clean subtree to JSON.
     expect(execFileMock).toHaveBeenCalledWith(
-      '/usr/bin/plutil',
-      expect.arrayContaining(['AppleSelectedInputSources']),
+      '/bin/sh',
+      [
+        '-c',
+        expect.stringMatching(
+          /^defaults export com\.apple\.HIToolbox - \| plutil -extract AppleSelectedInputSources xml1 .+ \| plutil -convert json/
+        )
+      ],
       expect.any(Object),
       expect.any(Function)
     )

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,6 +1,5 @@
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { homedir } from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { app, BrowserWindow, dialog, ipcMain, type IpcMainInvokeEvent } from 'electron'
@@ -24,12 +23,14 @@ import { isMarkdownDocumentName, markdownDocumentFromFilePath } from './markdown
 
 const KEYBOARD_INPUT_SOURCE_TIMEOUT_MS = 500
 const MAC_HITOOLBOX_DOMAIN = 'com.apple.HIToolbox'
-const MAC_HITOOLBOX_PREFERENCES_PATH = path.join(
-  homedir(),
-  'Library',
-  'Preferences',
-  `${MAC_HITOOLBOX_DOMAIN}.plist`
-)
+// Why: macOS 15's `plutil -extract <key> json` aborts on the (pure-string)
+// input-source array and the on-disk plist lags cfprefsd; read live prefs via
+// `defaults export`, extract as xml1 (dodges the json bug), then convert to JSON.
+const MAC_SELECTED_INPUT_SOURCES_JSON_COMMAND = [
+  `defaults export ${MAC_HITOOLBOX_DOMAIN} -`,
+  'plutil -extract AppleSelectedInputSources xml1 -o - -',
+  'plutil -convert json -o - -'
+].join(' | ')
 
 type RegisterAppHandlersOptions = {
   onBeforeRelaunch?: () => void | Promise<void>
@@ -196,8 +197,8 @@ function readSelectedInputSourceIdFromJson(stdout: string): string | null {
 async function readSelectedKeyboardInputSourceId(): Promise<string | null> {
   try {
     const stdout = await readCommandStdout(
-      '/usr/bin/plutil',
-      ['-extract', 'AppleSelectedInputSources', 'json', '-o', '-', MAC_HITOOLBOX_PREFERENCES_PATH],
+      '/bin/sh',
+      ['-c', MAC_SELECTED_INPUT_SOURCES_JSON_COMMAND],
       'Selected keyboard input source probe timed out'
     )
     return readSelectedInputSourceIdFromJson(stdout)

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -26,10 +26,11 @@ const MAC_HITOOLBOX_DOMAIN = 'com.apple.HIToolbox'
 // Why: macOS 15's `plutil -extract <key> json` aborts on the (pure-string)
 // input-source array and the on-disk plist lags cfprefsd; read live prefs via
 // `defaults export`, extract as xml1 (dodges the json bug), then convert to JSON.
+// Absolute paths so a GUI-launched app's minimal PATH can't shadow the tools.
 const MAC_SELECTED_INPUT_SOURCES_JSON_COMMAND = [
-  `defaults export ${MAC_HITOOLBOX_DOMAIN} -`,
-  'plutil -extract AppleSelectedInputSources xml1 -o - -',
-  'plutil -convert json -o - -'
+  `/usr/bin/defaults export ${MAC_HITOOLBOX_DOMAIN} -`,
+  '/usr/bin/plutil -extract AppleSelectedInputSources xml1 -o - -',
+  '/usr/bin/plutil -convert json -o - -'
 ].join(' | ')
 
 type RegisterAppHandlersOptions = {
@@ -119,13 +120,32 @@ function readCommandStdout(
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     let settled = false
-    let child: ReturnType<typeof execFile> | undefined
+    let child: ReturnType<typeof spawn> | undefined
+
+    // Why: the probe runs a `/bin/sh -c` pipeline, so signaling only the shell
+    // orphans wedged `defaults`/`plutil` stages on a stuck cfprefsd. Spawning
+    // detached makes the child a process-group leader, so one negative-pid
+    // SIGKILL reaps the shell and every stage; child.kill() covers the fallback.
+    const killTree = (): void => {
+      if (!child?.pid) {
+        return
+      }
+      try {
+        process.kill(-child.pid, 'SIGKILL')
+      } catch {
+        child.kill()
+      }
+    }
+
+    // Why: short timeout so a wedged macOS preference probe (corporate-managed
+    // config, sandbox policy, ...) never holds the handle indefinitely. This
+    // manual timer is the only timeout guard, so it owns the process-group kill.
     const timer = setTimeout(() => {
       if (settled) {
         return
       }
       settled = true
-      child?.kill()
+      killTree()
       reject(new Error(timeoutMessage))
     }, KEYBOARD_INPUT_SOURCE_TIMEOUT_MS)
 
@@ -138,24 +158,32 @@ function readCommandStdout(
       callback()
     }
 
-    // Why: execFile's timeout only signals `defaults`; if the callback
-    // never arrives, window-focus keyboard probes would remain pending.
     try {
-      child = execFile(
-        command,
-        args,
-        // Why: short timeout so a wedged macOS preference probe (corporate-managed
-        // config, sandbox policy, ...) never holds the handle indefinitely.
-        // Fall through to the fingerprint on timeout.
-        { encoding: 'utf8', timeout: KEYBOARD_INPUT_SOURCE_TIMEOUT_MS },
-        (error, stdout) => {
-          if (error) {
-            settle(() => reject(error))
-            return
-          }
-          settle(() => resolve(String(stdout ?? '')))
-        }
-      )
+      child = spawn(command, args, { detached: true, stdio: ['ignore', 'pipe', 'ignore'] })
+      let stdout = ''
+      child.stdout?.setEncoding('utf8')
+      child.stdout?.on('data', (chunk: string) => {
+        stdout += chunk
+      })
+      const failWith = (error: Error): void => {
+        killTree()
+        settle(() => reject(error))
+      }
+      // Why: an unhandled Readable 'error' would crash the main process; treat a
+      // stdout read failure the same as a child spawn error.
+      child.stdout?.on('error', failWith)
+      child.on('error', failWith)
+      child.on('close', (code, signal) => {
+        settle(() =>
+          code === 0
+            ? resolve(stdout)
+            : reject(
+                new Error(
+                  `${command} exited with ${signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`}`
+                )
+              )
+        )
+      })
     } catch (error) {
       settle(() => reject(error))
     }


### PR DESCRIPTION
## Problem
On macOS 15, typing Chinese with third-party IMEs (Sogou, Doubao) produced half-width `,.?` instead of full-width `，。？` in terminal panes and the agent chat input. Apple’s built-in Simplified Chinese IME was unaffected.

## Root cause
CJK punctuation forwarding (`forwardAsciiPunctuation`) only turns on when the active macOS input source is detected as CJK. That detection in `src/main/ipc/app.ts` read the selected input source with `plutil -extract AppleSelectedInputSources json -o - <HIToolbox.plist>`.
On macOS 15 `plutil -extract … json` aborts with `invalid object in plist for destination format` on the input-source array (even though it is all strings). The probe threw and fell back to the keyboard-layout id (`com.apple.keylayout.US`), which never matches the CJK term list, so full-width forwarding stayed off and xterm sent raw half-width keys. Apple’s built-in IME happened not to trip the plutil bug.

## Fix
Read live prefs via cfprefsd and dodge the json bug:
```
defaults export com.apple.HIToolbox - | plutil -extract AppleSelectedInputSources xml1 -o - - | plutil -convert json -o - -
```
The existing JSON parser and CJK term list are unchanged.

## Verification
- Reproduced + fixed on macOS 15.7.7 (24G720): new command returns `com.sogou.inputmethod.pinyin` → CJK matched → `forwardAsciiPunctuation=true`.
- `app.test.ts` command-shape assertion updated — 8/8 pass; `tc:node` clean; oxlint clean on changed files