### PR TITLE
Fix tracked upstream generation cache leak

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -118,6 +118,7 @@ import {
   updatePRState,
   updatePRTitle,
   _getMergeQueueCacheSizeForTests,
+  _getTrackedUpstreamBranchCacheSizesForTests,
   _resetOwnerRepoCache,
   _resetMergeQueueCacheForTests,
   __resetTrackedUpstreamBranchCacheForTests
@@ -1784,6 +1785,119 @@ describe('getPRForBranch', () => {
       (args as string[]).includes('refs/heads')
     )
     expect(trackedUpstreamCalls).toHaveLength(1)
+  })
+
+  it('releases tracked-upstream probe generations across runtime identities', async () => {
+    const sshGitProvider = {
+      exec: vi.fn().mockResolvedValue({ stdout: 'feature\0\n', stderr: '' })
+    }
+    getSshGitProviderMock.mockReturnValue(sshGitProvider)
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: JSON.stringify([]) })
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'feature\0\n', stderr: '' })
+
+    await getPRForBranch('/repo-root', 'feature')
+    await getPRForBranch('/repo-root', 'feature', null, null, null, {
+      localGitExecOptions: { wslDistro: 'Ubuntu' }
+    })
+    await getPRForBranch('/repo-root', 'feature', null, 'ssh-1')
+
+    expect(_getTrackedUpstreamBranchCacheSizesForTests()).toEqual({
+      snapshots: 3,
+      inFlight: 0,
+      generations: 0
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(sshGitProvider.exec).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds unique tracked-upstream snapshots and sweeps expired identities', async () => {
+    vi.useFakeTimers()
+    try {
+      getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+      ghExecFileAsyncMock.mockResolvedValue({ stdout: JSON.stringify([]) })
+      gitExecFileAsyncMock.mockResolvedValue({ stdout: 'feature\0\n', stderr: '' })
+
+      for (let index = 0; index < 513; index += 1) {
+        await getPRForBranch(`/repo-root-${index}`, 'feature')
+      }
+      await getPRForBranch('/repo-root-512', 'feature')
+
+      expect(_getTrackedUpstreamBranchCacheSizesForTests()).toEqual({
+        snapshots: 512,
+        inFlight: 0,
+        generations: 0
+      })
+      expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(513)
+
+      await vi.advanceTimersByTimeAsync(30_001)
+      await getPRForBranch('/repo-root-fresh', 'feature')
+
+      expect(_getTrackedUpstreamBranchCacheSizesForTests()).toEqual({
+        snapshots: 1,
+        inFlight: 0,
+        generations: 0
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps stale probe cleanup from releasing a replacement generation', async () => {
+    let resolveOldProbe: (value: { stdout: string; stderr: string }) => void
+    let resolveCurrentProbe: (value: { stdout: string; stderr: string }) => void
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: JSON.stringify([]) })
+    gitExecFileAsyncMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOldProbe = resolve
+          })
+      )
+      .mockResolvedValueOnce({ stdout: 'replacement\0\n', stderr: '' })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveCurrentProbe = resolve
+          })
+      )
+
+    const oldLookup = getPRForBranch('/repo-root', 'old')
+    await vi.waitFor(() => expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1))
+    __resetTrackedUpstreamBranchCacheForTests()
+    await getPRForBranch('/repo-root', 'replacement')
+    const currentLookup = getPRForBranch('/repo-root', 'current')
+    await vi.waitFor(() => expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(3))
+
+    resolveOldProbe!({ stdout: 'old\0\n', stderr: '' })
+    await oldLookup
+    expect(_getTrackedUpstreamBranchCacheSizesForTests()).toEqual({
+      snapshots: 0,
+      inFlight: 1,
+      generations: 1
+    })
+
+    resolveCurrentProbe!({ stdout: 'current\0\n', stderr: '' })
+    await currentLookup
+    expect(_getTrackedUpstreamBranchCacheSizesForTests()).toEqual({
+      snapshots: 1,
+      inFlight: 0,
+      generations: 0
+    })
+  })
+
+  it('releases tracked-upstream probe state when setup rejects', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: JSON.stringify([]) })
+    readLocalGitConfigSignatureMock.mockRejectedValue(new Error('git config unavailable'))
+
+    await expect(getPRForBranch('/repo-root', 'feature')).resolves.toBeNull()
+    expect(_getTrackedUpstreamBranchCacheSizesForTests()).toEqual({
+      snapshots: 0,
+      inFlight: 0,
+      generations: 0
+    })
   })
 
   it('does not fan out tracked-upstream probes after a transient for-each-ref failure', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2392,6 +2392,7 @@ type TrackedUpstreamBranch = {
 }
 
 const TRACKED_UPSTREAM_SNAPSHOT_CACHE_TTL_MS = 30_000
+const TRACKED_UPSTREAM_SNAPSHOT_CACHE_MAX_ENTRIES = 512
 
 type TrackedUpstreamSnapshotCacheEntry = {
   expiresAt: number
@@ -2411,12 +2412,49 @@ const trackedUpstreamSnapshotInFlight = new Map<
   string,
   Promise<TrackedUpstreamSnapshotProbeResult>
 >()
-const trackedUpstreamSnapshotGenerations = new Map<string, number>()
+const trackedUpstreamSnapshotGenerations = new Map<string, symbol>()
 
-function beginTrackedUpstreamSnapshotProbe(cacheKey: string): number {
-  const nextGeneration = (trackedUpstreamSnapshotGenerations.get(cacheKey) ?? 0) + 1
-  trackedUpstreamSnapshotGenerations.set(cacheKey, nextGeneration)
-  return nextGeneration
+function beginTrackedUpstreamSnapshotProbe(cacheKey: string): symbol {
+  const generation = Symbol()
+  trackedUpstreamSnapshotGenerations.set(cacheKey, generation)
+  return generation
+}
+
+function finishTrackedUpstreamSnapshotProbe(cacheKey: string, generation: symbol): void {
+  // Why: generations only guard an active probe; retaining completed repo keys
+  // leaks worktree/runtime identities after the short-lived snapshot TTL expires.
+  if (trackedUpstreamSnapshotGenerations.get(cacheKey) === generation) {
+    trackedUpstreamSnapshotGenerations.delete(cacheKey)
+  }
+}
+
+function pruneTrackedUpstreamSnapshotCache(now: number): void {
+  for (const [cacheKey, cached] of trackedUpstreamSnapshotCache) {
+    if (cached.expiresAt <= now) {
+      trackedUpstreamSnapshotCache.delete(cacheKey)
+    }
+  }
+  // Why: workspace/runtime churn can create unbounded unique keys within one
+  // TTL window, so expiry sweeping alone is not a memory bound.
+  while (trackedUpstreamSnapshotCache.size > TRACKED_UPSTREAM_SNAPSHOT_CACHE_MAX_ENTRIES) {
+    const oldestKey = trackedUpstreamSnapshotCache.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    trackedUpstreamSnapshotCache.delete(oldestKey)
+  }
+}
+
+export function _getTrackedUpstreamBranchCacheSizesForTests(): {
+  snapshots: number
+  inFlight: number
+  generations: number
+} {
+  return {
+    snapshots: trackedUpstreamSnapshotCache.size,
+    inFlight: trackedUpstreamSnapshotInFlight.size,
+    generations: trackedUpstreamSnapshotGenerations.size
+  }
 }
 
 export function __resetTrackedUpstreamBranchCacheForTests(): void {
@@ -2510,6 +2548,7 @@ async function getTrackedUpstreamBranch(
         upstreamsByBranchName: getCacheableTrackedUpstreamSnapshot(result.upstreamsByBranchName),
         expiresAt: Date.now() + TRACKED_UPSTREAM_SNAPSHOT_CACHE_TTL_MS
       })
+      pruneTrackedUpstreamSnapshotCache(Date.now())
     }
     if (trackedUpstreamSnapshotGenerations.get(cacheKey) !== probeGeneration) {
       const fresherCached = trackedUpstreamSnapshotCache.get(cacheKey)
@@ -2522,6 +2561,7 @@ async function getTrackedUpstreamBranch(
     if (trackedUpstreamSnapshotInFlight.get(cacheKey) === probe) {
       trackedUpstreamSnapshotInFlight.delete(cacheKey)
     }
+    finishTrackedUpstreamSnapshotProbe(cacheKey, probeGeneration)
   }
 }
 


### PR DESCRIPTION
## Description

Fixes the main-process tracked-upstream cache retaining repository and runtime identities after PR refresh probes complete.

- Active probe generations now use unique tokens and are removed in the guarded finally path, including rejected probes, without allowing an older completion to release a replacement probe.
- Snapshot entries are swept after cache writes and capped at 512 identities. This closes the related lazy-TTL retention path without adding timers, polling, or work to cache hits.
- Cache keys and execution routing remain separated across host, WSL distro, and SSH connection identities.

## Evidence

### Reproduction on current main

On main at 4df9457530, three completed lookups for distinct repositories produced:

- snapshots: 3
- inFlight: 0
- generations: 3

The snapshot and in-flight paths completed, but every repo/runtime generation key remained for the life of the main process.

### Fix proof

The regression coverage now proves:

- host, WSL, and SSH probes all release generation state and use the correct git executor;
- 513 unique identities retain at most 512 snapshots, a hot retained identity remains a cache hit, and the next write after the 30-second TTL sweeps expired entries;
- a stale completion cannot overwrite or release a replacement probe after identity reuse;
- setup rejection releases both in-flight and generation state.

Mutation checks were also run:

- disabling generation cleanup failed all three cleanup/rejection/runtime tests;
- restoring numeric generation reuse failed the stale-completion ABA test;
- disabling snapshot pruning failed the 513-identity bound test.

Validation:

- pnpm exec vitest run --config config/vitest.config.ts src/main/github/client.test.ts — 115 passed
- pnpm exec oxlint src/main/github/client.ts src/main/github/client.test.ts — passed
- pnpm typecheck:tsc:node — passed
- pnpm check:max-lines-ratchet — passed
- git diff --check origin/main...HEAD — passed
- two independent final adversarial reviewers returned clean in the same round

## ELI5

Orca kept a tally card for every repository and runtime it checked. The work finished, but the tally cards and some expired snapshots stayed in memory. Orca now throws away finished tally cards, clears expired snapshots during normal cache writes, and keeps a firm ceiling on how many snapshots can remain.

## Trade-offs

No correctness or user-visible regressions are expected. Cache hits do not gain any new scan or loop, and there are no new timers, listeners, network calls, or polling.

At the pathological scale of more than 512 distinct repository/runtime identities queried within one 30-second window, the oldest snapshot is evicted. If that identity is queried again, Orca performs one fresh bounded git for-each-ref scan. This intentional rare recomputation prevents unbounded main-process memory growth.