### PR TITLE
perf(renderer): mount jump palette content only while open

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.closed-render-gating.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.closed-render-gating.test.tsx
@@ -1,0 +1,255 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo, Worktree } from '../../../shared/types'
+import { useAppStore } from '@/store'
+import WorktreeJumpPalette from './WorktreeJumpPalette'
+
+// Why: called unconditionally at the top of WorktreeJumpPaletteContent, so its
+// call count is a direct render counter for the content component.
+const contentRenderProbe = vi.hoisted(() => vi.fn(() => []))
+
+vi.mock('@/hooks/useSettingsNavigationMetadata', () => ({
+  useSettingsNavigationMetadata: contentRenderProbe
+}))
+
+// Why: the gating tests target the shell/content mount seam, not cmdk/Radix
+// behavior — lightweight stand-ins keep the DOM assertions deterministic.
+vi.mock('@/components/ui/command', () => ({
+  CommandDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="worktree-jump-palette">{children}</div> : null,
+  CommandInput: ({ value }: { value: string }) => (
+    <input data-testid="palette-input" value={value} readOnly />
+  ),
+  CommandList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-command-item={value}>{children}</div>
+  )
+}))
+
+const initialAppState = useAppStore.getInitialState()
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'orca',
+    badgeColor: '#999999',
+    addedAt: 1
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-alpha',
+    repoId: 'repo-1',
+    path: '/repo/worktrees/alpha',
+    displayName: 'palette-alpha',
+    branch: 'feature/palette-alpha',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    ...overrides
+  }
+}
+
+// Why: replacing a map's identity without changing its contents is exactly the
+// store churn (#7558's re-render trigger) the closed palette must not react to.
+const CLOSED_CHURN_WRITES: readonly [string, () => void][] = [
+  ['prCache', () => useAppStore.setState((s) => ({ prCache: { ...s.prCache } }))],
+  ['issueCache', () => useAppStore.setState((s) => ({ issueCache: { ...s.issueCache } }))],
+  [
+    'retainedAgentsByPaneKey',
+    () =>
+      useAppStore.setState((s) => ({ retainedAgentsByPaneKey: { ...s.retainedAgentsByPaneKey } }))
+  ],
+  [
+    'unifiedTabsByWorktree',
+    () => useAppStore.setState((s) => ({ unifiedTabsByWorktree: { ...s.unifiedTabsByWorktree } }))
+  ],
+  [
+    'agentStatusByPaneKey',
+    () => useAppStore.setState((s) => ({ agentStatusByPaneKey: { ...s.agentStatusByPaneKey } }))
+  ],
+  [
+    'runtimePaneTitlesByTabId',
+    () =>
+      useAppStore.setState((s) => ({ runtimePaneTitlesByTabId: { ...s.runtimePaneTitlesByTabId } }))
+  ]
+]
+
+function churnAllClosedWriteTargets(): void {
+  for (const [, write] of CLOSED_CHURN_WRITES) {
+    act(() => write())
+  }
+}
+
+let container: HTMLDivElement | null = null
+let root: Root | null = null
+
+async function renderPalette(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<WorktreeJumpPalette />)
+  })
+}
+
+function paletteDialog(): Element | null {
+  return document.querySelector('[data-testid="worktree-jump-palette"]')
+}
+
+beforeEach(() => {
+  useAppStore.setState(initialAppState, true)
+  useAppStore.setState({
+    repos: [makeRepo()],
+    worktreesByRepo: {
+      'repo-1': [
+        makeWorktree(),
+        makeWorktree({
+          id: 'wt-bravo',
+          path: '/repo/worktrees/bravo',
+          displayName: 'palette-bravo',
+          branch: 'feature/palette-bravo',
+          sortOrder: 1
+        })
+      ]
+    },
+    showSleepingWorkspaces: true,
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false
+  })
+  contentRenderProbe.mockClear()
+})
+
+afterEach(async () => {
+  vi.useRealTimers()
+  if (root) {
+    await act(async () => {
+      root?.unmount()
+    })
+  }
+  container?.remove()
+  container = null
+  root = null
+  useAppStore.setState(initialAppState, true)
+})
+
+describe('WorktreeJumpPalette closed-render gating', () => {
+  it('mounts no content and renders zero times on store churn while closed', async () => {
+    await renderPalette()
+
+    expect(paletteDialog()).toBeNull()
+    expect(contentRenderProbe).not.toHaveBeenCalled()
+
+    churnAllClosedWriteTargets()
+
+    expect(contentRenderProbe).not.toHaveBeenCalled()
+    expect(paletteDialog()).toBeNull()
+  })
+
+  it('shows data mutated while closed as soon as it opens', async () => {
+    await renderPalette()
+
+    // A worktree created while the palette is closed must not render anything...
+    act(() => {
+      useAppStore.setState((s) => ({
+        worktreesByRepo: {
+          ...s.worktreesByRepo,
+          'repo-1': [
+            ...(s.worktreesByRepo['repo-1'] ?? []),
+            makeWorktree({
+              id: 'wt-charlie',
+              path: '/repo/worktrees/charlie',
+              displayName: 'palette-charlie',
+              branch: 'feature/palette-charlie',
+              sortOrder: 2
+            })
+          ]
+        }
+      }))
+    })
+    expect(contentRenderProbe).not.toHaveBeenCalled()
+
+    // ...but must be visible on the very first open, with no stale snapshot.
+    act(() => {
+      useAppStore.getState().openModal('worktree-palette')
+    })
+
+    expect(contentRenderProbe).toHaveBeenCalled()
+    const dialog = paletteDialog()
+    expect(dialog).not.toBeNull()
+    expect(dialog?.textContent).toContain('palette-alpha')
+    expect(dialog?.textContent).toContain('palette-charlie')
+  })
+
+  it('opens from the fully unmounted state via the store action the Cmd+J IPC handler drives', async () => {
+    await renderPalette()
+    expect(contentRenderProbe).not.toHaveBeenCalled()
+
+    // Why: the Cmd+J accelerator lives above this component (menu → IPC →
+    // useIpcEvents → openModal), so the shortcut path reduces to this action.
+    act(() => {
+      useAppStore.getState().openModal('worktree-palette')
+    })
+    expect(paletteDialog()).not.toBeNull()
+    expect(document.querySelector('[data-testid="palette-input"]')).not.toBeNull()
+
+    act(() => {
+      useAppStore.getState().closeModal()
+    })
+    expect(paletteDialog()).toBeNull()
+  })
+
+  it('unmounts content after the close linger and stops reacting to churn again', async () => {
+    vi.useFakeTimers()
+    await renderPalette()
+
+    act(() => {
+      useAppStore.getState().openModal('worktree-palette')
+    })
+    expect(contentRenderProbe).toHaveBeenCalled()
+
+    // Positive control: while open, the hot status maps are live-subscribed,
+    // so identity churn must re-render the content.
+    contentRenderProbe.mockClear()
+    act(() => {
+      useAppStore.setState((s) => ({ agentStatusByPaneKey: { ...s.agentStatusByPaneKey } }))
+    })
+    expect(contentRenderProbe).toHaveBeenCalled()
+
+    act(() => {
+      useAppStore.getState().closeModal()
+    })
+    // During the linger window the content must stay mounted with live status
+    // maps (`#7558` semantics) — dropping them here would flash the switcher
+    // rows empty mid close animation.
+    contentRenderProbe.mockClear()
+    act(() => {
+      useAppStore.setState((s) => ({ agentStatusByPaneKey: { ...s.agentStatusByPaneKey } }))
+    })
+    expect(contentRenderProbe).toHaveBeenCalled()
+
+    // Past the linger window the content unmounts.
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+
+    contentRenderProbe.mockClear()
+    churnAllClosedWriteTargets()
+    expect(contentRenderProbe).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -50,7 +50,8 @@ import {
   createWorktreePaletteRequestGuard,
   getNextWorktreePaletteSelection,
   getWorktreePaletteSelectionItemIds,
-  getWorktreePaletteCreateActionState
+  getWorktreePaletteCreateActionState,
+  type WorktreePaletteRequestGuard
 } from '@/lib/worktree-palette-create-action'
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
 import {
@@ -196,8 +197,9 @@ type PaletteListEntry = PaletteItem | CreateWorktreePaletteItem | SectionHeader 
 const CREATE_WORKSPACE_QUICK_ACTION_ITEM_ID = `quick-action:${CREATE_WORKSPACE_QUICK_ACTION_ID}`
 
 // Why: comfortably outlast the CommandDialog close animation (~150–200ms) so the
-// gated status maps stay live until the fading rows are gone from the DOM.
-const PALETTE_STATUS_INPUTS_LINGER_MS = 300
+// content — and its live status maps — stays mounted until the fading rows are
+// gone from the DOM.
+const PALETTE_CLOSE_LINGER_MS = 300
 
 function getComposerPrefetchRepoId(
   state: ReturnType<typeof useAppStore.getState>,
@@ -324,11 +326,58 @@ function getSettingsTargetFromSectionId(sectionId: string): {
   return { pane: sectionId as SettingsNavTarget, repoId: null }
 }
 
+// Why: `#7558` gated the two hottest status-map subscriptions while closed, but
+// the content component below still holds ~30 other store subscriptions
+// (prCache, unifiedTabsByWorktree, retainedAgentsByPaneKey, ...) that re-rendered
+// the closed palette on ordinary agent/terminal churn. This always-mounted shell
+// subscribes to a single boolean and mounts the content only while the dialog is
+// open or lingering through its close animation, so the closed cost collapses to
+// that one selector. Cmd+J lives above this component (menu accelerator → IPC →
+// openModal), so opening while unmounted still works.
 export default function WorktreeJumpPalette(): React.JSX.Element | null {
+  const visible = useAppStore((s) => s.activeModal === 'worktree-palette')
+  // Why: keep the content (and the hot status maps it subscribes to) mounted
+  // through the dialog's close animation. `visible` flips false synchronously on
+  // close, but the CommandDialog content stays in the DOM while it fades/zooms
+  // out — unmounting there would cut the animation short and flash the switcher
+  // rows empty. Linger a beat past close, then unmount.
+  const [lingering, setLingering] = useState(false)
+  useEffect(() => {
+    if (visible) {
+      setLingering(true)
+      return
+    }
+    const timer = window.setTimeout(() => setLingering(false), PALETTE_CLOSE_LINGER_MS)
+    return () => window.clearTimeout(timer)
+  }, [visible])
+  // Why: the guard must outlive content unmounts — a reopen invalidates the
+  // pending GH work-item lookup a previous create action left in flight.
+  const createLookupGuard = useMemo(() => createWorktreePaletteRequestGuard(), [])
+
+  if (!visible && !lingering) {
+    return null
+  }
+  return (
+    <WorktreeJumpPaletteContent
+      visible={visible}
+      lingering={lingering}
+      createLookupGuard={createLookupGuard}
+    />
+  )
+}
+
+export function WorktreeJumpPaletteContent({
+  visible,
+  lingering,
+  createLookupGuard
+}: {
+  visible: boolean
+  lingering: boolean
+  createLookupGuard: WorktreePaletteRequestGuard
+}): React.JSX.Element | null {
   // Why: subscribe this palette to language changes; translated memo contents
   // recompute on the rerender without using i18n.language as a fake dependency.
   useTranslation()
-  const visible = useAppStore((s) => s.activeModal === 'worktree-palette')
   const closeModal = useAppStore((s) => s.closeModal)
   const openModal = useAppStore((s) => s.openModal)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
@@ -343,31 +392,10 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const projectHostSetups = useAppStore((s) => s.projectHostSetups)
   const detectedWorktreesByRepo = useAppStore((s) => s.detectedWorktreesByRepo)
   const pendingWorktreeCreations = useAppStore((s) => s.pendingWorktreeCreations)
-  // Why: keep the (very hot) status maps subscribed through the dialog's close
-  // animation. `visible` flips false synchronously on close, but the CommandDialog
-  // content stays mounted while it fades/zooms out — dropping the maps to empty
-  // there would flash the switcher rows empty/reordered mid-animation. Linger a
-  // beat past close, then let the gate drop the subscription.
-  const [statusInputsLingering, setStatusInputsLingering] = useState(false)
-  useEffect(() => {
-    if (visible) {
-      setStatusInputsLingering(true)
-      return
-    }
-    const timer = window.setTimeout(
-      () => setStatusInputsLingering(false),
-      PALETTE_STATUS_INPUTS_LINGER_MS
-    )
-    return () => window.clearTimeout(timer)
-  }, [visible])
-  // Why: these five status maps drive per-worktree live/working dots and the
-  // switcher sort, but only matter while the palette is active. Two of them
-  // (agentStatusByPaneKey, runtimePaneTitlesByTabId) get a new identity on every
-  // agent-status / pane-title write app-wide, so subscribing to them while the
-  // always-mounted palette is closed re-rendered it on unrelated terminals. Gate
-  // the subscription on active-or-still-closing: a shared frozen constant while
-  // inactive keeps useShallow referentially equal across the churn, and the live
-  // maps flow through the instant the palette opens.
+  // Why: `#7558`'s selector gate — the shell's mount gate keeps this component
+  // active-only, but routing the same visible-or-lingering signal through the
+  // selector preserves the frozen-constant fallback should this ever render
+  // outside the shell (tests, future mounts).
   // - runtimePaneTitlesByTabId: split-pane tabs with a working agent in a
   //   non-focused pane still surface as 'working' (matches the sidebar spinner).
   // - ptyIdsByTabId: the live-pty source of truth — slept tabs keep a wake-hint
@@ -378,7 +406,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     tabsByWorktree
-  } = useAppStore(useShallow((s) => selectPaletteStatusInputs(s, visible || statusInputsLingering)))
+  } = useAppStore(useShallow((s) => selectPaletteStatusInputs(s, visible || lingering)))
   const prCache = useAppStore((s) => s.prCache)
   const issueCache = useAppStore((s) => s.issueCache)
   const migrationUnsupportedByPtyId = useAppStore((s) => s.migrationUnsupportedByPtyId)
@@ -432,7 +460,6 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const listRef = useRef<HTMLDivElement>(null)
   const fallbackFocusOuterFrameRef = useRef<number | null>(null)
   const fallbackFocusInnerFrameRef = useRef<number | null>(null)
-  const createLookupGuard = useMemo(() => createWorktreePaletteRequestGuard(), [])
   const preserveCreateLookupOnCloseRef = useRef(false)
 
   const repoMap = useMemo(() => new Map(repos.map((r) => [r.id, r])), [repos])

--- a/src/renderer/src/components/worktree-jump-palette-status-inputs.ts
+++ b/src/renderer/src/components/worktree-jump-palette-status-inputs.ts
@@ -14,13 +14,13 @@ export type PaletteStatusInputs = PaletteStatusInputsState
 // Why: shared frozen bundle returned whenever the Cmd+J jump palette isn't
 // active. The two hottest maps here — agentStatusByPaneKey and
 // runtimePaneTitlesByTabId — get a new top-level identity on every agent-status
-// transition and every terminal pane-title write app-wide. The palette is always
-// mounted (App.tsx renders <CommandDialog open={visible}>) and stays mounted for
-// the whole session once opened, so subscribing to them while it's closed
-// re-rendered the whole palette — and recomputed its per-worktree live/working-dot
-// sort over every worktree — on unrelated terminal chatter. A useShallow
-// subscription keeps this same reference across that churn, so the closed palette
-// stops reacting. Frozen so the shared singleton can't be mutated.
+// transition and every terminal pane-title write app-wide; subscribing to them
+// while the palette was closed re-rendered the whole palette — and recomputed its
+// per-worktree live/working-dot sort over every worktree — on unrelated terminal
+// chatter. The palette content now unmounts entirely while inactive (its shell
+// mounts it on visible-or-lingering), so this constant is the defense-in-depth
+// path for any render outside that gate. A useShallow subscription keeps this
+// same reference across the churn. Frozen so the shared singleton can't be mutated.
 export const EMPTY_PALETTE_STATUS_INPUTS: PaletteStatusInputs = Object.freeze({
   agentStatusByPaneKey: {},
   runtimePaneTitlesByTabId: {},


### PR DESCRIPTION
## Problem

`WorktreeJumpPalette` stays mounted for the whole session once opened (App.tsx lazy-mounts it and never unmounts). `#7558` gated the two hottest status-map subscriptions (`selectPaletteStatusInputs`) behind `visible || lingering`, but ~30 other store subscriptions in the component stayed live unconditionally — `prCache`, `issueCache`, `retainedAgentsByPaneKey`, `sleepingAgentSessionsByPaneKey`, `unifiedTabsByWorktree`, `browserPagesByWorkspace`, and more. Every moderate-frequency write to any of them re-rendered the closed palette (and re-ran its ~30 `useMemo`s) during ordinary agent/terminal use.

## Fix

Finish `#7558`'s approach structurally instead of slice-by-slice:

- **Shell** (`WorktreeJumpPalette`, always mounted): subscribes to a single boolean (`activeModal === 'worktree-palette'`), owns the existing 300ms close-animation linger timer and the create-lookup request guard, and mounts the content only while `visible || lingering`. Closed cost collapses to one boolean selector.
- **Content** (`WorktreeJumpPaletteContent`, same file — it's grandfathered in the max-lines baseline): all previous subscriptions, memos, and dialog rendering, unchanged. The `selectPaletteStatusInputs(s, visible || lingering)` gate is kept verbatim so `#7558`'s close-animation freshness semantics are preserved exactly.

Behavior preserved:

- **Shortcut / open while closed**: Cmd+J lives above the component (menu accelerator → IPC → `useIpcEvents` → `openModal`), so it opens the palette from the fully unmounted state.
- **Open freshness**: content mounts on the same render `visible` flips true and subscribes live immediately; open-time compute is the same work the open palette already did after `#7558` (status inputs change identity on open, so downstream memos recomputed anyway).
- **Close animation**: content lingers 300ms past close with live status maps — no empty-row flash mid fade-out; then unmounts.
- **Pending create lookups**: the request guard moved to the shell so it outlives content unmounts — reopening still invalidates a pending GH work-item lookup, exactly as before.

## Tests

New `WorktreeJumpPalette.closed-render-gating.test.tsx` (render-count pattern, extends `#7558`'s selector tests which still pass unchanged):

- closed palette: identity churn on `prCache`/`issueCache`/`retainedAgentsByPaneKey`/`unifiedTabsByWorktree`/`agentStatusByPaneKey`/`runtimePaneTitlesByTabId` → **zero** content renders
- data mutated while closed appears on the very first open (no stale snapshot)
- opening from the unmounted state via the store action the Cmd+J IPC handler drives
- live status-map subscription while open and during the linger window (positive controls), unmount + zero renders after the linger expires

`vitest` on all 6 palette-related suites: 48/48 green. Full `pnpm typecheck` clean. `check:max-lines-ratchet` OK (no new suppressions).

Made with [Orca](https://github.com/stablyai/orca) 🐋
