### PR TITLE
perf(renderer): drive the agent-completion feedback observer off the agent-status epoch

### DIFF
--- a/src/renderer/src/components/star-nag/StarNagAgentValueMomentObserver.test.tsx
+++ b/src/renderer/src/components/star-nag/StarNagAgentValueMomentObserver.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment happy-dom
 
-import { act } from 'react'
+import { act, Profiler } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { useAppStore } from '@/store'
 import { StarNagAgentValueMomentObserver } from './StarNagAgentValueMomentObserver'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
 type StarNagApi = {
   agentValueMoment: ReturnType<typeof vi.fn>
@@ -36,6 +38,25 @@ function renderObserver(): { root: Root; container: HTMLDivElement } {
     root.render(<StarNagAgentValueMomentObserver />)
   })
   return { root, container }
+}
+
+function renderObserverWithProfiler(): {
+  root: Root
+  container: HTMLDivElement
+  getRenderCount: () => number
+} {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  let renderCount = 0
+  act(() => {
+    root.render(
+      <Profiler id="star-nag-observer" onRender={() => (renderCount += 1)}>
+        <StarNagAgentValueMomentObserver />
+      </Profiler>
+    )
+  })
+  return { root, container, getRenderCount: () => renderCount }
 }
 
 function setAgentEntries(entries: Record<string, AgentStatusEntry>): void {
@@ -95,6 +116,52 @@ describe('StarNagAgentValueMomentObserver', () => {
 
     expect(agentValueMoment).toHaveBeenCalledTimes(1)
     expect(showAgentValueMoment).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not scan 500 agent statuses on 50 same-state working pings', () => {
+    const entries = Object.fromEntries(
+      Array.from({ length: 500 }, (_unused, index) => [
+        `pane-${index}`,
+        entry({ paneKey: `tab-${index}:leaf-1` })
+      ])
+    )
+    useAppStore.setState({ agentStatusByPaneKey: entries, agentStatusEpoch: 1 })
+    const rendered = renderObserverWithProfiler()
+    root = rendered.root
+    container = rendered.container
+    const initialRenders = rendered.getRenderCount()
+
+    // Why: separate acts model separate hook pings; main produced 50 renders and
+    // 25,000 completion-scan entry visits for this exact 500 x 50 scenario.
+    for (let ping = 0; ping < 50; ping += 1) {
+      act(() => {
+        useAppStore.setState((state) => ({
+          agentStatusByPaneKey: {
+            ...state.agentStatusByPaneKey,
+            'pane-0': entry({ paneKey: 'tab-0:leaf-1', updatedAt: ping + 2 })
+          }
+        }))
+      })
+    }
+    expect(rendered.getRenderCount()).toBe(initialRenders)
+
+    // A real transition bumps the epoch and must re-render.
+    setAgentEntries({ pane: entry({ state: 'done', updatedAt: 100 }) })
+    expect(rendered.getRenderCount()).toBeGreaterThan(initialRenders)
+  })
+
+  it('does not treat a removed and reused pane key as one completion transition', () => {
+    ;({ root, container } = renderObserver())
+
+    setAgentEntries({ pane: entry({ state: 'working' }) })
+    setAgentEntries({})
+    setAgentEntries({ pane: entry({ state: 'done', updatedAt: 2 }) })
+    act(() => {
+      vi.advanceTimersByTime(2400)
+    })
+
+    expect(agentValueMoment).not.toHaveBeenCalled()
+    expect(showAgentValueMoment).not.toHaveBeenCalled()
   })
 
   it('ignores interrupted or empty-prompt completions', () => {

--- a/src/renderer/src/components/star-nag/StarNagAgentValueMomentObserver.tsx
+++ b/src/renderer/src/components/star-nag/StarNagAgentValueMomentObserver.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { useShallow } from 'zustand/react/shallow'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { useAppStore } from '@/store'
 
@@ -48,14 +47,14 @@ function isTypingKeyEvent(event: KeyboardEvent): boolean {
 }
 
 export function StarNagAgentValueMomentObserver(): null {
-  const { agentStatusByPaneKey, agentStatusEpoch } = useAppStore(
-    useShallow((state) => ({
-      agentStatusByPaneKey: state.agentStatusByPaneKey,
-      agentStatusEpoch: state.agentStatusEpoch
-    }))
-  )
+  // Why: agentStatusByPaneKey is re-spread to a new object on every status ping
+  // (including high-frequency still-working pings that never change what we
+  // detect), so subscribing to the map re-rendered this always-mounted observer
+  // — and re-ran the app-wide done-transition scan — on every ping. agentStatusEpoch
+  // bumps on exactly the state transitions we care about, so drive off the epoch
+  // and read the map imperatively via getState().
+  const agentStatusEpoch = useAppStore((state) => state.agentStatusEpoch)
   const previousEntriesRef = useRef<AgentStatusSnapshot | null>(null)
-  const latestEntriesRef = useRef(agentStatusByPaneKey)
   const pendingRef = useRef(false)
   const requestedRef = useRef(false)
   const preparationRef = useRef<AgentValueMomentPreparation | null>(null)
@@ -72,7 +71,10 @@ export function StarNagAgentValueMomentObserver(): null {
         return
       }
       const elapsedSinceTyping = Date.now() - lastTypingAtRef.current
-      if (hasActiveAgent(latestEntriesRef.current) || elapsedSinceTyping < QUIET_WINDOW_MS) {
+      if (
+        hasActiveAgent(useAppStore.getState().agentStatusByPaneKey) ||
+        elapsedSinceTyping < QUIET_WINDOW_MS
+      ) {
         scheduleCheck()
         return
       }
@@ -86,7 +88,10 @@ export function StarNagAgentValueMomentObserver(): null {
           }
         }
         const freshElapsedSinceTyping = Date.now() - lastTypingAtRef.current
-        if (hasActiveAgent(latestEntriesRef.current) || freshElapsedSinceTyping < QUIET_WINDOW_MS) {
+        if (
+          hasActiveAgent(useAppStore.getState().agentStatusByPaneKey) ||
+          freshElapsedSinceTyping < QUIET_WINDOW_MS
+        ) {
           scheduleCheck()
           return
         }
@@ -96,10 +101,6 @@ export function StarNagAgentValueMomentObserver(): null {
       })()
     }, CHECK_DELAY_MS)
   }, [])
