### PR TITLE
perf(mobile): cap the scheduled-notification map (unbounded for remote users)

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -102,6 +102,14 @@ export default function RootLayout() {
         return
       }
       handledNotificationIdsRef.current.add(notificationId)
+      // Why: RootLayout never unmounts, so cap this tap-dedup set (FIFO) rather
+      // than letting it grow one id per notification tapped for the app's life.
+      if (handledNotificationIdsRef.current.size > 256) {
+        const oldest = handledNotificationIdsRef.current.values().next().value
+        if (oldest !== undefined) {
+          handledNotificationIdsRef.current.delete(oldest)
+        }
+      }
 
       const path = await getNavigationPath(response.notification.request.content.data)
       clearLastNotificationResponse()

--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Notifications from 'expo-notifications'
-import { subscribeToDesktopNotifications } from './mobile-notifications'
+import {
+  setScheduledNotificationsMaxForTests,
+  subscribeToDesktopNotifications
+} from './mobile-notifications'
 import type { RpcClient } from '../transport/rpc-client'
 import { loadPushNotificationsEnabled } from '../storage/preferences'
 
@@ -267,5 +270,49 @@ describe('subscribeToDesktopNotifications', () => {
     await flushAsync()
 
     expect(Notifications.dismissNotificationAsync).not.toHaveBeenCalled()
+  })
+
+  // Why: notificationId is unique per completion, so the map grew unbounded when
+  // the desktop never sent a dismiss (the remote-mobile case). It is now capped.
+  it('evicts the oldest scheduled entry once the cap is exceeded', async () => {
+    setScheduledNotificationsMaxForTests(1)
+    try {
+      vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+      vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+        status: 'granted',
+        canAskAgain: true
+      } as never)
+      vi.mocked(Notifications.scheduleNotificationAsync)
+        .mockResolvedValueOnce('scheduled-old')
+        .mockResolvedValueOnce('scheduled-new')
+      vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+      let onEvent: ((data: unknown) => void) | null = null
+      const client = {
+        subscribe: vi.fn((_method, _params, callback: (data: unknown) => void) => {
+          onEvent = callback
+          return vi.fn()
+        }),
+        getState: vi.fn(() => 'connected'),
+        sendRequest: vi.fn()
+      } as unknown as RpcClient
+
+      subscribeToDesktopNotifications(client, 'host-1')
+      onEvent?.({ type: 'notification', title: 't', body: 'b', notificationId: 'agent:old' })
+      await flushAsync()
+      onEvent?.({ type: 'notification', title: 't', body: 'b', notificationId: 'agent:new' })
+      await flushAsync()
+
+      // The older entry was evicted by the cap: dismissing it is a no-op...
+      onEvent?.({ type: 'dismiss', notificationId: 'agent:old' })
+      await flushAsync()
+      expect(Notifications.dismissNotificationAsync).not.toHaveBeenCalledWith('scheduled-old')
+
+      // ...while the most-recent entry is retained and still dismissable.
+      onEvent?.({ type: 'dismiss', notificationId: 'agent:new' })
+      await flushAsync()
+      expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('scheduled-new')
+    } finally {
+      setScheduledNotificationsMaxForTests()
+    }
   })
 })

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -31,8 +31,40 @@ type ScheduledNotificationState = {
 
 const scheduledNotificationsByHostAndNotificationId = new Map<string, ScheduledNotificationState>()
 
+// Why: notificationId embeds a per-completion timestamp (buildAgentNotificationId),
+// so every agent-task-complete inserts a new, never-reused key. Entries are only
+// removed when the desktop sends a matching dismiss — which a remote mobile user
+// (not at the desktop) frequently never gets — so the map grew for the app's whole
+// life. Bound it; a settled entry only retains a small identifier used for later
+// programmatic dismissal, unnecessary for long-past completions.
+const MAX_SCHEDULED_NOTIFICATIONS = 256
+let maxScheduledNotifications = MAX_SCHEDULED_NOTIFICATIONS
+
 function getStoredNotificationKey(hostId: string, notificationId: string): string {
   return `${encodeURIComponent(hostId)}:${encodeURIComponent(notificationId)}`
+}
+
+// Evict the oldest SETTLED entries (never one mid-schedule) until within the cap.
+// Map iteration is insertion order, so the first match is the oldest.
+function boundScheduledNotifications(): void {
+  while (scheduledNotificationsByHostAndNotificationId.size > maxScheduledNotifications) {
+    let evicted = false
+    for (const [key, state] of scheduledNotificationsByHostAndNotificationId) {
+      if (!state.pending) {
+        scheduledNotificationsByHostAndNotificationId.delete(key)
+        evicted = true
+        break
+      }
+    }
+    if (!evicted) {
+      break
+    }
+  }
+}
+
+/** Test-only: override the cap (pass no arg to restore the default). */
+export function setScheduledNotificationsMaxForTests(max?: number): void {
+  maxScheduledNotifications = max ?? MAX_SCHEDULED_NOTIFICATIONS
 }
 
 export type NotificationPermissionState = {
@@ -155,6 +187,7 @@ async function showLocalNotification(event: NotificationEvent, hostId: string): 
       return
     }
     notificationState.identifier = scheduledIdentifier
+    boundScheduledNotifications()
   } finally {
     if (notificationState.pending === pending) {
       notificationState.pending = undefined


### PR DESCRIPTION
## Description

`scheduledNotificationsByHostAndNotificationId` (`mobile/src/notifications/mobile-notifications.ts`) is a module-level `Map` that retains one entry per scheduled desktop notification. Its key embeds `notificationId`, which carries a **per-completion timestamp** (`buildAgentNotificationId` → `agent:<worktreeId>:<paneKey>:<stateStartedAt>`), so **every `agent-task-complete` inserts a new, never-reused key**.

Entries are removed only when the desktop sends a matching `dismiss` — which a **remote mobile user (not sitting at the desktop) frequently never receives** — so the map grew for the app's whole lifetime. Small per entry (~tens of bytes), but genuinely unbounded (≈10k notifications ≈ 1 MB, plus every unpaired-host entry).

The desktop sibling (`recentNotifications`) already prunes; mobile had no cap or TTL.

## Fix

- Bound the map to the **256 most-recent settled entries** (never evict one that is mid-schedule / `pending`). A settled entry only retains a small `identifier` used for later programmatic dismissal, unnecessary for long-past completions — so eviction has no user-visible effect.
- Also FIFO-cap `RootLayout`'s `handledNotificationIdsRef` tap-dedup `Set` (`_layout.tsx`) — `RootLayout` never unmounts, so it otherwise grew one id per **tapped** notification for the app's life.

## Evidence (red → green)

New test (cap overridden to 1): scheduling a second notification evicts the first, so a later `dismiss` for the evicted id is a **no-op** (`dismissNotificationAsync` not called with its identifier) while the retained one still dismisses. Without the cap the old entry survives → test fails.

`mobile-notifications.test.ts` — 7 tests green; `oxlint` clean. (Compiled + executed under the mobile vitest transform.)

## ELI5

The phone app kept a slip of paper for every "task done" buzz from your computer so it could later cancel that buzz. But each buzz has a unique id, and the cancel slip only gets thrown away if the computer tells the phone to — which usually never happens when you're away from your desk. So the pile of slips grew forever. Now it keeps only the 256 newest slips.

## Trade-offs / regression risk: none in practice

Evicting a settled entry only means Orca can no longer *programmatically* dismiss that specific (long-past) OS notification later — the notification itself is unaffected, and 256 recent notifications is far more than any realistic in-flight dismiss window. Mid-schedule entries are never evicted.

## Context

Part of a final leak-audit sweep. The mobile app was otherwise verified clean (RPC maps, terminal/browser streaming buffers, caches, listeners/timers all bounded with teardown). Sibling small-leak PRs this pass: #7643, #7645.

Made with [Orca](https://github.com/stablyai/orca) 🐋
