### PR TITLE
Fix terminal scroll intent cache leak

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-scroll-intent-tab-retirement.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-scroll-intent-tab-retirement.ts
@@ -1,0 +1,37 @@
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
+import { clearTerminalScrollIntentKey } from '../../lib/pane-manager/terminal-scroll-intent-key-store'
+import { collectLeafIdsInOrder } from './terminal-layout-leaf-ids'
+
+export function retireTerminalScrollIntentsForTabs(
+  layoutsByTabId: Readonly<Record<string, TerminalLayoutSnapshot | undefined>> | null | undefined,
+  tabIds: Iterable<string>
+): void {
+  // Why: cold-parked tabs have no PaneManager left to retire durable leaf ids
+  // when the store later removes the tab or its owning worktree.
+  const retiredLeafIds = new Set<string>()
+  for (const tabId of tabIds) {
+    const layout = layoutsByTabId?.[tabId]
+    for (const leafId of collectLeafIdsInOrder(layout?.root)) {
+      retiredLeafIds.add(leafId)
+    }
+    if (layout?.activeLeafId) {
+      retiredLeafIds.add(layout.activeLeafId)
+    }
+    if (layout?.expandedLeafId) {
+      retiredLeafIds.add(layout.expandedLeafId)
+    }
+    for (const leafRecord of [
+      layout?.ptyIdsByLeafId,
+      layout?.buffersByLeafId,
+      layout?.scrollbackRefsByLeafId,
+      layout?.titlesByLeafId
+    ]) {
+      for (const leafId of Object.keys(leafRecord ?? {})) {
+        retiredLeafIds.add(leafId)
+      }
+    }
+  }
+  for (const leafId of retiredLeafIds) {
+    clearTerminalScrollIntentKey(leafId)
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1781,7 +1781,7 @@ export function useTerminalPaneLifecycle({
       }
       panePtyBindings.clear()
       paneTransports.clear()
-      manager.destroy()
+      manager.destroy({ preserveTerminalScrollIntent: tabStillExists })
       releaseWebviewDragPassthrough?.()
       releaseWebviewDragPassthrough = null
       managerRef.current = null

--- a/src/renderer/src/lib/pane-manager/pane-manager-destroy-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-destroy-scroll-intent.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
+
+const clearTerminalScrollIntentKey = vi.hoisted(() => vi.fn())
+const disposePane = vi.hoisted(() => vi.fn())
+
+vi.mock('./terminal-scroll-intent', () => ({
+  clearTerminalScrollIntentKey
+}))
+
+vi.mock('./pane-lifecycle', () => ({
+  createPaneDOM: vi.fn(),
+  disposePane,
+  openTerminal: vi.fn(),
+  setLigaturesEnabled: vi.fn()
+}))
+
+import { PaneManager } from './pane-manager'
+
+const FIRST_LEAF_ID = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
+const SECOND_LEAF_ID = '22222222-2222-4222-8222-222222222222' as TerminalLeafId
+
+class TestRootElement {
+  innerHTML = ''
+
+  querySelectorAll(): HTMLElement[] {
+    return []
+  }
+}
+
+function createTestElement(): HTMLElement {
+  return new TestRootElement() as unknown as HTMLElement
+}
+
+function createPane(id: number, leafId: TerminalLeafId): ManagedPaneInternal {
+  return {
+    id,
+    leafId,
+    stablePaneId: leafId,
+    terminal: {} as never,
+    container: createTestElement(),
+    xtermContainer: createTestElement(),
+    linkTooltip: createTestElement(),
+    terminalGpuAcceleration: 'auto',
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    webglAddon: null,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    fitAddon: {} as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+function setManagerPanes(manager: PaneManager, panes: [number, ManagedPaneInternal][]): void {
+  ;(manager as unknown as { panes: Map<number, ManagedPaneInternal> }).panes = new Map(panes)
+}
+
+describe('PaneManager destroy scroll intent cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('clears keyed scroll intent for every pane on permanent destroy', () => {
+    const manager = new PaneManager(createTestElement(), {})
+    setManagerPanes(manager, [
+      [1, createPane(1, FIRST_LEAF_ID)],
+      [2, createPane(2, SECOND_LEAF_ID)]
+    ])
+
+    manager.destroy()
+
+    expect(clearTerminalScrollIntentKey).toHaveBeenCalledWith(FIRST_LEAF_ID)
+    expect(clearTerminalScrollIntentKey).toHaveBeenCalledWith(SECOND_LEAF_ID)
+  })
+
+  it('preserves keyed scroll intent when destroy is followed by a live-tab remount', () => {
+    const manager = new PaneManager(createTestElement(), {})
+    setManagerPanes(manager, [[1, createPane(1, FIRST_LEAF_ID)]])
+
+    manager.destroy({ preserveTerminalScrollIntent: true })
+
+    expect(disposePane).toHaveBeenCalledTimes(1)
+    expect(clearTerminalScrollIntentKey).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -50,6 +50,7 @@ import {
 } from './pane-split-close'
 import { FIRST_PANE_ID } from '../../../../shared/pane-key'
 import { splitPaneAroundMountedSubtree } from './pane-subtree-split'
+import { clearTerminalScrollIntentKey } from './terminal-scroll-intent'
 
 export type {
   PaneManagerOptions,
@@ -357,13 +358,21 @@ export class PaneManager {
     beginPaneDragFromPointerDown(handle, paneId, this.dragState, this.getDragCallbacks(), event)
   }
 
-  destroy(): void {
+  destroy(options: { preserveTerminalScrollIntent?: boolean } = {}): void {
     this.destroyed = true
     unregisterLivePaneManager(this)
     cancelActivePaneDrag(this.dragState)
     this.cancelPendingPaneReparentFrames()
+    const scrollIntentLeafIds = options.preserveTerminalScrollIntent
+      ? []
+      : Array.from(this.panes.values(), (pane) => pane.leafId)
     for (const pane of this.panes.values()) {
       disposePane(pane, this.panes)
+    }
+    for (const leafId of scrollIntentLeafIds) {
+      // Why: permanent manager teardown retires every leaf id. Tab rehomes pass
+      // preserveTerminalScrollIntent so the remount can restore scroll position.
+      clearTerminalScrollIntentKey(leafId)
     }
     this.identities.clear()
     disposeDividersIn(this.root)

--- a/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
@@ -3,10 +3,16 @@ import type { ManagedPaneInternal, ScrollState } from './pane-manager-types'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 
 const captureScrollState = vi.hoisted(() => vi.fn())
+const findPaneChildren = vi.hoisted(() => vi.fn())
+const promoteSibling = vi.hoisted(() => vi.fn())
+const removeDividers = vi.hoisted(() => vi.fn())
+const safeFit = vi.hoisted(() => vi.fn())
 const wrapInSplit = vi.hoisted(() => vi.fn())
 const openTerminal = vi.hoisted(() => vi.fn())
+const disposePane = vi.hoisted(() => vi.fn())
 const disposeWebgl = vi.hoisted(() => vi.fn())
 const clearPendingSplitScrollRestore = vi.hoisted(() => vi.fn())
+const clearTerminalScrollIntentKey = vi.hoisted(() => vi.fn())
 const scheduleSplitScrollRestore = vi.hoisted(() => vi.fn())
 const updateMultiPaneState = vi.hoisted(() => vi.fn())
 const applyPaneOpacity = vi.hoisted(() => vi.fn())
@@ -14,15 +20,15 @@ const applyDividerStyles = vi.hoisted(() => vi.fn())
 
 vi.mock('./pane-tree-ops', () => ({
   captureScrollState,
-  findPaneChildren: vi.fn(),
-  promoteSibling: vi.fn(),
-  removeDividers: vi.fn(),
-  safeFit: vi.fn(),
+  findPaneChildren,
+  promoteSibling,
+  removeDividers,
+  safeFit,
   wrapInSplit
 }))
 
 vi.mock('./pane-lifecycle', () => ({
-  disposePane: vi.fn(),
+  disposePane,
   openTerminal
 }))
 
@@ -35,6 +41,10 @@ vi.mock('./pane-split-scroll', () => ({
   scheduleSplitScrollRestore
 }))
 
+vi.mock('./terminal-scroll-intent', () => ({
+  clearTerminalScrollIntentKey
+}))
+
 vi.mock('./pane-drag-reorder', () => ({
   updateMultiPaneState
 }))
@@ -44,7 +54,11 @@ vi.mock('./pane-divider', () => ({
   applyPaneOpacity
 }))
 
-import { splitManagedPane } from './pane-split-close'
+import {
+  closeManagedPane,
+  detachManagedPaneForExternalMove,
+  splitManagedPane
+} from './pane-split-close'
 
 const TEST_LEAF_ID = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
 
@@ -67,6 +81,10 @@ class MockElement {
 
   querySelectorAll(): MockElement[] {
     return this.descendants
+  }
+
+  remove(): void {
+    this.parentElement = null
   }
 }
 
@@ -191,5 +209,62 @@ describe('splitManagedPane', () => {
       expect.any(Function),
       expect.any(Function)
     )
+  })
+
+  it('clears keyed scroll intent when a pane is permanently closed', () => {
+    const pane = createPane(1, null)
+    const siblingPane = createPane(2, null)
+    const root = new MockElement(['root'])
+    ;(pane.container as unknown as MockElement).parentElement = root
+    const panes = new Map<number, ManagedPaneInternal>([
+      [pane.id, pane],
+      [siblingPane.id, siblingPane]
+    ])
+    const onPaneClosed = vi.fn()
+
+    closeManagedPane({
+      paneId: pane.id,
+      activePaneId: pane.id,
+      panes,
+      root: root as unknown as HTMLElement,
+      styleOptions: {},
+      managerOptions: { onPaneClosed },
+      getDragCallbacks: () => ({}) as never,
+      releasePaneIdentity: vi.fn(),
+      setActivePaneId: vi.fn()
+    })
+
+    expect(clearTerminalScrollIntentKey).toHaveBeenCalledWith(TEST_LEAF_ID)
+    expect(onPaneClosed).toHaveBeenCalledWith(pane.id, {
+      paneId: pane.id,
+      leafId: TEST_LEAF_ID,
+      reason: 'close'
+    })
+  })
+
+  it('preserves keyed scroll intent when a pane is detached to a new tab', () => {
+    const pane = createPane(1, null)
+    const siblingPane = createPane(2, null)
+    const root = new MockElement(['root'])
+    ;(pane.container as unknown as MockElement).parentElement = root
+    const panes = new Map<number, ManagedPaneInternal>([
+      [pane.id, pane],
+      [siblingPane.id, siblingPane]
+    ])
+
+    const detached = detachManagedPaneForExternalMove({
+      paneId: pane.id,
+      activePaneId: pane.id,
+      panes,
+      root: root as unknown as HTMLElement,
+      styleOptions: {},
+      managerOptions: {},
+      getDragCallbacks: () => ({}) as never,
+      releasePaneIdentity: vi.fn(),
+      setActivePaneId: vi.fn()
+    })
+
+    expect(detached).toBe(true)
+    expect(clearTerminalScrollIntentKey).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -20,6 +20,7 @@ import { disposeWebgl } from './pane-webgl-renderer'
 import { clearPendingSplitScrollRestore, scheduleSplitScrollRestore } from './pane-split-scroll'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
 import { toPublicPane } from './pane-public-view'
+import { clearTerminalScrollIntentKey } from './terminal-scroll-intent'
 
 type MovedPaneSplitState = {
   pane: ManagedPaneInternal
@@ -174,6 +175,11 @@ function teardownManagedPane(args: CloseManagedPaneArgs, reason: 'close' | 'deta
   const closedLeafId = pane.leafId
   args.releasePaneIdentity(args.paneId)
   removePaneContainer(args, pane)
+  if (reason === 'close') {
+    // Why: detach remounts the same leaf in a new tab, but close retires the
+    // durable leaf id and its keyed scroll-intent snapshot.
+    clearTerminalScrollIntentKey(closedLeafId)
+  }
   const nextActivePaneId = activateReplacementPane(args)
   applyPaneOpacity(args.panes.values(), nextActivePaneId, args.styleOptions)
   for (const p of args.panes.values()) {

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-key-store.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-key-store.ts
@@ -1,0 +1,77 @@
+export type TerminalScrollIntentKey = string
+
+export type TerminalScrollIntent = {
+  kind: 'followOutput' | 'pinnedViewport'
+  bufferType: 'normal' | 'alternate'
+  viewportY: number
+  baseY: number
+}
+
+type TerminalScrollIntentKeyBinding = {
+  key: TerminalScrollIntentKey
+  retired: boolean
+}
+
+const bindingByTerminal = new WeakMap<object, TerminalScrollIntentKeyBinding>()
+const activeBindingByKey = new Map<TerminalScrollIntentKey, TerminalScrollIntentKeyBinding>()
+const intentByKey = new Map<TerminalScrollIntentKey, TerminalScrollIntent>()
+
+export function writeTerminalScrollIntentKey(terminal: object, intent: TerminalScrollIntent): void {
+  const binding = bindingByTerminal.get(terminal)
+  if (binding && !binding.retired && activeBindingByKey.get(binding.key) === binding) {
+    intentByKey.set(binding.key, intent)
+  }
+}
+
+export function readTerminalScrollIntentKey(terminal: object): TerminalScrollIntent | undefined {
+  const binding = bindingByTerminal.get(terminal)
+  if (!binding || binding.retired || activeBindingByKey.get(binding.key) !== binding) {
+    return undefined
+  }
+  return intentByKey.get(binding.key)
+}
+
+export function bindTerminalScrollIntentKey(
+  terminal: object,
+  key: TerminalScrollIntentKey | undefined
+): TerminalScrollIntent | undefined {
+  if (!key) {
+    return undefined
+  }
+  let binding = activeBindingByKey.get(key)
+  if (!binding) {
+    binding = { key, retired: false }
+    activeBindingByKey.set(key, binding)
+  }
+  bindingByTerminal.set(terminal, binding)
+  return intentByKey.get(key)
+}
+
+export function clearTerminalScrollIntentKey(key: TerminalScrollIntentKey): void {
+  const binding = activeBindingByKey.get(key)
+  if (binding) {
+    // Why: queued scroll samplers cannot be cancelled uniformly, so retire their
+    // binding before deleting state to prevent key resurrection and ABA writes.
+    binding.retired = true
+    if (activeBindingByKey.get(key) === binding) {
+      activeBindingByKey.delete(key)
+    }
+  }
+  intentByKey.delete(key)
+}
+
+export function _getTerminalScrollIntentKeyCountForTest(): number {
+  return activeBindingByKey.size
+}
+
+export function _getTerminalScrollIntentSnapshotCountForTest(): number {
+  return intentByKey.size
+}
+
+export function _clearTerminalScrollIntentKeysForTest(): void {
+  for (const binding of activeBindingByKey.values()) {
+    binding.retired = true
+  }
+  activeBindingByKey.clear()
+  intentByKey.clear()
+}

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  _clearTerminalScrollIntentKeysForTest,
+  _getTerminalScrollIntentKeyCountForTest,
+  _getTerminalScrollIntentSnapshotCountForTest,
   attachTerminalScrollIntentTracking,
   captureTerminalWriteScrollIntent,
+  clearTerminalScrollIntentKey,
   enforceTerminalCurrentScrollIntent,
   enforceTerminalWriteScrollIntent,
   getTerminalScrollIntentKind,
@@ -36,6 +40,23 @@ function createTerminal({
     })
   }
   return terminal
+}
+
+function installDeferredScrollIntentHarness(): () => Promise<void> {
+  const frameCallbacks: FrameRequestCallback[] = []
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frameCallbacks.push(callback)
+    return frameCallbacks.length
+  })
+  vi.useFakeTimers()
+
+  return async (): Promise<void> => {
+    await Promise.resolve()
+    while (frameCallbacks.length > 0) {
+      frameCallbacks.shift()?.(16)
+    }
+    await vi.runAllTimersAsync()
+  }
 }
 
 class TestElement extends EventTarget {
@@ -83,6 +104,7 @@ class TestElement extends EventTarget {
 
 describe('terminal scroll intent', () => {
   afterEach(() => {
+    _clearTerminalScrollIntentKeysForTest()
     vi.useRealTimers()
     vi.unstubAllGlobals()
   })
@@ -250,6 +272,82 @@ describe('terminal scroll intent', () => {
     expect(getTerminalScrollIntentKind(remountedTerminal)).toBe('pinnedViewport')
 
     firstDisposable.dispose()
+    remountedDisposable.dispose()
+  })
+
+  it('clears pane-keyed intent when the durable leaf id is retired', () => {
+    vi.stubGlobal('Element', TestElement)
+    const terminal = createTerminal({ viewportY: 76, baseY: 100 })
+    const host = new TestElement() as unknown as HTMLElement
+    const disposable = attachTerminalScrollIntentTracking(terminal, host, 'retired-leaf')
+    markTerminalPinnedViewport(terminal)
+
+    expect(_getTerminalScrollIntentKeyCountForTest()).toBe(1)
+
+    clearTerminalScrollIntentKey('retired-leaf')
+    expect(_getTerminalScrollIntentKeyCountForTest()).toBe(0)
+
+    const remountedTerminal = createTerminal({ viewportY: 100, baseY: 100 })
+    const remountedHost = new TestElement() as unknown as HTMLElement
+    const remountedDisposable = attachTerminalScrollIntentTracking(
+      remountedTerminal,
+      remountedHost,
+      'retired-leaf'
+    )
+
+    expect(getTerminalScrollIntentKind(remountedTerminal)).toBe('followOutput')
+
+    disposable.dispose()
+    remountedDisposable.dispose()
+  })
+
+  it('does not resurrect a retired key from deferred scroll sampling', async () => {
+    const flushDeferredScrollIntent = installDeferredScrollIntentHarness()
+    vi.stubGlobal('Element', TestElement)
+    const terminal = createTerminal({ viewportY: 100, baseY: 100 })
+    const host = new TestElement() as unknown as HTMLElement
+    const disposable = attachTerminalScrollIntentTracking(terminal, host, 'retired-leaf')
+
+    terminal.buffer.active.viewportY = 45
+    syncTerminalScrollIntentSoon(terminal)
+    disposable.dispose()
+    clearTerminalScrollIntentKey('retired-leaf')
+
+    await flushDeferredScrollIntent()
+
+    expect(_getTerminalScrollIntentKeyCountForTest()).toBe(0)
+    expect(_getTerminalScrollIntentSnapshotCountForTest()).toBe(0)
+  })
+
+  it('does not let a retired terminal overwrite a reused key', async () => {
+    const flushDeferredScrollIntent = installDeferredScrollIntentHarness()
+    vi.stubGlobal('Element', TestElement)
+    const oldTerminal = createTerminal({ viewportY: 100, baseY: 100 })
+    const oldHost = new TestElement() as unknown as HTMLElement
+    const oldDisposable = attachTerminalScrollIntentTracking(oldTerminal, oldHost, 'reused-leaf')
+
+    oldTerminal.buffer.active.viewportY = 20
+    syncTerminalScrollIntentSoon(oldTerminal)
+    oldDisposable.dispose()
+    clearTerminalScrollIntentKey('reused-leaf')
+
+    const newTerminal = createTerminal({ viewportY: 70, baseY: 100 })
+    const newHost = new TestElement() as unknown as HTMLElement
+    const newDisposable = attachTerminalScrollIntentTracking(newTerminal, newHost, 'reused-leaf')
+
+    await flushDeferredScrollIntent()
+
+    const remountedTerminal = createTerminal({ viewportY: 0, baseY: 100 })
+    const remountedHost = new TestElement() as unknown as HTMLElement
+    const remountedDisposable = attachTerminalScrollIntentTracking(
+      remountedTerminal,
+      remountedHost,
+      'reused-leaf'
+    )
+    enforceTerminalCurrentScrollIntent(remountedTerminal)
+
+    expect(remountedTerminal.scrollToLine).toHaveBeenCalledWith(70)
+    newDisposable.dispose()
     remountedDisposable.dispose()
   })
 

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -1,4 +1,20 @@
 import type { IDisposable } from '@xterm/xterm'
+import {
+  bindTerminalScrollIntentKey,
+  readTerminalScrollIntentKey,
+  writeTerminalScrollIntentKey
+} from './terminal-scroll-intent-key-store'
+import type {
+  TerminalScrollIntent,
+  TerminalScrollIntentKey
+} from './terminal-scroll-intent-key-store'
+
+export {
+  _clearTerminalScrollIntentKeysForTest,
+  _getTerminalScrollIntentKeyCountForTest,
+  _getTerminalScrollIntentSnapshotCountForTest,
+  clearTerminalScrollIntentKey
+} from './terminal-scroll-intent-key-store'
 
 type TerminalScrollIntentKind = 'followOutput' | 'pinnedViewport'
 
@@ -16,15 +32,6 @@ type TerminalScrollIntentTarget = {
   scrollToLine?: (line: number) => void
 }
 
-type TerminalScrollIntentKey = string
-
-type TerminalScrollIntent = {
-  kind: TerminalScrollIntentKind
-  bufferType: BufferType
-  viewportY: number
-  baseY: number
-}
-
 type TerminalScrollIntentWriteSnapshot = {
   kind: TerminalScrollIntentKind
   bufferType: BufferType
@@ -35,11 +42,6 @@ const terminalScrollIntentByTerminal = new WeakMap<
   TerminalScrollIntentTarget,
   TerminalScrollIntent
 >()
-const terminalScrollIntentKeyByTerminal = new WeakMap<
-  TerminalScrollIntentTarget,
-  TerminalScrollIntentKey
->()
-const terminalScrollIntentByKey = new Map<TerminalScrollIntentKey, TerminalScrollIntent>()
 
 const BOTTOM_TOLERANCE_ROWS = 1
 const XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES = [
@@ -81,10 +83,7 @@ function writeIntent(
   }
   const intent = { kind, ...snapshot }
   terminalScrollIntentByTerminal.set(terminal, intent)
-  const key = terminalScrollIntentKeyByTerminal.get(terminal)
-  if (key) {
-    terminalScrollIntentByKey.set(key, intent)
-  }
+  writeTerminalScrollIntentKey(terminal, intent)
   return intent
 }
 
@@ -93,23 +92,7 @@ function readStoredIntent(terminal: TerminalScrollIntentTarget): TerminalScrollI
   if (terminalIntent) {
     return terminalIntent
   }
-  const key = terminalScrollIntentKeyByTerminal.get(terminal)
-  return key ? terminalScrollIntentByKey.get(key) : undefined
-}
-
-function bindTerminalScrollIntentKey(
-  terminal: TerminalScrollIntentTarget,
-  key: TerminalScrollIntentKey | undefined
-): TerminalScrollIntent | undefined {
-  if (!key) {
-    return terminalScrollIntentByTerminal.get(terminal)
-  }
-  terminalScrollIntentKeyByTerminal.set(terminal, key)
-  const existing = terminalScrollIntentByKey.get(key)
-  if (existing) {
-    terminalScrollIntentByTerminal.set(terminal, existing)
-  }
-  return existing
+  return readTerminalScrollIntentKey(terminal)
 }
 
 function clampViewportY(viewportY: number, baseY: number): number {
@@ -256,7 +239,12 @@ export function attachTerminalScrollIntentTracking(
   host: HTMLElement,
   intentKey?: TerminalScrollIntentKey
 ): IDisposable {
-  if (!bindTerminalScrollIntentKey(terminal, intentKey)) {
+  const existingIntent = intentKey
+    ? bindTerminalScrollIntentKey(terminal, intentKey)
+    : terminalScrollIntentByTerminal.get(terminal)
+  if (existingIntent) {
+    terminalScrollIntentByTerminal.set(terminal, existingIntent)
+  } else {
     syncTerminalScrollIntentFromViewport(terminal)
   }
   let pointerScrollActive = false

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildWorktreeComparator } from '@/components/sidebar/smart-sort'
 import type * as AgentStatusModule from '@/lib/agent-status'
 import { getDefaultSettings } from '../../../../shared/constants'
@@ -84,6 +84,13 @@ import {
   loadSessionCommitDrafts,
   saveSessionCommitDrafts
 } from '@/lib/source-control-commit-draft-session'
+import {
+  _clearTerminalScrollIntentKeysForTest,
+  _getTerminalScrollIntentKeyCountForTest,
+  _getTerminalScrollIntentSnapshotCountForTest,
+  bindTerminalScrollIntentKey,
+  writeTerminalScrollIntentKey
+} from '@/lib/pane-manager/terminal-scroll-intent-key-store'
 
 // ─── Tests ────────────────────────────────────────────────────────────
 
@@ -767,6 +774,109 @@ describe('removeWorktree cascade', () => {
 
     expect(result).toEqual({ ok: true })
     expect(callOrder).toEqual(['remove', 'kill'])
+  })
+})
+
+describe('terminal scroll intent store retirement', () => {
+  afterEach(() => {
+    _clearTerminalScrollIntentKeysForTest()
+  })
+
+  it('retires scroll intent when a cold-parked tab closes without a pane manager', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const tabId = 'parked-tab'
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const parkedTerminal = {}
+    bindTerminalScrollIntentKey(parkedTerminal, leafId)
+    writeTerminalScrollIntentKey(parkedTerminal, {
+      kind: 'pinnedViewport',
+      bufferType: 'normal',
+      viewportY: 42,
+      baseY: 100
+    })
+    seedStore(store, {
+      tabsByWorktree: { [wt]: [makeTab({ id: tabId, worktreeId: wt })] },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: null,
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: 'parked-pty' }
+        }
+      }
+    })
+
+    store.getState().closeTab(tabId)
+
+    expect(_getTerminalScrollIntentKeyCountForTest()).toBe(0)
+    expect(_getTerminalScrollIntentSnapshotCountForTest()).toBe(0)
+  })
+
+  it('retires scroll intent when bulk worktree purge removes parked tabs', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const tabId = 'parked-tab'
+    const leafId = '22222222-2222-4222-8222-222222222222'
+    const parkedTerminal = {}
+    bindTerminalScrollIntentKey(parkedTerminal, leafId)
+    writeTerminalScrollIntentKey(parkedTerminal, {
+      kind: 'followOutput',
+      bufferType: 'normal',
+      viewportY: 100,
+      baseY: 100
+    })
+    seedStore(store, {
+      tabsByWorktree: { [wt]: [makeTab({ id: tabId, worktreeId: wt })] },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: { type: 'leaf', leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    store.getState().purgeWorktreeTerminalState([wt])
+
+    expect(_getTerminalScrollIntentKeyCountForTest()).toBe(0)
+    expect(_getTerminalScrollIntentSnapshotCountForTest()).toBe(0)
+  })
+
+  it('retires PTY-only rootless intent before worktree shutdown scrubs its leaf id', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const tabId = 'parked-tab'
+    const leafId = '33333333-3333-4333-8333-333333333333'
+    const parkedTerminal = {}
+    bindTerminalScrollIntentKey(parkedTerminal, leafId)
+    writeTerminalScrollIntentKey(parkedTerminal, {
+      kind: 'pinnedViewport',
+      bufferType: 'normal',
+      viewportY: 42,
+      baseY: 100
+    })
+    mockApi.worktrees.remove.mockResolvedValueOnce(undefined)
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: { [wt]: [makeTab({ id: tabId, worktreeId: wt })] },
+      ptyIdsByTabId: { [tabId]: ['parked-pty'] },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: null,
+          activeLeafId: null,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: 'parked-pty' }
+        }
+      }
+    })
+
+    await store.getState().removeWorktree(wt)
+
+    expect(_getTerminalScrollIntentKeyCountForTest()).toBe(0)
+    expect(_getTerminalScrollIntentSnapshotCountForTest()).toBe(0)
   })
 })
 

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -39,6 +39,7 @@ import {
   addAdditionalValidWorkspaceKeys,
   type WorkspaceSessionHydrationOptions
 } from '@/lib/workspace-session-hydration-keys'
+import { retireTerminalScrollIntentsForTabs } from '@/components/terminal-pane/terminal-scroll-intent-tab-retirement'
 
 export type TabSplitDirection = 'left' | 'right' | 'up' | 'down'
 
@@ -1838,6 +1839,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       return livePtyIds.length > 0 || tab.ptyId != null
     })
     const orphanTerminalIds = getOrphanTerminalIds(state, worktreeId)
+    retireTerminalScrollIntentsForTabs(state.terminalLayoutsByTabId, orphanTerminalIds)
     const ensuredGroupState =
       legacyRuntimeTerminalTabs.length > 0
         ? ensureGroup(

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -69,6 +69,7 @@ import {
   normalizeTerminalLayoutSnapshot,
   resolvePtyBoundActiveLeafId
 } from '@/components/terminal-pane/terminal-layout-leaf-ids'
+import { retireTerminalScrollIntentsForTabs } from '@/components/terminal-pane/terminal-scroll-intent-tab-retirement'
 import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
@@ -926,8 +927,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
   createTab: (worktreeId, targetGroupId, shellOverride, options) => {
     let tab!: TerminalTab
+    const stateBeforeCreate = get()
+    const orphanTerminalIds = getOrphanTerminalIds(stateBeforeCreate, worktreeId)
+    retireTerminalScrollIntentsForTabs(stateBeforeCreate.terminalLayoutsByTabId, orphanTerminalIds)
     set((s) => {
-      const orphanTerminalIds = getOrphanTerminalIds(s, worktreeId)
       const orphanCleanupPatch = buildOrphanTerminalCleanupPatch(s, worktreeId, orphanTerminalIds)
       const existing = (s.tabsByWorktree[worktreeId] ?? []).filter(
         (entry) => !orphanTerminalIds.has(entry.id)
@@ -1188,6 +1191,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   closeTab: (tabId, opts) => {
+    retireTerminalScrollIntentsForTabs(get().terminalLayoutsByTabId, [tabId])
     set((s) => {
       const next = { ...s.tabsByWorktree }
       let closingPtyId: string | null = null
@@ -2704,6 +2708,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   setTabLayout: (tabId, layout) => {
+    if (!layout) {
+      retireTerminalScrollIntentsForTabs(get().terminalLayoutsByTabId, [tabId])
+    }
     set((s) => {
       const next = { ...s.terminalLayoutsByTabId }
       if (layout) {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -49,6 +49,7 @@ import { markInputQuietSchedulerInput, scheduleAfterInputQuiet } from '@/lib/inp
 import { clearSessionCommitDraftForWorktree } from '@/lib/source-control-commit-draft-session'
 import { showLocalBaseRefUpdateSuggestionToast } from '@/components/sidebar/local-base-ref-suggestion-toast'
 import { showPreservedBranchToast } from '@/components/sidebar/preserved-branch-toast'
+import { retireTerminalScrollIntentsForTabs } from '@/components/terminal-pane/terminal-scroll-intent-tab-retirement'
 import { translate } from '@/i18n/i18n'
 import {
   getRepoExecutionHostId,
@@ -1913,6 +1914,7 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     // module-level map doesn't retain removed worktrees for the whole session.
     detachedHeadAutoDerivedDisplayNames.delete(id)
   }
+  retireTerminalScrollIntentsForTabs(s.terminalLayoutsByTabId, doomedTabIds)
   // Why: same rationale for the doomed tabs' foreground last-seen timestamps and
   // consumed agent-startup delivery guards — retired tab ids never recur.
   forgetForegroundTerminalTabs(doomedTabIds)
@@ -3227,6 +3229,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
               { timeoutMs: 60_000 }
             ))
 
+      // Why: terminal shutdown scrubs PTY-only leaf identity from rootless
+      // layouts, so retain the successful deletion's pre-shutdown snapshot.
+      const tabIds = new Set((get().tabsByWorktree[worktreeId] ?? []).map((tab) => tab.id))
+      const terminalLayoutsBeforeShutdown = get().terminalLayoutsByTabId
+
       const worktreeDisplayName = worktreeBeforeRemoval?.displayName?.trim()
       if (worktreeDisplayName) {
         try {
@@ -3263,8 +3270,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // Remove the now-orphaned project that pointed at the destroyed runtime-owned SSH target so it
       // can't surface as a dead, never-connectable project in the composer.
       await purgeOrphanedRuntimeSshProjects(get, destroyedRuntimeSshTargetIds)
-      const tabs = get().tabsByWorktree[worktreeId] ?? []
-      const tabIds = new Set(tabs.map((t) => t.id))
+      retireTerminalScrollIntentsForTabs(terminalLayoutsBeforeShutdown, tabIds)
 
       // Why: this path deletes tabsByWorktree wholesale (not via closeTab), so
       // purge the module-level maps keyed by this worktree/its tabs here too —


### PR DESCRIPTION
## Description

Fixes an unbounded renderer memory leak in terminal scroll-intent tracking.

Durable pane leaf IDs now have lease-based scroll-intent ownership. Permanent pane, tab, worktree, project, orphan, and null-layout removal retires the lease and deletes its snapshot. Detach, tab rehome, remount, and cold parking preserve the lease because the same durable leaf still exists.

Retired leases also reject late microtask, animation-frame, nested-frame, and timeout samplers, so stale callbacks cannot recreate a deleted key or overwrite a newer terminal that reuses the same key.

## Evidence

### Reproduction and red/green proof

The original implementation wrote durable `leafId` entries into module-level maps but never retired them. Repeated terminal pane/tab lifecycles therefore retained one scroll-intent entry per deleted leaf for the renderer session.

Two deterministic mutation tests exposed deeper races in the first cleanup attempt:

- deferred sampling after retirement reproduced key resurrection: expected 0 retained keys, got 1
- an old terminal reused after retirement reproduced an ABA overwrite: expected the new viewport at row 70, got the stale row 20

Both now pass because writes require the terminal's lease to be active and still own the key.

Store tests also prove authoritative cleanup when no live `PaneManager` remains, including a cold-parked, rootless layout whose only remaining leaf identity is in `ptyIdsByLeafId`. Explicit worktree deletion snapshots that identity after backend deletion succeeds but before terminal shutdown scrubs it.

### Verification on rebased head `0fcb5e3a0c`

- 142/142 affected tests passed across store cascades, pane close/detach, manager destroy, retirement, deferred resurrection, and ABA reuse
- targeted `oxlint` passed
- `pnpm run typecheck:web` passed
- `pnpm run check:max-lines-ratchet` passed
- `pnpm run check:reliability-gates` passed for all 33 manifest gates
- `git diff --check` passed
- two fresh exact-semantic-patch adversarial reviewers returned `No issues found`
- rebased conflict-free onto `origin/main` at `04a040801be`; stable patch ID remained `cb335fc4e2`, and range-diff reported semantic identity

### Terminal reliability proof

- **Reliability invariant:** `terminal-session.scroll-intent-lifecycle` — durable scroll intent survives detach/rehome/parking but is retired exactly when its leaf is permanently removed; retired owners cannot resurrect or ABA-overwrite it.
- **Material impact:** closes the unbounded retained-key bug class and makes late async samplers harmless across every authoritative deletion boundary.
- **Product change type:** renderer runtime and lifecycle hardening.
- **Performance risk inventory:** pane close/destroy, tab/worktree/project cleanup, and scroll sampling are touched. Typing, PTY output, resize, startup, provider listing, hidden-output delivery, IPC/RPC, git scans, and subprocesses are not changed.
- **No-regression evidence:** map-cardinality, deferred-callback, ABA-reuse, detach-preservation, cold-park, rootless-layout, and bulk-purge contract tests pass. No polling, provider calls, broad inventories, render scans, or unbounded new ownership were added.
- **Correctness oracle:** retained key/snapshot counts reach zero after permanent retirement; remounts preserve intent only while the leaf remains live; a reused key keeps the new terminal's viewport after all old callbacks flush.
- **Provider/platform coverage:** local, daemon, SSH, WSL, remote runtime, and mobile/relay are provider-agnostic and unaffected because the change only uses durable renderer leaf identity. macOS, Linux, and Windows are likewise unaffected by platform APIs or path behavior.
- **Diagnostics:** deterministic tests expose retained key and snapshot counts; no runtime telemetry or user data was added.
- **Residual gaps:** no manual cross-platform heap snapshot or Electron UI run; the behavior is covered at the deterministic ownership/store layer where the invariant lives.
- **Manifest/promotion status:** no dedicated gate was added or promoted; existing reliability manifest remains unchanged and valid. Coverage is unit/contract-level (`none` for promotion).
- **Rollback/demotion rule:** revert or follow up if detach/rehome loses scroll position, a permanent removal leaves nonzero key counts, or ABA/deferred-retirement tests fail.

## ELI5

Orca kept a tiny bookmark for every terminal pane so it could restore your scroll position. Closed panes left their bookmarks behind forever. Now each bookmark has an owner: moving a pane keeps it, truly deleting the pane removes it, and late messages from the old pane are ignored.

## Trade-offs

No end-user regressions.

Scroll position remains preserved across detach, rehome, remount, and cold parking. Permanently deleted panes no longer retain scroll state. The four existing deferred samplers are not cancelled, so a disposed terminal can remain referenced for at most about 80 ms; lease retirement makes those callbacks no-op for durable state, keeping this bounded and avoiding new scheduler ownership.