-
-  useEffect(() => {
-    latestEntriesRef.current = agentStatusByPaneKey
-  }, [agentStatusByPaneKey, agentStatusEpoch])
 
   useEffect(() => {
     const markTyping = (event: Event): void => {
@@ -119,17 +120,18 @@ export function StarNagAgentValueMomentObserver(): null {
   }, [])
 
   useEffect(() => {
+    const currentEntries = useAppStore.getState().agentStatusByPaneKey
     const previousEntries = previousEntriesRef.current
-    previousEntriesRef.current = agentStatusByPaneKey
+    previousEntriesRef.current = currentEntries
     if (!previousEntries || requestedRef.current) {
       return
     }
-    if (!hasSuccessfulDoneTransition(previousEntries, agentStatusByPaneKey)) {
+    if (!hasSuccessfulDoneTransition(previousEntries, currentEntries)) {
       return
     }
     pendingRef.current = true
     scheduleCheck()
-  }, [agentStatusByPaneKey, agentStatusEpoch, scheduleCheck])
+  }, [agentStatusEpoch, scheduleCheck])
 
   useEffect(() => {
     return () => {

--- a/src/renderer/src/store/slices/agent-status-worktree-purge-leak.test.ts
+++ b/src/renderer/src/store/slices/agent-status-worktree-purge-leak.test.ts
@@ -92,11 +92,13 @@ describe('bulk worktree purge evicts pane-scoped agent/unread/input maps (leak r
   it('purgeWorktreeTerminalState drops every pane-scoped map for the removed worktree', () => {
     const store = createTestStore()
     seedPaneState(store)
+    const epochBefore = store.getState().agentStatusEpoch
 
     store.getState().purgeWorktreeTerminalState([WT])
 
     const s = store.getState()
     expect(s.agentStatusByPaneKey[PANE]).toBeUndefined()
+    expect(s.agentStatusEpoch).toBe(epochBefore + 1)
     expect(s.agentLaunchConfigByPaneKey[PANE]).toBeUndefined()
     expect(s.acknowledgedAgentsByPaneKey[PANE]).toBeUndefined()
     expect(s.paneForegroundAgentByPaneKey[PANE]).toBeUndefined()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2080,6 +2080,7 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     }
     return next
   })()
+  const nextAgentStatusByPaneKey = omitByPaneKeyTabPrefix(s.agentStatusByPaneKey)
 
   return {
     // Worktree-scoped terminal/tab state
@@ -2120,7 +2121,10 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     // badge). retainedAgentsByPaneKey and runtimeAgentOrchestrationByPaneKey are
     // intentionally omitted here — both self-heal (pruneRetainedAgents on a
     // worktreesByRepo change; the runtime map is replaced wholesale each sync).
-    agentStatusByPaneKey: omitByPaneKeyTabPrefix(s.agentStatusByPaneKey),
+    agentStatusByPaneKey: nextAgentStatusByPaneKey,
+    ...(nextAgentStatusByPaneKey !== s.agentStatusByPaneKey
+      ? { agentStatusEpoch: s.agentStatusEpoch + 1 }
+      : {}),
     agentLaunchConfigByPaneKey: omitByPaneKeyTabPrefix(s.agentLaunchConfigByPaneKey),
     acknowledgedAgentsByPaneKey: omitByPaneKeyTabPrefix(s.acknowledgedAgentsByPaneKey),
     paneForegroundAgentByPaneKey: omitByPaneKeyTabPrefix(s.paneForegroundAgentByPaneKey),


### PR DESCRIPTION
## Description

The always-mounted agent-completion feedback observer subscribed to the entire `agentStatusByPaneKey` object. Every still-working status ping creates a new top-level object, so each ping re-rendered the observer and rescanned every agent entry even though no completion transition occurred.

This change subscribes the observer to the primitive `agentStatusEpoch` instead, then reads the current status map imperatively when a real transition or the idle timer requires it. It also increments the epoch when bulk worktree cleanup actually removes status entries, preventing stale completion history if a pane key is later reused.

## Evidence

- Reproduced on current `main` with 500 status entries and 50 same-state working pings: **50 observer renders** and therefore **25,000 completion-scan entry visits**.
- With this change, the same workload produces **0 observer renders** and **0 completion scans**. Real epoch-changing transitions still render and scan as intended.
- Mutation proof: restoring the old whole-map subscription makes the scaled regression test fail (`expected 0 renders, received 50`). Removing the bulk-purge epoch bump makes its regression test fail (`expected epoch 1, received 0`).
- Correctness coverage includes normal completion transitions, removal followed by same-key reuse, and bulk worktree purge.
- Validation after the final rebase: **7 test files / 142 tests passed**, Node typecheck passed, changed-file oxlint passed, formatting passed, max-lines ratchet passed, and diff validation passed.
- The full web typecheck still reports one pre-existing unrelated error in `useSessionRestoredBannerDismiss.test.tsx:27` (`Element` is not assignable to `HTMLDivElement`); this PR does not touch that file or type boundary.

## ELI5

The feedback watcher used to reread the whole attendance sheet every time any working agent said “still here.” Now it wakes only when someone actually starts, stops, becomes stale, or is removed. Routine heartbeats no longer make it redo the same work.

## Trade-offs

**No expected end-user regressions.** Completion feedback behavior and idle-timer freshness are preserved. The full status-map scan still runs on real epoch transitions, because those are the events that can change the answer; it no longer runs for same-state working pings. Bulk cleanup adds one primitive epoch update only when it actually removes at least one status entry.
