### PR TITLE
Fix worktree scan generation cache leak

### DIFF
--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -23,6 +23,8 @@ import { clearGitCapabilityStateForTests } from './git-capability-state'
 import {
   addSparseWorktree,
   addWorktree,
+  _getWorktreeScanCacheSizesForTests,
+  _resetWorktreeScanCacheForTests,
   listWorktreeGraph,
   listWorktrees,
   moveWorktree,
@@ -36,7 +38,13 @@ beforeEach(() => {
 })
 
 describe('listWorktrees in-flight sharing', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    gitExecFileAsyncMock.mockReset()
+    _resetWorktreeScanCacheForTests()
+    // Why: capability discovery serializes same-host callers; warming it lets
+    // these tests isolate the scan-generation overlap they are exercising.
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+    await listWorktrees('/capability-warmup')
     gitExecFileAsyncMock.mockReset()
   })
 
@@ -85,6 +93,126 @@ describe('listWorktrees in-flight sharing', () => {
     await Promise.all([listWorktrees('/repo-one'), listWorktrees('/repo-two')])
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retain scan generations after mutations without active scans', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+
+    await Promise.all(
+      Array.from({ length: 128 }, (_, index) =>
+        moveWorktree(`/repo-${index}`, `/repo-${index}-old`, `/repo-${index}-new`)
+      )
+    )
+
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 0, generations: 0 })
+  })
+
+  it('cleans mutation generations after stale scans settle and supports repo reuse', async () => {
+    const scanResolvers: ((stdout: string) => void)[] = []
+    let listCalls = 0
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCalls += 1
+        return new Promise((resolve) => {
+          scanResolvers.push((stdout) => resolve({ stdout }))
+        })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+
+    const staleScan = listWorktrees('/repo')
+    expect(scanResolvers).toHaveLength(1)
+
+    await moveWorktree('/repo', '/repo-old', '/repo-new')
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 1, generations: 1 })
+
+    const freshScan = listWorktrees('/repo')
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 2, generations: 1 })
+
+    scanResolvers[1]?.('worktree /repo-new\nHEAD fresh\nbranch refs/heads/main\n')
+    expect((await freshScan)[0]?.path).toBe('/repo-new')
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 1, generations: 1 })
+
+    scanResolvers[0]?.('worktree /repo\nHEAD stale\nbranch refs/heads/main\n')
+    expect((await staleScan)[0]?.path).toBe('/repo')
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 0, generations: 0 })
+
+    const firstReuse = listWorktrees('/repo')
+    const secondReuse = listWorktrees('/repo')
+    expect(listCalls).toBe(3)
+
+    scanResolvers[2]?.('worktree /repo-reused\nHEAD reused\nbranch refs/heads/main\n')
+    const [firstResult, secondResult] = await Promise.all([firstReuse, secondReuse])
+    expect(firstResult).toEqual(secondResult)
+    expect(firstResult[0]?.path).toBe('/repo-reused')
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 0, generations: 0 })
+  })
+
+  it('retires every overlapping scan generation across repeated mutations', async () => {
+    const scanResolvers: (() => void)[] = []
+    let listCalls = 0
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCalls += 1
+        return new Promise((resolve) => {
+          scanResolvers.push(() => resolve({ stdout: '' }))
+        })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+
+    const oldestScan = listWorktrees('/repo')
+    await moveWorktree('/repo', '/old-0', '/new-0')
+    const middleScan = listWorktrees('/repo')
+    await moveWorktree('/repo', '/old-1', '/new-1')
+    const newestScan = listWorktrees('/repo')
+
+    expect(listCalls).toBe(3)
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 3, generations: 1 })
+
+    scanResolvers[0]?.()
+    scanResolvers[2]?.()
+    scanResolvers[1]?.()
+    await Promise.all([oldestScan, middleScan, newestScan])
+
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 0, generations: 0 })
+  })
+
+  it('keeps WSL scans distinct while retiring both after a mutation', async () => {
+    const scanResolvers: (() => void)[] = []
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+    await Promise.all([
+      listWorktrees('/capability-warmup', { wslDistro: 'Ubuntu' }),
+      listWorktrees('/capability-warmup', { wslDistro: 'Debian' })
+    ])
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return new Promise((resolve) => {
+          scanResolvers.push(() => resolve({ stdout: '' }))
+        })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+
+    const staleUbuntu = listWorktrees('/repo', { wslDistro: 'Ubuntu' })
+    const staleDebian = listWorktrees('/repo', { wslDistro: 'Debian' })
+    expect(scanResolvers).toHaveLength(2)
+
+    await removeWorktree('/repo', '/worktree', false, {
+      knownRemovedWorktree: { branch: '', head: '' },
+      wslDistro: 'Ubuntu'
+    })
+    const freshUbuntu = listWorktrees('/repo', { wslDistro: 'Ubuntu' })
+    const freshDebian = listWorktrees('/repo', { wslDistro: 'Debian' })
+    expect(scanResolvers).toHaveLength(4)
+
+    for (const resolve of scanResolvers) {
+      resolve()
+    }
+    await Promise.all([staleUbuntu, staleDebian, freshUbuntu, freshDebian])
+
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 0, generations: 0 })
   })
 
   it('does not share scans for callers with an AbortSignal', async () => {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -643,8 +643,46 @@ const inFlightWorktreeScans = new Map<string, Promise<GitWorktreeInfo[]>>()
 // settle for their original callers).
 const worktreeScanGenerations = new Map<string, number>()
 
+function hasInFlightWorktreeScanForRepo(repoPath: string): boolean {
+  const keyPrefix = `${repoPath}\0`
+  for (const key of inFlightWorktreeScans.keys()) {
+    if (key.startsWith(keyPrefix)) {
+      return true
+    }
+  }
+  return false
+}
+
 function bumpWorktreeScanGeneration(repoPath: string): void {
+  // Why: generations only prevent joining a pre-mutation scan. Without an
+  // active scan, retaining the repo path just leaks completed mutation keys.
+  if (!hasInFlightWorktreeScanForRepo(repoPath)) {
+    return
+  }
   worktreeScanGenerations.set(repoPath, (worktreeScanGenerations.get(repoPath) ?? 0) + 1)
+}
+
+function pruneWorktreeScanGeneration(repoPath: string): void {
+  // Why: ordinary scan settlement should stay O(1); only repos invalidated
+  // during an active scan need the cross-generation in-flight check.
+  if (!worktreeScanGenerations.has(repoPath)) {
+    return
+  }
+  if (!hasInFlightWorktreeScanForRepo(repoPath)) {
+    worktreeScanGenerations.delete(repoPath)
+  }
+}
+
+export function _getWorktreeScanCacheSizesForTests(): { inFlight: number; generations: number } {
+  return {
+    inFlight: inFlightWorktreeScans.size,
+    generations: worktreeScanGenerations.size
+  }
+}
+
+export function _resetWorktreeScanCacheForTests(): void {
+  inFlightWorktreeScans.clear()
+  worktreeScanGenerations.clear()
 }
 
 /**
@@ -669,6 +707,7 @@ export function listWorktrees(
     if (inFlightWorktreeScans.get(key) === scan) {
       inFlightWorktreeScans.delete(key)
     }
+    pruneWorktreeScanGeneration(repoPath)
   })
   inFlightWorktreeScans.set(key, scan)
   return scan


### PR DESCRIPTION
## Description

Fixes a main-process memory leak in Git worktree scan-generation bookkeeping without weakening stale-scan protection.

Worktree mutations use a generation to keep callers that arrive after add/move/remove from joining a scan that started before the mutation. The generation is now created only when a shared scan for that repo is actually in flight, then removed after the last shared scan for that repo settles. Ordinary scan settlement exits in O(1) when no mutation generation exists.

## Evidence

### Reproduction before the fix

On main commit `2a01b416384a7ecdfd10268a4cc4a71a80490f55`, a temporary production-level harness drove 100 successful real `moveWorktree` completions across 100 distinct repos and inspected the production cache:

- Expected retained generation entries: **0**
- Actual retained generation entries: **100**

The entries had no cleanup path and accumulated for the life of the main process.

### Proof of fix

The regression suite now covers:

- 128 completed mutations across distinct repos retain **0** generation entries.
- A mutation during a stale shared scan forces the next caller onto a fresh scan.
- Fresh-before-stale settlement keeps the generation until the stale scan drains.
- Three overlapping scan generations survive repeated mutations and clean up in arbitrary settlement order.
- The same repo path can be reused after cleanup and resumes normal in-flight sharing.
- Ubuntu and Debian WSL scans remain distinct and both retire safely across mutation.
- Final cache size is **0 in-flight scans / 0 generations** after every lifecycle scenario.

Verified after rebasing onto main `6b7732d511879cc86f1674af47483348197e3e16`:

- `node ../../node_modules/vitest/vitest.mjs run --config config/vitest.config.ts --maxWorkers=1 src/main/git/worktree.test.ts` — **59/59 passed**
- `../../node_modules/.bin/oxlint src/main/git/worktree.ts src/main/git/worktree.test.ts` — passed
- `node config/scripts/check-max-lines-ratchet.mjs` — passed
- `git diff --check origin/main...HEAD` — passed
- Fresh Claude Fable 5 architecture/lifecycle review — no issues
- Fresh Codex GPT-5.5 xhigh reproduction/resource review — no issues

Node typecheck was attempted but the local dependency state cannot resolve the pre-existing `typescript-api` imports in `src/main/pi/agent-status-extension-source.test.ts` and `src/shared/remote-runtime-shared-control-boundary.test.ts`; neither file is touched by this PR.

## ELI5

Orca puts a number on a worktree scan so a request arriving after a worktree changes cannot accidentally reuse an older scan. Orca was writing those numbers even when there was no older scan, then keeping them forever. It now writes a number only when one is needed and erases it after all relevant scans finish.

## Trade-offs

**End-user regressions: none expected.** Post-mutation callers still cannot join stale in-flight scans, and ordinary cold-start scan settlement remains O(1).

A mutation may inspect the currently active scan keys to decide whether a generation is needed. Mutations are user-driven and already perform Git work; this adds no subprocesses, polling, timers, IPC, or provider fanout. The inspection is bounded by concurrently active scans, not historical repo count.

The changed cache exists only in the local/WSL main-process path. SSH/relay and source-control provider behavior (including GitLab) are unchanged. No Git command, deletion behavior, timeout, or destructive preflight changed, so no delete smoke was added. Live packaged Windows/WSL/SSH validation was not run; cross-platform safety is supported by platform-neutral string/Map logic and focused WSL coverage.