### PR TITLE
Bound custom pet blob cache

### DIFF
--- a/src/renderer/src/components/pet/pet-blob-cache.test.ts
+++ b/src/renderer/src/components/pet/pet-blob-cache.test.ts
@@ -1,15 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   blobUrlCache,
+  CUSTOM_PET_BLOB_CACHE_MAX,
   detectedSpriteCache,
   loadCustomBlobUrl,
+  retainCustomPetBlobCacheEntry,
   revokeCustomPetBlobUrl
 } from './pet-blob-cache'
 
 const TEST_PET_IDS = ['pet', 'late-pet', 'bundle-pet']
 
 afterEach(() => {
-  for (const id of TEST_PET_IDS) {
+  const ids = new Set([...TEST_PET_IDS, ...blobUrlCache.keys(), ...detectedSpriteCache.keys()])
+  for (const id of ids) {
     revokeCustomPetBlobUrl(id)
   }
   vi.restoreAllMocks()
@@ -103,5 +106,110 @@ describe('loadCustomBlobUrl', () => {
     )
     expect(bitmap.close).toHaveBeenCalledTimes(1)
     expect(detectedSpriteCache.has('bundle-pet')).toBe(false)
+  })
+
+  it('evicts least-recent custom pet blobs and closes detected sprite bitmaps', async () => {
+    const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+    stubPetRead(read)
+    let blobIndex = 0
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(() => `blob:pet-${blobIndex++}`)
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const evictedBitmap = { close: vi.fn() } as unknown as ImageBitmap
+
+    for (let index = 0; index < CUSTOM_PET_BLOB_CACHE_MAX; index += 1) {
+      await expect(loadCustomBlobUrl(`pet-${index}`, 'pet.png', 'image/png')).resolves.toBe(
+        `blob:pet-${index}`
+      )
+    }
+    detectedSpriteCache.set('pet-1', {
+      bitmaps: [evictedBitmap],
+      fps: 8,
+      frames: []
+    })
+
+    await expect(loadCustomBlobUrl('pet-0', 'pet.png', 'image/png')).resolves.toBe('blob:pet-0')
+    await expect(
+      loadCustomBlobUrl(`pet-${CUSTOM_PET_BLOB_CACHE_MAX}`, 'pet.png', 'image/png')
+    ).resolves.toBe(`blob:pet-${CUSTOM_PET_BLOB_CACHE_MAX}`)
+
+    expect(blobUrlCache.has('pet-0')).toBe(true)
+    expect(blobUrlCache.has('pet-1')).toBe(false)
+    expect(detectedSpriteCache.has('pet-1')).toBe(false)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:pet-1')
+    expect(evictedBitmap.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let stale load completions evict retained active media', async () => {
+    const resolvers = new Map<string, (buffer: ArrayBuffer) => void>()
+    const read = vi.fn(
+      (id: string) =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolvers.set(id, resolve)
+        })
+    )
+    stubPetRead(read)
+    let blobIndex = 0
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(() => `blob:pet-${blobIndex++}`)
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const releaseActive = retainCustomPetBlobCacheEntry('pet-16')
+    const loads = Array.from({ length: 17 }, (_, index) =>
+      loadCustomBlobUrl(`pet-${index}`, 'pet.png', 'image/png')
+    )
+
+    try {
+      resolvers.get('pet-16')!(new Uint8Array([16]).buffer)
+      const activeUrl = await loads[16]
+      const activeBitmap = { close: vi.fn() } as unknown as ImageBitmap
+      detectedSpriteCache.set('pet-16', { bitmaps: [activeBitmap], fps: 8, frames: [] })
+
+      for (let index = 0; index < 16; index += 1) {
+        resolvers.get(`pet-${index}`)!(new Uint8Array([index]).buffer)
+        await loads[index]
+      }
+
+      expect(blobUrlCache.get('pet-16')).toBe(activeUrl)
+      expect(revokeObjectURL).not.toHaveBeenCalledWith(activeUrl)
+      expect(activeBitmap.close).not.toHaveBeenCalled()
+      expect(blobUrlCache.size).toBe(CUSTOM_PET_BLOB_CACHE_MAX)
+
+      releaseActive()
+      const nextLoad = loadCustomBlobUrl('pet-17', 'pet.png', 'image/png')
+      resolvers.get('pet-17')!(new Uint8Array([17]).buffer)
+      await nextLoad
+
+      expect(blobUrlCache.has('pet-16')).toBe(false)
+      expect(revokeObjectURL).toHaveBeenCalledWith(activeUrl)
+      expect(activeBitmap.close).toHaveBeenCalledTimes(1)
+    } finally {
+      releaseActive()
+    }
+  })
+
+  it('shrinks a temporarily retained overflow when a consumer releases', async () => {
+    const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+    stubPetRead(read)
+    let blobIndex = 0
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(() => `blob:retained-${blobIndex++}`)
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const releases = Array.from({ length: 17 }, (_, index) =>
+      retainCustomPetBlobCacheEntry(`retained-${index}`)
+    )
+
+    try {
+      for (let index = 0; index < 17; index += 1) {
+        await loadCustomBlobUrl(`retained-${index}`, 'pet.png', 'image/png')
+      }
+      expect(blobUrlCache.size).toBe(17)
+
+      releases[0]()
+
+      expect(blobUrlCache.size).toBe(CUSTOM_PET_BLOB_CACHE_MAX)
+      expect(blobUrlCache.has('retained-0')).toBe(false)
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:retained-0')
+    } finally {
+      for (const release of releases) {
+        release()
+      }
+    }
   })
 })

