### PR TITLE
perf(opencode): GC orphaned per-session overlay directories

### DIFF
--- a/src/main/opencode/hook-service.test.ts
+++ b/src/main/opencode/hook-service.test.ts
@@ -8,6 +8,7 @@ import {
   readdirSync,
   rmSync,
   symlinkSync,
+  utimesSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -546,5 +547,86 @@ describe('OpenCodeHookService overlay mode (user OPENCODE_CONFIG_DIR set)', () =
       'export default "new"'
     )
     expect(existsSync(join(overlayDir, 'node_modules', 'opencode-runtime', 'index.js'))).toBe(true)
+  })
+})
+
+describe('OpenCodeHookService orphaned-dir GC', () => {
+  let userDataDir: string
+  let userConfigDir: string
+
+  beforeEach(() => {
+    userDataDir = mkdtempSync(join(tmpdir(), 'orca-opencode-gc-userdata-'))
+    getPathMock.mockImplementation((name: string) => {
+      if (name === 'userData') {
+        return userDataDir
+      }
+      throw new Error(`unexpected getPath(${name})`)
+    })
+    userConfigDir = mkdtempSync(join(tmpdir(), 'orca-opencode-gc-userconfig-'))
+    writeFileSync(join(userConfigDir, 'opencode.json'), '{}')
+  })
+
+  afterEach(() => {
+    rmSync(userDataDir, { recursive: true, force: true })
+    rmSync(userConfigDir, { recursive: true, force: true })
+  })
+
+  function ageEverything(dir: string, days: number): void {
+    // Deep utimes, children before parents so parent dir mtimes stay aged.
+    const stack = [dir]
+    const paths: string[] = []
+    while (stack.length > 0) {
+      const current = stack.pop()!
+      paths.push(current)
+      if (lstatSync(current).isDirectory()) {
+        for (const entry of readdirSync(current)) {
+          stack.push(join(current, entry))
+        }
+      }
+    }
+    const at = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    for (const path of paths.toReversed()) {
+      utimesSync(path, at, at)
+    }
+  }
+
+  it('a sweep spares shared and this-run overlays but removes aged orphans end-to-end', async () => {
+    const service = new OpenCodeHookService()
+    // Live dirs handed out this run: the shared config + one source overlay.
+    const sharedDir = service.buildPtyEnv('session-a').OPENCODE_CONFIG_DIR!
+    const liveOverlayDir = service.buildPtyEnv('session-b', userConfigDir).OPENCODE_CONFIG_DIR!
+    // Aged orphans in both roots, shaped exactly like real generated dirs.
+    const legacyOrphan = join(userDataDir, 'opencode-hooks', 'a'.repeat(32))
+    const overlayOrphan = join(userDataDir, 'opencode-config-overlays', 'b'.repeat(32))
+    for (const orphan of [legacyOrphan, overlayOrphan]) {
+      mkdirSync(join(orphan, 'plugins'), { recursive: true })
+      writeFileSync(join(orphan, 'plugins', 'orca-opencode-status.js'), '// stale')
+    }
+    // Age everything, live dirs included — only the handed-out reference
+    // (not recency) must be what saves the live overlay.
+    for (const dir of [sharedDir, liveOverlayDir, legacyOrphan, overlayOrphan]) {
+      ageEverything(dir, 60)
+    }
+
+    await service.runOrphanedDirGc()
+
+    expect(existsSync(sharedDir)).toBe(true)
+    expect(existsSync(liveOverlayDir)).toBe(true)
+    expect(existsSync(legacyOrphan)).toBe(false)
+    expect(existsSync(overlayOrphan)).toBe(false)
+  })
+
+  it('scheduleOrphanedDirGc arms at most one sweep per app run', () => {
+    vi.useFakeTimers()
+    try {
+      const service = new OpenCodeHookService()
+      const runSpy = vi.spyOn(service, 'runOrphanedDirGc').mockResolvedValue()
+      service.scheduleOrphanedDirGc(1000)
+      service.scheduleOrphanedDirGc(1000)
+      vi.advanceTimersByTime(10_000)
+      expect(runSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/opencode/hook-service.ts
+++ b/src/main/opencode/hook-service.ts
@@ -16,12 +16,14 @@ import {
 } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { mirrorEntry, safeRemoveTree } from '../pty/overlay-mirror'
-
-const ORCA_OPENCODE_PLUGIN_FILE = 'orca-opencode-status.js'
-const OPENCODE_LEGACY_HOOKS_DIR = 'opencode-hooks'
-const OPENCODE_OVERLAY_DIR = 'opencode-config-overlays'
-const OPENCODE_SHARED_CONFIG_DIR = 'shared'
-const OPENCODE_OVERLAY_MANIFEST_FILE = '.orca-opencode-overlay-manifest.json'
+import { sweepOrphanedOpenCodeDirs } from './overlay-dir-gc'
+import {
+  OPENCODE_LEGACY_HOOKS_DIR,
+  OPENCODE_OVERLAY_DIR,
+  OPENCODE_OVERLAY_MANIFEST_FILE,
+  OPENCODE_SHARED_CONFIG_DIR,
+  ORCA_OPENCODE_PLUGIN_FILE
+} from './overlay-dir-names'
 
 type OpenCodeOverlayManifest = {
   topLevelEntries: string[]
@@ -412,6 +414,11 @@ export function getOpenCodeFamilyPluginSource(hookPathname: string): string {
 // agent-hooks server (/hook/opencode), so OpenCode rides the same status
 // pipeline as Claude/Codex/Gemini.
 export class OpenCodeHookService {
+  // Why: every config dir handed to a PTY during this app run is live no
+  // matter how old its mtimes are — the GC sweep must never remove one.
+  private handedOutConfigDirs = new Set<string>()
+  private orphanDirGcScheduled = false
+
   clearPty(_ptyId: string): void {
     // Why: OpenCode can materialize thousands of plugin runtime files under
     // OPENCODE_CONFIG_DIR. This teardown runs on Electron's main process hot
@@ -437,6 +444,7 @@ export class OpenCodeHookService {
       if (!configDir) {
         return {}
       }
+      this.handedOutConfigDirs.add(configDir)
       return { OPENCODE_CONFIG_DIR: configDir }
     }
 
@@ -463,7 +471,48 @@ export class OpenCodeHookService {
       return { OPENCODE_CONFIG_DIR: existingConfigDir }
     }
 
+    this.handedOutConfigDirs.add(overlayDir)
     return { OPENCODE_CONFIG_DIR: overlayDir }
+  }
+
+  // Why: bulk-remove per-session/per-source config dirs that nothing has
+  // spawned against for 30+ days — a real machine accumulated ~35k files /
+  // 574MB of them. Runs at most once per app run, delayed and unref'd so it
+  // stays off the startup critical path; the sweep itself is bounded and
+  // yields between deletions.
+  scheduleOrphanedDirGc(delayMs = 3 * 60_000): void {
+    if (this.orphanDirGcScheduled) {
+      return
+    }
+    this.orphanDirGcScheduled = true
+    const timer = setTimeout(() => {
+      void this.runOrphanedDirGc().catch(() => {
+        // Best-effort maintenance; never let it surface as an app error.
+      })
+    }, delayMs)
+    timer.unref?.()
+  }
+
+  // Public so tests can run one sweep synchronously without timer plumbing.
+  async runOrphanedDirGc(): Promise<void> {
+    const referencedConfigDirs = new Set(this.handedOutConfigDirs)
+    // Why: a nested Orca (launched inside another Orca's terminal) can inherit
+    // an overlay path via env; treat inherited values as live too.
+    for (const value of [process.env.OPENCODE_CONFIG_DIR, process.env.ORCA_OPENCODE_CONFIG_DIR]) {
+      if (value) {
+        referencedConfigDirs.add(value)
+      }
+    }
+    const result = await sweepOrphanedOpenCodeDirs({
+      legacyHooksRoot: join(app.getPath('userData'), OPENCODE_LEGACY_HOOKS_DIR),
+      overlayRoot: join(app.getPath('userData'), OPENCODE_OVERLAY_DIR),
+      referencedConfigDirs
+    })
+    if (result.removed > 0 || result.failed > 0) {
+      console.log(
+        `[opencode-gc] removed ${result.removed} orphaned dir(s) (scanned ${result.scanned}, failed ${result.failed})`
+      )
+    }
   }
 
   private getOverlayRoot(): string {

--- a/src/main/opencode/overlay-dir-gc.test.ts
+++ b/src/main/opencode/overlay-dir-gc.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { safeRemoveTree } from '../pty/overlay-mirror'
+import { OPENCODE_DIR_GC_MAX_REMOVALS_PER_SWEEP, sweepOrphanedOpenCodeDirs } from './overlay-dir-gc'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+// Fixed "now" so age math never races the wall clock.
+const NOW = 1_800_000_000_000
+
+describe('sweepOrphanedOpenCodeDirs', () => {
+  let workRoot: string
+  let legacyHooksRoot: string
+  let overlayRoot: string
+
+  beforeEach(() => {
+    workRoot = mkdtempSync(join(tmpdir(), 'orca-opencode-gc-'))
+    legacyHooksRoot = join(workRoot, 'opencode-hooks')
+    overlayRoot = join(workRoot, 'opencode-config-overlays')
+    mkdirSync(legacyHooksRoot, { recursive: true })
+    mkdirSync(overlayRoot, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(workRoot, { recursive: true, force: true })
+  })
+
+  function makeConfigDir(
+    root: string,
+    name: string,
+    ageDays: number,
+    opts?: { pluginAgeDays?: number }
+  ): string {
+    const dir = join(root, name)
+    const pluginsDir = join(dir, 'plugins')
+    mkdirSync(pluginsDir, { recursive: true })
+    const pluginFile = join(pluginsDir, 'orca-opencode-status.js')
+    const manifestFile = join(dir, '.orca-opencode-overlay-manifest.json')
+    writeFileSync(pluginFile, '// plugin')
+    writeFileSync(manifestFile, '{}')
+    const at = (days: number) => new Date(NOW - days * DAY_MS)
+    const pluginAt = at(opts?.pluginAgeDays ?? ageDays)
+    // Files first, dirs last — utimes on a child does not touch the parent,
+    // but creating children above refreshed the dir mtimes.
+    utimesSync(pluginFile, pluginAt, pluginAt)
+    utimesSync(manifestFile, at(ageDays), at(ageDays))
+    utimesSync(pluginsDir, at(ageDays), at(ageDays))
+    utimesSync(dir, at(ageDays), at(ageDays))
+    return dir
+  }
+
+  function sweep(overrides?: Partial<Parameters<typeof sweepOrphanedOpenCodeDirs>[0]>) {
+    return sweepOrphanedOpenCodeDirs({
+      legacyHooksRoot,
+      overlayRoot,
+      referencedConfigDirs: new Set<string>(),
+      now: NOW,
+      ...overrides
+    })
+  }
+
+  const hexName = (n: number) => n.toString(16).padStart(32, '0')
+
+  it('removes old generated-name dirs under both roots and spares everything else', async () => {
+    const legacyHex = makeConfigDir(legacyHooksRoot, hexName(1), 60)
+    const legacyNumeric = makeConfigDir(legacyHooksRoot, '17', 60)
+    const shared = makeConfigDir(legacyHooksRoot, 'shared', 60)
+    const humanNamed = makeConfigDir(legacyHooksRoot, 'my-notes', 60)
+    const shortHex = makeConfigDir(legacyHooksRoot, 'abcdef', 60)
+    const overlayHex = makeConfigDir(overlayRoot, hexName(2), 60)
+    // Numeric counter ids only ever existed under the legacy root; an
+    // unexpected numeric name in the overlay root is not ours to delete.
+    const overlayNumeric = makeConfigDir(overlayRoot, '17', 60)
+
+    const result = await sweep()
+
+    expect(existsSync(legacyHex)).toBe(false)
+    expect(existsSync(legacyNumeric)).toBe(false)
+    expect(existsSync(overlayHex)).toBe(false)
+    expect(existsSync(shared)).toBe(true)
+    expect(existsSync(humanNamed)).toBe(true)
+    expect(existsSync(shortHex)).toBe(true)
+    expect(existsSync(overlayNumeric)).toBe(true)
+    expect(result.removed).toBe(3)
+    expect(result.keptUnrecognized).toBe(4)
+    expect(result.failed).toBe(0)
+  })
+
+  it('keeps an old dir referenced by a live session', async () => {
+    const referenced = makeConfigDir(overlayRoot, hexName(3), 60)
+    const orphan = makeConfigDir(overlayRoot, hexName(4), 60)
+
+    const result = await sweep({ referencedConfigDirs: new Set([referenced]) })
+
+    expect(existsSync(referenced)).toBe(true)
+    expect(existsSync(orphan)).toBe(false)
+    expect(result.keptReferenced).toBe(1)
+    expect(result.removed).toBe(1)
+  })
+
+  it('keeps a dir when a referenced path lives inside it', async () => {
+    const parent = makeConfigDir(overlayRoot, hexName(5), 60)
+
+    const result = await sweep({ referencedConfigDirs: new Set([join(parent, 'plugins')]) })
+
+    expect(existsSync(parent)).toBe(true)
+    expect(result.keptReferenced).toBe(1)
+  })
+
+  it('keeps orphans younger than the age gate', async () => {
+    const young = makeConfigDir(overlayRoot, hexName(6), 5)
+
+    const result = await sweep()
+
+    expect(existsSync(young)).toBe(true)
+    expect(result.keptYoung).toBe(1)
+    expect(result.removed).toBe(0)
+  })
+
+  it('treats a freshly rewritten plugin file as recency even when dir mtimes are stale', async () => {
+    // Why this matters: writeFileSync over an existing plugin file (the
+    // per-spawn rewrite) updates only the file mtime, so the dir mtime of an
+    // actively used config dir can be arbitrarily old.
+    const active = makeConfigDir(overlayRoot, hexName(7), 60, { pluginAgeDays: 1 })
+
+    const result = await sweep()
+
+    expect(existsSync(active)).toBe(true)
+    expect(result.keptYoung).toBe(1)
+  })
+
+  it('bounds removals per sweep and continues on a later sweep', async () => {
+    const orphans = Array.from({ length: 7 }, (_, i) =>
+      makeConfigDir(legacyHooksRoot, hexName(0x10 + i), 60)
+    )
+
+    const first = await sweep({ maxRemovals: 3 })
+    expect(first.removed).toBe(3)
+    expect(orphans.filter((dir) => existsSync(dir))).toHaveLength(4)
+
+    const second = await sweep({ maxRemovals: 3 })
+    expect(second.removed).toBe(3)
+    expect(orphans.filter((dir) => existsSync(dir))).toHaveLength(1)
+
+    const third = await sweep({ maxRemovals: 3 })
+    expect(third.removed).toBe(1)
+    expect(orphans.some((dir) => existsSync(dir))).toBe(false)
+  })
+
+  it('defaults the per-sweep bound to 500', () => {
+    expect(OPENCODE_DIR_GC_MAX_REMOVALS_PER_SWEEP).toBe(500)
+  })
+
+  it('continues past a dir whose removal fails (EBUSY/EPERM)', async () => {
+    const busy = makeConfigDir(legacyHooksRoot, hexName(0x20), 60)
+    const others = [
+      makeConfigDir(legacyHooksRoot, hexName(0x21), 60),
+      makeConfigDir(legacyHooksRoot, hexName(0x22), 60)
+    ]
+
+    const result = await sweep({
+      removeTree: (path) => {
+        if (path === busy) {
+          throw Object.assign(new Error('resource busy'), { code: 'EBUSY' })
+        }
+        safeRemoveTree(path)
+      }
+    })
+
+    expect(existsSync(busy)).toBe(true)
+    expect(others.some((dir) => existsSync(dir))).toBe(false)
+    expect(result.failed).toBe(1)
+    expect(result.removed).toBe(2)
+  })
+
+  it('is a no-op when the roots do not exist', async () => {
+    const result = await sweepOrphanedOpenCodeDirs({
+      legacyHooksRoot: join(workRoot, 'missing-a'),
+      overlayRoot: join(workRoot, 'missing-b'),
+      referencedConfigDirs: new Set<string>(),
+      now: NOW
+    })
+
+    expect(result).toEqual({
+      scanned: 0,
+      removed: 0,
+      keptReferenced: 0,
+      keptYoung: 0,
+      keptUnrecognized: 0,
+      failed: 0
+    })
+  })
+
+  it.runIf(process.platform !== 'win32')(
+    'never follows a symlinked entry even with a generated name',
+    async () => {
+      const outside = mkdtempSync(join(tmpdir(), 'orca-opencode-gc-outside-'))
+      try {
+        writeFileSync(join(outside, 'user-data.txt'), 'precious')
+        const linkPath = join(legacyHooksRoot, hexName(0x30))
+        symlinkSync(outside, linkPath, 'dir')
+
+        const result = await sweep()
+
+        expect(existsSync(join(outside, 'user-data.txt'))).toBe(true)
+        expect(existsSync(linkPath)).toBe(true)
+        expect(result.keptUnrecognized).toBe(1)
+        expect(result.removed).toBe(0)
+      } finally {
+        rmSync(outside, { recursive: true, force: true })
+      }
+    }
+  )
+})

--- a/src/main/opencode/overlay-dir-gc.ts
+++ b/src/main/opencode/overlay-dir-gc.ts
@@ -1,0 +1,173 @@
+// Why: the OpenCode hook service materializes one machine-generated config
+// dir per session/source under userData and historically never removed them —
+// a real machine accumulated ~35k files / 574MB of dead overlay state. This
+// sweep bulk-removes clearly-dead dirs under a deliberately conservative
+// policy: correctness beats reclaimed bytes, so anything ambiguous is kept
+// (an individual leftover dir is cheap; the win is removing thousands).
+import type { Dirent } from 'node:fs'
+import { lstat, readdir } from 'node:fs/promises'
+import { join, resolve, sep } from 'node:path'
+import { safeRemoveTree } from '../pty/overlay-mirror'
+import {
+  OPENCODE_OVERLAY_MANIFEST_FILE,
+  OPENCODE_SHARED_CONFIG_DIR,
+  ORCA_OPENCODE_PLUGIN_FILE
+} from './overlay-dir-names'
+
+// Why: only dirs whose names Orca itself generated are ever candidates —
+// 32-hex `toSafeDirName` hashes (current), plus the pre-#1155 numeric PTY
+// counters that only ever existed under the legacy hooks root. Anything a
+// human (or a future Orca version) placed here is out of reach of the sweep.
+const GENERATED_HASH_DIR_NAME = /^[0-9a-f]{32}$/
+const LEGACY_COUNTER_DIR_NAME = /^\d+$/
+
+// Why: 30 days of no spawn against a dir means no live terminal has been
+// using it; a session that resumes later self-heals because buildPtyEnv
+// recreates the overlay from the recorded source config dir on every spawn.
+export const OPENCODE_DIR_GC_MIN_AGE_MS = 30 * 24 * 60 * 60 * 1000
+// Why: bound per-run work so a first sweep over a years-old backlog cannot
+// monopolize the main process or thrash disk; later runs continue the job.
+export const OPENCODE_DIR_GC_MAX_REMOVALS_PER_SWEEP = 500
+
+export type OpenCodeDirGcOptions = {
+  legacyHooksRoot: string
+  overlayRoot: string
+  // Config dirs handed out to any PTY during this app run (plus inherited
+  // process.env values); these are live no matter what their mtimes say.
+  referencedConfigDirs: ReadonlySet<string>
+  now?: number
+  minAgeMs?: number
+  maxRemovals?: number
+  removeTree?: (path: string) => void
+  yieldBetweenRemovals?: () => Promise<void>
+}
+
+export type OpenCodeDirGcResult = {
+  scanned: number
+  removed: number
+  keptReferenced: number
+  keptYoung: number
+  keptUnrecognized: number
+  failed: number
+}
+
+function canonicalizeForComparison(path: string): string {
+  const resolved = resolve(path)
+  // Why: Windows paths compare case-insensitively; a casing mismatch between
+  // an env-sourced reference and the scanned path must not defeat the check.
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved
+}
+
+// Why: the per-spawn plugin rewrite (and manifest write) updates file mtimes
+// but NOT the parent dir's mtime, so the dir mtime alone under-reports
+// recency — on a live machine the shared dir's own mtime was weeks old while
+// its plugin file had been rewritten minutes earlier. Stat the fixed set of
+// paths the hook service touches on every spawn and take the newest.
+async function newestSpawnTouchedMtimeMs(dirPath: string): Promise<number> {
+  const spawnTouchedPaths = [
+    dirPath,
+    join(dirPath, OPENCODE_OVERLAY_MANIFEST_FILE),
+    join(dirPath, 'plugins'),
+    join(dirPath, 'plugins', ORCA_OPENCODE_PLUGIN_FILE)
+  ]
+  let newest = 0
+  for (const path of spawnTouchedPaths) {
+    try {
+      newest = Math.max(newest, (await lstat(path)).mtimeMs)
+    } catch {
+      // Missing entries contribute nothing to recency.
+    }
+  }
+  return newest
+}
+
+export async function sweepOrphanedOpenCodeDirs(
+  options: OpenCodeDirGcOptions
+): Promise<OpenCodeDirGcResult> {
+  const now = options.now ?? Date.now()
+  const minAgeMs = options.minAgeMs ?? OPENCODE_DIR_GC_MIN_AGE_MS
+  const maxRemovals = options.maxRemovals ?? OPENCODE_DIR_GC_MAX_REMOVALS_PER_SWEEP
+  const removeTree = options.removeTree ?? safeRemoveTree
+  const yieldBetweenRemovals =
+    options.yieldBetweenRemovals ?? (() => new Promise<void>((r) => setImmediate(r)))
+  const referencedDirs = [...options.referencedConfigDirs].map(canonicalizeForComparison)
+
+  const result: OpenCodeDirGcResult = {
+    scanned: 0,
+    removed: 0,
+    keptReferenced: 0,
+    keptYoung: 0,
+    keptUnrecognized: 0,
+    failed: 0
+  }
+
+  const sweepRoots = [
+    { root: options.legacyHooksRoot, allowNumericNames: true },
+    { root: options.overlayRoot, allowNumericNames: false }
+  ]
+
+  for (const { root, allowNumericNames } of sweepRoots) {
+    let entries: Dirent[]
+    try {
+      entries = await readdir(root, { withFileTypes: true })
+    } catch {
+      continue
+    }
+
+    for (const entry of entries) {
+      // Why: count failed attempts against the bound too — a failed removal
+      // may still have done significant IO before giving up.
+      if (result.removed + result.failed >= maxRemovals) {
+        return result
+      }
+      result.scanned++
+
+      // Why: `shared` is the still-active no-user-config OPENCODE_CONFIG_DIR
+      // (see writeSharedPluginConfig) — never a candidate, checked by name so
+      // even a shape-rule bug cannot reach it.
+      if (entry.name === OPENCODE_SHARED_CONFIG_DIR) {
+        result.keptUnrecognized++
+        continue
+      }
+      const isGeneratedName =
+        GENERATED_HASH_DIR_NAME.test(entry.name) ||
+        (allowNumericNames && LEGACY_COUNTER_DIR_NAME.test(entry.name))
+      // Why: isSymbolicLink checked alongside isDirectory — a symlinked entry
+      // is not Orca-generated and removing through it risks foreign data.
+      if (!isGeneratedName || entry.isSymbolicLink() || !entry.isDirectory()) {
+        result.keptUnrecognized++
+        continue
+      }
+
+      const candidate = join(root, entry.name)
+      const canonicalCandidate = canonicalizeForComparison(candidate)
+      const isReferenced = referencedDirs.some(
+        (dir) => dir === canonicalCandidate || dir.startsWith(canonicalCandidate + sep)
+      )
+      if (isReferenced) {
+        result.keptReferenced++
+        continue
+      }
+
+      const newestMtimeMs = await newestSpawnTouchedMtimeMs(candidate)
+      // Why: newestMtimeMs === 0 means every stat failed (dir vanished or is
+      // unreadable mid-sweep) — keep rather than guess.
+      if (newestMtimeMs === 0 || now - newestMtimeMs < minAgeMs) {
+        result.keptYoung++
+        continue
+      }
+
+      try {
+        removeTree(candidate)
+        result.removed++
+      } catch {
+        // Why: one EBUSY/EPERM dir (antivirus, open handles) must not abort
+        // the whole sweep; the dir stays and a later run retries it.
+        result.failed++
+      }
+      await yieldBetweenRemovals()
+    }
+  }
+
+  return result
+}

--- a/src/main/opencode/overlay-dir-names.ts
+++ b/src/main/opencode/overlay-dir-names.ts
@@ -1,0 +1,10 @@
+// Why: these on-disk names are shared between the hook service (which writes
+// the dirs) and the orphaned-dir GC sweep (which must recognize exactly the
+// same names). A separate module avoids a hook-service <-> gc import cycle and
+// keeps the GC importable without electron.
+
+export const ORCA_OPENCODE_PLUGIN_FILE = 'orca-opencode-status.js'
+export const OPENCODE_LEGACY_HOOKS_DIR = 'opencode-hooks'
+export const OPENCODE_OVERLAY_DIR = 'opencode-config-overlays'
+export const OPENCODE_SHARED_CONFIG_DIR = 'shared'
+export const OPENCODE_OVERLAY_MANIFEST_FILE = '.orca-opencode-overlay-manifest.json'

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -28,6 +28,7 @@ import {
   dismissNudge
 } from '../updater'
 import { scheduleHistoryGc } from '../terminal-history'
+import { openCodeHookService } from '../opencode/hook-service'
 import { hydrateLocalPtyRegistryAtBoot } from '../memory/hydrate-local-pty-registry'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import { getKnownWorktreeIdsForHistoryGc } from './history-gc-worktree-ids'
@@ -111,6 +112,10 @@ export function attachMainWindowServices(
   scheduleHistoryGc(async () => {
     return getKnownWorktreeIdsForHistoryGc(store)
   })
+  // Why: bulk-remove orphaned per-session OpenCode config dirs (35k files /
+  // 574MB observed). Internally once-per-run guarded, so macOS dock
+  // re-activation re-running this function does not re-sweep.
+  openCodeHookService.scheduleOrphanedDirGc()
   // Why: warm-reattach gap.
   // Daemon-hosted PTYs survive renderer restarts on purpose, so on a fresh
   // Orca launch the daemon's `listSessions()` returns sessions that


### PR DESCRIPTION
## Problem

`~/Library/Application Support/orca/opencode-hooks/` on a real machine held **34,955 files / 574 MB** of accumulated machine-generated OpenCode config state that nothing ever cleaned up:

- **`opencode-hooks/<32-hex>` and `opencode-hooks/<counter>`** — per-session/per-PTY plugin dirs written by older Orca versions (pre source-scoped overlays). Nothing writes or reads them anymore; ~9 of them carry full `node_modules` trees (~3.6k files each). Only `opencode-hooks/shared` is still live (`writeSharedPluginConfig`).
- **`opencode-config-overlays/<32-hex>`** — current source-scoped overlays; one per distinct user `OPENCODE_CONFIG_DIR`, never removed.

## Fix

A conservative, bounded, async GC sweep (`src/main/opencode/overlay-dir-gc.ts`), scheduled once per app run on a delayed (3 min) unref'd timer next to `scheduleHistoryGc`. A dir is removed only if **all** of the following hold:

1. **Name shape**: exactly a 32-hex `toSafeDirName` hash (or an all-numeric legacy counter, legacy root only). `shared` is additionally excluded by name; anything a human placed there is untouchable. Symlinked entries are never followed or removed.
2. **Not referenced**: the hook service now records every config dir it hands to a PTY this app run (covers local + daemon spawn paths — both go through `buildPtyEnv` in main), plus inherited `OPENCODE_CONFIG_DIR`/`ORCA_OPENCODE_CONFIG_DIR` from `process.env` (nested-Orca case). Prefix-containment counts as referenced.
3. **Age gate (30 days)**: newest mtime among the dir, its overlay manifest, `plugins/`, and `plugins/orca-opencode-status.js`. The plugin file is rewritten on every spawn, so any dir spawned against in the last 30 days looks young — the dir mtime alone under-reports recency (on the measured machine, `shared`'s dir mtime was a month old while its plugin file had been rewritten minutes earlier).
4. **Bounded work**: ≤500 removal attempts per run (failures count), yielding to the event loop between deletions; a later run continues where the sweep stopped. One EBUSY/EPERM dir doesn't abort the sweep. Removal reuses the audited `safeRemoveTree` (junction-safe, never descends links).

Deletion is also **self-healing**: resume/respawn recomputes the overlay via `buildPtyHostEnv → buildPtyEnv`, which recreates the dir from the recorded source config path — persisted resume state (`SleepingAgentLaunchConfig.agentEnv`) never replays a stored overlay path verbatim.

**Residual risk (accepted, documented):** an OpenCode process inside a daemon-held PTY adopted from a previous app run whose env is unrecoverable, running >30 days against a *custom user config* overlay with no new spawn in that window. Consequence is bounded (config was read at process start; next spawn rebuilds the overlay). Sessions without a custom config use `shared`, which is never touched.

## Validation on the real backlog

Ran the sweep against an mtime-preserving copy of the affected machine's real dirs:

| | before | after |
|---|---|---|
| files | 38,743 | 3,679 (`shared` only, fully intact) |
| size | 575 MB | 57 MB |

First sweep removed exactly 500 dirs in ~2 s (0 failures), second removed the remaining ~205, third removed 0.

## Tests

`src/main/opencode/overlay-dir-gc.test.ts` (temp-dir, deterministic fixed `now`): old orphans removed under both roots; `shared`/human-named/short-hex/wrong-root-numeric spared; referenced dir survives (incl. prefix containment); young orphans survive; fresh plugin file alone counts as recency; 7-orphans/bound-3 sweep continuation; EBUSY on one dir doesn't abort; missing roots no-op; symlink with generated name not followed.

`hook-service.test.ts`: end-to-end — dirs handed out this run survive a sweep even when artificially aged 60 days, orphans in both roots are removed; `scheduleOrphanedDirGc` arms at most one sweep per run.

Scoped vitest (43 tests, opencode module) + `attach-main-window-services`/`register-core-handlers` suites green; full `pnpm typecheck` clean; max-lines ratchet OK.

Made with [Orca](https://github.com/stablyai/orca) 🐋
