### PR TITLE
fix(settings): portal the IDE Font dropdown outside the settings section

### DIFF
--- a/src/renderer/src/components/settings/SettingsFormControls.font-autocomplete.test.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.font-autocomplete.test.tsx
@@ -41,6 +41,26 @@ describe('FontAutocomplete', () => {
     )
   }
 
+  function expectOptionsToBePortaled(): void {
+    expect(container.querySelector('[role="option"]')).toBeNull()
+  }
+
+  function getScrollArea(): HTMLElement {
+    const scrollArea = document.querySelector<HTMLElement>('[data-slot="scroll-area"]')
+    if (!scrollArea) {
+      throw new Error('Font autocomplete scroll area not found')
+    }
+    return scrollArea
+  }
+
+  function getScrollAreaViewport(): HTMLElement {
+    const viewport = document.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')
+    if (!viewport) {
+      throw new Error('Font autocomplete scroll area viewport not found')
+    }
+    return viewport
+  }
+
   async function typeIntoInput(input: HTMLInputElement, value: string): Promise<void> {
     await act(async () => {
       // Why: React tracks controlled input values through the native setter, so
@@ -82,6 +102,7 @@ describe('FontAutocomplete', () => {
         .querySelector<HTMLButtonElement>('[role="option"][aria-selected="true"]')
         ?.textContent?.trim()
     ).toBe('JetBrains Mono')
+    expectOptionsToBePortaled()
   })
 
   it('shows the full list on focus when the committed font has multiple matching suggestions', async () => {
@@ -111,6 +132,33 @@ describe('FontAutocomplete', () => {
       'Cascadia Mono PL',
       'Consolas'
     ])
+    expectOptionsToBePortaled()
+  })
+
+  it('bounds the portaled list to the available popover height', async () => {
+    function Harness(): ReactNode {
+      const [value, setValue] = useState('Cascadia Mono')
+      return (
+        <FontAutocomplete
+          value={value}
+          suggestions={['Arial', 'Cascadia Code', 'Cascadia Mono', 'Cascadia Mono PL', 'Consolas']}
+          onChange={setValue}
+        />
+      )
+    }
+
+    await act(async () => {
+      root.render(<Harness />)
+    })
+
+    await act(async () => {
+      getInput().focus()
+    })
+
+    expect(getScrollArea().style.maxHeight).toBe('var(--radix-popover-content-available-height)')
+    expect(getScrollAreaViewport().style.maxHeight).toBe(
+      'var(--radix-popover-content-available-height)'
+    )
   })
 
   it('keeps typed searches filtered even after the value updates', async () => {

--- a/src/renderer/src/components/settings/SettingsFormControls.font-autocomplete.test.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.font-autocomplete.test.tsx
@@ -34,7 +34,9 @@ describe('FontAutocomplete', () => {
   }
 
   function getOptionLabels(): string[] {
-    return Array.from(container.querySelectorAll<HTMLElement>('[role="option"]')).map(
+    // Why: the dropdown portals to document.body so it can escape the settings
+    // section; options are intentionally not descendants of the container.
+    return Array.from(document.querySelectorAll<HTMLElement>('[role="option"]')).map(
       (option) => option.textContent?.trim() ?? ''
     )
   }
@@ -76,7 +78,7 @@ describe('FontAutocomplete', () => {
     })
 
     expect(
-      container
+      document
         .querySelector<HTMLButtonElement>('[role="option"][aria-selected="true"]')
         ?.textContent?.trim()
     ).toBe('JetBrains Mono')

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ScrollArea } from '../ui/scroll-area'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
+import { Popover, PopoverAnchor, PopoverContent } from '../ui/popover'
 import { Check, ChevronsUpDown, CircleX } from 'lucide-react'
 import { normalizeColor, type TerminalThemeOption } from '@/lib/terminal-theme'
 import { MAX_THEME_RESULTS } from './SettingsConstants'
@@ -618,21 +619,12 @@ export function FontAutocomplete({
     }
   }
 
-  useEffect(() => {
-    if (!open) {
-      return
+  const handleOpenChange = (nextOpen: boolean): void => {
+    setOpen(nextOpen)
+    if (!nextOpen) {
+      setIsFilteringQuery(false)
     }
-
-    const handlePointerDown = (event: MouseEvent): void => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setOpen(false)
-        setIsFilteringQuery(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handlePointerDown)
-    return () => document.removeEventListener('mousedown', handlePointerDown)
-  }, [open])
+  }
 
   const normalizedQuery = query.trim().toLowerCase()
   const normalizedValue = value.trim().toLowerCase()
@@ -694,120 +686,145 @@ export function FontAutocomplete({
 
   return (
     <div ref={setRootNode} className="relative max-w-sm">
-      <div className="relative">
-        <Input
-          ref={inputRef}
-          value={query}
-          onChange={(e) => {
-            const next = e.target.value
-            setQuery(next)
-            setIsFilteringQuery(true)
-            onChange(next)
-            setOpen(true)
-          }}
-          onFocus={() => {
-            setIsFilteringQuery(false)
-            setOpen(true)
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Escape') {
-              if (open) {
-                e.preventDefault()
-                setOpen(false)
-                setIsFilteringQuery(false)
-              }
-              return
-            }
-
-            if (e.key === 'ArrowDown') {
-              e.preventDefault()
-              setOpen(true)
-              if (visibleSuggestions.length > 0) {
-                setHighlightedIndex((current) =>
-                  current < 0 ? 0 : Math.min(current + 1, visibleSuggestions.length - 1)
-                )
-              }
-              return
-            }
-
-            if (e.key === 'ArrowUp') {
-              e.preventDefault()
-              setOpen(true)
-              if (visibleSuggestions.length > 0) {
-                setHighlightedIndex((current) =>
-                  current < 0 ? visibleSuggestions.length - 1 : Math.max(current - 1, 0)
-                )
-              }
-              return
-            }
-
-            if (e.key === 'Enter' && open && highlightedIndex >= 0) {
-              const highlightedFont = visibleSuggestions[highlightedIndex]
-              if (highlightedFont) {
-                e.preventDefault()
-                commitValue(highlightedFont)
-              }
-            }
-          }}
-          placeholder={placeholder}
-          className="pr-18"
-          role="combobox"
-          aria-autocomplete="list"
-          aria-expanded={open}
-          aria-controls={listboxId}
-          aria-activedescendant={
-            open && highlightedIndex >= 0 ? `${listboxId}-option-${highlightedIndex}` : undefined
-          }
-        />
-        <div className="absolute inset-y-0 right-2 flex items-center gap-1">
-          {query ? (
-            <button
-              type="button"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => {
-                setQuery('')
-                setIsFilteringQuery(false)
-                onChange('')
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverAnchor asChild>
+          <div className="relative">
+            <Input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => {
+                const next = e.target.value
+                setQuery(next)
+                setIsFilteringQuery(true)
+                onChange(next)
                 setOpen(true)
-                focusInput()
               }}
-              className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              aria-label={translate(
-                'auto.components.settings.SettingsFormControls.a4ff6143f8',
-                'Clear font selection'
-              )}
-              title={translate('auto.components.settings.SettingsFormControls.74bcecd5ec', 'Clear')}
-            >
-              <CircleX className="size-3.5" />
-            </button>
-          ) : null}
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={() => {
-              const nextOpen = !open
-              setOpen(nextOpen)
-              if (!nextOpen) {
+              onFocus={() => {
                 setIsFilteringQuery(false)
-              }
-              if (nextOpen) {
-                focusInput()
-              }
-            }}
-            className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            aria-label={translate(
-              'auto.components.settings.SettingsFormControls.c766f8ac75',
-              'Toggle font suggestions'
-            )}
-            title={translate('auto.components.settings.SettingsFormControls.b55371ea18', 'Fonts')}
-          >
-            <ChevronsUpDown className="size-3.5" />
-          </button>
-        </div>
-      </div>
+                setOpen(true)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  if (open) {
+                    e.preventDefault()
+                    setOpen(false)
+                    setIsFilteringQuery(false)
+                  }
+                  return
+                }
 
-      {open ? (
-        <div className="absolute top-full z-20 mt-2 w-full overflow-hidden rounded-md border border-border/50 bg-popover shadow-md">
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault()
+                  setOpen(true)
+                  if (visibleSuggestions.length > 0) {
+                    setHighlightedIndex((current) =>
+                      current < 0 ? 0 : Math.min(current + 1, visibleSuggestions.length - 1)
+                    )
+                  }
+                  return
+                }
+
+                if (e.key === 'ArrowUp') {
+                  e.preventDefault()
+                  setOpen(true)
+                  if (visibleSuggestions.length > 0) {
+                    setHighlightedIndex((current) =>
+                      current < 0 ? visibleSuggestions.length - 1 : Math.max(current - 1, 0)
+                    )
+                  }
+                  return
+                }
+
+                if (e.key === 'Enter' && open && highlightedIndex >= 0) {
+                  const highlightedFont = visibleSuggestions[highlightedIndex]
+                  if (highlightedFont) {
+                    e.preventDefault()
+                    commitValue(highlightedFont)
+                  }
+                }
+              }}
+              placeholder={placeholder}
+              className="pr-18"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded={open}
+              aria-controls={listboxId}
+              aria-activedescendant={
+                open && highlightedIndex >= 0
+                  ? `${listboxId}-option-${highlightedIndex}`
+                  : undefined
+              }
+            />
+            <div className="absolute inset-y-0 right-2 flex items-center gap-1">
+              {query ? (
+                <button
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    setQuery('')
+                    setIsFilteringQuery(false)
+                    onChange('')
+                    setOpen(true)
+                    focusInput()
+                  }}
+                  className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  aria-label={translate(
+                    'auto.components.settings.SettingsFormControls.a4ff6143f8',
+                    'Clear font selection'
+                  )}
+                  title={translate(
+                    'auto.components.settings.SettingsFormControls.74bcecd5ec',
+                    'Clear'
+                  )}
+                >
+                  <CircleX className="size-3.5" />
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  const nextOpen = !open
+                  setOpen(nextOpen)
+                  if (!nextOpen) {
+                    setIsFilteringQuery(false)
+                  }
+                  if (nextOpen) {
+                    focusInput()
+                  }
+                }}
+                className="rounded-sm p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                aria-label={translate(
+                  'auto.components.settings.SettingsFormControls.c766f8ac75',
+                  'Toggle font suggestions'
+                )}
+                title={translate(
+                  'auto.components.settings.SettingsFormControls.b55371ea18',
+                  'Fonts'
+                )}
+              >
+                <ChevronsUpDown className="size-3.5" />
+              </button>
+            </div>
+          </div>
+        </PopoverAnchor>
+
+        {/* Why: portal the dropdown outside the settings section — an in-flow
+          absolute panel makes the highlighted option's scrollIntoView scroll
+          the whole settings pane, pushing the section content out of view. */}
+        <PopoverContent
+          align="start"
+          className="w-[var(--radix-popover-trigger-width)]"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onInteractOutside={(e) => {
+            // Why: the input and its clear/toggle buttons are the anchor, not
+            // the content, so Radix would otherwise dismiss on every click there.
+            if (rootRef.current?.contains(e.target as Node)) {
+              e.preventDefault()
+            }
+          }}
+        >
           <ScrollArea className={visibleSuggestions.length > 8 ? 'h-64' : undefined}>
             <div id={listboxId} role="listbox" className="p-1">
               {visibleSuggestions.length > 0 ? (
@@ -846,8 +863,8 @@ export function FontAutocomplete({
               )}
             </div>
           </ScrollArea>
-        </div>
-      ) : null}
+        </PopoverContent>
+      </Popover>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -683,6 +683,11 @@ export function FontAutocomplete({
   const focusInput = (): void => {
     inputRef.current?.focus()
   }
+  const popoverAvailableHeightStyle = {
+    // Why: tailwind-merge rewrites this arbitrary max-height class on the
+    // ScrollArea root, so keep the Radix available-height clamp as inline style.
+    maxHeight: 'var(--radix-popover-content-available-height)'
+  } as React.CSSProperties
 
   return (
     <div ref={setRootNode} className="relative max-w-sm">
@@ -825,7 +830,11 @@ export function FontAutocomplete({
             }
           }}
         >
-          <ScrollArea className={visibleSuggestions.length > 8 ? 'h-64' : undefined}>
+          <ScrollArea
+            className={visibleSuggestions.length > 8 ? 'h-64' : undefined}
+            style={popoverAvailableHeightStyle}
+            viewportProps={{ style: popoverAvailableHeightStyle }}
+          >
             <div id={listboxId} role="listbox" className="p-1">
               {visibleSuggestions.length > 0 ? (
                 visibleSuggestions.map((font, index) => (


### PR DESCRIPTION
## Summary

Fixes #7585

In **Settings > Appearance**, the **IDE Font** dropdown (`FontAutocomplete`) rendered as an absolutely-positioned panel *inside* the Interface section. When the committed font sits far down the list, the highlighted option's `scrollIntoView` scrolled the surrounding settings pane, pushing the section content (Theme, UI Zoom, IDE Font rows) out of view.

The dropdown now renders through the shared `Popover` primitive (`src/renderer/src/components/ui/popover.tsx`), which portals content to the document root — matching every other settings dropdown (e.g. the Language `Select`). Radix owns dismissal (outside interaction / Escape), replacing the manual document `mousedown` listener; `onInteractOutside` keeps the popover open while interacting with the anchored input and its clear/toggle buttons, and open/close auto-focus is prevented so typing in the input keeps working. This also fixes the same control on the Terminal appearance pane, which shares `FontAutocomplete`.

## Screenshots

**Before** — the dropdown renders inside the Interface section and re-opening it with a late-alphabet font scrolls the pane, pushing the section content out of view:

<img width="1486" height="818" alt="Before: section content pushed out of view" src="https://github.com/user-attachments/assets/90420151-c65a-4efd-b2f1-46ebdcbde2ec" />

**After** — same repro (committed font `FiraCode Nerd Font Mono`, dropdown re-opened): the dropdown portals to the document root and overlays the section; Theme, UI Zoom, and IDE Font rows stay in place and the pane does not scroll:

<img width="1568" height="984" alt="After: dropdown overlays the section, content stays in place" src="https://github.com/user-attachments/assets/752eba0b-d44e-4253-a495-7fa8a11cd638" />

## Testing

- [x] `pnpm lint` — changed files are clean (0 warnings/errors); the run reports one pre-existing `switch-exhaustiveness` error in `src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts`, untouched by this PR and present on `main`
- [x] `pnpm typecheck` — passes (node, cli, web)
- [x] `pnpm test` — 24 792 passed; 5 pre-existing failures in `src/main/ipc/pty.test.ts` (main-process PTY shell-ready-marker tests, untouched by this PR and failing identically without these changes)
- [x] `pnpm build` — passes (desktop + native)
- [x] Updated `SettingsFormControls.font-autocomplete.test.tsx` for the portal: option queries now target `document` instead of the render container, so the tests would catch a regression back to in-section rendering; all 3 tests pass and cover arrow-key navigation, full-list-on-focus, and typed filtering through the portal

Also validated end-to-end against the local dev build (macOS, `pnpm dev`) by driving the renderer over CDP: after committing `FiraCode Nerd Font Mono` and re-opening the dropdown, the listbox is portaled to `document.body` (not a descendant of the section), the committed option scrolls into view within the popover's own scroll area only, and `scrollTop` of every scrollable container on the page is unchanged.

## AI Review Report

Reviewed the full diff with an AI coding agent. Main risks checked and results:

- **Cross-platform (macOS / Linux / Windows)**: renderer-only React/DOM change; no `metaKey`/platform key handling, no file paths, no shell or Electron main-process code touched. Keyboard interactions (ArrowUp/Down, Enter, Escape) use platform-neutral `KeyboardEvent.key`. The shared `PopoverContent` already applies `WebkitAppRegion: no-drag`, so popovers overlapping the titlebar remain clickable on all platforms.
- **SSH / remote / local**: settings UI renders locally in all modes; font suggestions arrive through the existing unchanged IPC path. No behavior depends on local-only processes.
- **Agent / integration / git-provider compatibility**: not applicable — no agent, integration, or provider code paths touched.
- **Performance**: the popover mounts only while open (same as the previous conditional render); one document-level `mousedown` listener was removed in favor of Radix's dismissable-layer handling; `scrollIntoView({ block: 'nearest' })` is now bounded to the popover's own scroll area, eliminating the unintended ancestor-scroll work.
- **UI quality**: uses the design-system `Popover` surface (border/shadow/blur per STYLEGUIDE), width matches the anchor via `--radix-popover-trigger-width` (same pattern as `repo-multi-combobox` / `team-multi-combobox`), `align="start"`, and Radix collision handling flips the dropdown when near the viewport edge — previously it could render off-screen.
- **Behavioral edge cases verified**: clear ("×") and toggle buttons stay usable while open (`onInteractOutside` preventDefault for anchor interactions); Escape closes via both the input handler and Radix (idempotent); option `mousedown` preventDefault keeps input focus so `onClick` commit still fires; `aria-controls`/`aria-activedescendant` id references remain valid across the portal boundary.
- **Flagged and resolved during review**: initial concern that Radix's close auto-focus would steal focus from the input — addressed with `onOpenAutoFocus`/`onCloseAutoFocus` preventDefault; and that outside-click dismissal would fire for clicks on the anchored input — addressed with the `rootRef.contains` check.

## Security Audit

- No new input handling: the input's value flows through the same `onChange` path as before; font names are rendered as React text nodes (escaped), so no injection surface.
- No command execution, path handling, auth, secrets, or IPC changes — the diff is confined to one renderer component and its test.
- No dependency changes; `radix-ui` Popover was already a project dependency used by other components.
- Test change only relaxes a DOM query scope (`document` vs container) inside an isolated happy-dom environment; no security relevance.
- No follow-up needed.

## Notes

- No platform-specific behavior introduced; behavior is identical on macOS, Linux, and Windows.
- Manual validation was performed on macOS (dev build). The change is pure DOM/React portal behavior with no platform branches, so Linux/Windows risk is low.
- The dropdown can now flip above the input near the bottom viewport edge (Radix collision handling) — an intentional improvement over the previous always-below rendering, consistent with other dropdowns.
- Pre-existing repo issues surfaced by the full check run (unrelated to this PR): one `switch-exhaustiveness` lint error in `source-control-manual-review-url.ts` and 5 failing PTY tests in `src/main/ipc/pty.test.ts`.
- X (Twitter): [@dbachko](https://x.com/dbachko)

Generated with [Devin](https://devin.ai)

