### PR TITLE
Make center split divider more visible

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -205,9 +205,10 @@
   --git-graph-lane-5: #b66dff;
   --annotation-highlight: #f59e0b;
   /* Why: tab-group splits use a dedicated divider — `--border` is too faint on
-     card/editor surfaces when panes are side-by-side or stacked. */
-  --tab-group-split-divider: #d4d4d8;
-  --tab-group-split-divider-strong: #a1a1aa;
+     card/editor surfaces when panes are side-by-side or stacked. Default must
+     meet >=3:1 against `--card`, not only the hover/drag strong state. */
+  --tab-group-split-divider: #868690;
+  --tab-group-split-divider-strong: #71717a;
 }
 
 /* ── Dark Mode ───────────────────────────────────────── */
@@ -291,9 +292,9 @@
   --git-graph-lane-4: #40b0a6;
   --git-graph-lane-5: #b66dff;
   --annotation-highlight: #fbbf24;
-  /* Match terminal split divider defaults so tab-group splits read as clearly. */
-  --tab-group-split-divider: #3f3f46;
-  --tab-group-split-divider-strong: #71717a;
+  /* Brighter than terminal defaults so the always-visible line clears 3:1 on `--card`. */
+  --tab-group-split-divider: #71717a;
+  --tab-group-split-divider-strong: #a1a1aa;
 }
 
 .linear-priority-bars {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -101,6 +101,8 @@
   --color-status-success: var(--status-success);
   --color-status-success-background: var(--status-success-background);
   --color-status-success-border: var(--status-success-border);
+  --color-tab-group-split-divider: var(--tab-group-split-divider);
+  --color-tab-group-split-divider-strong: var(--tab-group-split-divider-strong);
   --color-git-graph-ref: var(--git-graph-ref);
   --color-git-graph-remote-ref: var(--git-graph-remote-ref);
   --color-git-graph-base-ref: var(--git-graph-base-ref);
@@ -202,6 +204,10 @@
   --git-graph-lane-4: #40b0a6;
   --git-graph-lane-5: #b66dff;
   --annotation-highlight: #f59e0b;
+  /* Why: tab-group splits use a dedicated divider — `--border` is too faint on
+     card/editor surfaces when panes are side-by-side or stacked. */
+  --tab-group-split-divider: #d4d4d8;
+  --tab-group-split-divider-strong: #a1a1aa;
 }
 
 /* ── Dark Mode ───────────────────────────────────────── */
@@ -285,6 +291,9 @@
   --git-graph-lane-4: #40b0a6;
   --git-graph-lane-5: #b66dff;
   --annotation-highlight: #fbbf24;
+  /* Match terminal split divider defaults so tab-group splits read as clearly. */
+  --tab-group-split-divider: #3f3f46;
+  --tab-group-split-divider-strong: #71717a;
 }
 
 .linear-priority-bars {
@@ -616,6 +625,52 @@
   height: 100dvh;
   width: 100vw;
   overflow: hidden;
+}
+
+/* Tab-group split resize handle — wide hit area, visible center line. */
+.tab-group-split-resize-handle {
+  flex-shrink: 0;
+  position: relative;
+  background: transparent;
+}
+
+.tab-group-split-resize-handle.is-vertical {
+  width: 6px;
+  cursor: col-resize;
+}
+
+.tab-group-split-resize-handle.is-horizontal {
+  height: 6px;
+  cursor: row-resize;
+}
+
+.tab-group-split-resize-handle::after {
+  content: '';
+  position: absolute;
+  border-radius: 1px;
+  background: var(--tab-group-split-divider);
+  transition: background 100ms ease;
+}
+
+.tab-group-split-resize-handle.is-vertical::after {
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 3px;
+  transform: translateX(-50%);
+}
+
+.tab-group-split-resize-handle.is-horizontal::after {
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 3px;
+  transform: translateY(-50%);
+}
+
+.tab-group-split-resize-handle:hover::after,
+.tab-group-split-resize-handle.is-dragging::after {
+  background: var(--tab-group-split-divider-strong);
 }
 
 /* ── Titlebar ────────────────────────────────────────── */

