### PR TITLE
docs: guide for pairing mobile through a self-hosted public relay

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -9,6 +9,7 @@ Keep this folder for versioned reference docs that are meant to survive past a s
 - Docs that other checked-in files link to.
 - Telemetry availability notes that dashboard authors need after the original design or implementation branch is gone. See [Telemetry Availability](./telemetry-availability.md).
 - Headless Linux server setup for remote `orca serve` hosts. See [Headless Linux Server](./headless-linux-server.md).
+- Mobile pairing through a self-hosted relay for desktops that roam between networks and can't reach the phone over a shared LAN or overlay network. See [Mobile Pairing Through a Self-Hosted Public Relay](./mobile-public-relay.md).
 - Feature education state, interaction tracking, and retention analytics notes that define how contextual tours are persisted and measured. See [Feature Education State](./feature-education-state.md), [Feature Discovery Interaction Tracking](./feature-discovery-interaction-tracking.md), and [Feature Education Retention Analytics](./feature-education-retention-analytics.md).
 - New-user parallel work telemetry notes that define how the parallel-work tour and setup guide should be measured against retention. See [New User Parallel Work Telemetry](./new-user-parallel-work-telemetry.md).
 

--- a/docs/reference/mobile-public-relay.md
+++ b/docs/reference/mobile-public-relay.md
@@ -79,8 +79,9 @@ which the reconnecting tunnel keeps failing to re-bind the port.
 Validate the config before restarting so a typo cannot lock you out:
 
 ```bash
-# Linux
-sudo sshd -t && sudo systemctl restart sshd
+# Linux. The sshd binary is `sshd` everywhere, but the systemd unit is
+# `ssh` on Debian/Ubuntu and `sshd` on RHEL/Fedora/Arch — use yours.
+sudo sshd -t && sudo systemctl restart ssh
 ```
 
 ```powershell
@@ -238,8 +239,9 @@ and use a trusted machine.
   sessions are reaped promptly.
 - Config changes not applying after an sshd restart: service managers
   sometimes report success without restarting the process. Compare the
-  sshd PID before and after with `systemctl show sshd -p MainPID`
-  (Linux) or `sc.exe queryex sshd` (Windows).
+  sshd PID before and after with `systemctl show ssh -p MainPID`
+  (Linux; the unit is `sshd` on RHEL/Fedora/Arch) or
+  `sc.exe queryex sshd` (Windows).
 - Windows relay with WSL2 mirrored networking: `netsh portproxy` rules
   silently do nothing under `networkingMode=mirrored`; the sshd reverse
   tunnel above is the working alternative. Mirrored mode can also

--- a/docs/reference/mobile-public-relay.md
+++ b/docs/reference/mobile-public-relay.md
@@ -1,0 +1,257 @@
+# Mobile Pairing Through a Self-Hosted Public Relay
+
+Use this guide when the Orca mobile app must reach a desktop that roams
+between networks (office, home, café) and you want a server you already
+own to act as the fixed public anchor: a cloud VPS, or a home server
+behind a DDNS domain. The only tool required is the SSH access you
+already have to that server.
+
+If both devices are always on the same Wi-Fi, you do not need any of
+this. If you run Tailscale (or another overlay network), pair with the
+overlay address instead; that is the path the pairing UI suggests
+first. And if your Orca host is itself a server with a stable address,
+see [Headless Linux Server](./headless-linux-server.md) and
+`orca serve --pairing-address`; this guide is for the case where the
+*desktop* moves around.
+
+Requires Orca v1.4.121 or later on the desktop: earlier versions
+rejected plain hostnames in the custom-address dialog
+([#7223](https://github.com/stablyai/orca/pull/7223)).
+
+## How It Works
+
+```text
+phone ──▶ relay.example.com:28477 ──▶ (reverse tunnel on relay) ──▶ desktop 127.0.0.1:6768
+                                            ▲
+                              opened outbound by the desktop,
+                              so the desktop can be anywhere
+```
+
+Three facts make this simple:
+
+- **The desktop runtime listens for mobile connections whenever Orca is
+  running.** It is a WebSocket server on `0.0.0.0:6768` by default.
+  There is no extra toggle to enable, and the desktop GUI does not
+  change the listening port (only `orca serve --port` does).
+- **The connection is end-to-end encrypted at the application layer.**
+  The pairing QR carries a per-device token and a Curve25519 public
+  key; both ends derive a shared key and encrypt everything above the
+  socket. The relay forwards ciphertext it cannot read or modify, so a
+  plain TCP path is enough and the relay needs no TLS certificate.
+  (Passive observers can see the handshake public keys, which are not
+  sensitive; the device token is only ever sent encrypted.)
+- **The desktop dials out.** The desktop opens an SSH reverse tunnel
+  *to* the relay, which makes the relay port forward back to the
+  desktop wherever it currently is. The phone only ever connects to the
+  relay's fixed address. Public tunnel addresses are an intended
+  pairing target: `orca serve --help` describes `--pairing-address` as
+  for "a LAN, Tailscale, SSH-forward, or public tunnel address".
+
+## Prerequisites
+
+- A relay server with a public TCP entry point: a VPS, or a home
+  machine reachable through DDNS plus a router port-forward.
+- SSH access from the desktop to that server.
+- Orca v1.4.121+ running on the desktop.
+- A relay port. This guide uses `28477`. Prefer an unused port below
+  32768; the WSL2 troubleshooting entry below explains why.
+
+## Relay Server: Allow Public Reverse Tunnels
+
+By default, sshd binds reverse-tunnel ports to the server's loopback
+interface only. Let the tunnel client choose a public bind address
+instead, and make the server drop half-dead tunnel sessions promptly so
+their port is freed for the desktop to reconnect. In
+`/etc/ssh/sshd_config` (Linux) or `C:\ProgramData\ssh\sshd_config`
+(Windows OpenSSH), add:
+
+```text
+GatewayPorts clientspecified
+ClientAliveInterval 15
+ClientAliveCountMax 3
+```
+
+Without `ClientAlive*`, a desktop that sleeps or switches networks
+leaves the relay holding the old session — and its bound port — until
+the kernel's default TCP keepalive reaps it (often ~2 hours), during
+which the reconnecting tunnel keeps failing to re-bind the port.
+
+Validate the config before restarting so a typo cannot lock you out:
+
+```bash
+# Linux
+sudo sshd -t && sudo systemctl restart sshd
+```
+
+```powershell
+# Windows (elevated PowerShell). The built-in "OpenSSH Server" feature
+# installs to C:\Windows\System32\OpenSSH; the standalone MSI installs
+# to C:\Program Files\OpenSSH. Use whichever path exists on your host.
+& "$env:SystemRoot\System32\OpenSSH\sshd.exe" -t -f C:\ProgramData\ssh\sshd_config
+Restart-Service sshd
+```
+
+Open the relay port in the server firewall:
+
+```bash
+# Linux (ufw)
+sudo ufw allow 28477/tcp
+```
+
+```powershell
+# Windows
+New-NetFirewallRule -DisplayName "Orca relay 28477" -Direction Inbound `
+  -Protocol TCP -LocalPort 28477 -Action Allow
+```
+
+On a cloud VPS, also open the port in the provider's security
+group or network firewall (AWS, GCP, Azure, Oracle, and others gate
+inbound traffic there before it reaches the host firewall). If the
+relay is a home machine behind a router, instead add a port-forward
+rule on the router (external `28477` to the server's LAN address, port
+`28477`) and confirm your DDNS record points at the home connection's
+current public IP.
+
+## Desktop: Keep a Reverse Tunnel Open
+
+Test the tunnel once by hand from the desktop (the machine running
+Orca). `user@relay` is your SSH login on the relay server:
+
+```bash
+ssh -N -o ExitOnForwardFailure=yes -R 0.0.0.0:28477:127.0.0.1:6768 user@relay
+```
+
+This binds `0.0.0.0:28477` on the relay and forwards every connection
+back to the desktop's local Orca port. While it runs, verify from a
+shell **on the relay server** that traffic really reaches Orca:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:28477/
+# 200 means the tunnel reached the desktop's Orca runtime
+```
+
+(The `200` is Orca's bundled web client answering through the tunnel.)
+
+Then make the tunnel survive reboots and network changes.
+
+**macOS.** Save as `~/Library/LaunchAgents/com.example.orca-relay.plist`,
+replacing `user@relay`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.example.orca-relay</string>
+  <key>ProgramArguments</key><array>
+    <string>/usr/bin/ssh</string>
+    <string>-N</string>
+    <string>-o</string><string>ExitOnForwardFailure=yes</string>
+    <string>-o</string><string>ServerAliveInterval=15</string>
+    <string>-o</string><string>ServerAliveCountMax=3</string>
+    <string>-R</string><string>0.0.0.0:28477:127.0.0.1:6768</string>
+    <string>user@relay</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>15</integer>
+</dict></plist>
+```
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.example.orca-relay.plist
+```
+
+**Linux.** Simplest is `autossh`; a systemd user unit wrapping the same
+`ssh` command works equally well:
+
+```bash
+autossh -M 0 -f -N \
+  -o ExitOnForwardFailure=yes -o ServerAliveInterval=15 -o ServerAliveCountMax=3 \
+  -R 0.0.0.0:28477:127.0.0.1:6768 user@relay
+```
+
+**Windows.** Run the same `ssh -N -R ...` command as a Scheduled Task
+(trigger *At log on*, action `ssh.exe` with the arguments above,
+restart on failure), or under any service wrapper you already use.
+
+The client-side `ServerAlive*` options make the desktop notice a dead
+relay and exit, so the supervisor (launchd, autossh, or Task Scheduler)
+restarts it; the relay-side `ClientAlive*` settings above are what free
+the bound port in time for that restart to succeed. Together they
+re-establish the tunnel after sleep or a network switch.
+
+## Pair the Phone
+
+1. On the desktop, open **Settings → Mobile**. In the
+   **Network Interface** section, open the address picker and choose
+   **Add custom address…**
+2. Enter your relay address with the port, for example
+   `relay.example.com:28477`, and confirm with **Use address**.
+3. Scan the pairing QR code with the Orca mobile app. To prove the
+   public path end to end, turn off Wi-Fi on the phone and pair over
+   cellular.
+
+The phone stores this endpoint and keeps using it as the desktop
+roams; you do not re-pair when the desktop changes networks. It will
+*not* follow a change of relay address, so if you move the relay,
+remove the host on the phone and pair again.
+
+Multiple desktops can share one relay: give each its own port
+(`28477`, `28478`, …) and its own tunnel. If you also apply the
+hardening below, give each desktop its own key with its own
+`permitlisten` port, or the second desktop's tunnel is refused.
+
+## Hardening (Optional But Recommended)
+
+Give the tunnel a dedicated SSH key that can do nothing except maintain
+this one forward. Generate a key, then prefix its line in
+`authorized_keys` on the relay:
+
+```text
+restrict,port-forwarding,permitlisten="0.0.0.0:28477" ssh-ed25519 AAAA... orca-relay
+```
+
+Two easy mistakes fail with `remote port forwarding failed` only at
+connect time: `restrict` alone disables all forwarding, so
+`port-forwarding` must be explicitly re-enabled after it, and
+`permitlisten` must name the bind address, because a bare
+`permitlisten="28477"` does not match a tunnel that asks for a public
+`0.0.0.0` bind. Note that `restrict` does not prevent command
+execution; use a dedicated low-privilege account on the relay if you
+want full confinement.
+
+What the public port exposes: anyone who finds it can load the Orca web
+client page and attempt a WebSocket handshake, but taking control
+requires the paired device's token and key, which never leave your
+devices unencrypted. The relay still terminates raw TCP from the
+internet, so treat it like any other public service: keep sshd patched
+and use a trusted machine.
+
+## Troubleshooting
+
+- `remote port forwarding failed` at tunnel start: the server is
+  missing `GatewayPorts clientspecified`, the port is already taken on
+  the server, an `authorized_keys` restriction (above) does not match
+  the requested bind address and port, or the desktop reconnected
+  before the relay released the previous session's port — set
+  `ClientAliveInterval`/`ClientAliveCountMax` on the relay so stale
+  sessions are reaped promptly.
+- Config changes not applying after an sshd restart: service managers
+  sometimes report success without restarting the process. Compare the
+  sshd PID before and after with `systemctl show sshd -p MainPID`
+  (Linux) or `sc.exe queryex sshd` (Windows).
+- Windows relay with WSL2 mirrored networking: `netsh portproxy` rules
+  silently do nothing under `networkingMode=mirrored`; the sshd reverse
+  tunnel above is the working alternative. Mirrored mode can also
+  invisibly reserve port ranges (binds fail with "address in use" while
+  `netstat` shows nothing), and ports inside the Linux ephemeral range
+  32768–60999 can be claimed at any time, which is why this guide picks
+  a relay port below 32768.
+- `curl` on the relay returns 200 but the phone cannot connect: that
+  check only proves the leg from the relay to the desktop. Test the
+  public leg with `curl http://relay.example.com:28477/` from outside
+  (for example, the phone on cellular), and re-check the router
+  port-forward, host firewall, and any cloud provider security group.
+- The address dialog rejects your domain: Orca older than v1.4.121 only
+  accepted IPv4 addresses and `*.ts.net` hostnames there; update the
+  desktop app.


