### PR TITLE
Prevent a stale client from wrongly clearing a worktree's linked PR

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -275,6 +275,7 @@ describe('registerWorktreeHandlers', () => {
     resolveManagedMrBase: ReturnType<typeof vi.fn>
     createTerminal: ReturnType<typeof vi.fn>
     splitTerminal: ReturnType<typeof vi.fn>
+    worktreeMetaPreconditionAllowsWrite: ReturnType<typeof vi.fn>
   }
 
   beforeEach(() => {
@@ -482,7 +483,8 @@ describe('registerWorktreeHandlers', () => {
         handle: 'term-setup',
         tabId: 'tab-startup',
         paneRuntimeId: -1
-      })
+      }),
+      worktreeMetaPreconditionAllowsWrite: vi.fn().mockResolvedValue(true)
     }
     registerWorktreeHandlers(mainWindow as never, store as never, runtimeStub as never)
   })
@@ -711,10 +713,10 @@ describe('registerWorktreeHandlers', () => {
     ])
   }
 
-  it('strips Orca provenance fields from renderer metadata updates', () => {
+  it('strips Orca provenance fields from renderer metadata updates', async () => {
     store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
 
-    const result = handlers['worktrees:updateMeta'](null, {
+    const result = await handlers['worktrees:updateMeta'](null, {
       worktreeId: 'repo-1::/workspace/feature-wt',
       updates: {
         comment: 'keep me',
@@ -729,7 +731,61 @@ describe('registerWorktreeHandlers', () => {
       comment: 'keep me',
       isPinned: true
     })
-    expect(result).toMatchObject({ comment: 'keep me', isPinned: true })
+    expect(result).toEqual({ applied: true })
+  })
+
+  it('applies a diverged-clear when the CAS precondition still holds', async () => {
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => ({ linkedPR: null, ...meta }))
+    runtimeStub.worktreeMetaPreconditionAllowsWrite.mockResolvedValue(true)
+
+    const result = await handlers['worktrees:updateMeta'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt',
+      updates: { linkedPR: null },
+      precondition: { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'aaaa' }
+    })
+
+    expect(runtimeStub.worktreeMetaPreconditionAllowsWrite).toHaveBeenCalledWith(
+      'repo-1::/workspace/feature-wt',
+      { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'aaaa' }
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-1::/workspace/feature-wt', {
+      linkedPR: null
+    })
+    expect(result).toEqual({ applied: true })
+  })
+
+  it('rejects a stale diverged-clear when the runtime CAS backstop denies the write', async () => {
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+    // STA-1394: main's authoritative state no longer matches the precondition
+    // (e.g. the head moved back onto the PR), so the clear must not persist.
+    runtimeStub.worktreeMetaPreconditionAllowsWrite.mockResolvedValue(false)
+
+    const result = await handlers['worktrees:updateMeta'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt',
+      updates: { linkedPR: null },
+      precondition: { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'X' }
+    })
+
+    expect(runtimeStub.worktreeMetaPreconditionAllowsWrite).toHaveBeenCalledWith(
+      'repo-1::/workspace/feature-wt',
+      { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'X' }
+    )
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+    expect(result).toEqual({ applied: false })
+  })
+
+  it('does not consult the runtime CAS backstop for ordinary (no-precondition) writes', async () => {
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:updateMeta'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt',
+      updates: { isUnread: false }
+    })
+
+    expect(runtimeStub.worktreeMetaPreconditionAllowsWrite).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-1::/workspace/feature-wt', {
+      isUnread: false
+    })
   })
 
   it('does not trust renderer-authored automation provenance during local create', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -4,6 +4,7 @@ import { ipcMain } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
+import type { WorktreeMetaPrecondition } from '../../shared/worktree-meta-precondition'
 import { isFolderRepo } from '../../shared/repo-kind'
 import {
   isWorkspaceKey,
@@ -1867,7 +1868,28 @@ export function registerWorktreeHandlers(
 
   ipcMain.handle(
     'worktrees:updateMeta',
-    (_event, args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => {
+    async (
+      _event,
+      args: {
+        worktreeId: string
+        updates: Partial<WorktreeMeta>
+        precondition?: WorktreeMetaPrecondition
+      }
+    ): Promise<{ applied: boolean }> => {
+      const { precondition } = args
+      // Why: main re-validates the caller's precondition against its authoritative
+      // worktree state (shared with the SSH/runtime write path) and rejects a
+      // stale write — the multi-window stale-clear race, STA-1394.
+      if (
+        precondition &&
+        !(await runtime.worktreeMetaPreconditionAllowsWrite(args.worktreeId, precondition))
+      ) {
+        console.warn(
+          `[ipc] Rejected stale worktree meta write for ${args.worktreeId}: precondition no longer holds`
+        )
+        // The renderer refetches and re-syncs its optimistic apply on applied:false.
+        return { applied: false }
+      }
       const updates =
         args.updates.displayName !== undefined
           ? {
@@ -1876,14 +1898,14 @@ export function registerWorktreeHandlers(
               firstAgentMessageRenameError: null
             }
           : args.updates
-      const meta = store.setWorktreeMeta(args.worktreeId, stripOrcaProvenanceMetaUpdates(updates))
+      store.setWorktreeMeta(args.worktreeId, stripOrcaProvenanceMetaUpdates(updates))
       // Do NOT call notifyWorktreesChanged here. The renderer applies meta
       // updates optimistically before calling this IPC, so a notification
       // would trigger a redundant fetchWorktrees round-trip that bumps
       // sortEpoch and reorders the sidebar — the exact bug PR #209 tried
       // to fix (clicking a card would clear isUnread → updateMeta →
       // worktrees:changed → fetchWorktrees → sortEpoch++ → re-sort).
-      return meta
+      return { applied: true }
     }
   )
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2263,8 +2263,11 @@ describe('OrcaRuntimeService', () => {
     await expect(
       runtime.updateManagedWorktreeMeta(`id:${result.worktree.id}`, { comment: 'note' })
     ).resolves.toMatchObject({
-      id: result.worktree.id,
-      comment: 'note'
+      applied: true,
+      worktree: {
+        id: result.worktree.id,
+        comment: 'note'
+      }
     })
     await expect(
       runtime.removeManagedWorktree('id:folder-repo::/workspace/folder')
@@ -20006,6 +20009,61 @@ describe('OrcaRuntimeService', () => {
     })
 
     expect(setWorktreeMeta).toHaveBeenCalledWith(TEST_WORKTREE_ID, { comment: 'keep me' })
+  })
+
+  it('applies a diverged-clear through the runtime CAS when the precondition holds', async () => {
+    const metaById: Record<string, WorktreeMeta> = {
+      [TEST_WORKTREE_ID]: makeWorktreeMeta({ instanceId: 'wt-instance', linkedPR: 42 })
+    }
+    const setWorktreeMeta = vi.fn((worktreeId: string, meta: Partial<WorktreeMeta>) => {
+      metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+      return metaById[worktreeId]
+    })
+    const runtimeStore = {
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    // MOCK_GIT_WORKTREES reports head 'abc' / branch 'feature/foo' for the fresh scan.
+    const result = await runtime.updateManagedWorktreeMeta(
+      `id:${TEST_WORKTREE_ID}`,
+      { linkedPR: null },
+      { expectedLinkedPR: 42, expectedBranch: 'feature/foo', expectedHead: 'abc' }
+    )
+
+    expect(result.applied).toBe(true)
+    expect(setWorktreeMeta).toHaveBeenCalledWith(TEST_WORKTREE_ID, { linkedPR: null })
+  })
+
+  it('rejects a stale diverged-clear when the freshly-scanned head has moved on', async () => {
+    const metaById: Record<string, WorktreeMeta> = {
+      [TEST_WORKTREE_ID]: makeWorktreeMeta({ instanceId: 'wt-instance', linkedPR: 42 })
+    }
+    const setWorktreeMeta = vi.fn((worktreeId: string, meta: Partial<WorktreeMeta>) => {
+      metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+      return metaById[worktreeId]
+    })
+    const runtimeStore = {
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    // Cache-lag regression (STA-1394): caller believed head was 'STALE', but the
+    // forced fresh scan reads the true current head 'abc' — reject the clear.
+    const result = await runtime.updateManagedWorktreeMeta(
+      `id:${TEST_WORKTREE_ID}`,
+      { linkedPR: null },
+      { expectedLinkedPR: 42, expectedBranch: 'feature/foo', expectedHead: 'STALE' }
+    )
+
+    expect(result.applied).toBe(false)
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
   })
 
   it('ignores stale instance-mismatched lineage when validating manual cycle repairs', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -156,6 +156,11 @@ import {
   splitWorktreeIdForFilesystem
 } from '../../shared/worktree-id'
 import {
+  worktreeMetaPreconditionHolds,
+  type WorktreeMetaPrecondition,
+  type WorktreeMetaPreconditionState
+} from '../../shared/worktree-meta-precondition'
+import {
   getProjectHostSetupForRepo,
   getProjectHostSetupWorktreeMeta
 } from '../../shared/project-host-setup-projection'
@@ -14555,6 +14560,89 @@ export class OrcaRuntimeService {
     return { base, behind: drift.behind, recentSubjects }
   }
 
+  /**
+   * Read the target worktree's authoritative { linkedPR, branch, head } for a
+   * compare-and-set (STA-1394). Forces a FRESH single-repo scan (never the
+   * 1s-TTL resolved cache, which a terminal `git checkout` can silently outrun)
+   * so a stale diverged-clear is deterministically rejected. Returns null when
+   * the worktree is unresolvable (deleted/renamed/scan failed); CAS callers
+   * treat null as a precondition failure and reject the write.
+   */
+  async resolveWorktreePreconditionState(
+    worktreeId: string
+  ): Promise<WorktreeMetaPreconditionState | null> {
+    const store = this.store
+    if (!store) {
+      return null
+    }
+    const parsed = splitWorktreeIdForFilesystem(worktreeId)
+    if (!parsed?.repoId || !parsed.worktreePath) {
+      return null
+    }
+    const repo = store.getRepos().find((entry) => entry.id === parsed.repoId)
+    if (!repo) {
+      return null
+    }
+    let scan: RuntimeWorktreeScanResult
+    try {
+      // Why: bound the CAS scan like computeResolvedWorktrees does — a slow
+      // (but connected) SSH target repo must not hang the awaiting updateMeta
+      // write. A timeout yields ok:false → treated as unresolvable → reject.
+      scan = await withTimeout(
+        this.listRepoWorktreesForResolution(repo),
+        RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
+        {
+          ok: false,
+          worktrees: []
+        }
+      )
+    } catch {
+      return null
+    }
+    // Why: a non-authoritative scan (e.g. disconnected SSH provider) can't prove
+    // the real head, so treat it as unresolvable and let the caller reject
+    // rather than accept a possibly-stale clear.
+    if (!scan.ok) {
+      return null
+    }
+    const gitWorktree = scan.worktrees.find((entry) =>
+      areWorktreePathsEqual(entry.path, parsed.worktreePath)
+    )
+    if (!gitWorktree) {
+      return null
+    }
+    return {
+      linkedPR: store.getWorktreeMeta(worktreeId)?.linkedPR ?? null,
+      branch: gitWorktree.branch,
+      head: gitWorktree.head
+    }
+  }
+
+  /**
+   * Evaluate a CAS precondition against main's authoritative state. Branch/head
+   * preconditions force a fresh target-repo scan (see
+   * resolveWorktreePreconditionState); a linkedPR-only precondition reads the
+   * in-memory store with no git cost. Reuses the shared pure comparator so the
+   * renderer early-out and this backstop cannot drift.
+   */
+  async worktreeMetaPreconditionAllowsWrite(
+    worktreeId: string,
+    precondition: WorktreeMetaPrecondition
+  ): Promise<boolean> {
+    if (precondition.expectedBranch !== undefined || precondition.expectedHead !== undefined) {
+      const state = await this.resolveWorktreePreconditionState(worktreeId)
+      if (!state) {
+        return false
+      }
+      return worktreeMetaPreconditionHolds(precondition, state)
+    }
+    return worktreeMetaPreconditionHolds(precondition, {
+      linkedPR: this.store?.getWorktreeMeta(worktreeId)?.linkedPR ?? null,
+      branch: undefined,
+      head: undefined
+    })
+  }
+
   async updateManagedWorktreeMeta(
     worktreeSelector: string,
     updates: Omit<Partial<WorktreeMeta>, 'pushTarget'> & {
@@ -14563,12 +14651,25 @@ export class OrcaRuntimeService {
         parentWorktree?: string
         noParent?: boolean
       }
-    }
-  ) {
+    },
+    precondition?: WorktreeMetaPrecondition
+  ): Promise<{ worktree: ResolvedWorktree; applied: boolean }> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
+    // CAS backstop (STA-1394): reject a stale write (e.g. the multi-window
+    // diverged-clear race) before touching the store, so remote/SSH windows
+    // funneling through this one runtime can't win the race either.
+    if (
+      precondition &&
+      !(await this.worktreeMetaPreconditionAllowsWrite(worktree.id, precondition))
+    ) {
+      console.warn(
+        `[runtime] Rejected stale worktree meta write for ${worktree.id}: precondition no longer holds`
+      )
+      return { worktree, applied: false }
+    }
     const { lineage, ...metaUpdates } = updates
     const shouldClearPushTarget =
       Object.prototype.hasOwnProperty.call(metaUpdates, 'pushTarget') &&
@@ -14634,7 +14735,7 @@ export class OrcaRuntimeService {
     // explicit push so the editor refreshes metadata changed outside the UI.
     this.invalidateResolvedWorktreeCache()
     this.notifyWorktreesChanged(worktree.repoId)
-    return await this.showManagedWorktree(`id:${worktree.id}`)
+    return { worktree: await this.showManagedWorktree(`id:${worktree.id}`), applied: true }
   }
 
   persistManagedWorktreeSortOrder(orderedIds: string[]): { updated: number } {

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -211,6 +211,16 @@ export const WorktreeSet = WorktreeSelector.extend({
     .optional(),
   diffComments: z.array(z.unknown()).optional(),
   mobileDiffReview: z.unknown().optional(),
+  // Why: optional main-side compare-and-set. When present, the runtime
+  // re-validates it against its authoritative worktree state and rejects a
+  // stale write (STA-1394). Absent = last-write-wins, today's behavior.
+  precondition: z
+    .object({
+      expectedLinkedPR: z.union([z.number(), z.null()]).optional(),
+      expectedBranch: z.string().optional(),
+      expectedHead: z.union([z.string(), z.null()]).optional()
+    })
+    .optional(),
   parentWorktree: OptionalString,
   noParent: OptionalBoolean
 }).superRefine((params, ctx) => {

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -665,7 +665,9 @@ describe('worktree RPC methods', () => {
   it('forwards Linear metadata through worktree.set', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
-      updateManagedWorktreeMeta: vi.fn().mockResolvedValue({ id: 'wt-1' })
+      updateManagedWorktreeMeta: vi
+        .fn()
+        .mockResolvedValue({ worktree: { id: 'wt-1' }, applied: true })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
 
@@ -685,14 +687,17 @@ describe('worktree RPC methods', () => {
         linkedLinearIssue: 'STA-335',
         linkedLinearIssueWorkspaceId: null,
         linkedLinearIssueOrganizationUrlKey: 'stably'
-      })
+      }),
+      undefined
     )
   })
 
   it('forwards push target clears through worktree.set', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
-      updateManagedWorktreeMeta: vi.fn().mockResolvedValue({ id: 'wt-1' })
+      updateManagedWorktreeMeta: vi
+        .fn()
+        .mockResolvedValue({ worktree: { id: 'wt-1' }, applied: true })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
 
@@ -710,7 +715,33 @@ describe('worktree RPC methods', () => {
       expect.objectContaining({
         linkedPR: null,
         pushTarget: null
+      }),
+      undefined
+    )
+  })
+
+  it('forwards the CAS precondition and surfaces a rejected applied:false', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateManagedWorktreeMeta: vi
+        .fn()
+        .mockResolvedValue({ worktree: { id: 'wt-1' }, applied: false })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('worktree.set', {
+        worktree: 'id:wt-1',
+        linkedPR: null,
+        precondition: { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'aaaa' }
       })
+    )
+
+    expect(response).toMatchObject({ ok: true, result: { applied: false } })
+    expect(runtime.updateManagedWorktreeMeta).toHaveBeenCalledWith(
+      'id:wt-1',
+      expect.objectContaining({ linkedPR: null }),
+      { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'aaaa' }
     )
   })
 

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -151,44 +151,52 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.set',
     params: WorktreeSet,
-    handler: async (params, { runtime }) => ({
-      worktree: await runtime.updateManagedWorktreeMeta(params.worktree, {
-        displayName: params.displayName,
-        linkedIssue: params.linkedIssue,
-        linkedPR: params.linkedPR,
-        linkedLinearIssue: params.linkedLinearIssue,
-        linkedLinearIssueWorkspaceId: params.linkedLinearIssueWorkspaceId,
-        linkedLinearIssueOrganizationUrlKey: params.linkedLinearIssueOrganizationUrlKey,
-        linkedGitLabMR: params.linkedGitLabMR,
-        linkedGitLabIssue: params.linkedGitLabIssue,
-        linkedBitbucketPR: params.linkedBitbucketPR,
-        linkedAzureDevOpsPR: params.linkedAzureDevOpsPR,
-        linkedGiteaPR: params.linkedGiteaPR,
-        comment: params.comment,
-        isArchived: params.isArchived,
-        isUnread: params.isUnread,
-        isPinned: params.isPinned,
-        sortOrder: params.sortOrder,
-        manualOrder: params.manualOrder,
-        lastActivityAt: params.lastActivityAt,
-        createdAt: params.createdAt,
-        sparseDirectories: params.sparseDirectories,
-        sparseBaseRef: params.sparseBaseRef,
-        sparsePresetId: params.sparsePresetId,
-        baseRef: params.baseRef,
-        workspaceStatus: params.workspaceStatus,
-        pushTarget: params.pushTarget,
-        diffComments: params.diffComments,
-        mobileDiffReview: params.mobileDiffReview,
-        lineage:
-          params.parentWorktree || params.noParent === true
-            ? {
-                parentWorktree: params.parentWorktree,
-                noParent: params.noParent === true
-              }
-            : undefined
-      } as Parameters<typeof runtime.updateManagedWorktreeMeta>[1])
-    })
+    // Why: return is additive ({ worktree, applied }) — `applied` carries the
+    // main-side CAS result (STA-1394) while existing consumers keep reading
+    // `.worktree`.
+    handler: async (params, { runtime }) => {
+      const { worktree, applied } = await runtime.updateManagedWorktreeMeta(
+        params.worktree,
+        {
+          displayName: params.displayName,
+          linkedIssue: params.linkedIssue,
+          linkedPR: params.linkedPR,
+          linkedLinearIssue: params.linkedLinearIssue,
+          linkedLinearIssueWorkspaceId: params.linkedLinearIssueWorkspaceId,
+          linkedLinearIssueOrganizationUrlKey: params.linkedLinearIssueOrganizationUrlKey,
+          linkedGitLabMR: params.linkedGitLabMR,
+          linkedGitLabIssue: params.linkedGitLabIssue,
+          linkedBitbucketPR: params.linkedBitbucketPR,
+          linkedAzureDevOpsPR: params.linkedAzureDevOpsPR,
+          linkedGiteaPR: params.linkedGiteaPR,
+          comment: params.comment,
+          isArchived: params.isArchived,
+          isUnread: params.isUnread,
+          isPinned: params.isPinned,
+          sortOrder: params.sortOrder,
+          manualOrder: params.manualOrder,
+          lastActivityAt: params.lastActivityAt,
+          createdAt: params.createdAt,
+          sparseDirectories: params.sparseDirectories,
+          sparseBaseRef: params.sparseBaseRef,
+          sparsePresetId: params.sparsePresetId,
+          baseRef: params.baseRef,
+          workspaceStatus: params.workspaceStatus,
+          pushTarget: params.pushTarget,
+          diffComments: params.diffComments,
+          mobileDiffReview: params.mobileDiffReview,
+          lineage:
+            params.parentWorktree || params.noParent === true
+              ? {
+                  parentWorktree: params.parentWorktree,
+                  noParent: params.noParent === true
+                }
+              : undefined
+        } as Parameters<typeof runtime.updateManagedWorktreeMeta>[1],
+        params.precondition
+      )
+      return { worktree, applied }
+    }
   }),
   defineMethod({
     name: 'worktree.persistSortOrder',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -194,6 +194,7 @@ import type {
   WarpThemeImportSource
 } from '../shared/terminal-custom-themes'
 import type { SetupScriptImportCandidate } from '../shared/setup-script-imports'
+import type { WorktreeMetaPrecondition } from '../shared/worktree-meta-precondition'
 import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
 import type { PublicKnownRuntimeEnvironment } from '../shared/runtime-environments'
 import type {
@@ -1064,7 +1065,11 @@ export type PreloadApi = {
       branchName: string
       expectedHead: string
     }) => Promise<ForceDeleteWorktreeBranchResult>
-    updateMeta: (args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => Promise<Worktree>
+    updateMeta: (args: {
+      worktreeId: string
+      updates: Partial<WorktreeMeta>
+      precondition?: WorktreeMetaPrecondition
+    }) => Promise<{ applied: boolean }>
     listLineage: () => Promise<{
       lineage: Record<string, WorktreeLineage>
       workspaceLineage?: Record<string, WorkspaceLineage>

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -2218,7 +2218,10 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     expect(updateWorktreeMeta).toHaveBeenCalledWith(
       worktreeId,
       { linkedPR: null },
-      { shouldApply: expect.any(Function) }
+      {
+        shouldApply: expect.any(Function),
+        precondition: expect.objectContaining({ expectedLinkedPR: 12 })
+      }
     )
     expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBeNull()
     expect(store.getState().prCache[`${repoId}::${branch}`]).toBeUndefined()
@@ -2267,7 +2270,10 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     expect(updateWorktreeMeta).toHaveBeenCalledWith(
       worktreeId,
       { linkedPR: null },
-      { shouldApply: expect.any(Function) }
+      {
+        shouldApply: expect.any(Function),
+        precondition: expect.objectContaining({ expectedLinkedPR: 12 })
+      }
     )
     expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBeNull()
   })
@@ -2583,7 +2589,10 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     expect(updateWorktreeMeta).toHaveBeenCalledWith(
       worktreeId,
       { linkedPR: null },
-      { shouldApply: expect.any(Function) }
+      {
+        shouldApply: expect.any(Function),
+        precondition: expect.objectContaining({ expectedLinkedPR: 12 })
+      }
     )
     expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBe(12)
     expect(store.getState().prCache[`${repoId}::${branch}`]).toMatchObject({
@@ -3055,7 +3064,10 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     expect(updateWorktreeMeta).toHaveBeenCalledWith(
       worktreeId,
       { linkedPR: null },
-      { shouldApply: expect.any(Function) }
+      {
+        shouldApply: expect.any(Function),
+        precondition: expect.objectContaining({ expectedLinkedPR: 12 })
+      }
     )
     expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBeNull()
   })

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -2988,7 +2988,15 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                   linkedPRNumber,
                   branch,
                   requestHeadOid: currentHeadOid
-                })
+                }),
+              // Why: shouldApply is renderer-local; the precondition lets main
+              // reject this clear if its authoritative head has since moved back
+              // onto the PR (the multi-window stale-clear race, STA-1394).
+              precondition: {
+                expectedLinkedPR: linkedPRNumber,
+                expectedBranch: branch,
+                expectedHead: currentHeadOid
+              }
             }
           )
         }
@@ -3142,7 +3150,14 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                     linkedPRNumber,
                     branch,
                     requestHeadOid
-                  })
+                  }),
+                // Why: main re-validates the precondition against its authoritative
+                // head so a stale window can't win this diverged-clear race (STA-1394).
+                precondition: {
+                  expectedLinkedPR: linkedPRNumber,
+                  expectedBranch: branch,
+                  expectedHead: requestHeadOid
+                }
               }
             )
           }
