### PR TITLE
perf(renderer): narrow FloatingTerminalPanel's per-worktree subscriptions to the floating key

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -170,10 +170,26 @@ export function FloatingTerminalPanel({
   onOpenChange,
   tourInteractionSnapshot
 }: FloatingTerminalPanelProps): React.JSX.Element | null {
-  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
-  const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
-  const unifiedTabsByWorktree = useAppStore((s) => s.unifiedTabsByWorktree)
+  // Why: these per-worktree maps get a new top-level identity whenever ANY
+  // worktree's tabs change (updateTabTitle re-spreads them on every real
+  // background-terminal title change), but the panel only ever reads the floating
+  // worktree's entry. Subscribe to that key directly so the panel — which stays
+  // mounted while closed once it owns tabs — does not re-render its hidden subtree
+  // on unrelated background churn. The store preserves each worktree's array
+  // identity, so these stay referentially stable when the floating entry is
+  // unchanged.
+  const tabs = useAppStore(
+    (s) => s.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_TERMINAL_TABS
+  )
+  const browserTabs = useAppStore(
+    (s) => s.browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_BROWSER_TABS
+  )
+  const groups = useAppStore(
+    (s) => s.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_GROUPS
+  )
+  const unifiedTabs = useAppStore(
+    (s) => s.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_UNIFIED_TABS
+  )
   const openFiles = useAppStore((s) => s.openFiles)
   const expandedPaneByTabId = useAppStore((s) => s.expandedPaneByTabId)
   const createTab = useAppStore((s) => s.createTab)
@@ -243,10 +259,6 @@ export function FloatingTerminalPanel({
     moved: boolean
   } | null>(null)
 
-  const tabs = tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_TERMINAL_TABS
-  const browserTabs = browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_BROWSER_TABS
-  const groups = groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_GROUPS
-  const unifiedTabs = unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_UNIFIED_TABS
   const floatingFiles = useMemo(
     () => openFiles.filter((file) => file.worktreeId === FLOATING_TERMINAL_WORKTREE_ID),
     [openFiles]

--- a/src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts
+++ b/src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts
@@ -104,6 +104,38 @@ describe('runtimePaneTitle → sortEpoch', () => {
     expect(store.getState().sortEpoch).toBe(sortEpoch)
   })
 
+  it("preserves other worktrees' tab-array identity when one worktree's title changes", () => {
+    // Why: per-worktree subscribers (e.g. FloatingTerminalPanel) read only their
+    // own tabsByWorktree entry. A real title change in a background worktree must
+    // give the top-level map a new identity (so the changed worktree updates)
+    // WITHOUT touching untouched worktrees' array identity, or every narrow
+    // subscriber would re-render on background title floods.
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: 'wt-fg', repoId: 'repo1', path: '/path/wt-fg' }),
+          makeWorktree({ id: 'wt-bg', repoId: 'repo1', path: '/path/wt-bg' })
+        ]
+      },
+      tabsByWorktree: {
+        'wt-fg': [makeTab({ id: 'tab-fg', worktreeId: 'wt-fg', title: 'Foreground' })],
+        'wt-bg': [makeTab({ id: 'tab-bg', worktreeId: 'wt-bg', title: 'Terminal 1' })]
+      }
+    })
+    const tabsByWorktreeBefore = store.getState().tabsByWorktree
+    const fgTabsBefore = store.getState().tabsByWorktree['wt-fg']
+
+    store.getState().updateTabTitle('tab-bg', 'Codex ready')
+
+    const tabsByWorktreeAfter = store.getState().tabsByWorktree
+    expect(tabsByWorktreeAfter).not.toBe(tabsByWorktreeBefore)
+    expect(tabsByWorktreeAfter['wt-bg']?.[0]?.title).toBe('Codex ready')
+    // The untouched worktree keeps its array reference, so a narrow subscriber to
+    // it does not re-render on the background title change.
+    expect(tabsByWorktreeAfter['wt-fg']).toBe(fgTabsBefore)
+  })
+
   it.each([
     ['Claude Code', '⠂ Claude Code', '⠐ Claude Code'],
     [


### PR DESCRIPTION
## What

`FloatingTerminalPanel` subscribed to four whole per-worktree maps — `tabsByWorktree`, `unifiedTabsByWorktree`, `browserTabsByWorktree`, `groupsByWorktree` — but only ever reads the `FLOATING_TERMINAL_WORKTREE_ID` entry of each in render (the other `state.*` reads at lines ~669/756/… are inside `getState()` event callbacks, not subscriptions).

`updateTabTitle` re-spreads the **top-level** `tabsByWorktree` and `unifiedTabsByWorktree` on every real (non-decorative) OSC title change in **any** background terminal. Because the panel stays mounted while closed once the floating workspace owns tabs (`App.tsx` `shouldMountFloatingTerminalPanel`), each whole-map subscription re-rendered the panel's hidden subtree on background title floods from unrelated worktrees.

## Fix (narrow subscription — #7545 family)

Subscribe to `s.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_TERMINAL_TABS` (and the same for the other three maps) instead of the whole map. The store already preserves each worktree's array identity across background title changes (`updateTabTitle` mutates only the owning worktree's entry — see the comment at `terminals.ts`), so the narrow selectors stay referentially stable and the panel re-renders only when its **own** floating tabs change. `EMPTY_*` are stable module-level constants, so identity holds when the floating entry is absent. Behavior is unchanged (only the floating key was ever read).

## Verification

- New store-invariant test in `runtime-pane-title-sort-epoch.test.ts`: a **real** title change in a background worktree gives the top-level `tabsByWorktree` a new identity (so the changed worktree updates) while **preserving** the untouched worktree's array reference — exactly what a narrow subscriber relies on.
- Existing `FloatingTerminalPanel.test.tsx` (59) and the slice suite (21) pass.
- `tsgo` typecheck clean; oxlint/oxfmt clean via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
