### PR TITLE
fix(source-control): keep unresolved PR comment prompts retryable (#7466)

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.test.tsx
@@ -247,6 +247,25 @@ describe('SourceControlAgentActionDialog', () => {
     expect(mocks.toastError).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps prompt editing available when async auto-start delivery fails', async () => {
+    mocks.onStart.mockImplementation(async () => {
+      await Promise.resolve()
+      return false
+    })
+    renderControlledDialog({
+      baseCommandInput: 'Resolve queued comments.',
+      savedCommandInputTemplate: '{basePrompt}'
+    })
+    expect(container.textContent).not.toContain('Launch agent')
+    await vi.waitFor(() => expect(mocks.onStart).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(container.textContent).toContain('Launch agent'))
+
+    expect(container.querySelector('textarea')?.value).toContain('{basePrompt}')
+    expect(container.textContent).toContain('Start agent')
+    expect(mocks.onLaunched).not.toHaveBeenCalled()
+    expect(mocks.onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
   it('does not auto-start when a saved receipt appears after the dialog is already open', async () => {
     let setSavedAgentId: (agent: TuiAgent | null) => void = () => {}
 

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
@@ -326,6 +326,18 @@ describe('PRCommentsList comment resolution selection', () => {
     expect(container.querySelector('button[role="checkbox"]')).toBeNull()
   })
 
+  it('keeps queued comments selected when clearRequest is null', () => {
+    const comments = [comment({ id: 1, threadId: 'thread-1', path: 'src/a.ts', isResolved: false })]
+    renderList({ comments })
+    clickButton('Queue for agent')
+
+    expect(hasButton('Send 1 queued comments to AI')).toBe(true)
+
+    renderList({ comments, clearRequest: null })
+
+    expect(hasButton('Send 1 queued comments to AI')).toBe(true)
+  })
+
   it('keeps a clear request pending until its review context is mounted', () => {
     const queuedComments = [
       comment({

--- a/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts
+++ b/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  focusTerminalTabSurface: vi.fn(),
+  launchAgentInNewTab: vi.fn(),
+  onClose: vi.fn(),
+  onLaunched: vi.fn(),
+  onSaveAgentDefault: vi.fn(),
+  onStart: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: mocks.focusTerminalTabSurface
+}))
+
+vi.mock('@/lib/launch-agent-in-new-tab', () => ({
+  launchAgentInNewTab: mocks.launchAgentInNewTab
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError }
+}))
+
+import { runSourceControlAgentActionStart } from './runSourceControlAgentActionStart'
+
+function buildArgs(
+  overrides: Partial<Parameters<typeof runSourceControlAgentActionStart>[0]> = {}
+): Parameters<typeof runSourceControlAgentActionStart>[0] {
+  return {
+    selectedAgent: 'codex',
+    trimmedCommandInput: 'Fix the bug',
+    agentArgs: '--model gpt-5',
+    commandTemplate: '{basePrompt}',
+    saveTargetValue: 'none',
+    actionId: 'resolveComments',
+    repoId: null,
+    settings: null,
+    repo: null,
+    worktreeId: 'wt-1',
+    groupId: 'group-1',
+    promptDelivery: 'submit-after-ready',
+    launchPlatform: 'linux',
+    launchSource: 'source_control_recovery',
+    onStart: undefined,
+    onSaveAgentDefault: mocks.onSaveAgentDefault,
+    onLaunched: mocks.onLaunched,
+    onClose: mocks.onClose,
+    ...overrides
+  }
+}
+
+describe('runSourceControlAgentActionStart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('waits for deferred prompt delivery before confirming a source-control launch', async () => {
+    mocks.launchAgentInNewTab.mockReturnValue({
+      tabId: 'tab-1',
+      startupPlan: {} as never,
+      pasteDraftAfterLaunch: true,
+      promptDeliveryResult: Promise.resolve({ delivered: true, failureNotified: false })
+    })
+
+    await expect(runSourceControlAgentActionStart(buildArgs())).resolves.toBe(true)
+
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('tab-1')
+    expect(mocks.onLaunched).toHaveBeenCalledTimes(1)
+    expect(mocks.onClose).toHaveBeenCalledTimes(1)
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('keeps the source-control dialog open when deferred prompt delivery fails', async () => {
+    mocks.launchAgentInNewTab.mockReturnValue({
+      tabId: 'tab-1',
+      startupPlan: {} as never,
+      pasteDraftAfterLaunch: true,
+      promptDeliveryResult: Promise.resolve({ delivered: false, failureNotified: false })
+    })
+
+    await expect(runSourceControlAgentActionStart(buildArgs())).resolves.toBe(false)
+
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('tab-1')
+    expect(mocks.onLaunched).not.toHaveBeenCalled()
+    expect(mocks.onClose).not.toHaveBeenCalled()
+    expect(mocks.onSaveAgentDefault).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('Could not start the selected agent.')
+  })
+
+  it('does not show a generic start failure when deferred delivery already notified the user', async () => {
+    mocks.launchAgentInNewTab.mockReturnValue({
+      tabId: 'tab-1',
+      startupPlan: {} as never,
+      pasteDraftAfterLaunch: true,
+      promptDeliveryResult: Promise.resolve({ delivered: false, failureNotified: true })
+    })
+
+    await expect(runSourceControlAgentActionStart(buildArgs())).resolves.toBe(false)
+
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('tab-1')
+    expect(mocks.onLaunched).not.toHaveBeenCalled()
+    expect(mocks.onClose).not.toHaveBeenCalled()
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('logs and treats a rejected promptDeliveryResult as a launch failure', async () => {
+    const error = new Error('boom')
+    const originalConsole = console
+    const consoleError = vi.fn()
+    vi.stubGlobal('console', { ...originalConsole, error: consoleError })
+    mocks.launchAgentInNewTab.mockReturnValue({
+      tabId: 'tab-1',
+      startupPlan: {} as never,
+      pasteDraftAfterLaunch: true,
+      promptDeliveryResult: Promise.reject(error)
+    })
+
+    try {
+      await expect(runSourceControlAgentActionStart(buildArgs())).resolves.toBe(false)
+
+      expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('tab-1')
+      expect(consoleError).toHaveBeenCalledWith('promptDeliveryResult rejected', error)
+      expect(mocks.onLaunched).not.toHaveBeenCalled()
+      expect(mocks.onClose).not.toHaveBeenCalled()
+      expect(mocks.toastError).toHaveBeenCalledWith('Could not start the selected agent.')
+    } finally {
+      vi.stubGlobal('console', originalConsole)
+    }
+  })
+
+  it('keeps non-deferred tab launches immediate', async () => {
+    mocks.launchAgentInNewTab.mockReturnValue({
+      tabId: 'tab-1',
+      startupPlan: {} as never,
+      pasteDraftAfterLaunch: true
+    })
+
+    await expect(
+      runSourceControlAgentActionStart(buildArgs({ promptDelivery: 'draft' }))
+    ).resolves.toBe(true)
+
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('tab-1')
+    expect(mocks.onLaunched).toHaveBeenCalledTimes(1)
+    expect(mocks.onClose).toHaveBeenCalledTimes(1)
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('keeps injected onStart successes immediate', async () => {
+    const onStart = vi.fn().mockResolvedValue(true)
+
+    await expect(
+      runSourceControlAgentActionStart(
+        buildArgs({
+          onStart,
+          worktreeId: undefined,
+          groupId: undefined
+        })
+      )
+    ).resolves.toBe(true)
+
+    expect(onStart).toHaveBeenCalledWith({
+      agent: 'codex',
+      commandInput: 'Fix the bug',
+      agentArgs: '--model gpt-5'
+    })
+    expect(mocks.launchAgentInNewTab).not.toHaveBeenCalled()
+    expect(mocks.onLaunched).toHaveBeenCalledTimes(1)
+    expect(mocks.onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.ts
+++ b/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.ts
@@ -62,6 +62,7 @@ export async function runSourceControlAgentActionStart({
   onClose
 }: RunSourceControlAgentActionStartArgs): Promise<boolean> {
   let launched = false
+  let launchFailureNotified = false
   if (onStart) {
     launched = await onStart({
       agent: selectedAgent,
@@ -83,14 +84,26 @@ export async function runSourceControlAgentActionStart({
     if (result?.tabId) {
       focusTerminalTabSurface(result.tabId)
     }
+    if (result?.promptDeliveryResult) {
+      try {
+        const deliveryResult = await result.promptDeliveryResult
+        launched = deliveryResult.delivered
+        launchFailureNotified = deliveryResult.failureNotified
+      } catch (error) {
+        console.error('promptDeliveryResult rejected', error)
+        launched = false
+      }
+    }
   }
   if (!launched) {
-    toast.error(
-      translate(
-        'auto.components.right.sidebar.SourceControlAgentActionDialog.8e856842d1',
-        'Could not start the selected agent.'
+    if (!launchFailureNotified) {
+      toast.error(
+        translate(
+          'auto.components.right.sidebar.SourceControlAgentActionDialog.8e856842d1',
+          'Could not start the selected agent.'
+        )
       )
-    )
+    }
     return false
   }
 

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -9,6 +9,7 @@ const mockPasteDraftWhenAgentReady = vi.fn()
 const mockSeedNativeChatLaunchPrompt = vi.fn()
 const mockMarkNativeChatLaunchPromptFailed = vi.fn()
 const mockTrack = vi.fn()
+const mockToastMessage = vi.fn()
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
@@ -80,7 +81,7 @@ vi.mock('@/store', () => ({
 const mockToastError = vi.fn()
 
 vi.mock('sonner', () => ({
-  toast: { message: vi.fn(), error: mockToastError }
+  toast: { message: mockToastMessage, error: mockToastError }
 }))
 
 vi.mock('@/components/tab-bar/reconcile-order', () => ({
@@ -545,7 +546,7 @@ describe('launchAgentInNewTab', () => {
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
     const prompt = 'x'.repeat(25_000)
 
-    launchAgentInNewTab({
+    const result = launchAgentInNewTab({
       agent: 'claude',
       worktreeId: 'wt-1',
       prompt,
@@ -553,6 +554,7 @@ describe('launchAgentInNewTab', () => {
       launchPlatform: 'win32'
     })
 
+    expect(result).not.toHaveProperty('promptDeliveryResult')
     expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
       'tab-1',
       expect.objectContaining({
@@ -570,16 +572,46 @@ describe('launchAgentInNewTab', () => {
     )
   })
 
+  it('logs rejected non-deferred prompt delivery without exposing it to callers', async () => {
+    const error = new Error('paste failed')
+    const originalConsole = console
+    const consoleError = vi.fn()
+    vi.stubGlobal('console', { ...originalConsole, error: consoleError })
+    mockPasteDraftWhenAgentReady.mockRejectedValue(error)
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+    const prompt = 'x'.repeat(25_000)
+
+    try {
+      const result = launchAgentInNewTab({
+        agent: 'claude',
+        worktreeId: 'wt-1',
+        prompt,
+        promptDelivery: 'draft',
+        launchPlatform: 'win32'
+      })
+
+      expect(result).not.toHaveProperty('promptDeliveryResult')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(consoleError).toHaveBeenCalledWith('Prompt delivery failed after launch', error)
+    } finally {
+      vi.stubGlobal('console', originalConsole)
+    }
+  })
+
   it('seeds working after Command Code submit-after-ready prompt delivery', async () => {
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
-    launchAgentInNewTab({
+    const result = launchAgentInNewTab({
       agent: 'command-code',
       worktreeId: 'wt-1',
       prompt: 'large generated prompt',
       promptDelivery: 'submit-after-ready'
     })
     store.terminalLayoutsByTabId = { 'tab-1': { activeLeafId: LEAF_ID } }
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: true,
+      failureNotified: false
+    })
     await Promise.resolve()
     await Promise.resolve()
 
@@ -610,15 +642,43 @@ describe('launchAgentInNewTab', () => {
     mockPasteDraftWhenAgentReady.mockResolvedValue(false)
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
-    launchAgentInNewTab({
+    const result = launchAgentInNewTab({
       agent: 'command-code',
       worktreeId: 'wt-1',
       prompt: 'large generated prompt',
       promptDelivery: 'submit-after-ready'
     })
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: false,
+      failureNotified: false
+    })
     await Promise.resolve()
 
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
+  })
+
+  it('marks failed submit-after-ready delivery as notified after readiness timeout toast', async () => {
+    mockPasteDraftWhenAgentReady.mockImplementation(({ onTimeout }) => {
+      onTimeout?.()
+      return Promise.resolve(false)
+    })
+    store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-1' } as never] }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'command-code',
+      worktreeId: 'wt-1',
+      prompt: 'large generated prompt',
+      promptDelivery: 'submit-after-ready'
+    })
+
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: false,
+      failureNotified: true
+    })
+    expect(mockToastMessage).toHaveBeenCalledWith(
+      "Your prompt wasn't sent — paste it once the agent is ready."
+    )
   })
 
   it('queues per-launch CLI arguments without putting generated prompts in argv', async () => {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -681,6 +681,75 @@ describe('launchAgentInNewTab', () => {
     )
   })
 
+  it('marks a cancelled submit-after-ready launch notified when the user closed the tab', async () => {
+    mockPasteDraftWhenAgentReady.mockImplementation(({ onTimeout }) => {
+      onTimeout?.()
+      return Promise.resolve(false)
+    })
+    // User closed the tab before the agent became ready — it is gone from the list.
+    store.tabsByWorktree = { 'wt-1': [] }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'command-code',
+      worktreeId: 'wt-1',
+      prompt: 'large generated prompt',
+      promptDelivery: 'submit-after-ready'
+    })
+
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: false,
+      failureNotified: true
+    })
+    expect(mockToastMessage).not.toHaveBeenCalled()
+  })
+
+  it('marks a cancelled submit-after-ready launch notified when the user switched worktrees', async () => {
+    mockPasteDraftWhenAgentReady.mockImplementation(({ onTimeout }) => {
+      onTimeout?.()
+      return Promise.resolve(false)
+    })
+    store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-1' } as never] }
+    store.activeWorktreeId = 'wt-2'
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'command-code',
+      worktreeId: 'wt-1',
+      prompt: 'large generated prompt',
+      promptDelivery: 'submit-after-ready'
+    })
+
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: false,
+      failureNotified: true
+    })
+    expect(mockToastMessage).not.toHaveBeenCalled()
+  })
+
+  it('leaves a genuine launch failure unnotified so the caller surfaces it', async () => {
+    mockPasteDraftWhenAgentReady.mockImplementation(({ onTimeout }) => {
+      onTimeout?.()
+      return Promise.resolve(false)
+    })
+    // PTY never spawned: a real failure, not a user cancellation.
+    store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', ptyId: null } as never] }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'command-code',
+      worktreeId: 'wt-1',
+      prompt: 'large generated prompt',
+      promptDelivery: 'submit-after-ready'
+    })
+
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: false,
+      failureNotified: false
+    })
+    expect(mockToastMessage).not.toHaveBeenCalled()
+  })
+
   it('queues per-launch CLI arguments without putting generated prompts in argv', async () => {
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -69,6 +69,7 @@ export type LaunchAgentInNewTabResult = {
   tabId: string | null
   startupPlan: AgentStartupPlan
   pasteDraftAfterLaunch: boolean
+  promptDeliveryResult?: Promise<{ delivered: boolean; failureNotified: boolean }>
 } | null
 
 /**
@@ -153,6 +154,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   let pasteDraftAfterLaunch: string | null = null
   let submitPastedPrompt = false
   let forcePasteAfterLaunch = false
+  let promptDeliveryResult: Promise<{ delivered: boolean; failureNotified: boolean }> | undefined
 
   if (hasPrompt && promptDelivery === 'submit-after-ready') {
     // Why: generated multi-line prompts are too large to echo through a shell
@@ -300,9 +302,9 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     // the user closed the tab or switched worktrees so the toast/telemetry
     // don't fire for user-initiated cancellation (mirrors the 5s launch
     // watchdog in QuickLaunchButton).
-    const tabId = tab.id
-    void deliverLaunchPromptToAgentTab({
-      tabId,
+    let failureNotified = false
+    const deliveryPromise = deliverLaunchPromptToAgentTab({
+      tabId: tab.id,
       content: pasteDraftAfterLaunch,
       agent,
       submit: submitPastedPrompt,
@@ -310,28 +312,28 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       onTimeout: () => {
         const state = useAppStore.getState()
         const tabsForWorktree = state.tabsByWorktree[worktreeId] ?? []
-        const tab = tabsForWorktree.find((t) => t.id === tabId)
+        const currentTab = tabsForWorktree.find((t) => t.id === tab.id)
         // Why: if the PTY never spawned, QuickLaunch's 5s watchdog already
         // surfaced the launch failure. Don't double-toast for the same root
         // cause. Looking up directly in `worktreeId` (not scanning every
         // worktree) also preserves "still in this worktree" intent.
-        if (!tab) {
+        if (!currentTab) {
           return // tab closed by user
         }
-        if (tab.ptyId === null) {
+        if (currentTab.ptyId === null) {
           return // launch failed; QuickLaunch handled the user-facing toast
         }
         if (state.activeWorktreeId !== worktreeId) {
           return
         }
-        const label = submitPastedPrompt ? 'prompt' : 'notes'
         toast.message(
           translate(
             'auto.lib.launch.agent.in.new.tab.a5a1f7033f',
             "Your {{value0}} wasn't sent — paste it once the agent is ready.",
-            { value0: label }
+            { value0: submitPastedPrompt ? 'prompt' : 'notes' }
           )
         )
+        failureNotified = true
         track('agent_error', {
           error_class: 'paste_readiness_timeout',
           agent_kind: tuiAgentToAgentKind(agent)
@@ -342,11 +344,19 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
         if (agent === 'command-code' && submitPastedPrompt) {
           // Why: Command Code has no prompt-submit hook; when Orca submits a
           // generated prompt after readiness, seed working at delivery time.
-          seedCommandCodeSubmittedPromptStatus(tabId, trimmedPrompt)
+          seedCommandCodeSubmittedPromptStatus(tab.id, trimmedPrompt)
         }
         onPromptDelivered?.()
       }
+      return { delivered, failureNotified: !delivered && failureNotified }
     })
+    if (promptDelivery === 'submit-after-ready') {
+      promptDeliveryResult = deliveryPromise
+    } else {
+      void deliveryPromise.catch((error) =>
+        console.error('Prompt delivery failed after launch', error)
+      )
+    }
   } else if (hasPrompt) {
     onPromptDelivered?.()
   }
@@ -373,5 +383,10 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   order.push(tab.id)
   fresh.setTabBarOrder(worktreeId, order)
 
-  return { tabId: tab.id, startupPlan, pasteDraftAfterLaunch: pasteDraftAfterLaunch !== null }
+  return {
+    tabId: tab.id,
+    startupPlan,
+    pasteDraftAfterLaunch: pasteDraftAfterLaunch !== null,
+    ...(promptDeliveryResult ? { promptDeliveryResult } : {})
+  }
 }

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -313,17 +313,17 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
         const state = useAppStore.getState()
         const tabsForWorktree = state.tabsByWorktree[worktreeId] ?? []
         const currentTab = tabsForWorktree.find((t) => t.id === tab.id)
-        // Why: if the PTY never spawned, QuickLaunch's 5s watchdog already
-        // surfaced the launch failure. Don't double-toast for the same root
-        // cause. Looking up directly in `worktreeId` (not scanning every
-        // worktree) also preserves "still in this worktree" intent.
-        if (!currentTab) {
-          return // tab closed by user
+        if (currentTab?.ptyId === null) {
+          // Why: PTY never spawned — a genuine launch failure. Stay silent so
+          // the single notice comes from the caller (source-control dialog
+          // toast, or QuickLaunch's watchdog); leaving failureNotified false lets it fire.
+          return
         }
-        if (currentTab.ptyId === null) {
-          return // launch failed; QuickLaunch handled the user-facing toast
-        }
-        if (state.activeWorktreeId !== worktreeId) {
+        if (!currentTab || state.activeWorktreeId !== worktreeId) {
+          // Why: user-initiated cancellation (closed the tab or switched
+          // worktrees) — mark notified so the deferred source-control caller
+          // suppresses its generic "couldn't start" toast too, not just this nudge.
+          failureNotified = true
           return
         }
         toast.message(


### PR DESCRIPTION
## Summary

- Keep unresolved PR comment prompts and queued selections retryable when required agent prompt delivery fails.
- Treat `submit-after-ready` source-control launches as successful only after prompt delivery reports success, so selected comments resolve only after the agent actually receives the prompt.
- Preserve the existing immediate launch path for non-deferred launches and injected `onStart` callers.

Part of #7466 — fixes the launch-failure and slow-start delivery paths. The codex self-update prompt-swallow case (false `delivered: true` from the readiness heuristic) is tracked separately, so the issue stays open until that lands.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/launch-agent-in-new-tab.test.ts src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts src/renderer/src/components/right-sidebar/SourceControlAgentActionDialog.test.tsx src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx` - passed; covers async prompt-delivery result propagation, source-control success gating, retry dialog recovery, selected-comment persistence, and negative-space launch modes.
- `pnpm run typecheck:web` - passed; covers TypeScript integration.

## AI Review Report

The diff stays in the renderer launch boundary. It preserves macOS, Linux, Windows, SSH, remote, and local routing, and it keeps provider-neutral behavior intact because the change only waits for deferred prompt delivery before declaring success.

## Security Audit

No new subprocesses, filesystem writes, credentials, IPC channels, or dependencies. The change only gates existing success-side effects on an already-owned delivery promise.

## Notes

The intended scope is the source-control launch success boundary. The fix reuses existing dialog recovery and selected-comment persistence rather than adding a new prompt store or retry UI.

