### PR TITLE
Bound safe-auto fork sync attempts

### DIFF
--- a/src/renderer/src/store/slices/repo-host-identity.ts
+++ b/src/renderer/src/store/slices/repo-host-identity.ts
@@ -25,14 +25,14 @@ export function repoMatchesHostIdentity(
   return repo.id === repoId && getRepoExecutionHostId(repo) === hostId
 }
 
-export function findRepoForHost(
-  repos: readonly RepoIdentityParts[],
+export function findRepoForHost<T extends RepoIdentityParts>(
+  repos: readonly T[],
   repoId: string,
   options: {
     hostId?: ExecutionHostId | string | null
     settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
   } = {}
-): RepoIdentityParts | null {
+): T | null {
   const matchingRepos = repos.filter((repo) => repo.id === repoId)
   if (matchingRepos.length === 0) {
     return null

--- a/src/renderer/src/store/slices/repos-safe-auto-fork-sync-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/repos-safe-auto-fork-sync-lifecycle.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import { createTestStore } from './store-test-helpers'
+import {
+  installReposRuntimeRoutingHarness,
+  reposList,
+  reposRemove,
+  runtimeEnvironmentCall
+} from './repos-runtime-routing-fixture'
+import { SAFE_AUTO_FORK_SYNC_COOLDOWN_MS } from './safe-auto-fork-sync-attempts'
+import type * as RuntimeGitClient from '../../runtime/runtime-git-client'
+
+const syncRuntimeGitForkDefaultBranch = vi.hoisted(() => vi.fn())
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+vi.mock('../../runtime/runtime-git-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof RuntimeGitClient>()),
+  syncRuntimeGitForkDefaultBranch
+}))
+
+installReposRuntimeRoutingHarness()
+
+const safeAutoRepo = (upstreamOwner: string, overrides: Partial<Repo> = {}): Repo => ({
+  id: 'fork-repo',
+  path: '/repos/fork',
+  displayName: 'Fork',
+  badgeColor: '#000',
+  addedAt: 1,
+  executionHostId: 'local',
+  forkSyncMode: 'safe-auto',
+  upstream: { owner: upstreamOwner, repo: 'upstream-repo' },
+  ...overrides
+})
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('safe-auto fork sync attempt lifecycle', () => {
+  beforeEach(() => {
+    syncRuntimeGitForkDefaultBranch.mockReset()
+    syncRuntimeGitForkDefaultBranch.mockResolvedValue({
+      status: 'up-to-date',
+      originRemote: 'origin',
+      upstreamRemote: 'upstream',
+      ahead: 0,
+      behind: 0
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not reuse a cooldown after the expected upstream identity changes', async () => {
+    const store = createTestStore()
+    reposList.mockResolvedValue([safeAutoRepo('first-owner')])
+    await store.getState().fetchRepos()
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1))
+
+    reposList.mockResolvedValue([safeAutoRepo('second-owner')])
+    await store.getState().fetchRepos()
+
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2))
+  })
+
+  it('queues an upstream change behind the current git operation', async () => {
+    const firstSync = deferred<{
+      status: 'up-to-date'
+      originRemote: string
+      upstreamRemote: string
+      ahead: number
+      behind: number
+    }>()
+    syncRuntimeGitForkDefaultBranch.mockReturnValueOnce(firstSync.promise)
+    const store = createTestStore()
+    reposList.mockResolvedValue([safeAutoRepo('first-owner')])
+    await store.getState().fetchRepos()
+
+    reposList.mockResolvedValue([safeAutoRepo('second-owner')])
+    await store.getState().fetchRepos()
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1)
+
+    firstSync.resolve({
+      status: 'up-to-date',
+      originRemote: 'origin',
+      upstreamRemote: 'upstream',
+      ahead: 0,
+      behind: 0
+    })
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2))
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ owner: 'second-owner' })
+    )
+  })
+
+  it('keeps one call for a true same-target cooldown', async () => {
+    const store = createTestStore()
+    reposList.mockResolvedValue([safeAutoRepo('same-owner')])
+
+    await store.getState().fetchRepos()
+    await store.getState().fetchRepos()
+
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not share cooldowns across profile auth boundaries', async () => {
+    const store = createTestStore()
+    reposList.mockResolvedValue([safeAutoRepo('same-owner')])
+    store.setState({ activeOrcaProfileId: 'profile-a' })
+    await store.getState().fetchRepos()
+
+    store.setState({ activeOrcaProfileId: 'profile-b' })
+    await store.getState().fetchRepos()
+
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2)
+  })
+
+  it('routes duplicate repo ids through the candidate runtime host', async () => {
+    const runtimeRepo = safeAutoRepo('same-owner', {
+      path: '/runtime/fork',
+      executionHostId: 'runtime:env-1'
+    })
+    runtimeEnvironmentCall.mockImplementation((args) => {
+      if (args.method === 'repo.list') {
+        return {
+          id: 'rpc-repos',
+          ok: true,
+          result: { repos: [runtimeRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return {
+        id: 'rpc-projects',
+        ok: true,
+        result: args.method === 'project.list' ? { projects: [] } : { setups: [] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+    const store = createTestStore()
+    store.setState({ repos: [safeAutoRepo('same-owner')] })
+
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1))
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: expect.objectContaining({ activeRuntimeEnvironmentId: 'env-1' }),
+        worktreePath: '/runtime/fork'
+      }),
+      expect.anything()
+    )
+  })
+
+  it('retries a rejected attempt after the cooldown without retrying early', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    syncRuntimeGitForkDefaultBranch.mockRejectedValueOnce(new Error('auth unavailable'))
+    const store = createTestStore()
+    reposList.mockResolvedValue([safeAutoRepo('same-owner')])
+
+    await store.getState().fetchRepos()
+    await Promise.resolve()
+    await store.getState().fetchRepos()
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(1_000 + SAFE_AUTO_FORK_SYNC_COOLDOWN_MS)
+    await store.getState().fetchRepos()
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts a new cooldown lifecycle after removal and re-add', async () => {
+    const store = createTestStore()
+    const repo = safeAutoRepo('same-owner')
+    reposList.mockResolvedValue([repo])
+    reposRemove.mockResolvedValue(undefined)
+    await store.getState().fetchRepos()
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1))
+
+    await store.getState().removeProject(repo.id)
+    reposList.mockResolvedValue([repo])
+    await store.getState().fetchRepos()
+
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2))
+  })
+
+  it('retires cooldowns when catalog reconciliation removes the repo', async () => {
+    const store = createTestStore()
+    const repo = safeAutoRepo('same-owner')
+    reposList.mockResolvedValue([repo])
+    await store.getState().fetchRepos()
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1))
+
+    reposList.mockResolvedValue([])
+    await store.getState().fetchRepos()
+    reposList.mockResolvedValue([repo])
+    await store.getState().fetchRepos()
+
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2))
+  })
+
+  it('retires after backend removal even when later cleanup throws', async () => {
+    const store = createTestStore()
+    const repo = safeAutoRepo('same-owner')
+    reposList.mockResolvedValue([repo])
+    reposRemove.mockResolvedValue(undefined)
+    await store.getState().fetchRepos()
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1))
+    store.setState({
+      clearOrcaHookTrustForRepo: vi.fn(() => {
+        throw new Error('cleanup failed')
+      })
+    })
+
+    await store.getState().removeProject(repo.id)
+    await store.getState().fetchRepos()
+
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2))
+  })
+
+  it('discards a stale runtime catalog after removal while allowing a fresh re-add', async () => {
+    const staleList = deferred<{
+      id: string
+      ok: true
+      result: { repos: Repo[] }
+      _meta: { runtimeId: string }
+    }>()
+    const staleRepo = safeAutoRepo('stale-owner', { executionHostId: 'runtime:env-1' })
+    const freshRepo = safeAutoRepo('fresh-owner', { executionHostId: 'runtime:env-1' })
+    let repoListCalls = 0
+    runtimeEnvironmentCall.mockImplementation((args) => {
+      if (args.method === 'repo.list') {
+        repoListCalls += 1
+        return repoListCalls === 1
+          ? staleList.promise
+          : {
+              id: 'rpc-fresh-repos',
+              ok: true,
+              result: { repos: [freshRepo] },
+              _meta: { runtimeId: 'runtime-remote' }
+            }
+      }
+      if (args.method === 'repo.rm') {
+        return {
+          id: 'rpc-remove',
+          ok: true,
+          result: { status: 'removed' },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return {
+        id: 'rpc-compatibility',
+        ok: true,
+        result: args.method === 'project.list' ? { projects: [] } : { setups: [] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+    const store = createTestStore()
+    store.setState({ repos: [freshRepo] })
+
+    const staleFetch = store.getState().fetchRuntimeEnvironmentRepos('env-1')
+    await store.getState().removeProject(freshRepo.id, { hostId: 'runtime:env-1' })
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+    staleList.resolve({
+      id: 'rpc-stale-repos',
+      ok: true,
+      result: { repos: [staleRepo] },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await staleFetch
+
+    expect(store.getState().repos).toContainEqual(
+      expect.objectContaining({ upstream: freshRepo.upstream })
+    )
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1)
+  })
+
+  it('retires the old operation when upstream metadata is cleared before removal', async () => {
+    const store = createTestStore()
+    const repo = safeAutoRepo('same-owner')
+    reposList.mockResolvedValue([repo])
+    reposRemove.mockResolvedValue(undefined)
+    await store.getState().fetchRepos()
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1))
+
+    store.setState({
+      repos: [{ ...repo, upstream: null, forkSyncMode: 'off' }]
+    })
+    await store.getState().removeProject(repo.id)
+    reposList.mockResolvedValue([repo])
+    await store.getState().fetchRepos()
+
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2))
+  })
+
+  it('waits for a removed lifecycle owner before syncing a same-key replacement', async () => {
+    const firstSync = deferred<{
+      status: 'up-to-date'
+      originRemote: string
+      upstreamRemote: string
+      ahead: number
+      behind: number
+    }>()
+    syncRuntimeGitForkDefaultBranch.mockReturnValueOnce(firstSync.promise)
+    const store = createTestStore()
+    const repo = safeAutoRepo('same-owner')
+    reposList.mockResolvedValue([repo])
+    reposRemove.mockResolvedValue(undefined)
+    await store.getState().fetchRepos()
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1)
+
+    await store.getState().removeProject(repo.id)
+    reposList.mockResolvedValue([repo])
+    await store.getState().fetchRepos()
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1)
+
+    firstSync.resolve({
+      status: 'up-to-date',
+      originRemote: 'origin',
+      upstreamRemote: 'upstream',
+      ahead: 0,
+      behind: 0
+    })
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2))
+  })
+
+  it('clears older profile cooldowns when removal retires a newer in-flight identity', async () => {
+    const secondSync = deferred<{
+      status: 'up-to-date'
+      originRemote: string
+      upstreamRemote: string
+      ahead: number
+      behind: number
+    }>()
+    syncRuntimeGitForkDefaultBranch.mockResolvedValueOnce({
+      status: 'up-to-date',
+      originRemote: 'origin',
+      upstreamRemote: 'upstream',
+      ahead: 0,
+      behind: 0
+    })
+    syncRuntimeGitForkDefaultBranch.mockReturnValueOnce(secondSync.promise)
+    const store = createTestStore()
+    const repo = safeAutoRepo('same-owner')
+    reposList.mockResolvedValue([repo])
+    reposRemove.mockResolvedValue(undefined)
+    store.setState({ activeOrcaProfileId: 'profile-a' })
+    await store.getState().fetchRepos()
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(1))
+
+    store.setState({ activeOrcaProfileId: 'profile-b' })
+    await store.getState().fetchRepos()
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2)
+    await store.getState().removeProject(repo.id)
+
+    store.setState({ activeOrcaProfileId: 'profile-a' })
+    reposList.mockResolvedValue([repo])
+    await store.getState().fetchRepos()
+    expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(2)
+
+    secondSync.resolve({
+      status: 'up-to-date',
+      originRemote: 'origin',
+      upstreamRemote: 'upstream',
+      ahead: 0,
+      behind: 0
+    })
+    await vi.waitFor(() => expect(syncRuntimeGitForkDefaultBranch).toHaveBeenCalledTimes(3))
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -87,10 +87,12 @@ import {
 import { cleanupEphemeralVmRuntimesForDeleted } from '@/lib/ephemeral-vm-runtime-cleanup'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { formatFolderWorkspaceCreateError } from '../../lib/folder-workspace-path-status'
+import {
+  createSafeAutoForkSyncAttemptKeys,
+  getSafeAutoForkSyncAttemptRegistry
+} from './safe-auto-fork-sync-attempts'
 
 const ERROR_TOAST_DURATION = 60_000
-const SAFE_AUTO_FORK_SYNC_COOLDOWN_MS = 10 * 60 * 1000
-const safeAutoForkSyncAttempts = new Map<string, { attemptedAt: number; promise?: Promise<void> }>()
 
 export type RepoUpdate = Partial<
   Pick<
@@ -204,6 +206,18 @@ function sanitizeRepoUpdate(updates: RepoUpdate): RepoUpdate {
 }
 
 const updateRepoChainsByStore = new WeakMap<() => AppState, Map<string, Promise<boolean>>>()
+const repoCatalogRemovalGenerationByStore = new WeakMap<object, number>()
+
+function getRepoCatalogRemovalGeneration(storeOwner: object): number {
+  return repoCatalogRemovalGenerationByStore.get(storeOwner) ?? 0
+}
+
+function invalidateCatalogsStartedBeforeRemoval(storeOwner: object): void {
+  repoCatalogRemovalGenerationByStore.set(
+    storeOwner,
+    getRepoCatalogRemovalGeneration(storeOwner) + 1
+  )
+}
 
 function getRepoUpdateChains(get: () => AppState): Map<string, Promise<boolean>> {
   let chains = updateRepoChainsByStore.get(get)
@@ -266,8 +280,40 @@ function getProjectUpdateRuntimeTarget(
     : { kind: 'local' }
 }
 
-function getSafeAutoForkSyncKey(repo: Repo): string {
-  return `${getRepoExecutionHostId(repo)}:${repo.id}:${repo.path}`
+function getSafeAutoForkSyncKeys(repo: Repo, profileId: string | null) {
+  return createSafeAutoForkSyncAttemptKeys({
+    profileId,
+    executionHostId: getRepoExecutionHostId(repo),
+    connectionId: repo.connectionId ?? null,
+    repoId: repo.id,
+    repoPath: repo.path,
+    remoteCanonicalKey: repo.gitRemoteIdentity?.canonicalKey ?? null,
+    upstreamOwner: repo.upstream?.owner ?? '',
+    upstreamRepo: repo.upstream?.repo ?? ''
+  })
+}
+
+function getLiveSafeAutoForkSyncCooldownKeys(state: AppState): string[] {
+  return state.repos
+    .filter((repo) => repo.kind !== 'folder' && repo.forkSyncMode === 'safe-auto' && repo.upstream)
+    .map((repo) => getSafeAutoForkSyncKeys(repo, state.activeOrcaProfileId).cooldownKey)
+}
+
+function retireRemovedSafeAutoForkSyncLifecycles(
+  get: () => AppState,
+  previousRepos: readonly Repo[],
+  currentRepos: readonly Repo[]
+): void {
+  const currentOperationKeys = new Set(
+    currentRepos.map((repo) => getSafeAutoForkSyncKeys(repo, null).operationKey)
+  )
+  const attempts = getSafeAutoForkSyncAttemptRegistry(get)
+  for (const repo of previousRepos) {
+    const operationKey = getSafeAutoForkSyncKeys(repo, null).operationKey
+    if (!currentOperationKeys.has(operationKey)) {
+      attempts.retire(operationKey)
+    }
+  }
 }
 
 function formatProjectPresenceProfileNames(profileNames: readonly string[]): string {
@@ -316,22 +362,20 @@ async function warnIfProjectKnownInAnotherProfile(
 }
 
 function scheduleSafeAutoForkSync(get: () => AppState, repos: readonly Repo[]): void {
+  const attempts = getSafeAutoForkSyncAttemptRegistry(get)
+  const now = Date.now()
+  attempts.prune(now, getLiveSafeAutoForkSyncCooldownKeys(get()))
   for (const repo of repos) {
     if (repo.kind === 'folder' || repo.forkSyncMode !== 'safe-auto' || !repo.upstream) {
       continue
     }
-    const key = getSafeAutoForkSyncKey(repo)
-    const existingAttempt = safeAutoForkSyncAttempts.get(key)
-    const now = Date.now()
-    if (
-      existingAttempt?.promise ||
-      (existingAttempt && now - existingAttempt.attemptedAt < SAFE_AUTO_FORK_SYNC_COOLDOWN_MS)
-    ) {
+    const keys = getSafeAutoForkSyncKeys(repo, get().activeOrcaProfileId)
+    if (!attempts.canStart(keys.operationKey, keys.cooldownKey, now)) {
       continue
     }
     const promise = syncRuntimeGitForkDefaultBranch(
       {
-        settings: settingsForRepoOwner(get(), repo.id),
+        settings: settingsForRepoOwner(get(), repo.id, getRepoExecutionHostId(repo)),
         worktreeId: repo.id,
         worktreePath: repo.path,
         connectionId: repo.connectionId ?? undefined
@@ -346,12 +390,25 @@ function scheduleSafeAutoForkSync(get: () => AppState, repos: readonly Repo[]): 
         console.info('Safe fork auto-sync skipped', error)
       })
       .finally(() => {
-        const current = safeAutoForkSyncAttempts.get(key)
-        if (current?.promise === promise) {
-          safeAutoForkSyncAttempts.set(key, { attemptedAt: now })
+        const completion = attempts.complete(keys.operationKey, promise)
+        if (completion !== 'retry') {
+          return
+        }
+        const profileId = get().activeOrcaProfileId
+        const replacement = get().repos.find(
+          (candidate) =>
+            candidate.kind !== 'folder' &&
+            candidate.forkSyncMode === 'safe-auto' &&
+            candidate.upstream &&
+            getSafeAutoForkSyncKeys(candidate, profileId).operationKey === keys.operationKey
+        )
+        if (replacement) {
+          // Why: removal can finish while the old git operation is still in flight.
+          // Wait for that owner to settle before retrying a same-path replacement.
+          scheduleSafeAutoForkSync(get, [replacement])
         }
       })
-    safeAutoForkSyncAttempts.set(key, { attemptedAt: now, promise })
+    attempts.start(keys.operationKey, keys.cooldownKey, now, promise)
   }
 }
 
@@ -1548,12 +1605,19 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     })
     try {
       const target = getActiveRuntimeTarget(get().settings)
+      const removalGeneration = getRepoCatalogRemovalGeneration(get)
       const catalog = await fetchRepoCatalogForTarget(target)
       // A newer fetchRepos superseded us while we awaited — drop this stale result.
       if (get().reposFetchGeneration !== generation) {
         return
       }
+      // Why: a catalog captured before a successful removal must not resurrect
+      // that repo or schedule its retired safe-auto lifecycle.
+      if (getRepoCatalogRemovalGeneration(get) !== removalGeneration) {
+        return
+      }
       let finalizedHostRepos: Repo[] = []
+      const previousRepos = get().repos
       set((s) => {
         // Why: after re-adoption re-points a repo onto a re-added SSH target, the
         // per-host merge leaves the stale row on the old (removed) target id — a
@@ -1597,6 +1661,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           )
         }
       })
+      retireRemovedSafeAutoForkSyncLifecycles(get, previousRepos, get().repos)
       scheduleSafeAutoForkSync(get, finalizedHostRepos)
     } catch (err) {
       console.error('Failed to fetch repos:', err)
@@ -1606,8 +1671,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   fetchRuntimeEnvironmentRepos: async (environmentId) => {
     try {
       const target = { kind: 'environment' as const, environmentId }
+      const removalGeneration = getRepoCatalogRemovalGeneration(get)
       const catalog = await fetchRepoCatalogForTarget(target)
+      if (getRepoCatalogRemovalGeneration(get) !== removalGeneration) {
+        return []
+      }
       let finalizedHostRepos: Repo[] = []
+      const previousRepos = get().repos
       set((s) => {
         const result = mergeFetchedRepoCatalog(catalog, s.repos)
         const reconciliation = reconcileSupersededSshRepos(result.repos, s)
@@ -1646,6 +1716,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           )
         }
       })
+      retireRemovedSafeAutoForkSyncLifecycles(get, previousRepos, get().repos)
       scheduleSafeAutoForkSync(get, finalizedHostRepos)
       return finalizedHostRepos
     } catch (err) {
@@ -1674,6 +1745,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return
       }
       let hostRepos: Repo[] = []
+      const previousRepos = get().repos
       set((s) => {
         const result = mergeFetchedRepoCatalog(catalog, s.repos)
         const reconciliation = reconcileSupersededSshRepos(result.repos, s)
@@ -1707,6 +1779,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           setupScriptPromptDismissedRepoIds: s.setupScriptPromptDismissedRepoIds
         }
       })
+      retireRemovedSafeAutoForkSyncLifecycles(get, previousRepos, get().repos)
       // Why: preserve the safe-auto fork sync that fetchRepos /
       // fetchRuntimeEnvironmentRepos schedule after merging each host, so
       // cold-start (which now routes through here) keeps updating safe-auto forks.
@@ -1727,10 +1800,23 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       })
     }
 
