### PR TITLE
Fix worktree warning dedupe retention

### DIFF
--- a/src/main/ipc/bounded-warning-dedupe.test.ts
+++ b/src/main/ipc/bounded-warning-dedupe.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_WARNING_DEDUPE_MAX_KEYS,
+  shouldEmitBoundedWarning
+} from './bounded-warning-dedupe'
+
+describe('shouldEmitBoundedWarning', () => {
+  it('keeps retained warning keys quiet without cascade eviction after saturation', () => {
+    const warningKeys = new Set<string>()
+
+    expect(shouldEmitBoundedWarning(warningKeys, 'retained-1', 3)).toBe(true)
+    expect(shouldEmitBoundedWarning(warningKeys, 'retained-2', 3)).toBe(true)
+    expect(shouldEmitBoundedWarning(warningKeys, 'retained-3', 3)).toBe(true)
+
+    expect(shouldEmitBoundedWarning(warningKeys, 'overflow', 3)).toBe(true)
+    expect(shouldEmitBoundedWarning(warningKeys, 'retained-1', 3)).toBe(false)
+    expect(shouldEmitBoundedWarning(warningKeys, 'retained-2', 3)).toBe(false)
+    expect(shouldEmitBoundedWarning(warningKeys, 'retained-3', 3)).toBe(false)
+    expect(shouldEmitBoundedWarning(warningKeys, 'overflow', 3)).toBe(true)
+
+    expect([...warningKeys]).toEqual(['retained-1', 'retained-2', 'retained-3'])
+  })
+
+  it('limits repeat emissions for a stable default-cap-plus-one scan', () => {
+    const warningKeys = new Set<string>()
+    const keys = Array.from(
+      { length: DEFAULT_WARNING_DEDUPE_MAX_KEYS + 1 },
+      (_, index) => `warning-${index}`
+    )
+
+    expect(keys.filter((key) => shouldEmitBoundedWarning(warningKeys, key))).toEqual(keys)
+    expect(keys.filter((key) => shouldEmitBoundedWarning(warningKeys, key))).toEqual([
+      keys.at(-1)
+    ])
+  })
+})

--- a/src/main/ipc/bounded-warning-dedupe.ts
+++ b/src/main/ipc/bounded-warning-dedupe.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_WARNING_DEDUPE_MAX_KEYS = 256
+
+// Why: diagnostic "warn once" keys often include dynamic paths/providers; keep
+// repeated warnings quiet without retaining every stale key forever.
+export function shouldEmitBoundedWarning(
+  warningKeys: Set<string>,
+  key: string,
+  maxKeys = DEFAULT_WARNING_DEDUPE_MAX_KEYS
+): boolean {
+  if (warningKeys.has(key)) {
+    return false
+  }
+  // Why: evicting during a stable max+1 scan cascades into re-emitting every warning.
+  if (warningKeys.size >= maxKeys) {
+    return true
+  }
+  warningKeys.add(key)
+  return true
+}

--- a/src/main/ipc/worktree-base-directory-watch-targets.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.ts
@@ -20,6 +20,7 @@ import {
   getWorktreePathSettings,
   hasRepoWorktreeBasePath
 } from './worktree-logic'
+import { shouldEmitBoundedWarning } from './bounded-warning-dedupe'
 import { resolveWorktreeCommonGitDirectory } from './worktree-common-git-directory'
 import type {
   WorktreeBaseRepoWatchConfig,
@@ -130,8 +131,7 @@ async function maybeAddBaseTarget(
   // Why: WSL UNC roots are unreliable for native watching; avoid project-level polling.
   if (isWslUncPath(workspaceRoot) || isWslUncPath(repo.path)) {
     const key = `${repo.id}:${workspaceRoot}`
-    if (!skippedWslWarnings.has(key)) {
-      skippedWslWarnings.add(key)
+    if (shouldEmitBoundedWarning(skippedWslWarnings, key)) {
       console.warn(
         `[worktree-base-watcher] skipping WSL worktree root watcher for ${workspaceRoot}`
       )
@@ -157,8 +157,7 @@ async function maybeAddBaseTarget(
     }
   } catch {
     const key = normalizeWatchKey(workspaceRoot)
-    if (!missingRootWarnings.has(key)) {
-      missingRootWarnings.add(key)
+    if (shouldEmitBoundedWarning(missingRootWarnings, key)) {
       console.warn(`[worktree-base-watcher] worktree root unavailable: ${workspaceRoot}`)
     }
   }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -99,6 +99,7 @@ import {
   releaseAutomationWorkspaceProvenanceRequest,
   resolveAutomationWorkspaceProvenance
 } from '../automations/workspace-provenance'
+import { shouldEmitBoundedWarning } from './bounded-warning-dedupe'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -563,10 +564,9 @@ function getDetectedWorktreeScanCacheKey(
 }
 
 function warnOnce(keySet: Set<string>, key: string, message: string, error?: unknown): void {
-  if (keySet.has(key)) {
+  if (!shouldEmitBoundedWarning(keySet, key)) {
     return
   }
-  keySet.add(key)
   if (error) {
     console.warn(message, error)
   } else {


### PR DESCRIPTION
## Description

Bound five long-lived diagnostic warning-dedupe sets used by main-process worktree watching and listing. Dynamic repo paths, WSL roots, SSH connections, and malformed metadata keys can no longer accumulate for the lifetime of the app.

The first 256 distinct keys in each warning category are retained. Once a category is saturated, additional keys may warn again on later failures but do not evict retained keys; this avoids the cascade where a stable 257-key scan re-emits every warning.

## Evidence

Before the fix, the five module-level Set values only grew or cleared in limited reset/success paths, so churn in removed repos, paths, providers, and metadata retained old strings indefinitely.

- Added bounded-warning-dedupe.ts with a 256-key default cap.
- Routed both watcher warning sets and all three worktree-list warning sets through the bounded helper.
- Added a default-cap-plus-one, two-pass regression. The rejected LRU policy emitted 257 warnings on both passes; the final saturation policy emits 257 on the first pass and exactly one overflow warning on the second while the set remains at 256.
- Focused validation: 3 test files, 195 tests passed.
- Changed-file oxlint passed.
- Node typecheck passed: pnpm run typecheck:tsc:node.
- Max-lines ratchet and git diff --check passed.
- Two independent final reviewers found no issues.
- Performance check: warning-only paths add constant-time Set membership and size checks. No polling, scans, subprocesses, IPC/RPC, provider calls, timers, listeners, storage writes, or render work were added.

## ELI5

Orca remembered which warnings it had already printed, but some warning names contained repo paths or SSH targets. That memory list could grow forever as projects changed. Orca now keeps at most 256 names per warning category without letting one extra failing project make every old warning noisy again.

## Trade-offs

The retained 256 keys continue to suppress duplicates. Keys first encountered after saturation are not stored, so those overflow failures can log again on later scans until a retained key is removed by an existing recovery path or the warning state is cleared.

This affects diagnostics only. Worktree discovery, watching, WSL handling, SSH providers, user data, and git behavior are unchanged. No end-user functional regressions are expected.