### PR TITLE
Fix local preflight context cache leak

### DIFF
--- a/src/renderer/src/lib/local-preflight-context-cache.test.ts
+++ b/src/renderer/src/lib/local-preflight-context-cache.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { AppState } from '@/store/types'
+import {
+  _getProjectRuntimePreflightContextCacheSizeForTest,
+  _getWslPreflightContextCacheSizeForTest,
+  _hasProjectRuntimePreflightContextCacheEntryForTest,
+  _hasWslPreflightContextCacheEntryForTest,
+  getLocalPreflightContext,
+  resetLocalPreflightContextCachesForTests
+} from './local-preflight-context'
+
+const WSL_CACHE_LIMIT = 128
+const PROJECT_RUNTIME_CACHE_LIMIT = 2048
+
+afterEach(() => {
+  resetLocalPreflightContextCachesForTests()
+})
+
+function makeWslState(distro: string): AppState {
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: null,
+    repos: [{ id: 'repo-1', path: `\\\\wsl.localhost\\${distro}\\home\\alice\\repo` }],
+    worktreesByRepo: {}
+  } as AppState
+}
+
+function makeWindowsProjectState(projectId: string): AppState {
+  return {
+    activeRepoId: projectId,
+    activeWorktreeId: null,
+    repos: [{ id: projectId, path: `C:\\Users\\alice\\${projectId}` }],
+    settings: {},
+    worktreesByRepo: {}
+  } as AppState
+}
+
+describe('local preflight context caches', () => {
+  it('releases an old WSL selector snapshot after sustained context churn', () => {
+    const first = getLocalPreflightContext(makeWslState('Distro0'), 'darwin')
+
+    for (let index = 1; index <= WSL_CACHE_LIMIT; index += 1) {
+      getLocalPreflightContext(makeWslState(`Distro${index}`), 'darwin')
+    }
+
+    expect(getLocalPreflightContext(makeWslState('Distro0'), 'darwin')).not.toBe(first)
+  })
+
+  it('caps cached WSL distro snapshots', () => {
+    for (let index = 0; index < WSL_CACHE_LIMIT + 1; index++) {
+      const distro = `Distro${index}`
+      expect(getLocalPreflightContext(makeWslState(distro), 'darwin')).toEqual({
+        wslDistro: distro
+      })
+    }
+
+    expect(_getWslPreflightContextCacheSizeForTest()).toBe(WSL_CACHE_LIMIT)
+    expect(_hasWslPreflightContextCacheEntryForTest('Distro0')).toBe(false)
+    expect(_hasWslPreflightContextCacheEntryForTest(`Distro${WSL_CACHE_LIMIT}`)).toBe(true)
+  })
+
+  it('caps cached project runtime snapshots without mutating order on reads', () => {
+    for (let index = 0; index < PROJECT_RUNTIME_CACHE_LIMIT; index++) {
+      getLocalPreflightContext(makeWindowsProjectState(`project-${index}`), 'win32')
+    }
+
+    getLocalPreflightContext(makeWindowsProjectState('project-0'), 'win32')
+    getLocalPreflightContext(
+      makeWindowsProjectState(`project-${PROJECT_RUNTIME_CACHE_LIMIT}`),
+      'win32'
+    )
+
+    expect(_getProjectRuntimePreflightContextCacheSizeForTest()).toBe(PROJECT_RUNTIME_CACHE_LIMIT)
+    expect(
+      _hasProjectRuntimePreflightContextCacheEntryForTest('project-0:windows-host:global-default')
+    ).toBe(false)
+    expect(
+      _hasProjectRuntimePreflightContextCacheEntryForTest('project-1:windows-host:global-default')
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/local-preflight-context-cache.ts
+++ b/src/renderer/src/lib/local-preflight-context-cache.ts
@@ -1,0 +1,106 @@
+import type { ProjectExecutionRuntimeResolution } from '../../../shared/project-execution-runtime'
+
+export type LocalPreflightContext =
+  | {
+      wslDistro?: string | null
+      wslDefault?: boolean
+      runtimeContextKey?: string
+      projectRuntime?: ProjectExecutionRuntimeResolution
+    }
+  | undefined
+
+// Why: selector snapshots must be reference-stable, but project/runtime ids can
+// churn as repos are added and removed during a long-lived renderer session.
+const WSL_PREFLIGHT_CONTEXT_CACHE_MAX = 128
+const PROJECT_RUNTIME_PREFLIGHT_CONTEXT_CACHE_MAX = 2048
+
+// Why: these reads run inside broad store selectors. Insertion-order eviction
+// keeps cache hits read-only instead of adding Map mutations to every store update.
+const wslPreflightContextsByDistro = new Map<string, NonNullable<LocalPreflightContext>>()
+const projectRuntimePreflightContextsByKey = new Map<string, NonNullable<LocalPreflightContext>>()
+
+export function resetLocalPreflightContextCachesForTests(): void {
+  wslPreflightContextsByDistro.clear()
+  projectRuntimePreflightContextsByKey.clear()
+}
+
+export function _getWslPreflightContextCacheSizeForTest(): number {
+  return wslPreflightContextsByDistro.size
+}
+
+export function _hasWslPreflightContextCacheEntryForTest(wslDistro: string): boolean {
+  return wslPreflightContextsByDistro.has(wslDistro)
+}
+
+export function _getProjectRuntimePreflightContextCacheSizeForTest(): number {
+  return projectRuntimePreflightContextsByKey.size
+}
+
+export function _hasProjectRuntimePreflightContextCacheEntryForTest(cacheKey: string): boolean {
+  return projectRuntimePreflightContextsByKey.has(cacheKey)
+}
+
+export function getWslPreflightContext(wslDistro: string): NonNullable<LocalPreflightContext> {
+  const cached = wslPreflightContextsByDistro.get(wslDistro)
+  if (cached) {
+    return cached
+  }
+
+  // Why: React/Zustand selectors must return a cached snapshot. A fresh object
+  // here triggers a useSyncExternalStore loop when Settings observes WSL repos.
+  const context = Object.freeze({ wslDistro })
+  storeCacheEntry(wslPreflightContextsByDistro, wslDistro, context, WSL_PREFLIGHT_CONTEXT_CACHE_MAX)
+  return context
+}
+
+export function getProjectRuntimePreflightContext(
+  resolution: ProjectExecutionRuntimeResolution
+): NonNullable<LocalPreflightContext> {
+  const cacheKey = getProjectRuntimeContextObjectCacheKey(resolution)
+  const cached = projectRuntimePreflightContextsByKey.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const wslDistro =
+    resolution.status === 'resolved' && resolution.runtime.kind === 'wsl'
+      ? resolution.runtime.distro
+      : undefined
+  // Why: selectors compare by reference; cache each resolved runtime context so
+  // adding projectRuntime does not reintroduce useSyncExternalStore churn.
+  const context = Object.freeze({
+    ...(wslDistro ? { wslDistro } : {}),
+    projectRuntime: resolution
+  })
+  storeCacheEntry(
+    projectRuntimePreflightContextsByKey,
+    cacheKey,
+    context,
+    PROJECT_RUNTIME_PREFLIGHT_CONTEXT_CACHE_MAX
+  )
+  return context
+}
+
+function getProjectRuntimeContextObjectCacheKey(
+  resolution: ProjectExecutionRuntimeResolution
+): string {
+  if (resolution.status === 'resolved') {
+    return `${resolution.runtime.cacheKey}:${resolution.runtime.reason}`
+  }
+  return `${resolution.repair.cacheKey}:${resolution.repair.source}`
+}
+
+function storeCacheEntry<T>(
+  cache: Map<string, T>,
+  key: string,
+  value: T,
+  maxEntries: number
+): void {
+  cache.set(key, value)
+  if (cache.size > maxEntries) {
+    const oldest = cache.keys().next()
+    if (!oldest.done) {
+      cache.delete(oldest.value)
+    }
+  }
+}

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -13,8 +13,21 @@ import {
   getCachedWindowsTerminalCapabilities,
   hasCachedWindowsTerminalCapabilities
 } from './windows-terminal-capabilities'
+import {
+  getProjectRuntimePreflightContext,
+  getWslPreflightContext,
+  type LocalPreflightContext
+} from './local-preflight-context-cache'
 
 export { localPreflightContextKey } from './local-preflight-context-key'
+export type { LocalPreflightContext } from './local-preflight-context-cache'
+export {
+  _getProjectRuntimePreflightContextCacheSizeForTest,
+  _getWslPreflightContextCacheSizeForTest,
+  _hasProjectRuntimePreflightContextCacheEntryForTest,
+  _hasWslPreflightContextCacheEntryForTest,
+  resetLocalPreflightContextCachesForTests
+} from './local-preflight-context-cache'
 
 type LocalProjectRuntimeState = Pick<
   AppState,
@@ -26,65 +39,8 @@ type LocalProjectRuntimeWslContext = {
   availableWslDistros?: readonly string[] | null
 }
 
-export type LocalPreflightContext =
-  | {
-      wslDistro?: string | null
-      wslDefault?: boolean
-      runtimeContextKey?: string
-      projectRuntime?: ProjectExecutionRuntimeResolution
-    }
-  | undefined
-
-const wslPreflightContextsByDistro = new Map<string, NonNullable<LocalPreflightContext>>()
-const projectRuntimePreflightContextsByKey = new Map<string, NonNullable<LocalPreflightContext>>()
-
 export function getWslDistroFromPath(path?: string | null): string | null {
   return path ? (parseWslUncPath(path)?.distro ?? null) : null
-}
-
-function getWslPreflightContext(wslDistro: string): NonNullable<LocalPreflightContext> {
-  const cached = wslPreflightContextsByDistro.get(wslDistro)
-  if (cached) {
-    return cached
-  }
-
-  // Why: React/Zustand selectors must return a cached snapshot. A fresh object
-  // here triggers a useSyncExternalStore loop when Settings observes WSL repos.
-  const context = Object.freeze({ wslDistro })
-  wslPreflightContextsByDistro.set(wslDistro, context)
-  return context
-}
-
-function getProjectRuntimeContextObjectCacheKey(
-  resolution: ProjectExecutionRuntimeResolution
-): string {
-  if (resolution.status === 'resolved') {
-    return `${resolution.runtime.cacheKey}:${resolution.runtime.reason}`
-  }
-  return `${resolution.repair.cacheKey}:${resolution.repair.source}`
-}
-
-function getProjectRuntimePreflightContext(
-  resolution: ProjectExecutionRuntimeResolution
-): NonNullable<LocalPreflightContext> {
-  const cacheKey = getProjectRuntimeContextObjectCacheKey(resolution)
-  const cached = projectRuntimePreflightContextsByKey.get(cacheKey)
-  if (cached) {
-    return cached
-  }
-
-  const wslDistro =
-    resolution.status === 'resolved' && resolution.runtime.kind === 'wsl'
-      ? resolution.runtime.distro
-      : undefined
-  // Why: selectors compare by reference; cache each resolved runtime context so
-  // adding projectRuntime does not reintroduce useSyncExternalStore churn.
-  const context = Object.freeze({
-    ...(wslDistro ? { wslDistro } : {}),
-    projectRuntime: resolution
-  })
-  projectRuntimePreflightContextsByKey.set(cacheKey, context)
-  return context
 }
 
 export function getLocalProjectExecutionRuntimeContext(


### PR DESCRIPTION
## Description

Fixes an unbounded renderer memory-retention bug in local preflight selector snapshots. The renderer kept every WSL distro and project-runtime context object it had ever seen for the lifetime of the process, even after projects and runtime identities disappeared.

The fix moves cache ownership into local-preflight-context-cache.ts and bounds insertion-order retention at:

- 128 WSL distro snapshots
- 2048 project-runtime snapshots

Cache hits remain read-only. New entries evict at most one oldest entry, avoiding Map mutation and garbage-collection pressure on broad Zustand selector reads.

## Evidence of Fix

Before the fix, a black-box reproduction requested RetentionDistro0, churned 256 distinct WSL contexts, then requested RetentionDistro0 again. The exact original object was still returned, proving the module-level Map retained the first snapshot indefinitely.

The permanent regression coverage now proves:

- the old WSL snapshot is released after 128 newer distinct contexts;
- WSL retention never exceeds 128 entries;
- project-runtime retention never exceeds 2048 entries;
- reading an entry does not mutate insertion order, so hot-path hits remain read-only.

Validation after the final rebase:

- 6 preflight-related test files passed, 71 tests total;
- the focused cache and context files passed, 30 tests total;
- changed-file oxlint passed;
- changed-file oxfmt check passed;
- max-lines ratchet passed with no new suppression;
- git diff check passed;
- two independent reviewers returned CLEAN on exact commit 7623338abb6660cbed07df4f30cab8ac67d291b7.

Web typecheck reached only three existing environment/baseline failures outside this diff: two missing typescript-api imports in the shared stale install and one Element versus HTMLDivElement error in useSessionRestoredBannerDismiss.test.tsx. It reported no changed-file diagnostic.

## ELI5

The UI kept a memo card for every project or WSL setup it had ever checked and never threw old cards away. Now each stack has a roomy limit. When a stack is full, adding one new card removes one oldest card.

## Trade-offs

Expected end-user regressions: zero.

Insertion-order eviction is intentional rather than LRU. Updating LRU order would require delete and set mutations on every cache hit inside widely used store selectors. With this design, an old but frequently read entry can be evicted only after more than 128 distinct WSL contexts or 2048 distinct project-runtime contexts are inserted. If that extreme churn occurs, the next read recreates one equivalent snapshot, which can cause at most one extra selector update; the semantic preflight key and result do not change, and subsequent reads are stable again.

The local-only guards remain unchanged: SSH and remote runtime identities do not enter these caches. Web and mobile remote clients continue using runtime RPC paths, and no provider-specific behavior, polling, timers, IPC fanout, network calls, or subprocess work was added.
