### PR TITLE
Release simulator launch pending guard on tab creation failure

### DIFF
--- a/src/renderer/src/lib/open-mobile-emulator-tab.test.ts
+++ b/src/renderer/src/lib/open-mobile-emulator-tab.test.ts
@@ -194,4 +194,74 @@ describe('openMobileEmulatorTab', () => {
     expect(callRuntimeRpc).not.toHaveBeenCalled()
     expect(ensureSimulatorTab).not.toHaveBeenCalled()
   })
+
+  it('clears manual launch pending state when the simulator tab cannot be created', async () => {
+    vi.mocked(ensureSimulatorTab).mockReturnValue(null)
+
+    await expect(openMobileEmulatorTab('wt-1', { targetGroupId: 'group-1' })).resolves.toBeNull()
+
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
+    expect(isManualSimulatorLaunchPending('wt-1')).toBe(false)
+  })
+
+  it('clears manual launch pending state when simulator tab creation throws', async () => {
+    vi.mocked(ensureSimulatorTab).mockImplementation(() => {
+      throw new Error('split group missing')
+    })
+
+    await expect(openMobileEmulatorTab('wt-1', { targetGroupId: 'group-1' })).rejects.toThrow(
+      'split group missing'
+    )
+
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
+    expect(isManualSimulatorLaunchPending('wt-1')).toBe(false)
+  })
+
+  it('allows a successful retry after simulator tab creation returns null', async () => {
+    vi.mocked(ensureSimulatorTab).mockReturnValueOnce(null).mockReturnValueOnce('sim-retry')
+    vi.mocked(callRuntimeRpc).mockResolvedValue(mockAttachResult)
+
+    await expect(openMobileEmulatorTab('wt-1', { targetGroupId: 'group-1' })).resolves.toBeNull()
+    await expect(openMobileEmulatorTab('wt-1', { targetGroupId: 'group-1' })).resolves.toBe(
+      'sim-retry'
+    )
+
+    expect(ensureSimulatorTab).toHaveBeenCalledTimes(2)
+    const attachCalls = vi.mocked(callRuntimeRpc).mock.calls.filter(([, method]) =>
+      method === 'emulator.attach'
+    )
+    expect(attachCalls).toHaveLength(1)
+    expect(isManualSimulatorLaunchPending('wt-1')).toBe(false)
+  })
+
+  it('does not release another in-flight launch when duplicate tab creation throws', async () => {
+    let resolveAttach: (value: typeof mockAttachResult) => void = () => {}
+    vi.mocked(callRuntimeRpc).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveAttach = resolve
+        })
+    )
+    vi.mocked(ensureSimulatorTab)
+      .mockImplementationOnce(() => {
+        mockStoreState.unifiedTabsByWorktree['wt-1'] = [{
+          id: 'sim-1',
+          contentType: 'simulator'
+        }]
+        return 'sim-1'
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('split group missing')
+      })
+
+    const firstLaunch = openMobileEmulatorTab('wt-1', { targetGroupId: 'group-1' })
+    await expect(openMobileEmulatorTab('wt-1', { targetGroupId: 'group-1' })).rejects.toThrow(
+      'split group missing'
+    )
+
+    expect(isManualSimulatorLaunchPending('wt-1')).toBe(true)
+    resolveAttach(mockAttachResult)
+    await firstLaunch
+    expect(isManualSimulatorLaunchPending('wt-1')).toBe(false)
+  })
 })

