### PR TITLE
fix(terminal): repaint revealed panes stuck behind xterm's paused-render gate

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -1,5 +1,6 @@
 import { WebglAddon } from '@xterm/addon-webgl'
 import type { ManagedPaneInternal } from './pane-manager-types'
+import { forceRepaintThroughRenderPause } from './terminal-render-pause-release'
 import {
   getTerminalWebglAutoDecision,
   resetTerminalWebglAutoDecision
@@ -126,9 +127,16 @@ export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
     // context-loss event. Clearing the atlas preserves GPU rendering and forces
     // a fresh paint when the pane becomes visible/focused again.
     pane.webglAddon?.clearTextureAtlas()
-    // Why: refresh even without a WebGL addon so recovery never silently
-    // no-ops — a DOM-rendered pane can hold stale pixels after reveal too.
-    pane.terminal.refresh(0, pane.terminal.rows - 1)
+    // Why: on reveal xterm's IntersectionObserver can still report the pane as
+    // not intersecting, so a plain refresh() is swallowed by RenderService's
+    // paused-render gate and the cleared model never repaints (stale bottom rows
+    // until a drag-select forces a redraw). Force the paused render through
+    // first; only fall back to refresh() when the terminal was not gated.
+    if (!forceRepaintThroughRenderPause(pane.terminal)) {
+      // Why: refresh even without a WebGL addon so recovery never silently
+      // no-ops — a DOM-rendered pane can hold stale pixels after reveal too.
+      pane.terminal.refresh(0, pane.terminal.rows - 1)
+    }
   } catch {
     /* ignore — pane may have been disposed in the meantime */
   }

