### PR TITLE
perf(daemon): reap idle legacy daemons and self-exit at zero sessions

### DIFF
--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -126,7 +126,12 @@ async function main(): Promise<void> {
     socketPath,
     tokenPath,
     log: daemonLog,
-    spawnSubprocess: (opts) => createPtySubprocess(opts)
+    spawnSubprocess: (opts) => createPtySubprocess(opts),
+    // Why: with zero sessions and zero clients the daemon is pure idle memory
+    // (see daemon-idle-exit.ts for the grace rationale). The server has
+    // already shut down cleanly when this fires, so exit(0) only reaps the
+    // process; next launch spawns a fresh daemon via the dead-socket path.
+    onIdleExit: () => process.exit(0)
   })
 
   // Signal readiness to parent via IPC (if available)

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -131,7 +131,10 @@ async function main(): Promise<void> {
     // (see daemon-idle-exit.ts for the grace rationale). The server has
     // already shut down cleanly when this fires, so exit(0) only reaps the
     // process; next launch spawns a fresh daemon via the dead-socket path.
-    onIdleExit: () => process.exit(0)
+    onIdleExit: () => {
+      daemonLog.close()
+      process.exit(0)
+    }
   })
 
   // Signal readiness to parent via IPC (if available)

--- a/src/main/daemon/daemon-idle-exit.test.ts
+++ b/src/main/daemon/daemon-idle-exit.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DAEMON_IDLE_EXIT_GRACE_MS, DaemonIdleExit } from './daemon-idle-exit'
+
+const GRACE_MS = 1_000
+
+function createIdleExit(opts: { graceMs?: number } = {}): {
+  idleExit: DaemonIdleExit
+  onExpired: ReturnType<typeof vi.fn>
+  setIdle: (value: boolean) => void
+} {
+  let idle = true
+  const onExpired = vi.fn()
+  const idleExit = new DaemonIdleExit({
+    isIdle: () => idle,
+    onExpired,
+    ...(opts.graceMs !== undefined ? { graceMs: opts.graceMs } : {})
+  })
+  return {
+    idleExit,
+    onExpired,
+    setIdle: (value: boolean) => {
+      idle = value
+    }
+  }
+}
+
+describe('DaemonIdleExit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires onExpired only after the full grace period while idle', () => {
+    const { idleExit, onExpired } = createIdleExit({ graceMs: GRACE_MS })
+
+    idleExit.evaluate()
+    expect(idleExit.isArmed()).toBe(true)
+
+    vi.advanceTimersByTime(GRACE_MS - 1)
+    expect(onExpired).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(onExpired).toHaveBeenCalledTimes(1)
+    expect(idleExit.isArmed()).toBe(false)
+  })
+
+  it('does not arm while non-idle', () => {
+    const { idleExit, onExpired, setIdle } = createIdleExit({ graceMs: GRACE_MS })
+    setIdle(false)
+
+    idleExit.evaluate()
+
+    expect(idleExit.isArmed()).toBe(false)
+    vi.advanceTimersByTime(GRACE_MS * 10)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('cancels a pending countdown when evaluated non-idle, then re-arms once idle again', () => {
+    const { idleExit, onExpired, setIdle } = createIdleExit({ graceMs: GRACE_MS })
+    idleExit.evaluate()
+    expect(idleExit.isArmed()).toBe(true)
+
+    setIdle(false)
+    idleExit.evaluate()
+    expect(idleExit.isArmed()).toBe(false)
+    vi.advanceTimersByTime(GRACE_MS * 2)
+    expect(onExpired).not.toHaveBeenCalled()
+
+    setIdle(true)
+    idleExit.evaluate()
+    vi.advanceTimersByTime(GRACE_MS)
+    expect(onExpired).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the original deadline on redundant idle evaluations', () => {
+    const { idleExit, onExpired } = createIdleExit({ graceMs: GRACE_MS })
+    idleExit.evaluate()
+
+    vi.advanceTimersByTime(GRACE_MS / 2)
+    idleExit.evaluate()
+
+    // A deadline-extending implementation would need another full grace here.
+    vi.advanceTimersByTime(GRACE_MS / 2)
+    expect(onExpired).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses to expire when idleness was lost without an evaluate call', () => {
+    const { idleExit, onExpired, setIdle } = createIdleExit({ graceMs: GRACE_MS })
+    idleExit.evaluate()
+
+    // Simulate a missed cancel path: state became non-idle but nobody called
+    // evaluate(). The fire-time re-check must keep the daemon alive.
+    setIdle(false)
+    vi.advanceTimersByTime(GRACE_MS)
+    expect(onExpired).not.toHaveBeenCalled()
+
+    // Recovery stays event-driven: the next idle evaluate re-arms.
+    setIdle(true)
+    idleExit.evaluate()
+    vi.advanceTimersByTime(GRACE_MS)
+    expect(onExpired).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispose cancels the countdown and blocks future arming', () => {
+    const { idleExit, onExpired } = createIdleExit({ graceMs: GRACE_MS })
+    idleExit.evaluate()
+
+    idleExit.dispose()
+    expect(idleExit.isArmed()).toBe(false)
+    vi.advanceTimersByTime(GRACE_MS * 2)
+
+    idleExit.evaluate()
+    expect(idleExit.isArmed()).toBe(false)
+    vi.advanceTimersByTime(GRACE_MS * 2)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('defaults to the 10-minute grace period', () => {
+    const { idleExit, onExpired } = createIdleExit()
+    idleExit.evaluate()
+
+    vi.advanceTimersByTime(DAEMON_IDLE_EXIT_GRACE_MS - 1)
+    expect(onExpired).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onExpired).toHaveBeenCalledTimes(1)
+  })
+
+  it('unrefs the countdown so it cannot keep the daemon process alive', () => {
+    vi.useRealTimers()
+    const { idleExit } = createIdleExit({ graceMs: 60_000 })
+    try {
+      idleExit.evaluate()
+      const timer = (idleExit as unknown as { timer: NodeJS.Timeout | null }).timer
+      expect(timer?.hasRef()).toBe(false)
+    } finally {
+      idleExit.dispose()
+    }
+  })
+})

--- a/src/main/daemon/daemon-idle-exit.ts
+++ b/src/main/daemon/daemon-idle-exit.ts
@@ -1,0 +1,76 @@
+// Why 10 minutes: the daemon's only job is holding PTY sessions across app
+// restarts/updates, so at 0 sessions there is nothing to preserve — the grace
+// only needs to outlast the reconnect window of an app update or restart
+// (seconds to a couple of minutes) plus headroom for a badly stalled machine,
+// while still bounding how long an orphaned daemon pins node + node-pty memory.
+export const DAEMON_IDLE_EXIT_GRACE_MS = 10 * 60 * 1000
+
+export type DaemonIdleExitOptions = {
+  /** Must return true only when the daemon holds zero sessions AND zero
+   *  connected clients. Re-checked at fire time, not just at arm time. */
+  isIdle: () => boolean
+  onExpired: () => void
+  graceMs?: number
+}
+
+/**
+ * Arms a single unref'd countdown whenever the daemon becomes idle and cancels
+ * it on any transition back to non-idle. Event-driven only — the owner calls
+ * evaluate() on every client/session count change; there is no polling.
+ */
+export class DaemonIdleExit {
+  private readonly isIdle: () => boolean
+  private readonly onExpired: () => void
+  private readonly graceMs: number
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private disposed = false
+
+  constructor(opts: DaemonIdleExitOptions) {
+    this.isIdle = opts.isIdle
+    this.onExpired = opts.onExpired
+    this.graceMs = opts.graceMs ?? DAEMON_IDLE_EXIT_GRACE_MS
+  }
+
+  evaluate(): void {
+    if (this.disposed) {
+      return
+    }
+    if (!this.isIdle()) {
+      this.cancel()
+      return
+    }
+    if (this.timer) {
+      // Why: the grace period measures time since the daemon *became* idle;
+      // redundant idle evaluations must not push the deadline out.
+      return
+    }
+    this.timer = setTimeout(() => {
+      this.timer = null
+      // Why: fail-safe re-check — if a future code change misses a cancel
+      // path, a daemon that gained a session or client since arming must keep
+      // running rather than exit and kill live terminals.
+      if (!this.disposed && this.isIdle()) {
+        this.onExpired()
+      }
+    }, this.graceMs)
+    // Why: an armed idle countdown must never be the thing keeping the daemon
+    // process alive once its server has otherwise drained.
+    this.timer.unref?.()
+  }
+
+  isArmed(): boolean {
+    return this.timer !== null
+  }
+
+  dispose(): void {
+    this.disposed = true
+    this.cancel()
+  }
+
+  private cancel(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+}

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -723,11 +723,126 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       }
     })
 
