### PR TITLE
feat(cli): add --env to `terminal create` for per-terminal env injection

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -57,7 +57,7 @@ export const BOOLEAN_FLAGS = new Set([
 ])
 
 export const REPEATED_FLAG_SEPARATOR = '\u0000'
-const REPEATABLE_STRING_FLAGS = new Set(['label'])
+const REPEATABLE_STRING_FLAGS = new Set(['label', 'env'])
 
 function setFlagValue(flags: Map<string, string | boolean>, name: string, value: string): void {
   const existing = flags.get(name)

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -28,6 +28,7 @@ import {
 import {
   getOptionalPositiveIntegerFlag,
   getOptionalStringFlag,
+  getRepeatedStringFlag,
   getRequiredStringFlag
 } from '../flags'
 import { RuntimeClientError } from '../runtime-client'
@@ -42,6 +43,24 @@ import {
 // timeout. Even without an explicit server timeout, the client must allow
 // long waits instead of failing at the generic 15s transport cap.
 const DEFAULT_TERMINAL_WAIT_RPC_TIMEOUT_MS = 5 * 60 * 1000
+
+// Parse repeated `--env KEY=VALUE` flags into an env record. Returns undefined
+// when none were passed so the RPC payload stays unchanged. The value may itself
+// contain `=` (e.g. base64/URLs); only the first `=` splits key from value.
+function parseEnvFlags(pairs: string[]): Record<string, string> | undefined {
+  if (pairs.length === 0) {
+    return undefined
+  }
+  const env: Record<string, string> = {}
+  for (const pair of pairs) {
+    const eq = pair.indexOf('=')
+    if (eq <= 0) {
+      throw new RuntimeClientError('invalid_argument', `--env must be KEY=VALUE, got: ${pair}`)
+    }
+    env[pair.slice(0, eq)] = pair.slice(eq + 1)
+  }
+  return env
+}
 
 const terminalFocusHandler: CommandHandler = async ({ flags, client, cwd, json }) => {
   const result = await client.call<{ focus: RuntimeTerminalFocus }>('terminal.focus', {
@@ -134,6 +153,7 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
     const useRendererBackedInteractiveTerminal =
       !client.isRemote && shouldUseRendererBackedInteractiveTerminal(command)
     const focus = flags.get('focus') === true
+    const env = parseEnvFlags(getRepeatedStringFlag(flags, 'env'))
     const result = await client.call<{ terminal: RuntimeTerminalCreate }>('terminal.create', {
       worktree: await getBrowserWorktreeSelector(flags, cwd, client),
       command,
@@ -142,6 +162,7 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       // path for browser-side features, but CLI creates must stay backgrounded
       // unless the caller explicitly asks for focus.
       focus,
+      ...(env ? { env } : {}),
       ...(focus ? { presentation: 'focused' } : {}),
       ...(useRendererBackedInteractiveTerminal ? { rendererBacked: true, activate: focus } : {})
     })

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -2798,6 +2798,60 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
+  it('passes repeated --env KEY=VALUE flags through terminal.create as an env record', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_terminal_create', {
+        terminal: { handle: 'term_1', worktreeId: 'repo-1::/tmp/repo', title: null }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'terminal',
+        'create',
+        '--worktree',
+        'path:/tmp/repo/feature',
+        '--command',
+        'codex',
+        '--env',
+        'CALLER_TOKEN=abc123',
+        '--env',
+        'CALLER_ID=42',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'terminal.create',
+      expect.objectContaining({
+        command: 'codex',
+        env: { CALLER_TOKEN: 'abc123', CALLER_ID: '42' }
+      })
+    )
+  })
+
+  it('rejects a malformed --env value that is not KEY=VALUE', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['terminal', 'create', '--worktree', 'path:/tmp/repo/feature', '--env', 'NOEQUALS', '--json'],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+      ok: false,
+      error: { code: 'invalid_argument', message: '--env must be KEY=VALUE, got: NOEQUALS' }
+    })
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('prints terminal.read fallback screen lines in json mode', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -220,16 +220,18 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['terminal', 'create'],
     summary: 'Create a terminal session in the current worktree',
     usage:
-      'orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--focus] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'command', 'title', 'focus'],
+      'orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--env <KEY=VALUE>]... [--focus] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'command', 'title', 'focus', 'env'],
     notes: [
       'Creates a visible terminal tab without switching focus when possible; falls back to a background handle if the UI cannot adopt it. Pass --focus to switch to it.',
-      'Use this, not worktree create, for a fresh agent in the current checkout.'
+      'Use this, not worktree create, for a fresh agent in the current checkout.',
+      'Pass --env KEY=VALUE (repeatable) to inject environment variables into the new terminal without altering the command, so an agent command is still recognized for its launch preset.'
     ],
     examples: [
       'orca terminal create --json',
       'orca terminal create --worktree active --command "codex" --json',
       'orca terminal create --worktree path:/projects/myapp --title "RUNNER" --command "opencode"',
+      'orca terminal create --worktree active --command "codex" --env FOO=bar --env BAZ=qux',
       'orca terminal create --worktree path:/projects/myapp --command "opencode" --focus'
     ]
   },

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7562,6 +7562,33 @@ describe('OrcaRuntimeService', () => {
     expect(spawnCall?.env?.ORCA_AGENT_HOOK_ENDPOINT).toBeUndefined()
   })
 
+  it('passes arbitrary caller env (the `terminal create --env` case) through to the spawned pty', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-env-passthrough' })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'codex',
+      env: { CALLER_TOKEN: 'abc123', CALLER_ID: '42' }
+    })
+
+    const spawnCall = spawn.mock.calls[0]?.[0] as { env?: Record<string, string> } | undefined
+    expect(spawnCall?.env).toEqual(
+      expect.objectContaining({
+        CALLER_TOKEN: 'abc123',
+        CALLER_ID: '42'
+      })
+    )
+    // The command is untouched by env injection, so agent launch-preset detection
+    // (YOLO) still applies.
+    expect(spawnCall).toEqual(expect.objectContaining({ command: 'codex' }))
+  })
+
   it.each([
     { label: 'canonical folder workspace selector', selector: TEST_FOLDER_WORKSPACE_KEY },
     { label: 'id-prefixed folder workspace selector', selector: `id:${TEST_FOLDER_WORKSPACE_KEY}` }

--- a/tests/e2e/orca-cli.e2e.ts
+++ b/tests/e2e/orca-cli.e2e.ts
@@ -1,0 +1,157 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { execFile } from 'node:child_process'
+import { access, chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import {
+  ensureOrcaRuntimeLaunched,
+  parseJsonOutput,
+  runOrcaCli
+} from './helpers/computer-cli-driver'
+
+// End-to-end coverage for the `orca terminal create --env` CLI flag against a REAL
+// runtime, reusing the same CLI-driver harness the computer-use e2e suites use
+// (compiled dev CLI → live runtime). Verifies the two seams the unit/runtime tests
+// cannot: that the flag survives a real CLI → RPC → pty round-trip and lands in the
+// spawned process env. Opt-in (ORCA_CLI_E2E=1) and POSIX-only (verifies via `env`).
+
+const execFileAsync = promisify(execFile)
+const PROJECT_ID = 'github:orca-e2e/testrepo'
+const REMOTE_URL = 'https://github.com/orca-e2e/testrepo.git'
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const e2eOptIn = process.env.ORCA_CLI_E2E === '1'
+const isPosix = process.platform !== 'win32'
+
+type WorktreeCreateResult = { result: { worktree: { id: string; path: string } } }
+
+describe.skipIf(!e2eOptIn || !isPosix)('orca CLI: terminal create --env (real runtime)', () => {
+  let repoDir: string
+  let worktreePath: string
+  let worktreeSelector: string
+
+  beforeAll(async () => {
+    repoDir = await mkdtemp(join(tmpdir(), 'orca-cli-e2e-repo-'))
+    const git = (args: string[]) => execFileAsync('git', args, { cwd: repoDir })
+    await git(['init'])
+    // A git remote gives the folder a deterministic project identity, which
+    // `project setup-existing-folder` requires to import it.
+    await git(['remote', 'add', 'origin', REMOTE_URL])
+    await git([
+      '-c',
+      'user.email=e2e@orca.test',
+      '-c',
+      'user.name=e2e',
+      'commit',
+      '--allow-empty',
+      '-m',
+      'init'
+    ])
+
+    await ensureOrcaRuntimeLaunched()
+
+    // Register the throwaway repo, then materialize a worktree to create a terminal in.
+    await runOrcaCli([
+      'project',
+      'setup-existing-folder',
+      '--project',
+      PROJECT_ID,
+      '--host',
+      'local',
+      '--path',
+      repoDir,
+      '--kind',
+      'git',
+      '--json'
+    ])
+    const created = parseJsonOutput<WorktreeCreateResult>(
+      (
+        await runOrcaCli([
+          'worktree',
+          'create',
+          '--project',
+          PROJECT_ID,
+          '--host',
+          'local',
+          '--name',
+          'e2e-main',
+          '--no-parent',
+          '--setup',
+          'skip',
+          '--json'
+        ])
+      ).stdout
+    )
+    worktreePath = created.result.worktree.path
+    worktreeSelector = `id:${created.result.worktree.id}`
+  }, 60000)
+
+  afterAll(async () => {
+    // Only clean up what this test created (its worktree); leave the shared runtime
+    // running, matching the mac/linux computer-use suites, which reuse it rather
+    // than tearing it down (only the windows serve-based suites call stopOrcaRuntime).
+    if (worktreeSelector) {
+      await runOrcaCli(['worktree', 'rm', '--worktree', worktreeSelector, '--json']).catch(() => {})
+    }
+    // worktreePath is <workspaces>/<repo>/e2e-main; also drop its parent workspace
+    // dir so nothing accumulates under ~/orca/workspaces.
+    const dirs = [repoDir, worktreePath, worktreePath ? dirname(worktreePath) : '']
+    for (const dir of dirs) {
+      if (dir) {
+        await rm(dir, { recursive: true, force: true }).catch(() => {})
+      }
+    }
+  })
+
+  test('injects repeated --env KEY=VALUE into the spawned terminal pty', async () => {
+    const outFile = join(repoDir, 'env-dump.txt')
+    const script = join(repoDir, 'dump-env.sh')
+    await writeFile(script, `#!/bin/sh\nenv > "${outFile}"\nsleep 30\n`)
+    await chmod(script, 0o755)
+
+    await runOrcaCli([
+      'terminal',
+      'create',
+      '--worktree',
+      worktreeSelector,
+      '--command',
+      script,
+      '--env',
+      'CALLER_TOKEN=abc123',
+      '--env',
+      'CALLER_ID=42',
+      '--json'
+    ])
+
+    // The dumped env appears once the pty has run the command.
+    const deadline = Date.now() + 15000
+    while (Date.now() < deadline) {
+      try {
+        await access(outFile)
+        break
+      } catch {
+        await delay(250)
+      }
+    }
+    const env = await readFile(outFile, 'utf8')
+    expect(env).toMatch(/^CALLER_TOKEN=abc123$/m)
+    expect(env).toMatch(/^CALLER_ID=42$/m)
+  }, 30000)
+
+  test('rejects a malformed --env value that is not KEY=VALUE', async () => {
+    await expect(
+      runOrcaCli([
+        'terminal',
+        'create',
+        '--worktree',
+        worktreeSelector,
+        '--command',
+        'sh',
+        '--env',
+        'NOEQUALS',
+        '--json'
+      ])
+    ).rejects.toThrow(/--env must be KEY=VALUE/)
+  })
+})

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -3,9 +3,10 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests/e2e/computer-*.e2e.ts'],
+    include: ['tests/e2e/computer-*.e2e.ts', 'tests/e2e/orca-cli.e2e.ts'],
     // Why: computer-use E2E files share the real desktop focus, clipboard, and
-    // app windows. Parallel files can steal focus from each other.
+    // app windows. Parallel files can steal focus from each other. The CLI e2e
+    // also boots a real (headless) runtime, so keep files serial here too.
     fileParallelism: false,
     testTimeout: 60_000,
     hookTimeout: 60_000


### PR DESCRIPTION
## Summary
Add a repeatable `--env KEY=VALUE` flag to `orca terminal create` that injects environment variables into the newly spawned terminal **without altering the command**.

## Motivation
Callers that programmatically spawn terminals (e.g. an orchestrator launching worker/agent terminals) frequently need to hand the child process context — identifiers, tokens, or config — through the environment. The only prior option was prefixing the command with `KEY=val <cmd>`, but that mutates the command string and defeats Orca's agent-command recognition and its per-agent launch presets. A dedicated flag keeps the command bare (so recognition/presets still apply) while still setting the variables on the pty.

The `terminal.create` RPC and runtime already accepted an `env` record; only the CLI seam was missing.

## Scope
CLI only:
- `args` marks `--env` repeatable.
- The terminal-create spec allows and documents the flag.
- The handler parses each `KEY=VALUE` (first `=` splits, so values may themselves contain `=`) into an env record forwarded to the existing RPC. A malformed value (missing `=`) is rejected with an actionable error.

Additive and backward compatible: no behavior change when `--env` is omitted.

## Testing
- **Unit (vitest, default):**
  - CLI: repeated `--env` is parsed into an env record on the `terminal.create` call; a malformed `--env NOEQUALS` is rejected with `must be KEY=VALUE`.
  - Runtime: arbitrary caller env passes through to the spawned pty and the command is left unchanged.
- **E2E (opt-in via `ORCA_CLI_E2E=1`, POSIX):** a new `tests/e2e/orca-cli.e2e.ts` drives the compiled CLI against a real runtime through the existing CLI-driver harness — registers a throwaway repo/worktree, runs `terminal create --env`, and asserts the variables land in the spawned process env; also covers the malformed-value rejection. Skipped in normal passes; reuses (does not tear down) the shared runtime like the POSIX computer-use suites.
- Typecheck (`tsconfig.cli`) and oxlint clean.

## ELI5

`orca terminal create` accepts repeatable `--env KEY=VALUE` without rewriting the command. Orchestrators can inject context into worker terminals cleanly.
