### PR TITLE
Fix PTY pre-handler exit retention

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3223,7 +3223,8 @@
         "PTY startup",
         "background terminal launch",
         "handler registration",
-        "failed shutdown recovery"
+        "failed shutdown recovery",
+        "daemon cold restore"
       ],
       "platforms": [
         "macos",
@@ -3247,8 +3248,8 @@
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/7695"
       ],
-      "invariant": "Before a PTY handler mounts, the singleton dispatcher is already listening and retained data, exit, and warning identities remain capped; data drains before exit; a fresh provider-reused PTY id cannot consume an older lifecycle's events; explicit reattach keeps its current backlog; and failed shutdown restore drains detached data before later live output.",
-      "oracle": "Drive first-use background exit-before-spawn-resolution, more than 64 exit-before-handler identities, warning-producing data churn, duplicate/reused ids, fresh-spawn and explicit-reattach ordering, handler registration at cap, and failed-shutdown restoration; assert listener-first capture, bounded eviction, exact latest-code delivery once, fresh-generation filtering, data-before-exit order, and detached-before-live output.",
+      "invariant": "Before a PTY handler mounts, the singleton dispatcher is already listening and retained data, exit, and warning identities remain capped; pre-spawn bytes reach background side-effect observers exactly once before live-sidecar handoff; data drains before exit; a fresh provider-reused PTY id or new-generation cold restore cannot consume an older lifecycle's events; explicit live reattach keeps its current backlog; and failed shutdown restore drains detached data before later live output without overwriting a newer remount handler.",
+      "oracle": "Drive first-use background data/exit before spawn resolution, real observer-to-sidecar handoff and handler replacement, more than 64 exit-before-handler identities, warning-producing data churn, duplicate/reused ids, fresh spawn, failed-reattach fallback, new-generation cold restore, explicit live reattach, handler registration at cap, and failed-shutdown restoration after a newer remount; assert listener-first capture, exactly-once observer handoff, bounded eviction, exact latest-code delivery once, fresh-generation filtering with restore payload preservation, data-before-exit order, and detached-before-live output routed to current authority.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts"
       ],
@@ -3272,15 +3273,15 @@
           "file": "src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts",
           "assertions": [
             "pre-handler data drains before its exit",
-            "fresh PTY-id reuse and failed-reattach fresh fallback filter old lifecycle events while explicit daemon reattach preserves pre-connect backlog",
-            "first-use eager registration attaches the singleton dispatcher before a fast background PTY can emit data or exit",
+            "fresh PTY-id reuse, failed-reattach fallback, and new-generation cold restore filter old lifecycle events while explicit daemon reattach preserves pre-connect backlog",
+            "first-use eager registration attaches the singleton dispatcher before a fast background PTY emits data or exit, routes retained bytes through its side-effect observer exactly once, and preserves a replacement handler",
             "a registered exit handler remains authoritative while 65 orphan exits churn through the bounded buffer"
           ]
         },
         {
           "file": "src/renderer/src/components/terminal-pane/pty-transport.test.ts",
           "assertions": [
-            "failed intentional shutdown restoration drains data received while detached before later live data"
+            "failed intentional shutdown restoration drains detached data before later live data to a newer remount handler without overwriting its data, replay, or teardown authority"
           ]
         }
       ],
@@ -3292,7 +3293,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts",
           "result": "passed",
           "durationSeconds": 1,
-          "summary": "5 test files passed, 115 tests passed on main@20ebe858af plus the #7695 candidate. Main@20ebe858af retained the 65th oldest exit (received code 0 instead of eviction); the bounded candidate evicts it and preserves listener-first and ordering/reuse cases."
+          "summary": "5 test files and 120 tests passed on main@dcfa91919f plus the #7695 candidate. The red repro on main@20ebe858af retained the 65th oldest exit (received code 0 instead of eviction); the candidate evicts it and preserves listener-first, exactly-once side-effect handoff, ordering/reuse, and new-generation cold-restore cases."
         }
       ],
       "runtimeBudget": {

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-07-10",
+  "updatedAt": "2026-07-11",
   "policy": {
     "maturityLevels": [
       "experimental",
@@ -3211,6 +3211,116 @@
         "Buffer-clean, pixels-stale variants are otherwise invisible to every buffer oracle in the manifest."
       ],
       "demotionRule": "Drop from the golden suite back to nightly diagnostic if diff thresholds cannot be kept stable across CI runners."
+    },
+    {
+      "id": "terminal-session.pre-handler-pty-ordering",
+      "title": "Pre-handler PTY data and exits stay bounded, ordered, and generation-safe",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "renderer-unit",
+      "surfaces": [
+        "PTY startup",
+        "background terminal launch",
+        "handler registration",
+        "failed shutdown recovery"
+      ],
+      "platforms": [
+        "macos",
+        "linux",
+        "windows"
+      ],
+      "providers": [
+        "local",
+        "daemon",
+        "ssh",
+        "wsl"
+      ],
+      "coveredPlatforms": [
+        "macos"
+      ],
+      "coveredProviders": [
+        "local",
+        "daemon"
+      ],
+      "coverageNotes": "Deterministic macOS renderer tests cover the shared IPC transport used by local, daemon, SSH, and WSL PTYs, including explicit daemon reattach. SSH and WSL have path-equivalent unit coverage but no live provider run. Remote-runtime/mobile use a different host-owned stream and are unaffected.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/pull/7695"
+      ],
+      "invariant": "Before a PTY handler mounts, retained data, exit, and warning identities remain capped; data drains before exit; a fresh provider-reused PTY id cannot consume an older lifecycle's events; explicit reattach keeps its current backlog; and failed shutdown restore drains detached data before later live output.",
+      "oracle": "Drive more than 64 exit-before-handler identities, warning-producing data churn, duplicate/reused ids, fresh-spawn and explicit-reattach ordering, handler registration at cap, and failed-shutdown restoration; assert bounded eviction, exact latest-code delivery once, fresh-generation filtering, data-before-exit order, and detached-before-live output.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts",
+        "src/renderer/src/components/terminal-pane/pty-transport.test.ts",
+        "src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts",
+        "src/renderer/src/lib/launch-agent-background-session.test.ts",
+        "src/renderer/src/lib/launch-worktree-background-terminals.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts",
+          "assertions": [
+            "65 exit-before-handler identities evict the oldest and retain the newest",
+            "a reused PTY id refreshes recency, delivers only its latest exit once, and filters older-lifecycle data and exits by cursor",
+            "warning identities are released with exact data-map eviction so warning state cannot grow independently"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts",
+          "assertions": [
+            "pre-handler data drains before its exit",
+            "fresh PTY-id reuse filters old lifecycle events while explicit daemon reattach preserves pre-connect backlog",
+            "a registered exit handler remains authoritative while 65 orphan exits churn through the bounded buffer"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal-pane/pty-transport.test.ts",
+          "assertions": [
+            "failed intentional shutdown restoration drains data received while detached before later live data"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-11",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts",
+          "result": "passed",
+          "durationSeconds": 1,
+          "summary": "5 test files passed, 112 tests passed on main@20ebe858af plus the #7695 candidate. The current-main repro retained the 65th oldest exit (received code 0 instead of eviction); the bounded candidate evicts it and preserves all ordering/reuse cases."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 10,
+        "scope": "renderer unit and contract tests"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "New deterministic gate; needs soak history before promotion."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "On current main the 65-identity repro fails because the oldest exit remains retained. The candidate passes the same oracle plus ordering, reuse, warning, and failed-restore cases. Needs saved CI history before blocking promotion."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Only the rare no-handler path adds one monotonic-number increment and constant-size Map operations. Data and exits each retain at most 64 PTY identities; warning identities are a subset of retained data identities. No polling, timers, provider listing, IPC/RPC, subprocesses, renderer fanout, or scans were added."
+      },
+      "promotionCriteria": [
+        "Soak for at least 100 consecutive passes or 14 days on required CI platforms.",
+        "Add live SSH and WSL fast-exit coverage or provider-contract equivalents.",
+        "Capture a saved intentional-break artifact for cursor filtering and failed-shutdown ordering."
+      ],
+      "knownGaps": [
+        "Under extreme churn beyond 64 undrained exits, the oldest exit is deliberately dropped; this matches the established pre-handler data budget and can leave only the newest 64 diagnostics.",
+        "SSH and WSL share the tested IPC path but lack live provider evidence.",
+        "Remote-runtime/mobile streams are host-owned and do not use this renderer pre-handler buffer."
+      ],
+      "demotionRule": "Demote or quarantine if ordering flakes, a live provider consumes an older lifecycle event, or the added cursor/bookkeeping appears in normal registered-handler throughput profiles."
     },
     {
       "id": "pty-delivery.renderer-lifecycle-accounting-reset",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3244,16 +3244,19 @@
         "local",
         "daemon"
       ],
-      "coverageNotes": "Deterministic macOS renderer tests cover the shared IPC transport used by local, daemon, SSH, and WSL PTYs, including explicit daemon reattach. SSH and WSL have path-equivalent unit coverage but no live provider run. Remote-runtime/mobile use a different host-owned stream and are unaffected.",
+      "coverageNotes": "Deterministic macOS renderer and protocol-v22 daemon tests cover local/shared IPC behavior, daemon stream-generation filtering, bounded create/attach buffering, cold restore, and explicit reattach. Protocol-v21 and older daemons omit the additive stream token and retain the cursor-only accepted race gap. SSH and WSL have path-equivalent renderer coverage but no live provider run. Remote-runtime/mobile use a different host-owned stream and are unaffected.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/7695"
       ],
-      "invariant": "Before a PTY handler mounts, the singleton dispatcher is already listening and retained data, exit, and warning identities remain capped; pre-spawn bytes reach background side-effect observers exactly once before live-sidecar handoff; data drains before exit; a fresh provider-reused PTY id or new-generation cold restore cannot consume an older lifecycle's events; explicit live reattach keeps its current backlog; and failed shutdown restore drains detached data before later live output without overwriting a newer remount handler.",
-      "oracle": "Drive first-use background data/exit before spawn resolution, real observer-to-sidecar handoff and handler replacement, more than 64 exit-before-handler identities, warning-producing data churn, duplicate/reused ids, fresh spawn, failed-reattach fallback, new-generation cold restore, explicit live reattach, handler registration at cap, and failed-shutdown restoration after a newer remount; assert listener-first capture, exactly-once observer handoff, bounded eviction, exact latest-code delivery once, fresh-generation filtering with restore payload preservation, data-before-exit order, and detached-before-live output routed to current authority.",
+      "invariant": "Before a PTY handler mounts, the singleton dispatcher is already listening and retained data, exit, and warning identities remain capped; pre-spawn bytes reach background side-effect observers exactly once before live-sidecar handoff; data drains before exit; protocol-v22 daemon data/exits must match the create/attach stream generation so a fresh provider-reused PTY id or new-generation cold restore cannot consume an older lifecycle's events; explicit live reattach keeps its current backlog; and failed shutdown restore drains detached data before later live output without overwriting a newer remount handler.",
+      "oracle": "Drive first-use background data/exit before spawn resolution, real observer-to-sidecar handoff and handler replacement, more than 64 exit-before-handler identities, warning-producing data churn, duplicate/reused ids, fresh spawn, failed-reattach fallback, old-generation queued data recovered through the real reattach snapshot, fast new-generation data/exit before its response, mixed-generation coalescing/splitting/keep-tail salvage, repeated pending-buffer overflow with surrogate pairs, cold restore, explicit live reattach/reconnect, tokenless legacy events, handler registration at cap, and failed-shutdown restoration after a newer remount; assert listener-first capture, exactly-once observer handoff, bounded eviction, matching stream-generation delivery, a 512 KiB pending-data cap with generation-correct gap facts, fresh-generation filtering with restore payload preservation, data-before-exit order, and detached-before-live output routed to current authority.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/daemon-server.test.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts"
       ],
       "testFiles": [
+        "src/main/daemon/daemon-stream-data-batcher.test.ts",
+        "src/main/daemon/daemon-pty-adapter.test.ts",
+        "src/main/daemon/daemon-server.test.ts",
         "src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts",
         "src/renderer/src/components/terminal-pane/pty-transport.test.ts",
         "src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts",
@@ -3262,10 +3265,35 @@
       ],
       "assertionRefs": [
         {
+          "file": "src/main/daemon/daemon-stream-data-batcher.test.ts",
+          "assertions": [
+            "mixed-generation keep-tail drops emit separately tokened gaps and preserve salvaged query ownership",
+            "coalesced old-generation and split new-generation data remain token-separated and ordered before matching exit"
+          ]
+        },
+        {
+          "file": "src/main/daemon/daemon-pty-adapter.test.ts",
+          "assertions": [
+            "queued old-generation data is recovered through the real warm-reattach snapshot while matching fast new-generation data and exit are accepted live",
+            "pending create/attach data stays within 512 KiB across repeated surrogate-bearing overflow and emits matching-token gaps without dropping exit/control facts",
+            "tokenless protocol-v21 events remain accepted, rejected provider calls release the shared selection barrier, and dispose cancels buffered delivery"
+          ]
+        },
+        {
+          "file": "src/main/daemon/daemon-server.test.ts",
+          "assertions": [
+            "create/attach returns an additive stream generation and batched data plus ordered exit carry the same token",
+            "queued pre-reattach data retains the old token and is present in the response snapshot while new live data and exit carry the replacement token",
+            "an older concurrently rejected attach cannot roll back the newer stream owner",
+            "protocol v22 remains version-isolated while v21 stays discoverable through its tokenless adapter"
+          ]
+        },
+        {
           "file": "src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts",
           "assertions": [
             "65 exit-before-handler identities evict the oldest and retain the newest",
             "a reused PTY id refreshes both data and exit recency, delivers only its latest exit once, and filters older-lifecycle data and exits by cursor",
+            "UTF-8 byte clamping preserves UTF-16 rawLength sequence units for non-ASCII terminal output",
             "warning identities are released with exact data-map eviction so warning state cannot grow independently"
           ]
         },
@@ -3290,10 +3318,10 @@
           "date": "2026-07-11",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/daemon-server.test.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts",
           "result": "passed",
           "durationSeconds": 1,
-          "summary": "5 test files and 120 tests passed on main@dcfa91919f plus the #7695 candidate. The red repro on main@20ebe858af retained the 65th oldest exit (received code 0 instead of eviction); the candidate evicts it and preserves listener-first, exactly-once side-effect handoff, ordering/reuse, and new-generation cold-restore cases."
+          "summary": "8 test files and 271 tests passed on main@a4583eb765 plus the #7695 candidate. The red repro on main@20ebe858af retained the 65th oldest exit (received code 0 instead of eviction); the candidate evicts it and preserves listener-first, exactly-once side-effect handoff, UTF-8-byte/UTF-16-sequence accounting, ordering/reuse, bounded protocol-v22 daemon generation filtering, and cold-restore cases."
         }
       ],
       "runtimeBudget": {
@@ -3310,7 +3338,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Only the rare no-handler path adds one monotonic-number increment and constant-size Map operations. Data and exits each retain at most 64 PTY identities; warning identities are a subset of retained data identities. No polling, timers, provider listing, IPC/RPC, subprocesses, renderer fanout, or scans were added."
+        "evidence": "Only the rare no-handler path adds one monotonic-number increment and constant-size Map operations. Data and exits each retain at most 64 PTY identities; warning identities are a subset of retained data identities. Protocol v22 adds one small generation field per daemon create/attach and queued stream entry; unresolved create/attach buffering coalesces matching data and caps retained payload at 512 KiB per session, with deterministic repeated-overflow and surrogate-pair accounting. No polling, timers, provider listing, extra RPC, subprocesses, renderer fanout, or scans were added."
       },
       "promotionCriteria": [
         "Soak for at least 100 consecutive passes or 14 days on required CI platforms.",
@@ -3319,10 +3347,12 @@
       ],
       "knownGaps": [
         "Under extreme churn beyond 64 undrained exits, the oldest exit is deliberately dropped; this matches the established pre-handler data budget and can leave only the newest 64 diagnostics.",
+        "An extreme output burst while create/attach is unresolved keeps only the newest 512 KiB of payload and emits a dataGap for snapshot recovery; exit and control facts remain ordered, but the intermediate live feed is intentionally not lossless.",
+        "Protocol-v21 and older daemons omit streamGeneration; new clients accept their tokenless events and retain the cursor-only probe-to-cold-restore race until the daemon upgrades.",
         "SSH and WSL share the tested IPC path but lack live provider evidence.",
         "Remote-runtime/mobile streams are host-owned and do not use this renderer pre-handler buffer."
       ],
-      "demotionRule": "Demote or quarantine if ordering flakes, a live provider consumes an older lifecycle event, or the added cursor/bookkeeping appears in normal registered-handler throughput profiles."
+      "demotionRule": "Demote or quarantine if ordering flakes, protocol-v22 accepts a mismatched stream generation or drops a matching fast-exit event, a live provider consumes an older lifecycle event, or the added cursor/generation bookkeeping appears in normal throughput profiles."
     },
     {
       "id": "pty-delivery.renderer-lifecycle-accounting-reset",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3247,8 +3247,8 @@
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/7695"
       ],
-      "invariant": "Before a PTY handler mounts, retained data, exit, and warning identities remain capped; data drains before exit; a fresh provider-reused PTY id cannot consume an older lifecycle's events; explicit reattach keeps its current backlog; and failed shutdown restore drains detached data before later live output.",
-      "oracle": "Drive more than 64 exit-before-handler identities, warning-producing data churn, duplicate/reused ids, fresh-spawn and explicit-reattach ordering, handler registration at cap, and failed-shutdown restoration; assert bounded eviction, exact latest-code delivery once, fresh-generation filtering, data-before-exit order, and detached-before-live output.",
+      "invariant": "Before a PTY handler mounts, the singleton dispatcher is already listening and retained data, exit, and warning identities remain capped; data drains before exit; a fresh provider-reused PTY id cannot consume an older lifecycle's events; explicit reattach keeps its current backlog; and failed shutdown restore drains detached data before later live output.",
+      "oracle": "Drive first-use background exit-before-spawn-resolution, more than 64 exit-before-handler identities, warning-producing data churn, duplicate/reused ids, fresh-spawn and explicit-reattach ordering, handler registration at cap, and failed-shutdown restoration; assert listener-first capture, bounded eviction, exact latest-code delivery once, fresh-generation filtering, data-before-exit order, and detached-before-live output.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts"
       ],
@@ -3273,6 +3273,7 @@
           "assertions": [
             "pre-handler data drains before its exit",
             "fresh PTY-id reuse and failed-reattach fresh fallback filter old lifecycle events while explicit daemon reattach preserves pre-connect backlog",
+            "first-use eager registration attaches the singleton dispatcher before a fast background PTY can emit data or exit",
             "a registered exit handler remains authoritative while 65 orphan exits churn through the bounded buffer"
           ]
         },
@@ -3291,7 +3292,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts",
           "result": "passed",
           "durationSeconds": 1,
-          "summary": "5 test files passed, 114 tests passed on main@20ebe858af plus the #7695 candidate. Main@20ebe858af retained the 65th oldest exit (received code 0 instead of eviction); the bounded candidate evicts it and preserves all ordering/reuse cases."
+          "summary": "5 test files passed, 115 tests passed on main@20ebe858af plus the #7695 candidate. Main@20ebe858af retained the 65th oldest exit (received code 0 instead of eviction); the bounded candidate evicts it and preserves listener-first and ordering/reuse cases."
         }
       ],
       "runtimeBudget": {

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3264,7 +3264,7 @@
           "file": "src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts",
           "assertions": [
             "65 exit-before-handler identities evict the oldest and retain the newest",
-            "a reused PTY id refreshes recency, delivers only its latest exit once, and filters older-lifecycle data and exits by cursor",
+            "a reused PTY id refreshes both data and exit recency, delivers only its latest exit once, and filters older-lifecycle data and exits by cursor",
             "warning identities are released with exact data-map eviction so warning state cannot grow independently"
           ]
         },
