### PR TITLE
Make Codex session-history source home configurable (host + WSL)

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -533,6 +533,56 @@ describe('CodexRuntimeHomeService', () => {
     }
   })
 
+  it('bridges WSL history from a configured per-distro source-home override', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const startWslCodexSessionBridgeInBackground = vi.fn(() => Promise.resolve())
+    vi.doMock('../codex/wsl-codex-session-bridge', () => ({
+      startWslCodexSessionBridgeInBackground
+    }))
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountId: null,
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } },
+        // Why: the override is a Linux path inside the distro, not <wslHome>/.codex.
+        codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.config/codex' } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const wslRuntimeHomePath = join(
+        wslHome,
+        '.local',
+        'share',
+        'orca',
+        'codex-runtime-home',
+        'home'
+      )
+
+      service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+
+      expect(startWslCodexSessionBridgeInBackground).toHaveBeenCalledTimes(1)
+      expect(startWslCodexSessionBridgeInBackground).toHaveBeenCalledWith({
+        distro: 'Ubuntu',
+        systemCodexHomePath: '/home/me/.config/codex',
+        managedCodexHomePath: wslRuntimeHomePath
+      })
+    } finally {
+      vi.doUnmock('../codex/wsl-codex-session-bridge')
+      vi.doUnmock('../wsl')
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
   it('starts WSL session bridging for the distro used by the materialized runtime home', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -40,6 +40,10 @@ import {
   syncSystemCodexResourcesIntoManagedHome
 } from '../codex/codex-home-paths'
 import { startSystemCodexSessionBridgeInBackground } from '../codex/codex-session-bridge'
+import {
+  resolveHostCodexSessionSourceHome,
+  resolveWslCodexSessionSourceHome
+} from '../codex/codex-session-source-home'
 import { startWslCodexSessionBridgeInBackground } from '../codex/wsl-codex-session-bridge'
 import {
   prepareSystemConfigForFreshRuntimeMirror,
@@ -146,7 +150,10 @@ export class CodexRuntimeHomeService {
     syncSystemConfigIntoManagedCodexHome()
     // Why: historical Codex sessions can be large; bridge them after launch
     // setup so starting a fresh Codex TUI never waits on a full tree walk.
-    void startSystemCodexSessionBridgeInBackground()
+    void startSystemCodexSessionBridgeInBackground(
+      {},
+      resolveHostCodexSessionSourceHome(this.store.getSettings())
+    )
     return this.getRuntimeHomePath()
   }
 
@@ -162,10 +169,11 @@ export class CodexRuntimeHomeService {
     if (!distro) {
       return
     }
-    const systemCodexHomePath = this.getWslSystemCodexHomePath({
-      runtime: 'wsl',
-      wslDistro: distro
-    })
+    // Why: history-only override lets custom-CODEX_HOME users bridge from their
+    // real home; falls back to <wslHome>/.codex, which auth/config still use.
+    const systemCodexHomePath =
+      resolveWslCodexSessionSourceHome(this.store.getSettings(), distro) ??
+      this.getWslSystemCodexHomePath({ runtime: 'wsl', wslDistro: distro })
     if (!systemCodexHomePath || systemCodexHomePath === runtimeHomePath) {
       return
     }

--- a/src/main/codex/codex-session-bridge.test.ts
+++ b/src/main/codex/codex-session-bridge.test.ts
@@ -215,6 +215,51 @@ describe('syncSystemCodexSessionsIntoManagedHome', () => {
     ).toBe(false)
   })
 
+  it('bridges from a custom source home override instead of ~/.codex', () => {
+    // Why: users with a custom CODEX_HOME point history discovery at that
+    // folder; the default ~/.codex must be ignored when an override is given.
+    const customSourceHome = join(fakeHomeDir, 'custom-codex')
+    const customSessionPath = join(
+      customSourceHome,
+      'sessions',
+      '2026',
+      '05',
+      '26',
+      'rollout-custom.jsonl'
+    )
+    mkdirSync(dirname(customSessionPath), { recursive: true })
+    writeFileSync(customSessionPath, '{"id":"custom"}\n', 'utf-8')
+
+    // A session under the default ~/.codex should NOT be bridged when overridden.
+    const defaultSessionPath = join(
+      getSystemCodexHomePath(),
+      'sessions',
+      '2026',
+      '05',
+      '26',
+      'rollout-default.jsonl'
+    )
+    mkdirSync(dirname(defaultSessionPath), { recursive: true })
+    writeFileSync(defaultSessionPath, '{"id":"default"}\n', 'utf-8')
+
+    syncSystemCodexSessionsIntoManagedHome(customSourceHome)
+
+    const bridgedCustomPath = join(
+      getRuntimeCodexHomePath(),
+      'sessions',
+      '2026',
+      '05',
+      '26',
+      'rollout-custom.jsonl'
+    )
+    expect(readFileSync(bridgedCustomPath, 'utf-8')).toBe('{"id":"custom"}\n')
+    expect(
+      existsSync(
+        join(getRuntimeCodexHomePath(), 'sessions', '2026', '05', '26', 'rollout-default.jsonl')
+      )
+    ).toBe(false)
+  })
+
   it('falls back to symlinks when hardlinks are unavailable', () => {
     fsMockState.failLink = true
     const systemSessionPath = join(

--- a/src/main/codex/codex-session-bridge.ts
+++ b/src/main/codex/codex-session-bridge.ts
@@ -42,9 +42,12 @@ let backgroundSessionBridgeTask: Promise<void> | null = null
 
 /**
  * Synchronously mirrors system session files into the managed runtime home.
+ *
+ * `sourceCodexHomePath` overrides the default ~/.codex history source for users
+ * who run Codex with a custom CODEX_HOME; it only affects history discovery.
  */
-export function syncSystemCodexSessionsIntoManagedHome(): void {
-  const systemSessionsRoot = join(getSystemCodexHomePath(), 'sessions')
+export function syncSystemCodexSessionsIntoManagedHome(sourceCodexHomePath?: string): void {
+  const systemSessionsRoot = join(sourceCodexHomePath || getSystemCodexHomePath(), 'sessions')
   if (!existsSync(systemSessionsRoot)) {
     return
   }
@@ -62,12 +65,13 @@ export function syncSystemCodexSessionsIntoManagedHome(): void {
  * background bridging without starting duplicate directory walks.
  */
 export function startSystemCodexSessionBridgeInBackground(
-  options: CodexSessionBridgeIncrementalOptions = {}
+  options: CodexSessionBridgeIncrementalOptions = {},
+  sourceCodexHomePath?: string
 ): Promise<void> {
   if (backgroundSessionBridgeTask) {
     return backgroundSessionBridgeTask
   }
-  const task = syncSystemCodexSessionsIntoManagedHomeIncrementally(options)
+  const task = syncSystemCodexSessionsIntoManagedHomeIncrementally(options, sourceCodexHomePath)
     .catch((error: unknown) => {
       console.warn('[codex-session-bridge] Background session bridge failed:', error)
     })
@@ -88,9 +92,10 @@ export function startSystemCodexSessionBridgeInBackground(
  * bridge operation equivalent to the synchronous path.
  */
 export async function syncSystemCodexSessionsIntoManagedHomeIncrementally(
-  options: CodexSessionBridgeIncrementalOptions = {}
+  options: CodexSessionBridgeIncrementalOptions = {},
+  sourceCodexHomePath?: string
 ): Promise<CodexSessionBridgeSummary> {
-  const systemSessionsRoot = join(getSystemCodexHomePath(), 'sessions')
+  const systemSessionsRoot = join(sourceCodexHomePath || getSystemCodexHomePath(), 'sessions')
   if (!existsSync(systemSessionsRoot)) {
     return { scannedFiles: 0, linkedFiles: 0 }
   }

--- a/src/main/codex/codex-session-source-home.test.ts
+++ b/src/main/codex/codex-session-source-home.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveHostCodexSessionSourceHome,
+  resolveWslCodexSessionSourceHome
+} from './codex-session-source-home'
+
+describe('resolveHostCodexSessionSourceHome', () => {
+  it('returns undefined when no override is configured', () => {
+    expect(resolveHostCodexSessionSourceHome({})).toBeUndefined()
+    expect(resolveHostCodexSessionSourceHome({ codexSessionSourceHome: {} })).toBeUndefined()
+  })
+
+  it('returns undefined for blank/whitespace overrides so the default is kept', () => {
+    expect(
+      resolveHostCodexSessionSourceHome({ codexSessionSourceHome: { host: '   ' } })
+    ).toBeUndefined()
+  })
+
+  it('returns the trimmed host override path', () => {
+    expect(
+      resolveHostCodexSessionSourceHome({ codexSessionSourceHome: { host: '  /custom/codex  ' } })
+    ).toBe('/custom/codex')
+  })
+})
+
+describe('resolveWslCodexSessionSourceHome', () => {
+  it('returns undefined when no per-distro override exists', () => {
+    expect(resolveWslCodexSessionSourceHome({}, 'Ubuntu')).toBeUndefined()
+    expect(
+      resolveWslCodexSessionSourceHome(
+        { codexSessionSourceHome: { wsl: { Debian: '/home/me/.codex' } } },
+        'Ubuntu'
+      )
+    ).toBeUndefined()
+  })
+
+  it('resolves a per-distro override for the matching distro', () => {
+    expect(
+      resolveWslCodexSessionSourceHome(
+        { codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.config/codex' } } },
+        'Ubuntu'
+      )
+    ).toBe('/home/me/.config/codex')
+  })
+
+  it('matches distro names case-insensitively, mirroring WSL', () => {
+    expect(
+      resolveWslCodexSessionSourceHome(
+        { codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.config/codex' } } },
+        'ubuntu'
+      )
+    ).toBe('/home/me/.config/codex')
+  })
+
+  it('ignores blank per-distro overrides so the default is kept', () => {
+    expect(
+      resolveWslCodexSessionSourceHome(
+        { codexSessionSourceHome: { wsl: { Ubuntu: '  ' } } },
+        'Ubuntu'
+      )
+    ).toBeUndefined()
+  })
+
+  it('does not leak the host override into WSL resolution', () => {
+    expect(
+      resolveWslCodexSessionSourceHome(
+        { codexSessionSourceHome: { host: '/custom/codex' } },
+        'Ubuntu'
+      )
+    ).toBeUndefined()
+  })
+})

--- a/src/main/codex/codex-session-source-home.ts
+++ b/src/main/codex/codex-session-source-home.ts
@@ -1,0 +1,43 @@
+import type { GlobalSettings } from '../../shared/types'
+
+/**
+ * Resolves the user-configured Codex *session history* source home, if any.
+ *
+ * Why: Orca relocates CODEX_HOME to a managed home, then bridges history from
+ * the user's real Codex home so /resume finds it. That source defaults to
+ * ~/.codex, but users who run Codex with a custom CODEX_HOME need to point
+ * history discovery at that folder. This override affects history only; auth,
+ * config, and hooks continue to read from ~/.codex.
+ */
+
+/** Host override; returns undefined to keep the default ~/.codex source. */
+export function resolveHostCodexSessionSourceHome(
+  settings: Pick<GlobalSettings, 'codexSessionSourceHome'>
+): string | undefined {
+  return normalizeSourceHome(settings.codexSessionSourceHome?.host)
+}
+
+/** Per-distro WSL override; returns undefined to keep the default <wslHome>/.codex source. */
+export function resolveWslCodexSessionSourceHome(
+  settings: Pick<GlobalSettings, 'codexSessionSourceHome'>,
+  distro: string
+): string | undefined {
+  const perDistro = settings.codexSessionSourceHome?.wsl
+  if (!perDistro) {
+    return undefined
+  }
+  // Why: distro keys are matched case-insensitively so "Ubuntu" and "ubuntu"
+  // resolve the same override, mirroring how WSL treats distro names.
+  const normalizedDistro = distro.trim().toLowerCase()
+  for (const [key, value] of Object.entries(perDistro)) {
+    if (key.trim().toLowerCase() === normalizedDistro) {
+      return normalizeSourceHome(value)
+    }
+  }
+  return undefined
+}
+
+function normalizeSourceHome(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -506,15 +506,6 @@ function AgentRow({
         <div className="min-w-0 flex-1 sm:min-w-[12rem]">
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium leading-none">{label}</span>
-            {isDetected ? (
-              <SettingsBadge tone="accent">
-                {translate('auto.components.settings.AgentsPane.c8794e622e', 'Detected')}
-              </SettingsBadge>
-            ) : (
-              <SettingsBadge tone="muted">
-                {translate('auto.components.settings.AgentsPane.df123171d1', 'Not installed')}
-              </SettingsBadge>
-            )}
             {!isEnabled && (
               <SettingsBadge tone="muted">
                 {translate('auto.components.settings.AgentsPane.8dc0192e48', 'Disabled')}
@@ -535,7 +526,7 @@ function AgentRow({
           </div>
         </div>
 
-        <div className="ml-auto grid shrink-0 grid-cols-[max-content_6.5rem_1.75rem_1.75rem_1.75rem] items-center gap-1.5">
+        <div className="ml-auto grid shrink-0 grid-cols-[max-content_6.5rem_1.75rem_1.75rem] items-center gap-1.5">
           <AgentAvailabilityControl
             label={label}
             isEnabled={isEnabled}
@@ -560,28 +551,6 @@ function AgentRow({
                 {isDefault
                   ? translate('auto.components.settings.AgentsPane.24e032fa34', 'Default')
                   : translate('auto.components.settings.AgentsPane.959b67385b', 'Set default')}
-              </Button>
-            )}
-          </div>
-
-          <div className="flex size-7 items-center justify-center">
-            {isDetected && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => setCmdOpen((prev) => !prev)}
-                title={translate(
-                  'auto.components.settings.AgentsPane.db9e9e5887',
-                  'Customize command'
-                )}
-                aria-expanded={cmdOpen}
-                className={cn(
-                  'size-7 text-muted-foreground hover:text-foreground',
-                  (cmdOpen || cmdOverride) && 'text-foreground'
-                )}
-              >
-                <Terminal className="size-3.5" />
               </Button>
             )}
           </div>

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -13,7 +13,11 @@ import { cn } from '@/lib/utils'
 import { AgentAwakeSetting } from './AgentAwakeSetting'
 import { AgentCacheTimerSection } from './AgentCacheTimerSection'
 import { AgentRuntimeSetting } from './AgentRuntimeSetting'
-import { normalizeGlobalWindowsRuntimeDefault } from '../../../../shared/project-execution-runtime'
+import {
+  AgentSessionSourceHomeInput,
+  buildCodexSessionSourceHomeControl,
+  type AgentSessionSourceHomeControl
+} from './codex-session-source-home-control'
 import {
   getAgentGeneratedTabTitlesDescription,
   getAgentGeneratedTabTitlesTitle
@@ -84,12 +88,6 @@ type AgentRowProps = {
   onSaveEnv: (value: Record<string, string>) => void
   /** Codex-only: current runtime scope label + persisted history-source override. */
   sessionSourceHome?: AgentSessionSourceHomeControl
-}
-
-type AgentSessionSourceHomeControl = {
-  runtimeLabel: string
-  value: string
-  onSave: (value: string) => void
 }
 
 type AgentCommandOverrideInputProps = {
@@ -687,58 +685,6 @@ function AgentRow({
   )
 }
 
-function AgentSessionSourceHomeInput({
-  runtimeLabel,
-  value,
-  onSave
-}: AgentSessionSourceHomeControl): React.JSX.Element {
-  const [draft, setDraft] = useState(value)
-
-  const commit = (): void => {
-    onSave(draft.trim())
-  }
-
-  return (
-    <div className="flex items-center gap-2">
-      <span className="shrink-0 text-xs text-muted-foreground">
-        {translate('auto.components.settings.AgentsPane.codexSessionSource', 'Session history')}
-      </span>
-      <Input
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={commit}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            commit()
-            e.currentTarget.blur()
-          }
-          if (e.key === 'Escape') {
-            setDraft(value)
-            e.currentTarget.blur()
-          }
-        }}
-        placeholder={runtimeLabel}
-        spellCheck={false}
-        className="h-7 flex-1 font-mono text-xs"
-      />
-      {value.trim() && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          onClick={() => {
-            onSave('')
-            setDraft('')
-          }}
-          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
-        >
-          {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
-        </Button>
-      )}
-    </div>
-  )
-}
-
 type DefaultAgentPillProps = {
   active: boolean
   onClick: () => void
@@ -832,57 +778,6 @@ export function AgentsPane({
       agentDefaultEnv: {
         ...agentDefaultEnv,
         [id]: value
-      }
-    })
-  }
-
-  // Why: the source-home override is scoped to the runtime the pane is showing
-  // (host or the selected WSL distro), mirroring how detected agents are scoped.
-  const codexRuntimeScope = normalizeGlobalWindowsRuntimeDefault(
-    settings.localWindowsRuntimeDefault
-  )
-  const codexSessionSourceHome = settings.codexSessionSourceHome
-  const buildCodexSessionSourceHomeControl = (): AgentSessionSourceHomeControl => {
-    // Why: a WSL scope with no selected distro can't target a per-distro history
-    // home, so fall back to the host control rather than a null distro key.
-    const wslDistro =
-      codexRuntimeScope.kind === 'wsl' ? codexRuntimeScope.distro?.trim() : undefined
-    if (wslDistro) {
-      return {
-        runtimeLabel: `${wslDistro}: ~/.codex`,
-        value: codexSessionSourceHome?.wsl?.[wslDistro] ?? '',
-        onSave: (value: string) =>
-          saveCodexSessionSourceHome({ runtime: 'wsl', distro: wslDistro, value })
-      }
-    }
-    return {
-      runtimeLabel: '~/.codex',
-      value: codexSessionSourceHome?.host ?? '',
-      onSave: (value: string) => saveCodexSessionSourceHome({ runtime: 'host', value })
-    }
-  }
-
-  const saveCodexSessionSourceHome = (
-    args: { runtime: 'host'; value: string } | { runtime: 'wsl'; distro: string; value: string }
-  ): void => {
-    const current = settings.codexSessionSourceHome ?? {}
-    const trimmed = args.value.trim()
-    if (args.runtime === 'host') {
-      updateSettings({
-        codexSessionSourceHome: { ...current, host: trimmed || undefined }
-      })
-      return
-    }
-    const nextWsl = { ...current.wsl }
-    if (trimmed) {
-      nextWsl[args.distro] = trimmed
-    } else {
-      delete nextWsl[args.distro]
-    }
-    updateSettings({
-      codexSessionSourceHome: {
-        ...current,
-        wsl: Object.keys(nextWsl).length > 0 ? nextWsl : undefined
       }
     })
   }
@@ -1037,7 +932,9 @@ export function AgentsPane({
                 onSaveArgs={(v) => saveAgentArgs(agent.id, v)}
                 onSaveEnv={(v) => saveAgentEnv(agent.id, v)}
                 sessionSourceHome={
-                  agent.id === 'codex' ? buildCodexSessionSourceHomeControl() : undefined
+                  agent.id === 'codex'
+                    ? buildCodexSessionSourceHomeControl(settings, updateSettings)
+                    : undefined
                 }
               />
             ))}

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -665,7 +665,7 @@ function AgentRow({
               />
             </div>
           )}
-          <p className="mt-1.5 text-[11px] text-muted-foreground">
+          <p className="mt-2 text-[11px] text-muted-foreground">
             {translate(
               'auto.components.settings.AgentsPane.f9f127d664',
               'Override the binary path or name, and edit the default launch arguments or environment for this agent.'
@@ -675,7 +675,7 @@ function AgentRow({
             <p className="mt-1 text-[11px] text-muted-foreground">
               {translate(
                 'auto.components.settings.AgentsPane.codexSessionSourceHelp',
-                'Orca links your existing Codex session history from this folder so /resume finds it. Set this only if you run Codex with a custom CODEX_HOME; it does not change which account or config Orca uses.'
+                'Orca runs Codex in an isolated home. Point this at your existing Codex home so Orca imports that history and /resume finds it. Leave empty to use ~/.codex; it does not change which account or config Orca uses.'
               )}
             </p>
           )}

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -284,42 +284,44 @@ function AgentCommandOverrideInput({
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className="shrink-0 text-xs text-muted-foreground">
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">
         {translate('auto.components.settings.AgentsPane.2e45ca29b6', 'Command')}
       </span>
-      <Input
-        value={cmdDraft}
-        onChange={(e) => setCmdDraft(e.target.value)}
-        onBlur={commitCmd}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            commitCmd()
-            e.currentTarget.blur()
-          }
-          if (e.key === 'Escape') {
-            setCmdDraft(draftSeed)
-            e.currentTarget.blur()
-          }
-        }}
-        placeholder={defaultCmd}
-        spellCheck={false}
-        className="h-7 flex-1 font-mono text-xs"
-      />
-      {cmdOverride && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          onClick={() => {
-            onSaveOverride('')
-            setCmdDraft(defaultCmd)
+      <div className="flex items-center gap-2">
+        <Input
+          value={cmdDraft}
+          onChange={(e) => setCmdDraft(e.target.value)}
+          onBlur={commitCmd}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              commitCmd()
+              e.currentTarget.blur()
+            }
+            if (e.key === 'Escape') {
+              setCmdDraft(draftSeed)
+              e.currentTarget.blur()
+            }
           }}
-          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
-        >
-          {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
-        </Button>
-      )}
+          placeholder={defaultCmd}
+          spellCheck={false}
+          className="h-7 flex-1 font-mono text-xs"
+        />
+        {cmdOverride && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              onSaveOverride('')
+              setCmdDraft(defaultCmd)
+            }}
+            className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
+          </Button>
+        )}
+      </div>
     </div>
   )
 }
@@ -337,45 +339,47 @@ function AgentDefaultArgsInput({
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className="shrink-0 text-xs text-muted-foreground">
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">
         {translate('auto.components.settings.AgentsPane.cfb3f35775', 'Arguments')}
       </span>
-      <Input
-        value={argsDraft}
-        onChange={(e) => setArgsDraft(e.target.value)}
-        onBlur={commitArgs}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            commitArgs()
-            e.currentTarget.blur()
-          }
-          if (e.key === 'Escape') {
-            setArgsDraft(draftSeed)
-            e.currentTarget.blur()
-          }
-        }}
-        placeholder={
-          defaultArgs ||
-          translate('auto.components.settings.AgentsPane.6f99bf5dd0', 'No default arguments')
-        }
-        spellCheck={false}
-        className="h-7 flex-1 font-mono text-xs"
-      />
-      {argsOverride !== defaultArgs && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          onClick={() => {
-            onSaveArgs(defaultArgs)
-            setArgsDraft(defaultArgs)
+      <div className="flex items-center gap-2">
+        <Input
+          value={argsDraft}
+          onChange={(e) => setArgsDraft(e.target.value)}
+          onBlur={commitArgs}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              commitArgs()
+              e.currentTarget.blur()
+            }
+            if (e.key === 'Escape') {
+              setArgsDraft(draftSeed)
+              e.currentTarget.blur()
+            }
           }}
-          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
-        >
-          {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
-        </Button>
-      )}
+          placeholder={
+            defaultArgs ||
+            translate('auto.components.settings.AgentsPane.6f99bf5dd0', 'No default arguments')
+          }
+          spellCheck={false}
+          className="h-7 flex-1 font-mono text-xs"
+        />
+        {argsOverride !== defaultArgs && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              onSaveArgs(defaultArgs)
+              setArgsDraft(defaultArgs)
+            }}
+            className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
+          </Button>
+        )}
+      </div>
     </div>
   )
 }
@@ -401,11 +405,11 @@ function AgentDefaultEnvInput({
   }
 
   return (
-    <div>
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">
+        {translate('auto.components.settings.AgentsPane.8fbe1f37c1', 'Environment')}
+      </span>
       <div className="flex items-center gap-2">
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {translate('auto.components.settings.AgentsPane.8fbe1f37c1', 'Environment')}
-        </span>
         <Input
           value={envDraft}
           onChange={(e) => {

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -489,10 +489,7 @@ function AgentRow({
   const envSummary = stringifyAgentDefaultEnvDraft(envOverride)
   const defaultEnvSummary = stringifyAgentDefaultEnvDraft(defaultEnv)
   const [cmdOpen, setCmdOpen] = useState(
-    Boolean(cmdOverride) ||
-      argsOverride !== defaultArgs ||
-      envSummary !== defaultEnvSummary ||
-      Boolean(sessionSourceHome?.value.trim())
+    Boolean(cmdOverride) || argsOverride !== defaultArgs || envSummary !== defaultEnvSummary
   )
 
   return (

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils'
 import { AgentAwakeSetting } from './AgentAwakeSetting'
 import { AgentCacheTimerSection } from './AgentCacheTimerSection'
 import { AgentRuntimeSetting } from './AgentRuntimeSetting'
+import { normalizeGlobalWindowsRuntimeDefault } from '../../../../shared/project-execution-runtime'
 import {
   getAgentGeneratedTabTitlesDescription,
   getAgentGeneratedTabTitlesTitle
@@ -81,6 +82,14 @@ type AgentRowProps = {
   onSaveOverride: (value: string) => void
   onSaveArgs: (value: string) => void
   onSaveEnv: (value: Record<string, string>) => void
+  /** Codex-only: current runtime scope label + persisted history-source override. */
+  sessionSourceHome?: AgentSessionSourceHomeControl
+}
+
+type AgentSessionSourceHomeControl = {
+  runtimeLabel: string
+  value: string
+  onSave: (value: string) => void
 }
 
 type AgentCommandOverrideInputProps = {
@@ -476,12 +485,16 @@ function AgentRow({
   onSetEnabled,
   onSaveOverride,
   onSaveArgs,
-  onSaveEnv
+  onSaveEnv,
+  sessionSourceHome
 }: AgentRowProps): React.JSX.Element {
   const envSummary = stringifyAgentDefaultEnvDraft(envOverride)
   const defaultEnvSummary = stringifyAgentDefaultEnvDraft(defaultEnv)
   const [cmdOpen, setCmdOpen] = useState(
-    Boolean(cmdOverride) || argsOverride !== defaultArgs || envSummary !== defaultEnvSummary
+    Boolean(cmdOverride) ||
+      argsOverride !== defaultArgs ||
+      envSummary !== defaultEnvSummary ||
+      Boolean(sessionSourceHome?.value.trim())
   )
 
   return (
@@ -644,13 +657,83 @@ function AgentRow({
               />
             </div>
           )}
+          {sessionSourceHome && (
+            <div className="mt-2">
+              <AgentSessionSourceHomeInput
+                key={`${agentId}:${sessionSourceHome.runtimeLabel}:${sessionSourceHome.value}`}
+                runtimeLabel={sessionSourceHome.runtimeLabel}
+                value={sessionSourceHome.value}
+                onSave={sessionSourceHome.onSave}
+              />
+            </div>
+          )}
           <p className="mt-1.5 text-[11px] text-muted-foreground">
             {translate(
               'auto.components.settings.AgentsPane.f9f127d664',
               'Override the binary path or name, and edit the default launch arguments or environment for this agent.'
             )}
           </p>
+          {sessionSourceHome && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {translate(
+                'auto.components.settings.AgentsPane.codexSessionSourceHelp',
+                'Orca links your existing Codex session history from this folder so /resume finds it. Set this only if you run Codex with a custom CODEX_HOME; it does not change which account or config Orca uses.'
+              )}
+            </p>
+          )}
         </div>
+      )}
+    </div>
+  )
+}
+
+function AgentSessionSourceHomeInput({
+  runtimeLabel,
+  value,
+  onSave
+}: AgentSessionSourceHomeControl): React.JSX.Element {
+  const [draft, setDraft] = useState(value)
+
+  const commit = (): void => {
+    onSave(draft.trim())
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {translate('auto.components.settings.AgentsPane.codexSessionSource', 'Session history')}
+      </span>
+      <Input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            commit()
+            e.currentTarget.blur()
+          }
+          if (e.key === 'Escape') {
+            setDraft(value)
+            e.currentTarget.blur()
+          }
+        }}
+        placeholder={runtimeLabel}
+        spellCheck={false}
+        className="h-7 flex-1 font-mono text-xs"
+      />
+      {value.trim() && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={() => {
+            onSave('')
+            setDraft('')
+          }}
+          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+        >
+          {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
+        </Button>
       )}
     </div>
   )
@@ -749,6 +832,57 @@ export function AgentsPane({
       agentDefaultEnv: {
         ...agentDefaultEnv,
         [id]: value
+      }
+    })
+  }
+
+  // Why: the source-home override is scoped to the runtime the pane is showing
+  // (host or the selected WSL distro), mirroring how detected agents are scoped.
+  const codexRuntimeScope = normalizeGlobalWindowsRuntimeDefault(
+    settings.localWindowsRuntimeDefault
+  )
+  const codexSessionSourceHome = settings.codexSessionSourceHome
+  const buildCodexSessionSourceHomeControl = (): AgentSessionSourceHomeControl => {
+    // Why: a WSL scope with no selected distro can't target a per-distro history
+    // home, so fall back to the host control rather than a null distro key.
+    const wslDistro =
+      codexRuntimeScope.kind === 'wsl' ? codexRuntimeScope.distro?.trim() : undefined
+    if (wslDistro) {
+      return {
+        runtimeLabel: `${wslDistro}: ~/.codex`,
+        value: codexSessionSourceHome?.wsl?.[wslDistro] ?? '',
+        onSave: (value: string) =>
+          saveCodexSessionSourceHome({ runtime: 'wsl', distro: wslDistro, value })
+      }
+    }
+    return {
+      runtimeLabel: '~/.codex',
+      value: codexSessionSourceHome?.host ?? '',
+      onSave: (value: string) => saveCodexSessionSourceHome({ runtime: 'host', value })
+    }
+  }
+
+  const saveCodexSessionSourceHome = (
+    args: { runtime: 'host'; value: string } | { runtime: 'wsl'; distro: string; value: string }
+  ): void => {
+    const current = settings.codexSessionSourceHome ?? {}
+    const trimmed = args.value.trim()
+    if (args.runtime === 'host') {
+      updateSettings({
+        codexSessionSourceHome: { ...current, host: trimmed || undefined }
+      })
+      return
+    }
+    const nextWsl = { ...current.wsl }
+    if (trimmed) {
+      nextWsl[args.distro] = trimmed
+    } else {
+      delete nextWsl[args.distro]
+    }
+    updateSettings({
+      codexSessionSourceHome: {
+        ...current,
+        wsl: Object.keys(nextWsl).length > 0 ? nextWsl : undefined
       }
     })
   }
@@ -902,6 +1036,9 @@ export function AgentsPane({
                 onSaveOverride={(v) => saveOverride(agent.id, v)}
                 onSaveArgs={(v) => saveAgentArgs(agent.id, v)}
                 onSaveEnv={(v) => saveAgentEnv(agent.id, v)}
+                sessionSourceHome={
+                  agent.id === 'codex' ? buildCodexSessionSourceHomeControl() : undefined
+                }
               />
             ))}
           </div>

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -668,14 +668,6 @@ function AgentRow({
               'Override the binary path or name, and edit the default launch arguments or environment for this agent.'
             )}
           </p>
-          {sessionSourceHome && (
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              {translate(
-                'auto.components.settings.AgentsPane.codexSessionSourceHelp',
-                'Orca runs Codex in an isolated home. Point this at your existing Codex home so Orca imports that history and /resume finds it. Leave empty to use ~/.codex; it does not change which account or config Orca uses.'
-              )}
-            </p>
-          )}
         </div>
       )}
     </div>

--- a/src/renderer/src/components/settings/codex-session-source-home-control.test.tsx
+++ b/src/renderer/src/components/settings/codex-session-source-home-control.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/types'
+import { buildCodexSessionSourceHomeControl } from './codex-session-source-home-control'
+
+function settingsWith(
+  overrides: Partial<Pick<GlobalSettings, 'codexSessionSourceHome' | 'localWindowsRuntimeDefault'>>
+): Pick<GlobalSettings, 'codexSessionSourceHome' | 'localWindowsRuntimeDefault'> {
+  return {
+    codexSessionSourceHome: overrides.codexSessionSourceHome,
+    localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault
+  }
+}
+
+describe('buildCodexSessionSourceHomeControl', () => {
+  it('reads and writes the host override on the host runtime', () => {
+    const updateSettings = vi.fn()
+    const control = buildCodexSessionSourceHomeControl(
+      settingsWith({ codexSessionSourceHome: { host: '/custom/codex' } }),
+      updateSettings
+    )
+
+    expect(control.runtimeLabel).toBe('~/.codex')
+    expect(control.value).toBe('/custom/codex')
+
+    control.onSave('/new/codex')
+    expect(updateSettings).toHaveBeenCalledWith({
+      codexSessionSourceHome: { host: '/new/codex' }
+    })
+  })
+
+  it('scopes to the selected WSL distro', () => {
+    const updateSettings = vi.fn()
+    const control = buildCodexSessionSourceHomeControl(
+      settingsWith({
+        codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.codex' } },
+        localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+      }),
+      updateSettings
+    )
+
+    expect(control.value).toBe('/home/me/.codex')
+    control.onSave('/home/me/.config/codex')
+    expect(updateSettings).toHaveBeenCalledWith({
+      codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.config/codex' } }
+    })
+  })
+
+  it('reads a stored WSL value when the reported distro casing differs', () => {
+    // Stored as "Ubuntu"; the runtime reports "ubuntu". The launch-time resolver
+    // matches case-insensitively, so the UI must surface the active value too.
+    const control = buildCodexSessionSourceHomeControl(
+      settingsWith({
+        codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.codex' } },
+        localWindowsRuntimeDefault: { kind: 'wsl', distro: 'ubuntu' }
+      }),
+      vi.fn()
+    )
+
+    expect(control.value).toBe('/home/me/.codex')
+  })
+
+  it('updates the existing WSL key in place instead of creating a duplicate casing', () => {
+    const updateSettings = vi.fn()
+    const control = buildCodexSessionSourceHomeControl(
+      settingsWith({
+        codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.codex' } },
+        localWindowsRuntimeDefault: { kind: 'wsl', distro: 'ubuntu' }
+      }),
+      updateSettings
+    )
+
+    control.onSave('/home/me/.config/codex')
+    // No stray "ubuntu" key alongside "Ubuntu".
+    expect(updateSettings).toHaveBeenCalledWith({
+      codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.config/codex' } }
+    })
+  })
+
+  it('clears the matching WSL key regardless of casing when reset', () => {
+    const updateSettings = vi.fn()
+    const control = buildCodexSessionSourceHomeControl(
+      settingsWith({
+        codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.codex' } },
+        localWindowsRuntimeDefault: { kind: 'wsl', distro: 'ubuntu' }
+      }),
+      updateSettings
+    )
+
+    control.onSave('')
+    // Removing the only key leaves no dangling wsl object.
+    expect(updateSettings).toHaveBeenCalledWith({
+      codexSessionSourceHome: { wsl: undefined }
+    })
+  })
+
+  it('falls back to the host control when a WSL scope has no selected distro', () => {
+    const control = buildCodexSessionSourceHomeControl(
+      settingsWith({
+        codexSessionSourceHome: { host: '/custom/codex' },
+        localWindowsRuntimeDefault: { kind: 'wsl', distro: null }
+      }),
+      vi.fn()
+    )
+
+    expect(control.runtimeLabel).toBe('~/.codex')
+    expect(control.value).toBe('/custom/codex')
+  })
+})

--- a/src/renderer/src/components/settings/codex-session-source-home-control.test.tsx
+++ b/src/renderer/src/components/settings/codex-session-source-home-control.test.tsx
@@ -7,7 +7,7 @@ function settingsWith(
 ): Pick<GlobalSettings, 'codexSessionSourceHome' | 'localWindowsRuntimeDefault'> {
   return {
     codexSessionSourceHome: overrides.codexSessionSourceHome,
-    localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault
+    localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' }
   }
 }
 

--- a/src/renderer/src/components/settings/codex-session-source-home-control.tsx
+++ b/src/renderer/src/components/settings/codex-session-source-home-control.tsx
@@ -20,6 +20,17 @@ type UpdateSettings = (updates: Partial<GlobalSettings>) => void | Promise<void>
  * Agents pane is showing (host or the selected WSL distro), so it mirrors how
  * detected agents are scoped. History-only: it never touches auth/config.
  */
+// Why: the launch-time resolver matches distro keys case-insensitively, so the
+// UI must resolve to the SAME stored key. Otherwise a casing mismatch would show
+// an empty override for an active value and, on edit, create a duplicate key.
+function findWslSourceHomeKey(
+  wsl: Record<string, string> | undefined,
+  distro: string
+): string | undefined {
+  const normalized = distro.trim().toLowerCase()
+  return Object.keys(wsl ?? {}).find((key) => key.trim().toLowerCase() === normalized)
+}
+
 export function buildCodexSessionSourceHomeControl(
   settings: Pick<GlobalSettings, 'codexSessionSourceHome' | 'localWindowsRuntimeDefault'>,
   updateSettings: UpdateSettings
@@ -30,13 +41,16 @@ export function buildCodexSessionSourceHomeControl(
   // home, so fall back to the host control rather than a null distro key.
   const wslDistro = runtimeScope.kind === 'wsl' ? runtimeScope.distro?.trim() : undefined
   if (wslDistro) {
+    const existingKey = findWslSourceHomeKey(sourceHome?.wsl, wslDistro)
     return {
       runtimeLabel: `${wslDistro}: ~/.codex`,
-      value: sourceHome?.wsl?.[wslDistro] ?? '',
+      value: (existingKey ? sourceHome?.wsl?.[existingKey] : undefined) ?? '',
+      // Save under the existing key when one matches (case-insensitively), so
+      // editing updates it in place instead of adding a differently-cased key.
       onSave: (value: string) =>
         saveCodexSessionSourceHome(settings, updateSettings, {
           runtime: 'wsl',
-          distro: wslDistro,
+          distro: existingKey ?? wslDistro,
           value
         })
     }
@@ -61,10 +75,13 @@ function saveCodexSessionSourceHome(
     return
   }
   const nextWsl = { ...current.wsl }
+  // Why: reuse an existing case-insensitive match so we never leave a stale
+  // duplicate key behind when the caller passes a differently-cased distro.
+  const targetKey = findWslSourceHomeKey(nextWsl, args.distro) ?? args.distro
   if (trimmed) {
-    nextWsl[args.distro] = trimmed
+    nextWsl[targetKey] = trimmed
   } else {
-    delete nextWsl[args.distro]
+    delete nextWsl[targetKey]
   }
   updateSettings({
     codexSessionSourceHome: {

--- a/src/renderer/src/components/settings/codex-session-source-home-control.tsx
+++ b/src/renderer/src/components/settings/codex-session-source-home-control.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
+import { Info } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/types'
 import { normalizeGlobalWindowsRuntimeDefault } from '../../../../shared/project-execution-runtime'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { translate } from '@/i18n/i18n'
 
 export type AgentSessionSourceHomeControl = {
@@ -85,11 +87,31 @@ export function AgentSessionSourceHomeInput({
 
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-xs text-muted-foreground">
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
         {translate(
           'auto.components.settings.AgentsPane.codexSessionSource',
           'Codex home to import from'
         )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={translate(
+                'auto.components.settings.AgentsPane.codexSessionSourceInfo',
+                'About importing Codex history'
+              )}
+              className="grid size-4 place-items-center rounded text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            >
+              <Info className="size-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={6} className="max-w-xs">
+            {translate(
+              'auto.components.settings.AgentsPane.codexSessionSourceTooltip',
+              'Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex.'
+            )}
+          </TooltipContent>
+        </Tooltip>
       </span>
       <div className="flex items-center gap-2">
         <Input

--- a/src/renderer/src/components/settings/codex-session-source-home-control.tsx
+++ b/src/renderer/src/components/settings/codex-session-source-home-control.tsx
@@ -84,42 +84,47 @@ export function AgentSessionSourceHomeInput({
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <span className="shrink-0 text-xs text-muted-foreground">
-        {translate('auto.components.settings.AgentsPane.codexSessionSource', 'Session history')}
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">
+        {translate(
+          'auto.components.settings.AgentsPane.codexSessionSource',
+          'Codex home to import from'
+        )}
       </span>
-      <Input
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={commit}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            commit()
-            e.currentTarget.blur()
-          }
-          if (e.key === 'Escape') {
-            setDraft(value)
-            e.currentTarget.blur()
-          }
-        }}
-        placeholder={runtimeLabel}
-        spellCheck={false}
-        className="h-7 flex-1 font-mono text-xs"
-      />
-      {value.trim() && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          onClick={() => {
-            onSave('')
-            setDraft('')
+      <div className="flex items-center gap-2">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              commit()
+              e.currentTarget.blur()
+            }
+            if (e.key === 'Escape') {
+              setDraft(value)
+              e.currentTarget.blur()
+            }
           }}
-          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
-        >
-          {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
-        </Button>
-      )}
+          placeholder={runtimeLabel}
+          spellCheck={false}
+          className="h-7 flex-1 font-mono text-xs"
+        />
+        {value.trim() && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              onSave('')
+              setDraft('')
+            }}
+            className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
+          </Button>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/codex-session-source-home-control.tsx
+++ b/src/renderer/src/components/settings/codex-session-source-home-control.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { normalizeGlobalWindowsRuntimeDefault } from '../../../../shared/project-execution-runtime'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { translate } from '@/i18n/i18n'
+
+export type AgentSessionSourceHomeControl = {
+  runtimeLabel: string
+  value: string
+  onSave: (value: string) => void
+}
+
+type UpdateSettings = (updates: Partial<GlobalSettings>) => void | Promise<void>
+
+/**
+ * Builds the Codex session-history source control scoped to the runtime the
+ * Agents pane is showing (host or the selected WSL distro), so it mirrors how
+ * detected agents are scoped. History-only: it never touches auth/config.
+ */
+export function buildCodexSessionSourceHomeControl(
+  settings: Pick<GlobalSettings, 'codexSessionSourceHome' | 'localWindowsRuntimeDefault'>,
+  updateSettings: UpdateSettings
+): AgentSessionSourceHomeControl {
+  const runtimeScope = normalizeGlobalWindowsRuntimeDefault(settings.localWindowsRuntimeDefault)
+  const sourceHome = settings.codexSessionSourceHome
+  // Why: a WSL scope with no selected distro can't target a per-distro history
+  // home, so fall back to the host control rather than a null distro key.
+  const wslDistro = runtimeScope.kind === 'wsl' ? runtimeScope.distro?.trim() : undefined
+  if (wslDistro) {
+    return {
+      runtimeLabel: `${wslDistro}: ~/.codex`,
+      value: sourceHome?.wsl?.[wslDistro] ?? '',
+      onSave: (value: string) =>
+        saveCodexSessionSourceHome(settings, updateSettings, {
+          runtime: 'wsl',
+          distro: wslDistro,
+          value
+        })
+    }
+  }
+  return {
+    runtimeLabel: '~/.codex',
+    value: sourceHome?.host ?? '',
+    onSave: (value: string) =>
+      saveCodexSessionSourceHome(settings, updateSettings, { runtime: 'host', value })
+  }
+}
+
+function saveCodexSessionSourceHome(
+  settings: Pick<GlobalSettings, 'codexSessionSourceHome'>,
+  updateSettings: UpdateSettings,
+  args: { runtime: 'host'; value: string } | { runtime: 'wsl'; distro: string; value: string }
+): void {
+  const current = settings.codexSessionSourceHome ?? {}
+  const trimmed = args.value.trim()
+  if (args.runtime === 'host') {
+    updateSettings({ codexSessionSourceHome: { ...current, host: trimmed || undefined } })
+    return
+  }
+  const nextWsl = { ...current.wsl }
+  if (trimmed) {
+    nextWsl[args.distro] = trimmed
+  } else {
+    delete nextWsl[args.distro]
+  }
+  updateSettings({
+    codexSessionSourceHome: {
+      ...current,
+      wsl: Object.keys(nextWsl).length > 0 ? nextWsl : undefined
+    }
+  })
+}
+
+export function AgentSessionSourceHomeInput({
+  runtimeLabel,
+  value,
+  onSave
+}: AgentSessionSourceHomeControl): React.JSX.Element {
+  const [draft, setDraft] = useState(value)
+
+  const commit = (): void => {
+    onSave(draft.trim())
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {translate('auto.components.settings.AgentsPane.codexSessionSource', 'Session history')}
+      </span>
+      <Input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            commit()
+            e.currentTarget.blur()
+          }
+          if (e.key === 'Escape') {
+            setDraft(value)
+            e.currentTarget.blur()
+          }
+        }}
+        placeholder={runtimeLabel}
+        spellCheck={false}
+        className="h-7 flex-1 font-mono text-xs"
+      />
+      {value.trim() && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={() => {
+            onSave('')
+            setDraft('')
+          }}
+          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+        >
+          {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4758,7 +4758,10 @@
           "agentPermissionsDescription": "Choose whether Orca launches agents with fewer permission prompts or with manual checks.",
           "agentPermissionsYolo": "Yolo",
           "agentPermissionsManual": "Manual",
-          "3f1bdf3cb4": "Environment text is too large to parse safely."
+          "3f1bdf3cb4": "Environment text is too large to parse safely.",
+          "codexSessionSource": "Codex home to import from",
+          "codexSessionSourceInfo": "About importing Codex history",
+          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex."
         },
         "AppIconSelector": {
           "d5a112dc9b": "Next icon",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4758,7 +4758,10 @@
           "agentPermissionsDescription": "Elige si Orca lanza agents con menos prompts de permisos o con checks manuales.",
           "agentPermissionsYolo": "Yolo",
           "agentPermissionsManual": "Manual",
-          "3f1bdf3cb4": "El texto de entorno es demasiado grande para analizarlo de forma segura."
+          "3f1bdf3cb4": "El texto de entorno es demasiado grande para analizarlo de forma segura.",
+          "codexSessionSource": "Codex home to import from",
+          "codexSessionSourceInfo": "About importing Codex history",
+          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex."
         },
         "AppIconSelector": {
           "d5a112dc9b": "Icono siguiente",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4743,7 +4743,10 @@
           "agentPermissionsDescription": "Choose whether Orca launches agents with fewer permission prompts or with manual checks.",
           "agentPermissionsYolo": "Yolo",
           "agentPermissionsManual": "手動",
-          "3f1bdf3cb4": "環境テキストが大きすぎるため安全に解析できません。"
+          "3f1bdf3cb4": "環境テキストが大きすぎるため安全に解析できません。",
+          "codexSessionSource": "Codex home to import from",
+          "codexSessionSourceInfo": "About importing Codex history",
+          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex."
         },
         "AppIconSelector": {
           "d5a112dc9b": "次へのアイコン",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4743,7 +4743,10 @@
           "agentPermissionsDescription": "Orca가 agents를 실행할 때 권한 프롬프트를 줄일지, 수동 확인을 유지할지 선택합니다.",
           "agentPermissionsYolo": "Yolo",
           "agentPermissionsManual": "수동",
-          "3f1bdf3cb4": "환경 텍스트가 너무 커서 안전하게 파싱할 수 없습니다."
+          "3f1bdf3cb4": "환경 텍스트가 너무 커서 안전하게 파싱할 수 없습니다.",
+          "codexSessionSource": "Codex home to import from",
+          "codexSessionSourceInfo": "About importing Codex history",
+          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex."
         },
         "AppIconSelector": {
           "d5a112dc9b": "다음 아이콘",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4743,7 +4743,10 @@
           "agentPermissionsDescription": "选择 Orca 是以更少的权限提示启动智能体，还是手动检查。",
           "agentPermissionsYolo": "Yolo",
           "agentPermissionsManual": "手动",
-          "3f1bdf3cb4": "环境文本过长，无法安全解析。"
+          "3f1bdf3cb4": "环境文本过长，无法安全解析。",
+          "codexSessionSource": "Codex home to import from",
+          "codexSessionSourceInfo": "About importing Codex history",
+          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex."
         },
         "AppIconSelector": {
           "d5a112dc9b": "下一个图标",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2784,6 +2784,16 @@ export type GlobalSettings = {
   geminiCliOAuthEnabled: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */
   agentCmdOverrides: Partial<Record<TuiAgent, string>>
+  /** Why: Orca bridges Codex session history from the user's real Codex home into
+   *  its managed home so /resume finds it, but defaults to ~/.codex. Users who run
+   *  Codex with a custom CODEX_HOME can point history discovery at that folder here.
+   *  History-only: this does not change which account/config/hooks Orca uses. */
+  codexSessionSourceHome?: {
+    /** Absolute host path; empty/undefined falls back to ~/.codex. */
+    host?: string
+    /** Per-WSL-distro absolute Linux path; missing distro falls back to <wslHome>/.codex. */
+    wsl?: Record<string, string>
+  }
   /** Per-agent default CLI arguments appended after the binary/path and before prompts. */
   agentDefaultArgs?: Partial<Record<TuiAgent, string>>
   /** Per-agent launch environment defaults used when yolo mode is exposed as env. */


### PR DESCRIPTION
## Summary
Orca bridges Codex session history from the user's real Codex home into its managed home so `/resume` can find it — but it **hardcodes that source to `~/.codex`**. Users who run Codex with a custom `CODEX_HOME` never had their history bridged, so their sessions were invisible inside Orca-launched Codex.

This adds a per-runtime **Session history** override in **Settings → Agents → Codex** (host + per-WSL-distro), wired into both the host session bridge and the WSL session bridge (#7477). Empty setting preserves current `~/.codex` behavior exactly.

## Scope: history-only (deliberate)
The override redirects **only** where the session bridge reads history from. Auth (`auth.json`), config (`config.toml`), and hooks continue to read from `~/.codex`. This keeps managed-account switching and SQLite isolation unaffected, and matches the UI copy ("where's my history", not "switch my account").

## Design notes
- Field is scoped to the runtime the pane is showing (host, or the selected WSL distro), mirroring how detected agents are already scoped — one context-aware field instead of N.
- The usage scanner is intentionally **not** rewired: custom-home sessions get hardlinked into the managed home by the bridge, which the scanner already reads.
- New logic extracted into `codex-session-source-home.ts` (resolver) and `codex-session-source-home-control.tsx` (UI) to keep `AgentsPane.tsx` growth minimal.

## Validation
- `pnpm run typecheck`, touched-file `oxlint`, `git diff --check`, `pnpm check:max-lines-ratchet` — all pass.
- 122 focused unit tests pass (resolver host/WSL/case-insensitive/empty-fallback; bridge honors override & ignores `~/.codex` when overridden; runtime-home-service passes override to both host and WSL bridges with auth/config untouched; AgentsPane).
- **Live end-to-end (real `codex` 0.142.5 on macOS):** set the host override via real settings IPC → ran the real bridge → confirmed the session was **hardlinked** into the managed home (shared inode) with **no `.sqlite` touched** → ran real `codex resume <id>`, which **found and loaded the bridged session** (rendered its recorded cwd, no error).

## Known limitation (pre-existing, out of scope)
Codex's `/resume` **picker** reads its list from `state_5.sqlite`, which Codex only populates for sessions it created (with a date cutoff). On my machine, ~4,000 of 6,436 on-disk sessions are absent from that index. So a bridged session is **resumable by id/path** but may **not appear in the interactive picker** — this is a pre-existing Codex indexing limitation that affects `main` (and #7477) equally. This PR does the same hardlink operation as `main`, just configurably; it neither introduces nor worsens the picker gap, and never writes to the SQLite index. Fixing picker visibility is a separate, larger effort (index population / Codex-side).

## Note
Branch is a couple of commits behind `main`; rebase before merge.

Made with [Orca](https://github.com/stablyai/orca) 🐋
