### PR TITLE
feat(orchestration): allow editing task dependencies via task-update

### DIFF
--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -106,12 +106,14 @@ A task is the work item, a dispatch assigns it to a terminal, and a gate blocks 
 ```bash
 orca orchestration task-create --spec <text> [--deps <json_array>] [--parent <task_id>] [--json]
 orca orchestration task-list [--status <status>] [--ready] [--json]
-orca orchestration task-update --id <task_id> --status <status> [--result <json>] [--json]
+orca orchestration task-update --id <task_id> [--status <status>] [--deps <json_array>] [--result <json>] [--json]
 orca orchestration dispatch --task <task_id> --to <handle> [--from <handle>] [--inject] [--json]
 orca orchestration dispatch-show --task <task_id> [--json]
 ```
 
 Task statuses: `pending`, `ready`, `dispatched`, `completed`, `failed`, `blocked`.
+
+`task-update` requires at least one of `--status` or `--deps`; deps are editable only while a task is `pending` or `ready`.
 
 Dispatch rules:
 

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -509,8 +509,8 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
   },
 
   'orchestration task-update': async ({ flags, client, json }) => {
-    const status = getRequiredStringFlag(flags, 'status')
-    if (!TASK_STATUS_VALUES.includes(status as (typeof TASK_STATUS_VALUES)[number])) {
+    const status = getOptionalStringFlag(flags, 'status')
+    if (status !== undefined && !TASK_STATUS_VALUES.includes(status as (typeof TASK_STATUS_VALUES)[number])) {
       throw new RuntimeClientError(
         'invalid_argument',
         `invalid status '${status}', expected one of: ${TASK_STATUS_VALUES.join(', ')}`
@@ -521,6 +521,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       {
         id: getRequiredStringFlag(flags, 'id'),
         status,
+        deps: getOptionalStringFlag(flags, 'deps'),
         result: getOptionalStringFlag(flags, 'result')
       }
     )

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -466,6 +466,7 @@ export function formatFlagHelp(flag: string): string {
     direction:
       '--direction <dir>      Direction: up|down|left|right for scroll, horizontal|vertical for split',
     'display-name': '--display-name <name>  Override the Orca display name',
+    deps: '--deps <json_array>   JSON array of task IDs this task depends on',
     'element-index': '--element-index <n>   Element index from get-app-state',
     title: '--title <text>         Custom title for the terminal tab (omit to reset)',
     enter: '--enter                Append Enter after sending text',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3293,6 +3293,45 @@ describe('orca cli worktree awareness', () => {
     errSpy.mockRestore()
   })
 
+  it('advertises --deps in task-update help', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    logSpy.mockClear()
+
+    await main(['orchestration', 'task-update', '--help'], '/tmp/repo')
+
+    const help = String(logSpy.mock.calls[0][0])
+    expect(help).toContain('[--deps <json_array>]')
+    expect(help).toContain('Update a task status or dependencies')
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('passes --deps through orchestration task-update', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_coord'
+    callMock.mockResolvedValueOnce({
+      id: 'req_task_update_deps',
+      ok: true,
+      result: {
+        task: { id: 'task_1', status: 'ready' }
+      },
+      _meta: {
+        runtimeId: 'runtime-1'
+      }
+    })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['orchestration', 'task-update', '--id', 'task_1', '--deps', '["task_2"]'],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith('orchestration.taskUpdate', {
+      id: 'task_1',
+      status: undefined,
+      deps: '["task_2"]',
+      result: undefined
+    })
+  })
+
   it('passes the caller terminal handle through orchestration task-create', async () => {
     process.env.ORCA_TERMINAL_HANDLE = 'term_creator'
     callMock.mockResolvedValueOnce({

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -81,11 +81,16 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['orchestration', 'task-update'],
-    summary: 'Update a task status',
+    summary: 'Update a task status or dependencies',
     usage:
-      'orca orchestration task-update --id <task_id> --status <status> [--result <json>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'id', 'status', 'result'],
-    notes: ['Valid --status values: pending, ready, dispatched, completed, failed, blocked.']
+      'orca orchestration task-update --id <task_id> [--status <status>] [--deps <json_array>] [--result <json>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'id', 'status', 'deps', 'result'],
+    notes: [
+      'Provide at least one of --status or --deps.',
+      'Valid --status values: pending, ready, dispatched, completed, failed, blocked.',
+      '--deps is a JSON array of task IDs; editable only while a task is pending or ready.',
+      'When both are given, --deps is applied before --status, so --status is the final word.'
+    ]
   },
   {
     path: ['orchestration', 'dispatch'],

--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -231,6 +231,62 @@ describe('OrchestrationDb', () => {
       expect(d.getTask(t3.id)?.status).toBe('ready')
     })
 
+    it('updateTaskDeps writes the deps column', () => {
+      const d = createDb()
+      const a = d.createTask({ spec: 'a' })
+      const b = d.createTask({ spec: 'b' })
+      const task = d.createTask({ spec: 'task', deps: [a.id] })
+
+      const updated = d.updateTaskDeps(task.id, [b.id])
+
+      expect(JSON.parse(updated!.deps)).toEqual([b.id])
+    })
+
+    it('updateTaskDeps promotes a pending task to ready when deps are satisfied', () => {
+      const d = createDb()
+      const done = d.createTask({ spec: 'done' })
+      d.updateTaskStatus(done.id, 'completed')
+      // Why: starts pending against an unsatisfied dep, then deps are rewritten
+      // to point only at the completed task.
+      const task = d.createTask({ spec: 'task', deps: ['task_unmet'] })
+
+      expect(d.getTask(task.id)?.status).toBe('pending')
+
+      d.updateTaskDeps(task.id, [done.id])
+
+      expect(d.getTask(task.id)?.status).toBe('ready')
+    })
+
+    it('updateTaskDeps demotes a ready task to pending when a dep is added', () => {
+      const d = createDb()
+      const blocker = d.createTask({ spec: 'blocker' })
+      // Why: a no-dep task is ready at creation; adding an incomplete dep must
+      // flip it back to pending so it is not dispatchable.
+      const task = d.createTask({ spec: 'task' })
+
+      expect(task.status).toBe('ready')
+
+      d.updateTaskDeps(task.id, [blocker.id])
+
+      expect(d.getTask(task.id)?.status).toBe('pending')
+    })
+
+    it('updateTaskDeps rejects deps edits once a task has left the pending/ready states', () => {
+      const d = createDb()
+      const dispatched = d.createTask({ spec: 'dispatched' })
+      d.updateTaskStatus(dispatched.id, 'dispatched')
+      const completed = d.createTask({ spec: 'completed' })
+      d.updateTaskStatus(completed.id, 'completed')
+
+      expect(() => d.updateTaskDeps(dispatched.id, [])).toThrow('pending or ready')
+      expect(() => d.updateTaskDeps(completed.id, [])).toThrow('pending or ready')
+    })
+
+    it('updateTaskDeps returns undefined for a nonexistent task', () => {
+      const d = createDb()
+      expect(d.updateTaskDeps('task_fake', [])).toBeUndefined()
+    })
+
     it('sets completed_at on completion', () => {
       const d = createDb()
       const task = d.createTask({ spec: 'do it' })

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -555,15 +555,42 @@ export class OrchestrationDb {
       if (!deps.includes(completedTaskId)) {
         continue
       }
-
-      const allDepsCompleted = deps.every((depId) => {
-        const dep = this.getTask(depId)
-        return dep?.status === 'completed'
-      })
-      if (allDepsCompleted) {
-        this.db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(task.id)
-      }
+      this.recomputeReadiness(task)
     }
+  }
+
+  // Why: shared per-task readiness check. Promotes pending→ready when every
+  // dep is completed and demotes ready→pending when a dep is no longer met.
+  // The demote path is only reachable via updateTaskDeps: a completion can only
+  // unblock dependents, never block them.
+  private recomputeReadiness(task: TaskRow): void {
+    const deps: string[] = JSON.parse(task.deps)
+    const allDepsCompleted = deps.every((depId) => this.getTask(depId)?.status === 'completed')
+    if (allDepsCompleted && task.status === 'pending') {
+      this.db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(task.id)
+    } else if (!allDepsCompleted && task.status === 'ready') {
+      this.db.prepare("UPDATE tasks SET status = 'pending' WHERE id = ?").run(task.id)
+    }
+  }
+
+  updateTaskDeps(id: string, deps: string[]): TaskRow | undefined {
+    const task = this.getTask(id)
+    if (!task) {
+      return undefined
+    }
+    // Why: deps encode the DAG edges that decide readiness; once a task is
+    // dispatched, blocked, or terminal its readiness is locked, so refuse to
+    // rewrite edges underneath it.
+    if (task.status !== 'pending' && task.status !== 'ready') {
+      throw new Error(
+        `Task ${id} is ${task.status}; deps can only be edited while pending or ready`
+      )
+    }
+    this.db.prepare('UPDATE tasks SET deps = ? WHERE id = ?').run(JSON.stringify(deps), id)
+    // Why: recompute in the same writer so a deps edit flips readiness
+    // synchronously — no window where the task is dispatchable but still pending.
+    this.recomputeReadiness(this.getTask(id)!)
+    return this.getTask(id)
   }
 
   // ── Dispatch Contexts ──

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1034,6 +1034,53 @@ describe('orchestration RPC methods', () => {
         call('orchestration.taskUpdate', { id: 'task_fake', status: 'completed' })
       ).rejects.toThrow('Task not found')
     })
+
+    it('updates deps and recomputes readiness', async () => {
+      setup()
+      const done = db.createTask({ spec: 'done' })
+      db.updateTaskStatus(done.id, 'completed')
+      const task = db.createTask({ spec: 'task', deps: ['task_unmet'] })
+
+      const result = (await call('orchestration.taskUpdate', {
+        id: task.id,
+        deps: JSON.stringify([done.id])
+      })) as { task: { status: string; deps: string } }
+
+      expect(JSON.parse(result.task.deps)).toEqual([done.id])
+      expect(result.task.status).toBe('ready')
+    })
+
+    it('rejects invalid deps JSON with the same message as taskCreate', async () => {
+      setup()
+      const task = db.createTask({ spec: 'task' })
+      await expect(
+        call('orchestration.taskUpdate', { id: task.id, deps: 'not-json' })
+      ).rejects.toThrow('Invalid --deps')
+    })
+
+    it('requires at least one of status or deps', async () => {
+      setup()
+      const task = db.createTask({ spec: 'task' })
+      await expect(call('orchestration.taskUpdate', { id: task.id })).rejects.toThrow(
+        'at least one of --status or --deps'
+      )
+    })
+
+    it('applies deps before status so an explicit status is the final word', async () => {
+      setup()
+      // Why: ready task; adding an unmet dep would demote it, but the caller
+      // also sets completed, which must win.
+      const task = db.createTask({ spec: 'task' })
+      const blocker = db.createTask({ spec: 'blocker' })
+
+      const result = (await call('orchestration.taskUpdate', {
+        id: task.id,
+        deps: JSON.stringify([blocker.id]),
+        status: 'completed'
+      })) as { task: { status: string } }
+
+      expect(result.task.status).toBe('completed')
+    })
   })
 
   describe('orchestration.dispatch', () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, OptionalBoolean, requiredString } from '../schemas'
-import type { MessageType, MessagePriority, TaskStatus } from '../../orchestration/db'
+import type { MessageType, MessagePriority, TaskRow, TaskStatus } from '../../orchestration/db'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { formatMessageBanner } from '../../orchestration/formatter'
 import { isGroupAddress, resolveGroupAddress } from '../../orchestration/groups'
@@ -28,6 +28,25 @@ const TASK_STATUSES: TaskStatus[] = [
   'failed',
   'blocked'
 ]
+
+// Why: task-create and task-update both accept --deps as a JSON array of task
+// id strings; parse it once so both surfaces throw the identical message.
+// Only an absent value means "not provided"; an explicit empty string is
+// malformed JSON and should error, not silently clear deps.
+function parseDepsParam(deps: string | undefined): string[] | undefined {
+  if (deps === undefined) {
+    return undefined
+  }
+  try {
+    const parsed = JSON.parse(deps)
+    if (!Array.isArray(parsed) || !parsed.every((d) => typeof d === 'string')) {
+      throw new Error('not an array of strings')
+    }
+    return parsed
+  } catch {
+    throw new Error('Invalid --deps: must be a JSON array of task IDs')
+  }
+}
 
 function getLifecycleGroupRecipientError(type: 'worker_done' | 'heartbeat'): string {
   return `${type} messages must be sent to a concrete coordinator terminal handle, not a group address.`
@@ -115,6 +134,8 @@ const TaskListParams = z.object({
 
 const TaskUpdateParams = z.object({
   id: requiredString('Missing --id'),
+  // Why: --status and --deps are independently optional so a caller can edit
+  // either one; the handler requires at least one to avoid a no-op.
   status: z
     .unknown()
     .transform((v) => {
@@ -125,9 +146,11 @@ const TaskUpdateParams = z.object({
     })
     .pipe(
       z.enum(['pending', 'ready', 'dispatched', 'completed', 'failed', 'blocked'], {
-        message: 'Missing --status'
+        message: 'Invalid --status'
       })
-    ),
+    )
+    .optional(),
+  deps: OptionalString,
   result: OptionalString
 })
 
@@ -362,23 +385,11 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
     params: TaskCreateParams,
     handler: (params, { runtime }) => {
       const db = runtime.getOrchestrationDb()
-      let deps: string[] | undefined
-      if (params.deps) {
-        try {
-          const parsed = JSON.parse(params.deps)
-          if (!Array.isArray(parsed) || !parsed.every((d) => typeof d === 'string')) {
-            throw new Error('not an array of strings')
-          }
-          deps = parsed
-        } catch {
-          throw new Error('Invalid --deps: must be a JSON array of task IDs')
-        }
-      }
       const task = db.createTask({
         spec: params.spec,
         taskTitle: params.taskTitle,
         displayName: params.displayName,
-        deps,
+        deps: parseDepsParam(params.deps),
         parentId: params.parent,
         createdByTerminalHandle: params.callerTerminalHandle
       })
@@ -415,7 +426,19 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
     params: TaskUpdateParams,
     handler: (params, { runtime }) => {
       const db = runtime.getOrchestrationDb()
-      const task = db.updateTaskStatus(params.id, params.status, params.result)
+      if (params.status === undefined && params.deps === undefined) {
+        throw new Error('task-update requires at least one of --status or --deps')
+      }
+      let task: TaskRow | undefined
+      // Why: apply deps first so an explicit --status is the final word. A deps
+      // edit can flip readiness, but the requested status overrides it; doing
+      // status first would let the deps recompute clobber it.
+      if (params.deps !== undefined) {
+        task = db.updateTaskDeps(params.id, parseDepsParam(params.deps) ?? [])
+      }
+      if (params.status !== undefined) {
+        task = db.updateTaskStatus(params.id, params.status, params.result)
+      }
       if (!task) {
         throw new Error(`Task not found: ${params.id}`)
       }


### PR DESCRIPTION
## Summary

Task dependencies were write-once at create time; correcting a bad `--deps` entry forced either orphaning the task or `reset --tasks` (a full graph wipe). This adds an in-place deps edit path through DB → RPC → CLI:

`orca orchestration task-update --id <id> [--status <status>] [--deps <json_array>] [--result <json>] [--json]`

- `OrchestrationDb.updateTaskDeps(id, deps)` writes the `deps` column and recomputes readiness (`pending`↔`ready`) in the same writer. The readiness check is extracted into `recomputeReadiness`, shared with the existing completion-driven `promoteReadyTasks` (no behavior change there).
- `orchestration.taskUpdate` gains an optional `--deps` (same JSON-array shape as `task-create`); `--status` becomes optional and the handler requires at least one of `--status` / `--deps`. Deps parsing is extracted into `parseDepsParam` so create and update throw the identical message.
- CLI: optional `--status`, new `--deps` flag, updated help and skill doc.

Scoped to deps editing only — not workspace scoping (#6587).

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

```
pnpm vitest run src/main/runtime/orchestration/db.test.ts -t "updateTaskDeps"
pnpm vitest run src/main/runtime/rpc/methods/orchestration.test.ts
pnpm vitest run src/cli/index.test.ts -t "task-update"
```

## AI Review Report

Two-axis review (Standards + Spec) run locally before opening.

- **Standards:** clean. Error phrasing (`Task <id> is <status>; deps can only be edited while pending or ready`) mirrors the existing dispatch-precondition message in `db.ts`; zod conventions follow `src/main/runtime/rpc/schemas.ts` (reuses `OptionalString`, outer `.optional()` after `.pipe()` per the Zod v4 rule documented there); the `promoteReadyTasks` transactional invariant is preserved — `recomputeReadiness` is only reachable from that path for `pending` rows, and `updateTaskDeps` re-reads via `getTask` after the readiness flip in the same writer. `parseDepsParam` removes previously-duplicated parsing between create and update.
- **Spec:** all three layers (DB → RPC → CLI) wired; the readiness recompute after a deps change is functionally correct. Two intentional design choices are called out in Notes.
- Cross-platform compatibility: N/A — no UI, shortcuts, paths, shell, or Electron platform behavior touched. `--deps` is parsed identically to `task-create`'s `--deps`, which already works cross-shell when quoted.

## Security Audit

`--deps` is parsed with `JSON.parse` and validated as an array of strings (`parseDepsParam`); malformed input throws before any DB write. No command execution, path handling, auth, secrets, or new dependencies. `updateTaskDeps` writes only the `deps` column of an existing task row keyed by id, via a better-sqlite3 prepared statement with placeholders (no injection).

## Notes

Two design choices, both deliberate:

1. **Deps editable only while `pending` / `ready`.** Deps encode the DAG edges that drive *only* the `pending`→`ready` readiness transition. Once a task is `dispatched` (a terminal is running it, with a dispatch context and preamble built on the current deps), rewriting edges underneath it is unsafe; for `completed` / `failed` it is meaningless; `blocked` is set by a decision gate, not deps. The issue's primary pain case — wrong `--deps` caught at/near creation — sits in the `pending` / `ready` window this allows.
2. **`--status` made optional + "at least one of `--status` / `--deps`".** Required so a deps-only edit (`task-update --id X --deps '[...]'`) doesn't force a redundant status argument. When both are given, deps is applied before status so an explicit `--status` is the final word.

Dep validation (existence / no-self-dependency / no-cycle) is intentionally out of scope: neither `createTask` nor `updateTaskDeps` validates beyond JSON shape today, and a self-dep/cycle wedges readiness permanently — worth a dedicated follow-up rather than expanding this PR.

Pre-existing (not from this PR): `pnpm lint` surfaces a `switch-exhaustiveness` failure in `src/renderer/src/components/settings/SourceControlActionRepoOverrideNote.tsx` on `main`; all files changed here pass `oxlint`.

## ELI5

Orchestration task dependencies can be edited in place via `task-update --deps`. You don’t need to wipe the whole task graph to fix a bad dependency list.
