### PR TITLE
fix(github): route PR merges through repo owner

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -3848,7 +3848,19 @@ function PRActionsPanel({
   const actionItem = { ...item, state: localState }
   const mergePresentation = presentGitHubPRMergeState(actionItem)
   const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
-  const sourceSettings = getTaskSourceRuntimeSettings(sourceContext)
+  const repoOwnerSettings = useAppStore(
+    useShallow((s) => getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null))
+  )
+  const sourceSettings = useMemo(
+    () =>
+      sourceContext?.provider === 'github'
+        ? ({
+            ...repoOwnerSettings,
+            ...getTaskSourceRuntimeSettings(sourceContext)
+          } as typeof repoOwnerSettings)
+        : repoOwnerSettings,
+    [repoOwnerSettings, sourceContext]
+  )
   const mergeTarget = getActiveRuntimeTarget(sourceSettings)
   const canMutateWithRepoContext =
     !!repoPath || !!projectOrigin || mergeTarget.kind === 'environment'

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -3851,16 +3851,18 @@ function PRActionsPanel({
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null))
   )
-  const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
-    [repoOwnerSettings, sourceContext]
-  )
+  const sourceSettings = useMemo(() => {
+    if (sourceContext?.provider !== 'github') {
+      return repoOwnerSettings
+    }
+    const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)
+    return sourceRuntimeSettings.activeRuntimeEnvironmentId
+      ? ({
+          ...repoOwnerSettings,
+          ...sourceRuntimeSettings
+        } as typeof repoOwnerSettings)
+      : repoOwnerSettings
+  }, [repoOwnerSettings, sourceContext])
   const mergeTarget = getActiveRuntimeTarget(sourceSettings)
   const canMutateWithRepoContext =
     !!repoPath || !!projectOrigin || mergeTarget.kind === 'environment'

