### PR TITLE
Stop wiping the shared WebGL glyph atlas on plain window refocus

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -151,6 +151,7 @@ import { AutomationService } from './automations/service'
 import { createHeadlessAutomationOutputSnapshotBuffer } from './automations/headless-dispatch'
 import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headless-workspace-create'
 import { AgentAwakeService } from './agent-awake-service'
+import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import {
   getCrashBreadcrumbSnapshot,
   recordCoalescedCrashBreadcrumb,
@@ -212,6 +213,7 @@ let starNag: StarNagService | null = null
 let agentAwakeService: AgentAwakeService | null = null
 let crashReports: CrashReportStore | null = null
 let unsubscribeAgentAwakeStatusChanges: (() => void) | null = null
+let unsubscribeSystemResumeBroadcast: (() => void) | null = null
 let watcherShutdownPromise: Promise<void> | null = null
 let watcherShutdownDone = false
 let automations: AutomationService | null = null
@@ -1653,6 +1655,7 @@ app.whenReady().then(async () => {
   // Why: browser sessions are used by desktop webviews and runtime profile
   // commands, so initialize them at app startup instead of a renderer IPC path.
   initializeBrowserSessionsForApp()
+  unsubscribeSystemResumeBroadcast = registerSystemResumeBroadcast()
   agentAwakeService = new AgentAwakeService()
   agentAwakeService.setEnabled(store.getSettings().keepComputerAwakeWhileAgentsRun)
   // Why: disk-hydrated status rows are UI continuity only. The service starts
@@ -2170,6 +2173,8 @@ app.whenReady().then(async () => {
 
 app.on('before-quit', () => {
   isQuitting = true
+  unsubscribeSystemResumeBroadcast?.()
+  unsubscribeSystemResumeBroadcast = null
   unsubscribeAgentAwakeStatusChanges?.()
   unsubscribeAgentAwakeStatusChanges = null
   agentAwakeService?.dispose()

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import { registerSystemResumeBroadcast, SYSTEM_RESUMED_CHANNEL } from './system-resume-broadcast'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  powerMonitor: { on: vi.fn(), off: vi.fn() }
+}))
+
+type ResumeListener = () => void
+
+function createResumeSource() {
+  const state: { listener: ResumeListener | null } = { listener: null }
+  const source = {
+    on: vi.fn((_event: 'resume', callback: ResumeListener) => {
+      state.listener = callback
+    }),
+    off: vi.fn((_event: 'resume', _callback: ResumeListener) => {
+      state.listener = null
+    })
+  }
+  return { source, fireResume: () => state.listener?.() }
+}
+
+function createWindow(destroyed = false): {
+  isDestroyed: () => boolean
+  webContents: { send: ReturnType<typeof vi.fn<(channel: string) => void>> }
+} {
+  return {
+    isDestroyed: () => destroyed,
+    webContents: { send: vi.fn<(channel: string) => void>() }
+  }
+}
+
+describe('registerSystemResumeBroadcast', () => {
+  it('broadcasts the resume channel to every live window', () => {
+    const { source, fireResume } = createResumeSource()
+    const liveWindow = createWindow()
+    const destroyedWindow = createWindow(true)
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [liveWindow, destroyedWindow]
+    })
+
+    fireResume()
+
+    expect(liveWindow.webContents.send).toHaveBeenCalledWith(SYSTEM_RESUMED_CHANNEL)
+    expect(destroyedWindow.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('stops broadcasting after unsubscribe', () => {
+    const { source, fireResume } = createResumeSource()
+    const window = createWindow()
+    const unsubscribe = registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [window]
+    })
+
+    unsubscribe()
+    fireResume()
+
+    expect(source.off).toHaveBeenCalledTimes(1)
+    expect(window.webContents.send).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -1,0 +1,39 @@
+import { BrowserWindow, powerMonitor } from 'electron'
+
+export const SYSTEM_RESUMED_CHANNEL = 'system:resumed'
+
+type ResumeEventSource = {
+  on(event: 'resume', listener: () => void): unknown
+  off(event: 'resume', listener: () => void): unknown
+}
+
+type ResumeBroadcastWindow = {
+  isDestroyed(): boolean
+  webContents: { send(channel: string): void }
+}
+
+type SystemResumeBroadcastOptions = {
+  resumeSource?: ResumeEventSource
+  getWindows?: () => ResumeBroadcastWindow[]
+}
+
+// Why: renderers cannot observe OS sleep/wake directly, and Linux has no
+// window-occlusion tracking so visibilitychange never fires around suspend.
+// Wake-sensitive renderer recovery needs this explicit resume signal.
+export function registerSystemResumeBroadcast(
+  options: SystemResumeBroadcastOptions = {}
+): () => void {
+  const resumeSource = options.resumeSource ?? powerMonitor
+  const getWindows = options.getWindows ?? (() => BrowserWindow.getAllWindows())
+  const onResume = (): void => {
+    for (const window of getWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send(SYSTEM_RESUMED_CHANNEL)
+      }
+    }
+  }
+  resumeSource.on('resume', onResume)
+  return () => {
+    resumeSource.off('resume', onResume)
+  }
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2678,6 +2678,7 @@ export type PreloadApi = {
     ) => () => void
     onSleepWorktree: (callback: (data: { worktreeId: string }) => void) => () => void
     onTerminalZoom: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
+    onSystemResumed: (callback: () => void) => () => void
     readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
     readSelectionClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
     saveClipboardImageAsTempFile: (args?: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3452,6 +3452,11 @@ const api = {
       ipcRenderer.on('terminal:zoom', listener)
       return () => ipcRenderer.removeListener('terminal:zoom', listener)
     },
+    onSystemResumed: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('system:resumed', listener)
+      return () => ipcRenderer.removeListener('system:resumed', listener)
+    },
     readClipboardText: (options?: ReadClipboardTextOptions): Promise<string> =>
       ipcRenderer.invoke('clipboard:readText', options),
     readSelectionClipboardText: (options?: ReadClipboardTextOptions): Promise<string> =>

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -83,9 +83,44 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     const manager = createManager()
     recoverVisibleTerminalWindowWake({
       manager: manager as never as PaneManager,
-      isActive: false
+      isActive: false,
+      clearGlyphAtlases: true
     })
 
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears shared glyph atlases only on genuine wake recovery', async () => {
+    const { resetAndRefreshAllTerminalWebglAtlases } = vi.mocked(
+      await import('@/lib/pane-manager/pane-manager-registry')
+    )
+    const manager = createManager()
+    recoverVisibleTerminalWindowWake({
+      manager: manager as never as PaneManager,
+      isActive: false,
+      clearGlyphAtlases: true
+    })
+
+    expect(resetAndRefreshAllTerminalWebglAtlases).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the warm glyph atlas on plain-refocus recovery', async () => {
+    // Deliberate reversal of the #6354 focus-clear: wiping the shared atlas on
+    // every refocus forces a mass re-rasterization that can hit xterm's atlas
+    // page-merge race (#4480) and garble streaming panes. Focus recovery must
+    // still resume rendering and schedule the pane-scoped repaint.
+    const { resetAndRefreshAllTerminalWebglAtlases } = vi.mocked(
+      await import('@/lib/pane-manager/pane-manager-registry')
+    )
+    const manager = createManager()
+    recoverVisibleTerminalWindowWake({
+      manager: manager as never as PaneManager,
+      isActive: false,
+      clearGlyphAtlases: false
+    })
+
+    expect(resetAndRefreshAllTerminalWebglAtlases).not.toHaveBeenCalled()
+    expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
     expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -31,13 +31,15 @@ type FakeManager = {
   getPanes: ReturnType<typeof vi.fn>
   resumeRendering: ReturnType<typeof vi.fn>
   scheduleRevealRepaint: ReturnType<typeof vi.fn>
+  scheduleRevealPresent: ReturnType<typeof vi.fn>
 }
 
 function createManager(order: string[] = []): FakeManager {
   return {
     getPanes: vi.fn(() => []),
     resumeRendering: vi.fn(() => order.push('resume-rendering')),
-    scheduleRevealRepaint: vi.fn(() => order.push('reveal-repaint'))
+    scheduleRevealRepaint: vi.fn(() => order.push('reveal-repaint')),
+    scheduleRevealPresent: vi.fn(() => order.push('reveal-present'))
   }
 }
 
@@ -79,7 +81,7 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     expect(order).toEqual(['resume-rendering', 'reveal-repaint'])
   })
 
-  it('schedules the repaint on window-wake recovery', () => {
+  it('schedules the atlas-clearing repaint on genuine wake recovery', () => {
     const manager = createManager()
     recoverVisibleTerminalWindowWake({
       manager: manager as never as PaneManager,
@@ -88,6 +90,7 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     })
 
     expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+    expect(manager.scheduleRevealPresent).not.toHaveBeenCalled()
   })
 
   it('clears shared glyph atlases only on genuine wake recovery', async () => {
@@ -108,7 +111,9 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     // Deliberate reversal of the #6354 focus-clear: wiping the shared atlas on
     // every refocus forces a mass re-rasterization that can hit xterm's atlas
     // page-merge race (#4480) and garble streaming panes. Focus recovery must
-    // still resume rendering and schedule the pane-scoped repaint.
+    // resume rendering and present WITHOUT the atlas-clearing reveal repaint —
+    // scheduleRevealRepaint clears each pane's (shared) atlas, so the refocus
+    // path must route to the atlas-preserving present instead.
     const { resetAndRefreshAllTerminalWebglAtlases } = vi.mocked(
       await import('@/lib/pane-manager/pane-manager-registry')
     )
@@ -121,6 +126,7 @@ describe('resumeTerminalVisibility reveal repaint', () => {
 
     expect(resetAndRefreshAllTerminalWebglAtlases).not.toHaveBeenCalled()
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
-    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+    expect(manager.scheduleRevealPresent).toHaveBeenCalledTimes(1)
+    expect(manager.scheduleRevealRepaint).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -40,6 +40,7 @@ type HideTerminalVisibilityResult = {
 type RecoverVisibleTerminalWindowWakeArgs = {
   manager: PaneManager
   isActive: boolean
+  clearGlyphAtlases: boolean
 }
 
 export function resumeTerminalVisibility({
@@ -123,7 +124,8 @@ export function hideTerminalVisibility({
 
 export function recoverVisibleTerminalWindowWake({
   manager,
-  isActive
+  isActive,
+  clearGlyphAtlases
 }: RecoverVisibleTerminalWindowWakeArgs): void {
   // Why: macOS screensaver/display wake can leave xterm visible but with a
   // stale renderer/input surface; Orca's own hidden-state resume never runs.
@@ -138,7 +140,14 @@ export function recoverVisibleTerminalWindowWake({
     fitPanes(manager)
   }
   enforceTerminalViewportIntents(manager)
-  resetAndRefreshAllTerminalWebglAtlases()
+  if (clearGlyphAtlases) {
+    // Why: only a genuine wake may wipe the shared glyph atlas. The wipe makes
+    // every same-config pane re-rasterize at once, and xterm's atlas page-merge
+    // clear-model flag is consumed by one renderer (xterm.js #4480), so panes
+    // that lose that race paint garbled glyphs mid-stream. A plain refocus
+    // keeps the warm atlas and relies on the reveal repaint below.
+    resetAndRefreshAllTerminalWebglAtlases()
+  }
   manager.scheduleRevealRepaint()
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -144,11 +144,15 @@ export function recoverVisibleTerminalWindowWake({
     // Why: only a genuine wake may wipe the shared glyph atlas. The wipe makes
     // every same-config pane re-rasterize at once, and xterm's atlas page-merge
     // clear-model flag is consumed by one renderer (xterm.js #4480), so panes
-    // that lose that race paint garbled glyphs mid-stream. A plain refocus
-    // keeps the warm atlas and relies on the reveal repaint below.
+    // that lose that race paint garbled glyphs mid-stream.
     resetAndRefreshAllTerminalWebglAtlases()
+    manager.scheduleRevealRepaint()
+  } else {
+    // Why: the reveal repaint clears each pane's texture atlas (a shared,
+    // same-config wipe), so a plain refocus must use the atlas-preserving
+    // present instead — otherwise it re-arms the same mid-stream garble race.
+    manager.scheduleRevealPresent()
   }
-  manager.scheduleRevealRepaint()
 }
 
 function requestLightTabBacklogRecovery(manager: PaneManager): void {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -672,7 +672,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.enforceTerminalCurrentScrollIntent).toHaveBeenLastCalledWith(terminalA)
   })
 
-  it('clears WebGL texture atlases when the active visible terminal regains focus', () => {
+  it('keeps the shared glyph atlas warm on plain window refocus', () => {
     const manager = {
       getPanes: vi.fn(() => []),
       resumeRendering: vi.fn(),
@@ -682,8 +682,11 @@ describe('useTerminalPaneGlobalEffects', () => {
       getActivePane: vi.fn(() => null)
     }
 
-    // Why: focus recovery resets every registered manager (shared glyph
-    // atlas), so the fake manager observes the reset through the registry.
+    // Why: deliberate reversal of the #6354 focus-clear. A refocus atlas wipe
+    // forces every pane to re-rasterize at once, and xterm's page-merge
+    // clear-model flag is consumed by a single renderer (#4480), so panes that
+    // lose the race paint garbled glyphs while an agent streams. Focus must
+    // stay a WebGL-retry + pane-scoped repaint boundary only.
     registerManagerForReset(manager)
     beginHookRender()
     useTerminalPaneGlobalEffects({
@@ -711,9 +714,15 @@ describe('useTerminalPaneGlobalEffects', () => {
       throw new Error('expected focus listener')
     }
     manager.resetWebglTextureAtlases.mockClear()
+    manager.scheduleRevealRepaint.mockClear()
+    listener(new Event('focus'))
+    listener(new Event('focus'))
     listener(new Event('focus'))
 
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    // Count proof: repeated refocus performs zero shared-atlas wipes while the
+    // pane-scoped repaint still covers stale pixels.
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalled()
   })
 
   it('recovers visible terminal rendering and input when the window regains focus', () => {
@@ -767,6 +776,56 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.flushTerminalOutput).toHaveBeenCalledWith(terminal, { maxChars: 64 * 1024 })
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
     expect(mocks.fitAndFocusPanes).toHaveBeenCalledWith(manager)
+    // Why: refocus recovery is atlas-preserving — no shared-atlas reset and no
+    // registry-wide repaint; the pane-scoped reveal repaint covers stale pixels.
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalled()
+  })
+
+  it('clears WebGL texture atlases when the OS resumes', () => {
+    const manager = {
+      getPanes: vi.fn(() => []),
+      resumeRendering: vi.fn(),
+      resetWebglTextureAtlases: vi.fn(),
+      scheduleRevealRepaint: vi.fn(),
+      refreshAllPanes: vi.fn(),
+      suspendRendering: vi.fn(),
+      getActivePane: vi.fn(() => null)
+    }
+    const captured: { onSystemResumed: (() => void) | null } = { onSystemResumed: null }
+    const unsubscribeSystemResumed = vi.fn()
+    ;(
+      window.api.ui as unknown as { onSystemResumed: (callback: () => void) => () => void }
+    ).onSystemResumed = vi.fn((callback: () => void) => {
+      captured.onSystemResumed = callback
+      return unsubscribeSystemResumed
+    })
+
+    registerManagerForReset(manager)
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      isActive: true,
+      isVisible: true,
+      isSyncFitEnabled: true,
+      paneCount: 0,
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map() },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      toggleExpandPane: vi.fn()
+    })
+
+    expect(captured.onSystemResumed).toBeTypeOf('function')
+    manager.resetWebglTextureAtlases.mockClear()
+    manager.refreshAllPanes.mockClear()
+    captured.onSystemResumed?.()
+
+    // Why: OS resume is a genuine wake — GPU state may be stale without a
+    // context-loss event, so the shared-atlas clear and full repaint still run.
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
     expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -131,6 +131,7 @@ function useMountForFileDrop(
     resumeRendering: ReturnType<typeof vi.fn>
     resetWebglTextureAtlases: ReturnType<typeof vi.fn>
     scheduleRevealRepaint: ReturnType<typeof vi.fn>
+    scheduleRevealPresent: ReturnType<typeof vi.fn>
     suspendRendering: ReturnType<typeof vi.fn>
     getActivePane: ReturnType<typeof vi.fn>
   }
@@ -148,6 +149,7 @@ function useMountForFileDrop(
     resumeRendering: vi.fn(),
     resetWebglTextureAtlases: vi.fn(),
     scheduleRevealRepaint: vi.fn(),
+    scheduleRevealPresent: vi.fn(),
     suspendRendering: vi.fn(),
     getActivePane: vi.fn(() => null)
   }
@@ -225,6 +227,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(() => order.push('resume')),
       resetWebglTextureAtlases: vi.fn(() => order.push('reset-atlas')),
       scheduleRevealRepaint: vi.fn(() => order.push('reveal-repaint')),
+      scheduleRevealPresent: vi.fn(() => order.push('reveal-present')),
       refreshAllPanes: vi.fn(() => order.push('refresh')),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -313,6 +316,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -393,6 +397,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -455,6 +460,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -509,6 +515,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
@@ -587,6 +594,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
     }
@@ -619,6 +627,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
@@ -678,6 +687,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
@@ -715,14 +725,17 @@ describe('useTerminalPaneGlobalEffects', () => {
     }
     manager.resetWebglTextureAtlases.mockClear()
     manager.scheduleRevealRepaint.mockClear()
+    manager.scheduleRevealPresent.mockClear()
     listener(new Event('focus'))
     listener(new Event('focus'))
     listener(new Event('focus'))
 
-    // Count proof: repeated refocus performs zero shared-atlas wipes while the
-    // pane-scoped repaint still covers stale pixels.
+    // Count proof: repeated refocus performs zero shared-atlas wipes. It routes
+    // to the atlas-preserving present (scheduleRevealPresent), never the
+    // atlas-clearing reveal repaint, which would clear each pane's shared atlas.
     expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
-    expect(manager.scheduleRevealRepaint).toHaveBeenCalled()
+    expect(manager.scheduleRevealRepaint).not.toHaveBeenCalled()
+    expect(manager.scheduleRevealPresent).toHaveBeenCalledTimes(3)
   })
 
   it('recovers visible terminal rendering and input when the window regains focus', () => {
@@ -732,6 +745,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal }))
@@ -766,6 +780,10 @@ describe('useTerminalPaneGlobalEffects', () => {
     manager.resumeRendering.mockClear()
     manager.resetWebglTextureAtlases.mockClear()
     manager.refreshAllPanes.mockClear()
+    // Clear the mount-time reveal spies so the assertions measure only the
+    // focus event, not the initial visibility resume.
+    manager.scheduleRevealRepaint.mockClear()
+    manager.scheduleRevealPresent.mockClear()
     mocks.fitAndFocusPanes.mockClear()
     mocks.flushTerminalOutput.mockClear()
     mocks.requestTerminalBacklogRecovery.mockClear()
@@ -776,11 +794,13 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.flushTerminalOutput).toHaveBeenCalledWith(terminal, { maxChars: 64 * 1024 })
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
     expect(mocks.fitAndFocusPanes).toHaveBeenCalledWith(manager)
-    // Why: refocus recovery is atlas-preserving — no shared-atlas reset and no
-    // registry-wide repaint; the pane-scoped reveal repaint covers stale pixels.
+    // Why: refocus recovery is atlas-preserving — no shared-atlas reset, no
+    // registry-wide repaint, and no atlas-clearing reveal repaint; the
+    // atlas-preserving present covers stale pixels.
     expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
     expect(manager.refreshAllPanes).not.toHaveBeenCalled()
-    expect(manager.scheduleRevealRepaint).toHaveBeenCalled()
+    expect(manager.scheduleRevealRepaint).not.toHaveBeenCalled()
+    expect(manager.scheduleRevealPresent).toHaveBeenCalledTimes(1)
   })
 
   it('clears WebGL texture atlases when the OS resumes', () => {
@@ -789,6 +809,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => null)
@@ -847,6 +868,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
@@ -902,6 +924,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
@@ -948,6 +971,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => pane)
     }
@@ -1004,6 +1028,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       getActivePane: vi.fn(() => pane)
     }
@@ -1120,6 +1145,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
@@ -1154,6 +1180,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       resumeRendering: vi.fn(),
       resetWebglTextureAtlases: vi.fn(),
       scheduleRevealRepaint: vi.fn(),
+      scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
       getActivePane: vi.fn(() => null)

--- a/src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.ts
@@ -20,6 +20,7 @@ export function useTerminalWindowWakeRecovery({
       return
     }
     let wakeRecoveryFrameId: number | null = null
+    let settledClearGlyphAtlases = false
     const cancelScheduledWakeRecovery = (): void => {
       if (wakeRecoveryFrameId === null || typeof cancelAnimationFrame !== 'function') {
         wakeRecoveryFrameId = null
@@ -28,9 +29,12 @@ export function useTerminalWindowWakeRecovery({
       cancelAnimationFrame(wakeRecoveryFrameId)
       wakeRecoveryFrameId = null
     }
-    const recoverVisibleWake = (): void => {
+    const recoverVisibleWake = (clearGlyphAtlases: boolean): void => {
       // Focus and visibility often fire together; keep one immediate recovery and one settled RAF pass.
       if (wakeRecoveryFrameId !== null) {
+        // Why: a pending settled pass may only upgrade in strength — a plain
+        // focus that lands after a genuine wake must not skip its atlas clear.
+        settledClearGlyphAtlases ||= clearGlyphAtlases
         return
       }
       const manager = managerRef.current
@@ -39,39 +43,60 @@ export function useTerminalWindowWakeRecovery({
       }
       recoverVisibleTerminalWindowWake({
         manager,
-        isActive: isActiveRef.current
+        isActive: isActiveRef.current,
+        clearGlyphAtlases
       })
       if (typeof requestAnimationFrame !== 'function') {
         return
       }
+      settledClearGlyphAtlases = clearGlyphAtlases
       wakeRecoveryFrameId = requestAnimationFrame(() => {
         wakeRecoveryFrameId = null
+        const clearGlyphAtlasesOnSettle = settledClearGlyphAtlases
+        settledClearGlyphAtlases = false
         const settledManager = managerRef.current
         if (!settledManager || !isVisibleRef.current) {
           return
         }
         recoverVisibleTerminalWindowWake({
           manager: settledManager,
-          isActive: isActiveRef.current
+          isActive: isActiveRef.current,
+          clearGlyphAtlases: clearGlyphAtlasesOnSettle
         })
       })
     }
-    const onFocus = (): void => recoverVisibleWake()
+    // Why: plain refocus (alt-tab, devtools) is frequent and often lands while
+    // an agent streams; wiping the shared glyph atlas then provokes xterm's
+    // page-merge race and paints garbled glyphs. Focus recovery keeps the warm
+    // atlas: it only retries WebGL attach, refits, and repaints pane-scoped.
+    const onFocus = (): void => recoverVisibleWake(false)
     const onVisibilityChange = (): void => {
       if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
-        recoverVisibleWake()
+        recoverVisibleWake(true)
+      }
+    }
+    // Why: Linux has no window-occlusion tracking, so visibilitychange never
+    // fires around system suspend; the main process broadcasts OS resume.
+    const onSystemResumed = (): void => {
+      if (typeof document === 'undefined' || document.visibilityState === 'visible') {
+        recoverVisibleWake(true)
       }
     }
     window.addEventListener('focus', onFocus)
     if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
       document.addEventListener('visibilitychange', onVisibilityChange)
     }
+    const unsubscribeSystemResumed =
+      typeof window.api?.ui?.onSystemResumed === 'function'
+        ? window.api.ui.onSystemResumed(onSystemResumed)
+        : null
     return () => {
       cancelScheduledWakeRecovery()
       window.removeEventListener('focus', onFocus)
       if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
         document.removeEventListener('visibilitychange', onVisibilityChange)
       }
+      unsubscribeSystemResumed?.()
     }
   }, [isActiveRef, isVisible, isVisibleRef, managerRef])
 }

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -41,7 +41,7 @@ import {
 } from './pane-rendering-control'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import { registerLivePaneManager, unregisterLivePaneManager } from './pane-manager-registry'
-import { schedulePaneRevealRepaint } from './pane-reveal-repaint'
+import { schedulePaneRevealPresent, schedulePaneRevealRepaint } from './pane-reveal-repaint'
 import { PaneIdentityRegistry } from './pane-identity-registry'
 import {
   closeManagedPane,
@@ -327,6 +327,12 @@ export class PaneManager {
     // disposed panes could throw in attach and latch the global WebGL
     // attach backoff, downgrading unrelated new panes to the DOM renderer.
     schedulePaneRevealRepaint(() => (this.destroyed ? [] : this.panes.values()))
+  }
+
+  scheduleRevealPresent(): void {
+    // Why: same destroy guard as scheduleRevealRepaint, but presents without
+    // clearing the shared glyph atlas — used by the plain-refocus recovery.
+    schedulePaneRevealPresent(() => (this.destroyed ? [] : this.panes.values()))
   }
 
   suspendRendering(): void {

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ManagedPaneInternal } from './pane-manager-types'
-import { schedulePaneRevealRepaint } from './pane-reveal-repaint'
+import { schedulePaneRevealPresent, schedulePaneRevealRepaint } from './pane-reveal-repaint'
 import { resetTerminalWebglSuggestion } from './pane-webgl-renderer'
 
 type FakeWebglAddon = { clearTextureAtlas: ReturnType<typeof vi.fn> }
@@ -143,5 +143,33 @@ describe('schedulePaneRevealRepaint', () => {
 
     expect(webglAddon.clearTextureAtlas).toHaveBeenCalledTimes(1)
     vi.useRealTimers()
+  })
+
+  describe('schedulePaneRevealPresent', () => {
+    it('presents the settled buffer without wiping the shared glyph atlas', () => {
+      // The plain-refocus path must NOT clear the atlas — the clear is a
+      // same-config shared wipe that re-arms the mid-stream page-merge race.
+      const webglAddon = { clearTextureAtlas: vi.fn() }
+      const pane = createPane({ webglAddon })
+      schedulePaneRevealPresent(() => [pane])
+
+      flushFrame()
+      expect(pane.terminal.refresh).not.toHaveBeenCalled()
+
+      flushFrame()
+      expect(webglAddon.clearTextureAtlas).not.toHaveBeenCalled()
+      expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+    })
+
+    it('still retries a missing WebGL attach on the settled frame', () => {
+      const pane = createPane()
+      schedulePaneRevealPresent(() => [pane])
+
+      flushFrame()
+      flushFrame()
+
+      expect(pane.webglAddon).not.toBeNull()
+      expect(pane.terminal.refresh).toHaveBeenCalled()
+    })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
@@ -15,6 +15,21 @@ function scheduleSettledFrame(callback: () => void): void {
   })
 }
 
+function forEachPaneOnSettledFrame(
+  getPanes: () => Iterable<ManagedPaneInternal>,
+  visit: (pane: ManagedPaneInternal) => void
+): void {
+  scheduleSettledFrame(() => {
+    for (const pane of getPanes()) {
+      try {
+        visit(pane)
+      } catch {
+        /* ignore — one pane's failure must not block repaint of the rest */
+      }
+    }
+  })
+}
+
 /**
  * Repaints a revealed tab's panes from their xterm buffers.
  *
@@ -26,14 +41,27 @@ function scheduleSettledFrame(callback: () => void): void {
  * settled — forces a full rebuild from the buffer without any PTY resize.
  */
 export function schedulePaneRevealRepaint(getPanes: () => Iterable<ManagedPaneInternal>): void {
-  scheduleSettledFrame(() => {
-    for (const pane of getPanes()) {
-      try {
-        reattachWebglIfNeeded(pane)
-        resetWebglTextureAtlas(pane)
-      } catch {
-        /* ignore — one pane's failure must not block repaint of the rest */
-      }
+  forEachPaneOnSettledFrame(getPanes, (pane) => {
+    reattachWebglIfNeeded(pane)
+    resetWebglTextureAtlas(pane)
+  })
+}
+
+/**
+ * Presents already-visible panes without clearing the shared glyph atlas.
+ *
+ * Why: a plain window refocus never hid its panes, so their WebGL model is
+ * already current — a `refresh` re-presents the live buffer (covering a
+ * compositor that dropped frames while occluded). Using the atlas-clearing
+ * reveal repaint here would wipe the atlas shared by every same-config pane and
+ * re-arm the mid-stream page-merge garble race (xterm.js issue 4480); this path
+ * must stay texture-atlas-preserving.
+ */
+export function schedulePaneRevealPresent(getPanes: () => Iterable<ManagedPaneInternal>): void {
+  forEachPaneOnSettledFrame(getPanes, (pane) => {
+    reattachWebglIfNeeded(pane)
+    if (pane.terminal.rows > 0) {
+      pane.terminal.refresh(0, pane.terminal.rows - 1)
     }
   })
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2223,6 +2223,9 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onCloseTerminal: () => noopUnsubscribe,
     onSleepWorktree: () => noopUnsubscribe,
     onTerminalZoom: () => noopUnsubscribe,
+    // Why: a paired web client has no OS sleep signal; occlusion-driven
+    // visibilitychange already covers its wake recovery.
+    onSystemResumed: () => noopUnsubscribe,
     onFileDrop: () => noopUnsubscribe,
     syncTrafficLights: () => {},
     setMarkdownEditorFocused: () => {},


### PR DESCRIPTION
## What changes

Refocusing the Orca window during an active agent stream could garble every glyph in the terminal for a split second (random characters, then self-heal). Reported internally: focus out to another app (or devtools), refocus, paste into a streaming Claude Code session.

**Root cause.** The window-wake recovery hook runs on every plain window `focus` event, twice per event (immediate + settled rAF pass), and each pass called `resetAndRefreshAllTerminalWebglAtlases()` — a full wipe of the xterm WebGL glyph atlas that is shared by every same-config pane. The wipe forces every visible pane to re-rasterize every glyph at once; colored TUI output multiplies glyph variants (the cache key includes fg/bg), so pages refill fast and hit the atlas page cap, forcing page merges. xterm's merge invalidation is a single shared clear-model flag consumed by whichever renderer draws first (xterm.js upstream issue `4480`), so sibling panes draw stale texture-page indices — garbled glyphs — until the next recovery pass repaints. Since `#7540`, output-driven recovery correctly waits for stream quiet, so a mid-stream garble stays visible for a beat instead of being repainted next frame.

**Fix — split recovery strength by what the event proves:**
- **Plain window focus** is now atlas-preserving: it still flushes hidden backlog, retries WebGL attach (the context-loss recovery boundary), refits, and schedules the pane-scoped reveal repaint — it no longer wipes the shared atlas or forces a registry-wide repaint.
- **Genuine wake** keeps the full atlas-clearing recovery: `visibilitychange → visible` (occlusion/display wake, unchanged), plus a new main-process `powerMonitor` resume broadcast (`system:resumed`) so system suspend/resume is recovered even on Linux, where Chromium has no window-occlusion tracking and `visibilitychange` never fires around suspend.
- A pending settled pass can only **upgrade** in strength: a focus event landing after a wake cannot cancel the wake's atlas clear.

This also extends `#7540`'s invariant (no atlas clear lands mid-stream) to the refocus path, which previously violated it on every alt-tab.

**Deliberate reversal.** The focus-path atlas clear came from `#6354` ("window wake recovery"). Its purpose — recovering a stale renderer/input surface after macOS display wake — is preserved via the visibility/resume paths and the pane-scoped reveal repaint (which did not exist at `#6354` time). The two tests pinning the old behavior are inverted with comments documenting why.

## Reliability contract

- **Class:** xterm-addon boundary containment / window-wake visible-resume.
- **Invariant:** plain refocus must never wipe the shared glyph atlas; genuine wake events must still run the full recovery including the clear; focus must remain a WebGL context-loss retry + repaint boundary.
- **Oracle:** unit tests assert repeated focus events perform **zero** `resetWebglTextureAtlases` calls while still resuming rendering, fitting, flushing backlog, and scheduling the reveal repaint; `visibilitychange → visible` and the OS-resume callback still reset + repaint all registered managers; the broadcast module unit test pins channel delivery to live windows only and unsubscribe behavior.
- **Product change type:** product runtime hardening (removes a garble trigger and dead-weight work from a hot path).

## Performance

Strictly removes work from the hot focus path: previously every alt-tab back into Orca ran 2 global atlas wipes + full repaints of every pane in the window (visible as GPU/raster spikes and the garble race); now it runs none. Added cost: one `powerMonitor` listener for the app lifetime and one IPC message per OS resume. No polling, no timers, no per-pane listeners. The repeated-focus count test pins zero wipes.

## Validation

- `vitest`: `system-resume-broadcast.test.ts`, `terminal-visibility-resume.test.ts`, `use-terminal-pane-global-effects.test.ts`, `terminal-webgl-atlas-recovery.test.ts`, `pty-connection.test.ts` — 359 tests green; full WebGL-containment gate suite (8 files, 39 tests) green.
- `pnpm run typecheck` (node + cli + web) clean; `oxlint` clean on touched files.
- Live smoke (dev instance, isolated user-data-dir): app boots with the new main-process broadcast registered; `window.api.ui.onSystemResumed` present in the real renderer; 3 blur/focus cycles with a live terminal mounted produced 0 console errors.

## Provider / platform

Renderer recovery is provider-agnostic (local / daemon / SSH / remote unchanged — the atlas is renderer-side only). The paired web client implements `onSystemResumed` as a no-op (browsers have no OS-resume signal; its wake recovery stays on `visibilitychange`). macOS/Windows: occlusion wake covered by `visibilitychange` as before, system resume now also covered by `powerMonitor`. Linux: system resume newly covered by `powerMonitor`.

## Residual gaps

- The upstream cross-renderer atlas race itself is not fixed — a page merge landing mid-stream can still garble briefly through organic atlas pressure; this PR removes the dominant trigger (the refocus wipe). Follow-up candidate: version the clear-model signal per renderer (upstream xterm.js change or local patch).
- Linux display-off *without* system suspend gets no atlas clear (no occlusion tracking, no resume event). GPU textures are not invalidated by display-off absent a context-loss event, which has its own recovery path — accepted gap.
- The `system:resumed` channel string is pinned by the main-side unit test and typecheck; a live OS sleep/wake pass on each platform has not been automated.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## Tests

Live Electron QA from this PR worktree (identity verified: `oscar @ fix/terminal-focus-atlas-wipe`), in `demo-project`, with **two real colorful alternate-screen TUIs sharing the WebGL glyph atlas** — a real Claude Code session (v2.1.202) and OpenCode:

- [x] Reproduced the reported gesture: blur → refocus → paste the exact reported commit URL into a streaming Claude Code session. No garble; URL and full colorful 1–40 stream render crisply.
- [x] 32+ `blur`/`focus` cycles fired **during** active Claude streaming (colorful ANSI output). Glyphs stayed crisp across every mid-stream capture — no full-pane garble.
- [x] Genuine-wake path still recovers: `visibilitychange → visible` (the path that *does* clear the shared atlas) followed by a tab reveal repainted the OpenCode banner + colored text and the Claude buffer cleanly — atlas wipe still works, no stale pixels.
- [x] Tab reveal OpenCode ↔ Claude both repaint correctly after the atlas was wiped.
- [x] `window.api.ui.onSystemResumed` present and subscribed in the real renderer.
- [x] **0 console errors** across the whole session (only pre-existing benign warnings: a Tooltip controlled/uncontrolled warning and a worktree-purge info line, both unrelated to terminals). xterm stayed mounted with WebGL canvases throughout.
- [x] `pnpm run typecheck` (node + cli + web), `pnpm run lint`, `git diff --check` clean.
- [x] `vitest`: touched suites + full WebGL-containment gate suite green (359 + 39 tests); repeated-focus count test pins **zero** shared-atlas wipes on refocus.

Cleanup: QA git worktree + branch removed, throwaway user-data-dir deleted, only the self-started dev instance stopped.


## Correction (follow-up commit)

A review caught that the first commit was incomplete: it dropped the registry-wide atlas wipe from the refocus path but still called `manager.scheduleRevealRepaint()`, which routes through `schedulePaneRevealRepaint → resetWebglTextureAtlas → webglAddon.clearTextureAtlas()` per pane. Since the glyph atlas is **shared** across same-config panes, that per-pane clear still wiped the shared atlas on every refocus — just scoped to one manager and deferred two frames — so the garble race was still reachable and "zero focus-path wipes" was not actually true. The original unit test only spied the manager's `resetWebglTextureAtlases` method, which this path bypasses.

Fixed by adding `schedulePaneRevealPresent`: it reattaches WebGL and presents the current buffer via `terminal.refresh(0, rows-1)` **without** clearing the texture atlas. A plain refocus never hid its panes, so their model is already current and a present suffices; the atlas-clearing reveal repaint is now used only on genuine wake. Tests were moved to the layer that actually clears — the reveal-present spec asserts `terminal.refresh` runs and `clearTextureAtlas` does **not**; the focus-path specs assert `scheduleRevealPresent` runs while `scheduleRevealRepaint` does not.

Re-validated live with two streaming TUIs (real Claude Code + OpenCode) sharing the atlas: 30+ mid-stream focus cycles stayed crisp on the corrected present path, and the genuine-wake atlas clear (visibilitychange) still repainted cleanly. Full WebGL-containment gate + new specs green (50 tests); typecheck + lint clean.

## On visibilitychange reliability with `backgroundThrottling: false` (macOS)

A second review note flagged that `createMainWindow` disables background throttling on macOS, which per Electron can keep `visibilityState === 'visible'` through occlusion, so `visibilitychange → visible` may not fire for occlusion/display wake. This is correct, but it is not a coverage gap in the corrected design: the macOS occlusion failure mode (that same block's comment: compositor layers failing to repaint after occlusion) is repaired by a **present**, not an atlas texture wipe — and the present now stays on the reliably-firing `focus` path. Events that genuinely invalidate atlas texture memory are still covered independently: system sleep/resume via `powerMonitor` resume (fires reliably), and GPU context loss via `onContextLoss → disposeWebgl` + reattach on resume. Occlusion/display-off does not lose texture memory, so the atlas clear that `visibilitychange` might miss on macOS is not the recovery those cases need. The `visibilitychange`/`resume` atlas clear remains as defense for drivers that corrupt texture state across true sleep.
