### PR TITLE
fix(gitlab): open the New-MR page on the fork project for fork-pushed branches

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control-manual-review-url.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-review-url.test.ts
@@ -137,6 +137,26 @@ describe('buildSourceControlManualReviewUrl', () => {
     )
   })
 
+  it('opens the GitLab New-MR page on the fork project when the branch was pushed to a fork', () => {
+    expect(
+      buildSourceControlManualReviewUrl({
+        baseRef: 'refs/remotes/upstream/main',
+        branchName: 'feature/fork-head',
+        repoRemoteName: 'upstream',
+        repoRemoteUrl: 'git@gitlab.company.test:group/sub/orca.git',
+        provider: 'gitlab',
+        pushTarget: {
+          remoteName: 'fork',
+          branchName: 'feature/fork-head',
+          remoteUrl: 'git@gitlab.company.test:contributor/orca.git'
+        }
+      })
+      // On the fork project — not group/sub/orca, where source_branch would 404.
+    ).toBe(
+      'https://gitlab.company.test/contributor/orca/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Ffork-head&merge_request%5Btarget_branch%5D=main'
+    )
+  })
+
   it('builds a Bitbucket manual pull request URL', () => {
     expect(
       buildSourceControlManualReviewUrl({

--- a/src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts
@@ -169,7 +169,12 @@ export function buildSourceControlManualReviewUrl(input: ManualReviewUrlInput): 
         githubHeadRef(baseRepo, headRepo, headBranch)
       )}?expand=1`
     case 'gitlab':
-      return appendQuery(`${baseRepo.webBaseUrl}/-/merge_requests/new`, {
+      // Why: the source branch lives in the head repo, so the New-MR page must
+      // be opened on that project — a fork's branch is invisible to the base
+      // project and its /-/merge_requests/new page would 404 the source_branch.
+      // GitLab defaults the target to the fork's upstream. headRepo === baseRepo
+      // for the non-fork case, so this is a no-op there.
+      return appendQuery(`${headRepo.webBaseUrl}/-/merge_requests/new`, {
         'merge_request[source_branch]': headBranch,
         'merge_request[target_branch]': baseBranch
       })


### PR DESCRIPTION
## Summary

Fixes GitLab "Create MR in browser" landing on a broken New-MR page (404) when the branch was pushed to a fork.

## ELI5

When you asked Orca to open a merge request for a branch you pushed to your own fork, it sent you to the wrong project's page — one that couldn't see your branch. Now it opens the right page where your branch actually lives.

## Root cause & fix

`buildSourceControlManualReviewUrl` computes a `headRepo` to support forks, but the GitLab branch of the switch ignored it and always built `/-/merge_requests/new` on the **base** repo. For a fork-pushed branch, the `source_branch` only exists on the fork project, so the base project's New-MR page 404s. The fix builds the GitLab URL on `headRepo.webBaseUrl` instead of `baseRepo.webBaseUrl`, matching what the GitHub branch already does. For non-fork remotes `headRepo === baseRepo`, so it's a no-op.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test file: `src/renderer/src/components/right-sidebar/source-control-manual-review-url.test.ts`
- Pass on branch: **17 passed (17)**, 1 file passed.
- Reverting the fix to `origin/main` fails the new fork case (**1 failed | 16 passed**):

```
× opens the GitLab New-MR page on the fork project when the branch was pushed to a fork
  Expected: https://gitlab.company.test/contributor/orca/-/merge_requests/new?...
  Received: https://gitlab.company.test/group/sub/orca/-/merge_requests/new?...
```

- Rebase clean (base `7ab601487c`, head `506840bba9`).
- Lint clean: `oxlint` on the fixed file reports no findings.

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression: only the GitLab branch of the switch changes, and `headRepo === baseRepo` for non-fork remotes, so existing self-hosted/origin GitLab links are byte-identical (covered by the passing self-hosted GitLab test). No other providers (GitHub/Bitbucket) are touched.

_Credit to original author @xianjianlf2 (Mark Xian). Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
