### PR TITLE
perf(native-chat): byte-cap the transcript read-cache to bound RSS (GB-scale leak)

### DIFF
--- a/src/main/native-chat/transcript-read-cache.test.ts
+++ b/src/main/native-chat/transcript-read-cache.test.ts
@@ -20,7 +20,8 @@ vi.mock('./transcript-reader', async (importOriginal) => {
 import { isTextBlock } from '../../shared/native-chat-types'
 import {
   clearNativeChatTranscriptCache,
-  readNativeChatTranscriptCached
+  readNativeChatTranscriptCached,
+  setNativeChatTranscriptCacheMaxBytesForTests
 } from './transcript-read-cache'
 
 let tempRoots: string[] = []
@@ -46,8 +47,26 @@ async function seedSession(sessionId: string, turns: number): Promise<string> {
   return filePath
 }
 
+// Writes a transcript file at an explicit path whose on-disk size is ~`bytes`
+// (padded via one big user message), returning the path. Read it back by passing
+// the path as `transcriptPath` so resolution doesn't depend on process.env.HOME.
+async function seedBigFile(name: string, bytes: number): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-cache-bytes-'))
+  tempRoots.push(root)
+  const filePath = join(root, `${name}.jsonl`)
+  const record = {
+    type: 'user',
+    uuid: `u-${name}`,
+    timestamp: '2026-06-01T10:00:00.000Z',
+    message: { role: 'user', content: 'x'.repeat(Math.max(1, bytes)) }
+  }
+  await writeFile(filePath, jsonLines([record]))
+  return filePath
+}
+
 beforeEach(() => {
   clearNativeChatTranscriptCache()
+  setNativeChatTranscriptCacheMaxBytesForTests()
   readSpy.mockClear()
 })
 
@@ -147,5 +166,60 @@ describe('readNativeChatTranscriptCached', () => {
     expect(readText(c)).not.toContain('from-worktree-A')
     // Distinct files must not share a cached parse object.
     expect(c).not.toBe(a)
+  })
+
+  // Why: each cached entry is a FULL unwindowed transcript parse; heavy agent
+  // sessions are tens of MB, so the count-only cap let 50 entries retain multiple
+  // GB in the one process serving desktop + every paired client. The byte budget
+  // evicts the oldest large entries while always keeping the most-recent.
+  it('evicts the oldest entry once total cached bytes exceed the budget', async () => {
+    // ~4 KB per file, budget 9 KB → holds 2, a third read evicts the oldest.
+    setNativeChatTranscriptCacheMaxBytesForTests(9 * 1024)
+    const fileA = await seedBigFile('big-a', 4 * 1024)
+    const fileB = await seedBigFile('big-b', 4 * 1024)
+    const fileC = await seedBigFile('big-c', 4 * 1024)
+
+    await readNativeChatTranscriptCached('claude', 'sa', fileA) // spy 1
+    await readNativeChatTranscriptCached('claude', 'sb', fileB) // spy 2
+    await readNativeChatTranscriptCached('claude', 'sc', fileC) // spy 3, evicts A
+    expect(readSpy).toHaveBeenCalledTimes(3)
+
+    // C is the most-recent → still cached (no re-read).
+    await readNativeChatTranscriptCached('claude', 'sc', fileC)
+    expect(readSpy).toHaveBeenCalledTimes(3)
+
+    // A was evicted by the byte cap → this re-reads (and evicts B in turn).
+    await readNativeChatTranscriptCached('claude', 'sa', fileA)
+    expect(readSpy).toHaveBeenCalledTimes(4)
+
+    // B is now evicted → also re-reads.
+    await readNativeChatTranscriptCached('claude', 'sb', fileB)
+    expect(readSpy).toHaveBeenCalledTimes(5)
+  })
+
+  it('keeps a single active transcript larger than the whole budget cached', async () => {
+    // A lone entry over budget must NOT be dropped, else every read re-parses.
+    setNativeChatTranscriptCacheMaxBytesForTests(1024)
+    const big = await seedBigFile('huge', 8 * 1024)
+    await readNativeChatTranscriptCached('claude', 'huge', big)
+    await readNativeChatTranscriptCached('claude', 'huge', big)
+    expect(readSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not evict small entries under the default budget (no regression for typical use)', async () => {
+    const files = await Promise.all([
+      seedBigFile('s1', 512),
+      seedBigFile('s2', 512),
+      seedBigFile('s3', 512)
+    ])
+    for (const [i, file] of files.entries()) {
+      await readNativeChatTranscriptCached('claude', `sess-${i}`, file)
+    }
+    expect(readSpy).toHaveBeenCalledTimes(3)
+    // Re-read all three: every one is still cached (byte budget never triggered).
+    for (const [i, file] of files.entries()) {
+      await readNativeChatTranscriptCached('claude', `sess-${i}`, file)
+    }
+    expect(readSpy).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/main/native-chat/transcript-read-cache.ts
+++ b/src/main/native-chat/transcript-read-cache.ts
@@ -21,6 +21,9 @@ type CachedTranscript = {
   result: ReadTranscriptResult
   /** mtime of the resolved file when cached; a newer mtime invalidates it. */
   mtimeMs: number
+  /** On-disk byte size of the resolved file — a cheap, monotonic proxy for this
+   *  entry's parsed memory footprint, used to bound the cache by total bytes. */
+  bytes: number
 }
 
 const cache = new Map<string, CachedTranscript>()
@@ -28,19 +31,36 @@ const cache = new Map<string, CachedTranscript>()
 // Why: cap the cache so a long-lived process browsing many sessions can't grow
 // it unbounded. Map preserves insertion order, so evicting the first key drops
 // the oldest entry (a simple LRU once re-inserts bump recency; see setCached).
-// Entry-count cap is fine for v1; a byte-aware cap is the follow-up if profiling
-// shows RSS pressure now that one process serves many remote clients.
 const MAX_CACHE_ENTRIES = 50
+// Why: a heavy Claude/Codex coding session's JSONL is routinely tens of MB (tool
+// results embed whole file contents, command output, and diffs), and each cached
+// entry is the full unwindowed parse. The count cap alone let 50 such entries
+// retain multiple GB in the one process that now serves desktop + every paired
+// web/mobile client. Bound total cached file bytes too; we always keep the most-
+// recent entry (see setCached) so an active transcript is never re-parsed on
+// every read, which caps the regression to extra re-parses only past this budget.
+const MAX_CACHE_BYTES = 128 * 1024 * 1024
+// Overridable only from tests so the byte-eviction path can be exercised without
+// writing hundreds of MB of fixtures; production always uses MAX_CACHE_BYTES.
+let maxCacheBytes = MAX_CACHE_BYTES
 
 function setCached(key: string, value: CachedTranscript): void {
   // Re-insert moves the key to the most-recent position for LRU eviction.
   cache.delete(key)
   cache.set(key, value)
-  while (cache.size > MAX_CACHE_ENTRIES) {
+  let totalBytes = 0
+  for (const entry of cache.values()) {
+    totalBytes += entry.bytes
+  }
+  // Evict oldest until within BOTH caps, but never drop the most-recent entry
+  // (cache.size > 1): a single active transcript larger than the whole budget
+  // must stay cached or every read would re-parse the full file.
+  while (cache.size > 1 && (cache.size > MAX_CACHE_ENTRIES || totalBytes > maxCacheBytes)) {
     const oldest = cache.keys().next().value
     if (oldest === undefined) {
       break
     }
+    totalBytes -= cache.get(oldest)?.bytes ?? 0
     cache.delete(oldest)
   }
 }
@@ -49,11 +69,12 @@ function cacheKey(agent: AgentType, filePath: string): string {
   return `${agent}:${filePath}`
 }
 
-async function fileMtimeMs(filePath: string): Promise<number> {
+async function fileStat(filePath: string): Promise<{ mtimeMs: number; bytes: number }> {
   try {
-    return (await stat(filePath)).mtimeMs
+    const stats = await stat(filePath)
+    return { mtimeMs: stats.mtimeMs, bytes: stats.size }
   } catch {
-    return Number.NaN
+    return { mtimeMs: Number.NaN, bytes: 0 }
   }
 }
 
@@ -74,7 +95,7 @@ export async function readNativeChatTranscriptCached(
   }
 
   const key = cacheKey(agent, filePath)
-  const mtimeMs = await fileMtimeMs(filePath)
+  const { mtimeMs, bytes } = await fileStat(filePath)
   const cached = cache.get(key)
   if (cached && Number.isFinite(mtimeMs) && cached.mtimeMs === mtimeMs) {
     // Bump recency so a frequently-read session survives eviction.
@@ -84,7 +105,7 @@ export async function readNativeChatTranscriptCached(
 
   const result = await readNativeChatTranscript(agent, sessionId, { filePath })
   if (Number.isFinite(mtimeMs)) {
-    setCached(key, { result, mtimeMs })
+    setCached(key, { result, mtimeMs, bytes })
   }
   return result
 }
@@ -92,4 +113,9 @@ export async function readNativeChatTranscriptCached(
 /** Test-only: drop the transcript parse cache between runs. */
 export function clearNativeChatTranscriptCache(): void {
   cache.clear()
+}
+
+/** Test-only: override the byte budget (pass no arg to restore the default). */
+export function setNativeChatTranscriptCacheMaxBytesForTests(bytes?: number): void {
+  maxCacheBytes = bytes ?? MAX_CACHE_BYTES
 }


### PR DESCRIPTION
## Description

The process-global native-chat **transcript read-cache** (`src/main/native-chat/transcript-read-cache.ts`) was capped **only by entry count** (`MAX_CACHE_ENTRIES = 50`) — with **no byte cap**. Each cached entry is a **full, unwindowed transcript parse**:

- `readNativeChatTranscript` applies **no** message cap (streams the entire JSONL session file).
- `toolResultOutput` returns tool-result strings **in full** — whole file contents, command output, and diffs, which are the bulk of a real agent transcript.

Heavy Claude/Codex coding sessions are routinely **5–50 MB** of JSONL on disk → **10–100 MB parsed** in memory. So 50 entries could retain **0.5–several GB** in the single process that now serves **desktop + every paired web/mobile client**. The file's own comment already flagged this:

> *"Entry-count cap is fine for v1; a byte-aware cap is the follow-up if profiling shows RSS pressure now that one process serves many remote clients."*

Reached from **both** the desktop IPC handler (`ipc/native-chat.ts`) **and** the runtime RPC handler that serves every remote client (`runtime/rpc/methods/native-chat.ts`), and re-cached on every agent write during an active session (file mtime changes). No purge on session/pane/worktree removal — entries persist for the process lifetime, subject only to the 50-entry LRU.

> Distinct from #7341, which fixed the cache **key** (resolved path vs `agent:sessionId`) — a correctness bug. The entry **size** dimension was never addressed.

## Fix

Reuse the `stat()` already issued for the mtime check to also read `.size` (a cheap, monotonic proxy for the parsed footprint), and bound the cache by **total cached file bytes** (`MAX_CACHE_BYTES = 128 MB`) in addition to the count cap:

- Evict oldest until under **both** caps…
- …but **always keep the most-recent entry** (`cache.size > 1`), so a single active transcript larger than the whole budget is never re-parsed on every read.

## Evidence (red → green)

New tests in `transcript-read-cache.test.ts` (with a test-only budget override so the byte-eviction path is exercised without 100 MB fixtures):

- **WITHOUT the byte condition:** *"evicts the oldest entry once total cached bytes exceed the budget"* **fails** — the oldest entry stays cached (`readSpy` 3 ≠ 4). **Leak reproduced.**
- **WITH the fix:** oldest large entries evict, the newest is always kept, and small entries under the default budget never evict (zero-regression for typical use). ✅

Verification:
- `transcript-read-cache.test.ts` — 8 tests ✅ (5 original + 3 new)
- `ipc/native-chat.test.ts` + `runtime/rpc/methods/native-chat.test.ts` — 18 total green ✅
- `oxlint` clean, `tsgo` node typecheck clean ✅

## ELI5

Orca keeps a shelf of the last 50 chat logs it read so it doesn't re-read them from disk. It counted *logs*, not their *size* — but a single AI coding log can be 100 MB. Fifty of those = a few GB just sitting on the shelf. Now it also watches the total size and clears out old big ones (always keeping the one you're currently looking at), so the shelf can't grow past ~128 MB.

## Trade-offs / regression risk: **near-zero**

- It's a **read-through cache**: an evicted entry is simply re-read from disk on next access — already the existing cache-miss path. **No behavior or output change.**
- The only cost is extra re-parses **if** a user's *simultaneously-hot* transcripts exceed 128 MB — exactly the users currently at OOM risk. Typical use (transcripts far under budget) is unaffected, and the newest/active transcript is **never** evicted, so the common "keep re-reading the session I'm watching" path never re-parses.
- 128 MB of *file bytes* ≈ 200–400 MB parsed worst case — a hard bound and ~10–25× lower than the previous several-GB ceiling.

## Note

This is one of **two** massive-scale candidates found this pass. The other — an uncapped unsent PTY backlog (`pendingData` in `main/ipc/pty.ts`) — is under separate verification (its fix risks dropping terminal output, so reachability is being confirmed first) and will be a separate PR if it holds up.

Made with [Orca](https://github.com/stablyai/orca) 🐋