### PR DESCRIPTION
## Summary

Adds `docs/reference/mobile-public-relay.md`: a setup guide for pairing the Orca mobile app with a **roaming desktop** through a self-hosted public relay (a VPS or a DDNS home server) using an SSH reverse tunnel — for users who don't run Tailscale.

This documents the user-facing side of #7222 / #7223: since v1.4.121 (the first stable release containing #7223) the custom-address dialog accepts any hostname (`relay.example.com:28477`), but there was no documentation for how to stand up the relay endpoint such an address points at. The repo already ships the server-side sibling ([Headless Linux Server](https://github.com/stablyai/orca/blob/main/docs/reference/headless-linux-server.md), for `orca serve` hosts with a stable address); this guide covers the complementary case where the desktop moves and dials out to a fixed anchor. `orca serve --help` already names "SSH-forward, or public tunnel address" as intended pairing targets, so the guide documents an intended-but-undocumented deployment shape rather than a workaround.

Also adds one index line to `docs/reference/README.md` (which lists "Public-facing docs that are not part of the root README" as in scope for this folder).

## Screenshots

No visual change (documentation only).

## Testing

Docs-only change — no source files touched, so `pnpm lint` / `typecheck` / `test` / `build` are unaffected (repo lint does not cover markdown). Instead, every command in the guide was executed against a real deployment before writing it down:

