### PR TITLE
Fix remote web session intent retention

### DIFF
--- a/src/renderer/src/runtime/remote-server-parity.test.ts
+++ b/src/renderer/src/runtime/remote-server-parity.test.ts
@@ -29,6 +29,7 @@ import {
 
 const WT = 'repo::/worktree'
 const ENV = 'web-env-1'
+const INTENT_SCOPE = { environmentId: ENV, worktreeId: WT }
 const NOW = 1_700_000_000_000
 const LEAF_A = '11111111-1111-4111-8111-111111111111'
 const LEAF_B = '22222222-2222-4222-8222-222222222222'
@@ -188,7 +189,7 @@ describe('parity §3: remote terminal create appends rightmost (matches local)',
       localTerminal('host-tab-1', 0, true),
       localTerminal('host-tab-2', 1, false)
     ])
-    recordWebSessionFocusIntent(WT, `host-tab-3::${LEAF_C}`)
+    recordWebSessionFocusIntent(INTENT_SCOPE, `host-tab-3::${LEAF_C}`, 'epoch-1')
     const patch = applyWebSessionTabsSnapshot(
       prior,
       makeSnapshot([
@@ -215,7 +216,7 @@ describe('parity §3: remote terminal create appends rightmost (matches local)',
       localTerminal('host-tab-1', 0, false),
       localTerminal('host-tab-2', 1, true)
     ])
-    recordWebSessionFocusIntent(WT, `host-tab-3::${LEAF_C}`)
+    recordWebSessionFocusIntent(INTENT_SCOPE, `host-tab-3::${LEAF_C}`, 'epoch-1')
     const patch = applyWebSessionTabsSnapshot(
       prior,
       makeSnapshot([
@@ -240,7 +241,7 @@ describe('parity §3: remote terminal create appends rightmost (matches local)',
 describe('parity §4: remote create focuses new tab; echoes never steal focus', () => {
   it('a client-initiated create focuses the new terminal (intent honored)', () => {
     const prior = stateWithLocalTerminals([localTerminal('host-tab-1', 0, true)])
-    recordWebSessionFocusIntent(WT, `host-tab-2::${LEAF_B}`)
+    recordWebSessionFocusIntent(INTENT_SCOPE, `host-tab-2::${LEAF_B}`, 'epoch-1')
     const patch = applyWebSessionTabsSnapshot(
       prior,
       makeSnapshot([
@@ -303,7 +304,7 @@ describe('parity §11: remote browser create focuses the new browser tab', () =>
   it('honors focus intent for a newly created browser session tab', () => {
     const pageId = 'browser-page-1'
     const prior = stateWithLocalTerminals([localTerminal('host-tab-1', 0, true)])
-    recordWebSessionFocusIntent(WT, pageId)
+    recordWebSessionFocusIntent(INTENT_SCOPE, pageId, 'epoch-1')
     const patch = applyWebSessionTabsSnapshot(
       prior,
       makeSnapshot([{ parentTab: 'host-tab-1', leaf: LEAF_A, active: false }], {

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -14,6 +14,23 @@ import {
   setWebRuntimeTabProps,
   splitWebRuntimeTerminal
 } from './web-runtime-session'
+import {
+  getWebSessionFocusIntentCountForTests,
+  peekWebSessionFocusIntent,
+  resetWebSessionFocusIntentForTests
+} from './web-session-focus-intent'
+import {
+  isWebSessionCloseIntentPending,
+  resetWebSessionCloseIntentForTests
+} from './web-session-close-intent'
+import {
+  resetWebSessionReorderIntentForTests,
+  resolveWebSessionReorderedOrder
+} from './web-session-reorder-intent'
+import {
+  rememberWebSessionPublicationEpoch,
+  resetWebSessionPublicationEpochsForTests
+} from './web-session-intent-scope'
 
 const mocks = vi.hoisted(() => ({
   getState: vi.fn(),
@@ -50,6 +67,14 @@ vi.mock('@/lib/worktree-runtime-owner', () => ({
 
 const ENVIRONMENT_ID = 'web-env-1'
 const WORKTREE_ID = 'repo::/worktree'
+const INTENT_SCOPE = { environmentId: ENVIRONMENT_ID, worktreeId: WORKTREE_ID }
+
+afterEach(() => {
+  resetWebSessionFocusIntentForTests()
+  resetWebSessionCloseIntentForTests()
+  resetWebSessionReorderIntentForTests()
+  resetWebSessionPublicationEpochsForTests()
+})
 
 function makeSnapshot(): RuntimeMobileSessionTabsResult {
   return {
@@ -216,6 +241,82 @@ describe('createWebRuntimeSessionBrowserTab', () => {
       environmentId: ENVIRONMENT_ID,
       remotePageId: 'remote-browser-page-1'
     })
+  })
+
+  it('binds browser focus to the causal post-create snapshot for the exact page', async () => {
+    const snapshot: RuntimeMobileSessionTabsResult = {
+      ...makeSnapshot(),
+      publicationEpoch: 'browser-create-success',
+      activeTabId: 'host-browser-tab',
+      activeTabType: 'browser',
+      tabs: [
+        {
+          type: 'browser',
+          id: 'host-browser-tab',
+          title: 'Example',
+          browserWorkspaceId: 'host-browser-workspace',
+          browserPageId: 'remote-browser-page-1',
+          url: 'https://example.com/',
+          loading: false,
+          canGoBack: false,
+          canGoForward: false,
+          isActive: true
+        }
+      ]
+    }
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'create',
+        ok: true,
+        result: { browserPageId: 'remote-browser-page-1' }
+      })
+      .mockResolvedValueOnce({ id: 'list', ok: true, result: snapshot })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await createWebRuntimeSessionBrowserTab({ worktreeId: WORKTREE_ID })
+    await vi.waitFor(() => expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalled())
+
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'browser-create-success')).toBe(
+      'remote-browser-page-1'
+    )
+  })
+
+  it('retires browser focus when causal post-create truth focuses another page', async () => {
+    const snapshot: RuntimeMobileSessionTabsResult = {
+      ...makeSnapshot(),
+      publicationEpoch: 'concurrent-newer',
+      activeTabId: 'other-browser-tab',
+      activeTabType: 'browser',
+      tabs: [
+        {
+          type: 'browser',
+          id: 'other-browser-tab',
+          title: 'Other',
+          browserWorkspaceId: 'other-browser-workspace',
+          browserPageId: 'other-browser-page',
+          url: 'https://other.example/',
+          loading: false,
+          canGoBack: false,
+          canGoForward: false,
+          isActive: true
+        }
+      ]
+    }
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'create',
+        ok: true,
+        result: { browserPageId: 'remote-browser-page-1' }
+      })
+      .mockResolvedValueOnce({ id: 'list', ok: true, result: snapshot })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await createWebRuntimeSessionBrowserTab({ worktreeId: WORKTREE_ID })
+    await vi.waitFor(() => expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalled())
+
+    expect(getWebSessionFocusIntentCountForTests()).toBe(0)
   })
 
   it('keeps the requested worktree selected while the browser snapshot catches up', async () => {
@@ -398,6 +499,41 @@ describe('createWebRuntimeSessionBrowserTab', () => {
     await vi.waitFor(() => expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalledTimes(1))
     expect(mocks.setRemoteBrowserPageHandle).not.toHaveBeenCalled()
   })
+
+  it('clears an unbound browser focus intent when create fails', async () => {
+    const runtimeCall = vi.fn().mockResolvedValueOnce({
+      id: 'create',
+      ok: false,
+      error: { code: 'FAILED', message: 'browser create rejected' }
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(createWebRuntimeSessionBrowserTab({ worktreeId: WORKTREE_ID })).resolves.toBe(
+      false
+    )
+
+    expect(getWebSessionFocusIntentCountForTests()).toBe(0)
+  })
+
+  it('clears browser focus when the causal post-create snapshot fails', async () => {
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'create',
+        ok: true,
+        result: { browserPageId: 'remote-browser-page-1' }
+      })
+      .mockResolvedValueOnce({
+        id: 'list',
+        ok: false,
+        error: { code: 'FAILED', message: 'snapshot unavailable' }
+      })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(createWebRuntimeSessionBrowserTab({ worktreeId: WORKTREE_ID })).resolves.toBe(true)
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(getWebSessionFocusIntentCountForTests()).toBe(0))
+  })
 })
 
 describe('createWebRuntimeSessionTerminal', () => {
@@ -431,8 +567,10 @@ describe('createWebRuntimeSessionTerminal', () => {
   })
 
   it('creates paired web terminals through session tabs so host activation is mirrored', async () => {
+    rememberWebSessionPublicationEpoch(INTENT_SCOPE, 'before-create')
     const snapshot = {
       ...makeSnapshot(),
+      publicationEpoch: 'create-success',
       snapshotVersion: 2,
       activeTabId: 'host-tab-2::leaf-1',
       activeTabType: 'terminal' as const,
@@ -525,6 +663,8 @@ describe('createWebRuntimeSessionTerminal', () => {
       snapshot,
       ENVIRONMENT_ID
     )
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'before-create')).toBeNull()
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'create-success')).toBe('host-tab-2::leaf-1')
   })
 
   it('can create a terminal without selecting the target worktree', async () => {
@@ -780,6 +920,38 @@ describe('moveWebRuntimeSessionTab', () => {
 
     expect(runtimeCall).not.toHaveBeenCalled()
   })
+
+  it('drops the exact optimistic reorder when the host RPC fails', async () => {
+    mocks.resolveHostSessionTabIdForWebSessionTab.mockImplementation(
+      (_state, args: { tabId: string }) => `host-${args.tabId}`
+    )
+    const runtimeCall = vi.fn().mockResolvedValueOnce({
+      id: 'move',
+      ok: false,
+      error: { code: 'FAILED', message: 'move rejected' }
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(
+      moveWebRuntimeSessionTab({
+        worktreeId: WORKTREE_ID,
+        tabId: 'tab-b',
+        targetGroupId: 'group-1',
+        kind: 'reorder',
+        tabOrder: ['tab-b', 'tab-a']
+      })
+    ).resolves.toBe(false)
+
+    expect(
+      resolveWebSessionReorderedOrder(
+        INTENT_SCOPE,
+        'group-1',
+        ['tab-a', 'tab-b'],
+        Date.now(),
+        'epoch-1'
+      )
+    ).toEqual(['tab-a', 'tab-b'])
+  })
 })
 
 describe('web runtime session tab actions', () => {
@@ -835,6 +1007,7 @@ describe('web runtime session tab actions', () => {
         tabId: 'local-browser-unified'
       })
     ).resolves.toBe(true)
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'epoch-1')).toBe('host-browser-unified')
     await expect(
       closeWebRuntimeSessionTab({
         worktreeId: WORKTREE_ID,
@@ -869,6 +1042,59 @@ describe('web runtime session tab actions', () => {
       timeoutMs: 15_000
     })
     expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalled()
+  })
+
+  it('binds activation focus to the successful host response epoch', async () => {
+    rememberWebSessionPublicationEpoch(INTENT_SCOPE, 'before-activate')
+    const runtimeCall = vi.fn().mockResolvedValueOnce({
+      id: 'activate',
+      ok: true,
+      result: {
+        ...makeSnapshot(),
+        publicationEpoch: 'activate-success',
+        activeTabId: 'host-browser-unified',
+        activeTabType: 'browser'
+      }
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(
+      activateWebRuntimeSessionTab({
+        worktreeId: WORKTREE_ID,
+        tabId: 'local-browser-unified'
+      })
+    ).resolves.toBe(true)
+
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'before-activate')).toBeNull()
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'activate-success')).toBe('host-browser-unified')
+  })
+
+  it('clears exact activate and close intents when their host RPC fails', async () => {
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'activate',
+        ok: false,
+        error: { code: 'FAILED', message: 'activate rejected' }
+      })
+      .mockResolvedValueOnce({
+        id: 'close',
+        ok: false,
+        error: { code: 'FAILED', message: 'close rejected' }
+      })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(
+      activateWebRuntimeSessionTab({ worktreeId: WORKTREE_ID, tabId: 'local-browser-unified' })
+    ).resolves.toBe(false)
+    await expect(
+      closeWebRuntimeSessionTab({ worktreeId: WORKTREE_ID, tabId: 'local-browser-unified' })
+    ).resolves.toBe(false)
+
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'epoch-1')).toBeNull()
+    expect(
+      isWebSessionCloseIntentPending(INTENT_SCOPE, 'host-browser-unified', Date.now(), 'epoch-1')
+    ).toBe(false)
   })
 })
 

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -19,9 +19,20 @@ import { useAppStore } from '../store'
 import { unwrapRuntimeRpcResult } from './runtime-rpc-client'
 import { parseRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
-import { recordWebSessionFocusIntent } from './web-session-focus-intent'
-import { recordWebSessionCloseIntent } from './web-session-close-intent'
-import { recordWebSessionReorderIntent } from './web-session-reorder-intent'
+import {
+  beginWebSessionFocusIntent,
+  cancelWebSessionFocusIntent,
+  completeWebSessionFocusIntent
+} from './web-session-focus-intent'
+import { clearWebSessionCloseIntent, recordWebSessionCloseIntent } from './web-session-close-intent'
+import {
+  clearWebSessionReorderIntent,
+  recordWebSessionReorderIntent
+} from './web-session-reorder-intent'
+import {
+  getWebSessionPublicationEpoch,
+  type WebSessionIntentScope
+} from './web-session-intent-scope'
 import { isWebTerminalSurfaceTabId, toHostSessionTabId } from './web-terminal-surface-id'
 
 export {
@@ -66,6 +77,11 @@ export async function createWebRuntimeSessionTerminal(args: {
   if (!environmentId || !isWebRuntimeSessionActive(environmentId)) {
     return false
   }
+  const intentScope = { environmentId, worktreeId: args.worktreeId }
+  const focusIntentToken =
+    args.activate === false
+      ? null
+      : beginWebSessionFocusIntent(intentScope, getWebSessionPublicationEpoch(intentScope))
 
   if (args.selectWorktree !== false) {
     selectWebRuntimeSessionWorktree(args.worktreeId)
@@ -95,11 +111,21 @@ export async function createWebRuntimeSessionTerminal(args: {
     if (args.activate !== false) {
       // Why: record focus intent so the reconcile follows the snapshot's active
       // tab to THIS new terminal, instead of sticky-keeping the prior tab.
-      recordWebSessionFocusIntent(args.worktreeId, createdTerminal.tab.id)
+      if (focusIntentToken !== null) {
+        completeWebSessionFocusIntent(
+          intentScope,
+          focusIntentToken,
+          createdTerminal.tab.id,
+          createdTerminal.publicationEpoch
+        )
+      }
     }
     await refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId)
     return true
   } catch (error) {
+    if (focusIntentToken !== null) {
+      cancelWebSessionFocusIntent(intentScope, focusIntentToken)
+    }
     console.warn(
       '[web-runtime-session] failed to create terminal:',
       error instanceof Error ? error.message : String(error)
@@ -123,6 +149,10 @@ export async function createWebRuntimeSessionBrowserTab(args: {
   if (!environmentId || !isWebRuntimeSessionActive(environmentId)) {
     return false
   }
+  const intentScope = { environmentId, worktreeId: args.worktreeId }
+  // Why: browser.tabCreate does not return the publication epoch. Leave this
+  // unbound until a snapshot actually reports the created page as active.
+  const focusIntentToken = beginWebSessionFocusIntent(intentScope, null)
 
   const shouldSelectWorktree = args.selectWorktree !== false
   const stagedFromWorktreeId = useAppStore.getState().activeWorktreeId
@@ -155,7 +185,9 @@ export async function createWebRuntimeSessionBrowserTab(args: {
     // Why: record focus intent (browser session tab id === browserPageId on a
     // headless host) so the reconcile follows the snapshot's active tab to this
     // new browser tab rather than sticky-keeping the prior one.
-    recordWebSessionFocusIntent(args.worktreeId, created.browserPageId)
+    if (focusIntentToken !== null) {
+      completeWebSessionFocusIntent(intentScope, focusIntentToken, created.browserPageId)
+    }
     stageWebRuntimeBrowserTab({
       environmentId,
       worktreeId: args.worktreeId,
@@ -167,9 +199,16 @@ export async function createWebRuntimeSessionBrowserTab(args: {
         (stagedFromWorktreeId === args.worktreeId ||
           useAppStore.getState().activeWorktreeId === args.worktreeId)
     })
-    void refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId)
+    void refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId, {
+      scope: intentScope,
+      token: focusIntentToken,
+      hostTabId: created.browserPageId
+    })
     return true
   } catch (error) {
+    if (focusIntentToken !== null) {
+      cancelWebSessionFocusIntent(intentScope, focusIntentToken)
+    }
     console.warn(
       '[web-runtime-session] failed to create browser tab:',
       error instanceof Error ? error.message : String(error)
@@ -251,7 +290,12 @@ function findLocalBrowserPageForRemotePage(
 
 async function refreshWebRuntimeSessionTabsSnapshot(
   environmentId: string,
-  worktreeId: string
+  worktreeId: string,
+  focusConfirmation?: {
+    scope: WebSessionIntentScope
+    token: number | null
+    hostTabId: string
+  }
 ): Promise<void> {
   try {
     const response = await window.api.runtimeEnvironments.call({
@@ -265,6 +309,25 @@ async function refreshWebRuntimeSessionTabsSnapshot(
     const snapshot = unwrapRuntimeRpcResult(
       response as RuntimeRpcResponse<RuntimeMobileSessionTabsResult>
     )
+    if (focusConfirmation?.token !== null && focusConfirmation?.token !== undefined) {
+      const activeTab = snapshot.tabs.find((tab) => tab.id === snapshot.activeTabId)
+      const confirmsFocus =
+        snapshot.activeTabId === focusConfirmation.hostTabId ||
+        (activeTab?.type === 'browser' && activeTab.browserPageId === focusConfirmation.hostTabId)
+      if (confirmsFocus) {
+        completeWebSessionFocusIntent(
+          focusConfirmation.scope,
+          focusConfirmation.token,
+          focusConfirmation.hostTabId,
+          snapshot.publicationEpoch
+        )
+      } else {
+        // Why: this fetch is causally after browser creation. If newer host
+        // truth focuses something else, retire the unbound create intent so a
+        // late older publication cannot steal focus back.
+        cancelWebSessionFocusIntent(focusConfirmation.scope, focusConfirmation.token)
+      }
+    }
     const { applyFreshWebSessionTabsSnapshot } = await import('./web-session-tabs-sync')
     useAppStore.setState((state) => {
       // Why: eager refreshes can resolve after the user has selected another
@@ -273,6 +336,11 @@ async function refreshWebRuntimeSessionTabsSnapshot(
       return patch === state ? state : patch
     })
   } catch (error) {
+    if (focusConfirmation?.token !== null && focusConfirmation?.token !== undefined) {
+      // Why: without a causal post-create snapshot, leaving this unbound lets a
+      // late old frame claim it and steal focus after the create call returned.
+      cancelWebSessionFocusIntent(focusConfirmation.scope, focusConfirmation.token)
+    }
     // Why: browser creation already succeeded on the host. If the eager parity
     // refresh fails, the long-lived session.tabs subscription can still catch up.
     console.warn(
@@ -346,12 +414,22 @@ export async function moveWebRuntimeSessionTab(
     return false
   }
 
+  const intentScope = { environmentId, worktreeId: args.worktreeId }
+  const intentPublicationEpoch = getWebSessionPublicationEpoch(intentScope)
+  let reorderIntentToken: number | null = null
+
   if (args.kind === 'reorder') {
     // Why: record the intended LOCAL order synchronously, before the async host
     // resolution below, so an in-flight pre-move snapshot carrying the old order
     // can't snap the tab back. The reconcile applies this until the host echoes
     // the new order. (tabOrder here is already local unified tab ids.)
-    recordWebSessionReorderIntent(args.worktreeId, args.targetGroupId, args.tabOrder, Date.now())
+    reorderIntentToken = recordWebSessionReorderIntent(
+      intentScope,
+      args.targetGroupId,
+      args.tabOrder,
+      Date.now(),
+      intentPublicationEpoch
+    )
   }
 
   try {
@@ -367,6 +445,9 @@ export async function moveWebRuntimeSessionTab(
     const movedHostTabId =
       args.kind === 'reorder' ? resolveHostBackedTabId(args.tabId) : toHostTabId(args.tabId)
     if (!movedHostTabId) {
+      if (reorderIntentToken !== null) {
+        clearWebSessionReorderIntent(intentScope, args.targetGroupId, reorderIntentToken)
+      }
       return false
     }
     const reorderedHostTabOrder =
@@ -376,6 +457,9 @@ export async function moveWebRuntimeSessionTab(
             .filter((tabId): tabId is string => Boolean(tabId))
         : null
     if (reorderedHostTabOrder && !reorderedHostTabOrder.includes(movedHostTabId)) {
+      if (reorderIntentToken !== null) {
+        clearWebSessionReorderIntent(intentScope, args.targetGroupId, reorderIntentToken)
+      }
       return false
     }
     const targetHostIndex =
@@ -425,6 +509,9 @@ export async function moveWebRuntimeSessionTab(
     unwrapRuntimeRpcResult(response as RuntimeRpcResponse<RuntimeMobileSessionTabMoveResult>)
     return true
   } catch (error) {
+    if (reorderIntentToken !== null) {
+      clearWebSessionReorderIntent(intentScope, args.targetGroupId, reorderIntentToken)
+    }
     console.warn(
       '[web-runtime-session] failed to move tab:',
       error instanceof Error ? error.message : String(error)
@@ -449,6 +536,25 @@ async function callWebRuntimeSessionTabMethod(
     return false
   }
 
+  const intentScope: WebSessionIntentScope = { environmentId, worktreeId: args.worktreeId }
+  const intentPublicationEpoch = getWebSessionPublicationEpoch(intentScope)
+  const focusIntentToken =
+    method === 'session.tabs.activate'
+      ? beginWebSessionFocusIntent(intentScope, intentPublicationEpoch)
+      : null
+  const closeIntentTokens: { hostTabId: string; token: number }[] = []
+  const recordCloseIntent = (hostTabId: string): void => {
+    const token = recordWebSessionCloseIntent(
+      intentScope,
+      hostTabId,
+      Date.now(),
+      intentPublicationEpoch
+    )
+    if (token !== null) {
+      closeIntentTokens.push({ hostTabId, token })
+    }
+  }
+
   if (method === 'session.tabs.close') {
     // Why: the caller prunes the local mirror synchronously, but the precise
     // host id resolution below sits behind an async import. A host snapshot
@@ -456,7 +562,7 @@ async function callWebRuntimeSessionTabMethod(
     // intent exists to suppress it (the immediate "flash back"). Record a
     // best-effort intent synchronously now — the resolved-id record below then
     // covers any id the static decode couldn't recover.
-    recordWebSessionCloseIntent(args.worktreeId, toHostSessionTabId(args.tabId), Date.now())
+    recordCloseIntent(toHostSessionTabId(args.tabId))
   }
 
   try {
@@ -472,7 +578,7 @@ async function callWebRuntimeSessionTabMethod(
       // Why: the local mirror is pruned before this resolves, so suppress this
       // host tab in the reconcile until the host snapshot confirms removal —
       // otherwise an in-flight pre-close snapshot makes the tab flash back.
-      recordWebSessionCloseIntent(args.worktreeId, hostTabId, Date.now())
+      recordCloseIntent(hostTabId)
     }
     const response = await window.api.runtimeEnvironments.call({
       selector: environmentId,
@@ -483,12 +589,30 @@ async function callWebRuntimeSessionTabMethod(
       },
       timeoutMs: 15_000
     })
-    unwrapRuntimeRpcResult(response as RuntimeRpcResponse<unknown>)
+    const result = unwrapRuntimeRpcResult(
+      response as RuntimeRpcResponse<RuntimeMobileSessionTabsResult | unknown>
+    )
+    if (focusIntentToken !== null) {
+      const publicationEpoch =
+        result &&
+        typeof result === 'object' &&
+        'publicationEpoch' in result &&
+        typeof result.publicationEpoch === 'string'
+          ? result.publicationEpoch
+          : intentPublicationEpoch
+      completeWebSessionFocusIntent(intentScope, focusIntentToken, hostTabId, publicationEpoch)
+    }
     if (method === 'session.tabs.close') {
       await refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId)
     }
     return true
   } catch (error) {
+    if (focusIntentToken !== null) {
+      cancelWebSessionFocusIntent(intentScope, focusIntentToken)
+    }
+    for (const intent of closeIntentTokens) {
+      clearWebSessionCloseIntent(intentScope, intent.hostTabId, intent.token)
+    }
     console.warn(
       `[web-runtime-session] failed to ${method === 'session.tabs.close' ? 'close' : 'activate'} tab:`,
       error instanceof Error ? error.message : String(error)

--- a/src/renderer/src/runtime/web-session-close-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-close-intent.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES,
+  MAX_WEB_SESSION_CLOSE_INTENT_SCOPES,
+  MAX_WEB_SESSION_CLOSE_INTENTS_PER_SCOPE,
+  clearWebSessionCloseIntent,
+  clearWebSessionCloseIntentsForEnvironment,
   clearWebSessionCloseIntentsForWorktree,
   getWebSessionCloseIntentCountsForTests,
   isWebSessionCloseIntentPending,
@@ -8,77 +11,127 @@ import {
   recordWebSessionCloseIntent,
   resetWebSessionCloseIntentForTests
 } from './web-session-close-intent'
+import type { WebSessionIntentScope } from './web-session-intent-scope'
 
-const WT = 'repo::/wt'
+const SCOPE = { environmentId: 'env-a', worktreeId: 'repo::/wt' }
+const EPOCH = 'host-generation-a'
+const NOW = 1_000
 
 afterEach(() => resetWebSessionCloseIntentForTests())
 
+function scope(environmentId: string, worktreeId: string): WebSessionIntentScope {
+  return { environmentId, worktreeId }
+}
+
+function isPending(
+  intentScope: WebSessionIntentScope,
+  hostTabId: string,
+  now = NOW,
+  epoch = EPOCH
+): boolean {
+  return isWebSessionCloseIntentPending(intentScope, hostTabId, now, epoch)
+}
+
 describe('web session close intent', () => {
-  it('marks a closing host tab pending until the host confirms removal', () => {
-    recordWebSessionCloseIntent(WT, 'host-tab-1', 1000)
-    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 1000)).toBe(true)
+  it('stays pending until the same host generation confirms removal', () => {
+    recordWebSessionCloseIntent(SCOPE, 'host-tab-1', NOW, EPOCH)
+    expect(isPending(SCOPE, 'host-tab-1')).toBe(true)
 
-    // A snapshot that still contains the tab keeps the intent (not confirmed).
-    reconcileWebSessionCloseIntents(WT, new Set(['host-tab-1', 'host-tab-2']))
-    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 1000)).toBe(true)
+    reconcileWebSessionCloseIntents(SCOPE, new Set(['host-tab-1', 'host-tab-2']), NOW, EPOCH)
+    expect(isPending(SCOPE, 'host-tab-1')).toBe(true)
 
-    // A snapshot WITHOUT the tab confirms removal and clears the intent.
-    reconcileWebSessionCloseIntents(WT, new Set(['host-tab-2']))
-    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 1000)).toBe(false)
+    reconcileWebSessionCloseIntents(SCOPE, new Set(['host-tab-2']), NOW, EPOCH)
+    expect(isPending(SCOPE, 'host-tab-1')).toBe(false)
   })
 
-  it('expires a never-confirmed close so the tab is not hidden forever', () => {
-    recordWebSessionCloseIntent(WT, 'host-tab-1', 1000)
-    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 1000)).toBe(true)
-    // Past the TTL with no confirming snapshot — stop suppressing.
-    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 1000 + 11_000)).toBe(false)
+  it('survives a slow reconnect longer than ten seconds', () => {
+    recordWebSessionCloseIntent(SCOPE, 'host-tab-1', NOW, EPOCH)
+
+    expect(isPending(SCOPE, 'host-tab-1', NOW + 120_000)).toBe(true)
   })
 
-  it('prunes expired worktree intents when recording a newer intent', () => {
-    recordWebSessionCloseIntent('old-worktree', 'host-tab-old', 1000)
+  it('isolates identical worktree and tab ids across hosts and generations', () => {
+    const otherHost = scope('env-b', SCOPE.worktreeId)
+    recordWebSessionCloseIntent(SCOPE, 'reused-tab', NOW, EPOCH)
+    recordWebSessionCloseIntent(otherHost, 'reused-tab', NOW, 'epoch-b')
 
-    recordWebSessionCloseIntent(WT, 'host-tab-1', 11_001)
-
-    expect(getWebSessionCloseIntentCountsForTests()).toEqual({ worktrees: 1, tabs: 1 })
-    expect(isWebSessionCloseIntentPending('old-worktree', 'host-tab-old', 11_001)).toBe(false)
-    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 11_001)).toBe(true)
+    expect(isPending(SCOPE, 'reused-tab', NOW, 'epoch-b')).toBe(false)
+    expect(isPending(SCOPE, 'reused-tab', NOW, EPOCH)).toBe(true)
+    expect(isPending(otherHost, 'reused-tab', NOW, 'epoch-b')).toBe(true)
   })
 
-  it('bounds worktree intents while retaining recently reused worktrees', () => {
-    recordWebSessionCloseIntent('keep', 'host-tab-keep', 1000)
-    for (let i = 0; i < MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES - 1; i += 1) {
-      recordWebSessionCloseIntent(`worktree-${i}`, 'host-tab', 1000)
+  it('suppresses a late pre-close frame after success and concurrent epoch advances', () => {
+    recordWebSessionCloseIntent(SCOPE, 'reused-tab', NOW, 'before-close')
+
+    reconcileWebSessionCloseIntents(SCOPE, new Set(), NOW + 1, 'close-success')
+    expect(isPending(SCOPE, 'reused-tab', NOW + 2, 'concurrent-newer')).toBe(false)
+    expect(isPending(SCOPE, 'reused-tab', NOW + 3, 'before-close')).toBe(true)
+    expect(isPending(SCOPE, 'reused-tab', NOW + 120_000, 'before-close')).toBe(true)
+  })
+
+  it('does not let an older failed RPC clear a newer retry', () => {
+    const older = recordWebSessionCloseIntent(SCOPE, 'host-tab-1', NOW, EPOCH)
+    const newer = recordWebSessionCloseIntent(SCOPE, 'host-tab-1', NOW + 1, EPOCH)
+    expect(older).not.toBeNull()
+    expect(newer).not.toBeNull()
+
+    clearWebSessionCloseIntent(SCOPE, 'host-tab-1', older!)
+
+    expect(isPending(SCOPE, 'host-tab-1', NOW + 1)).toBe(true)
+  })
+
+  it('clears only the current retry when the newer RPC fails first', () => {
+    recordWebSessionCloseIntent(SCOPE, 'host-tab-1', NOW, EPOCH)
+    const newer = recordWebSessionCloseIntent(SCOPE, 'host-tab-1', NOW + 1, EPOCH)
+
+    clearWebSessionCloseIntent(SCOPE, 'host-tab-1', newer!)
+
+    expect(isPending(SCOPE, 'host-tab-1', NOW + 1)).toBe(false)
+  })
+
+  it('bounds 10k tab intents inside one scope', () => {
+    for (let i = 0; i < 10_000; i += 1) {
+      recordWebSessionCloseIntent(SCOPE, `host-tab-${i}`, NOW, EPOCH)
     }
 
-    expect(isWebSessionCloseIntentPending('keep', 'host-tab-keep', 1000)).toBe(true)
+    expect(getWebSessionCloseIntentCountsForTests()).toEqual({
+      scopes: 1,
+      tabs: MAX_WEB_SESSION_CLOSE_INTENTS_PER_SCOPE
+    })
+    expect(isPending(SCOPE, 'host-tab-0')).toBe(false)
+    expect(isPending(SCOPE, 'host-tab-9999')).toBe(true)
+  })
 
-    recordWebSessionCloseIntent('worktree-new', 'host-tab-new', 1000)
+  it('bounds 10k host-worktree scopes', () => {
+    for (let i = 0; i < 10_000; i += 1) {
+      recordWebSessionCloseIntent(
+        scope(`env-${i}`, `worktree-${i}`),
+        `host-tab-${i}`,
+        NOW,
+        `epoch-${i}`
+      )
+    }
 
     expect(getWebSessionCloseIntentCountsForTests()).toEqual({
-      worktrees: MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES,
-      tabs: MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES
+      scopes: MAX_WEB_SESSION_CLOSE_INTENT_SCOPES,
+      tabs: MAX_WEB_SESSION_CLOSE_INTENT_SCOPES
     })
-    expect(isWebSessionCloseIntentPending('worktree-0', 'host-tab', 1000)).toBe(false)
-    expect(isWebSessionCloseIntentPending('keep', 'host-tab-keep', 1000)).toBe(true)
+    expect(isPending(scope('env-0', 'worktree-0'), 'host-tab-0', NOW, 'epoch-0')).toBe(false)
   })
 
-  it('scopes intents per worktree', () => {
-    recordWebSessionCloseIntent(WT, 'host-tab-1', 1000)
-    expect(isWebSessionCloseIntentPending('other::/wt', 'host-tab-1', 1000)).toBe(false)
-  })
+  it('clears one worktree or environment without touching another host', () => {
+    const sibling = scope(SCOPE.environmentId, 'repo::/sibling')
+    const otherHost = scope('env-b', SCOPE.worktreeId)
+    recordWebSessionCloseIntent(SCOPE, 'tab-a', NOW, EPOCH)
+    recordWebSessionCloseIntent(sibling, 'tab-b', NOW, EPOCH)
+    recordWebSessionCloseIntent(otherHost, 'tab-c', NOW, 'epoch-b')
 
-  it('ignores empty ids', () => {
-    recordWebSessionCloseIntent(WT, '   ', 1000)
-    expect(isWebSessionCloseIntentPending(WT, '', 1000)).toBe(false)
-  })
+    clearWebSessionCloseIntentsForWorktree(SCOPE)
+    expect(isPending(SCOPE, 'tab-a')).toBe(false)
+    expect(isPending(sibling, 'tab-b')).toBe(true)
 
-  it('clears one worktree without touching another', () => {
-    recordWebSessionCloseIntent(WT, 'host-tab-1', 1000)
-    recordWebSessionCloseIntent('repo::/other', 'host-tab-2', 1000)
-
-    clearWebSessionCloseIntentsForWorktree(WT)
-
-    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 1000)).toBe(false)
-    expect(isWebSessionCloseIntentPending('repo::/other', 'host-tab-2', 1000)).toBe(true)
+    clearWebSessionCloseIntentsForEnvironment(SCOPE.environmentId)
+    expect(isPending(sibling, 'tab-b')).toBe(false)
+    expect(isPending(otherHost, 'tab-c', NOW, 'epoch-b')).toBe(true)
   })
 })

--- a/src/renderer/src/runtime/web-session-close-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-close-intent.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES,
+  clearWebSessionCloseIntentsForWorktree,
+  getWebSessionCloseIntentCountsForTests,
   isWebSessionCloseIntentPending,
   reconcileWebSessionCloseIntents,
   recordWebSessionCloseIntent,
@@ -31,6 +34,34 @@ describe('web session close intent', () => {
     expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 1000 + 11_000)).toBe(false)
   })
 
+  it('prunes expired worktree intents when recording a newer intent', () => {
+    recordWebSessionCloseIntent('old-worktree', 'host-tab-old', 1000)
+
+    recordWebSessionCloseIntent(WT, 'host-tab-1', 11_001)
+
+    expect(getWebSessionCloseIntentCountsForTests()).toEqual({ worktrees: 1, tabs: 1 })
+    expect(isWebSessionCloseIntentPending('old-worktree', 'host-tab-old', 11_001)).toBe(false)
+    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 11_001)).toBe(true)
+  })
+
+  it('bounds worktree intents while retaining recently reused worktrees', () => {
+    recordWebSessionCloseIntent('keep', 'host-tab-keep', 1000)
+    for (let i = 0; i < MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES - 1; i += 1) {
+      recordWebSessionCloseIntent(`worktree-${i}`, 'host-tab', 1000)
+    }
+
+    expect(isWebSessionCloseIntentPending('keep', 'host-tab-keep', 1000)).toBe(true)
+
+    recordWebSessionCloseIntent('worktree-new', 'host-tab-new', 1000)
+
+    expect(getWebSessionCloseIntentCountsForTests()).toEqual({
+      worktrees: MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES,
+      tabs: MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES
+    })
+    expect(isWebSessionCloseIntentPending('worktree-0', 'host-tab', 1000)).toBe(false)
+    expect(isWebSessionCloseIntentPending('keep', 'host-tab-keep', 1000)).toBe(true)
+  })
+
   it('scopes intents per worktree', () => {
     recordWebSessionCloseIntent(WT, 'host-tab-1', 1000)
     expect(isWebSessionCloseIntentPending('other::/wt', 'host-tab-1', 1000)).toBe(false)
@@ -39,5 +70,15 @@ describe('web session close intent', () => {
   it('ignores empty ids', () => {
     recordWebSessionCloseIntent(WT, '   ', 1000)
     expect(isWebSessionCloseIntentPending(WT, '', 1000)).toBe(false)
+  })
+
+  it('clears one worktree without touching another', () => {
+    recordWebSessionCloseIntent(WT, 'host-tab-1', 1000)
+    recordWebSessionCloseIntent('repo::/other', 'host-tab-2', 1000)
+
+    clearWebSessionCloseIntentsForWorktree(WT)
+
+    expect(isWebSessionCloseIntentPending(WT, 'host-tab-1', 1000)).toBe(false)
+    expect(isWebSessionCloseIntentPending('repo::/other', 'host-tab-2', 1000)).toBe(true)
   })
 })

--- a/src/renderer/src/runtime/web-session-close-intent.ts
+++ b/src/renderer/src/runtime/web-session-close-intent.ts
@@ -13,11 +13,44 @@
 // permanently hiding a tab that legitimately still exists host-side.
 
 const CLOSE_INTENT_TTL_MS = 10_000
+export const MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES = 256
 
 type CloseIntent = { recordedAt: number }
 
 // worktreeId -> (hostTabId -> intent)
 const pendingCloseByWorktree = new Map<string, Map<string, CloseIntent>>()
+
+function deleteEmptyCloseIntentWorktree(worktreeId: string, byTab: Map<string, CloseIntent>): void {
+  if (byTab.size === 0) {
+    pendingCloseByWorktree.delete(worktreeId)
+  }
+}
+
+function refreshCloseIntentWorktree(worktreeId: string, byTab: Map<string, CloseIntent>): void {
+  pendingCloseByWorktree.delete(worktreeId)
+  pendingCloseByWorktree.set(worktreeId, byTab)
+}
+
+function pruneExpiredWebSessionCloseIntents(now: number): void {
+  for (const [worktreeId, byTab] of pendingCloseByWorktree) {
+    for (const [hostTabId, intent] of byTab) {
+      if (now - intent.recordedAt > CLOSE_INTENT_TTL_MS) {
+        byTab.delete(hostTabId)
+      }
+    }
+    deleteEmptyCloseIntentWorktree(worktreeId, byTab)
+  }
+}
+
+function trimWebSessionCloseIntentWorktrees(): void {
+  while (pendingCloseByWorktree.size > MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES) {
+    const oldestWorktreeId = pendingCloseByWorktree.keys().next().value
+    if (oldestWorktreeId === undefined) {
+      break
+    }
+    pendingCloseByWorktree.delete(oldestWorktreeId)
+  }
+}
 
 export function recordWebSessionCloseIntent(
   worktreeId: string,
@@ -28,12 +61,16 @@ export function recordWebSessionCloseIntent(
   if (!worktreeId || !trimmed) {
     return
   }
+  // Why: close intents already expire; prune all worktrees on new writes so
+  // removed worktrees that never reconcile again do not retain stale tab ids.
+  pruneExpiredWebSessionCloseIntents(now)
   let byTab = pendingCloseByWorktree.get(worktreeId)
   if (!byTab) {
     byTab = new Map()
-    pendingCloseByWorktree.set(worktreeId, byTab)
   }
+  refreshCloseIntentWorktree(worktreeId, byTab)
   byTab.set(trimmed, { recordedAt: now })
+  trimWebSessionCloseIntentWorktrees()
 }
 
 /**
@@ -47,17 +84,19 @@ export function isWebSessionCloseIntentPending(
   now: number
 ): boolean {
   const byTab = pendingCloseByWorktree.get(worktreeId)
-  const intent = byTab?.get(hostTabId)
+  if (!byTab) {
+    return false
+  }
+  const intent = byTab.get(hostTabId)
   if (!intent) {
     return false
   }
   if (now - intent.recordedAt > CLOSE_INTENT_TTL_MS) {
-    byTab!.delete(hostTabId)
-    if (byTab!.size === 0) {
-      pendingCloseByWorktree.delete(worktreeId)
-    }
+    byTab.delete(hostTabId)
+    deleteEmptyCloseIntentWorktree(worktreeId, byTab)
     return false
   }
+  refreshCloseIntentWorktree(worktreeId, byTab)
   return true
 }
 
@@ -82,11 +121,25 @@ export function reconcileWebSessionCloseIntents(
   for (const hostTabId of confirmed) {
     byTab.delete(hostTabId)
   }
-  if (byTab.size === 0) {
-    pendingCloseByWorktree.delete(worktreeId)
+  if (byTab.size > 0) {
+    refreshCloseIntentWorktree(worktreeId, byTab)
+    return
   }
+  pendingCloseByWorktree.delete(worktreeId)
+}
+
+export function clearWebSessionCloseIntentsForWorktree(worktreeId: string): void {
+  pendingCloseByWorktree.delete(worktreeId)
 }
 
 export function resetWebSessionCloseIntentForTests(): void {
   pendingCloseByWorktree.clear()
+}
+
+export function getWebSessionCloseIntentCountsForTests(): { worktrees: number; tabs: number } {
+  let tabs = 0
+  for (const byTab of pendingCloseByWorktree.values()) {
+    tabs += byTab.size
+  }
+  return { worktrees: pendingCloseByWorktree.size, tabs }
 }

--- a/src/renderer/src/runtime/web-session-close-intent.ts
+++ b/src/renderer/src/runtime/web-session-close-intent.ts
@@ -1,145 +1,177 @@
-// Why: closing a remote tab prunes the local mirror immediately for
-// responsiveness, then asks the host to close it. But an in-flight host snapshot
-// (published before the host processed the close, or the close RPC's own
-// pre-close subscribe replay) can arrive AFTER the local prune and still contain
-// the tab — the reconcile then re-materializes the just-closed tab, which the
-// host's real post-close snapshot removes again a beat later. That round trip is
-// the close "flash and reappear".
-//
-// The client records its own close intent here (host tab id pending removal).
-// The reconcile drops any host tab matching a pending intent until a snapshot
-// confirms the removal (tab absent), then clears it — mirroring the focus-intent
-// mechanism. A TTL guards against a never-confirmed close (e.g. failed RPC)
-// permanently hiding a tab that legitimately still exists host-side.
+import {
+  getWebSessionPublicationEpoch,
+  webSessionIntentEnvironmentPrefix,
+  webSessionIntentScopeKey,
+  type WebSessionIntentScope
+} from './web-session-intent-scope'
 
-const CLOSE_INTENT_TTL_MS = 10_000
-export const MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES = 256
+// Why: closing a remote tab prunes the local mirror immediately, but an
+// in-flight pre-close host snapshot can otherwise make the tab flash back.
+// Lifecycle cleanup and caps bound retention without expiring a valid intent
+// during a slow reconnect.
+export const MAX_WEB_SESSION_CLOSE_INTENT_SCOPES = 256
+export const MAX_WEB_SESSION_CLOSE_INTENTS_PER_SCOPE = 256
 
-type CloseIntent = { recordedAt: number }
+type CloseIntent = {
+  token: number
+  publicationEpoch: string | null
+}
 
-// worktreeId -> (hostTabId -> intent)
-const pendingCloseByWorktree = new Map<string, Map<string, CloseIntent>>()
+// host/runtime + worktree -> (host tab id -> intent)
+const pendingCloseByScope = new Map<string, Map<string, CloseIntent>>()
+let nextCloseIntentToken = 0
 
-function deleteEmptyCloseIntentWorktree(worktreeId: string, byTab: Map<string, CloseIntent>): void {
+function deleteEmptyCloseIntentScope(scopeKey: string, byTab: Map<string, CloseIntent>): void {
   if (byTab.size === 0) {
-    pendingCloseByWorktree.delete(worktreeId)
+    pendingCloseByScope.delete(scopeKey)
   }
 }
 
-function refreshCloseIntentWorktree(worktreeId: string, byTab: Map<string, CloseIntent>): void {
-  pendingCloseByWorktree.delete(worktreeId)
-  pendingCloseByWorktree.set(worktreeId, byTab)
+function refreshCloseIntentScope(scopeKey: string, byTab: Map<string, CloseIntent>): void {
+  pendingCloseByScope.delete(scopeKey)
+  pendingCloseByScope.set(scopeKey, byTab)
 }
 
-function pruneExpiredWebSessionCloseIntents(now: number): void {
-  for (const [worktreeId, byTab] of pendingCloseByWorktree) {
-    for (const [hostTabId, intent] of byTab) {
-      if (now - intent.recordedAt > CLOSE_INTENT_TTL_MS) {
-        byTab.delete(hostTabId)
-      }
-    }
-    deleteEmptyCloseIntentWorktree(worktreeId, byTab)
-  }
-}
-
-function trimWebSessionCloseIntentWorktrees(): void {
-  while (pendingCloseByWorktree.size > MAX_WEB_SESSION_CLOSE_INTENT_WORKTREES) {
-    const oldestWorktreeId = pendingCloseByWorktree.keys().next().value
-    if (oldestWorktreeId === undefined) {
+function trimWebSessionCloseIntentScopes(): void {
+  while (pendingCloseByScope.size > MAX_WEB_SESSION_CLOSE_INTENT_SCOPES) {
+    const oldestScopeKey = pendingCloseByScope.keys().next().value
+    if (oldestScopeKey === undefined) {
       break
     }
-    pendingCloseByWorktree.delete(oldestWorktreeId)
+    pendingCloseByScope.delete(oldestScopeKey)
+  }
+}
+
+function trimWebSessionCloseIntents(byTab: Map<string, CloseIntent>): void {
+  while (byTab.size > MAX_WEB_SESSION_CLOSE_INTENTS_PER_SCOPE) {
+    const oldestHostTabId = byTab.keys().next().value
+    if (oldestHostTabId === undefined) {
+      break
+    }
+    byTab.delete(oldestHostTabId)
   }
 }
 
 export function recordWebSessionCloseIntent(
-  worktreeId: string,
+  scope: WebSessionIntentScope,
   hostTabId: string,
-  now: number
-): void {
-  const trimmed = hostTabId.trim()
-  if (!worktreeId || !trimmed) {
-    return
+  _now: number,
+  publicationEpoch = getWebSessionPublicationEpoch(scope)
+): number | null {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const trimmedHostTabId = hostTabId.trim()
+  if (!scopeKey || !trimmedHostTabId) {
+    return null
   }
-  // Why: close intents already expire; prune all worktrees on new writes so
-  // removed worktrees that never reconcile again do not retain stale tab ids.
-  pruneExpiredWebSessionCloseIntents(now)
-  let byTab = pendingCloseByWorktree.get(worktreeId)
-  if (!byTab) {
-    byTab = new Map()
-  }
-  refreshCloseIntentWorktree(worktreeId, byTab)
-  byTab.set(trimmed, { recordedAt: now })
-  trimWebSessionCloseIntentWorktrees()
+  const byTab = pendingCloseByScope.get(scopeKey) ?? new Map<string, CloseIntent>()
+  refreshCloseIntentScope(scopeKey, byTab)
+  const token = ++nextCloseIntentToken
+  byTab.delete(trimmedHostTabId)
+  byTab.set(trimmedHostTabId, { token, publicationEpoch })
+  trimWebSessionCloseIntents(byTab)
+  trimWebSessionCloseIntentScopes()
+  return token
 }
 
-/**
- * Whether a host tab should be hidden because the client is closing it. Expired
- * intents are dropped (the close never confirmed — let the tab reappear rather
- * than hide it forever).
- */
-export function isWebSessionCloseIntentPending(
-  worktreeId: string,
-  hostTabId: string,
-  now: number
+function intentMatchesSnapshotGeneration(
+  intent: CloseIntent,
+  snapshotPublicationEpoch: string
 ): boolean {
-  const byTab = pendingCloseByWorktree.get(worktreeId)
-  if (!byTab) {
+  if (intent.publicationEpoch === null) {
+    intent.publicationEpoch = snapshotPublicationEpoch
+  }
+  return intent.publicationEpoch === snapshotPublicationEpoch
+}
+
+export function isWebSessionCloseIntentPending(
+  scope: WebSessionIntentScope,
+  hostTabId: string,
+  _now: number,
+  snapshotPublicationEpoch: string
+): boolean {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const byTab = scopeKey ? pendingCloseByScope.get(scopeKey) : undefined
+  const intent = byTab?.get(hostTabId)
+  if (!scopeKey || !byTab || !intent) {
     return false
   }
-  const intent = byTab.get(hostTabId)
-  if (!intent) {
+  if (!intentMatchesSnapshotGeneration(intent, snapshotPublicationEpoch)) {
     return false
   }
-  if (now - intent.recordedAt > CLOSE_INTENT_TTL_MS) {
-    byTab.delete(hostTabId)
-    deleteEmptyCloseIntentWorktree(worktreeId, byTab)
-    return false
-  }
-  refreshCloseIntentWorktree(worktreeId, byTab)
+  refreshCloseIntentScope(scopeKey, byTab)
   return true
 }
 
-/**
- * Clear close intents the host snapshot has confirmed: any pending host tab id
- * NOT in `presentHostTabIds` has been removed host-side, so the intent is done.
- */
 export function reconcileWebSessionCloseIntents(
-  worktreeId: string,
-  presentHostTabIds: ReadonlySet<string>
+  scope: WebSessionIntentScope,
+  presentHostTabIds: ReadonlySet<string>,
+  _now: number,
+  snapshotPublicationEpoch: string
 ): void {
-  const byTab = pendingCloseByWorktree.get(worktreeId)
-  if (!byTab) {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const byTab = scopeKey ? pendingCloseByScope.get(scopeKey) : undefined
+  if (!scopeKey || !byTab) {
     return
   }
-  const confirmed: string[] = []
-  for (const hostTabId of byTab.keys()) {
-    if (!presentHostTabIds.has(hostTabId)) {
-      confirmed.push(hostTabId)
+  for (const [hostTabId, intent] of byTab) {
+    const sameGeneration = intentMatchesSnapshotGeneration(intent, snapshotPublicationEpoch)
+    if (sameGeneration && !presentHostTabIds.has(hostTabId)) {
+      byTab.delete(hostTabId)
     }
   }
-  for (const hostTabId of confirmed) {
-    byTab.delete(hostTabId)
-  }
   if (byTab.size > 0) {
-    refreshCloseIntentWorktree(worktreeId, byTab)
+    refreshCloseIntentScope(scopeKey, byTab)
     return
   }
-  pendingCloseByWorktree.delete(worktreeId)
+  pendingCloseByScope.delete(scopeKey)
 }
 
-export function clearWebSessionCloseIntentsForWorktree(worktreeId: string): void {
-  pendingCloseByWorktree.delete(worktreeId)
+export function clearWebSessionCloseIntent(
+  scope: WebSessionIntentScope,
+  hostTabId: string,
+  token: number
+): void {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const byTab = scopeKey ? pendingCloseByScope.get(scopeKey) : undefined
+  if (!scopeKey || !byTab) {
+    return
+  }
+  const trimmedHostTabId = hostTabId.trim()
+  if (byTab.get(trimmedHostTabId)?.token !== token) {
+    return
+  }
+  byTab.delete(trimmedHostTabId)
+  deleteEmptyCloseIntentScope(scopeKey, byTab)
+}
+
+export function clearWebSessionCloseIntentsForWorktree(scope: WebSessionIntentScope): void {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  if (scopeKey) {
+    pendingCloseByScope.delete(scopeKey)
+  }
+}
+
+export function clearWebSessionCloseIntentsForEnvironment(environmentId: string): void {
+  const prefix = webSessionIntentEnvironmentPrefix(environmentId)
+  if (!prefix) {
+    return
+  }
+  for (const key of pendingCloseByScope.keys()) {
+    if (key.startsWith(prefix)) {
+      pendingCloseByScope.delete(key)
+    }
+  }
 }
 
 export function resetWebSessionCloseIntentForTests(): void {
-  pendingCloseByWorktree.clear()
+  pendingCloseByScope.clear()
+  nextCloseIntentToken = 0
 }
 
-export function getWebSessionCloseIntentCountsForTests(): { worktrees: number; tabs: number } {
+export function getWebSessionCloseIntentCountsForTests(): { scopes: number; tabs: number } {
   let tabs = 0
-  for (const byTab of pendingCloseByWorktree.values()) {
+  for (const byTab of pendingCloseByScope.values()) {
     tabs += byTab.size
   }
-  return { worktrees: pendingCloseByWorktree.size, tabs }
+  return { scopes: pendingCloseByScope.size, tabs }
 }

--- a/src/renderer/src/runtime/web-session-focus-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES,
+  clearWebSessionFocusIntent,
+  getWebSessionFocusIntentCountForTests,
+  peekWebSessionFocusIntent,
+  recordWebSessionFocusIntent,
+  resetWebSessionFocusIntentForTests
+} from './web-session-focus-intent'
+
+const WT = 'repo::/wt'
+
+afterEach(() => resetWebSessionFocusIntentForTests())
+
+describe('web session focus intent', () => {
+  it('expires a never-confirmed focus intent', () => {
+    recordWebSessionFocusIntent(WT, 'host-tab-1', 1000)
+
+    expect(peekWebSessionFocusIntent(WT, 1000)).toBe('host-tab-1')
+    expect(peekWebSessionFocusIntent(WT, 61_001)).toBeNull()
+    expect(getWebSessionFocusIntentCountForTests()).toBe(0)
+  })
+
+  it('bounds worktree intents while retaining recently reused worktrees', () => {
+    recordWebSessionFocusIntent('keep', 'host-tab-keep', 1000)
+    for (let i = 0; i < MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES - 1; i += 1) {
+      recordWebSessionFocusIntent(`worktree-${i}`, `host-tab-${i}`, 1000)
+    }
+
+    expect(peekWebSessionFocusIntent('keep', 1000)).toBe('host-tab-keep')
+
+    recordWebSessionFocusIntent('worktree-new', 'host-tab-new', 1000)
+
+    expect(getWebSessionFocusIntentCountForTests()).toBe(MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES)
+    expect(peekWebSessionFocusIntent('worktree-0', 1000)).toBeNull()
+    expect(peekWebSessionFocusIntent('keep', 1000)).toBe('host-tab-keep')
+  })
+
+  it('clears one worktree without touching another', () => {
+    recordWebSessionFocusIntent(WT, 'host-tab-1', 1000)
+    recordWebSessionFocusIntent('repo::/other', 'host-tab-2', 1000)
+
+    clearWebSessionFocusIntent(WT)
+
+    expect(peekWebSessionFocusIntent(WT, 1000)).toBeNull()
+    expect(peekWebSessionFocusIntent('repo::/other', 1000)).toBe('host-tab-2')
+  })
+})

--- a/src/renderer/src/runtime/web-session-focus-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent.test.ts
@@ -1,48 +1,176 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES,
+  MAX_WEB_SESSION_FOCUS_INTENT_SCOPES,
+  beginWebSessionFocusIntent,
   clearWebSessionFocusIntent,
+  clearWebSessionFocusIntentsForEnvironment,
+  completeWebSessionFocusIntent,
+  consumeWebSessionFocusIntent,
   getWebSessionFocusIntentCountForTests,
   peekWebSessionFocusIntent,
   recordWebSessionFocusIntent,
   resetWebSessionFocusIntentForTests
 } from './web-session-focus-intent'
+import {
+  MAX_WEB_SESSION_PUBLICATION_EPOCH_SCOPES,
+  MAX_WEB_SESSION_PUBLICATION_EPOCHS_PER_SCOPE,
+  getWebSessionPublicationEpoch,
+  getWebSessionPublicationEpochCountForTests,
+  getWebSessionPublicationEpochEntryCountForTests,
+  rememberWebSessionPublicationEpoch,
+  resetWebSessionPublicationEpochsForTests,
+  type WebSessionIntentScope
+} from './web-session-intent-scope'
 
-const WT = 'repo::/wt'
+const SCOPE = { environmentId: 'env-a', worktreeId: 'repo::/wt' }
+const EPOCH = 'host-generation-a'
 
-afterEach(() => resetWebSessionFocusIntentForTests())
+afterEach(() => {
+  resetWebSessionFocusIntentForTests()
+  resetWebSessionPublicationEpochsForTests()
+})
+
+function scope(environmentId: string, worktreeId: string): WebSessionIntentScope {
+  return { environmentId, worktreeId }
+}
 
 describe('web session focus intent', () => {
-  it('expires a never-confirmed focus intent', () => {
-    recordWebSessionFocusIntent(WT, 'host-tab-1', 1000)
+  it('survives a reconnect longer than sixty seconds in the same host generation', () => {
+    recordWebSessionFocusIntent(SCOPE, 'host-tab-1', EPOCH)
 
-    expect(peekWebSessionFocusIntent(WT, 1000)).toBe('host-tab-1')
-    expect(peekWebSessionFocusIntent(WT, 61_001)).toBeNull()
-    expect(getWebSessionFocusIntentCountForTests()).toBe(0)
+    expect(peekWebSessionFocusIntent(SCOPE, EPOCH)).toBe('host-tab-1')
   })
 
-  it('bounds worktree intents while retaining recently reused worktrees', () => {
-    recordWebSessionFocusIntent('keep', 'host-tab-keep', 1000)
-    for (let i = 0; i < MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES - 1; i += 1) {
-      recordWebSessionFocusIntent(`worktree-${i}`, `host-tab-${i}`, 1000)
+  it('isolates identical worktree and tab ids across runtime hosts', () => {
+    const otherHost = scope('env-b', SCOPE.worktreeId)
+    recordWebSessionFocusIntent(SCOPE, 'same-tab', EPOCH)
+    recordWebSessionFocusIntent(otherHost, 'same-tab', 'host-generation-b')
+
+    expect(peekWebSessionFocusIntent(SCOPE, EPOCH)).toBe('same-tab')
+    expect(peekWebSessionFocusIntent(otherHost, 'host-generation-b')).toBe('same-tab')
+  })
+
+  it('never applies an old host generation to a restarted host with reused ids', () => {
+    recordWebSessionFocusIntent(SCOPE, 'reused-tab', EPOCH)
+
+    expect(peekWebSessionFocusIntent(SCOPE, 'host-generation-b')).toBeNull()
+    expect(peekWebSessionFocusIntent(SCOPE, EPOCH)).toBe('reused-tab')
+  })
+
+  it('uses the owning RPC response epoch when a successful mutation advances it', () => {
+    const token = beginWebSessionFocusIntent(SCOPE, 'before-mutation')
+    completeWebSessionFocusIntent(SCOPE, token!, 'host-tab-1', 'owning-result')
+
+    expect(consumeWebSessionFocusIntent(SCOPE, 'before-mutation', new Set(['host-tab-1']))).toBe(
+      false
+    )
+    expect(consumeWebSessionFocusIntent(SCOPE, 'owning-result', new Set(['host-tab-1']))).toBe(true)
+  })
+
+  it('does not bind an unowned browser result to unrelated late frames', () => {
+    const token = beginWebSessionFocusIntent(SCOPE, null)
+    completeWebSessionFocusIntent(SCOPE, token!, 'new-browser-page')
+
+    expect(consumeWebSessionFocusIntent(SCOPE, 'stale-before', new Set(['old-tab']))).toBe(false)
+    expect(consumeWebSessionFocusIntent(SCOPE, 'concurrent-newer', new Set(['other-tab']))).toBe(
+      false
+    )
+    expect(
+      consumeWebSessionFocusIntent(SCOPE, 'owning-result', new Set(['new-browser-page']))
+    ).toBe(true)
+  })
+
+  it('clears an unbound browser create intent on environment disposal', () => {
+    const token = beginWebSessionFocusIntent(SCOPE, null)
+    completeWebSessionFocusIntent(SCOPE, token!, 'new-browser-page')
+
+    clearWebSessionFocusIntentsForEnvironment(SCOPE.environmentId)
+
+    expect(getWebSessionFocusIntentCountForTests()).toBe(0)
+    expect(
+      consumeWebSessionFocusIntent(SCOPE, 'owning-result', new Set(['new-browser-page']))
+    ).toBe(false)
+  })
+
+  it('ignores a late older create result after a newer focus operation completes', () => {
+    const older = beginWebSessionFocusIntent(SCOPE, EPOCH)
+    const newer = beginWebSessionFocusIntent(SCOPE, EPOCH)
+    expect(older).not.toBeNull()
+    expect(newer).not.toBeNull()
+
+    expect(completeWebSessionFocusIntent(SCOPE, newer!, 'new-tab')).toBe(true)
+    expect(completeWebSessionFocusIntent(SCOPE, older!, 'old-tab')).toBe(false)
+    expect(peekWebSessionFocusIntent(SCOPE, EPOCH)).toBe('new-tab')
+  })
+
+  it('ignores an older result even when it arrives before the newer result', () => {
+    const older = beginWebSessionFocusIntent(SCOPE, EPOCH)
+    const newer = beginWebSessionFocusIntent(SCOPE, EPOCH)
+
+    expect(completeWebSessionFocusIntent(SCOPE, older!, 'old-tab')).toBe(false)
+    expect(completeWebSessionFocusIntent(SCOPE, newer!, 'new-tab')).toBe(true)
+    expect(peekWebSessionFocusIntent(SCOPE, EPOCH)).toBe('new-tab')
+  })
+
+  it('bounds 10k host-worktree scopes while retaining recently reused scopes', () => {
+    recordWebSessionFocusIntent(SCOPE, 'keep-tab', EPOCH)
+    for (let i = 0; i < 10_000; i += 1) {
+      recordWebSessionFocusIntent(scope(`env-${i}`, `worktree-${i}`), `tab-${i}`, `epoch-${i}`)
     }
 
-    expect(peekWebSessionFocusIntent('keep', 1000)).toBe('host-tab-keep')
-
-    recordWebSessionFocusIntent('worktree-new', 'host-tab-new', 1000)
-
-    expect(getWebSessionFocusIntentCountForTests()).toBe(MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES)
-    expect(peekWebSessionFocusIntent('worktree-0', 1000)).toBeNull()
-    expect(peekWebSessionFocusIntent('keep', 1000)).toBe('host-tab-keep')
+    expect(getWebSessionFocusIntentCountForTests()).toBe(MAX_WEB_SESSION_FOCUS_INTENT_SCOPES)
+    expect(peekWebSessionFocusIntent(scope('env-0', 'worktree-0'), 'epoch-0')).toBeNull()
+    expect(peekWebSessionFocusIntent(scope('env-9999', 'worktree-9999'), 'epoch-9999')).toBe(
+      'tab-9999'
+    )
   })
 
-  it('clears one worktree without touching another', () => {
-    recordWebSessionFocusIntent(WT, 'host-tab-1', 1000)
-    recordWebSessionFocusIntent('repo::/other', 'host-tab-2', 1000)
+  it('bounds 10k remembered host publication generations', () => {
+    for (let i = 0; i < 10_000; i += 1) {
+      rememberWebSessionPublicationEpoch(scope(`env-${i}`, `worktree-${i}`), `epoch-${i}`)
+    }
 
-    clearWebSessionFocusIntent(WT)
+    expect(getWebSessionPublicationEpochCountForTests()).toBe(
+      MAX_WEB_SESSION_PUBLICATION_EPOCH_SCOPES
+    )
+    expect(getWebSessionPublicationEpoch(scope('env-0', 'worktree-0'))).toBeNull()
+    expect(getWebSessionPublicationEpoch(scope('env-9999', 'worktree-9999'))).toBe('epoch-9999')
+  })
 
-    expect(peekWebSessionFocusIntent(WT, 1000)).toBeNull()
-    expect(peekWebSessionFocusIntent('repo::/other', 1000)).toBe('host-tab-2')
+  it('does not roll action ownership back to a previously observed late epoch', () => {
+    rememberWebSessionPublicationEpoch(SCOPE, 'before-mutation')
+    rememberWebSessionPublicationEpoch(SCOPE, 'after-mutation')
+    rememberWebSessionPublicationEpoch(SCOPE, 'before-mutation')
+
+    expect(getWebSessionPublicationEpoch(SCOPE)).toBe('after-mutation')
+  })
+
+  it('bounds 10k publication epochs remembered inside one scope', () => {
+    for (let i = 0; i < 10_000; i += 1) {
+      rememberWebSessionPublicationEpoch(SCOPE, `epoch-${i}`)
+    }
+
+    expect(getWebSessionPublicationEpochCountForTests()).toBe(1)
+    expect(getWebSessionPublicationEpochEntryCountForTests()).toBe(
+      MAX_WEB_SESSION_PUBLICATION_EPOCHS_PER_SCOPE
+    )
+    rememberWebSessionPublicationEpoch(SCOPE, 'epoch-9999')
+    expect(getWebSessionPublicationEpoch(SCOPE)).toBe('epoch-9999')
+  })
+
+  it('clears one worktree or one environment without touching another host', () => {
+    const sibling = scope(SCOPE.environmentId, 'repo::/sibling')
+    const otherHost = scope('env-b', SCOPE.worktreeId)
+    recordWebSessionFocusIntent(SCOPE, 'tab-a', EPOCH)
+    recordWebSessionFocusIntent(sibling, 'tab-b', EPOCH)
+    recordWebSessionFocusIntent(otherHost, 'tab-c', 'epoch-b')
+
+    clearWebSessionFocusIntent(SCOPE)
+    expect(peekWebSessionFocusIntent(SCOPE, EPOCH)).toBeNull()
+    expect(peekWebSessionFocusIntent(sibling, EPOCH)).toBe('tab-b')
+
+    clearWebSessionFocusIntentsForEnvironment(SCOPE.environmentId)
+    expect(peekWebSessionFocusIntent(sibling, EPOCH)).toBeNull()
+    expect(peekWebSessionFocusIntent(otherHost, 'epoch-b')).toBe('tab-c')
   })
 })

--- a/src/renderer/src/runtime/web-session-focus-intent.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent.ts
@@ -1,78 +1,173 @@
+import {
+  getWebSessionPublicationEpoch,
+  webSessionIntentEnvironmentPrefix,
+  webSessionIntentScopeKey,
+  type WebSessionIntentScope
+} from './web-session-intent-scope'
+
 // Why: a remote tab create/activate is the ONE case where the session snapshot's
 // activeTabId reflects genuine user focus intent. Status-echo snapshots (e.g. an
 // agent "thinking" during a run) also set activeTabId but must NOT steal focus
 // (#5435). The snapshot can't distinguish these, so the client records its own
 // activation intent here: the reconcile only follows the snapshot's active tab
 // when it matches a pending intent the client itself initiated.
-//
-// Keyed by worktree id → the host session tab id the client expects to focus.
-// The intent persists until a snapshot matches it (surviving racing/duplicate
-// snapshots, unlike a transient per-snapshot flag).
 
-// Why: a create/activate echo should arrive quickly; if a removed worktree never
-// publishes again, the focus intent needs a bounded lifetime.
-const FOCUS_INTENT_TTL_MS = 60_000
-export const MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES = 256
+// Why: explicit host/worktree cleanup and an LRU cap bound retention without a
+// timeout that could discard valid focus after a long transport reconnect.
+export const MAX_WEB_SESSION_FOCUS_INTENT_SCOPES = 256
 
-type FocusIntent = { hostTabId: string; recordedAt: number }
+type FocusIntent = {
+  token: number
+  hostTabId: string | null
+  publicationEpoch: string | null
+}
 
-const pendingFocusByWorktree = new Map<string, FocusIntent>()
+const pendingFocusByScope = new Map<string, FocusIntent>()
+let nextFocusIntentToken = 0
 
-function pruneExpiredWebSessionFocusIntents(now: number): void {
-  for (const [worktreeId, intent] of pendingFocusByWorktree) {
-    if (now - intent.recordedAt > FOCUS_INTENT_TTL_MS) {
-      pendingFocusByWorktree.delete(worktreeId)
+function trimWebSessionFocusIntents(): void {
+  while (pendingFocusByScope.size > MAX_WEB_SESSION_FOCUS_INTENT_SCOPES) {
+    const oldestScopeKey = pendingFocusByScope.keys().next().value
+    if (oldestScopeKey === undefined) {
+      break
     }
+    pendingFocusByScope.delete(oldestScopeKey)
   }
 }
 
-function trimWebSessionFocusIntents(): void {
-  while (pendingFocusByWorktree.size > MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES) {
-    const oldestWorktreeId = pendingFocusByWorktree.keys().next().value
-    if (oldestWorktreeId === undefined) {
-      break
-    }
-    pendingFocusByWorktree.delete(oldestWorktreeId)
+export function beginWebSessionFocusIntent(
+  scope: WebSessionIntentScope,
+  publicationEpoch = getWebSessionPublicationEpoch(scope)
+): number | null {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  if (!scopeKey) {
+    return null
+  }
+  const token = ++nextFocusIntentToken
+  pendingFocusByScope.delete(scopeKey)
+  pendingFocusByScope.set(scopeKey, {
+    token,
+    hostTabId: null,
+    publicationEpoch
+  })
+  trimWebSessionFocusIntents()
+  return token
+}
+
+export function completeWebSessionFocusIntent(
+  scope: WebSessionIntentScope,
+  token: number,
+  hostTabId: string,
+  publicationEpoch?: string | null
+): boolean {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const intent = scopeKey ? pendingFocusByScope.get(scopeKey) : undefined
+  const trimmedHostTabId = hostTabId.trim()
+  if (!scopeKey || !intent || intent.token !== token || !trimmedHostTabId) {
+    return false
+  }
+  intent.hostTabId = trimmedHostTabId
+  if (publicationEpoch !== undefined) {
+    // Why: successful host mutations can advance the publication epoch. The
+    // owning RPC response is the causal generation for the resulting focus.
+    intent.publicationEpoch = publicationEpoch
+  }
+  pendingFocusByScope.delete(scopeKey)
+  pendingFocusByScope.set(scopeKey, intent)
+  return true
+}
+
+export function cancelWebSessionFocusIntent(scope: WebSessionIntentScope, token: number): void {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  if (scopeKey && pendingFocusByScope.get(scopeKey)?.token === token) {
+    pendingFocusByScope.delete(scopeKey)
   }
 }
 
 export function recordWebSessionFocusIntent(
-  worktreeId: string,
+  scope: WebSessionIntentScope,
   hostTabId: string,
-  now = Date.now()
+  publicationEpoch = getWebSessionPublicationEpoch(scope)
 ): void {
-  const trimmed = hostTabId.trim()
-  if (!worktreeId || !trimmed) {
-    return
+  const token = beginWebSessionFocusIntent(scope, publicationEpoch)
+  if (token !== null) {
+    completeWebSessionFocusIntent(scope, token, hostTabId)
   }
-  pruneExpiredWebSessionFocusIntents(now)
-  pendingFocusByWorktree.delete(worktreeId)
-  pendingFocusByWorktree.set(worktreeId, { hostTabId: trimmed, recordedAt: now })
-  trimWebSessionFocusIntents()
 }
 
-export function peekWebSessionFocusIntent(worktreeId: string, now = Date.now()): string | null {
-  const intent = pendingFocusByWorktree.get(worktreeId)
-  if (!intent) {
+export function peekWebSessionFocusIntent(
+  scope: WebSessionIntentScope,
+  snapshotPublicationEpoch: string
+): string | null {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const intent = scopeKey ? pendingFocusByScope.get(scopeKey) : undefined
+  if (!scopeKey || !intent || intent.hostTabId === null) {
     return null
   }
-  if (now - intent.recordedAt > FOCUS_INTENT_TTL_MS) {
-    pendingFocusByWorktree.delete(worktreeId)
+  if (intent.publicationEpoch === null) {
+    // Why: an action can precede the first snapshot. Bind it to the first host
+    // generation observed so a later host restart cannot reuse the tab id.
+    intent.publicationEpoch = snapshotPublicationEpoch
+  }
+  if (intent.publicationEpoch !== snapshotPublicationEpoch) {
     return null
   }
-  pendingFocusByWorktree.delete(worktreeId)
-  pendingFocusByWorktree.set(worktreeId, intent)
+  pendingFocusByScope.delete(scopeKey)
+  pendingFocusByScope.set(scopeKey, intent)
   return intent.hostTabId
 }
 
-export function clearWebSessionFocusIntent(worktreeId: string): void {
-  pendingFocusByWorktree.delete(worktreeId)
+export function consumeWebSessionFocusIntent(
+  scope: WebSessionIntentScope,
+  snapshotPublicationEpoch: string,
+  activeHostTabIds: ReadonlySet<string>
+): boolean {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const intent = scopeKey ? pendingFocusByScope.get(scopeKey) : undefined
+  if (
+    !scopeKey ||
+    !intent ||
+    intent.hostTabId === null ||
+    !activeHostTabIds.has(intent.hostTabId)
+  ) {
+    return false
+  }
+  if (intent.publicationEpoch === null) {
+    // Why: browser creation does not return an epoch. Bind only a snapshot that
+    // actually names the created page active, never an unrelated late frame.
+    intent.publicationEpoch = snapshotPublicationEpoch
+  }
+  if (intent.publicationEpoch !== snapshotPublicationEpoch) {
+    return false
+  }
+  pendingFocusByScope.delete(scopeKey)
+  return true
+}
+
+export function clearWebSessionFocusIntent(scope: WebSessionIntentScope): void {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  if (scopeKey) {
+    pendingFocusByScope.delete(scopeKey)
+  }
+}
+
+export function clearWebSessionFocusIntentsForEnvironment(environmentId: string): void {
+  const prefix = webSessionIntentEnvironmentPrefix(environmentId)
+  if (!prefix) {
+    return
+  }
+  for (const key of pendingFocusByScope.keys()) {
+    if (key.startsWith(prefix)) {
+      pendingFocusByScope.delete(key)
+    }
+  }
 }
 
 export function resetWebSessionFocusIntentForTests(): void {
-  pendingFocusByWorktree.clear()
+  pendingFocusByScope.clear()
+  nextFocusIntentToken = 0
 }
 
 export function getWebSessionFocusIntentCountForTests(): number {
-  return pendingFocusByWorktree.size
+  return pendingFocusByScope.size
 }

--- a/src/renderer/src/runtime/web-session-focus-intent.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent.ts
@@ -9,18 +9,60 @@
 // The intent persists until a snapshot matches it (surviving racing/duplicate
 // snapshots, unlike a transient per-snapshot flag).
 
-const pendingFocusByWorktree = new Map<string, string>()
+// Why: a create/activate echo should arrive quickly; if a removed worktree never
+// publishes again, the focus intent needs a bounded lifetime.
+const FOCUS_INTENT_TTL_MS = 60_000
+export const MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES = 256
 
-export function recordWebSessionFocusIntent(worktreeId: string, hostTabId: string): void {
+type FocusIntent = { hostTabId: string; recordedAt: number }
+
+const pendingFocusByWorktree = new Map<string, FocusIntent>()
+
+function pruneExpiredWebSessionFocusIntents(now: number): void {
+  for (const [worktreeId, intent] of pendingFocusByWorktree) {
+    if (now - intent.recordedAt > FOCUS_INTENT_TTL_MS) {
+      pendingFocusByWorktree.delete(worktreeId)
+    }
+  }
+}
+
+function trimWebSessionFocusIntents(): void {
+  while (pendingFocusByWorktree.size > MAX_WEB_SESSION_FOCUS_INTENT_WORKTREES) {
+    const oldestWorktreeId = pendingFocusByWorktree.keys().next().value
+    if (oldestWorktreeId === undefined) {
+      break
+    }
+    pendingFocusByWorktree.delete(oldestWorktreeId)
+  }
+}
+
+export function recordWebSessionFocusIntent(
+  worktreeId: string,
+  hostTabId: string,
+  now = Date.now()
+): void {
   const trimmed = hostTabId.trim()
   if (!worktreeId || !trimmed) {
     return
   }
-  pendingFocusByWorktree.set(worktreeId, trimmed)
+  pruneExpiredWebSessionFocusIntents(now)
+  pendingFocusByWorktree.delete(worktreeId)
+  pendingFocusByWorktree.set(worktreeId, { hostTabId: trimmed, recordedAt: now })
+  trimWebSessionFocusIntents()
 }
 
-export function peekWebSessionFocusIntent(worktreeId: string): string | null {
-  return pendingFocusByWorktree.get(worktreeId) ?? null
+export function peekWebSessionFocusIntent(worktreeId: string, now = Date.now()): string | null {
+  const intent = pendingFocusByWorktree.get(worktreeId)
+  if (!intent) {
+    return null
+  }
+  if (now - intent.recordedAt > FOCUS_INTENT_TTL_MS) {
+    pendingFocusByWorktree.delete(worktreeId)
+    return null
+  }
+  pendingFocusByWorktree.delete(worktreeId)
+  pendingFocusByWorktree.set(worktreeId, intent)
+  return intent.hostTabId
 }
 
 export function clearWebSessionFocusIntent(worktreeId: string): void {
@@ -29,4 +71,8 @@ export function clearWebSessionFocusIntent(worktreeId: string): void {
 
 export function resetWebSessionFocusIntentForTests(): void {
   pendingFocusByWorktree.clear()
+}
+
+export function getWebSessionFocusIntentCountForTests(): number {
+  return pendingFocusByWorktree.size
 }

--- a/src/renderer/src/runtime/web-session-intent-scope.ts
+++ b/src/renderer/src/runtime/web-session-intent-scope.ts
@@ -1,0 +1,118 @@
+export type WebSessionIntentScope = {
+  environmentId: string
+  worktreeId: string
+}
+
+type PublicationGeneration = {
+  publicationEpoch: string
+  seenPublicationEpochs: Set<string>
+}
+
+// Why: this registry follows the same bounded host/worktree ownership model as
+// the intents it annotates; removed scopes also receive explicit cleanup.
+export const MAX_WEB_SESSION_PUBLICATION_EPOCH_SCOPES = 256
+export const MAX_WEB_SESSION_PUBLICATION_EPOCHS_PER_SCOPE = 256
+
+const publicationGenerationByScope = new Map<string, PublicationGeneration>()
+
+function trimWebSessionPublicationEpochs(): void {
+  while (publicationGenerationByScope.size > MAX_WEB_SESSION_PUBLICATION_EPOCH_SCOPES) {
+    const oldestScopeKey = publicationGenerationByScope.keys().next().value
+    if (oldestScopeKey === undefined) {
+      break
+    }
+    publicationGenerationByScope.delete(oldestScopeKey)
+  }
+}
+
+export function webSessionIntentEnvironmentPrefix(environmentId: string): string | null {
+  const normalizedEnvironmentId = environmentId.trim()
+  return normalizedEnvironmentId ? `${JSON.stringify(normalizedEnvironmentId)}\u0000` : null
+}
+
+export function webSessionIntentScopeKey(scope: WebSessionIntentScope): string | null {
+  const environmentPrefix = webSessionIntentEnvironmentPrefix(scope.environmentId)
+  return environmentPrefix && scope.worktreeId ? `${environmentPrefix}${scope.worktreeId}` : null
+}
+
+export function rememberWebSessionPublicationEpoch(
+  scope: WebSessionIntentScope,
+  publicationEpoch: string
+): void {
+  const key = webSessionIntentScopeKey(scope)
+  if (!key || !publicationEpoch) {
+    return
+  }
+  const existing = publicationGenerationByScope.get(key)
+  if (existing?.publicationEpoch === publicationEpoch) {
+    publicationGenerationByScope.delete(key)
+    publicationGenerationByScope.set(key, existing)
+    return
+  }
+  if (existing?.seenPublicationEpochs.has(publicationEpoch)) {
+    // Why: different publication epochs can represent individual host
+    // mutations. A late frame from a previously observed epoch must not roll
+    // the generation used to bind a new user action backward.
+    publicationGenerationByScope.delete(key)
+    publicationGenerationByScope.set(key, existing)
+    return
+  }
+  const seenPublicationEpochs = existing?.seenPublicationEpochs ?? new Set<string>()
+  seenPublicationEpochs.add(publicationEpoch)
+  while (seenPublicationEpochs.size > MAX_WEB_SESSION_PUBLICATION_EPOCHS_PER_SCOPE) {
+    const oldestEpoch = seenPublicationEpochs.values().next().value
+    if (oldestEpoch === undefined) {
+      break
+    }
+    seenPublicationEpochs.delete(oldestEpoch)
+  }
+  publicationGenerationByScope.delete(key)
+  publicationGenerationByScope.set(key, { publicationEpoch, seenPublicationEpochs })
+  trimWebSessionPublicationEpochs()
+}
+
+export function getWebSessionPublicationEpoch(scope: WebSessionIntentScope): string | null {
+  const key = webSessionIntentScopeKey(scope)
+  const generation = key ? publicationGenerationByScope.get(key) : undefined
+  if (!key || !generation) {
+    return null
+  }
+  publicationGenerationByScope.delete(key)
+  publicationGenerationByScope.set(key, generation)
+  return generation.publicationEpoch
+}
+
+export function clearWebSessionPublicationEpoch(scope: WebSessionIntentScope): void {
+  const key = webSessionIntentScopeKey(scope)
+  if (key) {
+    publicationGenerationByScope.delete(key)
+  }
+}
+
+export function clearWebSessionPublicationEpochsForEnvironment(environmentId: string): void {
+  const prefix = webSessionIntentEnvironmentPrefix(environmentId)
+  if (!prefix) {
+    return
+  }
+  for (const key of publicationGenerationByScope.keys()) {
+    if (key.startsWith(prefix)) {
+      publicationGenerationByScope.delete(key)
+    }
+  }
+}
+
+export function resetWebSessionPublicationEpochsForTests(): void {
+  publicationGenerationByScope.clear()
+}
+
+export function getWebSessionPublicationEpochCountForTests(): number {
+  return publicationGenerationByScope.size
+}
+
+export function getWebSessionPublicationEpochEntryCountForTests(): number {
+  let epochs = 0
+  for (const generation of publicationGenerationByScope.values()) {
+    epochs += generation.seenPublicationEpochs.size
+  }
+  return epochs
+}

--- a/src/renderer/src/runtime/web-session-reorder-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-reorder-intent.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAX_WEB_SESSION_REORDER_INTENT_WORKTREES,
+  clearWebSessionReorderIntentsForWorktree,
+  getWebSessionReorderIntentCountsForTests,
+  recordWebSessionReorderIntent,
+  resetWebSessionReorderIntentForTests,
+  resolveWebSessionReorderedOrder
+} from './web-session-reorder-intent'
+
+const WT = 'repo::/wt'
+
+afterEach(() => resetWebSessionReorderIntentForTests())
+
+describe('web session reorder intent', () => {
+  it('prunes expired worktree intents when recording a newer intent', () => {
+    recordWebSessionReorderIntent('old-worktree', 'group-1', ['tab-b', 'tab-a'], 1000)
+
+    recordWebSessionReorderIntent(WT, 'group-1', ['tab-c', 'tab-d'], 11_001)
+
+    expect(getWebSessionReorderIntentCountsForTests()).toEqual({ worktrees: 1, groups: 1 })
+    expect(
+      resolveWebSessionReorderedOrder('old-worktree', 'group-1', ['tab-a', 'tab-b'], 11_001)
+    ).toEqual(['tab-a', 'tab-b'])
+    expect(resolveWebSessionReorderedOrder(WT, 'group-1', ['tab-d', 'tab-c'], 11_001)).toEqual([
+      'tab-c',
+      'tab-d'
+    ])
+  })
+
+  it('bounds worktree intents while retaining recently reused worktrees', () => {
+    recordWebSessionReorderIntent('keep', 'group-1', ['tab-b', 'tab-a'], 1000)
+    for (let i = 0; i < MAX_WEB_SESSION_REORDER_INTENT_WORKTREES - 1; i += 1) {
+      recordWebSessionReorderIntent(`worktree-${i}`, 'group-1', ['tab-b', 'tab-a'], 1000)
+    }
+
+    expect(resolveWebSessionReorderedOrder('keep', 'group-1', ['tab-a', 'tab-b'], 1000)).toEqual([
+      'tab-b',
+      'tab-a'
+    ])
+
+    recordWebSessionReorderIntent('worktree-new', 'group-1', ['tab-b', 'tab-a'], 1000)
+
+    expect(getWebSessionReorderIntentCountsForTests()).toEqual({
+      worktrees: MAX_WEB_SESSION_REORDER_INTENT_WORKTREES,
+      groups: MAX_WEB_SESSION_REORDER_INTENT_WORKTREES
+    })
+    expect(
+      resolveWebSessionReorderedOrder('worktree-0', 'group-1', ['tab-a', 'tab-b'], 1000)
+    ).toEqual(['tab-a', 'tab-b'])
+    expect(resolveWebSessionReorderedOrder('keep', 'group-1', ['tab-a', 'tab-b'], 1000)).toEqual([
+      'tab-b',
+      'tab-a'
+    ])
+  })
+
+  it('clears one worktree without touching another', () => {
+    recordWebSessionReorderIntent(WT, 'group-1', ['tab-b', 'tab-a'], 1000)
+    recordWebSessionReorderIntent('repo::/other', 'group-1', ['tab-d', 'tab-c'], 1000)
+
+    clearWebSessionReorderIntentsForWorktree(WT)
+
+    expect(resolveWebSessionReorderedOrder(WT, 'group-1', ['tab-a', 'tab-b'], 1000)).toEqual([
+      'tab-a',
+      'tab-b'
+    ])
+    expect(
+      resolveWebSessionReorderedOrder('repo::/other', 'group-1', ['tab-c', 'tab-d'], 1000)
+    ).toEqual(['tab-d', 'tab-c'])
+  })
+})

--- a/src/renderer/src/runtime/web-session-reorder-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-reorder-intent.test.ts
@@ -1,71 +1,162 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  MAX_WEB_SESSION_REORDER_INTENT_WORKTREES,
+  MAX_WEB_SESSION_REORDER_INTENT_SCOPES,
+  MAX_WEB_SESSION_REORDER_INTENTS_PER_SCOPE,
+  clearWebSessionReorderIntent,
+  clearWebSessionReorderIntentsForEnvironment,
   clearWebSessionReorderIntentsForWorktree,
   getWebSessionReorderIntentCountsForTests,
   recordWebSessionReorderIntent,
   resetWebSessionReorderIntentForTests,
   resolveWebSessionReorderedOrder
 } from './web-session-reorder-intent'
+import type { WebSessionIntentScope } from './web-session-intent-scope'
 
-const WT = 'repo::/wt'
+const SCOPE = { environmentId: 'env-a', worktreeId: 'repo::/wt' }
+const EPOCH = 'host-generation-a'
+const NOW = 1_000
 
 afterEach(() => resetWebSessionReorderIntentForTests())
 
+function scope(environmentId: string, worktreeId: string): WebSessionIntentScope {
+  return { environmentId, worktreeId }
+}
+
+function resolve(
+  intentScope: WebSessionIntentScope,
+  groupId: string,
+  hostOrder: string[],
+  now = NOW,
+  epoch = EPOCH
+): string[] {
+  return resolveWebSessionReorderedOrder(intentScope, groupId, hostOrder, now, epoch)
+}
+
 describe('web session reorder intent', () => {
-  it('prunes expired worktree intents when recording a newer intent', () => {
-    recordWebSessionReorderIntent('old-worktree', 'group-1', ['tab-b', 'tab-a'], 1000)
+  it('survives a slow reconnect longer than ten seconds', () => {
+    recordWebSessionReorderIntent(SCOPE, 'group-1', ['tab-b', 'tab-a'], NOW, EPOCH)
 
-    recordWebSessionReorderIntent(WT, 'group-1', ['tab-c', 'tab-d'], 11_001)
-
-    expect(getWebSessionReorderIntentCountsForTests()).toEqual({ worktrees: 1, groups: 1 })
-    expect(
-      resolveWebSessionReorderedOrder('old-worktree', 'group-1', ['tab-a', 'tab-b'], 11_001)
-    ).toEqual(['tab-a', 'tab-b'])
-    expect(resolveWebSessionReorderedOrder(WT, 'group-1', ['tab-d', 'tab-c'], 11_001)).toEqual([
-      'tab-c',
-      'tab-d'
-    ])
-  })
-
-  it('bounds worktree intents while retaining recently reused worktrees', () => {
-    recordWebSessionReorderIntent('keep', 'group-1', ['tab-b', 'tab-a'], 1000)
-    for (let i = 0; i < MAX_WEB_SESSION_REORDER_INTENT_WORKTREES - 1; i += 1) {
-      recordWebSessionReorderIntent(`worktree-${i}`, 'group-1', ['tab-b', 'tab-a'], 1000)
-    }
-
-    expect(resolveWebSessionReorderedOrder('keep', 'group-1', ['tab-a', 'tab-b'], 1000)).toEqual([
-      'tab-b',
-      'tab-a'
-    ])
-
-    recordWebSessionReorderIntent('worktree-new', 'group-1', ['tab-b', 'tab-a'], 1000)
-
-    expect(getWebSessionReorderIntentCountsForTests()).toEqual({
-      worktrees: MAX_WEB_SESSION_REORDER_INTENT_WORKTREES,
-      groups: MAX_WEB_SESSION_REORDER_INTENT_WORKTREES
-    })
-    expect(
-      resolveWebSessionReorderedOrder('worktree-0', 'group-1', ['tab-a', 'tab-b'], 1000)
-    ).toEqual(['tab-a', 'tab-b'])
-    expect(resolveWebSessionReorderedOrder('keep', 'group-1', ['tab-a', 'tab-b'], 1000)).toEqual([
+    expect(resolve(SCOPE, 'group-1', ['tab-a', 'tab-b'], NOW + 120_000, EPOCH)).toEqual([
       'tab-b',
       'tab-a'
     ])
   })
 
-  it('clears one worktree without touching another', () => {
-    recordWebSessionReorderIntent(WT, 'group-1', ['tab-b', 'tab-a'], 1000)
-    recordWebSessionReorderIntent('repo::/other', 'group-1', ['tab-d', 'tab-c'], 1000)
+  it('isolates identical worktree, group, and tab ids across hosts and generations', () => {
+    const otherHost = scope('env-b', SCOPE.worktreeId)
+    recordWebSessionReorderIntent(SCOPE, 'group-1', ['tab-b', 'tab-a'], NOW, EPOCH)
+    recordWebSessionReorderIntent(otherHost, 'group-1', ['tab-a', 'tab-b'], NOW, 'epoch-b')
 
-    clearWebSessionReorderIntentsForWorktree(WT)
-
-    expect(resolveWebSessionReorderedOrder(WT, 'group-1', ['tab-a', 'tab-b'], 1000)).toEqual([
+    expect(resolve(SCOPE, 'group-1', ['tab-a', 'tab-b'], NOW, 'epoch-b')).toEqual([
       'tab-a',
       'tab-b'
     ])
+    expect(resolve(SCOPE, 'group-1', ['tab-a', 'tab-b'])).toEqual(['tab-b', 'tab-a'])
+    expect(resolve(otherHost, 'group-1', ['tab-b', 'tab-a'], NOW, 'epoch-b')).toEqual([
+      'tab-a',
+      'tab-b'
+    ])
+  })
+
+  it('suppresses a late pre-move frame after success and concurrent epoch advances', () => {
+    recordWebSessionReorderIntent(SCOPE, 'group-1', ['tab-b', 'tab-a'], NOW, 'before-move')
+
+    expect(resolve(SCOPE, 'group-1', ['tab-b', 'tab-a'], NOW + 1, 'move-success')).toEqual([
+      'tab-b',
+      'tab-a'
+    ])
+    expect(resolve(SCOPE, 'group-1', ['tab-b', 'tab-a'], NOW + 2, 'concurrent-newer')).toEqual([
+      'tab-b',
+      'tab-a'
+    ])
+    expect(resolve(SCOPE, 'group-1', ['tab-a', 'tab-b'], NOW + 3, 'before-move')).toEqual([
+      'tab-b',
+      'tab-a'
+    ])
+    expect(resolve(SCOPE, 'group-1', ['tab-a', 'tab-b'], NOW + 120_000, 'before-move')).toEqual([
+      'tab-b',
+      'tab-a'
+    ])
+  })
+
+  it('does not let an older failed RPC clear a newer retry', () => {
+    const older = recordWebSessionReorderIntent(SCOPE, 'group-1', ['tab-b', 'tab-a'], NOW, EPOCH)
+    const newer = recordWebSessionReorderIntent(
+      SCOPE,
+      'group-1',
+      ['tab-c', 'tab-a'],
+      NOW + 1,
+      EPOCH
+    )
+    expect(older).not.toBeNull()
+    expect(newer).not.toBeNull()
+
+    clearWebSessionReorderIntent(SCOPE, 'group-1', older!)
+
+    expect(resolve(SCOPE, 'group-1', ['tab-a', 'tab-c'], NOW + 1)).toEqual(['tab-c', 'tab-a'])
+  })
+
+  it('clears only the current retry when the newer RPC fails first', () => {
+    recordWebSessionReorderIntent(SCOPE, 'group-1', ['tab-b', 'tab-a'], NOW, EPOCH)
+    const newer = recordWebSessionReorderIntent(
+      SCOPE,
+      'group-1',
+      ['tab-c', 'tab-a'],
+      NOW + 1,
+      EPOCH
+    )
+
+    clearWebSessionReorderIntent(SCOPE, 'group-1', newer!)
+
+    expect(resolve(SCOPE, 'group-1', ['tab-a', 'tab-c'], NOW + 1)).toEqual(['tab-a', 'tab-c'])
+  })
+
+  it('bounds 10k group intents inside one scope', () => {
+    for (let i = 0; i < 10_000; i += 1) {
+      recordWebSessionReorderIntent(SCOPE, `group-${i}`, ['tab-b', 'tab-a'], NOW, EPOCH)
+    }
+
+    expect(getWebSessionReorderIntentCountsForTests()).toEqual({
+      scopes: 1,
+      groups: MAX_WEB_SESSION_REORDER_INTENTS_PER_SCOPE
+    })
+    expect(resolve(SCOPE, 'group-0', ['tab-a', 'tab-b'])).toEqual(['tab-a', 'tab-b'])
+    expect(resolve(SCOPE, 'group-9999', ['tab-a', 'tab-b'])).toEqual(['tab-b', 'tab-a'])
+  })
+
+  it('bounds 10k host-worktree scopes', () => {
+    for (let i = 0; i < 10_000; i += 1) {
+      recordWebSessionReorderIntent(
+        scope(`env-${i}`, `worktree-${i}`),
+        'group-1',
+        ['tab-b', 'tab-a'],
+        NOW,
+        `epoch-${i}`
+      )
+    }
+
+    expect(getWebSessionReorderIntentCountsForTests()).toEqual({
+      scopes: MAX_WEB_SESSION_REORDER_INTENT_SCOPES,
+      groups: MAX_WEB_SESSION_REORDER_INTENT_SCOPES
+    })
     expect(
-      resolveWebSessionReorderedOrder('repo::/other', 'group-1', ['tab-c', 'tab-d'], 1000)
-    ).toEqual(['tab-d', 'tab-c'])
+      resolve(scope('env-0', 'worktree-0'), 'group-1', ['tab-a', 'tab-b'], NOW, 'epoch-0')
+    ).toEqual(['tab-a', 'tab-b'])
+  })
+
+  it('clears one worktree or environment without touching another host', () => {
+    const sibling = scope(SCOPE.environmentId, 'repo::/sibling')
+    const otherHost = scope('env-b', SCOPE.worktreeId)
+    recordWebSessionReorderIntent(SCOPE, 'group-1', ['b', 'a'], NOW, EPOCH)
+    recordWebSessionReorderIntent(sibling, 'group-1', ['d', 'c'], NOW, EPOCH)
+    recordWebSessionReorderIntent(otherHost, 'group-1', ['f', 'e'], NOW, 'epoch-b')
+
+    clearWebSessionReorderIntentsForWorktree(SCOPE)
+    expect(resolve(SCOPE, 'group-1', ['a', 'b'])).toEqual(['a', 'b'])
+    expect(resolve(sibling, 'group-1', ['c', 'd'])).toEqual(['d', 'c'])
+
+    clearWebSessionReorderIntentsForEnvironment(SCOPE.environmentId)
+    expect(resolve(sibling, 'group-1', ['c', 'd'])).toEqual(['c', 'd'])
+    expect(resolve(otherHost, 'group-1', ['e', 'f'], NOW, 'epoch-b')).toEqual(['f', 'e'])
   })
 })

--- a/src/renderer/src/runtime/web-session-reorder-intent.ts
+++ b/src/renderer/src/runtime/web-session-reorder-intent.ts
@@ -1,60 +1,56 @@
-// Why: reordering a remote tab updates the local group order immediately for
-// responsiveness, then asks the host to move the tab. But an in-flight host
-// snapshot (published before the host processed the move, or the move RPC's own
-// pre-move subscribe replay) can still carry the OLD order and arrive after the
-// local reorder — the reconcile then overwrites the optimistic order, snapping
-// the tab back to where it was. Close has the same hazard and guards it with a
-// close-intent; reorder had no equivalent, so it always lost the race.
-//
-// The client records its intended local tab order per group here. The reconcile
-// substitutes it for the host order until a snapshot confirms the move (host
-// order matches the intent) or the group membership changes (a newer truth), at
-// which point the intent clears. A TTL guards a never-confirmed move (e.g. a
-// rejected RPC) from pinning a stale order forever.
+import {
+  getWebSessionPublicationEpoch,
+  webSessionIntentEnvironmentPrefix,
+  webSessionIntentScopeKey,
+  type WebSessionIntentScope
+} from './web-session-intent-scope'
 
-const REORDER_INTENT_TTL_MS = 10_000
-export const MAX_WEB_SESSION_REORDER_INTENT_WORKTREES = 256
+// Why: optimistic paired-client reorders must suppress an in-flight old host
+// order. Lifecycle cleanup and caps bound retention without a correctness TTL.
+export const MAX_WEB_SESSION_REORDER_INTENT_SCOPES = 256
+export const MAX_WEB_SESSION_REORDER_INTENTS_PER_SCOPE = 256
 
-type ReorderIntent = { order: string[]; recordedAt: number }
+type ReorderIntent = {
+  token: number
+  order: string[]
+  publicationEpoch: string | null
+}
 
-// worktreeId -> (groupId -> intent)
-const pendingReorderByWorktree = new Map<string, Map<string, ReorderIntent>>()
+// host/runtime + worktree -> (group id -> intent)
+const pendingReorderByScope = new Map<string, Map<string, ReorderIntent>>()
+let nextReorderIntentToken = 0
 
-function deleteEmptyReorderIntentWorktree(
-  worktreeId: string,
+function deleteEmptyReorderIntentScope(
+  scopeKey: string,
   byGroup: Map<string, ReorderIntent>
 ): void {
   if (byGroup.size === 0) {
-    pendingReorderByWorktree.delete(worktreeId)
+    pendingReorderByScope.delete(scopeKey)
   }
 }
 
-function refreshReorderIntentWorktree(
-  worktreeId: string,
-  byGroup: Map<string, ReorderIntent>
-): void {
-  pendingReorderByWorktree.delete(worktreeId)
-  pendingReorderByWorktree.set(worktreeId, byGroup)
+function refreshReorderIntentScope(scopeKey: string, byGroup: Map<string, ReorderIntent>): void {
+  pendingReorderByScope.delete(scopeKey)
+  pendingReorderByScope.set(scopeKey, byGroup)
 }
 
-function pruneExpiredWebSessionReorderIntents(now: number): void {
-  for (const [worktreeId, byGroup] of pendingReorderByWorktree) {
-    for (const [groupId, intent] of byGroup) {
-      if (now - intent.recordedAt > REORDER_INTENT_TTL_MS) {
-        byGroup.delete(groupId)
-      }
-    }
-    deleteEmptyReorderIntentWorktree(worktreeId, byGroup)
-  }
-}
-
-function trimWebSessionReorderIntentWorktrees(): void {
-  while (pendingReorderByWorktree.size > MAX_WEB_SESSION_REORDER_INTENT_WORKTREES) {
-    const oldestWorktreeId = pendingReorderByWorktree.keys().next().value
-    if (oldestWorktreeId === undefined) {
+function trimWebSessionReorderIntentScopes(): void {
+  while (pendingReorderByScope.size > MAX_WEB_SESSION_REORDER_INTENT_SCOPES) {
+    const oldestScopeKey = pendingReorderByScope.keys().next().value
+    if (oldestScopeKey === undefined) {
       break
     }
-    pendingReorderByWorktree.delete(oldestWorktreeId)
+    pendingReorderByScope.delete(oldestScopeKey)
+  }
+}
+
+function trimWebSessionReorderIntents(byGroup: Map<string, ReorderIntent>): void {
+  while (byGroup.size > MAX_WEB_SESSION_REORDER_INTENTS_PER_SCOPE) {
+    const oldestGroupId = byGroup.keys().next().value
+    if (oldestGroupId === undefined) {
+      break
+    }
+    byGroup.delete(oldestGroupId)
   }
 }
 
@@ -71,82 +67,107 @@ function sameOrder(a: readonly string[], b: readonly string[]): boolean {
 }
 
 export function recordWebSessionReorderIntent(
-  worktreeId: string,
+  scope: WebSessionIntentScope,
   groupId: string,
   order: readonly string[],
-  now: number
-): void {
-  if (!worktreeId || !groupId || order.length === 0) {
-    return
+  _now: number,
+  publicationEpoch = getWebSessionPublicationEpoch(scope)
+): number | null {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  if (!scopeKey || !groupId || order.length === 0) {
+    return null
   }
-  // Why: reorder intents already expire; prune all worktrees on new writes so
-  // removed worktrees that never reconcile again do not retain stale orders.
-  pruneExpiredWebSessionReorderIntents(now)
-  let byGroup = pendingReorderByWorktree.get(worktreeId)
-  if (!byGroup) {
-    byGroup = new Map()
-  }
-  refreshReorderIntentWorktree(worktreeId, byGroup)
-  byGroup.set(groupId, { order: [...order], recordedAt: now })
-  trimWebSessionReorderIntentWorktrees()
+  const byGroup = pendingReorderByScope.get(scopeKey) ?? new Map<string, ReorderIntent>()
+  refreshReorderIntentScope(scopeKey, byGroup)
+  const token = ++nextReorderIntentToken
+  byGroup.delete(groupId)
+  byGroup.set(groupId, { token, order: [...order], publicationEpoch })
+  trimWebSessionReorderIntents(byGroup)
+  trimWebSessionReorderIntentScopes()
+  return token
 }
 
-/**
- * Resolve the local tab order a reconcile should apply for a group. When the
- * client has a pending reorder for this group whose membership still matches the
- * host order, the intended order wins (suppressing a stale pre-move snapshot).
- * The intent clears once the host confirms it (orders match), the membership
- * diverges (add/close changed the truth), or the TTL lapses.
- */
 export function resolveWebSessionReorderedOrder(
-  worktreeId: string,
+  scope: WebSessionIntentScope,
   groupId: string,
   hostOrder: string[],
-  now: number
+  _now: number,
+  snapshotPublicationEpoch: string
 ): string[] {
-  const byGroup = pendingReorderByWorktree.get(worktreeId)
-  if (!byGroup) {
-    return hostOrder
-  }
-  const intent = byGroup.get(groupId)
-  if (!intent) {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const byGroup = scopeKey ? pendingReorderByScope.get(scopeKey) : undefined
+  const intent = byGroup?.get(groupId)
+  if (!scopeKey || !byGroup || !intent) {
     return hostOrder
   }
   const clear = (): void => {
     byGroup.delete(groupId)
-    deleteEmptyReorderIntentWorktree(worktreeId, byGroup)
+    deleteEmptyReorderIntentScope(scopeKey, byGroup)
   }
-  if (now - intent.recordedAt > REORDER_INTENT_TTL_MS) {
-    clear()
+  if (intent.publicationEpoch === null) {
+    intent.publicationEpoch = snapshotPublicationEpoch
+  }
+  if (intent.publicationEpoch !== snapshotPublicationEpoch) {
     return hostOrder
   }
-  // Why: a membership change (tab added/closed elsewhere) is a newer truth than
-  // a pending reorder — defer to the host and drop the now-ambiguous intent.
+  // Why: membership changes are newer host truth than a pending reorder.
   if (!sameMembership(intent.order, hostOrder)) {
     clear()
     return hostOrder
   }
   if (sameOrder(intent.order, hostOrder)) {
-    // Host confirmed the move; nothing left to suppress.
     clear()
     return hostOrder
   }
-  refreshReorderIntentWorktree(worktreeId, byGroup)
+  refreshReorderIntentScope(scopeKey, byGroup)
   return [...intent.order]
 }
 
-export function clearWebSessionReorderIntentsForWorktree(worktreeId: string): void {
-  pendingReorderByWorktree.delete(worktreeId)
+export function clearWebSessionReorderIntent(
+  scope: WebSessionIntentScope,
+  groupId: string,
+  token: number
+): void {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  const byGroup = scopeKey ? pendingReorderByScope.get(scopeKey) : undefined
+  if (!scopeKey || !byGroup) {
+    return
+  }
+  if (byGroup.get(groupId)?.token !== token) {
+    return
+  }
+  byGroup.delete(groupId)
+  deleteEmptyReorderIntentScope(scopeKey, byGroup)
+}
+
+export function clearWebSessionReorderIntentsForWorktree(scope: WebSessionIntentScope): void {
+  const scopeKey = webSessionIntentScopeKey(scope)
+  if (scopeKey) {
+    pendingReorderByScope.delete(scopeKey)
+  }
+}
+
+export function clearWebSessionReorderIntentsForEnvironment(environmentId: string): void {
+  const prefix = webSessionIntentEnvironmentPrefix(environmentId)
+  if (!prefix) {
+    return
+  }
+  for (const key of pendingReorderByScope.keys()) {
+    if (key.startsWith(prefix)) {
+      pendingReorderByScope.delete(key)
+    }
+  }
 }
 
 export function resetWebSessionReorderIntentForTests(): void {
-  pendingReorderByWorktree.clear()
+  pendingReorderByScope.clear()
+  nextReorderIntentToken = 0
 }
 
-export function getWebSessionReorderIntentCountsForTests(): { worktrees: number; groups: number } {
+export function getWebSessionReorderIntentCountsForTests(): { scopes: number; groups: number } {
   let groups = 0
-  for (const byGroup of pendingReorderByWorktree.values()) {
+  for (const byGroup of pendingReorderByScope.values()) {
     groups += byGroup.size
   }
-  return { worktrees: pendingReorderByWorktree.size, groups }
+  return { scopes: pendingReorderByScope.size, groups }
 }

--- a/src/renderer/src/runtime/web-session-reorder-intent.ts
+++ b/src/renderer/src/runtime/web-session-reorder-intent.ts
@@ -13,11 +13,50 @@
 // rejected RPC) from pinning a stale order forever.
 
 const REORDER_INTENT_TTL_MS = 10_000
+export const MAX_WEB_SESSION_REORDER_INTENT_WORKTREES = 256
 
 type ReorderIntent = { order: string[]; recordedAt: number }
 
 // worktreeId -> (groupId -> intent)
 const pendingReorderByWorktree = new Map<string, Map<string, ReorderIntent>>()
+
+function deleteEmptyReorderIntentWorktree(
+  worktreeId: string,
+  byGroup: Map<string, ReorderIntent>
+): void {
+  if (byGroup.size === 0) {
+    pendingReorderByWorktree.delete(worktreeId)
+  }
+}
+
+function refreshReorderIntentWorktree(
+  worktreeId: string,
+  byGroup: Map<string, ReorderIntent>
+): void {
+  pendingReorderByWorktree.delete(worktreeId)
+  pendingReorderByWorktree.set(worktreeId, byGroup)
+}
+
+function pruneExpiredWebSessionReorderIntents(now: number): void {
+  for (const [worktreeId, byGroup] of pendingReorderByWorktree) {
+    for (const [groupId, intent] of byGroup) {
+      if (now - intent.recordedAt > REORDER_INTENT_TTL_MS) {
+        byGroup.delete(groupId)
+      }
+    }
+    deleteEmptyReorderIntentWorktree(worktreeId, byGroup)
+  }
+}
+
+function trimWebSessionReorderIntentWorktrees(): void {
+  while (pendingReorderByWorktree.size > MAX_WEB_SESSION_REORDER_INTENT_WORKTREES) {
+    const oldestWorktreeId = pendingReorderByWorktree.keys().next().value
+    if (oldestWorktreeId === undefined) {
+      break
+    }
+    pendingReorderByWorktree.delete(oldestWorktreeId)
+  }
+}
 
 function sameMembership(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) {
@@ -40,12 +79,16 @@ export function recordWebSessionReorderIntent(
   if (!worktreeId || !groupId || order.length === 0) {
     return
   }
+  // Why: reorder intents already expire; prune all worktrees on new writes so
+  // removed worktrees that never reconcile again do not retain stale orders.
+  pruneExpiredWebSessionReorderIntents(now)
   let byGroup = pendingReorderByWorktree.get(worktreeId)
   if (!byGroup) {
     byGroup = new Map()
-    pendingReorderByWorktree.set(worktreeId, byGroup)
   }
+  refreshReorderIntentWorktree(worktreeId, byGroup)
   byGroup.set(groupId, { order: [...order], recordedAt: now })
+  trimWebSessionReorderIntentWorktrees()
 }
 
 /**
@@ -62,15 +105,16 @@ export function resolveWebSessionReorderedOrder(
   now: number
 ): string[] {
   const byGroup = pendingReorderByWorktree.get(worktreeId)
-  const intent = byGroup?.get(groupId)
+  if (!byGroup) {
+    return hostOrder
+  }
+  const intent = byGroup.get(groupId)
   if (!intent) {
     return hostOrder
   }
   const clear = (): void => {
-    byGroup!.delete(groupId)
-    if (byGroup!.size === 0) {
-      pendingReorderByWorktree.delete(worktreeId)
-    }
+    byGroup.delete(groupId)
+    deleteEmptyReorderIntentWorktree(worktreeId, byGroup)
   }
   if (now - intent.recordedAt > REORDER_INTENT_TTL_MS) {
     clear()
@@ -87,6 +131,7 @@ export function resolveWebSessionReorderedOrder(
     clear()
     return hostOrder
   }
+  refreshReorderIntentWorktree(worktreeId, byGroup)
   return [...intent.order]
 }
 
@@ -96,4 +141,12 @@ export function clearWebSessionReorderIntentsForWorktree(worktreeId: string): vo
 
 export function resetWebSessionReorderIntentForTests(): void {
   pendingReorderByWorktree.clear()
+}
+
+export function getWebSessionReorderIntentCountsForTests(): { worktrees: number; groups: number } {
+  let groups = 0
+  for (const byGroup of pendingReorderByWorktree.values()) {
+    groups += byGroup.size
+  }
+  return { worktrees: pendingReorderByWorktree.size, groups }
 }

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -48,6 +48,7 @@ vi.mock('../store', () => ({
 
 const WT = 'repo::/worktree'
 const ENV = 'web-env-1'
+const INTENT_SCOPE = { environmentId: ENV, worktreeId: WT }
 const NOW = 1_700_000_000_000
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const SECOND_LEAF_ID = '22222222-2222-4222-8222-222222222222'
@@ -260,7 +261,7 @@ describe('applyWebSessionTabsSnapshot', () => {
       isActive: true
     }
     // Client closed host-tab-1; an in-flight pre-close snapshot still lists it.
-    recordWebSessionCloseIntent(WT, 'host-tab-1', NOW)
+    recordWebSessionCloseIntent(INTENT_SCOPE, 'host-tab-1', NOW, 'epoch-1')
     const stalePreClose = applyWebSessionTabsSnapshot(
       makeState(),
       makeSnapshot([surface]),
@@ -316,7 +317,7 @@ describe('applyWebSessionTabsSnapshot', () => {
 
     // Client dragged tab 2 ahead of tab 1; an in-flight snapshot still has the
     // original host order.
-    recordWebSessionReorderIntent(WT, 'host-group-1', [local2, local1], NOW)
+    recordWebSessionReorderIntent(INTENT_SCOPE, 'host-group-1', [local2, local1], NOW, 'epoch-1')
     const stalePreMove = applyWebSessionTabsSnapshot(
       makeState(),
       makeSnapshot(surfaces, { tabGroups: groupWithOrder(['host-tab-1', 'host-tab-2']) }),
@@ -585,9 +586,9 @@ describe('applyWebSessionTabsSnapshot', () => {
       freshness: 1,
       hostMappings: 1
     })
-    recordWebSessionFocusIntent(WT, 'host-browser-page', NOW)
-    recordWebSessionCloseIntent(WT, 'host-browser-unified', NOW)
-    recordWebSessionReorderIntent(WT, 'host-group-1', ['tab-b', 'tab-a'], NOW)
+    recordWebSessionFocusIntent(INTENT_SCOPE, 'host-browser-page', 'epoch-1')
+    recordWebSessionCloseIntent(INTENT_SCOPE, 'host-browser-unified', NOW, 'epoch-1')
+    recordWebSessionReorderIntent(INTENT_SCOPE, 'host-group-1', ['tab-b', 'tab-a'], NOW, 'epoch-1')
 
     applyFreshWebSessionTabsSnapshot(
       afterHostSnapshot,
@@ -609,10 +610,18 @@ describe('applyWebSessionTabsSnapshot', () => {
       freshness: 0,
       hostMappings: 0
     })
-    expect(peekWebSessionFocusIntent(WT, NOW + 1)).toBeNull()
-    expect(isWebSessionCloseIntentPending(WT, 'host-browser-unified', NOW + 1)).toBe(false)
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'epoch-1')).toBeNull()
     expect(
-      resolveWebSessionReorderedOrder(WT, 'host-group-1', ['tab-a', 'tab-b'], NOW + 1)
+      isWebSessionCloseIntentPending(INTENT_SCOPE, 'host-browser-unified', NOW + 1, 'epoch-1')
+    ).toBe(false)
+    expect(
+      resolveWebSessionReorderedOrder(
+        INTENT_SCOPE,
+        'host-group-1',
+        ['tab-a', 'tab-b'],
+        NOW + 1,
+        'epoch-1'
+      )
     ).toEqual(['tab-a', 'tab-b'])
   })
 
@@ -670,6 +679,13 @@ describe('applyWebSessionTabsSnapshot', () => {
       freshness: 2,
       hostMappings: 2
     })
+    const otherScope = { environmentId: 'web-env-2', worktreeId: 'repo::/other-worktree' }
+    recordWebSessionFocusIntent(INTENT_SCOPE, 'host-tab-a')
+    recordWebSessionFocusIntent(otherScope, 'host-tab-b')
+    recordWebSessionCloseIntent(INTENT_SCOPE, 'host-tab-a', NOW)
+    recordWebSessionCloseIntent(otherScope, 'host-tab-b', NOW)
+    recordWebSessionReorderIntent(INTENT_SCOPE, 'group-a', ['b', 'a'], NOW)
+    recordWebSessionReorderIntent(otherScope, 'group-b', ['d', 'c'], NOW)
 
     clearWebSessionTabsTrackingForEnvironment(ENV)
 
@@ -677,6 +693,16 @@ describe('applyWebSessionTabsSnapshot', () => {
       freshness: 1,
       hostMappings: 1
     })
+    expect(peekWebSessionFocusIntent(INTENT_SCOPE, 'epoch-1')).toBeNull()
+    expect(peekWebSessionFocusIntent(otherScope, 'epoch-1')).toBe('host-tab-b')
+    expect(isWebSessionCloseIntentPending(INTENT_SCOPE, 'host-tab-a', NOW, 'epoch-1')).toBe(false)
+    expect(isWebSessionCloseIntentPending(otherScope, 'host-tab-b', NOW, 'epoch-1')).toBe(true)
+    expect(
+      resolveWebSessionReorderedOrder(INTENT_SCOPE, 'group-a', ['a', 'b'], NOW, 'epoch-1')
+    ).toEqual(['a', 'b'])
+    expect(
+      resolveWebSessionReorderedOrder(otherScope, 'group-b', ['c', 'd'], NOW, 'epoch-1')
+    ).toEqual(['d', 'c'])
   })
 
   it('replaces stale local agent quick-launch tabs once host mirrors arrive', () => {
@@ -1999,13 +2025,11 @@ describe('applyWebSessionTabsSnapshot', () => {
     })
   })
 
-  it('focuses a brand-new remote terminal that the snapshot marks active', () => {
+  it('retains focus intent across a same-generation reconnect longer than 60 seconds', () => {
     // Why: opening a new terminal must take focus. Distinct from the #5435 case
     // above (existing tab echoed active = keep focus); here the active tab is new.
     const existingTabId = toWebTerminalSurfaceTabId('host-tab-1')
     const newTabId = toWebTerminalSurfaceTabId('host-tab-2')
-    // Simulate createWebRuntimeSessionTerminal recording focus intent for the new tab.
-    recordWebSessionFocusIntent(WT, `host-tab-2::${SECOND_LEAF_ID}`)
     const existingUnifiedTab: Tab = {
       id: existingTabId,
       entityId: existingTabId,
@@ -2021,77 +2045,86 @@ describe('applyWebSessionTabsSnapshot', () => {
       isPinned: false
     }
 
-    const patch = applyWebSessionTabsSnapshot(
-      makeState({
-        activeTabId: existingTabId,
-        activeTabIdByWorktree: { [WT]: existingTabId },
-        activeTabType: 'terminal',
-        activeTabTypeByWorktree: { [WT]: 'terminal' },
-        tabsByWorktree: {
-          [WT]: [
-            {
-              id: existingTabId,
-              ptyId: 'remote:web-env-1@@terminal-1',
-              worktreeId: WT,
-              title: 'shell',
-              customTitle: null,
-              color: null,
-              sortOrder: 0,
-              createdAt: NOW
-            }
-          ]
-        },
-        unifiedTabsByWorktree: { [WT]: [existingUnifiedTab] },
-        tabBarOrderByWorktree: { [WT]: [existingTabId] },
-        groupsByWorktree: {
-          [WT]: [
-            {
-              id: 'host-group-1',
-              worktreeId: WT,
-              activeTabId: existingTabId,
-              tabOrder: [existingTabId],
-              recentTabIds: [existingTabId]
-            }
-          ]
-        }
-      }),
-      makeSnapshot(
-        [
+    const state = makeState({
+      activeTabId: existingTabId,
+      activeTabIdByWorktree: { [WT]: existingTabId },
+      activeTabType: 'terminal',
+      activeTabTypeByWorktree: { [WT]: 'terminal' },
+      tabsByWorktree: {
+        [WT]: [
           {
-            type: 'terminal',
-            id: `host-tab-1::${LEAF_ID}`,
+            id: existingTabId,
+            ptyId: 'remote:web-env-1@@terminal-1',
+            worktreeId: WT,
             title: 'shell',
-            parentTabId: 'host-tab-1',
-            leafId: LEAF_ID,
-            isActive: false,
-            status: 'ready',
-            terminal: 'terminal-1'
-          },
-          {
-            type: 'terminal',
-            id: `host-tab-2::${SECOND_LEAF_ID}`,
-            title: 'new shell',
-            parentTabId: 'host-tab-2',
-            leafId: SECOND_LEAF_ID,
-            isActive: true,
-            status: 'ready',
-            terminal: 'terminal-2'
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: NOW
           }
-        ],
+        ]
+      },
+      unifiedTabsByWorktree: { [WT]: [existingUnifiedTab] },
+      tabBarOrderByWorktree: { [WT]: [existingTabId] },
+      groupsByWorktree: {
+        [WT]: [
+          {
+            id: 'host-group-1',
+            worktreeId: WT,
+            activeTabId: existingTabId,
+            tabOrder: [existingTabId],
+            recentTabIds: [existingTabId]
+          }
+        ]
+      }
+    })
+    const snapshot = makeSnapshot(
+      [
         {
-          activeTabId: `host-tab-2::${SECOND_LEAF_ID}`,
-          activeTabType: 'terminal',
-          tabGroups: [
-            {
-              id: 'host-group-1',
-              activeTabId: 'host-tab-2',
-              tabOrder: ['host-tab-1', 'host-tab-2']
-            }
-          ]
+          type: 'terminal',
+          id: `host-tab-1::${LEAF_ID}`,
+          title: 'shell',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: false,
+          status: 'ready',
+          terminal: 'terminal-1'
+        },
+        {
+          type: 'terminal',
+          id: `host-tab-2::${SECOND_LEAF_ID}`,
+          title: 'new shell',
+          parentTabId: 'host-tab-2',
+          leafId: SECOND_LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-2'
         }
-      ),
+      ],
+      {
+        activeTabId: `host-tab-2::${SECOND_LEAF_ID}`,
+        activeTabType: 'terminal',
+        tabGroups: [
+          {
+            id: 'host-group-1',
+            activeTabId: 'host-tab-2',
+            tabOrder: ['host-tab-1', 'host-tab-2']
+          }
+        ]
+      }
+    )
+
+    // Prime the host-owned generation, then model a transport reconnect replay
+    // of that exact snapshot after a long outage. Reconnect must not expire or
+    // clear the action that was recorded against the still-running host.
+    applyFreshWebSessionTabsSnapshot(state, snapshot, ENV, NOW)
+    recordWebSessionFocusIntent(INTENT_SCOPE, `host-tab-2::${SECOND_LEAF_ID}`)
+    acceptReplayedWebSessionTabsSnapshot(ENV, WT)
+    const patch = applyFreshWebSessionTabsSnapshot(
+      state,
+      snapshot,
       ENV,
-      NOW + 10
+      NOW + 120_000
     ) as Partial<WebSessionTabsSyncState>
 
     expect(patch.activeTabIdByWorktree?.[WT]).toBe(newTabId)

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -7,16 +7,19 @@ import { makePaneKey } from '../../../shared/stable-pane-id'
 import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import {
+  peekWebSessionFocusIntent,
   recordWebSessionFocusIntent,
   resetWebSessionFocusIntentForTests
 } from './web-session-focus-intent'
 import {
+  isWebSessionCloseIntentPending,
   recordWebSessionCloseIntent,
   resetWebSessionCloseIntentForTests
 } from './web-session-close-intent'
 import {
   recordWebSessionReorderIntent,
-  resetWebSessionReorderIntentForTests
+  resetWebSessionReorderIntentForTests,
+  resolveWebSessionReorderedOrder
 } from './web-session-reorder-intent'
 import type { BrowserPage, BrowserWorkspace, Tab, TerminalTab } from '../../../shared/types'
 import type { OpenFile } from '../store/slices/editor'
@@ -582,6 +585,9 @@ describe('applyWebSessionTabsSnapshot', () => {
       freshness: 1,
       hostMappings: 1
     })
+    recordWebSessionFocusIntent(WT, 'host-browser-page', NOW)
+    recordWebSessionCloseIntent(WT, 'host-browser-unified', NOW)
+    recordWebSessionReorderIntent(WT, 'host-group-1', ['tab-b', 'tab-a'], NOW)
 
     applyFreshWebSessionTabsSnapshot(
       afterHostSnapshot,
@@ -603,6 +609,11 @@ describe('applyWebSessionTabsSnapshot', () => {
       freshness: 0,
       hostMappings: 0
     })
+    expect(peekWebSessionFocusIntent(WT, NOW + 1)).toBeNull()
+    expect(isWebSessionCloseIntentPending(WT, 'host-browser-unified', NOW + 1)).toBe(false)
+    expect(
+      resolveWebSessionReorderedOrder(WT, 'host-group-1', ['tab-a', 'tab-b'], NOW + 1)
+    ).toEqual(['tab-a', 'tab-b'])
   })
 
   it('clears web session tracking maps for one runtime environment on teardown', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -53,6 +53,7 @@ import { resolveTerminalLayoutRoot } from './remote-terminal-layout-resolution'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 import { clearWebSessionFocusIntent, peekWebSessionFocusIntent } from './web-session-focus-intent'
 import {
+  clearWebSessionCloseIntentsForWorktree,
   isWebSessionCloseIntentPending,
   reconcileWebSessionCloseIntents
 } from './web-session-close-intent'
@@ -314,6 +315,8 @@ function clearWebSessionTabsTrackingForWorktree(environmentId: string, worktreeI
   latestSessionTabsSnapshotByWorktree.delete(key)
   lastHostTerminalTabCountByWorktree.delete(key)
   clearWebRuntimeWakeTerminalRespawnForWorktree(worktreeId)
+  clearWebSessionFocusIntent(worktreeId)
+  clearWebSessionCloseIntentsForWorktree(worktreeId)
   clearWebSessionReorderIntentsForWorktree(worktreeId)
   const keyPrefix = `${environmentId}:${worktreeId}:`
   for (const key of hostSessionTabIdByLocalKey.keys()) {
@@ -1655,7 +1658,7 @@ export function applyWebSessionTabsSnapshot(
   // An unsolicited server-active (e.g. an agent "thinking" echo) must not steal
   // focus — that's the #5435 contract. Intent matches by the host active tab id
   // (terminal session id, or browserPageId for browser tabs); consume it once.
-  const focusIntentHostTabId = peekWebSessionFocusIntent(worktreeId)
+  const focusIntentHostTabId = peekWebSessionFocusIntent(worktreeId, now)
   const honorSnapshotActiveFocus =
     focusIntentHostTabId !== null &&
     snapshot.activeTabId !== null &&

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -51,16 +51,29 @@ import {
 import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
 import { resolveTerminalLayoutRoot } from './remote-terminal-layout-resolution'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
-import { clearWebSessionFocusIntent, peekWebSessionFocusIntent } from './web-session-focus-intent'
+import {
+  clearWebSessionFocusIntent,
+  clearWebSessionFocusIntentsForEnvironment,
+  consumeWebSessionFocusIntent
+} from './web-session-focus-intent'
 import {
   clearWebSessionCloseIntentsForWorktree,
+  clearWebSessionCloseIntentsForEnvironment,
   isWebSessionCloseIntentPending,
   reconcileWebSessionCloseIntents
 } from './web-session-close-intent'
 import {
+  clearWebSessionReorderIntentsForEnvironment,
   clearWebSessionReorderIntentsForWorktree,
   resolveWebSessionReorderedOrder
 } from './web-session-reorder-intent'
+import {
+  clearWebSessionPublicationEpoch,
+  clearWebSessionPublicationEpochsForEnvironment,
+  rememberWebSessionPublicationEpoch,
+  resetWebSessionPublicationEpochsForTests,
+  type WebSessionIntentScope
+} from './web-session-intent-scope'
 import {
   beginWebRuntimeWakeTerminalRespawn,
   clearAllWebRuntimeWakeTerminalRespawn,
@@ -228,6 +241,10 @@ export function shouldApplyWebSessionTabsSnapshot(
     publicationEpoch: snapshot.publicationEpoch,
     snapshotVersion: snapshot.snapshotVersion
   })
+  rememberWebSessionPublicationEpoch(
+    { environmentId, worktreeId: snapshot.worktree },
+    snapshot.publicationEpoch
+  )
   return true
 }
 
@@ -298,6 +315,7 @@ export function resetWebSessionTabsSnapshotFreshnessForTests(): void {
   latestSessionTabsSnapshotByWorktree.clear()
   lastHostTerminalTabCountByWorktree.clear()
   hostSessionTabIdByLocalKey.clear()
+  resetWebSessionPublicationEpochsForTests()
 }
 
 export function _getWebSessionTabsTrackingCountsForTest(): {
@@ -311,13 +329,15 @@ export function _getWebSessionTabsTrackingCountsForTest(): {
 }
 
 function clearWebSessionTabsTrackingForWorktree(environmentId: string, worktreeId: string): void {
+  const intentScope = { environmentId, worktreeId }
   const key = sessionTabsFreshnessKey(environmentId, worktreeId)
   latestSessionTabsSnapshotByWorktree.delete(key)
   lastHostTerminalTabCountByWorktree.delete(key)
   clearWebRuntimeWakeTerminalRespawnForWorktree(worktreeId)
-  clearWebSessionFocusIntent(worktreeId)
-  clearWebSessionCloseIntentsForWorktree(worktreeId)
-  clearWebSessionReorderIntentsForWorktree(worktreeId)
+  clearWebSessionFocusIntent(intentScope)
+  clearWebSessionCloseIntentsForWorktree(intentScope)
+  clearWebSessionReorderIntentsForWorktree(intentScope)
+  clearWebSessionPublicationEpoch(intentScope)
   const keyPrefix = `${environmentId}:${worktreeId}:`
   for (const key of hostSessionTabIdByLocalKey.keys()) {
     if (key.startsWith(keyPrefix)) {
@@ -347,6 +367,10 @@ export function clearWebSessionTabsTrackingForEnvironment(environmentId: string)
       hostSessionTabIdByLocalKey.delete(key)
     }
   }
+  clearWebSessionFocusIntentsForEnvironment(trimmedEnvironmentId)
+  clearWebSessionCloseIntentsForEnvironment(trimmedEnvironmentId)
+  clearWebSessionReorderIntentsForEnvironment(trimmedEnvironmentId)
+  clearWebSessionPublicationEpochsForEnvironment(trimmedEnvironmentId)
   clearAllWebRuntimeWakeTerminalRespawn()
 }
 
@@ -1182,18 +1206,22 @@ function buildMirroredHostGroups({
   currentGroups,
   hostGroups,
   hostToLocalTabId,
+  intentScope,
   mirroredUnifiedIds,
   nextActiveUnifiedTabId,
   now,
+  publicationEpoch,
   validUnifiedTabIds,
   worktreeId
 }: {
   currentGroups: readonly TabGroup[]
   hostGroups: readonly RuntimeMobileSessionTabGroup[]
   hostToLocalTabId: ReadonlyMap<string, string>
+  intentScope: WebSessionIntentScope
   mirroredUnifiedIds: ReadonlySet<string>
   nextActiveUnifiedTabId: string | null
   now: number
+  publicationEpoch: string
   validUnifiedTabIds: ReadonlySet<string>
   worktreeId: string
 }): TabGroup[] | null {
@@ -1222,7 +1250,13 @@ function buildMirroredHostGroups({
     ]
     // Why: a pending client reorder for this group wins over a stale pre-move
     // host order until the host echoes the move (or membership changes).
-    const tabOrder = resolveWebSessionReorderedOrder(worktreeId, hostGroup.id, hostTabOrder, now)
+    const tabOrder = resolveWebSessionReorderedOrder(
+      intentScope,
+      hostGroup.id,
+      hostTabOrder,
+      now,
+      publicationEpoch
+    )
     if (tabOrder.length === 0) {
       continue
     }
@@ -1628,6 +1662,7 @@ export function applyWebSessionTabsSnapshot(
   if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
     return state
   }
+  const intentScope = { environmentId, worktreeId }
   // Why: a remote close prunes the local mirror immediately, but an in-flight
   // pre-close snapshot can still list the tab and flash it back. Drop any tab
   // the client is closing until the host confirms removal; reconcile the intents
@@ -1640,16 +1675,29 @@ export function applyWebSessionTabsSnapshot(
   const snapshotHostTabId = (tab: RuntimeMobileSessionTabsResult['tabs'][number]): string =>
     tab.type === 'terminal' ? tab.parentTabId : tab.id
   reconcileWebSessionCloseIntents(
-    worktreeId,
-    new Set(rawSnapshot.tabs.map((tab) => snapshotHostTabId(tab)))
+    intentScope,
+    new Set(rawSnapshot.tabs.map((tab) => snapshotHostTabId(tab))),
+    now,
+    rawSnapshot.publicationEpoch
   )
   const snapshot: RuntimeMobileSessionTabsResult = rawSnapshot.tabs.some((tab) =>
-    isWebSessionCloseIntentPending(worktreeId, snapshotHostTabId(tab), now)
+    isWebSessionCloseIntentPending(
+      intentScope,
+      snapshotHostTabId(tab),
+      now,
+      rawSnapshot.publicationEpoch
+    )
   )
     ? {
         ...rawSnapshot,
         tabs: rawSnapshot.tabs.filter(
-          (tab) => !isWebSessionCloseIntentPending(worktreeId, snapshotHostTabId(tab), now)
+          (tab) =>
+            !isWebSessionCloseIntentPending(
+              intentScope,
+              snapshotHostTabId(tab),
+              now,
+              rawSnapshot.publicationEpoch
+            )
         )
       }
     : rawSnapshot
@@ -1658,20 +1706,21 @@ export function applyWebSessionTabsSnapshot(
   // An unsolicited server-active (e.g. an agent "thinking" echo) must not steal
   // focus — that's the #5435 contract. Intent matches by the host active tab id
   // (terminal session id, or browserPageId for browser tabs); consume it once.
-  const focusIntentHostTabId = peekWebSessionFocusIntent(worktreeId, now)
-  const honorSnapshotActiveFocus =
-    focusIntentHostTabId !== null &&
-    snapshot.activeTabId !== null &&
-    (snapshot.activeTabId === focusIntentHostTabId ||
-      snapshot.tabs.some(
-        (tab) =>
-          tab.id === snapshot.activeTabId &&
-          tab.type === 'browser' &&
-          tab.browserPageId === focusIntentHostTabId
-      ))
-  if (honorSnapshotActiveFocus) {
-    clearWebSessionFocusIntent(worktreeId)
+  const activeHostTabIds = new Set<string>()
+  if (snapshot.activeTabId !== null) {
+    activeHostTabIds.add(snapshot.activeTabId)
+    const activeSnapshotTab = snapshot.tabs.find((tab) => tab.id === snapshot.activeTabId)
+    if (activeSnapshotTab?.type === 'terminal') {
+      activeHostTabIds.add(activeSnapshotTab.parentTabId)
+    } else if (activeSnapshotTab?.type === 'browser' && activeSnapshotTab.browserPageId) {
+      activeHostTabIds.add(activeSnapshotTab.browserPageId)
+    }
   }
+  const honorSnapshotActiveFocus = consumeWebSessionFocusIntent(
+    intentScope,
+    rawSnapshot.publicationEpoch,
+    activeHostTabIds
+  )
   const currentTerminalTabs = state.tabsByWorktree[worktreeId] ?? []
   const existingTerminalById = new Map(currentTerminalTabs.map((tab) => [tab.id, tab]))
   const terminalSurfaceTabs = snapshot.tabs.filter(isTerminalSurfaceTab)
@@ -1982,9 +2031,11 @@ export function applyWebSessionTabsSnapshot(
         currentGroups,
         hostGroups: snapshot.tabGroups,
         hostToLocalTabId,
+        intentScope,
         mirroredUnifiedIds,
         nextActiveUnifiedTabId,
         now,
+        publicationEpoch: snapshot.publicationEpoch,
         validUnifiedTabIds,
         worktreeId
       })


### PR DESCRIPTION
## Description

Fixes valid renderer-memory retention in paired web session focus, close, and reorder intent state, while hardening those intents against runtime-host collisions, host publication changes, slow reconnects, and late RPC results.

The core invariant is now: only the runtime environment + worktree + host publication that owns a user action may consume its optimistic focus/close/reorder intent.

## Evidence

Before this change:

- Focus intent state had no lifecycle bound.
- Close/reorder entries could remain after a removed or disconnected worktree stopped reconciling.
- Intents were keyed only by worktree ID, so two runtime hosts reusing the same worktree/tab/group IDs could interfere.
- Nested close-tab and reorder-group maps had no per-scope cap.
- A late failure from an older RPC could clear a newer retry.
- A fixed focus timeout would have introduced a real slow-reconnect regression, so this version deliberately has **no focus timeout**.

The fix:

- Scopes every intent by runtime environment + worktree.
- Binds terminal-create and activate focus to the owning RPC response's `publicationEpoch`.
- For browser create (whose RPC does not return an epoch), binds only when the causal post-create snapshot names the exact created page active; failure or newer focus truth cancels the token.
- Prevents a previously observed late publication from rolling future action ownership backward.
- Uses exact monotonic operation tokens, so older results/failures cannot clear or overwrite newer actions.
- Removes correctness timeouts from focus, close, and reorder. Slow reconnects beyond 120 seconds remain protected.
- Caps focus/close/reorder/publication ownership at 256 host-worktree scopes, with 256 close-tab, reorder-group, and remembered-publication entries per scope.
- Clears exact worktree state on removal and exact runtime-environment state on teardown.

### Verification

- `40` renderer runtime test files passed (`394` tests).
- `pnpm typecheck:web` passed.
- `pnpm typecheck:node` passed.
- Changed-file `oxlint` and `oxfmt --check` passed.
- `pnpm check:max-lines-ratchet` passed.
- Two independent read-only reviews of exact SHA `396926375107adb06fff557478876b998c3dde69` returned `VERDICT: CLEAN`.

Deterministic tests cover:

- identical worktree/tab/group IDs on different runtime hosts;
- terminal create and activation when the successful host mutation advances publication epoch;
- browser create exact-page binding, concurrent newer focus, create failure, causal snapshot failure, and disposal;
- host restart/publication reuse isolation;
- late focus results and close/reorder failures in both orders;
- stale pre-mutation frames after success and another publication advance;
- reconnects longer than 120 seconds;
- 10,000-scope and 10,000-entry churn with enforced caps;
- worktree and runtime-environment cleanup isolation.

### Live paired-client gap

A fresh host was launched from this exact worktree on unique CDP port `9333`; app identity was verified as `7689 @ sweep/pr-7689`, and the host store was healthy with no DevTools errors or stale runtime-connection error. A fresh web bundle and pairing URL were generated.

The paired web client then failed during unrelated startup before `window.__store` initialized (`TypeError: Cannot read properties of undefined (reading 'unavailableReason')`, alongside stale missing-worktree watcher state). Therefore host/web store parity and live >120-second reconnect/close/reorder behavior are **not claimed as proved**. This is an explicit residual validation gap.

## ELI5

Orca keeps small “the user just focused/closed/moved this remote tab” notes so an old server update cannot undo the click. Those notes could pile up, collide between servers, or be erased by an older failed request. They are now labeled with the exact server/workspace/publication that owns them, protected against late results, cleaned up with the connection/worktree lifecycle, and strictly capped without expiring during a slow reconnect.

## Trade-offs

- **Inherent review risk: HIGH. Residual merge risk: MODERATE.** This touches remote focus/close/reorder reconciliation across concurrent snapshots. Deterministic coverage is strong, but live paired-client parity remains unproved because of the unrelated startup crash above.
- Normal users should see no intended regression: there is no focus/close/reorder timeout, no data-loss path, and local-only session behavior is unchanged.
- Under extreme churn beyond 256 simultaneous host-worktree scopes or 256 close/reorder/publication entries in one scope, the oldest optimistic state is evicted. The possible symptom is a one-time missed focus suppression, close flash, or reorder snapback—not lost terminal/process/data state.
- No polling, timers, recurring IPC/RPC, subprocesses, storage writes, telemetry, or render fanout were added. The browser-create path reuses its existing one-shot `session.tabs.list` refresh to establish causal focus ownership.
- The implementation uses platform-neutral maps/IDs and keeps runtime-environment ownership explicit, so macOS/Linux/Windows and SSH-hosted runtime scopes do not share intent state. Git-provider behavior is unaffected.

Reliability classification: `terminal-session.snapshot-freshness` / remote session intent ownership. Roll back if telemetry or reports show focus loss/steal, closed-tab flash/reappearance, reorder snapback, or unexpected intent-cap eviction under ordinary workloads.
