### PR TITLE
fix: recover local terminal spawn from stale cwd

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -140,12 +140,12 @@
         "ssh",
         "remote-runtime"
       ],
-      "coverageNotes": "Local macOS evidence covers the shared cwd policy, main pty:spawn local fallback and strict SSH/session rejection, renderer IPC flag routing, and remote-runtime omission. Daemon shares the same pre-provider main cwd decision but lacks a live daemon-provider run; WSL path identity and mobile/API strictness remain gaps.",
+      "coverageNotes": "Local macOS evidence covers the shared cwd policy, main pty:spawn local fallback and strict SSH/session rejection, renderer IPC flag routing, metadata handoff, visible terminal notice, and remote-runtime omission. Daemon shares the same pre-provider main cwd decision but lacks a live daemon-provider run; WSL path identity and mobile/API strictness remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/7239"
       ],
-      "invariant": "A fresh local renderer terminal spawn may recover from a stale startup cwd outside the selected worktree only by spawning in that worktree root; remote, SSH, reattach, runtime, mobile, and API callers must not silently weaken cwd containment.",
-      "oracle": "The shared resolver returns the selected worktree root only when the explicit fallback policy is set, otherwise it rejects outside cwd values. The renderer sends cwdFallback only for fresh local IPC spawns, main honors it only when connectionId and sessionId are absent, and remote-runtime transport options omit the fallback.",
+      "invariant": "A fresh local renderer terminal spawn may recover from a stale startup cwd outside the selected worktree only by spawning in that worktree root and printing a generic in-terminal notice; remote, SSH, reattach, runtime, mobile, and API callers must not silently weaken cwd containment.",
+      "oracle": "The shared resolver returns the selected worktree root only when the explicit fallback policy is set, otherwise it rejects outside cwd values. The renderer sends cwdFallback only for fresh local IPC spawns, main honors it only when connectionId and sessionId are absent, main returns fallback metadata only after an actual fallback, IPC transport preserves that metadata, the connection layer writes a generic terminal notice without the rejected cwd, and remote-runtime transport options omit the fallback.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts",
@@ -163,6 +163,7 @@
           "file": "src/shared/terminal-startup-cwd.test.ts",
           "assertions": [
             "outside requested cwd values still throw by default",
+            "the explicit fallback callback fires only when an outside cwd is recovered",
             "explicit fallback returns the worktree root for stale absolute, non-ASCII, folder workspace, and canonical symlink-escape cwd values",
             "valid nested cwd values are preserved when fallback is enabled"
           ]
@@ -171,6 +172,7 @@
           "file": "src/main/ipc/pty.test.ts",
           "assertions": [
             "local renderer pty:spawn with cwdFallback worktree spawns in the selected worktree root",
+            "local fallback spawn responses include worktree fallback metadata",
             "outside cwd values without the fallback flag still reject",
             "connectionId and sessionId keep the cwd guard strict even when the fallback flag is present"
           ]
@@ -179,6 +181,7 @@
           "file": "src/renderer/src/components/terminal-pane/pty-transport.test.ts",
           "assertions": [
             "IPC transport sends cwdFallback only for local fresh spawns",
+            "IPC transport returns startup cwd fallback metadata to the connection layer",
             "SSH-tagged and session reattach spawns omit cwdFallback"
           ]
         },
@@ -186,6 +189,7 @@
           "file": "src/renderer/src/components/terminal-pane/pty-connection.test.ts",
           "assertions": [
             "fresh local IPC worktree spawns are marked with cwdFallback worktree",
+            "local startup cwd fallback metadata prints a generic in-terminal notice",
             "remote-runtime worktree spawns are not marked with cwdFallback"
           ]
         }
@@ -207,7 +211,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts",
           "result": "passed",
           "durationSeconds": 0.9,