- Relay: Windows 11 + OpenSSH for Windows 9.5p2 behind a home NAT with a DDNS domain and router port-forward; desktop: macOS (Orca v1.4.124, listener observed on `*:6768`).
- Fresh end-to-end run of the guide's tunnel command on an unused port: `ssh -N -o ExitOnForwardFailure=yes -R 0.0.0.0:<port>:127.0.0.1:6768` → server-side `netstat` shows the `0.0.0.0` bind, `curl http://127.0.0.1:<port>/` on the relay returns `200`, and the same check passes from the public internet against the DDNS domain. Phone paired and connected over cellular through this exact topology.
- The launchd plist passes `plutil -lint`.
- The custom-address flow was confirmed in the shipped v1.4.124 desktop app: in Settings → Mobile → Network Interface → **Add custom address…**, entering `<domain>:28477` is accepted and the **Use address** button enables. The dialog's own hint text lists "a DDNS domain" as a supported input, matching the path this guide documents.
- The hardening line was tested both ways on OpenSSH 9.5p2: `restrict,port-forwarding,permitlisten="0.0.0.0:<port>"` allows the tunnel (curl 200 through it) while a different port is refused with `remote port forwarding failed`. Two broken variants that look right but fail (`restrict` without `port-forwarding`; bare `permitlisten="<port>"` against a `0.0.0.0` bind) are called out in the guide because we hit them in testing, as is the fact that `restrict` does not block command execution.
- Linux relay/desktop snippets (`ufw`, `autossh`, `sshd -t && systemctl restart sshd`) follow the standard tools' documented usage but were not run on this rig; the Windows Scheduled Task suggestion is described as a pattern, not a copy-paste recipe.