--- a/src/renderer/src/components/pet/pet-blob-cache.ts
+++ b/src/renderer/src/components/pet/pet-blob-cache.ts
@@ -10,6 +10,7 @@ import { detectFramesFromImageData, type DetectedFrame } from './sprite-frame-de
 // cache means switching back and forth between images in the same session
 // doesn't re-fetch from main.
 export const blobUrlCache = new Map<string, string>()
+export const CUSTOM_PET_BLOB_CACHE_MAX = 16
 
 export type DetectedSpriteCacheEntry = {
   frames: DetectedFrame[]
@@ -25,6 +26,39 @@ export const detectedSpriteCache = new Map<string, DetectedSpriteCacheEntry>()
 const customPetBlobUrlLoads = new Map<string, Promise<string | null>>()
 const customPetBlobCacheEpoch = new Map<string, number>()
 const customPetBlobActiveLoadCounts = new Map<string, number>()
+const customPetBlobRetainCounts = new Map<string, number>()
+
+export function retainCustomPetBlobCacheEntry(id: string): () => void {
+  customPetBlobRetainCounts.set(id, (customPetBlobRetainCounts.get(id) ?? 0) + 1)
+  let retained = true
+  return () => {
+    if (!retained) {
+      return
+    }
+    retained = false
+    const nextCount = (customPetBlobRetainCounts.get(id) ?? 1) - 1
+    if (nextCount > 0) {
+      customPetBlobRetainCounts.set(id, nextCount)
+      return
+    }
+    customPetBlobRetainCounts.delete(id)
+    evictInactiveCustomPetBlobUrls()
+  }
+}
+
+export function peekCustomPetBlobUrl(id: string): string | null {
+  return blobUrlCache.get(id) ?? null
+}
+
+export function readCustomPetBlobUrl(id: string): string | null {
+  const cached = peekCustomPetBlobUrl(id)
+  if (!cached) {
+    return null
+  }
+  blobUrlCache.delete(id)
+  blobUrlCache.set(id, cached)
+  return cached
+}
 
 export async function loadCustomBlobUrl(
   id: string,
@@ -34,7 +68,7 @@ export async function loadCustomBlobUrl(
   spriteFps?: number,
   hasManifestSprite?: boolean
 ): Promise<string | null> {
-  const cached = blobUrlCache.get(id)
+  const cached = readCustomPetBlobUrl(id)
   if (cached) {
     return cached
   }
@@ -134,6 +168,26 @@ function cacheCustomPetBlobUrl(
   blobUrlCache.set(id, url)
   if (detected) {
     detectedSpriteCache.set(id, detected)
+  }
+  evictInactiveCustomPetBlobUrls()
+}
+
+function evictInactiveCustomPetBlobUrls(): void {
+  // Why: users can import many custom pets; inactive blob URLs and sprite
+  // bitmaps should not stay resident for the whole renderer session.
+  while (blobUrlCache.size > CUSTOM_PET_BLOB_CACHE_MAX) {
+    let evicted = false
+    for (const id of blobUrlCache.keys()) {
+      if (customPetBlobRetainCounts.has(id)) {
+        continue
+      }
+      clearCustomPetBlobCacheEntry(id)
+      evicted = true
+      break
+    }
+    if (!evicted) {
+      return
+    }
   }
 }
 

--- a/src/renderer/src/components/pet/usePetUrl.test.tsx
+++ b/src/renderer/src/components/pet/usePetUrl.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appState, cacheMocks } = vi.hoisted(() => ({
+  appState: {
+    current: {
+      petId: 'custom-a',
+      customPets: [
+        {
+          id: 'custom-a',
+          label: 'Custom A',
+          fileName: 'a.png',
+          mimeType: 'image/png',
+          kind: 'image' as const
+        }
+      ]
+    }
+  },
+  cacheMocks: {
+    peek: vi.fn(() => null),
+    read: vi.fn(() => null),
+    load: vi.fn(() => new Promise<null>(() => {})),
+    retain: vi.fn()
+  }
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: typeof appState.current) => unknown) =>
+    selector(appState.current)
+}))
+
+vi.mock('./pet-blob-cache', () => ({
+  detectedSpriteCache: new Map(),
+  loadCustomBlobUrl: cacheMocks.load,
+  peekCustomPetBlobUrl: cacheMocks.peek,
+  readCustomPetBlobUrl: cacheMocks.read,
+  retainCustomPetBlobCacheEntry: cacheMocks.retain
+}))
+
+import { usePetUrl } from './usePetUrl'
+
+beforeEach(() => {
+  cacheMocks.peek.mockClear()
+  cacheMocks.read.mockClear()
+  cacheMocks.load.mockClear()
+  cacheMocks.retain.mockReset()
+  appState.current = {
+    petId: 'custom-a',
+    customPets: [
+      {
+        id: 'custom-a',
+        label: 'Custom A',
+        fileName: 'a.png',
+        mimeType: 'image/png',
+        kind: 'image'
+      }
+    ]
+  }
+})
+
+describe('usePetUrl cache retention', () => {
+  it('retains only the committed custom pet and releases it on change and unmount', () => {
+    const releaseA = vi.fn()
+    const releaseB = vi.fn()
+    cacheMocks.retain.mockReturnValueOnce(releaseA).mockReturnValueOnce(releaseB)
+    const hook = renderHook(() => usePetUrl())
+
+    expect(cacheMocks.retain).toHaveBeenCalledWith('custom-a')
+    appState.current = {
+      petId: 'custom-b',
+      customPets: [
+        ...appState.current.customPets,
+        {
+          id: 'custom-b',
+          label: 'Custom B',
+          fileName: 'b.png',
+          mimeType: 'image/png',
+          kind: 'image'
+        }
+      ]
+    }
+    hook.rerender()
+
+    expect(releaseA).toHaveBeenCalledTimes(1)
+    expect(cacheMocks.retain).toHaveBeenLastCalledWith('custom-b')
+    hook.unmount()
+    expect(releaseB).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/pet/usePetUrl.ts
+++ b/src/renderer/src/components/pet/usePetUrl.ts
@@ -1,11 +1,13 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { CustomPet } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import { BUNDLED_PET, findBundledPet, isBundledPetId } from './pet-models'
 import {
-  blobUrlCache,
   detectedSpriteCache,
   loadCustomBlobUrl,
+  peekCustomPetBlobUrl,
+  readCustomPetBlobUrl,
+  retainCustomPetBlobCacheEntry,
   type DetectedSpriteCacheEntry
 } from './pet-blob-cache'
 
@@ -36,7 +38,7 @@ export function usePetUrl(): ResolvedPet {
   const customMeta = bundled ? null : customPets.find((m) => m.id === petId)
 
   const [customUrl, setCustomUrl] = useState<string | null>(() =>
-    customMeta ? (blobUrlCache.get(customMeta.id) ?? null) : null
+    customMeta ? peekCustomPetBlobUrl(customMeta.id) : null
   )
   // Why: track the last id we started loading so a rapid switch between
   // custom pets doesn't let a slower earlier response clobber the newer
@@ -58,12 +60,20 @@ export function usePetUrl(): ResolvedPet {
     customMeta.sprite.frameWidth > 0 &&
     customMeta.sprite.frameHeight > 0 &&
     customMeta.sprite.fps > 0
+  useLayoutEffect(() => {
+    if (!customId) {
+      return
+    }
+    // Why: cancelled older loads may finish after the active pet. Pin the
+    // committed URL/bitmaps so their cache insertion cannot evict active media.
+    return retainCustomPetBlobCacheEntry(customId)
+  }, [customId])
   useEffect(() => {
     if (!customId || !customFileName) {
       setCustomUrl(null)
       return
     }
-    const cached = blobUrlCache.get(customId)
+    const cached = readCustomPetBlobUrl(customId)
     if (cached) {
       setCustomUrl(cached)
       return


### PR DESCRIPTION
## Description

Bounds the renderer cache for custom pet blob URLs and detected sprite ImageBitmaps while protecting media that a committed overlay is actively using.

- Cache reads refresh recency and writes keep at most 16 inactive/recent custom pet entries.
- Eviction uses the existing ownership cleanup path, revoking the blob URL and closing every detected ImageBitmap.
- Committed usePetUrl consumers retain their current pet entry. Cancelled older loads that finish late cannot evict or close the active pet.
- Retention is reference-counted for multiple consumers, and releasing a consumer immediately re-applies the cache bound.

The cache remains renderer-local, so the same lifecycle applies in Electron and the paired web renderer. Orca Mobile does not import or render this desktop pet overlay.

## Evidence

### Reproduction on current main

On main, loading 17 distinct custom pet images retained all 17 blob URLs:

- blobUrlCache.size: 17
- unique blob URLs: 17
- revoked URLs: 0

There was no automatic cleanup unless a pet was explicitly removed or a load was invalidated.

### Fix proof

The regression coverage proves:

- the least-recent inactive entry is evicted after the seventeenth distinct load;
- cache hits refresh recency;
- eviction revokes the blob URL and closes detected sprite bitmaps;
- an active pet that finishes before 16 cancelled older loads remains cached and its bitmap stays open;
- after the active consumer releases, later churn may evict that entry and closes it exactly once;
- an all-retained overflow shrinks back to 16 as soon as a consumer releases;
- usePetUrl retains only the committed custom pet and releases it on pet change and unmount;
- explicit removal still invalidates and revokes late async completion.

Mutation checks were run:

- removing retain-aware eviction caused the stale-load test to revoke the active pet;
- removing release-time eviction left 17 retained entries after release;
- removing the hook retention lifecycle caused the hook test to observe zero retains;
- current main without the cap failed the 17-entry bound.

Validation:

- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/pet — 8 files / 24 tests passed
- pnpm exec oxlint on all four changed files — passed
- pnpm check:max-lines-ratchet — passed
- git diff --check origin/main...HEAD — passed
- two independent final adversarial reviewers returned clean in the same round
- typecheck:web reported no changed-file errors; the shared stale node_modules install is missing the locked typescript-api alias and also reports one unrelated existing DOM test type mismatch

## ELI5

Orca used to keep every custom pet picture it had shown. Now it keeps a small recent set and unloads the oldest inactive pictures. It also marks the pet currently on screen as in use, so a slow old load can never throw away the picture or animation frames that are still being drawn.

## Trade-offs

No correctness or user-visible regressions are expected for the active pet. The fix adds no polling, timers, background work, network requests, or per-frame work. Retain/release bookkeeping runs only when the committed pet changes or the overlay mounts or unmounts.

If a user switches among more than 16 custom pets in one renderer session, an older inactive pet may reload through the existing pet read path the next time it is selected. This can add a small delay on that rare switch in exchange for bounded renderer memory. If more than 16 overlays concurrently retain different custom pets, the cache may temporarily exceed 16 so active media is never revoked; it shrinks immediately as consumers release.