### PR TITLE
Fix native chat cleanup registration leak

### DIFF
--- a/src/main/ipc/native-chat-subscribe-lifecycle.test.ts
+++ b/src/main/ipc/native-chat-subscribe-lifecycle.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handlers, listeners, subscribeTranscript } = vi.hoisted(() => ({
+  handlers: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
+  listeners: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
+  subscribeTranscript: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (_event: unknown, args?: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }),
+    on: vi.fn((channel: string, handler: (_event: unknown, args?: unknown) => unknown) => {
+      listeners.set(channel, handler)
+    })
+  }
+}))
+
+vi.mock('../native-chat/transcript-watch', () => ({
+  subscribeNativeChatTranscript: subscribeTranscript
+}))
+
+import {
+  _getNativeChatPendingSubscriptionCountForTest,
+  _getNativeChatSenderCleanupCountForTest,
+  clearNativeChatSubscriptions,
+  registerNativeChatHandlers
+} from './native-chat'
+
+type TestSubscription = {
+  unsubscribe: ReturnType<typeof vi.fn>
+}
+
+type DeferredSubscription = {
+  promise: Promise<TestSubscription>
+  reject: (error: Error) => void
+  resolve: () => void
+  unsubscribe: ReturnType<typeof vi.fn>
+}
+
+type SenderHarness = {
+  destroy: () => void
+  registeredCleanupCount: () => number
+  sender: {
+    id: number
+    isDestroyed: () => boolean
+    once: (event: string, callback: () => void) => void
+    send: ReturnType<typeof vi.fn>
+  }
+}
+
+beforeEach(() => {
+  clearNativeChatSubscriptions()
+  handlers.clear()
+  listeners.clear()
+  subscribeTranscript.mockReset()
+  registerNativeChatHandlers()
+})
+
+function deferredSubscription(): DeferredSubscription {
+  const unsubscribe = vi.fn()
+  let resolvePromise: (subscription: TestSubscription) => void = () => {}
+  let rejectPromise: (error: Error) => void = () => {}
+  const promise = new Promise<TestSubscription>((resolve, reject) => {
+    resolvePromise = resolve
+    rejectPromise = reject
+  })
+  return {
+    promise,
+    reject: rejectPromise,
+    resolve: () => resolvePromise({ unsubscribe }),
+    unsubscribe
+  }
+}
+
+function createSender(id: number): SenderHarness {
+  let destroyed = false
+  const destroyedCallbacks: (() => void)[] = []
+  return {
+    destroy: () => {
+      destroyed = true
+      for (const callback of destroyedCallbacks) {
+        callback()
+      }
+    },
+    registeredCleanupCount: () => destroyedCallbacks.length,
+    sender: {
+      id,
+      isDestroyed: () => destroyed,
+      once: (event, callback) => {
+        if (event === 'destroyed') {
+          destroyedCallbacks.push(callback)
+        }
+      },
+      send: vi.fn()
+    }
+  }
+}
+
+function subscribe(sender: SenderHarness['sender'], subscriptionId: string): void {
+  const listener = listeners.get('nativeChat:subscribe')
+  if (!listener) {
+    throw new Error('subscribe listener not registered')
+  }
+  listener({ sender }, { subscriptionId, agent: 'claude', sessionId: `session-${subscriptionId}` })
+}
+
+function unsubscribe(sender: SenderHarness['sender'], subscriptionId: string): void {
+  const listener = listeners.get('nativeChat:unsubscribe')
+  if (!listener) {
+    throw new Error('unsubscribe listener not registered')
+  }
+  listener({ sender }, { subscriptionId })
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('timed out waiting for lifecycle state')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+describe('nativeChat subscribe lifecycle', () => {
+  it('closes a watcher that resolves after renderer unsubscribe', async () => {
+    const pending = deferredSubscription()
+    subscribeTranscript.mockReturnValueOnce(pending.promise)
+    const renderer = createSender(1)
+
+    subscribe(renderer.sender, 'unmount')
+    expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(1)
+    unsubscribe(renderer.sender, 'unmount')
+    expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(0)
+    unsubscribe(renderer.sender, 'unmount')
+    expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(0)
+
+    pending.resolve()
+    await waitFor(() => pending.unsubscribe.mock.calls.length === 1)
+    unsubscribe(renderer.sender, 'unmount')
+    expect(pending.unsubscribe).toHaveBeenCalledOnce()
+    renderer.destroy()
+    expect(_getNativeChatSenderCleanupCountForTest()).toBe(0)
+  })
+
+  it('closes a watcher that resolves after renderer destruction', async () => {
+    const pending = deferredSubscription()
+    subscribeTranscript.mockReturnValueOnce(pending.promise)
+    const renderer = createSender(2)
+
+    subscribe(renderer.sender, 'destroy')
+    renderer.destroy()
+    expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(0)
+    expect(_getNativeChatSenderCleanupCountForTest()).toBe(0)
+
+    pending.resolve()
+    await waitFor(() => pending.unsubscribe.mock.calls.length === 1)
+  })
+
+  it('keeps the latest same-id subscribe when setup resolves in reverse order', async () => {
+    const older = deferredSubscription()
+    const newer = deferredSubscription()
+    subscribeTranscript.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise)
+    const renderer = createSender(3)
+
+    subscribe(renderer.sender, 'same-id')
+    subscribe(renderer.sender, 'same-id')
+    expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(1)
+
+    newer.resolve()
+    await waitFor(() => _getNativeChatPendingSubscriptionCountForTest() === 0)
+    expect(newer.unsubscribe).not.toHaveBeenCalled()
+    older.resolve()
+    await waitFor(() => older.unsubscribe.mock.calls.length === 1)
+
+    unsubscribe(renderer.sender, 'same-id')
+    expect(newer.unsubscribe).toHaveBeenCalledOnce()
+    renderer.destroy()
+  })
+
+  it('clears rejected setup without duplicating sender cleanup registration', async () => {
+    const failed = deferredSubscription()
+    const retry = deferredSubscription()
+    subscribeTranscript.mockReturnValueOnce(failed.promise).mockReturnValueOnce(retry.promise)
+    const renderer = createSender(4)
+
+    subscribe(renderer.sender, 'retry')
+    failed.reject(new Error('watch setup failed'))
+    await waitFor(() => _getNativeChatPendingSubscriptionCountForTest() === 0)
+    expect(_getNativeChatSenderCleanupCountForTest()).toBe(1)
+
+    subscribe(renderer.sender, 'retry')
+    expect(renderer.registeredCleanupCount()).toBe(1)
+    retry.resolve()
+    await waitFor(() => _getNativeChatPendingSubscriptionCountForTest() === 0)
+    unsubscribe(renderer.sender, 'retry')
+    expect(retry.unsubscribe).toHaveBeenCalledOnce()
+    renderer.destroy()
+    expect(_getNativeChatSenderCleanupCountForTest()).toBe(0)
+  })
+
+  it('isolates late setup from a replacement renderer reusing the sender id', async () => {
+    const oldPending = deferredSubscription()
+    const replacementPending = deferredSubscription()
+    subscribeTranscript
+      .mockReturnValueOnce(oldPending.promise)
+      .mockReturnValueOnce(replacementPending.promise)
+    const oldRenderer = createSender(41)
+    const replacementRenderer = createSender(41)
+
+    subscribe(oldRenderer.sender, 'remount')
+    oldRenderer.destroy()
+    subscribe(replacementRenderer.sender, 'remount')
+    expect(replacementRenderer.registeredCleanupCount()).toBe(1)
+
+    replacementPending.resolve()
+    await waitFor(() => _getNativeChatPendingSubscriptionCountForTest() === 0)
+    oldPending.resolve()
+    await waitFor(() => oldPending.unsubscribe.mock.calls.length === 1)
+    expect(replacementPending.unsubscribe).not.toHaveBeenCalled()
+
+    replacementRenderer.destroy()
+    expect(replacementPending.unsubscribe).toHaveBeenCalledOnce()
+    expect(_getNativeChatSenderCleanupCountForTest()).toBe(0)
+  })
+})

