### PR TITLE
perf(ai-vault): reuse unchanged remote session files across scans

### DIFF
--- a/src/main/ai-vault/remote-session-scanner-file-stat.ts
+++ b/src/main/ai-vault/remote-session-scanner-file-stat.ts
@@ -1,0 +1,34 @@
+import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import type { FileStat, IFilesystemProvider } from '../providers/types'
+import type { FileWithMtime } from './session-scanner-types'
+import { errorMessage } from './session-scanner-values'
+
+export async function statRemoteFile(
+  provider: IFilesystemProvider,
+  path: string,
+  agent: AiVaultAgent,
+  executionHostId: ExecutionHostId,
+  issues: AiVaultScanIssue[]
+): Promise<FileWithMtime | null> {
+  try {
+    const stat = await provider.stat(path)
+    const mtimeMs = remoteStatMtimeMs(stat)
+    return {
+      path,
+      mtimeMs,
+      modifiedAt: new Date(mtimeMs).toISOString(),
+      sizeBytes: Number.isFinite(stat.size) ? stat.size : undefined
+    }
+  } catch (err) {
+    issues.push({ executionHostId, agent, path, message: errorMessage(err) })
+    return null
+  }
+}
+
+function remoteStatMtimeMs(stat: FileStat): number {
+  if (typeof stat.mtimeMs === 'number' && Number.isFinite(stat.mtimeMs)) {
+    return stat.mtimeMs
+  }
+  return stat.mtime > 10_000_000_000 ? stat.mtime : stat.mtime * 1000
+}

--- a/src/main/ai-vault/remote-session-scanner-parse-cache.test.ts
+++ b/src/main/ai-vault/remote-session-scanner-parse-cache.test.ts
@@ -20,12 +20,17 @@ const CLAUDE_ONE = '/home/ada/.claude/projects/repo/one.jsonl'
 const CLAUDE_TWO = '/home/ada/.claude/projects/repo/two.jsonl'
 const CODEX_A = '/home/ada/.codex/sessions/codex-a.jsonl'
 
-function scan(provider: MemoryRemoteProvider, executionHostId: ExecutionHostId = 'ssh:dev-box') {
+function scan(
+  provider: MemoryRemoteProvider,
+  executionHostId: ExecutionHostId = 'ssh:dev-box',
+  connectionIdentity: string | null = null
+) {
   return scanRemoteAiVaultSessions({
     provider,
     executionHostId,
     remoteHome: '/home/ada',
-    hostPlatform: getRemoteHostPlatform('linux-x64')
+    hostPlatform: getRemoteHostPlatform('linux-x64'),
+    connectionIdentity
   })
 }
 
@@ -150,25 +155,63 @@ describe('remote session parse cache', () => {
     expect(provider.readFileCalls).toEqual([CLAUDE_ONE])
   })
 
+  it('drops entries when the same target id points at a different machine', async () => {
+    // Same target id, same path, same (mtime,size) — only the machine behind
+    // the connection changed (ssh:updateTarget / config import / reprovision).
+    const content = claudeTranscript({ sessionId: 'one', title: 'Machine A session' })
+    const machineA = new MemoryRemoteProvider()
+    machineA.addFile(CLAUDE_ONE, content, 10)
+    await scan(machineA, 'ssh:dev-box', 'identity-a')
+    machineA.clearReadFileCalls()
+    await scan(machineA, 'ssh:dev-box', 'identity-a')
+    expect(machineA.readFileCalls).toEqual([])
+
+    const machineB = new MemoryRemoteProvider()
+    const contentB = claudeTranscript({ sessionId: 'one', title: 'Machine B session' })
+    // Equal size + equal mtime: only the identity gate can force the re-read.
+    expect(contentB.length).toBe(content.length)
+    machineB.addFile(CLAUDE_ONE, contentB, 10)
+    const repointed = await scan(machineB, 'ssh:dev-box', 'identity-b')
+    expect(machineB.readFileCalls).toEqual([CLAUDE_ONE])
+    expect(repointed.sessions[0]?.title).toBe('Machine B session')
+
+    // The new identity now caches normally.
+    machineB.clearReadFileCalls()
+    await scan(machineB, 'ssh:dev-box', 'identity-b')
+    expect(machineB.readFileCalls).toEqual([])
+  })
+
   it('bounds entries per host, evicting least recently used first', () => {
-    storeRemoteSessionParse('ssh:host-b', fileAt('/other-host'), null)
+    storeRemoteSessionParse('ssh:host-b', null, fileAt('/other-host'), null)
     for (let index = 0; index < REMOTE_PARSE_CACHE_MAX_ENTRIES_PER_HOST; index++) {
-      storeRemoteSessionParse('ssh:host-a', fileAt(`/f${index}`), null)
+      storeRemoteSessionParse('ssh:host-a', null, fileAt(`/f${index}`), null)
     }
 
     // Reading /f0 refreshes its recency, so the overflow evicts /f1 instead.
-    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/f0'))).not.toBeNull()
-    storeRemoteSessionParse('ssh:host-a', fileAt('/overflow'), null)
+    expect(readCachedRemoteSessionParse('ssh:host-a', null, fileAt('/f0'))).not.toBeNull()
+    storeRemoteSessionParse('ssh:host-a', null, fileAt('/overflow'), null)
 
-    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/f1'))).toBeNull()
-    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/f0'))).not.toBeNull()
-    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/overflow'))).not.toBeNull()
-    expect(readCachedRemoteSessionParse('ssh:host-b', fileAt('/other-host'))).not.toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-a', null, fileAt('/f1'))).toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-a', null, fileAt('/f0'))).not.toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-a', null, fileAt('/overflow'))).not.toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-b', null, fileAt('/other-host'))).not.toBeNull()
   })
 
   it('misses when the stat changed and when the host was never scanned', () => {
-    storeRemoteSessionParse('ssh:host-a', fileAt('/f', 1), null)
-    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/f', 2))).toBeNull()
-    expect(readCachedRemoteSessionParse('ssh:host-c', fileAt('/f', 1))).toBeNull()
+    storeRemoteSessionParse('ssh:host-a', null, fileAt('/f', 1), null)
+    expect(readCachedRemoteSessionParse('ssh:host-a', null, fileAt('/f', 2))).toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-c', null, fileAt('/f', 1))).toBeNull()
+  })
+
+  it('only serves entries whose connection identity matches exactly', () => {
+    storeRemoteSessionParse('ssh:host-a', 'identity-a', fileAt('/f'), null)
+    expect(readCachedRemoteSessionParse('ssh:host-a', 'identity-b', fileAt('/f'))).toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-a', null, fileAt('/f'))).toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-a', 'identity-a', fileAt('/f'))).not.toBeNull()
+
+    // Storing under a new identity resets the host, so switching back misses.
+    storeRemoteSessionParse('ssh:host-a', 'identity-b', fileAt('/g'), null)
+    expect(readCachedRemoteSessionParse('ssh:host-a', 'identity-a', fileAt('/f'))).toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-a', 'identity-b', fileAt('/g'))).not.toBeNull()
   })
 })

