### PR TITLE
perf(windows): skip dead cwd probes and cache CLI path resolution

### DIFF
--- a/src/main/providers/process-cwd.test.ts
+++ b/src/main/providers/process-cwd.test.ts
@@ -13,6 +13,14 @@ vi.mock('fs/promises', () => ({
   readlink: readlinkMock
 }))
 
+function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  return fn().finally(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  })
+}
+
 describe('resolveProcessCwd', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -28,6 +36,17 @@ describe('resolveProcessCwd', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('returns "" on win32 without attempting any probe', async () => {
+    await withPlatform('win32', async () => {
+      const { resolveProcessCwd } = await import('./process-cwd')
+
+      await expect(resolveProcessCwd(42)).resolves.toBe('')
+
+      expect(readlinkMock).not.toHaveBeenCalled()
+      expect(execFileMock).not.toHaveBeenCalled()
+    })
   })
 
   it('bounds cached cwd results across unique process ids', async () => {

--- a/src/main/providers/process-cwd.ts
+++ b/src/main/providers/process-cwd.ts
@@ -10,8 +10,9 @@ import { readlink } from 'node:fs/promises'
  * the duplication is cheaper than reshaping both bundle graphs.
  *
  * Tries `/proc/<pid>/cwd` on Linux, falls back to `lsof -d cwd` on macOS.
- * Returns `''` when neither works (including Windows, where `/proc` is
- * absent and `lsof` is not native).
+ * Returns `''` when neither works. Windows is unsupported and returns `''`
+ * without probing (see the early return below); real resolution there
+ * (NtQueryInformationProcess) is a potential follow-up.
  *
  * Results are coalesced and briefly cached per-pid: rapid repeat calls
  * (e.g. chained Cmd+D on macOS) reuse a single `lsof` child rather than
@@ -27,6 +28,11 @@ const resultCache = new Map<number, CacheEntry>()
 const inflight = new Map<number, Promise<string>>()
 
 export async function resolveProcessCwd(pid: number): Promise<string> {
+  // Why: Windows has no /proc and no native lsof — both probes are guaranteed
+  // to fail, so return the "unknown" sentinel before spawning anything.
+  if (process.platform === 'win32') {
+    return ''
+  }
   // Assumes the caller holds a live reference to `pid` for the TTL window.
   // If a pid is recycled within 1.5s of a prior query, the cache would
   // return the previous process's cwd — acceptable because our callers

--- a/src/main/win32-utils-command-resolution-cache.test.ts
+++ b/src/main/win32-utils-command-resolution-cache.test.ts
@@ -1,0 +1,122 @@
+import { delimiter, join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { resolveWindowsCommand as ResolveWindowsCommand } from './win32-utils'
+
+const { existsSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn<(path: string) => boolean>()
+}))
+
+vi.mock('node:fs', () => ({ existsSync: existsSyncMock }))
+
+const DIR_A = join('/fake', 'a')
+const DIR_B = join('/fake', 'b')
+const PATH_AB = [DIR_A, DIR_B].join(delimiter)
+
+async function importFreshResolver(): Promise<typeof ResolveWindowsCommand> {
+  // Fresh module per test so the module-level memo starts empty.
+  vi.resetModules()
+  return (await import('./win32-utils')).resolveWindowsCommand
+}
+
+function withWin32<T>(fn: () => T): T {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  try {
+    return fn()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  existsSyncMock.mockReset().mockReturnValue(false)
+  vi.spyOn(Date, 'now').mockReturnValue(100_000)
+})
+
+describe('resolveWindowsCommand memoization', () => {
+  it('probes once, then serves an identical (command, PATH) resolution with zero fs calls', async () => {
+    const resolveWindowsCommand = await importFreshResolver()
+    const ghShim = join(DIR_B, 'gh.exe')
+    existsSyncMock.mockImplementation((path) => path === ghShim)
+
+    withWin32(() => {
+      expect(resolveWindowsCommand('gh', { PATH: PATH_AB })).toBe(ghShim)
+    })
+    const probesForFirstResolution = existsSyncMock.mock.calls.length
+    expect(probesForFirstResolution).toBeGreaterThan(0)
+
+    withWin32(() => {
+      expect(resolveWindowsCommand('gh', { PATH: PATH_AB })).toBe(ghShim)
+    })
+    expect(existsSyncMock.mock.calls.length).toBe(probesForFirstResolution)
+  })
+
+  it('re-probes when the PATH string changes', async () => {
+    const resolveWindowsCommand = await importFreshResolver()
+    const ghInA = join(DIR_A, 'gh.cmd')
+    const ghInB = join(DIR_B, 'gh.cmd')
+    existsSyncMock.mockImplementation((path) => path === ghInA || path === ghInB)
+
+    withWin32(() => {
+      expect(resolveWindowsCommand('gh', { PATH: DIR_A })).toBe(ghInA)
+      expect(resolveWindowsCommand('gh', { PATH: DIR_B })).toBe(ghInB)
+    })
+  })
+
+  it('does not serve one command’s entry for another', async () => {
+    const resolveWindowsCommand = await importFreshResolver()
+    const ghShim = join(DIR_A, 'gh.cmd')
+    existsSyncMock.mockImplementation((path) => path === ghShim)
+
+    withWin32(() => {
+      expect(resolveWindowsCommand('gh', { PATH: PATH_AB })).toBe(ghShim)
+      expect(resolveWindowsCommand('glab', { PATH: PATH_AB })).toBe('glab')
+    })
+  })
+
+  it('caches a miss briefly, then finds a CLI installed mid-session after the retry window', async () => {
+    const resolveWindowsCommand = await importFreshResolver()
+
+    withWin32(() => {
+      expect(resolveWindowsCommand('glab', { PATH: PATH_AB })).toBe('glab')
+    })
+    const probesForFirstResolution = existsSyncMock.mock.calls.length
+
+    // Within the retry window: the miss is served from the memo, no re-scan.
+    vi.spyOn(Date, 'now').mockReturnValue(100_000 + 29_999)
+    withWin32(() => {
+      expect(resolveWindowsCommand('glab', { PATH: PATH_AB })).toBe('glab')
+    })
+    expect(existsSyncMock.mock.calls.length).toBe(probesForFirstResolution)
+
+    // Past the window with the CLI now installed: the re-probe finds it.
+    const glabShim = join(DIR_A, 'glab.exe')
+    existsSyncMock.mockImplementation((path) => path === glabShim)
+    vi.spyOn(Date, 'now').mockReturnValue(100_000 + 30_000)
+    withWin32(() => {
+      expect(resolveWindowsCommand('glab', { PATH: PATH_AB })).toBe(glabShim)
+    })
+    expect(existsSyncMock.mock.calls.length).toBeGreaterThan(probesForFirstResolution)
+
+    // The hit is now pinned: a later identical resolution does no fs work.
+    const probesAfterInstall = existsSyncMock.mock.calls.length
+    vi.spyOn(Date, 'now').mockReturnValue(100_000 + 500_000)
+    withWin32(() => {
+      expect(resolveWindowsCommand('glab', { PATH: PATH_AB })).toBe(glabShim)
+    })
+    expect(existsSyncMock.mock.calls.length).toBe(probesAfterInstall)
+  })
+
+  it('bypasses the memo entirely off win32 and for explicit paths', async () => {
+    const resolveWindowsCommand = await importFreshResolver()
+
+    expect(resolveWindowsCommand('gh', { PATH: PATH_AB })).toBe('gh')
+    withWin32(() => {
+      expect(resolveWindowsCommand(join('C:', 'tools', 'gh.exe'), { PATH: PATH_AB })).toBe(
+        join('C:', 'tools', 'gh.exe')
+      )
+    })
+    expect(existsSyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/win32-utils.ts
+++ b/src/main/win32-utils.ts
@@ -24,6 +24,17 @@ export function isWindowsBatchScript(commandPath: string): boolean {
   return process.platform === 'win32' && /\.(cmd|bat)$/i.test(commandPath)
 }
 
+// Why cache: a PATH scan is ~80-160 existsSync probes (dirs × 4 name variants)
+// and runs per gh/glab invocation; NTFS + Defender make each probe costly.
+// Keyed by (command, PATH string) so a PATH change invalidates via the key.
+// Hits are kept for the process lifetime; misses expire after a short TTL so
+// a CLI installed mid-session is picked up without re-scanning on every call.
+const COMMAND_RESOLUTION_CACHE_MAX_ENTRIES = 64
+const MISSING_COMMAND_RETRY_MS = 30_000
+
+type CommandResolutionEntry = { resolved: string; found: boolean; at: number }
+const commandResolutionCache = new Map<string, CommandResolutionEntry>()
+
 export function resolveWindowsCommand(
   command: string,
   env: NodeJS.ProcessEnv = process.env
@@ -40,6 +51,32 @@ export function resolveWindowsCommand(
     return command
   }
 
+  // \0 cannot appear in a command or env value, so the key is unambiguous.
+  const cacheKey = `${command}\0${pathEnv}`
+  const cached = commandResolutionCache.get(cacheKey)
+  if (cached && (cached.found || Date.now() - cached.at < MISSING_COMMAND_RETRY_MS)) {
+    return cached.resolved
+  }
+
+  const resolved = scanPathForCommand(command, pathEnv)
+  commandResolutionCache.set(cacheKey, {
+    resolved: resolved ?? command,
+    found: resolved !== null,
+    at: Date.now()
+  })
+  // Why bound: callers pass arbitrary env objects, so distinct PATH strings
+  // could otherwise accumulate keys for the process lifetime.
+  while (commandResolutionCache.size > COMMAND_RESOLUTION_CACHE_MAX_ENTRIES) {
+    const oldest = commandResolutionCache.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    commandResolutionCache.delete(oldest)
+  }
+  return resolved ?? command
+}
+
+function scanPathForCommand(command: string, pathEnv: string): string | null {
   for (const directory of pathEnv.split(delimiter).filter(Boolean)) {
     for (const name of [`${command}.cmd`, `${command}.exe`, `${command}.bat`, command]) {
       const candidate = join(directory, name)
@@ -48,7 +85,7 @@ export function resolveWindowsCommand(
       }
     }
   }
-  return command
+  return null
 }
 
 export const WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR = 'UNSAFE_WINDOWS_BATCH_ARGUMENTS'

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -88,6 +88,11 @@ export function resolveDefaultCwd(
  * Tries /proc on Linux and lsof on macOS before falling back to `fallbackCwd`.
  */
 export async function resolveProcessCwd(pid: number, fallbackCwd: string): Promise<string> {
+  // Why: a Windows relay host has no /proc and no native lsof — both probes
+  // are guaranteed to fail, so skip straight to the fallback without spawning.
+  if (process.platform === 'win32') {
+    return fallbackCwd
+  }
   // Try to read /proc/{pid}/cwd on Linux. Skip an existsSync gate — the
   // check+read pair races a concurrent exit anyway, and the catch already
   // falls through to lsof.

--- a/src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.test.ts
+++ b/src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.test.ts
@@ -60,8 +60,13 @@ async function flushMicrotasks(): Promise<void> {
 beforeEach(() => {
   vi.useFakeTimers()
   getCwdMock.mockReset().mockResolvedValue('')
+  // Pin a POSIX platform: the hook skips cwd polling entirely on win32, and
+  // the fallback UA sniff in getRendererAppPlatform is environment-dependent.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window.api shim
-  ;(window as any).api = { pty: { getCwd: getCwdMock } }
+  ;(window as any).api = {
+    pty: { getCwd: getCwdMock },
+    platform: { get: () => ({ platform: 'darwin' }) }
+  }
 
   useAppStore.setState(initialAppState, true)
   useAppStore.setState({
@@ -106,6 +111,25 @@ describe('useChecksPanelTerminalWorktree', () => {
 
     await renderHook(parentWorktree, false)
     await flushMicrotasks()
+
+    expect(getCwdMock).not.toHaveBeenCalled()
+    expect(latest?.worktree).toBe(parentWorktree)
+  })
+
+  it('does not poll on win32, where local cwd resolution is unsupported', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window.api shim
+    ;(window as any).api = {
+      pty: { getCwd: getCwdMock },
+      platform: { get: () => ({ platform: 'win32' }) }
+    }
+    getCwdMock.mockResolvedValue(`${CHILD_PATH}/src`)
+
+    await renderHook(parentWorktree)
+    await flushMicrotasks()
+    // Advance past several poll intervals to prove no timer was scheduled.
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+    })
 
     expect(getCwdMock).not.toHaveBeenCalled()
     expect(latest?.worktree).toBe(parentWorktree)

--- a/src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.ts
@@ -5,6 +5,7 @@ import { useAllWorktrees, useRepoMap } from '@/store/selectors'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import type { Worktree } from '../../../../shared/types'
 import {
   resolveChecksPanelTerminalPtyId,
@@ -32,7 +33,8 @@ type ChecksPanelTerminalWorktree = {
  * getCwd reads the local shell pid, so it is correct for that case. Remote
  * runtime PTYs are skipped (their cwd lives on the relay host). Polling is
  * gated on panel visibility, so a hidden panel does no background work and the
- * caller's fallback worktree is used.
+ * caller's fallback worktree is used. On Windows, where local cwd resolution
+ * is unsupported, polling is skipped entirely and the fallback is always used.
  *
  * Resolution is scoped to locally-executing worktrees: the cwd comes from a
  * local PTY, and worktree paths are not unique across hosts (an SSH worktree
@@ -75,7 +77,10 @@ export function useChecksPanelTerminalWorktree(args: {
     activeTerminalPtyId !== null &&
     !isRemoteRuntimePtyId(activeTerminalPtyId) &&
     parseAppSshPtyId(activeTerminalPtyId) === null
-  const shouldPollCwd = isPanelVisible && isLocalTerminalPty
+  // Why: cwd resolution is not implemented on Windows (getCwd always returns
+  // ''), so polling would just schedule a doomed IPC round-trip every 4s.
+  const isCwdResolutionSupported = getRendererAppPlatform() !== 'win32'
+  const shouldPollCwd = isPanelVisible && isLocalTerminalPty && isCwdResolutionSupported
 
   const [polledCwd, setPolledCwd] = useState<{ ptyId: string; cwd: string | null } | null>(null)
 


### PR DESCRIPTION
Two small, independent Windows wastes — one PR.

## Part A: dead cwd-probe spawns on Windows

`resolveProcessCwd` (main process) had no win32 branch: every `getCwd` call tried a `/proc/<pid>/cwd` readlink (always ENOENT on Windows) and then spawned `lsof` (doesn't exist on Windows), returning `''` only after both failed. The Checks panel's cwd-follow hook polls `getCwd` every 4s per visible active local terminal, so an open Checks panel scheduled a doomed spawn attempt every tick — for a feature that is a silent no-op on Windows.

- `src/main/providers/process-cwd.ts`: early-return `''` on win32 before any probe (zero readlink/spawn attempts); fixed the header comment that implied Windows was handled.
- `src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.ts`: skip scheduling the poll entirely on win32 (via `getRendererAppPlatform()`), so no 4s IPC round-trips are queued either. The panel keeps using the sidebar's active worktree as before.
- `src/relay/pty-shell-utils.ts`: same early return in the relay's duplicate of `resolveProcessCwd` (returns `fallbackCwd`), so a **Windows SSH relay host** doesn't spawn a doomed `lsof` per `getCwd` either.

**Out of scope / follow-up**: real cwd resolution on Windows (e.g. `NtQueryInformationProcess`) so the Checks-panel cwd-follow feature actually works there. This PR only removes the guaranteed-dead work.

## Part B: `resolveWindowsCommand` re-scanned the whole PATH per invocation

`src/main/win32-utils.ts` probed every PATH directory × 4 name variants (`.cmd`/`.exe`/`.bat`/bare) with synchronous `existsSync` on **every** call — ~80–160 fs probes per non-git CLI invocation (`gh`, `glab`) from `commandExecFileAsync`, made worse on NTFS + Defender.

Resolutions are now memoized keyed by `(command, PATH string)`:

- **Hits** are kept for the process lifetime (the brief's contract). A stale hit after an uninstall degrades to the same ENOENT the uncached code would eventually hit.
- **Misses** are cached too (a missing CLI must not re-scan on every call) but expire after **30s**, so `winget install gh` mid-session is discovered within one retry window. 30s bounds a missing CLI to at most one full PATH scan per half-minute while keeping recovery prompt relative to how often these CLIs are invoked (PR/checks polling paths).
- A PATH env change invalidates naturally via key inequality; the cache is bounded (64 entries, insertion-order eviction) since callers pass arbitrary env objects.

## Tests

- `process-cwd.test.ts`: win32 returns `''` with zero `readlink`/`execFile` attempts (mocked + counted).
- `use-checks-panel-terminal-worktree.test.ts`: on win32 the poll no-ops — `getCwd` is never called even after advancing past several poll intervals; existing tests now pin a POSIX platform explicitly.
- `win32-utils-command-resolution-cache.test.ts` (new): first resolution probes; second identical resolution performs 0 fs calls; PATH change re-probes; per-command isolation; miss cached within 30s then recovered after install; non-win32/explicit-path bypass never touches the memo.

Scoped vitest (42 tests across the 5 touched suites) and full `pnpm typecheck` pass.

Made with [Orca](https://github.com/stablyai/orca) 🐋
