### PR TITLE
fix(relay): expand Windows ~\ paths in session.resolveHome

### DIFF
--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -9,8 +9,7 @@
 // reconnects via `relay.js --connect`, bridging the new SSH channel's stdio to the existing relay's socket.
 
 import { createServer, createConnection, type Socket, type Server } from 'node:net'
-import { homedir } from 'node:os'
-import { resolve, join } from 'node:path'
+import { join } from 'node:path'
 import { unlinkSync, existsSync, statSync } from 'node:fs'
 import {
   RELAY_SENTINEL,
@@ -23,7 +22,7 @@ import {
 } from './protocol'
 import { readLaunchVersion, runConnectHandshake, setupDaemonHandshake } from './relay-handshake'
 import { RelayDispatcher } from './dispatcher'
-import { RelayContext } from './context'
+import { RelayContext, expandTilde } from './context'
 import { PtyHandler } from './pty-handler'
 import { FsHandler } from './fs-handler'
 import { installRelayLogRotation } from './rotating-log-writer'
@@ -402,13 +401,10 @@ async function main(): Promise<void> {
   // Why: `~` is a shell expansion Node's fs APIs don't understand; resolve it to an absolute path on the remote host before persisting.
   dispatcher.onRequest('session.resolveHome', async (params) => {
     const inputPath = params.path as string
-    if (inputPath === '~' || inputPath === '~/') {
-      return { resolvedPath: homedir() }
-    }
-    if (inputPath.startsWith('~/')) {
-      return { resolvedPath: resolve(homedir(), inputPath.slice(2)) }
-    }
-    return { resolvedPath: inputPath }
+    // Use the shared expander so Windows `~\…` paths resolve too — a remote
+    // relay host can be Windows, where a literal `~\` would otherwise fall
+    // through unexpanded and break every downstream fs op.
+    return { resolvedPath: expandTilde(inputPath) }
   })
 
   const ptyHandler = new PtyHandler(dispatcher, graceTimeMs)


### PR DESCRIPTION
## Summary

Fixes Windows relay hosts returning `~\…` home paths unexpanded, which broke every downstream filesystem operation on the resolved path.

## ELI5

On Windows, "home folder" is written with a backslash (`~\`). The relay didn't understand that shorthand, so it handed back a literal `~` and files couldn't be found. Now it translates the shorthand correctly.

## Root cause & fix

The relay's `session.resolveHome` handler had its own inline tilde expansion that only matched `~`, `~/`, and `~/…` — POSIX-only forms. A Windows relay host sending `~\` or `~\…` fell through unexpanded and was returned verbatim. The fix routes the handler through the shared `expandTilde()` in `src/relay/context.ts`, which preserves the existing POSIX cases and additionally maps `~\` → `homedir()` and `~\…` → `${homedir()}\<rest>`. Now-unused `homedir` and `resolve` imports are dropped from `relay.ts` (`resolve()` at the call site was the Promise resolver, not `path.resolve`, so removal is safe).

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Verified by code inspection: old-vs-new behavior is identical for all existing POSIX cases; only the previously-unhandled Windows `~\…` branch changes.
- Lint clean:

```
$ npx oxlint src/relay/relay.ts
EXIT=0 (clean)
```

- Rebased cleanly onto `origin/main`.
- No dedicated unit test was added in this change; the Windows expansion path is exercised by the shared `expandTilde` helper the handler now delegates to.

## Trade-offs

None — pure fix.

## Regression risk

Near-zero. Existing `~`, `~/`, and `~/…` inputs resolve byte-identically through `expandTilde()`; only the formerly-broken `~\…` branch gains new behavior. The removed imports are provably unused, and the `resolve()` at line 727 is the Promise resolver, not `path.resolve`.

---

*Credit to original author @xianjianlf2. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
