### PR TITLE
Bound simulator prelaunch handoff cache

### DIFF
--- a/src/renderer/src/lib/open-mobile-emulator-tab.test.ts
+++ b/src/renderer/src/lib/open-mobile-emulator-tab.test.ts
@@ -4,7 +4,8 @@ import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import { openMobileEmulatorTab } from './open-mobile-emulator-tab'
 import {
   consumePrelaunchedSimulatorSession,
-  isManualSimulatorLaunchPending
+  isManualSimulatorLaunchPending,
+  resetSimulatorLaunchCoordinationForTests
 } from './simulator-launch-coordination'
 import { cancelPendingSimulatorPaneShutdown } from './simulator-pane-shutdown-scheduler'
 import { ensureSimulatorTab, getSimulatorTabForWorktree } from './ensure-simulator-tab'
@@ -62,7 +63,7 @@ describe('openMobileEmulatorTab', () => {
     vi.mocked(getSimulatorTabForWorktree).mockReset()
     vi.mocked(getSimulatorTabForWorktree).mockReturnValue(null)
     vi.mocked(toast.error).mockReset()
-    consumePrelaunchedSimulatorSession('wt-1')
+    resetSimulatorLaunchCoordinationForTests()
   })
 
   afterEach(() => {

--- a/src/renderer/src/lib/simulator-launch-coordination.test.ts
+++ b/src/renderer/src/lib/simulator-launch-coordination.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EmulatorStreamInfo } from '@/components/emulator-pane/emulator-pane-types'
+import {
+  consumePrelaunchedSimulatorSession,
+  getPrelaunchedSimulatorSessionCountForTests,
+  rememberPrelaunchedSimulatorSession,
+  resetSimulatorLaunchCoordinationForTests
+} from './simulator-launch-coordination'
+
+function streamInfo(id: string): EmulatorStreamInfo {
+  return {
+    deviceUdid: id,
+    streamUrl: `http://127.0.0.1:3100/${id}/stream.mjpeg`,
+    wsUrl: `ws://127.0.0.1:3100/${id}/ws`
+  }
+}
+
+describe('simulator-launch-coordination', () => {
+  beforeEach(() => {
+    resetSimulatorLaunchCoordinationForTests()
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+  })
+
+  afterEach(() => {
+    resetSimulatorLaunchCoordinationForTests()
+    vi.useRealTimers()
+  })
+
+  it('expires unconsumed sessions at the TTL boundary', () => {
+    rememberPrelaunchedSimulatorSession('wt-fresh', streamInfo('device-fresh'))
+    rememberPrelaunchedSimulatorSession('wt-stale', streamInfo('device-stale'))
+
+    vi.advanceTimersByTime(29_999)
+
+    expect(consumePrelaunchedSimulatorSession('wt-fresh')).toMatchObject({
+      deviceUdid: 'device-fresh'
+    })
+
+    vi.advanceTimersByTime(1)
+
+    expect(consumePrelaunchedSimulatorSession('wt-stale')).toBeNull()
+    expect(getPrelaunchedSimulatorSessionCountForTests()).toBe(0)
+  })
+
+  it('measures handoff age independently of wall-clock corrections', () => {
+    vi.setSystemTime(100_000)
+    rememberPrelaunchedSimulatorSession('wt-rollback', streamInfo('device-rollback'))
+
+    vi.setSystemTime(0)
+    vi.advanceTimersByTime(30_000)
+
+    expect(consumePrelaunchedSimulatorSession('wt-rollback')).toBeNull()
+
+    rememberPrelaunchedSimulatorSession('wt-forward', streamInfo('device-forward'))
+    vi.setSystemTime(1_000_000)
+
+    expect(consumePrelaunchedSimulatorSession('wt-forward')).toMatchObject({
+      deviceUdid: 'device-forward'
+    })
+  })
+
+  it('caps prelaunched simulator sessions by oldest worktree key', () => {
+    for (let index = 0; index < 16; index += 1) {
+      rememberPrelaunchedSimulatorSession(`wt-${index}`, streamInfo(`device-${index}`))
+    }
+
+    rememberPrelaunchedSimulatorSession('wt-16', streamInfo('device-16'))
+
+    expect(consumePrelaunchedSimulatorSession('wt-0')).toBeNull()
+    expect(consumePrelaunchedSimulatorSession('wt-1')).toMatchObject({
+      deviceUdid: 'device-1'
+    })
+    expect(consumePrelaunchedSimulatorSession('wt-16')).toMatchObject({
+      deviceUdid: 'device-16'
+    })
+  })
+
+  it('treats a refreshed worktree key as the most recently remembered', () => {
+    for (let index = 0; index < 16; index += 1) {
+      rememberPrelaunchedSimulatorSession(`wt-${index}`, streamInfo(`device-${index}`))
+    }
+
+    rememberPrelaunchedSimulatorSession('wt-0', streamInfo('device-refreshed'))
+    rememberPrelaunchedSimulatorSession('wt-16', streamInfo('device-16'))
+
+    expect(consumePrelaunchedSimulatorSession('wt-1')).toBeNull()
+    expect(consumePrelaunchedSimulatorSession('wt-0')).toMatchObject({
+      deviceUdid: 'device-refreshed'
+    })
+    expect(consumePrelaunchedSimulatorSession('wt-16')).toMatchObject({
+      deviceUdid: 'device-16'
+    })
+  })
+
+  it('stays bounded through prolonged unconsumed-session churn', () => {
+    for (let index = 0; index < 5_000; index += 1) {
+      rememberPrelaunchedSimulatorSession(`wt-${index}`, streamInfo(`device-${index}`))
+      expect(getPrelaunchedSimulatorSessionCountForTests()).toBeLessThanOrEqual(16)
+    }
+
+    expect(consumePrelaunchedSimulatorSession('wt-4983')).toBeNull()
+    expect(consumePrelaunchedSimulatorSession('wt-4984')).toMatchObject({
+      deviceUdid: 'device-4984'
+    })
+    expect(consumePrelaunchedSimulatorSession('wt-4999')).toMatchObject({
+      deviceUdid: 'device-4999'
+    })
+  })
+})

--- a/src/renderer/src/lib/simulator-launch-coordination.ts
+++ b/src/renderer/src/lib/simulator-launch-coordination.ts
@@ -4,7 +4,31 @@ export const EMULATOR_MANUAL_LAUNCH_STARTED_EVENT = 'orca:emulator-launch-starte
 export const EMULATOR_MANUAL_LAUNCH_FAILED_EVENT = 'orca:emulator-launch-failed'
 
 const manualLaunchesByWorktree = new Set<string>()
-const prelaunchedSessionsByWorktree = new Map<string, EmulatorStreamInfo>()
+type PrelaunchedSimulatorSession = {
+  info: EmulatorStreamInfo
+  rememberedAt: number
+}
+
+// Why: prelaunch info is a short-lived handoff to the pane; if the pane never
+// consumes it, stale stream URLs should not stick to removed worktree ids.
+const PRELAUNCHED_SIMULATOR_SESSION_TTL_MS = 30_000
+const PRELAUNCHED_SIMULATOR_SESSION_MAX = 16
+const prelaunchedSessionsByWorktree = new Map<string, PrelaunchedSimulatorSession>()
+
+function prunePrelaunchedSimulatorSessions(now = performance.now()): void {
+  for (const [worktreeId, entry] of prelaunchedSessionsByWorktree) {
+    if (now - entry.rememberedAt >= PRELAUNCHED_SIMULATOR_SESSION_TTL_MS) {
+      prelaunchedSessionsByWorktree.delete(worktreeId)
+    }
+  }
+  while (prelaunchedSessionsByWorktree.size > PRELAUNCHED_SIMULATOR_SESSION_MAX) {
+    const oldest = prelaunchedSessionsByWorktree.keys().next().value
+    if (oldest === undefined) {
+      return
+    }
+    prelaunchedSessionsByWorktree.delete(oldest)
+  }
+}
 
 export function beginManualSimulatorLaunch(worktreeId: string): void {
   manualLaunchesByWorktree.add(worktreeId)
@@ -25,13 +49,31 @@ export function rememberPrelaunchedSimulatorSession(
   if (!info?.streamUrl && !info?.wsUrl) {
     return
   }
-  prelaunchedSessionsByWorktree.set(worktreeId, info)
+  // Why: the TTL measures elapsed handoff age, so wall-clock corrections must
+  // not resurrect stale stream metadata or discard a fresh handoff.
+  const rememberedAt = performance.now()
+  prelaunchedSessionsByWorktree.delete(worktreeId)
+  prelaunchedSessionsByWorktree.set(worktreeId, {
+    info,
+    rememberedAt
+  })
+  prunePrelaunchedSimulatorSessions(rememberedAt)
 }
 
 export function consumePrelaunchedSimulatorSession(worktreeId: string): EmulatorStreamInfo | null {
-  const info = prelaunchedSessionsByWorktree.get(worktreeId) ?? null
+  prunePrelaunchedSimulatorSessions()
+  const info = prelaunchedSessionsByWorktree.get(worktreeId)?.info ?? null
   prelaunchedSessionsByWorktree.delete(worktreeId)
   return info
+}
+
+export function resetSimulatorLaunchCoordinationForTests(): void {
+  manualLaunchesByWorktree.clear()
+  prelaunchedSessionsByWorktree.clear()
+}
+
+export function getPrelaunchedSimulatorSessionCountForTests(): number {
+  return prelaunchedSessionsByWorktree.size
 }
 
 export function dispatchManualSimulatorLaunchStarted(worktreeId: string): void {


### PR DESCRIPTION
## Summary

Simulator prelaunch stream metadata is a short-lived handoff from the manual launch or auto-attach path to the mounted emulator pane. Previously, every unconsumed handoff stayed in a renderer-level Map for the rest of the process.

This change measures handoff age with a monotonic clock, lazily rejects entries after 30 seconds, and caps the cache at the 16 most recently remembered worktree keys. A stale or evicted handoff safely falls back to the normal attach path.

## Screenshots

No visual change. Electron validation mounted the real Mobile Emulator pane and verified that it consumed the cached handoff, showed the expected connected device, and rendered a frame through Orca's main-process MJPEG path.

## Testing

- [ ] `pnpm lint` — changed-file lint and every structural gate pass; the full pipeline reaches an unrelated Korean localization interpolation mismatch already present byte-for-byte on current main.
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2,676 test files / 28,127 tests passed.
- [ ] `pnpm build` — the Electron development build compiled main, preload, and renderer successfully; a full release build was not run.
- [x] Added mutation-sensitive regression coverage for the 30-second TTL boundary, wall-clock rollback/forward correction, 16-entry bound, prolonged churn, and repeated-key recency.

Additional evidence:

- Reproduced the old implementation retaining 5,000 of 5,000 unique unconsumed entries.
- Both meaningful mutations fail their dedicated regression tests.
- A 100,000-write probe completed in 34.63 ms, retained exactly 16 entries, and had a post-GC heap delta of 2,248 bytes.
- Electron verified 100,000 writes retain 16 entries and mounting the pane consumes its cached handoff (count 1 to 0) with zero clean-scenario renderer errors.
- Changed-file oxlint, max-lines ratchet, and `git diff --check` passed.

## AI Review Report

Two valid adversarial review/fix rounds ran with independent root-cause and reproduction/resource lanes. Round 1 found two issues:

1. Wall-clock `Date.now()` could preserve stale metadata after clock rollback or discard a fresh handoff after forward correction. The TTL now uses one captured monotonic `performance.now()` timestamp, with rollback/forward regression coverage.
2. The original cap test did not prove that refreshing an existing key updates eviction recency. Added a mutation-sensitive 16-key refresh test that proves the refreshed payload survives and the next-oldest key is evicted.

Both fresh Round 2 reviewers returned clean. The review checked ownership, stale-state behavior, renderer lifecycle, memory/CPU cost, macOS/Linux/Windows behavior, Electron timing, local/SSH/remote routing, iOS/Android metadata, provider neutrality, and test isolation. No shortcut, label, path, shell, Git, provider, or platform-specific behavior changes.

## Security Audit

The cache stores only existing emulator stream metadata and remains renderer-local. Inputs continue through the same validation requiring a stream or WebSocket endpoint. The change adds no command execution, path handling, auth, secrets, dependency, IPC/RPC, telemetry, network request, or persistence surface. Expired or evicted metadata falls back to the existing local attach path. No security follow-up is needed.

## Notes

Normal panes consume the handoff immediately. If a pane waits longer than 30 seconds, or more than 16 newer worktrees prelaunch first, Orca discards the note and uses the normal attach path. That pathological case can cause one extra local attach attempt but avoids stale stream metadata.

Remember scans at most 17 entries and consume scans at most 16. The change adds no timer, polling, listener, subprocess, render, device-scan, SSH, or remote-runtime work. Physical OS suspend was not dynamically exercised; the independent 16-entry cap still guarantees bounded retention. Simulator ownership and cleanup are unchanged, and SSH/remote runtimes remain unaffected because emulator attach is local-only.