-    // Local first so local repos are present even if a remote fetch stalls.
     let failed = false
+    const fetchAndApplyCatalog = async (
+      target: ReturnType<typeof getActiveRuntimeTarget>
+    ): Promise<void> => {
+      const removalGeneration = getRepoCatalogRemovalGeneration(get)
+      const catalog = await fetchRepoCatalogForTarget(target)
+      if (getRepoCatalogRemovalGeneration(get) !== removalGeneration) {
+        // A fresh all-host load will refill this host without replaying deleted state.
+        failed = true
+        return
+      }
+      applyCatalog(catalog)
+    }
+
+    // Local first so local repos are present even if a remote fetch stalls.
     try {
-      applyCatalog(await fetchRepoCatalogForTarget({ kind: 'local' }))
+      await fetchAndApplyCatalog({ kind: 'local' })
     } catch (err) {
       failed = true
       console.error('Failed to fetch local repos for all-host load:', err)
@@ -1748,12 +1834,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     await Promise.all(
       environments.map(async (environment) => {
         try {
-          applyCatalog(
-            await fetchRepoCatalogForTarget({
-              kind: 'environment',
-              environmentId: environment.id
-            })
-          )
+          await fetchAndApplyCatalog({
+            kind: 'environment',
+            environmentId: environment.id
+          })
         } catch (err) {
           failed = true
           console.warn(`Skipped repos for runtime environment ${environment.id}:`, err)
@@ -2595,6 +2679,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
             ).result
       const repo = result.repo ? repoWithFetchedOwner(result.repo, target) : undefined
       const repoHostId = repo ? getRepoExecutionHostId(repo) : null
+      if (repo) {
+        invalidateCatalogsStartedBeforeRemoval(get)
+      }
       set((s) => {
         const projectHostSetups = s.projectHostSetups.filter(
           (setup) => setup.id !== result.setup.id
@@ -2616,6 +2703,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           ...omitSparsePresetsForRepos(s, removedRepoIds)
         }
       })
+      if (repo) {
+        getSafeAutoForkSyncAttemptRegistry(get).retire(
+          getSafeAutoForkSyncKeys(repo, null).operationKey
+        )
+      }
       return { ...result, repo }
     } catch (err) {
       console.error('Failed to delete project host setup:', err)
@@ -2754,6 +2846,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return
       }
       const ownerHostId = getRepoExecutionHostId(ownerRepo)
+      const safeAutoForkSyncKeys = getSafeAutoForkSyncKeys(ownerRepo, get().activeOrcaProfileId)
       // Why: an SSH-mode per-workspace-env's workspace is the repo's main worktree, so deleting it
       // routes here (project removal) rather than through removeWorktree. Tear down the backing
       // ephemeral runtime (Docker/VM + hidden SSH target) first so it doesn't leak when the project
@@ -2782,6 +2875,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           ? window.api.repos.removeForHost({ repoId: projectId, hostId: ownerHostId })
           : window.api.repos.remove({ repoId: projectId })
         : callRuntimeRpc(target, 'repo.rm', { repo: projectId }, { timeoutMs: 15_000 }))
+
+      // Why: backend deletion is authoritative even if later UI/cache cleanup fails.
+      // Retired owners only retry after a new lifecycle explicitly queues behind them.
+      invalidateCatalogsStartedBeforeRemoval(get)
+      getSafeAutoForkSyncAttemptRegistry(get).retire(safeAutoForkSyncKeys.operationKey)
 
       get().clearOrcaHookTrustForRepo(projectId)
       const repoPath = get().repos.find((repo) =>

--- a/src/renderer/src/store/slices/safe-auto-fork-sync-attempts.test.ts
+++ b/src/renderer/src/store/slices/safe-auto-fork-sync-attempts.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeGitRemoteUrl } from '../../../../shared/git-remote-identity'
+import {
+  createSafeAutoForkSyncAttemptKeys,
+  SafeAutoForkSyncAttemptRegistry,
+  SAFE_AUTO_FORK_SYNC_COMPLETED_MAX_ENTRIES,
+  SAFE_AUTO_FORK_SYNC_COOLDOWN_MS,
+  type SafeAutoForkSyncAttemptIdentity
+} from './safe-auto-fork-sync-attempts'
+
+const baseIdentity: SafeAutoForkSyncAttemptIdentity = {
+  profileId: 'profile-a',
+  executionHostId: 'local',
+  connectionId: null,
+  repoId: 'repo-a',
+  repoPath: '/repos/a',
+  remoteCanonicalKey: 'github.com/fork/a',
+  upstreamOwner: 'upstream-owner',
+  upstreamRepo: 'upstream-repo'
+}
+
+function rememberCompleted(
+  registry: SafeAutoForkSyncAttemptRegistry,
+  key: string,
+  attemptedAt: number
+): void {
+  const promise = Promise.resolve()
+  registry.start(key, key, attemptedAt, promise)
+  expect(registry.complete(key, promise)).toBe('completed')
+}
+
+describe('safe-auto fork sync attempt registry', () => {
+  it('expires completed attempts at the cooldown boundary', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    rememberCompleted(registry, 'old', 0)
+    rememberCompleted(registry, 'fresh', 1)
+
+    registry.prune(SAFE_AUTO_FORK_SYNC_COOLDOWN_MS)
+
+    expect(registry.hasCompleted('old')).toBe(false)
+    expect(registry.hasCompleted('fresh')).toBe(true)
+  })
+
+  it('bounds ten thousand non-live attempts while preserving in-flight ownership', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    const inFlight = new Promise<void>(() => {})
+    registry.start('in-flight', 'in-flight', 0, inFlight)
+
+    for (let index = 0; index < 10_000; index += 1) {
+      rememberCompleted(registry, `repo-${index}`, index)
+    }
+
+    expect(registry.inFlightCount).toBe(1)
+    expect(registry.hasInFlight('in-flight')).toBe(true)
+    expect(registry.completedCount).toBe(SAFE_AUTO_FORK_SYNC_COMPLETED_MAX_ENTRIES)
+    expect(registry.hasCompleted('repo-0')).toBe(false)
+    expect(registry.hasCompleted('repo-9999')).toBe(true)
+  })
+
+  it('preserves cooldowns for more than the history cap when every repo is still live', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    const liveKeys = Array.from(
+      { length: SAFE_AUTO_FORK_SYNC_COMPLETED_MAX_ENTRIES + 1 },
+      (_, index) => `live-${index}`
+    )
+    registry.prune(0, liveKeys)
+
+    for (const key of liveKeys) {
+      rememberCompleted(registry, key, 0)
+    }
+
+    expect(registry.completedCount).toBe(liveKeys.length)
+    for (const key of liveKeys) {
+      expect(registry.canStart(key, key, 1)).toBe(false)
+    }
+  })
+
+  it('does not let an old settlement overwrite a newer attempt with the same key', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    const oldPromise = Promise.resolve()
+    const newPromise = Promise.resolve()
+    registry.start('repo', 'old-cooldown', 1, oldPromise)
+    registry.start('repo', 'new-cooldown', 2, newPromise)
+
+    expect(registry.complete('repo', oldPromise)).toBe('stale')
+    expect(registry.hasInFlight('repo')).toBe(true)
+    expect(registry.complete('repo', newPromise)).toBe('completed')
+    expect(registry.hasCompleted('new-cooldown')).toBe(true)
+  })
+
+  it('queues changed cooldown identity behind the existing operation owner', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    const promise = Promise.resolve()
+    registry.start('operation', 'upstream-a', 1, promise)
+
+    expect(registry.canStart('operation', 'upstream-b', 2)).toBe(false)
+    expect(registry.complete('operation', promise)).toBe('retry')
+    expect(registry.hasCompleted('upstream-a')).toBe(true)
+    expect(registry.canStart('operation', 'upstream-b', 2)).toBe(true)
+  })
+
+  it('retires completed cooldowns and preserves in-flight ownership until settlement', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    rememberCompleted(registry, 'completed', 0)
+    const inFlight = Promise.resolve()
+    registry.start('in-flight', 'in-flight', 0, inFlight)
+
+    expect(registry.retire('completed')).toBe(true)
+    expect(registry.canStart('completed', 'completed', 1)).toBe(true)
+    expect(registry.retire('in-flight')).toBe(true)
+    expect(registry.canStart('in-flight', 'in-flight', 1)).toBe(false)
+    expect(registry.complete('in-flight', inFlight)).toBe('retry')
+    expect(registry.canStart('in-flight', 'in-flight', 1)).toBe(true)
+  })
+
+  it('drops retry intent that predates retirement but keeps a later lifecycle request', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    const promise = Promise.resolve()
+    registry.start('operation', 'old', 0, promise)
+    expect(registry.canStart('operation', 'changed-before-removal', 1)).toBe(false)
+
+    registry.retire('operation')
+    expect(registry.complete('operation', promise)).toBe('retired')
+
+    const replacementPromise = Promise.resolve()
+    registry.start('operation', 'replacement', 2, replacementPromise)
+    registry.retire('operation')
+    expect(registry.canStart('operation', 're-added', 3)).toBe(false)
+    expect(registry.complete('operation', replacementPromise)).toBe('retry')
+  })
+
+  it('keeps incremental non-live accounting exact across protection and retirement changes', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    registry.prune(0, ['a', 'b'])
+    rememberCompleted(registry, 'a', 0)
+    rememberCompleted(registry, 'b', 0)
+    rememberCompleted(registry, 'c', 0)
+    expect(registry.nonLiveHistoryCount).toBe(1)
+
+    registry.prune(1, ['b', 'c'])
+    expect(registry.nonLiveHistoryCount).toBe(1)
+    registry.retire('a')
+    expect(registry.nonLiveHistoryCount).toBe(0)
+
+    registry.prune(2)
+    expect(registry.nonLiveHistoryCount).toBe(2)
+    registry.retire('b')
+    registry.retire('c')
+    expect(registry.nonLiveHistoryCount).toBe(0)
+  })
+
+  it('retires every completed identity from the removed operation lifecycle', () => {
+    const registry = new SafeAutoForkSyncAttemptRegistry()
+    const oldPromise = Promise.resolve()
+    registry.start('operation', 'profile-a-upstream-a', 1, oldPromise)
+    expect(registry.complete('operation', oldPromise)).toBe('completed')
+    const currentPromise = Promise.resolve()
+    registry.start('operation', 'profile-b-upstream-b', 2, currentPromise)
+
+    expect(registry.retire('operation')).toBe(true)
+    expect(registry.hasCompleted('profile-a-upstream-a')).toBe(false)
+    expect(registry.complete('operation', currentPromise)).toBe('retired')
+    expect(registry.canStart('operation', 'profile-a-upstream-a', 3)).toBe(true)
+  })
+
+  it('separates profile, host, repo, path, remote, and upstream identities', () => {
+    const baseKeys = createSafeAutoForkSyncAttemptKeys(baseIdentity)
+    const mutations: SafeAutoForkSyncAttemptIdentity[] = [
+      { ...baseIdentity, profileId: 'profile-b' },
+      { ...baseIdentity, executionHostId: 'ssh:host-a', connectionId: 'host-a' },
+      { ...baseIdentity, executionHostId: 'runtime:env-a' },
+      { ...baseIdentity, repoId: 'repo-b' },
+      { ...baseIdentity, repoPath: '/repos/b' },
+      { ...baseIdentity, remoteCanonicalKey: 'github.com/fork/b' },
+      { ...baseIdentity, upstreamOwner: 'other-owner' },
+      { ...baseIdentity, upstreamRepo: 'other-repo' }
+    ]
+
+    expect(
+      new Set(mutations.map((identity) => createSafeAutoForkSyncAttemptKeys(identity).cooldownKey))
+        .size
+    ).toBe(mutations.length)
+    for (const mutation of mutations) {
+      expect(createSafeAutoForkSyncAttemptKeys(mutation).cooldownKey).not.toBe(baseKeys.cooldownKey)
+    }
+    expect(createSafeAutoForkSyncAttemptKeys(mutations[0]).operationKey).toBe(baseKeys.operationKey)
+    expect(createSafeAutoForkSyncAttemptKeys(mutations[5]).operationKey).toBe(baseKeys.operationKey)
+    expect(createSafeAutoForkSyncAttemptKeys(mutations[6]).operationKey).toBe(baseKeys.operationKey)
+    expect(createSafeAutoForkSyncAttemptKeys(mutations[1]).operationKey).not.toBe(
+      baseKeys.operationKey
+    )
+    expect(createSafeAutoForkSyncAttemptKeys(mutations[2]).operationKey).not.toBe(
+      baseKeys.operationKey
+    )
+  })
+
+  it('shares canonical SSH and HTTPS remotes without collapsing enterprise hosts', () => {
+    const sshRemote = normalizeGitRemoteUrl('git@github.example.com:Team/Fork.git')
+    const httpsRemote = normalizeGitRemoteUrl('https://github.example.com/Team/Fork.git')
+    const otherHost = normalizeGitRemoteUrl('https://other.example.com/Team/Fork.git')
+
+    expect(sshRemote).toBe(httpsRemote)
+    expect(
+      createSafeAutoForkSyncAttemptKeys({ ...baseIdentity, remoteCanonicalKey: sshRemote })
+        .cooldownKey
+    ).toBe(
+      createSafeAutoForkSyncAttemptKeys({ ...baseIdentity, remoteCanonicalKey: httpsRemote })
+        .cooldownKey
+    )
+    expect(
+      createSafeAutoForkSyncAttemptKeys({ ...baseIdentity, remoteCanonicalKey: otherHost })
+        .cooldownKey
+    ).not.toBe(
+      createSafeAutoForkSyncAttemptKeys({ ...baseIdentity, remoteCanonicalKey: sshRemote })
+        .cooldownKey
+    )
+  })
+})