+    // Why: legacy adoption now verifies live-session count first — seed one
+    // alive session so the v9 daemon qualifies for adoption.
+    const legacyRequests: string[] = []
+    daemonClientMock.mockImplementationOnce(function MockLegacyDaemonClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        request: vi.fn(async (method: string) => {
+          legacyRequests.push(method)
+          return { sessions: [{ sessionId: 'legacy-live', isAlive: true }] }
+        }),
+        disconnect: vi.fn()
+      }
+    })
+
     await mod.initDaemonPtyProvider()
 
     const { DaemonPtyRouter } = await import('./daemon-pty-router')
     expect(mod.getDaemonProvider()).toBeInstanceOf(DaemonPtyRouter)
     expect(adapterInstances.some((instance) => instance.protocolVersion === 9)).toBe(true)
+    // A legacy daemon that owns live sessions must never be shut down.
+    expect(legacyRequests).not.toContain('shutdown')
+    expect(killStaleDaemonMock).not.toHaveBeenCalled()
+  })
+
+  it('shuts down an alive legacy daemon with zero live sessions instead of adopting it', async () => {
+    const mod = await importFresh()
+    probeSocketExistsMock.mockImplementation((p?: string) => p?.endsWith('daemon-v9.sock') ?? false)
+    netConnectMock.mockImplementation(() => {
+      const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+      return {
+        on(event: string, cb: () => void) {
+          handlers[event]?.push(cb)
+          if (event === 'connect') {
+            queueMicrotask(() => cb())
+          }
+          return this
+        },
+        removeListener(event: string, cb: () => void) {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+          return this
+        },
+        destroy() {}
+      }
+    })
+    // Two DaemonClient constructions: the session-count query, then the
+    // cleanup client that issues the shutdown RPC.
+    const legacyRequests: [string, unknown][] = []
+    const makeLegacyClient = function MockLegacyDaemonClient(): unknown {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        request: vi.fn(async (method: string, payload: unknown) => {
+          legacyRequests.push([method, payload])
+          if (method === 'listSessions') {
+            // Why a dead entry instead of []: proves the isAlive filter gates
+            // reaping, not mere list emptiness.
+            return { sessions: [{ sessionId: 'legacy-dead', isAlive: false }] }
+          }
+          return {}
+        }),
+        disconnect: vi.fn()
+      }
+    }
+    daemonClientMock.mockImplementationOnce(makeLegacyClient)
+    daemonClientMock.mockImplementationOnce(makeLegacyClient)
+
+    await mod.initDaemonPtyProvider()
+
+    expect(daemonClientMock).toHaveBeenCalledWith({
+      socketPath: '/fake/daemon/daemon-v9.sock',
+      tokenPath: '/fake/daemon/daemon-v9.token',
+      protocolVersion: 9
+    })
+    expect(legacyRequests).toContainEqual(['shutdown', { killSessions: true }])
+    // The shutdown RPC path succeeded — no PID-based fallback kill.
+    expect(killStaleDaemonMock).not.toHaveBeenCalled()
+    // Not adopted: no legacy adapter, so the provider is a bare adapter.
+    expect(adapterInstances.some((instance) => instance.protocolVersion === 9)).toBe(false)
+    const { DaemonPtyRouter } = await import('./daemon-pty-router')
+    expect(mod.getDaemonProvider()).not.toBeInstanceOf(DaemonPtyRouter)
+  })
+
+  it('adopts a legacy daemon unchanged when the session-count query fails', async () => {
+    const mod = await importFresh()
+    probeSocketExistsMock.mockImplementation((p?: string) => p?.endsWith('daemon-v9.sock') ?? false)
+    netConnectMock.mockImplementation(() => {
+      const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+      return {
+        on(event: string, cb: () => void) {
+          handlers[event]?.push(cb)
+          if (event === 'connect') {
+            queueMicrotask(() => cb())
+          }
+          return this
+        },
+        removeListener(event: string, cb: () => void) {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+          return this
+        },
+        destroy() {}
+      }
+    })
+    const requestMock = vi.fn(async () => ({ sessions: [] }))
+    daemonClientMock.mockImplementationOnce(function MockWedgedLegacyDaemonClient() {
+      return {
+        ensureConnected: vi.fn(async () => {
+          throw new Error('legacy daemon not responding')
+        }),
+        request: requestMock,
+        disconnect: vi.fn()
+      }
+    })
+
+    await mod.initDaemonPtyProvider()
+
+    // Fail-safe: unverifiable session state must adopt exactly as before.
+    const { DaemonPtyRouter } = await import('./daemon-pty-router')
+    expect(mod.getDaemonProvider()).toBeInstanceOf(DaemonPtyRouter)
+    expect(adapterInstances.some((instance) => instance.protocolVersion === 9)).toBe(true)
+    expect(requestMock).not.toHaveBeenCalledWith('shutdown', expect.anything())
+    expect(killStaleDaemonMock).not.toHaveBeenCalled()
   })
 
   it('restart path with no legacy adapters yields a bare DaemonPtyAdapter (not wrapped in a router)', async () => {

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -845,6 +845,53 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(killStaleDaemonMock).not.toHaveBeenCalled()
   })
 