--- a/src/renderer/src/components/tab-bar/BrowserTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.test.tsx
@@ -42,6 +42,18 @@ vi.mock('@dnd-kit/sortable', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  ArrowDown: function ArrowDown(props: Record<string, unknown>) {
+    return { type: 'ArrowDown', props }
+  },
+  ArrowLeft: function ArrowLeft(props: Record<string, unknown>) {
+    return { type: 'ArrowLeft', props }
+  },
+  ArrowRight: function ArrowRight(props: Record<string, unknown>) {
+    return { type: 'ArrowRight', props }
+  },
+  ArrowUp: function ArrowUp(props: Record<string, unknown>) {
+    return { type: 'ArrowUp', props }
+  },
   Columns2: function Columns2(props: Record<string, unknown>) {
     return { type: 'Columns2', props }
   },
@@ -59,6 +71,9 @@ vi.mock('lucide-react', () => ({
   },
   PinOff: function PinOff(props: Record<string, unknown>) {
     return { type: 'PinOff', props }
+  },
+  PanelRightClose: function PanelRightClose(props: Record<string, unknown>) {
+    return { type: 'PanelRightClose', props }
   },
   Rows2: function Rows2(props: Record<string, unknown>) {
     return { type: 'Rows2', props }

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
-import { Globe, X, ExternalLink, Copy, Pin, PinOff } from 'lucide-react'
+import { Globe, X, ExternalLink, Copy, Pin, PinOff, PanelRightClose } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -279,37 +279,36 @@ export default function BrowserTab({
           sideOffset={0}
           align="start"
         >
+          <TabWorkspaceLayoutMenuSection
+            unifiedTabId={dragData.unifiedTabId}
+            groupId={dragData.groupId}
+            trailingSeparator
+          />
           <DropdownMenuItem onSelect={onDuplicate}>
-            <Copy className="mr-1.5 size-3.5" />
+            <Copy className="size-3.5" />
             {translate('auto.components.tab.bar.BrowserTab.5d6e89891f', 'Duplicate Tab')}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={onTogglePin}>
-            {isPinned ? (
-              <PinOff className="mr-1.5 size-3.5" />
-            ) : (
-              <Pin className="mr-1.5 size-3.5" />
-            )}
+            {isPinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}
             {isPinned
               ? translate('auto.components.tab.bar.BrowserTab.c5aaee8c39', 'Unpin Tab')
               : translate('auto.components.tab.bar.BrowserTab.911542656f', 'Pin Tab')}
           </DropdownMenuItem>
-          <TabWorkspaceLayoutMenuSection
-            unifiedTabId={dragData.unifiedTabId}
-            groupId={dragData.groupId}
-          />
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => !isPinned && onClose()} disabled={isPinned}>
+            <X className="size-3.5" />
             {translate('auto.components.tab.bar.BrowserTab.1611a1324b', 'Close')}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onCloseToRight} disabled={!hasTabsToRight}>
+            <PanelRightClose className="size-3.5" />
             {translate('auto.components.tab.bar.BrowserTab.9dd880bd56', 'Close Tabs To The Right')}
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => void window.api.shell.openUrl(openInBrowserUrl)}
             disabled={!isHttpUrl}
           >
-            <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+            <ExternalLink className="size-3.5" />
             {translate('auto.components.tab.bar.BrowserTab.6e0bc8f3a8', 'Open In Browser')}
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -58,6 +58,18 @@ vi.mock('@dnd-kit/sortable', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  ArrowDown: function ArrowDown(props: Record<string, unknown>) {
+    return { type: 'ArrowDown', props }
+  },
+  ArrowLeft: function ArrowLeft(props: Record<string, unknown>) {
+    return { type: 'ArrowLeft', props }
+  },
+  ArrowRight: function ArrowRight(props: Record<string, unknown>) {
+    return { type: 'ArrowRight', props }
+  },
+  ArrowUp: function ArrowUp(props: Record<string, unknown>) {
+    return { type: 'ArrowUp', props }
+  },
   Columns2: function Columns2(props: Record<string, unknown>) {
     return { type: 'Columns2', props }
   },
@@ -69,6 +81,12 @@ vi.mock('lucide-react', () => ({
   },
   Eye: function Eye(props: Record<string, unknown>) {
     return { type: 'Eye', props }
+  },
+  ListX: function ListX(props: Record<string, unknown>) {
+    return { type: 'ListX', props }
+  },
+  PanelRightClose: function PanelRightClose(props: Record<string, unknown>) {
+    return { type: 'PanelRightClose', props }
   },
   GitCompareArrows: function GitCompareArrows(props: Record<string, unknown>) {
     return { type: 'GitCompareArrows', props }

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
@@ -36,11 +36,32 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  ArrowDown: function ArrowDown(props: Record<string, unknown>) {
+    return { type: 'ArrowDown', props }
+  },
+  ArrowLeft: function ArrowLeft(props: Record<string, unknown>) {
+    return { type: 'ArrowLeft', props }
+  },
+  ArrowRight: function ArrowRight(props: Record<string, unknown>) {
+    return { type: 'ArrowRight', props }
+  },
+  ArrowUp: function ArrowUp(props: Record<string, unknown>) {
+    return { type: 'ArrowUp', props }
+  },
   Copy: function Copy(props: Record<string, unknown>) {
     return { type: 'Copy', props }
   },
   ExternalLink: function ExternalLink(props: Record<string, unknown>) {
     return { type: 'ExternalLink', props }
+  },
+  Eye: function Eye(props: Record<string, unknown>) {
+    return { type: 'Eye', props }
+  },
+  ListX: function ListX(props: Record<string, unknown>) {
+    return { type: 'ListX', props }
+  },
+  PanelRightClose: function PanelRightClose(props: Record<string, unknown>) {
+    return { type: 'PanelRightClose', props }
   },
   Columns2: function Columns2(props: Record<string, unknown>) {
     return { type: 'Columns2', props }
@@ -56,6 +77,9 @@ vi.mock('lucide-react', () => ({
   },
   PinOff: function PinOff(props: Record<string, unknown>) {
     return { type: 'PinOff', props }
+  },
+  X: function X(props: Record<string, unknown>) {
+    return { type: 'X', props }
   }
 }))
 

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -130,13 +130,13 @@ export function EditorFileTabContextMenu({
             onOpenRenameInput()
           }}
         >
-          <Pencil className="mr-1.5 size-3.5" />
+          <Pencil className="size-3.5" />
           {translate('auto.components.tab.bar.EditorFileTabContextMenu.68cc610e7f', 'Rename')}
           {renameShortcut ? <DropdownMenuShortcut>{renameShortcut}</DropdownMenuShortcut> : null}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onTogglePin}>
-          {isPinned ? <PinOff className="mr-1.5 size-3.5" /> : <Pin className="mr-1.5 size-3.5" />}
+          {isPinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5" />}
           {isPinned
             ? translate('auto.components.tab.bar.EditorFileTabContextMenu.8e9d603a09', 'Unpin Tab')
             : translate('auto.components.tab.bar.EditorFileTabContextMenu.fdd29eb669', 'Pin Tab')}
@@ -196,7 +196,7 @@ export function EditorFileTabContextMenu({
             void window.api.ui.writeClipboardText(file.filePath)
           }}
         >
-          <Copy className="w-3.5 h-3.5 mr-1.5" />
+          <Copy className="size-3.5" />
           {translate('auto.components.tab.bar.EditorFileTabContextMenu.5b85754786', 'Copy Path')}
         </DropdownMenuItem>
         <DropdownMenuItem
@@ -204,7 +204,7 @@ export function EditorFileTabContextMenu({
             void window.api.ui.writeClipboardText(file.relativePath)
           }}
         >
-          <Copy className="w-3.5 h-3.5 mr-1.5" />
+          <Copy className="size-3.5" />
           {translate(
             'auto.components.tab.bar.EditorFileTabContextMenu.52ce4f4605',
             'Copy Relative Path'
@@ -226,7 +226,7 @@ export function EditorFileTabContextMenu({
             window.api.shell.openPath(file.filePath)
           }}
         >
-          <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+          <ExternalLink className="size-3.5" />
           {revealLabel}
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -1,4 +1,14 @@
-import { Copy, ExternalLink, Pencil, Pin, PinOff } from 'lucide-react'
+import {
+  Copy,
+  ExternalLink,
+  Eye,
+  ListX,
+  PanelRightClose,
+  Pencil,
+  Pin,
+  PinOff,
+  X
+} from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -107,6 +117,11 @@ export function EditorFileTabContextMenu({
           event.preventDefault()
         }}
       >
+        <TabWorkspaceLayoutMenuSection
+          unifiedTabId={unifiedTabId}
+          groupId={groupId}
+          trailingSeparator
+        />
         <DropdownMenuItem
           disabled={!canRename || isRenaming}
           onSelect={() => {
@@ -126,13 +141,14 @@ export function EditorFileTabContextMenu({
             ? translate('auto.components.tab.bar.EditorFileTabContextMenu.8e9d603a09', 'Unpin Tab')
             : translate('auto.components.tab.bar.EditorFileTabContextMenu.fdd29eb669', 'Pin Tab')}
         </DropdownMenuItem>
-        <TabWorkspaceLayoutMenuSection unifiedTabId={unifiedTabId} groupId={groupId} />
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => !isPinned && onClose()} disabled={isPinned}>
+          <X className="size-3.5" />
           {translate('auto.components.tab.bar.EditorFileTabContextMenu.1ba8492c5b', 'Close')}
           {closeShortcut ? <DropdownMenuShortcut>{closeShortcut}</DropdownMenuShortcut> : null}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onCloseAll}>
+          <ListX className="size-3.5" />
           {translate(
             'auto.components.tab.bar.EditorFileTabContextMenu.ba1369dd24',
             'Close All Editor Tabs'
@@ -142,6 +158,7 @@ export function EditorFileTabContextMenu({
           ) : null}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onCloseToRight} disabled={!hasTabsToRight}>
+          <PanelRightClose className="size-3.5" />
           {translate(
             'auto.components.tab.bar.EditorFileTabContextMenu.e5ff31ccaf',
             'Close Tabs To The Right'
@@ -165,6 +182,7 @@ export function EditorFileTabContextMenu({
                 )
               }}
             >
+              <Eye className="size-3.5" />
               {translate(
                 'auto.components.tab.bar.EditorFileTabContextMenu.bfd5797ef4',
                 'Open Markdown Preview'

--- a/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
@@ -72,6 +72,18 @@ vi.mock('@dnd-kit/sortable', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  ArrowDown: function ArrowDown(props: Record<string, unknown>) {
+    return { type: 'ArrowDown', props }
+  },
+  ArrowLeft: function ArrowLeft(props: Record<string, unknown>) {
+    return { type: 'ArrowLeft', props }
+  },
+  ArrowRight: function ArrowRight(props: Record<string, unknown>) {
+    return { type: 'ArrowRight', props }
+  },
+  ArrowUp: function ArrowUp(props: Record<string, unknown>) {
+    return { type: 'ArrowUp', props }
+  },
   Columns2: function Columns2(props: Record<string, unknown>) {
     return { type: 'Columns2', props }
   },
@@ -84,6 +96,15 @@ vi.mock('lucide-react', () => ({
   PanelRightClose: function PanelRightClose(props: Record<string, unknown>) {
     return { type: 'PanelRightClose', props }
   },
+  ListX: function ListX(props: Record<string, unknown>) {
+    return { type: 'ListX', props }
+  },
+  MessageSquare: function MessageSquare(props: Record<string, unknown>) {
+    return { type: 'MessageSquare', props }
+  },
+  Pencil: function Pencil(props: Record<string, unknown>) {
+    return { type: 'Pencil', props }
+  },
   Pin: function Pin(props: Record<string, unknown>) {
     return { type: 'Pin', props }
   },
@@ -95,6 +116,9 @@ vi.mock('lucide-react', () => ({
   },
   X: function X(props: Record<string, unknown>) {
     return { type: 'X', props }
+  },
+  SquareTerminal: function SquareTerminal(props: Record<string, unknown>) {
+    return { type: 'SquareTerminal', props }
   }
 }))
 

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
@@ -227,9 +227,10 @@ describe('SortableTabContextMenu', () => {
     storeMock.dropUnifiedTab.mockReturnValue(true)
     const { container } = renderMenu()
 
-    expect(container.textContent).toContain('Split')
+    expect(container.textContent).toContain('Move Tab to Split')
+    expect(container.textContent).toContain('Split terminal')
 
-    act(() => getButton(container, 'Move tab right').click())
+    act(() => getButton(container, 'Right').click())
     expect(storeMock.dropUnifiedTab).toHaveBeenCalledWith('tab-1', {
       groupId: 'group-1',
       splitDirection: 'right'
@@ -252,7 +253,7 @@ describe('SortableTabContextMenu', () => {
     }
     const { container } = renderMenu()
 
-    expect(container.textContent).not.toContain('Move tab right')
+    expect(container.textContent).not.toContain('Move Tab to Split')
     expect(container.textContent).toContain('Split terminal right')
   })
 })

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
@@ -50,10 +50,20 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  ArrowDown: () => null,
+  ArrowLeft: () => null,
+  ArrowRight: () => null,
+  ArrowUp: () => null,
+  Columns2: () => null,
+  ListX: () => null,
+  MessageSquare: () => null,
   PanelBottomClose: () => null,
   PanelRightClose: () => null,
+  Pencil: () => null,
   Pin: () => null,
-  PinOff: () => null
+  PinOff: () => null,
+  SquareTerminal: () => null,
+  X: () => null
 }))
 
 vi.mock('@/i18n/i18n', () => ({
@@ -217,16 +227,16 @@ describe('SortableTabContextMenu', () => {
     storeMock.dropUnifiedTab.mockReturnValue(true)
     const { container } = renderMenu()
 
-    expect(container.textContent).toContain('Move Tab to Split')
+    expect(container.textContent).toContain('Split')
 
-    act(() => getButton(container, 'Right').click())
+    act(() => getButton(container, 'Move tab right').click())
     expect(storeMock.dropUnifiedTab).toHaveBeenCalledWith('tab-1', {
       groupId: 'group-1',
       splitDirection: 'right'
     })
   })
 
-  it('hides split actions for a single-tab group', () => {
+  it('hides move-tab split actions for a single-tab group', () => {
     storeMock.state = {
       ...storeMock.state,
       groupsByWorktree: {
@@ -242,6 +252,7 @@ describe('SortableTabContextMenu', () => {
     }
     const { container } = renderMenu()
 
-    expect(container.textContent).not.toContain('Move Tab to Split')
+    expect(container.textContent).not.toContain('Move tab right')
+    expect(container.textContent).toContain('Split terminal right')
   })
 })

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
@@ -1,10 +1,12 @@
 import {
   MessageSquare,
-  PanelBottomClose,
   PanelRightClose,
   Pin,
   PinOff,
-  SquareTerminal
+  Pencil,
+  SquareTerminal,
+  X,
+  ListX
 } from 'lucide-react'
 import {
   DropdownMenu,
@@ -18,8 +20,7 @@ import type { TerminalTab } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import { formatShortcutLabel, useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
-import { TabWorkspaceLayoutMenuSection } from './TabWorkspaceLayoutMenuSection'
-import { requestActiveTerminalPaneSplit } from './request-active-terminal-pane-split'
+import { TerminalTabSplitMenuSection } from './TerminalTabSplitMenuSection'
 
 const TAB_COLORS = [
   {
@@ -138,12 +139,6 @@ export function SortableTabContextMenu({
   const splitRightShortcut = formatShortcutLabel('terminal.splitRight', keybindings)
   const splitDownShortcut = formatShortcutLabel('terminal.splitDown', keybindings)
 
-  const splitActiveTerminalPane = (direction: 'vertical' | 'horizontal'): void => {
-    if (!isActive) {
-      onActivate(tab.id)
-    }
-    requestActiveTerminalPaneSplit({ tabId: tab.id, direction })
-  }
   const closeShortcut = useOptionalShortcutLabel('tab.close')
   const renameShortcut = useOptionalShortcutLabel('tab.rename')
 
@@ -158,13 +153,23 @@ export function SortableTabContextMenu({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" sideOffset={0} align="start">
-        {canToggleViewMode && onToggleViewMode && (
+        <TerminalTabSplitMenuSection
+          unifiedTabId={unifiedTabId}
+          groupId={groupId}
+          tabId={tab.id}
+          isActive={isActive}
+          onActivate={onActivate}
+          splitRightShortcut={splitRightShortcut}
+          splitDownShortcut={splitDownShortcut}
+        />
+        {canToggleViewMode && onToggleViewMode ? (
           <>
+            <DropdownMenuSeparator />
             <DropdownMenuItem onSelect={onToggleViewMode}>
               {isChatView ? (
-                <SquareTerminal className="mr-1.5 size-3.5" />
+                <SquareTerminal className="size-3.5 shrink-0" />
               ) : (
-                <MessageSquare className="mr-1.5 size-3.5" />
+                <MessageSquare className="size-3.5 shrink-0" />
               )}
               {isChatView
                 ? translate(
@@ -176,42 +181,31 @@ export function SortableTabContextMenu({
                     'Switch to chat view'
                   )}
             </DropdownMenuItem>
-            <DropdownMenuSeparator />
           </>
-        )}
-        <DropdownMenuItem onSelect={() => splitActiveTerminalPane('vertical')}>
-          <PanelRightClose />
-          {translate(
-            'auto.components.tab.bar.SortableTabContextMenu.splitTerminalRight',
-            'Split terminal right'
-          )}
-          <DropdownMenuShortcut>{splitRightShortcut}</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => splitActiveTerminalPane('horizontal')}>
-          <PanelBottomClose />
-          {translate(
-            'auto.components.tab.bar.SortableTabContextMenu.splitTerminalDown',
-            'Split terminal down'
-          )}
-          <DropdownMenuShortcut>{splitDownShortcut}</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        <TabWorkspaceLayoutMenuSection unifiedTabId={unifiedTabId} groupId={groupId} />
+        ) : null}
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onTogglePin}>
-          {isPinned ? <PinOff className="mr-1.5 size-3.5" /> : <Pin className="mr-1.5 size-3.5" />}
+          {isPinned ? (
+            <PinOff className="size-3.5 shrink-0" />
+          ) : (
+            <Pin className="size-3.5 shrink-0" />
+          )}
           {isPinned
             ? translate('auto.components.tab.bar.SortableTabContextMenu.417722e9c2', 'Unpin Tab')
             : translate('auto.components.tab.bar.SortableTabContextMenu.60f958ec75', 'Pin Tab')}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => !isPinned && onClose(tab.id)} disabled={isPinned}>
+          <X className="size-3.5" />
           {translate('auto.components.tab.bar.SortableTabContextMenu.89359a36f7', 'Close')}
           {closeShortcut ? <DropdownMenuShortcut>{closeShortcut}</DropdownMenuShortcut> : null}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => onCloseOthers(tab.id)} disabled={tabCount <= 1}>
+          <ListX className="size-3.5" />
           {translate('auto.components.tab.bar.SortableTabContextMenu.8d16f9cd30', 'Close Others')}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => onCloseToRight(tab.id)} disabled={!hasTabsToRight}>
+          <PanelRightClose className="size-3.5" />
           {translate(
             'auto.components.tab.bar.SortableTabContextMenu.c1ee099c7e',
             'Close Tabs To The Right'
@@ -219,6 +213,7 @@ export function SortableTabContextMenu({
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onRenameOpen}>
+          <Pencil className="size-3.5" />
           {translate('auto.components.tab.bar.SortableTabContextMenu.2f697b3c31', 'Change Title')}
           {renameShortcut ? <DropdownMenuShortcut>{renameShortcut}</DropdownMenuShortcut> : null}
         </DropdownMenuItem>

--- a/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
@@ -5,11 +5,25 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuItem
 } from '@/components/ui/dropdown-menu'
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Columns2 } from 'lucide-react'
 import type { TabSplitDirection } from '../../store/slices/tabs'
 import { translate } from '@/i18n/i18n'
 import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
 
 const PANE_COLUMN_DIRECTIONS: TabSplitDirection[] = ['right', 'left', 'down', 'up']
+
+function paneColumnDirectionIcon(direction: TabSplitDirection): React.JSX.Element {
+  switch (direction) {
+    case 'right':
+      return <ArrowRight className="size-3.5 shrink-0" />
+    case 'left':
+      return <ArrowLeft className="size-3.5 shrink-0" />
+    case 'down':
+      return <ArrowDown className="size-3.5 shrink-0" />
+    case 'up':
+      return <ArrowUp className="size-3.5 shrink-0" />
+  }
+}
 
 function paneColumnDirectionLabel(direction: TabSplitDirection): string {
   switch (direction) {
@@ -26,10 +40,12 @@ function paneColumnDirectionLabel(direction: TabSplitDirection): string {
 
 export function TabWorkspaceLayoutMenuSection({
   unifiedTabId,
-  groupId
+  groupId,
+  trailingSeparator = false
 }: {
   unifiedTabId: string
   groupId: string
+  trailingSeparator?: boolean
 }): React.JSX.Element | null {
   if (!canMoveTabToNewPaneColumn(unifiedTabId, groupId)) {
     return null
@@ -37,9 +53,9 @@ export function TabWorkspaceLayoutMenuSection({
 
   return (
     <>
-      <DropdownMenuSeparator />
       <DropdownMenuSub>
-        <DropdownMenuSubTrigger>
+        <DropdownMenuSubTrigger className="[&>svg:last-child]:size-3.5">
+          <Columns2 className="size-3.5 shrink-0" />
           {translate(
             'auto.components.tab.bar.TabWorkspaceLayoutMenuSection.moveToPaneColumn',
             'Move Tab to Split'
@@ -53,11 +69,13 @@ export function TabWorkspaceLayoutMenuSection({
                 moveTabToNewPaneColumn({ unifiedTabId, groupId, direction })
               }}
             >
+              {paneColumnDirectionIcon(direction)}
               {paneColumnDirectionLabel(direction)}
             </DropdownMenuItem>
           ))}
         </DropdownMenuSubContent>
       </DropdownMenuSub>
+      {trailingSeparator ? <DropdownMenuSeparator /> : null}
     </>
   )
 }

--- a/src/renderer/src/components/tab-bar/TerminalTabSplitMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabSplitMenuSection.tsx
@@ -6,59 +6,10 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger
 } from '@/components/ui/dropdown-menu'
-import {
-  ArrowDown,
-  ArrowLeft,
-  ArrowRight,
-  ArrowUp,
-  Columns2,
-  PanelBottomClose,
-  PanelRightClose
-} from 'lucide-react'
-import type { TabSplitDirection } from '../../store/slices/tabs'
+import { PanelBottomClose, PanelRightClose, SquareTerminal } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
-import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import { TabWorkspaceLayoutMenuSection } from './TabWorkspaceLayoutMenuSection'
 import { requestActiveTerminalPaneSplit } from './request-active-terminal-pane-split'
-
-const PANE_COLUMN_DIRECTIONS: TabSplitDirection[] = ['right', 'left', 'down', 'up']
-
-function moveTabDirectionIcon(direction: TabSplitDirection): React.JSX.Element {
-  switch (direction) {
-    case 'right':
-      return <ArrowRight className="size-3.5 shrink-0" />
-    case 'left':
-      return <ArrowLeft className="size-3.5 shrink-0" />
-    case 'down':
-      return <ArrowDown className="size-3.5 shrink-0" />
-    case 'up':
-      return <ArrowUp className="size-3.5 shrink-0" />
-  }
-}
-
-function moveTabDirectionLabel(direction: TabSplitDirection): string {
-  switch (direction) {
-    case 'right':
-      return translate(
-        'auto.components.tab.bar.TerminalTabSplitMenuSection.moveTabRight',
-        'Move tab right'
-      )
-    case 'left':
-      return translate(
-        'auto.components.tab.bar.TerminalTabSplitMenuSection.moveTabLeft',
-        'Move tab left'
-      )
-    case 'down':
-      return translate(
-        'auto.components.tab.bar.TerminalTabSplitMenuSection.moveTabDown',
-        'Move tab down'
-      )
-    case 'up':
-      return translate(
-        'auto.components.tab.bar.TerminalTabSplitMenuSection.moveTabUp',
-        'Move tab up'
-      )
-  }
-}
 
 export function TerminalTabSplitMenuSection({
   unifiedTabId,
@@ -79,8 +30,6 @@ export function TerminalTabSplitMenuSection({
   splitDownShortcut: string
   trailingSeparator?: boolean
 }): React.JSX.Element {
-  const canMoveTab = canMoveTabToNewPaneColumn(unifiedTabId, groupId)
-
   const splitActiveTerminalPane = (direction: 'vertical' | 'horizontal'): void => {
     if (!isActive) {
       onActivate(tabId)
@@ -90,26 +39,16 @@ export function TerminalTabSplitMenuSection({
 
   return (
     <>
+      <TabWorkspaceLayoutMenuSection unifiedTabId={unifiedTabId} groupId={groupId} />
       <DropdownMenuSub>
         <DropdownMenuSubTrigger className="[&>svg:last-child]:size-3.5">
-          <Columns2 className="size-3.5 shrink-0" />
-          {translate('auto.components.tab.bar.TerminalTabSplitMenuSection.split', 'Split')}
+          <SquareTerminal className="size-3.5 shrink-0" />
+          {translate(
+            'auto.components.tab.bar.TerminalTabSplitMenuSection.splitTerminal',
+            'Split terminal'
+          )}
         </DropdownMenuSubTrigger>
         <DropdownMenuSubContent className="min-w-[12rem]">
-          {canMoveTab
-            ? PANE_COLUMN_DIRECTIONS.map((direction) => (
-                <DropdownMenuItem
-                  key={direction}
-                  onSelect={() => {
-                    moveTabToNewPaneColumn({ unifiedTabId, groupId, direction })
-                  }}
-                >
-                  {moveTabDirectionIcon(direction)}
-                  {moveTabDirectionLabel(direction)}
-                </DropdownMenuItem>
-              ))
-            : null}
-          {canMoveTab ? <DropdownMenuSeparator /> : null}
           <DropdownMenuItem onSelect={() => splitActiveTerminalPane('vertical')}>
             <PanelRightClose className="size-3.5 shrink-0" />
             {translate(

--- a/src/renderer/src/components/tab-bar/TerminalTabSplitMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabSplitMenuSection.tsx
@@ -1,0 +1,134 @@
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Columns2,
+  PanelBottomClose,
+  PanelRightClose
+} from 'lucide-react'
+import type { TabSplitDirection } from '../../store/slices/tabs'
+import { translate } from '@/i18n/i18n'
+import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import { requestActiveTerminalPaneSplit } from './request-active-terminal-pane-split'
+
+const PANE_COLUMN_DIRECTIONS: TabSplitDirection[] = ['right', 'left', 'down', 'up']
+
+function moveTabDirectionIcon(direction: TabSplitDirection): React.JSX.Element {
+  switch (direction) {
+    case 'right':
+      return <ArrowRight className="size-3.5 shrink-0" />
+    case 'left':
+      return <ArrowLeft className="size-3.5 shrink-0" />
+    case 'down':
+      return <ArrowDown className="size-3.5 shrink-0" />
+    case 'up':
+      return <ArrowUp className="size-3.5 shrink-0" />
+  }
+}
+
+function moveTabDirectionLabel(direction: TabSplitDirection): string {
+  switch (direction) {
+    case 'right':
+      return translate(
+        'auto.components.tab.bar.TerminalTabSplitMenuSection.moveTabRight',
+        'Move tab right'
+      )
+    case 'left':
+      return translate(
+        'auto.components.tab.bar.TerminalTabSplitMenuSection.moveTabLeft',
+        'Move tab left'
+      )
+    case 'down':
+      return translate(
+        'auto.components.tab.bar.TerminalTabSplitMenuSection.moveTabDown',
+        'Move tab down'
+      )
+    case 'up':
+      return translate(
+        'auto.components.tab.bar.TerminalTabSplitMenuSection.moveTabUp',
+        'Move tab up'
+      )
+  }
+}
+
+export function TerminalTabSplitMenuSection({
+  unifiedTabId,
+  groupId,
+  tabId,
+  isActive,
+  onActivate,
+  splitRightShortcut,
+  splitDownShortcut,
+  trailingSeparator = false
+}: {
+  unifiedTabId: string
+  groupId: string
+  tabId: string
+  isActive: boolean
+  onActivate: (tabId: string) => void
+  splitRightShortcut: string
+  splitDownShortcut: string
+  trailingSeparator?: boolean
+}): React.JSX.Element {
+  const canMoveTab = canMoveTabToNewPaneColumn(unifiedTabId, groupId)
+
+  const splitActiveTerminalPane = (direction: 'vertical' | 'horizontal'): void => {
+    if (!isActive) {
+      onActivate(tabId)
+    }
+    requestActiveTerminalPaneSplit({ tabId, direction })
+  }
+
+  return (
+    <>
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger className="[&>svg:last-child]:size-3.5">
+          <Columns2 className="size-3.5 shrink-0" />
+          {translate('auto.components.tab.bar.TerminalTabSplitMenuSection.split', 'Split')}
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent className="min-w-[12rem]">
+          {canMoveTab
+            ? PANE_COLUMN_DIRECTIONS.map((direction) => (
+                <DropdownMenuItem
+                  key={direction}
+                  onSelect={() => {
+                    moveTabToNewPaneColumn({ unifiedTabId, groupId, direction })
+                  }}
+                >
+                  {moveTabDirectionIcon(direction)}
+                  {moveTabDirectionLabel(direction)}
+                </DropdownMenuItem>
+              ))
+            : null}
+          {canMoveTab ? <DropdownMenuSeparator /> : null}
+          <DropdownMenuItem onSelect={() => splitActiveTerminalPane('vertical')}>
+            <PanelRightClose className="size-3.5 shrink-0" />
+            {translate(
+              'auto.components.tab.bar.SortableTabContextMenu.splitTerminalRight',
+              'Split terminal right'
+            )}
+            <DropdownMenuShortcut>{splitRightShortcut}</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => splitActiveTerminalPane('horizontal')}>
+            <PanelBottomClose className="size-3.5 shrink-0" />
+            {translate(
+              'auto.components.tab.bar.SortableTabContextMenu.splitTerminalDown',
+              'Split terminal down'
+            )}
+            <DropdownMenuShortcut>{splitDownShortcut}</DropdownMenuShortcut>
+          </DropdownMenuItem>
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+      {trailingSeparator ? <DropdownMenuSeparator /> : null}
+    </>
+  )
+}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -29,6 +29,10 @@ export default function TabGroupPanel({
   hasSplitGroups,
   touchesRightEdge,
   touchesLeftEdge,
+  touchesBottomEdge = false,
+  suppressLeftBorder = false,
+  suppressRightBorder = false,
+  suppressBottomBorder = false,
   reserveClosedExplorerToggleSpace,
   reserveCollapsedSidebarHeaderSpace,
   isTabDragActive = false,
@@ -40,6 +44,10 @@ export default function TabGroupPanel({
   hasSplitGroups: boolean
   touchesRightEdge: boolean
   touchesLeftEdge: boolean
+  touchesBottomEdge?: boolean
+  suppressLeftBorder?: boolean
+  suppressRightBorder?: boolean
+  suppressBottomBorder?: boolean
   reserveClosedExplorerToggleSpace: boolean
   reserveCollapsedSidebarHeaderSpace: boolean
   isTabDragActive?: boolean
@@ -205,7 +213,13 @@ export default function TabGroupPanel({
             // border-l/border-r in those spots stacks a second 1px line
             // next to it, reading as a ~2px bar below the drag strip
             // (where the sibling border continues alone above).
-            ` ${touchesLeftEdge ? '' : 'border-l'} ${touchesRightEdge ? '' : 'border-r'} border-border border-b ${isFocused ? 'border-b-accent' : 'opacity-95'}`
+            ` ${
+              touchesLeftEdge || suppressLeftBorder ? '' : 'border-l'
+            } ${touchesRightEdge || suppressRightBorder ? '' : 'border-r'} ${
+              touchesBottomEdge || suppressBottomBorder ? '' : 'border-b'
+            } border-border ${
+              isFocused && !touchesBottomEdge && !suppressBottomBorder ? 'border-b-accent' : ''
+            } ${isFocused ? '' : 'opacity-95'}`
           : ''
       }`}
       onPointerDown={commands.focusGroup}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -103,9 +103,9 @@ function ResizeHandle({
 
   return (
     <div
-      className={`shrink-0 ${
-        isHorizontal ? 'w-1 cursor-col-resize' : 'h-1 cursor-row-resize'
-      } ${dragging ? 'bg-accent' : 'bg-border hover:bg-accent/50'}`}
+      className={`tab-group-split-resize-handle ${
+        isHorizontal ? 'is-vertical' : 'is-horizontal'
+      }${dragging ? ' is-dragging' : ''}`}
       onPointerDown={onPointerDown}
     />
   )
@@ -121,6 +121,10 @@ function SplitNode({
   touchesTopEdge,
   touchesRightEdge,
   touchesLeftEdge,
+  touchesBottomEdge,
+  suppressLeftBorder,
+  suppressRightBorder,
+  suppressBottomBorder,
   isTabDragActive,
   hoveredTabInsertion
 }: {
@@ -133,6 +137,10 @@ function SplitNode({
   touchesTopEdge: boolean
   touchesRightEdge: boolean
   touchesLeftEdge: boolean
+  touchesBottomEdge: boolean
+  suppressLeftBorder: boolean
+  suppressRightBorder: boolean
+  suppressBottomBorder: boolean
   isTabDragActive: boolean
   hoveredTabInsertion: HoveredTabInsertion | null
 }): React.JSX.Element {
@@ -152,6 +160,10 @@ function SplitNode({
         hasSplitGroups={hasSplitGroups}
         touchesRightEdge={touchesRightEdge}
         touchesLeftEdge={touchesLeftEdge}
+        touchesBottomEdge={touchesBottomEdge}
+        suppressLeftBorder={suppressLeftBorder}
+        suppressRightBorder={suppressRightBorder}
+        suppressBottomBorder={suppressBottomBorder}
         reserveClosedExplorerToggleSpace={touchesTopEdge && touchesRightEdge}
         reserveCollapsedSidebarHeaderSpace={touchesTopEdge && touchesLeftEdge}
         isTabDragActive={isTabDragActive}
@@ -181,6 +193,12 @@ function SplitNode({
           touchesTopEdge={touchesTopEdge}
           touchesRightEdge={isHorizontal ? false : touchesRightEdge}
           touchesLeftEdge={touchesLeftEdge}
+          touchesBottomEdge={isHorizontal ? touchesBottomEdge : false}
+          suppressLeftBorder={suppressLeftBorder}
+          // Why: the resize handle paints the inner seam — pane borders here
+          // stack into a triple-line bar beside the divider.
+          suppressRightBorder={isHorizontal ? true : suppressRightBorder}
+          suppressBottomBorder={isHorizontal ? suppressBottomBorder : true}
           isTabDragActive={isTabDragActive}
           hoveredTabInsertion={hoveredTabInsertion}
         />
@@ -201,6 +219,10 @@ function SplitNode({
           touchesTopEdge={isHorizontal ? touchesTopEdge : false}
           touchesRightEdge={touchesRightEdge}
           touchesLeftEdge={isHorizontal ? false : touchesLeftEdge}
+          touchesBottomEdge={touchesBottomEdge}
+          suppressLeftBorder={isHorizontal ? true : suppressLeftBorder}
+          suppressRightBorder={suppressRightBorder}
+          suppressBottomBorder={suppressBottomBorder}
           isTabDragActive={isTabDragActive}
           hoveredTabInsertion={hoveredTabInsertion}
         />
@@ -275,6 +297,10 @@ export default function TabGroupSplitLayout({
               touchesTopEdge={true}
               touchesRightEdge={true}
               touchesLeftEdge={true}
+              touchesBottomEdge={false}
+              suppressLeftBorder={false}
+              suppressRightBorder={false}
+              suppressBottomBorder={false}
               isTabDragActive={dragSplit.activeDrag !== null}
               hoveredTabInsertion={dragSplit.hoveredTabInsertion}
             />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2773,11 +2773,7 @@
             "a768f428f1": "Close tab"
           },
           "TerminalTabSplitMenuSection": {
-            "moveTabRight": "Move tab right",
-            "moveTabLeft": "Move tab left",
-            "moveTabDown": "Move tab down",
-            "moveTabUp": "Move tab up",
-            "split": "Split"
+            "splitTerminal": "Split terminal"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2771,6 +2771,13 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "Close tab",
             "a768f428f1": "Close tab"
+          },
+          "TerminalTabSplitMenuSection": {
+            "moveTabRight": "Move tab right",
+            "moveTabLeft": "Move tab left",
+            "moveTabDown": "Move tab down",
+            "moveTabUp": "Move tab up",
+            "split": "Split"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2773,11 +2773,7 @@
             "a768f428f1": "Cerrar pestaña"
           },
           "TerminalTabSplitMenuSection": {
-            "moveTabRight": "Move tab right",
-            "moveTabLeft": "Move tab left",
-            "moveTabDown": "Move tab down",
-            "moveTabUp": "Move tab up",
-            "split": "Split"
+            "splitTerminal": "Split terminal"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2771,6 +2771,13 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "Cerrar pestaña",
             "a768f428f1": "Cerrar pestaña"
+          },
+          "TerminalTabSplitMenuSection": {
+            "moveTabRight": "Move tab right",
+            "moveTabLeft": "Move tab left",
+            "moveTabDown": "Move tab down",
+            "moveTabUp": "Move tab up",
+            "split": "Split"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2773,11 +2773,7 @@
             "a768f428f1": "タブを閉じる"
           },
           "TerminalTabSplitMenuSection": {
-            "moveTabRight": "Move tab right",
-            "moveTabLeft": "Move tab left",
-            "moveTabDown": "Move tab down",
-            "moveTabUp": "Move tab up",
-            "split": "Split"
+            "splitTerminal": "Split terminal"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2771,6 +2771,13 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "タブを閉じる",
             "a768f428f1": "タブを閉じる"
+          },
+          "TerminalTabSplitMenuSection": {
+            "moveTabRight": "Move tab right",
+            "moveTabLeft": "Move tab left",
+            "moveTabDown": "Move tab down",
+            "moveTabUp": "Move tab up",
+            "split": "Split"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2773,11 +2773,7 @@
             "a768f428f1": "탭 닫기"
           },
           "TerminalTabSplitMenuSection": {
-            "moveTabRight": "Move tab right",
-            "moveTabLeft": "Move tab left",
-            "moveTabDown": "Move tab down",
-            "moveTabUp": "Move tab up",
-            "split": "Split"
+            "splitTerminal": "Split terminal"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2771,6 +2771,13 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "탭 닫기",
             "a768f428f1": "탭 닫기"
+          },
+          "TerminalTabSplitMenuSection": {
+            "moveTabRight": "Move tab right",
+            "moveTabLeft": "Move tab left",
+            "moveTabDown": "Move tab down",
+            "moveTabUp": "Move tab up",
+            "split": "Split"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2773,11 +2773,7 @@
             "a768f428f1": "关闭选项卡"
           },
           "TerminalTabSplitMenuSection": {
-            "moveTabRight": "Move tab right",
-            "moveTabLeft": "Move tab left",
-            "moveTabDown": "Move tab down",
-            "moveTabUp": "Move tab up",
-            "split": "Split"
+            "splitTerminal": "Split terminal"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2771,6 +2771,13 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "关闭选项卡",
             "a768f428f1": "关闭选项卡"
+          },
+          "TerminalTabSplitMenuSection": {
+            "moveTabRight": "Move tab right",
+            "moveTabLeft": "Move tab left",
+            "moveTabDown": "Move tab down",
+            "moveTabUp": "Move tab up",
+            "split": "Split"
           }
         }
       },


### PR DESCRIPTION
## Summary

Makes center split panes easier to read by giving tab-group split handles a wider hit area and dedicated divider tokens, and by avoiding stacked pane borders around the split seam.

Also consolidates terminal tab split actions into a Split submenu and adds icons to tab context-menu actions for clearer scanning.

## Screenshots

Not captured in this run. Visual change is limited to split divider/menu chrome.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional verification run:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts src/renderer/src/components/tab-bar/BrowserTab.test.tsx src/renderer/src/components/tab-bar/EditorFileTab.test.tsx src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx`
- `pnpm run sync:localization-catalog`

## AI Review Report

Ran the lightweight two-round AI review loop plus the required perf audit. The review checked correctness, type safety, error handling, security, performance, dead code/unused imports, and cross-platform impact for macOS, Linux, and Windows. This PR does not change keyboard shortcut handling, shell behavior, file paths, provider behavior, or Electron platform branching.

Findings addressed:

- Separated physical edge flags from inner border-suppression flags so panes do not incorrectly reserve top-right header space.
- Added the new terminal split menu component to git so tracked imports resolve in CI.
- Updated affected lucide icon mocks in tests.
- Synced localization catalogs for the new Split submenu labels.

Perf audit result: touched surfaces are renderer tab context menus, split resize-handle CSS/classes, and split-layout border props. No polling, subprocess work, broad store scans, terminal output work, persistence writes, IPC fanout, or expensive synchronous hot-path work was added. The resize path remains one rect read plus one ratio update per pointer event, matching prior behavior.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, IPC, or network surface is introduced. The new behavior is renderer-only UI composition and CSS/token styling. No follow-up security work needed.

## Notes

The split-handle colors are new design tokens defined in `main.css` for light and dark mode, then exposed through the Tailwind theme bindings.