--- a/src/renderer/src/store/slices/safe-auto-fork-sync-attempts.ts
+++ b/src/renderer/src/store/slices/safe-auto-fork-sync-attempts.ts
@@ -1,0 +1,209 @@
+export const SAFE_AUTO_FORK_SYNC_COOLDOWN_MS = 10 * 60 * 1000
+export const SAFE_AUTO_FORK_SYNC_COMPLETED_MAX_ENTRIES = 2048
+
+export type SafeAutoForkSyncAttemptIdentity = {
+  profileId: string | null
+  executionHostId: string
+  connectionId: string | null
+  repoId: string
+  repoPath: string
+  remoteCanonicalKey: string | null
+  upstreamOwner: string
+  upstreamRepo: string
+}
+
+type InFlightAttempt = {
+  cooldownKey: string
+  attemptedAt: number
+  promise: Promise<void>
+  retired: boolean
+  retryRequested: boolean
+}
+
+type CompletedAttempt = {
+  operationKey: string
+  attemptedAt: number
+}
+
+export type SafeAutoForkSyncAttemptKeys = {
+  operationKey: string
+  cooldownKey: string
+}
+
+export type SafeAutoForkSyncCompletion = 'completed' | 'retired' | 'retry' | 'stale'
+
+export function createSafeAutoForkSyncAttemptKeys(
+  identity: SafeAutoForkSyncAttemptIdentity
+): SafeAutoForkSyncAttemptKeys {
+  const operationKey = JSON.stringify([
+    identity.executionHostId,
+    identity.connectionId ?? '',
+    identity.repoId,
+    identity.repoPath
+  ])
+  return {
+    operationKey,
+    cooldownKey: JSON.stringify([
+      operationKey,
+      identity.profileId ?? '',
+      identity.remoteCanonicalKey ?? '',
+      identity.upstreamOwner.trim().toLowerCase(),
+      identity.upstreamRepo.trim().toLowerCase()
+    ])
+  }
+}
+
+export class SafeAutoForkSyncAttemptRegistry {
+  private readonly inFlight = new Map<string, InFlightAttempt>()
+  private readonly completed = new Map<string, CompletedAttempt>()
+  private readonly completedKeysByOperation = new Map<string, Set<string>>()
+  private liveCooldownKeys = new Set<string>()
+  private readonly nonLiveCompletedKeys = new Set<string>()
+
+  public constructor(
+    private readonly cooldownMs = SAFE_AUTO_FORK_SYNC_COOLDOWN_MS,
+    private readonly maxCompletedEntries = SAFE_AUTO_FORK_SYNC_COMPLETED_MAX_ENTRIES
+  ) {}
+
+  public prune(now: number, liveCooldownKeys: Iterable<string> = []): void {
+    this.liveCooldownKeys = new Set(liveCooldownKeys)
+    this.nonLiveCompletedKeys.clear()
+    for (const key of this.completed.keys()) {
+      if (!this.liveCooldownKeys.has(key)) {
+        this.nonLiveCompletedKeys.add(key)
+      }
+    }
+    for (const [key, attempt] of this.completed) {
+      if (now - attempt.attemptedAt >= this.cooldownMs) {
+        this.deleteCompleted(key)
+      }
+    }
+    this.evictCompletedOverflow()
+  }
+
+  public canStart(operationKey: string, cooldownKey: string, now: number): boolean {
+    const current = this.inFlight.get(operationKey)
+    if (current) {
+      if (current.retired || current.cooldownKey !== cooldownKey) {
+        current.retryRequested = true
+      }
+      return false
+    }
+    const completed = this.completed.get(cooldownKey)
+    return completed === undefined || now - completed.attemptedAt >= this.cooldownMs
+  }
+
+  public start(
+    operationKey: string,
+    cooldownKey: string,
+    attemptedAt: number,
+    promise: Promise<void>
+  ): void {
+    this.deleteCompleted(cooldownKey)
+    this.inFlight.set(operationKey, {
+      cooldownKey,
+      attemptedAt,
+      promise,
+      retired: false,
+      retryRequested: false
+    })
+  }
+
+  public complete(operationKey: string, promise: Promise<void>): SafeAutoForkSyncCompletion {
+    const current = this.inFlight.get(operationKey)
+    if (current?.promise !== promise) {
+      return 'stale'
+    }
+    this.inFlight.delete(operationKey)
+    if (current.retired) {
+      return current.retryRequested ? 'retry' : 'retired'
+    }
+    this.rememberCompleted(operationKey, current.cooldownKey, current.attemptedAt)
+    this.evictCompletedOverflow()
+    return current.retryRequested ? 'retry' : 'completed'
+  }
+
+  public retire(operationKey: string): boolean {
+    let retired = false
+    const current = this.inFlight.get(operationKey)
+    if (current) {
+      current.retired = true
+      current.retryRequested = false
+      retired = true
+    }
+    for (const cooldownKey of this.completedKeysByOperation.get(operationKey) ?? []) {
+      this.deleteCompleted(cooldownKey)
+      retired = true
+    }
+    return retired
+  }
+
+  public hasInFlight(operationKey: string): boolean {
+    return this.inFlight.has(operationKey)
+  }
+
+  public hasCompleted(cooldownKey: string): boolean {
+    return this.completed.has(cooldownKey)
+  }
+
+  public get inFlightCount(): number {
+    return this.inFlight.size
+  }
+
+  public get completedCount(): number {
+    return this.completed.size
+  }
+
+  public get nonLiveHistoryCount(): number {
+    return this.nonLiveCompletedKeys.size
+  }
+
+  private rememberCompleted(operationKey: string, cooldownKey: string, attemptedAt: number): void {
+    this.deleteCompleted(cooldownKey)
+    this.completed.set(cooldownKey, { operationKey, attemptedAt })
+    if (!this.liveCooldownKeys.has(cooldownKey)) {
+      this.nonLiveCompletedKeys.add(cooldownKey)
+    }
+    const keys = this.completedKeysByOperation.get(operationKey) ?? new Set<string>()
+    keys.add(cooldownKey)
+    this.completedKeysByOperation.set(operationKey, keys)
+  }
+
+  private deleteCompleted(cooldownKey: string): boolean {
+    const completed = this.completed.get(cooldownKey)
+    if (!completed) {
+      return false
+    }
+    this.completed.delete(cooldownKey)
+    this.nonLiveCompletedKeys.delete(cooldownKey)
+    const keys = this.completedKeysByOperation.get(completed.operationKey)
+    keys?.delete(cooldownKey)
+    if (keys?.size === 0) {
+      this.completedKeysByOperation.delete(completed.operationKey)
+    }
+    return true
+  }
+
+  private evictCompletedOverflow(): void {
+    while (this.nonLiveCompletedKeys.size > this.maxCompletedEntries) {
+      const oldestKey = this.nonLiveCompletedKeys.values().next().value
+      if (oldestKey === undefined) {
+        return
+      }
+      this.deleteCompleted(oldestKey)
+    }
+  }
+}
+
+const registriesByStoreOwner = new WeakMap<object, SafeAutoForkSyncAttemptRegistry>()
+
+export function getSafeAutoForkSyncAttemptRegistry(
+  storeOwner: object
+): SafeAutoForkSyncAttemptRegistry {
+  let registry = registriesByStoreOwner.get(storeOwner)
+  if (!registry) {
+    registry = new SafeAutoForkSyncAttemptRegistry()
+    registriesByStoreOwner.set(storeOwner, registry)
+  }
+  return registry
+}