-          "summary": "1 test file passed, 221 tests passed; covers main pty:spawn fallback and strict no-flag, SSH, and reattach rejection."
+          "summary": "1 test file passed, 221 tests passed; covers main pty:spawn fallback metadata and strict no-flag, SSH, and reattach rejection."
         },
         {
           "date": "2026-07-07",
@@ -216,7 +220,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts",
           "result": "passed",
           "durationSeconds": 0.4,
-          "summary": "1 test file passed, 56 tests passed; covers IPC transport cwdFallback forwarding only for local fresh spawns."
+          "summary": "1 test file passed, 57 tests passed; covers IPC transport cwdFallback forwarding only for local fresh spawns and fallback metadata handoff."
         },
         {
           "date": "2026-07-07",
@@ -224,8 +228,8 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts",
           "result": "passed",
-          "durationSeconds": 6.1,
-          "summary": "1 test file passed, 334 tests passed; covers local IPC marking and remote-runtime omission."
+          "durationSeconds": 6.3,
+          "summary": "1 test file passed, 335 tests passed; covers local IPC marking, the generic terminal fallback notice, and remote-runtime omission."
         }
       ],
       "runtimeBudget": {
@@ -242,7 +246,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The runtime change adds only constant-time option checks and a single existing cwd resolution on spawn; it adds no polling, provider listing, hidden-pane work, startup awaits, subprocesses, or render-loop work."
+        "evidence": "The runtime change adds only constant-time option checks, a single existing cwd resolution on spawn, and one bounded foreground terminal write only when fallback actually occurs; it adds no polling, provider listing, hidden-pane work, startup awaits, subprocesses, or render-loop work."
       },
       "promotionCriteria": [
         "Attach CI evidence for all declared test files.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -106,6 +106,157 @@
       "demotionRule": "Demote or quarantine if the gate flakes once without a product bug or harness bug filed to the owner."
     },
     {
+      "id": "terminal-session.startup-cwd-containment",
+      "title": "Fresh local terminal creation cannot be bricked by stale startup cwd",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "shared-main-renderer-contract",
+      "surfaces": [
+        "terminal lifecycle",
+        "tab creation",
+        "PTY spawn",
+        "startup cwd persistence",
+        "SSH and remote-runtime routing"
+      ],
+      "platforms": [
+        "macos",
+        "linux",
+        "windows"
+      ],
+      "providers": [
+        "local",
+        "daemon",
+        "ssh",
+        "wsl",
+        "remote-runtime",
+        "mobile"
+      ],
+      "coveredPlatforms": [
+        "macos"
+      ],
+      "coveredProviders": [
+        "local",
+        "ssh",
+        "remote-runtime"
+      ],
+      "coverageNotes": "Local macOS evidence covers the shared cwd policy, main pty:spawn local fallback and strict SSH/session rejection, renderer IPC flag routing, and remote-runtime omission. Daemon shares the same pre-provider main cwd decision but lacks a live daemon-provider run; WSL path identity and mobile/API strictness remain gaps.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/7239"
+      ],
+      "invariant": "A fresh local renderer terminal spawn may recover from a stale startup cwd outside the selected worktree only by spawning in that worktree root; remote, SSH, reattach, runtime, mobile, and API callers must not silently weaken cwd containment.",
+      "oracle": "The shared resolver returns the selected worktree root only when the explicit fallback policy is set, otherwise it rejects outside cwd values. The renderer sends cwdFallback only for fresh local IPC spawns, main honors it only when connectionId and sessionId are absent, and remote-runtime transport options omit the fallback.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts"
+      ],
+      "testFiles": [
+        "src/shared/terminal-startup-cwd.test.ts",
+        "src/main/ipc/pty.test.ts",
+        "src/renderer/src/components/terminal-pane/pty-transport.test.ts",
+        "src/renderer/src/components/terminal-pane/pty-connection.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/shared/terminal-startup-cwd.test.ts",
+          "assertions": [
+            "outside requested cwd values still throw by default",
+            "explicit fallback returns the worktree root for stale absolute, non-ASCII, folder workspace, and canonical symlink-escape cwd values",
+            "valid nested cwd values are preserved when fallback is enabled"
+          ]
+        },
+        {
+          "file": "src/main/ipc/pty.test.ts",
+          "assertions": [
+            "local renderer pty:spawn with cwdFallback worktree spawns in the selected worktree root",
+            "outside cwd values without the fallback flag still reject",
+            "connectionId and sessionId keep the cwd guard strict even when the fallback flag is present"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal-pane/pty-transport.test.ts",
+          "assertions": [
+            "IPC transport sends cwdFallback only for local fresh spawns",
+            "SSH-tagged and session reattach spawns omit cwdFallback"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal-pane/pty-connection.test.ts",
+          "assertions": [
+            "fresh local IPC worktree spawns are marked with cwdFallback worktree",
+            "remote-runtime worktree spawns are not marked with cwdFallback"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.2,
+          "summary": "1 test file passed, 19 tests passed; red repro failed before the fallback policy was implemented."
+        },
+        {
+          "date": "2026-07-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.9,
+          "summary": "1 test file passed, 221 tests passed; covers main pty:spawn fallback and strict no-flag, SSH, and reattach rejection."
+        },
+        {
+          "date": "2026-07-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.4,
+          "summary": "1 test file passed, 56 tests passed; covers IPC transport cwdFallback forwarding only for local fresh spawns."
+        },
+        {
+          "date": "2026-07-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts",
+          "result": "passed",
+          "durationSeconds": 6.1,
+          "summary": "1 test file passed, 334 tests passed; covers local IPC marking and remote-runtime omission."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "focused unit and IPC contract tests"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "New experimental gate added with local deterministic evidence only; needs CI soak before promotion."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The new shared and main IPC fallback tests failed with 'Terminal cwd must be inside the selected worktree.' before the fix and pass after it. Full live Electron reproduction from a production persisted session is not captured."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The runtime change adds only constant-time option checks and a single existing cwd resolution on spawn; it adds no polling, provider listing, hidden-pane work, startup awaits, subprocesses, or render-loop work."
+      },
+      "promotionCriteria": [
+        "Attach CI evidence for all declared test files.",
+        "Add a live Electron regression that opens a local terminal from a persisted stale startupCwd state and proves visible shell input/output in the worktree root.",
+        "Add WSL/mobile/API provider-contract coverage or explicitly narrow their risk scope."
+      ],
+      "knownGaps": [
+        "No live Electron fixture seeds the exact production persisted tab state from issue #7239.",
+        "Daemon coverage is via shared pre-provider main cwd routing, not a live daemon provider spawn.",
+        "WSL path identity, mobile/API strictness, Linux, and Windows are not directly exercised by this gate."
+      ],
+      "demotionRule": "Demote or quarantine if the gate flakes without a product bug or if a remote/session/API caller can silently fall back instead of rejecting an outside cwd."
+    },
+    {
       "id": "agent-session.provider-ownership",
       "title": "Provider sessions are resumed once per workspace ownership claim",
       "maturity": "experimental",

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -6164,6 +6164,71 @@ describe('registerPtyHandlers', () => {
     expect(options.cwd).toBe('/tmp/floating-notes')
   })
 
+  it('falls back to the worktree root for stale local renderer cwd values', async () => {
+    registerPtyHandlers(mainWindow as never)
+    const worktreePath = '/Users/motoki/orca/workspaces/nakamuramotoki/Fableと議論'
+
+    await handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+      cols: 80,
+      rows: 24,
+      cwd: '/var/tmp/orca-stale',
+      cwdFallback: 'worktree',
+      worktreeId: `repo-1::${worktreePath}`
+    })
+
+    const [, , options] = spawnMock.mock.calls.at(-1) as [string, string[], { cwd: string }]
+    expect(options.cwd).toBe(worktreePath)
+  })
+
+  it('rejects stale renderer cwd values without the fallback flag', async () => {
+    registerPtyHandlers(mainWindow as never)
+
+    await expect(
+      handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+        cols: 80,
+        rows: 24,
+        cwd: '/var/tmp/orca-stale',
+        worktreeId: 'repo-1::/repo/app'
+      })
+    ).rejects.toThrow('Terminal cwd must be inside the selected worktree.')
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps renderer PTY cwd strict when a connectionId is present', async () => {
+    registerPtyHandlers(mainWindow as never)
+
+    await expect(
+      handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+        cols: 80,
+        rows: 24,
+        cwd: '/var/tmp/orca-stale',
+        cwdFallback: 'worktree',
+        connectionId: 'ssh-1',
+        worktreeId: 'repo-1::/repo/app'
+      })
+    ).rejects.toThrow('Terminal cwd must be inside the selected worktree.')
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps renderer PTY cwd strict when a sessionId is present', async () => {
+    registerPtyHandlers(mainWindow as never)
+
+    await expect(
+      handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+        cols: 80,
+        rows: 24,
+        cwd: '/var/tmp/orca-stale',
+        cwdFallback: 'worktree',
+        sessionId: 'session-1',
+        worktreeId: 'repo-1::/repo/app'
+      })
+    ).rejects.toThrow('Terminal cwd must be inside the selected worktree.')
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
   it('rejects missing WSL worktree cwd instead of validating only the fallback Windows cwd', async () => {
     const originalPlatform = process.platform
     const originalUserProfile = process.env.USERPROFILE

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -6168,16 +6168,17 @@ describe('registerPtyHandlers', () => {
     registerPtyHandlers(mainWindow as never)
     const worktreePath = '/Users/motoki/orca/workspaces/nakamuramotoki/Fableと議論'
 
-    await handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+    const result = (await handlers.get('pty:spawn')!(mainWindowIpcEvent, {
       cols: 80,
       rows: 24,
       cwd: '/var/tmp/orca-stale',
       cwdFallback: 'worktree',
       worktreeId: `repo-1::${worktreePath}`
-    })
+    })) as { startupCwdFallback?: { kind: string; cwd: string } }
 
     const [, , options] = spawnMock.mock.calls.at(-1) as [string, string[], { cwd: string }]
     expect(options.cwd).toBe(worktreePath)
+    expect(result.startupCwdFallback).toEqual({ kind: 'worktree', cwd: worktreePath })
   })
 
   it('rejects stale renderer cwd values without the fallback flag', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2046,11 +2046,13 @@ export function registerPtyHandlers(
   const resolveGuardedPtySpawnCwd = (
     worktreeId: string | undefined,
     cwd: string | undefined,
-    connectionId?: string | null
+    connectionId?: string | null,
+    outsideWorktreeCwd?: 'throw' | 'fallback-to-worktree'
   ): string | undefined =>
     resolveTerminalStartupCwdForWorkspace({
       workspaceId: worktreeId,
       requestedCwd: cwd,
+      outsideWorktreeCwd,
       resolveFolderWorkspacePath: (folderWorkspaceId) =>
         store?.getFolderWorkspace(folderWorkspaceId)?.folderPath,
       // Why: realpath only makes sense on the local filesystem; SSH worktree
@@ -2637,6 +2639,7 @@ export function registerPtyHandlers(
         env?: Record<string, string>
         envToDelete?: string[]
         command?: string
+        cwdFallback?: 'worktree'
         commandDelivery?: 'renderer' | 'provider'
         launchConfig?: SleepingAgentLaunchConfig
         launchAgent?: TuiAgent
@@ -2677,7 +2680,16 @@ export function registerPtyHandlers(
         await startupPromise
       }
       await assertFolderWorkspacePtyPathUsable(args.worktreeId)
-      const cwd = resolveGuardedPtySpawnCwd(args.worktreeId, args.cwd, args.connectionId)
+      const outsideWorktreeCwd =
+        !args.connectionId && !args.sessionId && args.cwdFallback === 'worktree'
+          ? 'fallback-to-worktree'
+          : undefined
+      const cwd = resolveGuardedPtySpawnCwd(
+        args.worktreeId,
+        args.cwd,
+        args.connectionId,
+        outsideWorktreeCwd
+      )
       spawnTiming.mark('preflight')
       const provider = getProvider(args.connectionId)
       const isClaudeLaunch = !args.connectionId && isClaudeLaunchCommand(args.command)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2047,12 +2047,14 @@ export function registerPtyHandlers(
     worktreeId: string | undefined,
     cwd: string | undefined,
     connectionId?: string | null,
-    outsideWorktreeCwd?: 'throw' | 'fallback-to-worktree'
+    outsideWorktreeCwd?: 'throw' | 'fallback-to-worktree',
+    onOutsideWorktreeCwdFallback?: () => void
   ): string | undefined =>
     resolveTerminalStartupCwdForWorkspace({
       workspaceId: worktreeId,
       requestedCwd: cwd,
       outsideWorktreeCwd,
+      onOutsideWorktreeCwdFallback,
       resolveFolderWorkspacePath: (folderWorkspaceId) =>
         store?.getFolderWorkspace(folderWorkspaceId)?.folderPath,
       // Why: realpath only makes sense on the local filesystem; SSH worktree
@@ -2684,11 +2686,15 @@ export function registerPtyHandlers(
         !args.connectionId && !args.sessionId && args.cwdFallback === 'worktree'
           ? 'fallback-to-worktree'
           : undefined
+      let didFallbackToWorktreeCwd = false
       const cwd = resolveGuardedPtySpawnCwd(
         args.worktreeId,
         args.cwd,
         args.connectionId,
-        outsideWorktreeCwd
+        outsideWorktreeCwd,
+        () => {
+          didFallbackToWorktreeCwd = true
+        }
       )
       spawnTiming.mark('preflight')
       const provider = getProvider(args.connectionId)
@@ -3337,6 +3343,9 @@ export function registerPtyHandlers(
           ...result,
           ...(!result.isReattach && effectiveLaunchConfig
             ? { launchConfig: effectiveLaunchConfig }
+            : {}),
+          ...(didFallbackToWorktreeCwd && cwd
+            ? { startupCwdFallback: { kind: 'worktree' as const, cwd } }
             : {})
         }
         return resolvePaneSpawnReservation(reservationPaneKey, paneSpawnReservation, response)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1146,6 +1146,7 @@ export type PreloadApi = {
       replay?: string
       sessionExpired?: boolean
       coldRestore?: { scrollback: string; cwd: string }
+      startupCwdFallback?: { kind: 'worktree'; cwd: string }
     }>
     write: (id: string, data: string) => void
     writeAccepted: (id: string, data: string) => Promise<boolean>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1109,6 +1109,7 @@ export type PreloadApi = {
       cols: number
       rows: number
       cwd?: string
+      cwdFallback?: 'worktree'
       env?: Record<string, string>
       command?: string
       launchConfig?: SleepingAgentLaunchConfig

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -788,6 +788,7 @@ const api = {
       replay?: string
       sessionExpired?: boolean
       coldRestore?: { scrollback: string; cwd: string }
+      startupCwdFallback?: { kind: 'worktree'; cwd: string }
     }> => ipcRenderer.invoke('pty:spawn', opts),
 
     write: (id: string, data: string): void => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -752,6 +752,7 @@ const api = {
       cols: number
       rows: number
       cwd?: string
+      cwdFallback?: 'worktree'
       env?: Record<string, string>
       command?: string
       launchConfig?: SleepingAgentLaunchConfig

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -11582,6 +11582,7 @@ describe('connectPanePty', () => {
       'owner-runtime',
       expect.any(Object)
     )
+    expect(createdTransportOptions[0]?.cwdFallback).toBeUndefined()
     expect(transport.connect).toHaveBeenCalled()
   })
 
@@ -11619,6 +11620,7 @@ describe('connectPanePty', () => {
 
     expect(createRemoteRuntimePtyTransport).not.toHaveBeenCalled()
     expect(createIpcPtyTransport).toHaveBeenCalled()
+    expect(createdTransportOptions[0]?.cwdFallback).toBe('worktree')
     expect(transport.connect).toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -11624,6 +11624,31 @@ describe('connectPanePty', () => {
     expect(transport.connect).toHaveBeenCalled()
   })
 
+  it('prints a terminal notice when local startup cwd fallback happens', async () => {
+    const { connectPanePty, STARTUP_CWD_FALLBACK_NOTICE } = await import('./pty-connection')
+    const transport = createMockTransport('pty-fallback')
+    transport.connect.mockResolvedValueOnce({
+      id: 'pty-fallback',
+      startupCwdFallback: { kind: 'worktree', cwd: '/tmp/wt-1' }
+    })
+    transportFactoryQueue.push(transport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: null }]
+      }
+    } as StoreState
+
+    const pane = createPane(2)
+    const { writes } = captureCallbackTerminalWrites(pane)
+
+    connectPanePty(pane as never, createManager(2) as never, createDeps() as never)
+    await flushAsyncTicks()
+
+    expect(writes).toContain(STARTUP_CWD_FALLBACK_NOTICE)
+  })
+
   it('attaches restored remote PTYs for later split panes instead of spawning host tabs', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const existingTransport = createMockTransport('remote:env-1@@terminal-1')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2746,6 +2746,7 @@ export function connectPanePty(
     : undefined
   const transportOptions = {
     cwd: deps.cwd,
+    ...(runtimeEnvironmentId === null && !connectionId ? { cwdFallback: 'worktree' as const } : {}),
     env: paneEnv,
     command: shouldDeliverStartupViaTerminalPaste ? undefined : paneStartup?.command,
     startupCommandDelivery: shouldDeliverStartupViaTerminalPaste

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -188,6 +188,8 @@ const COMMAND_CODE_OUTPUT_DONE_SETTLE_MS = 1500
 const SSH_SHELL_READY_STARTUP_FALLBACK_MS = 1500
 const MANUAL_AGENT_COMMAND_MAX_CHARS = 4096
 const STARTUP_DRAFT_PASTE_QUIET_MS = 1500
+export const STARTUP_CWD_FALLBACK_NOTICE =
+  '\r\n[Orca opened this terminal at the worktree root because the remembered startup directory was outside this workspace.]\r\n'
 const STARTUP_DRAFT_PASTE_TIMEOUT_MS = 8000
 const HIDDEN_OUTPUT_RESTORE_SCROLLBACK_ROWS = 5000
 const HIDDEN_OUTPUT_RESTORE_PENDING_CHARS = 512 * 1024
@@ -3763,6 +3765,15 @@ export function connectPanePty(
             })
           }
           if (resolvedPtyId) {
+            if (
+              spawnedPtyId &&
+              typeof spawnedPtyId === 'object' &&
+              spawnedPtyId.startupCwdFallback?.kind === 'worktree'
+            ) {
+              writeTerminalOutput(pane.terminal, STARTUP_CWD_FALLBACK_NOTICE, {
+                foreground: true
+              })
+            }
             if (coldRestoreOverride?.hasSleepingRecord) {
               showSessionRestoredBanner()
             }

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -32,6 +32,7 @@ export type PtyConnectResult = {
   sessionExpired?: boolean
   coldRestore?: { scrollback: string; cwd: string }
   replay?: string
+  startupCwdFallback?: { kind: 'worktree'; cwd: string }
 }
 
 type PtyCallbacks = {

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -85,6 +85,7 @@ export type PtyTransport = {
 
 export type IpcPtyTransportOptions = {
   cwd?: string
+  cwdFallback?: 'worktree'
   env?: Record<string, string>
   command?: string
   launchConfig?: SleepingAgentLaunchConfig

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -163,6 +163,39 @@ describe('createIpcPtyTransport', () => {
     expect(sshTransport.getLocalSessionMetadata?.()).toBeNull()
   })
 
+  it('sends the local startup cwd fallback flag only for local IPC spawns', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+
+    const transport = createIpcPtyTransport({ cwdFallback: 'worktree' })
+    await transport.connect({ url: '', callbacks: {} })
+
+    expect(spawn).toHaveBeenCalledWith(expect.objectContaining({ cwdFallback: 'worktree' }))
+    transport.disconnect()
+  })
+
+  it('omits the startup cwd fallback flag when the IPC transport is SSH-tagged', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+
+    const transport = createIpcPtyTransport({ connectionId: 'ssh-1', cwdFallback: 'worktree' })
+    await transport.connect({ url: '', callbacks: {} })
+
+    expect(spawn).toHaveBeenCalledWith(expect.not.objectContaining({ cwdFallback: 'worktree' }))
+    transport.disconnect()
+  })
+
+  it('omits the startup cwd fallback flag for session reattach spawns', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+
+    const transport = createIpcPtyTransport({ cwdFallback: 'worktree' })
+    await transport.connect({ url: '', callbacks: {}, sessionId: 'session-1' })
+
+    expect(spawn).toHaveBeenCalledWith(expect.not.objectContaining({ cwdFallback: 'worktree' }))
+    transport.disconnect()
+  })
+
   it('defers title side effects until after terminal data is delivered', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const onTitleChange = vi.fn()

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -196,6 +196,23 @@ describe('createIpcPtyTransport', () => {
     transport.disconnect()
   })
 
+  it('returns startup cwd fallback metadata to the connection layer', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+    spawn.mockResolvedValueOnce({
+      id: 'pty-1',
+      startupCwdFallback: { kind: 'worktree', cwd: '/repo/app' }
+    })
+
+    const transport = createIpcPtyTransport({ cwdFallback: 'worktree' })
+
+    await expect(transport.connect({ url: '', callbacks: {} })).resolves.toEqual({
+      id: 'pty-1',
+      startupCwdFallback: { kind: 'worktree', cwd: '/repo/app' }
+    })
+    transport.disconnect()
+  })
+
   it('defers title side effects until after terminal data is delivered', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const onTitleChange = vi.fn()

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -439,6 +439,7 @@ export function createPtyOutputProcessor({
 export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTransport {
   const {
     cwd,
+    cwdFallback,
     env,
     command,
     launchConfig,
@@ -606,10 +607,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       }
 
       try {
+        const shouldSendLocalCwdFallback =
+          cwdFallback === 'worktree' && !connectionId && !options.sessionId
         const result = await window.api.pty.spawn({
           cols: options.cols ?? 80,
           rows: options.rows ?? 24,
           cwd,
+          ...(shouldSendLocalCwdFallback ? { cwdFallback } : {}),
           env: options.env ?? env,
           command: options.command ?? command,
           ...((options.launchConfig ?? launchConfig)

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -678,10 +678,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
             replay: spawnResult.replay
           } satisfies PtyConnectResult
         }
-        if (spawnResult.launchConfig) {
+        if (spawnResult.launchConfig || spawnResult.startupCwdFallback) {
           return {
             id: spawnResult.id,
-            launchConfig: spawnResult.launchConfig
+            ...(spawnResult.launchConfig ? { launchConfig: spawnResult.launchConfig } : {}),
+            ...(spawnResult.startupCwdFallback
+              ? { startupCwdFallback: spawnResult.startupCwdFallback }
+              : {})
           } satisfies PtyConnectResult
         }
         return spawnResult.id

--- a/src/shared/terminal-startup-cwd.test.ts
+++ b/src/shared/terminal-startup-cwd.test.ts
@@ -29,6 +29,33 @@ describe('resolveTerminalStartupCwd', () => {
     )
   })
 
+  it('falls back to the worktree root for an outside cwd when requested', () => {
+    expect(
+      resolveTerminalStartupCwd('/repo/app', '/var/tmp/orca-stale', {
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app')
+  })
+
+  it('falls back to a non-ASCII worktree root for an outside cwd when requested', () => {
+    // Why: issue #7239 reproduced in a Japanese-named worktree; fallback must
+    // preserve the selected worktree path verbatim.
+    const worktreePath = '/Users/motoki/orca/workspaces/nakamuramotoki/Fableと議論'
+    expect(
+      resolveTerminalStartupCwd(worktreePath, '/var/tmp/orca-stale', {
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe(worktreePath)
+  })
+
+  it('keeps nested cwd resolution unchanged with fallback enabled', () => {
+    expect(
+      resolveTerminalStartupCwd('/repo/app', '/repo/app/packages/web', {
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app/packages/web')
+  })
+
   it('trims whitespace-padded requested cwds before resolving', () => {
     expect(resolveTerminalStartupCwd('/repo/app', ' packages/web ')).toBe('/repo/app/packages/web')
   })
@@ -39,6 +66,17 @@ describe('resolveTerminalStartupCwd', () => {
     expect(
       resolveTerminalStartupCwd('/repo/app', 'link', { canonicalizePath: canonicalize })
     ).toBeUndefined()
+  })
+
+  it('falls back to the worktree root when a symlink escapes and fallback is requested', () => {
+    const canonicalize = (path: string): string | null =>
+      path === '/repo/app/link' ? '/outside/target' : path
+    expect(
+      resolveTerminalStartupCwd('/repo/app', 'link', {
+        canonicalizePath: canonicalize,
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app')
   })
 
   it('accepts cwds under a symlinked worktree root', () => {
@@ -76,6 +114,16 @@ describe('resolveTerminalStartupCwd', () => {
         requestedCwd: '/repo/app-other'
       })
     ).toThrow('Terminal cwd must be inside the selected worktree.')
+  })
+
+  it('falls back to the raw worktree root for stale renderer cwd values', () => {
+    expect(
+      resolveTerminalStartupCwdForWorkspace({
+        workspaceId: 'repo-1::/repo/app',
+        requestedCwd: '/var/tmp/orca-stale',
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app')
   })
 
   it('passes floating terminal cwds through untouched', () => {
@@ -119,5 +167,16 @@ describe('resolveTerminalStartupCwd', () => {
         resolveFolderWorkspacePath: (id) => (id === 'folder-1' ? '/repo/app' : null)
       })
     ).toThrow('Terminal cwd must be inside the selected worktree.')
+  })
+
+  it('falls back to a resolved folder workspace root for stale cwd values', () => {
+    expect(
+      resolveTerminalStartupCwdForWorkspace({
+        workspaceId: folderWorkspaceKey('folder-1'),
+        requestedCwd: '../other',
+        resolveFolderWorkspacePath: (id) => (id === 'folder-1' ? '/repo/app' : null),
+        outsideWorktreeCwd: 'fallback-to-worktree'
+      })
+    ).toBe('/repo/app')
   })
 })

--- a/src/shared/terminal-startup-cwd.test.ts
+++ b/src/shared/terminal-startup-cwd.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { FLOATING_TERMINAL_WORKTREE_ID } from './constants'
 import {
   resolveTerminalStartupCwd,
@@ -30,11 +30,14 @@ describe('resolveTerminalStartupCwd', () => {
   })
 
   it('falls back to the worktree root for an outside cwd when requested', () => {
+    const onOutsideWorktreeCwdFallback = vi.fn()
     expect(
       resolveTerminalStartupCwd('/repo/app', '/var/tmp/orca-stale', {
-        outsideWorktreeCwd: 'fallback-to-worktree'
+        outsideWorktreeCwd: 'fallback-to-worktree',
+        onOutsideWorktreeCwdFallback
       })
     ).toBe('/repo/app')
+    expect(onOutsideWorktreeCwdFallback).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to a non-ASCII worktree root for an outside cwd when requested', () => {
@@ -49,11 +52,14 @@ describe('resolveTerminalStartupCwd', () => {
   })
 
   it('keeps nested cwd resolution unchanged with fallback enabled', () => {
+    const onOutsideWorktreeCwdFallback = vi.fn()
     expect(
       resolveTerminalStartupCwd('/repo/app', '/repo/app/packages/web', {
-        outsideWorktreeCwd: 'fallback-to-worktree'
+        outsideWorktreeCwd: 'fallback-to-worktree',
+        onOutsideWorktreeCwdFallback
       })
     ).toBe('/repo/app/packages/web')
+    expect(onOutsideWorktreeCwdFallback).not.toHaveBeenCalled()
   })
 
   it('trims whitespace-padded requested cwds before resolving', () => {

--- a/src/shared/terminal-startup-cwd.ts
+++ b/src/shared/terminal-startup-cwd.ts
@@ -5,6 +5,7 @@ import { splitWorktreeIdForFilesystem } from './worktree-id'
 
 export type TerminalStartupCwdOptions = {
   outsideWorktreeCwd?: 'throw' | 'fallback-to-worktree'
+  onOutsideWorktreeCwdFallback?: () => void
   // Why: the string containment check can't see symlinks; only local callers
   // can canonicalize — SSH worktree paths live on the remote host.
   canonicalizePath?: (path: string) => string | null
@@ -22,6 +23,7 @@ export function resolveTerminalStartupCwd(
   const resolvedCwd = resolveRuntimePath(worktreePath, trimmedCwd)
   if (!isPathInsideOrEqual(worktreePath, resolvedCwd)) {
     if (options?.outsideWorktreeCwd === 'fallback-to-worktree') {
+      options.onOutsideWorktreeCwdFallback?.()
       return worktreePath
     }
     // Why: remote/session clients can request terminal cwd; never let that
@@ -38,6 +40,7 @@ export function resolveTerminalStartupCwd(
       !isPathInsideOrEqual(canonicalWorktreePath, canonicalCwd)
     ) {
       if (options.outsideWorktreeCwd === 'fallback-to-worktree') {
+        options.onOutsideWorktreeCwdFallback?.()
         return worktreePath
       }
       // Why: a symlink escaping the worktree can be legitimate (e.g. a pnpm
@@ -54,6 +57,7 @@ export function resolveTerminalStartupCwdForWorkspace(args: {
   requestedCwd?: string | null
   resolveFolderWorkspacePath?: (folderWorkspaceId: string) => string | null | undefined
   outsideWorktreeCwd?: TerminalStartupCwdOptions['outsideWorktreeCwd']
+  onOutsideWorktreeCwdFallback?: TerminalStartupCwdOptions['onOutsideWorktreeCwdFallback']
   canonicalizePath?: (path: string) => string | null
 }): string | undefined {
   if (!args.requestedCwd || args.requestedCwd.trim().length === 0) {
@@ -77,6 +81,7 @@ export function resolveTerminalStartupCwdForWorkspace(args: {
   }
   return resolveTerminalStartupCwd(workspacePath, args.requestedCwd, {
     outsideWorktreeCwd: args.outsideWorktreeCwd,
+    onOutsideWorktreeCwdFallback: args.onOutsideWorktreeCwdFallback,
     canonicalizePath: args.canonicalizePath
   })
 }

--- a/src/shared/terminal-startup-cwd.ts
+++ b/src/shared/terminal-startup-cwd.ts
@@ -4,6 +4,7 @@ import { parseWorkspaceKey } from './workspace-scope'
 import { splitWorktreeIdForFilesystem } from './worktree-id'
 
 export type TerminalStartupCwdOptions = {
+  outsideWorktreeCwd?: 'throw' | 'fallback-to-worktree'
   // Why: the string containment check can't see symlinks; only local callers
   // can canonicalize — SSH worktree paths live on the remote host.
   canonicalizePath?: (path: string) => string | null
@@ -20,6 +21,9 @@ export function resolveTerminalStartupCwd(
   }
   const resolvedCwd = resolveRuntimePath(worktreePath, trimmedCwd)
   if (!isPathInsideOrEqual(worktreePath, resolvedCwd)) {
+    if (options?.outsideWorktreeCwd === 'fallback-to-worktree') {
+      return worktreePath
+    }
     // Why: remote/session clients can request terminal cwd; never let that
     // become a shell outside the selected workspace.
     throw new Error('Terminal cwd must be inside the selected worktree.')
@@ -33,6 +37,9 @@ export function resolveTerminalStartupCwd(
       canonicalCwd &&
       !isPathInsideOrEqual(canonicalWorktreePath, canonicalCwd)
     ) {
+      if (options.outsideWorktreeCwd === 'fallback-to-worktree') {
+        return worktreePath
+      }
       // Why: a symlink escaping the worktree can be legitimate (e.g. a pnpm
       // store link), so fall back to the default cwd instead of failing the
       // spawn — but never grant the requested out-of-worktree shell.
@@ -46,6 +53,7 @@ export function resolveTerminalStartupCwdForWorkspace(args: {
   workspaceId?: string
   requestedCwd?: string | null
   resolveFolderWorkspacePath?: (folderWorkspaceId: string) => string | null | undefined
+  outsideWorktreeCwd?: TerminalStartupCwdOptions['outsideWorktreeCwd']
   canonicalizePath?: (path: string) => string | null
 }): string | undefined {
   if (!args.requestedCwd || args.requestedCwd.trim().length === 0) {
@@ -68,6 +76,7 @@ export function resolveTerminalStartupCwdForWorkspace(args: {
     return undefined
   }
   return resolveTerminalStartupCwd(workspacePath, args.requestedCwd, {
+    outsideWorktreeCwd: args.outsideWorktreeCwd,
     canonicalizePath: args.canonicalizePath
   })
 }


### PR DESCRIPTION
## Summary

- Recover fresh local UI terminal creation when a persisted/inherited `startupCwd` is stale or outside the selected worktree by falling back to that worktree root.
- Print a generic in-terminal notice when that fallback happens, without exposing the rejected/stale cwd path.
- Keep the cwd containment guard strict by default: SSH, remote-runtime, session reattach, runtime/API, mobile, and no-flag callers still reject outside cwd values.
- Add the experimental `terminal-session.startup-cwd-containment` reliability gate with shared, main IPC, renderer transport, connection-layer, and notice coverage.

Closes #7239.
Refs community PR #7297; I reproduced independently first, then adapted the same local-only fallback idea to the current branch and added issue-shaped non-ASCII path coverage plus the reliability gate.

## Repro Evidence

Red before the fix:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts -t "falls back"` failed with `Terminal cwd must be inside the selected worktree.` for stale outside cwd fallback cases.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts -t "falls back to the worktree root for stale local renderer cwd values"` failed with the same error in the actual `pty:spawn` path.

That reproduces the issue shape: a local renderer-backed new terminal sends `worktreeId` plus a stale outside `cwd`; main rejects before provider spawn, which is what produces the persistent terminal error toast.

## ELI5

Orca remembered a folder to start the next terminal in. In the bad state, that remembered folder was no longer inside the workspace, so the terminal guard stopped every new terminal from opening. Now, for a normal local "new terminal" click, Orca says: "that remembered folder is stale, so start at the workspace root instead," and it prints a short note in that terminal so the recovery is visible. It still refuses unsafe cwd requests from remote/session/API paths.

## Tradeoffs

- A stale local UI cwd now opens at the worktree root instead of the user's previously intended subfolder. That is less precise, but it restores terminal creation without allowing a shell outside the selected workspace.
- The fallback is explicit and fresh-local-only. This avoids weakening SSH, remote runtime, mobile/API, and session reattach containment where silently remapping cwd could hide a real caller bug or provider mismatch.
- The visible notice deliberately does not include the rejected cwd. Full paths can contain private repo/user names, so the terminal message says what happened without printing the stale path.
- No live Electron fixture seeds the exact production persisted session from #7239 yet; the gate records that as a promotion gap.

## Reliability Proof

**Reliability invariant:** `terminal-session.startup-cwd-containment` for #7239. A fresh local renderer terminal spawn may recover from a stale outside cwd only by spawning in the selected worktree root and printing a generic in-terminal notice; remote, SSH, reattach, runtime, mobile, and API callers must not silently weaken cwd containment.

**Material impact:** This turns the persistent "new terminal never opens" failure into a recoverable local UI spawn while preserving the safety guard that prevents shells from starting outside the selected worktree. The recovery is no longer silent because the affected terminal shows a scoped note.

**Product change type:** mixed runtime hardening + reliability gate/test coverage.

**Performance risk inventory:** touches terminal creation, `pty:spawn` preflight, startup cwd resolution, renderer transport option routing, and one terminal foreground write after a successful fallback. It does not touch typing, output delivery, focus loops, resize, render scheduling, provider listing, hidden-pane wakeups, git/worktree scans, or subprocess creation.

**No-regression evidence:** The runtime path adds constant-time option checks, uses the existing single cwd resolver during spawn, and performs one bounded terminal write only when fallback actually occurs. No polling, fanout, provider list, renderer loop, startup await, or subprocess work was added.

**Correctness evidence:**

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-startup-cwd.test.ts` passed: 19 tests.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts` passed: 221 tests.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts` passed: 57 tests.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` passed: 335 tests.
- `pnpm run typecheck` passed.
- `pnpm run check:reliability-gates` passed.
- `pnpm run check:max-lines-ratchet` passed.
- `pnpm exec oxlint <changed TS files>` passed.
- `git diff --check` passed.

**Provider/platform coverage:** local macOS covered, including a Japanese/non-ASCII worktree-root test matching #7239. SSH strictness is covered via `connectionId`; remote-runtime omission is covered in the connection tests. Daemon shares the same pre-provider main cwd decision but does not have a live daemon spawn run here. WSL/mobile/API and Linux/Windows live behavior are recorded as gate gaps.

**Residual gaps:** no live Electron persisted-session fixture for the exact production state; no live daemon-provider run; no direct WSL/mobile/API provider-contract run.

**Promotion status:** partial experimental gate. It should not be promoted until CI/soak evidence, live Electron reproduction, and the provider/platform gaps above are addressed.

**Rollback or demotion rule:** demote/quarantine if the gate flakes without a product bug, or if any remote/session/API path can silently fall back instead of rejecting an outside cwd.

## Additional Validation Notes

`pnpm run lint` was attempted and failed in unrelated existing code: `src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts:164` is missing the `null` case for the switch-exhaustiveness lint. I kept that source-control fix out of this terminal PR; targeted oxlint on the changed files passed.
