### PR TITLE
fix(gitlab): prevent global auth diagnostic from starting WSL

### DIFF
--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -353,6 +353,25 @@ describe('ghExecFileAsync WSL fallback', () => {
     )
   })
 
+  it('does not start default WSL for cwd-less glab when the fallback is disabled', async () => {
+    getDefaultWslDistroMock.mockReturnValue('Ubuntu')
+    execFileMock.mockImplementationOnce((_binary, _args, _options, callback) => {
+      callback(Object.assign(new Error('spawn glab ENOENT'), { code: 'ENOENT' }))
+    })
+
+    await expect(
+      glabExecFileAsync(['auth', 'status'], { allowDefaultWslFallback: false })
+    ).rejects.toThrow('spawn glab ENOENT')
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock).toHaveBeenCalledWith(
+      'glab',
+      ['auth', 'status'],
+      expect.objectContaining({ cwd: undefined }),
+      expect.any(Function)
+    )
+  })
+
   it('still retries idempotent glab transient failures', async () => {
     execFileMock
       .mockImplementationOnce((_binary, _args, _options, callback) => {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -1401,6 +1401,7 @@ type GlabExecOptions = Omit<GitExecOptions, 'cwd'> & {
   cwd?: string
   wslDistro?: string
   idempotent?: boolean
+  allowDefaultWslFallback?: boolean
 }
 
 /**
@@ -1435,6 +1436,7 @@ export async function glabExecFileAsync(
         resolved.wsl === null &&
         !options.cwd &&
         !options.wslDistro &&
+        options.allowDefaultWslFallback !== false &&
         isHostCommandMissing(err, 'glab')
       ) {
         const wslResolved = resolveDefaultWslCli('glab', args)

--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -245,6 +245,9 @@ describe('gitlab client — MR operations', () => {
         hosts: ['gitlab.com'],
         activeHost: 'gitlab.com'
       })
+      expect(glabExecFileAsyncMock).toHaveBeenCalledWith(['auth', 'status'], {
+        allowDefaultWslFallback: false
+      })
     })
   })
 

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -97,7 +97,11 @@ export async function diagnoseAuth(): Promise<GitLabAuthDiagnostic> {
       ? 'GLAB_TOKEN'
       : null
   try {
-    const { stdout, stderr } = await glabExecFileAsync(['auth', 'status'])
+    // Why: this global diagnostic can run for GitHub-only workspaces; on
+    // Windows the runner's default WSL fallback would start an unused distro.
+    const { stdout, stderr } = await glabExecFileAsync(['auth', 'status'], {
+      allowDefaultWslFallback: false
+    })
     const output = `${stdout}\n${stderr}`
     const hosts = parseGlabAuthStatusHosts(output)
     return {


### PR DESCRIPTION
## Summary

Fixes GitLab auth diagnostics on Windows so a GitHub-only workspace no longer starts the default WSL distro just to run `glab auth status`.

- Add an opt-out flag for default WSL fallback in `glab` command execution
- Disable default WSL fallback for GitLab auth diagnostics
- Preserve existing WSL routing for repo-scoped GitLab operations
- Add regression coverage for the disabled fallback path

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added/updated regression tests

Passed:

```powershell
pnpm.cmd vitest run --config config/vitest.config.ts src/main/git/runner-wsl-gh-fallback.test.ts src/main/gitlab/client-mr.test.ts
```

Additional tests run locally by the author also passed.

## AI Review Report

Reviewed against issue #7536 and Orca maintainer expectations.

- Windows-only WSL startup behavior for cwd-less `glab` calls
- Preservation of repo-scoped GitLab WSL routing
- Cross-platform impact on macOS, Linux, and Windows
- Provider-generic source control behavior
- Regression coverage for the exact fallback path

**Result:**

- Change is scoped to the global GitLab auth diagnostic.
- macOS/Linux behavior is unchanged.
- Windows repo-scoped GitLab operations still support WSL through existing cwd/distro routing.
- No UI shortcuts, labels, paths, renderer platform APIs, or Electron UI behavior were changed.

## Security Audit

Reviewed command execution, auth, path, and IPC impact.

- Reduces unexpected command execution by preventing global GitLab auth diagnostics from spawning `wsl.exe`
- Adds no new shell input or user-controlled command arguments
- Adds no new secrets handling, token storage, logging, or transmission
- Keeps the existing IPC/RPC route shape unchanged
- Preserves existing repo-scoped WSL command routing

No additional security follow-up identified.

## Notes

This intentionally changes only the global GitLab auth diagnostic. If `glab` exists only inside the default WSL distro, the global diagnostic may report it as unavailable unless a GitLab operation has repository/WSL context. That tradeoff is intentional because a provider diagnostic with no repository or runtime context should not wake an unused WSL distro.

## ELI5

On Windows, GitLab auth checks could spin up WSL even for GitHub-only work. Auth diagnostics no longer force that WSL fallback while repo-scoped ops still can use it.