@@ -3272,7 +3272,7 @@
           "file": "src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts",
           "assertions": [
             "pre-handler data drains before its exit",
-            "fresh PTY-id reuse filters old lifecycle events while explicit daemon reattach preserves pre-connect backlog",
+            "fresh PTY-id reuse and failed-reattach fresh fallback filter old lifecycle events while explicit daemon reattach preserves pre-connect backlog",
             "a registered exit handler remains authoritative while 65 orphan exits churn through the bounded buffer"
           ]
         },
@@ -3291,7 +3291,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts",
           "result": "passed",
           "durationSeconds": 1,
-          "summary": "5 test files passed, 112 tests passed on main@20ebe858af plus the #7695 candidate. The current-main repro retained the 65th oldest exit (received code 0 instead of eviction); the bounded candidate evicts it and preserves all ordering/reuse cases."
+          "summary": "5 test files passed, 114 tests passed on main@20ebe858af plus the #7695 candidate. Main@20ebe858af retained the 65th oldest exit (received code 0 instead of eviction); the bounded candidate evicts it and preserves all ordering/reuse cases."
         }
       ],
       "runtimeBudget": {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -133,6 +133,195 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(typeof result.id).toBe('string')
     })
 
+    it('recovers queued old-generation data from the reattach snapshot and accepts new live events', async () => {
+      const sessionId = 'generation-race'
+      await adapter.spawn({ cols: 80, rows: 24, sessionId })
+      const oldSubprocess = lastSubprocess
+      const data = vi.fn()
+      const exit = vi.fn()
+      adapter.onData(data)
+      adapter.onExit(exit)
+      const client = (
+        adapter as unknown as {
+          client: { request: (type: string, payload?: unknown) => Promise<unknown> }
+        }
+      ).client
+      const originalRequest = client.request.bind(client)
+      let raced = false
+      vi.spyOn(client, 'request').mockImplementation(async (type: string, payload?: unknown) => {
+        if (type !== 'createOrAttach' || raced) {
+          return originalRequest(type, payload)
+        }
+        raced = true
+        // This byte is already modelled by the daemon snapshot but still sits
+        // in the old stream generation's 2ms batch queue.
+        oldSubprocess._simulateData('old-queued-before-reattach')
+        const response = await originalRequest(type, payload)
+        // Same real PTY, newly attached stream callback: these events can beat
+        // the control-socket response back to the adapter.
+        oldSubprocess._simulateData('new-fast-data')
+        lastSubprocess._simulateExit(7)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        return response
+      })
+
+      const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId })
+
+      expect(reattach.isReattach).toBe(true)
+      expect(reattach.snapshot).toContain('old-queued-before-reattach')
+      expect(data).toHaveBeenCalledOnce()
+      expect(data).toHaveBeenCalledWith(expect.objectContaining({ data: 'new-fast-data' }))
+      expect(exit).toHaveBeenCalledOnce()
+      expect(exit).toHaveBeenCalledWith({ id: sessionId, code: 7 })
+    })
+
+    it('bounds pending response data, preserves exit, and emits a generation-correct gap', async () => {
+      const data = vi.fn()
+      const exit = vi.fn()
+      const background = vi.fn()
+      adapter.onData(data)
+      adapter.onExit(exit)
+      adapter.onBackgroundStreamEvent(background)
+      const internals = adapter as unknown as {
+        withPendingStreamGeneration: <T>(id: string, action: () => Promise<T>) => Promise<T>
+        recordPendingStreamGenerationResponse: (
+          id: string,
+          result: { streamGeneration?: number }
+        ) => void
+        routeDaemonEvent: (event: unknown) => void
+        pendingStreamGenerations: Map<string, { events: unknown[]; queuedDataChars: number }>
+      }
+      const sessionId = 'bounded-pending'
+      const tail = `${'x'.repeat(512 * 1024 - 1)}😀`
+
+      await internals.withPendingStreamGeneration(sessionId, async () => {
+        internals.routeDaemonEvent({
+          type: 'event',
+          event: 'data',
+          sessionId,
+          streamGeneration: 5,
+          payload: { data: `old-prefix${tail}` }
+        })
+        internals.routeDaemonEvent({
+          type: 'event',
+          event: 'transientFact',
+          sessionId,
+          streamGeneration: 5,
+          payload: { kind: 'bell' }
+        })
+        internals.routeDaemonEvent({
+          type: 'event',
+          event: 'data',
+          sessionId,
+          streamGeneration: 5,
+          payload: { data: `second-prefix${tail}` }
+        })
+        internals.routeDaemonEvent({
+          type: 'event',
+          event: 'exit',
+          sessionId,
+          streamGeneration: 5,
+          payload: { code: 23 }
+        })
+        const pending = internals.pendingStreamGenerations.get(sessionId)
+        expect(pending?.queuedDataChars).toBeLessThanOrEqual(512 * 1024)
+        expect(pending?.events).toHaveLength(5)
+        internals.recordPendingStreamGenerationResponse(sessionId, { streamGeneration: 5 })
+      })
+
+      expect(background.mock.calls.filter(([payload]) => payload.kind === 'dataGap')).toHaveLength(
+        2
+      )
+      expect(background).toHaveBeenCalledWith({
+        id: sessionId,
+        kind: 'transientFact',
+        fact: { kind: 'bell' }
+      })
+      const delivered = data.mock.calls.map(([payload]) => payload.data).join('')
+      expect(delivered.endsWith('😀')).toBe(true)
+      expect(delivered).not.toContain('�')
+      expect(exit).toHaveBeenCalledWith({ id: sessionId, code: 23 })
+    })
+
+    it('uses the tokenless v21 selection barrier and releases it after a rejected call', async () => {
+      const legacyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 21 })
+      const data = vi.fn()
+      const exit = vi.fn()
+      legacyAdapter.onData(data)
+      legacyAdapter.onExit(exit)
+      const internals = legacyAdapter as unknown as {
+        withPendingStreamGeneration: <T>(id: string, action: () => Promise<T>) => Promise<T>
+        recordPendingStreamGenerationResponse: (id: string, result: object) => void
+        routeDaemonEvent: (event: unknown) => void
+        pendingStreamGenerations: Map<string, unknown>
+      }
+
+      await internals.withPendingStreamGeneration('legacy-v21', async () => {
+        internals.routeDaemonEvent({
+          type: 'event',
+          event: 'data',
+          sessionId: 'legacy-v21',
+          payload: { data: 'legacy-live' }
+        })
+        internals.routeDaemonEvent({
+          type: 'event',
+          event: 'exit',
+          sessionId: 'legacy-v21',
+          payload: { code: 4 }
+        })
+        internals.recordPendingStreamGenerationResponse('legacy-v21', {})
+      })
+
+      await expect(
+        internals.withPendingStreamGeneration('rejected-v21', async () => {
+          throw new Error('create rejected')
+        })
+      ).rejects.toThrow('create rejected')
+      expect(internals.pendingStreamGenerations.has('rejected-v21')).toBe(false)
+      expect(data).toHaveBeenCalledWith({ id: 'legacy-v21', data: 'legacy-live' })
+      expect(exit).toHaveBeenCalledWith({ id: 'legacy-v21', code: 4 })
+      data.mockClear()
+      await internals.withPendingStreamGeneration('disposed-v21', async () => {
+        internals.routeDaemonEvent({
+          type: 'event',
+          event: 'data',
+          sessionId: 'disposed-v21',
+          payload: { data: 'must-not-escape-dispose' }
+        })
+        internals.recordPendingStreamGenerationResponse('disposed-v21', {})
+        legacyAdapter.dispose()
+      })
+      expect(data).not.toHaveBeenCalled()
+    })
+
+    it('accepts tokenless legacy daemon events as the documented cursor fallback', () => {
+      const data = vi.fn()
+      const exit = vi.fn()
+      adapter.onData(data)
+      adapter.onExit(exit)
+      const internals = adapter as unknown as {
+        activeStreamGenerations: Map<string, number>
+        routeDaemonEvent: (event: unknown) => void
+      }
+      internals.activeStreamGenerations.set('legacy-session', 42)
+
+      internals.routeDaemonEvent({
+        type: 'event',
+        event: 'data',
+        sessionId: 'legacy-session',
+        payload: { data: 'legacy-data' }
+      })
+      internals.routeDaemonEvent({
+        type: 'event',
+        event: 'exit',
+        sessionId: 'legacy-session',
+        payload: { code: 3 }
+      })
+
+      expect(data).toHaveBeenCalledWith({ id: 'legacy-session', data: 'legacy-data' })
+      expect(exit).toHaveBeenCalledWith({ id: 'legacy-session', code: 3 })
+    })
+
     it('uses worktreeId as session prefix when provided', async () => {
       const result = await adapter.spawn({ cols: 80, rows: 24, worktreeId: 'wt-1' })
       expect(result.id).toContain('wt-1')

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -31,11 +31,21 @@ import { isShellProcess } from '../../shared/agent-detection'
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import { shouldUseShellReadyStartupDelivery } from '../../shared/codex-startup-delivery'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
+import { clampToSafeSplitIndex } from './daemon-stream-data-split'
 
 type ColdRestorePayload = {
   scrollback: string
   cwd: string
   oscLinks?: TerminalOscLinkRange[]
+}
+
+type PendingStreamGeneration = {
+  callers: number
+  candidates: number[]
+  sawTokenlessResponse: boolean
+  events: DaemonEvent[]
+  queuedDataChars: number
+  cancelled: boolean
 }
 
 function getRecoveredHistorySeed(restoreInfo: ColdRestoreInfo): string | null {
@@ -60,6 +70,11 @@ export type DaemonPtyAdapterOptions = {
 
 const MAX_TOMBSTONES = 1000
 const MAX_CONCURRENT_CHECKPOINTS = 4
+// Why: create/attach responses share the control socket with other RPCs. A
+// wedged response must not let a flooding PTY retain unbounded stream data;
+// the gap asks the main-owned snapshot path to heal the deliberately dropped
+// prefix while exits and other control facts remain ordered.
+const MAX_PENDING_STREAM_DATA_CHARS = 512 * 1024
 
 export class TerminalKilledError extends Error {
   constructor(sessionId: string) {
@@ -102,6 +117,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private coldRestoreCache = new Map<string, ColdRestorePayload>()
   private sleepRestoreSessionIds = new Set<string>()
   private activeSessionIds = new Set<string>()
+  private activeStreamGenerations = new Map<string, number>()
+  private pendingStreamGenerations = new Map<string, PendingStreamGeneration>()
   private dirtySessionVersions = new Map<string, number>()
   // Why: a cold-restored session is a fresh shell whose on-disk checkpoint and
   // log belong to the pre-crash session. Incremental appends would land on
@@ -161,6 +178,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.producerResumesOwedOnReconnect.add(id)
       }
       this.pausedProducerSessionIds.clear()
+      this.activeStreamGenerations.clear()
+      for (const pending of this.pendingStreamGenerations.values()) {
+        pending.candidates.length = 0
+        pending.sawTokenlessResponse = false
+        pending.events.length = 0
+        pending.queuedDataChars = 0
+      }
     })
   }
 
@@ -169,12 +193,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
-    return this.withDaemonRetry(() => this.doSpawn(opts))
+    const sessionId = opts.sessionId ?? mintPtySessionId(opts.worktreeId)
+    return this.withPendingStreamGeneration(sessionId, () =>
+      this.withDaemonRetry(() => this.doSpawn(opts, sessionId))
+    )
   }
 
-  private async doSpawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
-    const sessionId = opts.sessionId ?? mintPtySessionId(opts.worktreeId)
-
+  private async doSpawn(opts: PtySpawnOptions, sessionId: string): Promise<PtySpawnResult> {
     if (this.killedSessionTombstones.has(sessionId)) {
       throw new TerminalKilledError(sessionId)
     }
@@ -227,8 +252,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
         ? CODEX_SHELL_READY_TIMEOUT_MS
         : undefined
 
-    const createOrAttach = (historySeed: string | null) =>
-      this.client.request<CreateOrAttachResult>('createOrAttach', {
+    const createOrAttach = async (historySeed: string | null): Promise<CreateOrAttachResult> => {
+      const createResult = await this.client.request<CreateOrAttachResult>('createOrAttach', {
         sessionId,
         cols: effectiveCols,
         rows: effectiveRows,
@@ -250,6 +275,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
         ...(shellReadyTimeoutMs !== undefined ? { shellReadyTimeoutMs } : {}),
         ...(historySeed ? { historySeed } : {})
       })
+      this.recordPendingStreamGenerationResponse(sessionId, createResult)
+      return createResult
+    }
 
     let scrollback = restoreInfo ? getRecoveredHistorySeed(restoreInfo) : null
     let result = await createOrAttach(scrollback)
@@ -425,15 +453,18 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   async attach(id: string): Promise<void> {
-    await this.ensureConnected()
-    if (!this.supportsAuthoritativeBufferSnapshots) {
-      this.setPtyBackgrounded(id, false)
-    }
+    await this.withPendingStreamGeneration(id, async () => {
+      await this.ensureConnected()
+      if (!this.supportsAuthoritativeBufferSnapshots) {
+        this.setPtyBackgrounded(id, false)
+      }
 
-    await this.client.request<CreateOrAttachResult>('createOrAttach', {
-      sessionId: id,
-      cols: 80,
-      rows: 24
+      const result = await this.client.request<CreateOrAttachResult>('createOrAttach', {
+        sessionId: id,
+        cols: 80,
+        rows: 24
+      })
+      this.recordPendingStreamGenerationResponse(id, result)
     })
   }
 
@@ -785,6 +816,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.sessionsNeedingFullCheckpoint.clear()
     this.pausedProducerSessionIds.clear()
     this.producerResumesOwedOnReconnect.clear()
+    this.cancelPendingStreamGenerations()
     this.stopCheckpointTimer()
     for (const id of ids) {
       this.coldRestoreCache.delete(id)
@@ -860,6 +892,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.coldRestoreCache.clear()
     this.pausedProducerSessionIds.clear()
     this.producerResumesOwedOnReconnect.clear()
+    this.cancelPendingStreamGenerations()
     this.removeEventListener?.()
     this.removeEventListener = null
     // Why: final checkpoints are written daemon-side in TerminalHost.dispose()
@@ -905,6 +938,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.producerResumesOwedOnReconnect.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
+    this.cancelPendingStreamGenerations()
     this.client.disconnect()
   }
 
@@ -1268,6 +1302,200 @@ export class DaemonPtyAdapter implements IPtyProvider {
     await this.respawnFn!()
   }
 
+  private async withPendingStreamGeneration<T>(
+    sessionId: string,
+    action: () => Promise<T>
+  ): Promise<T> {
+    let pending = this.pendingStreamGenerations.get(sessionId)
+    if (!pending) {
+      pending = {
+        callers: 0,
+        candidates: [],
+        sawTokenlessResponse: false,
+        events: [],
+        queuedDataChars: 0,
+        cancelled: false
+      }
+      this.pendingStreamGenerations.set(sessionId, pending)
+    }
+    pending.callers += 1
+    try {
+      return await action()
+    } finally {
+      pending.callers -= 1
+      if (pending.callers === 0) {
+        this.pendingStreamGenerations.delete(sessionId)
+        if (!pending.cancelled) {
+          this.finalizePendingStreamGeneration(sessionId, pending)
+        }
+      }
+    }
+  }
+
+  private finalizePendingStreamGeneration(
+    sessionId: string,
+    pending: PendingStreamGeneration
+  ): void {
+    const selectedGeneration =
+      pending.candidates.length > 0 ? Math.max(...pending.candidates) : undefined
+    const activeGeneration = this.activeStreamGenerations.get(sessionId)
+    const generation = selectedGeneration ?? activeGeneration
+    const useTokenlessFallback = selectedGeneration === undefined && pending.sawTokenlessResponse
+    if (selectedGeneration !== undefined) {
+      this.activeStreamGenerations.set(sessionId, selectedGeneration)
+    } else if (useTokenlessFallback) {
+      // Why: v21 and older have no token. Clear any newer-protocol token and
+      // retain the legacy daemon's cursor-only compatibility path.
+      this.activeStreamGenerations.delete(sessionId)
+    }
+    if (
+      selectedGeneration === undefined &&
+      !useTokenlessFallback &&
+      activeGeneration === undefined
+    ) {
+      return
+    }
+    for (const event of pending.events) {
+      if (
+        useTokenlessFallback ||
+        generation === undefined ||
+        event.streamGeneration === undefined ||
+        event.streamGeneration === generation
+      ) {
+        this.handleDaemonEvent(event)
+      }
+    }
+  }
+
+  private recordPendingStreamGenerationResponse(
+    sessionId: string,
+    result: CreateOrAttachResult
+  ): void {
+    const pending = this.pendingStreamGenerations.get(sessionId)
+    if (!pending) {
+      return
+    }
+    if (typeof result.streamGeneration === 'number') {
+      pending.candidates.push(result.streamGeneration)
+    } else {
+      pending.sawTokenlessResponse = true
+    }
+  }
+
+  private cancelPendingStreamGenerations(): void {
+    this.activeStreamGenerations.clear()
+    for (const pending of this.pendingStreamGenerations.values()) {
+      pending.cancelled = true
+      pending.candidates.length = 0
+      pending.events.length = 0
+      pending.queuedDataChars = 0
+    }
+    this.pendingStreamGenerations.clear()
+  }
+
+  private queuePendingStreamEvent(pending: PendingStreamGeneration, event: DaemonEvent): void {
+    if (event.event === 'data') {
+      const last = pending.events.at(-1)
+      if (
+        last?.event === 'data' &&
+        last.sessionId === event.sessionId &&
+        last.streamGeneration === event.streamGeneration &&
+        last.payload.sequenceChars === undefined &&
+        event.payload.sequenceChars === undefined
+      ) {
+        const priorSequenceChars = last.payload.sequenceChars ?? last.payload.data.length
+        const nextSequenceChars = event.payload.sequenceChars ?? event.payload.data.length
+        last.payload.data += event.payload.data
+        const combinedSequenceChars = priorSequenceChars + nextSequenceChars
+        last.payload.sequenceChars =
+          combinedSequenceChars === last.payload.data.length ? undefined : combinedSequenceChars
+      } else {
+        pending.events.push(event)
+      }
+      pending.queuedDataChars += event.payload.data.length
+      this.trimPendingStreamData(pending)
+      return
+    }
+    pending.events.push(event)
+  }
+
+  private trimPendingStreamData(pending: PendingStreamGeneration): void {
+    while (pending.queuedDataChars > MAX_PENDING_STREAM_DATA_CHARS) {
+      const index = pending.events.findIndex((event) => event.event === 'data')
+      if (index === -1) {
+        pending.queuedDataChars = 0
+        return
+      }
+      const event = pending.events[index]
+      if (event.event !== 'data') {
+        return
+      }
+      const excess = pending.queuedDataChars - MAX_PENDING_STREAM_DATA_CHARS
+      let cut = Math.min(excess, event.payload.data.length)
+      if (
+        cut < event.payload.data.length &&
+        event.payload.sequenceChars !== undefined &&
+        event.payload.sequenceChars !== 0
+      ) {
+        // Why: a non-1:1 event has no safe partial mapping from delivered
+        // bytes to source positions. Drop the whole event and preserve its
+        // exact sequence count on the generated gap.
+        cut = event.payload.data.length
+      }
+      if (cut < event.payload.data.length) {
+        const safeCut = clampToSafeSplitIndex(event.payload.data, 0, cut)
+        // Why: clamping backward would leave the hard cap one UTF-16 code
+        // unit over budget. Drop the complete surrogate pair instead.
+        cut = safeCut < cut ? Math.min(event.payload.data.length, cut + 1) : safeCut
+      }
+      const originalDataLength = event.payload.data.length
+      const originalSequenceChars = event.payload.sequenceChars ?? originalDataLength
+      const droppedSequenceChars =
+        cut >= originalDataLength ? originalSequenceChars : originalSequenceChars === 0 ? 0 : cut
+      const gap: DaemonEvent = {
+        type: 'event',
+        event: 'dataGap',
+        sessionId: event.sessionId,
+        ...(event.streamGeneration === undefined
+          ? {}
+          : { streamGeneration: event.streamGeneration }),
+        payload: { droppedChars: cut, sequenceChars: droppedSequenceChars }
+      }
+
+      if (cut >= originalDataLength) {
+        pending.events.splice(index, 1)
+      } else {
+        event.payload.data = event.payload.data.slice(cut)
+        const remainingSequenceChars = originalSequenceChars - droppedSequenceChars
+        event.payload.sequenceChars =
+          remainingSequenceChars === event.payload.data.length ? undefined : remainingSequenceChars
+      }
+      pending.queuedDataChars -= cut
+
+      const prior = pending.events[index - 1]
+      if (
+        prior?.event === 'dataGap' &&
+        prior.sessionId === gap.sessionId &&
+        prior.streamGeneration === gap.streamGeneration
+      ) {
+        const priorSequenceChars = prior.payload.sequenceChars ?? prior.payload.droppedChars
+        prior.payload.droppedChars += cut
+        prior.payload.sequenceChars = priorSequenceChars + droppedSequenceChars
+      } else {
+        pending.events.splice(index, 0, gap)
+      }
+    }
+  }
+
+  private isCurrentStreamEvent(event: DaemonEvent): boolean {
+    const activeGeneration = this.activeStreamGenerations.get(event.sessionId)
+    return (
+      activeGeneration === undefined ||
+      event.streamGeneration === undefined ||
+      event.streamGeneration === activeGeneration
+    )
+  }
+
   private setupEventRouting(): void {
     if (this.removeEventListener) {
       return
@@ -1279,74 +1507,91 @@ export class DaemonPtyAdapter implements IPtyProvider {
         return
       }
 
-      if (event.event === 'data') {
-        this.markSessionDirty(event.sessionId)
-        // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
-        for (const listener of [...this.dataListeners]) {
-          listener({
-            id: event.sessionId,
-            data: event.payload.data,
-            ...(event.payload.sequenceChars === undefined
-              ? {}
-              : { sequenceChars: event.payload.sequenceChars })
-          })
-        }
-      } else if (event.event === 'sessionBackgroundMarker') {
-        this.emitBackgroundStreamEvent({
+      this.routeDaemonEvent(event)
+    })
+  }
+
+  private routeDaemonEvent(event: DaemonEvent): void {
+    const pending = this.pendingStreamGenerations.get(event.sessionId)
+    if (pending) {
+      this.queuePendingStreamEvent(pending, event)
+      return
+    }
+    if (!this.isCurrentStreamEvent(event)) {
+      return
+    }
+    this.handleDaemonEvent(event)
+  }
+
+  private handleDaemonEvent(event: DaemonEvent): void {
+    if (event.event === 'data') {
+      this.markSessionDirty(event.sessionId)
+      // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
+      for (const listener of [...this.dataListeners]) {
+        listener({
           id: event.sessionId,
-          kind: 'backgroundMarker',
-          background: event.payload.background,
-          ...(event.payload.scanSeedAnsi !== undefined
-            ? { scanSeedAnsi: event.payload.scanSeedAnsi }
-            : {})
-        })
-      } else if (event.event === 'dataGap') {
-        this.emitBackgroundStreamEvent({
-          id: event.sessionId,
-          kind: 'dataGap',
-          droppedChars: event.payload.droppedChars,
+          data: event.payload.data,
           ...(event.payload.sequenceChars === undefined
             ? {}
             : { sequenceChars: event.payload.sequenceChars })
         })
-      } else if (event.event === 'transientFact') {
-        this.emitBackgroundStreamEvent({
-          id: event.sessionId,
-          kind: 'transientFact',
-          fact: event.payload
-        })
-      } else if (event.event === 'exit') {
-        this.activeSessionIds.delete(event.sessionId)
-        this.dirtySessionVersions.delete(event.sessionId)
-        // Why: an exited session must not be owed a resume on reconnect — a
-        // reused sessionId would receive a stray resumePty. Same for the
-        // background set: a reused id must start un-thinned.
-        this.pausedProducerSessionIds.delete(event.sessionId)
-        this.producerResumesOwedOnReconnect.delete(event.sessionId)
-        this.backgroundedSessionIds.delete(event.sessionId)
-        if (!this.sleepRestoreSessionIds.has(event.sessionId)) {
-          this.coldRestoreCache.delete(event.sessionId)
-        }
-        // Why: an exited session can never be checkpointed again, so its pending
-        // full-checkpoint flag is dead state. Without this, a cold-restored
-        // session that exits before its first checkpoint leaks a permanent entry.
-        this.sessionsNeedingFullCheckpoint.delete(event.sessionId)
-        // Why: a reused sessionId (renderer respawns a persisted ptyId) must
-        // not inherit the dead session's snapshot cooldown.
-        this.lastFullCheckpointAt.delete(event.sessionId)
-        this.stopCheckpointTimerIfIdle()
-        if (this.historyManager) {
-          void this.historyManager
-            .closeSession(event.sessionId, event.payload.code)
-            .catch((err) => console.warn('[history] closeSession failed:', event.sessionId, err))
-        }
-        this.initialCwds.delete(event.sessionId)
-        // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
-        for (const listener of [...this.exitListeners]) {
-          listener({ id: event.sessionId, code: event.payload.code })
-        }
       }
-    })
+    } else if (event.event === 'sessionBackgroundMarker') {
+      this.emitBackgroundStreamEvent({
+        id: event.sessionId,
+        kind: 'backgroundMarker',
+        background: event.payload.background,
+        ...(event.payload.scanSeedAnsi !== undefined
+          ? { scanSeedAnsi: event.payload.scanSeedAnsi }
+          : {})
+      })
+    } else if (event.event === 'dataGap') {
+      this.emitBackgroundStreamEvent({
+        id: event.sessionId,
+        kind: 'dataGap',
+        droppedChars: event.payload.droppedChars,
+        ...(event.payload.sequenceChars === undefined
+          ? {}
+          : { sequenceChars: event.payload.sequenceChars })
+      })
+    } else if (event.event === 'transientFact') {
+      this.emitBackgroundStreamEvent({
+        id: event.sessionId,
+        kind: 'transientFact',
+        fact: event.payload
+      })
+    } else if (event.event === 'exit') {
+      this.activeStreamGenerations.delete(event.sessionId)
+      this.activeSessionIds.delete(event.sessionId)
+      this.dirtySessionVersions.delete(event.sessionId)
+      // Why: an exited session must not be owed a resume on reconnect — a
+      // reused sessionId would receive a stray resumePty. Same for the
+      // background set: a reused id must start un-thinned.
+      this.pausedProducerSessionIds.delete(event.sessionId)
+      this.producerResumesOwedOnReconnect.delete(event.sessionId)
+      this.backgroundedSessionIds.delete(event.sessionId)
+      if (!this.sleepRestoreSessionIds.has(event.sessionId)) {
+        this.coldRestoreCache.delete(event.sessionId)
+      }
+      // Why: an exited session can never be checkpointed again, so its pending
+      // full-checkpoint flag is dead state. Without this, a cold-restored
+      // session that exits before its first checkpoint leaks a permanent entry.
+      this.sessionsNeedingFullCheckpoint.delete(event.sessionId)
+      // Why: a reused sessionId (renderer respawns a persisted ptyId) must
+      // not inherit the dead session's snapshot cooldown.
+      this.lastFullCheckpointAt.delete(event.sessionId)
+      this.stopCheckpointTimerIfIdle()
+      if (this.historyManager) {
+        void this.historyManager
+          .closeSession(event.sessionId, event.payload.code)
+          .catch((err) => console.warn('[history] closeSession failed:', event.sessionId, err))
+      }
+      this.initialCwds.delete(event.sessionId)
+      // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
+      for (const listener of [...this.exitListeners]) {
+        listener({ id: event.sessionId, code: event.payload.code })
+      }
+    }
   }
 }
 

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -6,9 +6,10 @@ import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
 import { DaemonServer } from './daemon-server'
 import { DaemonClient } from './client'
 import { encodeNdjson } from './ndjson'
-import { PROTOCOL_VERSION, type DaemonRequest } from './types'
+import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION, type DaemonRequest } from './types'
 import type { SubprocessHandle } from './session'
 import { getDaemonSocketPath } from './daemon-spawner'
+import type { TerminalHost } from './terminal-host'
 
 const confirmForegroundProcessMock = vi.fn(async () => 'droid')
 
@@ -49,6 +50,8 @@ function createMockSubprocess(): SubprocessHandle & {
 
 type DaemonServerPrivate = {
   server: Server | null
+  host: TerminalHost
+  streamGenerationBySessionId: Map<string, number>
   clients: Map<
     string,
     {
@@ -140,6 +143,11 @@ describe('DaemonServer', () => {
   }
 
   describe('startup', () => {
+    it('reserves v22 for stream generations while retaining v21 legacy discovery', () => {
+      expect(PROTOCOL_VERSION).toBe(22)
+      expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(21)
+    })
+
     it('creates token file and starts listening', async () => {
       await startServer()
 
@@ -377,11 +385,11 @@ describe('DaemonServer', () => {
           streamSocket
         })
 
-        await daemon.routeRequest('client-1', {
+        const firstSpawn = (await daemon.routeRequest('client-1', {
           id: 'req-1',
           type: 'createOrAttach',
           payload: { sessionId: 'test-session', cols: 80, rows: 24 }
-        })
+        })) as { streamGeneration: number }
 
         subprocess!._simulateData('background')
         expect(streamSocket.write).not.toHaveBeenCalled()
@@ -402,6 +410,19 @@ describe('DaemonServer', () => {
         expect(String(streamSocket.write.mock.calls[0]?.[0])).toContain('"data":"echo"')
         vi.advanceTimersByTime(8)
         expect(streamSocket.write).toHaveBeenCalledTimes(1)
+
+        streamSocket.write.mockClear()
+        const reattach = (await daemon.routeRequest('client-1', {
+          id: 'req-3',
+          type: 'createOrAttach',
+          payload: { sessionId: 'test-session', cols: 80, rows: 24 }
+        })) as { streamGeneration: number }
+        subprocess!._simulateData('after-reattach')
+        vi.advanceTimersByTime(8)
+        expect(reattach.streamGeneration).toBeGreaterThan(firstSpawn.streamGeneration)
+        expect(String(streamSocket.write.mock.calls[0]?.[0])).toContain(
+          `"streamGeneration":${reattach.streamGeneration}`
+        )
       } finally {
         vi.useRealTimers()
       }
@@ -433,11 +454,11 @@ describe('DaemonServer', () => {
           streamSocket
         })
 
-        await daemon.routeRequest('client-1', {
+        const spawnResult = (await daemon.routeRequest('client-1', {
           id: 'req-1',
           type: 'createOrAttach',
           payload: { sessionId: 'test-session', cols: 80, rows: 24 }
-        })
+        })) as { streamGeneration: number }
 
         subprocess!._simulateData('final-output')
         subprocess!._simulateExit(42)
@@ -447,8 +468,146 @@ describe('DaemonServer', () => {
         expect(String(streamSocket.write.mock.calls[0]?.[0])).toContain('"data":"final-output"')
         expect(String(streamSocket.write.mock.calls[1]?.[0])).toContain('"event":"exit"')
         expect(String(streamSocket.write.mock.calls[1]?.[0])).toContain('"code":42')
+        expect(String(streamSocket.write.mock.calls[0]?.[0])).toContain(
+          `"streamGeneration":${spawnResult.streamGeneration}`
+        )
+        expect(String(streamSocket.write.mock.calls[1]?.[0])).toContain(
+          `"streamGeneration":${spawnResult.streamGeneration}`
+        )
         vi.advanceTimersByTime(8)
         expect(streamSocket.write).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('keeps queued pre-reattach bytes old-tokened while new live data and exit use the new token', async () => {
+      vi.useFakeTimers()
+      try {
+        let subprocess: ReturnType<typeof createMockSubprocess>
+        server = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => {
+            subprocess = createMockSubprocess()
+            return subprocess
+          }
+        })
+        const daemon = server as unknown as DaemonServerPrivate
+        const streamSocket = {
+          destroyed: false,
+          writableLength: 0,
+          destroy: vi.fn(),
+          write: vi.fn()
+        } as unknown as Socket & { write: ReturnType<typeof vi.fn> }
+        daemon.clients.set('client-1', {
+          clientId: 'client-1',
+          controlSocket: { destroy: vi.fn() } as unknown as Socket,
+          streamSocket
+        })
+
+        const first = (await daemon.routeRequest('client-1', {
+          id: 'req-1',
+          type: 'createOrAttach',
+          payload: { sessionId: 'reattach-order', cols: 80, rows: 24 }
+        })) as { streamGeneration: number }
+        subprocess!._simulateData('queued-before-reattach')
+
+        const second = (await daemon.routeRequest('client-1', {
+          id: 'req-2',
+          type: 'createOrAttach',
+          payload: { sessionId: 'reattach-order', cols: 80, rows: 24 }
+        })) as { snapshot: { snapshotAnsi: string }; streamGeneration: number }
+        expect(second.snapshot.snapshotAnsi).toContain('queued-before-reattach')
+        expect(second.streamGeneration).toBeGreaterThan(first.streamGeneration)
+
+        subprocess!._simulateData('new-live-after-attach')
+        subprocess!._simulateExit(31)
+
+        const messages = streamSocket.write.mock.calls.map(
+          ([line]) =>
+            JSON.parse(String(line)) as {
+              event: string
+              streamGeneration?: number
+              payload: { data?: string; code?: number }
+            }
+        )
+        expect(messages).toEqual([
+          expect.objectContaining({
+            event: 'data',
+            streamGeneration: first.streamGeneration,
+            payload: expect.objectContaining({ data: 'queued-before-reattach' })
+          }),
+          expect.objectContaining({
+            event: 'data',
+            streamGeneration: second.streamGeneration,
+            payload: expect.objectContaining({ data: 'new-live-after-attach' })
+          }),
+          expect.objectContaining({
+            event: 'exit',
+            streamGeneration: second.streamGeneration,
+            payload: expect.objectContaining({ code: 31 })
+          })
+        ])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('does not let an older rejected attach roll back a newer concurrent stream owner', async () => {
+      vi.useFakeTimers()
+      try {
+        let subprocess: ReturnType<typeof createMockSubprocess>
+        server = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => {
+            subprocess = createMockSubprocess()
+            return subprocess
+          }
+        })
+        const daemon = server as unknown as DaemonServerPrivate
+        const streamSocket = {
+          destroyed: false,
+          writableLength: 0,
+          destroy: vi.fn(),
+          write: vi.fn()
+        } as unknown as Socket & { write: ReturnType<typeof vi.fn> }
+        daemon.clients.set('client-1', {
+          clientId: 'client-1',
+          controlSocket: { destroy: vi.fn() } as unknown as Socket,
+          streamSocket
+        })
+        const originalCreate = daemon.host.createOrAttach.bind(daemon.host)
+        let rejectOlder!: (error: Error) => void
+        const older = new Promise<never>((_resolve, reject) => {
+          rejectOlder = reject
+        })
+        vi.spyOn(daemon.host, 'createOrAttach')
+          .mockImplementationOnce(() => older)
+          .mockImplementationOnce((options) => originalCreate(options))
+
+        const olderRequest = daemon.routeRequest('client-1', {
+          id: 'req-older',
+          type: 'createOrAttach',
+          payload: { sessionId: 'concurrent-owner', cols: 80, rows: 24 }
+        })
+        const newer = (await daemon.routeRequest('client-1', {
+          id: 'req-newer',
+          type: 'createOrAttach',
+          payload: { sessionId: 'concurrent-owner', cols: 80, rows: 24 }
+        })) as { streamGeneration: number }
+        rejectOlder(new Error('older attach rejected'))
+        await expect(olderRequest).rejects.toThrow('older attach rejected')
+
+        expect(daemon.streamGenerationBySessionId.get('concurrent-owner')).toBe(
+          newer.streamGeneration
+        )
+        subprocess!._simulateData('newer-owner-data')
+        vi.advanceTimersByTime(2)
+        expect(String(streamSocket.write.mock.calls.at(-1)?.[0])).toContain(
+          `"streamGeneration":${newer.streamGeneration}`
+        )
       } finally {
         vi.useRealTimers()
       }

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -63,6 +63,7 @@ export class DaemonServer {
   private log: DaemonFileLog
 
   private clients = new Map<string, ConnectedClient>()
+  private nextStreamGeneration = 0
   private streamDataBatcher = new DaemonStreamDataBatcher(
     (clientId) => this.clients.get(clientId),
     {
@@ -86,15 +87,18 @@ export class DaemonServer {
   private transientFactRelay = new BackgroundTransientFactRelay((sessionId, fact) => {
     const clientId = this.streamClientIdBySessionId.get(sessionId)
     if (clientId) {
+      const streamGeneration = this.streamGenerationBySessionId.get(sessionId)
       this.streamDataBatcher.enqueueControlEvent(clientId, sessionId, {
         type: 'event',
         event: 'transientFact',
         sessionId,
+        ...(streamGeneration === undefined ? {} : { streamGeneration }),
         payload: fact
       })
     }
   })
   private streamClientIdBySessionId = new Map<string, string>()
+  private streamGenerationBySessionId = new Map<string, number>()
   private lastInputAtBySessionId = new Map<string, number>()
   private stopStreamBacklogProbe: () => void = () => {}
 
@@ -333,71 +337,101 @@ export class DaemonServer {
     switch (request.type) {
       case 'createOrAttach': {
         const p = request.payload
-        const result = await this.host.createOrAttach({
-          sessionId: p.sessionId,
-          cols: p.cols,
-          rows: p.rows,
-          cwd: p.cwd,
-          env: p.env,
-          envToDelete: p.envToDelete,
-          command: p.command,
-          startupCommandDelivery: p.startupCommandDelivery,
-          // Why: daemon RPC payloads are untrusted JSON. Persist only the
-          // allowlisted enum used for byte routing, never arbitrary identity.
-          ...(isTuiAgent(p.launchAgent) ? { launchAgent: p.launchAgent } : {}),
-          shellOverride: p.shellOverride,
-          terminalWindowsWslDistro: p.terminalWindowsWslDistro,
-          terminalWindowsPowerShellImplementation: p.terminalWindowsPowerShellImplementation,
-          shellReadySupported: p.shellReadySupported,
-          historySeed: p.historySeed,
-          ...(p.shellReadyTimeoutMs !== undefined
-            ? { shellReadyTimeoutMs: p.shellReadyTimeoutMs }
-            : {}),
-          streamClient: {
-            onData: (data) => {
-              // Scan BEFORE enqueue: the batcher may keep-tail drop this
-              // chunk, but its facts must be captured regardless.
-              this.transientFactRelay.onSessionData(p.sessionId, data)
-              const lastInputAt = this.lastInputAtBySessionId.get(p.sessionId)
-              const isInteractiveOutput =
-                data.length <= DaemonServer.INTERACTIVE_OUTPUT_MAX_CHARS &&
-                lastInputAt !== undefined &&
-                performance.now() - lastInputAt <= DaemonServer.INTERACTIVE_OUTPUT_WINDOW_MS
-              this.streamDataBatcher.enqueue(clientId, p.sessionId, data, {
-                flushImmediately: isInteractiveOutput,
-                flushMaxChars: DaemonServer.INTERACTIVE_OUTPUT_MAX_CHARS
-              })
-            },
-            onExit: (code) => {
-              // Why: exit tears down renderer handlers, so it must ride the
-              // ordered queue behind final output even when the shallow socket
-              // gate holds that output for a later drain pass.
-              this.log.log('session-exited', { sessionId: p.sessionId, code })
-              this.streamDataBatcher.enqueueControlEvent(clientId, p.sessionId, {
-                type: 'event',
-                event: 'exit',
-                sessionId: p.sessionId,
-                payload: { code }
-              })
-              this.streamDataBatcher.flush(clientId)
-              recordDaemonStreamBacklogEvent('sessionExit', {
-                sessionIdSuffix: p.sessionId.slice(-10)
-              })
-              this.transientFactRelay.onSessionExit(p.sessionId)
-              this.streamClientIdBySessionId.delete(p.sessionId)
-              this.lastInputAtBySessionId.delete(p.sessionId)
+        const streamGeneration = ++this.nextStreamGeneration
+        const previousStreamGeneration = this.streamGenerationBySessionId.get(p.sessionId)
+        this.streamGenerationBySessionId.set(p.sessionId, streamGeneration)
+        let result: Awaited<ReturnType<TerminalHost['createOrAttach']>>
+        try {
+          result = await this.host.createOrAttach({
+            sessionId: p.sessionId,
+            cols: p.cols,
+            rows: p.rows,
+            cwd: p.cwd,
+            env: p.env,
+            envToDelete: p.envToDelete,
+            command: p.command,
+            startupCommandDelivery: p.startupCommandDelivery,
+            // Why: daemon RPC payloads are untrusted JSON. Persist only the
+            // allowlisted enum used for byte routing, never arbitrary identity.
+            ...(isTuiAgent(p.launchAgent) ? { launchAgent: p.launchAgent } : {}),
+            shellOverride: p.shellOverride,
+            terminalWindowsWslDistro: p.terminalWindowsWslDistro,
+            terminalWindowsPowerShellImplementation: p.terminalWindowsPowerShellImplementation,
+            shellReadySupported: p.shellReadySupported,
+            historySeed: p.historySeed,
+            ...(p.shellReadyTimeoutMs !== undefined
+              ? { shellReadyTimeoutMs: p.shellReadyTimeoutMs }
+              : {}),
+            streamClient: {
+              onData: (data) => {
+                // Scan BEFORE enqueue: the batcher may keep-tail drop this
+                // chunk, but its facts must be captured regardless.
+                this.transientFactRelay.onSessionData(p.sessionId, data)
+                const lastInputAt = this.lastInputAtBySessionId.get(p.sessionId)
+                const isInteractiveOutput =
+                  data.length <= DaemonServer.INTERACTIVE_OUTPUT_MAX_CHARS &&
+                  lastInputAt !== undefined &&
+                  performance.now() - lastInputAt <= DaemonServer.INTERACTIVE_OUTPUT_WINDOW_MS
+                this.streamDataBatcher.enqueue(clientId, p.sessionId, data, {
+                  flushImmediately: isInteractiveOutput,
+                  flushMaxChars: DaemonServer.INTERACTIVE_OUTPUT_MAX_CHARS,
+                  streamGeneration
+                })
+              },
+              onExit: (code) => {
+                // Why: exit tears down renderer handlers, so it must ride the
+                // ordered queue behind final output even when the shallow socket
+                // gate holds that output for a later drain pass.
+                this.log.log('session-exited', { sessionId: p.sessionId, code })
+                this.streamDataBatcher.enqueueControlEvent(clientId, p.sessionId, {
+                  type: 'event',
+                  event: 'exit',
+                  sessionId: p.sessionId,
+                  streamGeneration,
+                  payload: { code }
+                })
+                this.streamDataBatcher.flush(clientId)
+                recordDaemonStreamBacklogEvent('sessionExit', {
+                  sessionIdSuffix: p.sessionId.slice(-10)
+                })
+                this.transientFactRelay.onSessionExit(p.sessionId)
+                // Why: a late callback from the replaced stream must not tear
+                // down ownership already installed by a newer attach.
+                if (this.streamGenerationBySessionId.get(p.sessionId) === streamGeneration) {
+                  this.streamClientIdBySessionId.delete(p.sessionId)
+                  this.streamGenerationBySessionId.delete(p.sessionId)
+                  this.lastInputAtBySessionId.delete(p.sessionId)
+                }
+              }
+            }
+          })
+        } catch (error) {
+          // Why: concurrent create/attach RPCs can settle out of order. A
+          // failed older request must not roll back a newer stream's owner.
+          if (this.streamGenerationBySessionId.get(p.sessionId) === streamGeneration) {
+            if (previousStreamGeneration === undefined) {
+              this.streamGenerationBySessionId.delete(p.sessionId)
+            } else {
+              this.streamGenerationBySessionId.set(p.sessionId, previousStreamGeneration)
             }
           }
-        })
-        this.streamClientIdBySessionId.set(p.sessionId, clientId)
+          throw error
+        }
+        if (this.streamGenerationBySessionId.get(p.sessionId) === streamGeneration) {
+          this.streamClientIdBySessionId.set(p.sessionId, clientId)
+        }
         // Why an attach-time marker: the adapter resyncs the background set on
         // a fresh connection, which can precede this attach — main's scan
         // suppression must still start at the head of the new stream.
-        if (this.transientFactRelay.isBackgrounded(p.sessionId)) {
+        if (
+          this.streamGenerationBySessionId.get(p.sessionId) === streamGeneration &&
+          this.transientFactRelay.isBackgrounded(p.sessionId)
+        ) {
           this.streamDataBatcher.enqueueControlEvent(clientId, p.sessionId, {
             type: 'event',
             event: 'sessionBackgroundMarker',
             sessionId: p.sessionId,
+            streamGeneration,
             payload: { background: true }
           })
         }
@@ -411,7 +445,8 @@ export class DaemonServer {
           pid: result.pid,
           shellState: result.shellState,
           ...(result.launchAgent ? { launchAgent: result.launchAgent } : {}),
-          ...(result.historySeeded !== undefined ? { historySeeded: result.historySeeded } : {})
+          ...(result.historySeeded !== undefined ? { historySeeded: result.historySeeded } : {}),
+          streamGeneration
         }
       }
 
@@ -480,10 +515,12 @@ export class DaemonServer {
         // and the normal flush/drain loop delivers them within milliseconds
         // (bounded ≤ the keep-tail drop cap), in order, ahead of the marker.
         const scanSeedAnsi = background ? '' : this.host.getPartialEscapeTailAnsi(sessionId)
+        const streamGeneration = this.streamGenerationBySessionId.get(sessionId)
         this.streamDataBatcher.enqueueControlEvent(streamClientId, sessionId, {
           type: 'event',
           event: 'sessionBackgroundMarker',
           sessionId,
+          ...(streamGeneration === undefined ? {} : { streamGeneration }),
           payload: {
             background,
             ...(scanSeedAnsi.length > 0 ? { scanSeedAnsi } : {})
@@ -596,6 +633,7 @@ export class DaemonServer {
     if (!client?.streamSocket) {
       return
     }
+    const streamGeneration = this.streamGenerationBySessionId.get(sessionId)
     // Why: write/resize are notification-heavy and intentionally do not wait
     // for replies. If their target session is gone, this synthetic exit is the
     // only signal the renderer gets to clear stale terminal pane bindings.
@@ -603,6 +641,7 @@ export class DaemonServer {
       type: 'event',
       event: 'exit',
       sessionId,
+      ...(streamGeneration === undefined ? {} : { streamGeneration }),
       payload: { code }
     })
     this.streamDataBatcher.flush(client.clientId)

--- a/src/main/daemon/daemon-stream-data-batcher.test.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.test.ts
@@ -25,6 +25,7 @@ function writtenData(streamSocket: { write: ReturnType<typeof vi.fn> }): string 
 type ParsedWrite = {
   event: string
   sessionId?: string
+  streamGeneration?: number
   payload?: { data?: string }
 }
 
@@ -407,6 +408,86 @@ describe('DaemonStreamDataBatcher', () => {
         0
       )
       expect(originalSequenceChars).toBe(`flood${dsr}${'x'.repeat(900 * 1024)}`.length + 300 * 1024)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps mixed-generation gaps and salvaged queries on their originating streams', () => {
+    vi.useFakeTimers()
+    try {
+      const dsr = '\x1b[6n'
+      const { batcher, streamSocket } = createBatcher({
+        isSessionDroppable: () => true,
+        salvageDroppedData: (dropped) => (dropped.includes(dsr) ? dsr : '')
+      })
+      batcher.enqueue('client-1', 'session-bg', `${dsr}${'a'.repeat(300 * 1024)}`, {
+        streamGeneration: 10
+      })
+      // Crossing the cap drops all of generation 10 and a prefix of 11. Each
+      // discarded range needs its own token; otherwise reattach filtering can
+      // mis-authorize an old query or reject the new stream's gap.
+      batcher.enqueue('client-1', 'session-bg', 'b'.repeat(900 * 1024), {
+        streamGeneration: 11
+      })
+      vi.advanceTimersByTime(2)
+
+      const messages = nonSentinelWrites(streamSocket)
+      const gaps = messages.filter((message) => message.event === 'dataGap')
+      expect(gaps.map((message) => message.streamGeneration)).toEqual([10, 11])
+      const salvaged = messages.find((message) => message.payload?.data === dsr)
+      expect(salvaged?.streamGeneration).toBe(10)
+      const keptNewData = messages
+        .filter((message) => message.event === 'data' && message.streamGeneration === 11)
+        .map((message) => message.payload?.data ?? '')
+        .join('')
+      expect(keptNewData.length).toBeGreaterThan(0)
+      expect(
+        messages.some(
+          (message) => message.event === 'data' && message.streamGeneration === undefined
+        )
+      ).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not coalesce generations and preserves split data before matching exit', () => {
+    vi.useFakeTimers()
+    try {
+      const { batcher, streamSocket } = createBatcher({ maxLineBytes: 180 })
+      batcher.enqueue('client-1', 'session-1', 'old-a', { streamGeneration: 1 })
+      batcher.enqueue('client-1', 'session-1', 'old-b', { streamGeneration: 1 })
+      batcher.enqueue('client-1', 'session-1', `${'new'.repeat(100)}😀`, {
+        streamGeneration: 2
+      })
+      batcher.enqueueControlEvent('client-1', 'session-1', {
+        type: 'event',
+        event: 'exit',
+        sessionId: 'session-1',
+        streamGeneration: 2,
+        payload: { code: 9 }
+      })
+      vi.advanceTimersByTime(2)
+
+      const messages = nonSentinelWrites(streamSocket)
+      expect(messages[0]).toMatchObject({
+        event: 'data',
+        streamGeneration: 1,
+        payload: { data: 'old-aold-b' }
+      })
+      const newWrites = messages.filter(
+        (message) => message.event === 'data' && message.streamGeneration === 2
+      )
+      expect(newWrites.length).toBeGreaterThan(1)
+      expect(newWrites.map((message) => message.payload?.data ?? '').join('')).toBe(
+        `${'new'.repeat(100)}😀`
+      )
+      expect(messages.at(-1)).toMatchObject({
+        event: 'exit',
+        streamGeneration: 2,
+        payload: { code: 9 }
+      })
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -10,7 +10,8 @@ import {
   backgroundSessionDropCapChars,
   backgroundSessionKeepTailChars,
   dropOldestQueuedForSession,
-  type PendingStreamDataBatch
+  type PendingStreamDataBatch,
+  type StreamQueueEntry
 } from './daemon-stream-keep-tail-drop'
 import type { DaemonEvent } from './types'
 
@@ -62,6 +63,7 @@ const SMALL_SESSION_HOLD_BYPASS_CHARS = 4 * 1024
 type EnqueueOptions = {
   flushImmediately?: boolean
   flushMaxChars?: number
+  streamGeneration?: number
 }
 
 type DaemonStreamDataBatcherOptions = {
@@ -107,10 +109,14 @@ export class DaemonStreamDataBatcher {
     const last = batch.queue.at(-1)
     // Never coalesce across a control entry — it marks a position in the
     // session's byte order.
-    if (last?.sessionId === sessionId && !last.control) {
+    const canCoalesce =
+      last?.sessionId === sessionId &&
+      !last.control &&
+      last.streamGeneration === options.streamGeneration
+    if (canCoalesce) {
       last.data += data
     } else {
-      batch.queue.push({ sessionId, data })
+      batch.queue.push({ sessionId, data, streamGeneration: options.streamGeneration })
     }
     batch.queuedChars += data.length
     batch.queuedCharsBySession.set(
@@ -164,7 +170,7 @@ export class DaemonStreamDataBatcher {
       return
     }
     const batch = this.getOrCreateBatch(clientId)
-    batch.queue.push({ sessionId, data: '', control })
+    batch.queue.push({ sessionId, data: '', streamGeneration: control.streamGeneration, control })
     if (!batch.timer) {
       batch.timer = setTimeout(() => this.flush(clientId), STREAM_DATA_BATCH_INTERVAL_MS)
     }
@@ -278,7 +284,11 @@ export class DaemonStreamDataBatcher {
       } else {
         batch.queuedCharsBySession.set(entry.sessionId, sessionHeldAfter)
       }
-      writeStreamDataEvents(socket, entry.sessionId, slice, this.maxLineBytes, sliceSequenceChars)
+      writeStreamDataEvents(
+        socket,
+        { ...entry, data: slice, sequenceChars: sliceSequenceChars },
+        this.maxLineBytes
+      )
       this.onAfterSocketWrite?.()
     }
     if (retained.length > 0) {
@@ -293,7 +303,7 @@ export class DaemonStreamDataBatcher {
       // immediately — verified — so the sentinel must be a real protocol
       // no-op line.) Event-driven, no timers; the per-client latch stops
       // sentinel stacking; 'drain' remains the backstop.
-      this.armHeldQueueRefill(socket, clientId, retained[0].sessionId)
+      this.armHeldQueueRefill(socket, clientId, retained[0])
       return
     }
     this.pendingByClient.delete(clientId)
@@ -301,15 +311,18 @@ export class DaemonStreamDataBatcher {
 
   private refillArmedClients = new Set<string>()
 
-  private armHeldQueueRefill(socket: Socket, clientId: string, sessionId: string): void {
+  private armHeldQueueRefill(socket: Socket, clientId: string, entry: StreamQueueEntry): void {
     if (this.refillArmedClients.has(clientId) || socket.destroyed) {
       return
     }
     this.refillArmedClients.add(clientId)
-    socket.write(encodeStreamDataEvent(sessionId, ''), () => {
-      this.refillArmedClients.delete(clientId)
-      this.flush(clientId)
-    })
+    socket.write(
+      encodeStreamDataEvent(entry.sessionId, '', undefined, entry.streamGeneration),
+      () => {
+        this.refillArmedClients.delete(clientId)
+        this.flush(clientId)
+      }
+    )
   }
 
   private queuedCharsForSession(batch: PendingStreamDataBatch, sessionId: string): number {
@@ -364,13 +377,7 @@ export class DaemonStreamDataBatcher {
         client.streamSocket.write(encodeNdjson(entry.control))
         this.onAfterSocketWrite?.()
       } else {
-        writeStreamDataEvents(
-          client.streamSocket,
-          entry.sessionId,
-          entry.data,
-          this.maxLineBytes,
-          entry.sequenceChars ?? entry.data.length
-        )
+        writeStreamDataEvents(client.streamSocket, entry, this.maxLineBytes)
         this.onAfterSocketWrite?.()
       }
     }

--- a/src/main/daemon/daemon-stream-data-split.ts
+++ b/src/main/daemon/daemon-stream-data-split.ts
@@ -9,18 +9,28 @@ import type { Socket } from 'node:net'
 export function encodeStreamDataEvent(
   sessionId: string,
   data: string,
-  sequenceChars?: number
+  sequenceChars?: number,
+  streamGeneration?: number
 ): string {
   return encodeNdjson({
     type: 'event',
     event: 'data',
     sessionId,
+    ...(streamGeneration === undefined ? {} : { streamGeneration }),
     payload: { data, ...(sequenceChars === undefined ? {} : { sequenceChars }) }
   })
 }
 
-function streamDataEventLineBytes(sessionId: string, data: string, sequenceChars?: number): number {
-  return Buffer.byteLength(encodeStreamDataEvent(sessionId, data, sequenceChars), 'utf8')
+function streamDataEventLineBytes(
+  sessionId: string,
+  data: string,
+  sequenceChars?: number,
+  streamGeneration?: number
+): number {
+  return Buffer.byteLength(
+    encodeStreamDataEvent(sessionId, data, sequenceChars, streamGeneration),
+    'utf8'
+  )
 }
 
 function isHighSurrogate(value: number): boolean {
@@ -56,9 +66,10 @@ export function splitStreamDataForNdjson(
   sessionId: string,
   data: string,
   maxLineBytes: number,
-  sequenceChars?: number
+  sequenceChars?: number,
+  streamGeneration?: number
 ): string[] {
-  if (streamDataEventLineBytes(sessionId, data, sequenceChars) <= maxLineBytes) {
+  if (streamDataEventLineBytes(sessionId, data, sequenceChars, streamGeneration) <= maxLineBytes) {
     return [data]
   }
 
@@ -78,7 +89,12 @@ export function splitStreamDataForNdjson(
       }
 
       if (
-        streamDataEventLineBytes(sessionId, data.slice(start, mid), sequenceChars) <= maxLineBytes
+        streamDataEventLineBytes(
+          sessionId,
+          data.slice(start, mid),
+          sequenceChars,
+          streamGeneration
+        ) <= maxLineBytes
       ) {
         best = mid
         low = rawMid + 1
@@ -97,18 +113,26 @@ export function splitStreamDataForNdjson(
 
 export function writeStreamDataEvents(
   streamSocket: Pick<Socket, 'write'>,
-  sessionId: string,
-  data: string,
-  maxLineBytes: number,
-  sequenceChars = data.length
+  event: {
+    sessionId: string
+    data: string
+    sequenceChars?: number
+    streamGeneration?: number
+  },
+  maxLineBytes: number
 ): void {
+  const { sessionId, data, streamGeneration } = event
+  const sequenceChars = event.sequenceChars ?? data.length
   const explicitSequenceChars = sequenceChars === data.length ? undefined : sequenceChars
   for (const chunk of splitStreamDataForNdjson(
     sessionId,
     data,
     maxLineBytes,
-    explicitSequenceChars
+    explicitSequenceChars,
+    streamGeneration
   )) {
-    streamSocket.write(encodeStreamDataEvent(sessionId, chunk, explicitSequenceChars))
+    streamSocket.write(
+      encodeStreamDataEvent(sessionId, chunk, explicitSequenceChars, streamGeneration)
+    )
   }
 }

--- a/src/main/daemon/daemon-stream-events.ts
+++ b/src/main/daemon/daemon-stream-events.ts
@@ -5,6 +5,7 @@ export type DataEvent = {
   type: 'event'
   event: 'data'
   sessionId: string
+  streamGeneration?: number
   payload: { data: string; sequenceChars?: number }
 }
 
@@ -12,6 +13,7 @@ export type ExitEvent = {
   type: 'event'
   event: 'exit'
   sessionId: string
+  streamGeneration?: number
   payload: { code: number }
 }
 
@@ -19,6 +21,7 @@ export type TerminalErrorEvent = {
   type: 'event'
   event: 'terminalError'
   sessionId: string
+  streamGeneration?: number
   payload: { message: string }
 }
 
@@ -38,6 +41,7 @@ export type SessionBackgroundMarkerEvent = {
   type: 'event'
   event: 'sessionBackgroundMarker'
   sessionId: string
+  streamGeneration?: number
   payload: { background: boolean; scanSeedAnsi?: string }
 }
 
@@ -48,6 +52,7 @@ export type DataGapEvent = {
   type: 'event'
   event: 'dataGap'
   sessionId: string
+  streamGeneration?: number
   payload: { droppedChars: number; sequenceChars?: number }
 }
 
@@ -66,6 +71,7 @@ export type TransientFactEvent = {
   type: 'event'
   event: 'transientFact'
   sessionId: string
+  streamGeneration?: number
   payload: DaemonTransientFact
 }
 

--- a/src/main/daemon/daemon-stream-keep-tail-drop.ts
+++ b/src/main/daemon/daemon-stream-keep-tail-drop.ts
@@ -18,6 +18,7 @@ import type { DaemonEvent, DataGapEvent } from './types'
 export type StreamQueueEntry = {
   sessionId: string
   data: string
+  streamGeneration?: number
   /** Original PTY characters represented by data. Salvaged query copies are
    * delivered bytes but represent zero new positions in the source stream. */
   sequenceChars?: number
@@ -83,46 +84,73 @@ export function dropOldestQueuedForSession(
   keepTailChars: number,
   salvageDroppedData: (dropped: string) => string
 ): void {
-  let toDrop = (batch.queuedCharsBySession.get(sessionId) ?? 0) - keepTailChars
-  if (toDrop <= 0) {
+  let remainingToDrop = (batch.queuedCharsBySession.get(sessionId) ?? 0) - keepTailChars
+  if (remainingToDrop <= 0) {
     return
   }
-  const totalDropped = toDrop
-  let droppedSequenceChars = 0
-  let salvaged = ''
-  const salvageIntoCap = (dropped: string): void => {
-    if (salvaged.length >= DROPPED_QUERY_SALVAGE_MAX_CHARS) {
-      return
-    }
-    salvaged = (salvaged + salvageDroppedData(dropped)).slice(0, DROPPED_QUERY_SALVAGE_MAX_CHARS)
-  }
-  let existingGap: DataGapEvent | null = null
-  let insertGapAt = -1
-  for (let i = 0; i < batch.queue.length && toDrop > 0; i++) {
-    const entry = batch.queue[i]
-    if (entry.sessionId !== sessionId) {
-      continue
-    }
-    if (entry.control) {
-      if (entry.control.event === 'dataGap') {
-        existingGap = entry.control
+  const generatedSalvageEntries = new Set<StreamQueueEntry>()
+  let totalDropped = 0
+
+  while (remainingToDrop > 0) {
+    let generation: number | undefined
+    let foundGeneration = false
+    let dropped = 0
+    let droppedSequenceChars = 0
+    let salvaged = ''
+    let existingGap: DataGapEvent | null = null
+    let insertGapAt = -1
+
+    const salvageIntoCap = (value: string): void => {
+      if (salvaged.length >= DROPPED_QUERY_SALVAGE_MAX_CHARS) {
+        return
       }
-      continue
+      salvaged = (salvaged + salvageDroppedData(value)).slice(0, DROPPED_QUERY_SALVAGE_MAX_CHARS)
     }
-    if (entry.data.length <= toDrop) {
-      toDrop -= entry.data.length
-      droppedSequenceChars += entry.sequenceChars ?? entry.data.length
-      salvageIntoCap(entry.data)
-      if (insertGapAt === -1) {
-        insertGapAt = i
+
+    for (let i = 0; i < batch.queue.length && dropped < remainingToDrop; i++) {
+      const entry = batch.queue[i]
+      if (entry.sessionId !== sessionId || generatedSalvageEntries.has(entry)) {
+        continue
       }
-      batch.queue.splice(i, 1)
-      i--
-    } else {
-      const cut = clampToSafeSplitIndex(entry.data, 0, toDrop)
+      if (entry.control) {
+        if (
+          entry.control.event === 'dataGap' &&
+          (!foundGeneration || entry.streamGeneration === generation)
+        ) {
+          existingGap = entry.control
+        }
+        continue
+      }
+      if (!foundGeneration) {
+        generation = entry.streamGeneration
+        foundGeneration = true
+        if (existingGap?.streamGeneration !== generation) {
+          existingGap = null
+        }
+      } else if (entry.streamGeneration !== generation) {
+        // Why: one gap/salvage pair must never claim bytes from two stream
+        // owners. The outer loop handles the next generation independently.
+        break
+      }
+
+      const available = remainingToDrop - dropped
+      if (entry.data.length <= available) {
+        dropped += entry.data.length
+        droppedSequenceChars += entry.sequenceChars ?? entry.data.length
+        salvageIntoCap(entry.data)
+        if (insertGapAt === -1) {
+          insertGapAt = i
+        }
+        batch.queue.splice(i, 1)
+        i--
+        continue
+      }
+
+      const cut = clampToSafeSplitIndex(entry.data, 0, available)
       if (cut > 0) {
         const entrySequenceChars = entry.sequenceChars ?? entry.data.length
         const cutSequenceChars = entrySequenceChars === 0 ? 0 : cut
+        dropped += cut
         droppedSequenceChars += cutSequenceChars
         salvageIntoCap(entry.data.slice(0, cut))
         entry.data = entry.data.slice(cut)
@@ -133,50 +161,68 @@ export function dropOldestQueuedForSession(
           insertGapAt = i
         }
       }
-      toDrop = 0
+      break
     }
-  }
-  const dropped = totalDropped - toDrop
-  if (dropped <= 0) {
-    return
-  }
-  batch.queuedChars -= dropped
-  batch.queuedCharsBySession.set(
-    sessionId,
-    Math.max(0, (batch.queuedCharsBySession.get(sessionId) ?? 0) - dropped)
-  )
-  if (existingGap) {
-    const priorSequenceChars = existingGap.payload.sequenceChars ?? existingGap.payload.droppedChars
-    existingGap.payload.droppedChars += dropped
-    existingGap.payload.sequenceChars = priorSequenceChars + droppedSequenceChars
-  } else {
-    recordDaemonStreamBacklogEvent('backgroundKeepTailDrop', {
-      sessionIdSuffix: sessionId.slice(-10),
-      droppedChars: dropped
-    })
-    batch.queue.splice(Math.max(0, insertGapAt), 0, {
+
+    if (!foundGeneration || dropped <= 0) {
+      break
+    }
+
+    totalDropped += dropped
+    remainingToDrop -= dropped
+    batch.queuedChars -= dropped
+    batch.queuedCharsBySession.set(
       sessionId,
-      data: '',
-      control: {
+      Math.max(0, (batch.queuedCharsBySession.get(sessionId) ?? 0) - dropped)
+    )
+
+    if (existingGap) {
+      const priorSequenceChars =
+        existingGap.payload.sequenceChars ?? existingGap.payload.droppedChars
+      existingGap.payload.droppedChars += dropped
+      existingGap.payload.sequenceChars = priorSequenceChars + droppedSequenceChars
+    } else {
+      const gap: DataGapEvent = {
         type: 'event',
         event: 'dataGap',
         sessionId,
+        ...(generation === undefined ? {} : { streamGeneration: generation }),
         payload: { droppedChars: dropped, sequenceChars: droppedSequenceChars }
       }
-    })
-    insertGapAt = Math.max(0, insertGapAt) + 1
+      batch.queue.splice(Math.max(0, insertGapAt), 0, {
+        sessionId,
+        data: '',
+        streamGeneration: generation,
+        control: gap
+      })
+      existingGap = gap
+    }
+
+    if (salvaged.length > 0) {
+      // Salvaged query bytes ride as a tiny data entry at the gap position —
+      // the writing program is blocked on their replies. Keep the originating
+      // token so a later attach cannot mistake them for the replacement stream.
+      const salvageEntry: StreamQueueEntry = {
+        sessionId,
+        data: salvaged,
+        streamGeneration: generation,
+        sequenceChars: 0
+      }
+      const at = batch.queue.findIndex((entry) => entry.control === existingGap) + 1
+      batch.queue.splice(at, 0, salvageEntry)
+      generatedSalvageEntries.add(salvageEntry)
+      batch.queuedChars += salvaged.length
+      batch.queuedCharsBySession.set(
+        sessionId,
+        (batch.queuedCharsBySession.get(sessionId) ?? 0) + salvaged.length
+      )
+    }
   }
-  if (salvaged.length > 0) {
-    // Salvaged query bytes ride as a tiny data entry at the gap position —
-    // the writing program is blocked on their replies.
-    const at = existingGap
-      ? batch.queue.findIndex((e) => e.control === existingGap) + 1
-      : insertGapAt
-    batch.queue.splice(at, 0, { sessionId, data: salvaged, sequenceChars: 0 })
-    batch.queuedChars += salvaged.length
-    batch.queuedCharsBySession.set(
-      sessionId,
-      (batch.queuedCharsBySession.get(sessionId) ?? 0) + salvaged.length
-    )
+
+  if (totalDropped > 0) {
+    recordDaemonStreamBacklogEvent('backgroundKeepTailDrop', {
+      sessionIdSuffix: sessionId.slice(-10),
+      droppedChars: totalDropped
+    })
   }
 }

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -16,9 +16,9 @@ import type { TuiAgent } from '../../shared/types'
 // when daemon-baked behavior cannot be delivered by on-disk wrapper refresh.
 // Why: bump when adding daemon wire behavior so same-version old daemons do
 // not silently accept the handshake and then reject new RPCs.
-export const PROTOCOL_VERSION = 21
+export const PROTOCOL_VERSION = 22
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
 ] as const
 
 // ─── Session State Machine ──────────────────────────────────────────
@@ -365,6 +365,8 @@ export type CreateOrAttachResult = {
   shellState: ShellReadyState
   historySeeded?: boolean
   launchAgent?: TuiAgent
+  /** Identifies the exact stream client installed by this create/attach. */
+  streamGeneration?: number
 }
 export type GetSnapshotResult = {
   snapshot: TerminalSnapshot | null

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -336,4 +336,95 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
 
     expect(events).toEqual(['data:last line\r\n', 'exit:3'])
   })
+
+  it('filters an older lifecycle when a fresh spawn reuses a PTY id', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const { ensurePtyDispatcher } = await import('./pty-dispatcher')
+    const events: string[] = []
+    let resolveSpawn: (value: { id: string }) => void = () => {}
+
+    ensurePtyDispatcher()
+    dispatcherCallback?.({ id: 'pty-reused', data: 'old-data' })
+    exitDispatcherCallback?.({ id: 'pty-reused', code: 1 })
+    ;(window.api.pty.spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSpawn = resolve
+      })
+    )
+
+    const transport = createIpcPtyTransport()
+    const connectPromise = transport.connect({
+      url: '',
+      callbacks: {
+        onData: (data) => events.push(`data:${data}`),
+        onExit: (code) => events.push(`exit:${code}`)
+      }
+    })
+    dispatcherCallback?.({ id: 'pty-reused', data: 'new-data' })
+    exitDispatcherCallback?.({ id: 'pty-reused', code: 2 })
+    resolveSpawn({ id: 'pty-reused' })
+    await connectPromise
+
+    expect(events).toEqual(['data:new-data', 'exit:2'])
+  })
+
+  it('preserves pre-connect backlog for an explicit daemon reattach', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const { ensurePtyDispatcher } = await import('./pty-dispatcher')
+    const events: string[] = []
+
+    ensurePtyDispatcher()
+    dispatcherCallback?.({ id: 'pty-reattach', data: 'reattach-data' })
+    exitDispatcherCallback?.({ id: 'pty-reattach', code: 4 })
+    ;(window.api.pty.spawn as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'pty-reattach',
+      isReattach: true
+    })
+
+    const transport = createIpcPtyTransport()
+    await transport.connect({
+      url: '',
+      sessionId: 'pty-reattach',
+      callbacks: {
+        onData: (data) => events.push(`data:${data}`),
+        onExit: (code) => events.push(`exit:${code}`)
+      }
+    })
+
+    expect(events).toEqual(['data:reattach-data', 'exit:4'])
+  })
+
+  it('never evicts a registered exit handler while orphan exits churn at the cap', async () => {
+    const { ensurePtyDispatcher, registerEagerPtyBuffer } = await import('./pty-dispatcher')
+    const registeredExit = vi.fn()
+
+    ensurePtyDispatcher()
+    registerEagerPtyBuffer('pty-registered', registeredExit)
+    for (let index = 0; index < 65; index += 1) {
+      exitDispatcherCallback?.({ id: `pty-orphan-${index}`, code: index })
+    }
+    exitDispatcherCallback?.({ id: 'pty-registered', code: 9 })
+
+    expect(registeredExit).toHaveBeenCalledOnce()
+    expect(registeredExit).toHaveBeenCalledWith('pty-registered', 9)
+  })
+
+  it('filters old lifecycle events for delayed background eager-buffer registration', async () => {
+    const { captureEagerPtyBufferRegistration, ensurePtyDispatcher } =
+      await import('./pty-dispatcher')
+    const eagerExit = vi.fn()
+
+    ensurePtyDispatcher()
+    dispatcherCallback?.({ id: 'pty-background-reused', data: 'old-background-data' })
+    exitDispatcherCallback?.({ id: 'pty-background-reused', code: 1 })
+    const registerEagerPtyBuffer = captureEagerPtyBufferRegistration()
+    dispatcherCallback?.({ id: 'pty-background-reused', data: 'new-background-data' })
+    exitDispatcherCallback?.({ id: 'pty-background-reused', code: 2 })
+
+    const handle = registerEagerPtyBuffer('pty-background-reused', eagerExit)
+    expect(handle.flush()).toBe('new-background-data')
+    await Promise.resolve()
+    expect(eagerExit).toHaveBeenCalledOnce()
+    expect(eagerExit).toHaveBeenCalledWith('pty-background-reused', 2)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -400,6 +400,49 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
     expect(events).toEqual(['data:fresh-data', 'exit:2'])
   })
 
+  it('filters an older lifecycle when cold restore starts a new reused-id generation', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const { ensurePtyDispatcher } = await import('./pty-dispatcher')
+    const events: string[] = []
+    let resolveSpawn: (value: {
+      id: string
+      coldRestore: { scrollback: string; cwd: string }
+    }) => void = () => {}
+
+    ensurePtyDispatcher()
+    dispatcherCallback?.({ id: 'pty-cold-restore', data: 'old-data' })
+    exitDispatcherCallback?.({ id: 'pty-cold-restore', code: 1 })
+    ;(window.api.pty.spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSpawn = resolve
+      })
+    )
+
+    const transport = createIpcPtyTransport()
+    const connectPromise = transport.connect({
+      url: '',
+      sessionId: 'pty-cold-restore',
+      callbacks: {
+        onData: (data) => events.push(`data:${data}`),
+        onExit: (code) => events.push(`exit:${code}`)
+      }
+    })
+    dispatcherCallback?.({ id: 'pty-cold-restore', data: 'restored-generation-data' })
+    resolveSpawn({
+      id: 'pty-cold-restore',
+      coldRestore: { scrollback: 'saved scrollback', cwd: '/saved' }
+    })
+
+    const result = await connectPromise
+    expect(events).toEqual(['data:restored-generation-data'])
+    expect(result).toEqual(
+      expect.objectContaining({ coldRestore: { scrollback: 'saved scrollback', cwd: '/saved' } })
+    )
+
+    exitDispatcherCallback?.({ id: 'pty-cold-restore', code: 2 })
+    expect(events).toEqual(['data:restored-generation-data', 'exit:2'])
+  })
+
   it('preserves pre-connect backlog for an explicit daemon reattach', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const { ensurePtyDispatcher } = await import('./pty-dispatcher')
@@ -442,7 +485,7 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
   })
 
   it('attaches the dispatcher before first-use eager-buffer spawn can emit an exit', async () => {
-    const { captureEagerPtyBufferRegistration } = await import('./pty-dispatcher')
+    const { captureEagerPtyBufferRegistration } = await import('./pty-eager-buffer-registration')
     const eagerExit = vi.fn()
 
     expect(exitDispatcherCallback).toBeNull()
@@ -460,21 +503,42 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
   })
 
   it('filters old lifecycle events for delayed background eager-buffer registration', async () => {
-    const { captureEagerPtyBufferRegistration, ensurePtyDispatcher } =
-      await import('./pty-dispatcher')
+    const { captureEagerPtyBufferRegistration } = await import('./pty-eager-buffer-registration')
+    const { ensurePtyDispatcher, ptyDataHandlers } = await import('./pty-dispatcher')
+    const { subscribeToPtyData } = await import('./pty-data-sidecar-subscriptions')
     const eagerExit = vi.fn()
+    const automationStatusObserver = vi.fn()
+    const replacementHandler = vi.fn()
 
     ensurePtyDispatcher()
     dispatcherCallback?.({ id: 'pty-background-reused', data: 'old-background-data' })
     exitDispatcherCallback?.({ id: 'pty-background-reused', code: 1 })
-    const registerEagerPtyBuffer = captureEagerPtyBufferRegistration()
+    const registerEagerPtyBuffer = captureEagerPtyBufferRegistration(automationStatusObserver)
     dispatcherCallback?.({ id: 'pty-background-reused', data: 'new-background-data' })
     exitDispatcherCallback?.({ id: 'pty-background-reused', code: 2 })
 
     const handle = registerEagerPtyBuffer('pty-background-reused', eagerExit)
     expect(handle.flush()).toBe('new-background-data')
+    expect(automationStatusObserver).toHaveBeenCalledOnce()
+    expect(automationStatusObserver).toHaveBeenCalledWith('new-background-data')
+    handle.stopObservingData?.()
+    const unsubscribeSidecar = subscribeToPtyData('pty-background-reused', automationStatusObserver)
+    ptyDataHandlers.set('pty-background-reused', replacementHandler)
+    dispatcherCallback?.({ id: 'pty-background-reused', data: 'live-sidecar-era-data' })
     await Promise.resolve()
+    handle.dispose()
+    dispatcherCallback?.({ id: 'pty-background-reused', data: 'replacement-owned-data' })
     expect(eagerExit).toHaveBeenCalledOnce()
     expect(eagerExit).toHaveBeenCalledWith('pty-background-reused', 2)
+    expect(automationStatusObserver.mock.calls).toEqual([
+      ['new-background-data'],
+      ['live-sidecar-era-data'],
+      ['replacement-owned-data']
+    ])
+    expect(replacementHandler.mock.calls).toEqual([
+      ['live-sidecar-era-data', undefined],
+      ['replacement-owned-data', undefined]
+    ])
+    unsubscribeSidecar()
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -441,6 +441,24 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
     expect(registeredExit).toHaveBeenCalledWith('pty-registered', 9)
   })
 
+  it('attaches the dispatcher before first-use eager-buffer spawn can emit an exit', async () => {
+    const { captureEagerPtyBufferRegistration } = await import('./pty-dispatcher')
+    const eagerExit = vi.fn()
+
+    expect(exitDispatcherCallback).toBeNull()
+    const registerEagerPtyBuffer = captureEagerPtyBufferRegistration()
+    expect(exitDispatcherCallback).not.toBeNull()
+    expect(window.api.pty.rendererDispatcherReady).toHaveBeenCalledOnce()
+
+    dispatcherCallback?.({ id: 'pty-first-background', data: 'fast-output' })
+    exitDispatcherCallback?.({ id: 'pty-first-background', code: 7 })
+    const handle = registerEagerPtyBuffer('pty-first-background', eagerExit)
+
+    expect(handle.flush()).toBe('fast-output')
+    await Promise.resolve()
+    expect(eagerExit).toHaveBeenCalledWith('pty-first-background', 7)
+  })
+
   it('filters old lifecycle events for delayed background eager-buffer registration', async () => {
     const { captureEagerPtyBufferRegistration, ensurePtyDispatcher } =
       await import('./pty-dispatcher')

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -368,6 +368,38 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
     expect(events).toEqual(['data:new-data', 'exit:2'])
   })
 
+  it('filters an older lifecycle when a failed reattach spawns fresh with the same id', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const { ensurePtyDispatcher } = await import('./pty-dispatcher')
+    const events: string[] = []
+    let resolveSpawn: (value: { id: string }) => void = () => {}
+
+    ensurePtyDispatcher()
+    dispatcherCallback?.({ id: 'pty-reattach-fallback', data: 'old-data' })
+    exitDispatcherCallback?.({ id: 'pty-reattach-fallback', code: 1 })
+    ;(window.api.pty.spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSpawn = resolve
+      })
+    )
+
+    const transport = createIpcPtyTransport()
+    const connectPromise = transport.connect({
+      url: '',
+      sessionId: 'pty-reattach-fallback',
+      callbacks: {
+        onData: (data) => events.push(`data:${data}`),
+        onExit: (code) => events.push(`exit:${code}`)
+      }
+    })
+    dispatcherCallback?.({ id: 'pty-reattach-fallback', data: 'fresh-data' })
+    exitDispatcherCallback?.({ id: 'pty-reattach-fallback', code: 2 })
+    resolveSpawn({ id: 'pty-reattach-fallback' })
+    await connectPromise
+
+    expect(events).toEqual(['data:fresh-data', 'exit:2'])
+  })
+
   it('preserves pre-connect backlog for an explicit daemon reattach', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const { ensurePtyDispatcher } = await import('./pty-dispatcher')

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -16,10 +16,12 @@ import { clampUtf8Tail, type EagerBufferChunk } from './pty-eager-buffer-clamp'
 import {
   bufferPreHandlerPtyData,
   bufferPreHandlerPtyExit,
+  capturePreHandlerPtyEventCursor,
   clearPreHandlerPtyState,
   drainPreHandlerPtyData,
   drainPreHandlerPtyExit
 } from './pty-pre-handler-buffer'
+export { capturePreHandlerPtyEventCursor }
 import {
   clearReceivedPtyCharTotal,
   isPtyPushDeliveryBlackholed,
@@ -105,6 +107,10 @@ export function restorePtyDataHandlersAfterFailedShutdown(
   for (const snapshot of snapshots) {
     if (snapshot.dataHandler) {
       ptyDataHandlers.set(snapshot.ptyId, snapshot.dataHandler)
+      // Why: a kill failure can restore this handler after main already sent
+      // a final data burst into the pre-handler buffer. Replay it before later
+      // live data so failure recovery neither leaks nor reorders output.
+      drainPreHandlerPtyData(snapshot.ptyId, snapshot.dataHandler)
     }
     if (snapshot.replayHandler) {
       ptyReplayHandlers.set(snapshot.ptyId, snapshot.replayHandler)
@@ -304,9 +310,15 @@ export function getEagerPtyBufferHandle(ptyId: string): EagerPtyHandle | undefin
 // runs a long-lived command (e.g. tail -f) in a worktree the user never opens.
 const EAGER_BUFFER_MAX_BYTES = TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT
 
+export function captureEagerPtyBufferRegistration(): typeof registerEagerPtyBuffer {
+  const afterCursor = capturePreHandlerPtyEventCursor()
+  return (ptyId, onExit) => registerEagerPtyBuffer(ptyId, onExit, afterCursor)
+}
+
 export function registerEagerPtyBuffer(
   ptyId: string,
-  onExit: (ptyId: string, code: number) => void
+  onExit: (ptyId: string, code: number) => void,
+  afterCursor?: number
 ): EagerPtyHandle {
   ensurePtyDispatcher()
   // Why: a head index instead of Array.shift() — shift() is O(n), making
@@ -378,13 +390,13 @@ export function registerEagerPtyBuffer(
   }
 
   eagerPtyHandles.set(ptyId, handle)
-  drainPreHandlerPtyData(ptyId, dataHandler)
+  drainPreHandlerPtyData(ptyId, dataHandler, afterCursor)
   // Why: launcher callbacks often capture the returned handle so they can
   // flush output on exit. Defer a pre-handler exit by one microtask so the
   // caller receives that handle before onExit fires.
   queueMicrotask(() => {
     if (ptyExitHandlers.get(ptyId) === exitHandler) {
-      drainPreHandlerPtyExit(ptyId, exitHandler)
+      drainPreHandlerPtyExit(ptyId, exitHandler, afterCursor)
     } else {
       clearPreHandlerPtyState(ptyId)
     }

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -105,17 +105,19 @@ export function restorePtyDataHandlersAfterFailedShutdown(
   snapshots: readonly PtyDataHandlerShutdownSnapshot[]
 ): void {
   for (const snapshot of snapshots) {
-    if (snapshot.dataHandler) {
-      ptyDataHandlers.set(snapshot.ptyId, snapshot.dataHandler)
+    const authoritativeDataHandler = ptyDataHandlers.get(snapshot.ptyId) ?? snapshot.dataHandler
+    if (authoritativeDataHandler) {
+      if (!ptyDataHandlers.has(snapshot.ptyId)) {
+        ptyDataHandlers.set(snapshot.ptyId, authoritativeDataHandler)
+      }
       // Why: a kill failure can restore this handler after main already sent
-      // a final data burst into the pre-handler buffer. Replay it before later
-      // live data so failure recovery neither leaks nor reorders output.
-      drainPreHandlerPtyData(snapshot.ptyId, snapshot.dataHandler)
+      // a final data burst. A newer remount owns delivery if it registered first.
+      drainPreHandlerPtyData(snapshot.ptyId, authoritativeDataHandler)
     }
-    if (snapshot.replayHandler) {
+    if (snapshot.replayHandler && !ptyReplayHandlers.has(snapshot.ptyId)) {
       ptyReplayHandlers.set(snapshot.ptyId, snapshot.replayHandler)
     }
-    if (snapshot.teardownHandler) {
+    if (snapshot.teardownHandler && !ptyTeardownHandlers.has(snapshot.ptyId)) {
       ptyTeardownHandlers.set(snapshot.ptyId, snapshot.teardownHandler)
     }
   }
@@ -298,7 +300,11 @@ export function subscribeToPtyExit(ptyId: string, watcher: (code: number) => voi
 // (prompt, MOTD) arrives via pty:data before xterm exists. These helpers buffer
 // that output so transport.attach() can replay it when the pane finally mounts.
 
-export type EagerPtyHandle = { flush: () => string; dispose: () => void }
+export type EagerPtyHandle = {
+  flush: () => string
+  dispose: () => void
+  stopObservingData?: () => void
+}
 const eagerPtyHandles = new Map<string, EagerPtyHandle>()
 
 export function getEagerPtyBufferHandle(ptyId: string): EagerPtyHandle | undefined {
@@ -310,18 +316,11 @@ export function getEagerPtyBufferHandle(ptyId: string): EagerPtyHandle | undefin
 // runs a long-lived command (e.g. tail -f) in a worktree the user never opens.
 const EAGER_BUFFER_MAX_BYTES = TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT
 
-export function captureEagerPtyBufferRegistration(): typeof registerEagerPtyBuffer {
-  // Why: pty:exit is not boot-gated like pty:data. Attach the singleton before
-  // spawn so a first-use background PTY cannot exit into a listener-less page.
-  ensurePtyDispatcher()
-  const afterCursor = capturePreHandlerPtyEventCursor()
-  return (ptyId, onExit) => registerEagerPtyBuffer(ptyId, onExit, afterCursor)
-}
-
 export function registerEagerPtyBuffer(
   ptyId: string,
   onExit: (ptyId: string, code: number) => void,
-  afterCursor?: number
+  afterCursor?: number,
+  observePreSubscriptionData?: (data: string) => void
 ): EagerPtyHandle {
   ensurePtyDispatcher()
   // Why: a head index instead of Array.shift() — shift() is O(n), making
@@ -336,6 +335,7 @@ export function registerEagerPtyBuffer(
     const chunk = clampUtf8Tail(data, EAGER_BUFFER_MAX_BYTES)
     chunks.push(chunk)
     bufferBytes += chunk.bytes
+    observePreSubscriptionData?.(data)
     // Drop whole leading chunks (keeping the prompt-bearing tail) until within cap.
     while (bufferBytes > EAGER_BUFFER_MAX_BYTES && head < chunks.length - 1) {
       bufferBytes -= chunks[head].bytes
@@ -375,6 +375,9 @@ export function registerEagerPtyBuffer(
       head = 0
       bufferBytes = 0
       return data
+    },
+    stopObservingData() {
+      observePreSubscriptionData = undefined
     },
     dispose() {
       // Why: dispose runs at pane attach (mount completed) — the pane's own

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -311,6 +311,9 @@ export function getEagerPtyBufferHandle(ptyId: string): EagerPtyHandle | undefin
 const EAGER_BUFFER_MAX_BYTES = TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT
 
 export function captureEagerPtyBufferRegistration(): typeof registerEagerPtyBuffer {
+  // Why: pty:exit is not boot-gated like pty:data. Attach the singleton before
+  // spawn so a first-use background PTY cannot exit into a listener-less page.
+  ensurePtyDispatcher()
   const afterCursor = capturePreHandlerPtyEventCursor()
   return (ptyId, onExit) => registerEagerPtyBuffer(ptyId, onExit, afterCursor)
 }

--- a/src/renderer/src/components/terminal-pane/pty-eager-buffer-registration.ts
+++ b/src/renderer/src/components/terminal-pane/pty-eager-buffer-registration.ts
@@ -1,0 +1,18 @@
+import { ensurePtyDispatcher, registerEagerPtyBuffer, type EagerPtyHandle } from './pty-dispatcher'
+import { capturePreHandlerPtyEventCursor } from './pty-pre-handler-buffer'
+
+export type EagerPtyBufferRegistration = (
+  ptyId: string,
+  onExit: (ptyId: string, code: number) => void
+) => EagerPtyHandle
+
+export function captureEagerPtyBufferRegistration(
+  observePreSubscriptionData?: (data: string) => void
+): EagerPtyBufferRegistration {
+  // Why: pty:exit is not boot-gated like pty:data. Attach before spawn and
+  // retain one cursor so reused ids cannot inherit an older lifecycle.
+  ensurePtyDispatcher()
+  const afterCursor = capturePreHandlerPtyEventCursor()
+  return (ptyId, onExit) =>
+    registerEagerPtyBuffer(ptyId, onExit, afterCursor, observePreSubscriptionData)
+}

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -1,17 +1,23 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   bufferPreHandlerPtyData,
+  bufferPreHandlerPtyExit,
   clearPreHandlerPtyState,
-  drainPreHandlerPtyData
+  drainPreHandlerPtyData,
+  drainPreHandlerPtyExit
 } from './pty-pre-handler-buffer'
 
 const RESCAN_PTY_ID = 'pty-pre-handler-rescan'
 const TRIM_PTY_ID = 'pty-pre-handler-trim'
+const EXIT_PTY_IDS = Array.from({ length: 65 }, (_, index) => `pty-pre-handler-exit-${index}`)
 
 describe('pre-handler PTY buffer', () => {
   afterEach(() => {
     clearPreHandlerPtyState(RESCAN_PTY_ID)
     clearPreHandlerPtyState(TRIM_PTY_ID)
+    for (const ptyId of EXIT_PTY_IDS) {
+      clearPreHandlerPtyState(ptyId)
+    }
   })
 
   it('does not rescan historical chunks while buffering small startup output', () => {
@@ -70,5 +76,23 @@ describe('pre-handler PTY buffer', () => {
     drainPreHandlerPtyData(TRIM_PTY_ID, (data) => drained.push(data))
     expect(drained).toHaveLength(512)
     expect(drained.join('')).toHaveLength(512 * 1_024)
+  })
+
+  it('bounds exits that arrive before any handler is registered', () => {
+    for (let index = 0; index < EXIT_PTY_IDS.length; index += 1) {
+      bufferPreHandlerPtyExit(EXIT_PTY_IDS[index], index)
+    }
+
+    let oldestExit: number | null = null
+    drainPreHandlerPtyExit(EXIT_PTY_IDS[0], (code) => {
+      oldestExit = code
+    })
+    let newestExit: number | null = null
+    drainPreHandlerPtyExit(EXIT_PTY_IDS.at(-1)!, (code) => {
+      newestExit = code
+    })
+
+    expect(oldestExit).toBeNull()
+    expect(newestExit).toBe(64)
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  PRE_HANDLER_PTY_MAX_PTYS,
   bufferPreHandlerPtyData,
   bufferPreHandlerPtyExit,
+  capturePreHandlerPtyEventCursor,
   clearPreHandlerPtyState,
   drainPreHandlerPtyData,
   drainPreHandlerPtyExit
@@ -9,13 +11,25 @@ import {
 
 const RESCAN_PTY_ID = 'pty-pre-handler-rescan'
 const TRIM_PTY_ID = 'pty-pre-handler-trim'
-const EXIT_PTY_IDS = Array.from({ length: 65 }, (_, index) => `pty-pre-handler-exit-${index}`)
+const REUSED_PTY_ID = 'pty-pre-handler-reused'
+const EXIT_PTY_IDS = Array.from(
+  { length: PRE_HANDLER_PTY_MAX_PTYS + 1 },
+  (_, index) => `pty-pre-handler-exit-${index}`
+)
+const WARN_PTY_IDS = Array.from(
+  { length: PRE_HANDLER_PTY_MAX_PTYS + 1 },
+  (_, index) => `pty-pre-handler-warn-${index}`
+)
 
 describe('pre-handler PTY buffer', () => {
   afterEach(() => {
     clearPreHandlerPtyState(RESCAN_PTY_ID)
     clearPreHandlerPtyState(TRIM_PTY_ID)
+    clearPreHandlerPtyState(REUSED_PTY_ID)
     for (const ptyId of EXIT_PTY_IDS) {
+      clearPreHandlerPtyState(ptyId)
+    }
+    for (const ptyId of WARN_PTY_IDS) {
       clearPreHandlerPtyState(ptyId)
     }
   })
@@ -93,6 +107,71 @@ describe('pre-handler PTY buffer', () => {
     })
 
     expect(oldestExit).toBeNull()
-    expect(newestExit).toBe(64)
+    expect(newestExit).toBe(PRE_HANDLER_PTY_MAX_PTYS)
+  })
+
+  it('keeps the latest exit for a reused PTY id and refreshes its recency', () => {
+    bufferPreHandlerPtyExit(EXIT_PTY_IDS[0], 1)
+    for (let index = 1; index < PRE_HANDLER_PTY_MAX_PTYS; index += 1) {
+      bufferPreHandlerPtyExit(EXIT_PTY_IDS[index], index)
+    }
+
+    bufferPreHandlerPtyExit(EXIT_PTY_IDS[0], 99)
+    bufferPreHandlerPtyExit(EXIT_PTY_IDS.at(-1)!, 100)
+
+    const oldestHandler = vi.fn()
+    drainPreHandlerPtyExit(EXIT_PTY_IDS[1], oldestHandler)
+    expect(oldestHandler).not.toHaveBeenCalled()
+    const reusedHandler = vi.fn()
+    drainPreHandlerPtyExit(EXIT_PTY_IDS[0], reusedHandler)
+    expect(reusedHandler).toHaveBeenCalledOnce()
+    expect(reusedHandler).toHaveBeenCalledWith(99)
+  })
+
+  it('clears an old lifecycle before a PTY id is reused and drains the new exit once', () => {
+    const ptyId = EXIT_PTY_IDS[0]
+    bufferPreHandlerPtyExit(ptyId, 1)
+    clearPreHandlerPtyState(ptyId)
+    bufferPreHandlerPtyExit(ptyId, 2)
+
+    const handler = vi.fn()
+    drainPreHandlerPtyExit(ptyId, handler)
+    drainPreHandlerPtyExit(ptyId, handler)
+
+    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).toHaveBeenCalledWith(2)
+  })
+
+  it('filters an older lifecycle when a fresh spawn reuses the same PTY id', () => {
+    bufferPreHandlerPtyData(REUSED_PTY_ID, 'old-data')
+    bufferPreHandlerPtyExit(REUSED_PTY_ID, 1)
+    const freshSpawnCursor = capturePreHandlerPtyEventCursor()
+    bufferPreHandlerPtyData(REUSED_PTY_ID, 'new-data')
+    bufferPreHandlerPtyExit(REUSED_PTY_ID, 2)
+
+    const dataHandler = vi.fn()
+    const exitHandler = vi.fn()
+    drainPreHandlerPtyData(REUSED_PTY_ID, dataHandler, freshSpawnCursor)
+    drainPreHandlerPtyExit(REUSED_PTY_ID, exitHandler, freshSpawnCursor)
+
+    expect(dataHandler).toHaveBeenCalledOnce()
+    expect(dataHandler).toHaveBeenCalledWith('new-data', undefined)
+    expect(exitHandler).toHaveBeenCalledOnce()
+    expect(exitHandler).toHaveBeenCalledWith(2)
+  })
+
+  it('bounds warned PTY identities with the data buffer eviction lifecycle', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const warningChunk = 'x'.repeat(64 * 1_024 + 1)
+
+    for (const ptyId of WARN_PTY_IDS) {
+      bufferPreHandlerPtyData(ptyId, warningChunk)
+    }
+    expect(warn).toHaveBeenCalledTimes(PRE_HANDLER_PTY_MAX_PTYS + 1)
+
+    // The first PTY was evicted when the 65th identity arrived. Reusing it
+    // must be warnable again instead of remaining forever in the warning set.
+    bufferPreHandlerPtyData(WARN_PTY_IDS[0], warningChunk)
+    expect(warn).toHaveBeenCalledTimes(PRE_HANDLER_PTY_MAX_PTYS + 2)
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -11,6 +11,7 @@ import {
 
 const RESCAN_PTY_ID = 'pty-pre-handler-rescan'
 const TRIM_PTY_ID = 'pty-pre-handler-trim'
+const UTF8_TRIM_PTY_ID = 'pty-pre-handler-utf8-trim'
 const REUSED_PTY_ID = 'pty-pre-handler-reused'
 const EXIT_PTY_IDS = Array.from(
   { length: PRE_HANDLER_PTY_MAX_PTYS + 1 },
@@ -29,6 +30,7 @@ describe('pre-handler PTY buffer', () => {
   afterEach(() => {
     clearPreHandlerPtyState(RESCAN_PTY_ID)
     clearPreHandlerPtyState(TRIM_PTY_ID)
+    clearPreHandlerPtyState(UTF8_TRIM_PTY_ID)
     clearPreHandlerPtyState(REUSED_PTY_ID)
     for (const ptyId of EXIT_PTY_IDS) {
       clearPreHandlerPtyState(ptyId)
@@ -97,6 +99,22 @@ describe('pre-handler PTY buffer', () => {
     drainPreHandlerPtyData(TRIM_PTY_ID, (data) => drained.push(data))
     expect(drained).toHaveLength(512)
     expect(drained.join('')).toHaveLength(512 * 1_024)
+  })
+
+  it('keeps clamped UTF-8 bytes separate from UTF-16 stream sequence units', () => {
+    const data = '😀'.repeat(200 * 1_024)
+    bufferPreHandlerPtyData(UTF8_TRIM_PTY_ID, data, {
+      seq: data.length,
+      rawLength: data.length
+    })
+
+    const handler = vi.fn()
+    drainPreHandlerPtyData(UTF8_TRIM_PTY_ID, handler)
+
+    expect(handler).toHaveBeenCalledOnce()
+    const [tail, meta] = handler.mock.calls[0]
+    expect(tail).toHaveLength(256 * 1_024)
+    expect(meta).toEqual({ seq: data.length, rawLength: tail.length })
   })
 
   it('bounds exits that arrive before any handler is registered', () => {

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -20,6 +20,10 @@ const WARN_PTY_IDS = Array.from(
   { length: PRE_HANDLER_PTY_MAX_PTYS + 1 },
   (_, index) => `pty-pre-handler-warn-${index}`
 )
+const DATA_PTY_IDS = Array.from(
+  { length: PRE_HANDLER_PTY_MAX_PTYS + 1 },
+  (_, index) => `pty-pre-handler-data-${index}`
+)
 
 describe('pre-handler PTY buffer', () => {
   afterEach(() => {
@@ -30,6 +34,9 @@ describe('pre-handler PTY buffer', () => {
       clearPreHandlerPtyState(ptyId)
     }
     for (const ptyId of WARN_PTY_IDS) {
+      clearPreHandlerPtyState(ptyId)
+    }
+    for (const ptyId of DATA_PTY_IDS) {
       clearPreHandlerPtyState(ptyId)
     }
   })
@@ -126,6 +133,26 @@ describe('pre-handler PTY buffer', () => {
     drainPreHandlerPtyExit(EXIT_PTY_IDS[0], reusedHandler)
     expect(reusedHandler).toHaveBeenCalledOnce()
     expect(reusedHandler).toHaveBeenCalledWith(99)
+  })
+
+  it('refreshes data recency when a reused PTY id receives current lifecycle output', () => {
+    bufferPreHandlerPtyData(DATA_PTY_IDS[0], 'old-data')
+    for (let index = 1; index < PRE_HANDLER_PTY_MAX_PTYS; index += 1) {
+      bufferPreHandlerPtyData(DATA_PTY_IDS[index], `data-${index}`)
+    }
+
+    bufferPreHandlerPtyData(DATA_PTY_IDS[0], 'current-data')
+    bufferPreHandlerPtyData(DATA_PTY_IDS.at(-1)!, 'newest-data')
+
+    const oldestHandler = vi.fn()
+    drainPreHandlerPtyData(DATA_PTY_IDS[1], oldestHandler)
+    expect(oldestHandler).not.toHaveBeenCalled()
+    const reusedHandler = vi.fn()
+    drainPreHandlerPtyData(DATA_PTY_IDS[0], reusedHandler)
+    expect(reusedHandler.mock.calls).toEqual([
+      ['old-data', undefined],
+      ['current-data', undefined]
+    ])
   })
 
   it('clears an old lifecycle before a PTY id is reused and drains the new exit once', () => {

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -191,14 +191,18 @@ describe('pre-handler PTY buffer', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const warningChunk = 'x'.repeat(64 * 1_024 + 1)
 
-    for (const ptyId of WARN_PTY_IDS) {
-      bufferPreHandlerPtyData(ptyId, warningChunk)
-    }
-    expect(warn).toHaveBeenCalledTimes(PRE_HANDLER_PTY_MAX_PTYS + 1)
+    try {
+      for (const ptyId of WARN_PTY_IDS) {
+        bufferPreHandlerPtyData(ptyId, warningChunk)
+      }
+      expect(warn).toHaveBeenCalledTimes(PRE_HANDLER_PTY_MAX_PTYS + 1)
 
-    // The first PTY was evicted when the 65th identity arrived. Reusing it
-    // must be warnable again instead of remaining forever in the warning set.
-    bufferPreHandlerPtyData(WARN_PTY_IDS[0], warningChunk)
-    expect(warn).toHaveBeenCalledTimes(PRE_HANDLER_PTY_MAX_PTYS + 2)
+      // The first PTY was evicted when the 65th identity arrived. Reusing it
+      // must be warnable again instead of remaining forever in the warning set.
+      bufferPreHandlerPtyData(WARN_PTY_IDS[0], warningChunk)
+      expect(warn).toHaveBeenCalledTimes(PRE_HANDLER_PTY_MAX_PTYS + 2)
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -4,6 +4,7 @@ import type { PtyDataMeta } from './pty-dispatcher'
 type BufferedPreHandlerPtyData = {
   data: string
   bytes: number
+  cursor: number
   meta?: PtyDataMeta
 }
 
@@ -14,28 +15,39 @@ type BufferedPreHandlerPtyState = {
 }
 
 const preHandlerPtyData = new Map<string, BufferedPreHandlerPtyState>()
-const preHandlerPtyExit = new Map<string, number>()
+const preHandlerPtyExit = new Map<string, { code: number; cursor: number }>()
+let preHandlerPtyEventCursor = 0
 
 // Why: Windows startup commands can emit output before pty:spawn resolves and
 // the pane registers its handler. Hold that tiny race window instead of ACKing
 // and dropping the first setup-script bytes.
 const PRE_HANDLER_PTY_DATA_MAX_BYTES = 512 * 1024
-const PRE_HANDLER_PTY_DATA_MAX_PTYS = 64
+export const PRE_HANDLER_PTY_MAX_PTYS = 64
 // Why: legit pre-attach windows drain within milliseconds and hold little
 // data. Sustained accumulation means a pane lost its data handler (the
 // frozen-pane detach/attach race) — leave a breadcrumb for trace capture.
 const PRE_HANDLER_PTY_DATA_WARN_BYTES = 64 * 1024
 const warnedLostHandlerPtyIds = new Set<string>()
 
+function nextPreHandlerPtyEventCursor(): number {
+  preHandlerPtyEventCursor += 1
+  return preHandlerPtyEventCursor
+}
+
+export function capturePreHandlerPtyEventCursor(): number {
+  return preHandlerPtyEventCursor
+}
+
 export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyDataMeta): void {
   const chunk = clampUtf8Tail(data, PRE_HANDLER_PTY_DATA_MAX_BYTES)
   if (!chunk.data) {
     return
   }
-  if (!preHandlerPtyData.has(ptyId) && preHandlerPtyData.size >= PRE_HANDLER_PTY_DATA_MAX_PTYS) {
+  if (!preHandlerPtyData.has(ptyId) && preHandlerPtyData.size >= PRE_HANDLER_PTY_MAX_PTYS) {
     const oldestPtyId = preHandlerPtyData.keys().next().value
     if (typeof oldestPtyId === 'string') {
       preHandlerPtyData.delete(oldestPtyId)
+      warnedLostHandlerPtyIds.delete(oldestPtyId)
     }
   }
   const bufferedMeta =
@@ -50,6 +62,7 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
   state.chunks.push({
     data: chunk.data,
     bytes: chunk.bytes,
+    cursor: nextPreHandlerPtyEventCursor(),
     ...(bufferedMeta ? { meta: bufferedMeta } : {})
   })
   state.bytes += chunk.bytes
@@ -57,7 +70,7 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
   // and head index keep that failure path linear instead of rescanning/shifting.
   while (state.bytes > PRE_HANDLER_PTY_DATA_MAX_BYTES && state.head < state.chunks.length - 1) {
     state.bytes -= state.chunks[state.head].bytes
-    state.chunks[state.head] = { data: '', bytes: 0 }
+    state.chunks[state.head] = { ...state.chunks[state.head], data: '', bytes: 0 }
     state.head += 1
   }
   if (state.head > 0 && state.head * 2 >= state.chunks.length) {
@@ -75,7 +88,8 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
 
 export function drainPreHandlerPtyData(
   ptyId: string,
-  handler: (data: string, meta?: PtyDataMeta) => void
+  handler: (data: string, meta?: PtyDataMeta) => void,
+  afterCursor?: number
 ): void {
   const state = preHandlerPtyData.get(ptyId)
   warnedLostHandlerPtyIds.delete(ptyId)
@@ -85,21 +99,40 @@ export function drainPreHandlerPtyData(
   preHandlerPtyData.delete(ptyId)
   for (let index = state.head; index < state.chunks.length; index += 1) {
     const chunk = state.chunks[index]
-    handler(chunk.data, chunk.meta)
+    if (afterCursor === undefined || chunk.cursor > afterCursor) {
+      handler(chunk.data, chunk.meta)
+    }
   }
 }
 
 export function bufferPreHandlerPtyExit(ptyId: string, code: number): void {
-  preHandlerPtyExit.set(ptyId, code)
+  // Why: PTYs that die before a pane mounts may never register a handler.
+  // Bound those orphan records without reducing the existing data allowance.
+  if (!preHandlerPtyExit.has(ptyId) && preHandlerPtyExit.size >= PRE_HANDLER_PTY_MAX_PTYS) {
+    const oldestPtyId = preHandlerPtyExit.keys().next().value
+    if (typeof oldestPtyId === 'string') {
+      preHandlerPtyExit.delete(oldestPtyId)
+    }
+  }
+  // Why: PTY ids can be reused by relay-style providers. A later exit is the
+  // current fact and refreshes recency so an older lifecycle cannot evict it.
+  preHandlerPtyExit.delete(ptyId)
+  preHandlerPtyExit.set(ptyId, { code, cursor: nextPreHandlerPtyEventCursor() })
 }
 
-export function drainPreHandlerPtyExit(ptyId: string, handler: (code: number) => void): void {
-  const code = preHandlerPtyExit.get(ptyId)
-  if (code === undefined) {
+export function drainPreHandlerPtyExit(
+  ptyId: string,
+  handler: (code: number) => void,
+  afterCursor?: number
+): void {
+  const exit = preHandlerPtyExit.get(ptyId)
+  if (!exit) {
     return
   }
   preHandlerPtyExit.delete(ptyId)
-  handler(code)
+  if (afterCursor === undefined || exit.cursor > afterCursor) {
+    handler(exit.code)
+  }
 }
 
 export function clearPreHandlerPtyData(ptyId: string): void {

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -50,9 +50,11 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
       warnedLostHandlerPtyIds.delete(oldestPtyId)
     }
   }
+  // Why: stream sequence cursors count UTF-16 code units; `bytes` is only the
+  // memory-cap unit and would move non-ASCII chunks to the wrong sequence.
   const bufferedMeta =
     meta && chunk.data.length !== data.length && typeof meta.rawLength === 'number'
-      ? { ...meta, rawLength: chunk.bytes }
+      ? { ...meta, rawLength: chunk.data.length }
       : meta
   let state = preHandlerPtyData.get(ptyId)
   if (!state) {

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -58,6 +58,11 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
   if (!state) {
     state = { chunks: [], head: 0, bytes: 0 }
     preHandlerPtyData.set(ptyId, state)
+  } else {
+    // Why: relay-style providers can reuse ids. New output makes this identity
+    // current, so later churn must evict an actually older buffered PTY.
+    preHandlerPtyData.delete(ptyId)
+    preHandlerPtyData.set(ptyId, state)
   }
   state.chunks.push({
     data: chunk.data,

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -1444,17 +1444,31 @@ describe('createIpcPtyTransport', () => {
     } = await import('./pty-transport')
     const onDataCallback = vi.fn()
     const transport = createIpcPtyTransport()
+    const replacementDataHandler = vi.fn()
+    const replacementReplayHandler = vi.fn()
+    const replacementTeardownHandler = vi.fn()
+    const { ptyDataHandlers, ptyReplayHandlers, ptyTeardownHandlers } =
+      await import('./pty-dispatcher')
 
     await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
 
     const snapshots = unregisterPtyDataHandlers(['pty-1'])
     onData?.({ id: 'pty-1', data: 'final burst while detached' })
     expect(onDataCallback).not.toHaveBeenCalled()
+    ptyDataHandlers.set('pty-1', replacementDataHandler)
+    ptyReplayHandlers.set('pty-1', replacementReplayHandler)
+    ptyTeardownHandlers.set('pty-1', replacementTeardownHandler)
 
     restorePtyDataHandlersAfterFailedShutdown(snapshots)
     onData?.({ id: 'pty-1', data: 'live again' })
 
-    expect(onDataCallback.mock.calls).toEqual([['final burst while detached'], ['live again']])
+    expect(onDataCallback).not.toHaveBeenCalled()
+    expect(replacementDataHandler.mock.calls).toEqual([
+      ['final burst while detached', undefined],
+      ['live again', undefined]
+    ])
+    expect(ptyReplayHandlers.get('pty-1')).toBe(replacementReplayHandler)
+    expect(ptyTeardownHandlers.get('pty-1')).toBe(replacementTeardownHandler)
   })
 
   it('unregisterPtyDataHandlers cancels staleTitleTimer so it cannot fire stale idle transition', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -1454,7 +1454,7 @@ describe('createIpcPtyTransport', () => {
     restorePtyDataHandlersAfterFailedShutdown(snapshots)
     onData?.({ id: 'pty-1', data: 'live again' })
 
-    expect(onDataCallback).toHaveBeenCalledWith('live again')
+    expect(onDataCallback.mock.calls).toEqual([['final burst while detached'], ['live again']])
   })
 
   it('unregisterPtyDataHandlers cancels staleTitleTimer so it cannot fire stale idle transition', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -22,7 +22,11 @@ import {
   ensurePtyDispatcher,
   getEagerPtyBufferHandle
 } from './pty-dispatcher'
-import { drainPreHandlerPtyData, drainPreHandlerPtyExit } from './pty-pre-handler-buffer'
+import {
+  capturePreHandlerPtyEventCursor,
+  drainPreHandlerPtyData,
+  drainPreHandlerPtyExit
+} from './pty-pre-handler-buffer'
 import { createPtyInputWriteQueue } from './pty-input-write-queue'
 import type { PtyDataMeta } from './pty-dispatcher'
 import type { IpcPtyTransportOptions, PtyConnectResult, PtyTransport } from './pty-transport-types'
@@ -581,7 +585,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
 
   // Why: shared by connect() and attach() to avoid duplicating title/bell/exit
   // logic across the two code paths that register a PTY.
-  function registerPtyDataHandler(id: string): void {
+  function registerPtyDataHandler(id: string, afterCursor?: number): void {
     // Why: relay pty.attach sends replay data via a dedicated pty:replay IPC
     // channel. Route it through onReplayData so the renderer engages the
     // replay guard and xterm auto-replies do not leak into the shell.
@@ -611,7 +615,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     }
     ptyDataHandlers.set(id, dataHandler)
     ownedDataAndReplayHandlers.set(id, { data: dataHandler, replay: replayHandler })
-    drainPreHandlerPtyData(id, dataHandler)
+    drainPreHandlerPtyData(id, dataHandler, afterCursor)
   }
 
   function clearAccumulatedState(): void {
@@ -649,7 +653,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     }
   }
 
-  function registerPtyExitHandler(id: string): void {
+  function registerPtyExitHandler(id: string, afterCursor?: number): void {
     const exitHandler = (code: number): void => {
       if (ptyId !== null && ptyId !== id) {
         // Why: a preserved sleep/reconnect session can report its old exit
@@ -674,7 +678,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     // would otherwise fire stale notifications after the data handler
     // is removed but before the exit event arrives.
     ptyTeardownHandlers.set(id, clearAccumulatedState)
-    drainPreHandlerPtyExit(id, exitHandler)
+    drainPreHandlerPtyExit(id, exitHandler, afterCursor)
   }
 
   return {
@@ -687,6 +691,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       }
 
       try {
+        const freshSpawnCursor = options.sessionId ? undefined : capturePreHandlerPtyEventCursor()
         // Why: missing-cwd recovery is only valid for fresh local spawns —
         // reattach must keep the session's exact cwd and SSH-tagged transports
         // resolve cwd on the remote host.
@@ -746,8 +751,10 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           onPtySpawn?.(spawnResult.id)
         }
 
-        registerPtyDataHandler(spawnResult.id)
-        registerPtyExitHandler(spawnResult.id)
+        const afterCursor =
+          spawnResult.isReattach || spawnResult.coldRestore ? undefined : freshSpawnCursor
+        registerPtyDataHandler(spawnResult.id, afterCursor)
+        registerPtyExitHandler(spawnResult.id, afterCursor)
         if (!connected || ptyId !== spawnResult.id) {
           return undefined
         }

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -753,8 +753,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           onPtySpawn?.(spawnResult.id)
         }
 
-        const afterCursor =
-          spawnResult.isReattach || spawnResult.coldRestore ? undefined : freshSpawnCursor
+        // Why: cold restore may start a new daemon generation with a reused id.
+        // Only explicit live reattach has authority to consume pre-spawn backlog.
+        const afterCursor = spawnResult.isReattach ? undefined : freshSpawnCursor
         registerPtyDataHandler(spawnResult.id, afterCursor)
         registerPtyExitHandler(spawnResult.id, afterCursor)
         if (!connected || ptyId !== spawnResult.id) {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -691,7 +691,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       }
 
       try {
-        const freshSpawnCursor = options.sessionId ? undefined : capturePreHandlerPtyEventCursor()
+        // Why: a requested reattach can fall back to a fresh PTY with the same
+        // id. Keep the cursor unless the provider confirms an actual restore.
+        const freshSpawnCursor = capturePreHandlerPtyEventCursor()
         // Why: missing-cwd recovery is only valid for fresh local spawns —
         // reattach must keep the session's exact cwd and SSH-tagged transports
         // resolve cwd on the remote host.

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -100,7 +100,7 @@ vi.mock('@/lib/agent-launch-platform', () => ({
 }))
 
 vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
-  registerEagerPtyBuffer: mockRegisterEagerPtyBuffer,
+  captureEagerPtyBufferRegistration: () => mockRegisterEagerPtyBuffer,
   subscribeToPtyExit: mockSubscribeToPtyExit
 }))
 

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -23,6 +23,7 @@ const mockPasteDraftWhenAgentReady = vi.fn()
 const mockMarkTrusted = vi.fn()
 const mockDispatchEvent = vi.fn()
 const mockGetAgentLaunchPlatformForRepo = vi.fn<() => NodeJS.Platform>()
+let capturedPreSubscriptionDataObserver: ((data: string) => void) | undefined
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
 function expectStablePaneSpawn(): string {
@@ -99,8 +100,14 @@ vi.mock('@/lib/agent-launch-platform', () => ({
   getAgentLaunchPlatformForRepo: mockGetAgentLaunchPlatformForRepo
 }))
 
+vi.mock('@/components/terminal-pane/pty-eager-buffer-registration', () => ({
+  captureEagerPtyBufferRegistration: (observer?: (data: string) => void) => {
+    capturedPreSubscriptionDataObserver = observer
+    return mockRegisterEagerPtyBuffer
+  }
+}))
+
 vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
-  captureEagerPtyBufferRegistration: () => mockRegisterEagerPtyBuffer,
   subscribeToPtyExit: mockSubscribeToPtyExit
 }))
 
@@ -113,6 +120,7 @@ describe('launchAgentBackgroundSession', () => {
     resetRemoteRuntimeTerminalMultiplexersForTests()
     clearRuntimeCompatibilityCacheForTests()
     vi.clearAllMocks()
+    capturedPreSubscriptionDataObserver = undefined
     mockGetAgentLaunchPlatformForRepo.mockReturnValue('linux')
     mockRuntimeEnvironmentTransportCall.mockImplementation(
       (args) =>
@@ -155,6 +163,13 @@ describe('launchAgentBackgroundSession', () => {
     })
     mockSubscribeToPtyData.mockReturnValue(vi.fn())
     mockSubscribeToPtyExit.mockReturnValue(vi.fn())
+    mockRegisterEagerPtyBuffer.mockReturnValue({
+      flush: () => '',
+      dispose: vi.fn(),
+      stopObservingData: () => {
+        capturedPreSubscriptionDataObserver = undefined
+      }
+    })
     vi.stubGlobal('window', {
       dispatchEvent: mockDispatchEvent,
       api: {
@@ -271,6 +286,34 @@ describe('launchAgentBackgroundSession', () => {
     expect(mockDispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ detail: { worktreeId: 'wt-1', tabIds: ['tab-1'] } })
     )
+  })
+
+  it('delivers pre-subscription background bytes to observers exactly once', async () => {
+    const onData = vi.fn()
+    mockRegisterEagerPtyBuffer.mockImplementationOnce(() => {
+      capturedPreSubscriptionDataObserver?.('early output')
+      return {
+        flush: () => '',
+        dispose: vi.fn(),
+        stopObservingData: () => {
+          capturedPreSubscriptionDataObserver = undefined
+        }
+      }
+    })
+    const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+    await launchAgentBackgroundSession({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      prompt: 'run the automation',
+      onData
+    })
+
+    expect(onData).toHaveBeenCalledWith('early output')
+    const dataSidecar = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
+    capturedPreSubscriptionDataObserver?.('live output')
+    dataSidecar('live output')
+    expect(onData.mock.calls).toEqual([['early output'], ['live output']])
   })
 
   it('records effective launch config returned by local PTY spawn', async () => {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -19,7 +19,7 @@ import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import {
-  registerEagerPtyBuffer,
+  captureEagerPtyBufferRegistration,
   subscribeToPtyExit,
   type EagerPtyHandle
 } from '@/components/terminal-pane/pty-dispatcher'
@@ -213,6 +213,7 @@ export async function launchAgentBackgroundSession(
       runtimeTerminalHandle = created.terminal.handle
       ptyId = toRemoteRuntimePtyId(runtimeTerminalHandle, runtimeTarget.environmentId)
     } else {
+      const registerEagerPtyBuffer = captureEagerPtyBufferRegistration()
       const result = await window.api.pty.spawn({
         cols: 120,
         rows: 40,
@@ -236,6 +237,7 @@ export async function launchAgentBackgroundSession(
         }
       })
       ptyId = result.id
+      eagerPtyBuffer = registerEagerPtyBuffer(ptyId, handleExit)
       if (result.launchConfig) {
         store.registerAgentLaunchConfig(paneKey, result.launchConfig, {
           agentType: agent,
@@ -283,7 +285,6 @@ export async function launchAgentBackgroundSession(
         .then((result) => handleExit(ptyId, result.wait.exitCode ?? 0))
         .catch(() => {})
     } else {
-      eagerPtyBuffer = registerEagerPtyBuffer(ptyId, handleExit)
       unsubscribeData = subscribeToPtyData(ptyId, handleData)
       // Why: opening the workspace attaches a real terminal transport and disposes
       // the eager exit handler. This sidecar keeps automation completion tracking

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -18,11 +18,8 @@ import {
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { makePaneKey } from '../../../shared/stable-pane-id'
-import {
-  captureEagerPtyBufferRegistration,
-  subscribeToPtyExit,
-  type EagerPtyHandle
-} from '@/components/terminal-pane/pty-dispatcher'
+import { subscribeToPtyExit, type EagerPtyHandle } from '@/components/terminal-pane/pty-dispatcher'
+import { captureEagerPtyBufferRegistration } from '@/components/terminal-pane/pty-eager-buffer-registration'
 import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
@@ -62,7 +59,6 @@ export async function launchAgentBackgroundSession(
       // Best-effort: continue with launch. The user can still accept the trust menu.
     }
   }
-  const agentArgs = resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs)
   const agentEnv = resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv)
   const launchPlatform = repo
     ? getAgentLaunchPlatformForRepo(
@@ -87,7 +83,7 @@ export async function launchAgentBackgroundSession(
     agent,
     prompt: hasPrompt && !isFollowupPath ? trimmedPrompt : '',
     cmdOverrides: store.settings?.agentCmdOverrides ?? {},
-    agentArgs,
+    agentArgs: resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs),
     agentEnv,
     platform: launchPlatform,
     shell: startupShell,
@@ -212,7 +208,9 @@ export async function launchAgentBackgroundSession(
       runtimeTerminalHandle = created.terminal.handle
       ptyId = toRemoteRuntimePtyId(runtimeTerminalHandle, runtimeTarget.environmentId)
     } else {
-      const registerEagerPtyBuffer = captureEagerPtyBufferRegistration()
+      // Why: bytes emitted before spawn resolves must reach automation/status
+      // observers as well as the pane buffer, without duplicating later sidecar data.
+      const registerEagerPtyBuffer = captureEagerPtyBufferRegistration(handleData)
       const result = await window.api.pty.spawn({
         cols: 120,
         rows: 40,
@@ -284,6 +282,7 @@ export async function launchAgentBackgroundSession(
         .then((result) => handleExit(ptyId, result.wait.exitCode ?? 0))
         .catch(() => {})
     } else {
+      eagerPtyBuffer?.stopObservingData?.()
       unsubscribeData = subscribeToPtyData(ptyId, handleData)
       // Why: opening the workspace attaches a real terminal transport and disposes
       // the eager exit handler. This sidecar keeps automation completion tracking

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -62,7 +62,6 @@ export async function launchAgentBackgroundSession(
       // Best-effort: continue with launch. The user can still accept the trust menu.
     }
   }
-  const cmdOverrides = store.settings?.agentCmdOverrides ?? {}
   const agentArgs = resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs)
   const agentEnv = resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv)
   const launchPlatform = repo
@@ -87,7 +86,7 @@ export async function launchAgentBackgroundSession(
   const startupPlan = buildAgentStartupPlan({
     agent,
     prompt: hasPrompt && !isFollowupPath ? trimmedPrompt : '',
-    cmdOverrides,
+    cmdOverrides: store.settings?.agentCmdOverrides ?? {},
     agentArgs,
     agentEnv,
     platform: launchPlatform,

--- a/src/renderer/src/lib/launch-worktree-background-terminals.test.ts
+++ b/src/renderer/src/lib/launch-worktree-background-terminals.test.ts
@@ -8,6 +8,7 @@ const mockSetTabLayout = vi.fn()
 const mockUpdateTabPtyId = vi.fn()
 const mockClearTabPtyId = vi.fn()
 const mockCloseTab = vi.fn()
+const mockEnsurePtyDispatcher = vi.fn()
 const mockRegisterEagerPtyBuffer = vi.fn()
 const mockGetActiveRuntimeTarget = vi.fn()
 
@@ -52,6 +53,7 @@ vi.mock('@/lib/browser-uuid', () => ({
 }))
 
 vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  ensurePtyDispatcher: mockEnsurePtyDispatcher,
   registerEagerPtyBuffer: mockRegisterEagerPtyBuffer
 }))
 
@@ -140,6 +142,9 @@ describe('launchWorktreeBackgroundTerminals', () => {
     expect(mockUpdateTabPtyId).toHaveBeenCalledWith('tab-1', 'pty-1')
     expect(mockUpdateTabPtyId).toHaveBeenCalledWith('tab-2', 'pty-2')
     expect(mockRegisterEagerPtyBuffer).toHaveBeenCalledTimes(2)
+    expect(mockEnsurePtyDispatcher.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSpawn.mock.invocationCallOrder[0] ?? 0
+    )
   })
 
   it('spawns setup in a split when setup launch mode requests a split', async () => {

--- a/src/renderer/src/lib/launch-worktree-background-terminals.ts
+++ b/src/renderer/src/lib/launch-worktree-background-terminals.ts
@@ -2,6 +2,7 @@ import {
   registerEagerPtyBuffer,
   type EagerPtyHandle
 } from '@/components/terminal-pane/pty-dispatcher'
+import { capturePreHandlerPtyEventCursor } from '@/components/terminal-pane/pty-pre-handler-buffer'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
@@ -110,12 +111,21 @@ function persistExitedPaneOutput(tabId: string, leafId: string, output: string):
   })
 }
 
-function registerBackgroundPaneBuffer(tabId: string, leafId: string, ptyId: string): void {
+function registerBackgroundPaneBuffer(
+  tabId: string,
+  leafId: string,
+  ptyId: string,
+  afterCursor: number
+): void {
   let eagerBuffer: EagerPtyHandle | null = null
-  eagerBuffer = registerEagerPtyBuffer(ptyId, (exitPtyId) => {
-    persistExitedPaneOutput(tabId, leafId, eagerBuffer?.flush() ?? '')
-    useAppStore.getState().clearTabPtyId(tabId, exitPtyId)
-  })
+  eagerBuffer = registerEagerPtyBuffer(
+    ptyId,
+    (exitPtyId) => {
+      persistExitedPaneOutput(tabId, leafId, eagerBuffer?.flush() ?? '')
+      useAppStore.getState().clearTabPtyId(tabId, exitPtyId)
+    },
+    afterCursor
+  )
 }
 
 function buildSetupCommand(setup: WorktreeSetupLaunch): string {
@@ -167,6 +177,7 @@ async function createBackgroundTab(args: {
   const leafId = createBrowserUuid()
   store.setTabLayout(tab.id, singlePaneLayoutSnapshot(leafId))
   let ptyId: string
+  const preHandlerCursor = capturePreHandlerPtyEventCursor()
   try {
     ptyId = await spawnPane({
       worktree: args.worktree,
@@ -182,7 +193,7 @@ async function createBackgroundTab(args: {
   }
   store.updateTabPtyId(tab.id, ptyId)
   store.setTabLayout(tab.id, singlePaneLayoutSnapshot(leafId, ptyId))
-  registerBackgroundPaneBuffer(tab.id, leafId, ptyId)
+  registerBackgroundPaneBuffer(tab.id, leafId, ptyId, preHandlerCursor)
   return { tabId: tab.id, primary: { leafId, ptyId } }
 }
 
@@ -195,6 +206,7 @@ async function addSetupSplit(args: {
 }): Promise<void> {
   const store = useAppStore.getState()
   const setupLeafId = createBrowserUuid()
+  const preHandlerCursor = capturePreHandlerPtyEventCursor()
   const setupPtyId = await spawnPane({
     worktree: args.worktree,
     connectionId: args.connectionId,
@@ -213,7 +225,7 @@ async function addSetupSplit(args: {
       getSetupTabTitle()
     )
   )
-  registerBackgroundPaneBuffer(args.tab.tabId, setupLeafId, setupPtyId)
+  registerBackgroundPaneBuffer(args.tab.tabId, setupLeafId, setupPtyId, preHandlerCursor)
 }
 
 function getDefaultTabLaunches(

--- a/src/renderer/src/lib/launch-worktree-background-terminals.ts
+++ b/src/renderer/src/lib/launch-worktree-background-terminals.ts
@@ -1,4 +1,5 @@
 import {
+  ensurePtyDispatcher,
   registerEagerPtyBuffer,
   type EagerPtyHandle
 } from '@/components/terminal-pane/pty-dispatcher'
@@ -177,6 +178,8 @@ async function createBackgroundTab(args: {
   const leafId = createBrowserUuid()
   store.setTabLayout(tab.id, singlePaneLayoutSnapshot(leafId))
   let ptyId: string
+  // Why: pty:exit is not held by main's renderer-ready data gate.
+  ensurePtyDispatcher()
   const preHandlerCursor = capturePreHandlerPtyEventCursor()
   try {
     ptyId = await spawnPane({
@@ -206,6 +209,8 @@ async function addSetupSplit(args: {
 }): Promise<void> {
   const store = useAppStore.getState()
   const setupLeafId = createBrowserUuid()
+  // Why: a setup shell may exit before spawn resolves on a first-use renderer.
+  ensurePtyDispatcher()
   const preHandlerCursor = capturePreHandlerPtyEventCursor()
   const setupPtyId = await spawnPane({
     worktree: args.worktree,


### PR DESCRIPTION
## Description

Hardens the renderer's pre-handler PTY lifecycle waiting room. Data and exit records now have independent 64-PTY bounds, lifecycle events carry a monotonic cursor, and protocol-v22 daemon streams carry an additive create/attach generation token so a provider-reused PTY id cannot consume stale output or exits. Fresh spawns—including a failed reattach fallback or a new-generation daemon cold restore—ignore older-lifecycle events, while explicit live reattach preserves the current PTY's backlog.

The singleton dispatcher is also attached before any first-use background spawn. That closes the interval where a very fast background terminal could exit before Orca had installed the global `pty:exit` listener. Bytes emitted in that interval reach background automation/status observers exactly once before ownership hands off to the live sidecar. Warning identities are removed with their exact data record, and failed intentional-shutdown restoration drains detached output to the current handler without overwriting a newer remount.

## Evidence

### Reproduction

On `main@20ebe858af`, the deterministic 65-PTY exit-before-handler repro failed: the oldest exit remained available (`received 0`) when eviction was expected. The original exit map therefore grew without a bound when panes never registered a handler.

### Correctness / proof of fix

The new experimental reliability gate `terminal-session.pre-handler-pty-ordering` drives:

- first-use background data/exit before spawn resolution and exactly-once observer handoff;
- more than 64 exit-before-handler identities;
- warning-producing data churn;
- reused PTY ids and stale lifecycle events;
- fresh spawn, failed-reattach fallback, new-generation daemon cold restore, and explicit live reattach;
- old daemon-generation data queued before a real warm reattach, matching fast new-generation data/exit before its response, mixed-generation split/coalescing/keep-tail salvage, and reattach token replacement;
- repeated 512 KiB pending-buffer overflow with surrogate-pair-safe accounting and generation-correct gap recovery;
- handler registration while orphan exits churn at the cap; and
- failed-shutdown restoration ordering and newer-remount handler authority.

Oracle: the listener is attached before capture/spawn; early bytes reach background side-effect observers exactly once through the real live-sidecar handoff; data and exits remain independently capped; warning bookkeeping cannot outgrow retained data; the latest exit is delivered exactly once; fresh and cold-restored generations reject stale events while preserving the restore payload; explicit live reattach preserves current backlog; and detached data drains before later live data to the current remount authority.

Validation on `main@a4583eb765` plus this branch:

- Reliability gate: 8 files, 271 tests passed.
- Adjacent renderer coverage: 18 files, 180 tests passed.
- PTY connection/main/SSH coverage: 3 files, 734 tests passed.
- `pnpm run typecheck:web` passed.
- Targeted oxlint and oxfmt passed for changed TypeScript files.
- Reliability manifest validation passed: 35 gates.
- `pnpm check:max-lines-ratchet` passed: 355 grandfathered files, no new bypasses.
- `git diff --check` passed.
- Multiple adversarial correctness/performance reviews completed with no remaining proven defects on the final head.

Core gate command:

```sh
pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/daemon-server.test.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts
```

## ELI5

Orca keeps terminal output and exits in a waiting room until a pane is ready. The waiting room now has limits, starts listening before background terminals launch, gives early output once to both the terminal and its automation bookkeeping, and uses a generation wristband for new daemon streams so leftovers from an older terminal with the same ID cannot enter.

## Trade-offs

Expected end-user regressions: **zero in ordinary use; one explicit bounded-overflow trade-off under an extreme unresolved attach burst**.

If more than 64 PTYs exit before any of their handlers can drain them, Orca deliberately drops the oldest undrained exit. This matches the existing bounded-data behavior and favors the newest diagnostics instead of allowing renderer-lifetime memory growth. The normal registered-handler path is unchanged.

While a daemon create/attach response is unresolved, Orca retains at most the newest 512 KiB of live payload per session. An extreme burst beyond that cap is represented by a generation-correct `dataGap` so the authoritative snapshot path can heal it; exit and control facts remain ordered, but that intermediate live feed is intentionally not lossless. This bounds main-process memory instead of allowing a wedged control response plus flooding PTY to grow without limit.

## Reliability proof

- **Reliability class / gate:** `terminal-session.pre-handler-pty-ordering`.
- **Invariant:** before a PTY handler mounts, the singleton dispatcher is listening; retained data, exits, and warning identities stay bounded; early bytes cross observer-to-sidecar ownership exactly once; data drains before exit; reused ids and new-generation cold restores cannot consume an older lifecycle's events; explicit live reattach preserves its current backlog; and failed shutdown restore drains detached data to the current handler without overwriting a newer remount.
- **Failure source:** #7695's unbounded pre-handler exit retention plus adjacent plausible ordering/reused-id races exposed while making the bound safe.
- **Material impact:** makes renderer-lifetime growth, lost first-use background exits, stale reused-id delivery, and reversed restore ordering harder to reintroduce through one deterministic contract.
- **Product change type:** runtime hardening plus deterministic reliability-gate coverage.
- **Diagnostics:** bounded warning identities and deterministic assertion failures identify which lifecycle/order invariant failed without recording terminal contents.
- **Promotion status:** experimental / partial. This new deterministic gate needs soak history and live provider evidence before blocking promotion.
- **Demotion rule:** demote or quarantine if ordering flakes, a live provider consumes an older lifecycle event, or the added cursor/bookkeeping appears in normal registered-handler throughput profiles.

## Performance / no-regression evidence

The renderer work is limited to the rare no-handler path: one monotonic-number increment and constant-size `Map` operations. Data and exits each retain at most 64 PTY identities; warning identities are a subset of retained data identities. Protocol v22 adds one small generation field to daemon create/attach responses and queued stream entries. Matching pending chunks coalesce, retained create/attach payload is capped at 512 KiB per session, and repeated surrogate-bearing overflow has deterministic byte-accounting coverage. No polling, timers, extra RPC, provider listing, subprocesses, storage writes, render scans, hidden-pane wake loops, startup awaits, or unbounded payload buffers/scans were added. Normal registered-handler terminal throughput bypasses renderer bookkeeping.

## Provider and platform coverage

- **Local PTY:** covered by deterministic renderer transport/lifecycle tests.
- **Daemon PTY:** protocol v22 covered, including batched token preservation, explicit live-reattach token replacement/backlog preservation, old-generation filtering, fast new-generation exit, and cold restore.
- **SSH and WSL:** use the same tested IPC path and have path-equivalent unit coverage; live-provider execution remains an accepted gap.
- **Remote-runtime / mobile / relay:** unaffected; these use a different host-owned stream rather than this renderer pre-handler buffer.
- **macOS:** directly tested.
- **Linux and Windows:** platform-neutral shared renderer logic and manifest scope; no live platform run in this evidence set.

## Residual gaps

- More than 64 undrained exits intentionally drops the oldest.
- An extreme output burst while create/attach is unresolved retains the newest 512 KiB and emits `dataGap`; exit/control facts are preserved, but the intermediate live feed is not lossless until snapshot recovery.
- Protocol-v21 and older daemons omit the additive generation token; tokenless events use the documented cursor fallback and retain the narrow probe-to-cold-restore race until daemon upgrade.
- SSH and WSL lack live-provider evidence for the fast-exit case.
- The new gate has no long-term flake/soak history yet.