@@ -4100,7 +4115,14 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               linkedPRNumber: clear.linkedPRNumber,
               branch: clear.branch,
               requestHeadOid: clear.requestHeadOid
-            })
+            }),
+          // Why: main re-validates the precondition against its authoritative
+          // head so a stale window can't win this diverged-clear race (STA-1394).
+          precondition: {
+            expectedLinkedPR: clear.linkedPRNumber,
+            expectedBranch: clear.branch,
+            expectedHead: clear.requestHeadOid
+          }
         }
       )
     }

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -26,6 +26,7 @@ import type {
   WorktreeCreationPhase
 } from '@/lib/pending-worktree-creation'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import type { WorktreeMetaPrecondition } from '../../../../shared/worktree-meta-precondition'
 export { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 
 export type WorktreeDeleteState = {
@@ -38,6 +39,13 @@ export type WorktreeMetaUpdateGuard = (worktree: Worktree | DetectedWorktree | u
 
 export type WorktreeMetaUpdateOptions = {
   shouldApply?: WorktreeMetaUpdateGuard
+  /**
+   * Optional main-side compare-and-set (STA-1394). When present, main
+   * re-validates it against its authoritative worktree state at write time and
+   * rejects the write on mismatch. `shouldApply` stays the cheap renderer-local
+   * early-out; this is the authoritative backstop.
+   */
+  precondition?: WorktreeMetaPrecondition
 }
 
 export type WorktreeRenameRequest = {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -68,7 +68,7 @@ const mockApi = {
     forceDeletePreservedBranch: vi.fn().mockResolvedValue({ deleted: true }),
     resolvePrBase: vi.fn(),
     resolveMrBase: vi.fn(),
-    updateMeta: vi.fn().mockResolvedValue(undefined),
+    updateMeta: vi.fn().mockResolvedValue({ applied: true, meta: {} }),
     updateLineage: vi.fn().mockResolvedValue(null)
   },
   pty: {
@@ -1907,6 +1907,60 @@ describe('worktree lineage state', () => {
     })
     expect(store.getState().worktreeLineageById).toEqual({})
     expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual(updatedChild)
+  })
+})
+
+describe('updateWorktreeMeta CAS reconcile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRemoteRuntimeMocks()
+  })
+
+  it('refetches worktrees when main rejects the write (applied:false)', async () => {
+    const store = createTestStore()
+    const existing = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      linkedPR: 12
+    })
+    store.setState({ worktreesByRepo: { repo1: [existing] } } as Partial<AppState>)
+    mockApi.worktrees.updateMeta.mockResolvedValueOnce({ applied: false, meta: {} })
+
+    await store.getState().updateWorktreeMeta(
+      'repo1::/path/wt1',
+      { linkedPR: null },
+      {
+        precondition: { expectedLinkedPR: 12, expectedBranch: 'feature', expectedHead: 'abc123' }
+      }
+    )
+
+    // A rejected clear means the optimistic local apply was wrong → re-sync.
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledWith(
+      expect.objectContaining({ repoId: 'repo1' })
+    )
+  })
+
+  it('does not refetch when main applies the write (applied:true)', async () => {
+    const store = createTestStore()
+    const existing = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      linkedPR: 12
+    })
+    store.setState({ worktreesByRepo: { repo1: [existing] } } as Partial<AppState>)
+    mockApi.worktrees.updateMeta.mockResolvedValueOnce({ applied: true, meta: {} })
+
+    await store.getState().updateWorktreeMeta(
+      'repo1::/path/wt1',
+      { linkedPR: null },
+      {
+        precondition: { expectedLinkedPR: 12, expectedBranch: 'feature', expectedHead: 'abc123' }
+      }
+    )
+
+    expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -57,6 +57,7 @@ import {
   type ExecutionHostId
 } from '../../../../shared/execution-host'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import type { WorktreeMetaPrecondition } from '../../../../shared/worktree-meta-precondition'
 import {
   folderWorkspaceKey,
   isWorkspaceKey,
@@ -1163,22 +1164,35 @@ function mergeWorkspaceLineageForHost(
 async function persistWorktreeMeta(
   settings: AppState['settings'],
   worktreeId: string,
-  updates: Partial<WorktreeMeta>
-): Promise<void> {
+  updates: Partial<WorktreeMeta>,
+  precondition?: WorktreeMetaPrecondition
+): Promise<{ applied: boolean }> {
   const target = getActiveRuntimeTarget(settings)
   if (target.kind === 'local') {
-    await window.api.worktrees.updateMeta({ worktreeId, updates })
-    return
+    const response = await window.api.worktrees.updateMeta({
+      worktreeId,
+      updates,
+      ...(precondition ? { precondition } : {})
+    })
+    // Why: default to applied when the response omits the flag (older main /
+    // LWW writes) — only an explicit `applied: false` is a CAS rejection.
+    return { applied: response?.applied ?? true }
   }
-  await callRuntimeRpc(
+  // Why: the runtime RPC return is additive ({ worktree, applied }) so paired/web
+  // and CLI consumers that read `.worktree` keep working; surface the real
+  // `applied` so the CAS is authoritative for SSH-mode multi-window writes too.
+  // Older remote runtimes omit `applied` → treat as applied (LWW back-compat).
+  const result = await callRuntimeRpc<{ applied?: boolean }>(
     target,
     'worktree.set',
     {
       worktree: toRuntimeWorktreeSelector(worktreeId),
-      ...encodePushTargetClearForRuntimeRpc(updates)
+      ...encodePushTargetClearForRuntimeRpc(updates),
+      ...(precondition ? { precondition } : {})
     },
     { timeoutMs: 15_000 }
   )
+  return { applied: result?.applied ?? true }
 }
 
 // Why: an SSH-mode per-workspace-env registers a project whose host is the runtime-owned SSH
@@ -3633,7 +3647,19 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     }
 
     try {
-      await persistWorktreeMeta(settingsForWorktreeOwner(get(), worktreeId), worktreeId, enriched)
+      const { applied } = await persistWorktreeMeta(
+        settingsForWorktreeOwner(get(), worktreeId),
+        worktreeId,
+        enriched,
+        options?.precondition
+      )
+      if (!applied) {
+        // Why: main's CAS rejected this write (its authoritative worktree state
+        // no longer matches the precondition), so the optimistic local apply was
+        // wrong — refetch to re-sync from main's authoritative state.
+        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+        return
+      }
       if (reviewRepo && reviewBranch && typeof get().fetchHostedReviewForBranch === 'function') {
         // Why: the old cache entry may have been populated by the previous
         // provider link. Refetch against the post-update links so stale lookups

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1831,6 +1831,53 @@ describe('web worktree preload API', () => {
       }
     ])
   })
+
+  it('forwards the CAS precondition and surfaces a rejected applied:false (never hardcodes true)', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: {
+              worktree: { id: 'repo-1::/workspace/review', path: '/workspace/review' },
+              applied: false
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const result = await globals.window.api.worktrees.updateMeta({
+      worktreeId: 'repo-1::/workspace/review',
+      updates: { linkedPR: null },
+      precondition: { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'aaaa' }
+    })
+
+    // The wrapper must surface the REAL applied from the RPC, not hardcode true,
+    // or the CAS is silently defeated for web/paired/mobile clients (STA-1394).
+    expect(result.applied).toBe(false)
+    expect(runtimeCalls).toEqual([
+      {
+        method: 'worktree.set',
+        params: {
+          worktree: 'id:repo-1::/workspace/review',
+          linkedPR: null,
+          precondition: { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'aaaa' }
+        }
+      }
+    ])
+  })
 })
 
 describe('web file preload API', () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1296,18 +1296,24 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         branchName,
         expectedHead
       }),
