### PR TITLE
fix(github): route all PR source-settings sites through a repo-owner-aware resolver (#7623)

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -57,6 +57,7 @@ import { Button } from '@/components/ui/button'
 import { ButtonGroup } from '@/components/ui/button-group'
 import { Input } from '@/components/ui/input'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { useResolvedGitHubSourceSettings } from '@/hooks/useResolvedGitHubSourceSettings'
 import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import {
   Accordion,
@@ -494,13 +495,7 @@ function PRAssigneesPanel({
   }))
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
-  )
+  const sourceSettings = useResolvedGitHubSourceSettings(item.repoId ?? null, sourceContext)
   const { isPending, run } = useImmediateMutation()
 
   // Why: PR assignees can change through background refetches; sync them
@@ -726,13 +721,7 @@ function PRReviewersPanel({
     reviewRequests: item.reviewRequests
   }))
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
-  )
+  const sourceSettings = useResolvedGitHubSourceSettings(item.repoId ?? null, sourceContext)
   const reviewerInputRef = useRef<HTMLInputElement | null>(null)
   const reviewerInputFocusFrameRef = useRef<number | null>(null)
   const reviewerPanelMountedRef = useRef(true)
@@ -3836,12 +3825,9 @@ function PRActionsPanel({
   const actionItem = { ...item, state: localState }
   const mergePresentation = presentGitHubPRMergeState(actionItem)
   const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
+  const sourceSettings = useResolvedGitHubSourceSettings(
+    repoId ?? item.repoId ?? null,
+    sourceContext
   )
   const mergeTarget = getActiveRuntimeTarget(sourceSettings)
   const canMutateWithRepoContext =
@@ -5588,13 +5574,7 @@ function GHEditSection({
       return Array.from(deduped.values()).sort((a, b) => b.number - a.number)
     })
   )
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
-  )
+  const sourceSettings = useResolvedGitHubSourceSettings(item.repoId ?? null, sourceContext)
   const { isPending, run } = useImmediateMutation()
   // Why: when the dialog opens from a Project view, mutations route through
   // *BySlug IPCs and we must keep `projectViewCache` in sync alongside

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -167,7 +167,8 @@ import { lookupGitHubWorkItemDetailsForSource } from '@/lib/github-work-item-sou
 import {
   canUseGitHubRepoContext,
   getGitHubRuntimeRepoId,
-  getGitHubSourceRuntimeHost
+  getGitHubSourceRuntimeHost,
+  resolveGitHubSourceSettings
 } from '@/lib/github-source-runtime-context'
 import IssueSourceIndicator, { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
 import {
@@ -211,7 +212,6 @@ import type {
 } from '../../../shared/types'
 import {
   getTaskSourceCacheScope,
-  getTaskSourceRuntimeSettings,
   type TaskSourceContext
 } from '../../../shared/task-source-context'
 import { PER_REPO_FETCH_LIMIT } from '../../../shared/work-items'
@@ -498,13 +498,7 @@ function PRAssigneesPanel({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()
@@ -736,13 +730,7 @@ function PRReviewersPanel({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const reviewerInputRef = useRef<HTMLInputElement | null>(null)
@@ -3851,18 +3839,10 @@ function PRActionsPanel({
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null))
   )
-  const sourceSettings = useMemo(() => {
-    if (sourceContext?.provider !== 'github') {
-      return repoOwnerSettings
-    }
-    const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)
-    return sourceRuntimeSettings.activeRuntimeEnvironmentId
-      ? ({
-          ...repoOwnerSettings,
-          ...sourceRuntimeSettings
-        } as typeof repoOwnerSettings)
-      : repoOwnerSettings
-  }, [repoOwnerSettings, sourceContext])
+  const sourceSettings = useMemo(
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
+    [repoOwnerSettings, sourceContext]
+  )
   const mergeTarget = getActiveRuntimeTarget(sourceSettings)
   const canMutateWithRepoContext =
     !!repoPath || !!projectOrigin || mergeTarget.kind === 'environment'
@@ -5274,10 +5254,10 @@ async function runIssueUpdate(args: {
   updates: Parameters<typeof window.api.gh.updateIssue>[0]['updates']
 }): Promise<void> {
   if (args.projectOrigin) {
-    const targetSettings =
-      args.sourceContext?.provider === 'github'
-        ? getTaskSourceRuntimeSettings(args.sourceContext)
-        : getGitHubMutationSettings(args.repoId)
+    const targetSettings = resolveGitHubSourceSettings(
+      getGitHubMutationSettings(args.repoId),
+      args.sourceContext
+    )
     const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: args.projectOrigin.owner,
@@ -5367,10 +5347,10 @@ async function runWorkItemBodyUpdate(args: {
     if (!targetSlug) {
       throw new Error('No GitHub repository context available for this pull request.')
     }
-    const targetSettings =
-      args.sourceContext?.provider === 'github'
-        ? getTaskSourceRuntimeSettings(args.sourceContext)
-        : getGitHubMutationSettings(args.item.repoId)
+    const targetSettings = resolveGitHubSourceSettings(
+      getGitHubMutationSettings(args.item.repoId),
+      args.sourceContext
+    )
     const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: targetSlug.owner,
@@ -5426,10 +5406,10 @@ async function runPullRequestStateUpdate(args: {
   updates: { state: 'open' | 'closed' }
 }): Promise<void> {
   if (args.projectOrigin) {
-    const targetSettings =
-      args.sourceContext?.provider === 'github'
-        ? getTaskSourceRuntimeSettings(args.sourceContext)
-        : getGitHubMutationSettings(args.repoId)
+    const targetSettings = resolveGitHubSourceSettings(
+      getGitHubMutationSettings(args.repoId),
+      args.sourceContext
+    )
     const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: args.projectOrigin.owner,
@@ -5612,13 +5592,7 @@ function GHEditSection({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -170,7 +170,8 @@ import { lookupGitHubWorkItemDetailsForSource } from '@/lib/github-work-item-sou
 import {
   canUseGitHubRepoContext,
   getGitHubRuntimeRepoId,
-  getGitHubSourceRuntimeHost
+  getGitHubSourceRuntimeHost,
+  resolveGitHubSourceSettings
 } from '@/lib/github-source-runtime-context'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
 import {
@@ -215,7 +216,6 @@ import type {
 } from '../../../shared/types'
 import {
   getTaskSourceCacheScope,
-  getTaskSourceRuntimeSettings,
   type TaskSourceContext
 } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
@@ -545,13 +545,7 @@ function PRAssigneesPanel({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()
@@ -780,13 +774,7 @@ function PRReviewersPanel({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const reviewerInputRef = useRef<HTMLInputElement | null>(null)
@@ -3236,13 +3224,7 @@ function ConversationTab({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const repoAssignees = useRepoAssignees(repoPath, item.repoId, sourceSettings)
@@ -3841,7 +3823,16 @@ function PRActionsPanel({
   const actionItem = { ...item, state: localState }
   const mergePresentation = presentGitHubPRMergeState(actionItem)
   const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
-  const sourceSettings = getTaskSourceRuntimeSettings(sourceContext)
+  // Why: merge must route through the repo OWNER host — a runtime-owned repo
+  // viewed from a local GitHub source has a null source runtime id, and routing
+  // by that lands on local gh:mergePR → "Access denied" (#6957/#7590).
+  const repoOwnerSettings = useAppStore(
+    useShallow((s) => getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null))
+  )
+  const sourceSettings = useMemo(
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
+    [repoOwnerSettings, sourceContext]
+  )
   const mergeTarget = getActiveRuntimeTarget(sourceSettings)
   const canMutateWithRepoContext =
     !!repoPath || !!projectOrigin || mergeTarget.kind === 'environment'
@@ -5540,10 +5531,10 @@ async function runIssueUpdate(args: {
   updates: Parameters<typeof window.api.gh.updateIssue>[0]['updates']
 }): Promise<void> {
   if (args.projectOrigin) {
-    const targetSettings =
-      args.sourceContext?.provider === 'github'
-        ? getTaskSourceRuntimeSettings(args.sourceContext)
-        : getGitHubMutationSettings(args.repoId)
+    const targetSettings = resolveGitHubSourceSettings(
+      getGitHubMutationSettings(args.repoId),
+      args.sourceContext
+    )
     const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: args.projectOrigin.owner,
@@ -5633,10 +5624,10 @@ async function runWorkItemBodyUpdate(args: {
     if (!targetSlug) {
       throw new Error('No GitHub repository context available for this pull request.')
     }
-    const targetSettings =
-      args.sourceContext?.provider === 'github'
-        ? getTaskSourceRuntimeSettings(args.sourceContext)
-        : getGitHubMutationSettings(args.item.repoId)
+    const targetSettings = resolveGitHubSourceSettings(
+      getGitHubMutationSettings(args.item.repoId),
+      args.sourceContext
+    )
     const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: targetSlug.owner,
@@ -5692,10 +5683,10 @@ async function runPullRequestStateUpdate(args: {
   updates: { state: 'open' | 'closed' }
 }): Promise<void> {
   if (args.projectOrigin) {
-    const targetSettings =
-      args.sourceContext?.provider === 'github'
-        ? getTaskSourceRuntimeSettings(args.sourceContext)
-        : getGitHubMutationSettings(args.repoId)
+    const targetSettings = resolveGitHubSourceSettings(
+      getGitHubMutationSettings(args.repoId),
+      args.sourceContext
+    )
     const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: args.projectOrigin.owner,
@@ -5811,13 +5802,7 @@ function GHEditSection({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -11,7 +11,6 @@ import React, {
 } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { useShallow } from 'zustand/react/shallow'
 import type { editor as monacoEditor } from 'monaco-editor'
 import {
   ArrowDown,
@@ -50,6 +49,7 @@ import { Button } from '@/components/ui/button'
 import { ButtonGroup } from '@/components/ui/button-group'
 import { Input } from '@/components/ui/input'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { useResolvedGitHubSourceSettings } from '@/hooks/useResolvedGitHubSourceSettings'
 import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import {
   Accordion,
@@ -541,13 +541,7 @@ function PRAssigneesPanel({
   }))
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
-  )
+  const sourceSettings = useResolvedGitHubSourceSettings(item.repoId ?? null, sourceContext)
   const { isPending, run } = useImmediateMutation()
 
   // Why: PR assignees can change through background refetches; sync them
@@ -770,13 +764,7 @@ function PRReviewersPanel({
     reviewRequests: item.reviewRequests
   }))
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
-  )
+  const sourceSettings = useResolvedGitHubSourceSettings(item.repoId ?? null, sourceContext)
   const reviewerInputRef = useRef<HTMLInputElement | null>(null)
   const reviewerInputFocusFrameRef = useRef<number | null>(null)
   const reviewerPanelMountedRef = useRef(true)
@@ -3220,12 +3208,9 @@ function ConversationTab({
   const bodyTextareaRef = useRef<HTMLTextAreaElement>(null)
   const bodyTextareaFocusFrameRef = useRef<number | null>(null)
   const canUseRepoMutationContext = canUseGitHubRepoContext(repoPath, sourceContext)
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
+  const sourceSettings = useResolvedGitHubSourceSettings(
+    item.repoId ?? repoId ?? null,
+    sourceContext
   )
   const repoAssignees = useRepoAssignees(repoPath, item.repoId, sourceSettings)
   const commentCounts = useMemo(() => getPRCommentAudienceCounts(comments), [comments])
@@ -3826,12 +3811,9 @@ function PRActionsPanel({
   // Why: merge must route through the repo OWNER host — a runtime-owned repo
   // viewed from a local GitHub source has a null source runtime id, and routing
   // by that lands on local gh:mergePR → "Access denied" (#6957/#7590).
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
+  const sourceSettings = useResolvedGitHubSourceSettings(
+    repoId ?? item.repoId ?? null,
+    sourceContext
   )
   const mergeTarget = getActiveRuntimeTarget(sourceSettings)
   const canMutateWithRepoContext =
@@ -5798,12 +5780,9 @@ function GHEditSection({
   const assigneesItemKey = `${item.repoId}\0${item.id}`
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
-  const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
-  )
-  const sourceSettings = useMemo(
-    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
-    [repoOwnerSettings, sourceContext]
+  const sourceSettings = useResolvedGitHubSourceSettings(
+    item.repoId ?? repoId ?? null,
+    sourceContext
   )
   const { isPending, run } = useImmediateMutation()
   // Why: when the dialog opens from a Project view, mutations route through

--- a/src/renderer/src/components/github-item-dialog-merge-routing.test.ts
+++ b/src/renderer/src/components/github-item-dialog-merge-routing.test.ts
@@ -3,37 +3,29 @@ import {
   getSettingsForRepoRuntimeOwner,
   type RepoRuntimeOwnerState
 } from '../lib/repo-runtime-owner'
+import { resolveGitHubSourceSettings } from '../lib/github-source-runtime-context'
 import { getActiveRuntimeTarget } from '../runtime/runtime-rpc-client'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
-import { getTaskSourceRuntimeSettings } from '../../../shared/task-source-context'
 
-// Why: mirrors the merge-routing decision inside GitHubItemDialog's
-// PRActionsPanel so a revert to source-only routing (issue #6957) fails here.
-// A runtime-owned repo whose GitHub source view is local must still merge on
-// the owner runtime, not fall back to local `gh:mergePR`.
+// Why: exercises the shared resolveGitHubSourceSettings helper that both
+// GitHubItemDialog and PullRequestPage merge panels route through, so a revert
+// to bare/unconditional source routing (issue #6957 / follow-up #7623) fails
+// here. A runtime-owned repo whose GitHub source view is local must still merge
+// on the owner runtime, not fall back to local `gh:mergePR`.
 function resolveMergeTarget(
   state: RepoRuntimeOwnerState,
   repoId: string | null,
   sourceContext: TaskSourceContext | null
 ): ReturnType<typeof getActiveRuntimeTarget> {
   const repoOwnerSettings = getSettingsForRepoRuntimeOwner(state, repoId)
-  const sourceSettings =
-    sourceContext?.provider !== 'github'
-      ? repoOwnerSettings
-      : (() => {
-          const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)
-          return sourceRuntimeSettings.activeRuntimeEnvironmentId
-            ? { ...repoOwnerSettings, ...sourceRuntimeSettings }
-            : repoOwnerSettings
-        })()
-  return getActiveRuntimeTarget(sourceSettings)
+  return getActiveRuntimeTarget(resolveGitHubSourceSettings(repoOwnerSettings, sourceContext))
 }
 
 function githubSource(hostId: TaskSourceContext['hostId']): TaskSourceContext {
   return { kind: 'task-source', provider: 'github', projectId: 'p', hostId, repoId: 'repo-1' }
 }
 
-describe('GitHubItemDialog PR merge routing', () => {
+describe('GitHub PR merge routing (shared repo-owner-aware resolver)', () => {
   const runtimeOwnedRepo: RepoRuntimeOwnerState = {
     settings: { activeRuntimeEnvironmentId: null },
     repos: [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:owner-runtime' }]

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -30,7 +30,7 @@ describe('GitHubItemDialog source host boundaries', () => {
     const source = componentSource('GitHubItemDialog.tsx')
     const section = sourceBetween(source, 'function PRReviewersPanel', 'function isPRFileViewed')
 
-    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
+    expect(section).toContain('useResolvedGitHubSourceSettings(item.repoId ?? null, sourceContext)')
     expect(section).toContain('useRepoAssigneesBySlug(')
     expect(section).toContain('sourceSettings')
     expect(section).toContain('useRepoAssignees(')
@@ -55,7 +55,7 @@ describe('GitHubItemDialog source host boundaries', () => {
       'function GitHubLabelsSettingsLink'
     )
 
-    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
+    expect(section).toContain('useResolvedGitHubSourceSettings(item.repoId ?? null, sourceContext)')
     expect(section).toContain('useRepoLabels(')
     expect(section).toContain('useRepoLabelsBySlug(slugOwner, slugRepo, sourceSettings)')
     expect(section).toContain('useRepoAssignees(')
@@ -190,10 +190,8 @@ describe('GitHubItemDialog source host boundaries', () => {
       'function CommentReactions'
     )
 
-    expect(actionsSection).toContain('getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId')
-    expect(actionsSection).toContain(
-      'resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)'
-    )
+    expect(actionsSection).toContain('useResolvedGitHubSourceSettings(')
+    expect(actionsSection).toContain('repoId ?? item.repoId ?? null,')
     expect(actionsSection).toContain('getActiveRuntimeTarget(sourceSettings)')
     expect(actionsSection).toContain(
       'const canMergeWithRepoContext = !!repoPath || mergeTarget.kind ==='

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -30,7 +30,7 @@ describe('GitHubItemDialog source host boundaries', () => {
     const source = componentSource('GitHubItemDialog.tsx')
     const section = sourceBetween(source, 'function PRReviewersPanel', 'function isPRFileViewed')
 
-    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(section).toContain('useRepoAssigneesBySlug(')
     expect(section).toContain('sourceSettings')
     expect(section).toContain('useRepoAssignees(')
@@ -55,7 +55,7 @@ describe('GitHubItemDialog source host boundaries', () => {
       'function GitHubLabelsSettingsLink'
     )
 
-    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(section).toContain('useRepoLabels(')
     expect(section).toContain('useRepoLabelsBySlug(slugOwner, slugRepo, sourceSettings)')
     expect(section).toContain('useRepoAssignees(')
@@ -65,8 +65,8 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(helperSection).toContain("'github.updatePRState'")
     expect(helperSection).toContain("'github.project.updateIssueBySlug'")
     expect(helperSection).toContain("'github.project.updatePullRequestBySlug'")
-    expect(helperSection).toContain("args.sourceContext?.provider === 'github'")
-    expect(helperSection).toContain('getTaskSourceRuntimeSettings(args.sourceContext)')
+    expect(helperSection).toContain('resolveGitHubSourceSettings(')
+    expect(helperSection).toContain('getGitHubMutationSettings(args.repoId)')
     expect(helperSection).toContain('notifyWorkItemDetailsMutation(')
     expect(helperSection).toContain(
       "repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? '')"
@@ -191,12 +191,9 @@ describe('GitHubItemDialog source host boundaries', () => {
     )
 
     expect(actionsSection).toContain('getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId')
-    expect(actionsSection).toContain('...repoOwnerSettings')
     expect(actionsSection).toContain(
-      'const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)'
+      'resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)'
     )
-    expect(actionsSection).toContain('sourceRuntimeSettings.activeRuntimeEnvironmentId')
-    expect(actionsSection).toContain('...sourceRuntimeSettings')
     expect(actionsSection).toContain('getActiveRuntimeTarget(sourceSettings)')
     expect(actionsSection).toContain(
       'const canMergeWithRepoContext = !!repoPath || mergeTarget.kind ==='

--- a/src/renderer/src/components/pull-request-page-host-boundary.test.ts
+++ b/src/renderer/src/components/pull-request-page-host-boundary.test.ts
@@ -21,7 +21,7 @@ describe('PullRequestPage host boundaries', () => {
     const source = componentSource('PullRequestPage.tsx')
     const section = sourceBetween(source, 'function PRReviewersPanel', 'function isPRFileViewed')
 
-    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(section).toContain('useRepoAssigneesBySlug(')
     expect(section).toContain('sourceSettings')
     expect(section).toContain('useRepoAssignees(')
@@ -46,7 +46,7 @@ describe('PullRequestPage host boundaries', () => {
     const section = sourceBetween(source, 'function GHEditSection', 'function GHCommentComposer')
 
     expect(section).toContain('getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null)')
-    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(section).toContain('useRepoLabels(')
     expect(section).toContain('useRepoLabelsBySlug(slugOwner, slugRepo, sourceSettings)')
     expect(section).toContain('useRepoAssignees(')
@@ -268,13 +268,13 @@ describe('PullRequestPage host boundaries', () => {
     expect(editHelperSection).toContain("'github.project.updateIssueBySlug'")
     expect(editHelperSection).toContain("'github.project.updatePullRequestBySlug'")
     expect(editHelperSection).toContain('sourceContext?: TaskSourceContext | null')
-    expect(editHelperSection).toContain("args.sourceContext?.provider === 'github'")
-    expect(editHelperSection).toContain('getTaskSourceRuntimeSettings(args.sourceContext)')
+    expect(editHelperSection).toContain('resolveGitHubSourceSettings(')
+    expect(editHelperSection).toContain('getGitHubMutationSettings(args.repoId)')
     expect(editHelperSection).toContain(
       "repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? '')"
     )
     expect(editHelperSection).toContain('{ local: false }')
-    expect(editSection).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(editSection).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(editSection).toContain('sourceContext,')
   })
 
@@ -286,7 +286,12 @@ describe('PullRequestPage host boundaries', () => {
       'function CommentReactions'
     )
 
-    expect(actionsSection).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(actionsSection).toContain(
+      'getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null)'
+    )
+    expect(actionsSection).toContain(
+      'resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)'
+    )
     expect(actionsSection).toContain('getActiveRuntimeTarget(sourceSettings)')
     expect(actionsSection).toContain(
       'const canMergeWithRepoContext = !!repoPath || mergeTarget.kind ==='

--- a/src/renderer/src/components/pull-request-page-host-boundary.test.ts
+++ b/src/renderer/src/components/pull-request-page-host-boundary.test.ts
@@ -21,7 +21,7 @@ describe('PullRequestPage host boundaries', () => {
     const source = componentSource('PullRequestPage.tsx')
     const section = sourceBetween(source, 'function PRReviewersPanel', 'function isPRFileViewed')
 
-    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
+    expect(section).toContain('useResolvedGitHubSourceSettings(item.repoId ?? null, sourceContext)')
     expect(section).toContain('useRepoAssigneesBySlug(')
     expect(section).toContain('sourceSettings')
     expect(section).toContain('useRepoAssignees(')
@@ -45,8 +45,8 @@ describe('PullRequestPage host boundaries', () => {
     const source = componentSource('PullRequestPage.tsx')
     const section = sourceBetween(source, 'function GHEditSection', 'function GHCommentComposer')
 
-    expect(section).toContain('getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null)')
-    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
+    expect(section).toContain('useResolvedGitHubSourceSettings(')
+    expect(section).toContain('item.repoId ?? repoId ?? null,')
     expect(section).toContain('useRepoLabels(')
     expect(section).toContain('useRepoLabelsBySlug(slugOwner, slugRepo, sourceSettings)')
     expect(section).toContain('useRepoAssignees(')
@@ -90,7 +90,8 @@ describe('PullRequestPage host boundaries', () => {
     const source = componentSource('PullRequestPage.tsx')
     const section = sourceBetween(source, 'function ConversationTab', 'const mentionOptions')
 
-    expect(section).toContain('getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null)')
+    expect(section).toContain('useResolvedGitHubSourceSettings(')
+    expect(section).toContain('item.repoId ?? repoId ?? null,')
     expect(section).toContain('useRepoAssignees(repoPath, item.repoId, sourceSettings)')
   })
 
@@ -274,7 +275,7 @@ describe('PullRequestPage host boundaries', () => {
       "repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? '')"
     )
     expect(editHelperSection).toContain('{ local: false }')
-    expect(editSection).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
+    expect(editSection).toContain('useResolvedGitHubSourceSettings(')
     expect(editSection).toContain('sourceContext,')
   })
 
@@ -286,12 +287,8 @@ describe('PullRequestPage host boundaries', () => {
       'function CommentReactions'
     )
 
-    expect(actionsSection).toContain(
-      'getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null)'
-    )
-    expect(actionsSection).toContain(
-      'resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)'
-    )
+    expect(actionsSection).toContain('useResolvedGitHubSourceSettings(')
+    expect(actionsSection).toContain('repoId ?? item.repoId ?? null,')
     expect(actionsSection).toContain('getActiveRuntimeTarget(sourceSettings)')
     expect(actionsSection).toContain(
       'const canMergeWithRepoContext = !!repoPath || mergeTarget.kind ==='

--- a/src/renderer/src/hooks/useResolvedGitHubSourceSettings.ts
+++ b/src/renderer/src/hooks/useResolvedGitHubSourceSettings.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import type { GlobalSettings } from '../../../shared/types'
+import { resolveGitHubSourceSettings } from '@/lib/github-source-runtime-context'
+import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { useAppStore } from '@/store'
+
+// Why: every GitHub source-settings panel must start from the repo-owner host
+// and apply the source override the same way (#6957/#7590); one hook keeps the
+// call sites consistent by construction instead of by copy-paste.
+export function useResolvedGitHubSourceSettings(
+  repoId: string | null,
+  sourceContext: TaskSourceContext | null | undefined
+): Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> {
+  const repoOwnerSettings = useAppStore(
+    useShallow((s) => getSettingsForRepoRuntimeOwner(s, repoId))
+  )
+  return useMemo(
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
+    [repoOwnerSettings, sourceContext]
+  )
+}

--- a/src/renderer/src/lib/github-source-runtime-context.ts
+++ b/src/renderer/src/lib/github-source-runtime-context.ts
@@ -2,8 +2,26 @@ import type { ParsedExecutionHost } from '../../../shared/execution-host'
 import { parseExecutionHostId } from '../../../shared/execution-host'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { getTaskSourceRuntimeSettings } from '../../../shared/task-source-context'
+import type { GlobalSettings } from '../../../shared/types'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+
+// Why: getTaskSourceRuntimeSettings always carries an activeRuntimeEnvironmentId
+// key (null for a local source), so spreading it unconditionally over the
+// repo-owner settings clobbers a valid owner runtime id and downgrades a
+// runtime-owned repo to local IPC (#6957/#7590). Keep the repo owner as the base
+// and let the source override win only when it resolves to a real runtime host.
+export function resolveGitHubSourceSettings<
+  T extends Pick<GlobalSettings, 'activeRuntimeEnvironmentId'>
+>(repoOwnerSettings: T, sourceContext: TaskSourceContext | null | undefined): T {
+  if (sourceContext?.provider !== 'github') {
+    return repoOwnerSettings
+  }
+  const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)
+  return sourceRuntimeSettings.activeRuntimeEnvironmentId
+    ? ({ ...repoOwnerSettings, ...sourceRuntimeSettings } as T)
+    : repoOwnerSettings
+}
 
 export type GitHubRuntimeHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
 


### PR DESCRIPTION
## Summary

Follow-up to #7590 (fixes #6957). `getTaskSourceRuntimeSettings(sourceContext)` always returns an object with an `activeRuntimeEnvironmentId` key present (value `null` for a local/non-runtime source). Using it **bare**, or spreading it **unconditionally** over the repo-owner settings, clobbers a valid repo-owner runtime id with `null` — so a runtime-owned/headless repo viewed from a local GitHub source gets downgraded to local `gh:` IPC and fails with `Access denied: unknown repository path` (merge) or reads against the wrong host (assignees/labels/reviewers).

This PR routes **every** GitHub source-settings site through one repo-owner-aware resolver:

- **Extract** `resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)` in `github-source-runtime-context.ts` — repo owner is the base; the GitHub source override wins only when it resolves to a real runtime host.
- **Fix the second live #6957 merge bug** in `PullRequestPage` → `PRActionsPanel`, which used the bare form with no repo-owner base at all (the standalone PR page's merge/auto-merge panel, distinct from the item dialog fixed in #7590).
- **Collapse the drift** — assignee/reviewer/edit read panels, the project-origin edit-mutation runners, and the already-guarded dialog merge panel in both `GitHubItemDialog` and `PullRequestPage` all now go through the shared resolver, removing the `bare` / `unconditional-spread` / `guarded` variants. (Fixing only the read panels would have left writes routing local while reads route the owner — an internal read/write split; folding the mutation runners in keeps them consistent. Behavior changes only in the exact #6957 case.)

No visual change.

## Screenshots

No visual change. Non-visual host-routing only; affects headless/runtime-owned (paired web/mobile/remote) clients. Local and SSH behavior unchanged.

## Testing

- [x] `pnpm lint` — clean for the changed files. One pre-existing error in an unrelated, untouched file (`right-sidebar/source-control-manual-review-url.ts`, `switch-exhaustiveness`) reproduces on pristine `origin/main`; it's a Node 26-vs-target-24 type-aware discrepancy in my local env, not introduced here.
- [x] `pnpm typecheck` — fully green (node/cli/web).
- [x] `pnpm test` — the merge-routing + source-boundary suites and 24,975 tests pass. The 31 failures are all in unrelated files (`window.localStorage` undefined) caused by my local Node 26 runtime (repo targets Node 24); none touch this changeset.
- [x] `pnpm run build:web` — renderer bundle builds cleanly. (`build:native` not run — no native code touched.)
- [x] Added or updated high-quality tests. The merge-routing regression test now consumes the **real** `resolveGitHubSourceSettings` helper, so a revert to bare/unconditional routing fails it; source-boundary assertions updated to the shared-helper form.

## AI Review Report

Reviewed the routing decision end to end: `getTaskSourceRuntimeSettings` always carries an `activeRuntimeEnvironmentId` key, so bare use ignores the repo owner and unconditional spread clobbers it with `null` — both re-create the #6957 local-IPC downgrade for runtime-owned repos. The fix centralizes the decision (repo-owner base + source override only when it resolves to a runtime host) and routes all eight sibling sites through it.

Cross-platform: pure renderer TypeScript, no shortcuts, labels, paths, shell behavior, or Electron platform APIs touched — identical on macOS, Linux, and Windows. SSH/remote/local: local and SSH paths are unchanged; the fix specifically restores correct routing for runtime-owned (paired web/mobile/remote) hosts. Provider scope: GitHub-only routing helper; no change to other git providers. Performance: replaces inline `useMemo` bodies with one shared pure function — no new work in hot paths.

## Security Audit

Reviewed IPC routing, repository authorization, path handling, command execution, secrets, and dependencies.

- Preserves local IPC repository authorization; prevents runtime-owned repository paths from being sent to local GitHub IPC (the #6957 access-denied vector).
- No new command execution, path parsing, secrets handling, or dependencies.

No additional security follow-up identified.

## Notes

- Non-visual host-routing fix. Local and SSH behavior unchanged; runtime-owned/headless repos now correctly stay on runtime RPC for merge **and** read paths.
- Scope is slightly broader than the issue's enumerated list: the project-origin edit-mutation runners were folded into the shared helper too, to avoid a new read/write routing split — behavior changes only in the #6957 case.

Closes #7623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

X: [@mark86202384100](https://x.com/mark86202384100)
