### PR TITLE
perf(renderer): purge seven per-tab/per-pty terminal maps on bulk worktree removal

### DIFF
--- a/src/renderer/src/store/slices/bulk-worktree-purge-terminal-maps-leak.test.ts
+++ b/src/renderer/src/store/slices/bulk-worktree-purge-terminal-maps-leak.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Memory-leak regression: seven per-tab / per-pty terminal+agent store maps were
+ * evicted on the SINGLE removeWorktree path (via closeTab / shutdownWorktreeTerminals)
+ * but NOT on the BULK path — `buildWorktreePurgeState`, reached by removeProject, the
+ * external-worktree-removal authoritative-scan reconcile, and the hydration-stale
+ * reconcile. That path runs no terminal teardown, so before the fix each map stranded
+ * an entry per tab/pane of every externally-removed worktree for the renderer's whole
+ * session (unbounded across add/remove-repo cycles). tabId and ptyId are ephemeral,
+ * never-reused key spaces.
+ *
+ * Tab-keyed (evicted via the doomed-tab set):
+ *   lastKnownRelayPtyIdByTabId, pendingInitialCwdByTabId,
+ *   pendingIssueCommandSplitByTabId, pendingSetupSplitByTabId, pendingStartupByTabId
+ * Pty-keyed (evicted via the doomed-pty set derived from ptyIdsByTabId):
+ *   codexRestartNoticeByPtyId, migrationUnsupportedByPtyId
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+const mockApi = {
+  worktrees: { list: vi.fn().mockResolvedValue([]), remove: vi.fn().mockResolvedValue(undefined) },
+  pty: { kill: vi.fn().mockResolvedValue(undefined) }
+}
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: mockApi }
+
+import { createTestStore, seedStore, makeWorktree, makeTab } from './store-test-helpers'
+
+const WT1 = 'repo1::/path/wt1'
+const WT2 = 'repo1::/path/wt2'
+const TAB1 = 'tab-wt1'
+const TAB2 = 'tab-wt2'
+const PTY1 = 'pty-wt1'
+const PTY2 = 'pty-wt2'
+
+function seedMaps(store: ReturnType<typeof createTestStore>): void {
+  seedStore(store, {
+    worktreesByRepo: {
+      repo1: [
+        makeWorktree({ id: WT1, repoId: 'repo1', path: '/path/wt1' }),
+        makeWorktree({ id: WT2, repoId: 'repo1', path: '/path/wt2' })
+      ]
+    },
+    tabsByWorktree: {
+      [WT1]: [makeTab({ id: TAB1, worktreeId: WT1, ptyId: PTY1 })],
+      [WT2]: [makeTab({ id: TAB2, worktreeId: WT2, ptyId: PTY2 })]
+    },
+    // Drives the doomed-ptyId derivation in buildWorktreePurgeState.
+    ptyIdsByTabId: { [TAB1]: [PTY1], [TAB2]: [PTY2] },
+    lastKnownRelayPtyIdByTabId: { [TAB1]: PTY1, [TAB2]: PTY2 },
+    pendingInitialCwdByTabId: { [TAB1]: '/path/wt1', [TAB2]: '/path/wt2' },
+    pendingIssueCommandSplitByTabId: {
+      [TAB1]: { command: 'a' },
+      [TAB2]: { command: 'b' }
+    },
+    pendingSetupSplitByTabId: {
+      [TAB1]: { command: 'setup-a', direction: 'vertical' },
+      [TAB2]: { command: 'setup-b', direction: 'vertical' }
+    },
+    pendingStartupByTabId: { [TAB1]: { command: 'start-a' }, [TAB2]: { command: 'start-b' } },
+    codexRestartNoticeByPtyId: {
+      [PTY1]: { previousAccountLabel: 'a1', nextAccountLabel: 'a2' },
+      [PTY2]: { previousAccountLabel: 'b1', nextAccountLabel: 'b2' }
+    },
+    migrationUnsupportedByPtyId: {
+      [PTY1]: {
+        ptyId: PTY1,
+        paneKey: `${TAB1}:leaf-1`,
+        reason: 'legacy-numeric-pane-key',
+        source: 'local',
+        updatedAt: 1
+      },
+      [PTY2]: {
+        ptyId: PTY2,
+        paneKey: `${TAB2}:leaf-1`,
+        reason: 'legacy-numeric-pane-key',
+        source: 'local',
+        updatedAt: 2
+      }
+    }
+  })
+}
+
+describe('bulk worktree purge evicts the per-tab/per-pty terminal maps it previously leaked', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('drops removed worktree entries (both tabId- and ptyId-keyed), retains survivors', () => {
+    const store = createTestStore()
+    seedMaps(store)
+
+    store.getState().purgeWorktreeTerminalState([WT1])
+    const s = store.getState()
+
+    // Removed worktree's tab/pty: every map evicted.
+    expect(s.lastKnownRelayPtyIdByTabId[TAB1]).toBeUndefined()
+    expect(s.pendingInitialCwdByTabId[TAB1]).toBeUndefined()
+    expect(s.pendingIssueCommandSplitByTabId[TAB1]).toBeUndefined()
+    expect(s.pendingSetupSplitByTabId[TAB1]).toBeUndefined()
+    expect(s.pendingStartupByTabId[TAB1]).toBeUndefined()
+    expect(s.codexRestartNoticeByPtyId[PTY1]).toBeUndefined()
+    expect(s.migrationUnsupportedByPtyId[PTY1]).toBeUndefined()
+
+    // Surviving worktree's tab/pty: every entry retained (no over-eviction).
+    expect(s.lastKnownRelayPtyIdByTabId[TAB2]).toBe(PTY2)
+    expect(s.pendingInitialCwdByTabId[TAB2]).toBe('/path/wt2')
+    expect(s.pendingIssueCommandSplitByTabId[TAB2]).toEqual({ command: 'b' })
+    expect(s.pendingSetupSplitByTabId[TAB2]).toEqual({ command: 'setup-b', direction: 'vertical' })
+    expect(s.pendingStartupByTabId[TAB2]).toEqual({ command: 'start-b' })
+    expect(s.codexRestartNoticeByPtyId[PTY2]).toBeDefined()
+    expect(s.migrationUnsupportedByPtyId[PTY2]).toBeDefined()
+  })
+})

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1829,12 +1829,20 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
 
   // Collect every tab id (and removed file id) we are about to orphan.
   const doomedTabIds = new Set<string>()
