### PR TITLE
fix(codex): mirror sandbox state into managed homes

### DIFF
--- a/src/main/codex/codex-home-paths.test.ts
+++ b/src/main/codex/codex-home-paths.test.ts
@@ -65,6 +65,14 @@ function getRuntimeCodexHomePath(): string {
   return join(userDataDir, 'codex-runtime-home', 'home')
 }
 
+function getSystemSandboxPath(): string {
+  return join(getSystemCodexHomePath(), '.sandbox')
+}
+
+function getRuntimeSandboxPath(): string {
+  return join(getRuntimeCodexHomePath(), '.sandbox')
+}
+
 function normalizeLinkTarget(linkTarget: string): string {
   return process.platform === 'win32'
     ? linkTarget.replace(/^\\\\\?\\/, '').toLowerCase()
@@ -161,6 +169,18 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
     expect(existsSync(join(getRuntimeCodexHomePath(), 'history.jsonl'))).toBe(false)
   })
 
+  it('mirrors the system .sandbox resource into the managed runtime home', () => {
+    mkdirSync(getSystemSandboxPath(), { recursive: true })
+    writeFileSync(join(getSystemSandboxPath(), 'state.json'), '{"sandbox":"system"}\n')
+
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(readFileSync(join(getRuntimeSandboxPath(), 'state.json'), 'utf-8')).toBe(
+      '{"sandbox":"system"}\n'
+    )
+    expectSymbolicLinkTargetIfLinked(getRuntimeSandboxPath(), getSystemSandboxPath())
+  })
+
   it('does not replace an existing runtime-owned resource entry', () => {
     mkdirSync(join(getSystemCodexHomePath(), 'skills'), { recursive: true })
     mkdirSync(join(getRuntimeCodexHomePath(), 'skills'), { recursive: true })
@@ -173,6 +193,36 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
     expect(lstatSync(runtimeSkillsPath).isSymbolicLink()).toBe(false)
     expect(readFileSync(join(runtimeSkillsPath, 'runtime.md'), 'utf-8')).toBe('runtime\n')
     expect(existsSync(join(runtimeSkillsPath, 'system.md'))).toBe(false)
+  })
+
+  it('removes an owned .sandbox fallback copy when the system resource disappears', () => {
+    fsMockState.failSymlink = true
+    mkdirSync(getSystemSandboxPath(), { recursive: true })
+    writeFileSync(join(getSystemSandboxPath(), 'state.json'), '{"sandbox":"system"}\n')
+
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(lstatSync(getRuntimeSandboxPath()).isSymbolicLink()).toBe(false)
+    expect(readFileSync(join(getRuntimeSandboxPath(), 'state.json'), 'utf-8')).toBe(
+      '{"sandbox":"system"}\n'
+    )
+
+    rmSync(getSystemSandboxPath(), { recursive: true, force: true })
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(existsSync(getRuntimeSandboxPath())).toBe(false)
+  })
+
+  it('preserves a non-owned managed .sandbox directory when the system resource is absent', () => {
+    mkdirSync(getRuntimeSandboxPath(), { recursive: true })
+    writeFileSync(join(getRuntimeSandboxPath(), 'state.json'), '{"sandbox":"runtime"}\n')
+
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(lstatSync(getRuntimeSandboxPath()).isSymbolicLink()).toBe(false)
+    expect(readFileSync(join(getRuntimeSandboxPath(), 'state.json'), 'utf-8')).toBe(
+      '{"sandbox":"runtime"}\n'
+    )
   })
 
   it('removes owned symlinks for deleted system resources without touching unrelated runtime links', () => {

--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -19,6 +19,7 @@ const CODEX_SYSTEM_RESOURCE_ENTRIES = [
   'hooks',
   'plugins',
   'plugin-state',
+  '.sandbox',
   'profile-v2',
   'themes',
   'prompts'


### PR DESCRIPTION
## Summary

- Mirror Codex `.sandbox` state into Orca's managed Codex home along with the other launch-time Codex resources.
- This keeps managed Codex auth isolation intact while letting nested Codex processes inherit the same sandbox state Orca prepares for the managed `CODEX_HOME`.

Closes #7555.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-home-paths.test.ts` passed, `Test Files 1 passed (1)`, `Tests 9 passed (9)`.
- `pnpm run typecheck:node` passed.

## AI Review Report

The diff stays inside Codex managed-home resource mirroring and its tests. No UI, Electron windowing, SSH, remote provider, or command-execution policy changed. Windows behavior still goes through the existing resource sync helper, which already prefers junctions and falls back to owned copies.

## Security Audit

The change reuses the existing ownership marker and target checks, so Orca still removes only managed resources it owns and leaves user-created managed runtime state alone. Adding `.sandbox` to the shared resource list does not introduce a new copy path or new overwrite rule.

## Notes

No visual change. Unit coverage proves `.sandbox` mirrors into managed homes, owned fallback copies clean up, and non-owned managed `.sandbox` directories survive when the canonical resource is absent.

## ELI5

Managed Codex homes didn’t include Codex’s `.sandbox` state, so nested processes could disagree. Sandbox state is mirrored with other managed Codex resources at launch.
