### PR TITLE
Bound GitLab known-host cache by connection

### DIFF
--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -211,6 +211,14 @@ describe('gitlab client — MR operations', () => {
       })
     })
 
+    it('does not run cwd-inferred glab for an unresolved SSH project', async () => {
+      getProjectRefMock.mockResolvedValueOnce(null)
+
+      await expect(getMergeRequest('/remote/repo', 5, 'ssh-1')).resolves.toBeNull()
+
+      expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+    })
+
     it('returns null when glab errors', async () => {
       getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
       glabExecFileAsyncMock.mockRejectedValueOnce(new Error('not found'))

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -41,6 +41,7 @@ import {
   type LocalGitExecOptions,
   type ProjectRef
 } from './gl-utils'
+import { assertProjectRefCurrentForConnection } from './gitlab-project-ref-lifecycle'
 import type { IssueListState } from './issues'
 import {
   hasHostedReviewLocalGitOptions,
@@ -272,6 +273,11 @@ export async function getMergeRequest(
   const localGitArgs = hostedReviewLocalGitOptionArgs(options)
   const localGitOptions = localGitArgs[0] ?? {}
   const projectRef = await getProjectRef(repoPath, knownHosts, connectionId, ...localGitArgs)
+  if (connectionId && !projectRef) {
+    // Why: SSH repos have no safe cwd-inferred fallback after lifecycle
+    // resolution expires; glab could otherwise inspect an unrelated local repo.
+    return null
+  }
   await acquire()
   try {
     const args = projectRef
@@ -551,6 +557,7 @@ export async function getWorkItemByProjectRef(
 ): Promise<GitLabWorkItem | null> {
   await acquire()
   try {
+    assertProjectRefCurrentForConnection(projectRef, connectionId)
     const resource = type === 'mr' ? 'merge_requests' : 'issues'
     const { stdout } = await glabExecFileAsync(
       [

--- a/src/main/gitlab/gitlab-known-host-cache.ts
+++ b/src/main/gitlab/gitlab-known-host-cache.ts
@@ -120,9 +120,7 @@ export function rememberGlabKnownHost(host: string, connectionId?: string | null
   )
 }
 
-export async function getGlabKnownHosts(
-  connectionId?: string | null
-): Promise<readonly string[]> {
+export async function getGlabKnownHosts(connectionId?: string | null): Promise<readonly string[]> {
   const key = connectionCacheKey(connectionId)
   const sshProviderRegistrationId = connectionId
     ? getSshGitProviderRegistrationId(connectionId)

--- a/src/main/gitlab/gitlab-known-host-cache.ts
+++ b/src/main/gitlab/gitlab-known-host-cache.ts
@@ -1,0 +1,183 @@
+import { glabExecFileAsync } from '../git/runner'
+import { getSshGitProviderRegistrationId } from '../providers/ssh-git-dispatch'
+import { DEFAULT_GITLAB_HOSTS, normalizeGitLabHost } from './project-ref-parser'
+
+const REMOTE_KNOWN_HOSTS_CACHE_MAX_CONNECTIONS = 128
+const LOCAL_CONNECTION_KEY = '\0local'
+
+type KnownHostsCacheEntry = {
+  hosts: readonly string[]
+  sshProviderRegistrationId: number | undefined
+}
+
+type KnownHostsLifecycle = {
+  connectionId: string | null
+  sshProviderRegistrationId: number | undefined
+}
+
+// Why: each SSH target can resolve a different self-hosted GitLab context;
+// the local CLI context remains isolated under its own pinned cache key.
+const knownHostsCacheByConnection = new Map<string, KnownHostsCacheEntry>()
+let knownHostsLifecycleByResult = new WeakMap<readonly string[], KnownHostsLifecycle>()
+
+function connectionCacheKey(connectionId?: string | null): string {
+  return connectionId ? `ssh:${connectionId}` : LOCAL_CONNECTION_KEY
+}
+
+function sshProviderRegistrationChanged(
+  connectionId: string | null | undefined,
+  expectedRegistrationId: number | undefined
+): boolean {
+  if (!connectionId) {
+    return false
+  }
+  return getSshGitProviderRegistrationId(connectionId) !== expectedRegistrationId
+}
+
+function staleSshProviderError(connectionId: string | null | undefined): Error {
+  return new Error(
+    `SSH connection ${connectionId ?? 'unknown'} changed while GitLab auth was resolving`
+  )
+}
+
+function rememberKnownHostsCacheEntry(
+  cacheKey: string,
+  entry: KnownHostsCacheEntry,
+  connectionId?: string | null
+): void {
+  knownHostsLifecycleByResult.set(entry.hosts, {
+    connectionId: connectionId ?? null,
+    sshProviderRegistrationId: entry.sshProviderRegistrationId
+  })
+  knownHostsCacheByConnection.delete(cacheKey)
+  knownHostsCacheByConnection.set(cacheKey, entry)
+  const maxEntries =
+    REMOTE_KNOWN_HOSTS_CACHE_MAX_CONNECTIONS +
+    (knownHostsCacheByConnection.has(LOCAL_CONNECTION_KEY) ? 1 : 0)
+  while (knownHostsCacheByConnection.size > maxEntries) {
+    const keys = knownHostsCacheByConnection.keys()
+    let oldestKey = keys.next().value
+    if (oldestKey === LOCAL_CONNECTION_KEY) {
+      oldestKey = keys.next().value
+    }
+    if (oldestKey === undefined) {
+      return
+    }
+    knownHostsCacheByConnection.delete(oldestKey)
+  }
+}
+
+/** @internal - exposed for tests only */
+export function _resetKnownHostsCache(): void {
+  knownHostsCacheByConnection.clear()
+  knownHostsLifecycleByResult = new WeakMap()
+}
+
+/** @internal - exposed for tests only */
+export function _getKnownHostsCacheSize(): number {
+  return knownHostsCacheByConnection.size
+}
+
+export function areGlabKnownHostsCurrentForConnection(
+  hosts: readonly string[],
+  connectionId?: string | null
+): boolean {
+  const lifecycle = knownHostsLifecycleByResult.get(hosts)
+  if (!lifecycle) {
+    // Explicit caller-supplied host lists predate lifecycle-tagged cache results.
+    return true
+  }
+  if (lifecycle.connectionId !== (connectionId ?? null)) {
+    return false
+  }
+  return (
+    !connectionId ||
+    getSshGitProviderRegistrationId(connectionId) === lifecycle.sshProviderRegistrationId
+  )
+}
+
+export function rememberGlabKnownHost(host: string, connectionId?: string | null): void {
+  const normalizedHost = normalizeGitLabHost(host)
+  const key = connectionCacheKey(connectionId)
+  const cached = knownHostsCacheByConnection.get(key)
+  const sshProviderRegistrationId = connectionId
+    ? getSshGitProviderRegistrationId(connectionId)
+    : undefined
+  if (
+    !cached ||
+    cached.sshProviderRegistrationId !== sshProviderRegistrationId ||
+    cached.hosts.map(normalizeGitLabHost).includes(normalizedHost)
+  ) {
+    return
+  }
+  rememberKnownHostsCacheEntry(
+    key,
+    {
+      hosts: [...cached.hosts, normalizedHost],
+      sshProviderRegistrationId
+    },
+    connectionId
+  )
+}
+
+export async function getGlabKnownHosts(
+  connectionId?: string | null
+): Promise<readonly string[]> {
+  const key = connectionCacheKey(connectionId)
+  const sshProviderRegistrationId = connectionId
+    ? getSshGitProviderRegistrationId(connectionId)
+    : undefined
+  const cached = knownHostsCacheByConnection.get(key)
+  if (cached && cached.sshProviderRegistrationId === sshProviderRegistrationId) {
+    rememberKnownHostsCacheEntry(key, cached, connectionId)
+    return cached.hosts
+  }
+  if (cached) {
+    knownHostsCacheByConnection.delete(key)
+  }
+  try {
+    // Why: auth status is host-scoped, but the resulting host set must stay
+    // isolated from other SSH connection lifecycles and the local context.
+    const { stdout, stderr } = await glabExecFileAsync(['auth', 'status'])
+    if (sshProviderRegistrationChanged(connectionId, sshProviderRegistrationId)) {
+      throw staleSshProviderError(connectionId)
+    }
+    const hosts = parseGlabAuthStatusHosts(`${stdout}\n${stderr}`)
+    const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...hosts]))
+    rememberKnownHostsCacheEntry(key, { hosts: merged, sshProviderRegistrationId }, connectionId)
+    return merged
+  } catch {
+    // Why: returning even default hosts would let the old request continue
+    // project resolution against a replacement provider that reused the id.
+    if (sshProviderRegistrationChanged(connectionId, sshProviderRegistrationId)) {
+      throw staleSshProviderError(connectionId)
+    }
+    // Failed auth probes remain retryable after CLI/tunnel readiness changes.
+    const fallback = [...DEFAULT_GITLAB_HOSTS]
+    knownHostsLifecycleByResult.set(fallback, {
+      connectionId: connectionId ?? null,
+      sshProviderRegistrationId
+    })
+    return fallback
+  }
+}
+
+export function parseGlabAuthStatusHosts(output: string): string[] {
+  const hosts = new Set<string>()
+  // Why: self-hosted GitLab can run on a non-default port, so port-qualified
+  // services must remain distinct throughout host selection.
+  for (const m of output.matchAll(/logged in to ([a-zA-Z0-9.-]+(?::\d+)?)/gi)) {
+    hosts.add(m[1].toLowerCase())
+  }
+  for (const line of output.split('\n')) {
+    const bareLine = line.trim()
+    const hostLine = bareLine.endsWith(':') ? bareLine.slice(0, -1) : bareLine
+    if (
+      line === bareLine &&
+      /^[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?(?::\d+)?$/.test(hostLine)
+    ) {
+      hosts.add(hostLine.toLowerCase())
+    }
+  }
+  return Array.from(hosts)
+}

--- a/src/main/gitlab/gitlab-project-ref-lifecycle.test.ts
+++ b/src/main/gitlab/gitlab-project-ref-lifecycle.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as GlUtils from './gl-utils'
+
+const { acquireMock, gitExecFileAsyncMock, glabExecFileAsyncMock, releaseMock } = vi.hoisted(
+  () => ({
+    acquireMock: vi.fn(),
+    gitExecFileAsyncMock: vi.fn(),
+    glabExecFileAsyncMock: vi.fn(),
+    releaseMock: vi.fn()
+  })
+)
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  glabExecFileAsync: glabExecFileAsyncMock
+}))
+
+vi.mock('./gl-utils', async () => {
+  const actual = await vi.importActual<typeof GlUtils>('./gl-utils')
+  return {
+    ...actual,
+    acquire: acquireMock,
+    glabExecFileAsync: glabExecFileAsyncMock,
+    release: releaseMock
+  }
+})
+
+import {
+  _resetKnownHostsCache,
+  _resetProjectRefCache,
+  getProjectRefForRemote,
+  type ProjectRef
+} from './gl-utils'
+import { updateIssue } from './issues'
+import { getWorkItemDetails } from './work-item-details'
+import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
+
+const CONNECTION_ID = 'conn-lifecycle'
+
+function blockAtGitLabApiBoundary(): { atBoundary: Promise<void>; continueOperation: () => void } {
+  let continueOperation = (): void => {}
+  let reachedBoundary = (): void => {}
+  const atBoundary = new Promise<void>((resolve) => {
+    reachedBoundary = resolve
+  })
+  const blocked = new Promise<void>((resolve) => {
+    continueOperation = resolve
+  })
+  acquireMock.mockImplementationOnce(() => {
+    reachedBoundary()
+    return blocked
+  })
+  return { atBoundary, continueOperation }
+}
+
+async function resolveTransportedProjectRef(oldProviderExec: ReturnType<typeof vi.fn>) {
+  registerSshGitProvider(CONNECTION_ID, { exec: oldProviderExec } as never)
+  const projectRef = await getProjectRefForRemote('/repo', 'origin', ['gitlab.com'], CONNECTION_ID)
+  expect(projectRef).not.toBeNull()
+  expect(projectRef).toMatchObject({
+    sshConnectionLease: {
+      connectionId: CONNECTION_ID,
+      providerRegistrationId: expect.any(Number)
+    }
+  })
+  // Why: JSON cloning matches the renderer/RPC round trip that used to drop
+  // process-local WeakMap provenance before a later read or mutation.
+  return JSON.parse(JSON.stringify(projectRef)) as ProjectRef
+}
+
+describe('GitLab project ref SSH lifecycle', () => {
+  beforeEach(() => {
+    acquireMock.mockReset()
+    gitExecFileAsyncMock.mockReset()
+    glabExecFileAsyncMock.mockReset()
+    releaseMock.mockReset()
+    _resetKnownHostsCache()
+    _resetProjectRefCache()
+    unregisterSshGitProvider(CONNECTION_ID)
+    glabExecFileAsyncMock.mockResolvedValue({
+      stdout: 'Logged in to gitlab.com as user\n',
+      stderr: ''
+    })
+  })
+
+  afterEach(() => unregisterSshGitProvider(CONNECTION_ID))
+
+  it('aborts a transported read when SSH changes before the API call', async () => {
+    const oldProviderExec = vi.fn().mockResolvedValue({
+      stdout: 'git@gitlab.com:old/project.git\n',
+      stderr: ''
+    })
+    const replacementProviderExec = vi.fn()
+    const projectRef = await resolveTransportedProjectRef(oldProviderExec)
+    const { atBoundary, continueOperation } = blockAtGitLabApiBoundary()
+
+    const operation = getWorkItemDetails('/repo', 7, 'issue', undefined, CONNECTION_ID, projectRef)
+    await atBoundary
+    unregisterSshGitProvider(CONNECTION_ID)
+    registerSshGitProvider(CONNECTION_ID, { exec: replacementProviderExec } as never)
+    glabExecFileAsyncMock.mockClear()
+    glabExecFileAsyncMock.mockResolvedValue({
+      stdout: JSON.stringify({ iid: 7, title: 'stale', state: 'opened' }),
+      stderr: ''
+    })
+    continueOperation()
+
+    await expect(operation).resolves.toBeNull()
+    expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(replacementProviderExec).not.toHaveBeenCalled()
+  })
+
+  it('aborts a transported write when SSH changes before the API call', async () => {
+    const oldProviderExec = vi.fn().mockResolvedValue({
+      stdout: 'git@gitlab.com:old/project.git\n',
+      stderr: ''
+    })
+    const replacementProviderExec = vi.fn()
+    const projectRef = await resolveTransportedProjectRef(oldProviderExec)
+    const { atBoundary, continueOperation } = blockAtGitLabApiBoundary()
+
+    const operation = updateIssue(
+      '/repo',
+      8,
+      { title: 'Do not send' },
+      undefined,
+      CONNECTION_ID,
+      projectRef
+    )
+    await atBoundary
+    unregisterSshGitProvider(CONNECTION_ID)
+    registerSshGitProvider(CONNECTION_ID, { exec: replacementProviderExec } as never)
+    glabExecFileAsyncMock.mockClear()
+    continueOperation()
+
+    await expect(operation).resolves.toMatchObject({ ok: false })
+    expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(replacementProviderExec).not.toHaveBeenCalled()
+  })
+
+  it('rechecks field edits after waiting at the API boundary', async () => {
+    const oldProviderExec = vi.fn().mockResolvedValue({
+      stdout: 'git@gitlab.com:old/project.git\n',
+      stderr: ''
+    })
+    const replacementProviderExec = vi.fn()
+    registerSshGitProvider(CONNECTION_ID, { exec: oldProviderExec } as never)
+    const { atBoundary, continueOperation } = blockAtGitLabApiBoundary()
+
+    const operation = updateIssue('/repo', 9, { title: 'Do not send' }, 'origin', CONNECTION_ID)
+    await atBoundary
+    unregisterSshGitProvider(CONNECTION_ID)
+    registerSshGitProvider(CONNECTION_ID, { exec: replacementProviderExec } as never)
+    glabExecFileAsyncMock.mockClear()
+    continueOperation()
+
+    await expect(operation).resolves.toMatchObject({ ok: false })
+    expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(replacementProviderExec).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/gitlab/gitlab-project-ref-lifecycle.ts
+++ b/src/main/gitlab/gitlab-project-ref-lifecycle.ts
@@ -1,0 +1,42 @@
+import { getSshGitProviderRegistrationId } from '../providers/ssh-git-dispatch'
+import type { ProjectRef } from './project-ref-parser'
+
+type ProjectRefLifecycle = {
+  connectionId: string
+  providerRegistrationId: number
+}
+
+export function rememberProjectRefLifecycle(
+  projectRef: ProjectRef,
+  connectionId: string | null | undefined,
+  sshProviderRegistrationId: number | undefined
+): void {
+  if (!connectionId || sshProviderRegistrationId === undefined) {
+    return
+  }
+  // Why: project refs cross IPC/RPC before later mutations, so lifecycle
+  // provenance must be serializable rather than process-local metadata.
+  projectRef.sshConnectionLease = {
+    connectionId,
+    providerRegistrationId: sshProviderRegistrationId
+  }
+}
+
+export function assertProjectRefCurrentForConnection(
+  projectRef: ProjectRef,
+  connectionId: string | null | undefined
+): void {
+  const lifecycle: ProjectRefLifecycle | undefined = projectRef.sshConnectionLease
+  // Why: pasted URLs and locally resolved refs are not tied to an SSH
+  // provider registration and remain usable across all provider types.
+  if (!lifecycle) {
+    return
+  }
+  const currentConnectionId = connectionId ?? null
+  if (
+    lifecycle.connectionId !== currentConnectionId ||
+    getSshGitProviderRegistrationId(lifecycle.connectionId) !== lifecycle.providerRegistrationId
+  ) {
+    throw new Error('GitLab project resolution expired after the SSH connection changed')
+  }
+}

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -1,7 +1,15 @@
 import { gitExecFileAsync, glabExecFileAsync } from '../git/runner'
 import type { IssueSourcePreference } from '../../shared/types'
-import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import {
+  getSshGitProvider,
+  getSshGitProviderRegistrationId
+} from '../providers/ssh-git-dispatch'
 import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
+import {
+  areGlabKnownHostsCurrentForConnection,
+  parseGlabAuthStatusHosts,
+  rememberGlabKnownHost
+} from './gitlab-known-host-cache'
 import {
   DEFAULT_GITLAB_HOSTS,
   normalizeGitLabHost,
@@ -11,6 +19,12 @@ import {
 } from './project-ref-parser'
 
 export { DEFAULT_GITLAB_HOSTS, parseGitLabProjectRef }
+export {
+  _getKnownHostsCacheSize,
+  _resetKnownHostsCache,
+  getGlabKnownHosts,
+  parseGlabAuthStatusHosts
+} from './gitlab-known-host-cache'
 export type { ProjectRef }
 
 export type LocalGitExecOptions = {
@@ -19,18 +33,6 @@ export type LocalGitExecOptions = {
 
 const PROJECT_REF_CACHE_MAX_ENTRIES = 512
 const projectRefCache = new Map<string, ProjectRef | null>()
-
-// Why: known hosts are cached PER connection. A repo on an SSH connection
-// authenticates against a different glab context than the local one, so a
-// process-global cache would leak one connection's hosts into another (and
-// poison a connection that probes before its tunnel is ready). The local
-// context uses the `'local'` key.
-const LOCAL_CONNECTION_KEY = 'local'
-const knownHostsCacheByConnection = new Map<string, readonly string[]>()
-
-function connectionCacheKey(connectionId?: string | null): string {
-  return connectionId ?? LOCAL_CONNECTION_KEY
-}
 
 /** @internal - exposed for tests only */
 export function _resetProjectRefCache(): void {
@@ -41,11 +43,6 @@ export function _resetProjectRefCache(): void {
 /** @internal - exposed for tests only */
 export function _getProjectRefCacheSize(): number {
   return projectRefCache.size
-}
-
-/** @internal - exposed for tests only */
-export function _resetKnownHostsCache(): void {
-  knownHostsCacheByConnection.clear()
 }
 
 function rememberProjectRefCacheEntry(cacheKey: string, value: ProjectRef | null): void {
@@ -66,7 +63,15 @@ export async function getProjectRefForRemote(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ProjectRef | null> {
-  const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
+  if (!areGlabKnownHostsCurrentForConnection(knownHosts, connectionId)) {
+    return null
+  }
+  const sshProviderRegistrationId = connectionId
+    ? getSshGitProviderRegistrationId(connectionId)
+    : undefined
+  const runtimeKey = connectionId
+    ? `${connectionId}:${sshProviderRegistrationId ?? 'disconnected'}`
+    : `local:${localGitOptions.wslDistro ?? 'host'}`
   const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}\0${knownHosts.join(',')}`
   if (projectRefCache.has(cacheKey)) {
     return projectRefCache.get(cacheKey)!
@@ -78,6 +83,7 @@ export async function getProjectRefForRemote(
       remoteName,
       knownHosts,
       connectionId,
+      sshProviderRegistrationId,
       cacheKey,
       localGitOptions
     )
@@ -89,12 +95,17 @@ async function resolveProjectRefForRemote(
   remoteName: string,
   knownHosts: readonly string[],
   connectionId: string | null | undefined,
+  sshProviderRegistrationId: number | undefined,
   cacheKey: string,
   localGitOptions: LocalGitExecOptions
 ): Promise<ProjectRef | null> {
   try {
     const sshGitProvider = connectionId ? getSshGitProvider(connectionId) : null
-    if (connectionId && !sshGitProvider) {
+    if (
+      connectionId &&
+      (!sshGitProvider ||
+        getSshGitProviderRegistrationId(connectionId) !== sshProviderRegistrationId)
+    ) {
       return null
     }
     const { stdout } = sshGitProvider
@@ -103,6 +114,12 @@ async function resolveProjectRefForRemote(
           cwd: repoPath,
           ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
         })
+    if (
+      connectionId &&
+      getSshGitProviderRegistrationId(connectionId) !== sshProviderRegistrationId
+    ) {
+      return null
+    }
     const result = parseGitLabProjectRef(stdout, knownHosts)
     if (result) {
       rememberProjectRefCacheEntry(cacheKey, result)
@@ -116,7 +133,9 @@ async function resolveProjectRefForRemote(
         remoteCandidate,
         connectionId,
         localGitOptions
-      ))
+      )) &&
+      (!connectionId ||
+        getSshGitProviderRegistrationId(connectionId) === sshProviderRegistrationId)
     ) {
       rememberGlabKnownHost(remoteCandidate.host, connectionId)
       rememberProjectRefCacheEntry(cacheKey, remoteCandidate)
@@ -230,16 +249,6 @@ export function glabHostnameArgs(
   return connectionId && projectRef?.host ? ['--hostname', projectRef.host] : []
 }
 
-function rememberGlabKnownHost(host: string, connectionId?: string | null): void {
-  const normalizedHost = normalizeGitLabHost(host)
-  const key = connectionCacheKey(connectionId)
-  const cached = knownHostsCacheByConnection.get(key)
-  if (!cached || cached.map(normalizeGitLabHost).includes(normalizedHost)) {
-    return
-  }
-  knownHostsCacheByConnection.set(key, [...cached, normalizedHost])
-}
-
 async function isGlabConfiguredForRemoteHost(
   repoPath: string,
   projectRef: Pick<ProjectRef, 'host'>,
@@ -261,51 +270,4 @@ async function isGlabConfiguredForRemoteHost(
     const hosts = parseGlabAuthStatusHosts(output).map(normalizeGitLabHost)
     return hosts.includes(normalizeGitLabHost(projectRef.host))
   }
-}
-
-export async function getGlabKnownHosts(connectionId?: string | null): Promise<readonly string[]> {
-  const key = connectionCacheKey(connectionId)
-  const cached = knownHostsCacheByConnection.get(key)
-  if (cached) {
-    return cached
-  }
-  try {
-    // Why: `glab auth status` is host-scoped, not cwd-scoped — glab reads its
-    // own config to list authenticated hosts. The connectionId is threaded so
-    // the RESULT is cached per connection (a connected repo can have a
-    // different set of authenticated self-hosted hosts than the local one),
-    // mirroring how project-ref resolution caches per connection.
-    const { stdout, stderr } = await glabExecFileAsync(['auth', 'status'])
-    const hosts = parseGlabAuthStatusHosts(`${stdout}\n${stderr}`)
-    const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...hosts]))
-    knownHostsCacheByConnection.set(key, merged)
-    return merged
-  } catch {
-    // Auth check failed (glab not installed, no auth, tunnel not ready,
-    // etc.) — fall back to the canonical default for THIS call, but do NOT
-    // cache the fallback. A later probe (e.g. after the SSH tunnel comes
-    // up) must be able to discover the real self-hosted host.
-    return [...DEFAULT_GITLAB_HOSTS]
-  }
-}
-
-export function parseGlabAuthStatusHosts(output: string): string[] {
-  const hosts = new Set<string>()
-  // Why: self-hosted GitLab can run on a non-default port (e.g.
-  // `gitlab.example.com:8443`); capture the optional `:port` so two services
-  // on the same hostname but different ports stay distinct downstream.
-  for (const m of output.matchAll(/logged in to ([a-zA-Z0-9.-]+(?::\d+)?)/gi)) {
-    hosts.add(m[1].toLowerCase())
-  }
-  for (const line of output.split('\n')) {
-    const bareLine = line.trim()
-    const hostLine = bareLine.endsWith(':') ? bareLine.slice(0, -1) : bareLine
-    if (
-      line === bareLine &&
-      /^[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?(?::\d+)?$/.test(hostLine)
-    ) {
-      hosts.add(hostLine.toLowerCase())
-    }
-  }
-  return Array.from(hosts)
 }

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -1,9 +1,6 @@
 import { gitExecFileAsync, glabExecFileAsync } from '../git/runner'
 import type { IssueSourcePreference } from '../../shared/types'
-import {
-  getSshGitProvider,
-  getSshGitProviderRegistrationId
-} from '../providers/ssh-git-dispatch'
+import { getSshGitProvider, getSshGitProviderRegistrationId } from '../providers/ssh-git-dispatch'
 import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
 import {
   areGlabKnownHostsCurrentForConnection,
@@ -17,6 +14,10 @@ import {
   parseRemoteProjectRefCandidate,
   type ProjectRef
 } from './project-ref-parser'
+import {
+  assertProjectRefCurrentForConnection,
+  rememberProjectRefLifecycle
+} from './gitlab-project-ref-lifecycle'
 
 export { DEFAULT_GITLAB_HOSTS, parseGitLabProjectRef }
 export {
@@ -122,22 +123,26 @@ async function resolveProjectRefForRemote(
     }
     const result = parseGitLabProjectRef(stdout, knownHosts)
     if (result) {
+      rememberProjectRefLifecycle(result, connectionId, sshProviderRegistrationId)
       rememberProjectRefCacheEntry(cacheKey, result)
       return result
     }
     const remoteCandidate = parseRemoteProjectRefCandidate(stdout)
     if (
       remoteCandidate &&
+      (!connectionId ||
+        getSshGitProviderRegistrationId(connectionId) === sshProviderRegistrationId) &&
       (await isGlabConfiguredForRemoteHost(
         repoPath,
         remoteCandidate,
         connectionId,
+        sshProviderRegistrationId,
         localGitOptions
       )) &&
-      (!connectionId ||
-        getSshGitProviderRegistrationId(connectionId) === sshProviderRegistrationId)
+      (!connectionId || getSshGitProviderRegistrationId(connectionId) === sshProviderRegistrationId)
     ) {
       rememberGlabKnownHost(remoteCandidate.host, connectionId)
+      rememberProjectRefLifecycle(remoteCandidate, connectionId, sshProviderRegistrationId)
       rememberProjectRefCacheEntry(cacheKey, remoteCandidate)
       return remoteCandidate
     }
@@ -243,9 +248,12 @@ export function glabRepoExecOptions(
 }
 
 export function glabHostnameArgs(
-  projectRef: Pick<ProjectRef, 'host'> | null | undefined,
+  projectRef: ProjectRef | null | undefined,
   connectionId?: string | null
 ): string[] {
+  if (projectRef) {
+    assertProjectRefCurrentForConnection(projectRef, connectionId)
+  }
   return connectionId && projectRef?.host ? ['--hostname', projectRef.host] : []
 }
 
@@ -253,8 +261,12 @@ async function isGlabConfiguredForRemoteHost(
   repoPath: string,
   projectRef: Pick<ProjectRef, 'host'>,
   connectionId?: string | null,
+  sshProviderRegistrationId?: number,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<boolean> {
+  if (connectionId && getSshGitProviderRegistrationId(connectionId) !== sshProviderRegistrationId) {
+    return false
+  }
   try {
     const result = await glabExecFileAsync(
       ['auth', 'status', '--hostname', projectRef.host],

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -154,7 +154,9 @@ describe('gitlab project ref resolution', () => {
     sshExecMock.mockResolvedValueOnce({ stdout: 'git@gitlab.com:remote/orca.git\n', stderr: '' })
     registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
 
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+    await expect(
+      getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')
+    ).resolves.toMatchObject({
       host: 'gitlab.com',
       path: 'remote/orca'
     })
@@ -170,14 +172,18 @@ describe('gitlab project ref resolution', () => {
     const provider = { exec: sshExecMock } as never
     registerSshGitProvider('conn-1', provider)
 
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+    await expect(
+      getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')
+    ).resolves.toMatchObject({
       host: 'gitlab.com',
       path: 'old/orca'
     })
     unregisterSshGitProvider('conn-1')
     registerSshGitProvider('conn-1', provider)
 
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+    await expect(
+      getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')
+    ).resolves.toMatchObject({
       host: 'gitlab.com',
       path: 'new/orca'
     })
@@ -200,14 +206,18 @@ describe('gitlab project ref resolution', () => {
 
     unregisterSshGitProvider('conn-1')
     registerSshGitProvider('conn-1', provider)
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+    await expect(
+      getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')
+    ).resolves.toMatchObject({
       host: 'gitlab.com',
       path: 'new/orca'
     })
     resolveOldProbe({ stdout: 'git@gitlab.com:old/orca.git\n', stderr: '' })
     await expect(oldProbe).resolves.toBeNull()
 
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+    await expect(
+      getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')
+    ).resolves.toMatchObject({
       host: 'gitlab.com',
       path: 'new/orca'
     })
@@ -236,7 +246,9 @@ describe('gitlab project ref resolution', () => {
     })
     registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
 
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+    await expect(
+      getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')
+    ).resolves.toMatchObject({
       host: 'gitlab.com',
       path: 'remote/orca'
     })
@@ -249,7 +261,9 @@ describe('gitlab project ref resolution', () => {
     registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
 
     await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toBeNull()
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+    await expect(
+      getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')
+    ).resolves.toMatchObject({
       host: 'gitlab.com',
       path: 'remote/orca'
     })

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -12,6 +12,7 @@ vi.mock('../git/runner', () => ({
 }))
 
 import {
+  _getKnownHostsCacheSize,
   _getProjectRefCacheSize,
   _resetKnownHostsCache,
   _resetProjectRefCache,
@@ -160,6 +161,57 @@ describe('gitlab project ref resolution', () => {
 
     expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo')
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('does not reuse a cached project ref after an SSH connection id is reused', async () => {
+    sshExecMock
+      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:old/orca.git\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:new/orca.git\n', stderr: '' })
+    const provider = { exec: sshExecMock } as never
+    registerSshGitProvider('conn-1', provider)
+
+    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'old/orca'
+    })
+    unregisterSshGitProvider('conn-1')
+    registerSshGitProvider('conn-1', provider)
+
+    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'new/orca'
+    })
+    expect(sshExecMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let a removed SSH provider finish project-ref work for its replacement', async () => {
+    let resolveOldProbe: (value: { stdout: string; stderr: string }) => void = () => {}
+    sshExecMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOldProbe = resolve
+          })
+      )
+      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:new/orca.git\n', stderr: '' })
+    const provider = { exec: sshExecMock } as never
+    registerSshGitProvider('conn-1', provider)
+    const oldProbe = getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')
+
+    unregisterSshGitProvider('conn-1')
+    registerSshGitProvider('conn-1', provider)
+    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'new/orca'
+    })
+    resolveOldProbe({ stdout: 'git@gitlab.com:old/orca.git\n', stderr: '' })
+    await expect(oldProbe).resolves.toBeNull()
+
+    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'new/orca'
+    })
+    expect(sshExecMock).toHaveBeenCalledTimes(2)
   })
 
   it('bounds cached project refs for distinct repo paths', async () => {
@@ -425,7 +477,10 @@ describe('getGlabKnownHosts', () => {
   beforeEach(() => {
     glabExecFileAsyncMock.mockReset()
     _resetKnownHostsCache()
+    unregisterSshGitProvider('conn-reused')
   })
+
+  afterEach(() => unregisterSshGitProvider('conn-reused'))
 
   it('returns gitlab.com plus auth-status hosts, deduped', async () => {
     glabExecFileAsyncMock.mockResolvedValueOnce({
@@ -481,6 +536,126 @@ describe('getGlabKnownHosts', () => {
       'gitlab.example.com:8080'
     ])
     expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('bounds known-host caches by connection and refreshes recency', async () => {
+    glabExecFileAsyncMock.mockResolvedValue({
+      stdout: '✓ Logged in to gitlab.com as user\n',
+      stderr: ''
+    })
+
+    for (let i = 0; i < 128; i += 1) {
+      await getGlabKnownHosts(`conn-${i}`)
+    }
+
+    await getGlabKnownHosts('conn-0')
+    await getGlabKnownHosts('conn-128')
+
+    expect(_getKnownHostsCacheSize()).toBe(128)
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(129)
+
+    await getGlabKnownHosts('conn-0')
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(129)
+
+    await getGlabKnownHosts('conn-1')
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(130)
+  })
+
+  it('stays bounded through prolonged connection churn without evicting local auth', async () => {
+    glabExecFileAsyncMock.mockResolvedValue({
+      stdout: '✓ Logged in to gitlab.com as user\n',
+      stderr: ''
+    })
+
+    await getGlabKnownHosts()
+    for (let i = 0; i < 5_000; i += 1) {
+      await getGlabKnownHosts(`churn-${i}`)
+      expect(_getKnownHostsCacheSize()).toBeLessThanOrEqual(129)
+    }
+
+    await getGlabKnownHosts()
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(5_001)
+    await getGlabKnownHosts('churn-4999')
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(5_001)
+    await getGlabKnownHosts('churn-0')
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(5_002)
+  })
+
+  it('invalidates cached auth when an SSH connection id is reused', async () => {
+    glabExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'Logged in to old.gitlab.test as user\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'Logged in to new.gitlab.test as user\n', stderr: '' })
+    const provider = { exec: vi.fn() } as never
+    registerSshGitProvider('conn-reused', provider)
+
+    await expect(getGlabKnownHosts('conn-reused')).resolves.toContain('old.gitlab.test')
+    unregisterSshGitProvider('conn-reused')
+    registerSshGitProvider('conn-reused', provider)
+
+    await expect(getGlabKnownHosts('conn-reused')).resolves.toContain('new.gitlab.test')
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts a chained lookup when its auth probe outlives the SSH registration', async () => {
+    let resolveOldProbe: (value: { stdout: string; stderr: string }) => void = () => {}
+    glabExecFileAsyncMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOldProbe = resolve
+        })
+    )
+    const oldProviderExec = vi.fn()
+    const replacementProviderExec = vi.fn()
+    registerSshGitProvider('conn-reused', { exec: oldProviderExec } as never)
+    const oldOperation = getGlabKnownHosts('conn-reused').then((knownHosts) =>
+      getProjectRefForRemote('/repo', 'origin', knownHosts, 'conn-reused')
+    )
+
+    unregisterSshGitProvider('conn-reused')
+    registerSshGitProvider('conn-reused', { exec: replacementProviderExec } as never)
+    resolveOldProbe({ stdout: 'Logged in to old.gitlab.test as user\n', stderr: '' })
+
+    await expect(oldOperation).rejects.toThrow('changed while GitLab auth was resolving')
+    expect(oldProviderExec).not.toHaveBeenCalled()
+    expect(replacementProviderExec).not.toHaveBeenCalled()
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('aborts a chained lookup when SSH changes after auth resolves', async () => {
+    let resolveAuthProbe: (value: { stdout: string; stderr: string }) => void = () => {}
+    let continueProjectRef: () => void = () => {}
+    let reachedProjectBarrier: () => void = () => {}
+    const projectBarrier = new Promise<void>((resolve) => {
+      continueProjectRef = resolve
+    })
+    const atProjectBarrier = new Promise<void>((resolve) => {
+      reachedProjectBarrier = resolve
+    })
+    glabExecFileAsyncMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAuthProbe = resolve
+        })
+    )
+    const oldProviderExec = vi.fn()
+    const replacementProviderExec = vi.fn()
+    registerSshGitProvider('conn-reused', { exec: oldProviderExec } as never)
+    const oldOperation = getGlabKnownHosts('conn-reused').then(async (knownHosts) => {
+      reachedProjectBarrier()
+      await projectBarrier
+      return getProjectRefForRemote('/repo', 'origin', knownHosts, 'conn-reused')
+    })
+
+    resolveAuthProbe({ stdout: 'Logged in to old.gitlab.test as user\n', stderr: '' })
+    await atProjectBarrier
+    unregisterSshGitProvider('conn-reused')
+    registerSshGitProvider('conn-reused', { exec: replacementProviderExec } as never)
+    continueProjectRef()
+
+    await expect(oldOperation).resolves.toBeNull()
+    expect(oldProviderExec).not.toHaveBeenCalled()
+    expect(replacementProviderExec).not.toHaveBeenCalled()
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('does not permanently cache the failure fallback — a later probe can re-discover hosts', async () => {

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -10,6 +10,7 @@ export { glabExecFileAsync, gitExecFileAsync }
 export { classifyGlabError, classifyListIssuesError } from './glab-error-classification'
 export {
   DEFAULT_GITLAB_HOSTS,
+  _getKnownHostsCacheSize,
   _getProjectRefCacheSize,
   _resetKnownHostsCache,
   _resetProjectRefCache,

--- a/src/main/gitlab/issues.ts
+++ b/src/main/gitlab/issues.ts
@@ -298,14 +298,7 @@ export async function updateIssue(
   }
 
   // Field edits via `glab issue update`.
-  const editArgs: string[] = [
-    'issue',
-    'update',
-    String(issueNumber),
-    '-R',
-    repoFlag,
-    ...glabHostnameArgs(projectRef, connectionId)
-  ]
+  const editArgs: string[] = ['issue', 'update', String(issueNumber), '-R', repoFlag]
   let hasEditArgs = false
 
   if (updates.title) {
@@ -333,7 +326,7 @@ export async function updateIssue(
     await acquire()
     try {
       await glabExecFileAsync(
-        editArgs,
+        [...editArgs, ...glabHostnameArgs(projectRef, connectionId)],
         glabRepoExecOptions(repoPath, connectionId, localGitOptions)
       )
     } catch (err) {

--- a/src/main/gitlab/merge-request-creation.ts
+++ b/src/main/gitlab/merge-request-creation.ts
@@ -20,6 +20,7 @@ import {
   glabRepoExecOptions,
   release
 } from './gl-utils'
+import { assertProjectRefCurrentForConnection } from './gitlab-project-ref-lifecycle'
 import { findOpenMRByHeadBase, parseMergeRequestPayload } from './merge-request-creation-lookup'
 
 function execErrorMessage(error: unknown): string {
@@ -168,6 +169,7 @@ export async function createGitLabMergeRequest(
 
   await acquire()
   try {
+    assertProjectRefCurrentForConnection(projectRef, connectionId)
     const body =
       input.useTemplate && !input.body?.trim()
         ? await readMergeRequestTemplate(repoPath, connectionId)

--- a/src/main/ipc/gitlab.test.ts
+++ b/src/main/ipc/gitlab.test.ts
@@ -521,11 +521,17 @@ describe('GitLab IPC handlers', () => {
     getWorkItemByProjectRefMock.mockResolvedValue({ type: 'mr', number: 8 })
     registerGitLabHandlers(storeWithRepos([repo()], projects) as Store)
     const localGitOptions = { wslDistro: 'Ubuntu' }
+    const projectRef = {
+      host: 'gitlab.example.com',
+      path: 'group/project',
+      sshConnectionLease: { connectionId: 'ssh-1', providerRegistrationId: 42 }
+    }
 
     await ipcHandlers.get('gitlab:workItemDetails')?.(null, {
       repoPath: '/local/orca',
       iid: 8,
-      type: 'mr'
+      type: 'mr',
+      projectRef
     })
     await ipcHandlers.get('gitlab:closeMR')?.(null, { repoPath: '/local/orca', iid: 8 })
     await ipcHandlers.get('gitlab:reopenMR')?.(null, { repoPath: '/local/orca', iid: 8 })
@@ -537,7 +543,8 @@ describe('GitLab IPC handlers', () => {
     await ipcHandlers.get('gitlab:updateMR')?.(null, {
       repoPath: '/local/orca',
       iid: 8,
-      updates: { title: 'Renamed' }
+      updates: { title: 'Renamed' },
+      projectRef
     })
     await ipcHandlers.get('gitlab:updateMRReviewers')?.(null, {
       repoPath: '/local/orca',
@@ -576,7 +583,7 @@ describe('GitLab IPC handlers', () => {
       'mr',
       undefined,
       null,
-      undefined,
+      projectRef,
       localGitOptions
     )
     expect(closeMRMock).toHaveBeenCalledWith(
@@ -610,7 +617,7 @@ describe('GitLab IPC handlers', () => {
       { title: 'Renamed' },
       undefined,
       null,
-      undefined,
+      projectRef,
       localGitOptions
     )
     expect(updateMRReviewersMock).toHaveBeenCalledWith(

--- a/src/main/ipc/gitlab.ts
+++ b/src/main/ipc/gitlab.ts
@@ -263,7 +263,11 @@ export function registerGitLabHandlers(store: Store): void {
     'gitlab:updateIssue',
     async (
       _event,
-      args: GitLabRepoSelectorArgs & { number: number; updates: GitLabIssueUpdate }
+      args: GitLabRepoSelectorArgs & {
+        number: number
+        updates: GitLabIssueUpdate
+        projectRef?: ProjectRef | null
+      }
     ) => {
       const repo = assertRegisteredRepo(args, store)
       return updateIssue(
@@ -272,7 +276,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.updates,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -280,7 +284,14 @@ export function registerGitLabHandlers(store: Store): void {
 
   ipcMain.handle(
     'gitlab:addIssueComment',
-    async (_event, args: GitLabRepoSelectorArgs & { number: number; body: string }) => {
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & {
+        number: number
+        body: string
+        projectRef?: ProjectRef | null
+      }
+    ) => {
       const repo = assertRegisteredRepo(args, store)
       return addIssueComment(
         repo.path,
@@ -288,7 +299,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.body,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -349,7 +360,14 @@ export function registerGitLabHandlers(store: Store): void {
   // Powers GitLabItemDialog's tabs.
   ipcMain.handle(
     'gitlab:workItemDetails',
-    async (_event, args: GitLabRepoSelectorArgs & { iid: number; type: 'issue' | 'mr' }) => {
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & {
+        iid: number
+        type: 'issue' | 'mr'
+        projectRef?: ProjectRef | null
+      }
+    ) => {
       const repo = assertRegisteredRepo(args, store)
       return getWorkItemDetails(
         repo.path,
@@ -357,7 +375,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.type,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -365,14 +383,17 @@ export function registerGitLabHandlers(store: Store): void {
 
   ipcMain.handle(
     'gitlab:closeMR',
-    async (_event, args: GitLabRepoSelectorArgs & { iid: number }) => {
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & { iid: number; projectRef?: ProjectRef | null }
+    ) => {
       const repo = assertRegisteredRepo(args, store)
       return closeMR(
         repo.path,
         args.iid,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -380,14 +401,17 @@ export function registerGitLabHandlers(store: Store): void {
 
   ipcMain.handle(
     'gitlab:reopenMR',
-    async (_event, args: GitLabRepoSelectorArgs & { iid: number }) => {
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & { iid: number; projectRef?: ProjectRef | null }
+    ) => {
       const repo = assertRegisteredRepo(args, store)
       return reopenMR(
         repo.path,
         args.iid,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -397,7 +421,11 @@ export function registerGitLabHandlers(store: Store): void {
     'gitlab:mergeMR',
     async (
       _event,
-      args: GitLabRepoSelectorArgs & { iid: number; method?: 'merge' | 'squash' | 'rebase' }
+      args: GitLabRepoSelectorArgs & {
+        iid: number
+        method?: 'merge' | 'squash' | 'rebase'
+        projectRef?: ProjectRef | null
+      }
     ) => {
       const repo = assertRegisteredRepo(args, store)
       return mergeMR(
@@ -406,7 +434,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.method ?? 'merge',
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -414,7 +442,14 @@ export function registerGitLabHandlers(store: Store): void {
 
   ipcMain.handle(
     'gitlab:updateMR',
-    async (_event, args: GitLabRepoSelectorArgs & { iid: number; updates: GitLabMRUpdate }) => {
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & {
+        iid: number
+        updates: GitLabMRUpdate
+        projectRef?: ProjectRef | null
+      }
+    ) => {
       const repo = assertRegisteredRepo(args, store)
       return updateMR(
         repo.path,
@@ -422,7 +457,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.updates,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -456,7 +491,14 @@ export function registerGitLabHandlers(store: Store): void {
 
   ipcMain.handle(
     'gitlab:addMRComment',
-    async (_event, args: GitLabRepoSelectorArgs & { iid: number; body: string }) => {
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & {
+        iid: number
+        body: string
+        projectRef?: ProjectRef | null
+      }
+    ) => {
       const repo = assertRegisteredRepo(args, store)
       return addMRComment(
         repo.path,
@@ -464,7 +506,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.body,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -500,7 +542,12 @@ export function registerGitLabHandlers(store: Store): void {
     'gitlab:resolveMRDiscussion',
     async (
       _event,
-      args: GitLabRepoSelectorArgs & { iid: number; discussionId: string; resolved: boolean }
+      args: GitLabRepoSelectorArgs & {
+        iid: number
+        discussionId: string
+        resolved: boolean
+        projectRef?: ProjectRef | null
+      }
     ) => {
       const repo = assertRegisteredRepo(args, store)
       return resolveMRDiscussion(
@@ -510,7 +557,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.resolved,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        undefined,
+        args.projectRef,
         ...localGitOptionArgs(store, repo)
       )
     }

--- a/src/main/providers/ssh-git-dispatch.test.ts
+++ b/src/main/providers/ssh-git-dispatch.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getSshGitProvider,
+  getSshGitProviderRegistrationId,
+  registerSshGitProvider,
+  unregisterSshGitProvider
+} from './ssh-git-dispatch'
+
+describe('SSH git provider registration identity', () => {
+  afterEach(() => unregisterSshGitProvider('conn-1'))
+
+  it('changes identity when the same connection id and provider are registered again', () => {
+    const provider = {} as never
+    registerSshGitProvider('conn-1', provider)
+    const firstRegistrationId = getSshGitProviderRegistrationId('conn-1')
+
+    registerSshGitProvider('conn-1', provider)
+
+    expect(getSshGitProvider('conn-1')).toBe(provider)
+    expect(getSshGitProviderRegistrationId('conn-1')).not.toBe(firstRegistrationId)
+  })
+
+  it('removes provider and lifecycle identity together', () => {
+    registerSshGitProvider('conn-1', {} as never)
+
+    unregisterSshGitProvider('conn-1')
+
+    expect(getSshGitProvider('conn-1')).toBeUndefined()
+    expect(getSshGitProviderRegistrationId('conn-1')).toBeUndefined()
+  })
+})

--- a/src/main/providers/ssh-git-dispatch.ts
+++ b/src/main/providers/ssh-git-dispatch.ts
@@ -1,20 +1,31 @@
 import type { SshGitProvider } from './ssh-git-provider'
 
 const sshProviders = new Map<string, SshGitProvider>()
+const sshProviderRegistrationIds = new Map<string, number>()
+let nextSshProviderRegistrationId = 1
 
 export const SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE =
   'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
 
 export function registerSshGitProvider(connectionId: string, provider: SshGitProvider): void {
   sshProviders.set(connectionId, provider)
+  // Why: connection ids can be removed and reused; cache consumers need a
+  // lightweight lifecycle identity that does not retain the provider graph.
+  sshProviderRegistrationIds.set(connectionId, nextSshProviderRegistrationId)
+  nextSshProviderRegistrationId += 1
 }
 
 export function unregisterSshGitProvider(connectionId: string): void {
   sshProviders.delete(connectionId)
+  sshProviderRegistrationIds.delete(connectionId)
 }
 
 export function getSshGitProvider(connectionId: string): SshGitProvider | undefined {
   return sshProviders.get(connectionId)
+}
+
+export function getSshGitProviderRegistrationId(connectionId: string): number | undefined {
+  return sshProviderRegistrationIds.get(connectionId)
 }
 
 export function requireSshGitProvider(connectionId: string): SshGitProvider {

--- a/src/main/runtime/rpc/methods/gitlab.test.ts
+++ b/src/main/runtime/rpc/methods/gitlab.test.ts
@@ -35,7 +35,11 @@ describe('gitlab RPC methods', () => {
       getGitLabRepoWorkItemByPath: vi.fn().mockResolvedValue({ id: 'gitlab-issue-7' })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: GITLAB_METHODS })
-    const projectRef = { host: 'gitlab.example.com', path: 'group/project' }
+    const projectRef = {
+      host: 'gitlab.example.com',
+      path: 'group/project',
+      sshConnectionLease: { connectionId: 'ssh-1', providerRegistrationId: 42 }
+    }
 
     await dispatcher.dispatch(makeRequest('gitlab.diagnoseAuth'))
     await dispatcher.dispatch(

--- a/src/main/runtime/rpc/methods/gitlab.ts
+++ b/src/main/runtime/rpc/methods/gitlab.ts
@@ -19,7 +19,13 @@ const GitLabRateLimit = z
 const GitLabProjectRef = z
   .object({
     host: requiredString('Missing GitLab host'),
-    path: requiredString('Missing GitLab project path')
+    path: requiredString('Missing GitLab project path'),
+    sshConnectionLease: z
+      .object({
+        connectionId: requiredString('Missing SSH connection id'),
+        providerRegistrationId: z.number().int().positive()
+      })
+      .optional()
   })
   .optional()
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1755,12 +1755,14 @@ export type PreloadApi = {
       args: GitLabRepoSelectorArgs & {
         number: number
         updates: GitLabIssueUpdate
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<{ ok: true } | { ok: false; error: string }>
     addIssueComment: (
       args: GitLabRepoSelectorArgs & {
         number: number
         body: string
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<GitLabCommentResult>
     listLabels: (args: GitLabRepoSelectorArgs) => Promise<string[]>
@@ -1772,28 +1774,33 @@ export type PreloadApi = {
       args: GitLabRepoSelectorArgs & {
         iid: number
         type: 'issue' | 'mr'
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<GitLabWorkItemDetails | null>
     closeMR: (
       args: GitLabRepoSelectorArgs & {
         iid: number
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<{ ok: true } | { ok: false; error: string }>
     reopenMR: (
       args: GitLabRepoSelectorArgs & {
         iid: number
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<{ ok: true } | { ok: false; error: string }>
     mergeMR: (
       args: GitLabRepoSelectorArgs & {
         iid: number
         method?: 'merge' | 'squash' | 'rebase'
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<{ ok: true } | { ok: false; error: string }>
     updateMR: (
       args: GitLabRepoSelectorArgs & {
         iid: number
         updates: GitLabMRUpdate
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<{ ok: true } | { ok: false; error: string }>
     updateMRReviewers: (
@@ -1807,6 +1814,7 @@ export type PreloadApi = {
       args: GitLabRepoSelectorArgs & {
         iid: number
         body: string
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<GitLabCommentResult>
     addMRInlineComment: (
@@ -1821,6 +1829,7 @@ export type PreloadApi = {
         iid: number
         discussionId: string
         resolved: boolean
+        projectRef?: GitLabProjectRef | null
       }
     ) => Promise<GitLabDiscussionResolveResult>
     jobTrace: (

--- a/src/preload/gitlab.ts
+++ b/src/preload/gitlab.ts
@@ -3,6 +3,7 @@
    conflict on every upstream sync of the much larger central preload
    file. Composed back into `api.gl` from `index.ts`. */
 import { ipcRenderer } from 'electron'
+import type { GitLabProjectRef } from '../shared/gitlab-types'
 import type { TaskSourceContext } from '../shared/task-source-context'
 
 type GitLabRepoSelectorArgs = {
@@ -72,12 +73,17 @@ export const glApi = {
     args: GitLabRepoSelectorArgs & {
       number: number
       updates: unknown
+      projectRef?: GitLabProjectRef | null
     }
   ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('gitlab:updateIssue', args),
 
   addIssueComment: (
-    args: GitLabRepoSelectorArgs & { number: number; body: string }
+    args: GitLabRepoSelectorArgs & {
+      number: number
+      body: string
+      projectRef?: GitLabProjectRef | null
+    }
   ): Promise<unknown> => ipcRenderer.invoke('gitlab:addIssueComment', args),
 
   listLabels: (args: GitLabRepoSelectorArgs): Promise<string[]> =>
@@ -93,12 +99,14 @@ export const glApi = {
     args: GitLabRepoSelectorArgs & {
       iid: number
       type: 'issue' | 'mr'
+      projectRef?: GitLabProjectRef | null
     }
   ): Promise<unknown> => ipcRenderer.invoke('gitlab:workItemDetails', args),
 
   closeMR: (
     args: GitLabRepoSelectorArgs & {
       iid: number
+      projectRef?: GitLabProjectRef | null
     }
   ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('gitlab:closeMR', args),
@@ -106,6 +114,7 @@ export const glApi = {
   reopenMR: (
     args: GitLabRepoSelectorArgs & {
       iid: number
+      projectRef?: GitLabProjectRef | null
     }
   ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('gitlab:reopenMR', args),
@@ -114,6 +123,7 @@ export const glApi = {
     args: GitLabRepoSelectorArgs & {
       iid: number
       method?: 'merge' | 'squash' | 'rebase'
+      projectRef?: GitLabProjectRef | null
     }
   ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('gitlab:mergeMR', args),
@@ -122,6 +132,7 @@ export const glApi = {
     args: GitLabRepoSelectorArgs & {
       iid: number
       updates: unknown
+      projectRef?: GitLabProjectRef | null
     }
   ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('gitlab:updateMR', args),
@@ -134,8 +145,13 @@ export const glApi = {
     }
   ): Promise<unknown> => ipcRenderer.invoke('gitlab:updateMRReviewers', args),
 
-  addMRComment: (args: GitLabRepoSelectorArgs & { iid: number; body: string }): Promise<unknown> =>
-    ipcRenderer.invoke('gitlab:addMRComment', args),
+  addMRComment: (
+    args: GitLabRepoSelectorArgs & {
+      iid: number
+      body: string
+      projectRef?: GitLabProjectRef | null
+    }
+  ): Promise<unknown> => ipcRenderer.invoke('gitlab:addMRComment', args),
 
   addMRInlineComment: (
     args: GitLabRepoSelectorArgs & {
@@ -150,6 +166,7 @@ export const glApi = {
       iid: number
       discussionId: string
       resolved: boolean
+      projectRef?: GitLabProjectRef | null
     }
   ): Promise<unknown> => ipcRenderer.invoke('gitlab:resolveMRDiscussion', args),
 

--- a/src/renderer/src/components/GitLabItemDialog.tsx
+++ b/src/renderer/src/components/GitLabItemDialog.tsx
@@ -395,7 +395,12 @@ export default function GitLabItemDialog({
     setLoading(true)
     setError(null)
     void window.api.gl
-      .workItemDetails({ ...repoSelector, iid: item.number, type: item.type })
+      .workItemDetails({
+        ...repoSelector,
+        iid: item.number,
+        type: item.type,
+        projectRef: item.projectRef ?? null
+      })
       .then((data) => {
         if (stale) {
           return
@@ -546,7 +551,12 @@ export default function GitLabItemDialog({
 
     setDetailsSaving(true)
     try {
-      const res = await window.api.gl.updateMR({ ...repoSelector, iid: item.number, updates })
+      const res = await window.api.gl.updateMR({
+        ...repoSelector,
+        iid: item.number,
+        updates,
+        projectRef: item.projectRef ?? null
+      })
       if (res.ok) {
         if (mountedRef.current) {
           setDetails((current) =>
@@ -811,7 +821,11 @@ export default function GitLabItemDialog({
     }
     setActionInFlight('close')
     try {
-      const res = await window.api.gl.closeMR({ ...repoSelector, iid: item.number })
+      const res = await window.api.gl.closeMR({
+        ...repoSelector,
+        iid: item.number,
+        projectRef: item.projectRef ?? null
+      })
       if (res.ok) {
         if (mountedRef.current) {
           useAppStore.getState().recordFeatureInteraction('gitlab-tasks')
@@ -840,7 +854,11 @@ export default function GitLabItemDialog({
     }
     setActionInFlight('reopen')
     try {
-      const res = await window.api.gl.reopenMR({ ...repoSelector, iid: item.number })
+      const res = await window.api.gl.reopenMR({
+        ...repoSelector,
+        iid: item.number,
+        projectRef: item.projectRef ?? null
+      })
       if (res.ok) {
         if (mountedRef.current) {
           useAppStore.getState().recordFeatureInteraction('gitlab-tasks')
@@ -869,7 +887,11 @@ export default function GitLabItemDialog({
     }
     setActionInFlight('merge')
     try {
-      const res = await window.api.gl.mergeMR({ ...repoSelector, iid: item.number })
+      const res = await window.api.gl.mergeMR({
+        ...repoSelector,
+        iid: item.number,
+        projectRef: item.projectRef ?? null
+      })
       if (res.ok) {
         if (mountedRef.current) {
           useAppStore.getState().recordFeatureInteraction('gitlab-tasks')
@@ -915,12 +937,14 @@ export default function GitLabItemDialog({
           ? await window.api.gl.addMRComment({
               ...repoSelector,
               iid: item.number,
-              body: bodyState.body
+              body: bodyState.body,
+              projectRef: item.projectRef ?? null
             })
           : await window.api.gl.addIssueComment({
               ...repoSelector,
               number: item.number,
-              body: bodyState.body
+              body: bodyState.body,
+              projectRef: item.projectRef ?? null
             })
       if (res.ok) {
         if (mountedRef.current) {
@@ -955,7 +979,8 @@ export default function GitLabItemDialog({
           ...repoSelector,
           iid: item.number,
           discussionId: threadId,
-          resolved
+          resolved,
+          projectRef: item.projectRef ?? null
         })
         if (res.ok) {
           if (mountedRef.current) {

--- a/src/renderer/src/components/task-drawer-source-boundary.test.ts
+++ b/src/renderer/src/components/task-drawer-source-boundary.test.ts
@@ -53,12 +53,16 @@ describe('task drawer source boundaries', () => {
       'const repoSelector = useMemo',
       'const updateCommentDraft'
     )
+    const detailsRead = sourceBetween(source, '.workItemDetails({', '.then((data)')
+    const mrUpdate = sourceBetween(source, '.updateMR({', 'if (res.ok)')
 
     expect(selector).toContain('...(repoId ? { repoId } : {})')
     expect(selector).toContain('...(sourceContext ? { sourceContext } : {})')
     expect(selector).toContain('}, [repoId, repoPath, sourceContext])')
-    expect(source).toContain('workItemDetails({ ...repoSelector')
-    expect(source).toContain('updateMR({ ...repoSelector')
+    expect(detailsRead).toContain('...repoSelector')
+    expect(detailsRead).toContain('projectRef: item.projectRef ?? null')
+    expect(mrUpdate).toContain('...repoSelector')
+    expect(mrUpdate).toContain('projectRef: item.projectRef ?? null')
     expect(source).toContain('addMRComment({')
     expect(source).toContain('addIssueComment({')
     expect(source).toContain('...repoSelector')

--- a/src/shared/gitlab-types.ts
+++ b/src/shared/gitlab-types.ts
@@ -13,7 +13,15 @@ import type { CheckStatus, ClassifiedError, PRConflictSummary } from './types'
 // (b) self-hosted instances live on hostnames other than gitlab.com so the
 // host has to travel with the path for URL construction and glab host
 // targeting. Aliased as `ProjectRef` in `src/main/gitlab/gl-utils.ts`.
-export type GitLabProjectRef = { host: string; path: string }
+export type GitLabProjectRef = {
+  host: string
+  path: string
+  /** Why: renderer/RPC round trips must retain the SSH registration that resolved this ref. */
+  sshConnectionLease?: {
+    connectionId: string
+    providerRegistrationId: number
+  }
+}
 
 // ── GitLab MR / issue / work-item shapes ────────────────────────────
 // Why: parallel to the GitHub PR/Issue/WorkItem types above. Native


### PR DESCRIPTION
## Description

Bounds GitLab known-host discovery to the 128 most-recent SSH connection contexts while keeping the local GitLab context pinned. Cache entries and resolved project refs carry the SSH provider registration that produced them, so removing and reusing a connection ID cannot reuse authentication or project state from the prior connection.

The lifecycle lease is serializable across desktop IPC and runtime RPC. GitLab detail reads, comments, edits, close/reopen/merge actions, job operations, and MR creation revalidate it at the final operation boundary. SSH MR lookup also refuses the unsafe cwd-inferred fallback when project resolution expires.

## Evidence

Reproduction: resolve a GitLab project under SSH registration A, JSON-round-trip the project ref as Electron/RPC does, pause the read or write at the GitLab concurrency boundary, unregister A, and register B under the same connection ID. Before this repair, the old ref could continue into an API operation after the ID was reused.

Fix proof:

- Barrier regressions prove both the transported detail read and issue write return failure/null after A becomes B.
- Both tests prove glab execution and the replacement provider B are never called.
- Desktop IPC and runtime RPC tests prove sshConnectionLease survives transport into read and mutation overrides.
- SSH MR detail tests prove an unresolved remote project never falls back to cwd-inferred glab MR lookup.
- Cache churn tests exercise 5,000 connection contexts, keep the remote cache at 128 entries plus the pinned local entry, refresh LRU recency, and re-probe evicted entries.
- Local, WSL, pasted-project, self-hosted GitLab, ordinary SSH, and generic provider suites remain green.

CI repair after the first push: verify exposed a real source-boundary test failure because the test still required the old one-line workItemDetails and updateMR call spelling after production expanded those calls to transport projectRef. The corrected test now inspects each actual call block and requires both the shared repo/source selector and the serialized projectRef lease. This preserves the original boundary and strengthens it against dropping lease transport.

Validation on current main 5b1fcb0ff0:

- original failing task-drawer boundary test: 4 passed;
- 12 core GitLab/SSH/IPC/RPC files: 156 passed;
- broader 21-file GitLab/SSH/boundary matrix: 242 passed;
- changed-file oxlint and oxfmt check passed;
- max-lines ratchet passed with no new suppression;
- git diff check passed;
- two independent final reviewers returned CLEAN on exact commit 8fa87e40d520ce0762b33ae41820c15b080b573e.

Node typecheck is blocked locally by the shared stale install missing the newly locked typescript-api alias in two unrelated baseline tests. It reported no changed-file diagnostic; CI uses a fresh dependency install.

Performance/security check: registration validation is one O(1) map lookup per GitLab boundary, adds no polling, timers, listeners, subprocesses, or provider fanout, and the new cache is deterministically bounded. The lease stores only a connection ID and numeric registration ID; it does not retain provider, relay, credential, or filesystem object graphs.

## ELI5

Orca kept a GitLab address book for every SSH connection it had seen. It now keeps only the recent address books. Each resolved GitLab project also gets a small ticket saying which exact SSH connection created it. If that connection is replaced while Orca is waiting, the old ticket is rejected instead of letting an action reach the replacement connection.

## Trade-offs

Expected end-user regressions: zero.

After more than 128 distinct remote GitLab connection contexts in one app session, revisiting an evicted context may run glab auth status once to rebuild its small cache entry. If an SSH connection is replaced while a GitLab action is queued, that stale action now fails safely and can be retried after refresh instead of reading or changing the wrong project. Local GitLab, WSL, pasted URLs, self-hosted instances, and non-GitLab providers keep their existing behavior.