## AI Review Report

The guide's technical claims were verified against the v1.4.124 source rather than written from memory; several drafts were corrected as a result:

- Desktop WS listener: always on while Orca runs, `0.0.0.0:6768` default (`src/main/runtime/runtime-rpc.ts`, `src/main/index.ts` passes `enableWebSocket: true` unconditionally) — an earlier draft wrongly implied a settings toggle exists. GUI changes only the advertised address, not the listening port (`orca serve --port` is the only port knob).
- E2EE: pairing payload fields and tweetnacl (Curve25519) handshake per `src/shared/pairing.ts` / `src/main/runtime/rpc/e2ee-channel.ts`; the device token is only ever sent encrypted, handshake public keys are visible to the relay — the guide states exactly that rather than claiming "zero plaintext".
- UI copy quoted in the pairing steps ("Add custom address…", "Use address", Settings → Mobile → Network Interface) matches `NetworkInterfacePicker.tsx` / `MobileNetworkInterfaceSection.tsx` in v1.4.124 and the strings shipped in the packaged app.
- Mobile behavior: endpoint persisted on the phone (`mobile/src/transport/host-store.ts`); phones can remove a host but not edit its endpoint, so the guide says "remove and re-pair", not "edit".
- Cross-platform: relay instructions cover Linux and Windows sshd; desktop persistence covers macOS (launchd), Linux (autossh/systemd), Windows (Scheduled Task); paths and commands are per-platform and marked as such.

