### PR TITLE
Fix PR comment selection persistence leak

### DIFF
--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment happy-dom
 
-import { act, type ReactNode } from 'react'
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+import { act, StrictMode, Suspense, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -86,20 +88,47 @@ function comment(overrides: Partial<PRComment>): PRComment {
 function renderList(props: {
   comments: PRComment[]
   contextKey?: string
+  strictMode?: boolean
   onResolveSelectedCommentsWithAI?: (groups: PRCommentGroup[]) => void
   clearRequest?: PRCommentsListSelectionClearRequest | null
 }): void {
+  const list = (
+    <TooltipProvider>
+      <PRCommentsList
+        comments={props.comments}
+        commentsLoading={false}
+        selectionContextKey={props.contextKey ?? 'review:42'}
+        selectionClearRequest={props.clearRequest}
+        onResolveSelectedCommentsWithAI={props.onResolveSelectedCommentsWithAI ?? vi.fn()}
+      />
+    </TooltipProvider>
+  )
+  act(() => {
+    root.render(props.strictMode ? <StrictMode>{list}</StrictMode> : list)
+  })
+}
+
+const neverSettles = new Promise<void>(() => {})
+
+function SuspendForever(): ReactNode {
+  throw neverSettles
+}
+
+function renderAbandonedList(comments: PRComment[], contextKey: string): void {
   act(() => {
     root.render(
-      <TooltipProvider>
-        <PRCommentsList
-          comments={props.comments}
-          commentsLoading={false}
-          selectionContextKey={props.contextKey ?? 'review:42'}
-          selectionClearRequest={props.clearRequest}
-          onResolveSelectedCommentsWithAI={props.onResolveSelectedCommentsWithAI ?? vi.fn()}
-        />
-      </TooltipProvider>
+      <Suspense fallback={<div>Loading review</div>}>
+        <TooltipProvider>
+          <PRCommentsList
+            key={`abandoned:${contextKey}`}
+            comments={comments}
+            commentsLoading={false}
+            selectionContextKey={contextKey}
+            onResolveSelectedCommentsWithAI={vi.fn()}
+          />
+          <SuspendForever />
+        </TooltipProvider>
+      </Suspense>
     )
   })
 }
@@ -306,6 +335,23 @@ describe('PRCommentsList comment resolution selection', () => {
     expect(container.querySelector('button[role="checkbox"]')).toBeNull()
   })
 
+  it('drops an empty selection from the persisted context cache', () => {
+    renderList({
+      comments: [comment({ id: 1, threadId: 'thread-1', path: 'src/a.ts', isResolved: false })]
+    })
+    clickButton('Queue for agent')
+
+    const selectedCheckbox = container.querySelector<HTMLButtonElement>(
+      'button[role="checkbox"][aria-checked="true"]'
+    )
+    expect(selectedCheckbox).not.toBeNull()
+    act(() => {
+      selectedCheckbox?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(getPRCommentsListSelectionCountForTests()).toBe(0)
+  })
+
   it('clears sent standalone bot comments from the queue when the parent confirms launch', () => {
     const comments = [
       comment({
@@ -381,6 +427,46 @@ describe('PRCommentsList comment resolution selection', () => {
     })
 
     expect(hasButton('Send 1 queued comments to AI')).toBe(false)
+    expect(getPRCommentsListSelectionCountForTests()).toBe(0)
+  })
+
+  it('keeps GitHub and GitLab review selections isolated under Strict Mode replay', () => {
+    const comments = [comment({ id: 1, threadId: 'thread-1', path: 'src/a.ts' })]
+    const githubContext = 'local::repo::branch::github::42::github-head'
+    const gitlabContext = 'local::repo::branch::gitlab::42::gitlab-head'
+
+    renderList({ comments, contextKey: githubContext, strictMode: true })
+    clickButton('Queue for agent')
+    renderList({ comments, contextKey: gitlabContext, strictMode: true })
+    clickButton('Queue for agent')
+
+    expect(getPRCommentsListSelectionCountForTests()).toBe(2)
+    renderList({ comments, contextKey: githubContext, strictMode: true })
+    expect(hasButton('Send 1 queued comments to AI')).toBe(true)
+    renderList({ comments, contextKey: gitlabContext, strictMode: true })
+    expect(hasButton('Send 1 queued comments to AI')).toBe(true)
+  })
+
+  it('does not refresh LRU recency for an abandoned Suspense render', () => {
+    const comments = [comment({ id: 1, threadId: 'thread-1', path: 'src/a.ts' })]
+    const queueContext = (contextKey: string): void => {
+      renderList({ comments, contextKey })
+      clickButton('Queue for agent')
+    }
+
+    queueContext('review:oldest')
+    for (let i = 0; i < MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS - 1; i += 1) {
+      queueContext(`review:recent-${i}`)
+    }
+
+    renderAbandonedList(comments, 'review:oldest')
+    expect(container.textContent).toContain('Loading review')
+    queueContext('review:new')
+
+    renderList({ comments, contextKey: 'review:oldest' })
+    expect(hasButton('Send 1 queued comments to AI')).toBe(false)
+    renderList({ comments, contextKey: 'review:recent-0' })
+    expect(hasButton('Send 1 queued comments to AI')).toBe(true)
   })
 
   it('bounds persisted review contexts while retaining recently restored selections', () => {

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
@@ -51,6 +51,7 @@ import {
   MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS,
   clearPRCommentsListSelectionsForTests,
   getPRCommentsListSelectionCountForTests,
+  seedPRCommentsListSelectionForTests,
   type PRCommentsListSelectionClearRequest
 } from './pr-comments-list-selection'
 import { PRCommentsList } from './checks-panel-content'
@@ -449,19 +450,19 @@ describe('PRCommentsList comment resolution selection', () => {
 
   it('does not refresh LRU recency for an abandoned Suspense render', () => {
     const comments = [comment({ id: 1, threadId: 'thread-1', path: 'src/a.ts' })]
-    const queueContext = (contextKey: string): void => {
-      renderList({ comments, contextKey })
-      clickButton('Queue for agent')
+    const queuedGroupIds = ['thread:thread-1'] as const
+    const seedContext = (contextKey: string): void => {
+      seedPRCommentsListSelectionForTests(contextKey, queuedGroupIds)
     }
 
-    queueContext('review:oldest')
+    seedContext('review:oldest')
     for (let i = 0; i < MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS - 1; i += 1) {
-      queueContext(`review:recent-${i}`)
+      seedContext(`review:recent-${i}`)
     }
 
     renderAbandonedList(comments, 'review:oldest')
     expect(container.textContent).toContain('Loading review')
-    queueContext('review:new')
+    seedContext('review:new')
 
     renderList({ comments, contextKey: 'review:oldest' })
     expect(hasButton('Send 1 queued comments to AI')).toBe(false)
@@ -471,21 +472,21 @@ describe('PRCommentsList comment resolution selection', () => {
 
   it('bounds persisted review contexts while retaining recently restored selections', () => {
     const comments = [comment({ id: 1, threadId: 'thread-1', path: 'src/a.ts', isResolved: false })]
-    const queueContext = (contextKey: string): void => {
-      renderList({ comments, contextKey })
-      clickButton('Queue for agent')
-      expect(hasButton('Send 1 queued comments to AI')).toBe(true)
+    const queuedGroupIds = ['thread:thread-1'] as const
+    const seedContext = (contextKey: string): void => {
+      seedPRCommentsListSelectionForTests(contextKey, queuedGroupIds)
     }
 
-    queueContext('review:keep')
+    seedContext('review:keep')
     for (let i = 0; i < MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS - 1; i += 1) {
-      queueContext(`review:stale-${i}`)
+      seedContext(`review:stale-${i}`)
     }
 
+    // Why: committed remount must refresh LRU recency for the restored context.
     renderList({ comments, contextKey: 'review:keep' })
     expect(hasButton('Send 1 queued comments to AI')).toBe(true)
 
-    queueContext('review:new')
+    seedContext('review:new')
 
     expect(getPRCommentsListSelectionCountForTests()).toBe(
       MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
@@ -46,7 +46,9 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 import type { PRComment } from '../../../../shared/types'
 import type { PRCommentGroup } from '@/lib/pr-comment-groups'
 import {
-  clearPRCommentsListSelection,
+  MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS,
+  clearPRCommentsListSelectionsForTests,
+  getPRCommentsListSelectionCountForTests,
   type PRCommentsListSelectionClearRequest
 } from './pr-comments-list-selection'
 import { PRCommentsList } from './checks-panel-content'
@@ -55,7 +57,7 @@ let container: HTMLDivElement
 let root: Root
 
 beforeEach(() => {
-  clearPRCommentsListSelection('review:42')
+  clearPRCommentsListSelectionsForTests()
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -66,6 +68,7 @@ afterEach(() => {
     root.unmount()
   })
   container.remove()
+  clearPRCommentsListSelectionsForTests()
 })
 
 function comment(overrides: Partial<PRComment>): PRComment {
@@ -378,5 +381,34 @@ describe('PRCommentsList comment resolution selection', () => {
     })
 
     expect(hasButton('Send 1 queued comments to AI')).toBe(false)
+  })
+
+  it('bounds persisted review contexts while retaining recently restored selections', () => {
+    const comments = [comment({ id: 1, threadId: 'thread-1', path: 'src/a.ts', isResolved: false })]
+    const queueContext = (contextKey: string): void => {
+      renderList({ comments, contextKey })
+      clickButton('Queue for agent')
+      expect(hasButton('Send 1 queued comments to AI')).toBe(true)
+    }
+
+    queueContext('review:keep')
+    for (let i = 0; i < MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS - 1; i += 1) {
+      queueContext(`review:stale-${i}`)
+    }
+
+    renderList({ comments, contextKey: 'review:keep' })
+    expect(hasButton('Send 1 queued comments to AI')).toBe(true)
+
+    queueContext('review:new')
+
+    expect(getPRCommentsListSelectionCountForTests()).toBe(
+      MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS
+    )
+
+    renderList({ comments, contextKey: 'review:stale-0' })
+    expect(hasButton('Send 1 queued comments to AI')).toBe(false)
+
+    renderList({ comments, contextKey: 'review:keep' })
+    expect(hasButton('Send 1 queued comments to AI')).toBe(true)
   })
 })

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.ts
@@ -26,10 +26,23 @@ type PRCommentsListSelectionState = {
 }
 
 const EMPTY_SELECTED_GROUP_IDS = new Set<string>()
+// Why: queued selections need to survive sidebar remounts, but old PR/MR
+// contexts can disappear without another clear signal in a long renderer run.
+export const MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS = 256
 const persistedSelectionByContextKey = new Map<
   string,
   { isSelectingForAI: boolean; selectedGroupIds: Set<string> }
 >()
+
+function trimPersistedSelectionContexts(): void {
+  while (persistedSelectionByContextKey.size > MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS) {
+    const oldestContextKey = persistedSelectionByContextKey.keys().next().value
+    if (oldestContextKey === undefined) {
+      break
+    }
+    persistedSelectionByContextKey.delete(oldestContextKey)
+  }
+}
 
 function persistSelectionState(state: PRCommentsListSelectionState): void {
   if (!state.contextKey) {
@@ -39,14 +52,20 @@ function persistSelectionState(state: PRCommentsListSelectionState): void {
     persistedSelectionByContextKey.delete(state.contextKey)
     return
   }
+  persistedSelectionByContextKey.delete(state.contextKey)
   persistedSelectionByContextKey.set(state.contextKey, {
     isSelectingForAI: state.isSelectingForAI,
     selectedGroupIds: new Set(state.selectedGroupIds)
   })
+  trimPersistedSelectionContexts()
 }
 
 function createSelectionState(contextKey: string | undefined): PRCommentsListSelectionState {
   const persisted = contextKey ? persistedSelectionByContextKey.get(contextKey) : undefined
+  if (contextKey && persisted) {
+    persistedSelectionByContextKey.delete(contextKey)
+    persistedSelectionByContextKey.set(contextKey, persisted)
+  }
   return {
     contextKey,
     isSelectingForAI: persisted?.isSelectingForAI ?? false,
@@ -58,6 +77,14 @@ export function clearPRCommentsListSelection(contextKey: string | undefined): vo
   if (contextKey) {
     persistedSelectionByContextKey.delete(contextKey)
   }
+}
+
+export function clearPRCommentsListSelectionsForTests(): void {
+  persistedSelectionByContextKey.clear()
+}
+
+export function getPRCommentsListSelectionCountForTests(): number {
+  return persistedSelectionByContextKey.size
 }
 
 export function usePRCommentsListSelection(

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.ts
@@ -28,7 +28,7 @@ type PRCommentsListSelectionState = {
 const EMPTY_SELECTED_GROUP_IDS = new Set<string>()
 // Why: queued selections need to survive sidebar remounts, but old PR/MR
 // contexts can disappear without another clear signal in a long renderer run.
-export const MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS = 256
+export const MAX_PERSISTED_PR_COMMENTS_LIST_SELECTIONS = 1024
 const persistedSelectionByContextKey = new Map<
   string,
   { isSelectingForAI: boolean; selectedGroupIds: Set<string> }

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.ts
@@ -48,7 +48,7 @@ function persistSelectionState(state: PRCommentsListSelectionState): void {
   if (!state.contextKey) {
     return
   }
-  if (!state.isSelectingForAI && state.selectedGroupIds.size === 0) {
+  if (state.selectedGroupIds.size === 0) {
     persistedSelectionByContextKey.delete(state.contextKey)
     return
   }
@@ -60,12 +60,20 @@ function persistSelectionState(state: PRCommentsListSelectionState): void {
   trimPersistedSelectionContexts()
 }
 
-function createSelectionState(contextKey: string | undefined): PRCommentsListSelectionState {
-  const persisted = contextKey ? persistedSelectionByContextKey.get(contextKey) : undefined
-  if (contextKey && persisted) {
-    persistedSelectionByContextKey.delete(contextKey)
-    persistedSelectionByContextKey.set(contextKey, persisted)
+function refreshPersistedSelectionContext(contextKey: string | undefined): void {
+  if (!contextKey) {
+    return
   }
+  const persisted = persistedSelectionByContextKey.get(contextKey)
+  if (!persisted) {
+    return
+  }
+  persistedSelectionByContextKey.delete(contextKey)
+  persistedSelectionByContextKey.set(contextKey, persisted)
+}
+
+function readSelectionState(contextKey: string | undefined): PRCommentsListSelectionState {
+  const persisted = contextKey ? persistedSelectionByContextKey.get(contextKey) : undefined
   return {
     contextKey,
     isSelectingForAI: persisted?.isSelectingForAI ?? false,
@@ -93,14 +101,21 @@ export function usePRCommentsListSelection(
   clearRequest?: PRCommentsListSelectionClearRequest | null
 ): PRCommentsListSelection {
   const lastClearRequestTokenRef = useRef<number | null>(null)
-  const [selectionState, setSelectionState] = useState<PRCommentsListSelectionState>(() =>
-    createSelectionState(selectionContextKey)
-  )
+  const [renderedSelectionState, setRenderedSelectionState] =
+    useState<PRCommentsListSelectionState>(() => readSelectionState(selectionContextKey))
+  const selectionState =
+    renderedSelectionState.contextKey === selectionContextKey
+      ? renderedSelectionState
+      : readSelectionState(selectionContextKey)
+  const commitSelectionState = useCallback((next: PRCommentsListSelectionState): void => {
+    persistSelectionState(next)
+    setRenderedSelectionState(next)
+  }, [])
 
   useEffect(() => {
-    setSelectionState((prev) =>
-      prev.contextKey === selectionContextKey ? prev : createSelectionState(selectionContextKey)
-    )
+    // Why: only a committed context may affect LRU order; render can be
+    // abandoned or replayed by Strict Mode/Suspense.
+    refreshPersistedSelectionContext(selectionContextKey)
   }, [selectionContextKey])
 
   useEffect(() => {
@@ -117,9 +132,8 @@ export function usePRCommentsListSelection(
       isSelectingForAI: false,
       selectedGroupIds: new Set<string>()
     }
-    persistSelectionState(next)
-    setSelectionState(next)
-  }, [clearRequest, selectionContextKey])
+    commitSelectionState(next)
+  }, [clearRequest, commitSelectionState, selectionContextKey])
 
   // Why: selectable groups come from the unfiltered list so switching the
   // audience filter doesn't silently drop already-selected comments.
@@ -165,10 +179,10 @@ export function usePRCommentsListSelection(
       isSelectingForAI: selectionState.isSelectingForAI,
       selectedGroupIds: new Set(selectedGroupIds)
     }
-    persistSelectionState(next)
-    setSelectionState(next)
+    commitSelectionState(next)
   }, [
     candidateSelectedGroupIds,
+    commitSelectionState,
     comments.length,
     isCurrentSelectionContext,
     selectedGroupIds,
@@ -196,10 +210,9 @@ export function usePRCommentsListSelection(
         isSelectingForAI: true,
         selectedGroupIds: new Set([groupId])
       }
-      persistSelectionState(next)
-      setSelectionState(next)
+      commitSelectionState(next)
     },
-    [selectableGroupsById, selectionContextKey]
+    [commitSelectionState, selectableGroupsById, selectionContextKey]
   )
 
   const clearSelection = useCallback((): void => {
@@ -208,34 +221,32 @@ export function usePRCommentsListSelection(
       isSelectingForAI: false,
       selectedGroupIds: new Set<string>()
     }
-    persistSelectionState(next)
-    setSelectionState(next)
-  }, [selectionContextKey])
+    commitSelectionState(next)
+  }, [commitSelectionState, selectionContextKey])
 
   const toggleGroupSelection = useCallback(
     (groupId: string, checked: boolean): void => {
       if (!selectableGroupsById.has(groupId)) {
         return
       }
-      setSelectionState((prev) => {
-        const base =
-          prev.contextKey === selectionContextKey ? prev.selectedGroupIds : EMPTY_SELECTED_GROUP_IDS
-        const next = new Set([...base].filter((id) => selectableGroupsById.has(id)))
-        if (checked) {
-          next.add(groupId)
-        } else {
-          next.delete(groupId)
-        }
-        const nextState = {
-          contextKey: selectionContextKey,
-          isSelectingForAI: true,
-          selectedGroupIds: next
-        }
-        persistSelectionState(nextState)
-        return nextState
+      const current = readSelectionState(selectionContextKey)
+      const base =
+        current.contextKey === selectionContextKey
+          ? current.selectedGroupIds
+          : EMPTY_SELECTED_GROUP_IDS
+      const next = new Set([...base].filter((id) => selectableGroupsById.has(id)))
+      if (checked) {
+        next.add(groupId)
+      } else {
+        next.delete(groupId)
+      }
+      commitSelectionState({
+        contextKey: selectionContextKey,
+        isSelectingForAI: true,
+        selectedGroupIds: next
       })
     },
-    [selectableGroupsById, selectionContextKey]
+    [commitSelectionState, selectableGroupsById, selectionContextKey]
   )
 
   return {

--- a/src/renderer/src/components/right-sidebar/pr-comments-list-selection.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comments-list-selection.ts
@@ -95,6 +95,19 @@ export function getPRCommentsListSelectionCountForTests(): number {
   return persistedSelectionByContextKey.size
 }
 
+// Why: bound/LRU tests need to fill the cache without 1024 React mounts per case.
+export function seedPRCommentsListSelectionForTests(
+  contextKey: string,
+  selectedGroupIds: Iterable<string>,
+  isSelectingForAI = true
+): void {
+  persistSelectionState({
+    contextKey,
+    isSelectingForAI,
+    selectedGroupIds: new Set(selectedGroupIds)
+  })
+}
+
 export function usePRCommentsListSelection(
   comments: PRComment[],
   selectionContextKey: string | undefined,


### PR DESCRIPTION
## Description

Bounds the renderer-only PR/MR queued-comment selection cache to the 1024 most recently used non-empty review contexts. The cache still preserves unsent selections across sidebar remounts and review switches, but old contexts cannot accumulate for the lifetime of the renderer.

The lifecycle handling was also hardened during review:

- Cache recency changes only after a review context commits, never during render.
- User actions persist from their event handlers rather than from a React state updater.
- Context switches read the correct cached state immediately without remounting the full comments panel.
- Empty selections always remove their cache entry.
- Existing host/repo/branch/provider/review/head-qualified keys preserve GitHub, GitLab, local, SSH, and runtime isolation.

## Evidence

### Original failure

persistedSelectionByContextKey was a module-level Map with no size bound. Queueing comments in distinct PR/MR contexts retained every context until that exact context was explicitly cleared. Empty states with isSelectingForAI=true could also remain retained.

A cap-removal mutation reproduces the original class: adding the 1025th distinct non-empty context produces 1025 retained entries instead of 1024 and leaves the oldest stale context restorable.

### Proof of fix

The targeted renderer suite now proves:

- Exactly 1024 contexts remain after inserting a 1025th.
- The oldest stale context is evicted.
- A recently restored context survives eviction.
- An abandoned Suspense render cannot refresh LRU recency.
- Strict Mode replay preserves isolated GitHub and GitLab selections.
- Resolving or deselecting the last queued group leaves zero persisted entries.
- Existing queue, send, clear, filter, remount, and delayed clear-request behavior still works.

Post-rebase verification on head with 1024 bound:

- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx — 14/14 passed
- Focused oxlint — passed
- Focused oxfmt --check — passed
- pnpm check:max-lines-ratchet — passed
- git diff --check — passed
- Adversarial lifecycle and resource audit — no actionable defect found

pnpm typecheck:web is currently blocked in this shared workspace by pre-existing errors outside this PR: an unrelated terminal-banner test DOM type mismatch and two untouched tests unable to resolve typescript-api. No changed-file type error was reported; GitHub CI remains authoritative for the full typecheck.

## ELI5

Orca remembers comments that you queued for an agent so the queue survives closing and reopening the sidebar. Previously, it could keep one of those notes for every review you ever visited during a long app session. Now it keeps the 1024 most recently used non-empty notes and throws away the oldest one when a newer note needs room.

## Trade-offs

This is not literally zero-regression behavior. If one renderer session accumulates unsent queued selections in more than 1024 distinct PR/MR review contexts, the least-recently-used queue will no longer restore and those comments must be queued again. Current and recently revisited queues are preserved.

No normal review workflow, provider behavior, network/API traffic, polling, IPC/RPC, subprocess work, listener/timer count, or disk persistence changes. Each write performs constant-time Map recency operations and at most the bounded eviction needed to return to 1024 entries. Selected IDs are copied so callers cannot mutate retained cache state.