### PR TITLE
perf(ssh): bound the system-ssh port-forward stderr tail

### DIFF
--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -267,6 +267,27 @@ describe('SshPortForwardManager', () => {
     )
   })
 
+  it('keeps only a bounded tail of a chatty forward stderr (memory-leak regression)', async () => {
+    const onForwardClosed = vi.fn()
+    manager.setCallbacks({ onForwardClosed })
+    const forward = createFakeSystemSshForward()
+    startSystemSshPortForwardProcessMock.mockReturnValue(forward)
+    const conn = createSystemSshConn()
+
+    await manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    // A long-lived forward against a chatty remote sshd: emit >64 KB of stderr.
+    forward.process.stderr.emit('data', Buffer.from(`HEAD_MARKER${'x'.repeat(70 * 1024)}`))
+    forward.process.stderr.emit('data', Buffer.from('TAIL_MARKER'))
+    forward.process.emit('exit', 255)
+
+    const detail = onForwardClosed.mock.calls[0]?.[1]?.detail as string
+    // The oldest bytes are trimmed; the most-recent tail is retained.
+    expect(detail).toContain('TAIL_MARKER')
+    expect(detail).not.toContain('HEAD_MARKER')
+    // Bounded well below the ~70 KB produced.
+    expect(detail.length).toBeLessThan(66 * 1024)
+  })
+
   it('lists forwards filtered by connectionId', async () => {
     const conn = createMockConn()
     await manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)

--- a/src/main/ssh/system-ssh-port-forward-provider.ts
+++ b/src/main/ssh/system-ssh-port-forward-provider.ts
@@ -33,9 +33,17 @@ export class SystemSshPortForwardProvider implements SshPortForwardProvider {
         )
 
     await forward.waitForStartup()
+    // Why: this stderr stays attached for the forward's whole lifetime but is
+    // only used to build the exit-error detail, so keep a bounded tail — a chatty
+    // remote sshd could otherwise grow it unbounded on a long-lived forward
+    // (mirrors MAX_RELAY_STARTUP_BUFFER_BYTES in ssh-relay-deploy-helpers).
+    const MAX_STDERR_TAIL_BYTES = 64 * 1024
     let stderr = ''
     const onStderr = (chunk: Buffer): void => {
       stderr += chunk.toString('utf-8')
+      if (stderr.length > MAX_STDERR_TAIL_BYTES) {
+        stderr = stderr.slice(-MAX_STDERR_TAIL_BYTES)
+      }
     }
     forward.process.stderr?.on('data', onStderr)
 


### PR DESCRIPTION
## Description

The stderr handler in `system-ssh-port-forward-provider.ts` stays attached for the forward process's **entire lifetime** and appends every chunk to an unbounded string (`stderr += chunk.toString()`), which is only ever read once — to build the exit-error detail on an unexpected exit. A chatty or warning-spamming remote sshd over a long-lived `ssh -N -L` forward could grow it without bound. Low frequency in practice (a healthy forward is near-silent), but genuinely unbounded.

## Fix

Keep only the most-recent **64 KB tail**, mirroring `MAX_RELAY_STARTUP_BUFFER_BYTES` in `ssh-relay-deploy-helpers.ts` (which caps the same way for the same reason). The tail is what the error message surfaces anyway.

## Evidence (red → green)

New test emits >64 KB of stderr then exits:
- **WITHOUT the cap:** the whole string is retained — the bound assertion fails.
- **WITH the fix:** the recent `TAIL_MARKER` is kept, the leading `HEAD_MARKER` is dropped, and the detail stays below the produced size. ✅

`ssh-port-forward.test.ts` — 20 tests green; oxlint + tsgo node clean.

## ELI5

When Orca opens an SSH tunnel, it keeps a log of anything the remote server complains about, so it can explain a crash. It never trimmed that log, so a noisy server could make it grow forever. Now it keeps only the last 64 KB — enough to explain a failure, no more.

## Trade-offs / regression risk: none

The error detail already only needs the recent tail; trimming older bytes doesn't change any surfaced message in practice.

## Context

Final finding of a leak-audit sweep. Sibling small-leak PRs this pass: #7643, #7645, #7646.

Made with [Orca](https://github.com/stablyai/orca) 🐋
