### PR TITLE
Keep GitHub PR status working when the rate-limit budget can't be read (GHES with rate limiting disabled)

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -3,14 +3,19 @@ request timestamps, and follow-up scheduling against shared module state. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GitHubPRRefreshCandidate, PRInfo } from '../../shared/types'
 
-const { sendMock, getAllWebContentsMock, getPRForBranchOutcomeMock, getRateLimitMock } = vi.hoisted(
-  () => ({
-    sendMock: vi.fn(),
-    getAllWebContentsMock: vi.fn(),
-    getPRForBranchOutcomeMock: vi.fn(),
-    getRateLimitMock: vi.fn()
-  })
-)
+const {
+  sendMock,
+  getAllWebContentsMock,
+  getPRForBranchOutcomeMock,
+  getRateLimitMock,
+  rateLimitGuardMock
+} = vi.hoisted(() => ({
+  sendMock: vi.fn(),
+  getAllWebContentsMock: vi.fn(),
+  getPRForBranchOutcomeMock: vi.fn(),
+  getRateLimitMock: vi.fn(),
+  rateLimitGuardMock: vi.fn()
+}))
 
 vi.mock('electron', () => ({
   webContents: {
@@ -25,7 +30,7 @@ vi.mock('./client', () => ({
 vi.mock('./rate-limit', () => ({
   getRateLimit: getRateLimitMock,
   noteRateLimitSpend: vi.fn(),
-  rateLimitGuard: vi.fn(() => ({ blocked: false }))
+  rateLimitGuard: rateLimitGuardMock
 }))
 
 function makeCandidate(
@@ -80,6 +85,8 @@ describe('pr-refresh-coordinator', () => {
     getAllWebContentsMock.mockReset()
     getPRForBranchOutcomeMock.mockReset()
     getRateLimitMock.mockReset()
+    rateLimitGuardMock.mockReset()
+    rateLimitGuardMock.mockReturnValue({ blocked: false })
     getAllWebContentsMock.mockReturnValue([
       {
         id: 1,
@@ -505,13 +512,45 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(5)
   })
 
+  it('proceeds with background refreshes when the budget probe fails (fail open)', async () => {
+    const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
+    // Why: regression for #7553 — GHES with rate limiting disabled 404s every
+    // probe; an unreadable budget must not pause refreshes.
+    getRateLimitMock.mockResolvedValue({
+      ok: false,
+      error: 'HTTP 404: Rate limiting is not enabled.'
+    })
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    enqueuePRRefresh(makeCandidate(), 'active', 80, 1)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+    const pausedEvents = sendMock.mock.calls
+      .map(([, event]) => event)
+      .filter((event) => event.status === 'paused' && event.skippedReason === 'rate-limit')
+    expect(pausedEvents).toHaveLength(0)
+  })
+
   it('does not consume active burst slots for rate-limit pauses', async () => {
     const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
-    getRateLimitMock
-      .mockResolvedValueOnce({ ok: false })
-      .mockResolvedValueOnce({ ok: false })
-      .mockResolvedValueOnce({ ok: false })
-      .mockResolvedValue({ ok: true })
+    // Why: keyed on drained items (one getRateLimit call each) rather than
+    // guard-call counts, so the guard's per-bucket evaluation order stays free
+    // to change without breaking the slot-accounting assertion.
+    let drainedItems = 0
+    getRateLimitMock.mockImplementation(async () => {
+      drainedItems += 1
+      return { ok: true }
+    })
+    rateLimitGuardMock.mockImplementation(() =>
+      drainedItems <= 3
+        ? { blocked: true, remaining: 0, limit: 5000, resetAt: 61 }
+        : { blocked: false }
+    )
     getPRForBranchOutcomeMock.mockResolvedValue({
       kind: 'upstream-error',
       errorType: 'unknown',

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -708,20 +708,11 @@ async function drainQueue(): Promise<void> {
       )
 
       if (isBackground(next.reason)) {
-        const rateLimit = await getRateLimit()
-        if (!rateLimit.ok) {
-          const retryAt = Date.now() + 30_000
-          queue.set(next.key, { ...next, dueAt: retryAt })
-          broadcast({
-            aliases,
-            reason: next.reason,
-            status: 'paused',
-            pausedUntil: retryAt,
-            skippedReason: 'rate-limit'
-          })
-          scheduleDrain(30_000)
-          continue
-        }
+        // Why: the probe only warms rateLimitGuard's cached snapshot, so a
+        // failed probe must fail open — GHES with rate limiting disabled 404s
+        // every probe (#7553). A genuinely broken gh surfaces per-key as typed
+        // fetch outcomes instead (visible keys additionally back off).
+        await getRateLimit()
         const buckets = backgroundRefreshBuckets()
         const blockedGuard = buckets
           .map((bucket) => rateLimitGuard(bucket))

--- a/src/main/github/rate-limit.test.ts
+++ b/src/main/github/rate-limit.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ghExecFileAsyncMock } = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  ghExecFileAsync: ghExecFileAsyncMock
+}))
+
+vi.mock('./gh-utils', () => ({
+  acquire: vi.fn(),
+  release: vi.fn()
+}))
+
+import { getRateLimit, rateLimitGuard, _resetRateLimitCache } from './rate-limit'
+
+const PAYLOAD = JSON.stringify({
+  resources: {
+    core: { limit: 5000, remaining: 4200, reset: 1_700_000_000 },
+    search: { limit: 30, remaining: 28, reset: 1_700_000_000 },
+    graphql: { limit: 5000, remaining: 4900, reset: 1_700_000_000 }
+  }
+})
+
+describe('getRateLimit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    ghExecFileAsyncMock.mockReset()
+    _resetRateLimitCache()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('parses bucket counts from gh api rate_limit', async () => {
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: PAYLOAD })
+
+    const result = await getRateLimit()
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: {
+        core: { limit: 5000, remaining: 4200, resetAt: 1_700_000_000 },
+        search: { limit: 30, remaining: 28, resetAt: 1_700_000_000 },
+        graphql: { limit: 5000, remaining: 4900, resetAt: 1_700_000_000 },
+        fetchedAt: 1_000
+      }
+    })
+  })
+
+  it('caches a failed probe for the TTL instead of re-spawning gh', async () => {
+    // Why: regression for #7553 — GHES with rate limiting disabled fails every
+    // probe. Refreshes fail open past the failure, so without a negative cache
+    // each queued refresh would spawn its own doomed gh subprocess.
+    ghExecFileAsyncMock.mockRejectedValue(new Error('HTTP 404: Rate limiting is not enabled.'))
+
+    const first = await getRateLimit()
+    const second = await getRateLimit()
+
+    expect(first).toEqual({ ok: false, error: 'HTTP 404: Rate limiting is not enabled.' })
+    expect(second).toEqual(first)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-probes after the failure TTL elapses and recovers on success', async () => {
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('boom'))
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: PAYLOAD })
+
+    expect((await getRateLimit()).ok).toBe(false)
+    expect((await getRateLimit()).ok).toBe(false)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(1_000 + 30_000)
+
+    expect((await getRateLimit()).ok).toBe(true)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('bypasses the failure cache when forced', async () => {
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('boom'))
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: PAYLOAD })
+
+    expect((await getRateLimit()).ok).toBe(false)
+    expect((await getRateLimit({ force: true })).ok).toBe(true)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('rateLimitGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    ghExecFileAsyncMock.mockReset()
+    _resetRateLimitCache()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  async function cacheExhaustedSnapshot(resetEpochSeconds: number): Promise<void> {
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        resources: {
+          core: { limit: 5000, remaining: 3, reset: resetEpochSeconds },
+          search: { limit: 30, remaining: 28, reset: resetEpochSeconds },
+          graphql: { limit: 5000, remaining: 4900, reset: resetEpochSeconds }
+        }
+      })
+    })
+    expect((await getRateLimit()).ok).toBe(true)
+  }
+
+  it('blocks below the floor while resetAt is in the future', async () => {
+    await cacheExhaustedSnapshot(61)
+
+    expect(rateLimitGuard('core')).toEqual({
+      blocked: true,
+      remaining: 3,
+      limit: 5000,
+      resetAt: 61
+    })
+  })
+
+  it('fails open once the blocking bucket resetAt has elapsed', async () => {
+    // Why: probes can fail indefinitely (sleep past resetAt, network blip), so
+    // a stale exhausted snapshot must not block once GitHub has already reset
+    // the budget — a past-due pause would spin the coordinator drain loop.
+    await cacheExhaustedSnapshot(61)
+
+    vi.setSystemTime(61_000)
+
+    expect(rateLimitGuard('core')).toEqual({ blocked: false })
+  })
+})

--- a/src/main/github/rate-limit.ts
+++ b/src/main/github/rate-limit.ts
@@ -35,6 +35,11 @@ import {
 // 1-per-second "is it safe now?" polling pattern UIs tend to fall into.
 const RATE_LIMIT_CACHE_TTL_MS = 30_000
 let cached: GitHubRateLimitSnapshot | null = null
+// Why: failed probes are cached for the same TTL as successes. Refreshes fail
+// open past a failed probe, so on a host that can never report a budget (GHES
+// with rate limiting disabled 404s every probe) an uncached failure would cost
+// a gh subprocess per queued refresh.
+let probeFailure: { at: number; error: string } | null = null
 
 type GhRateLimitPayload = {
   resources?: {
@@ -66,6 +71,7 @@ function parseBucket(
 /** @internal — test-only */
 export function _resetRateLimitCache(): void {
   cached = null
+  probeFailure = null
 }
 
 // Why: hard-stop thresholds for the circuit breaker. We refuse to issue a new
@@ -196,6 +202,9 @@ export async function getRateLimit(options?: { force?: boolean }): Promise<GetRa
   if (!options?.force && cached && Date.now() - cached.fetchedAt < RATE_LIMIT_CACHE_TTL_MS) {
     return { ok: true, snapshot: cached }
   }
+  if (!options?.force && probeFailure && Date.now() - probeFailure.at < RATE_LIMIT_CACHE_TTL_MS) {
+    return { ok: false, error: probeFailure.error }
+  }
   if (!options?.force && probeInFlight) {
     return probeInFlight
   }
@@ -222,9 +231,11 @@ async function fetchRateLimitSnapshot(): Promise<GetRateLimitResult> {
       fetchedAt: Date.now()
     }
     cached = snapshot
+    probeFailure = null
     return { ok: true, snapshot }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
+    probeFailure = { at: Date.now(), error: message }
     return { ok: false, error: message }
   } finally {
     release()


### PR DESCRIPTION
Fixes #7553

## What changes

On GitHub Enterprise Server instances with rate limiting disabled, `gh api rate_limit` returns HTTP 404 ("Rate limiting is not enabled."). Orca treated any failed budget probe as "pause ALL background GitHub refreshes, retry in 30s" — permanently blocking the PR/Checks panel on those hosts ("Cannot find PR. GitHub refresh is paused due to the current rate limit budget"), with no workaround.

This PR makes the budget probe advisory — probe failures can no longer block anything:

- **Probe failures fail open.** The coordinator's `!rateLimit.ok` pause branch is removed; the probe now only warms `rateLimitGuard`'s cached snapshot. The genuine-exhaustion gate (guard blocked → pause until `resetAt`) is kept.
- **Failed probes are negative-cached** for the same 30s TTL as successes (cleared on success, bypassed by force-refresh), so a host that can never report a budget costs at most one `gh` subprocess per TTL window instead of one per queued refresh.
- **`rateLimitGuard` fails open once the blocking bucket's `resetAt` has elapsed.** The removed pause was accidentally load-bearing: it was the only mechanism keeping guard retry times in the future when the snapshot can't refresh. Without this, a stale exhausted snapshot plus indefinitely-failing probes (sleep past `resetAt`, wake with network briefly down) would hand the drain loop past-due retries and spin it synchronously. Past `resetAt`, GitHub has by definition reset the budget, so failing open is also semantically correct.

## What does not change

- Genuine exhaustion on github.com still pauses background refreshes until `resetAt` — the probe endpoint is exempt from rate limiting, so it keeps succeeding during real exhaustion and the snapshot stays current.
- Manual refreshes were never gated and still aren't.
- The Settings "GitHub API budget is unavailable" card still shows on GHES with limiting disabled — now purely informational (nothing is blocked; force-refresh works). A display-only "rate limiting is disabled on this host" mapping is a deliberate follow-up.
- GitLab has a separate host-scoped budget probe and no coordinator gate; untouched.

## Why fail-open instead of special-casing the 404

The pause branch shipped in `#1716` with no stated rationale, and it contradicted the module's own design: `assertRateLimitBudget` already ignored probe failures, `rateLimitGuard` already failed open on a missing snapshot and on unknown limits ("don't block on missing data"), and per-key `errorBackoff` already handles a genuinely broken `gh`. GitHub documents the 404 as the defined response when rate limiting is disabled — an unreadable budget is not evidence of exhaustion.

## Validation

- **Unit:** new `rate-limit.test.ts` (payload parse; failure negative-cache TTL, recovery, force bypass; guard blocks below floor with future `resetAt`; guard fails open at elapsed `resetAt`). Coordinator regression test: a failing probe proceeds with zero rate-limit pauses. Burst-slot accounting test re-keyed to drained items so guard evaluation order stays free to change.
- **Live (dev build, macOS):** launched with a `gh` wrapper returning the exact GHES 404 for `api rate_limit` while passing all other commands through. The Checks panel fetched and rendered open PRs in a freshly created worktree (uncacheable) where it previously dead-ended; over ~35 min: 51 failed probes vs 436 successful `gh` calls, probe rate held at ~1 per 30s; Settings budget card force-refresh works and stays stable.
- **Review:** independent design review plus two rounds of two-reviewer adversarial code review; final round clean on both.
- **Perf:** on affected hosts, subprocess and IPC broadcast volume strictly decrease (the old pause loop re-probed and re-broadcast every 30s per queued entry, forever). Healthy github.com behavior is unchanged. No new timers, listeners, or storage growth.
- **Static:** typecheck clean, focused vitest 37/37, oxlint clean on touched files, `git diff --check` clean.

## Risks / residual

- With a persistently broken local `gh`, background refreshes now attempt real fetches — bounded by the existing 20/5min background budget, 3/30s active caps, and visible-key exponential backoff — and surface truthful per-key errors instead of the old false "rate-limit paused" state.
- A near-floor snapshot followed by persistent probe failures can pause background refreshes at most until that snapshot's `resetAt` (≤1h), after which the elapsed-`resetAt` fail-open clears it.
- SSH-backed refresh candidates strictly improve: a broken local probe no longer pauses remote-executing refreshes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
