### PR TITLE
Fix Codex title index cache leak

### DIFF
--- a/src/main/ai-vault/session-scanner-codex-title-index.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-title-index.test.ts
@@ -1,0 +1,140 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  _getCodexSessionIndexTitleCacheSizeForTest,
+  _hasCodexSessionIndexTitleCacheEntryForTest,
+  _readCachedCodexSessionIndexTitlesForTest,
+  _storeCodexSessionIndexTitleCacheEntryForTest,
+  readCodexSessionIndexTitle,
+  resetCodexSessionIndexTitleCacheForTests
+} from './session-scanner-codex-title-index'
+
+const CACHE_LIMIT = 64
+
+let tempRoots: string[] = []
+
+afterEach(async () => {
+  resetCodexSessionIndexTitleCacheForTests()
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+async function createCodexHome(index: number): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-codex-title-index-'))
+  tempRoots.push(root)
+  const codexHome = join(root, `codex-home-${index}`)
+  await mkdir(join(codexHome, 'sessions'), { recursive: true })
+  await writeFile(
+    join(codexHome, 'session_index.jsonl'),
+    `${JSON.stringify({ id: `session-${index}`, thread_name: `Title ${index}` })}\n`
+  )
+  return codexHome
+}
+
+async function readTitle(codexHome: string, index: number): Promise<string | null> {
+  return readCodexSessionIndexTitle(
+    join(codexHome, 'sessions', `session-${index}.jsonl`),
+    codexHome,
+    `session-${index}`
+  )
+}
+
+describe('codex session index title cache', () => {
+  it('caps cached title indexes by Codex home', async () => {
+    const homes: string[] = []
+
+    for (let index = 0; index < CACHE_LIMIT + 1; index++) {
+      const codexHome = await createCodexHome(index)
+      homes.push(codexHome)
+      expect(await readTitle(codexHome, index)).toBe(`Title ${index}`)
+    }
+
+    expect(_getCodexSessionIndexTitleCacheSizeForTest()).toBe(CACHE_LIMIT)
+    expect(_hasCodexSessionIndexTitleCacheEntryForTest(homes[0])).toBe(false)
+    expect(_hasCodexSessionIndexTitleCacheEntryForTest(homes[CACHE_LIMIT])).toBe(true)
+  })
+
+  it('refreshes cache recency when an existing Codex home is reused', async () => {
+    const homes: string[] = []
+    for (let index = 0; index < CACHE_LIMIT; index++) {
+      const codexHome = await createCodexHome(index)
+      homes.push(codexHome)
+      await readTitle(codexHome, index)
+    }
+
+    await readTitle(homes[0], 0)
+    const extraHome = await createCodexHome(CACHE_LIMIT)
+    await readTitle(extraHome, CACHE_LIMIT)
+
+    expect(_getCodexSessionIndexTitleCacheSizeForTest()).toBe(CACHE_LIMIT)
+    expect(_hasCodexSessionIndexTitleCacheEntryForTest(homes[0])).toBe(true)
+    expect(_hasCodexSessionIndexTitleCacheEntryForTest(homes[1])).toBe(false)
+  })
+
+  it('does not resurrect a pending cache hit after that home is evicted', async () => {
+    let resolveSlowTitles: (titles: Map<string, string>) => void = () => {}
+    const slowTitles = new Promise<Map<string, string>>((resolve) => {
+      resolveSlowTitles = resolve
+    })
+    _storeCodexSessionIndexTitleCacheEntryForTest('slow-home', 'stable', slowTitles)
+    const pendingHit = _readCachedCodexSessionIndexTitlesForTest('slow-home', 'stable')
+
+    for (let index = 0; index < CACHE_LIMIT; index += 1) {
+      _storeCodexSessionIndexTitleCacheEntryForTest(
+        `replacement-home-${index}`,
+        `signature-${index}`,
+        Promise.resolve(new Map([[`session-${index}`, `Title ${index}`]]))
+      )
+    }
+    expect(_getCodexSessionIndexTitleCacheSizeForTest()).toBe(CACHE_LIMIT)
+    expect(_hasCodexSessionIndexTitleCacheEntryForTest('slow-home')).toBe(false)
+
+    const titles = new Map([['slow-session', 'Slow title']])
+    resolveSlowTitles(titles)
+
+    await expect(pendingHit).resolves.toBe(titles)
+    expect(_getCodexSessionIndexTitleCacheSizeForTest()).toBe(CACHE_LIMIT)
+    expect(_hasCodexSessionIndexTitleCacheEntryForTest('slow-home')).toBe(false)
+  })
+
+  it('does not replace a newer same-home entry when an older cache hit resolves', async () => {
+    let resolveOldTitles: (titles: Map<string, string>) => void = () => {}
+    const oldTitles = new Promise<Map<string, string>>((resolve) => {
+      resolveOldTitles = resolve
+    })
+    _storeCodexSessionIndexTitleCacheEntryForTest('same-home', 'old', oldTitles)
+    const pendingOldHit = _readCachedCodexSessionIndexTitlesForTest('same-home', 'old')
+
+    const newTitles = new Map([['new-session', 'New title']])
+    _storeCodexSessionIndexTitleCacheEntryForTest('same-home', 'new', Promise.resolve(newTitles))
+    const resolvedOldTitles = new Map([['old-session', 'Old title']])
+    resolveOldTitles(resolvedOldTitles)
+
+    await expect(pendingOldHit).resolves.toBe(resolvedOldTitles)
+    await expect(_readCachedCodexSessionIndexTitlesForTest('same-home', 'new')).resolves.toBe(
+      newTitles
+    )
+    expect(_getCodexSessionIndexTitleCacheSizeForTest()).toBe(1)
+  })
+
+  it('preserves a newer same-home entry when an older cache hit rejects', async () => {
+    let rejectOldTitles: (error: Error) => void = () => {}
+    const oldTitles = new Promise<Map<string, string>>((_resolve, reject) => {
+      rejectOldTitles = reject
+    })
+    _storeCodexSessionIndexTitleCacheEntryForTest('same-home', 'old', oldTitles)
+    const pendingOldHit = _readCachedCodexSessionIndexTitlesForTest('same-home', 'old')
+
+    const newTitles = new Map([['new-session', 'New title']])
+    _storeCodexSessionIndexTitleCacheEntryForTest('same-home', 'new', Promise.resolve(newTitles))
+    rejectOldTitles(new Error('old read failed'))
+
+    await expect(pendingOldHit).rejects.toThrow('old read failed')
+    await expect(_readCachedCodexSessionIndexTitlesForTest('same-home', 'new')).resolves.toBe(
+      newTitles
+    )
+    expect(_getCodexSessionIndexTitleCacheSizeForTest()).toBe(1)
+  })
+})

--- a/src/main/ai-vault/session-scanner-codex-title-index.ts
+++ b/src/main/ai-vault/session-scanner-codex-title-index.ts
@@ -8,6 +8,9 @@ import { extractString, normalizeTitleText, parseJsonObject } from './session-sc
 // carry no title of their own, so parsers look the thread name up here.
 
 const CODEX_SESSION_INDEX_FILE = 'session_index.jsonl'
+// Why: custom and WSL Codex homes can vary over a long-lived main process;
+// each cached home can retain a full session_index title map.
+const CODEX_SESSION_INDEX_TITLE_CACHE_MAX = 64
 
 type CodexSessionIndexTitleCacheEntry = {
   signature: string
@@ -15,6 +18,36 @@ type CodexSessionIndexTitleCacheEntry = {
 }
 
 const codexSessionIndexTitleCache = new Map<string, Promise<CodexSessionIndexTitleCacheEntry>>()
+
+export function resetCodexSessionIndexTitleCacheForTests(): void {
+  codexSessionIndexTitleCache.clear()
+}
+
+export function _getCodexSessionIndexTitleCacheSizeForTest(): number {
+  return codexSessionIndexTitleCache.size
+}
+
+export function _hasCodexSessionIndexTitleCacheEntryForTest(codexHome: string): boolean {
+  return codexSessionIndexTitleCache.has(codexHome)
+}
+
+export function _storeCodexSessionIndexTitleCacheEntryForTest(
+  codexHome: string,
+  signature: string,
+  titles: Promise<Map<string, string>>
+): void {
+  storeCodexSessionIndexTitleCacheEntry(
+    codexHome,
+    titles.then((resolvedTitles) => ({ signature, titles: resolvedTitles }))
+  )
+}
+
+export function _readCachedCodexSessionIndexTitlesForTest(
+  codexHome: string,
+  signature: string
+): Promise<Map<string, string> | undefined> {
+  return readCachedCodexSessionIndexTitles(codexHome, signature)
+}
 
 export async function readCodexSessionIndexTitle(
   sessionFilePath: string,
@@ -50,20 +83,52 @@ async function readCodexSessionIndexTitles(codexHome: string): Promise<Map<strin
     return new Map()
   }
 
-  const cached = codexSessionIndexTitleCache.get(codexHome)
-  if (cached) {
-    const entry = await cached
-    if (entry.signature === signature) {
-      return entry.titles
-    }
+  const cachedTitles = await readCachedCodexSessionIndexTitles(codexHome, signature)
+  if (cachedTitles) {
+    return cachedTitles
   }
 
   const pending = readCodexSessionIndexTitlesFromDisk(indexPath).then((titles) => ({
     signature,
     titles
   }))
-  codexSessionIndexTitleCache.set(codexHome, pending)
+  storeCodexSessionIndexTitleCacheEntry(codexHome, pending)
   return (await pending).titles
+}
+
+async function readCachedCodexSessionIndexTitles(
+  codexHome: string,
+  signature: string
+): Promise<Map<string, string> | undefined> {
+  const cached = codexSessionIndexTitleCache.get(codexHome)
+  if (!cached) {
+    return undefined
+  }
+  const entry = await cached
+  if (entry.signature !== signature) {
+    return undefined
+  }
+  // Why: another scan can evict or replace this Promise while it resolves;
+  // only the still-current entry may refresh recency without bypassing the cap.
+  if (codexSessionIndexTitleCache.get(codexHome) === cached) {
+    codexSessionIndexTitleCache.delete(codexHome)
+    codexSessionIndexTitleCache.set(codexHome, cached)
+  }
+  return entry.titles
+}
+
+function storeCodexSessionIndexTitleCacheEntry(
+  codexHome: string,
+  pending: Promise<CodexSessionIndexTitleCacheEntry>
+): void {
+  codexSessionIndexTitleCache.delete(codexHome)
+  codexSessionIndexTitleCache.set(codexHome, pending)
+  if (codexSessionIndexTitleCache.size > CODEX_SESSION_INDEX_TITLE_CACHE_MAX) {
+    const oldest = codexSessionIndexTitleCache.keys().next()
+    if (!oldest.done) {
+      codexSessionIndexTitleCache.delete(oldest.value)
+    }
+  }
 }
 
 async function readCodexSessionIndexTitlesFromDisk(


### PR DESCRIPTION
## Description

Fixes an AI Vault main-process memory leak in the local Codex session title-index cache. The module-level cache retained one full `session_index.jsonl` title map for every Codex home ever scanned, including custom, WSL, and Orca-managed homes.

The cache is now a 64-home least-recently-used map. Hits refresh recency, inserts evict the oldest home, and a promise-identity guard prevents an evicted or replaced in-flight entry from reappearing after its read finishes.

## Evidence

### Reproduction before the fix

On current `main`, scanning 65 distinct Codex homes retained 65 title-index cache entries. The regression expectation `cache size <= 64` failed with `received 65`, proving growth was linear in distinct homes.

### Proof of fix

The focused regression suite now proves:

- 65 distinct homes leave exactly 64 cached entries and evict the oldest.
- Reusing a home refreshes its recency.
- A pending cache hit cannot resurrect itself after eviction.
- An older in-flight read cannot replace a newer entry for the same home.
- A rejected older in-flight read cannot disturb the newer same-home entry.

Mutation proof: temporarily removing the promise-identity guard made the pending-eviction regression fail with `expected 64, received 65`. Restoring the guard made it pass.

Post-rebase verification on commit `575af616a4`:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ai-vault/session-scanner-codex-title-index.test.ts src/main/ai-vault/session-scanner-parse-cache-agents.test.ts src/main/ai-vault/session-scanner.test.ts src/main/ai-vault/remote-session-scanner.test.ts` — 4 files, 47 tests passed.
- `pnpm typecheck:tsc:node` — passed.
- Changed-file `oxlint` — passed.
- Changed-file `oxfmt --check` — passed.
- `pnpm check:max-lines-ratchet` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Two independent adversarial reviewers returned no issues. They traced cap, recency, concurrent eviction, same-key replacement, rejection, signature mismatch, WSL and Windows aliases, and the separate SSH scanner boundary.

## ELI5

Orca kept a notebook of Codex session titles for every history folder it had ever seen and never threw one away. It now keeps only the 64 most recently used notebooks. If an old notebook finishes loading after it was already discarded or replaced, it is not allowed to sneak back onto the shelf.

## Trade-offs

No end-user correctness regressions are expected.

After more than 64 distinct Codex homes in one main-process lifetime, revisiting an evicted home rereads its title index from disk once. That is a small bounded cache-miss cost in exchange for bounded memory. Normal default, WSL, and Orca-managed setups are far below the cap.

Windows path-casing aliases can still occupy separate keys, but total retention remains capped at 64. SSH and remote scanning use a separate per-scan cache and are unchanged.

## Performance / No-regression check

Cache hits add one constant-time `Map.delete` plus `Map.set` to refresh recency. Inserts add one constant-time size check and at most one oldest-key deletion. No polling, timers, IPC, RPC, subprocesses, renderer work, or additional disk reads were added to the steady-state hit path.

Local session parsing is batched at eight concurrent candidates, so evicted in-flight promises remain caller-bounded while active and are not retained by the cache.