### PR TITLE
perf(renderer): keep worktree activity summaries ref-stable across unrelated churn

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { shallow } from 'zustand/shallow'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalTab } from '../../../../shared/types'
@@ -162,6 +163,119 @@ describe('selectWorktreeAgentActivitySummary', () => {
       hasLiveDone: true
     })
     expect(nowSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('limits summary-reference churn to the transitioning worktree at scale', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(2_000)
+    const worktreeIds = Array.from({ length: 12 }, (_, index) => `repo::/wt-${index}`)
+    const tabsByWorktree = Object.fromEntries(
+      worktreeIds.map((worktreeId, index) => [worktreeId, [makeTab(`tab-${index}`, worktreeId)]])
+    )
+    const initialStatuses = Object.fromEntries(
+      worktreeIds.map((_, index) => {
+        const paneKey = makePaneKey(`tab-${index}`, LEAF_ID)
+        return [paneKey, makeAgentStatusEntry({ paneKey, state: 'working' })]
+      })
+    )
+    const changedPaneKey = makePaneKey('tab-11', LEAF_ID)
+    const baseInputs = {
+      tabsByWorktree,
+      migrationUnsupportedByPtyId: {},
+      runtimeAgentOrchestrationByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    }
+    const state: AgentActivityInput = {
+      ...baseInputs,
+      agentStatusEpoch: 0,
+      agentStatusByPaneKey: initialStatuses
+    }
+    const changedState: AgentActivityInput = {
+      ...baseInputs,
+      agentStatusEpoch: 1,
+      agentStatusByPaneKey: {
+        ...initialStatuses,
+        [changedPaneKey]: makeAgentStatusEntry({ paneKey: changedPaneKey, state: 'done' })
+      }
+    }
+
+    const before = worktreeIds.map((worktreeId) =>
+      selectWorktreeAgentActivitySummary(state, worktreeId)
+    )
+    const after = worktreeIds.map((worktreeId) =>
+      selectWorktreeAgentActivitySummary(changedState, worktreeId)
+    )
+    const changedReferenceCount = after.filter((summary, index) => summary !== before[index]).length
+    const shallowNotificationCount = after.filter(
+      (summary, index) => !shallow(summary, before[index])
+    ).length
+
+    // Why: shallow store subscriptions wake on the nested pane-id map reference.
+    // One transition must not schedule downstream work for every other card.
+    expect(changedReferenceCount).toBe(1)
+    expect(shallowNotificationCount).toBe(1)
+    expect(after[11]).toMatchObject({ hasLiveWorking: false, hasLiveDone: true })
+  })
+
+  it('reuses only summaries whose pane membership is still current', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(2_000)
+    const worktreeId = 'repo::/wt-1'
+    const firstPaneKey = makePaneKey('tab-1', LEAF_ID)
+    const secondPaneKey = makePaneKey('tab-2', LEAF_ID)
+    const replacementPaneKey = makePaneKey('tab-3', LEAF_ID)
+    const sharedInputs = {
+      migrationUnsupportedByPtyId: {},
+      runtimeAgentOrchestrationByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    }
+    const initial: AgentActivityInput = {
+      ...sharedInputs,
+      tabsByWorktree: {
+        [worktreeId]: [makeTab('tab-1', worktreeId), makeTab('tab-2', worktreeId)]
+      },
+      agentStatusEpoch: 0,
+      agentStatusByPaneKey: {
+        [firstPaneKey]: makeAgentStatusEntry({ paneKey: firstPaneKey, state: 'working' }),
+        [secondPaneKey]: makeAgentStatusEntry({ paneKey: secondPaneKey, state: 'working' })
+      }
+    }
+    const reordered: AgentActivityInput = {
+      ...initial,
+      agentStatusEpoch: 1,
+      agentStatusByPaneKey: {
+        [secondPaneKey]: initial.agentStatusByPaneKey[secondPaneKey],
+        [firstPaneKey]: initial.agentStatusByPaneKey[firstPaneKey]
+      }
+    }
+    const replacement: AgentActivityInput = {
+      ...sharedInputs,
+      tabsByWorktree: { [worktreeId]: [makeTab('tab-3', worktreeId)] },
+      agentStatusEpoch: 2,
+      agentStatusByPaneKey: {
+        [replacementPaneKey]: makeAgentStatusEntry({
+          paneKey: replacementPaneKey,
+          state: 'working'
+        })
+      }
+    }
+    const removed: AgentActivityInput = {
+      ...replacement,
+      agentStatusEpoch: 3,
+      agentStatusByPaneKey: {}
+    }
+
+    const first = selectWorktreeAgentActivitySummary(initial, worktreeId)
+    const afterReorder = selectWorktreeAgentActivitySummary(reordered, worktreeId)
+    const afterReplacement = selectWorktreeAgentActivitySummary(replacement, worktreeId)
+    const afterRemoval = selectWorktreeAgentActivitySummary(removed, worktreeId)
+
+    expect(afterReorder).toBe(first)
+    expect(afterReplacement).not.toBe(first)
+    expect(afterReplacement.agentStatusPaneIdsByTabId).toEqual({
+      'tab-3': new Set([LEAF_ID])
+    })
+    expect(afterRemoval).not.toBe(afterReplacement)
+    expect(afterRemoval).toMatchObject({ hasLiveWorking: false })
+    expect(afterRemoval.agentStatusPaneIdsByTabId).toEqual({})
   })
 
   it('summarizes worktree-attributed rows missing from the tab list', () => {

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -139,6 +139,18 @@ function getWorktreeAgentActivitySummaries(
     addParentPaneId(summary, orchestration, retained.worktreeId, tabIdToWorktreeId)
   }
 
+  // Why: epoch changes rebuild every summary, so reuse structurally equal results
+  // to keep unrelated worktree subscriptions from scheduling card renders.
+  const previousSummaries = agentActivityCache?.summaries
+  if (previousSummaries) {
+    for (const [worktreeId, summary] of summaries) {
+      const previous = previousSummaries.get(worktreeId)
+      if (previous && summariesEqual(previous, summary)) {
+        summaries.set(worktreeId, previous)
+      }
+    }
+  }
+
   agentActivityCache = {
     tabsByWorktree: state.tabsByWorktree,
     agentStatusEpoch: state.agentStatusEpoch,
@@ -148,6 +160,48 @@ function getWorktreeAgentActivitySummaries(
     summaries
   }
   return summaries
+}
+
+function summariesEqual(
+  previous: WorktreeAgentActivitySummary,
+  next: WorktreeAgentActivitySummary
+): boolean {
+  return (
+    previous.hasPermission === next.hasPermission &&
+    previous.hasLiveWorking === next.hasLiveWorking &&
+    previous.hasLiveDone === next.hasLiveDone &&
+    previous.hasRetainedDone === next.hasRetainedDone &&
+    agentStatusPaneIdsByTabIdEqual(
+      previous.agentStatusPaneIdsByTabId,
+      next.agentStatusPaneIdsByTabId
+    )
+  )
+}
+
+function agentStatusPaneIdsByTabIdEqual(
+  previous: Record<string, ReadonlySet<string>>,
+  next: Record<string, ReadonlySet<string>>
+): boolean {
+  if (previous === next) {
+    return true
+  }
+  const previousKeys = Object.keys(previous)
+  if (previousKeys.length !== Object.keys(next).length) {
+    return false
+  }
+  for (const tabId of previousKeys) {
+    const previousPaneIds = previous[tabId]
+    const nextPaneIds = next[tabId]
+    if (!nextPaneIds || previousPaneIds.size !== nextPaneIds.size) {
+      return false
+    }
+    for (const paneId of previousPaneIds) {
+      if (!nextPaneIds.has(paneId)) {
+        return false
+      }
+    }
+  }
+  return true
 }
 
 function resolveEntryOrchestration(


### PR DESCRIPTION
## Description

Every visible worktree card derives an agent-activity summary from one shared selector cache. An agent status transition or freshness tick invalidates that cache globally. The selector must still rebuild its O(worktrees + agents + retained agents) index, but previously it returned fresh nested pane-ID maps for every worktree, so shallow subscriptions treated every card with agents as changed.

This change structurally compares each rebuilt summary with the preceding generation and reuses the previous object when all four status flags and every tab/pane set are unchanged. Only worktrees whose effective activity changed notify their card subscriptions.

## Evidence

- **Reproduced before the fix:** in a deterministic 12-worktree fixture, one unrelated worktree transition from working to done changed **12/12 summary references** and produced **12/12 shallow-subscription notifications**.
- **Verified after the fix:** the same transition changes **1/12 summary references** and produces **1/12 shallow-subscription notifications**.
- Added cache-safety coverage proving entry reorder safely reuses an equal summary, while worktree/pane replacement and removal return fresh current summaries instead of stale pane membership.
- Focused validation after the final rebase: **52 tests passed** across activity summaries, the activity-status hook, section activity, card status inputs, status resolution, and freshness selectors.
- Changed-file oxlint and oxfmt checks passed; max-lines ratchet passed; diff check passed.
- Two independent read-only reviewers returned **CLEAN** on final SHA 611c509b477d55fce35ec33e460fcfc70dca455b, covering performance evidence and architecture/correctness/lifecycle respectively.
- Validation gap: the shared workspace's aggregate typecheck/full suite is currently blocked by unrelated baseline/environment failures (missing newly locked typescript-api resolution, an unrelated restored-banner DOM type mismatch, and existing terminal snapshot serialization failures). The touched focused suites and changed-file gates are clean; CI remains the authoritative clean-install check.

## ELI5

Imagine 12 dashboard lights. When one agent finished, Orca recalculated all 12 lights and handed React 12 brand-new boxes, even though 11 boxes contained exactly the same answer. React opened all 12 boxes again. Orca now keeps the old box for each unchanged light, so only the one light that actually changed needs attention.

## Trade-offs

- Epoch-triggered summary construction is still O(worktrees + agents + retained agents); this PR removes downstream notification/render fanout, not the shared index rebuild itself.
- Each rebuild adds a linear structural comparison over the summaries and represented pane memberships. That bounded comparison is intentionally cheaper than scheduling status resolution and React work for every unchanged card.
- The cache retains only the current summary map and reuses behaviorally identical values, so memory remains bounded by current summarized worktrees.
- No IPC, RPC, git-provider, SSH, platform, or remote-runtime contract changes. Paired web/remote clients use the same normalized renderer state semantics.
- **Expected end-user regressions: zero.** Status-dot behavior is unchanged; only redundant work is skipped.