--- a/src/renderer/src/lib/pane-manager/terminal-render-pause-release.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-render-pause-release.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { forceRepaintThroughRenderPause } from './terminal-render-pause-release'
+
+type FakeRenderService = {
+  _isPaused?: boolean
+  _needsFullRefresh?: boolean
+  refreshRows?: ReturnType<typeof vi.fn>
+}
+
+function createTerminal(options: {
+  rows?: number
+  renderService?: FakeRenderService | null
+  withoutCore?: boolean
+}): unknown {
+  const { rows = 24, renderService, withoutCore } = options
+  if (withoutCore) {
+    return { rows }
+  }
+  return {
+    rows,
+    _core: { _renderService: renderService ?? null }
+  }
+}
+
+describe('forceRepaintThroughRenderPause', () => {
+  it('drives a synchronous full-viewport render and clears the pause latches when paused', () => {
+    const refreshRows = vi.fn()
+    const renderService: FakeRenderService = {
+      _isPaused: true,
+      _needsFullRefresh: true,
+      refreshRows
+    }
+    const terminal = createTerminal({ rows: 30, renderService })
+
+    expect(forceRepaintThroughRenderPause(terminal)).toBe(true)
+    expect(refreshRows).toHaveBeenCalledWith(0, 29, true)
+    expect(renderService._isPaused).toBe(false)
+    expect(renderService._needsFullRefresh).toBe(false)
+  })
+
+  it('leaves the terminal untouched and returns false when not paused', () => {
+    const refreshRows = vi.fn()
+    const renderService: FakeRenderService = {
+      _isPaused: false,
+      _needsFullRefresh: false,
+      refreshRows
+    }
+    const terminal = createTerminal({ renderService })
+
+    expect(forceRepaintThroughRenderPause(terminal)).toBe(false)
+    expect(refreshRows).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the render service internals are unavailable', () => {
+    expect(forceRepaintThroughRenderPause(createTerminal({ withoutCore: true }))).toBe(false)
+    expect(forceRepaintThroughRenderPause(createTerminal({ renderService: null }))).toBe(false)
+    expect(forceRepaintThroughRenderPause(createTerminal({ renderService: {} }))).toBe(false)
+    expect(forceRepaintThroughRenderPause(null)).toBe(false)
+  })
+
+  it('returns false without rendering when the row count is invalid', () => {
+    const refreshRows = vi.fn()
+    const terminal = createTerminal({
+      rows: 0,
+      renderService: { _isPaused: true, refreshRows }
+    })
+
+    expect(forceRepaintThroughRenderPause(terminal)).toBe(false)
+    expect(refreshRows).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the forced render throws (disposed mid-frame)', () => {
+    const renderService: FakeRenderService = {
+      _isPaused: true,
+      _needsFullRefresh: true,
+      refreshRows: vi.fn(() => {
+        throw new Error('terminal disposed')
+      })
+    }
+    const terminal = createTerminal({ renderService })
+
+    expect(forceRepaintThroughRenderPause(terminal)).toBe(false)
+    // Latch is still cleared — the observer reasserts authority on its next
+    // callback, and we must not leave a half-serviced full-refresh queued.
+    expect(renderService._isPaused).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-render-pause-release.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-render-pause-release.ts
@@ -1,0 +1,73 @@
+/**
+ * Forces a full synchronous repaint through xterm's RenderService even when its
+ * IntersectionObserver still reports the screen element as not intersecting.
+ *
+ * Why: on tab/worktree reveal the pane is DOM-visible but xterm's own
+ * observer callback can lag a frame (worse under load), leaving
+ * `RenderService._isPaused === true`. While paused, `refreshRows` early-returns
+ * and only latches `_needsFullRefresh`, so the reveal-repaint's
+ * `terminal.refresh()` is swallowed — the freshly-cleared render model never
+ * repaints and the canvas keeps compositing stale rows (classic "bottom rows
+ * missing until you drag-select" symptom). We can't wait for the observer, so
+ * we clear the latch and drive one synchronous full render ourselves; the
+ * observer reasserts authority naturally on its next callback.
+ *
+ * All access is behind typeof guards: an xterm upgrade that renames these
+ * internals degrades to a no-op (callers keep their existing refresh path), it
+ * never throws into a render frame.
+ */
+
+type MaybePausableRenderService = {
+  _isPaused?: boolean
+  _needsFullRefresh?: boolean
+  refreshRows?: (start: number, end: number, sync?: boolean) => void
+}
+
+type PausableRenderService = MaybePausableRenderService & {
+  refreshRows: (start: number, end: number, sync?: boolean) => void
+}
+
+type TerminalWithRenderService = {
+  rows?: number
+  _core?: {
+    _renderService?: MaybePausableRenderService
+  }
+}
+
+function getRenderService(terminal: unknown): PausableRenderService | null {
+  const service = (terminal as TerminalWithRenderService | null)?._core?._renderService
+  return service && typeof service.refreshRows === 'function'
+    ? (service as PausableRenderService)
+    : null
+}
+
+/**
+ * If xterm's renderer is paused (observer hasn't caught up to the reveal),
+ * clear the pause latch and force a synchronous full-viewport repaint.
+ * Returns true when it drove the render, false when it left the terminal
+ * untouched (not paused, or internals unavailable) so the caller can fall back
+ * to its normal `terminal.refresh()`.
+ */
+export function forceRepaintThroughRenderPause(terminal: unknown): boolean {
+  const service = getRenderService(terminal)
+  if (!service || service._isPaused !== true) {
+    return false
+  }
+
+  const rows = (terminal as TerminalWithRenderService).rows
+  if (typeof rows !== 'number' || rows < 1) {
+    return false
+  }
+
+  // Why: leave the latch as if the pending full refresh was serviced — we are
+  // about to service it — so the observer's next callback doesn't queue a
+  // redundant second full repaint.
+  service._isPaused = false
+  service._needsFullRefresh = false
+  try {
+    service.refreshRows(0, rows - 1, true)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/tests/e2e/terminal-reveal-paused-render-repro.spec.ts
+++ b/tests/e2e/terminal-reveal-paused-render-repro.spec.ts
@@ -1,0 +1,268 @@
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { getActiveTabId, waitForSessionReady } from './helpers/store'
+import {
+  execInTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { captureStableTabScreenshot } from './terminal-tab-screenshot'
+import { compareTerminalScreenshots } from './terminal-screenshot-diff'
+
+/**
+ * Reproduction for the "missing bottom rows on reveal, recover on drag-select"
+ * bug (PR #7614). The mechanism is xterm's RenderService gating refreshRows() on
+ * its IntersectionObserver: while `_isPaused` is true (the observer can lag a
+ * frame behind a just-revealed pane, worse under load), refresh() early-returns
+ * and only latches `_needsFullRefresh`. The reveal-repaint's terminal.refresh()
+ * is then swallowed and the freshly-cleared render model never repaints.
+ *
+ * This spec drives the REAL production reveal path (manager.resetWebglTextureAtlases
+ * -> resetWebglTextureAtlas -> forceRepaintThroughRenderPause) against a real
+ * xterm Terminal + RenderService. It:
+ *   1. proves the bug: while paused, a plain refresh() renders nothing;
+ *   2. proves the fix: the real reveal repaint forces a full-viewport render
+ *      through the paused gate and clears the pause latch;
+ *   3. confirms recovery at the pixel level.
+ *
+ * The paused state is set deterministically rather than raced, because headless
+ * Electron does not reliably reproduce the observer-lag timing (documented for
+ * this bug class). The gate we force is the exact one the field bug hits.
+ */
+
+const BOTTOM_MARKER = 'REVEAL_PAUSED_RENDER_BOTTOM_MARKER'
+
+type RenderProbeResult = {
+  paused: boolean
+  renderedRanges: [number, number][]
+  rows: number
+}
+
+type RevealRenderDebug = {
+  installProbe: () => boolean
+  setPaused: (paused: boolean) => boolean
+  dirtyModelLikeReveal: () => boolean
+  plainRefresh: () => void
+  runRealRevealRepaint: () => void
+  read: () => RenderProbeResult
+}
+
+type RevealProbeWindow = Window & {
+  __revealRenderProbe?: RevealRenderDebug
+}
+
+/**
+ * Installs an in-page probe that instruments the active pane's REAL xterm
+ * RenderService. Everything here runs against production objects; the only
+ * test-only code is the recording wrapper around `_renderRows` and the manual
+ * flip of `_isPaused` that stands in for the observer-lag race.
+ */
+async function installRevealRenderProbe(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((tabId) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!manager || !pane) {
+      throw new Error('No active pane for reveal render probe')
+    }
+
+    type PausableRenderService = {
+      _isPaused?: boolean
+      _needsFullRefresh?: boolean
+      _renderRows?: (start: number, end: number) => void
+      __revealProbeRanges?: [number, number][]
+      __revealProbeInstalled?: boolean
+    }
+    type TerminalInternals = {
+      rows?: number
+      _core?: { _renderService?: PausableRenderService }
+      buffer?: { active?: { getLine?: (y: number) => unknown } }
+      refresh?: (start: number, end: number) => void
+    }
+
+    const terminal = pane.terminal as unknown as TerminalInternals
+    const service = terminal._core?._renderService
+    if (!service || typeof service._renderRows !== 'function') {
+      throw new Error('Real RenderService._renderRows unavailable — cannot probe')
+    }
+
+    const debug: RevealRenderDebug = {
+      installProbe: () => {
+        if (service.__revealProbeInstalled) {
+          service.__revealProbeRanges = []
+          return true
+        }
+        service.__revealProbeRanges = []
+        const original = service._renderRows!.bind(service)
+        service._renderRows = (start: number, end: number): void => {
+          service.__revealProbeRanges!.push([start, end])
+          original(start, end)
+        }
+        service.__revealProbeInstalled = true
+        return true
+      },
+      setPaused: (paused: boolean) => {
+        service._isPaused = paused
+        return service._isPaused === paused
+      },
+      dirtyModelLikeReveal: () => {
+        // Why: reveal clears the WebGL render model so a full rebuild is forced.
+        // clearTextureAtlas() routes through RenderService and, crucially, also
+        // requests a redraw — which is exactly what the paused gate then eats.
+        const withAtlas = pane as unknown as {
+          webglAddon?: { clearTextureAtlas?: () => void }
+        }
+        withAtlas.webglAddon?.clearTextureAtlas?.()
+        return true
+      },
+      plainRefresh: () => {
+        const rows = terminal.rows ?? 0
+        terminal.refresh?.(0, Math.max(0, rows - 1))
+      },
+      runRealRevealRepaint: () => {
+        // The real production reveal path — contains the fix under test.
+        manager.resetWebglTextureAtlases()
+      },
+      read: () => ({
+        paused: service._isPaused === true,
+        renderedRanges: (service.__revealProbeRanges ?? []).slice(),
+        rows: terminal.rows ?? 0
+      })
+    }
+
+    ;(window as RevealProbeWindow).__revealRenderProbe = debug
+  }, tabId)
+}
+
+async function probeRead(page: Page): Promise<RenderProbeResult> {
+  return page.evaluate(() => {
+    const probe = (window as RevealProbeWindow).__revealRenderProbe
+    if (!probe) {
+      throw new Error('Reveal render probe not installed')
+    }
+    return probe.read()
+  })
+}
+
+async function probeCall(
+  page: Page,
+  method:
+    | 'installProbe'
+    | 'setPaused'
+    | 'dirtyModelLikeReveal'
+    | 'plainRefresh'
+    | 'runRealRevealRepaint',
+  paused?: boolean
+): Promise<void> {
+  await page.evaluate(
+    ({ method, paused }) => {
+      const probe = (window as RevealProbeWindow).__revealRenderProbe
+      if (!probe) {
+        throw new Error('Reveal render probe not installed')
+      }
+      if (method === 'setPaused') {
+        probe.setPaused(paused ?? false)
+        return
+      }
+      ;(probe[method] as () => void)()
+    },
+    { method, paused }
+  )
+}
+
+async function forceWebglOn(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const state = window.__store?.getState()
+    if (state?.settings) {
+      window.__store?.setState({
+        settings: { ...state.settings, terminalGpuAcceleration: 'on' }
+      })
+    }
+    window.__paneManagers?.get(id)?.setTerminalGpuAcceleration?.('on')
+  }, tabId)
+}
+
+test.describe('terminal reveal paused-render recovery', () => {
+  test("reveal repaint forces a render through xterm's paused gate", async ({ orcaPage }) => {
+    // Why: __store / __paneManagers live on the main Orca renderer window
+    // (orcaPage), not Playwright's default first page.
+    const page = orcaPage
+    await waitForSessionReady(page)
+    await waitForActiveTerminalManager(page)
+    const tabId = (await getActiveTabId(page))!
+    const ptyId = await waitForActivePanePtyId(page)
+
+    await forceWebglOn(page, tabId)
+
+    // Fill the viewport down to the bottom so a swallowed repaint is observable
+    // both in the render ranges and on-screen.
+    await execInTerminal(
+      page,
+      ptyId,
+      `for i in $(seq 1 40); do echo "line $i ${BOTTOM_MARKER}_$i"; done`
+    )
+    await waitForTerminalOutput(page, `${BOTTOM_MARKER}_40`)
+    // Clear-screen + reprint so the marker sits on the real bottom rows.
+    await execInTerminal(
+      page,
+      ptyId,
+      `clear; printf '%s\\n' "$(seq 1 30)"; echo "${BOTTOM_MARKER}_FINAL"`
+    )
+    await waitForTerminalOutput(page, `${BOTTOM_MARKER}_FINAL`)
+
+    const revealed = await captureStableTabScreenshot(page, tabId)
+
+    await installRevealRenderProbe(page, tabId)
+    await probeCall(page, 'installProbe')
+
+    // ---- Control: prove the bug. This sequence (clearTextureAtlas + refresh)
+    // is byte-for-byte the PRE-FIX resetWebglTextureAtlas on origin/main, so it
+    // faithfully replays the old reveal path. While paused, it renders nothing.
+    await probeCall(page, 'setPaused', true)
+    await probeCall(page, 'dirtyModelLikeReveal')
+    await probeCall(page, 'plainRefresh')
+    // Give any (non-existent) queued render a frame to land.
+    await page.waitForTimeout(80)
+    const afterPlainRefresh = await probeRead(page)
+
+    expect(afterPlainRefresh.paused, 'terminal is in the paused-render state').toBe(true)
+    expect(
+      afterPlainRefresh.renderedRanges,
+      'BUG REPRODUCED: while paused, plain refresh() is swallowed by the gate — no render fires'
+    ).toHaveLength(0)
+
+    // ---- Fix: the real reveal repaint must force a full render through the gate.
+    await probeCall(page, 'setPaused', true)
+    await probeCall(page, 'dirtyModelLikeReveal')
+    await probeCall(page, 'runRealRevealRepaint')
+    await page.waitForTimeout(80)
+    const afterRealReveal = await probeRead(page)
+
+    expect(
+      afterRealReveal.renderedRanges.length,
+      'FIX: reveal repaint drove at least one render despite the paused gate'
+    ).toBeGreaterThan(0)
+
+    const fullViewportRender = afterRealReveal.renderedRanges.some(
+      ([start, end]) => start === 0 && end >= afterRealReveal.rows - 1
+    )
+    expect(
+      fullViewportRender,
+      'FIX: reveal repaint rendered the FULL viewport (0..rows-1), not a partial range'
+    ).toBe(true)
+
+    expect(
+      afterRealReveal.paused,
+      'FIX: pause latch is cleared so the observer can reassert authority cleanly'
+    ).toBe(false)
+
+    // ---- Pixel-level confirmation: the surface still shows the correct content
+    // after being driven through the paused gate (no stale/blank bottom rows).
+    const afterFix = await captureStableTabScreenshot(page, tabId)
+    const diff = compareTerminalScreenshots(revealed, afterFix)
+    expect(
+      diff.matches,
+      `recovered surface matches the revealed content (diffRatio=${diff.diffRatio})`
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

When switching back to a workspace/tab, a TUI (e.g. Claude Code) sometimes shows **stale/missing rows near the bottom** that only reappear when you right-click-drag to select the missing area. It happens more often when the machine is under load.

## Root cause

On reveal, `resetWebglTextureAtlas` (`pane-webgl-renderer.ts`) clears xterm's WebGL render model (`clearTextureAtlas()`) and calls `terminal.refresh(0, rows-1)` to force a full repaint from the buffer.

But xterm's `RenderService.refreshRows()` has an early-return gated on its **IntersectionObserver**:

```ts
public refreshRows(start, end, sync = false, ...) {
  if (this._isPaused) {           // observer hasn't reported the pane as intersecting yet
    this._needsFullRefresh = true;
    return;                       // <-- our refresh() is swallowed
  }
  ...
}
```

When a pane is revealed it is DOM-visible, but the observer's callback can lag a frame (more likely under load, when layout/overlay settle is slower). In that window `_isPaused` is still `true`, so the reveal-repaint's `refresh()` just latches `_needsFullRefresh` and returns. The freshly-cleared model never repaints, and the canvas keeps compositing pre-hide pixels. A drag-select recovers it because `handleSelectionChanged` drives a render that isn't behind the same gate.

Note the `sync: true` path (already used by the foreground render-settle) does **not** help — the `_isPaused` check runs *before* the `sync` branch.

## Fix

Add `forceRepaintThroughRenderPause()`: when the render service is paused, clear the pause latch and drive **one synchronous full-viewport render** ourselves, rather than waiting on the observer. xterm's observer reasserts authority on its next callback (it always recomputes `_isPaused` from the entry), so the transient clear is self-correcting.

`resetWebglTextureAtlas` now calls this first and only falls back to `terminal.refresh()` when the terminal wasn't gated (preserving current behavior for DOM-rendered panes and non-xterm targets).

All internal access is behind `typeof` guards and `try/catch`: an xterm upgrade that renames these internals **degrades to the existing `refresh()` path** instead of throwing into a render frame.

## Testing

- New unit suite `terminal-render-pause-release.test.ts` (5 tests): paused → forces `refreshRows(0, rows-1, true)` + clears both latches; not-paused → untouched, returns false; missing internals → false; invalid row count → false; forced render throws → false but latch still cleared.
- Existing `pane-reveal-repaint` and `pane-webgl-renderer` suites still pass (fake terminals have no render service → fall through to `refresh()` unchanged).
- `pnpm typecheck` + `oxlint` clean.

## Notes

This is a general fix (the paused-render gate is upstream xterm, and the reveal-repaint machinery is identical on `main`), so it targets `main` rather than the `orca-performance` branch. It also plausibly addresses the teammate-reproduced garbled/glyph output when pasting right after the app was unfocused — same paused-render-gate class.

Made with [Orca](https://github.com/stablyai/orca) 🐋
