### PR TITLE
Fix offline runtime worktree refresh call fanout

### DIFF
--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   callRuntimeRpc,
   assertRuntimeEnvironmentCapability,
+  clearRecentRuntimeCompatibilityFailure,
   clearRuntimeCompatibilityCacheForTests,
   getActiveRuntimeTarget,
   RuntimeRpcCallError,
@@ -280,6 +281,92 @@ describe('runtime RPC client routing', () => {
     ).rejects.toThrow('offline')
 
     expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual(['status.get'])
+  })
+
+  it('re-probes after a status success clears a recent compatibility failure', async () => {
+    let statusCalls = 0
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      if (method === 'status.get') {
+        statusCalls += 1
+        if (statusCalls === 1) {
+          return Promise.resolve({
+            id: 'status',
+            ok: false,
+            error: { code: 'runtime_unavailable', message: 'offline' },
+            _meta: { runtimeId: 'remote-runtime' }
+          })
+        }
+        return Promise.resolve({
+          id: 'status',
+          ok: true,
+          result: {
+            runtimeId: 'remote-runtime',
+            graphStatus: 'ready',
+            runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+            minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+          },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      }
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result: { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+    const target = { kind: 'environment', environmentId: 'env-back-online' } as const
+
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, { reuseRecentCompatibilityFailure: true })
+    ).rejects.toThrow('offline')
+    clearRecentRuntimeCompatibilityFailure('env-back-online')
+    await expect(
+      callRuntimeRpc(target, 'worktree.detectedList', undefined, {
+        reuseRecentCompatibilityFailure: true
+      })
+    ).resolves.toEqual({ ok: true })
+
+    expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
+      'status.get',
+      'status.get',
+      'worktree.detectedList'
+    ])
+  })
+
+  it('keeps a proven-compatible cache entry when clearing recent failures', async () => {
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      if (method === 'status.get') {
+        return Promise.resolve({
+          id: 'status',
+          ok: true,
+          result: {
+            runtimeId: 'remote-runtime',
+            graphStatus: 'ready',
+            runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+            minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+          },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      }
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result: { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+    const target = { kind: 'environment', environmentId: 'env-still-ok' } as const
+
+    await expect(callRuntimeRpc(target, 'repo.list')).resolves.toEqual({ ok: true })
+    clearRecentRuntimeCompatibilityFailure('env-still-ok')
+    await expect(callRuntimeRpc(target, 'git.status')).resolves.toEqual({ ok: true })
+
+    expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
+      'status.get',
+      'repo.list',
+      'git.status'
+    ])
   })
 
   it('checks advertised runtime capabilities after protocol compatibility', async () => {

--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -263,6 +263,25 @@ describe('runtime RPC client routing', () => {
     ])
   })
 
+  it('lets background compatibility checks reuse a recent foreground failure', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'status',
+      ok: false,
+      error: { code: 'runtime_unavailable', message: 'offline' },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+    const target = { kind: 'environment', environmentId: 'env-offline' } as const
+
+    await expect(callRuntimeRpc(target, 'git.status')).rejects.toThrow('offline')
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, {
+        reuseRecentCompatibilityFailure: true
+      })
+    ).rejects.toThrow('offline')
+
+    expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual(['status.get'])
+  })
+
   it('checks advertised runtime capabilities after protocol compatibility', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'status',

--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -369,6 +369,70 @@ describe('runtime RPC client routing', () => {
     ])
   })
 
