### PR TITLE
Fix flaky terminal typing-latency E2E test under CI load

### DIFF
--- a/tests/e2e/terminal-history-size-typing-latency.spec.ts
+++ b/tests/e2e/terminal-history-size-typing-latency.spec.ts
@@ -20,7 +20,9 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 // exactly as it does in real agent sessions.
 const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
 const MAX_MEDIAN_KEY_LATENCY_MS = 250
-const MAX_WORST_KEY_LATENCY_MS = 1_000
+// Why: median is the responsiveness guard (and the #5096 signal); worst-of-16 is a
+// CI-scheduling/5s-checkpoint spike proxy, so it only backstops a catastrophic hang.
+const MAX_WORST_KEY_LATENCY_MS = 3_000
 const FILL_DONE_TIMEOUT_MS = 240_000
 const FILL_PHASES = [10_000, 40_000] as const
 


### PR DESCRIPTION
## What changes

Makes the last flaky test in the scheduled E2E suite reliable: `terminal-history-size-typing-latency` now treats its **worst-key** latency gate as a catastrophic-hang detector (1000ms → 3000ms) and keeps the **median** gate strict (250ms). **Test-only; no product code.**

## Why

After #7470 + #7468 the suite is 9/10 shards green; this was the only remaining failure. The gate `worstMs = max(16 keystrokes) < 1000ms` flaked on a shared CI runner: one keystroke colliding with the harness's *intentional* 5s dirty-session checkpoint (or a GC/scheduler spike) pushed the raw max to ~1036ms while the terminal stayed fully responsive (median 7.2ms; the higher-history phase was fine at 14.6ms — the signature of scheduling noise, not lag).

The test exists for **issue #5096 — input lag that *grows with session history*** — a sustained phenomenon caught by the **median** gate (unchanged, strict at 250ms). The worst-of-16 raw max doesn't map to that bug; it's a fragile single-spike proxy. So relaxing it to a hang backstop forfeits **zero** real coverage.

## Why 3000ms

Matches the catastrophic-hang worst-key ceiling #7470 just established for the sibling perf suites (`artificial-opencode` hidden-pressure 3000ms; ssh-docker-relay-perf 2000ms), with the median as the responsiveness guard. 3000ms is ~3x the observed spike and a clear "the terminal hung" line, not a responsiveness threshold.

## What still fails / what's preserved

- A genuine **#5096 regression** (severe sustained lag) → still fails via the strict `median < 250ms` gate (asserted on all three phases).
- A genuine **multi-second hang** → still fails via `worst < 3000ms`.
- Now tolerated: a single keystroke spiking 1–3s once per 16 under CI load with a healthy median — not user-visible sustained lag.

## Design review

Independent review (Claude + Codex): sound to implement, no regression masked; confirmed the median gate preserves the #5096 guard and 3000ms matches the merged #7470 precedent. Several supporting-claim accuracy fixes were folded into the design notes.

## Validation

- **Local (macOS):** passes (13.1s); worst 5–47ms across phases, median 3.7–5.5ms — local can't reproduce the CI-load spike, so this proves no breakage, not de-flaking.
- **CI (Linux):** dispatched E2E on this branch; will confirm the spec passes and no other spec regresses. (One green run isn't statistical proof of de-flaking, but 3000ms gives 3x margin over the observed 1036ms spike.)
- Static: pre-commit oxlint + oxfmt clean.

## Non-goals / risk

- Not touching the deeper daemon-checkpoint-vs-keystroke interaction (#5096 area) — this is a test-threshold correction only.
- A *moderate* history-correlated growth below the absolute 250ms median line would pass — but the old `worst < 1000ms` gate also let that through, so no coverage is lost; a growth-relative median is a larger redesign, out of scope.

Made with [Orca](https://github.com/stablyai/orca) 🐋
