### PR TITLE
perf(native-chat): LRU-bound the pending-send and command-marker scope caches

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -347,3 +347,42 @@ describe('applyCommandMarkerBoundaries', () => {
     ).toEqual(['new'])
   })
 })
+
+describe('scope-cache key counts stay bounded (memory-leak regression)', () => {
+  // The per-key arrays were capped at 8, but the KEY count (paneKey/agent/session,
+  // all ephemeral) was unbounded, so distinct panes/sessions accumulated forever.
+  // Both caches now LRU-bound the key count at 128 (shared helper, #7566).
+  const CAP = 128
+
+  it('appendCommandMarkerCache evicts the oldest scope key past the cap', () => {
+    clearCommandMarkerCacheForTests()
+    for (let i = 0; i < CAP + 5; i++) {
+      appendCommandMarkerCache(
+        { paneKey: 'tab:leaf', agent: 'claude', sessionId: `s${i}` },
+        '/clear'
+      )
+    }
+    // Oldest sessions evicted; the most-recent CAP survive.
+    expect(
+      readCommandMarkerCache({ paneKey: 'tab:leaf', agent: 'claude', sessionId: 's0' })
+    ).toEqual([])
+    expect(
+      readCommandMarkerCache({ paneKey: 'tab:leaf', agent: 'claude', sessionId: 's4' })
+    ).toEqual([])
+    expect(
+      readCommandMarkerCache({ paneKey: 'tab:leaf', agent: 'claude', sessionId: `s${CAP + 4}` })
+    ).toHaveLength(1)
+  })
+
+  it('writePendingSendCache evicts the oldest scope key past the cap', () => {
+    clearPendingSendCacheForTests()
+    const send = (id: string): NativeChatPendingSend => ({ id, text: id, sentAt: 1 })
+    for (let i = 0; i < CAP + 5; i++) {
+      writePendingSendCache({ paneKey: `tab-${i}:leaf`, agent: 'claude' }, [send(`m${i}`)])
+    }
+    expect(readPendingSendCache({ paneKey: 'tab-0:leaf', agent: 'claude' })).toEqual([])
+    expect(readPendingSendCache({ paneKey: `tab-${CAP + 4}:leaf`, agent: 'claude' })).toHaveLength(
+      1
+    )
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -5,6 +5,7 @@
 
 import { isTextBlock, type NativeChatMessage } from '../../../../shared/native-chat-types'
 import { stripImagePromptMarker } from './native-chat-image-transcript-markers'
+import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
 import type { NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
 
 /** An optimistic, not-yet-confirmed composer send. */
@@ -44,7 +45,10 @@ export function writePendingSendCache(
   if (next.length === 0) {
     pendingSendCache.delete(key)
   } else {
-    pendingSendCache.set(key, next)
+    // Why: the empty-drain path above clears keys on the normal confirm flow,
+    // but a pane closed with an unconfirmed send (agent crash / early close)
+    // would strand its entry forever. LRU-bound the key count too.
+    setBoundedScopeCacheEntry(pendingSendCache, key, next)
   }
   return [...next]
 }
@@ -233,7 +237,11 @@ export function appendCommandMarkerCache(
     ...(commandMarkerCache.get(key) ?? []),
     { id: `${sentAt}-${commandMarkerCounter}`, command, sentAt }
   ].slice(-COMMAND_MARKER_LIMIT)
-  commandMarkerCache.set(key, next)
+  // Why: the per-key array is capped at 8, but the KEY (paneKey\0agent\0sessionId,
+  // sessionId changes on every /clear) is ephemeral and was never evicted, so it
+  // grew one entry per (pane, session) for the renderer's whole life. LRU-bound
+  // the key count (mirrors the #7566 draft/attachment caches in this folder).
+  setBoundedScopeCacheEntry(commandMarkerCache, key, next)
   return [...next]
 }
 


### PR DESCRIPTION
## Description

Two module-level caches in `native-chat-pending.ts` capped their **per-key arrays** (8 entries) but never bounded the **number of keys** — and the keys are ephemeral, so distinct panes/sessions accumulated for the renderer's whole session:

- **`commandMarkerCache`** (`:210`) — keyed by `paneKey\0agent\0sessionId`. `sessionId` changes on every `/clear` and `paneKey` embeds an ephemeral `leafId`, so each `(pane, session)` stranded a key. The only removal was a test-only `clear()`.
- **`pendingSendCache`** (`:28`) — self-cleans on the normal empty-drain path, but a pane closed with an **unconfirmed** send (agent crash / pane closed before the transcript advances) left its non-empty entry keyed forever.

Values are tiny (≤8 small objects) so this is a slow leak, but real and unbounded — the same class as the draft/attachment caches #7566 fixed in this exact folder.

## Fix

Route both writes through the existing **`setBoundedScopeCacheEntry`** LRU helper (`native-chat-composer-scope-cache.ts`, cap 128) that #7566 already applied to the sibling caches — same pattern, same file family, just missed here. `delete`-then-`set` keeps the actively-used scope most-recent so only the oldest untouched scopes are shed.

## Evidence (red → green)

New tests append 133 distinct scopes to each cache:
- **WITHOUT the cap:** all 133 keys remain readable — the two eviction tests fail.
- **WITH the fix:** the oldest keys evict, the most-recent 128 survive. ✅

`native-chat-pending.test.ts` — 29 tests green; oxlint clean.

## ELI5

The chat view keeps little sticky notes about each pane's queued messages and slash-command feedback. It limited how many notes per pane but not how many *panes* — and every `/clear` or new session counted as a new pane, so the note pile grew forever. Now it keeps notes for only the 128 most-recent panes and quietly drops the oldest.

## Trade-offs / regression risk: none

Only the oldest **untouched** scopes are evicted; any actively-used pane stays most-recent and is never dropped. An evicted scope simply starts empty next time (these are convenience/optimistic-UI caches, not source of truth).

Made with [Orca](https://github.com/stablyai/orca) 🐋