### PR DESCRIPTION
## Description

Fixes two related safe-auto fork-sync bugs in long-lived renderer sessions:

- completed cooldown records could accumulate across removed or changed repositories;
- the old path-only cooldown could suppress a valid sync after profile, upstream, provider identity, or repo lifecycle changes.

The renderer now owns attempts per Zustand store, separates git-operation ownership from cooldown identity, retires removed lifecycles, queues changed identities behind an existing git operation, and bounds non-live history without evicting live-repo cooldowns.

## Evidence

### Reproduction before the fix

On current `main`, a focused regression reproduced stale suppression:

1. Fetch a safe-auto fork whose expected upstream owner is A.
2. Change the fetched repo metadata to expected upstream owner B inside the 10-minute cooldown.
3. Fetch again.

Expected: two calls to `syncRuntimeGitForkDefaultBranch`, one for each upstream identity.

Actual before fix: one call. The path-only cooldown incorrectly treated B as the already-attempted A identity.

The original implementation also retained completed entries indefinitely when repositories were removed or their host/id/path identity churned.

### Proof after the fix

New regression coverage proves:

- upstream, profile/auth, provider canonical identity, repo, path, local/SSH/runtime host, and connection boundaries;
- same-target dedupe and changed-target queueing without concurrent git mutations;
- exact-promise settlement, including stale/late completion;
- removal/re-add, removal while in flight, upstream metadata cleared before removal, older profile cooldown retirement, and cleanup failure after authoritative backend deletion;
- stale catalog results captured before removal cannot resurrect a repo, while a fresh post-removal catalog can re-add it;
- 10,000 non-live completed attempts are bounded to 2,048 history entries;
- more than 2,048 currently live repo cooldowns are preserved and do not resync early;
- SSH/HTTPS canonical equivalence while keeping enterprise hosts distinct.

