### PR TITLE
Keep terminals created from Orca Mobile alive when the desktop renderer is throttled or stalled

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1609,6 +1609,47 @@ describe('registerPtyHandlers', () => {
         expect(spawnOptions.env.ORCA_AGENT_HOOK_TOKEN).toBe('agent-token')
       })
 
+      it('threads the validated pane identity into registerPty for a runtime-created daemon PTY (#7587)', async () => {
+        type RuntimeSpawnController = {
+          spawn(args: {
+            cols: number
+            rows: number
+            worktreeId?: string
+            tabId?: string
+            leafId?: string
+            env?: Record<string, string>
+          }): Promise<{ id: string }>
+        }
+        const leafId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+        setupDaemonAdapter()
+        const runtime = {
+          setPtyController: vi.fn(),
+          registerPty: vi.fn(),
+          onPtySpawned: vi.fn(),
+          onPtyExit: vi.fn(),
+          onPtyData: vi.fn()
+        }
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never)
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+        await controller.spawn({
+          cols: 80,
+          rows: 24,
+          worktreeId: 'wt-runtime',
+          tabId: 'tab-1',
+          leafId
+        })
+
+        // Why: runtime-created spawns (e.g. the mobile-create materialize path)
+        // must thread the same {tabId, leafId} so the catch-path rescue can find
+        // and keep their live PTY (#7587).
+        expect(runtime.registerPty).toHaveBeenCalledWith(expect.any(String), 'wt-runtime', null, {
+          tabId: 'tab-1',
+          leafId
+        })
+      })
+
       it('uses the owning project WSL runtime for runtime-created daemon PTYs', async () => {
         await withWin32Platform(async () => {
           _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
@@ -4126,6 +4167,67 @@ describe('registerPtyHandlers', () => {
       expect.any(String),
       'term_agent_teams'
     )
+  })
+
+  it('threads the validated pane identity into registerPty for a renderer PTY spawn (#7587)', async () => {
+    const leafId = '88888888-8888-4888-8888-888888888888'
+    const runtime = {
+      setPtyController: vi.fn(),
+      preAllocateHandleForPty: vi.fn(() => 'term_seam'),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      registerPty: vi.fn(),
+      getDriver: vi.fn(() => ({ kind: 'host' })),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+      cols: 80,
+      rows: 24,
+      cwd: '/repo',
+      tabId: 'tab-1',
+      leafId,
+      worktreeId: 'wt-1'
+    })
+
+    // Why: this is the load-bearing wiring for #7587 — the runtime can only back a
+    // stalled mobile create from a live spawn if the spawn threads {tabId, leafId}.
+    expect(runtime.registerPty).toHaveBeenCalledWith(expect.any(String), 'wt-1', null, {
+      tabId: 'tab-1',
+      leafId
+    })
+  })
+
+  it('omits the pane identity from registerPty when the leafId is not a terminal leaf (#7587)', async () => {
+    const runtime = {
+      setPtyController: vi.fn(),
+      preAllocateHandleForPty: vi.fn(() => 'term_seam'),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      registerPty: vi.fn(),
+      getDriver: vi.fn(() => ({ kind: 'host' })),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+      cols: 80,
+      rows: 24,
+      cwd: '/repo',
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      worktreeId: 'wt-1'
+    })
+
+    // Why: legacy numeric pane ids (`pane:N`) are not terminal leaf ids, so the
+    // spawn seam must not fabricate a binding for them (registerPty would ignore
+    // it anyway); this pins that the seam passes a clean `undefined`.
+    expect(runtime.registerPty).toHaveBeenCalledWith(expect.any(String), 'wt-1', null, undefined)
   })
 
   it('refreshes native Agent Teams env when captured teammate mode lives in launch args', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2301,7 +2301,21 @@ export function registerPtyHandlers(
           runtime?.registerPreAllocatedHandleForPty(result.id, args.preAllocatedHandle)
         }
         if (args.worktreeId) {
-          runtime?.registerPty(result.id, args.worktreeId, args.connectionId ?? null)
+          runtime?.registerPty(
+            result.id,
+            args.worktreeId,
+            args.connectionId ?? null,
+            // Why: thread the validated pane identity so main can back a pending
+            // mobile create from this live spawn even if graph-sync stalls (#7587).
+            // Bound tabId like the sibling metadataPaneKey/spawnOptions.tabId here.
+            typeof args.tabId === 'string' &&
+              isValidTerminalTabId(args.tabId) &&
+              args.tabId.length <= 512 &&
+              typeof args.leafId === 'string' &&
+              isTerminalLeafId(args.leafId)
+              ? { tabId: args.tabId, leafId: args.leafId }
+              : undefined
+          )
         }
         if (isClaudeLaunch) {
           markClaudePtySpawned(result.id)
@@ -3180,7 +3194,21 @@ export function registerPtyHandlers(
           args.worktreeId.length > 0 &&
           args.worktreeId.length <= 512
         ) {
-          runtime?.registerPty(result.id, args.worktreeId, args.connectionId ?? null)
+          runtime?.registerPty(
+            result.id,
+            args.worktreeId,
+            args.connectionId ?? null,
+            // Why: pass the validated pane identity so a mobile create waiting on
+            // this renderer tab can publish its surface main-side when graph-sync
+            // is throttled, instead of destroying the live PTY (#7587). Bound the
+            // untrusted tabId like the sibling metadataPaneKey/spawnOptions.tabId.
+            typeof args.tabId === 'string' &&
+              isValidTerminalTabId(args.tabId) &&
+              args.tabId.length <= 512 &&
+              metadataLeafId !== null
+              ? { tabId: args.tabId, leafId: metadataLeafId }
+              : undefined
+          )
         }
         if (isClaudeLaunch) {
           markClaudePtySpawned(result.id)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2311,9 +2311,8 @@ export function registerPtyHandlers(
             typeof args.tabId === 'string' &&
               isValidTerminalTabId(args.tabId) &&
               args.tabId.length <= 512 &&
-              typeof args.leafId === 'string' &&
-              isTerminalLeafId(args.leafId)
-              ? { tabId: args.tabId, leafId: args.leafId }
+              metadataLeafId !== null
+              ? { tabId: args.tabId, leafId: metadataLeafId }
               : undefined
           )
         }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17957,6 +17957,29 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  // Why: the five #7587 mobile-create tests need an identical full notifier where
+  // only closeTerminal is observed; one factory keeps notifier-interface changes
+  // in a single place.
+  function createMobileCreateTestNotifier(
+    closeTerminal: (tabId: string, paneRuntimeId?: number) => void
+  ) {
+    return {
+      focusTerminal: vi.fn(),
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn(),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      closeTerminal,
+      closeSessionTab: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    }
+  }
+
   it('rolls back a mobile create when the materialize spawn fails and no live PTY backs the tab', async () => {
     vi.useFakeTimers()
     try {
@@ -17974,21 +17997,7 @@ describe('OrcaRuntimeService', () => {
         kill: () => true,
         getForegroundProcess: async () => null
       })
-      runtime.setNotifier({
-        focusTerminal: vi.fn(),
-        worktreesChanged: vi.fn(),
-        reposChanged: vi.fn(),
-        activateWorktree: vi.fn(),
-        createTerminal: vi.fn(),
-        revealTerminalSession: vi.fn(),
-        splitTerminal: vi.fn(),
-        renameTerminal: vi.fn(),
-        closeTerminal,
-        closeSessionTab: vi.fn(),
-        sleepWorktree: vi.fn(),
-        terminalFitOverrideChanged: vi.fn(),
-        terminalDriverChanged: vi.fn()
-      })
+      runtime.setNotifier(createMobileCreateTestNotifier(closeTerminal))
       const webContents = { send: vi.fn() }
       const send = vi.fn((_channel: string, payload: { requestId: string }) => {
         ipcMain.emit(
@@ -18057,21 +18066,7 @@ describe('OrcaRuntimeService', () => {
       const leafId = '44444444-4444-4444-8444-444444444444'
       const closeTerminal = vi.fn()
       const runtime = new OrcaRuntimeService(store)
-      runtime.setNotifier({
-        focusTerminal: vi.fn(),
-        worktreesChanged: vi.fn(),
-        reposChanged: vi.fn(),
-        activateWorktree: vi.fn(),
-        createTerminal: vi.fn(),
-        revealTerminalSession: vi.fn(),
-        splitTerminal: vi.fn(),
-        renameTerminal: vi.fn(),
-        closeTerminal,
-        closeSessionTab: vi.fn(),
-        sleepWorktree: vi.fn(),
-        terminalFitOverrideChanged: vi.fn(),
-        terminalDriverChanged: vi.fn()
-      })
+      runtime.setNotifier(createMobileCreateTestNotifier(closeTerminal))
       // Why: reply with a tabId but NEVER sync a matching mobileSessionTabs graph,
       // reproducing a throttled/hidden renderer that spawns the PTY yet stalls its
       // graph-sync publication past the surface timeout (#7587).
@@ -18131,21 +18126,7 @@ describe('OrcaRuntimeService', () => {
       const leafId = '55555555-5555-4555-8555-555555555555'
       const closeTerminal = vi.fn()
       const runtime = new OrcaRuntimeService(store)
-      runtime.setNotifier({
-        focusTerminal: vi.fn(),
-        worktreesChanged: vi.fn(),
-        reposChanged: vi.fn(),
-        activateWorktree: vi.fn(),
-        createTerminal: vi.fn(),
-        revealTerminalSession: vi.fn(),
-        splitTerminal: vi.fn(),
-        renameTerminal: vi.fn(),
-        closeTerminal,
-        closeSessionTab: vi.fn(),
-        sleepWorktree: vi.fn(),
-        terminalFitOverrideChanged: vi.fn(),
-        terminalDriverChanged: vi.fn()
-      })
+      runtime.setNotifier(createMobileCreateTestNotifier(closeTerminal))
       // Why: the spawn and the tabCreate reply travel independent IPC channels;
       // here the renderer registers the live PTY before it replies, so only the
       // create's immediate pre-wait check can resolve it — asserting it settles
@@ -18204,21 +18185,7 @@ describe('OrcaRuntimeService', () => {
       const leafId = '66666666-6666-4666-8666-666666666666'
       const closeTerminal = vi.fn()
       const runtime = new OrcaRuntimeService(store)
-      runtime.setNotifier({
-        focusTerminal: vi.fn(),
-        worktreesChanged: vi.fn(),
-        reposChanged: vi.fn(),
-        activateWorktree: vi.fn(),
-        createTerminal: vi.fn(),
-        revealTerminalSession: vi.fn(),
-        splitTerminal: vi.fn(),
-        renameTerminal: vi.fn(),
-        closeTerminal,
-        closeSessionTab: vi.fn(),
-        sleepWorktree: vi.fn(),
-        terminalFitOverrideChanged: vi.fn(),
-        terminalDriverChanged: vi.fn()
-      })
+      runtime.setNotifier(createMobileCreateTestNotifier(closeTerminal))
       const webContents = { send: vi.fn() }
       const send = vi.fn((_channel: string, payload: { requestId: string }) => {
         ipcMain.emit(
@@ -18325,21 +18292,7 @@ describe('OrcaRuntimeService', () => {
       const leafId = '77777777-7777-4777-8777-777777777777'
       const closeTerminal = vi.fn()
       const runtime = new OrcaRuntimeService(store)
-      runtime.setNotifier({
-        focusTerminal: vi.fn(),
-        worktreesChanged: vi.fn(),
-        reposChanged: vi.fn(),
-        activateWorktree: vi.fn(),
-        createTerminal: vi.fn(),
-        revealTerminalSession: vi.fn(),
-        splitTerminal: vi.fn(),
-        renameTerminal: vi.fn(),
-        closeTerminal,
-        closeSessionTab: vi.fn(),
-        sleepWorktree: vi.fn(),
-        terminalFitOverrideChanged: vi.fn(),
-        terminalDriverChanged: vi.fn()
-      })
+      runtime.setNotifier(createMobileCreateTestNotifier(closeTerminal))
       // Why: the renderer pane identity can reach the runtime via leaf graph-sync
       // (recordPtyWorktree) without registerPty, and leaf-sync never calls the
       // pty-backed rescue; so when the mobileSessionTabs publication stalls past

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17957,6 +17957,460 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('rolls back a mobile create when the materialize spawn fails and no live PTY backs the tab', async () => {
+    vi.useFakeTimers()
+    try {
+      const pendingLeafId = '99999999-9999-4999-8999-999999999999'
+      const closeTerminal = vi.fn()
+      // Why: the renderer publishes a handle-less shell surface (no ptyId) and the
+      // runtime materialize spawn then fails, so NO live PTY ever backs the tab.
+      // The catch must roll back — the #7587 rescue is gated on a live PTY, not on
+      // the mere presence of a surface, or a dead shell would resolve as success.
+      const spawn = vi.fn().mockRejectedValue(new Error('spawn failed'))
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn,
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      runtime.setNotifier({
+        focusTerminal: vi.fn(),
+        worktreesChanged: vi.fn(),
+        reposChanged: vi.fn(),
+        activateWorktree: vi.fn(),
+        createTerminal: vi.fn(),
+        revealTerminalSession: vi.fn(),
+        splitTerminal: vi.fn(),
+        renameTerminal: vi.fn(),
+        closeTerminal,
+        closeSessionTab: vi.fn(),
+        sleepWorktree: vi.fn(),
+        terminalFitOverrideChanged: vi.fn(),
+        terminalDriverChanged: vi.fn()
+      })
+      const webContents = { send: vi.fn() }
+      const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+        ipcMain.emit(
+          'terminal:tabCreateReply',
+          { sender: webContents },
+          { requestId: payload.requestId, tabId: 'tab-pending', title: 'Terminal' }
+        )
+      })
+      webContents.send = send
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      electronMocks.BrowserWindow.fromId.mockReturnValue({
+        isDestroyed: () => false,
+        webContents
+      })
+
+      const create = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        activate: true
+      })
+      const settled = create.then(
+        () => ({ ok: true as const }),
+        (error: Error) => ({ ok: false as const, error })
+      )
+      await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+
+      // Only the tab shell publishes (no ptyId → never ready); no PTY ever binds.
+      runtime.syncWindowGraph(1, {
+        tabs: [],
+        leaves: [],
+        mobileSessionTabs: [
+          {
+            worktree: TEST_WORKTREE_ID,
+            publicationEpoch: 'renderer-pending',
+            snapshotVersion: 1,
+            activeGroupId: 'group-1',
+            activeTabId: `tab-pending::${pendingLeafId}`,
+            activeTabType: 'terminal',
+            tabs: [
+              {
+                type: 'terminal',
+                id: `tab-pending::${pendingLeafId}`,
+                parentTabId: 'tab-pending',
+                leafId: pendingLeafId,
+                title: 'Terminal',
+                isActive: true
+              }
+            ]
+          }
+        ]
+      })
+
+      // Ready-fallback (1s) expires → materialize runs → spawn rejects → catch.
+      await vi.advanceTimersByTimeAsync(2_000)
+      const outcome = await settled
+
+      expect(outcome.ok).toBe(false)
+      expect(closeTerminal).toHaveBeenCalledWith('tab-pending')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a mobile-created terminal alive when the renderer never publishes the surface', async () => {
+    vi.useFakeTimers()
+    try {
+      const leafId = '44444444-4444-4444-8444-444444444444'
+      const closeTerminal = vi.fn()
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setNotifier({
+        focusTerminal: vi.fn(),
+        worktreesChanged: vi.fn(),
+        reposChanged: vi.fn(),
+        activateWorktree: vi.fn(),
+        createTerminal: vi.fn(),
+        revealTerminalSession: vi.fn(),
+        splitTerminal: vi.fn(),
+        renameTerminal: vi.fn(),
+        closeTerminal,
+        closeSessionTab: vi.fn(),
+        sleepWorktree: vi.fn(),
+        terminalFitOverrideChanged: vi.fn(),
+        terminalDriverChanged: vi.fn()
+      })
+      // Why: reply with a tabId but NEVER sync a matching mobileSessionTabs graph,
+      // reproducing a throttled/hidden renderer that spawns the PTY yet stalls its
+      // graph-sync publication past the surface timeout (#7587).
+      const webContents = { send: vi.fn() }
+      const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+        ipcMain.emit(
+          'terminal:tabCreateReply',
+          { sender: webContents },
+          { requestId: payload.requestId, tabId: 'tab-alive', title: 'Terminal' }
+        )
+      })
+      webContents.send = send
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      electronMocks.BrowserWindow.fromId.mockReturnValue({
+        isDestroyed: () => false,
+        webContents
+      })
+
+      const create = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        activate: true
+      })
+      let settled = false
+      const settledCreate = create.finally(() => {
+        settled = true
+      })
+      await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+
+      // The renderer's own PTY spawn registers with the tab binding — the same
+      // call the pty IPC layer now makes — without any mobileSessionTabs sync.
+      runtime.registerPty('pty-alive', TEST_WORKTREE_ID, null, {
+        tabId: 'tab-alive',
+        leafId
+      })
+
+      // Resolves promptly, well under MOBILE_TERMINAL_SURFACE_TIMEOUT_MS (10s).
+      await vi.advanceTimersByTimeAsync(50)
+      const result = await settledCreate
+
+      expect(settled).toBe(true)
+      expect(result.tab).toMatchObject({
+        type: 'terminal',
+        parentTabId: 'tab-alive',
+        leafId,
+        status: 'ready',
+        terminal: expect.stringMatching(/^term_/)
+      })
+      expect(closeTerminal).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a mobile-created terminal alive when the renderer PTY spawn races ahead of the reply', async () => {
+    vi.useFakeTimers()
+    try {
+      const leafId = '55555555-5555-4555-8555-555555555555'
+      const closeTerminal = vi.fn()
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setNotifier({
+        focusTerminal: vi.fn(),
+        worktreesChanged: vi.fn(),
+        reposChanged: vi.fn(),
+        activateWorktree: vi.fn(),
+        createTerminal: vi.fn(),
+        revealTerminalSession: vi.fn(),
+        splitTerminal: vi.fn(),
+        renameTerminal: vi.fn(),
+        closeTerminal,
+        closeSessionTab: vi.fn(),
+        sleepWorktree: vi.fn(),
+        terminalFitOverrideChanged: vi.fn(),
+        terminalDriverChanged: vi.fn()
+      })
+      // Why: the spawn and the tabCreate reply travel independent IPC channels;
+      // here the renderer registers the live PTY before it replies, so only the
+      // create's immediate pre-wait check can resolve it — asserting it settles
+      // well under the surface timeout pins that site, not the catch backstop.
+      const webContents = { send: vi.fn() }
+      const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+        runtime.registerPty('pty-early', TEST_WORKTREE_ID, null, {
+          tabId: 'tab-early',
+          leafId
+        })
+        ipcMain.emit(
+          'terminal:tabCreateReply',
+          { sender: webContents },
+          { requestId: payload.requestId, tabId: 'tab-early', title: 'Terminal' }
+        )
+      })
+      webContents.send = send
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      electronMocks.BrowserWindow.fromId.mockReturnValue({
+        isDestroyed: () => false,
+        webContents
+      })
+
+      const create = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        activate: true
+      })
+      let settled = false
+      const settledCreate = create.finally(() => {
+        settled = true
+      })
+      await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+
+      // Resolves via the immediate pre-wait rescue, well under the 10s timeout;
+      // reverting that site would only resolve later through the catch path.
+      await vi.advanceTimersByTimeAsync(50)
+      expect(settled).toBe(true)
+      const result = await settledCreate
+
+      expect(result.tab).toMatchObject({
+        type: 'terminal',
+        parentTabId: 'tab-early',
+        leafId,
+        status: 'ready',
+        terminal: expect.stringMatching(/^term_/)
+      })
+      expect(closeTerminal).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a mobile-created terminal alive when the renderer snapshot is rejected by the version guard', async () => {
+    vi.useFakeTimers()
+    try {
+      const leafId = '66666666-6666-4666-8666-666666666666'
+      const closeTerminal = vi.fn()
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setNotifier({
+        focusTerminal: vi.fn(),
+        worktreesChanged: vi.fn(),
+        reposChanged: vi.fn(),
+        activateWorktree: vi.fn(),
+        createTerminal: vi.fn(),
+        revealTerminalSession: vi.fn(),
+        splitTerminal: vi.fn(),
+        renameTerminal: vi.fn(),
+        closeTerminal,
+        closeSessionTab: vi.fn(),
+        sleepWorktree: vi.fn(),
+        terminalFitOverrideChanged: vi.fn(),
+        terminalDriverChanged: vi.fn()
+      })
+      const webContents = { send: vi.fn() }
+      const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+        ipcMain.emit(
+          'terminal:tabCreateReply',
+          { sender: webContents },
+          { requestId: payload.requestId, tabId: 'tab-guard', title: 'Terminal' }
+        )
+      })
+      webContents.send = send
+      runtime.attachWindow(1)
+      electronMocks.BrowserWindow.fromId.mockReturnValue({
+        isDestroyed: () => false,
+        webContents
+      })
+      // Why: seed an inflated stored version under a stable epoch (no headless /
+      // serve-owned tabs, so the preserve-merge can't lift the version via
+      // Math.max) — this is the state prior renderer publications leave behind.
+      runtime.syncWindowGraph(1, {
+        tabs: [],
+        leaves: [],
+        mobileSessionTabs: [
+          {
+            worktree: TEST_WORKTREE_ID,
+            publicationEpoch: 'epoch-guard',
+            snapshotVersion: 50,
+            activeGroupId: 'group-guard',
+            activeTabId: null,
+            activeTabType: null,
+            tabs: []
+          }
+        ]
+      })
+
+      const create = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        activate: true
+      })
+      let settled = false
+      const settledCreate = create.finally(() => {
+        settled = true
+      })
+      await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+
+      // The renderer publishes the new tab, but with a stale (lower) version
+      // under the same epoch, so syncMobileSessionTabs rejects it and the surface
+      // never lands via graph-sync — the reporter's exact stall variant (#7587).
+      runtime.syncWindowGraph(1, {
+        tabs: [],
+        leaves: [],
+        mobileSessionTabs: [
+          {
+            worktree: TEST_WORKTREE_ID,
+            publicationEpoch: 'epoch-guard',
+            snapshotVersion: 1,
+            activeGroupId: 'group-guard',
+            activeTabId: `tab-guard::${leafId}`,
+            activeTabType: 'terminal',
+            tabs: [
+              {
+                type: 'terminal',
+                id: `tab-guard::${leafId}`,
+                parentTabId: 'tab-guard',
+                leafId,
+                title: 'Terminal',
+                isActive: true
+              }
+            ]
+          }
+        ]
+      })
+      await vi.advanceTimersByTimeAsync(50)
+      // The rejected renderer sync must not have resolved the create.
+      expect(settled).toBe(false)
+      // Prove the rejection: the stored snapshot still lacks the tab.
+      const beforeRescue = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+      expect(
+        beforeRescue.tabs.some((tab) => tab.type === 'terminal' && tab.parentTabId === 'tab-guard')
+      ).toBe(false)
+
+      // The renderer's own PTY spawn registers with the binding and rescues it.
+      runtime.registerPty('pty-guard', TEST_WORKTREE_ID, null, {
+        tabId: 'tab-guard',
+        leafId
+      })
+      await vi.advanceTimersByTimeAsync(50)
+      const result = await settledCreate
+
+      expect(settled).toBe(true)
+      expect(result.tab).toMatchObject({
+        type: 'terminal',
+        parentTabId: 'tab-guard',
+        leafId,
+        status: 'ready',
+        terminal: expect.stringMatching(/^term_/)
+      })
+      expect(closeTerminal).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a mobile-created terminal alive at the surface timeout when only a leaf-synced PTY backs the tab', async () => {
+    vi.useFakeTimers()
+    try {
+      const leafId = '77777777-7777-4777-8777-777777777777'
+      const closeTerminal = vi.fn()
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setNotifier({
+        focusTerminal: vi.fn(),
+        worktreesChanged: vi.fn(),
+        reposChanged: vi.fn(),
+        activateWorktree: vi.fn(),
+        createTerminal: vi.fn(),
+        revealTerminalSession: vi.fn(),
+        splitTerminal: vi.fn(),
+        renameTerminal: vi.fn(),
+        closeTerminal,
+        closeSessionTab: vi.fn(),
+        sleepWorktree: vi.fn(),
+        terminalFitOverrideChanged: vi.fn(),
+        terminalDriverChanged: vi.fn()
+      })
+      // Why: the renderer pane identity can reach the runtime via leaf graph-sync
+      // (recordPtyWorktree) without registerPty, and leaf-sync never calls the
+      // pty-backed rescue; so when the mobileSessionTabs publication stalls past
+      // the surface timeout, only the catch-path rescue saves the live session —
+      // this pins the third #7587 rescue site, which the other tests never reach.
+      const webContents = { send: vi.fn() }
+      const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+        ipcMain.emit(
+          'terminal:tabCreateReply',
+          { sender: webContents },
+          { requestId: payload.requestId, tabId: 'tab-catch', title: 'Terminal' }
+        )
+      })
+      webContents.send = send
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      electronMocks.BrowserWindow.fromId.mockReturnValue({
+        isDestroyed: () => false,
+        webContents
+      })
+
+      const create = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        activate: true
+      })
+      let settled = false
+      const settledCreate = create.finally(() => {
+        settled = true
+      })
+      await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+
+      // Let the create clear its immediate pre-wait check (no live PTY yet) and
+      // park in waitForMobileTerminalSurface before any identity arrives.
+      await vi.advanceTimersByTimeAsync(50)
+
+      // Renderer pane identity arrives via leaf graph-sync — NOT registerPty — so
+      // no rescue fires here, and the mobileSessionTabs surface is never published.
+      runtime.syncWindowGraph(1, {
+        tabs: [],
+        leaves: [
+          {
+            tabId: 'tab-catch',
+            worktreeId: TEST_WORKTREE_ID,
+            leafId,
+            paneRuntimeId: 1,
+            ptyId: 'pty-catch'
+          }
+        ]
+      })
+
+      // Surface still unpublished, so the create is still pending.
+      expect(settled).toBe(false)
+
+      // Cross MOBILE_TERMINAL_SURFACE_TIMEOUT_MS (10s): the catch path must rescue
+      // from the live PTY instead of rolling the session back destructively.
+      await vi.advanceTimersByTimeAsync(11_000)
+      const result = await settledCreate
+
+      expect(settled).toBe(true)
+      expect(result.tab).toMatchObject({
+        type: 'terminal',
+        parentTabId: 'tab-catch',
+        leafId,
+        status: 'ready',
+        terminal: expect.stringMatching(/^term_/)
+      })
+      expect(closeTerminal).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('reports browser tab creation as unsupported for a windowless host with no offscreen backend', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.syncWindowGraph(0, { tabs: [], leaves: [] })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -175,7 +175,7 @@ import { TASK_PROVIDERS } from '../../shared/task-providers'
 import { FIRST_PANE_ID } from '../../shared/pane-key'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../shared/stable-pane-id'
 import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
-import { isValidHostTerminalTabId } from '../../shared/terminal-tab-id'
+import { isValidHostTerminalTabId, isValidTerminalTabId } from '../../shared/terminal-tab-id'
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '../../shared/tui-agent-startup'
 import { repoIsRemote } from '../../shared/agent-launch-remote'
 import {
@@ -2010,6 +2010,15 @@ export class OrcaRuntimeService {
   private mobileTerminalCreateByMutationId = new Map<
     string,
     Promise<RuntimeMobileSessionCreateTerminalResult>
+  >()
+  // Why: a mobile create waits for the renderer to publish the new tab's surface
+  // via graph-sync, but a throttled/hidden renderer can park that past the surface
+  // timeout and the create would then destroy the live PTY (#7587). This lets the
+  // renderer's own PTY spawn publish the surface main-side, scoped to in-flight
+  // creates so ordinary renderer spawns never publish here.
+  private pendingMobileTerminalCreatesByKey = new Map<
+    string,
+    { activate: boolean; selectIfNoActiveTab: boolean }
   >()
   private mobileSessionTabListeners = new Set<(snapshot: RuntimeMobileSessionTabsResult) => void>()
   private leaves = new Map<string, RuntimeLeafRecord>()
@@ -5213,8 +5222,28 @@ export class OrcaRuntimeService {
     }
   }
 
-  registerPty(ptyId: string, worktreeId: string, connectionId: string | null = null): void {
-    this.recordPtyWorktree(ptyId, worktreeId, { connected: true, connectionId })
+  registerPty(
+    ptyId: string,
+    worktreeId: string,
+    connectionId: string | null = null,
+    binding?: { tabId: string; leafId: string }
+  ): void {
+    // Why: record the renderer pane identity at spawn time so a stalled graph
+    // sync can't hide that a live PTY already backs a pending mobile create.
+    const paneKey =
+      binding && isValidTerminalTabId(binding.tabId) && isTerminalLeafId(binding.leafId)
+        ? makePaneKey(binding.tabId, binding.leafId)
+        : null
+    this.recordPtyWorktree(ptyId, worktreeId, {
+      connected: true,
+      connectionId,
+      ...(binding && paneKey ? { tabId: binding.tabId, paneKey } : {})
+    })
+    // Why: the renderer's own PTY spawn is the reliable signal that the pending
+    // mobile create's tab is live; publish its surface main-side (#7587).
+    if (binding && paneKey) {
+      this.ensurePtyBackedMobileSurfaceForRendererTab(worktreeId, binding.tabId)
+    }
   }
 
   /**
@@ -16130,7 +16159,22 @@ export class OrcaRuntimeService {
     if (opts.activate !== false) {
       this.notifier?.focusTerminal(reply.tabId, worktreeId, null)
     }
+    // Why: register the wait before the renderer's PTY spawn arrives so that
+    // spawn (registerPty) can publish the pty-backed surface main-side even if
+    // graph-sync is stalled (#7587). Removed in the finally below.
+    const pendingCreateKey = `${worktreeId}::${reply.tabId}`
+    // Why: a rescue publishes into the active group (opts.targetGroupId is not
+    // threaded); the renderer's reconciling publication then moves the tab to the
+    // requested group, so any wrong-group placement is cosmetic and stall-window-only.
+    this.pendingMobileTerminalCreatesByKey.set(pendingCreateKey, {
+      activate: opts.activate !== false,
+      selectIfNoActiveTab: true
+    })
     try {
+      // Why: the PTY spawn and the tabCreate reply race on independent IPC
+      // channels; if the spawn already registered, publish immediately so the
+      // wait resolves without depending on a graph sync.
+      this.ensurePtyBackedMobileSurfaceForRendererTab(worktreeId, reply.tabId)
       const surface = await this.waitForMobileTerminalSurface(worktreeId, reply.tabId, {
         timeoutMs: MOBILE_TERMINAL_SURFACE_TIMEOUT_MS
       })
@@ -16167,12 +16211,24 @@ export class OrcaRuntimeService {
         }
       )
     } catch (error) {
-      // Why: the renderer created the tab but its terminal surface never
-      // published (PTY spawn/handle failure). Roll the half-created tab back via
-      // the renderer close path so it can't linger as a ghost in mobile
-      // snapshots, then surface the failure to the caller.
+      // Why: publication latency (throttled/hidden renderer), not spawn failure,
+      // can trip the surface timeout. Rescue only when a live PTY actually backs
+      // the tab — gating on a surface would let a handle-less shell (or a failed
+      // materialize) resolve as success and skip the ghost-tab rollback (#7587).
+      if (this.findLiveRegisteredPtyForRendererTab(worktreeId, reply.tabId)) {
+        const rescued = this.ensurePtyBackedMobileSurfaceForRendererTab(worktreeId, reply.tabId)
+        if (rescued) {
+          return rescued
+        }
+      }
+      // Why: the renderer created the tab but no live PTY backs it (true PTY
+      // spawn/handle failure). Roll the half-created tab back via the renderer
+      // close path so it can't linger as a ghost in mobile snapshots, then
+      // surface the failure to the caller.
       this.notifier?.closeTerminal(reply.tabId)
       throw error
+    } finally {
+      this.pendingMobileTerminalCreatesByKey.delete(pendingCreateKey)
     }
   }
 
@@ -16443,6 +16499,61 @@ export class OrcaRuntimeService {
       return null
     }
     return surface
+  }
+
+  // Why: for an in-flight mobile create whose surface hasn't published yet,
+  // publish it main-side from the live renderer PTY so the create doesn't wait
+  // on a stalled graph sync and destroy the session (#7587). No-op unless a
+  // matching create is pending and a live bound PTY exists; never double-inserts.
+  private ensurePtyBackedMobileSurfaceForRendererTab(
+    worktreeId: string,
+    tabId: string
+  ): RuntimeMobileSessionCreateTerminalResult | null {
+    const pending = this.pendingMobileTerminalCreatesByKey.get(`${worktreeId}::${tabId}`)
+    if (!pending) {
+      return null
+    }
+    const existing = this.findMobileTerminalSurface(worktreeId, tabId)
+    if (existing) {
+      // Why: the renderer's own publication already landed; stay idempotent.
+      return existing
+    }
+    const pty = this.findLiveRegisteredPtyForRendererTab(worktreeId, tabId)
+    const leafId = pty ? parsePaneKey(pty.paneKey ?? '')?.leafId : undefined
+    if (!pty || !leafId) {
+      return null
+    }
+    this.publishPtyBackedMobileSessionTerminal(worktreeId, pty, {
+      tabId,
+      leafId,
+      title: null,
+      activate: pending.activate,
+      selectIfNoActiveTab: pending.selectIfNoActiveTab
+    })
+    // Why: waitForMobileTerminalSurface's check closures are drained only inside
+    // syncWindowGraph; a main-side publish must drain them too or the pending
+    // wait won't observe the insertion (mirrors syncWindowGraph's drain).
+    for (const cb of [...this.graphSyncCallbacks]) {
+      cb()
+    }
+    return this.findMobileTerminalSurface(worktreeId, tabId)
+  }
+
+  private findLiveRegisteredPtyForRendererTab(
+    worktreeId: string,
+    tabId: string
+  ): RuntimePtyWorktreeRecord | null {
+    for (const pty of this.ptysById.values()) {
+      if (
+        pty.worktreeId === worktreeId &&
+        pty.tabId === tabId &&
+        pty.connected &&
+        parsePaneKey(pty.paneKey ?? '')?.leafId
+      ) {
+        return pty
+      }
+    }
+    return null
   }
 
   private isReadyMobileTerminalSurface(


### PR DESCRIPTION
Fixes #7587.

## What changes

Creating a terminal from Orca Mobile (or any paired remote client) no longer destroys the just-spawned agent session when the desktop renderer's snapshot publications are delayed. Previously, `runCreateMobileSessionTerminal` waited up to 10s for the new tab to appear in `mobileSessionTabsByWorktree` — a map fed only by renderer graph-sync publications on this path — and on timeout rolled the tab back through the destructive close path (`pty:kill` with `keepHistory: false`), deleting the session's `terminal-history/` folder and unregistering its Claude live-session id. A hidden/occluded desktop window (Chromium background timer throttling; Orca keeps Electron's default `backgroundThrottling`) or a busy renderer can park the 16ms publication coalescer past 10s, so every mobile create spawned a real agent session and reaped it ~10s later — exactly the reported behavior.

Now the runtime publishes the tab surface main-side from the renderer's own PTY spawn (the `pty:spawn` IPC already carries validated `tabId`/`leafId`), scoped strictly to creates that are actively waiting: a pending-create registry keyed by `(worktreeId, tabId)` is checked when the renderer PTY registers, immediately after the tab-create reply, and as a last chance at timeout. The publish reuses `publishPtyBackedMobileSessionTerminal` — the same mechanism runtime-spawned terminals already use — and drains `graphSyncCallbacks` so the pending wait resolves promptly instead of after 10s.

## What does not change

- True spawn failure (no live PTY for the created tab) still rolls back exactly as before, including the `Timed out waiting for terminal surface after creation` error. The timeout rescue is explicitly gated on a live PTY so a handle-less tab shell can never resolve as success.
- Ordinary desktop tab creation never triggers main-side publication — the pending-create registry scoping means renderer snapshots remain authoritative for renderer tabs.
- No RPC contract, mobile app, timeout value, or `backgroundThrottling` changes.
- The mobile-snapshot freshness guard and `touchMobileSessionSnapshotsForPty` are untouched; `#7400` (stale mobile snapshot contents) is adjacent but separate and not addressed here.

## Root cause and reproduction

Reproduced live before the fix on macOS HEAD with a paired physical iPhone driving the real `session.tabs.createTerminal` RPC over the app's E2EE channel: with renderer graph-sync publications stalled (via the renderer module's own `setRuntimeGraphSyncEnabled(false)` kill switch — a faithful stand-in for a parked/throttled sync timer), the create failed at 10,566ms with the exact reported error, the Claude PTY's `terminal-history/` folder was deleted, and its live id was unregistered. With publications flowing, 7/7 creates succeeded — including under agent title-churn storms and with the desktop focused on a different worktree. Both trigger variants (publication stall, and the freshness-guard version rejection hypothesized in the issue) collapse to the same dependency this PR removes.

## Process summary (Brennan's PR process)

- **Design:** scratch design doc reviewed by the session lead (the full design-review loop was explicitly skipped at Brennan's instruction). Fix direction: remove the create path's dependency on renderer publication timing (root cause), mirroring the existing runtime-spawned-terminal mechanism rather than tuning timeouts or disabling throttling.
- **Implementation:** four files — `src/main/runtime/orca-runtime.ts` (extended `registerPty` binding, pending-create registry, `ensurePtyBackedMobileSurfaceForRendererTab` helper wired at three race sites, live-PTY-gated rescue before the rollback in the timeout catch), `src/main/ipc/pty.ts` (both `registerPty` call sites pass the validated, length-bounded `tabId`/`leafId` binding), plus regression tests in `orca-runtime.test.ts` and `pty.test.ts`. One deviation from the design doc: the two pty.ts call-site roles were labeled in reverse; the binding applies at both, no behavior difference.
- **Completeness verification:** COMPLETE — all six audit items PASS (three rescue sites traced end-to-end; registry cleaned on every exit path; rollback preserved for the no-live-PTY case; `registerPty` backward compatible at all call sites; exited PTYs not treated as live; mobile client contract satisfied with `status: 'ready'` + `term_` handle). When no prior snapshot exists the rescue publishes under a `headless:pty-backed:` epoch that the merge logic actively preserves.
- **Headline behavior status: implemented** — the full pipeline (mobile **+** → RPC → renderer tab create → PTY spawn → surface published → tab visible and persistent on mobile) survives a stalled renderer; no scope narrowing.
- **Broad app consistency:** the mobile/web remote create path now matches the runtime-spawned-terminal path (main-side pty-backed publication at spawn). Desktop tab creation, headless/serve mode, and SSH-connected worktrees (binding travels through the same spawn args; PTY records keep `connectionId`) are unchanged.
- **Code review:** 4-round review/fix loop (two fresh parallel reviewers per round). One Medium correctness finding caught and fixed (the timeout rescue could have returned a dead handle-less shell surface as success — now gated on a live PTY, with a dedicated gate-lock test), plus test-coverage and input-bounding Lows. A final confirmation round with two fresh parallel reviewers returned **CLEAN / CLEAN**.

## Reliability regression gate

Touched P0-capable classes: tab creation/binding, mobile/remote provider contract, PTY identity (read-only consumption of existing spawn args). Eight new deterministic tests:

1. "keeps a mobile-created terminal alive when the renderer never publishes the surface" — the core regression lock; hangs on pre-fix code, resolves in ~50ms fake time with the fix.
2. "…when the renderer PTY spawn races ahead of the reply" — pins the immediate pre-wait check.
3. "…when the renderer snapshot is rejected by the version guard" — the issue reporter's hypothesized `#7400`-style trigger, with the guard rejection asserted directly on the stored snapshot before the rescue.
4. "…at the surface timeout when only a leaf-synced PTY backs the tab" — pins the catch-path last-chance rescue.
5. "rolls back a mobile create when the materialize spawn fails and no live PTY backs the tab" — gate-lock proving the rescue cannot resolve a handle-less shell as success.
6.-8. IPC seam tests: both `registerPty` call sites thread the validated binding; a non-UUID leaf id yields no binding.

Existing rollback and pending-surface materialization tests remain green and meaningful.

## Risks and non-goals

- Transient cosmetic window: if a stale in-flight renderer snapshot (ms-wide window; snapshots build from current store state, so none are queued) lands after the main-side publish under a renderer epoch, the pty-backed tab can briefly disappear from the mobile snapshot until the renderer's next publication. No reconciliation path closes the PTY or deletes history — verified. Strictly better than the pre-fix behavior (session destroyed).
- A stalled SPLIT create publishes a flat (non-split) surface, and the rescue publishes into the active group (`targetGroupId` not threaded); the renderer's reconciling publication corrects both. Stall-window-only, cosmetic.
- Two bounded, intentional behavior deltas from populating `tabId`/`paneKey` at spawn (previously set on first data/graph-sync): (a) the agent-status pty-record fallback now attributes bound-but-leafless PTYs under the same `paneKey` the mounted leaf later uses (per status transition, stall-window only); (b) `findPtyForMobileTerminalTab`'s worktree-only fallback no longer matches freshly-bound PTYs — stricter, more correct identity matching. CLI/headless spawns carry no tab identity, so their loose-match escape hatch is unchanged.
- Non-goals: `#7400` freshness-guard semantics, `backgroundThrottling`, mobile app changes.

## Perf audit

NO-REGRESSION. PTY-spawn hot path adds O(1) guards + one Map miss per spawn (startup bulk-restore unaffected; the pending registry is empty). The O(n) PTY scan is gated behind the pending-create registry check and runs only for in-flight mobile creates. The `graphSyncCallbacks` drain fires only when the helper actually publishes; callbacks are read-only self-removing closures (no re-entrancy). No new timers, polling, subscriptions, IPC, or storage writes; renderer process and startup untouched.

## Validation

- `pnpm tc` (node/cli/web) — pass, re-run after every fix wave.
- `pnpm vitest run … pty.test.ts orca-runtime.test.ts rpc/methods/session-tabs.test.ts` — **796/796 pass** (re-run independently by the lead; new tests re-run 3× with zero flake).
- `oxlint` on changed files — clean.
- **Live end-to-end validation (before/after on the same rig):** dev desktop paired with a real Orca Mobile client over the app's own pairing deep-link + E2EE channel; renderer publications force-stalled via the module kill switch.
  - **Pre-fix:** create failed at 10,566ms with `Timed out waiting for terminal surface after creation`; the session's history folder was deleted and its live id unregistered (file watcher captured the reap).
  - **Post-fix, same stalled condition:** `session.tabs.createTerminal {agent:'claude'}` resolved in **553ms** with `status:'ready'` and a `term_` handle; the session survived 45s+ with live id and history folder intact; the mobile UI showed the new Claude Code tab streaming the live session.
  - **Reconciliation:** after re-enabling publications, the desktop adopted the same tab in its tab strip with the phone-control overlay attributing input to the mobile client.
  - **Healthy-path control:** create with publications flowing resolved in 337ms.
  - Supplementary independent QA (real mobile UI tap-through on an iOS Simulator): **+ → Terminal** from the mobile session screen produced a persistent tab well past the old ~10s reap window.

## Post-PR stabilization

`verify` and `track-community-pr` checks pass (re-run green after the follow-up commit). CodeRabbit raised two trivial maintainability nitpicks (reuse the in-scope `metadataLeafId` at the controller spawn site; dedupe the repeated notifier mock in the new tests) — both applied in `fa7e9144c`, re-validated (typecheck + 796/796 tests), no inline or actionable comments remain.


## Regression & back-compat review (independent)

Independent post-implementation review — fresh read of the diff plus three parallel verification sweeps (mobile RPC / group-placement, a full audit of every `tabId`/`paneKey` reader, and a tests + typecheck run). **Verdict: no regressions found, backwards-compatible — safe to ship.**

**Back-compat — safe.** The entire diff is 4 files, all in `src/main/` (desktop main process): `ipc/pty.ts`, `runtime/orca-runtime.ts`, and their tests. No changes to `mobile/`, `shared/`, RPC contracts, persisted schemas, or IPC message shapes. The new `registerPty` 4th argument is optional and internal to main, and the renderer→main `pty:spawn` IPC already carried `tabId`/`leafId`. Cross-version matrix: old mobile ↔ new desktop simply stops reaping the tab (a strict improvement — verified that all three mobile `session.tabs.createTerminal` call sites send unchanged params); new desktop ↔ old mobile is identical; there are no mobile-side changes, so new-mobile ↔ old-desktop is N/A. Both `registerPty` call sites also cover SSH/reattach terminals, which benefit most since slower spawns are more stall-prone.

**Correctness — no regressions.** All 15 readers of `pty.tabId`/`pty.paneKey` were audited: the value written at spawn (`makePaneKey(tabId, leafId)`) is byte-identical to what graph-sync writes a few ms later; every reader either benefits from earlier population or keys on `connected`/`worktreeId` and is unaffected; and the `tabId === null && paneKey === null` worktree-only adoption branch stays safe because the fix never populates identity for the daemon/restored PTYs that branch targets. The pty-backed surface resolves as `status: 'ready'` precisely because the recorded `tabId`/`paneKey` is what `mobileTerminalTabMatchesPty` needs to locate the live PTY while `this.leaves` is unsynced. Reconciliation reuses the proven `publishPtyBackedMobileSessionTerminal` + `syncMobileSessionTabs` dedup path (no tab duplication); the helper is idempotent, scoped to in-flight creates, cleaned up in `finally`, and drains a copy of `graphSyncCallbacks` (re-entrancy-safe). Group-flash is a non-issue for mobile (never sends `targetGroupId`) and is cosmetic + stall-window-only for the desktop-paired web client, which also passes `activate: true`.

**Performance — neutral-to-positive.** Healthy creates can resolve faster (main-side publish vs. waiting on the throttled graph-sync timer). Per-spawn cost is one O(1) `Map.get` that early-returns when no create is pending; the O(n) PTY scan runs only on the in-flight mobile-create path. No hot-path impact, no new timers/polling/IPC.

**Tests — green.** 781 targeted tests pass; node-scoped typecheck (`typecheck:node`, covers both changed files) is clean. Rescue paths, true-failure rollback, and the `registerPty` binding-validation bounds are all covered. One optional gap: no direct negative assertion that an ordinary renderer spawn with no in-flight create refrains from publishing (enforced in source by the pending-create registry scoping).