Three independent review passes (technical correctness vs. source, privacy/leakage of the deployment it was tested on, and consistency with `docs/reference/` conventions) ran over the final text; remaining findings were fixed before opening this PR.

## Security Audit

The guide tells users to expose a TCP port to the internet, so it addresses that directly instead of leaving it implicit:

- States precisely what the public port exposes (the bundled web client page and the ability to attempt a WS handshake) and what gates control (per-device token + keypair, never sent in the clear — pairing parameters travel in the URL fragment, which proxies/logs don't see).
- Recommends a dedicated SSH key locked down with `restrict,port-forwarding,permitlisten` (tested, including the failure modes), and notes `restrict` alone does not prevent command execution — recommending a low-privilege account for full confinement.
- Config-safety habits are baked into the steps: `sshd -t` before restart, `ExitOnForwardFailure` so a broken forward fails loudly, and a troubleshooting entry for service managers that report an sshd restart that didn't happen.
- No secrets, real hostnames, or real IPs appear in the guide; all examples use `relay.example.com` / placeholder ports.

## Notes

- The real-world test matrix is macOS desktop ↔ Windows OpenSSH relay; Linux-side commands are standard but flagged above as not exercised on this exact setup. Happy to adjust anything maintainers want phrased differently.
- The guide deliberately does not cover pre-v1.4.121 workarounds (the DevTools IPC route); it points users to update instead.

X handle for a contributor shoutout: @lynda94366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Docs explain pairing mobile through a self-hosted public relay with an SSH reverse tunnel. Useful if you don’t use Tailscale but still want mobile access on the go.
