### PR TITLE
docs(terminal): document terminal read --json result schema

### DIFF
--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -168,6 +168,20 @@ orca terminal switch --terminal <handle> --json
 orca terminal close --terminal <handle> --json
 ```
 
+When you call `terminal read --json`, the response is wrapped as `result.terminal` with:
+
+- `handle` — terminal handle echoed from the request.
+- `status` — `running` | `exited` | `unknown`.
+- `tail` — `string[]`, the output lines returned by this read.
+- `truncated` — older output is unrecoverable (retained buffer trimmed, or a non-pageable partial line was clipped).
+- `limited` — this read hit `--limit` but more output is retained (page via cursors).
+- `oldestCursor` — retained-history entry point; start reading older retained output with `--cursor <oldestCursor>`.
+- `nextCursor` — forward paging cursor; pass its value to `--cursor` to read newer output (equals `latestCursor` when caught up).
+- `latestCursor` — newest retained extent; forward paging is complete when `nextCursor` reaches it.
+- `returnedLineCount` — number of lines in this `tail`.
+
+Cursor values are non-negative integer line offsets serialized as strings (e.g. `"3000"`); pass the digits to `--cursor`.
+
 Terminal rules:
 
 - `--terminal` is optional for most commands; omitted means the active terminal in the current worktree.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -459,7 +459,7 @@ export function formatFlagHelp(flag: string): string {
     'base-branch': '--base-branch <ref>    Base branch/ref to create the worktree from',
     command: '--command <text>       Command to run in the terminal on startup',
     comment: '--comment <text>       Comment stored in Orca metadata',
-    cursor: '--cursor <n>           Line cursor from a previous read (returns only new output)',
+    cursor: '--cursor <n>           Line-offset cursor from a prior read; pass nextCursor to page newer output',
     action: '--action <name>       Secondary accessibility action name',
     activate: '--activate             Reveal the new worktree in the Orca app',
     app: '--app <app>            App name, bundle ID, or pid:N',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -307,6 +307,33 @@ describe('orca root help', () => {
     )
     expect(callMock).not.toHaveBeenCalled()
   })
+
+  it('documents the terminal read --json result schema in command help', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    logSpy.mockClear()
+
+    await main(['terminal', 'read', '--help'], '/tmp/repo')
+
+    const help = String(logSpy.mock.calls[0][0])
+    // Why: the RuntimeTerminalRead fields are otherwise only surfaced as loose
+    // text in the human formatter; --help is where consumers look them up.
+    expect(help).toContain('orca terminal read')
+    expect(help).toContain('--cursor <n>')
+    for (const field of [
+      'handle',
+      'status',
+      'tail',
+      'truncated',
+      'limited',
+      'oldestCursor',
+      'nextCursor',
+      'latestCursor',
+      'returnedLineCount'
+    ]) {
+      expect(help).toContain(field)
+    }
+    expect(callMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('orca cli worktree awareness', () => {

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -187,6 +187,16 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'cursor', 'limit'],
     notes: [
       'Omit --terminal to target the active terminal in the current worktree.',
+      '--json result (result.terminal):',
+      '  handle             terminal handle echoed from the request',
+      '  status             running | exited | unknown',
+      '  tail               string[], the output lines returned by this read',
+      '  truncated          older output is unrecoverable (retained buffer trimmed, or a non-pageable partial line was clipped)',
+      '  limited            this read hit --limit but more output is retained (page via cursors)',
+      '  oldestCursor       retained-history entry point; start reading older retained output with --cursor <oldestCursor>',
+      '  nextCursor         forward paging cursor; pass its value to --cursor to read newer output (equals latestCursor when caught up)',
+      '  latestCursor       newest retained extent; forward paging is complete when nextCursor reaches it',
+      '  returnedLineCount  number of lines in this tail',
       'Use --cursor with the nextCursor value from a previous read to get only new output since that read.',
       'Use --limit to request more retained lines for long agent responses; output reports oldestCursor when older lines were dropped.',
       'Useful for capturing the response to a command: read before sending, then read --cursor <prev> after waiting.'


### PR DESCRIPTION
## Summary

`terminal read --help` documented only the input flags; the shape of the `--json` result was nowhere except the human formatter's loose `cursor:` / `latest cursor:` text lines. Consumers had to guess field names, and the `nextCursor` vs `latestCursor` paging distinction was not surfaced.

This documents `result.terminal.*` in `terminal read --help` (field table under Notes), mirrors an agent-framed field reference in `skills/orca-cli/SKILL.md`, and sharpens the `--cursor` flag wording to point at `nextCursor` for paging.

Field semantics were verified against `RuntimeTerminalRead` (`src/shared/runtime-types.ts`) and `readTerminalTail` (`src/main/runtime/orca-runtime.ts`) rather than just the issue excerpt — e.g. cursor values are non-negative integer line offsets serialized as strings, and `nextCursor` equals `latestCursor` (never `null`) at the newest extent.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

```
pnpm vitest run src/cli/index.test.ts -t "documents the terminal read --json result schema"
```

## AI Review Report

Two-axis review (Standards + Spec) run locally before opening.

- **Standards:** clean. The schema is transcribed in three surfaces (help notes, skill doc, test); this is inherent to documentation and matches the hand-authored help convention used across the CLI, so no codegen was introduced. Wording was unified across the help and skill surfaces after a first pass flagged divergence.
- **Spec:** every field the issue's "What would help" lists is documented (`status`, `tail[]`, `truncated`, `limited`, `oldestCursor` / `nextCursor` / `latestCursor`, `returnedLineCount`), and the "which cursor drives `--cursor` paging" requirement is explicit (`nextCursor`). No spec requirement missing.
- Cross-platform compatibility: N/A — text-only help/skill documentation; no shortcuts, labels, paths, shell behavior, or Electron platform differences touched.

## Security Audit

N/A — documentation and a help substring test only. No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface touched.

## Notes

`--cursor` stays `--cursor <n>` (not renamed to an opaque-token placeholder). The implementation treats it as a non-negative integer line offset — the CLI validates `/^\d+$/` (`src/cli/handlers/terminal.ts`) and the runtime `readTerminalTail` does integer arithmetic on it — so `<n>` is the accurate placeholder, and response cursors are its stringified values.

## ELI5

`terminal read --json` field shapes are documented in help and the CLI skill. Cursor vs latestCursor paging is spelled out so tools don’t guess wrong fields.