--- a/src/main/ai-vault/remote-session-scanner-parse-cache.test.ts
+++ b/src/main/ai-vault/remote-session-scanner-parse-cache.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { scanRemoteAiVaultSessions } from './remote-session-scanner'
+import {
+  evictRemoteSessionParseCache,
+  readCachedRemoteSessionParse,
+  REMOTE_PARSE_CACHE_MAX_ENTRIES_PER_HOST,
+  resetRemoteSessionParseCacheForTests,
+  storeRemoteSessionParse
+} from './remote-session-scanner-parse-cache'
+import {
+  codexTranscript,
+  jsonLines,
+  MemoryRemoteProvider
+} from './remote-session-scanner-test-provider'
+import type { FileWithMtime } from './session-scanner-types'
+
+const CLAUDE_ONE = '/home/ada/.claude/projects/repo/one.jsonl'
+const CLAUDE_TWO = '/home/ada/.claude/projects/repo/two.jsonl'
+const CODEX_A = '/home/ada/.codex/sessions/codex-a.jsonl'
+
+function scan(provider: MemoryRemoteProvider, executionHostId: ExecutionHostId = 'ssh:dev-box') {
+  return scanRemoteAiVaultSessions({
+    provider,
+    executionHostId,
+    remoteHome: '/home/ada',
+    hostPlatform: getRemoteHostPlatform('linux-x64')
+  })
+}
+
+function claudeTranscript(args: { sessionId: string; title: string; messages?: number }): string {
+  const records: unknown[] = [
+    {
+      sessionId: args.sessionId,
+      timestamp: '2026-07-04T04:00:00.000Z',
+      type: 'user',
+      cwd: '/home/ada/repo',
+      message: { content: [{ type: 'text', text: args.title }] }
+    }
+  ]
+  for (let index = 1; index < (args.messages ?? 2); index++) {
+    records.push({
+      sessionId: args.sessionId,
+      timestamp: `2026-07-04T04:00:0${index}.000Z`,
+      type: 'assistant',
+      message: { model: 'claude-opus-4', content: `Answer ${index}` }
+    })
+  }
+  return jsonLines(records)
+}
+
+function fileAt(path: string, mtimeMs = 1): FileWithMtime {
+  return { path, mtimeMs, modifiedAt: new Date(mtimeMs).toISOString(), sizeBytes: 1 }
+}
+
+describe('remote session parse cache', () => {
+  beforeEach(() => {
+    resetRemoteSessionParseCacheForTests()
+  })
+
+  it('reads every body once, then rescans unchanged files with zero reads', async () => {
+    const provider = new MemoryRemoteProvider()
+    provider.addFile(CLAUDE_ONE, claudeTranscript({ sessionId: 'one', title: 'First' }), 10)
+    provider.addFile(CLAUDE_TWO, claudeTranscript({ sessionId: 'two', title: 'Second' }), 20)
+    provider.addFile(
+      CODEX_A,
+      codexTranscript({
+        sessionId: 'codex-a',
+        title: 'Codex session',
+        cwd: '/home/ada/repo',
+        timestamp: '2026-07-04T05:00:00.000Z'
+      }),
+      30
+    )
+
+    const first = await scan(provider)
+    expect(first.issues).toEqual([])
+    expect(first.sessions).toHaveLength(3)
+    const firstReads = new Set(provider.readFileCalls)
+    expect(firstReads).toContain(CLAUDE_ONE)
+    expect(firstReads).toContain(CLAUDE_TWO)
+    expect(firstReads).toContain(CODEX_A)
+
+    provider.clearReadFileCalls()
+    const second = await scan(provider)
+    expect(provider.readFileCalls).toEqual([])
+    expect(second.sessions).toEqual(first.sessions)
+    expect(second.issues).toEqual([])
+  })
+
+  it('re-reads exactly the file whose mtime changed', async () => {
+    const provider = new MemoryRemoteProvider()
+    provider.addFile(CLAUDE_ONE, claudeTranscript({ sessionId: 'one', title: 'First' }), 10)
+    provider.addFile(CLAUDE_TWO, claudeTranscript({ sessionId: 'two', title: 'Second' }), 20)
+    await scan(provider)
+
+    provider.addFile(
+      CLAUDE_TWO,
+      claudeTranscript({ sessionId: 'two', title: 'Second', messages: 3 }),
+      25
+    )
+    provider.clearReadFileCalls()
+    const result = await scan(provider)
+
+    expect(provider.readFileCalls).toEqual([CLAUDE_TWO])
+    expect(result.sessions.find((session) => session.sessionId === 'two')?.messageCount).toBe(3)
+  })
+
+  it('re-reads a file whose size changed even when the mtime did not', async () => {
+    const provider = new MemoryRemoteProvider()
+    provider.addFile(CLAUDE_ONE, claudeTranscript({ sessionId: 'one', title: 'First' }), 10)
+    await scan(provider)
+
+    provider.addFile(
+      CLAUDE_ONE,
+      claudeTranscript({ sessionId: 'one', title: 'First', messages: 4 }),
+      10
+    )
+    provider.clearReadFileCalls()
+    const result = await scan(provider)
+
+    expect(provider.readFileCalls).toEqual([CLAUDE_ONE])
+    expect(result.sessions[0]?.messageCount).toBe(4)
+  })
+
+  it('never serves entries cached for one host to another host', async () => {
+    const content = claudeTranscript({ sessionId: 'shared', title: 'Same path everywhere' })
+    const providerA = new MemoryRemoteProvider()
+    providerA.addFile(CLAUDE_ONE, content, 10)
+    await scan(providerA, 'ssh:host-a')
+
+    const providerB = new MemoryRemoteProvider()
+    providerB.addFile(CLAUDE_ONE, content, 10)
+    const result = await scan(providerB, 'ssh:host-b')
+
+    expect(providerB.readFileCalls).toContain(CLAUDE_ONE)
+    expect(result.sessions[0]?.executionHostId).toBe('ssh:host-b')
+  })
+
+  it('re-reads bodies after the host cache is evicted', async () => {
+    const provider = new MemoryRemoteProvider()
+    provider.addFile(CLAUDE_ONE, claudeTranscript({ sessionId: 'one', title: 'First' }), 10)
+    await scan(provider)
+
+    evictRemoteSessionParseCache('ssh:dev-box')
+    provider.clearReadFileCalls()
+    await scan(provider)
+
+    expect(provider.readFileCalls).toEqual([CLAUDE_ONE])
+  })
+
+  it('bounds entries per host, evicting least recently used first', () => {
+    storeRemoteSessionParse('ssh:host-b', fileAt('/other-host'), null)
+    for (let index = 0; index < REMOTE_PARSE_CACHE_MAX_ENTRIES_PER_HOST; index++) {
+      storeRemoteSessionParse('ssh:host-a', fileAt(`/f${index}`), null)
+    }
+
+    // Reading /f0 refreshes its recency, so the overflow evicts /f1 instead.
+    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/f0'))).not.toBeNull()
+    storeRemoteSessionParse('ssh:host-a', fileAt('/overflow'), null)
+
+    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/f1'))).toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/f0'))).not.toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/overflow'))).not.toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-b', fileAt('/other-host'))).not.toBeNull()
+  })
+
+  it('misses when the stat changed and when the host was never scanned', () => {
+    storeRemoteSessionParse('ssh:host-a', fileAt('/f', 1), null)
+    expect(readCachedRemoteSessionParse('ssh:host-a', fileAt('/f', 2))).toBeNull()
+    expect(readCachedRemoteSessionParse('ssh:host-c', fileAt('/f', 1))).toBeNull()
+  })
+})