+  // Why: some terminal/agent maps are keyed by ptyId, not tabId. Collect the
+  // doomed panes' ptyIds now (while ptyIdsByTabId is still populated) so this
+  // bulk path can evict them the same way shutdownWorktreeTerminals does on the
+  // single-removeWorktree path.
+  const doomedPtyIds = new Set<string>()
   const doomedBrowserWorkspaceIds = new Set<string>()
   const doomedPageIds = new Set<string>()
   const removedFileIds = new Set<string>()
   for (const id of worktreeIdSet) {
     for (const tab of s.tabsByWorktree[id] ?? []) {
       doomedTabIds.add(tab.id)
+      for (const ptyId of s.ptyIdsByTabId[tab.id] ?? []) {
+        doomedPtyIds.add(ptyId)
+      }
       // Why: a removed worktree's panes are gone for good, so drop their
       // hibernation output epochs from that module-level map (mirrors the
       // hosted-review prune above). A future pane mints a fresh leafId at epoch 0.
@@ -1920,6 +1928,17 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     for (const tabId of doomedTabIds) {
       if (tabId in out) {
         delete out[tabId]
+        changed = true
+      }
+    }
+    return changed ? out : obj
+  }
+  const omitByPtyId = <T>(obj: Record<string, T>): Record<string, T> => {
+    let changed = false
+    const out = { ...obj }
+    for (const ptyId of doomedPtyIds) {
+      if (ptyId in out) {
+        delete out[ptyId]
         changed = true
       }
     }
@@ -2018,6 +2037,21 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     // this path never runs terminal teardown, so nothing else evicts them.
     expandedPaneByTabId: omitByTabId(s.expandedPaneByTabId),
     canExpandPaneByTabId: omitByTabId(s.canExpandPaneByTabId),
+    // Why: these per-tab / per-pty terminal+agent maps are evicted on the single
+    // removeWorktree path (via closeTab / shutdownWorktreeTerminals) but this bulk
+    // reconcile / remove-project / hydration-stale path runs no terminal teardown,
+    // so without these lines each one strands an entry per tab/pane of every
+    // externally-removed worktree for the renderer's whole session. lastKnownRelay
+    // and the two ptyId maps retain an entry for a live pane's entire lifetime
+    // (highest value); the pending* one-shots are consumed at pane mount so usually
+    // already empty at removal, but strand when a tab's pane never mounted.
+    lastKnownRelayPtyIdByTabId: omitByTabId(s.lastKnownRelayPtyIdByTabId),
+    pendingInitialCwdByTabId: omitByTabId(s.pendingInitialCwdByTabId),
+    pendingIssueCommandSplitByTabId: omitByTabId(s.pendingIssueCommandSplitByTabId),
+    pendingSetupSplitByTabId: omitByTabId(s.pendingSetupSplitByTabId),
+    pendingStartupByTabId: omitByTabId(s.pendingStartupByTabId),
+    codexRestartNoticeByPtyId: omitByPtyId(s.codexRestartNoticeByPtyId),
+    migrationUnsupportedByPtyId: omitByPtyId(s.migrationUnsupportedByPtyId),
     // Why: these tab/pane-scoped agent-status, unread, and input maps are only
     // cleared on the single removeWorktree path (via shutdownWorktreeTerminals /
     // dropAgentStatusByWorktree / clearPaneForegroundAgentByWorktree, which read


### PR DESCRIPTION
## Description

`buildWorktreePurgeState` is the **bulk** worktree-removal reducer — reached by `removeProject`, the external-`git worktree remove` authoritative-scan reconcile, and the hydration-stale reconcile. Unlike the single-`removeWorktree` path it runs **no** terminal teardown, so it must explicitly evict every per-tab/per-pty store map. It evicted ~8 tab-keyed maps but **silently missed 7** that `closeTab` / `shutdownWorktreeTerminals` do evict:

| Map | Key | Retention |
|-----|-----|-----------|
| `lastKnownRelayPtyIdByTabId` | tabId | **whole pane lifetime** (esp. SSH panes) |
| `migrationUnsupportedByPtyId` | ptyId | whole pane lifetime |
| `codexRestartNoticeByPtyId` | ptyId | whole pane lifetime |
| `pendingInitialCwdByTabId` | tabId | until the pane mounts |
| `pendingIssueCommandSplitByTabId` | tabId | until the pane mounts |
| `pendingSetupSplitByTabId` | tabId | until the pane mounts |
| `pendingStartupByTabId` | tabId | until the pane mounts |

`tabId`/`ptyId` are ephemeral, never-reused key spaces, so each map stranded one entry per tab/pane of every externally-removed worktree **for the renderer's whole session** — unbounded across repeated add/remove-repo (or external worktree removal) cycles. This is the same purge-symmetry class as #7383 / #7534 / #7562.

## Fix

- Derive `doomedPtyIds` from `s.ptyIdsByTabId` at the top of the reducer (while it's still populated) — the exact derivation `shutdownWorktreeTerminals` already uses for `shutdownPtyIds`.
- Add an `omitByPtyId` helper mirroring the existing `omitByTabId`.
- Evict all 7 maps in the reducer's return (5 via `omitByTabId`, 2 via `omitByPtyId`).

## Evidence (red → green)

New regression test `bulk-worktree-purge-terminal-maps-leak.test.ts` seeds two worktrees (each 1 tab + 1 pty) into all 7 maps, then calls `purgeWorktreeTerminalState([WT1])`:

- **WITHOUT the fix:** `AssertionError: expected 'pty-wt1' to be undefined` — `lastKnownRelayPtyIdByTabId[TAB1]` (and the other 6) survive the bulk purge. **Leak reproduced.**
- **WITH the fix:** all 7 doomed entries evict; all 7 surviving-worktree entries are retained (no over-eviction). ✅

Verification:
- `bulk-worktree-purge-terminal-maps-leak.test.ts` ✅
- 14 neighboring purge/removal tests green (`tab-worktree-orphan-map-purge-leak`, `worktree-removal-maps-leak`, `agent-status-worktree-purge-leak`, `repos-remove-project-purge-leak`) ✅
- `oxlint` clean, `tsgo` web typecheck clean ✅

## Verified NOT leaks (deliberately excluded)

- `pendingSnapshotByPtyId` + `pendingColdRestoreByPtyId` — **dead code**: never populated or consumed outside tests (grep-confirmed), so despite `closeTab` deleting them they cannot grow. Left untouched (a separate dead-code cleanup, not a leak fix).
- `pendingReconnectPtyIdByTabId` / `reconnectedPtyIdsByTabId` / `deferredSshSessionIdsByTabId` — rebuilt-fresh-each-hydration / local variable / consumption-driven; outside the `closeTab` eviction contract.

## ELI5

Deleting a repo/worktree uses a "big cleanup" broom (bulk) and, for the normal in-app close, a "single-room" broom. The single-room broom swept 7 extra scraps of scratch paper — leftover notes about each terminal pane. The big broom skipped those 7, so every repo you removed left a small pile behind that stuck around until you quit the app. Now the big broom sweeps them too.

## Trade-offs / regression risk: **none**

- Every evicted entry belongs only to a tab/pane of a just-removed worktree — the test asserts surviving worktrees keep all their entries.
- No user-visible behavior changes: these are in-memory bookkeeping maps consumed at pane mount or during a live pane's status transitions. A removed worktree has no panes to mount or transition, so nothing reads the evicted entries.
- The only behavior-adjacent map, `pendingStartupByTabId` (a startup one-shot), is already cleared for the same tabs on the single-removeWorktree path — this only brings the bulk path to parity.

Made with [Orca](https://github.com/stablyai/orca) 🐋
