### PR TITLE
Fix Monaco Peek References preview collapse

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1915,6 +1915,16 @@
   pointer-events: auto;
 }
 
+/* Why: Monaco leaves the peek preview container `inline-block` and only sizes the
+   editor child, so the container shrink-wraps the child in BOTH axes while the
+   inherited automaticLayout ResizeObserver measures the container — a feedback
+   loop that ratchets the preview to blank at fractional zoom/DPI (issue #7405).
+   Pinning both dimensions to the splitview slot severs the loop. */
+.monaco-editor .reference-zone-widget .preview.inline {
+  height: 100%;
+  width: 100%;
+}
+
 /* ── Git conflict decorations ───────────────────────────────────── */
 
 .monaco-editor .orca-conflict-marker-line {

--- a/src/renderer/src/lib/monaco-peek-preview-options.test.ts
+++ b/src/renderer/src/lib/monaco-peek-preview-options.test.ts
@@ -8,14 +8,17 @@ type FakePreviewEditor = Pick<Monaco.editor.ICodeEditor, 'updateOptions'>
 
 type FakeReferenceWidgetInstance = {
   _preview?: FakePreviewEditor
-  _fillBody: (containerElement: HTMLElement) => void
-  _revealReference: (...args: unknown[]) => Promise<unknown>
+  _fillBody?: (containerElement: HTMLElement) => void
+  _revealReference?: (...args: unknown[]) => Promise<unknown>
 }
 
 function createReferenceWidgetConstructor(hooks: {
   fillBody?: (instance: FakeReferenceWidgetInstance) => void
   revealReference?: (instance: FakeReferenceWidgetInstance) => Promise<unknown>
-}): { prototype: FakeReferenceWidgetInstance } {
+}): {
+  prototype: FakeReferenceWidgetInstance &
+    Required<Pick<FakeReferenceWidgetInstance, '_fillBody' | '_revealReference'>>
+} {
   return {
     prototype: {
       _fillBody(this: FakeReferenceWidgetInstance): void {
@@ -70,6 +73,15 @@ describe('installMonacoPeekReferencesPreviewOptions', () => {
 
     expect(calls).toEqual(['updateOptions', 'revealReference', 'updateOptions'])
     expect(preview.updateOptions).toHaveBeenCalledWith(peekPreviewOptions)
+  })
+
+  it('skips patching when the private Monaco hooks are missing', () => {
+    const referenceWidget: { prototype: FakeReferenceWidgetInstance } = { prototype: {} }
+
+    installMonacoPeekReferencesPreviewOptions(referenceWidget)
+
+    expect(referenceWidget.prototype._fillBody).toBeUndefined()
+    expect(referenceWidget.prototype._revealReference).toBeUndefined()
   })
 
   it('does not wrap ReferenceWidget more than once', async () => {

--- a/src/renderer/src/lib/monaco-peek-preview-options.test.ts
+++ b/src/renderer/src/lib/monaco-peek-preview-options.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+import type * as Monaco from 'monaco-editor'
+import { installMonacoPeekReferencesPreviewOptions } from './monaco-peek-preview-options'
+
+type FakePreviewEditor = Pick<Monaco.editor.ICodeEditor, 'updateOptions'>
+
+type FakeReferenceWidgetInstance = {
+  _preview?: FakePreviewEditor
+  _fillBody: (containerElement: HTMLElement) => void
+  _revealReference: (...args: unknown[]) => Promise<unknown>
+}
+
+function createReferenceWidgetConstructor(hooks: {
+  fillBody?: (instance: FakeReferenceWidgetInstance) => void
+  revealReference?: (instance: FakeReferenceWidgetInstance) => Promise<unknown>
+}): { prototype: FakeReferenceWidgetInstance } {
+  return {
+    prototype: {
+      _fillBody(this: FakeReferenceWidgetInstance): void {
+        hooks.fillBody?.(this)
+      },
+      async _revealReference(this: FakeReferenceWidgetInstance): Promise<unknown> {
+        return hooks.revealReference?.(this)
+      }
+    }
+  }
+}
+
+function createPreviewEditor(): FakePreviewEditor {
+  return { updateOptions: vi.fn() }
+}
+
+const peekPreviewOptions = {
+  smoothScrolling: false,
+  stickyScroll: { enabled: false },
+  wordWrap: 'off'
+}
+
+describe('installMonacoPeekReferencesPreviewOptions', () => {
+  it('updates the embedded preview after ReferenceWidget creates it', () => {
+    const preview = createPreviewEditor()
+    const referenceWidget = createReferenceWidgetConstructor({
+      fillBody(instance) {
+        instance._preview = preview
+      }
+    })
+
+    installMonacoPeekReferencesPreviewOptions(referenceWidget)
+    referenceWidget.prototype._fillBody(document.createElement('div'))
+
+    expect(preview.updateOptions).toHaveBeenCalledWith(peekPreviewOptions)
+  })
+
+  it('updates the embedded preview before revealing a reference', async () => {
+    const calls: string[] = []
+    const preview: FakePreviewEditor = {
+      updateOptions: vi.fn(() => calls.push('updateOptions'))
+    }
+    const referenceWidget = createReferenceWidgetConstructor({
+      revealReference: async () => {
+        calls.push('revealReference')
+      }
+    })
+    referenceWidget.prototype._preview = preview
+
+    installMonacoPeekReferencesPreviewOptions(referenceWidget)
+    await referenceWidget.prototype._revealReference('reference')
+
+    expect(calls).toEqual(['updateOptions', 'revealReference', 'updateOptions'])
+    expect(preview.updateOptions).toHaveBeenCalledWith(peekPreviewOptions)
+  })
+
+  it('does not wrap ReferenceWidget more than once', async () => {
+    const preview = createPreviewEditor()
+    const referenceWidget = createReferenceWidgetConstructor({})
+    referenceWidget.prototype._preview = preview
+
+    installMonacoPeekReferencesPreviewOptions(referenceWidget)
+    installMonacoPeekReferencesPreviewOptions(referenceWidget)
+    await referenceWidget.prototype._revealReference('reference')
+
+    expect(preview.updateOptions).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/lib/monaco-peek-preview-options.ts
+++ b/src/renderer/src/lib/monaco-peek-preview-options.ts
@@ -11,8 +11,8 @@ const PEEK_REFERENCES_PREVIEW_OPTIONS: Monaco.editor.IEditorOptions = {
 
 type ReferenceWidgetInstance = {
   _preview?: PeekPreviewEditor
-  _fillBody: (containerElement: HTMLElement) => void
-  _revealReference: (...args: unknown[]) => Promise<unknown>
+  _fillBody?: (containerElement: HTMLElement) => void
+  _revealReference?: (...args: unknown[]) => Promise<unknown>
 }
 
 type ReferenceWidgetConstructor = {
@@ -37,6 +37,11 @@ export function installMonacoPeekReferencesPreviewOptions(
 
   const originalFillBody = prototype._fillBody
   const originalRevealReference = prototype._revealReference
+  // Why: these are private Monaco members with no stability guarantee; if an
+  // upgrade removes either, skip patching so Peek keeps Monaco's defaults.
+  if (typeof originalFillBody !== 'function' || typeof originalRevealReference !== 'function') {
+    return
+  }
 
   prototype._fillBody = function fillBodyWithPeekPreviewOptions(
     this: ReferenceWidgetInstance,

--- a/src/renderer/src/lib/monaco-peek-preview-options.ts
+++ b/src/renderer/src/lib/monaco-peek-preview-options.ts
@@ -1,0 +1,62 @@
+import type * as Monaco from 'monaco-editor'
+import { ReferenceWidget as MonacoReferenceWidget } from 'monaco-editor/esm/vs/editor/contrib/gotoSymbol/browser/peek/referencesWidget.js'
+
+type PeekPreviewEditor = Pick<Monaco.editor.ICodeEditor, 'updateOptions'>
+
+const PEEK_REFERENCES_PREVIEW_OPTIONS: Monaco.editor.IEditorOptions = {
+  smoothScrolling: false,
+  stickyScroll: { enabled: false },
+  wordWrap: 'off'
+}
+
+type ReferenceWidgetInstance = {
+  _preview?: PeekPreviewEditor
+  _fillBody: (containerElement: HTMLElement) => void
+  _revealReference: (...args: unknown[]) => Promise<unknown>
+}
+
+type ReferenceWidgetConstructor = {
+  prototype: ReferenceWidgetInstance & {
+    __orcaPeekPreviewOptionsInstalled?: true
+  }
+}
+
+function applyPeekReferencesPreviewOptions(editor: PeekPreviewEditor | undefined): void {
+  // Why: Monaco embedded editors inherit Orca's full-editor options first.
+  // Peek previews are transient readers, so keep scroll/wrap widgets out of them.
+  editor?.updateOptions(PEEK_REFERENCES_PREVIEW_OPTIONS)
+}
+
+export function installMonacoPeekReferencesPreviewOptions(
+  referenceWidget: ReferenceWidgetConstructor = MonacoReferenceWidget as unknown as ReferenceWidgetConstructor
+): void {
+  const prototype = referenceWidget.prototype
+  if (prototype.__orcaPeekPreviewOptionsInstalled) {
+    return
+  }
+
+  const originalFillBody = prototype._fillBody
+  const originalRevealReference = prototype._revealReference
+
+  prototype._fillBody = function fillBodyWithPeekPreviewOptions(
+    this: ReferenceWidgetInstance,
+    containerElement: HTMLElement
+  ): void {
+    originalFillBody.call(this, containerElement)
+    applyPeekReferencesPreviewOptions(this._preview)
+  }
+
+  prototype._revealReference = async function revealReferenceWithPeekPreviewOptions(
+    this: ReferenceWidgetInstance,
+    ...args: unknown[]
+  ): Promise<unknown> {
+    applyPeekReferencesPreviewOptions(this._preview)
+    try {
+      return await originalRevealReference.apply(this, args)
+    } finally {
+      applyPeekReferencesPreviewOptions(this._preview)
+    }
+  }
+
+  prototype.__orcaPeekPreviewOptionsInstalled = true
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -13,6 +13,7 @@ import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
 import { installMonacoDelayerCancellationGuard } from './monaco-delayer-cancellation-guard'
 import { installMonacoDiffEditorDisposalGuard } from './monaco-diff-editor-disposal'
+import { installMonacoPeekReferencesPreviewOptions } from './monaco-peek-preview-options'
 import { installMonacoContextMenuPaste } from '@/components/editor/install-monaco-context-menu-paste'
 
 globalThis.MonacoEnvironment = {
@@ -78,6 +79,7 @@ registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)
+installMonacoPeekReferencesPreviewOptions()
 // Why: Monaco's built-in context-menu Paste reads navigator.clipboard, which is
 // blocked in Orca's sandboxed renderer. Route it through the trusted IPC bridge
 // so right-click Paste works like Cmd+V (which already works via native events).


### PR DESCRIPTION
## Summary
- Fix the Peek References preview pane collapsing to blank (issue `#7405`): restore container sizing for `.preview.inline` in `src/renderer/src/assets/main.css`, pinning **both** height and width to the splitview slot.
- Companion `ReferenceWidget` prototype patch applies reader options to the embedded preview (`wordWrap`/`smoothScrolling`/`stickyScroll` off) and is guarded to skip cleanly if a Monaco upgrade removes the private hooks.

## Root cause (empirically proven in production builds)
Monaco's own CSS makes the peek panes `display: inline-block`, and the preview pane's splitview layout callback only sizes the editor **child** — never the `.preview.inline` container — so the container shrink-wraps the editor in both axes (the ref-tree pane is safe because Monaco pins its size inline). Orca's editors set `automaticLayout: true`, which the embedded preview editor inherits, so a ResizeObserver measures that same container: a feedback loop. At fractional device scales (Electron zoom steps → factor 1.2^±0.5; Windows fractional DPI) measurement truncation ratchets the preview ~1px/frame — height drains to blank (the reported symptom) and width leaves a growing blank gutter before the list. Integer zoom is stable, which is why dev testing missed it.

## Verification (isolated prod app instances, rAF samplers on `.preview.inline`)
| Build | zoom 0 | zoom 0.5 | zoom −0.5 | zoom 1.5 |
|---|---|---|---|---|
| Baseline (no fix) | stable | 332→318px, gutter grows | **335→5px, blank** | 335→265px, collapsing |
| Options patch only | stable | 326→318px, gutter→41px | **335→5px, blank** | 335→265px, gutter→82px |
| This PR (CSS both axes) | stable | **pixel-stable, gutter 0** | **pixel-stable, gutter 0** | **pixel-stable, gutter 0** |

Prototype patch verified active in the prod bundle (sticky scroll absent, `nowrap` in preview view-lines). The previously shipped scrollbar `visibility` rule (`#7584`) addresses a separate Tailwind class-collision symptom and is kept.

## Testing
- `pnpm vitest run src/renderer/src/lib/monaco-peek-preview-options.test.ts` (4 tests)
- `pnpm --silent exec tsc --noEmit --pretty false --project tsconfig.json`
- `VITE_EXPOSE_STORE=true pnpm build:electron-vite` + zoom-sweep probe against the built app (scratch script, not committed)

Made with [Orca](https://github.com/stablyai/orca) 🐋