--- a/src/renderer/src/components/github-item-dialog-merge-routing.test.ts
+++ b/src/renderer/src/components/github-item-dialog-merge-routing.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getSettingsForRepoRuntimeOwner,
+  type RepoRuntimeOwnerState
+} from '../lib/repo-runtime-owner'
+import { getActiveRuntimeTarget } from '../runtime/runtime-rpc-client'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { getTaskSourceRuntimeSettings } from '../../../shared/task-source-context'
+
+// Why: mirrors the merge-routing decision inside GitHubItemDialog's
+// PRActionsPanel so a revert to source-only routing (issue #6957) fails here.
+// A runtime-owned repo whose GitHub source view is local must still merge on
+// the owner runtime, not fall back to local `gh:mergePR`.
+function resolveMergeTarget(
+  state: RepoRuntimeOwnerState,
+  repoId: string | null,
+  sourceContext: TaskSourceContext | null
+): ReturnType<typeof getActiveRuntimeTarget> {
+  const repoOwnerSettings = getSettingsForRepoRuntimeOwner(state, repoId)
+  const sourceSettings =
+    sourceContext?.provider !== 'github'
+      ? repoOwnerSettings
+      : (() => {
+          const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)
+          return sourceRuntimeSettings.activeRuntimeEnvironmentId
+            ? { ...repoOwnerSettings, ...sourceRuntimeSettings }
+            : repoOwnerSettings
+        })()
+  return getActiveRuntimeTarget(sourceSettings)
+}
+
+function githubSource(hostId: TaskSourceContext['hostId']): TaskSourceContext {
+  return { kind: 'task-source', provider: 'github', projectId: 'p', hostId, repoId: 'repo-1' }
+}
+
+describe('GitHubItemDialog PR merge routing', () => {
+  const runtimeOwnedRepo: RepoRuntimeOwnerState = {
+    settings: { activeRuntimeEnvironmentId: null },
+    repos: [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:owner-runtime' }]
+  }
+
+  it('routes a runtime-owned repo to its owner runtime when the source view is local (#6957)', () => {
+    expect(resolveMergeTarget(runtimeOwnedRepo, 'repo-1', githubSource('local'))).toEqual({
+      kind: 'environment',
+      environmentId: 'owner-runtime'
+    })
+  })
+
+  it('routes a runtime-owned repo to its owner runtime when there is no source context', () => {
+    expect(resolveMergeTarget(runtimeOwnedRepo, 'repo-1', null)).toEqual({
+      kind: 'environment',
+      environmentId: 'owner-runtime'
+    })
+  })
+
+  it('lets a runtime source override the repo owner when both are runtimes', () => {
+    expect(
+      resolveMergeTarget(runtimeOwnedRepo, 'repo-1', githubSource('runtime:source-runtime'))
+    ).toEqual({ kind: 'environment', environmentId: 'source-runtime' })
+  })
+
+  it('keeps an explicitly-local repo on local IPC even while a runtime is focused', () => {
+    const localRepo: RepoRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
+      repos: [{ id: 'repo-1', connectionId: null, executionHostId: 'local' }]
+    }
+    expect(resolveMergeTarget(localRepo, 'repo-1', githubSource('local'))).toEqual({
+      kind: 'local'
+    })
+  })
+})

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -192,7 +192,11 @@ describe('GitHubItemDialog source host boundaries', () => {
 
     expect(actionsSection).toContain('getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId')
     expect(actionsSection).toContain('...repoOwnerSettings')
-    expect(actionsSection).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(actionsSection).toContain(
+      'const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)'
+    )
+    expect(actionsSection).toContain('sourceRuntimeSettings.activeRuntimeEnvironmentId')
+    expect(actionsSection).toContain('...sourceRuntimeSettings')
     expect(actionsSection).toContain('getActiveRuntimeTarget(sourceSettings)')
     expect(actionsSection).toContain(
       'const canMergeWithRepoContext = !!repoPath || mergeTarget.kind ==='

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -91,8 +91,8 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(source).toContain('sourceContext,')
     expect(cacheKeySection).toContain('sourceCacheScope')
     expect(source).toContain('getTaskSourceCacheScope(sourceContext)')
-    expect(matchInvalidationSection).toContain(
-      'if (removed) {\n    workItemDetailsCacheGeneration += 1'
+    expect(matchInvalidationSection).toMatch(
+      /if \(removed\) {\s+workItemDetailsCacheGeneration \+= 1/
     )
   })
 
@@ -190,6 +190,8 @@ describe('GitHubItemDialog source host boundaries', () => {
       'function CommentReactions'
     )
 
+    expect(actionsSection).toContain('getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId')
+    expect(actionsSection).toContain('...repoOwnerSettings')
     expect(actionsSection).toContain('getTaskSourceRuntimeSettings(sourceContext)')
     expect(actionsSection).toContain('getActiveRuntimeTarget(sourceSettings)')
     expect(actionsSection).toContain(


### PR DESCRIPTION
## Summary

Fixes PR merge and auto-merge routing for headless/runtime-owned GitHub repositories. These actions now use the repository owner's runtime settings before applying source-context overrides, ensuring runtime repository paths stay on runtime RPC instead of incorrectly falling back to local `gh:mergePR`. Fixes #6957

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added focused regression coverage for GitHub item dialog merge routing.

## AI Review Report

AI review traced the failure from `GitHubItemDialog` PR actions through local IPC and runtime RPC. It identified that merge routing relied on `sourceContext` alone, which could incorrectly route runtime-owned repositories to local IPC and trigger `Access denied: unknown repository path`.

The routing now prefers the repository owner's runtime settings before applying GitHub source-context overrides. Cross-platform review covered macOS, Linux, and Windows. This PR does not modify shortcuts, labels, shell behavior, paths, or platform-specific Electron APIs.

## Security Audit

Reviewed IPC, path handling, command execution, authentication, dependencies, and runtime-routing risks.

- Preserves local IPC repository authorization
- Prevents headless/runtime repository paths from being sent to local GitHub IPC
- Introduces no new command execution, path parsing, secrets handling, or dependencies

No additional security follow-up identified.

## Notes

This is a non-visual routing fix. Local and SSH behavior remain unchanged, while runtime-owned repositories now correctly stay on runtime RPC.