### PR TITLE
feat(ai-vault): add OMP sessions to the AI Vault session browser

### DIFF
--- a/src/main/ai-vault/remote-session-scanner-sources.ts
+++ b/src/main/ai-vault/remote-session-scanner-sources.ts
@@ -15,7 +15,7 @@ import {
   parseHermesSessionContent
 } from './session-scanner-secondary-parsers'
 import type { FileWithMtime } from './session-scanner-types'
-import { normalizePiSessionsDir } from './session-scanner-values'
+import { normalizeAgentSessionsDir } from './session-scanner-values'
 import { remoteCodexIndexTitles } from './remote-session-scanner-codex-index'
 import type {
   RemoteParserOptions,
@@ -83,6 +83,7 @@ export function remoteSessionSources(
       parseDevinSessionContent
     ),
     jsonlSource('pi', remoteHome, hostPlatform, remotePiSessionsSegments(), piParser),
+    jsonlSource('omp', remoteHome, hostPlatform, remoteOmpSessionsSegments(), ompParser),
     jsonlSource(
       'droid',
       remoteHome,
@@ -203,6 +204,15 @@ function piParser(
   return parseMessageGraphSessionContent('pi', file, content, platform, options)
 }
 
+function ompParser(
+  file: FileWithMtime,
+  content: string,
+  platform: NodeJS.Platform,
+  options: RemoteParserOptions
+): Promise<AiVaultSession | null> {
+  return parseMessageGraphSessionContent('omp', file, content, platform, options)
+}
+
 function openClawParser(
   file: FileWithMtime,
   content: string,
@@ -217,5 +227,9 @@ function remotePathSegments(path: string): string[] {
 }
 
 function remotePiSessionsSegments(): string[] {
-  return normalizePiSessionsDir('/.pi/agent/sessions').split('/').filter(Boolean)
+  return normalizeAgentSessionsDir('/.pi/agent/sessions', '.pi').split('/').filter(Boolean)
+}
+
+function remoteOmpSessionsSegments(): string[] {
+  return normalizeAgentSessionsDir('/.omp/agent/sessions', '.omp').split('/').filter(Boolean)
 }

--- a/src/main/ai-vault/session-scanner-accumulator.ts
+++ b/src/main/ai-vault/session-scanner-accumulator.ts
@@ -113,6 +113,7 @@ export function finalizeSession(
     resumeCommand: buildAiVaultResumeCommand({
       agent: accumulator.agent,
       sessionId,
+      resumeFilePath: accumulator.filePath,
       cwd: accumulator.cwd,
       platform,
       codexHome: options.codexHome

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -64,6 +64,8 @@ export async function parseAgentSessionFile(
       return parseMessageGraphSessionFile('openclaw', candidate.file, platform)
     case 'pi':
       return parseMessageGraphSessionFile('pi', candidate.file, platform)
+    case 'omp':
+      return parseMessageGraphSessionFile('omp', candidate.file, platform)
     case 'droid':
       return parseDroidSessionFile(candidate.file, platform)
     case 'devin':

--- a/src/main/ai-vault/session-scanner-codex-workers.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-workers.test.ts
@@ -117,6 +117,7 @@ describe('scanAiVaultSessions Codex worker sessions', () => {
       openclawStateDir: join(root, 'openclaw-state'),
       openclawLegacyStateDir: join(root, 'openclaw-legacy-state'),
       piSessionsDir: join(root, 'pi-sessions'),
+      ompSessionsDir: join(root, 'omp-sessions'),
       droidSessionsDir: join(root, 'droid-sessions'),
       droidProjectsDir: join(root, 'droid-projects'),
       kimiSessionsDir: join(root, 'kimi-sessions'),

--- a/src/main/ai-vault/session-scanner-graph-parsers.ts
+++ b/src/main/ai-vault/session-scanner-graph-parsers.ts
@@ -163,8 +163,12 @@ export function rovoPartsText(parts: unknown[], role: 'user' | 'assistant'): str
   return extractContentText(textParts)
 }
 
+// Agents whose transcripts are append-only message-graph JSONL (session +
+// model_change + message records). OMP is a Pi fork and shares the format.
+export type MessageGraphAgent = 'openclaw' | 'pi' | 'omp'
+
 export async function parseMessageGraphSessionFile(
-  agent: 'openclaw' | 'pi',
+  agent: MessageGraphAgent,
   file: FileWithMtime,
   platform: NodeJS.Platform = process.platform
 ): Promise<AiVaultSession | null> {
@@ -176,7 +180,7 @@ export async function parseMessageGraphSessionFile(
 }
 
 export async function parseMessageGraphSessionContent(
-  agent: 'openclaw' | 'pi',
+  agent: MessageGraphAgent,
   file: FileWithMtime,
   content: string,
   platform: NodeJS.Platform = process.platform,
@@ -206,7 +210,10 @@ function consumeMessageGraphRecordLine(accumulator: SessionAccumulator, line: st
     return
   }
   if (record.type === 'model_change') {
-    accumulator.model = extractString(record.modelId) ?? accumulator.model
+    // Pi writes `modelId`; OMP writes `model`. Prefer either so an in-progress
+    // session shows its model before the first assistant reply lands.
+    accumulator.model =
+      extractString(record.modelId) ?? extractString(record.model) ?? accumulator.model
     return
   }
   if (record.type !== 'message') {
@@ -227,7 +234,7 @@ function consumeMessageGraphRecordLine(accumulator: SessionAccumulator, line: st
 }
 
 export function createMessageGraphSessionResumeState(
-  agent: 'openclaw' | 'pi',
+  agent: MessageGraphAgent,
   file: FileWithMtime
 ): ResumableSessionParseState {
   return accumulatorFoldResumeState(
@@ -237,7 +244,7 @@ export function createMessageGraphSessionResumeState(
 }
 
 async function parseMessageGraphSessionLines(args: {
-  agent: 'openclaw' | 'pi'
+  agent: MessageGraphAgent
   file: FileWithMtime
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform

--- a/src/main/ai-vault/session-scanner-incremental-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-incremental-fixtures.ts
@@ -188,6 +188,56 @@ export function piFixture(): IncrementalAgentFixture {
   }
 }
 
+// OMP is a Pi fork sharing the message-graph format, but keys the model on
+// `model` (not Pi's `modelId`); its own fixture exercises the registry's 'omp'
+// branch and that model-key difference. (The session `title` is included for
+// realism only — the parser derives the title from the first user message.)
+export function ompFixture(): IncrementalAgentFixture {
+  return {
+    agent: 'omp',
+    fileName: '2026-05-01T10-00-00-000Z_cccccccc-dddd-4eee-8fff-000000000000.jsonl',
+    seedLines: [
+      JSON.stringify({
+        type: 'session',
+        version: 3,
+        id: 'cccccccc-dddd-4eee-8fff-000000000000',
+        cwd: '/repo/app',
+        title: 'OMP session title',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      }),
+      JSON.stringify({
+        type: 'model_change',
+        model: 'gpt-5.4-mini',
+        timestamp: '2026-05-01T10:00:01.000Z'
+      }),
+      JSON.stringify({
+        type: 'message',
+        message: { role: 'user', content: [{ type: 'text', text: 'omp seed question' }] },
+        timestamp: '2026-05-01T10:00:05.000Z'
+      })
+    ],
+    appendLines: [
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'omp incremental answer' }],
+          model: 'gpt-5.4-mini',
+          usage: { input: 40, output: 20, totalTokens: 60 }
+        },
+        timestamp: '2026-05-01T10:01:00.000Z'
+      })
+    ],
+    truncatedLines: [
+      JSON.stringify({
+        type: 'session',
+        id: 'cccccccc-dddd-4eee-8fff-000000000000',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      })
+    ]
+  }
+}
+
 export function geminiJsonlFixture(): IncrementalAgentFixture {
   return {
     agent: 'gemini',
@@ -235,6 +285,7 @@ export function allIncrementalAgentFixtures(): IncrementalAgentFixture[] {
     droidFixture(),
     openclawFixture(),
     piFixture(),
+    ompFixture(),
     geminiJsonlFixture()
   ]
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -36,7 +36,8 @@ function isolatedScanRoots(root: string) {
     piSessionsDir: join(root, 'pi-sessions'),
     droidSessionsDir: join(root, 'droid-sessions'),
     droidProjectsDir: join(root, 'droid-projects'),
-    kimiSessionsDir: join(root, 'kimi-sessions')
+    kimiSessionsDir: join(root, 'kimi-sessions'),
+    ompSessionsDir: join(root, 'omp-sessions')
   }
 }
 

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -68,7 +68,12 @@ function resumableStateFactoryFor(
       return candidate.file.path.endsWith('.jsonl')
         ? () => createGeminiJsonlSessionResumeState(candidate.file)
         : null
-    default:
+    case 'devin':
+    case 'grok':
+    case 'hermes':
+    case 'kimi':
+    case 'opencode':
+    case 'rovo':
       return null
   }
 }
@@ -104,7 +109,7 @@ function storeEntry(path: string, entry: SessionParseCacheEntry): void {
 /**
  * Parse a session file, reusing prior work where the file is provably
  * unchanged (mtime+size) and, for append-only JSONL transcripts (Claude,
- * Codex, Cursor, Copilot, Droid, OpenClaw/Pi, Gemini-JSONL), resuming the
+ * Codex, Cursor, Copilot, Droid, OpenClaw/Pi/OMP, Gemini-JSONL), resuming the
  * parse from the last consumed byte when the file only grew. This is what
  * keeps the renderer's ~5s forced rescans from re-reading gigabytes of
  * transcripts (STA-1278/STA-1417: main process pegging one core during

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -59,7 +59,8 @@ function resumableStateFactoryFor(
     case 'droid':
       return () => createDroidSessionResumeState(candidate.file)
     case 'openclaw':
-    case 'pi': {
+    case 'pi':
+    case 'omp': {
       const agent = candidate.agent
       return () => createMessageGraphSessionResumeState(agent, candidate.file)
     }

--- a/src/main/ai-vault/session-scanner-source-discovery.ts
+++ b/src/main/ai-vault/session-scanner-source-discovery.ts
@@ -6,7 +6,7 @@ import { discoverFiles, discoverOpenClawFiles } from './session-scanner-discover
 import { droidDiscoveries, kimiDiscoveries } from './session-scanner-droid-kimi-sources'
 import { opencodeDiscoveries } from './session-scanner-opencode-sources'
 import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner-types'
-import { normalizePiSessionsDir } from './session-scanner-values'
+import { normalizeAgentSessionsDir } from './session-scanner-values'
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects')
 export const DEFAULT_CODEX_HOME_DIR = join(homedir(), '.codex')
@@ -25,8 +25,13 @@ const GROK_SESSIONS_DIR = join(
 const HERMES_SESSIONS_DIR = join(homedir(), '.hermes', 'sessions')
 const ROVO_SESSIONS_DIR = join(homedir(), '.rovodev', 'sessions')
 const OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR?.trim() || join(homedir(), '.openclaw')
-const PI_SESSIONS_DIR = normalizePiSessionsDir(
-  process.env.PI_CODING_AGENT_DIR?.trim() || join(homedir(), '.pi', 'agent', 'sessions')
+const PI_SESSIONS_DIR = normalizeAgentSessionsDir(
+  process.env.PI_CODING_AGENT_DIR?.trim() || join(homedir(), '.pi', 'agent', 'sessions'),
+  '.pi'
+)
+const OMP_SESSIONS_DIR = normalizeAgentSessionsDir(
+  process.env.OMP_CODING_AGENT_DIR?.trim() || join(homedir(), '.omp', 'agent', 'sessions'),
+  '.omp'
 )
 // Why: Devin ATIF transcripts are stored under <DEVIN_HOME>/transcripts.
 const DEVIN_TRANSCRIPTS_DIR = join(
@@ -124,7 +129,8 @@ function standardDiscoveries(
     ...devinDiscoveries(options, wslHomeDirs, limit, issues),
     ...hermesDiscoveries(options, wslHomeDirs, limit, issues),
     ...rovoDiscoveries(options, wslHomeDirs, limit, issues),
-    ...piDiscoveries(options, wslHomeDirs, limit, issues)
+    ...piDiscoveries(options, wslHomeDirs, limit, issues),
+    ...ompDiscoveries(options, wslHomeDirs, limit, issues)
   ]
 }
 
@@ -241,6 +247,21 @@ function piDiscoveries(
     'sessions'
   ]).map((rootDir) =>
     discoverFiles({ rootDir, limit, agent: 'pi', issues, extensions: ['.jsonl'] })
+  )
+}
+
+function ompDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(options.ompSessionsDir ?? OMP_SESSIONS_DIR, wslHomeDirs, [
+    '.omp',
+    'agent',
+    'sessions'
+  ]).map((rootDir) =>
+    discoverFiles({ rootDir, limit, agent: 'omp', issues, extensions: ['.jsonl'] })
   )
 }
 

--- a/src/main/ai-vault/session-scanner-test-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-test-fixtures.ts
@@ -19,6 +19,7 @@ export function isolatedScanRoots(root: string) {
     openclawStateDir: join(root, 'openclaw-state'),
     openclawLegacyStateDir: join(root, 'openclaw-legacy-state'),
     piSessionsDir: join(root, 'pi-sessions'),
+    ompSessionsDir: join(root, 'omp-sessions'),
     droidSessionsDir: join(root, 'droid-sessions'),
     droidProjectsDir: join(root, 'droid-projects'),
     kimiSessionsDir: join(root, 'kimi-sessions')

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -25,6 +25,7 @@ export type AiVaultScanOptions = {
   openclawStateDir?: string
   openclawLegacyStateDir?: string
   piSessionsDir?: string
+  ompSessionsDir?: string
   droidSessionsDir?: string
   droidProjectsDir?: string
   kimiSessionsDir?: string

--- a/src/main/ai-vault/session-scanner-values.test.ts
+++ b/src/main/ai-vault/session-scanner-values.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   extractPreviewContentText,
+  normalizeAgentSessionsDir,
   normalizePreviewText,
   normalizeTitleText
 } from './session-scanner-values'
@@ -50,5 +51,21 @@ describe('AI Vault session scanner text values', () => {
     const result = normalizePreviewText(`${'a'.repeat(216)}😀tail`)
 
     expect(result).toBe(`${'a'.repeat(216)}...`)
+  })
+
+  it('expands Pi and OMP agent homes to their session directories', () => {
+    expect(normalizeAgentSessionsDir('/agents/.pi', '.pi')).toBe('/agents/.pi/agent/sessions')
+    expect(normalizeAgentSessionsDir('/agents/.pi/agent', '.pi')).toBe('/agents/.pi/agent/sessions')
+    expect(normalizeAgentSessionsDir('/agents/.pi/agent/sessions', '.pi')).toBe(
+      '/agents/.pi/agent/sessions'
+    )
+
+    expect(normalizeAgentSessionsDir('/agents/.omp', '.omp')).toBe('/agents/.omp/agent/sessions')
+    expect(normalizeAgentSessionsDir('/agents/.omp/agent', '.omp')).toBe(
+      '/agents/.omp/agent/sessions'
+    )
+    expect(normalizeAgentSessionsDir('/agents/.omp/agent/sessions', '.omp')).toBe(
+      '/agents/.omp/agent/sessions'
+    )
   })
 })

--- a/src/main/ai-vault/session-scanner-values.ts
+++ b/src/main/ai-vault/session-scanner-values.ts
@@ -126,10 +126,15 @@ export function findOpenCodeStorageRoot(filePath: string): string | null {
   return dirname(sessionRoot)
 }
 
-export function normalizePiSessionsDir(rawValue: string): string {
+// Pi and OMP (a Pi fork) both store transcripts under
+// <home>/<agentHomeDirName>/agent/sessions; accept any prefix of that path.
+export function normalizeAgentSessionsDir(
+  rawValue: string,
+  agentHomeDirName: '.pi' | '.omp'
+): string {
   const trimmed = rawValue.trim()
   if (!trimmed) {
-    return join(homedir(), '.pi', 'agent', 'sessions')
+    return join(homedir(), agentHomeDirName, 'agent', 'sessions')
   }
   const normalized = trimmed.replace(/[\\/]+$/, '')
   const leaf = basename(normalized)
@@ -139,7 +144,7 @@ export function normalizePiSessionsDir(rawValue: string): string {
   if (leaf === 'agent') {
     return join(normalized, 'sessions')
   }
-  if (leaf === '.pi') {
+  if (leaf === agentHomeDirName) {
     return join(normalized, 'agent', 'sessions')
   }
   return normalized

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { AI_VAULT_AGENTS, buildAiVaultResumeCommand } from '../../shared/ai-vault-types'
+import { AI_VAULT_AGENTS } from '../../shared/ai-vault-types'
 import { scanAiVaultSessions } from './session-scanner'
 import { isolatedScanRoots, jsonLines } from './session-scanner-test-fixtures'
 
@@ -584,6 +584,44 @@ describe('scanAiVaultSessions', () => {
       ])
     )
 
+    const ompSessionFile = join(roots.ompSessionsDir, 'omp-session.jsonl')
+    await mkdir(roots.ompSessionsDir, { recursive: true })
+    await writeFile(
+      ompSessionFile,
+      jsonLines([
+        {
+          type: 'session',
+          version: 3,
+          id: 'omp-session',
+          title: 'OMP session title',
+          timestamp: '2026-05-01T10:08:30.000Z',
+          cwd: '/tmp/omp'
+        },
+        {
+          type: 'model_change',
+          model: 'gpt-5.4-mini',
+          timestamp: '2026-05-01T10:08:30.500Z'
+        },
+        {
+          type: 'message',
+          timestamp: '2026-05-01T10:08:31.000Z',
+          message: { role: 'user', content: [{ type: 'text', text: 'OMP title' }] }
+        },
+        {
+          type: 'message',
+          timestamp: '2026-05-01T10:08:32.000Z',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'OMP answer' }],
+            model: 'gpt-5.4-mini',
+            // totalTokens deliberately != input+output so the assertion proves
+            // the explicit-total field is read, not an input/output sum.
+            usage: { input: 10, output: 5, totalTokens: 160 }
+          }
+        }
+      ])
+    )
+
     await mkdir(roots.devinTranscriptsDir, { recursive: true })
     await writeFile(
       join(roots.devinTranscriptsDir, 'devin-session.json'),
@@ -719,11 +757,48 @@ describe('scanAiVaultSessions', () => {
       "cd '/tmp/openclaw' && openclaw --resume 'openclaw-session'"
     )
     expect(commandByAgent.get('pi')).toBe("cd '/tmp/pi' && pi --session 'pi-session'")
+    // OMP resumes by absolute transcript path, not by internal session id.
+    expect(commandByAgent.get('omp')).toBe(`cd '/tmp/omp' && omp --resume '${ompSessionFile}'`)
     expect(commandByAgent.get('devin')).toBe("cd '/tmp/devin' && devin --resume 'devin-session'")
     expect(commandByAgent.get('droid')).toBe("cd '/tmp/droid' && droid --resume 'droid-session'")
     expect(commandByAgent.get('kimi')).toBe(
       "cd '/tmp/kimi' && kimi --session 'session_kimi-session'"
     )
+
+    const ompSession = result.sessions.find((session) => session.agent === 'omp')
+    expect(ompSession?.model).toBe('gpt-5.4-mini')
+    expect(ompSession?.totalTokens).toBe(160)
+  })
+
+  it('captures an in-progress OMP model from model_change before any assistant reply', async () => {
+    // OMP writes the model on `model_change.model` (not Pi's `modelId`). With no
+    // assistant message yet, the model must still come through — proving the
+    // model_change fallback rather than assistant-message capture.
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-omp-mc-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    await mkdir(roots.ompSessionsDir, { recursive: true })
+    await writeFile(
+      join(roots.ompSessionsDir, 'omp-in-progress.jsonl'),
+      jsonLines([
+        {
+          type: 'session',
+          id: 'omp-in-progress',
+          timestamp: '2026-05-01T10:00:00.000Z',
+          cwd: '/tmp/omp'
+        },
+        { type: 'model_change', model: 'omp-mc-only-model', timestamp: '2026-05-01T10:00:01.000Z' },
+        {
+          type: 'message',
+          timestamp: '2026-05-01T10:00:02.000Z',
+          message: { role: 'user', content: [{ type: 'text', text: 'first prompt' }] }
+        }
+      ])
+    )
+
+    const result = await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 5 })
+    const session = result.sessions.find((s) => s.agent === 'omp')
+    expect(session?.model).toBe('omp-mc-only-model')
   })
 
   it('strips newline-heavy Grok user_query envelopes without regex matching', async () => {
@@ -767,44 +842,5 @@ describe('scanAiVaultSessions', () => {
         pattern.source.includes('[\\s\\S]')
     )
     expect(usedGrokWrapperMatch).toBe(false)
-  })
-})
-
-describe('buildAiVaultResumeCommand', () => {
-  it('wraps Windows cwd changes in cmd so PowerShell and cmd launch the same resume command', () => {
-    expect(
-      buildAiVaultResumeCommand({
-        agent: 'codex',
-        sessionId: 'session-1',
-        cwd: 'C:\\Users\\Ada Lovelace\\repo',
-        platform: 'win32'
-      })
-    ).toBe('cmd /d /s /c "cd /d ""C:\\Users\\Ada Lovelace\\repo"" && codex resume ""session-1"""')
-  })
-
-  it('carries non-default Codex homes in copied resume commands', () => {
-    expect(
-      buildAiVaultResumeCommand({
-        agent: 'codex',
-        sessionId: 'session-1',
-        cwd: '/repo/app',
-        platform: 'darwin',
-        codexHome: '/Users/ada/Library/Application Support/Orca/codex-runtime-home/home'
-      })
-    ).toBe(
-      "cd '/repo/app' && CODEX_HOME='/Users/ada/Library/Application Support/Orca/codex-runtime-home/home' codex resume 'session-1'"
-    )
-
-    expect(
-      buildAiVaultResumeCommand({
-        agent: 'codex',
-        sessionId: 'session-1',
-        cwd: 'C:\\Users\\Ada Lovelace\\repo',
-        platform: 'win32',
-        codexHome: 'C:\\Users\\Ada\\AppData\\Roaming\\Orca\\codex-runtime-home\\home'
-      })
-    ).toBe(
-      'cmd /d /s /c "cd /d ""C:\\Users\\Ada Lovelace\\repo"" && set ""CODEX_HOME=C:\\Users\\Ada\\AppData\\Roaming\\Orca\\codex-runtime-home\\home"" && codex resume ""session-1"""'
-    )
   })
 })

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
@@ -154,7 +154,10 @@ export function AiVaultSessionVirtualList({
   })
 
   return (
-    <div ref={listScrollRef} className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
+    <div
+      ref={listScrollRef}
+      className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-sleek"
+    >
       {loading && sessionsCount === 0 ? <SessionLoadingState /> : null}
 
       {!loading && sessionsCount === 0 && !error ? (

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -123,6 +123,29 @@ describe('ai vault resume command runtime', () => {
     ).toBe("cd 'C:\\Users\\alice\\repo' && claude '--resume' 'session one'")
   })
 
+  it('resumes a local OMP session by its absolute transcript path, not its id', () => {
+    // Regression: local rebuilds must forward session.filePath so OMP resumes by
+    // path (not the internal id) even when the session lives in a non-default store.
+    const state = makeState({ worktreePath: 'C:\\Users\\alice\\repo' })
+
+    const command = buildAiVaultResumeCommandForWorktree({
+      state,
+      worktreeId: 'repo-1::worktree-1',
+      session: {
+        agent: 'omp',
+        sessionId: '019f27cd-4268-7000-96e7-62f42a55c144',
+        filePath: 'C:\\Users\\alice\\.omp\\agent\\sessions\\repo\\sess.jsonl',
+        cwd: 'C:\\Users\\alice\\repo',
+        codexHome: null
+      }
+    })
+
+    expect(command).toBe(
+      'cmd /d /s /c "cd /d ""C:\\Users\\alice\\repo"" && omp --resume ""C:\\Users\\alice\\.omp\\agent\\sessions\\repo\\sess.jsonl"""'
+    )
+    expect(command).not.toContain('019f27cd-4268-7000-96e7-62f42a55c144')
+  })
+
   it('keeps the cmd wrapper for the copy-to-clipboard command on Windows', () => {
     // Regression guard: the copy path is self-contained for pasting into cmd.exe
     // and must stay cmd-wrapped even though the queued path now follows the shell.

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -26,7 +26,9 @@ type AiVaultResumeCommandSession = Pick<
   AiVaultSession,
   'agent' | 'sessionId' | 'cwd' | 'codexHome'
 > &
-  Partial<Pick<AiVaultSession, 'executionHostId' | 'executionHostPlatform' | 'resumeCommand'>>
+  Partial<
+    Pick<AiVaultSession, 'executionHostId' | 'executionHostPlatform' | 'resumeCommand' | 'filePath'>
+  >
 
 export type AiVaultResumeStartup = {
   command: string
@@ -127,6 +129,10 @@ export function buildAiVaultResumeStartupForWorktree(args: {
     command: buildAiVaultResumeCommand({
       agent: args.session.agent,
       sessionId: args.session.sessionId,
+      // Why: OMP resumes by absolute transcript path, so local rebuilds must
+      // forward it too — otherwise a custom OMP_CODING_AGENT_DIR / WSL-store
+      // session would resume by id against the default store and miss.
+      resumeFilePath: args.session.filePath,
       cwd: args.session.cwd,
       platform,
       commandOverride: args.commandOverride,

--- a/src/shared/ai-vault-resume-command.test.ts
+++ b/src/shared/ai-vault-resume-command.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildAiVaultResumeCommand } from './ai-vault-types'
+
+describe('buildAiVaultResumeCommand', () => {
+  it('wraps Windows cwd changes in cmd so PowerShell and cmd launch the same resume command', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'codex',
+        sessionId: 'session-1',
+        cwd: 'C:\\Users\\Ada Lovelace\\repo',
+        platform: 'win32'
+      })
+    ).toBe('cmd /d /s /c "cd /d ""C:\\Users\\Ada Lovelace\\repo"" && codex resume ""session-1"""')
+  })
+
+  it('carries non-default Codex homes in copied resume commands', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'codex',
+        sessionId: 'session-1',
+        cwd: '/repo/app',
+        platform: 'darwin',
+        codexHome: '/Users/ada/Library/Application Support/Orca/codex-runtime-home/home'
+      })
+    ).toBe(
+      "cd '/repo/app' && CODEX_HOME='/Users/ada/Library/Application Support/Orca/codex-runtime-home/home' codex resume 'session-1'"
+    )
+
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'codex',
+        sessionId: 'session-1',
+        cwd: 'C:\\Users\\Ada Lovelace\\repo',
+        platform: 'win32',
+        codexHome: 'C:\\Users\\Ada\\AppData\\Roaming\\Orca\\codex-runtime-home\\home'
+      })
+    ).toBe(
+      'cmd /d /s /c "cd /d ""C:\\Users\\Ada Lovelace\\repo"" && set ""CODEX_HOME=C:\\Users\\Ada\\AppData\\Roaming\\Orca\\codex-runtime-home\\home"" && codex resume ""session-1"""'
+    )
+  })
+
+  it('resumes OMP by absolute transcript path so it resolves across session-dir roots', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'omp',
+        sessionId: '019f27cd-4268-7000-96e7-62f42a55c144',
+        resumeFilePath:
+          '/Users/ada/.omp/agent/sessions/repo/2026-07-03T11-30-29-357Z_019f27be/OmpScannerTests.jsonl',
+        cwd: '/Users/ada/repo',
+        platform: 'darwin'
+      })
+    ).toBe(
+      "cd '/Users/ada/repo' && omp --resume '/Users/ada/.omp/agent/sessions/repo/2026-07-03T11-30-29-357Z_019f27be/OmpScannerTests.jsonl'"
+    )
+  })
+
+  it('falls back to the session id when no OMP transcript path is known', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'omp',
+        sessionId: '019f27cd-4268-7000-96e7-62f42a55c144',
+        resumeFilePath: null,
+        cwd: '/Users/ada/repo',
+        platform: 'darwin'
+      })
+    ).toBe("cd '/Users/ada/repo' && omp --resume '019f27cd-4268-7000-96e7-62f42a55c144'")
+  })
+})

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -12,6 +12,7 @@ export const AI_VAULT_AGENTS = [
   'codex',
   'hermes',
   'pi',
+  'omp',
   'cursor',
   'gemini',
   'rovo',
@@ -34,6 +35,7 @@ export const AI_VAULT_AGENT_LABELS = {
   codex: 'Codex',
   hermes: 'Hermes',
   pi: 'Pi',
+  omp: 'OMP',
   cursor: 'Cursor',
   gemini: 'Gemini',
   rovo: 'Rovo Dev',
@@ -102,10 +104,16 @@ export function buildAiVaultResumeCommand(args: {
   platform: NodeJS.Platform
   commandOverride?: string | null
   codexHome?: string | null
+  resumeFilePath?: string | null
 }): string {
-  const { agent, sessionId, cwd, platform, commandOverride, codexHome } = args
+  const { agent, sessionId, cwd, platform, commandOverride, codexHome, resumeFilePath } = args
   const baseCommand = commandOverride?.trim() || defaultAiVaultResumeCommandBase(agent)
-  const sessionArg = quoteShellArg(sessionId, platform)
+  // Why: OMP's `--resume` accepts an absolute transcript path, which resolves
+  // regardless of which session-dir root (custom OMP_CODING_AGENT_DIR / WSL
+  // home) the file was discovered under, where an id-prefix lookup scoped to
+  // the default store would miss it. Falls back to the id if no path is known.
+  const resumeTarget = agent === 'omp' && resumeFilePath?.trim() ? resumeFilePath.trim() : sessionId
+  const sessionArg = quoteShellArg(resumeTarget, platform)
   const resumeCommand = buildAgentResumeInvocation(agent, baseCommand, sessionArg)
 
   return buildAiVaultResumeShellCommand({ resumeCommand, cwd, platform, codexHome })
@@ -222,6 +230,9 @@ function buildAgentResumeInvocation(
     case 'devin':
     case 'openclaw':
     case 'droid':
+    // Why: OMP resumes by absolute transcript path (see buildAiVaultResumeCommand),
+    // but the `--resume <arg>` invocation form is identical to the others here.
+    case 'omp':
       return `${baseCommand} --resume ${sessionArg}`
   }
 }


### PR DESCRIPTION
## Summary

Adds **OMP** ("Oh My Pi", a Pi fork) to the AI Vault / Agents session catalog so
historical `.omp/agent/sessions/**/*.jsonl` transcripts are discovered, parsed,
and resumable from the right-sidebar session browser — **locally and over SSH**.

This takes over and supersedes #7255 (thanks @gatsby74 — credited via
`Co-authored-by`). That branch was green against its own base but **stale against
current `main`**, which had since refactored the scanner. Rebuilt on current
`main` and hardened via an adversarial multi-lens review.

## What it does

- **Discovery** mirrors Pi exactly (`OMP_CODING_AGENT_DIR` env, WSL home roots,
  per-agent scan limit, `.jsonl`) in the **local** scanner *and* the **remote/SSH**
  scanner.
- **Parsing** goes through the shared message-graph parser via a new
  `MessageGraphAgent` type. Captures the model from `model_change.model` (OMP's
  key — Pi uses `modelId`) or the assistant message, and tokens from `usage`.
- **Incremental parse cache**: OMP joins the openclaw/pi branch so ~5s rescans
  resume from the last byte instead of re-reading whole transcripts (STA-1278/1417).
- **Resume by absolute transcript path** (`omp --resume <path>`) — it resolves
  regardless of which session-dir root the file was discovered under (custom
  `OMP_CODING_AGENT_DIR` / WSL store), where an id-prefix lookup against the
  default store would miss. Threaded through both the scanner **and** the
  renderer's local resume/copy rebuild.
- **Renderer** reuses the existing `OmpIcon` / agent catalog / dynamic grouping
  (OMP was already a first-class agent elsewhere); adds `overflow-x-hidden` so a
  long worktree chip can't widen the sidebar.

Also generalizes `normalizePiSessionsDir` → `normalizeAgentSessionsDir(dir, home)`.

## Fixes found while taking over (not in #7255)

These would have shipped broken had #7255 merged onto current `main`:

1. **Type-widening / incremental gaps** — `main` had added incremental parsing
   (`createMessageGraphSessionResumeState`, etc.) typed `'openclaw' | 'pi'`; only
   one signature was widened. Fixed via a `MessageGraphAgent` alias + routing OMP
   through the incremental cache.
2. **Remote/SSH scanner build break** — the `normalizePiSessionsDir` rename broke
   `remote-session-scanner-sources.ts` (not in the PR's file set). Fixed + added
   OMP remote discovery parity with Pi.
3. **Local resume bypassed the feature (major)** — the renderer rebuilds the
   resume command for *local* sessions and never forwarded `filePath`, so local
   OMP resumed by id instead of path. Now threads `resumeFilePath` through
   `buildAiVaultResumeStartupForWorktree`. (Caught by adversarial review.)

Test coverage strengthened: the moved `buildAiVaultResumeCommand` suite now lives
next to the function (`src/shared/ai-vault-resume-command.test.ts`), an
incremental-parity fixture exercises the `omp` branch, and dedicated tests prove
`model_change.model` capture, explicit-total token capture, and local resume-by-path.

## Verification

- `pnpm typecheck`, `pnpm build:electron-vite`, targeted `vitest` (ai-vault +
  shared + renderer resume) — all green (113 tests).
- **Real data**: ran the actual scanner against 10 real `~/.omp` transcripts —
  correct titles, cwd, model (`gpt-5.4-mini`), token totals, and
  `omp --resume '<absolute path>'` commands.
- **In-app**: `aiVault.listSessions` IPC returned all 10 OMP sessions in the
  running build; the panel rendered an OMP row with the OMP icon + label + msg
  count under its worktree group (screenshot in a comment).

Closes #7255.

Made with [Orca](https://github.com/stablyai/orca) 🐋
