### PR TITLE
fix(ssh): accept GitHub restricted-shell SSH probes (#6988)

### DIFF
--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -1099,6 +1099,199 @@ describe('SshConnection', () => {
     expect(conn.canRunConcurrentExecCommands()).toBe(false)
   })
 
+  it('accepts GitHub restricted-shell SSH probes with resolved user fallback', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'github.com', user: 'git' })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: undefined
+      }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+  })
+
+  it('accepts GitHub restricted-shell SSH probes with resolved host and target username', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'github.com', user: undefined })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'git'
+      }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+  })
+
+  it('accepts ssh.github.com restricted-shell SSH probes', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'ssh.github.com', user: 'git' })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'ssh.github.com',
+        host: 'ssh.github.com',
+        username: 'git'
+      }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+  })
+
+  it('accepts GitHub restricted-shell SSH probes when OpenSSH config resolution fails', async () => {
+    vi.stubEnv('ORCA_SSH_FORCE_SYSTEM_TRANSPORT', '1')
+    vi.mocked(resolveWithSshG).mockRejectedValueOnce(new Error('ssh -G failed'))
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'git'
+      }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+    expect(conn.getSystemSshResolvedConfig()).toBeNull()
+  })
+
+  it('rejects non-GitHub SSH probes with GitHub invalid-command text', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'gitlab.com', user: 'git' })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'git'
+      }),
+      createCallbacks()
+    )
+
+    await expect(conn.connect()).rejects.toThrow('System SSH probe failed (exit 1)')
+    expect(conn.usesSystemSshTransport()).toBe(false)
+  })
+
+  it('accepts GitHub restricted-shell SSH probes when target username overrides resolved user', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'github.com', user: 'deploy' })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'git'
+      }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+  })
+
+  it('rejects GitHub restricted-shell SSH probes when target username overrides resolved git user', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'github.com', user: 'git' })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'deploy'
+      }),
+      createCallbacks()
+    )
+
+    await expect(conn.connect()).rejects.toThrow('System SSH probe failed (exit 1)')
+    expect(conn.usesSystemSshTransport()).toBe(false)
+  })
+
+  it('rejects GitHub restricted-shell SSH probes with extra stderr text', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'github.com', user: 'git' })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(
+        1,
+        'remote: rejected\nInvalid command: echo ORCA-SYSTEM-SSH-OK\ntry again'
+      )
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'git'
+      }),
+      createCallbacks()
+    )
+
+    await expect(conn.connect()).rejects.toThrow('System SSH probe failed (exit 1)')
+    expect(conn.usesSystemSshTransport()).toBe(false)
+  })
+
+  it('rejects GitHub restricted-shell SSH probes for non-git users', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'github.com', user: 'deploy' })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'deploy'
+      }),
+      createCallbacks()
+    )
+
+    await expect(conn.connect()).rejects.toThrow('System SSH probe failed (exit 1)')
+    expect(conn.usesSystemSshTransport()).toBe(false)
+  })
+
   it('retries a failed system SSH probe without ControlMaster and disables mux for the session', async () => {
     getOrcaControlSocketPathMock.mockImplementation(
       (_target: SshTarget, options?: { disableControlMaster?: boolean }) =>

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -1165,6 +1165,35 @@ describe('SshConnection', () => {
     expect(conn.usesSystemSshTransport()).toBe(true)
   })
 
+  it('accepts GitHub restricted-shell SSH probes with the real git:// advisory transcript', async () => {
+    // Real 4-line stderr GitHub returns for an invalid command (issue #6988).
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'github.com', user: 'git' })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(
+        1,
+        'Invalid command: echo ORCA-SYSTEM-SSH-OK\n' +
+          '  You appear to be using ssh to clone a git:// URL.\n' +
+          '  Make sure your core.gitProxy config option and the\n' +
+          '  GIT_PROXY_COMMAND environment variable are NOT set.'
+      )
+    )
+    const conn = new SshConnection(
+      createTarget({
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'git'
+      }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+  })
+
   it('accepts GitHub restricted-shell SSH probes when OpenSSH config resolution fails', async () => {
     vi.stubEnv('ORCA_SSH_FORCE_SYSTEM_TRANSPORT', '1')
     vi.mocked(resolveWithSshG).mockRejectedValueOnce(new Error('ssh -G failed'))

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -66,6 +66,34 @@ function cloneResolvedConfig(config: SshResolvedConfig | null): SshResolvedConfi
   return { ...config, identityFile: [...config.identityFile] }
 }
 
+function isGitHubRestrictedShellProbeSuccess(
+  target: SshTarget,
+  resolvedConfig: SshResolvedConfig | null,
+  code: number | null,
+  stderr: string
+): boolean {
+  if (code !== 1) {
+    return false
+  }
+
+  const effectiveUser = (target.username?.trim() || resolvedConfig?.user?.trim())?.toLowerCase()
+  if (effectiveUser !== 'git') {
+    return false
+  }
+
+  if (stderr.trim() !== 'Invalid command: echo ORCA-SYSTEM-SSH-OK') {
+    return false
+  }
+
+  const resolvedHost = resolvedConfig?.hostname?.trim()
+  const hostCandidates = resolvedHost ? [resolvedHost] : [target.host, target.configHost]
+
+  return hostCandidates.some((host) => {
+    const normalizedHost = host?.trim().toLowerCase()
+    return normalizedHost === 'github.com' || normalizedHost === 'ssh.github.com'
+  })
+}
+
 export class SshConnection {
   private client: SshClient | null = null
   private proxyProcess: ChildProcess | null = null
@@ -847,16 +875,24 @@ export class SshConnection {
               reject(new Error('SSH connection attempt was cancelled'))
               return
             }
-            if (code !== 0 || !stdout.includes('ORCA-SYSTEM-SSH-OK')) {
-              reject(
-                new Error(
-                  `System SSH probe failed${code != null ? ` (exit ${code})` : ''}.${stderr ? ` stderr: ${stderr.trim()}` : ''}`
-                )
+            if (
+              (code === 0 && stdout.includes('ORCA-SYSTEM-SSH-OK')) ||
+              isGitHubRestrictedShellProbeSuccess(
+                this.target,
+                this.systemSshResolvedConfig,
+                code,
+                stderr
               )
+            ) {
+              this.setState('connected')
+              resolve()
               return
             }
-            this.setState('connected')
-            resolve()
+            reject(
+              new Error(
+                `System SSH probe failed${code != null ? ` (exit ${code})` : ''}.${stderr ? ` stderr: ${stderr.trim()}` : ''}`
+              )
+            )
           })
         }
         const timeout = setTimeout(() => {

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -81,7 +81,9 @@ function isGitHubRestrictedShellProbeSuccess(
     return false
   }
 
-  if (stderr.trim() !== 'Invalid command: echo ORCA-SYSTEM-SSH-OK') {
+  // GitHub appends git:// advisory lines after the invalid-command line (issue #6988), so match the first line only.
+  const firstLine = stderr.split('\n', 1)[0]?.trim()
+  if (firstLine !== 'Invalid command: echo ORCA-SYSTEM-SSH-OK') {
     return false
   }
 


### PR DESCRIPTION
# fix(ssh): accept GitHub restricted-shell SSH probes (#6988)

## Summary
Fixes system SSH probes failing against `git@github.com` / `git@ssh.github.com` when GitHub's restricted shell returns its real multi-line rejection, which blocked SSH connections for the environment reported in #6988.

## ELI5
When Orca checks that SSH to GitHub works, GitHub answers with a short rejection plus a few extra advisory lines. Orca only understood the one-line version, so it wrongly thought the check failed. Now it reads just the first line and recognizes the success.

## Root cause & fix
`isGitHubRestrictedShellProbeSuccess` compared the **entire** trimmed stderr for exact equality with `Invalid command: echo ORCA-SYSTEM-SSH-OK`. GitHub's real restricted-shell rejection is multi-line (the invalid-command line followed by `git://` advisory lines), so `trim()` left the interior lines intact, the equality was false, and `connect()` threw `System SSH probe failed (exit 1)`. The fix matches the **first** stderr line instead of the whole string (`stderr.split('\n', 1)[0]?.trim()`), while preserving the existing `exit==1`, `effectiveUser=='git'`, and `github.com`/`ssh.github.com` scoping.

## Evidence
Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test file: `src/main/ssh/ssh-connection.test.ts` — a new case feeds the real 4-line #6988 transcript (invalid-command line + 3 `git://` advisory lines) and asserts the probe is accepted (state `connected`, `usesSystemSshTransport` true).
- Full suite passes on branch; reverting the fix makes the new case fail (the predicate returns false and `connect()` throws `System SSH probe failed (exit 1)`).

```
npx vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection.test.ts
-> Test Files  1 passed (1)
   Tests       86 passed (86)
```

- Lint clean: `oxlint src/main/ssh/ssh-connection.ts src/main/ssh/ssh-connection.test.ts` reports no warnings/errors; no `max-lines` disable added. Typecheck n/a (runtime logic defect, not a type break).

## Trade-offs
None — pure fix. Still rejects the PR's `remote: rejected\n...\ntry again` case, since its first line is `remote: rejected`, and non-GitHub hosts remain unaffected.

## Regression risk
Zero-regression: the change only broadens the buggy success branch for the already-scoped GitHub restricted-shell case; all other predicate conditions (exit code, `git` user, host scoping) are byte-identical, and non-matching first lines still return false. Proven by the passing suite (86/86) and the fail-on-revert of the new #6988 case.

_Credit to @rodboev for the original fix design. Validated, rebased, and hardened via automated bug-bash review; original fix design preserved. This session's takeover added the first-line match (replacing whole-stderr equality) plus the real 4-line #6988 transcript test that the original whole-string check would not have satisfied._
