### PR TITLE
perf(editor): debounce git-conflict decoration rebuilds

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -32,7 +32,10 @@ import {
   createMarkdownDocLinkDecorationController,
   type MarkdownDocLinkDecorationController
 } from './monaco-markdown-doc-link-decorations'
-import { buildGitConflictDecorations, hasGitConflictMarkers } from './monaco-conflict-decorations'
+import {
+  createGitConflictDecorationRefresher,
+  type GitConflictDecorationRefresher
+} from './monaco-conflict-decoration-refresh'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import type { DiffComment } from '../../../../shared/types'
 import { isMarkdownComment } from '@/lib/diff-comment-compat'
@@ -109,7 +112,8 @@ export default function MonacoEditor({
   const languageRef = useRef(language)
   languageRef.current = language
   const markdownDocLinkDecorationsRef = useRef<MarkdownDocLinkDecorationController | null>(null)
-  const conflictDecorationsRef = useRef<editor.IEditorDecorationsCollection | null>(null)
+  const conflictDecorationRefresherRef = useRef<GitConflictDecorationRefresher | null>(null)
+  const conflictScanFilePathRef = useRef<string | null>(null)
   const revealDecorationRef = useRef<editor.IEditorDecorationsCollection | null>(null)
   const revealHighlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const revealRafRef = useRef<number | null>(null)
@@ -503,8 +507,8 @@ export default function MonacoEditor({
           window.cancelAnimationFrame(autoHeightFrame)
           autoHeightFrame = null
         }
-        conflictDecorationsRef.current?.clear()
-        conflictDecorationsRef.current = null
+        conflictDecorationRefresherRef.current?.dispose()
+        conflictDecorationRefresherRef.current = null
         editorRef.current = null
         setMountedEditor(null)
         setCommentPopover(null)
@@ -727,20 +731,24 @@ export default function MonacoEditor({
       return
     }
 
-    if (!conflictDecorationsEnabled || !hasGitConflictMarkers(content)) {
-      conflictDecorationsRef.current?.clear()
+    // Why: the disabled check must stay ahead of any content scan so the
+    // default (non-conflict) editing path never pays a per-keystroke parse.
+    if (!conflictDecorationsEnabled) {
+      conflictDecorationRefresherRef.current?.clear()
       return
     }
 
     // Why: Git conflict marker lines are ordinary file text; Monaco needs
     // explicit decorations so unresolved blocks remain visible while editing.
-    const decorations = buildGitConflictDecorations(content)
-    if (!conflictDecorationsRef.current) {
-      conflictDecorationsRef.current = ed.createDecorationsCollection(decorations)
-      return
+    if (!conflictDecorationRefresherRef.current) {
+      conflictDecorationRefresherRef.current = createGitConflictDecorationRefresher(ed)
     }
-    conflictDecorationsRef.current.set(decorations)
-  }, [conflictDecorationsEnabled, content, mountedEditor])
+    // Why: this component is keyed per pane, so switching files reuses the
+    // instance; a file/model swap must redecorate immediately, not debounced.
+    const fileChanged = conflictScanFilePathRef.current !== filePath
+    conflictScanFilePathRef.current = filePath
+    conflictDecorationRefresherRef.current.refresh(content, { immediate: fileChanged })
+  }, [conflictDecorationsEnabled, content, mountedEditor, filePath])
 
   useEffect(() => {
     updateMarkdownCompletionDocuments()
@@ -753,8 +761,8 @@ export default function MonacoEditor({
       }
       markdownDocLinkDecorationsRef.current?.dispose()
       markdownDocLinkDecorationsRef.current = null
-      conflictDecorationsRef.current?.clear()
-      conflictDecorationsRef.current = null
+      conflictDecorationRefresherRef.current?.dispose()
+      conflictDecorationRefresherRef.current = null
     }
   }, [])
 

--- a/src/renderer/src/components/editor/monaco-conflict-decoration-refresh.test.ts
+++ b/src/renderer/src/components/editor/monaco-conflict-decoration-refresh.test.ts
@@ -1,0 +1,179 @@
+import type { editor } from 'monaco-editor'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createGitConflictDecorationRefresher,
+  GIT_CONFLICT_DECORATION_REFRESH_DELAY_MS
+} from './monaco-conflict-decoration-refresh'
+import { buildGitConflictDecorations, hasGitConflictMarkers } from './monaco-conflict-decorations'
+
+// Why: spy-wrap the real scanners so tests can count full-content scans while
+// keeping genuine marker parsing (the perf contract is "how often", not "what").
+vi.mock('./monaco-conflict-decorations', { spy: true })
+
+const CONFLICT_LINES = ['<<<<<<< HEAD', 'current', '=======', 'incoming', '>>>>>>> branch']
+
+function conflictContentWithPrefix(prefixLineCount: number): string {
+  return [
+    ...Array.from({ length: prefixLineCount }, (_, i) => `line ${i}`),
+    ...CONFLICT_LINES
+  ].join('\n')
+}
+
+function scanCount(): number {
+  return (
+    vi.mocked(hasGitConflictMarkers).mock.calls.length +
+    vi.mocked(buildGitConflictDecorations).mock.calls.length
+  )
+}
+
+function createFakeEditor(): {
+  editorInstance: editor.IStandaloneCodeEditor
+  set: ReturnType<typeof vi.fn>
+  clear: ReturnType<typeof vi.fn>
+  createDecorationsCollection: ReturnType<typeof vi.fn>
+} {
+  const set = vi.fn()
+  const clear = vi.fn()
+  const createDecorationsCollection = vi.fn(() => ({ set, clear }))
+  return {
+    editorInstance: { createDecorationsCollection } as unknown as editor.IStandaloneCodeEditor,
+    set,
+    clear,
+    createDecorationsCollection
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})
+
+describe('createGitConflictDecorationRefresher', () => {
+  it('scans immediately on the first refresh so decorations appear at mount', () => {
+    const { editorInstance, createDecorationsCollection } = createFakeEditor()
+    const refresher = createGitConflictDecorationRefresher(editorInstance)
+
+    refresher.refresh(conflictContentWithPrefix(1))
+
+    expect(createDecorationsCollection).toHaveBeenCalledTimes(1)
+    expect(createDecorationsCollection.mock.calls[0]?.[0]).not.toHaveLength(0)
+    expect(scanCount()).toBe(2)
+  })
+
+  it('coalesces a burst of content changes into exactly one scan and rebuild after settle', () => {
+    const { editorInstance, set } = createFakeEditor()
+    const refresher = createGitConflictDecorationRefresher(editorInstance)
+    refresher.refresh(conflictContentWithPrefix(0))
+    vi.clearAllMocks()
+
+    for (let keystroke = 1; keystroke <= 5; keystroke += 1) {
+      refresher.refresh(conflictContentWithPrefix(keystroke))
+      vi.advanceTimersByTime(GIT_CONFLICT_DECORATION_REFRESH_DELAY_MS - 1)
+    }
+    expect(scanCount()).toBe(0)
+    expect(set).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(vi.mocked(hasGitConflictMarkers)).toHaveBeenCalledExactlyOnceWith(
+      conflictContentWithPrefix(5)
+    )
+    expect(vi.mocked(buildGitConflictDecorations)).toHaveBeenCalledTimes(1)
+    expect(set).toHaveBeenCalledTimes(1)
+    // The rebuild reflects the final keystroke: 5 prefix lines put the conflict
+    // start marker on line 6, so the leading "current" section starts on line 7.
+    expect(set.mock.calls[0]?.[0]?.[0]?.range.startLineNumber).toBe(7)
+  })
+
+  it('reflects added and removed conflict markers after the debounce settles', () => {
+    const { editorInstance, set, clear, createDecorationsCollection } = createFakeEditor()
+    const refresher = createGitConflictDecorationRefresher(editorInstance)
+
+    refresher.refresh('no markers yet')
+    expect(createDecorationsCollection).not.toHaveBeenCalled()
+
+    refresher.refresh(conflictContentWithPrefix(0))
+    vi.advanceTimersByTime(GIT_CONFLICT_DECORATION_REFRESH_DELAY_MS)
+    expect(createDecorationsCollection).toHaveBeenCalledTimes(1)
+    expect(createDecorationsCollection.mock.calls[0]?.[0]).not.toHaveLength(0)
+
+    refresher.refresh('resolved, markers deleted')
+    expect(clear).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(GIT_CONFLICT_DECORATION_REFRESH_DELAY_MS)
+    expect(clear).toHaveBeenCalledTimes(1)
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('never rescans identical content and drops a superseded pending scan on undo', () => {
+    const { editorInstance, set } = createFakeEditor()
+    const refresher = createGitConflictDecorationRefresher(editorInstance)
+    const applied = conflictContentWithPrefix(0)
+    refresher.refresh(applied)
+    vi.clearAllMocks()
+
+    refresher.refresh(applied)
+    vi.runAllTimers()
+    expect(scanCount()).toBe(0)
+
+    refresher.refresh(conflictContentWithPrefix(1))
+    refresher.refresh(applied)
+    vi.runAllTimers()
+    expect(scanCount()).toBe(0)
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('rebuilds immediately when asked (file/model switch), cancelling pending work', () => {
+    const { editorInstance, set } = createFakeEditor()
+    const refresher = createGitConflictDecorationRefresher(editorInstance)
+    refresher.refresh(conflictContentWithPrefix(0))
+    refresher.refresh(conflictContentWithPrefix(1))
+    vi.clearAllMocks()
+
+    refresher.refresh(conflictContentWithPrefix(3), { immediate: true })
+    expect(set).toHaveBeenCalledTimes(1)
+    // 3 prefix lines: marker on line 4, leading "current" section on line 5.
+    expect(set.mock.calls[0]?.[0]?.[0]?.range.startLineNumber).toBe(5)
+
+    vi.runAllTimers()
+    expect(set).toHaveBeenCalledTimes(1)
+  })
+
+  it('clear() drops decorations and pending scans without ever scanning', () => {
+    const { editorInstance, set, clear } = createFakeEditor()
+    const refresher = createGitConflictDecorationRefresher(editorInstance)
+    refresher.refresh(conflictContentWithPrefix(0))
+    refresher.refresh(conflictContentWithPrefix(1))
+    vi.clearAllMocks()
+
+    // Disabled-mode regression pin: typing maps to clear() calls, zero scans.
+    refresher.clear()
+    refresher.clear()
+    vi.runAllTimers()
+    expect(scanCount()).toBe(0)
+    expect(set).not.toHaveBeenCalled()
+    expect(clear).toHaveBeenCalledTimes(2)
+
+    // Re-enabling rescans immediately instead of debouncing behind stale state.
+    refresher.refresh(conflictContentWithPrefix(2))
+    expect(set).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispose mid-debounce leaks no timer and never touches decorations afterwards', () => {
+    const { editorInstance, set, clear } = createFakeEditor()
+    const refresher = createGitConflictDecorationRefresher(editorInstance)
+    refresher.refresh(conflictContentWithPrefix(0))
+    refresher.refresh(conflictContentWithPrefix(1))
+    vi.clearAllMocks()
+
+    refresher.dispose()
+    expect(clear).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+
+    vi.runAllTimers()
+    expect(scanCount()).toBe(0)
+    expect(set).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/monaco-conflict-decoration-refresh.ts
+++ b/src/renderer/src/components/editor/monaco-conflict-decoration-refresh.ts
@@ -1,0 +1,75 @@
+import type { editor } from 'monaco-editor'
+import { buildGitConflictDecorations, hasGitConflictMarkers } from './monaco-conflict-decorations'
+
+export const GIT_CONFLICT_DECORATION_REFRESH_DELAY_MS = 120
+
+export type GitConflictDecorationRefresher = {
+  refresh: (content: string, options?: { immediate?: boolean }) => void
+  clear: () => void
+  dispose: () => void
+}
+
+export function createGitConflictDecorationRefresher(
+  editorInstance: editor.IStandaloneCodeEditor
+): GitConflictDecorationRefresher {
+  let collection: editor.IEditorDecorationsCollection | null = null
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null
+  let lastScannedContent: string | null = null
+
+  const cancelPendingRefresh = (): void => {
+    if (refreshTimer === null) {
+      return
+    }
+    clearTimeout(refreshTimer)
+    refreshTimer = null
+  }
+
+  const applyNow = (content: string): void => {
+    cancelPendingRefresh()
+    lastScannedContent = content
+    if (!hasGitConflictMarkers(content)) {
+      collection?.clear()
+      return
+    }
+    const decorations = buildGitConflictDecorations(content)
+    if (!collection) {
+      collection = editorInstance.createDecorationsCollection(decorations)
+      return
+    }
+    collection.set(decorations)
+  }
+
+  const refresh = (content: string, options?: { immediate?: boolean }): void => {
+    if (content === lastScannedContent) {
+      // Why: decorations already reflect this content; a pending rescan for
+      // superseded text (e.g. undo back to the applied state) must not fire.
+      cancelPendingRefresh()
+      return
+    }
+    if (options?.immediate || lastScannedContent === null) {
+      applyNow(content)
+      return
+    }
+    cancelPendingRefresh()
+    // Why: controlled `content` changes on every keystroke; coalescing avoids a
+    // full conflict re-parse per key. One rebuild lands after typing settles.
+    refreshTimer = setTimeout(() => applyNow(content), GIT_CONFLICT_DECORATION_REFRESH_DELAY_MS)
+  }
+
+  const clear = (): void => {
+    cancelPendingRefresh()
+    // Why: resetting the gate makes the next enabled refresh scan immediately
+    // instead of debouncing behind stale "already scanned" state.
+    lastScannedContent = null
+    collection?.clear()
+  }
+
+  return {
+    refresh,
+    clear,
+    dispose: () => {
+      clear()
+      collection = null
+    }
+  }
+}


### PR DESCRIPTION
## Problem

While a conflict-resolution surface has `conflictDecorationsEnabled` set, the conflict-decoration effect in `MonacoEditor.tsx` listed the controlled `content` prop in its deps — so every keystroke ran `hasGitConflictMarkers` (O(n) full-line scan) plus `buildGitConflictDecorations` (full re-parse) plus `collection.set(...)`, with no debounce and no previous-content gate. Typing lag scaled with file size. Normal (non-conflict) editing was unaffected because the disabled short-circuit runs before any scan.

## Fix

Extracted `monaco-conflict-decoration-refresh.ts`, following the in-repo sibling pattern in `monaco-markdown-doc-link-decorations.ts` (same 120ms delay):

- **Debounce**: content changes coalesce behind a 120ms timer; exactly one scan+rebuild lands after typing settles.
- **Previous-content gate**: identical content never rescans, and an undo back to the applied state drops the superseded pending scan.
- **Immediate paths kept**: first scan at mount, re-enable after a disabled period, and file/model switches (the component is keyed per pane, so file switches arrive as prop changes) all redecorate synchronously — no 120ms flash of stale/missing decorations.
- **Disabled-mode zero-scan short-circuit stays first**: the `!conflictDecorationsEnabled` check still precedes any content scan; disabled surfaces only ever call `clear()`, which never parses.
- **Lifecycle**: `clear()`/`dispose()` cancel the pending timer; the editor `onDidDispose` hook and the component unmount cleanup both dispose the refresher, so an unmount mid-debounce can't touch decorations afterwards.

Behavior trade-off (per the sibling pattern): decoration updates while typing lag by up to ~120ms after the last keystroke; Monaco's own decoration stickiness keeps existing ranges tracking edits in the interim.

## Tests

New `monaco-conflict-decoration-refresh.test.ts` (fake timers, deterministic; scan counts via spy-wrapped real parsers):

- Burst of 5 content changes inside the debounce window → zero scans until settle, then exactly one scan+rebuild reflecting the final content.
- Marker add/remove → decorations created/cleared post-settle.
- Identical-content refreshes and undo-mid-debounce → zero rescans.
- `immediate` refresh (file switch) → synchronous rebuild, pending work cancelled.
- `clear()` (disabled-mode pin) → zero scans, pending cancelled, re-enable rescans immediately.
- `dispose()` mid-debounce → no leaked timer (`vi.getTimerCount() === 0`), no post-dispose decoration writes.

## Validation

- `pnpm vitest run --config config/vitest.config.ts` on the new suite plus adjacent `monaco-conflict-decorations.test.ts` and `monaco-markdown-doc-link-decorations.test.ts`: 26 passed.
- `pnpm typecheck`: clean.
- `oxlint` / `oxfmt` on touched files: clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