--- a/src/main/ipc/native-chat.test.ts
+++ b/src/main/ipc/native-chat.test.ts
@@ -20,6 +20,7 @@ vi.mock('electron', () => ({
 }))
 
 import {
+  _getNativeChatSenderCleanupCountForTest,
   clearNativeChatSubscriptions,
   clearNativeChatTranscriptCache,
   registerNativeChatHandlers
@@ -229,6 +230,67 @@ describe('nativeChat:readSession handler', () => {
       // Destroyed window tears down the watcher without error.
       expect(destroyedCb).toBeDefined()
       destroyedCb!()
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+    }
+  })
+
+  it('drops cleanup registration when sender is destroyed before subscribe completes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-ipc-destroy-race-'))
+    tempRoots.push(root)
+    const projectDir = join(root, '.claude', 'projects', '-repo')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(
+      join(projectDir, 'sess-race.jsonl'),
+      `${jsonLines([
+        {
+          type: 'user',
+          uuid: 'u-race',
+          timestamp: '2026-06-01T10:00:00.000Z',
+          message: { role: 'user', content: 'Race' }
+        }
+      ])}\n`
+    )
+
+    registerNativeChatHandlers()
+    const subscribe = listeners.get('nativeChat:subscribe')
+    expect(subscribe).toBeDefined()
+
+    let destroyed = false
+    let destroyedCb: (() => void) | undefined
+    const sender = {
+      id: 41,
+      isDestroyed: () => destroyed,
+      once: (event: string, cb: () => void) => {
+        if (event === 'destroyed') {
+          destroyedCb = cb
+        }
+      },
+      send: vi.fn()
+    }
+
+    const previousHome = process.env.HOME
+    process.env.HOME = root
+    try {
+      subscribe!(
+        { sender },
+        {
+          subscriptionId: 'sub-race',
+          agent: 'claude',
+          sessionId: 'sess-race'
+        }
+      )
+
+      expect(destroyedCb).toBeDefined()
+      destroyed = true
+      destroyedCb!()
+
+      await waitFor(() => _getNativeChatSenderCleanupCountForTest() === 0)
+      expect(sender.send).not.toHaveBeenCalled()
     } finally {
       if (previousHome === undefined) {
         delete process.env.HOME

--- a/src/main/ipc/native-chat.ts
+++ b/src/main/ipc/native-chat.ts
@@ -71,9 +71,17 @@ type LiveSubscription = {
 // same renderer can watch several panes, and a destroyed window tears down all
 // of its watchers — strict teardown to avoid fd leaks (plan U4 risk).
 const liveSubscriptions = new Map<number, Map<string, LiveSubscription>>()
+// Why: unsubscribe and renderer destruction must invalidate async watcher setup
+// before it can publish a late subscription into the live map.
+const pendingSubscriptions = new Map<number, Map<string, symbol>>()
 const senderCleanupRegistered = new Set<number>()
 
 function teardownSubscription(senderId: number, subscriptionId: string): void {
+  const pendingBySubId = pendingSubscriptions.get(senderId)
+  pendingBySubId?.delete(subscriptionId)
+  if (pendingBySubId?.size === 0) {
+    pendingSubscriptions.delete(senderId)
+  }
   const bySubId = liveSubscriptions.get(senderId)
   const live = bySubId?.get(subscriptionId)
   if (!live || !bySubId) {
@@ -87,6 +95,9 @@ function teardownSubscription(senderId: number, subscriptionId: string): void {
 }
 
 function teardownAllForSender(senderId: number): void {
+  // The destroyed event can arrive before async subscription setup stores a watcher.
+  senderCleanupRegistered.delete(senderId)
+  pendingSubscriptions.delete(senderId)
   const bySubId = liveSubscriptions.get(senderId)
   if (!bySubId) {
     return
@@ -95,7 +106,6 @@ function teardownAllForSender(senderId: number): void {
     live.subscription.unsubscribe()
   }
   liveSubscriptions.delete(senderId)
-  senderCleanupRegistered.delete(senderId)
 }
 
 function registerSenderCleanup(sender: WebContents): void {
@@ -107,6 +117,27 @@ function registerSenderCleanup(sender: WebContents): void {
   sender.once('destroyed', () => teardownAllForSender(sender.id))
 }
 
+function beginPendingSubscription(senderId: number, subscriptionId: string): symbol {
+  teardownSubscription(senderId, subscriptionId)
+  const token = Symbol(subscriptionId)
+  const bySubId = pendingSubscriptions.get(senderId) ?? new Map<string, symbol>()
+  bySubId.set(subscriptionId, token)
+  pendingSubscriptions.set(senderId, bySubId)
+  return token
+}
+
+function takePendingSubscription(senderId: number, subscriptionId: string, token: symbol): boolean {
+  const bySubId = pendingSubscriptions.get(senderId)
+  if (bySubId?.get(subscriptionId) !== token) {
+    return false
+  }
+  bySubId.delete(subscriptionId)
+  if (bySubId.size === 0) {
+    pendingSubscriptions.delete(senderId)
+  }
+  return true
+}
+
 async function handleSubscribe(event: IpcMainEvent, args: NativeChatSubscribeArgs): Promise<void> {
   const sender = event.sender
   if (sender.isDestroyed()) {
@@ -114,26 +145,32 @@ async function handleSubscribe(event: IpcMainEvent, args: NativeChatSubscribeArg
   }
   const { subscriptionId, agent, sessionId, transcriptPath } = args
   // Replace any prior subscription under the same id (session change/resubscribe).
-  teardownSubscription(sender.id, subscriptionId)
+  const pendingToken = beginPendingSubscription(sender.id, subscriptionId)
   registerSenderCleanup(sender)
 
-  const subscription = await subscribeNativeChatTranscript({
-    agent,
-    sessionId,
-    transcriptPath,
-    onAppend: (messages) => {
-      if (sender.isDestroyed()) {
-        return
+  let subscription: NativeChatTranscriptSubscription
+  try {
+    subscription = await subscribeNativeChatTranscript({
+      agent,
+      sessionId,
+      transcriptPath,
+      onAppend: (messages) => {
+        if (sender.isDestroyed()) {
+          return
+        }
+        const payload: NativeChatAppendedPayload = { subscriptionId, messages }
+        sender.send('nativeChat:appended', payload)
       }
-      const payload: NativeChatAppendedPayload = { subscriptionId, messages }
-      sender.send('nativeChat:appended', payload)
-    }
-  })
+    })
+  } catch {
+    takePendingSubscription(sender.id, subscriptionId, pendingToken)
+    return
+  }
 
-  // The window may have gone away (or the subscription been replaced) while we
-  // resolved the file path — don't register a now-orphaned watcher.
-  const stillCurrent = !sender.isDestroyed()
-  if (!stillCurrent) {
+  // Why: unmount, destruction, or a newer same-id subscribe can invalidate setup
+  // while path resolution is pending; only the owning token may publish its watcher.
+  const stillCurrent = takePendingSubscription(sender.id, subscriptionId, pendingToken)
+  if (sender.isDestroyed() || !stillCurrent) {
     subscription.unsubscribe()
     return
   }
@@ -147,12 +184,26 @@ async function handleSubscribe(event: IpcMainEvent, args: NativeChatSubscribeArg
   liveSubscriptions.set(sender.id, bySubId)
 }
 
-/** Test-only: drop all live transcript subscriptions between runs. */
+/** Test-only: drop all live and pending transcript subscriptions between runs. */
 export function clearNativeChatSubscriptions(): void {
-  const senderIds = Array.from(liveSubscriptions.keys())
+  const senderIds = new Set([...liveSubscriptions.keys(), ...pendingSubscriptions.keys()])
   for (const senderId of senderIds) {
     teardownAllForSender(senderId)
   }
+  pendingSubscriptions.clear()
+  senderCleanupRegistered.clear()
+}
+
+export function _getNativeChatSenderCleanupCountForTest(): number {
+  return senderCleanupRegistered.size
+}
+
+export function _getNativeChatPendingSubscriptionCountForTest(): number {
+  let count = 0
+  for (const bySubId of pendingSubscriptions.values()) {
+    count += bySubId.size
+  }
+  return count
 }
 
 export function registerNativeChatHandlers(): void {


### PR DESCRIPTION
## Description

Fixes the native-chat subscription lifecycle leak in the desktop Electron IPC path.

Previously, cleanup tracked only fully-created transcript watchers. If a renderer unsubscribed, unmounted, or was destroyed while `subscribeNativeChatTranscript()` was still resolving, teardown could not invalidate that pending setup. The late result could install an orphan watcher, retain sender cleanup bookkeeping, or let an older same-ID request replace a newer one.

The fix gives every pending `(webContents.id, subscriptionId)` setup a unique Symbol token. Unsubscribe, renderer destruction, replacement, and test teardown invalidate that token. Only the still-current token may transfer its resolved watcher into the live subscription map; stale results immediately unsubscribe.

## Evidence

### Reproduction before the fix

On current `main`, a renderer subscribed and was destroyed before async watcher setup completed. Destruction found no live watcher and returned before deleting its sender cleanup marker. A replacement renderer reusing sender ID `41` then failed to receive a `destroyed` cleanup callback because the stale marker incorrectly claimed cleanup was already registered.

The deterministic reproduction failed with:

`expected replacementDestroyedCb to be defined; received undefined`

Review of the borrowed patch also found a broader root-cause case: renderer unsubscribe or React unmount before setup resolution found no live entry, so the late watcher could still be published and retained until the whole renderer was destroyed.

### Proof of fix

A new deterministic lifecycle suite proves:

- unsubscribe before resolution invalidates pending ownership and closes the late watcher
- repeated unsubscribe before and after resolution is idempotent
- renderer destruction removes marker and pending state, then closes a late watcher
- two same-ID subscribes resolving in reverse order preserve the newer request
- rejected setup clears pending ownership and retry does not duplicate the destruction listener
- renderer-ID remount/ABA keeps old late setup isolated from the replacement renderer
- stale watchers unsubscribe exactly once while the current watcher remains live until teardown

Mutation proof:

- removing pending invalidation made the unmount test fail with `expected pending count 0, received 1`
- ignoring token identity made the reverse-resolution test time out because the older setup replaced the newer watcher

Post-rebase verification on commit `327482c1fc`:

- Seven cross-surface Vitest files passed: 48 tests covering desktop IPC, transcript watcher cleanup, runtime RPC, paired-web transport, renderer live-session behavior, and remote request connections.
- `pnpm typecheck:tsc:node` passed.
- Changed-file `oxlint` passed.
- Changed-file `oxfmt --check` passed.
- `pnpm check:max-lines-ratchet` passed.
- `git diff --check origin/main...HEAD` passed.
- Two fresh independent adversarial reviewers returned no issues on the exact semantic patch. The final rebase preserved stable patch ID `1308bf0a61b272b6d5913a99a94cccd92830b2af`.

The full web typecheck still reports one unrelated existing error in `useSessionRestoredBannerDismiss.test.tsx` where an `Element` fixture is typed as `HTMLDivElement`; this PR changes no renderer or web code.

## ELI5

Starting a chat watcher is like ordering a key while it is being cut. Before this fix, closing the chat could cancel only keys already delivered. A key that arrived late could still unlock and keep watching the file.

Each order now gets a unique claim ticket. Closing, replacing, or destroying the chat cancels that ticket. When a key arrives, Orca accepts it only if its exact ticket is still current; otherwise the key is destroyed immediately.

## Trade-offs

No end-user regressions are expected.

Each in-flight desktop native-chat subscription temporarily adds one Symbol and one small Map entry. Both are removed on success, unsubscribe, destruction, replacement, rejection, or test teardown. This is bounded by active subscription setup and replaces unbounded orphan watcher retention.

Latest-request-wins is now enforced for concurrent same-ID subscriptions. An unsubscribed or superseded setup can no longer emit updates or replace the current watcher.

Paired web and mobile runtime subscriptions use a separate connection-scoped cleanup registry with an existing late-handle cancellation path. SSH-owned panes that use the desktop adapter receive this fixed IPC lifecycle. No protocol, transcript parsing, polling, or UI behavior changes.

## Performance / No-regression check

The hot path adds constant-time Map lookups, insertion, deletion, and one Symbol allocation per setup. No polling, timers, filesystem reads, IPC messages, RPC calls, subprocesses, or renderer work were added. Stale resolved watchers are closed immediately instead of remaining active.