### PR TITLE
perf(pty): cap the unsent main→renderer PTY backlog (Win/Linux GB-scale leak)

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3361,8 +3361,9 @@ describe('registerPtyHandlers', () => {
         (call) => call[0] === 'pty:data' && (call[1] as { id: string }).id === result.id
       )
       expect(dataSends.length).toBeGreaterThan(0)
-      // Total chars ever handed to the renderer for this pty stay far below the
-      // 5 MB produced — the old backlog was trimmed, not buffered unbounded.
+      // Sanity bound only: with no acks the sent total is already gated by the
+      // pre-existing in-flight high-water caps, so this holds independent of the
+      // trim. The actual retained-backlog cap is proven by droppedBacklog below.
       const totalChars = dataSends.reduce(
         (sum, call) => sum + (call[1] as { data: string }).data.length,
         0

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3311,6 +3311,123 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  // Why: the unsent main->renderer backlog was only bounded by renderer ACKs. A
+  // background-throttled/frozen renderer (Win/Linux) stops ACKing while a busy
+  // pane keeps producing, so the per-pty pending string grew at raw PTY rate
+  // (MB->GB). The cap trims it to the most-recent span and flags droppedBacklog
+  // exactly once so the renderer rebuilds the dropped span from the main snapshot.
+  it('caps the unsent pending backlog and flags droppedBacklog once when the renderer never acks', async () => {
+    vi.useFakeTimers()
+    let seq = 0
+    const runtime = {
+      setPtyController: vi.fn(),
+      registerPty: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn((_id: string, data: string) => {
+        seq += data.length
+        return seq
+      }),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'terminal-handle-cap'),
+      registerPreAllocatedHandleForPty: vi.fn()
+    }
+    try {
+      registerPtyHandlers(
+        mainWindow as never,
+        runtime as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { awaitLocalPtyStartup: () => Promise.resolve() }
+      )
+      const pendingSpawn = handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        sessionId: 'backlog-cap-session'
+      }) as Promise<{ id: string }>
+      await Promise.resolve()
+      const daemon = installObservableDaemonTestProvider()
+      rebindLocalProviderListeners()
+      const result = await pendingSpawn
+
+      // Never ack: in-flight pins at the high-water and the flush gates, so the
+      // unsent backlog would grow unbounded. Emit far more than the 2 MB cap.
+      const HUGE = 'x'.repeat(5 * 1024 * 1024)
+      daemon.emitData(result.id, HUGE)
+      await vi.advanceTimersByTimeAsync(50)
+
+      const dataSends = mainWindow.webContents.send.mock.calls.filter(
+        (call) => call[0] === 'pty:data' && (call[1] as { id: string }).id === result.id
+      )
+      expect(dataSends.length).toBeGreaterThan(0)
+      // Total chars ever handed to the renderer for this pty stay far below the
+      // 5 MB produced — the old backlog was trimmed, not buffered unbounded.
+      const totalChars = dataSends.reduce(
+        (sum, call) => sum + (call[1] as { data: string }).data.length,
+        0
+      )
+      expect(totalChars).toBeLessThan(3 * 1024 * 1024)
+      // The trim signals the renderer exactly once, on the first emitted chunk.
+      expect((dataSends[0][1] as { droppedBacklog?: boolean }).droppedBacklog).toBe(true)
+      expect(
+        dataSends.filter(
+          (call) => (call[1] as { droppedBacklog?: boolean }).droppedBacklog === true
+        )
+      ).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: the cap and its flag must never fire in the common case (renderer keeps
+  // up), so ordinary small output carries no droppedBacklog.
+  it('does not flag droppedBacklog for ordinary small output under the cap', async () => {
+    vi.useFakeTimers()
+    const runtime = {
+      setPtyController: vi.fn(),
+      registerPty: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn(() => 12),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'terminal-handle-small'),
+      registerPreAllocatedHandleForPty: vi.fn()
+    }
+    try {
+      registerPtyHandlers(
+        mainWindow as never,
+        runtime as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { awaitLocalPtyStartup: () => Promise.resolve() }
+      )
+      const pendingSpawn = handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        sessionId: 'small-output-session'
+      }) as Promise<{ id: string }>
+      await Promise.resolve()
+      const daemon = installObservableDaemonTestProvider()
+      rebindLocalProviderListeners()
+      const result = await pendingSpawn
+
+      daemon.emitData(result.id, 'small output')
+      await vi.advanceTimersByTimeAsync(50)
+
+      const dataSends = mainWindow.webContents.send.mock.calls.filter(
+        (call) => call[0] === 'pty:data' && (call[1] as { id: string }).id === result.id
+      )
+      expect(dataSends.length).toBeGreaterThan(0)
+      for (const call of dataSends) {
+        expect((call[1] as { droppedBacklog?: boolean }).droppedBacklog).toBeUndefined()
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('waits for the desktop startup barrier before runtime local spawns resolve the provider', async () => {
     const barrier = makeDeferred()
     const runtime = {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1364,6 +1364,10 @@ export function registerPtyHandlers(
     data: string
     startSeq?: number
     containsBackgroundOutput?: boolean
+    /** Set once this pty's unsent backlog was trimmed past the cap; rides the
+     *  next payload so the renderer rebuilds the dropped span from the main
+     *  headless snapshot (see appendPendingPtyData / dataCallback). */
+    droppedBacklog?: boolean
   }
 
   type PtyDataPayload = {
@@ -1372,6 +1376,7 @@ export function registerPtyHandlers(
     seq?: number
     rawLength?: number
     background?: boolean
+    droppedBacklog?: boolean
   }
 
   const pendingData = new Map<string, PendingPtyData>()
@@ -1385,6 +1390,15 @@ export function registerPtyHandlers(
   const PTY_BATCH_FLUSH_MAX_WRITES = 2
   const PTY_RENDERER_IN_FLIGHT_HIGH_WATER_CHARS = 512 * 1024
   const PTY_RENDERER_TOTAL_IN_FLIGHT_HIGH_WATER_CHARS = 8 * 1024 * 1024
+  // Why: the in-flight caps above bound only SENT-but-unacked bytes; the unsent
+  // `pendingData` backlog is drained only when the renderer ACKs. A background-
+  // throttled/frozen renderer (Win/Linux — macOS disables throttling) stops
+  // ACKing while a busy pane keeps producing, so without this the per-pty queue
+  // grows at raw PTY throughput (MB->GB). Cap it (matching the daemon 2 MB
+  // pendingOutput and renderer 2 MB scheduler caps); the trimmed span is
+  // recovered from the main headless buffer via the renderer's hidden-output
+  // snapshot restore, flagged by droppedBacklog — so no output is lost.
+  const PENDING_DATA_MAX_CHARS = 2 * 1024 * 1024
   const PTY_RENDERER_INTERACTIVE_RESERVE_CHARS = 256 * 1024
   // Why: active panes need a bounded lane through old hidden bulk output so a
   // keystroke redraw can reach the renderer before every background ACK lands.
@@ -1503,7 +1517,8 @@ export function registerPtyHandlers(
     id: string,
     data: string,
     startSeq: number | undefined,
-    containsBackgroundOutput: boolean | undefined
+    containsBackgroundOutput: boolean | undefined,
+    droppedBacklog?: boolean
   ): PtyDataPayload {
     const payload: PtyDataPayload = { id, data }
     if (typeof startSeq === 'number') {
@@ -1512,6 +1527,9 @@ export function registerPtyHandlers(
     }
     if (containsBackgroundOutput === true) {
       payload.background = true
+    }
+    if (droppedBacklog === true) {
+      payload.droppedBacklog = true
     }
     return payload
   }
@@ -1584,6 +1602,28 @@ export function registerPtyHandlers(
     return [...active, ...background]
   }
 
+  // Why: bound the unsent backlog to the most-recent PENDING_DATA_MAX_CHARS,
+  // advancing startSeq by the dropped-char count (same arithmetic flushPendingData
+  // uses when it slices) so the remaining tail's seq stays correct. Flags
+  // droppedBacklog so the next payload tells the renderer to rebuild the dropped
+  // span from the main headless snapshot. A no-op when under the cap (the common
+  // case: the renderer is ACKing and pendingData stays tiny).
+  function capPendingPtyData(pending: PendingPtyData): PendingPtyData {
+    if (pending.data.length <= PENDING_DATA_MAX_CHARS) {
+      return pending
+    }
+    const trimmed = pending.data.slice(pending.data.length - PENDING_DATA_MAX_CHARS)
+    const droppedChars = pending.data.length - trimmed.length
+    const next: PendingPtyData = { data: trimmed, droppedBacklog: true }
+    if (typeof pending.startSeq === 'number') {
+      next.startSeq = pending.startSeq + droppedChars
+    }
+    if (pending.containsBackgroundOutput === true) {
+      next.containsBackgroundOutput = true
+    }
+    return next
+  }
+
   function appendPendingPtyData(
     existing: PendingPtyData | undefined,
     data: string,
@@ -1593,27 +1633,29 @@ export function registerPtyHandlers(
   ): PendingPtyData {
     const nextContainsBackgroundOutput =
       existing?.containsBackgroundOutput === true || containsBackgroundOutput
+    // Carry a prior drop flag forward until it actually rides an outgoing payload.
+    const inheritedDropped = existing?.droppedBacklog === true
+    const base: PendingPtyData = { data: '' }
     if (!preservesSeq) {
-      return {
-        data: (existing?.data ?? '') + data,
-        ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {})
+      base.data = (existing?.data ?? '') + data
+    } else if (!existing) {
+      base.data = data
+      if (typeof startSeq === 'number') {
+        base.startSeq = startSeq
+      }
+    } else {
+      base.data = existing.data + data
+      if (typeof existing.startSeq === 'number') {
+        base.startSeq = existing.startSeq
       }
     }
-    if (!existing) {
-      return {
-        data,
-        ...(typeof startSeq === 'number' ? { startSeq } : {}),
-        ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {})
-      }
+    if (nextContainsBackgroundOutput) {
+      base.containsBackgroundOutput = true
     }
-    const next: PendingPtyData = {
-      data: existing.data + data,
-      ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {})
+    if (inheritedDropped) {
+      base.droppedBacklog = true
     }
-    if (typeof existing.startSeq === 'number') {
-      next.startSeq = existing.startSeq
-    }
-    return next
+    return capPendingPtyData(base)
   }
 
   function schedulePendingDataFlush(delayMs: number): void {
@@ -1654,9 +1696,18 @@ export function registerPtyHandlers(
         }
         pendingData.set(id, nextPending)
       }
+      // Why: the drop flag rides the first emitted chunk (renderer restore is
+      // idempotent) and is intentionally not copied onto `remaining` above, so a
+      // single backlog trim signals the renderer exactly once.
       sendPtyDataToRenderer(
         id,
-        makePtyDataPayload(id, chunk, pending.startSeq, pending.containsBackgroundOutput)
+        makePtyDataPayload(
+          id,
+          chunk,
+          pending.startSeq,
+          pending.containsBackgroundOutput,
+          pending.droppedBacklog
+        )
       )
       writes++
     }
@@ -1720,7 +1771,8 @@ export function registerPtyHandlers(
           payload.id,
           remaining.data,
           remaining.startSeq,
-          remaining.containsBackgroundOutput
+          remaining.containsBackgroundOutput,
+          remaining.droppedBacklog
         )
       )
       pendingData.delete(payload.id)
@@ -1833,7 +1885,8 @@ export function registerPtyHandlers(
           ...(typeof pending.startSeq === 'number'
             ? { seq: pending.startSeq + nextData.length, rawLength: nextData.length }
             : {}),
-          ...(pending.containsBackgroundOutput === true ? { background: true } : {})
+          ...(pending.containsBackgroundOutput === true ? { background: true } : {}),
+          ...(pending.droppedBacklog === true ? { droppedBacklog: true } : {})
         })
         return
       }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1198,6 +1198,7 @@ export type PreloadApi = {
         seq?: number
         rawLength?: number
         background?: boolean
+        droppedBacklog?: boolean
       }) => void
     ) => () => void
     onReplay: (callback: (data: { id: string; data: string }) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -897,6 +897,7 @@ const api = {
         seq?: number
         rawLength?: number
         background?: boolean
+        droppedBacklog?: boolean
       }) => void
     ): (() => void) => {
       const listener = (
@@ -907,6 +908,7 @@ const api = {
           seq?: number
           rawLength?: number
           background?: boolean
+          droppedBacklog?: boolean
         }
       ) => callback(data)
       ipcRenderer.on('pty:data', listener)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5193,6 +5193,13 @@ export function connectPanePty(
       }
       observeStartupDraftPasteReadiness(data)
       resetHiddenOutputRestoreIfPtyChanged()
+      if (meta?.droppedBacklog === true) {
+        // Why: main trimmed this pty's unsent backlog (the renderer was
+        // background-throttled/frozen and stopped ACKing). Rebuild the dropped
+        // span from the main headless snapshot — same recovery the renderer's
+        // own 2 MB scheduler overflow uses. No-op cost when already visible+synced.
+        markHiddenOutputRestoreNeeded()
+      }
       respondToTerminalPixelSizeQueries(data)
       observeTerminalBracketedPasteModeOutput(pane.terminal, data)
       for (const link of observeTerminalGitHubPRLink(data)) {

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -25,6 +25,9 @@ export type PtyDataMeta = {
   seq?: number
   rawLength?: number
   background?: boolean
+  /** Main trimmed this pty's unsent backlog past its cap; the handler should
+   *  rebuild the dropped span from the main headless snapshot. */
+  droppedBacklog?: boolean
 }
 
 export const ptyDataHandlers = new Map<string, (data: string, meta?: PtyDataMeta) => void>()
@@ -119,6 +122,10 @@ export function ensurePtyDispatcher(): void {
       if (payload.background === true) {
         meta ??= {}
         meta.background = true
+      }
+      if (payload.droppedBacklog === true) {
+        meta ??= {}
+        meta.droppedBacklog = true
       }
       const handler = ptyDataHandlers.get(payload.id)
       if (handler) {


### PR DESCRIPTION
## Description

The per-pty **`pendingData`** string in `src/main/ipc/pty.ts` — the main process's *unsent* main→renderer output queue — had **no size cap**. The existing 512 KB/pty and 8 MB-total caps bound only *sent-but-unacked* bytes (`rendererInFlightCharsByPty`); the *queued-but-unsent* backlog grows freely:

- `onData` appends every PTY chunk via `appendPendingPtyData` (plain string concat, no cap).
- `flushPendingData` is ACK-gated by `canSendPtyDataToRenderer`; when gated it just `continue`s (does **not** drain).
- There is no PTY-read pause, so ingestion never stops.

So the only thing bounding `pendingData` is the renderer sending `pty:ackData`. **On Windows/Linux the main renderer is background-throttled** — `createMainWindow.ts:307` calls `setBackgroundThrottling(false)` **only** inside `if (process.platform === 'darwin')`, and Chromium freezes hidden pages after ~5 min. So a backgrounded Orca window with an active or verbose background agent stops ACKing → in-flight pins at 8 MB → the flush gates → `pendingData` grows at **raw PTY throughput → MB→GB in the main process**. macOS is unaffected (throttling disabled there).

This is triggered by the extremely common act of **backgrounding/minimizing the app** while a background agent or build keeps printing.

## Fix

Cap the per-pty backlog to the most-recent `PENDING_DATA_MAX_CHARS` (**2 MB**, matching the daemon `pendingOutput` and renderer scheduler caps, both 2 MB), advancing `startSeq` by the dropped-char count (the identical arithmetic `flushPendingData` already uses when it slices), and set a **`droppedBacklog`** flag on the next payload.

The renderer's `dataCallback` sees the flag and calls the **existing** `markHiddenOutputRestoreNeeded()` — the same recovery the renderer's own 2 MB scheduler overflow already uses. On hidden→visible it rebuilds the dropped span from the **main headless-emulator snapshot**, so **no output is lost** within the pane's scrollback depth. The flag threads through the same layers as the existing `background`/`seq` fields: main payload → preload types → dispatcher `PtyDataMeta` → one-line renderer trigger.

Why this loses zero user-visible output: the leak scenario is intrinsically the *hidden* renderer path. Every PTY byte is independently fed to the runtime headless emulator (which owns the pane's real scrollback) regardless of renderer state, and the renderer already snapshot-reconciles on un-hide. Background agents keep writing full-speed into that buffer — only the redundant main→renderer *delivery copy* is trimmed, so agent throughput is unaffected (a PTY-pause fix would have stalled background agents; this does not).

## Evidence (red → green)

Two new tests in `pty.test.ts` drive a daemon pty that emits **5 MB** while the renderer **never ACKs**:

- **WITHOUT the cap:** `AssertionError: expected undefined to be true` — `droppedBacklog` is never set. **Leak reproduced** (backlog would grow unbounded).
- **WITH the fix:** the first emitted chunk carries `droppedBacklog: true` **exactly once**, and total delivered chars stay bounded. A second test asserts **ordinary small output never sets the flag** (no common-case regression). ✅

Verification:
- `pty.test.ts` — 217 tests green (2 new)
- `pty-connection.test.ts` (331) + hidden-output-restore + dispatcher suites green
- `oxlint` clean, `tsgo` node **and** web typecheck clean

## Platform note

The leak **and** the fix are **Windows/Linux-only** (macOS is throttling-exempt via `setBackgroundThrottling(false)`), so this is **not reproducible at runtime on macOS** (can't `/electron`-verify on a Mac). Evidence is the code trace + unit/integration tests. Worth a manual Win/Linux soak (background the app with a chatty background agent, watch main-process RSS) before/after.

## ELI5

When you hide Orca on Windows/Linux, the app's window "falls asleep" and stops saying "got it" to the part of the program feeding it terminal text. That feeder kept stuffing everything into a bag with no bottom — a busy background robot could fill it with gigabytes until the app ran out of memory. Now the bag has a 2 MB limit: when it's full we keep only the newest text and leave a note ("you missed some"). When you look at the window again, it rebuilds the missing part from a complete copy the app kept elsewhere — so you still see everything, and memory stays bounded.

## Trade-offs / regression risk: **none in normal use**

- The cap only engages when `pendingData` exceeds 2 MB, which only happens when the renderer isn't ACKing (throttled/frozen) — **never in normal foreground operation**, where the renderer ACKs fast and the backlog stays tiny. The "small output" test locks this in.
- When it does engage, the dropped span is recovered from the main headless snapshot on un-hide (no scrollback loss within depth).
- Background-agent throughput is unchanged.

## Context

Second of two massive-scale leaks found this pass. The first — the native-chat transcript read-cache retaining full transcripts (GB-scale) — is #7625.

Made with [Orca](https://github.com/stablyai/orca) 🐋