--- a/src/renderer/src/lib/open-mobile-emulator-tab.ts
+++ b/src/renderer/src/lib/open-mobile-emulator-tab.ts
@@ -72,46 +72,55 @@ export async function openMobileEmulatorTab(
 
   cancelPendingSimulatorPaneShutdown(worktreeId)
   const alreadyLaunching = isManualSimulatorLaunchPending(worktreeId)
-  if (!alreadyLaunching) {
-    beginManualSimulatorLaunch(worktreeId)
+  if (alreadyLaunching) {
+    return ensureSimulatorTab(worktreeId, {
+      placement: options.placement ?? 'rightSplit',
+      targetGroupId,
+      surfacePane: true
+    })
   }
-  const tabId = ensureSimulatorTab(worktreeId, {
-    placement: options.placement ?? 'rightSplit',
-    targetGroupId,
-    surfacePane: true
-  })
-  if (!tabId || alreadyLaunching) {
-    return tabId
-  }
-  dispatchManualSimulatorLaunchStarted(worktreeId)
+  beginManualSimulatorLaunch(worktreeId)
   try {
-    // Why: the pane is visible but inert while serve-sim settles; the actual
-    // stream is handed to it only after attach returns ready info.
-    const result = await callRuntimeRpc<EmulatorAttachResult>(
-      { kind: 'local' },
-      'emulator.attach',
-      {
-        worktree: worktreeId,
-        focus: false
-      }
-    )
-    if (!result.attached || !result.info) {
-      throw new Error('Could not start the emulator.')
+    // Why: this scope owns the guard from before tab creation through attach;
+    // every early return or error must release it so a retry can proceed.
+    const tabId = ensureSimulatorTab(worktreeId, {
+      placement: options.placement ?? 'rightSplit',
+      targetGroupId,
+      surfacePane: true
+    })
+    if (!tabId) {
+      return null
     }
-    // Why: users can close the tab while serve-sim is still starting; after
-    // attach registers the managed session, clean it up if no pane remains.
-    if (await shutdownManagedSimulatorIfNoPane(worktreeId, tabId)) {
+    dispatchManualSimulatorLaunchStarted(worktreeId)
+    try {
+      // Why: the pane is visible but inert while serve-sim settles; the actual
+      // stream is handed to it only after attach returns ready info.
+      const result = await callRuntimeRpc<EmulatorAttachResult>(
+        { kind: 'local' },
+        'emulator.attach',
+        {
+          worktree: worktreeId,
+          focus: false
+        }
+      )
+      if (!result.attached || !result.info) {
+        throw new Error('Could not start the emulator.')
+      }
+      // Why: users can close the tab while serve-sim is still starting; after
+      // attach registers the managed session, clean it up if no pane remains.
+      if (await shutdownManagedSimulatorIfNoPane(worktreeId, tabId)) {
+        return tabId
+      }
+
+      rememberPrelaunchedSimulatorSession(worktreeId, result.info)
+      dispatchPrelaunchedSession(worktreeId, result.info)
+      return tabId
+    } catch (error) {
+      const message = getLaunchErrorMessage(error)
+      toast.error(message)
+      dispatchManualSimulatorLaunchFailed(worktreeId, message)
       return tabId
     }
-
-    rememberPrelaunchedSimulatorSession(worktreeId, result.info)
-    dispatchPrelaunchedSession(worktreeId, result.info)
-    return tabId
-  } catch (error) {
-    const message = getLaunchErrorMessage(error)
-    toast.error(message)
-    dispatchManualSimulatorLaunchFailed(worktreeId, message)
-    return tabId
   } finally {
     finishManualSimulatorLaunch(worktreeId)
   }


### PR DESCRIPTION
## Description

Fixes the manual mobile-emulator launch guard so it is always released when simulator tab creation returns `null` or throws. The guard now has one explicit owner: a single `try/finally` spans tab creation, attach, managed shutdown checks, and every success/failure/early-return path. A duplicate caller observes the existing guard but never releases another caller’s in-flight launch.

## Evidence

Reproduction on main `5e100914d3`: forcing `ensureSimulatorTab()` to return `null` made `openMobileEmulatorTab()` return while `isManualSimulatorLaunchPending(worktreeId)` remained `true`. That leaves the emulator pane loading state stuck and prevents a later launch from owning a fresh attach.

Fix evidence on `0d1f808168`:

- 11 focused `openMobileEmulatorTab` tests pass locally; an independent reviewer ran 25 affected tests.
- New mutation-sensitive tests cover tab creation returning `null`, tab creation throwing, successful retry after failure, and a duplicate throwing without releasing the original in-flight launch. Existing tests cover attach success/failure and closing the tab while attach is pending.
- `pnpm exec oxlint` on both changed files, `pnpm tc:web`, `pnpm check:max-lines-ratchet`, and `git diff --check` pass.
- Two fresh independent reviewers returned no issues.

Performance/resource evidence: this only changes control-flow ownership around the existing per-worktree `Set`. It adds no polling, timers, listeners, IPC/RPC calls, renders, scans, or retained state. The owner-scoped `finally` reduces leak risk by guaranteeing the Set entry is removed.

Platform/runtime evidence: the guard is renderer-side and keyed by opaque worktree ID, with no path, shell, keyboard, Git-provider, or OS assumptions. Local, remote, and SSH-backed worktrees use the same renderer coordination path; the existing runtime RPC target and emulator shutdown behavior are unchanged.

## ELI5

Orca puts a “launch in progress” sticky note on a workspace while it opens the emulator. If creating the emulator tab failed early, Orca forgot to remove the note, so every later attempt thought somebody else was still launching. Now the code that places the note always removes it, even when tab creation fails, while a second caller cannot remove the first caller’s note.

## Trade-offs

No expected end-user regressions. Successful launches, attach failures, duplicate clicks, tab-close cleanup, local/remote behavior, and emulator RPC behavior are unchanged. The only behavioral change is that a failed tab-creation attempt no longer leaves the launch guard stuck, allowing a later retry. No new resource, performance, privacy, telemetry, or provider-specific cost.