### PR TITLE
Keep the Peek References scrollbar visible

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1904,13 +1904,14 @@
   text-underline-offset: 2px;
 }
 
-/* Why: Monaco owns Peek References scrollables and auto-hides faded needed
-   vertical thumbs while the widget stays open; revalidate these classes on upgrade. */
+/* Why: Monaco's faded scrollbar uses the class `invisible`, which collides with
+   Tailwind's `.invisible` utility (visibility: hidden) — so also restore visibility. */
 .monaco-editor
   .reference-zone-widget
   .monaco-scrollable-element
   > .scrollbar.vertical.invisible.fade {
   opacity: 1;
+  visibility: visible;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
Keeps the vertical scrollbar in the code editor's **Peek References** view visible while the panel is open, instead of disappearing shortly after the panel opens (issue `#7405`).

**What changes:** in the Peek References view, the vertical scrollbar no longer auto-hides on idle — it stays visible while the panel is open.
**What does not change:** no other scrollbar in the app is affected. A Peek list that is short enough to not need scrolling still shows no scrollbar, and the horizontal peek scrollbar is untouched.

## Background
PR `#7479` tried to fix this by forcing `opacity: 1` on the faded peek scrollbar. That worked in `pnpm dev` but **not in a production build** — the scrollbar still disappeared.

## Root cause
Monaco marks its faded scrollbar with the class `invisible` (full class list `invisible scrollbar vertical fade`). Orca uses Tailwind v4, which ships an `.invisible { visibility: hidden }` utility that the production CSS emits (19 source files use the `invisible` className). Monaco's runtime class collides with Tailwind's utility, so the faded scrollbar is hidden via `visibility: hidden`. The `#7479` fix only overrode `opacity`, which cannot defeat `visibility: hidden`, so the scrollbar stayed invisible in production.

## Fix
Add `visibility: visible` to the same scoped, unlayered rule (which already forced `opacity: 1; pointer-events: auto`). The rule is unlayered, so it wins over Tailwind's `@layer utilities` `.invisible` regardless of specificity — no `!important` needed. The `.fade` qualifier keeps the override limited to the "needed but idle-faded" scrollbar, so a Peek list with nothing to scroll still shows no empty track.

## Design approach
Single scoped CSS declaration on the existing Peek-only rule; no JS, no flag, trivially revertible.

## Design-review outcome
Engineering design-doc review returned CLEAN after verifying every load-bearing claim against source and the built bundle (unlayered rule beats `@layer utilities`; Monaco's `.fade` semantics; the 19-file utility origin). It tightened honesty around the pre-reveal scrollbar state and the (out-of-scope) horizontal scrollbar.

## Implementation / deviations
One-line addition (`visibility: visible;`) plus a corrected "why" comment in `src/renderer/src/assets/main.css`. No other files changed. No deviations from the design.

## Completeness verification
CLEAN — the change is scoped to the Peek widget, still requires `.fade`, the rule is unlayered, and only `main.css` is touched.

## Headline behavior status
**Implemented.** Against the real rebuilt production bundle, the faded-needed peek vertical scrollbar computes `opacity: 1; visibility: visible` (stays visible); a not-needed scrollbar and the horizontal scrollbar stay hidden.

## Broad app consistency
Source-of-truth behavior is Monaco's idle auto-hide of scrollbars everywhere. The Tailwind `.invisible` collision is global, but for the main editor/diff/lists hide-on-idle is the intended behavior, so it is harmless there; only the Peek view is where users expect the scrollbar to persist (what `#7479` targeted). This change stays scoped to `.reference-zone-widget` and does not alter any scrollbar elsewhere. Fixing the global Tailwind/Monaco `.invisible` collision, and the horizontal peek scrollbar, are intentional non-goals.

## Risks / non-goals
- The peek vertical scrollbar no longer fades on idle (it stays shown) — this is the requested behavior.
- Non-goals: the global Tailwind/Monaco `.invisible` collision, the horizontal peek scrollbar, and showing a track when there is nothing to scroll.

## Performance
No regression: a single `visibility` declaration on a deeply-scoped selector evaluated only within the transient Peek widget. No JS, listeners, polling, IPC, render-loop, or broadly-matching selector.

## Validation
- Deterministic Playwright cascade test against the real `out/renderer/assets/*.css`: faded-needed vertical peek scrollbar → `opacity 1`, `visibility visible`; not-needed → hidden; horizontal-idle → hidden.
- Code review (high effort): one conventions finding (comment length vs AGENTS.md) — fixed. No correctness/scope/perf findings.
- Live Electron validation of the production preview: opened a real Peek References view (Shift+F12, 61 references), and after the scrollbar idled into its faded state it computed `visibility: visible; opacity: 1` (stays visible); unneeded sibling scrollbars stayed hidden; 0 renderer console errors. Screenshot captured (shared with the reviewer; not committed).
- `pnpm build:electron-vite`: PASS. Scrollbar-style lint check: PASS.

## Cross-platform / SSH
Renderer-only CSS; identical on macOS/Linux/Windows and under SSH (renderer runs locally in all cases).

Made with [Orca](https://github.com/stablyai/orca) 🐋