+  it('re-probes when a status success clears a still-pending compatibility probe', async () => {
+    // Reconnect race: the offline probe stays queued on the dropped connection
+    // (pending, not yet failed) while a fresh status publish reports the host
+    // reachable. The clear must drop that doomed pending probe so the next
+    // reuse-flagged call starts a fresh probe instead of coalescing onto it.
+    let rejectFirstStatus!: (error: Error) => void
+    let statusCalls = 0
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      if (method === 'status.get') {
+        statusCalls += 1
+        if (statusCalls === 1) {
+          return new Promise((_, reject) => {
+            rejectFirstStatus = reject
+          })
+        }
+        return Promise.resolve({
+          id: 'status',
+          ok: true,
+          result: {
+            runtimeId: 'remote-runtime',
+            graphStatus: 'ready',
+            runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+            minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+          },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      }
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result: { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+    const target = { kind: 'environment', environmentId: 'env-reconnect' } as const
+
+    const pendingResult = callRuntimeRpc(target, 'repo.list', undefined, {
+      reuseRecentCompatibilityFailure: true
+    }).then(
+      () => 'resolved',
+      (error) => `rejected:${error.message}`
+    )
+    // Let the first status.get register its in-flight cache entry.
+    await Promise.resolve()
+
+    clearRecentRuntimeCompatibilityFailure('env-reconnect')
+
+    const secondCall = callRuntimeRpc(target, 'worktree.detectedList', undefined, {
+      reuseRecentCompatibilityFailure: true
+    })
+    await Promise.resolve()
+    // The doomed pending probe rejects; it must not fail the fresh re-probe.
+    rejectFirstStatus(new Error('stale connection closed'))
+
+    await expect(secondCall).resolves.toEqual({ ok: true })
+    await expect(pendingResult).resolves.toBe('rejected:stale connection closed')
+
+    expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
+      'status.get',
+      'status.get',
+      'worktree.detectedList'
+    ])
+  })
+
   it('checks advertised runtime capabilities after protocol compatibility', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'status',

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -171,6 +171,21 @@ function rememberRuntimeEnvironmentCompatibility(
   }
 }
 
+// Why: a live status.get answer proves a cached "offline" compatibility
+// failure is stale. Drop only failure entries so reachability-triggered
+// refreshes re-probe instead of reusing the failure for the rest of its TTL,
+// while proven-compatible successes stay cached.
+export function clearRecentRuntimeCompatibilityFailure(environmentId: string): void {
+  const trimmed = environmentId.trim()
+  if (!trimmed) {
+    return
+  }
+  const cached = runtimeCompatibilityChecks.get(trimmed)
+  if (cached && cached.failedAt !== null) {
+    runtimeCompatibilityChecks.delete(trimmed)
+  }
+}
+
 export function clearRuntimeCompatibilityCache(environmentId?: string | null): void {
   const trimmed = environmentId?.trim()
   if (trimmed) {

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -13,7 +13,6 @@ const RECENT_RUNTIME_COMPATIBILITY_FAILURE_TTL_MS = 60_000
 type RuntimeCompatibilityCacheEntry = {
   check: Promise<void>
   failedAt: number | null
-  reuseFailure: boolean
 }
 
 const runtimeCompatibilityChecks = new Map<string, RuntimeCompatibilityCacheEntry>()
@@ -105,8 +104,7 @@ async function ensureRuntimeEnvironmentCompatible(
   }
   const entry: RuntimeCompatibilityCacheEntry = {
     check: Promise.resolve(),
-    failedAt: null,
-    reuseFailure: options.reuseRecentCompatibilityFailure === true
+    failedAt: null
   }
   const check = (async () => {
     const response = await window.api.runtimeEnvironments.call({
@@ -148,10 +146,7 @@ function getCachedRuntimeCompatibilityCheck(
     runtimeCompatibilityChecks.delete(environmentId)
     return null
   }
-  if (
-    cached.failedAt !== null &&
-    (!cached.reuseFailure || options.reuseRecentCompatibilityFailure !== true)
-  ) {
+  if (cached.failedAt !== null && options.reuseRecentCompatibilityFailure !== true) {
     return null
   }
   runtimeCompatibilityChecks.delete(environmentId)
@@ -192,8 +187,7 @@ export function markRuntimeEnvironmentCompatible(environmentId: string): void {
   }
   rememberRuntimeEnvironmentCompatibility(trimmed, {
     check: Promise.resolve(),
-    failedAt: null,
-    reuseFailure: false
+    failedAt: null
   })
 }
 

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -13,6 +13,9 @@ const RECENT_RUNTIME_COMPATIBILITY_FAILURE_TTL_MS = 60_000
 type RuntimeCompatibilityCacheEntry = {
   check: Promise<void>
   failedAt: number | null
+  // True only once status.get settled and proved compatible. Stays false while
+  // the probe is in flight, so a recovery clear can drop a doomed pending probe.
+  provenCompatible: boolean
 }
 
 const runtimeCompatibilityChecks = new Map<string, RuntimeCompatibilityCacheEntry>()
@@ -104,7 +107,8 @@ async function ensureRuntimeEnvironmentCompatible(
   }
   const entry: RuntimeCompatibilityCacheEntry = {
     check: Promise.resolve(),
-    failedAt: null
+    failedAt: null,
+    provenCompatible: false
   }
   const check = (async () => {
     const response = await window.api.runtimeEnvironments.call({
@@ -121,6 +125,9 @@ async function ensureRuntimeEnvironmentCompatible(
   rememberRuntimeEnvironmentCompatibility(environmentId, entry)
   try {
     await check
+    if (runtimeCompatibilityChecks.get(environmentId) === entry) {
+      entry.provenCompatible = true
+    }
   } catch (error) {
     if (runtimeCompatibilityChecks.get(environmentId) === entry) {
       // Why: startup asks each remote for repos, groups, then folders; an
@@ -171,17 +178,18 @@ function rememberRuntimeEnvironmentCompatibility(
   }
 }
 
-// Why: a live status.get answer proves a cached "offline" compatibility
-// failure is stale. Drop only failure entries so reachability-triggered
-// refreshes re-probe instead of reusing the failure for the rest of its TTL,
-// while proven-compatible successes stay cached.
+// Why: a live status.get answer proves any cached compatibility verdict that is
+// not a settled success is stale. Drop settled failures AND still-pending probes
+// (a probe queued on the dropped connection is doomed, and a reachability-
+// triggered refresh must not coalesce onto it) so the refresh re-probes. Only
+// proven-compatible successes stay cached.
 export function clearRecentRuntimeCompatibilityFailure(environmentId: string): void {
   const trimmed = environmentId.trim()
   if (!trimmed) {
     return
   }
   const cached = runtimeCompatibilityChecks.get(trimmed)
-  if (cached && cached.failedAt !== null) {
+  if (cached && !cached.provenCompatible) {
     runtimeCompatibilityChecks.delete(trimmed)
   }
 }
@@ -202,7 +210,8 @@ export function markRuntimeEnvironmentCompatible(environmentId: string): void {
   }
   rememberRuntimeEnvironmentCompatibility(trimmed, {
     check: Promise.resolve(),
-    failedAt: null
+    failedAt: null,
+    provenCompatible: true
   })
 }
 

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -206,6 +206,85 @@ describe('runtime-status slice', () => {
     clearRuntimeCompatibilityCacheForTests()
   })
 
+  it('drops a recent compatibility failure on a direct non-null status publish', async () => {
+    // Why: paths like Settings "Connect" publish the host online via
+    // setRuntimeEnvironmentStatus directly (not refreshRuntimeEnvironmentStatus)
+    // and then trigger a reuse-flagged repo.list. The stale failure must drop so
+    // that reuse-flagged catalog fetch re-probes the now-reachable host.
+    clearRuntimeCompatibilityCacheForTests()
+    let offline = true
+    const call = vi.fn().mockImplementation(({ method }: { method: string }) => {
+      if (offline || method === 'status.get') {
+        return Promise.resolve(
+          offline
+            ? {
+                id: 'status',
+                ok: false,
+                error: { code: 'runtime_unavailable', message: 'offline' },
+                _meta: { runtimeId: 'runtime-a' }
+              }
+            : createCompatibleRuntimeStatusResponse('runtime-a')
+        )
+      }
+      return Promise.resolve({ id: method, ok: true, result: { ok: true }, _meta: {} })
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call } } })
+    const store = createSliceStore()
+    const target = { kind: 'environment', environmentId: 'env-a' } as const
+
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, { reuseRecentCompatibilityFailure: true })
+    ).rejects.toThrow('offline')
+
+    offline = false
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
+
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, { reuseRecentCompatibilityFailure: true })
+    ).resolves.toEqual({ ok: true })
+    clearRuntimeCompatibilityCacheForTests()
+  })
+
+  it('preserves a recent compatibility failure on a null (offline) status publish', async () => {
+    // Why: recording an unreachable host must not undermine the fanout fix — a
+    // null status is not proof of reachability, so reuse-flagged sweeps keep
+    // reusing the one recent failure instead of re-probing per repo.
+    clearRuntimeCompatibilityCacheForTests()
+    let offline = true
+    const call = vi.fn().mockImplementation(({ method }: { method: string }) => {
+      if (offline || method === 'status.get') {
+        return Promise.resolve(
+          offline
+            ? {
+                id: 'status',
+                ok: false,
+                error: { code: 'runtime_unavailable', message: 'offline' },
+                _meta: { runtimeId: 'runtime-a' }
+              }
+            : createCompatibleRuntimeStatusResponse('runtime-a')
+        )
+      }
+      return Promise.resolve({ id: method, ok: true, result: { ok: true }, _meta: {} })
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call } } })
+    const store = createSliceStore()
+    const target = { kind: 'environment', environmentId: 'env-a' } as const
+
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, { reuseRecentCompatibilityFailure: true })
+    ).rejects.toThrow('offline')
+
+    // A null publish (host still unreachable) must keep the failure pinned even
+    // after the transport would answer, so the reuse-flagged caller does not probe.
+    offline = false
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 1 })
+
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, { reuseRecentCompatibilityFailure: true })
+    ).rejects.toThrow('offline')
+    clearRuntimeCompatibilityCacheForTests()
+  })
+
   it('records null and returns false when a runtime refresh fails', async () => {
     const getStatus = vi.fn().mockRejectedValue(new Error('closed'))
     stubRuntimeEnvironmentApi({ getStatus })

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import { createCompatibleRuntimeStatusResponse } from '../../runtime/runtime-compatibility-test-fixture'
+import {
+  callRuntimeRpc,
+  clearRuntimeCompatibilityCacheForTests
+} from '../../runtime/runtime-rpc-client'
 import { createRuntimeStatusSlice, type RuntimeStatusSlice } from './runtime-status'
 
 function createSliceStore() {
@@ -160,6 +164,46 @@ describe('runtime-status slice', () => {
     expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status?.runtimeId).toBe(
       'runtime-a'
     )
+  })
+
+  it('drops a recent compatibility failure once a status refresh succeeds', async () => {
+    clearRuntimeCompatibilityCacheForTests()
+    let offline = true
+    const call = vi.fn().mockImplementation(({ method }: { method: string }) => {
+      if (offline || method === 'status.get') {
+        return Promise.resolve(
+          offline
+            ? {
+                id: 'status',
+                ok: false,
+                error: { code: 'runtime_unavailable', message: 'offline' },
+                _meta: { runtimeId: 'runtime-a' }
+              }
+            : createCompatibleRuntimeStatusResponse('runtime-a')
+        )
+      }
+      return Promise.resolve({ id: method, ok: true, result: { ok: true }, _meta: {} })
+    })
+    const getStatus = vi.fn().mockResolvedValue(createCompatibleRuntimeStatusResponse('runtime-a'))
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { getStatus, call } } })
+    const store = createSliceStore()
+    const target = { kind: 'environment', environmentId: 'env-a' } as const
+
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, { reuseRecentCompatibilityFailure: true })
+    ).rejects.toThrow('offline')
+    // Reuse-flagged callers stay pinned to the recent failure until recovery.
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, { reuseRecentCompatibilityFailure: true })
+    ).rejects.toThrow('offline')
+
+    offline = false
+    await store.getState().refreshRuntimeEnvironmentStatus('env-a')
+
+    await expect(
+      callRuntimeRpc(target, 'repo.list', undefined, { reuseRecentCompatibilityFailure: true })
+    ).resolves.toEqual({ ok: true })
+    clearRuntimeCompatibilityCacheForTests()
   })
 
   it('records null and returns false when a runtime refresh fails', async () => {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -68,12 +68,19 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     get().retainRuntimeDetectedAgents?.(environments.map((environment) => environment.id))
   },
 
-  setRuntimeEnvironmentStatus: (environmentId, status) =>
+  setRuntimeEnvironmentStatus: (environmentId, status) => {
+    // Why: a non-null status proves the runtime just answered, so drop any stale
+    // "offline" compat failure before this online transition fires the
+    // reuse-flagged background refetches — a recovered host must re-probe.
+    if (status.status !== null) {
+      clearRecentRuntimeCompatibilityFailure(environmentId)
+    }
     set((s) => {
       const next = new Map(s.runtimeStatusByEnvironmentId)
       next.set(environmentId, status)
       return { runtimeStatusByEnvironmentId: next }
-    }),
+    })
+  },
 
   clearRuntimeEnvironmentStatus: (environmentId) =>
     set((s) => {
@@ -106,11 +113,8 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
         timeoutMs
       })
       const status = unwrapRuntimeRpcResult<RuntimeStatus>(response)
