### PR TITLE
fix: use runtime agent IDs in workspace composer (rebased #7141, Closes #7082)

### DIFF
--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -159,6 +159,40 @@ describe('useComposerState host-context boundaries', () => {
     expect(submitSection).toContain('runtimeEnvironmentId: folderTargetRuntimeEnvironmentId')
   })
 
+  it('detects composer agents against the repo host: SSH, then runtime, then local (#7082)', () => {
+    // Why: a repo owned by a paired runtime must show the runtime's agents, not
+    // the local machine's. SSH stays first priority; runtime falls through before
+    // local so an SSH repo never double-detects. Regression guard for #7082.
+    const selectorSection = sourceBetween(
+      HOOK_SOURCE,
+      'const detectedAgentList = useAppStore',
+      'const ensureDetectedAgents = useAppStore'
+    )
+    expect(selectorSection).toContain('if (isRemote) {')
+    expect(selectorSection).toContain('s.remoteDetectedAgentIds[connectionId]')
+    expect(selectorSection).toContain('if (runtimeEnvironmentId) {')
+    expect(selectorSection).toContain('s.runtimeDetectedAgentIds[runtimeEnvironmentId]')
+    expect(selectorSection).toContain('return s.detectedAgentIds')
+    // SSH branch is checked before the runtime branch.
+    expect(selectorSection.indexOf('if (isRemote) {')).toBeLessThan(
+      selectorSection.indexOf('if (runtimeEnvironmentId) {')
+    )
+
+    expect(HOOK_SOURCE).toContain(
+      'const runtimeEnvironmentId = selectedRepoSettings?.activeRuntimeEnvironmentId?.trim() || null'
+    )
+
+    // Detection effect fans out to the same three hosts in the same order and
+    // re-runs when the runtime environment changes.
+    const detectSection = sourceBetween(HOOK_SOURCE, 'const detect = isRemote', 'void detect.then')
+    expect(detectSection).toContain('ensureRemoteDetectedAgents(connectionId)')
+    expect(detectSection).toContain('ensureRuntimeDetectedAgents(runtimeEnvironmentId)')
+    expect(detectSection).toContain('ensureDetectedAgents()')
+    expect(HOOK_SOURCE).toContain(
+      '}, [connectionId, runtimeEnvironmentId, isRemote, selectedRepoSshStatus, disabledTuiAgents])'
+    )
+  })
+
   it('seeds initial workspace run target from the task source context', () => {
     expect(
       resolveInitialWorkspaceRunSeed({

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1122,20 +1122,25 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const [tuiAgent, setTuiAgent] = useState<TuiAgent>(
     persistDraft ? (newWorkspaceDraft?.agent ?? fallbackDefaultAgent) : fallbackDefaultAgent
   )
-  // Why: when the selected repo is remote (has a connectionId), read the
-  // per-connection agent list instead of the local one. This ensures the
-  // Create Workspace dialog shows agents installed on the SSH host, not the
-  // local machine.
+  // Why: when the selected repo has a connectionId or runtime environment, read
+  // the per-host agent list instead of the local one. This ensures the Create
+  // Workspace dialog shows agents installed on the SSH host or paired runtime,
+  // not the local machine.
   const connectionId = selectedRepoConnectionId
   const isRemote = typeof connectionId === 'string'
+  const runtimeEnvironmentId = selectedRepoSettings?.activeRuntimeEnvironmentId?.trim() || null
   const detectedAgentList = useAppStore((s) => {
     if (isRemote) {
       return s.remoteDetectedAgentIds[connectionId] ?? null
+    }
+    if (runtimeEnvironmentId) {
+      return s.runtimeDetectedAgentIds[runtimeEnvironmentId] ?? null
     }
     return s.detectedAgentIds
   })
   const ensureDetectedAgents = useAppStore((s) => s.ensureDetectedAgents)
   const ensureRemoteDetectedAgents = useAppStore((s) => s.ensureRemoteDetectedAgents)
+  const ensureRuntimeDetectedAgents = useAppStore((s) => s.ensureRuntimeDetectedAgents)
   const detectedAgentIds = useMemo<Set<TuiAgent> | null>(
     () => (detectedAgentList ? new Set(detectedAgentList) : null),
     [detectedAgentList]
@@ -1696,14 +1701,18 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   ])
 
   // Why: detect agents for the selected repo. For local repos this runs once
-  // on mount (deduped by the store). For remote repos it re-runs when the
-  // selected repo changes so the agent list matches the SSH host.
+  // on mount (deduped by the store). For remote/runtime repos it re-runs when
+  // the selected repo changes so the agent list matches the correct host.
   useEffect(() => {
     if (isRemote && selectedRepoSshStatus !== 'connected') {
       return
     }
     let cancelled = false
-    const detect = isRemote ? ensureRemoteDetectedAgents(connectionId) : ensureDetectedAgents()
+    const detect = isRemote
+      ? ensureRemoteDetectedAgents(connectionId)
+      : runtimeEnvironmentId
+        ? ensureRuntimeDetectedAgents(runtimeEnvironmentId)
+        : ensureDetectedAgents()
     void detect.then((ids) => {
       if (cancelled) {
         return
@@ -1722,11 +1731,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     return () => {
       cancelled = true
     }
-    // Why: re-run when connectionId changes (user picks a different repo) so
-    // detection targets the correct host. Draft/settings deps are intentionally
-    // excluded — detection is a best-effort PATH snapshot.
+    // Why: re-run when connectionId/runtimeEnvironmentId changes (user picks a
+    // different repo) so detection targets the correct host. Draft/settings deps
+    // are intentionally excluded — detection is a best-effort PATH snapshot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectionId, isRemote, selectedRepoSshStatus, disabledTuiAgents])
+  }, [connectionId, runtimeEnvironmentId, isRemote, selectedRepoSshStatus, disabledTuiAgents])
 
   // Per-repo: load yaml hooks + issue command template.
   useEffect(() => {


### PR DESCRIPTION
## Rebased + reviewed takeover of #7141 (do not merge without maintainer sign-off)

This branch is a **rebase of community PR #7141 onto current `main`** plus a regression test, opened to run full CI (`pr.yml`), which does not run on the original community fork PR (that PR only gets the `track-community-pr` check).

### Original fix (from @sudoeren, #7141 — Closes #7082)
`useComposerState` read the **local** detected-agent list (`s.detectedAgentIds`) for any repo without an SSH `connectionId` — including repos owned by a **paired runtime environment**. So on a Windows client paired to a Linux `orca serve` runtime, the Create Workspace picker hid runtime-detected agents (e.g. Codex) even though the runtime detects and can launch them. The fix falls through to the runtime agent list (`runtimeDetectedAgentIds[environmentId]` / `ensureRuntimeDetectedAgents`) when `selectedRepoSettings.activeRuntimeEnvironmentId` is set, before reaching the local list.

### Review notes
- **Precedence** SSH → runtime → local matches `getActiveRuntimeTarget` / `getRuntimeEnvironmentIdForRepo`. SSH and runtime are mutually exclusive by construction (a connection-owned repo resolves `activeRuntimeEnvironmentId` to `null`), so no double-detection.
- **Mobile** safe — shares the same composer; `preflight.detectAgents` is on the mobile RPC allowlist; the same runtime-detect path is already exercised by the TabBar; `.catch(() => [])` degrades gracefully.
- **SSH / Windows / GitLab** unaffected — agent detection is provider-agnostic and the SSH branch is untouched.

### Added in this branch
- Regression test locking the SSH → runtime → local host-detection precedence in the selector and detection effect.

### Local verification (all green)
oxlint (0 errors) · full typecheck (node+cli+web) · reliability-gate manifest · styled-scrollbars · targeted store/composer tests · host-context-boundary tests.

Made with [Orca](https://github.com/stablyai/orca) 🐋