Verification on pushed SHA `26d0fa7666d4a7e2930513339abd3f399bc59eb9`:

- affected surface: 9 test files / 69 tests passed;
- new registry + lifecycle suites: 24 tests passed;
- `pnpm typecheck:web`;
- changed-file `oxlint` and `oxfmt --check`;
- `pnpm check:max-lines-ratchet`;
- `git diff --check`;
- full Vitest run: 28,331 passed, 42 skipped, with one unrelated terminal timing test failure; that exact test passed immediately in isolation.

The existing local, SSH relay, and runtime fork-sync paths retain their 60-second timeout containment. No git command, dependency, workflow, build script, or provider API changed.

## ELI5

Orca keeps a short-lived note saying, “I already tried syncing this fork.” Previously, those notes could pile up forever, and a note for one upstream account could accidentally block a different upstream account.

Now each note has the right repo/account/host identity, old removed-repo notes are retired, live work is never duplicated, and obsolete history is capped.

## Trade-offs / behavior impact

No normal end-user regression is expected.

- Memory is honestly bounded as **O(current live safe-auto repos) + at most 2,048 non-live completed history entries + in-flight operations**. Live cooldowns are intentionally protected from eviction so large catalogs do not create repeated git/network storms.
- Failed automatic attempts keep the existing 10-minute cooldown. This avoids repeated auth/network churn, but automatic recovery can wait up to 10 minutes; manual **Sync Now** still bypasses this cache.
- A catalog response started before a successful removal is discarded. A later fresh fetch can re-add a genuinely restored repo; at worst, that host waits for the next refresh instead of replaying deleted state.
- Residual pre-existing gap: persisted `gitRemoteIdentity` identifies the provider/upstream repository and is not a freshly-read actual `origin` URL. If a user repoints `origin` to another fork inside the 10-minute cooldown while path/profile/upstream stay unchanged, automatic sync may wait for cooldown expiry. Manual **Sync Now** remains available.
- Inherent risk is moderate because this changes renderer-global async git-attempt ownership. Residual risk is low-to-moderate after race, routing, scale, rejection, and late-settlement coverage.