-      // Why: the online-set/reachable-set transitions this probe feeds are the
-      // one-shot triggers for background catalog/worktree refetches. Those
-      // refetches reuse recent compatibility failures, so drop a stale failure
-      // now that the runtime demonstrably answers.
-      clearRecentRuntimeCompatibilityFailure(environmentId)
+      // setRuntimeEnvironmentStatus drops any stale compat failure on a non-null
+      // (reachable) status, so a recovered host's reuse-flagged refetches re-probe.
       get().setRuntimeEnvironmentStatus(environmentId, { status, checkedAt: Date.now() })
       return true
     } catch {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -2,7 +2,10 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
-import { unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
+import {
+  clearRecentRuntimeCompatibilityFailure,
+  unwrapRuntimeRpcResult
+} from '@/runtime/runtime-rpc-client'
 
 /** Live status for one saved runtime environment, as last observed by the
  * renderer. `status === null` records a probe that failed or timed out so the
@@ -103,6 +106,11 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
         timeoutMs
       })
       const status = unwrapRuntimeRpcResult<RuntimeStatus>(response)
+      // Why: the online-set/reachable-set transitions this probe feeds are the
+      // one-shot triggers for background catalog/worktree refetches. Those
+      // refetches reuse recent compatibility failures, so drop a stale failure
+      // now that the runtime demonstrably answers.
+      clearRecentRuntimeCompatibilityFailure(environmentId)
       get().setRuntimeEnvironmentStatus(environmentId, { status, checkedAt: Date.now() })
       return true
     } catch {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -132,6 +132,7 @@ function createTestStore() {
         openModal: vi.fn(),
         shutdownWorktreeTerminals: vi.fn().mockResolvedValue(undefined),
         shutdownWorktreeBrowsers: vi.fn().mockResolvedValue(undefined),
+        ptyIdsByTabId: {},
         tabsByWorktree: {},
         tabBarOrderByWorktree: {},
         pendingReconnectTabByWorktree: {},
@@ -5809,6 +5810,48 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
     expect(maxActiveScans).toBeLessThanOrEqual(WORKTREE_REFRESH_CONCURRENCY)
     expect(mockApi.worktrees.list).toHaveBeenCalledTimes(repos.length)
     expect(store.getState().hasHydratedWorktreePurge).toBe(true)
+  })
+
+  it('reuses an offline runtime preflight across hydrated all-worktree refresh repos', async () => {
+    const store = createTestStore()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const repos = Array.from({ length: WORKTREE_REFRESH_CONCURRENCY + 2 }, (_, index) => ({
+      id: `runtime-repo-${index}`,
+      path: `/remote/repos/${index}`,
+      displayName: `runtime-repo-${index}`,
+      badgeColor: '#000',
+      addedAt: 0,
+      executionHostId: 'runtime:env-offline'
+    }))
+
+    runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'status.get') {
+        return Promise.resolve({
+          id: 'status',
+          ok: false,
+          error: { code: 'runtime_unavailable', message: 'offline' },
+          _meta: { runtimeId: 'runtime-offline' }
+        })
+      }
+      return runtimeEnvironmentCall(args)
+    })
+
+    try {
+      store.setState({
+        hasHydratedWorktreePurge: true,
+        repos
+      } as unknown as Partial<AppState>)
+
+      await store.getState().fetchAllWorktrees()
+    } finally {
+      consoleError.mockRestore()
+    }
+
+    expect(runtimeEnvironmentTransportCall.mock.calls.map((call) => call[0].method)).toEqual([
+      'status.get'
+    ])
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
   })
 
   it('preserves floating workspace state while purging a real stale worktree', async () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -5854,6 +5854,61 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
     expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
   })
 
+  it('does not coalesce a foreground re-probe onto a background reuse:true scan for a remote repo', async () => {
+    // Why: the reuse flag is part of the coalescing key for remote targets, so a
+    // foreground fetchWorktrees (reuse:false) must run its own compat-preflighted
+    // scan instead of sharing a background reuse:true scan that may have reused a
+    // stale failure — the foreground caller must always re-probe.
+    const store = createTestStore()
+    const remote = makeWorktree({ id: 'repo1::/remote/wt', repoId: 'repo1', path: '/remote/wt' })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      hasHydratedWorktreePurge: true,
+      repos: [
+        {
+          id: 'repo1',
+          path: '/r1',
+          displayName: 'R1',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'runtime:env-1'
+        }
+      ]
+    } as Partial<AppState>)
+
+    let scanStartedCount = 0
+    const scanReleases: (() => void)[] = []
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'worktree.detectedList') {
+        scanStartedCount += 1
+        return new Promise((resolve) => {
+          scanReleases.push(() =>
+            resolve({
+              id: 'rpc',
+              ok: true,
+              result: makeDetectedResult('repo1', [remote]),
+              _meta: { runtimeId: 'runtime-remote' }
+            })
+          )
+        })
+      }
+      return Promise.resolve({ id: method, ok: true, result: {}, _meta: {} })
+    })
+
+    const background = store.getState().fetchAllWorktrees()
+    const foreground = store.getState().fetchWorktrees('repo1')
+    // Flush microtasks so both compat preflights settle and both scans block.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(scanStartedCount).toBe(2)
+
+    scanReleases.forEach((release) => release())
+    await Promise.all([background, foreground])
+    expect(store.getState().worktreesByRepo.repo1?.map((worktree) => worktree.id)).toEqual([
+      remote.id
+    ])
+  })
+
   it('preserves floating workspace state while purging a real stale worktree', async () => {
     const store = createTestStore()
     const wtA = makeWorktree({ id: 'repoA::/a/wt1', repoId: 'repoA', path: '/a/wt1' })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -84,6 +84,10 @@ const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
 const hostedReviewPushTargetLookupsInFlight = new Set<string>()
 const detectedWorktreeRefreshesInFlight = new Map<string, Promise<DetectedWorktreeListResult>>()
 
+type BackgroundRuntimeRefreshOptions = {
+  reuseRecentCompatibilityFailure?: boolean
+}
+
 async function mapReposForWorktreeRefresh<TRepo extends { id: string }, TResult>(
   repos: readonly TRepo[],
   mapper: (repo: TRepo) => Promise<TResult>
@@ -857,7 +861,8 @@ function settingsForWorktreeOwner(
 
 async function listDetectedWorktreesForRepo(
   settings: AppState['settings'],
-  repoId: string
+  repoId: string,
+  options: BackgroundRuntimeRefreshOptions = {}
 ): Promise<DetectedWorktreeListResult> {
   const target = getActiveRuntimeTarget(settings)
   if (target.kind === 'local') {
@@ -875,7 +880,10 @@ async function listDetectedWorktreesForRepo(
       target,
       'worktree.detectedList',
       { repo: repoId },
-      { timeoutMs: 15_000 }
+      {
+        timeoutMs: 15_000,
+        reuseRecentCompatibilityFailure: options.reuseRecentCompatibilityFailure
+      }
     )
   } catch (error) {
     if (!isRuntimeMethodNotFoundError(error)) {
@@ -885,7 +893,10 @@ async function listDetectedWorktreesForRepo(
       target,
       'worktree.list',
       { repo: repoId, limit: REMOTE_WORKTREE_LIST_PARITY_LIMIT },
-      { timeoutMs: 15_000 }
+      {
+        timeoutMs: 15_000,
+        reuseRecentCompatibilityFailure: options.reuseRecentCompatibilityFailure
+      }
     )
     return toLegacyDetectedWorktreeResult(repoId, legacy)
   }
@@ -909,7 +920,11 @@ function detectedWorktreeRefreshKey(
 async function listDetectedWorktreesForRepoCoalesced(
   settings: AppState['settings'],
   repoId: string,
-  options: { executionHostId: ExecutionHostId; requireAuthoritative?: boolean }
+  options: {
+    executionHostId: ExecutionHostId
+    requireAuthoritative?: boolean
+    reuseRecentCompatibilityFailure?: boolean
+  }
 ): Promise<DetectedWorktreeListResult> {
   const key = detectedWorktreeRefreshKey(settings, repoId, options)
   const existing = detectedWorktreeRefreshesInFlight.get(key)
@@ -918,7 +933,9 @@ async function listDetectedWorktreesForRepoCoalesced(
   }
   // Why: startup/event fan-out can ask for the same repo/host refresh many
   // times at once; share only the scan promise so state merge semantics stay local.
-  const refresh = listDetectedWorktreesForRepo(settings, repoId)
+  const refresh = listDetectedWorktreesForRepo(settings, repoId, {
+    reuseRecentCompatibilityFailure: options.reuseRecentCompatibilityFailure
+  })
   detectedWorktreeRefreshesInFlight.set(key, refresh)
   try {
     return await refresh
@@ -929,7 +946,10 @@ async function listDetectedWorktreesForRepoCoalesced(
   }
 }
 
-async function listWorktreeLineageForRuntime(settings: AppState['settings']): Promise<{
+async function listWorktreeLineageForRuntime(
+  settings: AppState['settings'],
+  options: BackgroundRuntimeRefreshOptions = {}
+): Promise<{
   worktreeLineageById: Record<string, WorktreeLineage>
   workspaceLineageByChildKey: Record<string, WorkspaceLineage>
 }> {
@@ -956,7 +976,10 @@ async function listWorktreeLineageForRuntime(settings: AppState['settings']): Pr
     await callRuntimeRpc<{
       lineage: Record<string, WorktreeLineage>
       workspaceLineage?: Record<string, WorkspaceLineage>
-    }>(target, 'worktree.lineageList', undefined, { timeoutMs: 15_000 })
+    }>(target, 'worktree.lineageList', undefined, {
+      timeoutMs: 15_000,
+      reuseRecentCompatibilityFailure: options.reuseRecentCompatibilityFailure
+    })
   )
 }
 
@@ -1062,9 +1085,10 @@ function applyWorktreeLineageUpdate(
 
 async function refreshWorktreeLineageForSettings(
   settings: AppState['settings'],
-  set: Parameters<StateCreator<AppState>>[0]
+  set: Parameters<StateCreator<AppState>>[0],
+  options: BackgroundRuntimeRefreshOptions = {}
 ): Promise<void> {
-  const lineage = await listWorktreeLineageForRuntime(settings)
+  const lineage = await listWorktreeLineageForRuntime(settings, options)
   const hostId = getSettingsFocusedExecutionHostId(settings)
   set((s) => ({
     worktreeLineageById: mergeLineageForHost(s, hostId, lineage.worktreeLineageById),
@@ -1084,7 +1108,9 @@ async function refreshRemoteWorktreeLineageBestEffort(
     return
   }
   try {
-    const lineage = await listWorktreeLineageForRuntime(settings)
+    const lineage = await listWorktreeLineageForRuntime(settings, {
+      reuseRecentCompatibilityFailure: true
+    })
     const hostId = getSettingsFocusedExecutionHostId(settings)
     set((s) => ({
       worktreeLineageById: mergeLineageForHost(s, hostId, lineage.worktreeLineageById),
@@ -2359,46 +2385,59 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     // double-probe the IPC for the per-repo success signal.
     if (get().hasHydratedWorktreePurge) {
       await mapReposForWorktreeRefresh(repos, async (r) => {
-        const hostId = getRepoExecutionHostId(r)
-        const setup = getProjectHostSetupForRepoHost(get(), r.id, hostId)
-        const settings = settingsForKnownRepoOwner(get().settings, r)
-        const detected = await listDetectedWorktreesForRepoCoalesced(settings, r.id, {
-          executionHostId: hostId
-        })
-        const worktrees = sanitizeHostedReviewLinksForBranchClears(
-          toVisibleWorktrees(detected, hostId, setup),
-          get().worktreesByRepo[r.id]
-        )
-        set((s) => {
-          const matchOptions = worktreeHostMatchOptions(s, r.id, hostId)
-          const removedIds = getRemovedWorktreeIdsAfterAuthoritativeScan(s, r.id, detected, hostId)
-          const mergedWorktrees = mergeWorktreesForHost(
-            s.worktreesByRepo[r.id],
-            worktrees,
-            hostId,
-            matchOptions
+        try {
+          const hostId = getRepoExecutionHostId(r)
+          const setup = getProjectHostSetupForRepoHost(get(), r.id, hostId)
+          const settings = settingsForKnownRepoOwner(get().settings, r)
+          const detected = await listDetectedWorktreesForRepoCoalesced(settings, r.id, {
+            executionHostId: hostId,
+            reuseRecentCompatibilityFailure: true
+          })
+          const worktrees = sanitizeHostedReviewLinksForBranchClears(
+            toVisibleWorktrees(detected, hostId, setup),
+            get().worktreesByRepo[r.id]
           )
-          const mergedDetected = mergeDetectedWorktreesForHost(
-            s.detectedWorktreesByRepo[r.id],
-            detected,
-            hostId,
-            setup,
-            matchOptions
-          )
-          if (
-            areWorktreesEqual(s.worktreesByRepo[r.id], mergedWorktrees) &&
-            areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[r.id], mergedDetected) &&
-            removedIds.length === 0
-          ) {
-            return s
+          set((s) => {
+            const matchOptions = worktreeHostMatchOptions(s, r.id, hostId)
+            const removedIds = getRemovedWorktreeIdsAfterAuthoritativeScan(
+              s,
+              r.id,
+              detected,
+              hostId
+            )
+            const mergedWorktrees = mergeWorktreesForHost(
+              s.worktreesByRepo[r.id],
+              worktrees,
+              hostId,
+              matchOptions
+            )
+            const mergedDetected = mergeDetectedWorktreesForHost(
+              s.detectedWorktreesByRepo[r.id],
+              detected,
+              hostId,
+              setup,
+              matchOptions
+            )
+            if (
+              areWorktreesEqual(s.worktreesByRepo[r.id], mergedWorktrees) &&
+              areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[r.id], mergedDetected) &&
+              removedIds.length === 0
+            ) {
+              return s
+            }
+            return {
+              worktreesByRepo: { ...s.worktreesByRepo, [r.id]: mergedWorktrees },
+              detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [r.id]: mergedDetected },
+              sortEpoch: s.sortEpoch + 1,
+              ...(removedIds.length > 0 ? buildWorktreePurgeState(s, removedIds) : {})
+            }
+          })
+        } catch (err) {
+          if (notifyRuntimeScopeForbiddenIfNeeded(err)) {
+            return
           }
-          return {
-            worktreesByRepo: { ...s.worktreesByRepo, [r.id]: mergedWorktrees },
-            detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [r.id]: mergedDetected },
-            sortEpoch: s.sortEpoch + 1,
-            ...(removedIds.length > 0 ? buildWorktreePurgeState(s, removedIds) : {})
-          }
-        })
+          console.error(`Failed to fetch worktrees for repo ${r.id}:`, err)
+        }
       })
       return
     }
@@ -2428,7 +2467,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           const detected = await listDetectedWorktreesForRepoCoalesced(
             settingsForKnownRepoOwner(get().settings, r),
             r.id,
-            { executionHostId: hostId }
+            { executionHostId: hostId, reuseRecentCompatibilityFailure: true }
           )
           const current = get().worktreesByRepo[r.id]
           const list = sanitizeHostedReviewLinksForBranchClears(
@@ -2541,7 +2580,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     try {
       // Why: lineage is a focused-host refresh — fetch from the focused host and
       // host-merge so other hosts' previously fetched lineage is preserved.
-      await refreshWorktreeLineageForSettings(get().settings, set)
+      await refreshWorktreeLineageForSettings(get().settings, set, {
+        reuseRecentCompatibilityFailure: true
+      })
     } catch (err) {
       console.error('Failed to fetch worktree lineage:', err)
     }

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -905,16 +905,28 @@ async function listDetectedWorktreesForRepo(
 function detectedWorktreeRefreshKey(
   settings: AppState['settings'],
   repoId: string,
-  options: { executionHostId: ExecutionHostId; requireAuthoritative?: boolean }
+  options: {
+    executionHostId: ExecutionHostId
+    requireAuthoritative?: boolean
+    reuseRecentCompatibilityFailure?: boolean
+  }
 ): string {
   const target = getActiveRuntimeTarget(settings)
   const targetKey = target.kind === 'local' ? 'local' : `runtime:${target.environmentId}`
-  return [
+  const parts = [
     repoId,
     options.executionHostId,
     targetKey,
     options.requireAuthoritative === true ? 'authoritative' : 'best-effort'
-  ].join('\n')
+  ]
+  // Why: only remote targets run a compat preflight, so a foreground (reuse:false)
+  // refresh must not coalesce onto a background reuse:true scan that reused a
+  // stale failure — it must re-probe. Local targets have no preflight; keep them
+  // coalesced so a foreground/background collision stays one git scan.
+  if (target.kind === 'environment') {
+    parts.push(options.reuseRecentCompatibilityFailure === true ? 'reuse-failure' : 'reprobe')
+  }
+  return parts.join('\n')
 }
 
 async function listDetectedWorktreesForRepoCoalesced(


### PR DESCRIPTION
## Summary
- Treat the 1.4.126 remote worktree/catalog refresh as background inventory so an offline runtime reuses one recent compatibility failure instead of probing once per repo.
- Catch hydrated all-worktree per-repo refresh failures so offline runtimes do not surface unhandled `runtimeEnvironments:call` rejections.
- Add regression coverage for many runtime-owned repos sharing one offline preflight, plus cache behavior that keeps foreground/user actions retryable.

## Review hardening (added after self-review)
The reuse cache introduced a recovery gap: the "runtime came back online" refetch triggers (sidebar online-set effect, reachable-set scheduler, Settings Connect) are one-shot, and running them with failure-reuse enabled could swallow the recovery refetch and leave a recovered host's worktrees stale for up to the 60s TTL. Hardened in four follow-up commits, each with a revert-verified regression test:

- **Drop stale compat failures when a status probe succeeds** — a live `status.get` answer proves any cached "offline" verdict stale; failure entries are cleared so recovery-triggered refetches re-probe. Proven-compatible successes stay cached.
- **Clear at the single online-status writer** — the clear lives in `setRuntimeEnvironmentStatus` (guarded on non-null status), so direct publishers like Settings Connect are covered, not just the probe helper.
- **Drop in-flight (not just settled-failed) probes on a live status publish** — a probe still pending on a dropped connection is doomed; tracking `provenCompatible` lets recovery drop it so the refetch doesn't coalesce onto it.
- **Key detected-worktree coalescing on the reuse flag (remote targets only)** — a foreground refresh (no reuse) can no longer coalesce onto a background scan that reused a stale failure; local targets keep single-scan coalescing.

## Test plan
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/runtime-rpc-client.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/store/slices/runtime-status.test.ts (228 passed)
- pnpm run typecheck:web
- Electron dev-build smoke: local repo add → hydrated fetchAllWorktrees → sidebar lists worktrees + discovered worktrees normally.
- Electron dead-runtime rig (unreachable `ws://` endpoint set as the active runtime, fast-fail connection-refused): a full catalog + all-worktree + lineage sweep completed in ~300ms with exactly **1** caught error and **0** unhandled rejections — the whole burst shared one compat probe.

## Notes
This is a 1.4.126 regression in behavior: the unreachable-runtime error path was older, but the deferred post-startup remote catalog/worktree refresh (added by the deferred-remote-catalogs startup change, first shipped in 1.4.126) added the new fanout surface.

**What this does not fix.** The user recording shows a sustained ~9/s stream of *uncaught* `runtimeEnvironments:call` rejections; this PR removes the catalog-sweep contribution but not the repeating drivers. Status from investigation:
- **Live-reproduced (dead-runtime rig):** `runtime-client-events-sync` retries `runtimeEnvironments:subscribe` on a flat ~1s timer with no backoff for as long as the env is desired — one WebSocket connect attempt per second per unreachable runtime, indefinitely (console warnings, caught). `web-session-tabs-sync` adds initial-load failures on the same transitions.
- **Code-diagnosed, not yet reproduced:** the provider-metadata layer as the likely main pacer of the recording — `metadata-request-cache.ts` caches only successes (no negative cache), and the slug/team hooks (`useGitHubSlugMetadata.ts`, Linear team hooks) key fetch effects on the unstable `settings` object, so a failure's setState re-runs the effect and re-issues the call, doubled by the compat preflight. Reproducing needs a configured project/PR surface bound to the unreachable runtime, which the clean rig didn't have.
- Tailscale only sets the pace: with it up, connects to the dead peer fast-fail (~110ms); with it disabled the same attempts blackhole into 15–30s timeouts, so the loop looks stopped. The Tailscale text in the error is generic unreachable-runtime hint copy, not a Tailscale-specific check.

Follow-up seams: short-TTL negative cache in `metadata-request-cache.ts`, backoff (or reachability gating) for the subscribe retry in `runtime-client-events-sync.ts`, a reachability gate at the `callRuntimeRpc` seam, and primitive (`activeRuntimeEnvironmentId`) effect deps in the slug hooks.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## Crash-triage summary

### Description

Addresses the reproducible technical failure behind the uncaptured 1.4.126 remote-server project-panel report submitted at 2026-07-07T12:37:36Z. A hydrated remote catalog refresh launched one runtime compatibility call per saved repo and allowed per-repo failures such as `repo_not_found` to escape as unhandled rejections. The change shares one recent background compatibility failure across that burst and contains each repo refresh failure without deleting the cached project rows.

### Clear, undeniable fix evidence

- Field artifact: immediately before the repeated failed project activations, the renderer recorded an unhandled `RuntimeRpcCallError: repo_not_found` from `callRuntimeRpc -> listDetectedWorktreesForRepo -> fetchAllWorktrees`.
- Before-fix source: the hydrated `fetchAllWorktrees` branch awaited each per-repo remote scan without a `try/catch`, so one rejection escaped the background refresh.
- After-fix Electron dead-runtime rig: the full catalog/worktree/lineage sweep completed in about 300 ms with exactly **1 caught error and 0 unhandled rejections**.
- Current-main focused verification: four regression gates passed across runtime RPC caching, hydrated worktree refresh containment/coalescing, recovery cache clearing, and foreground re-probing.

The artifact did not capture element geometry, so this proves removal of the recorded rejection/fanout path, not every possible cause of the user’s visual “vibrating” description. The original PR’s “What this does not fix” section preserves the remaining retry-loop gaps explicitly.

### ELI5

When a saved remote server was unavailable or no longer knew a repo, Orca asked the same failing question separately for every project card, and some answers escaped as uncaught errors. Orca now shares one background answer, keeps the last known project list on failure, and lets deliberate foreground actions retry immediately.

### Trade-offs

- Background inventory may reuse a recent compatibility failure for up to the existing 60-second TTL, reducing retry pressure while a runtime is offline. A successful status update clears that failure early, and foreground actions never reuse it.
- Cached remote worktrees remain visible until an authoritative refresh succeeds; this favors stable navigation over eagerly deleting rows during a transient failure.
- This PR does not eliminate the separate subscription/provider-metadata retry loops documented above, so an unreachable runtime can still generate caught retry traffic.