-    updateMeta: async ({ worktreeId, updates }) => {
+    updateMeta: async ({ worktreeId, updates, precondition }) => {
       const rpcUpdates =
         Object.prototype.hasOwnProperty.call(updates, 'pushTarget') &&
         updates.pushTarget === undefined
           ? { ...updates, pushTarget: null }
           : updates
-      return (
-        await callRuntimeResult<{ worktree: Worktree }>('worktree.set', {
+      // Why: surface the REAL `applied` from the RPC (never hardcode true) so
+      // the main-side CAS is authoritative for web/paired/mobile clients too —
+      // the SSH/paired multi-window scenario STA-1394 must cover.
+      const response = await callRuntimeResult<{ worktree: Worktree; applied?: boolean }>(
+        'worktree.set',
+        {
           worktree: toRuntimeWorktreeSelector(worktreeId),
-          ...rpcUpdates
-        })
-      ).worktree
+          ...rpcUpdates,
+          ...(precondition ? { precondition } : {})
+        }
+      )
+      return { applied: response.applied ?? true }
     },
     listLineage: async () =>
       await callRuntimeResult<{

--- a/src/shared/worktree-meta-precondition.test.ts
+++ b/src/shared/worktree-meta-precondition.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import {
+  worktreeMetaPreconditionHolds,
+  type WorktreeMetaPrecondition,
+  type WorktreeMetaPreconditionState
+} from './worktree-meta-precondition'
+
+const CURRENT: WorktreeMetaPreconditionState = {
+  linkedPR: 42,
+  branch: 'feature/x',
+  head: 'aaaa'
+}
+
+type PreconditionCase = {
+  name: string
+  precondition: WorktreeMetaPrecondition
+  current: WorktreeMetaPreconditionState
+  expected: boolean
+}
+
+describe('worktreeMetaPreconditionHolds', () => {
+  const cases: PreconditionCase[] = [
+    // Empty precondition → always holds (LWW callers never opt in).
+    { name: 'empty precondition holds', precondition: {}, current: CURRENT, expected: true },
+
+    // Each field present and matching.
+    {
+      name: 'linkedPR present + matches',
+      precondition: { expectedLinkedPR: 42 },
+      current: CURRENT,
+      expected: true
+    },
+    {
+      name: 'branch present + matches',
+      precondition: { expectedBranch: 'feature/x' },
+      current: CURRENT,
+      expected: true
+    },
+    {
+      name: 'head present + matches',
+      precondition: { expectedHead: 'aaaa' },
+      current: CURRENT,
+      expected: true
+    },
+    {
+      name: 'full triple matches',
+      precondition: { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'aaaa' },
+      current: CURRENT,
+      expected: true
+    },
+
+    // Each field present and mismatching.
+    {
+      name: 'linkedPR mismatch',
+      precondition: { expectedLinkedPR: 7 },
+      current: CURRENT,
+      expected: false
+    },
+    {
+      name: 'branch mismatch',
+      precondition: { expectedBranch: 'feature/other' },
+      current: CURRENT,
+      expected: false
+    },
+    {
+      name: 'head mismatch (the diverged-clear discriminator)',
+      precondition: { expectedHead: 'bbbb' },
+      current: CURRENT,
+      expected: false
+    },
+    {
+      name: 'full triple with only head moved → rejected',
+      precondition: { expectedLinkedPR: 42, expectedBranch: 'feature/x', expectedHead: 'bbbb' },
+      current: CURRENT,
+      expected: false
+    },
+
+    // Absent fields are skipped even when current differs.
+    {
+      name: 'absent branch/head skipped, linkedPR-only matches',
+      precondition: { expectedLinkedPR: 42 },
+      current: { linkedPR: 42, branch: 'totally-different', head: 'zzzz' },
+      expected: true
+    },
+
+    // Branch normalization: refs/heads/ prefix stripped on both sides.
+    {
+      name: 'branch precondition with refs/heads/ prefix matches bare current',
+      precondition: { expectedBranch: 'refs/heads/feature/x' },
+      current: CURRENT,
+      expected: true
+    },
+    {
+      name: 'bare branch precondition matches refs/heads/ current',
+      precondition: { expectedBranch: 'feature/x' },
+      current: { ...CURRENT, branch: 'refs/heads/feature/x' },
+      expected: true
+    },
+
+    // null-normalization: expected null vs undefined/null current.
+    {
+      name: 'expectedLinkedPR null matches current null',
+      precondition: { expectedLinkedPR: null },
+      current: { ...CURRENT, linkedPR: null },
+      expected: true
+    },
+    {
+      name: 'expectedLinkedPR null mismatches a real PR',
+      precondition: { expectedLinkedPR: null },
+      current: CURRENT,
+      expected: false
+    },
+    {
+      name: 'expectedHead null matches current undefined head',
+      precondition: { expectedHead: null },
+      current: { ...CURRENT, head: undefined },
+      expected: true
+    },
+    {
+      name: 'expectedHead null matches current null head',
+      precondition: { expectedHead: null },
+      current: { ...CURRENT, head: null },
+      expected: true
+    },
+    {
+      name: 'expectedHead null mismatches a real head',
+      precondition: { expectedHead: null },
+      current: CURRENT,
+      expected: false
+    },
+
+    // Branch precondition present but current branch undefined → mismatch.
+    {
+      name: 'branch precondition against undefined current branch mismatches',
+      precondition: { expectedBranch: 'feature/x' },
+      current: { ...CURRENT, branch: undefined },
+      expected: false
+    }
+  ]
+
+  for (const { name, precondition, current, expected } of cases) {
+    it(name, () => {
+      expect(worktreeMetaPreconditionHolds(precondition, current)).toBe(expected)
+    })
+  }
+})

--- a/src/shared/worktree-meta-precondition.ts
+++ b/src/shared/worktree-meta-precondition.ts
@@ -1,0 +1,60 @@
+/**
+ * Serializable precondition for a compare-and-set (CAS) worktree-meta write.
+ *
+ * A caller records what it believed true (persisted linkedPR, git branch, git
+ * head) when it decided to mutate. Main re-validates that belief against its
+ * authoritative worktree state at write time and rejects stale mutations,
+ * regardless of which renderer sent them (STA-1394). Only the fields present
+ * here are compared, so a caller can constrain any subset (linkedPR-only, or
+ * the full triple the diverged-clear path needs).
+ */
+export type WorktreeMetaPrecondition = {
+  /** Expected persisted linkedPR at write time; null means "expected unlinked". */
+  expectedLinkedPR?: number | null
+  /** Expected worktree branch (with or without refs/heads/ prefix — normalized before compare). */
+  expectedBranch?: string
+  /** Expected git HEAD oid; null means "expected no head". */
+  expectedHead?: string | null
+}
+
+/** Authoritative "current" snapshot main compares the precondition against. */
+export type WorktreeMetaPreconditionState = {
+  linkedPR: number | null
+  branch: string | undefined
+  head: string | null | undefined
+}
+
+function stripBranchRef(branch: string | undefined): string | undefined {
+  return branch?.replace(/^refs\/heads\//, '')
+}
+
+/**
+ * Returns true when every field PRESENT in `precondition` still matches
+ * `current`. Absent fields are skipped, so an empty precondition always holds.
+ */
+export function worktreeMetaPreconditionHolds(
+  precondition: WorktreeMetaPrecondition,
+  current: WorktreeMetaPreconditionState
+): boolean {
+  // Why: IPC/JSON drops `undefined` keys, so `!== undefined` (not a truthiness
+  // check) distinguishes an absent field from a real expected value of `null`.
+  if (
+    precondition.expectedLinkedPR !== undefined &&
+    (precondition.expectedLinkedPR ?? null) !== (current.linkedPR ?? null)
+  ) {
+    return false
+  }
+  if (
+    precondition.expectedBranch !== undefined &&
+    stripBranchRef(precondition.expectedBranch) !== stripBranchRef(current.branch)
+  ) {
+    return false
+  }
+  if (
+    precondition.expectedHead !== undefined &&
+    (precondition.expectedHead ?? null) !== (current.head ?? null)
+  ) {
+    return false
+  }
+  return true
+}


### PR DESCRIPTION
## What changes

Prevents a valid linked PR on a worktree from being **wrongly cleared by a stale client**. The automatic "this merged PR's head diverged, clear the link" decision runs in the renderer against that client's own store snapshot, and the guard that vetoes a bad clear (`shouldApply`) is a client-side closure that **cannot cross the RPC boundary**. So when the write lands on the host via the `worktree.set` RPC, the host applied it with no authoritative check. This adds a host-side compare-and-set: the caller sends the precondition it believed true (expected linkedPR/branch/head), and the **host** re-validates it against a fresh read of its own worktree state before writing, rejecting a stale clear regardless of which client sent it.

**What does not change:** every ordinary metadata write (rename, unread, pin, workspace status, sort order, comment, base ref, diff comments, manual PR link/unlink) keeps last-write-wins semantics and pays zero added cost. The check is opt-in — only the automatic merged-PR divergence clear supplies a precondition. The renderer's cheap `shouldApply` early-out is unchanged; the host-side check is the correctness backstop.

## The reachable race (corrected from the ticket)

The ticket framed this as "two desktop windows." Orca only ever runs one desktop window (`src/main/index.ts:2160` creates a window only when none exist), so that framing is wrong. The **actually reachable** case is a **second renderer = a paired web/mobile client**:

- A paired client runs the same diverged-clear logic. Its `fetchPRForBranch` is live over the host via the `refreshPRNow` → `github.prForBranch` shim (`web-preload-api.ts:1803`), which passes `currentHeadOid` and reaches the shared github-slice diverged-clear (`github.ts:2981`/`:3135`). (`#7460` patched that same shim to thread `currentHeadOid` precisely because web clients run these lookups.)
- The client's `updateWorktreeMeta` lands on the host through the `worktree.set` RPC. The `shouldApply` guard is a client-side closure and **cannot** cross the RPC, so pre-change the host applied the clear with no re-check.
- A paired phone with a lagging store over a flaky network is a *worse* version of the race than two windows ever were: same wrong clear, a much larger staleness window, and zero host-side guard.

Sequence: worktree linked to a merged PR whose HEAD diverged → user/agent moves HEAD back onto the PR's line → the paired client's store still shows the diverged head (network/store lag) → its clear passes its local guard and, pre-change, persists on the host. It self-heals on the next successful lookup, so severity is low and no user report exists — but the guard was advisory, not authoritative.

## Design approach

- A small shared, serializable precondition (`expectedLinkedPR` / `expectedBranch` / `expectedHead`) and one pure comparator (`src/shared/worktree-meta-precondition.ts`) used by the renderer early-out and the host write path, so the logic can't drift. Serializable is the point: it crosses the RPC where `shouldApply` can't.
- The diverged-clear sites pass that precondition alongside the existing `shouldApply`. The host re-validates it and skips the write on mismatch, returning `applied: false`; the client reconciles the optimistic clear via `fetchWorktrees`.
- **The CAS lives at the seam where every write lands.** Both the local desktop IPC (`worktrees:updateMeta`) and the remote `worktree.set` RPC route through one host method (`updateManagedWorktreeMeta` → `worktreeMetaPreconditionAllowsWrite`), so a desktop write and a paired-client write get the identical authoritative check. The `worktree.set` return is kept **additive** (`{ worktree, applied }`) so existing consumers are unaffected, and the web/paired `updateMeta` shim surfaces the real `applied`.
- **Why the head must be read fresh on the host:** the host's 1s-TTL resolved-worktree cache is not invalidated by a terminal `git checkout`, so a cached read could still show the old head and **wrongly accept** the stale clear. When a branch/head precondition is present the host forces a fresh scan of **only the target worktree's repo** (one bounded `git worktree list`, never a per-write `rev-parse`, never an all-repos recompute). That fresh read on the host — where the real git state lives — is what makes the check authoritative against any lagging client.

## Design review

A delegated design-review loop caught two issues fixed before implementation: (1) the original "the host is never behind the freshest client" argument was **false** for a cached read (above), corrected to a forced fresh scan; (2) the `worktree.set` return is dereferenced by web-preload, CLI, and mobile paths, so the RPC return was kept additive and the web shim made to surface the real `applied`.

## Headline behavior status: **implemented** (verified live + unit-tested at the RPC seam)

- Live desktop end-to-end in a dev build through the real renderer → IPC → host fresh-scan path: a clear with a **wrong** expected head was **rejected** by the host (`[ipc] Rejected stale worktree meta write … precondition no longer holds`) and the reconcile **restored** the link; a clear with the **correct** head **applied**.
- The paired/remote seam is covered by `updateManagedWorktreeMeta` unit tests (rejects a stale clear when the fresh scan reads a moved head) and the web-preload test (the shim threads `precondition` and surfaces `applied:false`). This is the seam a paired client's write lands on, so the reachable case is exercised through real host code.

## Broad app consistency

Source of truth is the host-persisted `linkedPR`; every surface that shows a PR link (sidebar card, Checks panel, Source Control, mobile) reads it via the store fed from the host. The change is at the persistence/CAS seam below all of them — it changes *whether* a stale auto-clear persists, not how any surface renders. GitLab/other providers unchanged (diverged-clear is GitHub-specific; the precondition type is provider-neutral for future reuse).

## Risks, ambiguities, non-goals

- **Non-goals:** changing explicit user-initiated unlink (stays last-write-wins — a user clicking unlink should win), reworking the `#7460` clear logic, or adding CAS to non-`linkedPR` fields.
- **Accepted, safe tradeoff:** if the host's fresh scan can't prove the head (disconnected/slow SSH provider, timeout), the host treats the worktree as unresolvable and **rejects** the clear rather than accept an unverified one — the merged-PR link persists a bit longer and self-heals on the next refresh. Bounded by the same 5s timeout the sibling resolver uses.
- **Return-shape contract change:** the local `worktrees:updateMeta` renderer-facing return is now `{ applied }` (the previously-returned `meta` was unused by every consumer and had a transport-divergent shape, so it was dropped); the `worktree.set` RPC return is additive. Consumers were audited exhaustively.

## Perf

Delegated perf audit: **no regression.** Ordinary (no-precondition) meta writes stay a synchronous in-memory store merge with zero git cost and no added await. The fresh scan runs only on the rare diverged-clear path, is single-repo (not an all-repos recompute that could block on an unrelated slow SSH repo), self-terminates, and is bounded by a 5s timeout. No new listeners/timers/leaks.

## Code review

High-effort adversarial review (three independent finder angles + verification): **zero hard correctness bugs**; the line-by-line pass could not construct any input→wrong-output scenario against the CAS. Applied three low-severity cleanups: deduplicated the IPC/runtime dispatch (IPC delegates to one public host method), dropped the unused/transport-divergent `meta` return field (which also reverted an unrelated `getDefaultWorktreeMeta` export), and removed dangling scratch-doc references from committed comments.

## Validation

- `worktree-meta-precondition` pure-comparator table tests (18); IPC handler apply/reject/no-precondition-skip; host CAS holds/rejects incl. the **cache-lag regression** (fresh scan reads a moved head → reject); renderer `!applied → refetch`; RPC precondition forwarding + `applied:false` surfacing; web/paired shim never hardcodes `applied: true`.
- `pnpm run typecheck` clean; oxlint clean; touched suites green (775 main + 411 renderer + 18 shared).
- Live Electron validation above, with screenshots captured for the reviewer.

## Accepted gaps

No automated two-client E2E harness exists for the exact reorder race (needs a precise timing window; no user report). Covered by the seam-level unit tests — including the cache-lag regression that guards against reintroducing a cached read, and the host-side `updateManagedWorktreeMeta`/web-preload tests that exercise the paired-client seam — plus the live desktop end-to-end validation.
