### PR TITLE
Fix GitHub PR runtime routing

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -187,6 +187,7 @@ import PullRequestPage from '@/components/PullRequestPage'
 import GitLabItemDialog from '@/components/GitLabItemDialog'
 import ProjectViewWrapper from '@/components/github-project/ProjectViewWrapper'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { resolveGitHubSourceSettings } from '@/lib/github-source-runtime-context'
 import {
   buildExecutionHostRegistry,
   type ExecutionHostRegistryEntry
@@ -225,7 +226,6 @@ import { projectHostSetupProjectionFromRepos } from '../../../shared/project-hos
 import { TASK_SOURCE_CONTEXT_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import {
   getTaskSourceCacheScope,
-  getTaskSourceRuntimeSettings,
   normalizeTaskSourceContext,
   type TaskSourceContext
 } from '../../../shared/task-source-context'
@@ -1042,13 +1042,7 @@ function GHStatusCell({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, repo?.id ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const parsedIssueLink = useMemo(() => parseGitHubIssueOrPRLink(item.url), [item.url])
@@ -1678,13 +1672,7 @@ function GHAssigneesCell({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, repo?.id ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const [open, setOpen] = useState(false)
@@ -2008,13 +1996,7 @@ function PRReviewCell({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, repo?.id ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const reviewerInputRef = useRef<HTMLInputElement | null>(null)
@@ -2655,13 +2637,7 @@ function PRMergeCell({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, repo?.id ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   if (item.type !== 'pr') {
@@ -4157,13 +4133,7 @@ export default function TaskPage(): React.JSX.Element {
       { repos: [newIssueTargetRepo], settings },
       newIssueTargetRepo.id
     )
-    const targetSettings =
-      newIssueSourceContext?.provider === 'github'
-        ? {
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(newIssueSourceContext)
-          }
-        : repoOwnerSettings
+    const targetSettings = resolveGitHubSourceSettings(repoOwnerSettings, newIssueSourceContext)
     const target = getActiveRuntimeTarget(targetSettings)
     if (target.kind !== 'environment') {
       return null

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -41,7 +41,7 @@ describe('GitHubItemDialog source host boundaries', () => {
     )
     const section = source
 
-    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(section).toContain('useRepoAssigneesBySlug(')
     expect(section).toContain('sourceSettings')
     expect(section).toContain('useRepoAssignees(')
@@ -66,7 +66,7 @@ describe('GitHubItemDialog source host boundaries', () => {
     const section = source
     const helperSection = componentSource('github/github-work-item-edit-mutations.ts')
 
-    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(section).toContain('useRepoLabels(')
     expect(section).toContain('useRepoLabelsBySlug(')
     expect(section).toContain('projectOrigin?.host')

--- a/src/renderer/src/components/github-item-dialog/edit-item-fields/gh-edit-section.tsx
+++ b/src/renderer/src/components/github-item-dialog/edit-item-fields/gh-edit-section.tsx
@@ -3,12 +3,10 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { useRepoLabels, useRepoAssignees, useImmediateMutation } from '@/hooks/useIssueMetadata'
 import { useRepoLabelsBySlug, useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
-import {
-  getTaskSourceRuntimeSettings,
-  type TaskSourceContext
-} from '../../../../../shared/task-source-context'
+import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { resolveGitHubSourceSettings } from '@/lib/github-source-runtime-context'
 import {
   getTaskPageGitHubDuplicateCandidates,
   getTaskPageGitHubDuplicateTargetErrorMessage,
@@ -96,16 +94,10 @@ export function GHEditSection({
     })
   )
   const repoOwnerSettings = useAppStore(
-    useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
+    useShallow((s) => getSettingsForRepoRuntimeOwner(s, repoId ?? item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()

--- a/src/renderer/src/components/github-item-dialog/land-pull-request/pr-reviewers-panel.tsx
+++ b/src/renderer/src/components/github-item-dialog/land-pull-request/pr-reviewers-panel.tsx
@@ -12,12 +12,12 @@ import {
   filterGitHubPRReviewerCandidates,
   getGitHubPRReviewerQueryState
 } from '@/components/github/github-pr-reviewer-candidate-filter'
-import { getTaskSourceRuntimeSettings } from '../../../../../shared/task-source-context'
 import type { GitHubAssignableUser } from '../../../../../shared/github/pull-request-types'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { resolveGitHubSourceSettings } from '@/lib/github-source-runtime-context'
 import { resolvePullRequestRepo } from '@/components/github/github-work-item-identity'
 import { mergeReviewerSuggestions } from '@/components/github/work-item-state-presentation'
 import type { GitHubItemDialogProjectOrigin } from '../load-item-details/github-item-dialog-types'
@@ -60,13 +60,7 @@ export function PRReviewersPanel({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const reviewerInputRef = useRef<HTMLInputElement | null>(null)

--- a/src/renderer/src/components/github/PRAssigneesPanel.tsx
+++ b/src/renderer/src/components/github/PRAssigneesPanel.tsx
@@ -15,12 +15,10 @@ import {
 } from '@/components/github/github-work-item-identity'
 import { runIssueUpdate } from '@/components/github/github-work-item-edit-mutations'
 import { ReviewerAvatar } from '@/components/github/work-item-state-presentation'
-import {
-  getTaskSourceRuntimeSettings,
-  type TaskSourceContext
-} from '../../../../shared/task-source-context'
+import type { TaskSourceContext } from '../../../../shared/task-source-context'
 import type { GitHubAssignableUser } from '../../../../shared/github/pull-request-types'
 import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
+import { resolveGitHubSourceSettings } from '@/lib/github-source-runtime-context'
 
 export function PRAssigneesPanel({
   item,
@@ -50,13 +48,7 @@ export function PRAssigneesPanel({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()

--- a/src/renderer/src/components/pull-request-page-host-boundary.test.ts
+++ b/src/renderer/src/components/pull-request-page-host-boundary.test.ts
@@ -76,7 +76,7 @@ describe('PullRequestPage host boundaries', () => {
   it('routes reviewer metadata and mutations through the PR repo owner host', () => {
     const section = reviewersSource
 
-    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(section).toContain('useRepoAssigneesBySlug(')
     expect(section).toContain('sourceSettings')
     expect(section).toContain('useRepoAssignees(')
@@ -101,7 +101,7 @@ describe('PullRequestPage host boundaries', () => {
     const section = editSource
 
     expect(section).toContain('getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null)')
-    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(section).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(section).toContain('useRepoLabels(')
     expect(section).toContain('useRepoLabelsBySlug(')
     expect(section).toContain('projectOrigin?.host')
@@ -321,7 +321,7 @@ describe('PullRequestPage host boundaries', () => {
       "repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? '')"
     )
     expect(editHelperSection).toContain('{ local: false }')
-    expect(editSource).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(editSource).toContain('resolveGitHubSourceSettings(repoOwnerSettings, sourceContext)')
     expect(editSource).toContain('sourceContext,')
   })
 

--- a/src/renderer/src/components/pull-request-page/conversation/tab.tsx
+++ b/src/renderer/src/components/pull-request-page/conversation/tab.tsx
@@ -5,7 +5,10 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { useRepoAssignees } from '@/hooks/useIssueMetadata'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
-import { canUseGitHubRepoContext } from '@/lib/github-source-runtime-context'
+import {
+  canUseGitHubRepoContext,
+  resolveGitHubSourceSettings
+} from '@/lib/github-source-runtime-context'
 import { usePRBotAuthorOverrides } from '@/lib/pr-bot-author-overrides'
 import {
   filterPRCommentsByAudience,
@@ -23,7 +26,6 @@ import {
   resolveGitHubBodyDraft,
   shouldSyncGitHubBodyDraft
 } from '@/components/github-body-draft-state'
-import { getTaskSourceRuntimeSettings } from '../../../../../shared/task-source-context'
 import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 import type {
   GitHubAssignableUser,
@@ -106,13 +108,7 @@ export function ConversationTab({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const repoAssignees = useRepoAssignees(repoPath, item.repoId, sourceSettings)

--- a/src/renderer/src/components/pull-request-page/edit/section.tsx
+++ b/src/renderer/src/components/pull-request-page/edit/section.tsx
@@ -7,10 +7,10 @@ import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { useImmediateMutation, useRepoAssignees, useRepoLabels } from '@/hooks/useIssueMetadata'
 import { useRepoAssigneesBySlug, useRepoLabelsBySlug } from '@/hooks/useGitHubSlugMetadata'
-import { getTaskSourceRuntimeSettings } from '../../../../../shared/task-source-context'
 import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { resolveGitHubSourceSettings } from '@/lib/github-source-runtime-context'
 import { getStateLabel } from '@/components/github/work-item-state-presentation'
 import { translate } from '@/i18n/i18n'
 import type { PullRequestPageProjectOrigin } from '../page-types'
@@ -56,13 +56,7 @@ export function GHEditSection({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()

--- a/src/renderer/src/components/pull-request-page/reviewers/panel.tsx
+++ b/src/renderer/src/components/pull-request-page/reviewers/panel.tsx
@@ -3,12 +3,12 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { useRepoAssignees } from '@/hooks/useIssueMetadata'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
-import { getTaskSourceRuntimeSettings } from '../../../../../shared/task-source-context'
 import type { TaskSourceContext } from '../../../../../shared/task-source-context'
 import type { GitHubAssignableUser } from '../../../../../shared/github/pull-request-types'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { resolveGitHubSourceSettings } from '@/lib/github-source-runtime-context'
 import { resolvePullRequestRepo } from '@/components/github/github-work-item-identity'
 import { getGitHubPRReviewerRows } from '@/components/github-pr-reviewer-display'
 import { mergeReviewerSuggestions } from '@/components/github/work-item-state-presentation'
@@ -57,13 +57,7 @@ export function PRReviewersPanel({
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )
   const sourceSettings = useMemo(
-    () =>
-      sourceContext?.provider === 'github'
-        ? ({
-            ...repoOwnerSettings,
-            ...getTaskSourceRuntimeSettings(sourceContext)
-          } as typeof repoOwnerSettings)
-        : repoOwnerSettings,
+    () => resolveGitHubSourceSettings(repoOwnerSettings, sourceContext),
     [repoOwnerSettings, sourceContext]
   )
   const submittingRef = useRef(false)

--- a/src/renderer/src/components/task-page-source-switch-boundary.test.ts
+++ b/src/renderer/src/components/task-page-source-switch-boundary.test.ts
@@ -74,6 +74,25 @@ describe('TaskPage source switching host boundary', () => {
     expect(TASK_PAGE_SOURCE).toContain('runtimePreflightStatusByHostId')
   })
 
+  it('resolves GitHub task actions without letting local source context erase repo ownership', () => {
+    const sections = [
+      sourceBetween(TASK_PAGE_SOURCE, 'function GHStatusCell', 'function GitHubAssigneeAvatar'),
+      sourceBetween(TASK_PAGE_SOURCE, 'function GHAssigneesCell', 'const triggerContent ='),
+      sourceBetween(TASK_PAGE_SOURCE, 'function PRReviewCell', 'function PRChecksCell'),
+      sourceBetween(TASK_PAGE_SOURCE, 'function PRMergeCell', 'const handleAutoMerge'),
+      sourceBetween(
+        TASK_PAGE_SOURCE,
+        'const newIssueRuntimeTarget = useMemo',
+        'const newIssueRepoLabels'
+      )
+    ]
+
+    for (const section of sections) {
+      expect(section).toContain('resolveGitHubSourceSettings(')
+      expect(section).not.toContain('...getTaskSourceRuntimeSettings(')
+    }
+  })
+
   it('preserves exact GitLab project identity when opening or starting from an item', () => {
     const sourceContextBuilder = sourceBetween(
       TASK_PAGE_SOURCE,

--- a/src/renderer/src/lib/github-source-runtime-context.test.ts
+++ b/src/renderer/src/lib/github-source-runtime-context.test.ts
@@ -62,12 +62,31 @@ describe('GitHub source runtime context', () => {
       activeRuntimeEnvironmentId: 'repo-owner-env'
     }
 
+    const resolved = resolveGitHubSourceSettings(repoOwnerSettings, {
+      ...runtimeSourceContext,
+      hostId: 'local'
+    })
+
+    expect(resolved).toBe(repoOwnerSettings)
+  })
+
+  it('keeps the repo owner runtime for SSH and non-GitHub sources', () => {
+    const repoOwnerSettings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> = {
+      activeRuntimeEnvironmentId: 'repo-owner-env'
+    }
+
     expect(
       resolveGitHubSourceSettings(repoOwnerSettings, {
         ...runtimeSourceContext,
-        hostId: 'local'
+        hostId: 'ssh:connection-1'
       })
-    ).toEqual({ activeRuntimeEnvironmentId: 'repo-owner-env' })
+    ).toBe(repoOwnerSettings)
+    expect(
+      resolveGitHubSourceSettings(repoOwnerSettings, {
+        ...runtimeSourceContext,
+        provider: 'gitlab'
+      })
+    ).toBe(repoOwnerSettings)
   })
 
   it('uses the GitHub source runtime when it is remote', () => {

--- a/src/renderer/src/lib/github-source-runtime-context.test.ts
+++ b/src/renderer/src/lib/github-source-runtime-context.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
+import type { GlobalSettings } from '../../../shared/types'
 import { getActiveRuntimeTarget } from '../runtime/runtime-rpc-client'
 import {
   canUseGitHubRepoContext,
   getGitHubMutationRoutingSettings,
   getGitHubRuntimeRepoId,
   getGitHubSourceRuntimeHost,
-  getGitHubSourceRuntimeTarget
+  getGitHubSourceRuntimeTarget,
+  resolveGitHubSourceSettings
 } from './github-source-runtime-context'
 import type { RepoRuntimeOwnerState } from './repo-runtime-owner'
 
@@ -53,6 +55,29 @@ describe('GitHub source runtime context', () => {
     expect(
       getGitHubRuntimeRepoId({ ...runtimeSourceContext, provider: 'gitlab' }, 'fallback')
     ).toBe('fallback')
+  })
+
+  it('keeps the repo owner runtime when the GitHub source is local', () => {
+    const repoOwnerSettings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> = {
+      activeRuntimeEnvironmentId: 'repo-owner-env'
+    }
+
+    expect(
+      resolveGitHubSourceSettings(repoOwnerSettings, {
+        ...runtimeSourceContext,
+        hostId: 'local'
+      })
+    ).toEqual({ activeRuntimeEnvironmentId: 'repo-owner-env' })
+  })
+
+  it('uses the GitHub source runtime when it is remote', () => {
+    const repoOwnerSettings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> = {
+      activeRuntimeEnvironmentId: 'repo-owner-env'
+    }
+
+    expect(resolveGitHubSourceSettings(repoOwnerSettings, runtimeSourceContext)).toEqual({
+      activeRuntimeEnvironmentId: 'env-1'
+    })
   })
 })
 

--- a/src/renderer/src/lib/github-source-runtime-context.test.ts
+++ b/src/renderer/src/lib/github-source-runtime-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
-import type { GlobalSettings } from '../../../shared/types'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
 import { getActiveRuntimeTarget } from '../runtime/runtime-rpc-client'
 import {
   canUseGitHubRepoContext,

--- a/src/renderer/src/lib/github-source-runtime-context.ts
+++ b/src/renderer/src/lib/github-source-runtime-context.ts
@@ -39,22 +39,20 @@ export function getGitHubMutationRoutingSettings(
   repoId: string | null | undefined,
   sourceContext: TaskSourceContext | null | undefined
 ): Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> {
-  const sourceHost = getGitHubSourceRuntimeHost(sourceContext)
-  return {
-    activeRuntimeEnvironmentId:
-      sourceHost?.environmentId ?? getExplicitRuntimeOwnerEnvironmentId(state, repoId)
-  }
+  return resolveGitHubSourceSettings(
+    { activeRuntimeEnvironmentId: getExplicitRuntimeOwnerEnvironmentId(state, repoId) },
+    sourceContext
+  )
 }
 
+// Why: a local source context must not erase the runtime that owns the repo;
+// only an explicit GitHub runtime source may override repo-owner routing.
 export function resolveGitHubSourceSettings<
   T extends Pick<GlobalSettings, 'activeRuntimeEnvironmentId'>
 >(repoOwnerSettings: T, sourceContext: TaskSourceContext | null | undefined): T {
-  if (sourceContext?.provider !== 'github') {
-    return repoOwnerSettings
-  }
-  const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)
-  return sourceRuntimeSettings.activeRuntimeEnvironmentId
-    ? ({ ...repoOwnerSettings, ...sourceRuntimeSettings } as T)
+  const sourceHost = getGitHubSourceRuntimeHost(sourceContext)
+  return sourceHost
+    ? { ...repoOwnerSettings, activeRuntimeEnvironmentId: sourceHost.environmentId }
     : repoOwnerSettings
 }
 

--- a/src/renderer/src/lib/github-source-runtime-context.ts
+++ b/src/renderer/src/lib/github-source-runtime-context.ts
@@ -46,6 +46,18 @@ export function getGitHubMutationRoutingSettings(
   }
 }
 
+export function resolveGitHubSourceSettings<
+  T extends Pick<GlobalSettings, 'activeRuntimeEnvironmentId'>
+>(repoOwnerSettings: T, sourceContext: TaskSourceContext | null | undefined): T {
+  if (sourceContext?.provider !== 'github') {
+    return repoOwnerSettings
+  }
+  const sourceRuntimeSettings = getTaskSourceRuntimeSettings(sourceContext)
+  return sourceRuntimeSettings.activeRuntimeEnvironmentId
+    ? ({ ...repoOwnerSettings, ...sourceRuntimeSettings } as T)
+    : repoOwnerSettings
+}
+
 export function canUseGitHubRepoContext(
   repoPath: string | null | undefined,
   sourceContext: TaskSourceContext | null | undefined


### PR DESCRIPTION
## Summary

- add a shared GitHub source settings resolver that keeps repo-owner runtime routing unless the task source has its own runtime host
- use that resolver for PR page and GitHub item dialog assignee, reviewer, conversation/edit metadata, and merge action routing
- add regression coverage for local GitHub source context not clobbering a repo-owner runtime id

Fixes #7623.

## Testing

- `pnpm test src/renderer/src/lib/github-source-runtime-context.test.ts src/renderer/src/components/pull-request-page-host-boundary.test.ts src/renderer/src/components/github-item-dialog-source-boundary.test.ts`
- `pnpm run typecheck`
- `pnpm exec oxlint src/renderer/src/lib/github-source-runtime-context.ts src/renderer/src/lib/github-source-runtime-context.test.ts src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/github-item-dialog-source-boundary.test.ts src/renderer/src/components/pull-request-page-host-boundary.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/github-source-runtime-context.ts src/renderer/src/lib/github-source-runtime-context.test.ts src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/github-item-dialog-source-boundary.test.ts src/renderer/src/components/pull-request-page-host-boundary.test.ts`
- `pnpm run build` reached native build after desktop and web build completed; native failed under sandboxed Swift cache permissions
- `pnpm run build:native` passed with elevated permissions

Known local baseline issues:

- `pnpm run lint` fails on an unrelated switch-exhaustiveness error in `src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts`
- full `pnpm test` produced unrelated socket, daemon, browser, and localStorage failures in broad integration suites, then was interrupted after it stopped producing output

## Review notes

- Cross-platform: no platform-specific paths or shortcuts changed.
- Local, remote, SSH: local source context now preserves repo-owner runtime routing; runtime source context still overrides when it carries a runtime host.
- Providers: change is GitHub-only and does not affect GitLab, Jira, Linear, or generic source-control routing.
- Performance: small synchronous helper used in existing memoized call sites.
- Security: no credential handling, filesystem access, or network surface changed.
- UI: no visual change.

X handle: not provided.

## ELI5

GitHub PR actions sometimes used the wrong runtime host when a task source had its own host. Assignee, reviewers, and merge routing now follow the correct repo-owner runtime.
