### PR TITLE
perf(renderer): FIFO-cap recentlyClosedAgentStatusTabIds (renderer twin of #7561)

### DIFF
--- a/src/renderer/src/store/slices/agent-status-drop-ipc.test.ts
+++ b/src/renderer/src/store/slices/agent-status-drop-ipc.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { TerminalTab } from '../../../../shared/types'
 import type { RetainedAgentEntry } from './agent-status'
+import { RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX } from './agent-status'
 import { createTestStore } from './store-test-helpers'
 
 // Why: dropAgentStatus and dismissRetainedAgentsByWorktree mirror the renderer-
@@ -118,6 +119,24 @@ describe('dropAgentStatusByTabPrefix -> IPC fan-out', () => {
       'tab-old': true,
       'tab-new': true
     })
+  })
+
+  it('FIFO-caps recentlyClosedAgentStatusTabIds so it cannot grow unbounded', () => {
+    stubWindowApi()
+    const store = createTestStore()
+    const cap = RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX
+
+    for (let i = 0; i < cap + 5; i++) {
+      store.getState().dropAgentStatusByTabPrefix(`tab-${i}`)
+    }
+
+    const closed = store.getState().recentlyClosedAgentStatusTabIds
+    expect(Object.keys(closed)).toHaveLength(cap)
+    // Oldest evicted, most-recent retained (a status event for a tab closed
+    // >cap tabs ago cannot still arrive, so suppression is unaffected).
+    expect(closed['tab-0']).toBeUndefined()
+    expect(closed['tab-4']).toBeUndefined()
+    expect(closed[`tab-${cap + 4}`]).toBe(true)
   })
 })
 

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -733,6 +733,35 @@ function getLaunchConfigForEntry(
     : undefined
 }
 
+// Why: the renderer twin of the main-process closedAgentStatusTabIds set that
+// #7561 FIFO-capped. It suppresses late hook/status events for a just-closed tab,
+// so it must outlive the tab briefly — but tabId is ephemeral and it was only
+// ever added to, growing one entry per tab-close for the renderer's whole life.
+export const RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX = 1024
+
+// delete-then-set for LRU recency, then evict the oldest keys past the cap (Record
+// key order is insertion order for non-integer string keys). A status event for a
+// tab closed >MAX tabs ago cannot still arrive, so eviction is safe.
+function boundRecentlyClosedAgentStatusTabIds(
+  existing: Record<string, true>,
+  tabId: string
+): Record<string, true> {
+  const next: Record<string, true> = {}
+  for (const key of Object.keys(existing)) {
+    if (key !== tabId) {
+      next[key] = true
+    }
+  }
+  next[tabId] = true
+  const keys = Object.keys(next)
+  if (keys.length > RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX) {
+    for (const stale of keys.slice(0, keys.length - RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX)) {
+      delete next[stale]
+    }
+  }
+  return next
+}
+
 function getLaunchConfigForStatusMetadata(
   state: AppState,
   metadata: AgentLaunchConfigStatusMetadata
@@ -1632,10 +1661,10 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             delete nextAck[k]
           }
         }
-        const nextClosedTabs: Record<string, true> = {
-          ...s.recentlyClosedAgentStatusTabIds,
-          [tabIdPrefix]: true
-        }
+        const nextClosedTabs = boundRecentlyClosedAgentStatusTabIds(
+          s.recentlyClosedAgentStatusTabIds,
+          tabIdPrefix
+        )
 
         if (
           liveKeys.length === 0 &&


### PR DESCRIPTION
## Description

`recentlyClosedAgentStatusTabIds` (agent-status store, `Record<string, true>`) suppresses late hook/status events for a just-closed terminal tab. It was **only ever added to** — one `true` entry per agent-tab close, keyed by the ephemeral `tabId`, **never deleted or capped** — so it grew for the renderer's whole session.

It's the **renderer twin** of the main-process `closedAgentStatusTabIds` set that **#7561** already FIFO-capped at 1024. Its unread/editor siblings (`recentlyClosedEditorTabsByWorktree`, `recentlyClosedBrowserTabsByWorktree`) are purged in `buildWorktreePurgeState`; this one had no eviction at all.

Tiny values, so a slow leak — but genuinely unbounded, and it grows on a very common action (closing an agent tab).

## Fix

Bound it to the **1024 most-recent** closed tabs via delete-then-set LRU with oldest-key eviction (a `Record`'s key order is insertion order for non-integer string keys), mirroring #7561. A status event for a tab closed >1024 tabs ago cannot still arrive, so **suppression behavior is unchanged**.

## Evidence (red → green)

New test closes 1029 tabs:
- **WITHOUT the cap:** all 1029 markers persist — test fails.
- **WITH the fix:** exactly 1024 markers remain, oldest evicted, most-recent retained. ✅

`agent-status-drop-ipc.test.ts` (9) + `agent-status.test.ts` + purge-leak suite — 47 green; `tsgo` web + oxlint clean.

## ELI5

When you close an agent tab, Orca writes its name on a "don't listen to this tab anymore" list so a late message can't pop back up. It never crossed anything off that list, so it grew every time you closed a tab. Now it keeps only the 1024 most-recent names — plenty to catch any late message, and it can't grow forever.

## Trade-offs / regression risk: none

The suppression only needs to outlive the tab briefly (to swallow trailing in-flight status IPC). 1024 closed tabs of headroom is far beyond any race window, and evicting an ancient entry cannot un-suppress a real event because no event for a long-closed tab can still arrive.

## Context

Part of a final leak-audit sweep. Sibling small-leak PRs this pass: #7643 (native-chat scope caches).

Made with [Orca](https://github.com/stablyai/orca) 🐋