+  it('bounds an unresponsive legacy session query and fail-safe adopts the daemon', async () => {
+    vi.useFakeTimers()
+    try {
+      const mod = await importFresh()
+      probeSocketExistsMock.mockImplementation(
+        (p?: string) => p?.endsWith('daemon-v9.sock') ?? false
+      )
+      netConnectMock.mockImplementation(() => {
+        const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+        return {
+          on(event: string, cb: () => void) {
+            handlers[event]?.push(cb)
+            if (event === 'connect') {
+              queueMicrotask(() => cb())
+            }
+            return this
+          },
+          removeListener(event: string, cb: () => void) {
+            handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+            return this
+          },
+          destroy() {}
+        }
+      })
+      const disconnectMock = vi.fn()
+      daemonClientMock.mockImplementationOnce(function MockHungLegacyDaemonClient() {
+        return {
+          ensureConnected: vi.fn(async () => {}),
+          request: vi.fn(() => new Promise<never>(() => {})),
+          disconnect: disconnectMock
+        }
+      })
+
+      const initPromise = mod.initDaemonPtyProvider()
+      await vi.advanceTimersByTimeAsync(1000)
+      await initPromise
+
+      const { DaemonPtyRouter } = await import('./daemon-pty-router')
+      expect(mod.getDaemonProvider()).toBeInstanceOf(DaemonPtyRouter)
+      expect(adapterInstances.some((instance) => instance.protocolVersion === 9)).toBe(true)
+      expect(disconnectMock).toHaveBeenCalledOnce()
+      expect(killStaleDaemonMock).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('restart path with no legacy adapters yields a bare DaemonPtyAdapter (not wrapped in a router)', async () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -74,6 +74,7 @@ let adapter: DaemonProvider | null = null
 // the second entry would read the already-disposed current adapter and
 // race cleanupDaemonForProtocol against a half-spawned replacement.
 let restartInFlight: Promise<RestartDaemonResult> | null = null
+const LEGACY_SESSION_QUERY_TIMEOUT_MS = 1000
 
 function getRuntimeDir(): string {
   const dir = join(app.getPath('userData'), 'daemon')
@@ -160,13 +161,31 @@ async function getAliveDaemonSessionCount(
   protocolVersion = PROTOCOL_VERSION
 ): Promise<number | null> {
   const client = new DaemonClient({ socketPath, tokenPath, protocolVersion })
+  let timeout: ReturnType<typeof setTimeout> | null = null
   try {
-    await client.ensureConnected()
-    const result = await client.request<ListSessionsResult>('listSessions', undefined)
+    // Why: legacy versions are checked serially during startup. A daemon that
+    // accepts sockets but stops answering RPCs must fail-safe to adoption
+    // promptly instead of multiplying the client's 30s timeout by versions.
+    const result = await Promise.race([
+      (async () => {
+        await client.ensureConnected()
+        return client.request<ListSessionsResult>('listSessions', undefined)
+      })(),
+      new Promise<null>((resolve) => {
+        timeout = setTimeout(() => resolve(null), LEGACY_SESSION_QUERY_TIMEOUT_MS)
+        timeout.unref?.()
+      })
+    ])
+    if (!result) {
+      return null
+    }
     return result.sessions.filter((session) => session.isAlive).length
   } catch {
     return null
   } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
     client.disconnect()
   }
 }

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -891,6 +891,24 @@ async function createLegacyDaemonAdapters(runtimeDir: string): Promise<DaemonPty
       }
       continue
     }
+    // Why: an alive legacy daemon with zero live sessions has nothing left to
+    // preserve, but adoption would pin its node + node-pty processes forever —
+    // every protocol bump re-adopts it on the next launch. Reap it through the
+    // existing shutdown/cleanup path instead. A failed session-count query
+    // (null) fail-safes to adoption exactly as before, so a daemon whose
+    // sessions cannot be verified is never killed.
+    const liveSessionCount = await getAliveDaemonSessionCount(
+      socketPath,
+      tokenPath,
+      protocolVersion
+    )
+    if (liveSessionCount === 0) {
+      console.warn(
+        `[daemon] Shutting down idle legacy daemon (protocol v${protocolVersion}) with no live sessions`
+      )
+      await cleanupDaemonForProtocol(runtimeDir, protocolVersion)
+      continue
+    }
     // Why: old daemon PTYs can be running long-lived agents during an app
     // upgrade. Keep those sessions routed to their original daemon while new
     // terminals use the current protocol, instead of killing background work.

--- a/src/main/daemon/daemon-main.test.ts
+++ b/src/main/daemon/daemon-main.test.ts
@@ -74,6 +74,28 @@ describe('startDaemon', () => {
     client.disconnect()
   })
 
+  it('passes idle-exit options through to the server', async () => {
+    let resolveExited!: () => void
+    const idleExited = new Promise<void>((resolve) => {
+      resolveExited = resolve
+    })
+    const onIdleExit = vi.fn(() => resolveExited())
+    daemon = await startDaemon({
+      socketPath,
+      tokenPath,
+      spawnSubprocess: () => createMockSubprocess(),
+      onIdleExit,
+      idleExitGraceMs: 40
+    })
+
+    await idleExited
+
+    expect(onIdleExit).toHaveBeenCalledTimes(1)
+    // The idle exit already shut the server down — connections are refused.
+    const client = new DaemonClient({ socketPath, tokenPath })
+    await expect(client.ensureConnected()).rejects.toThrow()
+  })
+
   it('shuts down cleanly', async () => {
     daemon = await startDaemon({
       socketPath,

--- a/src/main/daemon/daemon-main.ts
+++ b/src/main/daemon/daemon-main.ts
@@ -6,6 +6,8 @@ export type DaemonStartOptions = {
   tokenPath: string
   spawnSubprocess: DaemonServerOptions['spawnSubprocess']
   log?: DaemonFileLog
+  onIdleExit?: DaemonServerOptions['onIdleExit']
+  idleExitGraceMs?: DaemonServerOptions['idleExitGraceMs']
 }
 
 export type DaemonHandle = {
@@ -17,7 +19,9 @@ export async function startDaemon(opts: DaemonStartOptions): Promise<DaemonHandl
     socketPath: opts.socketPath,
     tokenPath: opts.tokenPath,
     spawnSubprocess: opts.spawnSubprocess,
-    ...(opts.log ? { log: opts.log } : {})
+    ...(opts.log ? { log: opts.log } : {}),
+    onIdleExit: opts.onIdleExit,
+    idleExitGraceMs: opts.idleExitGraceMs
   })
 
   await server.start()

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'node:os'
+import { createServer as createNetServer } from 'node:net'
 import { join } from 'node:path'
 import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { DaemonClient } from './client'
@@ -1969,6 +1970,36 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       ])
       expect(r1.id).toBeDefined()
       expect(r2.id).toBeDefined()
+      expect(respawnFn).toHaveBeenCalledOnce()
+
+      respawnAdapter.dispose()
+      await respawnServer?.shutdown()
+    })
+
+    it('classifies a socket destroyed before the hello response as daemon-gone and respawns', async () => {
+      // Why: a daemon entering shutdown (idle exit) destroys sockets that were
+      // accepted but had not completed hello. The client surfaces that as
+      // 'Connection closed before hello response', which must trigger the same
+      // respawn-and-retry as a dead socket — not surface to the caller.
+      await server.shutdown()
+      const barrier = createNetServer((socket) => socket.destroy())
+      await new Promise<void>((resolve) => barrier.listen(socketPath, resolve))
+
+      let respawnServer: DaemonServer | undefined
+      const respawnFn = vi.fn(async () => {
+        await new Promise<void>((resolve) => barrier.close(() => resolve()))
+        rmSync(socketPath, { force: true })
+        respawnServer = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => createMockSubprocess()
+        })
+        await respawnServer.start()
+      })
+      const respawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+
+      const result = await respawnAdapter.spawn({ cols: 80, rows: 24 })
+      expect(result.id).toBeDefined()
       expect(respawnFn).toHaveBeenCalledOnce()
 
       respawnAdapter.dispose()

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1341,6 +1341,19 @@ function isDaemonGoneError(err: unknown): boolean {
   if ((errno.code === 'ENOENT' || errno.code === 'ECONNREFUSED') && errno.syscall === 'connect') {
     return true
   }
+  // Why: a daemon entering shutdown (idle exit) destroys sockets that were
+  // accepted but had not completed hello. Depending on whether the client's
+  // hello write had flushed, that surfaces as EPIPE on the write or as a clean
+  // close before the hello reply — both mean the daemon is going away and a
+  // respawn should be attempted. Hello *rejections* (bad token/version) reply
+  // ok:false with different messages, so they can never trigger a respawn.
+  if (errno.code === 'EPIPE' && errno.syscall === 'write') {
+    return true
+  }
   const msg = err.message
-  return msg === 'Connection lost' || msg === 'Not connected'
+  return (
+    msg === 'Connection lost' ||
+    msg === 'Not connected' ||
+    msg === 'Connection closed before hello response'
+  )
 }

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -640,6 +640,49 @@ describe('DaemonServer', () => {
       expect(onIdleExit).not.toHaveBeenCalled()
     })
 
+    it('destroys a pre-hello socket at idle exit instead of letting it hold the daemon open', async () => {
+      // Why: sockets that never complete hello are invisible to the client
+      // map. Without the shutdown barrier they would keep server.close() —
+      // and therefore onIdleExit — pending forever (zombie daemon), or worse,
+      // complete hello against a half-shut server.
+      const { idleExited, onIdleExit } = await startServerWithIdleExit(200)
+
+      const rawSocket = connect(socketPath)
+      const rawClosed = new Promise<void>((resolve) => rawSocket.once('close', resolve))
+      rawSocket.on('error', () => {})
+
+      await idleExited
+      await rawClosed
+
+      expect(onIdleExit).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses hello and createOrAttach once shutdown has begun', async () => {
+      const spawned: unknown[] = []
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        spawnSubprocess: () => {
+          const subprocess = createMockSubprocess()
+          spawned.push(subprocess)
+          return subprocess
+        }
+      })
+      await server.start()
+      await server.shutdown()
+
+      const daemon = server as unknown as DaemonServerPrivate
+      await expect(
+        daemon.routeRequest('late-client', {
+          id: 'req-late-1',
+          type: 'createOrAttach',
+          payload: { sessionId: 'late-session', cols: 80, rows: 24 }
+        })
+      ).rejects.toThrow(/shutting down/)
+      expect(spawned).toHaveLength(0)
+      expect(daemon.clients.size).toBe(0)
+    })
+
     it('never fires while a session is alive and exits after the last session ends', async () => {
       const { idleExited, onIdleExit, lastSubprocess } = await startServerWithIdleExit(75)
       const daemon = server as unknown as DaemonServerPrivate

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -54,6 +54,7 @@ type DaemonServerPrivate = {
       streamSocket: Socket | null
     }
   >
+  idleExit: { isArmed(): boolean } | null
   routeRequest(clientId: string, request: DaemonRequest): Promise<unknown>
 }
 
@@ -580,6 +581,87 @@ describe('DaemonServer', () => {
 
       const c = new DaemonClient({ socketPath, tokenPath })
       await expect(c.ensureConnected()).rejects.toThrow()
+    })
+  })
+
+  describe('idle self-exit', () => {
+    async function startServerWithIdleExit(graceMs: number): Promise<{
+      idleExited: Promise<void>
+      onIdleExit: ReturnType<typeof vi.fn>
+      lastSubprocess: () => ReturnType<typeof createMockSubprocess> | null
+    }> {
+      let resolveExited!: () => void
+      const idleExited = new Promise<void>((resolve) => {
+        resolveExited = resolve
+      })
+      const onIdleExit = vi.fn(() => resolveExited())
+      let subprocess: ReturnType<typeof createMockSubprocess> | null = null
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        spawnSubprocess: () => {
+          subprocess = createMockSubprocess()
+          return subprocess
+        },
+        onIdleExit,
+        idleExitGraceMs: graceMs
+      })
+      await server.start()
+      return { idleExited, onIdleExit, lastSubprocess: () => subprocess }
+    }
+
+    function idleArmed(): boolean {
+      return (server as unknown as DaemonServerPrivate).idleExit?.isArmed() ?? false
+    }
+
+    it('shuts down cleanly and calls onIdleExit after the grace period with no clients and no sessions', async () => {
+      const { idleExited, onIdleExit } = await startServerWithIdleExit(40)
+
+      await idleExited
+
+      expect(onIdleExit).toHaveBeenCalledTimes(1)
+      // The clean shutdown ran before onIdleExit — the socket no longer accepts.
+      client = new DaemonClient({ socketPath, tokenPath })
+      await expect(client.ensureConnected()).rejects.toThrow()
+    })
+
+    it('is canceled by a client connect and re-armed by the disconnect', async () => {
+      // Why a huge grace: these assertions are about arm/cancel wiring, which
+      // is observable deterministically — the countdown must never actually
+      // fire during this test. Timing semantics live in daemon-idle-exit.test.
+      const { onIdleExit } = await startServerWithIdleExit(60_000)
+      expect(idleArmed()).toBe(true)
+
+      const control = await connectRawHello('control', 'idle-exit-client')
+      expect(idleArmed()).toBe(false)
+
+      control.destroy()
+      await waitFor(() => idleArmed())
+      expect(onIdleExit).not.toHaveBeenCalled()
+    })
+
+    it('never fires while a session is alive and exits after the last session ends', async () => {
+      const { idleExited, onIdleExit, lastSubprocess } = await startServerWithIdleExit(75)
+      const daemon = server as unknown as DaemonServerPrivate
+
+      // Create a session with zero connected clients — the exact state the
+      // daemon exists for (holding sessions across app restarts).
+      await daemon.routeRequest('ghost-client', {
+        id: 'req-idle-1',
+        type: 'createOrAttach',
+        payload: { sessionId: 'idle-session', cols: 80, rows: 24 }
+      })
+      expect(idleArmed()).toBe(false)
+
+      // Bounded real-time check on top of the deterministic assertion above:
+      // 3x the grace elapses and the daemon must still be running.
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      expect(onIdleExit).not.toHaveBeenCalled()
+
+      lastSubprocess()?._simulateExit(0)
+
+      await idleExited
+      expect(onIdleExit).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -585,7 +585,10 @@ describe('DaemonServer', () => {
   })
 
   describe('idle self-exit', () => {
-    async function startServerWithIdleExit(graceMs: number): Promise<{
+    async function startServerWithIdleExit(
+      graceMs: number,
+      opts: { beforeStart?: (srv: DaemonServer) => Promise<void> } = {}
+    ): Promise<{
       idleExited: Promise<void>
       onIdleExit: ReturnType<typeof vi.fn>
       lastSubprocess: () => ReturnType<typeof createMockSubprocess> | null
@@ -606,6 +609,7 @@ describe('DaemonServer', () => {
         onIdleExit,
         idleExitGraceMs: graceMs
       })
+      await opts.beforeStart?.(server)
       await server.start()
       return { idleExited, onIdleExit, lastSubprocess: () => subprocess }
     }
@@ -684,15 +688,20 @@ describe('DaemonServer', () => {
     })
 
     it('never fires while a session is alive and exits after the last session ends', async () => {
-      const { idleExited, onIdleExit, lastSubprocess } = await startServerWithIdleExit(75)
-      const daemon = server as unknown as DaemonServerPrivate
-
-      // Create a session with zero connected clients — the exact state the
-      // daemon exists for (holding sessions across app restarts).
-      await daemon.routeRequest('ghost-client', {
-        id: 'req-idle-1',
-        type: 'createOrAttach',
-        payload: { sessionId: 'idle-session', cols: 80, rows: 24 }
+      // Why seed the session before start(): start() is what arms the
+      // countdown, so with a session already present the timer never arms at
+      // all. The invariant is proven deterministically instead of racing a
+      // cancel against a short grace on a loaded machine.
+      const { idleExited, onIdleExit, lastSubprocess } = await startServerWithIdleExit(75, {
+        beforeStart: async (srv) => {
+          // A session with zero connected clients — the exact state the
+          // daemon exists for (holding sessions across app restarts).
+          await (srv as unknown as DaemonServerPrivate).routeRequest('ghost-client', {
+            id: 'req-idle-1',
+            type: 'createOrAttach',
+            payload: { sessionId: 'idle-session', cols: 80, rows: 24 }
+          })
+        }
       })
       expect(idleArmed()).toBe(false)
 

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -55,6 +55,7 @@ type DaemonServerPrivate = {
     }
   >
   idleExit: { isArmed(): boolean } | null
+  shuttingDown: boolean
   routeRequest(clientId: string, request: DaemonRequest): Promise<unknown>
 }
 
@@ -684,6 +685,42 @@ describe('DaemonServer', () => {
         })
       ).rejects.toThrow(/shutting down/)
       expect(spawned).toHaveLength(0)
+      expect(daemon.clients.size).toBe(0)
+    })
+
+    it('destroys sockets that connect or hello after the shutdown barrier is raised', async () => {
+      // Why raise only the flag: while the listener is still accepting, the
+      // handleConnection/handleFirstMessage barriers are the only defense
+      // against a socket becoming a client on a half-shut server.
+      await startServer()
+      const daemon = server as unknown as DaemonServerPrivate
+
+      // Admitted before the barrier, hello still unsent.
+      const preBarrier = connect(socketPath)
+      await new Promise<void>((resolve) => preBarrier.once('connect', resolve))
+      const preBarrierClosed = new Promise<void>((resolve) => preBarrier.once('close', resolve))
+      preBarrier.on('error', () => {})
+
+      daemon.shuttingDown = true
+
+      // A valid late hello must be destroyed unanswered, never registered.
+      preBarrier.write(
+        encodeNdjson({
+          type: 'hello',
+          version: PROTOCOL_VERSION,
+          token: readFileSync(tokenPath, 'utf-8').trim(),
+          clientId: 'late-hello',
+          role: 'control'
+        })
+      )
+      await preBarrierClosed
+      expect(daemon.clients.size).toBe(0)
+
+      // A brand-new connection after the barrier is destroyed on arrival.
+      const postBarrier = connect(socketPath)
+      const postBarrierClosed = new Promise<void>((resolve) => postBarrier.once('close', resolve))
+      postBarrier.on('error', () => {})
+      await postBarrierClosed
       expect(daemon.clients.size).toBe(0)
     })
 

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -8,6 +8,7 @@ import { writeFileSync, chmodSync, unlinkSync } from 'node:fs'
 import { StringDecoder } from 'node:string_decoder'
 import { encodeNdjson, createNdjsonParser } from './ndjson'
 import { TerminalHost } from './terminal-host'
+import { DaemonIdleExit } from './daemon-idle-exit'
 import { DaemonStreamDataBatcher } from './daemon-stream-data-batcher'
 import {
   BackgroundTransientFactRelay,
@@ -35,6 +36,11 @@ export type DaemonServerOptions = {
   tokenPath: string
   ptySpawnHealthCheck?: () => Promise<void>
   log?: DaemonFileLog
+  /** When set, the daemon self-exits (clean shutdown, then this callback)
+   *  after idleExitGraceMs at 0 sessions and 0 connected clients. Omitted in
+   *  tests/embeds that must not tear the server down on their own. */
+  onIdleExit?: () => void
+  idleExitGraceMs?: number
   spawnSubprocess: (opts: {
     sessionId: string
     cols: number
@@ -96,6 +102,7 @@ export class DaemonServer {
   private streamClientIdBySessionId = new Map<string, string>()
   private lastInputAtBySessionId = new Map<string, number>()
   private stopStreamBacklogProbe: () => void = () => {}
+  private idleExit: DaemonIdleExit | null = null
 
   // Why: main-process PTY IPC has the same recent-input bypass, but daemon
   // output reaches main only after this stream layer. Keeping the window here
@@ -108,7 +115,10 @@ export class DaemonServer {
     this.socketPath = opts.socketPath
     this.tokenPath = opts.tokenPath
     this.token = randomUUID()
-    this.host = new TerminalHost({ spawnSubprocess: opts.spawnSubprocess })
+    this.host = new TerminalHost({
+      spawnSubprocess: opts.spawnSubprocess,
+      onSessionCountChange: () => this.idleExit?.evaluate()
+    })
     this.ptySpawnHealthCheck = opts.ptySpawnHealthCheck ?? checkPtySpawnHealth
     this.stopStreamBacklogProbe = startDaemonStreamBacklogProbe(() => ({
       clients: Array.from(this.clients.values(), (client) => ({
@@ -119,6 +129,20 @@ export class DaemonServer {
       backgroundedSessionIdSuffixes: this.transientFactRelay.backgroundedSessionIdSuffixes()
     }))
     this.log = opts.log ?? createNoopDaemonFileLog()
+    const onIdleExit = opts.onIdleExit
+    if (onIdleExit) {
+      this.idleExit = new DaemonIdleExit({
+        graceMs: opts.idleExitGraceMs,
+        // Why: sessions are the daemon's reason to exist and a connected
+        // client means an app is (or is about to start) using this daemon.
+        // Both must be zero before the idle countdown may run.
+        isIdle: () => this.clients.size === 0 && this.host.sessionCount() === 0,
+        onExpired: () => {
+          console.warn('[daemon] No sessions and no clients for the idle grace period — exiting')
+          void this.shutdown().then(() => onIdleExit())
+        }
+      })
+    }
   }
 
   async start(): Promise<void> {
@@ -140,6 +164,9 @@ export class DaemonServer {
         } catch {
           // Best-effort on platforms that support it
         }
+        // Why: a daemon spawned by an app that dies before ever connecting
+        // must still idle-exit; arm the countdown from birth, not first use.
+        this.idleExit?.evaluate()
         resolve()
       })
     })
@@ -148,6 +175,9 @@ export class DaemonServer {
   async shutdown(): Promise<void> {
     this.stopStreamBacklogProbe()
     this.transientFactRelay.dispose()
+    // Why: dispose before teardown mutates client/session counts, so the idle
+    // countdown can never re-arm or fire against a half-shut-down server.
+    this.idleExit?.dispose()
     this.host.dispose()
     this.streamDataBatcher.clear()
 
@@ -228,6 +258,7 @@ export class DaemonServer {
         streamSocket: null
       }
       this.clients.set(hello.clientId, client)
+      this.idleExit?.evaluate()
       this.setupControlSocket(socket, hello.clientId)
       if (previous) {
         // Why: a reconnect can reuse a clientId before the old sockets notice
@@ -269,6 +300,7 @@ export class DaemonServer {
       this.streamDataBatcher.clear(clientId)
       client.streamSocket?.destroy()
       this.clients.delete(clientId)
+      this.idleExit?.evaluate()
     })
   }
 

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -144,14 +144,16 @@ export class DaemonServer {
         // Both must be zero before the idle countdown may run.
         isIdle: () => this.clients.size === 0 && this.host.sessionCount() === 0,
         onExpired: () => {
-          console.warn('[daemon] No sessions and no clients for the idle grace period — exiting')
+          // Why: the detached daemon runs with stdio 'ignore', so the file log
+          // is the only place the exit reason survives for diagnostic bundles.
+          this.log.log('idle-exit')
           // Why: idleness was just verified, so exiting after a failed
           // shutdown cannot lose sessions — but staying alive would strand a
           // half-shut daemon that can never re-arm its idle countdown.
           void this.shutdown().then(
             () => onIdleExit(),
             (err) => {
-              console.error('[daemon] Idle shutdown failed — exiting anyway:', err)
+              this.log.log('idle-exit-shutdown-error', { message: (err as Error)?.message })
               onIdleExit()
             }
           )

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -103,6 +103,12 @@ export class DaemonServer {
   private lastInputAtBySessionId = new Map<string, number>()
   private stopStreamBacklogProbe: () => void = () => {}
   private idleExit: DaemonIdleExit | null = null
+  // Why: sockets accepted but not yet past hello are invisible to `clients`,
+  // so shutdown could otherwise strand them: a late hello would resurrect a
+  // half-shut server, and an open pre-hello socket would hold server.close()
+  // (and thus idle exit) open forever.
+  private openSockets = new Set<Socket>()
+  private shuttingDown = false
 
   // Why: main-process PTY IPC has the same recent-input bypass, but daemon
   // output reaches main only after this stream layer. Keeping the window here
@@ -139,7 +145,16 @@ export class DaemonServer {
         isIdle: () => this.clients.size === 0 && this.host.sessionCount() === 0,
         onExpired: () => {
           console.warn('[daemon] No sessions and no clients for the idle grace period — exiting')
-          void this.shutdown().then(() => onIdleExit())
+          // Why: idleness was just verified, so exiting after a failed
+          // shutdown cannot lose sessions — but staying alive would strand a
+          // half-shut daemon that can never re-arm its idle countdown.
+          void this.shutdown().then(
+            () => onIdleExit(),
+            (err) => {
+              console.error('[daemon] Idle shutdown failed — exiting anyway:', err)
+              onIdleExit()
+            }
+          )
         }
       })
     }
@@ -173,6 +188,10 @@ export class DaemonServer {
   }
 
   async shutdown(): Promise<void> {
+    // Why: hard barrier, set synchronously before any teardown — after this,
+    // no accepted socket may become a client and no RPC may create a session,
+    // so shutdown can never race a live PTY into a half-shut server.
+    this.shuttingDown = true
     this.stopStreamBacklogProbe()
     this.transientFactRelay.dispose()
     // Why: dispose before teardown mutates client/session counts, so the idle
@@ -186,6 +205,13 @@ export class DaemonServer {
       client.streamSocket?.destroy()
     }
     this.clients.clear()
+
+    // Why: pre-hello sockets are not in `clients`; leaving them open would
+    // hold server.close() — and therefore the idle-exit callback — forever.
+    for (const socket of this.openSockets) {
+      socket.destroy()
+    }
+    this.openSockets.clear()
 
     return new Promise<void>((resolve) => {
       if (this.server) {
@@ -203,6 +229,12 @@ export class DaemonServer {
   }
 
   private handleConnection(socket: Socket): void {
+    if (this.shuttingDown) {
+      socket.destroy()
+      return
+    }
+    this.openSockets.add(socket)
+    socket.once('close', () => this.openSockets.delete(socket))
     // Why: clients can send multibyte prompt/input text split across socket
     // chunks; keep UTF-8 sequences intact before NDJSON parsing.
     const decoder = new StringDecoder('utf8')
@@ -222,6 +254,13 @@ export class DaemonServer {
     msg: unknown,
     _parser: ReturnType<typeof createNdjsonParser>
   ): void {
+    // Why: a hello queued before shutdown destroyed its socket can still be
+    // delivered in the same tick; accepting it would register a client on a
+    // server whose host and listener are already torn down.
+    if (this.shuttingDown) {
+      socket.destroy()
+      return
+    }
     const hello = msg as HelloMessage
     if (hello.type !== 'hello') {
       this.log.log('client-hello-rejected', { reason: 'expected-hello' })
@@ -359,6 +398,9 @@ export class DaemonServer {
   }
 
   private async routeRequest(clientId: string, request: DaemonRequest): Promise<unknown> {
+    if (this.shuttingDown) {
+      throw new Error('Daemon server is shutting down')
+    }
     const client = this.clients.get(clientId)
 
     switch (request.type) {

--- a/src/main/daemon/terminal-host-contract.ts
+++ b/src/main/daemon/terminal-host-contract.ts
@@ -1,0 +1,64 @@
+import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
+import type { SubprocessHandle } from './session'
+import type { ShellReadyState, TakePendingOutputResult, TerminalSnapshot } from './types'
+
+export type CreateOrAttachOptions = {
+  sessionId: string
+  cols: number
+  rows: number
+  cwd?: string
+  env?: Record<string, string>
+  envToDelete?: string[]
+  command?: string
+  startupCommandDelivery?: StartupCommandDelivery
+  /** Explicit shell the renderer asked for (e.g. 'wsl.exe' for "New WSL
+   *  terminal" from the "+" menu). Forwarded to the subprocess spawner so the
+   *  daemon path honors per-tab shell selection the same way LocalPtyProvider
+   *  does. */
+  shellOverride?: string
+  terminalWindowsWslDistro?: string | null
+  terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
+  shellReadySupported?: boolean
+  shellReadyTimeoutMs?: number
+  historySeed?: string
+  streamClient: { onData: (data: string) => void; onExit: (code: number) => void }
+}
+
+export type CreateOrAttachResult = {
+  isNew: boolean
+  snapshot: TerminalSnapshot | null
+  pid: number | null
+  shellState: ShellReadyState
+  historySeeded?: boolean
+  attachToken: symbol
+}
+
+export type TerminalHostOptions = {
+  spawnSubprocess: (opts: {
+    sessionId: string
+    cols: number
+    rows: number
+    cwd?: string
+    env?: Record<string, string>
+    envToDelete?: string[]
+    command?: string
+    startupCommandDelivery?: StartupCommandDelivery
+    shellOverride?: string
+    terminalWindowsWslDistro?: string | null
+    terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
+  }) => SubprocessHandle
+  // Why: on graceful shutdown, the host writes final checkpoints for all live
+  // sessions before killing them. This bypasses the RPC round-trip — the daemon
+  // writes checkpoints in-process, guaranteeing completion before teardown.
+  onFinalCheckpoint?: (
+    sessionId: string,
+    snapshot: TerminalSnapshot,
+    records: TakePendingOutputResult['records']
+  ) => void
+  // Why: production keeps a large cap, but tests need a small deterministic cap
+  // without spawning thousands of full terminal sessions.
+  maxTombstones?: number
+  // Why: lets the daemon server re-evaluate idle-exit eligibility on every
+  // session-map transition instead of polling the host.
+  onSessionCountChange?: () => void
+}

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -516,4 +516,45 @@ describe('TerminalHost', () => {
       expect(liveSub.dispose).toHaveBeenCalled()
     })
   })
+
+  describe('onSessionCountChange', () => {
+    // Why: the daemon's idle-exit countdown arms/cancels purely off this hook;
+    // a missed notification on any transition silently disables idle exit (or
+    // worse, lets it fire with a session alive). Pin every transition.
+    it('notifies on create, natural-exit reap, and dispose', async () => {
+      const onSessionCountChange = vi.fn()
+      host.dispose()
+      host = new TerminalHost({
+        spawnSubprocess: spawnFn as MockSpawnFn,
+        onSessionCountChange
+      })
+
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 80,
+        rows: 24,
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+      expect(host.sessionCount()).toBe(1)
+      expect(onSessionCountChange).toHaveBeenCalledTimes(1)
+
+      // Natural exit reaps synchronously — this is the transition that lets
+      // an otherwise-empty daemon start its idle countdown.
+      lastSubprocess._onExitCb?.(0)
+      expect(host.sessionCount()).toBe(0)
+      expect(onSessionCountChange).toHaveBeenCalledTimes(2)
+
+      await host.createOrAttach({
+        sessionId: 'session-2',
+        cols: 80,
+        rows: 24,
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+      expect(onSessionCountChange).toHaveBeenCalledTimes(3)
+
+      host.dispose()
+      expect(host.sessionCount()).toBe(0)
+      expect(onSessionCountChange).toHaveBeenCalledTimes(4)
+    })
+  })
 })

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -429,6 +429,20 @@ describe('TerminalHost', () => {
       expect(lastSubprocess.dispose).toHaveBeenCalled()
     })
 
+    it('rejects createOrAttach after dispose without spawning a subprocess', async () => {
+      host.dispose()
+
+      await expect(
+        host.createOrAttach({
+          sessionId: 'post-dispose',
+          cols: 80,
+          rows: 24,
+          streamClient: { onData: vi.fn(), onExit: vi.fn() }
+        })
+      ).rejects.toThrow(/disposed/)
+      expect(spawnFn).not.toHaveBeenCalled()
+    })
+
     it('releases held shell-ready marker prefixes before final checkpoint', async () => {
       host.dispose()
       const onFinalCheckpoint = vi.fn()

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -1,78 +1,16 @@
-import { Session, type SubprocessHandle } from './session'
+import { Session } from './session'
 import { normalizePtySize } from './daemon-pty-size'
 import { resolveProcessCwd } from '../providers/process-cwd'
-import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
-import type {
-  SessionInfo,
-  TakePendingOutputResult,
-  TerminalSnapshot,
-  ShellReadyState
-} from './types'
+import type { SessionInfo, TakePendingOutputResult, TerminalSnapshot } from './types'
 import { SessionNotFoundError } from './types'
+import type {
+  CreateOrAttachOptions,
+  CreateOrAttachResult,
+  TerminalHostOptions
+} from './terminal-host-contract'
 
 const DEFAULT_MAX_TOMBSTONES = 1000
-
-export type CreateOrAttachOptions = {
-  sessionId: string
-  cols: number
-  rows: number
-  cwd?: string
-  env?: Record<string, string>
-  envToDelete?: string[]
-  command?: string
-  startupCommandDelivery?: StartupCommandDelivery
-  /** Explicit shell the renderer asked for (e.g. 'wsl.exe' for "New WSL
-   *  terminal" from the "+" menu). Forwarded to the subprocess spawner so the
-   *  daemon path honors per-tab shell selection the same way LocalPtyProvider
-   *  does. */
-  shellOverride?: string
-  terminalWindowsWslDistro?: string | null
-  terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
-  shellReadySupported?: boolean
-  shellReadyTimeoutMs?: number
-  historySeed?: string
-  streamClient: { onData: (data: string) => void; onExit: (code: number) => void }
-}
-
-export type CreateOrAttachResult = {
-  isNew: boolean
-  snapshot: TerminalSnapshot | null
-  pid: number | null
-  shellState: ShellReadyState
-  historySeeded?: boolean
-  attachToken: symbol
-}
-
-export type TerminalHostOptions = {
-  spawnSubprocess: (opts: {
-    sessionId: string
-    cols: number
-    rows: number
-    cwd?: string
-    env?: Record<string, string>
-    envToDelete?: string[]
-    command?: string
-    startupCommandDelivery?: StartupCommandDelivery
-    shellOverride?: string
-    terminalWindowsWslDistro?: string | null
-    terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
-  }) => SubprocessHandle
-  // Why: on graceful shutdown, the host writes final checkpoints for all live
-  // sessions before killing them. This bypasses the RPC round-trip — the daemon
-  // writes checkpoints in-process, guaranteeing completion before teardown.
-  onFinalCheckpoint?: (
-    sessionId: string,
-    snapshot: TerminalSnapshot,
-    records: TakePendingOutputResult['records']
-  ) => void
-  // Why: production keeps a large cap, but tests need a small deterministic cap
-  // without spawning thousands of full terminal sessions.
-  maxTombstones?: number
-  // Why: lets the daemon server re-evaluate idle-exit eligibility on every
-  // session-map transition instead of polling the host.
-  onSessionCountChange?: () => void
-}
 
 export class TerminalHost {
   private sessions = new Map<string, Session>()

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -69,6 +69,9 @@ export type TerminalHostOptions = {
   // Why: production keeps a large cap, but tests need a small deterministic cap
   // without spawning thousands of full terminal sessions.
   maxTombstones?: number
+  // Why: lets the daemon server re-evaluate idle-exit eligibility on every
+  // session-map transition instead of polling the host.
+  onSessionCountChange?: () => void
 }
 
 export class TerminalHost {
@@ -77,11 +80,20 @@ export class TerminalHost {
   private spawnSubprocess: TerminalHostOptions['spawnSubprocess']
   private onFinalCheckpoint: TerminalHostOptions['onFinalCheckpoint']
   private maxTombstones: number
+  private onSessionCountChange: TerminalHostOptions['onSessionCountChange']
 
   constructor(opts: TerminalHostOptions) {
     this.spawnSubprocess = opts.spawnSubprocess
     this.onFinalCheckpoint = opts.onFinalCheckpoint
     this.maxTombstones = opts.maxTombstones ?? DEFAULT_MAX_TOMBSTONES
+    this.onSessionCountChange = opts.onSessionCountChange
+  }
+
+  // Why: counts every tracked session — alive, terminating, or exited-but-not-
+  // yet-reaped. Idle-exit must stay conservative: any entry in the map means
+  // the daemon may still owe someone state, so it is not idle.
+  sessionCount(): number {
+    return this.sessions.size
   }
 
   /**
@@ -155,6 +167,7 @@ export class TerminalHost {
     })
 
     this.sessions.set(opts.sessionId, session)
+    this.onSessionCountChange?.()
 
     const token = session.attachClient(opts.streamClient)
 
@@ -238,6 +251,7 @@ export class TerminalHost {
     }
     session.dispose()
     this.sessions.delete(sessionId)
+    this.onSessionCountChange?.()
   }
 
   signal(sessionId: string, sig: string): void {
@@ -388,6 +402,7 @@ export class TerminalHost {
     }
     this.sessions.clear()
     this.killedTombstones.clear()
+    this.onSessionCountChange?.()
   }
 
   private getAliveSession(sessionId: string): Session {

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -81,6 +81,7 @@ export class TerminalHost {
   private onFinalCheckpoint: TerminalHostOptions['onFinalCheckpoint']
   private maxTombstones: number
   private onSessionCountChange: TerminalHostOptions['onSessionCountChange']
+  private disposed = false
 
   constructor(opts: TerminalHostOptions) {
     this.spawnSubprocess = opts.spawnSubprocess
@@ -103,6 +104,11 @@ export class TerminalHost {
    * already deliver them through shell launch arguments.
    */
   async createOrAttach(opts: CreateOrAttachOptions): Promise<CreateOrAttachResult> {
+    // Why: a request that slips in while the daemon is shutting down must not
+    // spawn a PTY the dying process would silently take down with it.
+    if (this.disposed) {
+      throw new Error('TerminalHost is disposed')
+    }
     const existing = this.sessions.get(opts.sessionId)
 
     // Why: a session that has been asked to terminate (kill() called but the
@@ -366,6 +372,7 @@ export class TerminalHost {
   }
 
   dispose(): void {
+    this.disposed = true
     // Why: write final checkpoints before killing sessions so graceful shutdown
     // has zero data loss. The checkpoint callback writes synchronously to disk.
     if (this.onFinalCheckpoint) {


### PR DESCRIPTION
## Problem

The PTY daemon never idle-exits: it only terminates on SIGTERM/SIGINT or an explicit `shutdown` RPC. Worse, every app launch adopts ALIVE legacy-protocol daemons (v1–v17 sockets) with no session-count check and never shuts them down — a legacy daemon with zero sessions is re-adopted forever, each one pinning a node + node-pty process in memory indefinitely. Protocol bumps guarantee these accumulate on long-lived installs (verified on a machine at 99.6% RAM from Orca-managed processes).

## Fix

1. **Legacy reaping at adoption** (`daemon-init.ts`): before adopting an alive legacy daemon, query its live-session count. `0` live sessions → issue shutdown through the existing `cleanupDaemonForProtocol` path (shutdown RPC, `killStaleDaemon` fallback, socket/pid file cleanup) and skip adoption. Any live session, or a **failed query (`null`), fail-safes to adoption exactly as before** — a daemon whose sessions cannot be verified is never killed.
2. **Idle self-exit for the current-protocol daemon** (`daemon-idle-exit.ts`, `daemon-server.ts`, `daemon-entry.ts`): a single unref'd countdown arms whenever the daemon holds 0 sessions AND 0 connected clients, and cancels on any session creation or client connect. Strictly event-driven (server start, client hello, control-socket close, session-map transitions via a new `TerminalHost.onSessionCountChange` hook) — no polling. At fire time the idle predicate is re-checked as a fail-safe, then the server shuts down cleanly before `process.exit(0)`. Shutdown is a hard barrier: a `shuttingDown` flag set synchronously at the top of `shutdown()` refuses new connections, late hellos, and RPCs, destroys every accepted socket (including pre-hello ones invisible to the client map), and `TerminalHost` rejects `createOrAttach` after dispose — so an idle exit can never race an accepted-but-unhandshaken socket into a live PTY on a half-shut server, and a failed shutdown still exits instead of stranding a zombie. Grace is 10 minutes: the daemon's whole purpose is holding sessions across app restarts/updates, so at 0 sessions the grace only needs to outlast an update/restart reconnect window.
3. **Barrier-race recovery in the app** (`daemon-pty-adapter.ts`): a client whose socket is accepted just before the barrier rises but destroyed before its hello completes surfaces `EPIPE` on the hello write or `Connection closed before hello response` on a clean close. Both are now classified daemon-gone, so `withDaemonRetry` respawns and retries instead of failing that terminal create. Hello *rejections* (bad token/version) reply `ok:false` with different messages and still never trigger a respawn.

## ELI5

Orca keeps your terminals alive in a small helper program (the "daemon") that runs outside the app — that's why a running agent survives when Orca restarts or updates. The problem: a helper with nothing left to do never went away. Once all its terminals were closed it just sat there forever, and every time Orca bumped the helper's internal protocol version, the next launch would find the previous helper and keep that one alive too. Long-time users slowly collected a pile of do-nothing helpers, each pinning memory.

This PR does two things. First, at launch, if Orca finds an old-generation helper holding zero terminals, it now tells it to shut down instead of adopting it. Second, the current helper now shuts itself down after sitting completely empty — no terminals, no app connected — for 10 minutes.

Both are deliberately cautious. If the helper owns even one live terminal, or Orca can't verify what it owns (it doesn't answer, the query fails), nothing is touched — it's kept exactly as before. An empty helper holds nothing a user could lose, and the next launch just starts a fresh one, which is the same path Orca already uses when a helper crashes. A hard shutdown barrier also guarantees a helper can never half-die: once it starts shutting down it refuses all new connections and finishes exiting, so the app can never end up talking to a dying helper.

## Design alternatives considered

- **Exit the instant the last terminal closes** (no grace): rejected — the daemon exists to survive app restarts/updates for warm reattach; a grace window is the standard tradeoff for reattach-oriented daemons, and 10 minutes comfortably outlasts an update cycle while bounding idle memory.
- **Parent-process watchdog** (kill daemon when the app dies): orthogonal — the daemon must outlive the app by design. A watchdog addresses a different failure mode (crash-orphaned daemon *with* live sessions), which is exactly open PR #4639's territory and stays complementary to this PR.
- **Launch-time sweep only** (no self-exit): insufficient — a user who never relaunches Orca would keep an empty daemon forever. Self-exit covers end-of-life without depending on a future launch; the launch-time reap covers the pre-v18 backlog that predates self-exit code.
- Open PR #4429 implements the same legacy-reap half of this PR (and corroborates the leak profile); this PR is a superset and #4429 can be closed when this lands.

Known residual coverage notes: the pre-v18 backlog needs one future app launch to be reaped; a legacy daemon adopted *with* sessions that later drain mid-run is only reaped at the next launch (it runs old code with no self-exit); crash-orphaned daemons with live sessions are out of scope here (see #4639).

## Reliability proof (terminal-session-reliability contract)

- **Touched class:** `startup-upgrade.persisted-session-corpus` / daemon startup reconcile; manifest gate `terminal-provider.daemon-startup-degraded-contract` ("preserve valid live daemon sessions, reap only true orphans").
- **Invariant:** a daemon that reports live sessions, or whose session state cannot be verified, is never shut down; the idle countdown can never fire while any tracked session (alive, terminating, or exited-but-unreaped) or any connected client exists; and once shutdown begins, no accepted socket can become a client and no RPC can create a session (idle exit cannot pass the point of no return while any accepted socket could still become live work).
- **Failure source:** July 2026 perf audit — idle daemon accumulation across protocol bumps; no end-of-life reaping for legacy daemons.
- **Product change type:** perf hardening + runtime hardening, with new deterministic gate tests.
- **Oracle / correctness evidence:**
  - `daemon-init.test.ts`: alive legacy daemon with 0 live sessions (list contains a dead entry, proving the `isAlive` filter gates reaping) → `shutdown {killSessions:true}` issued via the v9-protocol client, no adapter constructed, no PID-fallback kill; alive legacy daemon with a live session → adopted unchanged, no shutdown issued; session-count query failure → adopted unchanged (fail-safe).
  - `daemon-idle-exit.test.ts` (fake timers, fully deterministic): fires only after the full grace; cancels on non-idle evaluate; re-arms; keeps the original deadline on redundant evaluates; fire-time re-check refuses to expire if idleness was lost without a cancel (fail-safe); dispose blocks future arming; default grace is 10 min; countdown is unref'd (`hasRef() === false`).
  - `daemon-server.test.ts` (real sockets): idle daemon with 0 clients/0 sessions shuts down and calls `onIdleExit`; client connect deterministically cancels the countdown and disconnect re-arms it; a session seeded before `start()` prevents the countdown from ever arming, survives a 3x-grace real-time wait, and the daemon exits only after that session ends.
  - `daemon-server.test.ts` (shutdown barrier): a pre-hello socket open at idle-fire time is destroyed and the daemon still exits (pre-fix this scenario hangs `server.close()` forever); after `shutdown()`, `createOrAttach` is refused and spawns nothing; and a mutation-killing test raises only the `shuttingDown` flag while the listener still accepts, then proves a pre-admitted socket's late valid hello and a brand-new connection are both destroyed unregistered (deleting either barrier guard fails it).
  - `daemon-pty-adapter.test.ts`: a barrier server that destroys pre-hello sockets makes the adapter respawn and retry (fails without the daemon-gone classification fix).
  - `terminal-host.test.ts`: `createOrAttach` after `dispose()` rejects without spawning a subprocess; `onSessionCountChange` fires on create, natural-exit reap, and dispose (mutation-verified: deleting the create-side notify fails it).
  - `daemon-main.test.ts`: idle-exit options pass through `startDaemon` to the server.
- **No-regression evidence:** all logic is event-driven (no polling loops, no hidden-pane wakeups); the only startup-path addition is one `listSessions` round-trip per ALIVE legacy daemon inside `createLegacyDaemonAdapters`, which already runs socket probes per legacy version and executes concurrently with window load behind the existing abort guard. A dedicated perf audit confirmed: the app's persistent daemon control socket means a running Orca always counts as a connected client, so idle exit can only ever fire on a truly orphaned daemon; there is no exit/respawn churn loop (nothing auto-reconnects; a post-reap spawn pays one ordinary cold fork). Full daemon directory suite: 49 files, 703 tests passed (2 skipped pre-existing). `pnpm typecheck` clean. `check:reliability-gates` passed (30 gates).
- **Provider/platform coverage:** daemon provider covered by the tests above; local/SSH/WSL/remote-runtime/mobile unaffected (this daemon is local-machine infrastructure; SSH/relay terminals do not route through it). macOS/Linux covered by the unix-socket paths; Windows named pipes use the same `probeSocket`/`cleanupDaemonForProtocol` helpers, which already gate `existsSync`/`unlinkSync` behind `process.platform !== 'win32'` — no new path handling was added, so named-pipe behavior is identical by construction (covered-by-existing-helpers, no new Windows-only branch to test).
- **Residual gaps:**
  - The daemon cannot unlink its own pid file on idle exit (it doesn't know the path); the next launch's `killStaleDaemon` verifies pid + process start time before acting, so a recycled pid is safe. The stale pid/token files are cleaned by the existing dead-socket cleanup on next launch.
  - Very old legacy daemons that predate the `listSessions` RPC fail the query and are adopted (fail-safe), same as today.
  - The adapter regression test covers the destroyed-pre-hello-socket race as a class; whether a given run surfaces the EPIPE or the clean-close variant depends on write-flush timing (both are classified, so the test is deterministic either way).
  - Legacy reap has the same theoretical adopt-vs-kill TOCTOU as the existing `shouldPreserveDaemonWithLiveSessions` pattern (only reachable with two different-version app instances launching simultaneously) — not a new risk class.
  - Manifest not modified: `terminal-provider.daemon-startup-degraded-contract` is an experimental gate whose executable corpus is tracked on the pending reliability stack; these tests strengthen the same invariant family from this PR's files.
- **Promotion status:** none → the new tests run in the standard vitest suite; no gate promoted.
- **Rollback/demotion rule:** any report of a daemon exiting while it owned sessions, or of a legacy daemon with live sessions being reaped, demotes this to revert-first — the fail-safe paths (`liveSessionCount === null` → adopt; fire-time `isIdle()` re-check) are the load-bearing guards.

## Post-rebase re-review (2026-07-09, second pass)

Rebased onto latest `main` (v1.4.131-rc.2 era) to clear conflicts with `#7538` (Windows terminal update-survival) and `#7849` (daemon file log + startup CI hard-fail), which rewrote parts of the same files. Semantic interactions re-reviewed: no fights — the idle countdown cannot arm while the app holds its persistent daemon client connection, and the `#7849` boot smoke SIGTERMs well inside the grace window.

- **Conflict-resolution improvement:** idle-exit diagnostics route through `#7849`'s `DaemonFileLog` (`idle-exit` and `idle-exit-shutdown-error` events in `daemon-server.ts`, `daemonLog.close()` before `process.exit(0)` in `daemon-entry.ts`) instead of `console.warn`, which goes nowhere in the detached stdio-ignore daemon. The exit reason now lands in diagnostic bundles.
- **Review-loop fix:** the two-reviewer review/fix loop surfaced that `isDaemonGoneError` did not classify a pre-hello socket teardown, so the barrier race would fail one terminal create instead of respawning (see Fix #3). Applied with a real-socket regression test; a follow-up mutation-killing test pins the `handleConnection`/`handleFirstMessage` barrier guards themselves. Final round: two independent reviewers on the complete diff, both returned clean with no blocking findings.
- **Test-only hardening:** deflaked the "never fires while a session is alive" test — the session is now seeded before `server.start()` arms the countdown, so the invariant is proven by the timer *never arming* instead of racing a cancel against a 75 ms grace on a loaded machine; added a deterministic `TerminalHost.onSessionCountChange` wiring test covering create, natural-exit reap, and dispose (mutation-verified).
- **End-to-end validation against the real built `daemon-entry.js`** (grace patched to 5 s in a scratch copy of the bundle only; source untouched): 12/12 checks — idle-from-birth exit at exactly grace with `idle-exit` + `daemon-log-closed` in the log and the socket unlinked; a connected client blocks exit for 3x grace and disconnect re-arms it; a live PTY session with **zero** clients blocks exit (the data-loss invariant) and the daemon exits only after that session ends; a pre-hello socket is destroyed by the shutdown barrier and cannot hang `server.close()`.
- **Real-app Electron validation** (dev build, scratch user-data dir): planted a live protocol-v17 daemon with zero sessions → app launch reaped it (three independent signals: `[daemon] Shutting down idle legacy daemon (protocol v17) with no live sessions` in the main-process log, the v17 process gone from the process table, the v17 socket unlinked) while a working terminal came up on a fresh v18 daemon (full-app screenshot captured locally under `validation-screenshots/`, untracked); re-planted the v17 daemon *holding a live PTY session* → app launch adopted it untouched (daemon and its session shell both still alive, no reap log line).
- **Post-rebase evidence:** `pnpm typecheck` clean; daemon suite 49 files / 703 tests passed; `check:reliability-gates` 30 gates pass; `#7849`'s `daemon-boot-smoke.mjs` PASS against the built bundle. The one `pnpm lint` failure is pre-existing on `main` from `#7684` (`notification-authorization-status.ts`, untouched here).

## Evidence commands

- `pnpm vitest run --config config/vitest.config.ts src/main/daemon` → 48 files passed (1 skipped pre-existing), 703 tests passed (2 skipped pre-existing)
- `pnpm typecheck` → clean
- `pnpm run check:reliability-gates` → 30 gates pass
- `node config/scripts/daemon-boot-smoke.mjs` → PASS (real PTY served end-to-end under plain Node)

Made with [Orca](https://github.com/stablyai/orca) 🐋