--- a/src/main/ai-vault/remote-session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/remote-session-scanner-parse-cache.ts
@@ -13,27 +13,42 @@ type RemoteSessionParseCacheEntry = {
   session: AiVaultSession | null
 }
 
+type RemoteHostParseCache = {
+  // Opaque connect-time machine identity supplied by the scan. A target id
+  // can be repointed at a different machine (ssh:updateTarget, ssh-config
+  // import, runtime reprovision) without being removed, so entries are only
+  // valid while the scan talks to the machine they were read from.
+  connectionIdentity: string | null
+  entries: Map<string, RemoteSessionParseCacheEntry>
+}
+
 export type RemoteSessionParseCacheHit = {
   session: AiVaultSession | null
 }
 
 // Keyed by execution host so identical remote paths on different hosts can
-// never serve each other's sessions. Reconnects keep entries (paths and
-// mtimes stay valid); target removal evicts via evictRemoteSessionParseCache.
-const cacheByHost = new Map<ExecutionHostId, Map<string, RemoteSessionParseCacheEntry>>()
+// never serve each other's sessions. Reconnects to the same machine keep
+// entries (paths and mtimes stay valid); an identity change resets the host's
+// entries and target removal evicts via evictRemoteSessionParseCache.
+const cacheByHost = new Map<ExecutionHostId, RemoteHostParseCache>()
 
 /**
- * Return the parse result cached for this remote file when its (mtime, size)
- * stat is unchanged, refreshing its LRU recency. A hit means the rescan skips
- * the SSH body transfer and re-parse entirely; `null` means read + parse.
+ * Return the parse result cached for this remote file when the host's
+ * connection identity matches and the (mtime, size) stat is unchanged,
+ * refreshing its LRU recency. A hit means the rescan skips the SSH body
+ * transfer and re-parse entirely; `null` means read + parse.
  */
 export function readCachedRemoteSessionParse(
   executionHostId: ExecutionHostId,
+  connectionIdentity: string | null,
   file: FileWithMtime
 ): RemoteSessionParseCacheHit | null {
   const hostCache = cacheByHost.get(executionHostId)
-  const entry = hostCache?.get(file.path)
-  if (!hostCache || !entry) {
+  if (!hostCache || hostCache.connectionIdentity !== connectionIdentity) {
+    return null
+  }
+  const entry = hostCache.entries.get(file.path)
+  if (!entry) {
     return null
   }
   const unchanged =
@@ -42,31 +57,34 @@ export function readCachedRemoteSessionParse(
   if (!unchanged) {
     return null
   }
-  hostCache.delete(file.path)
-  hostCache.set(file.path, entry)
+  hostCache.entries.delete(file.path)
+  hostCache.entries.set(file.path, entry)
   return { session: entry.session }
 }
 
 export function storeRemoteSessionParse(
   executionHostId: ExecutionHostId,
+  connectionIdentity: string | null,
   file: FileWithMtime,
   session: AiVaultSession | null
 ): void {
   let hostCache = cacheByHost.get(executionHostId)
-  if (!hostCache) {
-    hostCache = new Map()
+  if (!hostCache || hostCache.connectionIdentity !== connectionIdentity) {
+    // A different machine now answers for this host id: entries read from the
+    // previous machine must never be served again, so drop them wholesale.
+    hostCache = { connectionIdentity, entries: new Map() }
     cacheByHost.set(executionHostId, hostCache)
   }
-  hostCache.delete(file.path)
-  hostCache.set(file.path, {
+  hostCache.entries.delete(file.path)
+  hostCache.entries.set(file.path, {
     mtimeMs: file.mtimeMs,
     sizeBytes: file.sizeBytes ?? null,
     session
   })
-  if (hostCache.size > REMOTE_PARSE_CACHE_MAX_ENTRIES_PER_HOST) {
-    const oldest = hostCache.keys().next()
+  if (hostCache.entries.size > REMOTE_PARSE_CACHE_MAX_ENTRIES_PER_HOST) {
+    const oldest = hostCache.entries.keys().next()
     if (!oldest.done) {
-      hostCache.delete(oldest.value)
+      hostCache.entries.delete(oldest.value)
     }
   }
 }

--- a/src/main/ai-vault/remote-session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/remote-session-scanner-parse-cache.ts
@@ -1,0 +1,80 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import type { FileWithMtime } from './session-scanner-types'
+
+// Sized past the remote recency cap (1000) plus the in-scope parse cap (2000)
+// so a full steady-state result set stays resident between rescans; matches
+// the local session-scanner-parse-cache bound.
+export const REMOTE_PARSE_CACHE_MAX_ENTRIES_PER_HOST = 4096
+
+type RemoteSessionParseCacheEntry = {
+  mtimeMs: number
+  sizeBytes: number | null
+  session: AiVaultSession | null
+}
+
+export type RemoteSessionParseCacheHit = {
+  session: AiVaultSession | null
+}
+
+// Keyed by execution host so identical remote paths on different hosts can
+// never serve each other's sessions. Reconnects keep entries (paths and
+// mtimes stay valid); target removal evicts via evictRemoteSessionParseCache.
+const cacheByHost = new Map<ExecutionHostId, Map<string, RemoteSessionParseCacheEntry>>()
+
+/**
+ * Return the parse result cached for this remote file when its (mtime, size)
+ * stat is unchanged, refreshing its LRU recency. A hit means the rescan skips
+ * the SSH body transfer and re-parse entirely; `null` means read + parse.
+ */
+export function readCachedRemoteSessionParse(
+  executionHostId: ExecutionHostId,
+  file: FileWithMtime
+): RemoteSessionParseCacheHit | null {
+  const hostCache = cacheByHost.get(executionHostId)
+  const entry = hostCache?.get(file.path)
+  if (!hostCache || !entry) {
+    return null
+  }
+  const unchanged =
+    entry.mtimeMs === file.mtimeMs &&
+    (entry.sizeBytes === null || file.sizeBytes === undefined || entry.sizeBytes === file.sizeBytes)
+  if (!unchanged) {
+    return null
+  }
+  hostCache.delete(file.path)
+  hostCache.set(file.path, entry)
+  return { session: entry.session }
+}
+
+export function storeRemoteSessionParse(
+  executionHostId: ExecutionHostId,
+  file: FileWithMtime,
+  session: AiVaultSession | null
+): void {
+  let hostCache = cacheByHost.get(executionHostId)
+  if (!hostCache) {
+    hostCache = new Map()
+    cacheByHost.set(executionHostId, hostCache)
+  }
+  hostCache.delete(file.path)
+  hostCache.set(file.path, {
+    mtimeMs: file.mtimeMs,
+    sizeBytes: file.sizeBytes ?? null,
+    session
+  })
+  if (hostCache.size > REMOTE_PARSE_CACHE_MAX_ENTRIES_PER_HOST) {
+    const oldest = hostCache.keys().next()
+    if (!oldest.done) {
+      hostCache.delete(oldest.value)
+    }
+  }
+}
+
+export function evictRemoteSessionParseCache(executionHostId: ExecutionHostId): void {
+  cacheByHost.delete(executionHostId)
+}
+
+export function resetRemoteSessionParseCacheForTests(): void {
+  cacheByHost.clear()
+}

--- a/src/main/ai-vault/remote-session-scanner-test-provider.ts
+++ b/src/main/ai-vault/remote-session-scanner-test-provider.ts
@@ -1,0 +1,119 @@
+import type { DirEntry } from '../../shared/types'
+import type { FileReadResult, FileStat, IFilesystemProvider } from '../providers/types'
+
+/**
+ * In-memory remote filesystem for remote-session-scanner tests. Records every
+ * readFile call (each one models a full SSH body transfer) so parse-cache
+ * tests can assert exactly which bodies a rescan re-reads.
+ */
+export class MemoryRemoteProvider implements IFilesystemProvider {
+  private readonly files = new Map<string, { content: string; mtimeMs: number }>()
+  readonly readFileCalls: string[] = []
+
+  addFile(path: string, content: string, mtimeMs: number): void {
+    this.files.set(normalize(path), { content, mtimeMs })
+  }
+
+  clearReadFileCalls(): void {
+    this.readFileCalls.length = 0
+  }
+
+  async readDir(dirPath: string): Promise<DirEntry[]> {
+    const dir = normalize(dirPath)
+    const prefix = dir.endsWith('/') ? dir : `${dir}/`
+    const entries = new Map<string, DirEntry>()
+    for (const path of this.files.keys()) {
+      if (!path.startsWith(prefix)) {
+        continue
+      }
+      const relative = path.slice(prefix.length)
+      if (!relative) {
+        continue
+      }
+      const [name, ...rest] = relative.split('/')
+      if (!name) {
+        continue
+      }
+      entries.set(name, {
+        name,
+        isDirectory: rest.length > 0,
+        isSymlink: false
+      })
+    }
+    return [...entries.values()].sort((left, right) => left.name.localeCompare(right.name))
+  }
+
+  async readFile(filePath: string): Promise<FileReadResult> {
+    const normalized = normalize(filePath)
+    this.readFileCalls.push(normalized)
+    const file = this.files.get(normalized)
+    if (!file) {
+      throw new Error(`ENOENT: ${filePath}`)
+    }
+    return { content: file.content, isBinary: false }
+  }
+
+  async stat(filePath: string): Promise<FileStat> {
+    const file = this.files.get(normalize(filePath))
+    if (!file) {
+      throw new Error(`ENOENT: ${filePath}`)
+    }
+    return { size: file.content.length, type: 'file', mtime: file.mtimeMs, mtimeMs: file.mtimeMs }
+  }
+
+  writeFile = unsupported
+  writeFileBase64 = unsupported
+  writeFileBase64Chunk = unsupported
+  deletePath = unsupported
+  createFile = unsupported
+  createDir = unsupported
+  createDirNoClobber = unsupported
+  rename = unsupported
+  renameNoClobber = unsupported
+  copy = unsupported
+  realpath = async (path: string): Promise<string> => path
+  search = unsupported
+  listFiles = unsupported
+  watch = unsupported
+}
+
+async function unsupported(): Promise<never> {
+  throw new Error('unsupported')
+}
+
+function normalize(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+export function jsonLines(records: unknown[]): string {
+  return records.map((record) => JSON.stringify(record)).join('\n')
+}
+
+export function codexTranscript(args: {
+  sessionId: string
+  title: string
+  cwd: string
+  timestamp: string
+  threadSource?: string
+}): string {
+  return jsonLines([
+    {
+      timestamp: args.timestamp,
+      type: 'session_meta',
+      payload: {
+        id: args.sessionId,
+        cwd: args.cwd,
+        ...(args.threadSource ? { thread_source: args.threadSource } : {})
+      }
+    },
+    {
+      timestamp: args.timestamp.replace(':00.000Z', ':01.000Z'),
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'text', text: args.title }]
+      }
+    }
+  ])
+}

--- a/src/main/ai-vault/remote-session-scanner-types.ts
+++ b/src/main/ai-vault/remote-session-scanner-types.ts
@@ -7,6 +7,9 @@ import type { FileWithMtime } from './session-scanner-types'
 export type RemoteScannerContext = {
   provider: IFilesystemProvider
   executionHostId: ExecutionHostId
+  // Connect-time machine identity for the parse cache; entries cached under a
+  // different identity (a repointed target id) are never served.
+  connectionIdentity: string | null
   hostPlatform: RemoteHostPlatform
   titleCaches: Map<string, Promise<Map<string, string>>>
 }

--- a/src/main/ai-vault/remote-session-scanner.test.ts
+++ b/src/main/ai-vault/remote-session-scanner.test.ts
@@ -1,86 +1,18 @@
-import { describe, expect, it } from 'vitest'
-import type { DirEntry } from '../../shared/types'
-import type { FileReadResult, FileStat, IFilesystemProvider } from '../providers/types'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import { scanRemoteAiVaultSessions } from './remote-session-scanner'
-
-class MemoryRemoteProvider implements IFilesystemProvider {
-  private readonly files = new Map<string, { content: string; mtimeMs: number }>()
-
-  addFile(path: string, content: string, mtimeMs: number): void {
-    this.files.set(normalize(path), { content, mtimeMs })
-  }
-
-  async readDir(dirPath: string): Promise<DirEntry[]> {
-    const dir = normalize(dirPath)
-    const prefix = dir.endsWith('/') ? dir : `${dir}/`
-    const entries = new Map<string, DirEntry>()
-    for (const path of this.files.keys()) {
-      if (!path.startsWith(prefix)) {
-        continue
-      }
-      const relative = path.slice(prefix.length)
-      if (!relative) {
-        continue
-      }
-      const [name, ...rest] = relative.split('/')
-      if (!name) {
-        continue
-      }
-      entries.set(name, {
-        name,
-        isDirectory: rest.length > 0,
-        isSymlink: false
-      })
-    }
-    return [...entries.values()].sort((left, right) => left.name.localeCompare(right.name))
-  }
-
-  async readFile(filePath: string): Promise<FileReadResult> {
-    const file = this.files.get(normalize(filePath))
-    if (!file) {
-      throw new Error(`ENOENT: ${filePath}`)
-    }
-    return { content: file.content, isBinary: false }
-  }
-
-  async stat(filePath: string): Promise<FileStat> {
-    const file = this.files.get(normalize(filePath))
-    if (!file) {
-      throw new Error(`ENOENT: ${filePath}`)
-    }
-    return { size: file.content.length, type: 'file', mtime: file.mtimeMs, mtimeMs: file.mtimeMs }
-  }
-
-  writeFile = unsupported
-  writeFileBase64 = unsupported
-  writeFileBase64Chunk = unsupported
-  deletePath = unsupported
-  createFile = unsupported
-  createDir = unsupported
-  createDirNoClobber = unsupported
-  rename = unsupported
-  renameNoClobber = unsupported
-  copy = unsupported
-  realpath = async (path: string): Promise<string> => path
-  search = unsupported
-  listFiles = unsupported
-  watch = unsupported
-}
-
-async function unsupported(): Promise<never> {
-  throw new Error('unsupported')
-}
-
-function normalize(path: string): string {
-  return path.replace(/\\/g, '/').replace(/\/+$/, '')
-}
-
-function jsonLines(records: unknown[]): string {
-  return records.map((record) => JSON.stringify(record)).join('\n')
-}
+import { resetRemoteSessionParseCacheForTests } from './remote-session-scanner-parse-cache'
+import {
+  codexTranscript,
+  jsonLines,
+  MemoryRemoteProvider
+} from './remote-session-scanner-test-provider'
 
 describe('scanRemoteAiVaultSessions', () => {
+  beforeEach(() => {
+    resetRemoteSessionParseCacheForTests()
+  })
+
   it('parses remote default and Orca-managed Codex homes with SSH host ids', async () => {
     const provider = new MemoryRemoteProvider()
     provider.addFile(
@@ -313,32 +245,3 @@ describe('scanRemoteAiVaultSessions', () => {
     ])
   })
 })
-
-function codexTranscript(args: {
-  sessionId: string
-  title: string
-  cwd: string
-  timestamp: string
-  threadSource?: string
-}): string {
-  return jsonLines([
-    {
-      timestamp: args.timestamp,
-      type: 'session_meta',
-      payload: {
-        id: args.sessionId,
-        cwd: args.cwd,
-        ...(args.threadSource ? { thread_source: args.threadSource } : {})
-      }
-    },
-    {
-      timestamp: args.timestamp.replace(':00.000Z', ':01.000Z'),
-      type: 'response_item',
-      payload: {
-        type: 'message',
-        role: 'user',
-        content: [{ type: 'text', text: args.title }]
-      }
-    }
-  ])
-}

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -1,18 +1,18 @@
 import { extname } from 'node:path'
 import type {
-  AiVaultAgent,
   AiVaultListResult,
   AiVaultScanIssue,
   AiVaultSession
 } from '../../shared/ai-vault-types'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
 import type { ExecutionHostId } from '../../shared/execution-host'
-import type { FileStat, IFilesystemProvider } from '../providers/types'
+import type { IFilesystemProvider } from '../providers/types'
 import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import { sessionSortTime } from './session-scanner-accumulator'
 import type { FileWithMtime } from './session-scanner-types'
 import { errorMessage } from './session-scanner-values'
+import { statRemoteFile } from './remote-session-scanner-file-stat'
 import {
   readCachedRemoteSessionParse,
   storeRemoteSessionParse
@@ -33,6 +33,7 @@ export async function scanRemoteAiVaultSessions(args: {
   executionHostId: ExecutionHostId
   remoteHome: string
   hostPlatform: RemoteHostPlatform
+  connectionIdentity?: string | null
   limit?: number
   scopePaths?: readonly string[]
 }): Promise<AiVaultListResult> {
@@ -41,6 +42,7 @@ export async function scanRemoteAiVaultSessions(args: {
   const context: RemoteScannerContext = {
     provider: args.provider,
     executionHostId: args.executionHostId,
+    connectionIdentity: args.connectionIdentity ?? null,
     hostPlatform: args.hostPlatform,
     titleCaches: new Map()
   }
@@ -201,18 +203,32 @@ async function parseRemoteSessionCandidate(
   // A (mtime,size)-unchanged file skips the SSH body transfer and re-parse
   // entirely; rescans previously re-read every candidate in full. Like the
   // local cache, an unchanged Codex transcript keeps its cached index title.
-  const cached = readCachedRemoteSessionParse(context.executionHostId, candidate.file)
+  const cached = readCachedRemoteSessionParse(
+    context.executionHostId,
+    context.connectionIdentity,
+    candidate.file
+  )
   if (cached) {
     return cached.session
   }
   try {
     const read = await context.provider.readFile(candidate.file.path)
     if (read.isBinary) {
-      storeRemoteSessionParse(context.executionHostId, candidate.file, null)
+      storeRemoteSessionParse(
+        context.executionHostId,
+        context.connectionIdentity,
+        candidate.file,
+        null
+      )
       return null
     }
     const session = await candidate.source.parse(candidate.file, read.content, context)
-    storeRemoteSessionParse(context.executionHostId, candidate.file, session)
+    storeRemoteSessionParse(
+      context.executionHostId,
+      context.connectionIdentity,
+      candidate.file,
+      session
+    )
     return session
   } catch (err) {
     // Failures stay uncached so the issue resurfaces on every scan and a
@@ -251,35 +267,6 @@ function isRemoteSessionInScope(session: AiVaultSession, scopePaths: readonly st
 
 function normalizeRemoteScopePaths(scopePaths: readonly string[]): string[] {
   return scopePaths.map((scopePath) => scopePath.trim()).filter(Boolean)
-}
-
-async function statRemoteFile(
-  provider: IFilesystemProvider,
-  path: string,
-  agent: AiVaultAgent,
-  executionHostId: ExecutionHostId,
-  issues: AiVaultScanIssue[]
-): Promise<FileWithMtime | null> {
-  try {
-    const stat = await provider.stat(path)
-    const mtimeMs = remoteStatMtimeMs(stat)
-    return {
-      path,
-      mtimeMs,
-      modifiedAt: new Date(mtimeMs).toISOString(),
-      sizeBytes: Number.isFinite(stat.size) ? stat.size : undefined
-    }
-  } catch (err) {
-    issues.push({ executionHostId, agent, path, message: errorMessage(err) })
-    return null
-  }
-}
-
-function remoteStatMtimeMs(stat: FileStat): number {
-  if (typeof stat.mtimeMs === 'number' && Number.isFinite(stat.mtimeMs)) {
-    return stat.mtimeMs
-  }
-  return stat.mtime > 10_000_000_000 ? stat.mtime : stat.mtime * 1000
 }
 
 function canStopParsingRemoteSessions(

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -13,6 +13,10 @@ import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import { sessionSortTime } from './session-scanner-accumulator'
 import type { FileWithMtime } from './session-scanner-types'
 import { errorMessage } from './session-scanner-values'
+import {
+  readCachedRemoteSessionParse,
+  storeRemoteSessionParse
+} from './remote-session-scanner-parse-cache'
 import { remoteSessionSources } from './remote-session-scanner-sources'
 import type {
   RemoteScannerContext,
@@ -194,13 +198,25 @@ async function parseRemoteSessionCandidate(
   context: RemoteScannerContext,
   issues: AiVaultScanIssue[]
 ): Promise<AiVaultSession | null> {
+  // A (mtime,size)-unchanged file skips the SSH body transfer and re-parse
+  // entirely; rescans previously re-read every candidate in full. Like the
+  // local cache, an unchanged Codex transcript keeps its cached index title.
+  const cached = readCachedRemoteSessionParse(context.executionHostId, candidate.file)
+  if (cached) {
+    return cached.session
+  }
   try {
     const read = await context.provider.readFile(candidate.file.path)
     if (read.isBinary) {
+      storeRemoteSessionParse(context.executionHostId, candidate.file, null)
       return null
     }
-    return candidate.source.parse(candidate.file, read.content, context)
+    const session = await candidate.source.parse(candidate.file, read.content, context)
+    storeRemoteSessionParse(context.executionHostId, candidate.file, session)
+    return session
   } catch (err) {
+    // Failures stay uncached so the issue resurfaces on every scan and a
+    // transient read error retries next time.
     issues.push({
       executionHostId: context.executionHostId,
       agent: candidate.source.agent,
@@ -247,7 +263,12 @@ async function statRemoteFile(
   try {
     const stat = await provider.stat(path)
     const mtimeMs = remoteStatMtimeMs(stat)
-    return { path, mtimeMs, modifiedAt: new Date(mtimeMs).toISOString() }
+    return {
+      path,
+      mtimeMs,
+      modifiedAt: new Date(mtimeMs).toISOString(),
+      sizeBytes: Number.isFinite(stat.size) ? stat.size : undefined
+    }
   } catch (err) {
     issues.push({ executionHostId, agent, path, message: errorMessage(err) })
     return null

--- a/src/main/ipc/ai-vault.test.ts
+++ b/src/main/ipc/ai-vault.test.ts
@@ -83,6 +83,7 @@ describe('listAiVaultSessions host routing', () => {
         provider,
         executionHostId: 'ssh:dev-box',
         remoteHome: '/home/ada',
+        connectionIdentity: 'identity-dev-box',
         scopePaths: ['/home/ada/repo']
       })
     )
@@ -128,7 +129,8 @@ function hostInfo(targetId: string) {
     targetId,
     executionHostId: `ssh:${targetId}` as const,
     remoteHome: '/home/ada',
-    hostPlatform: getRemoteHostPlatform('linux-x64')
+    hostPlatform: getRemoteHostPlatform('linux-x64'),
+    connectionIdentity: `identity-${targetId}`
   }
 }
 

--- a/src/main/ipc/ai-vault.ts
+++ b/src/main/ipc/ai-vault.ts
@@ -151,6 +151,7 @@ async function scanSshAiVaultSessions(
     executionHostId: hostInfo.executionHostId,
     remoteHome: hostInfo.remoteHome,
     hostPlatform: hostInfo.hostPlatform,
+    connectionIdentity: hostInfo.connectionIdentity,
     limit: args?.limit,
     scopePaths: args?.scopePaths
   })

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -16,7 +16,8 @@ import type {
   SshConnectionState
 } from '../../shared/ssh-types'
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../shared/constants'
-import { isRuntimeOwnedSshTargetId } from '../../shared/execution-host'
+import { isRuntimeOwnedSshTargetId, toSshExecutionHostId } from '../../shared/execution-host'
+import { evictRemoteSessionParseCache } from '../ai-vault/remote-session-scanner-parse-cache'
 import { isAuthError } from '../ssh/ssh-connection-utils'
 import { forceStopRelayForTarget } from '../ssh/ssh-relay-reset'
 import { isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
@@ -115,6 +116,9 @@ export async function removeRegisteredSshTarget(targetId: string): Promise<void>
     )
   }
   persistedStore?.removeSshRemotePtyLeases(targetId)
+  // Why: reconnects keep cached session parses (paths/mtimes stay valid), but
+  // a removed target must not pin its parsed transcripts in main-process memory.
+  evictRemoteSessionParseCache(toSshExecutionHostId(targetId))
   sshStore.removeTarget(targetId)
 }
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -61,7 +61,8 @@ import {
   type DetectedPort,
   MAX_SSH_RELAY_GRACE_PERIOD_SECONDS,
   MIN_SSH_RELAY_GRACE_PERIOD_SECONDS,
-  SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD
+  SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD,
+  type SshTarget
 } from '../../shared/ssh-types'
 import type { Store } from '../persistence'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
@@ -113,6 +114,25 @@ export type SshRelayAiVaultHostInfo = {
   executionHostId: ExecutionHostId
   remoteHome: string
   hostPlatform: RemoteHostPlatform
+  /** Opaque connect-time machine identity; null while no connection is live. */
+  connectionIdentity: string | null
+}
+
+// Identifies the machine an AI-vault scan actually reads from: the target
+// snapshot the live connection dialed. Store edits (ssh:updateTarget, config
+// import, runtime reprovision) don't take effect until reconnect, so the
+// stored target may describe a different machine than the active provider.
+// Auth-only fields (identityFile/agent/identitiesOnly) are excluded — they
+// change how we authenticate, not whose files we read.
+function aiVaultConnectionIdentity(target: SshTarget): string {
+  return JSON.stringify([
+    target.configHost ?? null,
+    target.host,
+    target.port,
+    target.username,
+    target.proxyCommand ?? null,
+    target.jumpHost ?? null
+  ])
 }
 
 const RECONNECT_REPLAY_DUPLICATE_WINDOW_MS = 1000
@@ -230,11 +250,13 @@ export class SshRelaySession {
     if (!env) {
       return null
     }
+    const connectionTarget = this.currentConnection?.getTarget() ?? null
     return {
       targetId: this.targetId,
       executionHostId: toSshExecutionHostId(this.targetId),
       remoteHome: env.remoteHome,
-      hostPlatform: env.hostPlatform
+      hostPlatform: env.hostPlatform,
+      connectionIdentity: connectionTarget ? aiVaultConnectionIdentity(connectionTarget) : null
     }
   }
 


### PR DESCRIPTION
## Problem

Every remote AI-vault rescan re-reads **every** candidate session file over SSH in full — up to 1000 recent + 2000 in-scope transcripts — and re-parses them from scratch. `#7593` (merged) added (mtime,size) reuse and incremental parsing for all local agents, but the remote path was explicitly not covered: `parseRemoteSessionCandidate` went straight to `provider.readFile` on every scan even though the remote stat already exposed mtime and size. Symptom: repeated multi-MB SSH transfers + full re-parses on every vault refresh for SSH/`all` scopes, scaling with session count and file size.

## Fix

Extends `#7593`'s local-only fix to the SSH path:

- **New `remote-session-scanner-parse-cache.ts`**: parse results cached per execution host, keyed by remote path with an (mtime,size) signature. On rescan, an unchanged file skips the SSH body transfer and re-parse entirely (zero body reads); only new/changed files are read. A changed file is fully re-read (remote incremental/resumable-fold parsing is a follow-up — noted below).
- **Bound**: LRU with 4096 entries per host, matching the local cache bound (sized past the 1000 recent + 2000 in-scope caps so a steady-state result set stays resident).
- **Identity/invalidation**: entries are keyed by `ExecutionHostId` (`ssh:<targetId>`) and tagged with an opaque **connect-time connection identity** (host, port, username, configHost, proxy/jump — auth-only fields excluded), captured from the live connection's target snapshot and threaded through `SshRelayAiVaultHostInfo`. A repointed target id — `ssh:updateTarget`, `~/.ssh/config` re-import, or runtime reprovision — mismatches on the next scan and drops that host's entries, even when path + (mtime,size) coincide across machines. The identity deliberately comes from the **connection**, not the store: store edits only take effect at reconnect, so the provider keeps reading the old machine until then, and evicting at edit time would let interim scans re-poison the cache. Reconnects to the same machine keep the cache; target removal evicts via a hook in `removeRegisteredSshTarget` (same `toSshExecutionHostId` key the scanner uses).
- Read/parse **failures stay uncached** so scan issues resurface every scan and transient errors retry; binary/filtered files cache a null session so they are not re-transferred.
- `statRemoteFile` now carries `sizeBytes` from the existing remote `FileStat` (previously discarded) and moved to `remote-session-scanner-file-stat.ts` to respect max-lines.

Behavior notes (both match the local cache's accepted trade-offs): rescans return the same session object instances for unchanged files, and an unchanged Codex transcript keeps its cached `session_index.jsonl` title until the transcript itself changes.

**Memory (per-host, not global):** the bound is 4096 entries per host with no ceiling across hosts, so worst-case retention scales with scanned-host count (`hosts × ≤4096 × ~2–5 KB/session`; realistic footprint single-digit MB). Entries are freed on target removal and dropped on identity change, but are deliberately **retained across disconnect/reconnect** — a reconnect to the same machine keeps the cache warm and skips re-transferring every transcript, which is the point; a disconnected-but-not-removed host keeps its working set resident until removal. A global backstop LRU and/or idle-grace eviction of disconnected hosts are possible follow-ups if main-process retention ever matters.

## Not regressed

- Cross-host correctness (dedicated leakage test + repointed-target-id test), scope filtering (applied outside the cache), recency caps / early-stop (cache only changes how a candidate is parsed, not which candidates are considered), per-host memory bounds in main (per-host LRU + identity reset + removal eviction — total scales with host count; see the Memory note above).

## Tests

`remote-session-scanner-parse-cache.test.ts` (deterministic, counts `readFile` calls on an in-memory provider — each call models a full SSH body transfer):

- First scan reads N bodies; second scan with unchanged stats performs **zero** reads and returns identical sessions.
- mtime change → exactly that file re-read; size-only change (same mtime) → exactly that file re-read.
- Entries cached for one host are never served to another; sessions carry the correct `executionHostId`.
- **Repointed target id**: same host id, same path, equal mtime **and equal byte size** on a different machine → the identity gate alone forces the re-read and returns the new machine's session; the new identity then caches normally.
- Identity mismatch misses at the cache-unit level; storing under a new identity resets the host so switching back also misses.
- LRU bound respected per host, recency refresh verified, flooding one host leaves other hosts' entries intact.
- Host eviction → bodies re-read on the next scan.

Also extracted the in-memory remote provider into `remote-session-scanner-test-provider.ts` (shared by both remote scanner test files) and added a cache reset to the existing suite.

`pnpm vitest run src/main/ai-vault src/main/ipc/ai-vault.test.ts src/main/ssh` ✅ (660 tests) · `pnpm typecheck` ✅ · oxfmt/oxlint clean on touched files.

## Follow-up

Remote incremental append-parsing (resumable-fold over SSH, the stretch goal) is not taken here: it needs ranged remote reads which `IFilesystemProvider.readFile` doesn't expose, so v1 keeps the plumbing simple with full re-read of changed files only.
